### PR TITLE
mount: Add client option feature

### DIFF
--- a/src/common/read_plan_executor.h
+++ b/src/common/read_plan_executor.h
@@ -80,13 +80,13 @@ public:
 		return networking_failures_;
 	}
 
-	/// Counter for the .saunafds_tweaks file.
+	/// Counter for the .saunafs_tweaks file.
 	static std::atomic<uint64_t> executions_total_;
 
-	/// Counter for the .saunafds_tweaks file.
+	/// Counter for the .saunafs_tweaks file.
 	static std::atomic<uint64_t> executions_with_additional_operations_;
 
-	/// Counter for the .saunafds_tweaks file.
+	/// Counter for the .saunafs_tweaks file.
 	static std::atomic<uint64_t> executions_finished_by_additional_operations_;
 
 protected:

--- a/src/main/main.cc
+++ b/src/main/main.cc
@@ -782,7 +782,7 @@ void usage(const char *appname) {
 	printf(
 "usage: %s [-vdu] [-t locktimeout] [-c cfgfile] [start|stop|restart|reload|test|isalive]\n"
 "\n"
-"-v : print version number and exit\n"
+"-v[|V] : print version number and exit\n"
 "-d : run in foreground\n"
 "-u : log undefined config variables\n"
 "-t locktimeout : how long wait for lockfile\n"
@@ -829,9 +829,10 @@ int main(int argc,char **argv) {
 	lockmemory = 0;
 	appname = argv[0];
 
-	while ((ch = getopt(argc, argv, "o:c:p:dht:uvx?")) != -1) {
+	while ((ch = getopt(argc, argv, "o:c:p:dht:uvVx?")) != -1) {
 		switch(ch) {
 			case 'v':
+			case 'V':
 				printf("version: %s\n",SAUNAFS_PACKAGE_VERSION);
 				return 0;
 			case 'd':

--- a/src/mount/chunk_reader.h
+++ b/src/mount/chunk_reader.h
@@ -72,7 +72,7 @@ public:
 		return location_->version;
 	}
 
-	/// Counter for the .saunafds_tweaks file.
+	/// Counter for the .saunafs_tweaks file.
 	static std::atomic<uint64_t> preparations;
 
 private:

--- a/src/mount/fuse/main.cc
+++ b/src/mount/fuse/main.cc
@@ -249,6 +249,7 @@ static int mainloop(struct fuse_args *args, struct fuse_cmdline_opts *fuse_opts,
 	params.acl_cache_timeout = gMountOptions.aclcacheto;
 	params.acl_cache_size = gMountOptions.aclcachesize;
 	params.debug_mode = gMountOptions.debug;
+	params.direct_io = gMountOptions.directio;
 
 	if (!gMountOptions.meta) {
 		SaunaClient::fs_init(params);

--- a/src/mount/fuse/mount_config.cc
+++ b/src/mount/fuse/mount_config.cc
@@ -72,6 +72,7 @@ struct fuse_opt gSfsOptsStage2[] = {
 	SFS_OPT("sfssugidclearmode=%s", sugidclearmodestr, 0),
 	SFS_OPT("sfsattrcacheto=%lf", attrcacheto, 0),
 	SFS_OPT("sfsentrycacheto=%lf", entrycacheto, 0),
+	SFS_OPT("sfsdirectio=%d", directio, 0),
 	SFS_OPT("sfsdirentrycacheto=%lf", direntrycacheto, 0),
 	SFS_OPT("sfsaclcacheto=%lf", aclcacheto, 0),
 	SFS_OPT("sfsreportreservedperiod=%u", reportreservedperiod, 0),
@@ -152,6 +153,7 @@ void usage(const char *progname) {
 				"(default: %.2f)\n"
 "    -o sfsentrycacheto=SEC      set file entry cache timeout in seconds "
 				"(default: %.2f)\n"
+"    -o sfsdirectio=0|1          set DirectIO mode (default: 0)\n"
 "    -o sfsdirentrycacheto=SEC   set directory entry cache timeout in seconds "
 				"(default: %.2f)\n"
 "    -o sfsdirentrycachesize=N   define directory entry cache size in number "

--- a/src/mount/fuse/mount_config.cc
+++ b/src/mount/fuse/mount_config.cc
@@ -115,11 +115,6 @@ void usage(const char *progname) {
 
 	printf("general options:\n");
 	fuse_cmdline_help();
-printf(
-"    -o opt,[opt...]         mount options\n"
-"    -h   --help             print help\n"
-"    -V   --version          print version\n"
-"\n");
 
 	printf(
 "SFS options:\n"

--- a/src/mount/fuse/mount_config.h
+++ b/src/mount/fuse/mount_config.h
@@ -112,6 +112,7 @@ struct sfsopts_ {
 	unsigned symlinkcachetimeout;
 	double bandwidthoveruse;
 	int nonemptymount;
+	bool directio;
 
 	sfsopts_()
 		: masterhost(NULL),
@@ -165,7 +166,8 @@ struct sfsopts_ {
 		prefetchxorstripes(SaunaClient::FsInitParams::kDefaultPrefetchXorStripes),
 		symlinkcachetimeout(SaunaClient::FsInitParams::kDefaultSymlinkCacheTimeout),
 		bandwidthoveruse(SaunaClient::FsInitParams::kDefaultBandwidthOveruse),
-		nonemptymount(SaunaClient::FsInitParams::kDefaultNonEmptyMounts)
+		nonemptymount(SaunaClient::FsInitParams::kDefaultNonEmptyMounts),
+		directio(SaunaClient::FsInitParams::kDirectIO)
 	{ }
 };
 

--- a/src/mount/sauna_client.cc
+++ b/src/mount/sauna_client.cc
@@ -3239,7 +3239,7 @@ std::vector<ChunkserverListEntry> getchunkservers() {
 void init(int debug_mode_, int keep_cache_, double direntry_cache_timeout_, unsigned direntry_cache_size_,
 		double entry_cache_timeout_, double attr_cache_timeout_, int mkdir_copy_sgid_,
 		SugidClearMode sugid_clear_mode_, bool use_rwlock_,
-		double acl_cache_timeout_, unsigned acl_cache_size_) {
+		double acl_cache_timeout_, unsigned acl_cache_size_, bool direct_io) {
 	debug_mode = debug_mode_;
 	keep_cache = keep_cache_;
 	direntry_cache_timeout = direntry_cache_timeout_;
@@ -3251,6 +3251,7 @@ void init(int debug_mode_, int keep_cache_, double direntry_cache_timeout_, unsi
 	uint64_t timeout = (uint64_t)(direntry_cache_timeout * 1000000);
 	gDirEntryCache.setTimeout(timeout);
 	gDirEntryCacheMaxSize = direntry_cache_size_;
+	gDirectIo = direct_io;
 	if (debug_mode) {
 		safs::log_debug("cache parameters: file_keep_cache={} direntry_cache_timeout={:.2f}"
 		                " entry_cache_timeout={:.2f} attr_cache_timeout={:.2f}",
@@ -3323,7 +3324,7 @@ void fs_init(FsInitParams &params) {
 	init(params.debug_mode, params.keep_cache, params.direntry_cache_timeout, params.direntry_cache_size,
 		params.entry_cache_timeout, params.attr_cache_timeout, params.mkdir_copy_sgid,
 		params.sugid_clear_mode, params.use_rw_lock,
-		params.acl_cache_timeout, params.acl_cache_size);
+		params.acl_cache_timeout, params.acl_cache_size, params.direct_io);
 }
 
 void fs_term() {

--- a/src/mount/sauna_client.h
+++ b/src/mount/sauna_client.h
@@ -107,6 +107,7 @@ struct FsInitParams {
 	static constexpr double   kDefaultAclCacheTimeout = 1.0;
 	static constexpr unsigned kDefaultAclCacheSize = 1000;
 	static constexpr bool     kDefaultVerbose = false;
+	static constexpr bool     kDirectIO = false;
 
 	// Thank you, GCC 4.6, for no delegating constructors
 	FsInitParams()
@@ -135,7 +136,8 @@ struct FsInitParams {
 	             mkdir_copy_sgid(kDefaultMkdirCopySgid), sugid_clear_mode(kDefaultSugidClearMode),
 	             use_rw_lock(kDefaultUseRwLock),
 	             acl_cache_timeout(kDefaultAclCacheTimeout), acl_cache_size(kDefaultAclCacheSize),
-	             verbose(kDefaultVerbose) {
+	             verbose(kDefaultVerbose),
+	             direct_io(kDirectIO) {
 	}
 
 	FsInitParams(const std::string &bind_host, const std::string &host, const std::string &port, const std::string &mountpoint)
@@ -164,7 +166,8 @@ struct FsInitParams {
 	             mkdir_copy_sgid(kDefaultMkdirCopySgid), sugid_clear_mode(kDefaultSugidClearMode),
 	             use_rw_lock(kDefaultUseRwLock),
 	             acl_cache_timeout(kDefaultAclCacheTimeout), acl_cache_size(kDefaultAclCacheSize),
-	             verbose(kDefaultVerbose) {
+	             verbose(kDefaultVerbose),
+	             direct_io(kDirectIO) {
 	}
 
 	std::string bind_host;
@@ -211,6 +214,7 @@ struct FsInitParams {
 	unsigned acl_cache_size;
 
 	bool verbose;
+	bool direct_io;
 
 	std::string io_limits_config_file;
 };

--- a/tests/setup_machine.sh
+++ b/tests/setup_machine.sh
@@ -203,6 +203,13 @@ if [ ! -f /etc/sudoers.d/saunafstest ] || ! grep '# Ganesha' /etc/sudoers.d/saun
 	END
 fi
 
+if [ ! -f /etc/sudoers.d/saunafstest ] || grep '# Client' /etc/sudoers.d/saunafstest >/dev/null; then
+	cat <<-'END' >>/etc/sudoers.d/saunafstest
+		# Client
+		saunafstest ALL = NOPASSWD: /usr/bin/tee
+	END
+fi
+
 echo ; echo 'Fixing GIDs of users'
 for name in saunafstest saunafstest_{0..9}; do
 	uid=$(getent passwd "$name" | cut -d: -f3)

--- a/tests/test_suites/SanityChecks/test_mount_directio.sh
+++ b/tests/test_suites/SanityChecks/test_mount_directio.sh
@@ -1,0 +1,21 @@
+#
+# To run this test you need to add the following lines to /etc/sudoers.d/saunafstest:
+#
+# saunafstest ALL = NOPASSWD: /usr/bin/tee
+#
+#
+MOUNTS=2 \
+  USE_RAMDISK=YES \
+  MOUNT_0_EXTRA_CONFIG="sfsdirectio=0" \
+  MOUNT_1_EXTRA_CONFIG="sfsdirectio=1" \
+  setup_local_empty_saunafs info
+
+expect_equals "false" "$(cat ${info[mount0]}/.saunafs_tweaks | grep -i directio | awk '{print $2}')"
+expect_equals "true" "$(cat ${info[mount1]}/.saunafs_tweaks | grep -i directio | awk '{print $2}')"
+
+# Modify the DirectIO option on the fly
+echo "DirectIO=true" | sudo tee ${info[mount0]}/.saunafs_tweaks
+echo "DirectIO=false" | sudo tee ${info[mount1]}/.saunafs_tweaks
+
+expect_equals "true" "$(cat ${info[mount0]}/.saunafs_tweaks | grep -i directio | awk '{print $2}')"
+expect_equals "false" "$(cat ${info[mount1]}/.saunafs_tweaks | grep -i directio | awk '{print $2}')"


### PR DESCRIPTION
The DirectIO flag on the client was set only thought the hidden tweak file.
A mount option is added to set DirectIO mode at client initialization stage.
A functional test is added to test the new feature.
A duplicated message from usage help command is removed at client.
The version (-v|-V) flag is set case insensitive on every module.