### PR TITLE
tests: Fix pread_eio_in_chunkserver_some_disks

### DIFF
--- a/tests/test_suites/ShortSystemTests/test_pread_eio_in_chunkserver_some_disks.sh
+++ b/tests/test_suites/ShortSystemTests/test_pread_eio_in_chunkserver_some_disks.sh
@@ -29,9 +29,9 @@ FILE_SIZE=300K file-generate goal{1..2}/medium_{1..10}
 FILE_SIZE=5M   file-generate goal{1..2}/big_{1..10}
 
 # Count chunks in the system. Expect that each chunk has one copy on CS0 and one copy on CS1.
-chunks=$(saunafs_probe_master info | awk '{print $12}')
+chunks=$(saunafs_probe_master info | awk '{print $13}')
 assert_equals 60 $chunks
-assert_equals 90 $(saunafs_probe_master info | awk '{print $13}')
+assert_equals 90 $(saunafs_probe_master info | awk '{print $14}')
 assert_less_than 30 "$(find_chunkserver_metadata_chunks 0 | wc -l)"
 assert_less_than 30 "$(find_chunkserver_metadata_chunks 1 | wc -l)"
 


### PR DESCRIPTION
The indexes were shifted after the addition of the soft links to the output of the 'saunafs-probe' info command. This commit only changes the indexes to fix the test.