### PR TITLE
all: Refactor initializations based on runtabs

### DIFF
--- a/src/common/run_tab.h
+++ b/src/common/run_tab.h
@@ -1,9 +1,5 @@
 /*
-   Copyright 2005-2010 Jakub Kruszona-Zawadzki, Gemius SA
-   Copyright 2013-2014 EditShare
-   Copyright 2013-2015 Skytechnology sp. z o.o.
    Copyright 2023      Leil Storage OÜ
-
 
    SaunaFS is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -18,19 +14,16 @@
    along with SaunaFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "common/platform.h"
+#pragma once
 
-#include <vector>
+#include <functional>
+#include <string>
 
-#include "common/run_tab.h"
-#include "master/masterconn.h"
+/// Simple function prototype for callbacks
+using RunTabFuntion = std::function<int()>;
 
-/// Functions to call before normal startup
-inline const std::vector<RunTab> earlyRunTabs = {};
-
-/// Functions to call during normal startup
-inline const std::vector<RunTab> runTabs = {
-    RunTab{masterconn_init, "connection with master"}};
-
-/// Functions to call delayed after the initialization is correct
-inline const std::vector<RunTab> lateRunTabs = {};
+/// Structure to pack the function and a descriptive name together
+struct RunTab {
+	RunTabFuntion function;  ///< Actual function to call
+	std::string name;        ///< Descriptive name (useful to log errors)
+};

--- a/src/main/main.cc
+++ b/src/main/main.cc
@@ -136,37 +136,41 @@ static void signal_pipe_serv(const std::vector<pollfd> &pdesc) {
 	}
 }
 
+bool initialize(const std::vector<RunTab> &tabs) {
+	bool isOk = true;
 
-int initialize(run_tab* tab) {
-	uint32_t i;
-	int ok;
-	ok = 1;
-	for (i=0 ; (long int)(tab[i].fn)!=0 && ok ; i++) {
+	for (const auto &tab : tabs) {
 		eventloop_updatetime();
+
 		try {
-			if (tab[i].fn()<0) {
-				safs_pretty_syslog(LOG_ERR,"init: %s failed",tab[i].name);
-				ok=0;
+			if (tab.function() < 0) {
+				safs_pretty_syslog(LOG_ERR, "init: %s failed",
+				                   tab.name.c_str());
+				isOk = false;
+				break;
 			}
-		} catch (const std::exception& e) {
+		} catch (const std::exception &e) {
 			safs_pretty_syslog(LOG_ERR, "%s", e.what());
-			ok = 0;
+			isOk = false;
+			break;
 		}
 	}
+
 	eventloop_updatetime();
-	return ok;
+
+	return isOk;
 }
 
-int initialize_early(void) {
-	return initialize(EarlyRunTab);
+bool initialize_early() {
+	return initialize(earlyRunTabs);
 }
 
-int initialize(void) {
-	return initialize(RunTab);
+bool initialize() {
+	return initialize(runTabs);
 }
 
-int initialize_late(void) {
-	return initialize(LateRunTab);
+bool initialize_late() {
+	return initialize(lateRunTabs);
 }
 
 const std::string& set_syslog_ident() {


### PR DESCRIPTION
The initialization behavior, shared between master, metalogger and chunkserver, was written in plain old C. This commit updates the related parts in the code to be more readable in C++. The refactor scope was:

- Remove duplicated code from the init.h files (there are 3 of them).
- Remove dead code (unused macros and includes).
- Replace C-like callbacks by std::function.
- Replace char * by std::string.
- Replace the C style arrays by std::vector.
- Refactor the 'initialize' function to be more readable.
- Document the main ideas.