### PR TITLE
tests: Update GaneshaTests suite

### DIFF
--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_connectathon_nfs_suite.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_connectathon_nfs_suite.sh
@@ -7,7 +7,7 @@
 # The path for the Ganesha daemon should match the installation folder inside the test.
 #
 
-timeout_set 3 minutes
+timeout_set 2 minutes
 
 CHUNKSERVERS=5 \
 	USE_RAMDISK=YES \

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_copy_file.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_copy_file.sh
@@ -7,7 +7,7 @@
 # The path for the Ganesha daemon should match the installation folder inside the test.
 #
 
-timeout_set 3 minutes
+timeout_set 45 seconds
 
 CHUNKSERVERS=5 \
 	USE_RAMDISK=YES \

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_file_corruption_on_master_failover.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_file_corruption_on_master_failover.sh
@@ -45,7 +45,7 @@ NFS_KRB5 {
 }
 NFSV4 {
 	Grace_Period = 5;
-	Lease_Lifetime = 3;
+	Lease_Lifetime = 5;
 }
 EXPORT {
 	Attr_Expiration_Time = 0;

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_fio_random_mix_reads_writes.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_fio_random_mix_reads_writes.sh
@@ -11,7 +11,7 @@
 #
 assert_program_installed fio
 
-timeout_set 3 minutes
+timeout_set 45 seconds
 
 CHUNKSERVERS=5 \
 	USE_RAMDISK=YES \
@@ -74,7 +74,7 @@ EOF
 
 sudo /usr/bin/ganesha.nfsd -f ${info[mount0]}/ganesha.conf
 
-sleep 15
+assert_eventually 'showmount -e localhost'
 sudo mount -vvvv localhost:/ $TEMP_DIR/mnt/ganesha
 
 echo ""
@@ -84,7 +84,7 @@ cd ${TEMP_DIR}/mnt/ganesha
 # Run fio random mix of read and write on top of Ganesha Client
 fio --name=fiotest_random_mix_read_write --directory=${TEMP_DIR}/mnt/ganesha \
     --size=200M --rw=randrw --numjobs=5 --ioengine=psync --group_reporting   \
-    --bs=4M --direct=1 --iodepth=4
+    --bs=4M --direct=1 --iodepth=1
 
 echo ""
 echo "List of created files at the Ganesha Client:"

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_fio_random_reads.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_fio_random_reads.sh
@@ -11,7 +11,7 @@
 #
 assert_program_installed fio
 
-timeout_set 3 minutes
+timeout_set 45 seconds
 
 CHUNKSERVERS=5 \
 	USE_RAMDISK=YES \
@@ -74,7 +74,7 @@ EOF
 
 sudo /usr/bin/ganesha.nfsd -f ${info[mount0]}/ganesha.conf
 
-sleep 15
+assert_eventually 'showmount -e localhost'
 sudo mount -vvvv localhost:/ $TEMP_DIR/mnt/ganesha
 
 echo ""

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_fio_random_writes.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_fio_random_writes.sh
@@ -11,7 +11,7 @@
 #
 assert_program_installed fio
 
-timeout_set 3 minutes
+timeout_set 45 seconds
 
 CHUNKSERVERS=5 \
 	USE_RAMDISK=YES \
@@ -74,7 +74,7 @@ EOF
 
 sudo /usr/bin/ganesha.nfsd -f ${info[mount0]}/ganesha.conf
 
-sleep 15
+assert_eventually 'showmount -e localhost'
 sudo mount -vvvv localhost:/ $TEMP_DIR/mnt/ganesha
 
 echo ""

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_fio_sequential_mix_reads_writes.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_fio_sequential_mix_reads_writes.sh
@@ -12,7 +12,7 @@
 
 assert_program_installed fio
 
-timeout_set 3 minutes
+timeout_set 45 seconds
 
 CHUNKSERVERS=5 \
 	USE_RAMDISK=YES \
@@ -75,7 +75,7 @@ EOF
 
 sudo /usr/bin/ganesha.nfsd -f ${info[mount0]}/ganesha.conf
 
-sleep 15
+assert_eventually 'showmount -e localhost'
 sudo mount -vvvv localhost:/ $TEMP_DIR/mnt/ganesha
 
 echo ""
@@ -85,7 +85,7 @@ cd ${TEMP_DIR}/mnt/ganesha
 # Run fio sequential mix of read and write on top of Ganesha Client
 fio --name=fiotest_seq_mix_read_write --directory=${TEMP_DIR}/mnt/ganesha \
     --size=200M --rw=rw --numjobs=5 --ioengine=psync --group_reporting    \
-    --bs=4M --direct=1 --iodepth=4
+    --bs=4M --direct=1 --iodepth=1
 
 echo ""
 echo "List of created files at the Ganesha Client:"

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_fio_sequential_reads.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_fio_sequential_reads.sh
@@ -12,7 +12,7 @@
 
 assert_program_installed fio
 
-timeout_set 3 minutes
+timeout_set 45 seconds
 
 CHUNKSERVERS=5 \
 	USE_RAMDISK=YES \
@@ -75,7 +75,7 @@ EOF
 
 sudo /usr/bin/ganesha.nfsd -f ${info[mount0]}/ganesha.conf
 
-sleep 15
+assert_eventually 'showmount -e localhost'
 sudo mount -vvvv localhost:/ $TEMP_DIR/mnt/ganesha
 
 echo ""

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_fio_sequential_writes.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_fio_sequential_writes.sh
@@ -12,7 +12,7 @@
 
 assert_program_installed fio
 
-timeout_set 3 minutes
+timeout_set 45 seconds
 
 CHUNKSERVERS=5 \
 	USE_RAMDISK=YES \
@@ -76,7 +76,7 @@ EOF
 
 sudo /usr/bin/ganesha.nfsd -f ${info[mount0]}/ganesha.conf
 
-sleep 15
+assert_eventually 'showmount -e localhost'
 sudo mount -vvvv localhost:/data $TEMP_DIR/mnt/ganesha
 
 echo ""

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_multi_export.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_multi_export.sh
@@ -7,7 +7,7 @@
 # The path for the Ganesha daemon should match the installation folder inside the test.
 #
 
-timeout_set 2 minutes
+timeout_set 45 seconds
 
 CHUNKSERVERS=5 \
 	USE_RAMDISK=YES \

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_vs_linux_client_dd_read.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_vs_linux_client_dd_read.sh
@@ -10,9 +10,8 @@
 # Verify the performance of Ganesha and Linux clients when performing read
 # with dd tool.
 #
-assert_program_installed fio
 
-timeout_set 3 minutes
+timeout_set 45 seconds
 
 CHUNKSERVERS=5 \
 	USE_RAMDISK=YES \
@@ -75,7 +74,7 @@ EOF
 
 sudo /usr/bin/ganesha.nfsd -f ${info[mount0]}/ganesha.conf
 
-sleep 15
+assert_eventually 'showmount -e localhost'
 sudo mount -vvvv localhost:/ $TEMP_DIR/mnt/ganesha
 
 # Generate the file to be read

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_vs_linux_client_dd_write.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_vs_linux_client_dd_write.sh
@@ -10,9 +10,8 @@
 # Verify the performance of Ganesha and Linux clients when performing write
 # with dd tool.
 #
-assert_program_installed fio
 
-timeout_set 3 minutes
+timeout_set 45 seconds
 
 CHUNKSERVERS=5 \
 	USE_RAMDISK=YES \
@@ -76,7 +75,7 @@ EOF
 
 sudo /usr/bin/ganesha.nfsd -f ${info[mount0]}/ganesha.conf
 
-sleep 15
+assert_eventually 'showmount -e localhost'
 sudo mount -vvvv localhost:/ $TEMP_DIR/mnt/ganesha
 
 echo ""

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_vs_linux_client_random_mix_rw.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_vs_linux_client_random_mix_rw.sh
@@ -12,7 +12,7 @@
 #
 assert_program_installed fio
 
-timeout_set 3 minutes
+timeout_set 45 seconds
 
 CHUNKSERVERS=5 \
 	USE_RAMDISK=YES \
@@ -76,7 +76,7 @@ EOF
 
 sudo /usr/bin/ganesha.nfsd -f ${info[mount0]}/ganesha.conf
 
-sleep 15
+assert_eventually 'showmount -e localhost'
 sudo mount -vvvv localhost:/ $TEMP_DIR/mnt/ganesha
 
 echo ""

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_vs_linux_client_sequential_read.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_vs_linux_client_sequential_read.sh
@@ -12,7 +12,7 @@
 #
 assert_program_installed fio
 
-timeout_set 3 minutes
+timeout_set 45 seconds
 
 CHUNKSERVERS=5 \
 	USE_RAMDISK=YES \
@@ -76,7 +76,7 @@ EOF
 
 sudo /usr/bin/ganesha.nfsd -f ${info[mount0]}/ganesha.conf
 
-sleep 15
+assert_eventually 'showmount -e localhost'
 sudo mount -vvvv localhost:/ $TEMP_DIR/mnt/ganesha
 
 echo ""

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_vs_linux_client_sequential_write.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_vs_linux_client_sequential_write.sh
@@ -12,7 +12,7 @@
 #
 assert_program_installed fio
 
-timeout_set 3 minutes
+timeout_set 45 seconds
 
 CHUNKSERVERS=5 \
 	USE_RAMDISK=YES \
@@ -76,7 +76,7 @@ EOF
 
 sudo /usr/bin/ganesha.nfsd -f ${info[mount0]}/ganesha.conf
 
-sleep 15
+assert_eventually 'showmount -e localhost'
 sudo mount -vvvv localhost:/ $TEMP_DIR/mnt/ganesha
 
 echo ""


### PR DESCRIPTION
This commit applies a patch to the GaneshaTests suite that contains fixes and improvements to parameters like timeout, Lease_Lifetime and iodepth (fio).

The most important changes are:
- Adjust timeout of tests.
- Set Lease_Lifetime equal to Grace_Period because is not recommended to use a Lease_Lifetime less than Grace_Period.
- Replace sleep calls before connecting nfs client with assert eventually macro.
- Set iodepth=1 for fio mixed tests because fio does not allow to use iodepth=4 for these mixed workloads.
- Remove unneeded validation of fio installation for tests using dd.