### PR TITLE
Fix mount when master down

### DIFF
--- a/src/mount/mastercomm.h
+++ b/src/mount/mastercomm.h
@@ -36,6 +36,10 @@
 #include "protocol/directory_entry.h"
 #include "protocol/named_inode_entry.h"
 
+#ifdef _WIN32
+inline std::atomic_bool gIsDisconnectedFromMaster;
+#endif
+
 void fs_getmasterlocation(uint8_t loc[14]);
 uint32_t fs_getsrcip(void);
 

--- a/src/mount/sauna_client.cc
+++ b/src/mount/sauna_client.cc
@@ -230,6 +230,8 @@ uint8_t session_flags;
 
 uint8_t get_session_flags() { return session_flags; }
 
+bool isMasterDisconnected() { return gIsDisconnectedFromMaster.load(); }
+
 #define LOCAL_USERS_THRESHOLD 0x30000
 static int32_t mounting_uid = USE_LOCAL_ID;
 static int32_t mounting_gid = USE_LOCAL_ID;

--- a/src/mount/sauna_client.h
+++ b/src/mount/sauna_client.h
@@ -334,6 +334,8 @@ struct RequestException : public std::exception {
 
 uint8_t get_session_flags();
 
+bool isMasterDisconnected();
+
 void update_last_winfsp_context(const unsigned int uid, const unsigned int gid);
 
 void convert_winfsp_context_to_master_context(unsigned int& uid, unsigned int& gid);


### PR DESCRIPTION
When master server disconnected, windows client
was unable to be used and the process terminated.
With this change is its possible to the windows
client to know when master is disconnected and
make the mountpoint still accessible.