### PR TITLE
chunkserver: Fix global variables visibility

### DIFF
--- a/src/chunkserver/chunkserver-common/global_shared_resources.h
+++ b/src/chunkserver/chunkserver-common/global_shared_resources.h
@@ -36,6 +36,6 @@ inline std::vector<std::unique_ptr<CondVarWithWaitCount>> gFreeCondVars;
 /// Active Disks scans in progress.
 /// Note: theoretically it would return a false positive if scans haven't
 /// started yet, but it's a _very_ unlikely situation.
-static std::atomic_int gScansInProgress(0);
+inline std::atomic_int gScansInProgress(0);
 
-static std::atomic_bool gPerformFsync;
+inline std::atomic_bool gPerformFsync(true);


### PR DESCRIPTION
The static variable gPerformSync was not shared correctly between the chunkserver and the chunkserver-common at runtime. Causing different values from each side.

This commit makes it inline, which also fixes the
ShortSystemTest.test_fsync_eio_in_chunkserver.

The variable gScansInProgress was also changed to be inline to avoid the same issue.