### PR TITLE
tests: Fix test_saunafs_upgrade_ec_basic

### DIFF
--- a/tests/test_suites/ShortSystemTests/test_saunafs_upgrade_ec_basic.sh
+++ b/tests/test_suites/ShortSystemTests/test_saunafs_upgrade_ec_basic.sh
@@ -19,13 +19,13 @@ REPLICATION_TIMEOUT='30 seconds'
 
 # Start test with master, 5 chunkservers and mount running old SaunaFS code
 # Ensure that we work on legacy version
-assert_equals 1 $(saunafs_admin_master info | grep $SAUNAFSXX_TAG | wc -l)
-assert_equals 5 $(saunafs_admin_master list-chunkservers | grep $SAUNAFSXX_TAG | wc -l)
-assert_equals 1 $(saunafs_admin_master list-mounts | grep $SAUNAFSXX_TAG | wc -l)
+assert_equals 1 $(saunafs_old_admin_master info | grep $SAUNAFSXX_TAG | wc -l)
+assert_equals 5 $(saunafs_old_admin_master list-chunkservers | grep $SAUNAFSXX_TAG | wc -l)
+assert_equals 1 $(saunafs_old_admin_master list-mounts | grep $SAUNAFSXX_TAG | wc -l)
 
 cd "${info[mount0]}"
 mkdir dir
-assert_success saunafsXX sfssetgoal ec32 dir
+assert_success saunafsXX saunafs setgoal ec32 dir
 cd dir
 
 function generate_file {

--- a/tests/tools/saunafsXX.sh
+++ b/tests/tools/saunafsXX.sh
@@ -27,7 +27,7 @@ Dir::Cache "${TEMP_DIR}/apt/var/cache/apt";
 Dir::Etc::Parts "${TEMP_DIR}/apt/apt.conf.d";
 END
 		local destdir="${TEMP_DIR}/apt/var/cache/apt/archives"
-		echo "deb [arch=amd64] https://repo.saunafs.com/repository/saunafs-ubuntu-22.04/ ${codename} main" >${TEMP_DIR}/apt/saunafs.list
+		echo "deb [arch=amd64 trusted=yes] https://repo.saunafs.com/repository/saunafs-ubuntu-22.04/ ${codename} main" >${TEMP_DIR}/apt/saunafs.list
 		env APT_CONFIG="${TEMP_DIR}/apt/apt.conf" apt-get update
 		env APT_CONFIG="${TEMP_DIR}/apt/apt.conf" apt-get -y --allow-downgrades install -d \
 			saunafs-master=${SAUNAFSXX_TAG_APT} \


### PR DESCRIPTION
The test is now using the new tools and we 'trust' the gpg key of our own repo.