### PR TITLE
fix(tools): ARM64 compilation on Linux

### DIFF
--- a/src/tools/recursive_remove.cc
+++ b/src/tools/recursive_remove.cc
@@ -122,7 +122,7 @@ static int recursive_remove(const char *file_name, int long_wait) {
 }
 
 int recursive_remove_run(int argc, char **argv) {
-	char ch;
+	int ch;
 	int status;
 	int long_wait = 0;
 


### PR DESCRIPTION
`char` is unsigned on ARM64, versus signed on x86. This causes a warning on ARM64 platforms in the condition below, because `ch` can never be -1 if it's on an ARM64. This fixes that by using int instead, like elsewhere in the tools directory.

Closes #70