### PR TITLE
chunkserver: Reallocate methods for plugin reuse

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,10 @@ cmake_minimum_required(VERSION 3.20)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Enable symbol export for loadable modules, ensuring same shared resource
+# references. Needed for the plugins, as they are shared libraries.
+set(CMAKE_ENABLE_EXPORTS ON)
+
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)

--- a/src/chunkserver/chunkserver-common/global_shared_resources.h
+++ b/src/chunkserver/chunkserver-common/global_shared_resources.h
@@ -32,3 +32,10 @@ inline std::mutex gDisksMutex;
 
 /// Container to reuse free condition variables (guarded by `gChunksMapMutex`)
 inline std::vector<std::unique_ptr<CondVarWithWaitCount>> gFreeCondVars;
+
+/// Active Disks scans in progress.
+/// Note: theoretically it would return a false positive if scans haven't
+/// started yet, but it's a _very_ unlikely situation.
+static std::atomic_int gScansInProgress(0);
+
+static std::atomic_bool gPerformFsync;

--- a/src/chunkserver/chunkserver-common/hdd_utils.cc
+++ b/src/chunkserver/chunkserver-common/hdd_utils.cc
@@ -1,9 +1,14 @@
+#include "common/platform.h"
+
 #include "hdd_utils.h"
 
 #include <sys/time.h>
 
 #include "chunkserver-common/global_shared_resources.h"
+#include "chunkserver-common/hdd_stats.h"
+#include "common/event_loop.h"
 #include "devtools/TracePrinter.h"
