### PR TITLE
feat(chunkserver): Extend getDiskForNewChunk

### DIFF
--- a/src/chunkserver/chunkserver-common/default_disk_manager.cc
+++ b/src/chunkserver/chunkserver-common/default_disk_manager.cc
@@ -228,7 +228,8 @@ void DefaultDiskManager::reloadDisksFromCfg() {
 	}
 }
 
-IDisk* DefaultDiskManager::getDiskForNewChunk() {
+IDisk *DefaultDiskManager::getDiskForNewChunk(
+    [[maybe_unused]] const ChunkPartType &chunkType) {
 	TRACETHIS();
 	IDisk *bestDisk = DiskNotFound;
 	double maxCarry = 1.0;

--- a/src/chunkserver/chunkserver-common/default_disk_manager.h
+++ b/src/chunkserver/chunkserver-common/default_disk_manager.h
@@ -58,5 +58,6 @@ public:
 	 * This concrete implementation obtains a balanced distribution using all
 	 * available disks.
 	 */
-	IDisk* getDiskForNewChunk() override;
+	IDisk *getDiskForNewChunk(
+	    [[maybe_unused]] const ChunkPartType &chunkType) override;
 };

--- a/src/chunkserver/chunkserver-common/disk_manager_interface.h
+++ b/src/chunkserver/chunkserver-common/disk_manager_interface.h
@@ -49,5 +49,6 @@ public:
 
 	/// Get the disk to use for a new chunk. Concrete implementations will use
 	/// different strategies.
-	virtual IDisk* getDiskForNewChunk() = 0;
+	virtual IDisk *getDiskForNewChunk(
+	    [[maybe_unused]] const ChunkPartType &chunkType) = 0;
 };

--- a/src/chunkserver/hddspacemgr.cc
+++ b/src/chunkserver/hddspacemgr.cc
@@ -226,10 +226,6 @@ static IChunk *hddChunkCreate(IDisk *disk, uint64_t chunkId,
 	return chunk;
 }
 
-static inline IDisk* hddGetDiskForNewChunk() {
-	return gDiskManager->getDiskForNewChunk();
-}
-
 void hddSendDataToMaster(IDisk *disk, bool isForRemoval) {
 	TRACETHIS();
 	bool markedForDeletion = disk->isMarkedForDeletion();
@@ -833,7 +829,7 @@ std::pair<int, IChunk *> hddInternalCreateChunk(uint64_t chunkId,
 	{
 		std::scoped_lock disksLockGuard(gDisksMutex);
 
-		disk = hddGetDiskForNewChunk();
+		disk = gDiskManager->getDiskForNewChunk(chunkType);
 
 		if (disk == DiskNotFound) {
 			return {SAUNAFS_ERROR_NOSPACE, ChunkNotFound};
@@ -1019,7 +1015,7 @@ static int hddInternalDuplicate(uint64_t chunkId, uint32_t chunkVersion,
 
 	{
 		std::unique_lock disksUniqueLock(gDisksMutex);
-		dupDisk = hddGetDiskForNewChunk();
+		dupDisk = gDiskManager->getDiskForNewChunk(chunkType);
 		if (dupDisk == DiskNotFound) {
 			disksUniqueLock.unlock();
 			hddChunkRelease(originalChunk);
@@ -1523,7 +1519,7 @@ static int hddInternalDuplicateTruncate(uint64_t chunkId, uint32_t chunkVersion,
 	{
 		std::unique_lock disksUniqueLock(gDisksMutex);
 
-		dupDisk = hddGetDiskForNewChunk();
+		dupDisk = gDiskManager->getDiskForNewChunk(chunkType);
 
 		if (dupDisk == DiskNotFound) {
 			disksUniqueLock.unlock();


### PR DESCRIPTION
The functions based on IDiskManager::getDiskForNewChunk now accept a ChunkPartType as argument, to allow disk assignments based on the this type. The default implementation does not use it yet, but it is needed for the plugins.