### PR TITLE
fix(deploy): Allow to pass a file as an argument

### DIFF
--- a/tests/ci_build/run-delivery-nexus-deb.sh
+++ b/tests/ci_build/run-delivery-nexus-deb.sh
@@ -18,7 +18,6 @@ declare nexus_auth="$(echo ${nexus_username}:${nexus_password})"
 
 
 declare source_dir="${1:-}"
-[ -d "${source_dir}" ] || die "Source directory '${source_dir}' does not exist"
 
 declare files=$(find "${source_dir}" -type f -name '*.deb')
 


### PR DESCRIPTION
This change makes more generic the script allowing to pass
also a file instead of just a folder.