### PR TITLE
fix(chunkserver): Improve plugin related logs

### DIFF
--- a/src/chunkserver/hddspacemgr.cc
+++ b/src/chunkserver/hddspacemgr.cc
@@ -2924,14 +2924,21 @@ int loadPlugins() {
 	std::string pluginsInstallDirPath = PLUGINS_PATH "/chunkserver";
 	std::string pluginsBuildDirPath = BUILD_PATH "/plugins/chunkserver";
 
+	// Try to load plugins first from the installation directory
 	if (!pluginManager.loadPlugins(pluginsInstallDirPath)) {
-		safs_pretty_syslog(LOG_WARNING, "Loading plugins from %s failed!!!",
+		safs_pretty_syslog(LOG_NOTICE,
+		                   "PluginManager: No plugins loaded from: %s",
 		                   pluginsInstallDirPath.c_str());
+
+		// If no plugins were loaded from the installation directory,
+		// try to load them from the build directory (useful for development)
 		if (!pluginManager.loadPlugins(pluginsBuildDirPath)) {
-			safs_pretty_syslog(LOG_WARNING, "Loading plugins from %s failed!!!",
+			safs_pretty_syslog(LOG_NOTICE,
+			                   "PluginManager: No plugins loaded from: %s",
 			                   pluginsBuildDirPath.c_str());
 		}
 	}
+
 	pluginManager.showLoadedPlugins();
 
 	return SAUNAFS_STATUS_OK;

--- a/src/chunkserver/plugin_manager.cc
+++ b/src/chunkserver/plugin_manager.cc
@@ -5,12 +5,13 @@
 #include "common/slogger.h"
 
 bool PluginManager::loadPlugins(const std::string &directory) {
-	// Check whether directory exists or is empty
 	if (!boost::filesystem::is_directory(directory) ||
 	    boost::filesystem::is_empty(directory)) {
-		safs_pretty_errlog(LOG_WARNING,
-		                   "Directory %s does not exist or is empty",
-		                   directory.c_str());
+		// It is normal to not have any plugins in many scenarios
+		safs_pretty_syslog(
+		    LOG_NOTICE,
+		    "PluginManager: Directory %s does not exist or is empty",
+		    directory.c_str());
 		return false;
 	}
 


### PR DESCRIPTION
The previous mesages were shown as warnings, but is normal to not have plugins to load. This commit uses less severe messages in the plugin loading sections.