### PR TITLE
chore: Add .clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,43 @@
+#
+# -modernize-use-trailing-return-type,
+# -modernize-use-nodiscard,
+# -modernize-avoid-bind,
+# -modernize-use-transparent-functors,
+# -modernize-use-bool-literals,
+# -modernize-use-uncaught-exceptions,
+# -modernize-use-noexcept,
+# -modernize-concat-nested-namespaces,
+# -modernize-deprecated-headers,
+# -modernize-raw-string-literal,
+# -modernize-replace-random-shuffle,
+# -modernize-use-nullptr,
+# -modernize-use-override,
+# -modernize-use-using,
+#
+# -cppcoreguidelines-pro-type-vararg,
+# -cppcoreguidelines-avoid-magic-numbers,
+# -cppcoreguidelines-pro-bounds-pointer-arithmetic,
+# -readability-magic-numbers,
+# -misc-non-private-member-variables-in-classes,
+Checks: "-*,
+  bugprone-*,
+    -bugprone-easily-swappable-parameters,
+  cert-*,
+  -cert-err58-cpp
+  clang-analyzer-*,
+  cppcoreguidelines-*,
+  -google-*,
+  -llvm*,
+  misc-*,
+    -misc-non-private-member-variables-in-classes,
+  modernize-*,
+    -modernize-use-trailing-return-type,
+    -modernize-use-nodiscard,
+  performance-*,
+  portability-*,
+  readability-*,"
+
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+FormatStyle:     file
+


### PR DESCRIPTION
clang-tidy is similar to cppcheck, but it is more powerful and has a greater amount of diagnostics, particulary regarding idiomatic C++. It can be used in conjunction with cppcheck in both editors and potentially the CI. I've been personally using this file for a few months now, tweaking it to suppress unwanted diagnostics, and I believe it is good enough to warrant inclusion.