### PR TITLE
fix(saunafs-admin): Fix saunafs-admin for windows

### DIFF
--- a/src/admin/main.cc
+++ b/src/admin/main.cc
@@ -48,6 +48,7 @@
 #include "common/human_readable_format.h"
 #include "protocol/SFSCommunication.h"
 #include "common/sfserr.h"
+#include "common/sockets.h"
 
 int main(int argc, const char** argv) {
 	std::vector<const SaunaFsAdminCommand*> allCommands = {
@@ -80,6 +81,9 @@ int main(int argc, const char** argv) {
 		if (argc < 2) {
 			throw WrongUsageException("No command name provided");
 		}
+#ifdef _WIN32
+		socketinit();
+#endif
 		command_name = argv[1];
 		std::vector<std::string> arguments(argv + 2, argv + argc);
 		for (auto command : allCommands) {
@@ -90,6 +94,9 @@ int main(int argc, const char** argv) {
 						supportedOptions.push_back(optionWithDescription.first);
 					}
 					command->run(Options(supportedOptions, arguments));
+#ifdef _WIN32
+					socketrelease();
+#endif
 					return 0;
 				} catch (Options::ParseError& ex) {
 					throw WrongUsageException("Wrong usage of " + command->name()
@@ -139,8 +146,14 @@ int main(int argc, const char** argv) {
 				}
 			}
 		}
+#ifdef _WIN32
+		socketrelease();
+#endif
 		return 1;
 	} catch (Exception& ex) {
+#ifdef _WIN32
+		socketrelease();
+#endif
 		std::cerr << "Error: " << ex.what() << std::endl;
 		return 1;
 	}


### PR DESCRIPTION
The previous implementation of saunafs-admin was failing on Windows environment when trying to connect to an specific master server instance due to not correctly initializing the socket communication for Windows. This commit fixes that issue.