### PR TITLE
tests: Fix upgrade_general test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,7 +191,7 @@ endif()
 project(saunafs)
 
 if(NOT PACKAGE_VERSION)
-  set(PACKAGE_VERSION "4.0.1-devel" CACHE STRING "Package version")
+  set(PACKAGE_VERSION "4.1.0-devel" CACHE STRING "Package version")
 endif()
 
 string(REGEX MATCH "^([0-9]+)\\.([0-9]+)\\.([0-9]+)" PACKAGE_VERSION_MATCH ${PACKAGE_VERSION})

--- a/tests/test_suites/ShortSystemTests/test_saunafs_upgrade_general.sh
+++ b/tests/test_suites/ShortSystemTests/test_saunafs_upgrade_general.sh
@@ -3,7 +3,11 @@ timeout_set 90 seconds
 # A long scenario of SaunaFS upgrade from legacy to current version,
 # checking if multiple mini-things work properly, in one test.
 #
-# TODO: Rethink this test, we shouldn't do partial upgrades like this.
+# TODO: Rethink this test, we shouldn't do partial upgrades like this. However,
+# there may be reasons why we need do it (for example, because of the hardware
+# it can be impossible to upgrade everything at once, or where it's useful to
+# test a newer client against an existing cluster, perhaps for compatibility
+# reasons).
 
 export SAFS_MOUNT_COMMAND="sfsmount"
 
@@ -47,7 +51,6 @@ saunafs_master_daemon restart
 saunafs_master_n 1 restart
 
 # Ensure that versions are switched
-echo $(saunafs_admin_master info)
 assert_equals 0 $(saunafs_admin_master info | grep $SAUNAFSXX_TAG | wc -l)
 saunafs_wait_for_all_ready_chunkservers
 # Check if files can still be read:

--- a/tests/test_suites/ShortSystemTests/test_saunafs_upgrade_general.sh
+++ b/tests/test_suites/ShortSystemTests/test_saunafs_upgrade_general.sh
@@ -2,6 +2,8 @@ timeout_set 90 seconds
 
 # A long scenario of SaunaFS upgrade from legacy to current version,
 # checking if multiple mini-things work properly, in one test.
+#
+# TODO: Rethink this test, we shouldn't do partial upgrades like this.
 
 export SAFS_MOUNT_COMMAND="sfsmount"
 
@@ -17,16 +19,15 @@ REPLICATION_TIMEOUT='30 seconds'
 
 # Start the test with master, 2 chunkservers and mount running old SaunaFS code
 # Ensure that we work on legacy version
-assert_equals 1 $(saunafs_admin_master info | grep $SAUNAFSXX_TAG | wc -l)
-assert_equals 2 $(saunafs_admin_master list-chunkservers | grep $SAUNAFSXX_TAG | wc -l)
-assert_equals 1 $(saunafs_admin_master list-mounts | grep $SAUNAFSXX_TAG | wc -l)
+assert_equals 1 $(saunafs_old_admin_master info | grep $SAUNAFSXX_TAG | wc -l)
+assert_equals 2 $(saunafs_old_admin_master list-chunkservers | grep $SAUNAFSXX_TAG | wc -l)
+assert_equals 1 $(saunafs_old_admin_master list-mounts | grep $SAUNAFSXX_TAG | wc -l)
 
 cd "${info[mount0]}"
 mkdir dir
-assert_success saunafsXX sfssetgoal 2 dir
+assert_success saunafsXX saunafs setgoal 2 dir
 cd dir
 
-# Start the test with master, two chunkservers and mount running old SaunaFS code
 function generate_file {
 	FILE_SIZE=12345678 BLOCK_SIZE=12345 file-generate $1
 }
