### PR TITLE
ci(.github): Add check for Conventional Commits

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -1,0 +1,11 @@
+name: Conventional Commits
+on:
+  pull_request:
+    branches: [ dev ]
+jobs:
+  build:
+    name: Conventional Commits
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: webiny/action-conventional-commits@v1.3.0


### PR DESCRIPTION
This is to make sure all future commits are written according to this document https://www.conventionalcommits.org/en/v1.0.0/. This will allow us to automate release note generations