### PR TITLE
fix(errors): Add explicit std string include

### DIFF
--- a/src/errors/sfserr.cc
+++ b/src/errors/sfserr.cc
@@ -24,6 +24,7 @@
 #include <cerrno>
 #include <cstring>
 #include <mutex>
+#include <string>
 #include <unordered_map>
 
 #include "saunafs_error_codes.h"


### PR DESCRIPTION
In some configurations, the compiler does not find the std string header automatically. This commit just adds the header to avoid these scenarios.