### PR TITLE
data: Remove deprecated examples

### DIFF
--- a/src/data/sfsgoals.cfg
+++ b/src/data/sfsgoals.cfg
@@ -22,11 +22,8 @@
 # 12 local_copy_on_mars : mars _               # at least one copy in the Martian datacenter
 # 13 cached_on_ssd : ssd _
 # 14 very_important_file : _ _ _ _
-# 15 default_xor3 : $xor3
-# 16 fast_read : $xor2 { ssd ssd hdd }
-# 17 xor5 : $xor5 { hdd }                      # at least one part on hdd
-# 14 min_two_locations: _ locationA locationB  # one copy in A, one in B, third anywhere
-# 15 fast_access      : ssd _ _                # one copy on ssd, two additional on any drives
-# 16 two_manufacturers: WD HT                  # one on WD disk, one on HT disk
-# 17 default_ec : $ec(5,2)                     # erasure code with 5 data parts and 2 parity parts
-# 18 wide_ec : $ec(17,9) { ssd ssd }           # erasure code 17+9 with at least two parts on ssd
+# 15 min_two_locations: _ locationA locationB  # one copy in A, one in B, third anywhere
+# 16 fast_access      : ssd _ _                # one copy on ssd, two additional on any drives
+# 17 two_manufacturers: WD HT                  # one on WD disk, one on HT disk
+# 18 default_ec : $ec(5,2)                     # erasure code with 5 data parts and 2 parity parts
+# 19 wide_ec : $ec(17,9) { ssd ssd }           # erasure code 17+9 with at least two parts on ssd


### PR DESCRIPTION
This removes both XOR and tapeserver from the configuration examples, since we do not support anymore.