### PR TITLE
fix(mount): Fix mount process stop when unmount

### DIFF
--- a/doc/sfsmount.1.adoc
+++ b/doc/sfsmount.1.adoc
@@ -219,6 +219,10 @@ during crashes when allegedly flushed data is still being processed.
 Whether to use FUSE DirectIO. This may improve performance when reading large
 files under certain conditions.
 
+*-o sfsfumountlazy=*'0|1'::
+Enables monitoring process for avoiding mount process to still run after
+an umount lazy command executed over the client's mountpoint.
+
 General mount options (see *mount*(8) manual):
 
 *-o rw* | *-o ro*::

--- a/src/mount/fuse/mount_config.cc
+++ b/src/mount/fuse/mount_config.cc
@@ -92,6 +92,7 @@ struct fuse_opt gSfsOptsStage2[] = {
 	SFS_OPT("sfsdirentrycachesize=%u", direntrycachesize, 0),
 	SFS_OPT("nostdmountoptions", nostdmountoptions, 1),
 	SFS_OPT("sfsignoreflush", ignoreflush, 1),
+	SFS_OPT("sfsfumountlazy=%d", fumountlazy, 0),
 
 	SFS_OPT("enablefilelocks=%u", filelocks, 0),
 	SFS_OPT("nonempty", nonemptymount, 1),
@@ -225,6 +226,8 @@ void usage(const char *progname) {
 "    -o sfsignoreflush           Advanced: use with caution. Ignore flush usual "
 				"behavior by replying SUCCESS to it immediately. Targets fast "
 				"creation of small files, but may cause data loss during crashes.\n"
+"    -o sfsfumountlazy=0|1       enables/disables force umount when lazy "
+				"umount executed (default: 0)\n"
 "\n",
 		SaunaClient::FsInitParams::kDefaultUseRwLock,
 		SaunaClient::FsInitParams::kDefaultMkdirCopySgid,

--- a/src/mount/fuse/mount_config.h
+++ b/src/mount/fuse/mount_config.h
@@ -114,6 +114,7 @@ struct sfsopts_ {
 	int nonemptymount;
 	bool directio;
 	int ignoreflush;
+	bool fumountlazy;
 
 	sfsopts_()
 		: masterhost(NULL),
@@ -169,7 +170,8 @@ struct sfsopts_ {
 		bandwidthoveruse(SaunaClient::FsInitParams::kDefaultBandwidthOveruse),
 		nonemptymount(SaunaClient::FsInitParams::kDefaultNonEmptyMounts),
 		directio(SaunaClient::FsInitParams::kDirectIO),
-		ignoreflush(SaunaClient::FsInitParams::kDefaultIgnoreFlush)
+		ignoreflush(SaunaClient::FsInitParams::kDefaultIgnoreFlush),
+		fumountlazy(SaunaClient::FsInitParams::kDefaultForceUnmountLazy)
 	{ }
 };
 

--- a/tests/test_suites/SanityChecks/test_force_umount_lazy.sh
+++ b/tests/test_suites/SanityChecks/test_force_umount_lazy.sh
@@ -1,0 +1,28 @@
+USE_RAMDISK=YES \
+    MOUNT_EXTRA_CONFIG="sfsfumountlazy=1" \
+    setup_local_empty_saunafs info
+
+# Change directory to the mount point
+cd "${info[mount0]}"
+
+# List contents of the current directory
+ls
+
+# Check if sfsmount process is running
+if pgrep -fa sfsmount > /dev/null; then
+    echo "sfsmount process is running."
+    
+    # Lazily unmount the mount point
+    umount -l "${info[mount0]}"
+
+    sleep 5
+    
+    # Check again to ensure sfsmount process has stopped
+    if pgrep -fa sfsmount > /dev/null; then
+        echo "Failed to stop sfsmount process." 
+    else
+        echo "sfsmount process has been successfully stopped."
+    fi
+else
+    echo "No sfsmount process is currently running."
+fi


### PR DESCRIPTION
When unmounting the client's mountpoint, sometimes the process did not stop, this commit adds a
monitoring process for solving this issue.