### PR TITLE
feat(chunkserver): Expose gDiskManager to plugins

### DIFF
--- a/src/chunkserver/chunkserver-common/global_shared_resources.h
+++ b/src/chunkserver/chunkserver-common/global_shared_resources.h
@@ -2,6 +2,7 @@
 
 #include "chunkserver-common/chunk_map.h"
 #include "chunkserver-common/disk_interface.h"
+#include "chunkserver-common/disk_manager_interface.h"
 #include "chunkserver-common/indexed_resource_pool.h"
 #include "chunkserver-common/open_chunk.h"
 
@@ -29,6 +30,14 @@ inline std::vector<std::unique_ptr<IDisk>> gDisks;
 
 /// Protects gDisks + all data in structures (except Disk::cstat)
 inline std::mutex gDisksMutex;
+
+/// Configuration variable to define the type of DiskManager to be used.
+/// The default is an instance of DefaultDiskManager, but can be be changed from
+/// plugins offering custom implementations of IDiskManager.
+inline std::string gDiskManagerType = "default";
+
+/// The DiskManager instance to be used by the Chunkserver.
+inline std::unique_ptr<IDiskManager> gDiskManager;
 
 /// Container to reuse free condition variables (guarded by `gChunksMapMutex`)
 inline std::vector<std::unique_ptr<CondVarWithWaitCount>> gFreeCondVars;

--- a/src/chunkserver/hddspacemgr.cc
+++ b/src/chunkserver/hddspacemgr.cc
@@ -110,9 +110,6 @@ static IoStat gIoStat;
 
 static PluginManager pluginManager;
 
-static std::unique_ptr<IDiskManager> gDiskManager =
-    std::make_unique<DefaultDiskManager>();
-
 void hddGetDamagedChunks(std::vector<ChunkWithType>& chunks,
                          std::size_t limit) {
 	TRACETHIS();
@@ -2853,6 +2850,22 @@ int hddLateInit() {
 	}
 
 	return 0;
+}
+
+/// Initializes the default disk manager and reads the disk manager type from
+/// configuration. This function must be called before plugins initialization.
+int initDiskManager() {
+	// Initialize the default disk manager and set the disk manager type.
+	// The default will be overwritten if the DISK_MANAGER_TYPE is set in
+	// the configuration file.
+	gDiskManager = std::make_unique<DefaultDiskManager>();
+
+	std::string diskManagerType = cfg_get("DISK_MANAGER_TYPE", "default");
+	std::transform(diskManagerType.begin(), diskManagerType.end(),
+	               diskManagerType.begin(), ::tolower);
+	gDiskManagerType = std::move(diskManagerType);
+
+	return SAUNAFS_STATUS_OK;
 }
 
 int loadPlugins() {

--- a/src/chunkserver/hddspacemgr.h
+++ b/src/chunkserver/hddspacemgr.h
@@ -93,6 +93,7 @@ int hddChunkOperation(uint64_t chunkId, uint32_t chunkVersion,
 void hddAddChunkToTestQueue(ChunkWithVersionAndType chunk);
 
 /* initialization */
+int initDiskManager();
 int loadPlugins();
 int hddLateInit();
 int hddInit();

--- a/src/chunkserver/init.h
+++ b/src/chunkserver/init.h
@@ -34,8 +34,9 @@ inline const std::vector<RunTab> earlyRunTabs = {};
 
 /// Functions to call during normal startup
 inline const std::vector<RunTab> runTabs = {
-    RunTab{rnd_init, "random generator"}, RunTab{loadPlugins, "plugin manager"},
-    RunTab{hddInit, "hdd space manager"},
+    RunTab{rnd_init, "random generator"},
+    RunTab{initDiskManager, "disk manager"},  // Always before "plugin manager"
+    RunTab{loadPlugins, "plugin manager"}, RunTab{hddInit, "hdd space manager"},
     // Has to be before "masterconn"
     RunTab{mainNetworkThreadInit, "main server module"},
     RunTab{masterconn_init, "master connection module"},

--- a/src/data/sfschunkserver.cfg.in
+++ b/src/data/sfschunkserver.cfg.in
@@ -133,6 +133,12 @@
 ## (Default: 1), i.e. enabled.
 #PERFORM_FSYNC = 1
 
+## [ADVANCED] The DiskManager is responsible for assigning each chunk to a
+## specific disk. By default the chunks are distributed in a balanced way among
+## all the available disks. This variable can be changed to select a custom
+## DiskManager implementation loaded from plugins.
+## (Default: DEFAULT), the default balanced distribution will be used.
+# DISK_MANAGER_TYPE = DEFAULT
 
 ## deprecated, to be removed.
 # BACK_LOGS = 50


### PR DESCRIPTION
This change exposes the gDiskManager to the plugins by moving it to the chunkserver-common library. The DISK_MANAGER_TYPE configuration variable was also added to select the specific disk manager to use at run time.