### PR TITLE
mount: Extend DirEntryCache to save requests to master

### DIFF
--- a/src/mount/direntry_cache.h
+++ b/src/mount/direntry_cache.h
@@ -21,6 +21,7 @@
 #include "common/platform.h"
 
 #include <atomic>
+#include <limits>
 
 #include "common/attributes.h"
 #include "common/shared_mutex.h"
@@ -31,9 +32,9 @@
 #include <boost/intrusive/list.hpp>
 #include <boost/intrusive/set.hpp>
 
-#define INVALID_INDEX 0xffff
-#define INVALID_PARENT 0xffffffff
-#define EMPTY_NAME ""
+constexpr uint64_t kInvalidIndex = std::numeric_limits<uint64_t>::max();
+constexpr uint32_t kInvalidParent = std::numeric_limits<uint32_t>::max();
+constexpr char kEmptyName[] = "";
 
 /*! \brief Cache for directory entries
  *
@@ -356,7 +357,7 @@ public:
 		if (inode_it != inode_multiset_.end()) {
 			erase(std::addressof(*inode_it));
 		}
-		addEntry(ctx, parent_inode, inode, INVALID_INDEX, INVALID_INDEX, name, attr, timestamp);
+		addEntry(ctx, parent_inode, inode, kInvalidIndex, kInvalidIndex, name, attr, timestamp);
 	}
 
 	/*! \brief Add directory entry information to cache.
@@ -377,7 +378,7 @@ public:
 		if (inode_it != inode_multiset_.end()) {
 			erase(std::addressof(*inode_it));
 		}
-		addEntry(ctx, INVALID_PARENT, inode, INVALID_INDEX, INVALID_INDEX, EMPTY_NAME, attr, timestamp);
+		addEntry(ctx, kInvalidParent, inode, kInvalidIndex, kInvalidIndex, kEmptyName, attr, timestamp);
 	}
 
 	/*! \brief Add data to cache from container.
@@ -574,11 +575,11 @@ public:
 
 protected:
 	void erase(DirEntry *entry) {
-		if (entry->parent_inode != INVALID_PARENT && !entry->name.empty()) {
+		if (entry->parent_inode != kInvalidParent && !entry->name.empty()) {
 			lookup_set_.erase(lookup_set_.iterator_to(*entry));
 		}
-		if (entry->parent_inode != INVALID_PARENT &&
-		    entry->index != INVALID_INDEX) {
+		if (entry->parent_inode != kInvalidParent &&
+		    entry->index != kInvalidIndex) {
 			index_set_.erase(index_set_.iterator_to(*entry));
 		}
 		inode_multiset_.erase(inode_multiset_.iterator_to(*entry));
@@ -615,10 +616,12 @@ protected:
 	              std::string name, Attributes attr, uint64_t timestamp) {
 		DirEntry *entry = new DirEntry(ctx, parent_inode, inode, index,
 		                               next_index, name, attr, timestamp);
-		if (parent_inode != INVALID_PARENT && !name.empty()) {
+		assert(entry);
+
+		if (parent_inode != kInvalidParent && !name.empty()) {
 			lookup_set_.insert(*entry);
 		}
-		if (parent_inode != INVALID_PARENT && index != INVALID_INDEX) {
+		if (parent_inode != kInvalidParent && index != kInvalidIndex) {
 			index_set_.insert(*entry);
 		}
 		inode_multiset_.insert(*entry);

--- a/src/mount/direntry_cache.h
+++ b/src/mount/direntry_cache.h
@@ -607,6 +607,7 @@ protected:
 		fifo_list_.push_back(entry);
 		entry.timestamp = timestamp;
 		entry.attr = de.attributes;
+		entry.next_index = de.next_index;
 	}
 
 	void addEntry(const SaunaClient::Context &ctx, uint32_t parent_inode,

--- a/src/mount/direntry_cache.h
+++ b/src/mount/direntry_cache.h
@@ -324,6 +324,10 @@ public:
 		if (index_it != index_set_.end()) {
 			erase(std::addressof(*index_it));
 		}
+		auto inode_it = find(ctx, inode);
+		if (inode_it != inode_multiset_.end()) {
+			erase(std::addressof(*inode_it));
+		}
 		addEntry(ctx, parent_inode, inode, index, next_index, name, attr, timestamp);
 	}
 
@@ -348,6 +352,10 @@ public:
 		if (lookup_it != lookup_set_.end()) {
 			erase(std::addressof(*lookup_it));
 		}
+		auto inode_it = find(ctx, inode);
+		if (inode_it != inode_multiset_.end()) {
+			erase(std::addressof(*inode_it));
+		}
 		addEntry(ctx, parent_inode, inode, INVALID_INDEX, INVALID_INDEX, name, attr, timestamp);
 	}
 
@@ -365,6 +373,10 @@ public:
 			return;
 		}
 		removeExpired(1, timestamp);
+		auto inode_it = find(ctx, inode);
+		if (inode_it != inode_multiset_.end()) {
+			erase(std::addressof(*inode_it));
+		}
 		addEntry(ctx, INVALID_PARENT, inode, INVALID_INDEX, INVALID_INDEX, EMPTY_NAME, attr, timestamp);
 	}
 

--- a/src/mount/direntry_cache.h
+++ b/src/mount/direntry_cache.h
@@ -622,6 +622,22 @@ protected:
 		}
 		inode_multiset_.insert(*entry);
 		fifo_list_.push_back(*entry);
+		if (lookup_set_.size() < index_set_.size()) {
+			auto size1 = index_set_.size();
+			auto size2 = lookup_set_.size();
+			safs::log_err(
+			    "Inconsistent DirEntryCache: lookup set should have at least "
+			    "as many entries as index set, index:%lu > lookup:%lu",
+			    size1, size2);
+		}
+		if (inode_multiset_.size() < lookup_set_.size()) {
+			auto size1 = lookup_set_.size();
+			auto size2 = inode_multiset_.size();
+			safs::log_err(
+			    "Inconsistent DirEntryCache: inode multiset should have at "
+			    "least as many entries as lookup set, lookup:%lu > inode:%lu",
+			    size1, size2);
+		}
 	}
 
 	Timer timer_;

--- a/src/mount/direntry_cache_unittest.cc
+++ b/src/mount/direntry_cache_unittest.cc
@@ -49,7 +49,38 @@ public:
 	InodeMultiset::const_iterator inode_end() const {
 		return inode_multiset_.end();
 	}
+
+	size_t index_size() const {
+		return index_set_.size();
+	}
+
+	size_t lookup_size() const {
+		return lookup_set_.size();
+	}
 };
+
+void check_expected_content(
+    DirEntryCacheIntrospect &cache,
+    std::vector<std::tuple<int, int, int, std::string>> index_output,
+    std::vector<std::tuple<int, int, int, std::string>> lookup_output) {
+	auto index_it = cache.index_begin();
+	auto index_output_it = index_output.begin();
+	while (index_it != cache.index_end()) {
+		ASSERT_EQ(*index_output_it, std::make_tuple(index_it->inode, index_it->parent_inode, index_it->index, index_it->name));
+		index_it++;
+		index_output_it++;
+	}
+	ASSERT_TRUE(index_output_it == index_output.end());
+
+	auto lookup_it = cache.lookup_begin();
+	auto lookup_output_it = lookup_output.begin();
+	while (lookup_it != cache.lookup_end()) {
+		ASSERT_EQ(*lookup_output_it, std::make_tuple(lookup_it->inode, lookup_it->parent_inode, lookup_it->index, lookup_it->name));
+		lookup_it++;
+		lookup_output_it++;
+	}
+	ASSERT_TRUE(lookup_output_it == lookup_output.end());
+}
 
 TEST(DirEntryCache, Basic) {
 	DirEntryCacheIntrospect cache(5000000);
@@ -85,46 +116,61 @@ TEST(DirEntryCache, Basic) {
 			{3, 4, 12, "a2", attributes_with_6}
 		}, current_time
 	);
+	size_t initial_size = cache.size();
+
+	// Overwrite old lookup entry, but do not insert in the index set
+	cache.insert(SaunaClient::Context(1, 2, 0, 0), 11, 15, "a1",
+	             dummy_attributes, current_time);
+
+	ASSERT_EQ(cache.size(), initial_size);
+	ASSERT_EQ(cache.size(), cache.lookup_size());
+	ASSERT_EQ(cache.size(), cache.index_size() + 1);
+
+	// Insert to the lookup set (different ctx) and do not insert in the index
+	// set
+	cache.insert(SaunaClient::Context(0, 0, 0, 0), 11, 15, "a1",
+	             dummy_attributes, current_time);
+
+	ASSERT_EQ(cache.size(), initial_size + 1);
+	ASSERT_EQ(cache.size(), cache.lookup_size());
+	ASSERT_EQ(cache.size(), cache.index_size() + 2);
+
+	// Add plain inode entry
+	cache.insert(SaunaClient::Context(0, 0, 0, 0), 6, dummy_attributes,
+	             current_time);
+
+	ASSERT_EQ(cache.size(), initial_size + 2);
+	ASSERT_EQ(cache.size(), cache.lookup_size() + 1);
+	ASSERT_EQ(cache.size(), cache.index_size() + 3);
+
+	// Overwrite plain inode entry, should remove old entries in index and
+	// lookup sets
+	cache.insert(SaunaClient::Context(0, 0, 0, 0), 12, attributes_with_6,
+	             current_time);
+
+	ASSERT_EQ(cache.size(), initial_size + 2);
+	ASSERT_EQ(cache.size(), cache.lookup_size() + 2);
+	ASSERT_EQ(cache.size(), cache.index_size() + 4);
 
 	std::vector<std::tuple<int, int, int, std::string>> index_output {
 		std::make_tuple(7, 9, 0, "a1"),
 		std::make_tuple(11, 9, 1, "a4"),
 		std::make_tuple(13, 9, 2, "a3"),
-		std::make_tuple(12, 9, 3, "a2"),
-		std::make_tuple(5, 11, 7, "a1"),
 		std::make_tuple(4, 11, 8, "a2"),
 		std::make_tuple(3, 11, 9, "a3")
 	};
 
 	std::vector<std::tuple<int, int, int, std::string>> lookup_output {
 		std::make_tuple(7, 9, 0, "a1"),
-		std::make_tuple(12, 9, 3, "a2"),
 		std::make_tuple(13, 9, 2, "a3"),
 		std::make_tuple(11, 9, 1, "a4"),
-		std::make_tuple(5, 11, 7, "a1"),
+		std::make_tuple(15, 11, INVALID_INDEX, "a1"),
+		std::make_tuple(15, 11, INVALID_INDEX, "a1"),
 		std::make_tuple(4, 11, 8, "a2"),
 		std::make_tuple(3, 11, 9, "a3")
 	};
 
-	auto index_it = cache.index_begin();
-	auto index_output_it = index_output.begin();
-	ASSERT_EQ(cache.size(), index_output.size());
-	while (index_it != cache.index_end()) {
-		ASSERT_EQ(*index_output_it, std::make_tuple(index_it->inode, index_it->parent_inode, index_it->index, index_it->name));
-		index_it++;
-		index_output_it++;
-	}
-	ASSERT_TRUE(index_output_it == index_output.end());
-
-	auto lookup_it = cache.lookup_begin();
-	auto lookup_output_it = lookup_output.begin();
-	ASSERT_EQ(cache.size(), lookup_output.size());
-	while (lookup_it != cache.lookup_end()) {
-		ASSERT_EQ(*lookup_output_it, std::make_tuple(lookup_it->inode, lookup_it->parent_inode, lookup_it->index, lookup_it->name));
-		lookup_it++;
-		lookup_output_it++;
-	}
-	ASSERT_TRUE(lookup_output_it == lookup_output.end());
+	check_expected_content(cache, index_output, lookup_output);
 
 	auto by_inode_it = cache.find(SaunaClient::Context(0, 0, 0, 0), 12);
 	ASSERT_NE(by_inode_it, cache.inode_end());
@@ -132,6 +178,12 @@ TEST(DirEntryCache, Basic) {
 	by_inode_it++;
 	ASSERT_NE(by_inode_it, cache.inode_end());
 	ASSERT_EQ(by_inode_it->attr[0], 9);
+	by_inode_it++;
+	ASSERT_NE(by_inode_it, cache.inode_end());
+	ASSERT_EQ(by_inode_it->inode, 15);
+	by_inode_it++;
+	ASSERT_NE(by_inode_it, cache.inode_end());
+	ASSERT_EQ(by_inode_it->inode, 15);
 	by_inode_it++;
 	ASSERT_EQ(by_inode_it, cache.inode_end());
 }
@@ -143,9 +195,29 @@ TEST(DirEntryCache, Repetitions) {
 	dummy_attributes.fill(0);
 	auto current_time = cache.updateTime();
 
-	cache.insertSequence(SaunaClient::Context(0, 0, 0, 0), 9, std::vector<DirectoryEntry>{{0, 1, 7, "a1", dummy_attributes}}, current_time);
-	cache.insertSequence(SaunaClient::Context(0, 0, 0, 0), 9, std::vector<DirectoryEntry>{{1, 2, 7, "a1", dummy_attributes}}, current_time);
+	cache.insertSequence(
+	    SaunaClient::Context(0, 0, 0, 0), 9,
+	    std::vector<DirectoryEntry>{{0, 1, 7, "a1", dummy_attributes},
+	                                {1, 2, 8, "a2", dummy_attributes},
+	                                {2, 3, 9, "a3", dummy_attributes},
+	                                {3, 4, 10, "a4", dummy_attributes},
+	                                {4, 5, 11, "a5", dummy_attributes},
+	                                {5, 6, 12, "a6", dummy_attributes}},
+	    current_time);
+	// Lookup set finds the entries and should overwrite them
+	cache.insertSequence(
+	    SaunaClient::Context(0, 0, 0, 0), 9,
+	    std::vector<DirectoryEntry>{{1, 2, 8, "a1", dummy_attributes},
+	                                {2, 3, 9, "a2", dummy_attributes},
+	                                {3, 4, 10, "a3", dummy_attributes},
+	                                {4, 5, 11, "a4", dummy_attributes},
+	                                {5, 6, 12, "a5", dummy_attributes},
+									{6, 7, 13, "a6", dummy_attributes}},
+	    current_time);
+
+	ASSERT_EQ(cache.size(), 6);
 	cache.removeOldest(5);
+	ASSERT_EQ(cache.size(), 1);
 }
 
 TEST(DirEntryCache, RandomOrder) {
@@ -153,10 +225,6 @@ TEST(DirEntryCache, RandomOrder) {
 
 	Attributes dummy_attributes;
 	dummy_attributes.fill(0);
-	Attributes attributes_with_6 = dummy_attributes;
-	Attributes attributes_with_9 = dummy_attributes;
-	attributes_with_6[0] = 6;
-	attributes_with_9[0] = 9;
 	auto current_time = cache.updateTime();
 	cache.insertSequence(
 		SaunaClient::Context(0, 0, 0, 0), 9,
@@ -197,24 +265,28 @@ TEST(DirEntryCache, RandomOrder) {
 		std::make_tuple(4, 9, 8, "a5"),
 		std::make_tuple(3, 9, 9, "a6")
 	};
+	
+	check_expected_content(cache, index_output, lookup_output);
 
-	auto index_it = cache.index_begin();
-	auto index_output_it = index_output.begin();
-	ASSERT_EQ(cache.size(), index_output.size());
-	while (index_it != cache.index_end()) {
-		ASSERT_EQ(*index_output_it, std::make_tuple(index_it->inode, index_it->parent_inode, index_it->index, index_it->name));
-		index_it++;
-		index_output_it++;
-	}
-	ASSERT_TRUE(index_output_it == index_output.end());
+	cache.insert(SaunaClient::Context(0, 0, 0, 0), 9, 10, 3, 100, "a7",
+	             dummy_attributes, current_time);
+	// Check last entry was actually inserted
+	auto lookup_it = cache.lookup_end();
+	lookup_it--;
+	ASSERT_EQ(lookup_it->inode, 10);
+	// Should remove the sequence of entries starting from index 0, including the last one inserted
+	cache.invalidate(SaunaClient::Context(0, 0, 0, 0), 9, 0);
 
-	auto lookup_it = cache.lookup_begin();
-	auto lookup_output_it = lookup_output.begin();
-	ASSERT_EQ(cache.size(), lookup_output.size());
-	while (lookup_it != cache.lookup_end()) {
-		ASSERT_EQ(*lookup_output_it, std::make_tuple(lookup_it->inode, lookup_it->parent_inode, lookup_it->index, lookup_it->name));
-		lookup_it++;
-		lookup_output_it++;
-	}
-	ASSERT_TRUE(lookup_output_it == lookup_output.end());
+	index_output = {
+		std::make_tuple(5, 9, 7, "a4"),
+		std::make_tuple(4, 9, 8, "a5"),
+		std::make_tuple(3, 9, 9, "a6")
+	};
+
+	lookup_output = {
+		std::make_tuple(5, 9, 7, "a4"),
+		std::make_tuple(4, 9, 8, "a5"),
+		std::make_tuple(3, 9, 9, "a6")
+	};
+	check_expected_content(cache, index_output, lookup_output);
 }

--- a/src/mount/direntry_cache_unittest.cc
+++ b/src/mount/direntry_cache_unittest.cc
@@ -164,8 +164,8 @@ TEST(DirEntryCache, Basic) {
 		std::make_tuple(7, 9, 0, "a1"),
 		std::make_tuple(13, 9, 2, "a3"),
 		std::make_tuple(11, 9, 1, "a4"),
-		std::make_tuple(15, 11, INVALID_INDEX, "a1"),
-		std::make_tuple(15, 11, INVALID_INDEX, "a1"),
+		std::make_tuple(15, 11, kInvalidParent, "a1"),
+		std::make_tuple(15, 11, kInvalidParent, "a1"),
 		std::make_tuple(4, 11, 8, "a2"),
 		std::make_tuple(3, 11, 9, "a3")
 	};
@@ -212,7 +212,7 @@ TEST(DirEntryCache, Repetitions) {
 	                                {3, 4, 10, "a3", dummy_attributes},
 	                                {4, 5, 11, "a4", dummy_attributes},
 	                                {5, 6, 12, "a5", dummy_attributes},
-									{6, 7, 13, "a6", dummy_attributes}},
+	                                {6, 7, 13, "a6", dummy_attributes}},
 	    current_time);
 
 	ASSERT_EQ(cache.size(), 6);

--- a/src/mount/sauna_client.cc
+++ b/src/mount/sauna_client.cc
@@ -817,6 +817,24 @@ EntryParam lookup(Context &ctx, Inode parent, const char *name) {
 	if (maxfleng>(uint64_t)(e.attr.st_size)) {
 		e.attr.st_size=maxfleng;
 	}
+
+	// If lookup succeeded and data did not come from cache, then cache it 
+	if (!icacheflag) {
+		auto data_acquire_time = gDirEntryCache.updateTime();
+
+		std::unique_lock<shared_mutex> write_guard(gDirEntryCache.rwlock());
+		gDirEntryCache.updateTime();
+
+		gDirEntryCache.insert(ctx, parent, e.ino, std::string(name), attr,
+		                      data_acquire_time);
+		if (gDirEntryCache.size() > gDirEntryCacheMaxSize) {
+			gDirEntryCache.removeOldest(gDirEntryCache.size() -
+			                            gDirEntryCacheMaxSize);
+		}
+
+		write_guard.unlock();
+	}
+
 	makeattrstr(attrstr,256,&e.attr);
 	oplog_printf(ctx, "lookup (%lu,%s)%s: OK (%.1f,%lu,%.1f,%s)",
 			(unsigned long int)parent,
@@ -836,6 +854,7 @@ AttrReply getattr(Context &ctx, Inode ino) {
 	Attributes attr;
 	char attrstr[256];
 	int status;
+	bool fromcache;
 
 	if (debug_mode) {
 		oplog_printf(ctx, "getattr (%lu) ...", (unsigned long int)ino);
@@ -858,10 +877,12 @@ AttrReply getattr(Context &ctx, Inode ino) {
 		}
 		stats_inc(OP_DIRCACHE_GETATTR);
 		status = SAUNAFS_STATUS_OK;
+		fromcache = 1;
 	} else {
 		stats_inc(OP_GETATTR);
 		RETRY_ON_ERROR_WITH_UPDATED_CREDENTIALS(status, ctx,
 		fs_getattr(ino,ctx.uid,ctx.gid,attr));
+		fromcache = 0;
 	}
 	if (status != SAUNAFS_STATUS_OK) {
 		oplog_printf(ctx, "getattr (%lu): %s",
@@ -878,9 +899,27 @@ AttrReply getattr(Context &ctx, Inode ino) {
 #ifdef _WIN32
 	patch_uid_gid_fields(o_stbuf);
 #endif
+
+	// If getattr succeeded and data did not come from cache, then cache it
+	if (!fromcache) {
+		auto data_acquire_time = gDirEntryCache.updateTime();
+
+		std::unique_lock<shared_mutex> write_guard(gDirEntryCache.rwlock());
+		gDirEntryCache.updateTime();
+
+		gDirEntryCache.insert(ctx, ino, attr, data_acquire_time);
+		if (gDirEntryCache.size() > gDirEntryCacheMaxSize) {
+			gDirEntryCache.removeOldest(gDirEntryCache.size() -
+			                            gDirEntryCacheMaxSize);
+		}
+
+		write_guard.unlock();
+	}
+
 	makeattrstr(attrstr,256,&o_stbuf);
-	oplog_printf(ctx, "getattr (%lu): OK (%.1f,%s)",
+	oplog_printf(ctx, "getattr (%lu)%s: OK (%.1f,%s)",
 			(unsigned long int)ino,
+			fromcache?" (using open dir cache)":"",
 			attr_timeout,
 			attrstr);
 	return AttrReply{o_stbuf, attr_timeout};


### PR DESCRIPTION
Client was not caching any coming data from master after succeeding in the lookup and getattr syscalls. This behavior may cause to issue extra requests to master for no good reason as that data can be cached.

To get it done, inserting single entry without full info (parent inode, name, index and next index) to the DirEntryCache must be implemented and therefore, untie its inner lookup and index sets.

This change is specially important in reducing the amount of lookup requests from Windows client to master server, with  huge impact in the small files read/write issue and performance of many other operations.