### PR TITLE
tests,ci: Remove Ganesha unneeded dependencies

### DIFF
--- a/tests/ci_build/ganesha/Dockerfile
+++ b/tests/ci_build/ganesha/Dockerfile
@@ -34,7 +34,6 @@ RUN set -e ; \
           bison \
           build-essential \
           byacc \
-          ceph \
           cmake \
           dbus \
           docbook \
@@ -50,21 +49,16 @@ RUN set -e ; \
           libboost-program-options-dev \
           libboost-system-dev \
           libcap-dev \
-          libcephfs-dev \
           libdbus-1-dev \
-          libglusterfs-dev \
           libgssapi-krb5-2 \
           libjemalloc-dev \
           libjudy-dev \
           libkrb5-dev \
           libkrb5support0 \
           libnfsidmap-dev \
-          libradospp-dev \
-          libradosstriper-dev \
-          librgw-dev \
+          libnsl-dev \
           libsqlite3-dev \
           liburcu-dev \
-          xfslibs-dev \
           pkg-config \
           wget \
           unzip \
@@ -84,8 +78,18 @@ RUN set -e ; \
         mkdir nfs-ganesha-${GANESHA_VERSION}/build ; \
         cmake -Bnfs-ganesha-${GANESHA_VERSION}/build \
             -DCMAKE_INSTALL_PREFIX=/ \
+            -DUSE_9P=NO \
+            -DUSE_FSAL_CEPH=NO \
+            -DUSE_FSAL_GLUSTER=NO \
+            -DUSE_FSAL_GPFS=NO \
+            -DUSE_FSAL_KVSFS=NO \
+            -DUSE_FSAL_LIZARDFS=NO \
+            -DUSE_FSAL_LUSTRE=NO \
+            -DUSE_FSAL_PROXY_V3=NO \
+            -DUSE_FSAL_PROXY_V4=NO \
+            -DUSE_FSAL_RGW=NO \
+            -DUSE_FSAL_XFS=NO \
             -DUSE_GSS=NO \
-            -DUSE_FSAL_SAUNAFS=NO \
             -Snfs-ganesha-${GANESHA_VERSION}/src; \
         make -Cnfs-ganesha-${GANESHA_VERSION}/build -j$(($(nproc)*3/4+1)) install ; \
         rm -rf nfs-ganesha-${GANESHA_VERSION} ntirpc-${NTIRPC_VERSION} ; \

--- a/tests/setup_machine.sh
+++ b/tests/setup_machine.sh
@@ -101,7 +101,6 @@ common_packages=(
 	# fio
 	bison
 	byacc
-	ceph
 	dbus
 	doxygen
 	flex
@@ -147,19 +146,14 @@ apt_packages=(
 	krb5-user
 	libacl1-dev
 	libcap-dev
-	libcephfs-dev
 	libdbus-1-dev
-	libglusterfs-dev
 	libgssapi-krb5-2
 	libjemalloc-dev
 	libkrb5-dev
 	libkrb5support0
 	libnfsidmap-dev
-	libradospp-dev
-	libradosstriper-dev
-	librgw-dev
+	libnsl-dev
 	libsqlite3-dev
-	xfslibs-dev
 )
 dnf_packages=(
 	boost-filesystem
@@ -178,6 +172,7 @@ dnf_packages=(
 	libblkid-devel
 	libcutl-devel
 	libdb-devel
+	libnsl
 	libtirpc-devel
 	netcat
 	pam-devel
@@ -209,14 +204,8 @@ dnf_packages=(
 	krb5-workstation
 	libacl-devel
 	libcap-devel
-	libcephfs-devel
-	libglusterfs-devel
 	libnfsidmap-devel
-	librados-devel
-	libradosstriper-devel
-	librgw-devel
 	libsqlite3x-devel
-	xfsprogs-devel
 )
 python_packages=(
 	asciidoc


### PR DESCRIPTION
Previously, for building Ganesha there were included some FSALs like CEPH, GLUSTER and RGW that are enabled by default. It added extra dependencies not needed by SaunaFS that can be removed after disabling not needed FSALs.

This commit removes additional dependencies introduced by Ganesha. By removing these dependencies, SaunaFS installation will take less space and time.

The list of removed dependencies is:
- ceph, libcephfs-dev, libglusterfs-dev, librgw-dev, xfslibs-dev

It was also added libnsl dependency, that is needed by libntirpc library when building Ganesha in Ubuntu 24.04.