### PR TITLE
all: Apply fix to build using gcc-13 on release

### DIFF
--- a/src/common/small_vector.h
+++ b/src/common/small_vector.h
@@ -22,7 +22,10 @@
 
 #include <algorithm>
 #include <array>
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
 #include <boost/container/small_vector.hpp>
+#pragma GCC diagnostic pop
 #include <cassert>
 #include <cstddef>
 #include <memory>

--- a/src/uraft/uraft.h
+++ b/src/uraft/uraft.h
@@ -2,8 +2,8 @@
 
 #include "common/platform.h"
 
-#include <boost/asio.hpp>
 #include <boost/array.hpp>
+#include <boost/asio.hpp>
 
 /*! \brief Implementation of modified Raft consensus algorithm.
  *


### PR DESCRIPTION
When using cmake flag RelWithDebInfo using gcc version 13 two issues arise:

- common: the small_vector template raises the Werror=stringop-overflow so compiler is instructed to ignore this warning until a proper fix can be applied.
- uraft: boost::asio std::exchange is not found.