### PR TITLE
fix: Update services to wait for network

### DIFF
--- a/rpm/service-files/saunafs-cgiserv.service
+++ b/rpm/service-files/saunafs-cgiserv.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=SaunaFS CGI server daemon
 Documentation=man:saunafs-cgiserver
-After=network.target
+After=network-online.target network.target
 
 [Service]
 Environment=BIND_HOST=0.0.0.0

--- a/rpm/service-files/saunafs-chunkserver.service
+++ b/rpm/service-files/saunafs-chunkserver.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=SaunaFS chunkserver daemon
 Documentation=man:sfschunkserver
-After=network.target
+After=network-online.target network.target
 
 [Service]
 Type=forking

--- a/rpm/service-files/saunafs-ha-master.service
+++ b/rpm/service-files/saunafs-ha-master.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=SaunaFS master server daemon
-After=syslog.target network.target
+After=syslog.target network-online.target network.target
 PartOf=saunafs-uraft.service
 
 [Service]

--- a/rpm/service-files/saunafs-master.service
+++ b/rpm/service-files/saunafs-master.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=SaunaFS master server daemon
 Documentation=man:sfsmaster
-After=network.target
+After=network-online.target network.target
 
 [Service]
 Type=forking

--- a/rpm/service-files/saunafs-metalogger.service
+++ b/rpm/service-files/saunafs-metalogger.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=SaunaFS metalogger server daemon
 Documentation=man:sfsmetalogger
-After=network.target
+After=network-online.target network.target
 
 [Service]
 Type=forking

--- a/rpm/service-files/saunafs-uraft.service
+++ b/rpm/service-files/saunafs-uraft.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=SaunaFS uraft high availability daemon
 Requires=saunafs-ha-master.service
-After=network.target
+After=network-online.target network.target
 After=saunafs-ha-master.service
 
 [Service]


### PR DESCRIPTION
network.target is not giving warranty that IP addresses are set
network-online.target gives such assurances
https://systemd.io/NETWORK_ONLINE/

Co-authored-by: Antuan <antuan@leil.io>
Co-authored-by: Crash <crash@leil.io>