### PR TITLE
fix: Fix DirEntryCache behavior

### DIFF
--- a/src/mount/direntry_cache.h
+++ b/src/mount/direntry_cache.h
@@ -575,7 +575,8 @@ public:
 
 protected:
 	void erase(DirEntry *entry) {
-		if (entry->parent_inode != kInvalidParent && !entry->name.empty()) {
+		// The 'no more entries' marker has empty name and should be erased
+		if (entry->parent_inode != kInvalidParent || !entry->name.empty()) {
 			lookup_set_.erase(lookup_set_.iterator_to(*entry));
 		}
 		if (entry->parent_inode != kInvalidParent &&
@@ -618,7 +619,7 @@ protected:
 		                               next_index, name, attr, timestamp);
 		assert(entry);
 
-		if (parent_inode != kInvalidParent && !name.empty()) {
+		if (parent_inode != kInvalidParent || !name.empty()) {
 			lookup_set_.insert(*entry);
 		}
 		if (parent_inode != kInvalidParent && index != kInvalidIndex) {

--- a/src/mount/direntry_cache.h
+++ b/src/mount/direntry_cache.h
@@ -487,7 +487,7 @@ public:
 		std::unique_lock<SharedMutex> guard(rwlock_);
 		// lookup_set_ should contain all the elements inside index_set
 		auto it = lookup_set_.lower_bound(
-		    std::make_tuple(parent_inode, 0, 0, ""), LookupCompare());
+		    std::make_tuple(parent_inode, ctx.uid, ctx.gid, ""), LookupCompare());
 		while (it != lookup_set_.end() &&
 		       std::make_tuple(parent_inode, ctx.uid, ctx.gid) ==
 		               std::make_tuple(it->parent_inode, it->uid, it->gid)) {

--- a/src/mount/direntry_cache.h
+++ b/src/mount/direntry_cache.h
@@ -629,17 +629,17 @@ protected:
 		if (lookup_set_.size() < index_set_.size()) {
 			auto size1 = index_set_.size();
 			auto size2 = lookup_set_.size();
-			safs::log_err(
+			safs_pretty_syslog(LOG_ERR,
 			    "Inconsistent DirEntryCache: lookup set should have at least "
-			    "as many entries as index set, index:%lu > lookup:%lu",
+			    "as many entries as index set, index size:%lu > lookup size:%lu",
 			    size1, size2);
 		}
 		if (inode_multiset_.size() < lookup_set_.size()) {
 			auto size1 = lookup_set_.size();
 			auto size2 = inode_multiset_.size();
-			safs::log_err(
+			safs_pretty_syslog(LOG_ERR,
 			    "Inconsistent DirEntryCache: inode multiset should have at "
-			    "least as many entries as lookup set, lookup:%lu > inode:%lu",
+			    "least as many entries as lookup set, lookup size:%lu > inode size:%lu",
 			    size1, size2);
 		}
 	}

--- a/src/mount/direntry_cache.h
+++ b/src/mount/direntry_cache.h
@@ -35,6 +35,7 @@
 
 constexpr uint64_t kInvalidIndex = std::numeric_limits<uint64_t>::max();
 constexpr uint32_t kInvalidParent = std::numeric_limits<uint32_t>::max();
+constexpr uint32_t kNoMoreEntriesMarker = 0;
 constexpr char kEmptyName[] = "";
 
 /*! \brief Cache for directory entries
@@ -264,8 +265,7 @@ public:
 	 * \return True if inode has been found in cache, false otherwise.
 	 */
 	bool lookup(const SaunaClient::Context &ctx, uint32_t inode, Attributes &attr) {
-		// 'no more entries' marker
-		if (inode == 0) {
+		if (inode == kNoMoreEntriesMarker) {
 			return false;
 		}
 		shared_lock<SharedMutex> guard(rwlock_);

--- a/src/mount/direntry_cache.h
+++ b/src/mount/direntry_cache.h
@@ -272,7 +272,7 @@ public:
 		auto it = find(ctx, inode);
 		bool ret = false;
 		uint64_t newest_timestamp = 0;
-		while (it == inode_multiset_.end() && it->inode == inode) {
+		while (it != inode_multiset_.end() && it->inode == inode) {
 			if (!expired(*it, current_time_) &&
 			    it->timestamp > newest_timestamp && it->uid == ctx.uid &&
 			    it->gid == ctx.gid) {

--- a/src/mount/direntry_cache.h
+++ b/src/mount/direntry_cache.h
@@ -575,16 +575,23 @@ public:
 
 protected:
 	void erase(DirEntry *entry) {
+		if (entry == nullptr) {
+			return;
+		}
+
 		// The 'no more entries' marker has empty name and should be erased
 		if (entry->parent_inode != kInvalidParent || !entry->name.empty()) {
 			lookup_set_.erase(lookup_set_.iterator_to(*entry));
 		}
+
 		if (entry->parent_inode != kInvalidParent &&
 		    entry->index != kInvalidIndex) {
 			index_set_.erase(index_set_.iterator_to(*entry));
 		}
+
 		inode_multiset_.erase(inode_multiset_.iterator_to(*entry));
 		fifo_list_.erase(fifo_list_.iterator_to(*entry));
+
 		delete entry;
 	}
 

--- a/src/mount/sauna_client.cc
+++ b/src/mount/sauna_client.cc
@@ -837,7 +837,7 @@ EntryParam lookup(Context &ctx, Inode parent, const char *name) {
 		e.attr.st_size=maxfleng;
 	}
 
-	// If lookup succeeded and data did not come from cache, then cache it 
+	// If lookup succeeded and data did not come from cache, then cache it
 	if (!icacheflag) {
 		auto data_acquire_time = gDirEntryCache.updateTime();
 
@@ -1641,6 +1641,7 @@ EntryParam link(Context &ctx, Inode ino, Inode newparent, const char *newname) {
 				saunafs_error_string(status));
 		throw RequestException(status);
 	} else {
+		gDirEntryCache.lockAndInvalidateInode(inode);
 		gDirEntryCache.lockAndInvalidateParent(newparent);
 		e.ino = inode;
 		mattr = attr_get_mattr(attr);


### PR DESCRIPTION
Our current dev branch is not passing our tests because it is failing on some Ganesha tests. This PR fixes those tests and also some  ShortSystemTests that were failing.

The errors that caused the various failures were introduced while merging the extend-dircache branch, therefore the fixes are related to its behavior.