### PR TITLE
fix: Fix slogger dependencies compilation

### DIFF
--- a/src/slogger/CMakeLists.txt
+++ b/src/slogger/CMakeLists.txt
@@ -1,5 +1,4 @@
 collect_sources(SLOGGER)
 
 shared_add_library(slogger ${SLOGGER_SOURCES})
-target_link_libraries(slogger sfserr)
-target_link_libraries(slogger_pic sfserr_pic)
+shared_target_link_libraries(slogger STATIC sfserr SHARED sfserr_pic)


### PR DESCRIPTION
First split off of slogger related code from
common libraries were compiled with shared
libraries approach, making it not portable to
compile in other systems, this commit fixes that.