### PR TITLE
tests: Clean up space used by the tests

### DIFF
--- a/tests/tools/test.sh
+++ b/tests/tools/test.sh
@@ -204,9 +204,10 @@ test_cleanup() {
 	fi
 
 	# Clean the disks used by chunkservers
-	for d in $SAUNAFS_DISKS $SAUNAFS_LOOP_DISKS; do
-		rm -rf "$d"/chunks[0-9A-F][0-9A-F]
-		rm -f "$d"/.lock
+	for disk in ${SAUNAFS_DISKS} ${SAUNAFS_LOOP_DISKS}; do
+		rm -rf "${disk}"/meta/chunks[0-9A-F][0-9A-F]
+		rm -rf "${disk}"/data/chunks[0-9A-F][0-9A-F]
+		rm -f "${disk}"/.lock
 	done
 }
 


### PR DESCRIPTION
Previously, after running the tests, used space was not cleaned because the path for disks and loop devices was not correctly setup. Therefore, the used space by the tests needed to be cleaned manually to avoid the disks become full.

This commit updates the path for disks and loop devices including data and meta folders. Consequently, the space used by the tests is now cleaned up correctly.