### PR TITLE
all: Increase the nofile security limits

### DIFF
--- a/debian/saunafs-common.postinst
+++ b/debian/saunafs-common.postinst
@@ -12,8 +12,8 @@ case "${1}" in
 			adduser --quiet --system --group --no-create-home --home /var/lib/saunafs saunafs
 		fi
 		if [ ! -f $sau_limits_conf ]; then
-			echo "saunafs soft nofile 10000" > $sau_limits_conf
-			echo "saunafs hard nofile 10000" >> $sau_limits_conf
+			echo "saunafs soft nofile 131072" > $sau_limits_conf
+			echo "saunafs hard nofile 131072" >> $sau_limits_conf
 			chmod 0644 $sau_limits_conf
 		fi
 		if [ ! -f $sau_pam_d ]; then

--- a/rpm/saunafs.spec
+++ b/rpm/saunafs.spec
@@ -138,8 +138,8 @@ if ! getent passwd %{sau_user} > /dev/null 2>&1 ; then
 	adduser --system -g %{sau_group} --no-create-home --home-dir %{sau_datadir} %{sau_user}
 fi
 if [ ! -f %{sau_limits_conf} ]; then
-	echo "%{sau_user} soft nofile 10000" > %{sau_limits_conf}
-	echo "%{sau_user} hard nofile 10000" >> %{sau_limits_conf}
+	echo "%{sau_user} soft nofile 131072" > %{sau_limits_conf}
+	echo "%{sau_user} hard nofile 131072" >> %{sau_limits_conf}
 	chmod 0644 %{sau_limits_conf}
 fi
 if [ ! -f %{sau_pam_d} ]; then
@@ -188,8 +188,8 @@ if ! getent passwd %{sau_user} > /dev/null 2>&1 ; then
 	adduser --system -g %{sau_group} --no-create-home --home-dir %{sau_datadir} %{sau_user}
 fi
 if [ ! -f %{sau_limits_conf} ]; then
-	echo "%{sau_user} soft nofile 10000" > %{sau_limits_conf}
-	echo "%{sau_user} hard nofile 10000" >> %{sau_limits_conf}
+	echo "%{sau_user} soft nofile 131072" > %{sau_limits_conf}
+	echo "%{sau_user} hard nofile 131072" >> %{sau_limits_conf}
 	chmod 0644 %{sau_limits_conf}
 fi
 if [ ! -f %{sau_pam_d} ]; then


### PR DESCRIPTION
The previous limit (10000) in the number of open files (nofile) for user saunafs was too small for two main reasons:
- In the past we had to change this limit on customer side. Some workloads are requesting a big number of open file descriptors at least in the chunkserver side.
- The new SPLIT format for the chunks can double the usage.

This commit increases the limit and makes it base 2.