### PR TITLE
mount: Fix UB when clients reconnect

### DIFF
--- a/src/protocol/SFSCommunication.h
+++ b/src/protocol/SFSCommunication.h
@@ -1239,7 +1239,7 @@ enum class SugidClearMode {
 /// msgid:32 status:8
 
 //0x01E6
-#define SAU_CLTOMA_REGISTER_CONFIG (1000U + 485U)
+#define SAU_CLTOMA_REGISTER_CONFIG (1000U + 486U)
 /// config:STDSTRING
 
 /// version==0 msgid:32 status:8


### PR DESCRIPTION
In commit 488ee3e, fs_connect contained a procedure to send client configuration, however this used fs_send_custom, which used fs_threc_flush that locks the FD. While this is fine when initially connecting, it causes problems when fs_receive_thread tries to create a new session when reconnecting, because it also locks the FD, causing undefined behaviour. This commit fixes this by bringing the function out of fs_connect, and unlocking the FD before calling the configuration function, and then locking it again. This fixes a lot of tests (see below for a list).

Also fixes an error in SFSCommunication.h introduced in the commit, which was noticed while fixing this issue.

Tests fixed:

* ShortSystemTests.test_metadata_recovery
* ShortSystemTests.test_multiple_master_promotions
* ShortSystemTests.test_shadow_metadata_generate
* ShortSystemTests.test_shadow_promotion_during_dumping
* ShortSystemTests.test_shadow_reloading_metadata
* ShortSystemTests.test_shadow_sessions
* Potentially may fix tests in LongSystemTests as well.