### PR TITLE
chore(.gitignore): Add .dockerignore and update .gitignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,12 +1,6 @@
 *~
 .DS_Store
-
-# External libraries #
-######################
-/external/googletest-release-1.7.0
-/external/nfs-ganesha-*
-/external/ntirpc-*
-/external/spdlog-0.14.0
+.git
 
 # Vim files #
 #############
@@ -76,17 +70,6 @@ compile_commands.json
 # clangd #
 ##########
 .cache
-
-# submodules #
-##############
-src/chunkserver/plugins/zonefs_disk
-tests/ci_build/run-smr-tests.sh
-tests/test_suites/SMRTests
-
-# Windows #
-###########
-src/mount/windows
-create-win-release.bat
 
 # Test setup #
 ##############


### PR DESCRIPTION
.dockerignore allows docker images building from the source context to ignore files, including build files and .git, which can balloon the context and significantly slow down image build times. The file is very similar to .gitignore, with minor changes specific for docker

On that note, .gitignore has been updated to not include files that are made by setup_machine.sh, and its aesthetics has been tidied up.