### PR TITLE
fix(tests): Upgrade tests

### DIFF
--- a/tests/test_suites/TestTemplates/test_saunafs_upgrade_overwrite_file.inc
+++ b/tests/test_suites/TestTemplates/test_saunafs_upgrade_overwrite_file.inc
@@ -31,7 +31,7 @@ assert_saunafsXX_services_count_equals 1 ${CHUNKSERVERS} 1
 
 cd "${info[mount0]}"
 mkdir dir
-assert_success saunafsXX sfssetgoal $GOAL dir
+assert_success saunafsXX saunafs setgoal $GOAL dir
 cd dir
 
 echo "Starting test"

--- a/tests/test_suites/TestTemplates/test_saunafs_upgrade_undergoal_chunks.inc
+++ b/tests/test_suites/TestTemplates/test_saunafs_upgrade_undergoal_chunks.inc
@@ -35,7 +35,7 @@ assert_saunafsXX_services_count_equals 1 $CHUNKSERVERS_MINIMUM 1
 
 cd "${info[mount0]}"
 mkdir dir
-assert_success saunafsXX sfssetgoal $GOAL dir
+assert_success saunafsXX saunafs setgoal $GOAL dir
 cd dir
 
 # map filesize -> cnt, e.g. 20M -> 5 (5 files of filesize 20M)

--- a/tests/tools/saunafsXX.sh
+++ b/tests/tools/saunafsXX.sh
@@ -27,7 +27,6 @@ Dir::Cache "${TEMP_DIR}/apt/var/cache/apt";
 Dir::Etc::Parts "${TEMP_DIR}/apt/apt.conf.d";
 END
 		local destdir="${TEMP_DIR}/apt/var/cache/apt/archives"
-		echo "deb [arch=amd64 trusted=yes] https://repo.saunafs.com/repository/saunafs-ubuntu-22.04/ ${codename} main" >${TEMP_DIR}/apt/saunafs.list
 		env APT_CONFIG="${TEMP_DIR}/apt/apt.conf" apt-get update
 		env APT_CONFIG="${TEMP_DIR}/apt/apt.conf" apt-get -y --allow-downgrades install -d \
 			saunafs-master=${SAUNAFSXX_TAG_APT} \
@@ -141,7 +140,9 @@ assert_saunafsXX_services_count_equals() {
 }
 
 assert_no_saunafsXX_services_active() {
-	assert_saunafsXX_services_count_equals 0 0 0
+	assert_equals 0 "$(saunafs_admin_master info | grep "${SAUNAFSXX_TAG}" | wc -l)"
+	assert_equals 0 "$(saunafs_admin_master list-chunkservers | grep "${SAUNAFSXX_TAG}" | wc -l)"
+	assert_equals 0 "$(saunafs_admin_master list-mounts | grep "${SAUNAFSXX_TAG}" | wc -l)"
 }
 
 # TODO: Add metalogger and other service support


### PR DESCRIPTION
This is a series of 2 commits squashed:

fix(tests): Upgrade tests on freshly installed machines

This commit fixes an issue from earlier regarding updates to setup_machine.sh. Now that the SaunaFS key is acquired from the setup_machine.sh script and it adds the repository, there is no need to add a source to the script when doing upgrade tests. Doing so would conflict with the already setup repository

fix(tests): Long upgrade tests

* Fix no old version checking by using latest client instead.
* Fix recursion bug by not using sfs* tools, instead using saunafs