### PR TITLE
tests: Fix test_shadow_reject

### DIFF
--- a/tests/test_suites/ShortSystemTests/test_shadow_reject.sh
+++ b/tests/test_suites/ShortSystemTests/test_shadow_reject.sh
@@ -39,7 +39,6 @@ run_my_client() {
 # Shadow accepts matocl connections, but doesn't respond to most messages. TODO: verify it.
 #run_my_client assert_success 0 1 matocl
 run_my_client assert_success 0 1 matocs
-run_my_client assert_success 0 1 matots
 run_my_client assert_success 0 1 matoml
 
 rm ${TEMP_DIR}/mato*_exit_status
@@ -50,5 +49,4 @@ saunafs_admin_shadow 1 reload-config
 sleep 1
 run_my_client assert_failure 1 0 matocl
 run_my_client assert_failure 1 0 matocs
-run_my_client assert_failure 1 0 matots
 run_my_client assert_failure 1 0 matoml


### PR DESCRIPTION
The calls to tape server were removed. We dropped support for it in commit: 344ff92e4da8147e98c59fecff3cb7ac7cb0e850.