### PR TITLE
feat(master): Allow localhost connections to master

### DIFF
--- a/src/chunkserver/masterconn.cc
+++ b/src/chunkserver/masterconn.cc
@@ -521,14 +521,9 @@ int masterconn_initconnect(masterconn *eptr) {
 		}
 		eptr->bindip = bip;
 		if (tcpresolve(MasterHost,MasterPort,&mip,&mport,0)>=0) {
-			if ((mip&0xFF000000)!=0x7F000000) {
 				eptr->masterip = mip;
 				eptr->masterport = mport;
 				eptr->masteraddrvalid = 1;
-			} else {
-				safs_pretty_syslog(LOG_WARNING,"master connection module: localhost (%u.%u.%u.%u) can't be used for connecting with master (use ip address of network controller)",(mip>>24)&0xFF,(mip>>16)&0xFF,(mip>>8)&0xFF,mip&0xFF);
-				return -1;
-			}
 		} else {
 			safs_pretty_syslog(LOG_WARNING,"master connection module: can't resolve master host/port (%s:%s)",MasterHost,MasterPort);
 			return -1;
@@ -804,14 +799,10 @@ void masterconn_reload(void) {
 			eptr->mode = KILL;
 		}
 		if (tcpresolve(MasterHost,MasterPort,&mip,&mport,0)>=0) {
-			if ((mip&0xFF000000)!=0x7F000000) {
-				if (eptr->masterip!=mip || eptr->masterport!=mport) {
-					eptr->masterip = mip;
-					eptr->masterport = mport;
-					eptr->mode = KILL;
-				}
-			} else {
-				safs_pretty_syslog(LOG_WARNING,"master connection module: localhost (%u.%u.%u.%u) can't be used for connecting with master (use ip address of network controller)",(mip>>24)&0xFF,(mip>>16)&0xFF,(mip>>8)&0xFF,mip&0xFF);
+			if (eptr->masterip != mip || eptr->masterport != mport) {
+				eptr->masterip = mip;
+				eptr->masterport = mport;
+				eptr->mode = KILL;
 			}
 		} else {
 			safs_pretty_syslog(LOG_WARNING,"master connection module: can't resolve master host/port (%s:%s)",MasterHost,MasterPort);

--- a/src/master/matocsserv.cc
+++ b/src/master/matocsserv.cc
@@ -1028,12 +1028,6 @@ void matocsserv_register_host(matocsserventry *eptr, uint32_t version, uint32_t 
 		free(eptr->servstrip);
 	}
 	eptr->servstrip = matocsserv_makestrip(eptr->servip);
-	if (((eptr->servip)&0xFF000000) == 0x7F000000) {
-		safs_pretty_syslog(LOG_NOTICE, "chunkserver connected using localhost (IP: %s) - you can't use"
-				" localhost for communication between chunkserver and master", eptr->servstrip);
-		eptr->mode=KILL;
-		return;
-	}
 	if (csdb_new_connection(eptr->servip,eptr->servport,eptr)<0) {
 		safs_pretty_syslog(LOG_WARNING,"chunk-server already connected !!!");
 		eptr->mode=KILL;


### PR DESCRIPTION
Since MooseFS, localhost couldn't be used to connect to master in certain circumstances. Since this is a valid use case (especially for testing), this commit removes the checks disallowing connections from localhost.