### PR TITLE
fix: Ignore array-bound warnings from headers

### DIFF
--- a/src/chunkserver/chunkserver-common/disk_chunks.h
+++ b/src/chunkserver/chunkserver-common/disk_chunks.h
@@ -2,7 +2,13 @@
 
 #include <cstddef>
 #include <limits>
+
+// A fix for https://stackoverflow.com/q/77034039/10788155
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
 #include <vector>
+#pragma GCC diagnostic pop
 
 #define NO_CHUNKS_IN_COLLECTION nullptr
 

--- a/src/chunkserver/disk_chunks_unittest.cc
+++ b/src/chunkserver/disk_chunks_unittest.cc
@@ -1,4 +1,10 @@
+// A fix for https://stackoverflow.com/q/77034039/10788155
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
 #include <bitset>
+#pragma GCC diagnostic pop
+
 #include <numeric>
 
 #include <gtest/gtest.h>

--- a/src/chunkserver/disk_unittest.cc
+++ b/src/chunkserver/disk_unittest.cc
@@ -1,4 +1,9 @@
+// A fix for https://stackoverflow.com/q/77034039/10788155
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
 #include <gtest/gtest.h>
+#pragma GCC diagnostic pop
 
 #include "chunkserver/cmr_disk.h"
 

--- a/src/chunkserver/plugin_manager.h
+++ b/src/chunkserver/plugin_manager.h
@@ -1,6 +1,11 @@
 #pragma once
 
+// A fix for https://stackoverflow.com/q/77034039/10788155
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
 #include <map>
+#pragma GCC diagnostic pop
 
 #include <boost/dll/import.hpp>
 #include <boost/filesystem.hpp>

--- a/src/common/platform.h
+++ b/src/common/platform.h
@@ -30,7 +30,13 @@
 
 #ifndef SAUNAFS_HAVE_STD_TO_STRING
 
+// A fix for https://stackoverflow.com/q/77034039/10788155
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
 #include <sstream>
+#pragma GCC diagnostic pop
+
 #include <string>
 
 namespace std {

--- a/src/mount/client/saunafs_c_api.cc
+++ b/src/mount/client/saunafs_c_api.cc
@@ -19,7 +19,13 @@
  */
 
 #include <cassert>
+
+// A fix for https://stackoverflow.com/q/77034039/10788155
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
 #include <system_error>
+#pragma GCC diagnostic pop
 
 #include "saunafs_c_api.h"
 #include "common/saunafs_error_codes.h"

--- a/utils/sfs_ping.cc
+++ b/utils/sfs_ping.cc
@@ -19,7 +19,14 @@
 
 #include <sys/time.h>
 #include <unistd.h>
+
+// A fix for https://stackoverflow.com/q/77034039/10788155
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
 #include <iostream>
+#pragma GCC diagnostic pop
+
 #include <string>
 
 #include "protocol/SFSCommunication.h"

--- a/utils/sfs_pingserv.cc
+++ b/utils/sfs_pingserv.cc
@@ -19,7 +19,14 @@
 
 #include <sys/time.h>
 #include <sys/socket.h>
+
+// A fix for https://stackoverflow.com/q/77034039/10788155
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
 #include <iostream>
+#pragma GCC diagnostic pop
+
 #include <string>
 
 #include "protocol/SFSCommunication.h"


### PR DESCRIPTION
Modern versions of GCC produce false positive warnings. These come from external standard libraries. This patch ignores these warnings for specific headers.