### PR TITLE
chunkserver: Add thread names

### DIFF
--- a/src/chunkserver/bgjobs.cc
+++ b/src/chunkserver/bgjobs.cc
@@ -182,6 +182,11 @@ static inline int job_receive_status(jobpool *jp,uint32_t *jobid,uint8_t *status
 
 void* job_worker(void *th_arg) {
 	TRACETHIS();
+
+	static std::atomic_uint16_t workersCounter(0);
+	std::string threadName = "jobWorker " + std::to_string(workersCounter++);
+	pthread_setname_np(pthread_self(), threadName.c_str());
+
 	jobpool *jp = (jobpool*)th_arg;
 	job *jptr;
 	uint8_t *jptrarg;

--- a/src/chunkserver/hddspacemgr.cc
+++ b/src/chunkserver/hddspacemgr.cc
@@ -2129,6 +2129,8 @@ int hddChunkOperation(uint64_t chunkId, uint32_t chunkVersion,
 static UniqueQueue<ChunkWithVersionAndType> gTestChunkQueue;
 
 static void hddTestChunkThread() {
+	pthread_setname_np(pthread_self(), "testChunkThread");
+
 	bool terminate = false;
 
 	while (!terminate) {
@@ -2164,6 +2166,9 @@ void hddAddChunkToTestQueue(ChunkWithVersionAndType chunk) {
 
 void hddTesterThread() {
 	TRACETHIS();
+
+	pthread_setname_np(pthread_self(), "testerThread");
+
 	IChunk *chunk;
 	uint64_t chunkId;
 	uint32_t version;
@@ -2466,6 +2471,9 @@ void hddDiskScanThread(IDisk *disk) {
 
 void hddDisksThread() {
 	TRACETHIS();
+
+	pthread_setname_np(pthread_self(), "disksThread");
+
 	while (!gTerminate) {
 		hddCheckDisks();
 		sleep(1);
@@ -2476,6 +2484,8 @@ void hddFreeResourcesThread() {
 	static const int kDelayedStep = 2;
 	static const int kMaxFreeUnused = 1024;
 	TRACETHIS();
+
+	pthread_setname_np(pthread_self(), "freeResThread");
 
 	while (!gTerminate) {
 		gOpenChunks.freeUnused(eventloop_time(), gChunksMapMutex,

--- a/src/chunkserver/network_worker_thread.cc
+++ b/src/chunkserver/network_worker_thread.cc
@@ -1527,6 +1527,11 @@ NetworkWorkerThread::NetworkWorkerThread(uint32_t nrOfBgjobsWorkers, uint32_t bg
 
 void NetworkWorkerThread::operator()() {
 	TRACETHIS();
+
+	static std::atomic_uint16_t threadCounter(0);
+	std::string threadName = "networkWorker " + std::to_string(threadCounter++);
+	pthread_setname_np(pthread_self(), threadName.c_str());
+
 	while (!doTerminate) {
 		preparePollFds();
 		int i = poll(pdesc.data(), pdesc.size(), 50);


### PR DESCRIPTION
This change renames the chunkserver threads to better identify them at runtime. It is useful for debugging and profiling purposes.

Note: thread names can be up to 16 characters.