### PR TITLE
ci, mount: Fix segFault on libsaunafsmount_shared

### DIFF
--- a/src/mount/tweaks.cc
+++ b/src/mount/tweaks.cc
@@ -96,5 +96,3 @@ std::string Tweaks::getAllValues() const {
 	}
 	return ss.str();
 }
-
-Tweaks gTweaks;

--- a/src/mount/tweaks.h
+++ b/src/mount/tweaks.h
@@ -53,4 +53,4 @@ private:
 	std::unique_ptr<Impl> impl_;
 };
 
-extern Tweaks gTweaks;
+inline Tweaks gTweaks;

--- a/tests/ci_build/run-build.sh
+++ b/tests/ci_build/run-build.sh
@@ -54,7 +54,7 @@ case "${build_type,,}" in
 		;;
 	test)
 		CMAKE_SAUNAFS_ARGUMENTS+=(
-			-DCMAKE_BUILD_TYPE=RelWithDbInfo
+			-DCMAKE_BUILD_TYPE=RelWithDebInfo
 			-DCMAKE_INSTALL_PREFIX="${WORKSPACE}/install/saunafs/"
 			-DENABLE_TESTS=ON
 			-DCODE_COVERAGE=OFF


### PR DESCRIPTION
A typo at CMAKE_BUILD_TYPE made the cmake to build the code in Debug mode by default. This was making a segFault error pass un-detected because linkage modification introduced at PR#19.