### PR TITLE
feat(common): Improve the hddSizeParse function

### DIFF
--- a/src/common/cfg.h
+++ b/src/common/cfg.h
@@ -29,6 +29,8 @@
 
 #define _CONFIG_MAKE_PROTOTYPE(fname,type) type cfg_get##fname(const char *name,const type def)
 
+static constexpr int64_t kInvalidConversion = -1;
+
 int cfg_load (const char *fname,int logundefined);
 int cfg_reload (void);
 void cfg_term (void);
@@ -48,6 +50,19 @@ std::string cfg_yaml_string();
 /// service_name. The value in the map must be a valid YAML string
 std::string cfg_yaml_list(std::string service_name,
                           std::map<std::string, std::string> &services);
+
+/**
+ * @brief Parses a string representing a size and converts it to bytes.
+ *
+ * The function supports suffixes for kilo (K, KB, Ki or KiB) or the same
+ * formats for mega, giga, tera, peta and exa. The function is case insensitive.
+ *
+ * @param str The string to parse.
+ * @return The size in bytes as an int64_t. If the string cannot be parsed,
+ *         or if the parsed value is larger than the maximum representable
+ *         int64_t value, the function returns kInvalidConversion.
+ */
+int64_t cfg_parse_size(const std::string& str);
 
 int cfg_isdefined(const char *name);
 

--- a/src/common/cfg_unittest.cc
+++ b/src/common/cfg_unittest.cc
@@ -1,0 +1,71 @@
+/*
+   Copyright 2023      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "common/platform.h"
+
+#include <gtest/gtest.h>
+
+#include "common/cfg.h"
+
+TEST(CfgTests, CfgParseSize) {
+	// Bytes
+	EXPECT_EQ(0, cfg_parse_size("0"));
+	EXPECT_EQ(100, cfg_parse_size("100"));
+	EXPECT_EQ(1, cfg_parse_size("1"));
+	EXPECT_EQ(1, cfg_parse_size("1b"));
+	EXPECT_EQ(1, cfg_parse_size("1B"));
+
+	// Kilo
+	EXPECT_EQ(1000, cfg_parse_size("1k"));
+	EXPECT_EQ(1000, cfg_parse_size("1K"));
+	EXPECT_EQ(1024, cfg_parse_size("1Ki"));
+	EXPECT_EQ(1024, cfg_parse_size("1kI"));
+	EXPECT_EQ(1024, cfg_parse_size("1ki"));
+	EXPECT_EQ(1000, cfg_parse_size("1KB"));
+	EXPECT_EQ(1000, cfg_parse_size("1kb"));
+	EXPECT_EQ(1000, cfg_parse_size("1Kb"));
+	EXPECT_EQ(1000, cfg_parse_size("1kB"));
+	EXPECT_EQ(1024, cfg_parse_size("1kib"));
+	EXPECT_EQ(1024, cfg_parse_size("1KiB"));
+	EXPECT_EQ(1024, cfg_parse_size("1kIB"));
+	EXPECT_EQ(1024, cfg_parse_size("1kiB"));
+
+	// Giga
+	EXPECT_EQ(1000000000, cfg_parse_size("1G"));
+	EXPECT_EQ(1000000000, cfg_parse_size("1GB"));
+	EXPECT_EQ(1073741824, cfg_parse_size("1Gi"));
+	EXPECT_EQ(1073741824, cfg_parse_size("1GiB"));
+
+	// With spaces
+	EXPECT_EQ(1024, cfg_parse_size("1 KiB"));
+	EXPECT_EQ(1024, cfg_parse_size("1KiB "));
+	EXPECT_EQ(1024, cfg_parse_size(" 1 KiB "));
+
+	// With dots
+	EXPECT_EQ(1024, cfg_parse_size("1.KiB"));
+	EXPECT_EQ(512, cfg_parse_size(".5 KiB"));
+	EXPECT_EQ(512, cfg_parse_size("0.5 KiB"));
+	EXPECT_EQ(1500, cfg_parse_size("1.5K"));
+
+	// Invalid values or suffixes
+	EXPECT_EQ(-1, cfg_parse_size(""));
+	EXPECT_EQ(-1, cfg_parse_size("1x"));
+	EXPECT_EQ(-1, cfg_parse_size("1Bx"));
+	EXPECT_EQ(-1, cfg_parse_size("1 KBx"));
+	EXPECT_EQ(-1, cfg_parse_size("1_KiB"));
+}


### PR DESCRIPTION
The previous version was completely implemented from the scratch. The proposed version uses modern C++ and std::stod to increase readability and safety. The commit makes it also more flexible with different suffixes for the size and improves the error handling.

The function initially was in the hddspacemgr.cc in the chunkserver, but it is very general and will be used from the plugins soon, so it makes sense to move it to the common library.

An unit test file was also added to verify different combinations.