### PR TITLE
all: Fix build under ENABLE_TRACES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ option(ENABLE_POLONAISE         "Enable polonaise"                              
 option(ENABLE_CLIENT_LIB        "Enable dynamic client library (libsaunafs-client)"     OFF)
 # end of SaunaFS options
 option(ENABLE_TRACES            "Enable traces"                                          OFF)
+option(ENABLE_SYSLOG_FOR_TRACES "Enable usage of syslog instead of stdout for traces"    OFF)
 option(ENABLE_CRC               "Enable checksums"                                       ON)
 option(ENABLE_REQUEST_LOG       "Enable logging request times"                           OFF)
 option(USE_LEGACY_READ_MESSAGES "Enable sending old type of messages by mount"           OFF)
@@ -128,6 +129,7 @@ message(STATUS "ENABLE_CLIENT_LIB: ${ENABLE_CLIENT_LIB}")
 message(STATUS "ENABLE_URAFT: ${ENABLE_URAFT}")
 # end of SaunaFS options values
 message(STATUS "ENABLE_TRACES: ${ENABLE_TRACES}")
+message(STATUS "ENABLE_SYSLOG_FOR_TRACES: ${ENABLE_SYSLOG_FOR_TRACES}")
 message(STATUS "ENABLE_CRC: ${ENABLE_CRC}")
 message(STATUS "ENABLE_REQUEST_LOG: ${ENABLE_REQUEST_LOG}")
 message(STATUS "USE_LEGACY_READ_MESSAGES: ${USE_LEGACY_READ_MESSAGES}")
@@ -291,6 +293,10 @@ endif()
 
 if(ENABLE_TRACES)
   add_definitions(-DENABLE_TRACES)
+
+  if (ENABLE_SYSLOG_FOR_TRACES)
+    add_definitions(-DENABLE_SYSLOG_FOR_TRACES)
+  endif()
 endif()
 
 if(ENABLE_REQUEST_LOG)

--- a/src/chunkserver/chunkserver-common/hdd_utils.cc
+++ b/src/chunkserver/chunkserver-common/hdd_utils.cc
@@ -45,7 +45,7 @@ void hddReportDamagedChunk(uint64_t chunkId, ChunkPartType chunkType) {
 bool hddChunkTryLock(IChunk *chunk) {
 	assert(gChunksMapMutex.try_lock() == false);
 	assert(chunk);
-	TRACETHIS1(chunk->chunkid);
+	TRACETHIS1(chunk->id());
 	bool ret = false;
 
 	if (chunk != nullptr && chunk->state() == ChunkState::Available) {
@@ -136,7 +136,7 @@ int chunkWriteCrc(IChunk *chunk) {
 
 int hddIOEnd(IChunk *chunk) {
 	assert(chunk);
-	TRACETHIS1(c->chunkid);
+	TRACETHIS1(chunk->id());
 
 	if (chunk->wasChanged()) {
 		int status = chunkWriteCrc(chunk);
@@ -282,7 +282,7 @@ IChunk *hddChunkFindAndLock(uint64_t chunkId, ChunkPartType chunkType) {
 IChunk *hddChunkFindOrCreatePlusLock(IDisk *disk, uint64_t chunkid,
                                      ChunkPartType chunkType,
                                      disk::ChunkGetMode creationMode) {
-	TRACETHIS2(chunkid, (unsigned)cflag);
+	TRACETHIS2(chunkid, (unsigned)creationMode);
 	IChunk *chunk = nullptr;
 	IDisk *effectiveDisk = disk;
 

--- a/src/chunkserver/cmr_disk.cc
+++ b/src/chunkserver/cmr_disk.cc
@@ -85,7 +85,7 @@ void CmrDisk::refreshDataDiskUsage() {
 
 int CmrDisk::updateChunkAttributes(IChunk *chunk, bool isFromScan) {
 	assert(chunk);
-	TRACETHIS1(chunk->chunkid);
+	TRACETHIS1(chunk->id());
 
 	(void)isFromScan;  // Not needed for conventional disks
 
@@ -353,7 +353,7 @@ int CmrDisk::writeChunkBlock(IChunk *chunk, uint32_t version, uint16_t blocknum,
                              const uint8_t *buffer) {
 	assert(chunk);
 	LOG_AVG_TILL_END_OF_SCOPE0("writeChunkBlock");
-	TRACETHIS3(chunk->chunkid, offset, size);
+	TRACETHIS3(chunk->id(), offsetInBlock, size);
 	uint32_t preCrc, postCrc, combinedCrc, chcrc;
 
 	if (chunk->version() != version && version > 0) {

--- a/src/chunkserver/hddspacemgr.cc
+++ b/src/chunkserver/hddspacemgr.cc
@@ -582,7 +582,7 @@ int hddGetLoadFactor() {
 int hddOpen(IChunk *chunk) {
 	assert(chunk);
 	LOG_AVG_TILL_END_OF_SCOPE0("hddOpen");
-	TRACETHIS1(chunk->chunkid);
+	TRACETHIS1(chunk->id());
 
 	int status = hddIOBegin(chunk, 0);
 	PRINTTHIS(status);
@@ -608,7 +608,7 @@ int hddOpen(uint64_t chunkId, ChunkPartType chunkType) {
 
 int hddClose(IChunk *chunk) {
 	assert(chunk);
-	TRACETHIS1(chunk->chunkid);
+	TRACETHIS1(chunk->id());
 	int status = hddIOEnd(chunk);
 	PRINTTHIS(status);
 	if (status != SAUNAFS_STATUS_OK) {
@@ -632,7 +632,7 @@ int hddReadCrcAndBlock(IChunk *chunk, uint16_t blockNumber,
                        OutputBuffer *outputBuffer) {
 	LOG_AVG_TILL_END_OF_SCOPE0("hddReadCrcAndBlock");
 	assert(chunk);
-	TRACETHIS2(c->chunkid, blocknum);
+	TRACETHIS2(chunk->id(), blockNumber);
 
 	int bytesRead = 0;
 

--- a/src/devtools/TracePrinter.h
+++ b/src/devtools/TracePrinter.h
@@ -33,10 +33,13 @@
 #include <sys/time.h>
 #include <cstdio>
 #include <map>
-#include <memory>
 #include <mutex>
 #include <string>
 #include <boost/format.hpp>
+
+#ifdef ENABLE_SYSLOG_FOR_TRACES
+#include "common/slogger.h"
+#endif
 
 class ThreadPrinter {
 private:
@@ -95,7 +98,16 @@ public:
 
 		struct timeval tv;
 		gettimeofday(&tv, NULL);
-		fprintf(stdout, "%s%lu.%06lu Thread %9lx %s%s\033[0m\n", colourStr.c_str(), tv.tv_sec, tv.tv_usec, myId, indentStr.c_str(), message.c_str());
+
+#ifdef ENABLE_SYSLOG_FOR_TRACES
+		safs_pretty_syslog(LOG_NOTICE, "%lu.%06lu Thread %9lx %s%s", tv.tv_sec,
+		                   tv.tv_usec, myId, indentStr.c_str(),
+		                   message.c_str());
+#else
+		fprintf(stdout, "%s%lu.%06lu Thread %9lx %s%s\033[0m\n",
+		        colourStr.c_str(), tv.tv_sec, tv.tv_usec, myId,
+		        indentStr.c_str(), message.c_str());
+#endif
 	}
 
 protected:


### PR DESCRIPTION
Some of the calls to the traces macros were not updated in previous commits. This change fixes the building by updating these calls with correct parameters and extends the TracePrinter to optionally output to our usual syslog.

To use the traces, just enable the option ENABLE_TRACES in the cmake call. By default it prints to stdout, so, to print to the syslog, the option ENABLE_SYSLOG_FOR_TRACES must be enabled too (useful when running the tests).

To disable the traces for specific modules, add the following line in the module cmake file:

remove_definitions(-DENABLE_SYSLOG_FOR_TRACES)