### PR TITLE
fix(mount): Fix Windows master connection checking

### DIFF
--- a/src/mount/mastercomm.cc
+++ b/src/mount/mastercomm.cc
@@ -365,6 +365,11 @@ static bool fs_threc_send_receive(threc *rec, bool filter, PacketHeader::Type ex
 					}
 				}
 			}
+#ifdef _WIN32
+			else if (gIsDisconnectedFromMaster.load()) {
+				return false;
+			}
+#endif
 			sleep(sleep_time(cnt));
 			continue;
 		}
@@ -376,13 +381,6 @@ static bool fs_threc_send_receive(threc *rec, bool filter, PacketHeader::Type ex
 const uint8_t* fs_sendandreceive(threc *rec, uint32_t expected_cmd, uint32_t *answer_leng) {
 	// this function is only for compatibility with Legacy code
 	sassert(expected_cmd <= PacketHeader::kMaxOldPacketType);
-
-#ifdef _WIN32
-	if (gIsDisconnectedFromMaster.load()) {
-		*answer_leng = 0;
-		return NO_DATA_RECEIVED_FROM_MASTER;
-	}
-#endif
 
 	if (fs_threc_send_receive(rec, true, expected_cmd)) {
 		const uint8_t *answer;


### PR DESCRIPTION
In the previous implementation, the client was not properly working when
the master server was restarted and first getattr operations where
executed on Windows. This change makes the mount to first try to
properly reconnect to master and if not, directly assume no data was
received from master, thus avoid the mount process to crash when
trying to use the mountpoint.