### PR TITLE
mount, tests: Improve DirEntryCache scenarios coverage

### DIFF
--- a/src/mount/direntry_cache.h
+++ b/src/mount/direntry_cache.h
@@ -493,9 +493,7 @@ public:
 		// the parent, like in unlink
 		auto iter = inode_multiset_.lower_bound(parent_inode, InodeCompare());
 
-		while (iter != inode_multiset_.end() &&
-		       (iter->inode == parent_inode ||
-		        iter->parent_inode == kInvalidParent)) {
+		while (iter != inode_multiset_.end() && iter->inode == parent_inode) {
 			DirEntry *entry = std::addressof(*iter);
 			++iter;
 			erase(entry);
@@ -514,12 +512,14 @@ public:
 		// lookup_set_ should contain all the elements inside index_set
 		auto it = lookup_set_.lower_bound(
 		    std::make_tuple(parent_inode, ctx.uid, ctx.gid, ""), LookupCompare());
-		while (it != lookup_set_.end() &&
-		       std::make_tuple(parent_inode, ctx.uid, ctx.gid) ==
-		               std::make_tuple(it->parent_inode, it->uid, it->gid)) {
-			DirEntry *entry = std::addressof(*it);
+		while (it != lookup_set_.end() && parent_inode == it->parent_inode) {
+			if (ctx.uid == it->uid && ctx.gid == it->gid) {
+				DirEntry *entry = std::addressof(*it);
+				++it;
+				erase(entry);
+				continue;
+			}
 			++it;
-			erase(entry);
 		}
 
 		// Make sure inode_multiset_ is also clean of outdated entries.
@@ -527,12 +527,14 @@ public:
 		// the parent, like in unlink
 		auto iter = inode_multiset_.lower_bound(parent_inode, InodeCompare());
 
-		while (iter != inode_multiset_.end() &&
-		       (iter->inode == parent_inode ||
-		        iter->parent_inode == kInvalidParent)) {
-			DirEntry *entry = std::addressof(*iter);
+		while (iter != inode_multiset_.end() && iter->inode == parent_inode) {
+			if (ctx.uid == iter->uid && ctx.gid == iter->gid) {
+				DirEntry *entry = std::addressof(*iter);
+				++iter;
+				erase(entry);
+				continue;
+			}
 			++iter;
-			erase(entry);
 		}
 	}
 

--- a/src/mount/sauna_client.cc
+++ b/src/mount/sauna_client.cc
@@ -838,8 +838,10 @@ EntryParam lookup(Context &ctx, Inode parent, const char *name) {
 		e.attr.st_size=maxfleng;
 	}
 
-	// If lookup succeeded and data did not come from cache, then cache it
-	if (!icacheflag) {
+	// If lookup succeeded and data did not come from cache, then cache it.
+	// Files with at least one hardlink are impossible to keep track of, so it is 
+	// better to don't track them.
+	if (!icacheflag && !(e.attr.st_nlink > 1 && attr[0] == TYPE_FILE)) {
 		auto data_acquire_time = gDirEntryCache.updateTime();
 
 		std::unique_lock<shared_mutex> write_guard(gDirEntryCache.rwlock());
@@ -919,8 +921,10 @@ AttrReply getattr(Context &ctx, Inode ino) {
 	patch_uid_gid_fields(o_stbuf);
 #endif
 
-	// If getattr succeeded and data did not come from cache, then cache it
-	if (!fromCache) {
+	// If lookup succeeded and data did not come from cache, then cache it.
+	// Files with at least one hardlink are impossible to keep track of, so it is 
+	// better to don't track them.
+	if (!fromCache && !(o_stbuf.st_nlink > 1 && attr[0] == TYPE_FILE)) {
 		auto data_acquire_time = gDirEntryCache.updateTime();
 
 		std::unique_lock<shared_mutex> write_guard(gDirEntryCache.rwlock());

--- a/tests/test_suites/ShortSystemTests/test_direntrycache_checks.sh
+++ b/tests/test_suites/ShortSystemTests/test_direntrycache_checks.sh
@@ -1,0 +1,156 @@
+#
+# The goal of this test is to check the DirEntryCache behavior from the point of view of 
+# the syscalls involved in its behavior. Performs checks on the currently expected behavior
+# of the lookup, getattr, setattr, setxattr, mknod, mkdir, unlink, rmdir, rename, link and 
+# write syscalls regarding DirEntryCache.
+#
+CHUNKSERVERS=1 \
+	MOUNTS=2 \
+	MOUNT_EXTRA_CONFIG="sfsdirentrycacheto=2" \
+	USE_RAMDISK=YES \
+	setup_local_empty_saunafs info
+
+# A couple of functions to easily get the size and number of links to an inode
+get_size() {
+	ls -l $1 | cut -d " " -f 5
+}
+
+get_nliks() {
+	ls -l $1 | cut -d " " -f 2
+}
+
+cd ${info[mount0]}
+
+echo -n "1234" > file
+
+assert_equals "$(get_size file)" "$(get_size ${info[mount1]}/file)" 4
+assert_equals "$(get_nliks file)" "$(get_nliks ${info[mount1]}/file)" 1
+
+dd if=/dev/zero of=file count=1 bs=1 seek=4 &>/dev/null
+
+assert_equals "$(get_size file)" 5
+assert_equals "$(get_size ${info[mount1]}/file)" 4
+
+# mkdir clears cache of the parent folder
+mkdir ${info[mount1]}/folder
+
+assert_equals "$(get_size file)" "$(get_size ${info[mount1]}/file)" 5
+
+dd if=/dev/zero of=${info[mount1]}/file count=1 bs=1 seek=5 &>/dev/null
+
+assert_equals "$(get_size file)" 5
+assert_equals "$(get_size ${info[mount1]}/file)" 6
+
+# mknod clears cache of the parent folder
+touch file2
+
+assert_equals "$(get_size file)" "$(get_size ${info[mount1]}/file)" 6
+
+cd folder
+dd if=/dev/zero of=${info[mount1]}/file count=1 bs=1 seek=6 &>/dev/null
+assert_equals "$(get_size ${info[mount0]}/file)" 6
+
+# create only clear cache of the parent folder
+echo -n "0" > file3
+assert_equals "$(get_size ${info[mount0]}/file)" 6
+assert_equals "$(get_size file3)" 1
+
+dd if=/dev/zero of=${info[mount1]}/folder/file3 count=1 bs=1 seek=1 &>/dev/null
+
+assert_equals "$(get_size ${info[mount0]}/file)" 6
+assert_equals "$(get_size ${info[mount1]}/file)" 7
+assert_equals "$(get_size file3)" 1
+assert_equals "$(get_size ${info[mount1]}/folder/file3)" 2
+
+# link clears cache of the involved inode and the parent folder
+link "${info[mount0]}/file" link
+
+assert_equals "$(get_nliks ${info[mount0]}/file)" 2
+assert_equals "$(get_nliks ${info[mount1]}/file)" 1
+assert_equals "$(get_size ${info[mount0]}/file)" "$(get_size ${info[mount1]}/file)" 7
+assert_equals "$(get_size file3)" "$(get_size ${info[mount1]}/folder/file3)" 2
+
+# setattr clears cache of the involved inode
+truncate -s 6 ${info[mount1]}/folder/link
+echo -n "0" > file4
+
+# remember new file created (file4) cleared parent folder cache, but files with at least one 
+# hardlink are also not kept in cache
+assert_equals "$(get_size ${info[mount0]}/file)" "$(get_size ${info[mount0]}/folder/link)" 6 
+assert_equals "$(get_size ${info[mount1]}/file)" "$(get_size ${info[mount1]}/folder/link)" 6
+assert_equals "$(get_size file4)" "$(get_size ${info[mount1]}/folder/file4)" 1
+assert_equals "$(get_nliks ${info[mount0]}/file)" "$(get_nliks ${info[mount1]}/file)" 2
+
+dd if=/dev/zero of=${info[mount0]}/file count=1 bs=1 seek=6 &>/dev/null
+dd if=/dev/zero of=file4 count=1 bs=1 seek=1 &>/dev/null
+
+# files with at least one hardlink are not kept in cache
+assert_equals "$(get_size ${info[mount1]}/file)" "$(get_size ${info[mount0]}/file)" 7
+assert_equals "$(get_size file4)" 2
+assert_equals "$(get_size ${info[mount1]}/folder/file4)" 1
+
+# rename clears cache of both current and new parent folder
+mv ${info[mount1]}/folder/file3 ${info[mount1]}/file3
+
+assert_equals "$(get_size ${info[mount0]}/file)" "$(get_size ${info[mount1]}/file)" 7
+assert_equals "$(get_size file4)" "$(get_size ${info[mount1]}/folder/file4)" 2
+
+rm link
+cd ..
+
+# files with at least one hardlink are also not kept in cache
+assert_equals "$(get_nliks ${info[mount1]}/file)" "$(get_nliks file)" 1
+
+dd if=/dev/zero of=file count=1 bs=1 seek=7 &>/dev/null
+
+assert_equals "$(get_size file)" 8
+assert_equals "$(get_size ${info[mount1]}/file)" 7
+
+# once again setattr
+chmod 777 ${info[mount1]}/file
+
+assert_equals "$(get_size file)" "$(get_size ${info[mount1]}/file)" 8
+
+dd if=/dev/zero of=${info[mount1]}/file count=1 bs=1 seek=8 &>/dev/null
+
+assert_equals "$(get_size file)" 8
+assert_equals "$(get_size ${info[mount1]}/file)" 9
+
+# unlink clears cache of the parent folder
+unlink file2
+
+assert_equals "$(get_size file)" "$(get_size ${info[mount1]}/file)" 9
+
+truncate -s 7 file
+
+assert_equals "$(get_size file)" 7
+assert_equals "$(get_size ${info[mount1]}/file)" 9
+
+# unlinking anywhere else does not clear the parent cache
+rm ${info[mount1]}/folder/file4
+assert_equals "$(get_size ${info[mount1]}/file)" 9
+
+# rmdir clears cache of the parent folder
+rmdir ${info[mount1]}/folder
+
+assert_equals "$(get_size file)" "$(get_size ${info[mount1]}/file)" 7
+
+truncate -s 5 ${info[mount1]}/file
+
+assert_equals "$(get_size file)" 7
+assert_equals "$(get_size ${info[mount1]}/file)" 5
+
+# setxattr clears cache of the involved inode
+setfacl -m u:saunafstest:r-x file
+
+assert_equals "$(get_size file)" "$(get_size ${info[mount1]}/file)" 5
+
+truncate -s 3 file
+
+assert_equals "$(get_size file)" 3
+assert_equals "$(get_size ${info[mount1]}/file)" 5
+
+# readdir overrides the cache of the involved folder
+ls ${info[mount1]} &>/dev/null
+
+assert_equals "$(get_size file)" "$(get_size ${info[mount1]}/file)" 3


### PR DESCRIPTION
This PR includes the following:
- a new test: test_dircache_checks. It is included in the ShortSystemTests test suite for now and attempts to cover most of the syscalls which has something to do with the DirEntryCache.
- two more tests for the DirEntryCache unittests covering latest changes.
- fixes in the DirEntryCache behavior