+#include "devtools/request_log.h"
 
 void hddAddErrorAndPreserveErrno(IChunk *chunk) {
 	TRACETHIS();
@@ -101,4 +106,329 @@ void hddRemoveChunkFromContainers(IChunk *chunk) {
 	}
 
 	gChunksMap.erase(chunkIter);
+}
+
+int chunkWriteCrc(IChunk *chunk) {
+	TRACETHIS();
+	assert(chunk);
+
+	chunk->owner()->setNeedRefresh(true);
+
+	uint8_t *crcData = gOpenChunks.getResource(chunk->metaFD()).crcData();
+
+	{
+		DiskWriteStatsUpdater updater(chunk->owner(), chunk->getCrcBlockSize());
+		ssize_t ret = chunk->owner()->writeCrc(chunk, crcData);
+
+		if (ret != static_cast<ssize_t>(chunk->getCrcBlockSize())) {
+			int errmem = errno;
+			safs_silent_errlog(LOG_WARNING,
+			                   "chunk_writecrc: file: %s - write error",
+			                   chunk->metaFilename().c_str());
+			errno = errmem;
+			updater.markWriteAsFailed();
+			return SAUNAFS_ERROR_IO;
+		}
+	}
+
+	HddStats::overheadWrite(chunk->getCrcBlockSize());
+	return SAUNAFS_STATUS_OK;
+}
+
+int hddIOEnd(IChunk *chunk) {
+	assert(chunk);
+	TRACETHIS1(c->chunkid);
+
+	if (chunk->wasChanged()) {
+		int status = chunkWriteCrc(chunk);
+		PRINTTHIS(status);
+
+		if (status != SAUNAFS_STATUS_OK) {
+			// FIXME(hazeman): We are probably leaking fd here.
+			int errmem = errno;
+			safs_silent_errlog(LOG_WARNING, "hddIOEnd: file:%s - write error",
+			                   chunk->metaFilename().c_str());
+			errno = errmem;
+			return status;
+		}
+
+		if (gPerformFsync) {
+			uint64_t startTime = getMicroSecsTime();
+			status = chunk->owner()->fsyncChunk(chunk);
+
+			if (status != SAUNAFS_STATUS_OK) {
+				int errmem = errno;
+				safs_silent_errlog(LOG_WARNING,
+				                   "hddIOEnd: file:%s - fsync error",
+				                   chunk->metaFilename().c_str());
+				errno = errmem;
+				return status;
+			}
+
+			HddStats::dataFSync(chunk->owner(), getMicroSecsTime() - startTime);
+		}
+
+		chunk->setWasChanged(false);
+	}
+
+	if (chunk->refCount() <= 0) {
+		safs_silent_syslog(LOG_WARNING,
+		                   "hddIOEnd: refcount = 0 - "
+		                   "This should never happen!");
+		errno = 0;
+
+		return SAUNAFS_STATUS_OK;
+	}
+
+	chunk->setRefCount(chunk->refCount() - 1);
+
+	if (chunk->refCount() == 0) {
+		gOpenChunks.release(chunk->metaFD(), eventloop_time());
+	}
+
+	errno = 0;
+	chunk->setValidAttr(0);
+
+	return SAUNAFS_STATUS_OK;
+}
+
+int hddIOBegin(IChunk *chunk, int newFlag, uint32_t chunkVersion) {
+	LOG_AVG_TILL_END_OF_SCOPE0("hddIOBegin");
+	TRACETHIS();
+	assert(chunk);
+	int status;
+
+	{  // We can move this chunk as last one to be tested
+		std::lock_guard testsLockGuard(gTestsMutex);
+		chunk->owner()->chunks().markAsTested(chunk);
+	}
+
+	if (chunk->refCount() == 0) {
+		bool add = (chunk->metaFD() < 0);
+
+		assert(!(newFlag && chunk->metaFD() >= 0));
+
+		gOpenChunks.acquire(chunk->metaFD());  // Ignored if c->fd < 0
+
+		if (chunk->metaFD() < 0) {
+			// Try to free some long unused descriptors
+			gOpenChunks.freeUnused(eventloop_time(), gChunksMapMutex);
+			for (int i = 0; i < kOpenRetryCount; ++i) {
+				if (newFlag) {
+					chunk->owner()->creat(chunk);
+				} else {
+					chunk->owner()->open(chunk);
+				}
+				if (chunk->metaFD() < 0 && errno != ENFILE) {
+					safs_silent_errlog(LOG_WARNING,
+					                   "hddIOBegin: file:%s - open error",
+					                   chunk->metaFilename().c_str());
+					return SAUNAFS_ERROR_IO;
+				} else if (chunk->metaFD() >= 0) {
+					gOpenChunks.acquire(chunk->metaFD(), OpenChunk(chunk));
+					break;
+				} else {  // chunk->fd < 0 && errno == ENFILE
+					usleep((kOpenRetry_ms * 1000) << i);
+					// Force free unused descriptors
+					auto freed = gOpenChunks.freeUnused(disk::kMaxUInt32Number,
+					                                    gChunksMapMutex, 4);
+					safs_pretty_syslog(LOG_NOTICE,
+					                   "hddIOBegin: freed unused: %d", freed);
+				}
+			}
+			if (chunk->metaFD() < 0) {
+				safs_silent_errlog(LOG_WARNING,
+				                   "hddIOBegin: file: %s - open error",
+				                   chunk->metaFilename().c_str());
+				return SAUNAFS_ERROR_IO;
+			}
+		}
+
+		if (newFlag) {
+			uint8_t *crcData =
+			    gOpenChunks.getResource(chunk->metaFD()).crcData();
+			memset(crcData, 0, chunk->getCrcBlockSize());
+		} else if (add) {
+			chunk->readaheadHeader();
+			uint8_t *crcData =
+			    gOpenChunks.getResource(chunk->metaFD()).crcData();
+			status = chunk->owner()->readChunkCrc(chunk, chunkVersion, crcData);
+			if (status != SAUNAFS_STATUS_OK) {
+				int errmem = errno;
+				gOpenChunks.release(chunk->metaFD(), eventloop_time());
+				safs_silent_errlog(LOG_WARNING,
+				                   "hddIOBegin: file:%s - read error",
+				                   chunk->metaFilename().c_str());
+				errno = errmem;
+				return status;
+			}
+		}
+	}
+
+	chunk->setRefCount(chunk->refCount() + 1);
+	errno = 0;
+
+	return SAUNAFS_STATUS_OK;
+}
+
+bool hddScansInProgress() { return gScansInProgress != 0; }
+
+IChunk *hddChunkFindAndLock(uint64_t chunkId, ChunkPartType chunkType) {
+	LOG_AVG_TILL_END_OF_SCOPE0("chunk_find");
+
+	return hddChunkFindOrCreatePlusLock(nullptr, chunkId, chunkType,
+	                                    disk::ChunkGetMode::kFindOnly);
+}
+
+IChunk *hddChunkFindOrCreatePlusLock(IDisk *disk, uint64_t chunkid,
+                                     ChunkPartType chunkType,
+                                     disk::ChunkGetMode creationMode) {
+	TRACETHIS2(chunkid, (unsigned)cflag);
+	IChunk *chunk = nullptr;
+	IDisk *effectiveDisk = disk;
+
+	std::unique_lock chunksMapLock(gChunksMapMutex);
+	auto chunkIter = gChunksMap.find(makeChunkKey(chunkid, chunkType));
+
+	if (chunkIter == gChunksMap.end()) {  // The chunk does not exists
+		if (creationMode !=
+		    disk::ChunkGetMode::kFindOnly) {  // Create it if requested
+			chunk =
+			    hddRecreateChunk(effectiveDisk, nullptr, chunkid, chunkType);
+		}
+
+		return chunk;
+	}
+
+	chunk = chunkIter->second.get();
+	effectiveDisk = chunk->owner();
+
+	if (creationMode == disk::ChunkGetMode::kCreateOnly) {
+		if (chunk->state() == ChunkState::Available ||
+		    chunk->state() == ChunkState::Locked) {
+			return nullptr;
+		}
+	}
+
+	while (true) {
+		switch (chunk->state()) {
+		case ChunkState::Available:
+			chunk->setState(ChunkState::Locked);
+			chunksMapLock.unlock();
+			if (chunk->validAttr() == 0) {
+				if (effectiveDisk->updateChunkAttributes(chunk, false) ==
+				    SAUNAFS_ERROR_NOCHUNK) {
+					// The chunk was found as available, but we can not
+					// update its attributes, let's recreate it only if
+					// requested
+					if (creationMode != disk::ChunkGetMode::kFindOnly) {
+						effectiveDisk->unlinkChunk(chunk);
+						chunksMapLock.lock();
+						chunk = hddRecreateChunk(effectiveDisk, chunk, chunkid,
+						                         chunkType);
+						return chunk;
+					}
+
+					// The Chunk is damaged, remove it from disk and from
+					// memory
+					hddReportDamagedChunk(chunk->id(), chunk->type());
+					effectiveDisk->unlinkChunk(chunk);
+					hddDeleteChunkFromRegistry(chunk);
+					return nullptr;
+				}
+			}
+			return chunk;
+		case ChunkState::Deleted:
+			if (creationMode != disk::ChunkGetMode::kFindOnly) {  // Reuse it
+				chunk =
+				    hddRecreateChunk(effectiveDisk, chunk, chunkid, chunkType);
+				return chunk;
+			}
+			if (chunk->condVar() !=
+			    nullptr) {  // waiting threads - wake them up
+				chunk->condVar()->condVar.notify_one();
+			} else {  // no more waiting threads - remove
+				hddRemoveChunkFromContainers(chunk);
+			}
+			return nullptr;
+		case ChunkState::ToBeDeleted:
+		case ChunkState::Locked:
+			if (chunk->condVar() == nullptr) {
+				// Try to reuse one if possible.
+				if (!gFreeCondVars.empty()) {
+					chunk->setCondVar(std::move(gFreeCondVars.back()));
+					gFreeCondVars.pop_back();
+				} else {
+					chunk->setCondVar(std::make_unique<CondVarWithWaitCount>());
+				}
+			}
+			chunk->condVar()->numberOfWaitingThreads++;
+			auto status = chunk->condVar()->condVar.wait_for(
+			    chunksMapLock,
+			    std::chrono::seconds(kSecondsToWaitForLockedChunk_));
+			chunk->condVar()->numberOfWaitingThreads--;
+			if (chunk->condVar()->numberOfWaitingThreads == 0) {
+				// No more waiting threads, store it to be reused
+				gFreeCondVars.emplace_back(std::move(chunk->condVar()));
+			}
+			if (status == std::cv_status::timeout) {
+				safs_pretty_syslog(LOG_WARNING, "Chunk locked for long time");
+				return nullptr;
+			}
+		}
+	}
+}
+
+IChunk *hddRecreateChunk(IDisk *disk, IChunk *chunk, uint64_t chunkId,
+                         ChunkPartType type) {
+	std::unique_ptr<CondVarWithWaitCount> waiting;
+
+	if (chunk != ChunkNotFound) {
+		assert(chunk->id() == chunkId);
+
+		if (chunk->state() != ChunkState::Deleted &&
+		    chunk->owner() != nullptr) {
+			const std::scoped_lock lock(gTestsMutex);
+			disk->chunks().remove(chunk);
+			disk->setNeedRefresh(true);
+		}
+
+		waiting = std::move(chunk->condVar());
+
+		// It's possible to reuse object chunk if the format is the same,
+		// but it doesn't happen often enough to justify adding extra code.
+		hddRemoveChunkFromContainers(chunk);
+	}
+
+	if (disk == DiskNotFound) { return ChunkNotFound; }
+
+	chunk = disk->instantiateNewConcreteChunk(chunkId, type);
+	passert(chunk);
+
+	bool success = gChunksMap
+	                   .insert({makeChunkKey(chunkId, type),
+	                            std::unique_ptr<IChunk>(chunk)})
+	                   .second;
+	massert(success,
+	        "Cannot insert new chunk to the map as a chunk with "
+	        "its chunkId and chunkPartType already exists");
+
+	chunk->setCondVar(std::move(waiting));
+
+	return chunk;
+}
+
+/* chunk operations */
+void hddDeleteChunkFromRegistry(IChunk *chunk) {
+	TRACETHIS();
+	assert(chunk);
+
+	const std::lock_guard chunksMapLockGuard(gChunksMapMutex);
+
+	if (chunk->condVar()) {
+		chunk->setState(ChunkState::Deleted);
+		chunk->condVar()->condVar.notify_one();
+	} else {
+		hddRemoveChunkFromContainers(chunk);
+	}
 }

