### PR TITLE
mount: Reduce readings during ec write

### DIFF
--- a/src/chunkserver/hddspacemgr.cc
+++ b/src/chunkserver/hddspacemgr.cc
@@ -775,6 +775,8 @@ int hddRead(uint64_t chunkId, uint32_t version, ChunkPartType chunkType,
 	LOG_AVG_TILL_END_OF_SCOPE0("hddRead");
 	TRACETHIS3(chunkId, offset, size);
 
+	safs_silent_syslog(LOG_DEBUG, "chunkserver.hddRead");
+
 	uint32_t offsetWithinBlock = offset % SFSBLOCKSIZE;
 
 	if ((size == 0) || ((offsetWithinBlock + size) > SFSBLOCKSIZE)) {

--- a/src/mount/chunk_locator.h
+++ b/src/mount/chunk_locator.h
@@ -97,6 +97,10 @@ public:
 	virtual void locateAndLockChunk(uint32_t inode, uint32_t index);
 	virtual void unlockChunk();
 
+	uint64_t fileLength() const { 
+		return locationInfo_.fileLength; 
+	}
+
 	uint32_t chunkIndex() {
 		return index_;
 	}

--- a/src/mount/chunk_locator.h
+++ b/src/mount/chunk_locator.h
@@ -97,7 +97,7 @@ public:
 	virtual void locateAndLockChunk(uint32_t inode, uint32_t index);
 	virtual void unlockChunk();
 
-	uint64_t fileLength() const { 
+	inline uint64_t fileLength() const { 
 		return locationInfo_.fileLength; 
 	}
 

--- a/src/mount/chunk_writer.cc
+++ b/src/mount/chunk_writer.cc
@@ -500,13 +500,16 @@ void ChunkWriter::fillStripe(Operation &operation, int first_block, std::vector<
 	int hole_size = 0;
 	int range_end = std::min(combinedStripeSize_, SFSBLOCKSINCHUNK - first_block);
 	for (int i = 0; i < range_end; ++i) {
-		if (first_block + i == chunkSizeInBlocks_) {
+		if (first_block + i >= chunkSizeInBlocks_) {
 			if (hole_size > 0) {
 				fillOperation(operation, first_block, hole_start, hole_size,
 				              stripe_element);
+				hole_size = 0;
 			}
-			fillNotExisting(operation, first_block, i, range_end - i, stripe_element);
-			return;
+			if (stripe_element[i] == nullptr) {
+				fillNotExisting(operation, first_block, i, 1, stripe_element);
+			}
+			continue;
 		}
 		if (stripe_element[i] == nullptr) {
 			if (hole_size == 0) {

--- a/src/mount/chunk_writer.h
+++ b/src/mount/chunk_writer.h
@@ -62,7 +62,7 @@ public:
 	 *        that we initialize; it represents the maximum time that can elapse when we are
 	 *        waiting for each chunkserver to accept connection or send a status message
 	 */
-	void init(WriteChunkLocator* locator, uint32_t chunkserverTimeout_ms);
+	void init(WriteChunkLocator* locator, uint32_t chunkserverTimeout_ms, uint32_t chunkSize);
 
 	/*!
 	 * \return minimum number of blocks which will be written to chunkservers by
@@ -175,6 +175,7 @@ private:
 	bool acceptsNewOperations_;
 	int combinedStripeSize_;
 	int dataChainFd_;
+	int chunkSizeInBlocks_;
 
 	std::map<int, std::unique_ptr<WriteExecutor>> executors_;
 	std::list<WriteCacheBlock> journal_;
@@ -186,6 +187,8 @@ private:
 	void startOperation(Operation operation);
 	void fillOperation(Operation &operation, int first_block, int first_index, int size,
 			std::vector<uint8_t *> &stripe_element);
+	void fillNotExisting(Operation &operation, int first_block, int first_index, int size,
+	                     std::vector<uint8_t *> &stripe_element);
 	void fillStripe(Operation &operation, int first_block, std::vector<uint8_t *> &stripe_element);
 	void readBlocks(int block_index, int size, int block_from, int block_to,
 			std::vector<WriteCacheBlock> &blocks);

--- a/src/mount/chunk_writer.h
+++ b/src/mount/chunk_writer.h
@@ -62,7 +62,7 @@ public:
 	 *        that we initialize; it represents the maximum time that can elapse when we are
 	 *        waiting for each chunkserver to accept connection or send a status message
 	 */
-	void init(WriteChunkLocator* locator, uint32_t chunkserverTimeout_ms, uint32_t chunkSize);
+	void init(WriteChunkLocator* locator, uint32_t chunkserverTimeout_ms);
 
 	/*!
 	 * \return minimum number of blocks which will be written to chunkservers by
@@ -126,6 +126,8 @@ public:
 	std::list<WriteCacheBlock> releaseJournal();
 
 	bool acceptsNewOperations() { return acceptsNewOperations_; }
+
+	void setChunkSizeInBlocks(uint32_t chunkSize);
 
 private:
 	typedef uint32_t WriteId;

--- a/src/mount/chunk_writer.h
+++ b/src/mount/chunk_writer.h
@@ -127,7 +127,10 @@ public:
 
 	bool acceptsNewOperations() { return acceptsNewOperations_; }
 
-	void setChunkSizeInBlocks(uint32_t chunkSize);
+	inline void setChunkSizeInBlocks(uint32_t chunkSize) {
+		chunkSizeInBlocks_ =
+		    (chunkSize == 0 ? 0 : (chunkSize - 1) / SFSBLOCKSIZE + 1);
+	}
 
 private:
 	typedef uint32_t WriteId;
@@ -189,7 +192,8 @@ private:
 	void startOperation(Operation operation);
 	void fillOperation(Operation &operation, int first_block, int first_index, int size,
 			std::vector<uint8_t *> &stripe_element);
-	void fillNotExisting(Operation &operation, int first_block, int first_index, int size,
+	void fillNotExisting(Operation &operation, int first_block, int first_index,
+	                     int blocks_number,
 	                     std::vector<uint8_t *> &stripe_element);
 	void fillStripe(Operation &operation, int first_block, std::vector<uint8_t *> &stripe_element);
 	void readBlocks(int block_index, int size, int block_from, int block_to,

--- a/src/mount/sauna_client.cc
+++ b/src/mount/sauna_client.cc
@@ -2362,13 +2362,12 @@ BytesWritten write(Context &ctx, Inode ino, const char *buf, size_t size, off_t 
 
 	Attributes attr;
 	attr.fill(0);
-	if (usedircache) { 
+	if (usedircache) {
 		gDirEntryCache.lookup(ctx, ino, attr); 
 	}
-	stat *stbuf = new stat;
-	attr_to_stat(ino, attr, stbuf);
-	size_t currentSize = stbuf->st_size;
-	delete stbuf;
+	struct stat stbuf;
+	attr_to_stat(ino, attr, &stbuf);
+	size_t currentSize = stbuf.st_size;
 
 	err = write_data(fileinfo->data,off,size,(const uint8_t*)buf, currentSize);
 	gDirEntryCache.lockAndInvalidateInode(ino);

--- a/src/mount/sauna_client.cc
+++ b/src/mount/sauna_client.cc
@@ -2363,13 +2363,14 @@ BytesWritten write(Context &ctx, Inode ino, const char *buf, size_t size, off_t 
 	Attributes attr;
 	attr.fill(0);
 	if (usedircache) {
-		gDirEntryCache.lookup(ctx, ino, attr); 
+		gDirEntryCache.lookup(ctx, ino, attr);
 	}
 	struct stat stbuf;
 	attr_to_stat(ino, attr, &stbuf);
 	size_t currentSize = stbuf.st_size;
 
-	err = write_data(fileinfo->data,off,size,(const uint8_t*)buf, currentSize);
+	err = write_data(fileinfo->data, off, size, (const uint8_t *)buf,
+	                 currentSize);
 	gDirEntryCache.lockAndInvalidateInode(ino);
 	if (err != SAUNAFS_STATUS_OK) {
 		oplog_printf(ctx, "write (%lu,%" PRIu64 ",%" PRIu64 "): (physical) %s",

--- a/src/mount/writedata.cc
+++ b/src/mount/writedata.cc
@@ -445,7 +445,10 @@ void InodeChunkWriter::processJob(inodedata* inodeData) {
 			// Optimization -- talk with chunkservers only if we have to write any data.
 			// Don't do this if we just have to release some previously unlocked lock.
 			if (haveDataToWrite) {
-				writer.init(locator.get(), gChunkserverTimeout_ms);
+				writer.init(
+				    locator.get(), gChunkserverTimeout_ms,
+				    std::min(inodeData_->maxfleng - chunkIndex_ * SFSCHUNKSIZE,
+				             (uint64_t)SFSCHUNKSIZE));
 				processDataChain(writer);
 				writer.finish(kTimeToFinishOperations * 1000);
 
@@ -798,10 +801,12 @@ int write_blocks(inodedata *id, uint64_t offset, uint32_t size, const uint8_t* d
 	return 0;
 }
 
-int write_data(void *vid, uint64_t offset, uint32_t size, const uint8_t* data) {
+int write_data(void *vid, uint64_t offset, uint32_t size, const uint8_t *data,
+               size_t currentSize) {
 	LOG_AVG_TILL_END_OF_SCOPE0("write_data");
 	int status;
 	inodedata *id = (inodedata*) vid;
+	id->maxfleng = std::max(id->maxfleng, currentSize);
 	if (id == NULL) {
 		return SAUNAFS_ERROR_IO;
 	}

--- a/src/mount/writedata.cc
+++ b/src/mount/writedata.cc
@@ -445,10 +445,7 @@ void InodeChunkWriter::processJob(inodedata* inodeData) {
 			// Optimization -- talk with chunkservers only if we have to write any data.
 			// Don't do this if we just have to release some previously unlocked lock.
 			if (haveDataToWrite) {
-				writer.init(
-				    locator.get(), gChunkserverTimeout_ms,
-				    std::min(inodeData_->maxfleng - chunkIndex_ * SFSCHUNKSIZE,
-				             (uint64_t)SFSCHUNKSIZE));
+				writer.init(locator.get(), gChunkserverTimeout_ms);
 				processDataChain(writer);
 				writer.finish(kTimeToFinishOperations * 1000);
 
@@ -526,6 +523,9 @@ void InodeChunkWriter::processDataChain(ChunkWriter& writer) {
 	uint32_t maximumTime = kMaximumTime;
 	bool otherJobsAreWaiting = false;
 	while (true) {
+		writer.setChunkSizeInBlocks(
+		    std::min(inodeData_->maxfleng - chunkIndex_ * SFSCHUNKSIZE,
+		             (uint64_t)SFSCHUNKSIZE));
 		bool newOtherJobsAreWaiting = !queue_isempty(jqueue);
 		if (!otherJobsAreWaiting && newOtherJobsAreWaiting) {
 			// Some new jobs have just arrived in the queue -- we should finish faster.
@@ -806,13 +806,13 @@ int write_data(void *vid, uint64_t offset, uint32_t size, const uint8_t *data,
 	LOG_AVG_TILL_END_OF_SCOPE0("write_data");
 	int status;
 	inodedata *id = (inodedata*) vid;
-	id->maxfleng = std::max(id->maxfleng, currentSize);
 	if (id == NULL) {
 		return SAUNAFS_ERROR_IO;
 	}
 
 	Glock lock(gMutex);
 	status = id->status;
+	id->maxfleng = std::max(id->maxfleng, currentSize);
 	if (status == SAUNAFS_STATUS_OK) {
 		if (offset + size > id->maxfleng) {     // move fleng
 			id->maxfleng = offset + size;

--- a/src/mount/writedata.cc
+++ b/src/mount/writedata.cc
@@ -523,9 +523,6 @@ void InodeChunkWriter::processDataChain(ChunkWriter& writer) {
 	uint32_t maximumTime = kMaximumTime;
 	bool otherJobsAreWaiting = false;
 	while (true) {
-		writer.setChunkSizeInBlocks(
-		    std::min(inodeData_->maxfleng - chunkIndex_ * SFSCHUNKSIZE,
-		             (uint64_t)SFSCHUNKSIZE));
 		bool newOtherJobsAreWaiting = !queue_isempty(jqueue);
 		if (!otherJobsAreWaiting && newOtherJobsAreWaiting) {
 			// Some new jobs have just arrived in the queue -- we should finish faster.
@@ -576,6 +573,9 @@ void InodeChunkWriter::processDataChain(ChunkWriter& writer) {
 			can_expect_next_block = haveAnyBlockInCurrentChunk(lock);
 		}
 
+		writer.setChunkSizeInBlocks(
+		    std::min(inodeData_->maxfleng - chunkIndex_ * SFSCHUNKSIZE,
+		             (uint64_t)SFSCHUNKSIZE));
 		if (writer.startNewOperations(can_expect_next_block) > 0) {
 			Glock lock(gMutex);
 			inodeData_->lastWriteToChunkservers.reset();

--- a/src/mount/writedata.cc
+++ b/src/mount/writedata.cc
@@ -983,6 +983,9 @@ int write_data_truncate(uint32_t inode, bool opened, uint32_t uid, uint32_t gid,
 	});
 
 	if (endOffset > length) {
+		// Make maxfleng big enough for the upcoming writes
+		id->maxfleng = endOffset;
+
 		// Something has to be written, so pass our lock to writing threads
 		sassert(id->dataChain.empty());
 		id->locator.reset(new TruncateWriteChunkLocator(inode, length / SFSCHUNKSIZE, lockId));

--- a/src/mount/writedata.h
+++ b/src/mount/writedata.h
@@ -37,4 +37,5 @@ uint64_t write_data_getmaxfleng(uint32_t inode);
 int write_data_flush_inode(uint32_t inode);
 int write_data_truncate(uint32_t inode, bool opened, uint32_t uid, uint32_t gid, uint64_t length,
 		Attributes& attr);
-int write_data(void *vid, uint64_t offset, uint32_t size, const uint8_t *buff);
+int write_data(void *vid, uint64_t offset, uint32_t size, const uint8_t *buff,
+               size_t currentSize);

--- a/src/mount/writedata.h
+++ b/src/mount/writedata.h
@@ -22,6 +22,7 @@
 
 #include "common/platform.h"
 
+#include <cstddef>
 #include <inttypes.h>
 
 #include "common/attributes.h"

--- a/tests/test_suites/ShortSystemTests/test_ec_truncate_atomicity.sh
+++ b/tests/test_suites/ShortSystemTests/test_ec_truncate_atomicity.sh
@@ -1,0 +1,46 @@
+timeout_set '1 minute'
+
+CHUNKSERVERS=11 \
+	MASTER_CUSTOM_GOALS="3 ec32: \$ec(3,2)`
+	`|4 ec42: \$ec(4,2)`
+	`|7 ec72: \$ec(7,2)`
+	`|9 ec92: \$ec(9,2)" \
+	DISK_PER_CHUNKSERVER=1 \
+	MOUNTS=5 \
+	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER" \
+	USE_RAMDISK=YES \
+	setup_local_empty_saunafs info
+
+# Create a source file -- a valid file-generated file which consists of 200 kB of data
+source="$RAMDISK_DIR/source"
+FILE_SIZE=200K file-generate "$source"
+
+cd "${info[mount0]}"
+for ec in 3 4 7 9; do
+	# Create a file which consists of 400 kB of random data
+	file="file$ec"
+	touch "$file"
+	saunafs setgoal ec${ec}2 "$file"
+	head -c 400K /dev/urandom > "$file"
+
+	# Run in parallel 200 dd processes, each copies different 1 kB of data from the source file
+	# Distribute these processes between 3 first mountpoints (mount0, mount1, mount2)
+	for i in {0..199}; do
+		( sleep 0.$((2 * i + 100)) && dd if="$source" of="${info[mount$((i%3))]}/$file" \
+				bs=1KiB skip=$i seek=$i count=1 conv=notrunc 2>/dev/null ) &
+	done
+	# In the meanwhile, shorten file from 400K to 200K, chopping 1 kB in each of 200 steps
+	# Sometimes share mountpoint with dd (mount2), sometimes not (mount3, mount4)
+	for i in {399..200}; do
+		truncate -s ${i}K "${info[mount$((2 + i % 3))]}/$file"
+	done
+	wait # Wait for all dd processes to finish
+
+	# Now file should be equal to the source file. Let's validate it!
+	MESSAGE="Testing ec(${ec},2)" assert_success file-validate "$file"
+done
+
+# Remove data parts 1 and 2 of each chunk to verify parity parts
+find_all_chunks -name "*ec2_1_of*" | xargs rm -vf
+find_all_chunks -name "*ec2_2_of*" | xargs rm -vf
+MESSAGE="Verification of parity parts" expect_success file-validate file*

--- a/tests/test_suites/ShortSystemTests/test_no_reads_during_small_ec_files_write.sh
+++ b/tests/test_suites/ShortSystemTests/test_no_reads_during_small_ec_files_write.sh
@@ -1,0 +1,20 @@
+CHUNKSERVERS=6 \
+	USE_RAMDISK=YES \
+	MASTER_CUSTOM_GOALS="1 ec42: \$ec(4,2)" \
+	AUTO_SHADOW_MASTER="NO" \
+	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER" \
+	CHUNKSERVER_EXTRA_CONFIG="GARBAGE_COLLECTION_FREQ_MS = 0`
+			`|HDD_TEST_FREQ = 100000`
+			`|MAGIC_DEBUG_LOG = $TEMP_DIR/log`
+			`|LOG_FLUSH_ON=DEBUG" \
+	setup_local_empty_saunafs info
+
+cd "${info[mount0]}"
+
+for i in {1..100}; do
+	dd if=/dev/zero of=file${i} bs=33 count=1 oflag=direct status=progress
+done
+
+number_of_extra_reads=$(grep chunkserver.hddRead $TEMP_DIR/log | wc -l);
+
+assert_equals "0" "${number_of_extra_reads}"

--- a/tests/test_suites/ShortSystemTests/test_reads_during_small_ec_files_write_parallel.sh
+++ b/tests/test_suites/ShortSystemTests/test_reads_during_small_ec_files_write_parallel.sh
@@ -1,0 +1,82 @@
+CHUNKSERVERS=6 \
+	MOUNTS=2 \
+	USE_RAMDISK=YES \
+	MASTER_CUSTOM_GOALS="1 ec42: \$ec(4,2)" \
+	AUTO_SHADOW_MASTER="NO" \
+	MOUNT_0_EXTRA_CONFIG="sfscachemode=NEVER" \
+	MOUNT_1_EXTRA_CONFIG="sfscachemode=NEVER" \
+	CHUNKSERVER_EXTRA_CONFIG="GARBAGE_COLLECTION_FREQ_MS = 0`
+			`|HDD_TEST_FREQ = 100000`
+			`|MAGIC_DEBUG_LOG = $TEMP_DIR/log`
+			`|LOG_FLUSH_ON=DEBUG" \
+	setup_local_empty_saunafs info
+
+# This script tests an optimization in handling 
+# small files during Erasure Coding (EC) writes. 
+# It addresses a previous issue where the client 
+# would unnecessarily request missing data parts 
+# from chunk servers, even beyond the file size, 
+# adding overhead. The script creates a small 
+# 1-byte file with known content and writes this 
+# content at specific positions (0, 64K, 128K, 192K) 
+# on two mount points. After each write operation, 
+# it reads back the data from these positions and 
+# checks that the read data is the same as the 
+# known content. It also checks that there were 
+# no extra reads during these operations. 
+# This test ensures that remaining blocks are not 
+# requested, eliminating unnecessary requests, 
+# reducing overhead, and improving efficiency, 
+# especially for small files.
+
+# Array of positions to write to
+positions=(0 64K 128K 192K)
+expected_reads_one_mountpoint=(0 1 3 6)
+total_expected_reads=24
+
+# Write known content from one mountpoint
+for index in ${!positions[@]}; do
+	position=${positions[$index]}
+
+	# Write known content at positions 0, 64K, 128K, and 192K on mount0
+	echo -n "1" | dd of="${info[mount0]}/file0" seek=$position bs=1 count=1 oflag=direct status=progress
+
+	# Check the number of extra reads
+	number_of_extra_reads=$(grep chunkserver.hddRead $TEMP_DIR/log | wc -l);
+
+	# Assert that the number of extra reads is as expected
+	assert_equals ${expected_reads_one_mountpoint[$index]} "${number_of_extra_reads}"
+done
+
+# Write known content from two mountpoints in parallel 
+for index in ${!positions[@]}; do
+	position=${positions[$index]}
+
+	# Write known content at positions 0, 64K, 128K, and 192K on mount0
+	echo -n "1" | dd of="${info[mount0]}/file1" seek=$position bs=1 count=1 oflag=direct status=progress &
+
+	# In parallel, write known content at the same positions on mount1
+	echo -n "1" | dd of="${info[mount1]}/file1" seek=$position bs=1 count=1 oflag=direct status=progress &
+
+	# Wait for the writes to finish
+	wait
+done
+
+# Check the number of extra reads
+number_of_extra_reads=$(grep chunkserver.hddRead $TEMP_DIR/log | wc -l);
+
+# Assert that the number of extra reads is as expected
+assert_less_or_equal "${number_of_extra_reads}" "${total_expected_reads}"
+
+# Check that all data was correctly written
+for position in ${positions[@]}; do
+	# Read back the data from mount0 and mount1
+	data_mount0_file0=$(dd if="${info[mount0]}/file0" bs=1 count=1 skip=$position status=none)
+	data_mount0_file1=$(dd if="${info[mount0]}/file1" bs=1 count=1 skip=$position status=none)
+	data_mount1_file1=$(dd if="${info[mount1]}/file1" bs=1 count=1 skip=$position status=none)
+
+	# Assert that the data read back is the same as the known content
+	assert_equals "1" "$data_mount0_file0"
+	assert_equals "1" "$data_mount0_file1"
+	assert_equals "1" "$data_mount1_file1"
+done


### PR DESCRIPTION
Tests performed show that during EC writes the client connects and asks
to the chunkservers for the missing data parts of the current stripe,
which are the data parts the client are not writing. This is required if
the file is bigger than the last byte it is writing, but it should not
ask for data on offsets beyond the file size. It is specially important
for the writings of small files, and removing those extra requests
should reduce overhead.

Current solution manages to calculate chunkSizeInBlocks_ for each
ChunkWriter at the moment of initialization from the field maxfleng of
the current inode's inodedata. Thus, the maxfleng field should be
updated the best way possible. The chunkSizeInBlocks_ is then used to
check if client ws about to was to chunkservers for not existing data.