### PR TITLE
feat(chunkserver): Introduce DiskEnergyManager

### DIFF
--- a/src/chunkserver/chunkserver-common/disk_energy_manager_interface.h
+++ b/src/chunkserver/chunkserver-common/disk_energy_manager_interface.h
@@ -1,0 +1,53 @@
+/*
+   Copyright 2023 Leil Storage
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "common/platform.h"
+
+#include "chunkserver-common/disk_interface.h"
+
+/**
+ * \brief Interface for disk energy management.
+ *
+ * This class is responsible for managing the energy of the disks.
+ *
+ * The most basic feature is to decide which disk to use for a new chunk.
+ *
+ * Concrete implementations will take care of the details of the energy
+ * management.
+ */
+class IDiskEnergyManager {
+public:
+	/// Default constructor
+	IDiskEnergyManager() = default;
+
+	// No need to copy or move them so far
+
+	IDiskEnergyManager(const IDiskEnergyManager &) = delete;
+	IDiskEnergyManager(IDiskEnergyManager &&) = delete;
+	IDiskEnergyManager &operator=(const IDiskEnergyManager &) = delete;
+	IDiskEnergyManager &operator=(IDiskEnergyManager &&) = delete;
+
+	/// Virtual destructor needed for correct polymorphism
+	virtual ~IDiskEnergyManager() = default;
+
+	/// Get the disk to use for a new chunk according to the energy management
+	/// policy.
+	virtual IDisk* getDiskForNewChunk() = 0;
+};

--- a/src/chunkserver/chunkserver-common/disk_interface.h
+++ b/src/chunkserver/chunkserver-common/disk_interface.h
@@ -8,6 +8,8 @@
 #include "common/chunk_part_type.h"
 #include "common/disk_info.h"
 
+#define DiskNotFound nullptr
+
 class IChunk;
 
 /// Represents a data disk in the Chunkserver context.

--- a/src/chunkserver/chunkserver-common/hdd_utils.h
+++ b/src/chunkserver/chunkserver-common/hdd_utils.h
@@ -9,7 +9,6 @@
 #include "protocol/chunks_with_type.h"
 
 #define ChunkNotFound nullptr
-#define DiskNotFound nullptr
 
 // master reports
 inline std::deque<ChunkWithType> gDamagedChunks;

--- a/src/chunkserver/default_disk_energy_manager.cc
+++ b/src/chunkserver/default_disk_energy_manager.cc
@@ -1,0 +1,99 @@
+/*
+   Copyright 2023 Leil Storage
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "common/platform.h"
+
+#include "chunkserver/default_disk_energy_manager.h"
+#include "chunkserver-common/global_shared_resources.h"
+#include "devtools/TracePrinter.h"
+
+IDisk* DefaultDiskEnergyManager::getDiskForNewChunk() {
+	TRACETHIS();
+	IDisk *bestDisk = DiskNotFound;
+	double maxCarry = 1.0;
+	double minPercentAvail = std::numeric_limits<double>::max();
+	double maxPercentAvail = 0.0;
+	double s,d;
+	double percentAvail;
+
+	if (gDisks.empty()) {
+		return DiskNotFound;
+	}
+
+	for (const auto &disk : gDisks) {
+		if (!disk->isSelectableForNewChunk()) {
+			continue;
+		}
+
+		if (disk->carry() >= maxCarry) {
+			maxCarry = disk->carry();
+			bestDisk = disk.get();
+		}
+
+		percentAvail = static_cast<double>(disk->availableSpace()) /
+		               static_cast<double>(disk->totalSpace());
+		minPercentAvail = std::min(minPercentAvail, percentAvail);
+		maxPercentAvail = std::max(maxPercentAvail, percentAvail);
+	}
+
+	if (bestDisk != DiskNotFound) {
+		// Lower the probability of being choosen again
+		bestDisk->setCarry(bestDisk->carry() - 1.0);
+		return bestDisk;
+	}
+
+	if (maxPercentAvail == 0.0) {  // no space
+		return DiskNotFound;
+	}
+
+	if (maxPercentAvail < 0.01) {
+		s = 0.0;
+	} else {
+		s = minPercentAvail * 0.8;
+		if (s < 0.01) {
+			s = 0.01;
+		}
+	}
+
+	d = maxPercentAvail - s;
+	maxCarry = 1.0;
+
+	for (auto &disk : gDisks) {
+		if (!disk->isSelectableForNewChunk()) {
+			continue;
+		}
+
+		percentAvail = static_cast<double>(disk->availableSpace()) /
+		               static_cast<double>(disk->totalSpace());
+
+		if (percentAvail > s) {
+			disk->setCarry(disk->carry() + ((percentAvail - s) / d));
+		}
+
+		if (disk->carry() >= maxCarry) {
+			maxCarry = disk->carry();
+			bestDisk = disk.get();
+		}
+	}
+
+	if (bestDisk != DiskNotFound) {  // should be always true here
+		bestDisk->setCarry(bestDisk->carry() - 1.0);
+	}
+
+	return bestDisk;
+}

--- a/src/chunkserver/default_disk_energy_manager.h
+++ b/src/chunkserver/default_disk_energy_manager.h
@@ -1,0 +1,57 @@
+/*
+   Copyright 2023 Leil Storage
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "common/platform.h"
+
+#include "chunkserver-common/disk_energy_manager_interface.h"
+
+/**
+ * \brief Default implementation of the disk energy manager.
+ *
+ * This class implements a strategy for assigning chunks across all available
+ * drives. The strategy aims to maintain a balanced distribution of chunks,
+ * ensuring that each drive is utilized effectively.
+ *
+ * This was the approach used so far.
+ */
+class DefaultDiskEnergyManager : public IDiskEnergyManager {
+public:
+	/// Default constructor
+	DefaultDiskEnergyManager() = default;
+
+	// No need to copy or move them so far
+
+	DefaultDiskEnergyManager(const DefaultDiskEnergyManager &) = delete;
+	DefaultDiskEnergyManager(DefaultDiskEnergyManager &&) = delete;
+	DefaultDiskEnergyManager &operator=(const DefaultDiskEnergyManager &) =
+	    delete;
+	DefaultDiskEnergyManager &operator=(DefaultDiskEnergyManager &&) = delete;
+
+	/// Virtual destructor needed for correct polymorphism
+	virtual ~DefaultDiskEnergyManager() = default;
+
+	/**
+	 * \brief Get the disk to store a new chunk.
+	 *
+	 * This concrete implementation obtains a balanced distribution using all
+	 * available disks.
+	 */
+	IDisk* getDiskForNewChunk() override;
+};


### PR DESCRIPTION
Previously, the disk assignment was done in a function inside the hddspacemgr.cc file, which works fine for basic placement of chunks in the disks, but is not enough if an advanced power management system is required.

This commit introduces the IDiskEnergyManager interface and the DefaultDiskEnergyManager concrete implementation, to provide the extension points for a future more complex energy management system.

So far, the only virtual function is getDiskForNewChunk, but others will appear soon.

The DefaultDiskEnergyManager provides the same distribution as before.