### PR TITLE
chunkserver: Fix test_advanced_readahead_params

### DIFF
--- a/src/chunkserver/chunkserver-common/hdd_utils.cc
+++ b/src/chunkserver/chunkserver-common/hdd_utils.cc
@@ -65,7 +65,6 @@ void hddChunkRelease(IChunk *chunk) {
 	if (chunk->state() == ChunkState::Locked) {
 		chunk->setState(ChunkState::Available);
 		if (chunk->condVar()) {
-			chunksMapUniqueLock.unlock();
 			chunk->condVar()->condVar.notify_one();
 		}
 	} else if (chunk->state() == ChunkState::ToBeDeleted) {


### PR DESCRIPTION
Looks like, under heavy workloads scenarios, the chunk->condVar() was left in an underterminate state (probably because of std::move in other thread), causing a segfault in the chunkserver side.

This commit makes sure that we still own the lock when the condition variable is signaled.