### PR TITLE
fix: Release compilation on GCC 14

### DIFF
--- a/src/common/goal.cc
+++ b/src/common/goal.cc
@@ -63,8 +63,8 @@ void Goal::Slice::mergeIn(const Slice &other) {
 	assert(type_ == other.type_);
 	assert(size() == other.size());
 
-	std::array<std::array<int, kMaxPartsCount>, kMaxPartsCount> cost;
-	std::array<int, kMaxPartsCount> assignment;
+	std::array<std::array<int, kMaxPartsCount>, kMaxPartsCount> cost{};
+	std::array<int, kMaxPartsCount> assignment{};
 
 	Labels tmp_union;
 


### PR DESCRIPTION
When building with "Release" CMAKE_BUILD_TYPE, the compilation fails on Arch Linux with GCC 14.1.1, complaining about uninitialized array's.

This small commit fixes that and two linter errors.