### PR TITLE
fix(tests): Various fixes for the testing framework 

### DIFF
--- a/tests/run-test.sh
+++ b/tests/run-test.sh
@@ -94,20 +94,22 @@ unwrap_generators $1
 
 nice nice sudo -HEu saunafstest sh -c "chmod -Rf a+rwX ${ERROR_DIR}"
 for log_file in "$ERROR_DIR"/* ; do
-	log_file_name=$(basename "$log_file")
+	log_file_basename=$(basename "$log_file")
 	if [[ -s ${log_file} ]]; then
 		status=1
-		if [[ $log_file_name != syslog.log ]]; then
+		if [[ $log_file_basename != syslog.log ]]; then
 			# Do not inform users that there is nonempty syslog
 			# It is always nonempty if the test failed
-			echo "(FATAL) Errors in ${log_file_name}" | tee "${ERROR_FILE}" #error file lifetime is: all tests
+			echo "(FATAL) Errors in ${log_file_basename}" | tee "${ERROR_FILE}" #error file lifetime is: all tests
 			# print all non-binary files to stdout
-			if file --mime-encoding "${log_file_name}" | awk '{exit $2=="binary"}'; then
+			# awk will return 0 if it doesn't find binary, and 1 if
+			# it does, which is what we want for the return value
+			if file --mime-encoding "${log_file}" | awk '{exit $2=="binary"}'; then
 				cat "${log_file}"
 			fi
 		fi
 		if [[ $TEST_OUTPUT_DIR ]]; then
-			cp "${log_file}" "$TEST_OUTPUT_DIR/$(date '+%F_%T')__$(basename $1 .sh)__${log_file_name}"
+			cp "${log_file}" "$TEST_OUTPUT_DIR/$(date '+%F_%T')__$(basename $1 .sh)__${log_file_basename}"
 		fi
 	fi
 done

--- a/tests/setup_machine.sh
+++ b/tests/setup_machine.sh
@@ -289,6 +289,7 @@ fi
 if ! [[ -f /etc/sudoers.d/saunafstest ]] || \
 		! grep drop_caches /etc/sudoers.d/saunafstest >/dev/null; then
 	cat >/etc/sudoers.d/saunafstest <<-END
+		Defaults rlimit_core=default
 		ALL ALL = (saunafstest) NOPASSWD: ALL
 		ALL ALL = NOPASSWD: /usr/bin/pkill -9 -u saunafstest
 		ALL ALL = NOPASSWD: /bin/rm -rf /tmp/saunafs_error_dir

--- a/tests/tools/assert.sh
+++ b/tests/tools/assert.sh
@@ -178,8 +178,8 @@ assert_template_eventually_equals_() {
 	local timeout=$(rescale_timeout_for_assert_eventually_ "${3:-}")
 	if ! wait_for "[[ \$($command1) == \$($command2) ]]" "$timeout"; then
 		diff="$(diff -u5 <(eval "$command1") <(eval "$command2") || true)"
-		$FAIL_FUNCTION "'$command1' didn't output the same as '$command2' within $timeout`
-				`"$'\n'"$diff"
+		$FAIL_FUNCTION "'$command1' didn't output the same as '$command2' within $timeout
+				"$'\n'"$diff"
 	fi
 }
 

--- a/tests/tools/assert.sh
+++ b/tests/tools/assert.sh
@@ -178,8 +178,7 @@ assert_template_eventually_equals_() {
 	local timeout=$(rescale_timeout_for_assert_eventually_ "${3:-}")
 	if ! wait_for "[[ \$($command1) == \$($command2) ]]" "$timeout"; then
 		diff="$(diff -u5 <(eval "$command1") <(eval "$command2") || true)"
-		$FAIL_FUNCTION "'$command1' didn't output the same as '$command2' within $timeout
-				"$'\n'"$diff"
+		$FAIL_FUNCTION "'$command1' didn't output the same as '$command2' within $timeout "$'\n'"$diff"
 	fi
 }
 

--- a/tests/tools/test.sh
+++ b/tests/tools/test.sh
@@ -86,8 +86,8 @@ debug_command() {
 	fi
 	if (( depth <= DEBUG_LEVEL )); then
 		local indent=">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
-		echo "${indent:0:$depth} $(basename "${BASH_SOURCE[1]}"):${BASH_LINENO[0]}:`
-				`${FUNCNAME[1]}(): ${BASH_COMMAND}" >&2 | true
+		echo "${indent:0:$depth} $(basename "${BASH_SOURCE[1]}"):${BASH_LINENO[0]}:
+				${FUNCNAME[1]}(): ${BASH_COMMAND}" >&2 | true
 	fi
 }
 

--- a/tests/tools/test.sh
+++ b/tests/tools/test.sh
@@ -86,8 +86,12 @@ debug_command() {
 	fi
 	if (( depth <= DEBUG_LEVEL )); then
 		local indent=">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
-		echo "${indent:0:$depth} $(basename "${BASH_SOURCE[1]}"):${BASH_LINENO[0]}:
-				${FUNCNAME[1]}(): ${BASH_COMMAND}" >&2 | true
+		local level=${indent:0:$depth}
+		local source=$(basename "${BASH_SOURCE[1]}")
+		local line=${BASH_LINENO[0]}
+		local function=${FUNCNAME[1]}
+		local command=${BASH_COMMAND}
+		echo "${level} ${source}:${line}: ${function}(): ${command}" >&2 | true
 	fi
 }
 


### PR DESCRIPTION
This is a series of 3 commits:

tidy(tests): Remove unnecessary ticks

This messes up some editor syntax highlighting

fix(tests): Fix binary output being outputted

The variable used in the conditional is different from the actual
filename used. This conditional would always succeed since awk would
return 0 if the conditional in awk would not match, which it didn't
since stdout was empty (only stderr was populated with the error
message, but it is disregarded).

fix(tests): Coredumps not being generated

At least 3 years ago, `sudo` had a change of behaviour regarding
coredumps. This fixes that by setting the default for cores as the
system.