### PR TITLE
mount (win): Fix .saunafs_tweaks behavior

### DIFF
--- a/src/mount/special_inode.h
+++ b/src/mount/special_inode.h
@@ -58,6 +58,26 @@ namespace InodeOphistory {
 }
 
 namespace InodeTweaks {
+#ifdef _WIN32
+	static inline bool isWStringFromWindows(const std::string &value) {
+		// Detecting Windows API wide string format
+		return !value.empty() && value[0] == -1;
+	}
+
+	static inline std::string convertWStringFromWindowsToString(
+		const std::string &value) {
+		// This conversion is necessary due to the special encoding format
+		// of Windows API strings, which may include a Byte Order Mark (BOM)
+		// and use UTF-16 encoding. The conversion ensures compatibility
+		// with UTF-8 encoded strings, which are more universally supported.
+		std::string result;
+		for (int i = 2; i < (int)value.size(); i += 2) {
+			result.push_back(value[i]);
+		}
+		return result;
+	}
+#endif
+
 	extern const Attributes attr;
 	extern const SaunaClient::Inode inode_;
 }


### PR DESCRIPTION
Attempting to update the value of a variable from the `.saunafs_tweaks` file under some Windows machines has been unsuccessful due to a read operation being executed after the corresponding write operation. This resulted in the changes from the write operation not being reflected because the `getAllValues` function, which resets the `.saunafs_tweaks` values to their defaults and did not check if a write operation had been executed.

This issue was resolved by adding a check in the read operation function related to `.saunafs_tweaks`. If the file had been written to, a procedure is initiated that constructs the expected string format and applies the correct update operation on the `.saunafs_tweaks` data, according to the format of the input from PowerShell commands.