### PR TITLE
common, master: Auction optimization related improvements

### DIFF
--- a/src/common/chunk_copies_calculator.cc
+++ b/src/common/chunk_copies_calculator.cc
@@ -97,10 +97,8 @@ void ChunkCopiesCalculator::optimize() {
 		                                       target_slice.size());
 
 		Goal::Slice result(target_slice.getType());
-		i = 0;
-		for (auto result_part : result) {
-			result_part = target_slice[assignment[i]];
-			++i;
+		for (int k = 0, m = target_slice.size(); k < m; ++k) {
+			result[k] = target_slice[assignment[k]];
 		}
 		target_slice = std::move(result);
 	}

--- a/src/common/chunk_copies_calculator.cc
+++ b/src/common/chunk_copies_calculator.cc
@@ -63,41 +63,87 @@ void ChunkCopiesCalculator::removePart(const Goal::Slice::Type &slice_type, int 
 	}
 }
 
-void ChunkCopiesCalculator::optimize() {
+/**
+ * @brief Check if the provided slice should be skipped or not by the optimize function. 
+ * 
+ * A slice can be skipped if all their parts require the same because all of its 
+ * permutations are equal.
+ * 
+ * @param slice ```Slice``` to be checked.
+ * @return true The slice should be skipped. --
+ * @return false The slice should not be skipped.
+ */
+bool isSkippable(Goal::Slice &slice) {
+	for (int i = 1; i < slice.size(); ++i) {
+		if (!LinearAssignmentCache::OptimizerInputOutput::partsMatch(
+		        slice[0], slice[i])) {
+			return false;
+		}
+	}
+	return true;
+}
+
+void ChunkCopiesCalculator::optimize(
+    bool useLinearAssignmentOptimizer,
+    LinearAssignmentCache *linearAssignmentCache) {
 	constexpr int max_slice_op = 10 * Goal::kMaxExpectedCopies;
 
 	for (auto &target_slice : target_) {
+		if (!useLinearAssignmentOptimizer) {
+			break;
+		}
+
 		auto slice_it = available_.find(target_slice.getType());
-		if (slice_it == available_.end() ||
-		    target_slice.size() <= 1) {
+		if (slice_it == available_.end() || target_slice.size() <= 1) {
 			continue;
 		}
-		const Goal::Slice &src_slice = *slice_it;
 
-		std::array<std::array<int, Goal::Slice::kMaxPartsCount>,
-		           Goal::Slice::kMaxPartsCount> cost;
-		std::array<int, Goal::Slice::kMaxPartsCount> assignment, object_assignment;
-
-		int i = 0;
-		for(const auto &src_part : src_slice) {
-			int j = 0;
-			for(const auto &target_part : static_cast<const Goal::Slice&>(target_slice)) {
-				auto op_count = operationCount(src_part, target_part);
-				op_count =
-				        std::make_pair(std::min(op_count.first, max_slice_op - 1),
-				                       std::min(op_count.second, max_slice_op - 1));
-				cost[i][j] = max_slice_op * max_slice_op -
-				             (max_slice_op * op_count.first + op_count.second);
-				++j;
-			}
-			++i;
+		if (isSkippable(target_slice)) {
+			continue;
 		}
 
-		linear_assignment::auctionOptimization(cost, assignment, object_assignment,
-		                                       target_slice.size());
+		Goal::Slice &src_slice = *slice_it;
+		std::array<int, Goal::Slice::kMaxPartsCount> assignment;
+		bool isCacheAvailable =
+		    (linearAssignmentCache != LinearAssignmentCache::kNotProvidedCache);
+		if (!isCacheAvailable ||
+		    !linearAssignmentCache
+		         ->checkMatchAndGetResult<Goal::Slice::kMaxPartsCount>(
+		             target_slice, src_slice, assignment)) {
+			std::array<std::array<int, Goal::Slice::kMaxPartsCount>,
+			           Goal::Slice::kMaxPartsCount>
+			    cost;
+			std::array<int, Goal::Slice::kMaxPartsCount> object_assignment;
+
+			int src = 0;
+			for (const auto &src_part :
+			     static_cast<const Goal::Slice&>(src_slice)) {
+				int target = 0;
+				for (const auto &target_part :
+				     static_cast<const Goal::Slice&>(target_slice)) {
+					auto op_count = operationCount(src_part, target_part);
+					op_count = std::make_pair(
+					    std::min(op_count.first, max_slice_op - 1),
+					    std::min(op_count.second, max_slice_op - 1));
+					cost[src][target] =
+					    max_slice_op * max_slice_op -
+					    (max_slice_op * op_count.first + op_count.second);
+					++target;
+				}
+				++src;
+			}
+
+			linear_assignment::auctionOptimization(
+			    cost, assignment, object_assignment, target_slice.size());
+
+			if (isCacheAvailable) {
+				linearAssignmentCache->store<Goal::Slice::kMaxPartsCount>(
+				    target_slice, src_slice, assignment);
+			}
+		}
 
 		Goal::Slice result(target_slice.getType());
-		for (int k = 0, m = target_slice.size(); k < m; ++k) {
+		for (int k = 0; k < target_slice.size(); ++k) {
 			result[k] = target_slice[assignment[k]];
 		}
 		target_slice = std::move(result);

--- a/src/common/chunk_copies_calculator.h
+++ b/src/common/chunk_copies_calculator.h
@@ -27,6 +27,7 @@
 #include "common/chunks_availability_state.h"
 #include "common/goal.h"
 #include "common/flat_map.h"
+#include "common/linear_assignment_cache.h"
 #include "common/media_label.h"
 
 /*! \brief Class used to calculate required operations to achieve chunk goal.
@@ -79,7 +80,9 @@ public:
 	 *
 	 * All query functions might be used only after this function has been executed.
 	 */
-	void optimize();
+	void optimize(bool useLinearAssignmentOptimizer = true,
+	              LinearAssignmentCache *linearAssignmentCache =
+	                  LinearAssignmentCache::kNotProvidedCache);
 
 	/*! \brief Evaluate chunk redundancy level.
 	 *

--- a/src/common/linear_assignment_cache.h
+++ b/src/common/linear_assignment_cache.h
@@ -1,0 +1,196 @@
+/*
+   Copyright 2023 Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "common/platform.h"
+
+#include <algorithm>
+#include <array>
+
+#include "common/goal.h"
+
+/**
+ * @brief Cache for linear assignment optimizer input/output.
+ *
+ * Note this cache can be used in multiple scenarios, and the output for the
+ * same input can differ for different scenarios.
+ *
+ * Implementation allows:
+ *   - query (```checkMatchAndGetResult```) for the assignment calculated by the
+ * ```auctionOptimization``` function given a pair of target and source slice.
+ * If no cached entry matches input, then no assignment is replied.
+ *   - ```store``` the assignment calculated by the ```auctionOptimization```
+ * function and the input that generated it.
+ *
+ * The cost of both functions is proportional to the sum of the number of parts
+ * in the two slices and the sum of the number of labels with copies for each of
+ * those parts.
+ *
+ * Polynomial hashing on the concatenation of both slices is used to find an
+ * integer that identifies the input. This values is then used to fast index in
+ * the entries container and query/store data.
+ */
+class LinearAssignmentCache {
+public:
+	static constexpr LinearAssignmentCache *kNotProvidedCache = nullptr;
+
+	// Single linear optimizer input/output pair.
+	class OptimizerInputOutput {
+	public:
+		OptimizerInputOutput()
+		    : target_slice_(Goal::Slice::Type(1)),
+		      source_slice_(Goal::Slice::Type(1)),
+		      assignment_() {}
+
+		static bool partsMatch(const detail::Slice::PartProxy &part1,
+		                       const detail::Slice::PartProxy &part2) {
+			return part1.size() == part2.size() &&
+			       std::equal(part1.begin(), part1.end(), part2.begin());
+		}
+
+		template <std::size_t N>
+		bool checkMatchAndGetResult(Goal::Slice &target_slice,
+		                            Goal::Slice &source_slice,
+		                            std::array<int, N> &assignment) {
+			if (target_slice.getType() != target_slice_.getType() ||
+			    source_slice.getType() != source_slice_.getType()) {
+				return false;
+			}
+			assert(target_slice.size() == target_slice_.size());
+			assert(source_slice.size() == source_slice_.size());
+
+			for (int i = 0; i < target_slice.size(); ++i) {
+				if (!partsMatch(target_slice[i], target_slice_[i])) {
+					return false;
+				}
+			}
+
+			for (int i = 0; i < source_slice.size(); ++i) {
+				if (!partsMatch(source_slice[i], source_slice_[i])) {
+					return false;
+				}
+			}
+
+			// match is good
+			std::copy(assignment_.begin(), assignment_.end(),
+			          assignment.begin());
+
+			return true;
+		}
+
+		template <std::size_t N>
+		void store(Goal::Slice &target_slice, Goal::Slice &source_slice,
+		           std::array<int, N> &assignment) {
+			target_slice_ = target_slice;
+			source_slice_ = source_slice;
+			assignment_.assign(assignment.begin(), assignment.end());
+		}
+
+	private:
+		Goal::Slice target_slice_, source_slice_;
+		std::vector<int> assignment_;
+	};
+
+	using HashType = int64_t;
+	using EntriesContainer = std::unordered_map<HashType, OptimizerInputOutput>;
+
+	LinearAssignmentCache() : cachedData_() {}
+
+	static HashType getLabelValue(MediaLabel label) {
+		return static_cast<MediaLabelManager::HandleValue>(label);
+	}
+
+	/**
+	 * @brief Calculate hash of a part.
+	 *
+	 * Hash of a part is P(```kBasePart_```) mod ```kModPart_```. P is a
+	 * polynomial whose coeficients are values dependant on each (labelId,
+	 * copies) pair of the part.
+	 *
+	 * @param part Part to be calculated hash.
+	 * @return Hash of the given part.
+	 */
+	static HashType hashPart(const detail::Slice::PartProxy &part) {
+		HashType hash = 1;
+		for (const auto &[labelId, copies] : part) {
+			HashType label_hash =
+			    (getLabelValue(labelId) * Goal::kMaxExpectedCopies + copies) %
+			    kBasePart_;
+			hash = (hash * kBasePart_ + label_hash) % kModPart_;
+		}
+		return hash;
+	}
+
+	/**
+	 * @brief Calculate hash of a slice starting from a given hash.
+	 *
+	 * Hash of a part is Q(```kBaseSlice_```) mod ```kModSlice_```. Q is a
+	 * polynomial whose coeficients are the hashed of each of the parts in the
+	 * slice.
+	 *
+	 * @param startingHash Could be the ```kInitialStartingHash_``` or some hash
+	 * calculation from a previos slice.
+	 * @param slice Slice to be calculated hash.
+	 * @return Hash of the given slice starting from the provided hash.
+	 */
+	static HashType hashSlice(HashType startingHash, Goal::Slice &slice) {
+		HashType hash = startingHash;
+		for (const auto &part : slice) {
+			HashType part_value = hashPart(part);
+			hash = (hash * kBaseSlice_ + part_value) % kModSlice_;
+		}
+		return hash;
+	}
+
+	/**
+	 * @brief Calculate the hash of a concatenation of slices.
+	 *
+	 * Note the order is important.
+	 */
+	static HashType hashSlicePair(Goal::Slice &target_slice,
+	                              Goal::Slice &source_slice) {
+		HashType hash = hashSlice(kInitialStartingHash_, target_slice);
+		hash = hashSlice(hash, source_slice);
+		return hash;
+	}
+
+	template <std::size_t N>
+	bool checkMatchAndGetResult(Goal::Slice &target_slice,
+	                            Goal::Slice &source_slice,
+	                            std::array<int, N> &assignment) {
+		HashType hash = hashSlicePair(target_slice, source_slice);
+		return cachedData_[hash].checkMatchAndGetResult<N>(
+		    target_slice, source_slice, assignment);
+	}
+
+	template <std::size_t N>
+	void store(Goal::Slice &target_slice, Goal::Slice &source_slice,
+	           std::array<int, N> &assignment) {
+		HashType hash = hashSlicePair(target_slice, source_slice);
+		cachedData_[hash].store<N>(target_slice, source_slice, assignment);
+	}
+
+protected:
+	static constexpr HashType kBasePart_ = 50000017;
+	static constexpr HashType kModPart_ = 100000007;
+	static constexpr HashType kBaseSlice_ = 500000009;
+	static constexpr HashType kModSlice_ = 1000000007;
+	static constexpr HashType kInitialStartingHash_ = 1;
+	EntriesContainer cachedData_;
+};

--- a/src/common/linear_assignment_cache_unittest.cc
+++ b/src/common/linear_assignment_cache_unittest.cc
@@ -1,0 +1,238 @@
+/*
+   Copyright 2023 Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "common/platform.h"
+#include "common/linear_assignment_cache.h"
+
+#include <gtest/gtest.h>
+#include <vector>
+
+#include "common/random.h"
+#include "common/slice_traits.h"
+
+class LinearAssignmentCacheIntrospect : public LinearAssignmentCache {
+public:
+	EntriesContainer &data() { return cachedData_; }
+
+	static HashType basePart() { return kBasePart_; }
+
+	static HashType modPart() { return kModPart_; }
+
+	static HashType baseSlice() { return kBaseSlice_; }
+
+	static HashType modSlice() { return kModSlice_; }
+
+	static HashType initialStartingHash() { return kInitialStartingHash_; }
+};
+
+using LACI = LinearAssignmentCacheIntrospect;
+using SimpleSlice = std::vector<std::vector<std::pair<int, int>>>;
+
+int64_t expectedHashSlice(int64_t initialHash, SimpleSlice &slice) {
+	int64_t hash = initialHash;
+	for (auto part : slice) {
+		int64_t hashPart = 1;
+		for (auto [labelId, copies] : part) {
+			hashPart = (hashPart * LACI::basePart() +
+			            (labelId * Goal::kMaxExpectedCopies + copies) %
+			                LACI::basePart()) %
+			           LACI::modPart();
+		}
+		hash = (hash * LACI::baseSlice() + hashPart) % LACI::modSlice();
+	}
+	return hash;
+}
+
+int64_t expectedHash(SimpleSlice &targetSlice, SimpleSlice &sourceSlice) {
+	int64_t hash = LACI::initialStartingHash();
+	hash = expectedHashSlice(hash, targetSlice);
+	hash = expectedHashSlice(hash, sourceSlice);
+	return hash;
+}
+
+void buildSliceFromSimpleSlice(SimpleSlice &simpleSlice, Goal::Slice &slice) {
+	for (size_t i = 0; i < simpleSlice.size(); i++) {
+		for (auto [labelId, copies] : simpleSlice[i]) {
+			slice[i][MediaLabel(labelId)] = copies;
+		}
+	}
+}
+
+TEST(LinearAssignmentCacheTests, TestBasic) {
+	LACI laci;
+
+	Goal::Slice targetSlice(
+	    Goal::Slice::Type{slice_traits::ec::getSliceType(5, 2)});
+	Goal::Slice sourceSlice(
+	    Goal::Slice::Type{slice_traits::ec::getSliceType(5, 2)});
+	Goal::Slice sourceSliceSwapped(
+	    Goal::Slice::Type{slice_traits::ec::getSliceType(5, 2)});
+	SimpleSlice simpleTargetSlice = {{{1, 1}, {65535, 2}},
+	                                 {{2, 1}},
+	                                 {{3, 1}},
+	                                 {{1, 3}, {3, 1}, {65535, 1}},
+	                                 {{65535, 1}},
+	                                 {{1, 1}},
+	                                 {{1, 100}, {3, 2}}};
+	SimpleSlice simpleSourceSlice = {
+	    {{1, 1}},     {{3, 1}, {65535, 1}}, {{2, 1}}, {{1, 1}, {65535, 1}},
+	    {{65535, 1}}, {{1, 10}, {3, 1}},    {{3, 1}},
+	};
+	std::array<int, 7> assignment = {5, 3, 1, 0, 4, 6, 2};
+
+	SimpleSlice simpleSourceSliceSwapped = simpleSourceSlice;
+	swap(simpleSourceSliceSwapped[1], simpleSourceSliceSwapped[4]);
+	// for some reason it is not possible to call swap on arrays, so manual
+	// swapping goes between elements at indexes 1 and 4
+	std::array<int, 7> assignmentSwapped = {5, 4, 1, 0, 3, 6, 2};
+
+	buildSliceFromSimpleSlice(simpleTargetSlice, targetSlice);
+	buildSliceFromSimpleSlice(simpleSourceSlice, sourceSlice);
+	buildSliceFromSimpleSlice(simpleSourceSliceSwapped, sourceSliceSwapped);
+	std::array<int, 7> replyAssignment;
+	replyAssignment.fill(0);
+
+	int64_t hash = expectedHash(simpleTargetSlice, simpleSourceSlice);
+	int64_t innerHash =
+	    LinearAssignmentCache::hashSlicePair(targetSlice, sourceSlice);
+	ASSERT_EQ(hash, innerHash);
+
+	// the cache is empty
+	ASSERT_FALSE(
+	    laci.checkMatchAndGetResult(targetSlice, sourceSlice, replyAssignment));
+	for (auto value : replyAssignment) { ASSERT_EQ(value, 0); }
+
+	laci.store(targetSlice, sourceSlice, assignment);
+
+	// the assignment can be found querying the cache
+	ASSERT_TRUE(
+	    laci.checkMatchAndGetResult(targetSlice, sourceSlice, replyAssignment));
+	for (size_t i = 0; i < replyAssignment.size(); i++) {
+		ASSERT_EQ(replyAssignment[i], assignment[i]);
+	}
+	replyAssignment.fill(0);
+
+	// and directly to the expected entry
+	ASSERT_TRUE(laci.data()[hash].checkMatchAndGetResult(
+	    targetSlice, sourceSlice, replyAssignment));
+	for (size_t i = 0; i < replyAssignment.size(); i++) {
+		ASSERT_EQ(replyAssignment[i], assignment[i]);
+	}
+	replyAssignment.fill(0);
+
+	// the swapped input cannot be flund until now
+	ASSERT_FALSE(laci.checkMatchAndGetResult(targetSlice, sourceSliceSwapped,
+	                                         replyAssignment));
+	for (auto value : replyAssignment) { ASSERT_EQ(value, 0); }
+
+	laci.store(targetSlice, sourceSliceSwapped, assignmentSwapped);
+
+	// now both can be found
+	ASSERT_TRUE(
+	    laci.checkMatchAndGetResult(targetSlice, sourceSlice, replyAssignment));
+	for (size_t i = 0; i < replyAssignment.size(); i++) {
+		ASSERT_EQ(replyAssignment[i], assignment[i]);
+	}
+	replyAssignment.fill(0);
+	ASSERT_TRUE(laci.checkMatchAndGetResult(targetSlice, sourceSliceSwapped,
+	                                        replyAssignment));
+	for (size_t i = 0; i < replyAssignment.size(); i++) {
+		ASSERT_EQ(replyAssignment[i], assignmentSwapped[i]);
+	}
+	replyAssignment.fill(0);
+
+	laci.data()[hash] = LinearAssignmentCache::OptimizerInputOutput();
+
+	// the original entry has already been deleted, so cache should not find it
+	ASSERT_FALSE(
+	    laci.checkMatchAndGetResult(targetSlice, sourceSlice, replyAssignment));
+	for (auto value : replyAssignment) { ASSERT_EQ(value, 0); }
+}
+
+TEST(LinearAssignmentCacheTests, TestOverwriteCollide) {
+	LACI laci;
+
+	Goal::Slice targetSliceEC(
+	    Goal::Slice::Type{slice_traits::ec::getSliceType(2, 2)});
+	Goal::Slice sourceSliceEC(
+	    Goal::Slice::Type{slice_traits::ec::getSliceType(2, 2)});
+	SimpleSlice simpleTargetSliceEC = {{{1, 1}}, {{1, 1}}, {{2, 1}}, {{2, 1}}};
+	SimpleSlice simpleSourceSliceEC = {{{1, 1}}, {{2, 1}}, {}, {}};
+	std::array<int, 7> assignmentEC = {0, 2, 1, 3};
+
+	// note the number of part copies is not realistic, but will serve for the
+	// test purposes
+	Goal::Slice targetSliceXor(Goal::Slice::Type{Goal::Slice::Type::kXor3});
+	Goal::Slice sourceSliceXor(Goal::Slice::Type{Goal::Slice::Type::kXor3});
+	SimpleSlice simpleTargetSliceXor = {
+	    {{1, 1}}, {{1, 1}}, {{2, 1}}, {{1, Goal::kMaxExpectedCopies + 1}}};
+	SimpleSlice simpleSourceSliceXor = {
+	    {{1, 1}}, {{1, Goal::kMaxExpectedCopies + 1}}, {}, {}};
+	std::array<int, 7> assignmentXor = {0, 3, 1, 2};
+
+	buildSliceFromSimpleSlice(simpleTargetSliceEC, targetSliceEC);
+	buildSliceFromSimpleSlice(simpleSourceSliceEC, sourceSliceEC);
+	buildSliceFromSimpleSlice(simpleTargetSliceXor, targetSliceXor);
+	buildSliceFromSimpleSlice(simpleSourceSliceXor, sourceSliceXor);
+	std::array<int, 7> replyAssignment;
+	replyAssignment.fill(0);
+
+	int64_t hashEC = expectedHash(simpleTargetSliceEC, simpleSourceSliceEC);
+	int64_t hashXor = expectedHash(simpleTargetSliceXor, simpleSourceSliceXor);
+	int64_t innerHashEC =
+	    LinearAssignmentCache::hashSlicePair(targetSliceEC, sourceSliceEC);
+	int64_t innerHashXor =
+	    LinearAssignmentCache::hashSlicePair(targetSliceXor, sourceSliceXor);
+	ASSERT_EQ(hashEC, innerHashEC);
+	ASSERT_EQ(hashXor, innerHashXor);
+	ASSERT_EQ(hashXor, hashEC);  // the pair of slices will collide
+
+	// cache is empty, neither should be found
+	ASSERT_FALSE(laci.checkMatchAndGetResult(targetSliceEC, sourceSliceEC,
+	                                         replyAssignment));
+	for (auto value : replyAssignment) { ASSERT_EQ(value, 0); }
+	ASSERT_FALSE(laci.checkMatchAndGetResult(targetSliceXor, sourceSliceXor,
+	                                         replyAssignment));
+	for (auto value : replyAssignment) { ASSERT_EQ(value, 0); }
+
+	laci.store(targetSliceEC, sourceSliceEC, assignmentEC);
+
+	// cache has EC input, Xor is not found
+	ASSERT_TRUE(laci.checkMatchAndGetResult(targetSliceEC, sourceSliceEC,
+	                                        replyAssignment));
+	for (size_t i = 0; i < replyAssignment.size(); i++) {
+		ASSERT_EQ(replyAssignment[i], assignmentEC[i]);
+	}
+	replyAssignment.fill(0);
+	ASSERT_FALSE(laci.checkMatchAndGetResult(targetSliceXor, sourceSliceXor,
+	                                         replyAssignment));
+	for (auto value : replyAssignment) { ASSERT_EQ(value, 0); }
+
+	// Xor input overwrites previous EC input
+	laci.store(targetSliceXor, sourceSliceXor, assignmentXor);
+
+	// cache has only Xor input, EC is not found
+	ASSERT_FALSE(laci.checkMatchAndGetResult(targetSliceEC, sourceSliceEC,
+	                                         replyAssignment));
+	for (auto value : replyAssignment) { ASSERT_EQ(value, 0); }
+	ASSERT_TRUE(laci.checkMatchAndGetResult(targetSliceXor, sourceSliceXor,
+	                                        replyAssignment));
+	for (size_t i = 0; i < replyAssignment.size(); i++) {
+		ASSERT_EQ(replyAssignment[i], assignmentXor[i]);
+	}
+}

--- a/src/data/sfsmaster.cfg.in
+++ b/src/data/sfsmaster.cfg.in
@@ -118,6 +118,11 @@
 ## (Default: 60)
 # CHUNKS_LOOP_MAX_CPU = 60
 
+## Use linear assignment in chunks optimization. It is suggested to 
+## disable it if not using labeled chunkservers (Boolean, 0 or 1).
+## (Default: 1)
+# USE_LINEAR_ASSIGNMENT_OPTIMIZER = 1
+
 ## Soft maximum number of chunks to delete on one chunkserver.
 ## (Default: 10)
 # CHUNKS_SOFT_DEL_LIMIT = 10


### PR DESCRIPTION
It was found that the slices list was not properly updated with the result of the auction algorithm and separately some tests showed high CPU usages in idle master specially in the ```optimize``` and ```auctionStep``` functions.

This pull request attempts to fix those issues and proposes these changes:
- apply result of the auction optimization algorithm in the optimize function.
- cache already calculated values in this function to avoid recalculating them again.
- try to skip as much as possible unnecessary computing.
- add option to directly disable these computations.