### PR TITLE
fix(build): Fix cmake syntax warning

### DIFF
--- a/cmake/Packing.cmake
+++ b/cmake/Packing.cmake
@@ -11,7 +11,7 @@ set(CPACK_PACKAGE_CONTACT "contact@saunafs.com"
         CACHE STRING "Contact email for package"
 )
 
-set(CPACK_PACKAGE_VENDOR "The SaunaFS Team <"${CPACK_PACKAGE_CONTACT}">"
+set(CPACK_PACKAGE_VENDOR "The SaunaFS Team <${CPACK_PACKAGE_CONTACT}>"
         CACHE STRING "Vendor of package"
 )
 


### PR DESCRIPTION
The content of file cmake/Packing.cmake was producing a syntax warning during fresh installation due to a syntax issue, this commit solves that.