### PR TITLE
chore: Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+[*{.cc,h}]
+indent_style = tab
+indent_size = 4
+
+[*.sh]
+space_redirects = true
+keep_padding    = true
+

--- a/.editorconfig
+++ b/.editorconfig
@@ -5,12 +5,16 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 charset = utf-8
+indent_style = space
+indent_size = 4
 
 [*{.cc,h}]
 indent_style = tab
 indent_size = 4
 
-[*.sh]
+[{*.bash,*.sh,Dockerfile,Dockerfile.*,Makefile,*.mk}]
+indent_style = tab
+indent_size = 4
 space_redirects = true
-keep_padding    = true
+keep_padding = true
 


### PR DESCRIPTION
.editorconfig allows signalling to code editors how files should be formatted when opening and when writing. For example, since most of us uses 4-width tabs, the default should be to use those (especially because tab sizes can vary, from 2 to 8 to any size). This can be modified per filetype. Another thing is to ensure that files should end with LF, not CRLF.