### PR TITLE
chunkserver: Fix race condition in BuffersPool

### DIFF
--- a/src/chunkserver/buffers_pool.h
+++ b/src/chunkserver/buffers_pool.h
@@ -48,11 +48,12 @@ public:
 	 * @return The existent buffer or a newly created one.
 	 */
 	std::shared_ptr<T> get(size_t capacity) {
+		std::lock_guard lock(mutex_);
+
 		if (buffers_.empty()) {
 			return std::make_shared<T>(capacity);
 		}
 
-		std::lock_guard lock(mutex_);
 		auto buffer = buffers_.front();
 
 		if (buffer->capacity() == capacity) {
@@ -80,7 +81,7 @@ public:
 
 private:
 	/// Maximum number of buffers in the pool.
-	static constexpr size_t kMaxSize = 128;
+	static constexpr size_t kMaxSize = 1024;
 	/// Buffers pool (container).
 	std::queue<std::shared_ptr<T>> buffers_;
 	/// Mutex to protect the pool.


### PR DESCRIPTION
The check for buffers_.empty() was not protected, causing segmentation fault when multiple NetworkWorkers were configured.

The queue max size (kMaxSize) was also increased by 8, to better support heavy workloads.