@@ -35,13 +36,18 @@ function generate_file {
 assert_success generate_file file0
 assert_success file-validate file0
 
-# Start shadow
-saunafs_master_n 1 restart
+# Start old shadow
+saunafsXX_shadow_daemon_n 1 start
 assert_eventually "saunafs_shadow_synchronized 1"
 
-# Replace old SaunaFS master with SaunaFS master:
+# Replace old SaunaFS master with newer SaunaFS master:
 saunafs_master_daemon restart
+
+# Replace shadow
+saunafs_master_n 1 restart
+
 # Ensure that versions are switched
+echo $(saunafs_admin_master info)
 assert_equals 0 $(saunafs_admin_master info | grep $SAUNAFSXX_TAG | wc -l)
 saunafs_wait_for_all_ready_chunkservers
 # Check if files can still be read:
@@ -49,11 +55,12 @@ assert_success file-validate file0
 # Check if setgoal/getgoal still work:
 assert_success mkdir dir
 for goal in {1..9}; do
-	assert_equals "dir: $goal" "$(saunafsXX sfssetgoal "$goal" dir || echo FAILED)"
-	assert_equals "dir: $goal" "$(saunafsXX sfsgetgoal dir || echo FAILED)"
+	assert_equals "dir: $goal" "$(saunafsXX saunafs setgoal "$goal" dir || echo FAILED)"
+	assert_equals "dir: $goal" "$(saunafsXX saunafs getgoal dir || echo FAILED)"
 	expected="dir:"$'\n'" directories with goal  $goal :          1"
-	assert_equals "$expected" "$(saunafsXX sfsgetgoal -r dir || echo FAILED)"
+	assert_equals "$expected" "$(saunafsXX saunafs getgoal -r dir || echo FAILED)"
 done
+
 
 # Check if replication from old SaunaFS CS (chunkserver) to SaunaFS CS works:
 saunafsXX_chunkserver_daemon 1 stop
@@ -61,7 +68,7 @@ assert_success generate_file file1
 assert_success file-validate file1
 saunafs_chunkserver_daemon 1 start
 assert_eventually \
-	'[[ $(saunafsXX sfscheckfile file1 | grep "chunks with 2 copies" | wc -l) == 1 ]]' "$REPLICATION_TIMEOUT"
+	'[[ $(saunafsXX saunafs checkfile file1 | grep "chunks with 2 copies" | wc -l) == 1 ]]' "$REPLICATION_TIMEOUT"
 saunafsXX_chunkserver_daemon 0 stop
 # Check if SaunaFS CS can serve newly replicated chunks to old SaunaFS client:
 assert_success file-validate file1

--- a/tests/tools/saunafs.sh
+++ b/tests/tools/saunafs.sh
@@ -3,7 +3,6 @@
 # If out_var provided an associative array with name $out_var
 # is created and it contains information about the filestystem
 setup_local_empty_saunafs() {
-	MASTER_START_PARAM=${MASTER_START_PARAM:-}
 	local use_legacy=${USE_LEGACY:-}
 	local use_saunafsXX=${START_WITH_LEGACY_SAUNAFS:-}
 	local use_ramdisk=${USE_RAMDISK:-}
@@ -22,6 +21,7 @@ setup_local_empty_saunafs() {
 	local etcdir=$TEMP_DIR/saunafs/etc
 	local vardir=$TEMP_DIR/saunafs/var
 	local mntdir=$TEMP_DIR/mnt
+	local master_start_param=${MASTER_START_PARAM:-}
 	local shadow_start_param=${SHADOW_START_PARAM:-}
 	declare -gA saunafs_info_
 	saunafs_info_[chunkserver_count]=$number_of_chunkservers
@@ -69,7 +69,7 @@ setup_local_empty_saunafs() {
 	saunafs_info_[masterserver_count]=$number_of_masterservers
 
 	# Start one masterserver with personality master
-	saunafs_master_daemon start ${MASTER_START_PARAM}
+	saunafs_master_daemon start ${master_start_param}
 
 	# Prepare the metalogger, so that any test can start it
 	prepare_metalogger_

--- a/tests/tools/saunafs.sh
+++ b/tests/tools/saunafs.sh
@@ -3,6 +3,7 @@
 # If out_var provided an associative array with name $out_var
 # is created and it contains information about the filestystem
 setup_local_empty_saunafs() {
+	MASTER_START_PARAM=${MASTER_START_PARAM:-}
 	local use_legacy=${USE_LEGACY:-}
 	local use_saunafsXX=${START_WITH_LEGACY_SAUNAFS:-}
 	local use_ramdisk=${USE_RAMDISK:-}
@@ -21,7 +22,6 @@ setup_local_empty_saunafs() {
 	local etcdir=$TEMP_DIR/saunafs/etc
 	local vardir=$TEMP_DIR/saunafs/var
 	local mntdir=$TEMP_DIR/mnt
-	local master_start_param=${MASTER_START_PARAM:-}
 	local shadow_start_param=${SHADOW_START_PARAM:-}
 	declare -gA saunafs_info_
 	saunafs_info_[chunkserver_count]=$number_of_chunkservers
@@ -52,9 +52,6 @@ setup_local_empty_saunafs() {
 	fi
 
 	if [[ $use_saunafsXX ]]; then
-		# In old suite, when legacy version was >= 3.11, we set `use_new_goal_config`=true
-		# Maybe that's not what we want? (look at if above)
-		use_new_goal_config="true"
 		SAUNAFSXX_DIR=${SAUNAFSXX_DIR_BASE}/install/usr
 		export PATH="${SAUNAFSXX_DIR}/bin:${SAUNAFSXX_DIR}/sbin:$PATH"
 		install_saunafsXX
@@ -72,7 +69,7 @@ setup_local_empty_saunafs() {
 	saunafs_info_[masterserver_count]=$number_of_masterservers
 
 	# Start one masterserver with personality master
-	saunafs_master_daemon start ${master_start_param}
+	saunafs_master_daemon start ${MASTER_START_PARAM}
 
 	# Prepare the metalogger, so that any test can start it
 	prepare_metalogger_
@@ -809,6 +806,19 @@ saunafs_admin_master() {
 	shift
 	local port=${saunafs_info_[matocl]}
 	saunafs-admin "$command" localhost "$port" "$@" <<<"${saunafs_info_[admin_password]}"
+}
+
+# A generic function to run old SaunaFS admin commands.
+#
+# Usage examples:
+# saunafs_old_admin_master info
+# saunafs_old_admin_master list-chunkservers
+# saunafs_old_admin_master list-mounts
+saunafs_old_admin_master() {
+	local command="$1"
+	shift
+	local port=${saunafs_info_[matocl]}
+	"$SAUNAFSXX_DIR/bin/saunafs-admin" "$command" localhost "$port" "$@"
 }
 
 # A useful shortcut for saunafs-admin commands which require authentication

--- a/tests/tools/saunafsXX.sh
+++ b/tests/tools/saunafsXX.sh
@@ -1,6 +1,11 @@
 # Older (unsupported) versions of SaunaFS used in tests and sources of its packages
-# TODO: Remove
-SAUNAFSXX_TAG="3.12.0"
+#
+# TODO: Rename the functions to something better, like *saunafs_old
+# TODO: Don't use build information in debian package versions. It causes
+# problems when downgrading, because you need to include the build information
+# in the downgrade command.
+SAUNAFSXX_TAG_APT="4.0.1-20240301-164017-stable-main-82161d4f"
+SAUNAFSXX_TAG="4.0.1"
 
 install_saunafsXX() {
 	rm -rf "$SAUNAFSXX_DIR"
@@ -22,46 +27,22 @@ Dir::Cache "${TEMP_DIR}/apt/var/cache/apt";
 Dir::Etc::Parts "${TEMP_DIR}/apt/apt.conf.d";
 END
 		local destdir="${TEMP_DIR}/apt/var/cache/apt/archives"
-		echo "deb [trusted=yes] https://dev.saunafs.com/packages/ ${codename}/" >${TEMP_DIR}/apt/saunafs.list
+		echo "deb [arch=amd64] https://repo.saunafs.com/repository/saunafs-ubuntu-22.04/ ${codename} main" >${TEMP_DIR}/apt/saunafs.list
 		env APT_CONFIG="${TEMP_DIR}/apt/apt.conf" apt-get update
 		env APT_CONFIG="${TEMP_DIR}/apt/apt.conf" apt-get -y --allow-downgrades install -d \
-			saunafs-master=${SAUNAFSXX_TAG} \
-			saunafs-chunkserver=${SAUNAFSXX_TAG} \
-			saunafs-client=${SAUNAFSXX_TAG}
+			saunafs-master=${SAUNAFSXX_TAG_APT} \
+			saunafs-chunkserver=${SAUNAFSXX_TAG_APT} \
+			saunafs-client=${SAUNAFSXX_TAG_APT} \
+			saunafs-adm=${SAUNAFSXX_TAG_APT}
+			# Not used right now
+			# saunafs-metalogger=${SAUNAFSXX_TAG_APT}
 		# unpack binaries
 		cd ${destdir}
 		find . -name "*master*.deb" | xargs dpkg-deb --fsys-tarfile | tar -x ./usr/sbin/sfsmaster
 		find . -name "*chunkserver*.deb" | xargs dpkg-deb --fsys-tarfile | tar -x ./usr/sbin/sfschunkserver
 		find . -name "*client*.deb" | xargs dpkg-deb --fsys-tarfile | tar -x ./usr/bin/
-		cp -Rp usr/ ${SAUNAFSXX_DIR_BASE}/install
-		cd -
-		;;
-	CentOS | Fedora)
-		local destdir="${TEMP_DIR}/saunafsxx_packages"
-		mkdir ${destdir}
-		local url=""
-		if [ "$distro" == CentOS ]; then
-			url="http://dev.saunafs.com/packages/centos.saunafs.repo"
-		else
-			url="http://dev.saunafs.com/packages/fedora.saunafs.repo"
-		fi
-		mkdir -p ${TEMP_DIR}/dnf/etc/yum.repos.d
-		cat >${TEMP_DIR}/dnf/dnf.conf <<END
-[main]
-logdir=${TEMP_DIR}/dnf/var/log
-cachedir=${TEMP_DIR}/dnf/var/cache
-persistdir=${TEMP_DIR}/dnf/var/lib/dnf
-reposdir=${TEMP_DIR}/dnf/etc/yum.repos.d
-END
-		wget "$url" -O ${TEMP_DIR}/dnf/etc/yum.repos.d/saunafs.repo
-		for pkg in {saunafs-master,saunafs-chunkserver,saunafs-client}-${SAUNAFSXX_TAG}; do
-			fakeroot dnf -y --config=${TEMP_DIR}/dnf/dnf.conf --destdir=${destdir} download ${pkg}
-		done
-		# unpack binaries
-		cd ${destdir}
-		find . -name "*master*.rpm" | xargs rpm2cpio | cpio -idm ./usr/sbin/sfsmaster
-		find . -name "*chunkserver*.rpm" | xargs rpm2cpio | cpio -idm ./usr/sbin/sfschunkserver
-		find . -name "*client*.rpm" | xargs rpm2cpio | cpio -idm ./usr/bin/*
+		find . -name "*adm*.deb" | xargs dpkg-deb --fsys-tarfile | tar -x ./usr/bin/
+		# find . -name "*metalogger*.deb" | xargs dpkg-deb --fsys-tarfile | tar -x ./usr/sbin/
 		cp -Rp usr/ ${SAUNAFSXX_DIR_BASE}/install
 		cd -
 		;;
@@ -75,6 +56,9 @@ END
 
 test_saunafsXX_executables() {
 	local awk_version_pattern="/$(sed 's/[.]/[.]/g' <<<$SAUNAFSXX_TAG)/"
+	echo $($SAUNAFSXX_DIR/bin/sfsmount --version 2>&1)
+	echo $($SAUNAFSXX_DIR/sbin/sfschunkserver -v)
+	echo $($SAUNAFSXX_DIR/sbin/sfsmaster -v)
 	test -x "$SAUNAFSXX_DIR/bin/sfsmount"
 	test -x "$SAUNAFSXX_DIR/sbin/sfschunkserver"
 	test -x "$SAUNAFSXX_DIR/sbin/sfsmaster"
@@ -90,6 +74,17 @@ saunafsXX_chunkserver_daemon() {
 
 saunafsXX_master_daemon() {
 	"$SAUNAFSXX_DIR/sbin/sfsmaster" -c "${saunafs_info_[master_cfg]}" "$1" | cat
+	return ${PIPESTATUS[0]}
+}
+
+saunafsXX_shadow_daemon_n() {
+	local id=$1
+	shift
+	if is_windows_system; then
+		windows_server_aux "$SAUNAFSXX_DIR/sbin/sfsmaster -c ${saunafs_info_[master${id}_cfg]}" "$@"
+	else
+		"$SAUNAFSXX_DIR/sbin/sfsmaster" -c "${saunafs_info_[master${id}_cfg]}" "$@" | cat
+	fi
 	return ${PIPESTATUS[0]}
 }
 
@@ -110,11 +105,13 @@ assert_saunafsXX_services_count_equals() {
 	local mas_expected="${1}"
 	local cs_expected="${2}"
 	local cli_expected="${3}"
-	assert_equals "${mas_expected}" "$(saunafs_admin_master info | grep "${SAUNAFSXX_TAG}" | wc -l)"
-	assert_equals "${cs_expected}" "$(saunafs_admin_master list-chunkservers | grep "${SAUNAFSXX_TAG}" | wc -l)"
-	assert_equals "${cli_expected}" "$(saunafs_admin_master list-mounts | grep "${SAUNAFSXX_TAG}" | wc -l)"
+	assert_equals "${mas_expected}" "$(saunafs_old_admin_master info | grep "${SAUNAFSXX_TAG}" | wc -l)"
+	assert_equals "${cs_expected}" "$(saunafs_old_admin_master list-chunkservers | grep "${SAUNAFSXX_TAG}" | wc -l)"
+	assert_equals "${cli_expected}" "$(saunafs_old_admin_master list-mounts | grep "${SAUNAFSXX_TAG}" | wc -l)"
 }
 
 assert_no_saunafsXX_services_active() {
 	assert_saunafsXX_services_count_equals 0 0 0
 }
+
+# TODO: Add metalogger and other service support

--- a/tests/tools/saunafsXX.sh
+++ b/tests/tools/saunafsXX.sh
@@ -46,6 +46,36 @@ END
 		cp -Rp usr/ ${SAUNAFSXX_DIR_BASE}/install
 		cd -
 		;;
+#  We don't support testing CentOS and Fedora anymore, but the code is left
+#  here for reference.
+#
+# 	CentOS | Fedora)
+# 		local destdir="${TEMP_DIR}/saunafsxx_packages"
+# 		mkdir ${destdir}
+# 		local url=""
+# 		if [ "$distro" == CentOS ]; then
+# 			url="http://dev.saunafs.com/packages/centos.saunafs.repo"
+# 		else
+# 			url="http://dev.saunafs.com/packages/fedora.saunafs.repo"
+# 		fi
+# 		mkdir -p ${TEMP_DIR}/dnf/etc/yum.repos.d
+# 		cat >${TEMP_DIR}/dnf/dnf.conf <<END
+# [main]
+# logdir=${TEMP_DIR}/dnf/var/log
+# cachedir=${TEMP_DIR}/dnf/var/cache
+# persistdir=${TEMP_DIR}/dnf/var/lib/dnf
+# reposdir=${TEMP_DIR}/dnf/etc/yum.repos.d
+# END
+# 		wget "$url" -O ${TEMP_DIR}/dnf/etc/yum.repos.d/saunafs.repo
+# 		for pkg in {saunafs-master,saunafs-chunkserver,saunafs-client}-${SAUNAFSXX_TAG}; do
+# 			fakeroot dnf -y --config=${TEMP_DIR}/dnf/dnf.conf --destdir=${destdir} download ${pkg}
+# 		done
+# 		# unpack binaries
+# 		cd ${destdir}
+# 		find . -name "*master*.rpm" | xargs rpm2cpio | cpio -idm ./usr/sbin/sfsmaster
+# 		find . -name "*chunkserver*.rpm" | xargs rpm2cpio | cpio -idm ./usr/sbin/sfschunkserver
+# 		find . -name "*client*.rpm" | xargs rpm2cpio | cpio -idm ./usr/bin/*
+#
 	*)
 		test_fail "Your distribution ($distro) is not supported."
 		;;


### PR DESCRIPTION
This test was problematic for a number reasons, from broken links and version tags to incompatible versions to recursive bash calls (that almost crashed my VM) to shadow not connecting to master.

First was broken links. While this was generally easy to fix, previous LizardFS (rightly) did not include build information in the package versions. Including this information is problematic for both the script (which works around for the moment) and the user, since they both need to find the build information when downgrading, which is not standard behaviour expected of Debian packages.

Second problem was incompatible version changes. It seems that #15 (thanks @lgsilva3087 for pointing me towards this) broke the expected behaviour of `saunafs-admin info` command, so older clients couldn't parse the requests. While this wasn't a problem for fixing the tests (since we shouldn't test mixed versions anyway), it reminded me about the problem of what is exactly our public API, and I believe that anything affecting protocol should be considered our public API in terms of semantic versioning. We should also test this API somehow, perhaps by using a custom client to check how they behave with newer versions of master/chunkserver/etc.

Third was recursive bash. It seems this issue from LizardFS (https://github.com/lizardfs/lizardfs/issues/886) came back knocking and almost crashed my VM. Seems it's problematic in our tests as well...

Finally, newer shadow also had incompatibility with older master. Why I do not know, however for now I worked around by using the older shadow to start and then later switching over to newer once master is restarted. This may have not been the intention of the test though.

Which brings me to my final point, and that is testing mix versions of SaunaFS. I don't see why this is exactly necessary, we shouldn't even probably allow newer versions to interact with older versions (that are in the SaunaFS repository, discarding custom clients) and require a full upgrade instead. This test doesn't do that, but gradually upgrades and checks if everything is working. Perhaps this test needs some rethinking. For now, I've kept the changes minimal.