--- a/src/chunkserver/hddspacemgr.cc
+++ b/src/chunkserver/hddspacemgr.cc
@@ -18,6 +18,8 @@
    along with SaunaFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "common/platform.h"
+
 #include "hddspacemgr.h"
 
 #ifdef SAUNAFS_HAVE_FALLOC_FL_PUNCH_HOLE_IN_LINUX_FALLOC_H
@@ -83,6 +85,7 @@
 #include "common/exceptions.h"
 #include "common/massert.h"
 #include "common/legacy_vector.h"
+#include "common/saunafs_error_codes.h"
 #include "common/serialization.h"
 #include "common/slice_traits.h"
 #include "common/slogger.h"
@@ -101,13 +104,6 @@ inline std::atomic_bool gCheckCrcWhenReading{true};
 
 /// Value of HDD_ADVISE_NO_CACHE from config
 static std::atomic_bool gAdviseNoCache;
-
-static std::atomic<bool> gPerformFsync;
-
-/// Active Disks scans in progress.
-/// Note: theoretically it would return a false positive if scans haven't
-/// started yet, but it's a _very_ unlikely situation.
-static std::atomic_int gScansInProgress(0);
 
 static IoStat gIoStat;
 
@@ -231,14 +227,6 @@ static IChunk *hddChunkCreate(IDisk *disk, uint64_t chunkId,
 	disk->chunks().insert(chunk);
 
 	return chunk;
-}
-
-static inline IChunk *hddChunkFindAndLock(uint64_t chunkId,
-                                          ChunkPartType chunkType) {
-	LOG_AVG_TILL_END_OF_SCOPE0("chunk_find");
-
-	return hddChunkFindOrCreatePlusLock(nullptr, chunkId, chunkType,
-	                                    disk::ChunkGetMode::kFindOnly);
 }
 
 static inline IDisk* hddGetDiskForNewChunk() {
@@ -590,168 +578,6 @@ int hddGetLoadFactor() {
 	return gIoStat.getLoadFactor();
 }
 
-static inline int chunkWriteCrc(IChunk *chunk) {
-	TRACETHIS();
-	assert(chunk);
-
-	chunk->owner()->setNeedRefresh(true);
-
-	uint8_t *crcData = gOpenChunks.getResource(chunk->metaFD()).crcData();
-
-	{
-		DiskWriteStatsUpdater updater(chunk->owner(), chunk->getCrcBlockSize());
-		ssize_t ret = chunk->owner()->writeCrc(chunk, crcData);
-
-		if (ret != static_cast<ssize_t>(chunk->getCrcBlockSize())) {
-			int errmem = errno;
-			safs_silent_errlog(LOG_WARNING,
-			                   "chunk_writecrc: file: %s - write error",
-			                   chunk->metaFilename().c_str());
-			errno = errmem;
-			updater.markWriteAsFailed();
-			return SAUNAFS_ERROR_IO;
-		}
-	}
-
-	HddStats::overheadWrite(chunk->getCrcBlockSize());
-	return SAUNAFS_STATUS_OK;
-}
-
-static int hddIOBegin(IChunk *chunk, int newFlag,
-                      uint32_t chunkVersion = disk::kMaxUInt32Number) {
-	LOG_AVG_TILL_END_OF_SCOPE0("hddIOBegin");
-	TRACETHIS();
-	assert(chunk);
-	int status;
-
-	{	// We can move this chunk as last one to be tested
-		std::lock_guard testsLockGuard(gTestsMutex);
-		chunk->owner()->chunks().markAsTested(chunk);
-	}
-
-	if (chunk->refCount() == 0) {
-		bool add = (chunk->metaFD() < 0);
-
-		assert(!(newFlag && chunk->metaFD() >= 0));
-
-		gOpenChunks.acquire(chunk->metaFD());  // Ignored if c->fd < 0
-
-		if (chunk->metaFD() < 0) {
-			// Try to free some long unused descriptors
-			gOpenChunks.freeUnused(eventloop_time(), gChunksMapMutex);
-			for (int i = 0; i < kOpenRetryCount; ++i) {
-				if (newFlag) {
-					chunk->owner()->creat(chunk);
-				} else {
-					chunk->owner()->open(chunk);
-				}
-				if (chunk->metaFD() < 0 && errno != ENFILE) {
-					safs_silent_errlog(LOG_WARNING,
-					                   "hddIOBegin: file:%s - open error",
-					                   chunk->metaFilename().c_str());
-					return SAUNAFS_ERROR_IO;
-				} else if (chunk->metaFD() >= 0) {
-					gOpenChunks.acquire(chunk->metaFD(), OpenChunk(chunk));
-					break;
-				} else { // chunk->fd < 0 && errno == ENFILE
-					usleep((kOpenRetry_ms * 1000) << i);
-					// Force free unused descriptors
-					auto freed = gOpenChunks.freeUnused(disk::kMaxUInt32Number,
-					                                    gChunksMapMutex, 4);
-					safs_pretty_syslog(LOG_NOTICE,
-					                   "hddIOBegin: freed unused: %d", freed);
-				}
-			}
-			if (chunk->metaFD() < 0) {
-				safs_silent_errlog(LOG_WARNING,
-				                   "hddIOBegin: file: %s - open error",
-				                   chunk->metaFilename().c_str());
-				return SAUNAFS_ERROR_IO;
-			}
-		}
-
-		if (newFlag) {
-			uint8_t *crcData = gOpenChunks.getResource(chunk->metaFD()).crcData();
-			memset(crcData, 0, chunk->getCrcBlockSize());
-		} else if (add) {
-			chunk->readaheadHeader();
-			uint8_t *crcData = gOpenChunks.getResource(chunk->metaFD()).crcData();
-			status = chunk->owner()->readChunkCrc(chunk, chunkVersion, crcData);
-			if (status != SAUNAFS_STATUS_OK) {
-				int errmem = errno;
-				gOpenChunks.release(chunk->metaFD(), eventloop_time());
-				safs_silent_errlog(LOG_WARNING,
-				                   "hddIOBegin: file:%s - read error",
-				                   chunk->metaFilename().c_str());
-				errno = errmem;
-				return status;
-			}
-		}
-	}
-
-	chunk->setRefCount(chunk->refCount() + 1);
-	errno = 0;
-
-	return SAUNAFS_STATUS_OK;
-}
-
-static int hddIOEnd(IChunk *chunk) {
-	assert(chunk);
-	TRACETHIS1(c->chunkid);
-
-	if (chunk->wasChanged()) {
-		int status = chunkWriteCrc(chunk);
-		PRINTTHIS(status);
-
-		if (status != SAUNAFS_STATUS_OK) {
-			    // FIXME(hazeman): We are probably leaking fd here.
-			    int errmem = errno;
-			    safs_silent_errlog(LOG_WARNING,
-			                       "hddIOEnd: file:%s - write error",
-			                       chunk->metaFilename().c_str());
-			    errno = errmem;
-			    return status;
-		}
-
-		if (gPerformFsync) {
-			uint64_t startTime = getMicroSecsTime();
-			status = chunk->owner()->fsyncChunk(chunk);
-
-			if (status != SAUNAFS_STATUS_OK) {
-				int errmem = errno;
-				safs_silent_errlog(LOG_WARNING,
-				                   "hddIOEnd: file:%s - fsync error",
-				                   chunk->metaFilename().c_str());
-				errno = errmem;
-				return status;
-			}
-
-			HddStats::dataFSync(chunk->owner(), getMicroSecsTime() - startTime);
-		}
-
-		chunk->setWasChanged(false);
-	}
-
-	if (chunk->refCount() <= 0) {
-		safs_silent_syslog(LOG_WARNING, "hddIOEnd: refcount = 0 - "
-		                                "This should never happen!");
-		errno = 0;
-
-		return SAUNAFS_STATUS_OK;
-	}
-
-	chunk->setRefCount(chunk->refCount() - 1);
-
-	if (chunk->refCount() == 0) {
-		gOpenChunks.release(chunk->metaFD(), eventloop_time());
-	}
-
-	errno = 0;
-	chunk->setValidAttr(0);
-
-	return SAUNAFS_STATUS_OK;
-}
-
 /* I/O operations */
 int hddOpen(IChunk *chunk) {
 	assert(chunk);
@@ -1063,163 +889,6 @@ int hddChunkGetNumberOfBlocks(uint64_t chunkId, ChunkPartType chunkType,
 	hddChunkRelease(chunk);
 
 	return SAUNAFS_STATUS_OK;
-}
-
-/* chunk operations */
-void hddDeleteChunkFromRegistry(IChunk *chunk) {
-	TRACETHIS();
-	assert(chunk);
-
-	const std::lock_guard chunksMapLockGuard(gChunksMapMutex);
-
-	if (chunk->condVar()) {
-		chunk->setState(ChunkState::Deleted);
-		chunk->condVar()->condVar.notify_one();
-	} else {
-		hddRemoveChunkFromContainers(chunk);
-	}
-}
-
-IChunk *hddRecreateChunk(IDisk *disk, IChunk *chunk, uint64_t chunkId,
-                         ChunkPartType type) {
-	std::unique_ptr<CondVarWithWaitCount> waiting;
-
-	if (chunk != ChunkNotFound) {
-		assert(chunk->id() == chunkId);
-
-		if (chunk->state() != ChunkState::Deleted &&
-		    chunk->owner() != nullptr) {
-			const std::scoped_lock lock(gTestsMutex);
-			disk->chunks().remove(chunk);
-			disk->setNeedRefresh(true);
-		}
-
-		waiting = std::move(chunk->condVar());
-
-		// It's possible to reuse object chunk if the format is the same,
-		// but it doesn't happen often enough to justify adding extra code.
-		hddRemoveChunkFromContainers(chunk);
-	}
-
-	if (disk == DiskNotFound) {
-		return ChunkNotFound;
-	}
-
-	chunk = disk->instantiateNewConcreteChunk(chunkId, type);
-	passert(chunk);
-
-	bool success = gChunksMap
-	                   .insert({makeChunkKey(chunkId, type),
-	                            std::unique_ptr<IChunk>(chunk)})
-	                   .second;
-	massert(success,
-	        "Cannot insert new chunk to the map as a chunk with "
-	        "its chunkId and chunkPartType already exists");
-
-	chunk->setCondVar(std::move(waiting));
-
-	return chunk;
-}
-
-IChunk *hddChunkFindOrCreatePlusLock(IDisk *disk, uint64_t chunkid,
-                                     ChunkPartType chunkType,
-                                     disk::ChunkGetMode creationMode) {
-	TRACETHIS2(chunkid, (unsigned)cflag);
-	IChunk *chunk = nullptr;
-	IDisk *effectiveDisk = disk;
-
-	std::unique_lock chunksMapLock(gChunksMapMutex);
-	auto chunkIter = gChunksMap.find(makeChunkKey(chunkid, chunkType));
-
-	if (chunkIter == gChunksMap.end()) {  // The chunk does not exists
-		if (creationMode !=
-		    disk::ChunkGetMode::kFindOnly) {  // Create it if requested
-			chunk = hddRecreateChunk(effectiveDisk, nullptr, chunkid, chunkType);
-		}
-
-		return chunk;
-	}
-
-	chunk = chunkIter->second.get();
-	effectiveDisk = chunk->owner();
-
-	if (creationMode == disk::ChunkGetMode::kCreateOnly) {
-		if (chunk->state() == ChunkState::Available ||
-		    chunk->state() == ChunkState::Locked) {
-			return nullptr;
-		}
-	}
-
-	while (true) {
-		switch (chunk->state()) {
-			case ChunkState::Available:
-				chunk->setState(ChunkState::Locked);
-				chunksMapLock.unlock();
-				if (chunk->validAttr() == 0) {
-					if (effectiveDisk->updateChunkAttributes(chunk, false) ==
-					    SAUNAFS_ERROR_NOCHUNK) {
-						// The chunk was found as available, but we can not
-						// update its attributes, let's recreate it only if
-						// requested
-						if (creationMode != disk::ChunkGetMode::kFindOnly) {
-							effectiveDisk->unlinkChunk(chunk);
-							chunksMapLock.lock();
-							chunk = hddRecreateChunk(effectiveDisk, chunk, chunkid,
-							                      chunkType);
-							return chunk;
-						}
-
-						// The Chunk is damaged, remove it from disk and from
-						// memory
-						hddReportDamagedChunk(chunk->id(), chunk->type());
-						effectiveDisk->unlinkChunk(chunk);
-						hddDeleteChunkFromRegistry(chunk);
-						return nullptr;
-					}
-				}
-				return chunk;
-			case ChunkState::Deleted:
-				if (creationMode !=
-				    disk::ChunkGetMode::kFindOnly) {  // Reuse it
-					chunk =
-					    hddRecreateChunk(effectiveDisk, chunk, chunkid, chunkType);
-					return chunk;
-				}
-				if (chunk->condVar() !=
-				    nullptr) {  // waiting threads - wake them up
-					chunk->condVar()->condVar.notify_one();
-				} else {  // no more waiting threads - remove
-					hddRemoveChunkFromContainers(chunk);
-				}
-				return nullptr;
-			case ChunkState::ToBeDeleted:
-			case ChunkState::Locked:
-				if (chunk->condVar() == nullptr) {
-					// Try to reuse one if possible.
-					if (!gFreeCondVars.empty()) {
-						chunk->setCondVar(std::move(gFreeCondVars.back()));
-						gFreeCondVars.pop_back();
-					} else {
-						chunk->setCondVar(
-						    std::make_unique<CondVarWithWaitCount>());
-					}
-				}
-				chunk->condVar()->numberOfWaitingThreads++;
-				auto status = chunk->condVar()->condVar.wait_for(
-				    chunksMapLock,
-				    std::chrono::seconds(kSecondsToWaitForLockedChunk_));
-				chunk->condVar()->numberOfWaitingThreads--;
-				if (chunk->condVar()->numberOfWaitingThreads == 0) {
-					// No more waiting threads, store it to be reused
-					gFreeCondVars.emplace_back(std::move(chunk->condVar()));
-				}
-				if (status == std::cv_status::timeout) {
-					safs_pretty_syslog(LOG_WARNING,
-					                   "Chunk locked for long time");
-					return nullptr;
-				}
-		}
-	}
 }
 
 std::pair<int, IChunk *> hddInternalCreateChunk(uint64_t chunkId,
@@ -2455,55 +2124,6 @@ int hddChunkOperation(uint64_t chunkId, uint32_t chunkVersion,
 	}
 }
 
-static int hddDefragmentChunk(uint64_t chunkId, ChunkPartType chunkType) {
-	auto *chunk = hddChunkFindAndLock(chunkId, chunkType);
-
-	if (chunk == ChunkNotFound) {
-		return SAUNAFS_ERROR_NOCHUNK;
-	}
-
-	bool chunkToBeFixed = chunk->isDirty();
-
-	if (!chunkToBeFixed) {
-		hddChunkRelease(chunk);
-		return SAUNAFS_STATUS_OK;
-	}
-
-	int status = hddIOBegin(chunk, 0);
-
-	if (status != SAUNAFS_STATUS_OK) {
-		hddAddErrorAndPreserveErrno(chunk);
-		hddChunkRelease(chunk);
-		safs_pretty_syslog(LOG_WARNING, "hddDefragmentChunk: IO begin error");
-
-		return SAUNAFS_ERROR_IO;
-	}
-
-	auto *crcData = gOpenChunks.getResource(chunk->metaFD()).crcData();
-	status = chunk->owner()->defragmentOrMoveChunk(chunk, crcData);
-
-	if (status != SAUNAFS_STATUS_OK) {
-		// test failed -- defragmentation failed
-		hddIOEnd(chunk);
-		hddChunkRelease(chunk);
-		safs_pretty_syslog(LOG_WARNING, "hddDefragmentChunk: defragmentation "
-		                                "error");
-		return SAUNAFS_ERROR_IO;
-	}
-
-	status = hddIOEnd(chunk);
-	if (status != SAUNAFS_STATUS_OK) {
-		hddAddErrorAndPreserveErrno(chunk);
-		hddChunkRelease(chunk);
-		safs_pretty_syslog(LOG_WARNING, "hddDefragmentChunk: IO end error");
-		return SAUNAFS_ERROR_IO;
-	}
-
-	hddChunkRelease(chunk);
-
-	return SAUNAFS_STATUS_OK;
-}
-
 static UniqueQueue<ChunkWithVersionAndType> gTestChunkQueue;
 
 static void hddTestChunkThread() {
@@ -2609,20 +2229,9 @@ void hddTesterThread() {
 			}
 		}
 
-		if (chunkId > 0) {
-			if (hddInternalTestChunk(chunkId, version, chunkType) !=
-			    SAUNAFS_STATUS_OK) {
-				hddReportDamagedChunk(chunkId, chunkType);
-			} else { // The test was correct
-				if ((*disksIt)->isZonedDevice()) {
-					int status =
-					    hddDefragmentChunk(chunk->id(), chunk->type());
-
-					if (status != SAUNAFS_STATUS_OK) {
-						hddReportDamagedChunk(chunkId, chunkType);
-					}
-				}
-			}
+		if (chunkId > 0 && hddInternalTestChunk(chunkId, version, chunkType) !=
+		                       SAUNAFS_STATUS_OK) {
+			hddReportDamagedChunk(chunkId, chunkType);
 		}
 
 		endMicroSecs = getMicroSecsTime();
@@ -2851,10 +2460,6 @@ void hddDiskScanThread(IDisk *disk) {
 
 	disk->setScanState(IDisk::ScanState::kThreadFinished);
 	disk->setScanProgress(100);
-}
-
-bool hddScansInProgress() {
-	return gScansInProgress != 0;
 }
 
 void hddDisksThread() {

--- a/src/chunkserver/hddspacemgr.h
+++ b/src/chunkserver/hddspacemgr.h
@@ -30,9 +30,6 @@
 #include "common/chunk_with_version_and_type.h"
 #include "protocol/chunks_with_type.h"
 
-#define ChunkNotFound nullptr
-#define DiskNotFound nullptr
-
 uint32_t hddGetAndResetErrorCounter();
 
 void hddGetDamagedChunks(std::vector<ChunkWithType>& chunks, std::size_t limit);
@@ -77,8 +74,6 @@ int hddChunkWriteBlock(uint64_t chunkId, uint32_t version,
 int hddChunkGetNumberOfBlocks(uint64_t chunkId, ChunkPartType chunkType,
                               uint32_t version, uint16_t *blocks);
 
-bool hddScansInProgress();
-
 /* chunk operations */
 
 /* all chunk operations in one call */
@@ -110,26 +105,6 @@ int hddInit();
 /// Deletes the chunk from the registry and from the disk's testlist in a
 /// thread-safe way.
 void hddDeleteChunkFromRegistry(IChunk *chunk);
-
-/// Remove old chunk and create new one in its place.
-///
-/// \param disk pointer to disk object which will be the owner if new chunk
-/// \param chunk pointer to old object
-/// \param chunkId chunk id that will be reused
-/// \param type type of new chunk object
-/// \return address of the new object or ChunkNotFound
-///
-/// \note ChunkId and threads waiting for this object are preserved.
-IChunk *hddRecreateChunk(IDisk *disk, IChunk *chunk, uint64_t chunkId,
-                         ChunkPartType type);
-
-/// Finds an existing chunk or creates a new one, and locks it anyway.
-///
-/// The function locks the returned chunk (may block if the chunk is already
-/// locked). To unlock it, use \ref hddChunkRelease.
-IChunk *hddChunkFindOrCreatePlusLock(IDisk *disk, uint64_t chunkid,
-                                     ChunkPartType chunkType,
-                                     disk::ChunkGetMode creationMode);
 
 /** \brief Creates a new chunk on disk
  *

--- a/src/chunkserver/masterconn.cc
+++ b/src/chunkserver/masterconn.cc
@@ -37,6 +37,7 @@
 
 #include <list>
 
+#include "chunkserver-common/hdd_utils.h"
 #include "chunkserver/bgjobs.h"
 #include "chunkserver/hddspacemgr.h"
 #include "chunkserver/network_main_thread.h"


### PR DESCRIPTION
Relocate disk space utilities to chunkserver-common for plugins access.
The main reason for doing this was to enable some important methods from hddspacemgr.cc
to be accessed from new plugins implemented.

- Move methods from `hddspacemgr.cc` to `hdd_utils.cc` for plugin-compatible access.
- Adjust `hddspacemgr.cc` to use the new `hdd_utils.cc` location, ensuring plugin compatibility.
- Prepare `hdd_utils.cc` for plugin support by enhancing modularity and accessibility.

The reallocated methods were:
- `chunkWriteCrc`
- `hddIOEnd`
- `hddIOBegin`
- `hddScansInProgress`
- `hddChunkFindAndLock`
- `hddChunkFindOrCreatePlusLock`
- `hddRecreateChunk`
- `hddDeleteChunkFromRegistry`

Also, deleted code related to defragmentation on `hddTesterThread` from `hddspacemgr.cc`
