### PR TITLE
tests: Fix test new mount vs old saunafs

### DIFF
--- a/src/common/metadata.cc
+++ b/src/common/metadata.cc
@@ -90,12 +90,17 @@ uint64_t metadataGetVersion(const std::string& file) {
 		throw MetadataCheckException("Can't read the metadata file");
 	}
 
-	if (memcmp(chkbuff, SFSSIGNATURE "M 2.9", strlen(SFSSIGNATURE "M 2.9")) == 0) {
+	std::string signature = std::string(chkbuff, 8);
+	std::string sfsSignature = std::string(SFSSIGNATURE "M 2.9");
+	std::string sauSignature = std::string(SAUSIGNATURE "M 2.9");
+
+	if (signature == sfsSignature || signature == sauSignature) {
 		memcpy(eofmark,"[SFS EOF MARKER]",16);
 	} else {
 		close(fd);
-		throw MetadataCheckException("Bad format of the metadata file");
+		throw MetadataCheckException("Bad EOF MARKER in the metadata file.");
 	}
+
 	const uint8_t* ptr = reinterpret_cast<const uint8_t*>(chkbuff + 8 + 4);
 	uint64_t version;
 	version = get64bit(&ptr);

--- a/tests/test_suites/ShortSystemTests/test_saunafs_upgrade_new_mount_with_old_saunafs.sh
+++ b/tests/test_suites/ShortSystemTests/test_saunafs_upgrade_new_mount_with_old_saunafs.sh
@@ -15,13 +15,13 @@ CHUNKSERVERS=2 \
 
 # Start test with master, 2 chunkservers and 2 mounts running legacy SaunaFS code
 # Ensure that we work on legacy version
-assert_equals 1 $(saunafs_admin_master info | grep $SAUNAFSXX_TAG | wc -l)
-assert_equals 2 $(saunafs_admin_master list-chunkservers | grep $SAUNAFSXX_TAG | wc -l)
-assert_equals 2 $(saunafs_admin_master list-mounts | grep $SAUNAFSXX_TAG | wc -l)
+assert_equals 1 $(saunafs_old_admin_master info | grep $SAUNAFSXX_TAG | wc -l)
+assert_equals 2 $(saunafs_old_admin_master list-chunkservers | grep $SAUNAFSXX_TAG | wc -l)
+assert_equals 2 $(saunafs_old_admin_master list-mounts | grep $SAUNAFSXX_TAG | wc -l)
 
 cd "${info[mount0]}"
 mkdir dir0
-assert_success saunafsXX sfssetgoal 2 dir0
+assert_success saunafsXX saunafs setgoal 2 dir0
 cd dir0
 
 function generate_file {
@@ -44,7 +44,7 @@ assert_success file-validate file0
 
 cd ..
 mkdir dir1
-assert_success saunafsXX sfssetgoal 2 dir1
+assert_success saunafsXX saunafs setgoal 2 dir1
 cd dir1
 # Test if reading and writing on new SaunaFS mount works:
 assert_success generate_file file1


### PR DESCRIPTION
It was failing for the following reasons:
- The previous version uses SAU as EOF marker for the metadata file insted of the new SFS.
- The new admin tool was also expecting an extra item in the 'admin info' command.
- The sfs* tools are deprecated (sfsgetgoal does not exists).

This applies the following fixes:
- Also check for old signature in the metadata EOF marker.
- Use saunafs_old_admin_master instead of saunafs_admin_master.
- Use, for instance, 'saunafsXX saunafs setgoal' instead of 'saunafsXX sfssetgoal'.