### PR TITLE
chore: Ignore the ICE submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,8 +81,10 @@ compile_commands.json
 # submodules #
 ##############
 src/chunkserver/plugins/zonefs_disk
+src/chunkserver/plugins/ice_disk_energy_manager
 tests/ci_build/run-smr-tests.sh
 tests/test_suites/SMRTests
+tests/test_suites/ICETests
 
 # Windows #
 ###########


### PR DESCRIPTION
The submodule directories should be ignored in saunafs.