### PR TITLE
 admin: Add USE_LINEAR_ASSIGNMENT_OPTIMIZER to master default config

### DIFF
--- a/src/admin/dump_config_command.cc
+++ b/src/admin/dump_config_command.cc
@@ -102,6 +102,7 @@ const static std::unordered_map<std::string, std::string> defaultOptionsMaster =
     {"CHUNKS_LOOP_MIN_TIME", "300"},
     {"CHUNKS_LOOP_PERIOD", "1000"},
     {"CHUNKS_LOOP_MAX_CPU", "60"},
+    {"USE_LINEAR_ASSIGNMENT_OPTIMIZER", "1"},
     {"CHUNKS_SOFT_DEL_LIMIT", "10"},
     {"CHUNKS_HARD_DEL_LIMIT", "25"},
     {"CHUNKS_WRITE_REP_LIMIT", "2"},


### PR DESCRIPTION
The recently added ```USE_LINEAR_ASSIGNMENT_OPTIMIZER``` option to master server was missing in the list of master default options, and should be shown there.