### PR TITLE
tests: Update check on probe info command

### DIFF
--- a/tests/test_suites/ShortSystemTests/test_probe_info.sh
+++ b/tests/test_suites/ShortSystemTests/test_probe_info.sh
@@ -14,5 +14,5 @@ done
 
 rm dir_3/file
 rm dir_xor2/file
-expect_equals "$SAUNAFS_VERSION 2 0 0 9 5 4 4 7 7" \
+expect_equals "$SAUNAFS_VERSION 2 0 0 9 5 4 0 4 7 7" \
 	"$(saunafs-probe info --porcelain localhost "${info[matocl]}" | cut -d' ' -f 1,6-)"


### PR DESCRIPTION
After Metadata parallel loading (# 15), the metadata server is returning an extra field for symlinks amount inodes to the info command of saunafs-probe tool. This commit fix a functional test checking this tool.