### PR TITLE
feat(metrics): Add rest of master chartdata metrics

### DIFF
--- a/src/master/chartsdata.cc
+++ b/src/master/chartsdata.cc
@@ -18,6 +18,9 @@
    along with SaunaFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
+
+/* DEPRECATED (master/chartsdata.h): Use src/metrics instead */
+
 #include "common/platform.h"
 
 #include "master/chartsdata.h"

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -43,6 +43,7 @@
 #include "master/matomlserv.h"
 #include "master/recursive_remove_task.h"
 #include "master/task_manager.h"
+#include "metrics/metrics.h"
 #include "protocol/matocl.h"
 
 std::array<uint32_t, FsStats::Size> gFsStatsArray = {{}};
@@ -351,6 +352,7 @@ void fs_statfs(const FsContext &context, uint64_t *totalspace, uint64_t *availsp
 		}
 	}
 	++gFsStatsArray[FsStats::Statfs];
+	metrics::Counter::increment(metrics::Counter::Master::FS_STATFS);
 }
 #endif /* #ifndef METARESTORE */
 
@@ -418,6 +420,7 @@ uint8_t fs_lookup(const FsContext &context, uint32_t parent, const HString &name
 			}
 			fsnodes_fill_attr(wd, wd, context.uid(), context.gid(), context.auid(), context.agid(), context.sesflags(), attr);
 			++gFsStatsArray[FsStats::Lookup];
+			metrics::Counter::increment(metrics::Counter::Master::FS_LOOKUP);
 			return SAUNAFS_STATUS_OK;
 		}
 		if (name.length() == 2 && name[1] == '.') {  // parent
@@ -441,6 +444,7 @@ uint8_t fs_lookup(const FsContext &context, uint32_t parent, const HString &name
 				}
 			}
 			++gFsStatsArray[FsStats::Lookup];
+			metrics::Counter::increment(metrics::Counter::Master::FS_LOOKUP);
 			return SAUNAFS_STATUS_OK;
 		}
 	}
@@ -455,6 +459,7 @@ uint8_t fs_lookup(const FsContext &context, uint32_t parent, const HString &name
 	*inode = child->id;
 	fsnodes_fill_attr(child, wd, context.uid(), context.gid(), context.auid(), context.agid(), context.sesflags(), attr);
 	++gFsStatsArray[FsStats::Lookup];
+	metrics::Counter::increment(metrics::Counter::Master::FS_LOOKUP);
 	return SAUNAFS_STATUS_OK;
 }
 
@@ -537,6 +542,7 @@ uint8_t fs_getattr(const FsContext &context, uint32_t inode, Attributes &attr) {
 
 	fsnodes_fill_attr(p, NULL, context.uid(), context.gid(), context.auid(), context.agid(), context.sesflags(), attr);
 	++gFsStatsArray[FsStats::Getattr];
+	metrics::Counter::increment(metrics::Counter::Master::FS_GETATTR);
 	return SAUNAFS_STATUS_OK;
 }
 
@@ -588,6 +594,7 @@ uint8_t fs_try_setlength(const FsContext &context, uint32_t inode, uint8_t opene
 	}
 	fsnodes_fill_attr(p, NULL, context.uid(), context.gid(), context.auid(), context.agid(), context.sesflags(), attr);
 	++gFsStatsArray[FsStats::Setattr];
+	metrics::Counter::increment(metrics::Counter::Master::FS_SETATTR);
 	return SAUNAFS_STATUS_OK;
 }
 #endif
@@ -681,6 +688,7 @@ uint8_t fs_do_setlength(const FsContext &context, uint32_t inode, uint64_t lengt
 	fsnodes_update_checksum(p);
 	fsnodes_fill_attr(p, NULL, context.uid(), context.gid(), context.auid(), context.agid(), context.sesflags(), attr);
 	++gFsStatsArray[FsStats::Setattr];
+	metrics::Counter::increment(metrics::Counter::Master::FS_SETATTR);
 	return SAUNAFS_STATUS_OK;
 }
 
@@ -814,6 +822,7 @@ uint8_t fs_setattr(const FsContext &context, uint32_t inode, uint8_t setmask, ui
 	fsnodes_fill_attr(p, NULL, context.uid(), context.gid(), context.auid(), context.agid(), context.sesflags(), attr);
 	fsnodes_update_checksum(p);
 	++gFsStatsArray[FsStats::Setattr];
+	metrics::Counter::increment(metrics::Counter::Master::FS_SETATTR);
 	return SAUNAFS_STATUS_OK;
 }
 #endif
@@ -890,6 +899,7 @@ uint8_t fs_readlink(const FsContext &context, uint32_t inode, std::string &path)
 	path = (std::string)static_cast<FSNodeSymlink*>(p)->path;
 	fs_update_atime(p, ts);
 	++gFsStatsArray[FsStats::Readlink];
+	metrics::Counter::increment(metrics::Counter::Master::FS_READLINK);
 	return SAUNAFS_STATUS_OK;
 }
 #endif
@@ -953,6 +963,7 @@ uint8_t fs_symlink(const FsContext &context, uint32_t parent, const HString &nam
 	}
 #ifndef METARESTORE
 	++gFsStatsArray[FsStats::Symlink];
+	metrics::Counter::increment(metrics::Counter::Master::FS_SYMLINK);
 #endif /* #ifndef METARESTORE */
 	return SAUNAFS_STATUS_OK;
 }
@@ -1007,6 +1018,7 @@ uint8_t fs_mknod(const FsContext &context, uint32_t parent, const HString &name,
 	             wd->id, fsnodes_escape_name(name).c_str(), type, p->mode & 07777, context.uid(), context.gid(),
 	             rdev, p->id);
 	++gFsStatsArray[FsStats::Mknod];
+	metrics::Counter::increment(metrics::Counter::Master::FS_MKNOD);
 	fsnodes_update_checksum(p);
 	return SAUNAFS_STATUS_OK;
 }
@@ -1050,6 +1062,7 @@ uint8_t fs_mkdir(const FsContext &context, uint32_t parent, const HString &name,
 	             wd->id, fsnodes_escape_name(name).c_str(), FSNode::kDirectory, p->mode & 07777,
 	             context.uid(), context.gid(), 0, p->id);
 	++gFsStatsArray[FsStats::Mkdir];
+	metrics::Counter::increment(metrics::Counter::Master::FS_MKDIR);
 	return SAUNAFS_STATUS_OK;
 }
 #endif
@@ -1121,6 +1134,7 @@ uint8_t fs_unlink(const FsContext &context, uint32_t parent, const HString &name
 	             fsnodes_escape_name(name).c_str(), child->id);
 	fsnodes_unlink(ts, static_cast<FSNodeDirectory*>(wd), name, child);
 	++gFsStatsArray[FsStats::Unlink];
+	metrics::Counter::increment(metrics::Counter::Master::FS_UNLINK);
 	return SAUNAFS_STATUS_OK;
 }
 
@@ -1192,6 +1206,7 @@ uint8_t fs_rmdir(const FsContext &context, uint32_t parent, const HString &name)
 	             fsnodes_escape_name(name).c_str(), child->id);
 	fsnodes_unlink(ts, static_cast<FSNodeDirectory*>(wd), name, child);
 	++gFsStatsArray[FsStats::Rmdir];
+	metrics::Counter::increment(metrics::Counter::Master::FS_RMDIR);
 	return SAUNAFS_STATUS_OK;
 }
 #endif
@@ -1320,6 +1335,7 @@ uint8_t fs_rename(const FsContext &context, uint32_t parent_src, const HString &
 	}
 #ifndef METARESTORE
 	++gFsStatsArray[FsStats::Rename];
+	metrics::Counter::increment(metrics::Counter::Master::FS_RENAME);
 #endif
 	return SAUNAFS_STATUS_OK;
 }
@@ -1367,6 +1383,7 @@ uint8_t fs_link(const FsContext &context, uint32_t inode_src, uint32_t parent_ds
 	}
 #ifndef METARESTORE
 	++gFsStatsArray[FsStats::Link];
+	metrics::Counter::increment(metrics::Counter::Master::FS_LINK);
 #endif
 	return SAUNAFS_STATUS_OK;
 }
@@ -1721,6 +1738,7 @@ void fs_readdir_data(const FsContext &context, uint8_t flags, void *dnode, uint8
 					   context.sesflags(), static_cast<FSNodeDirectory*>(p), dbuff,
 	                   flags & GETDIR_FLAG_WITHATTR);
 	++gFsStatsArray[FsStats::Readdir];
+	metrics::Counter::increment(metrics::Counter::Master::FS_READDIR);
 }
 
 template <typename SerializableDirentType>
@@ -1750,6 +1768,7 @@ uint8_t fs_readdir(const FsContext &context, uint32_t inode, uint64_t first_entr
 		       first_entry, number_of_entries, dir_entries);
 
 	++gFsStatsArray[FsStats::Readdir];
+	metrics::Counter::increment(metrics::Counter::Master::FS_READDIR);
 
 	return SAUNAFS_STATUS_OK;
 }
@@ -1806,6 +1825,7 @@ uint8_t fs_opencheck(const FsContext &context, uint32_t inode, uint8_t flags, At
 	}
 	fsnodes_fill_attr(p, NULL, context.uid(), context.gid(), context.auid(), context.agid(), context.sesflags(), attr);
 	++gFsStatsArray[FsStats::Open];
+	metrics::Counter::increment(metrics::Counter::Master::FS_OPEN);
 	return SAUNAFS_STATUS_OK;
 }
 #endif
@@ -1935,6 +1955,7 @@ uint8_t fs_readchunk(uint32_t inode, uint32_t indx, uint64_t *chunkid, uint64_t 
 	*length = p->length;
 	fs_update_atime(p, ts);
 	++gFsStatsArray[FsStats::Read];
+	metrics::Counter::increment(metrics::Counter::Master::FS_READ);
 	return SAUNAFS_STATUS_OK;
 }
 #endif
@@ -2036,6 +2057,7 @@ uint8_t fs_writechunk(const FsContext &context, uint32_t inode, uint32_t indx, b
 	fsnodes_update_checksum(p);
 #ifndef METARESTORE
 	++gFsStatsArray[FsStats::Write];
+	metrics::Counter::increment(metrics::Counter::Master::FS_WRITE);
 #endif
 	return SAUNAFS_STATUS_OK;
 }

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -5268,6 +5268,7 @@ void matoclserv_read(matoclserventry *eptr) {
 		}
 		eptr->inputpacket.startptr+=i;
 		eptr->inputpacket.bytesleft-=i;
+		metrics::Counter::increment(metrics::Counter::Master::CLIENT_RX_BYTES, i);
 		stats_brcvd+=i;
 
 		if (eptr->inputpacket.bytesleft>0) {
@@ -5303,7 +5304,7 @@ void matoclserv_read(matoclserventry *eptr) {
 			eptr->inputpacket.startptr = eptr->hdrbuff;
 			matoclserv_gotpacket(eptr,type,eptr->inputpacket.packet,size);
 			stats_prcvd++;
-			metrics::Counter::increment(metrics::Counter::CLIENT_RX_PACKETS);
+			metrics::Counter::increment(metrics::Counter::Master::CLIENT_RX_PACKETS);
 
 			if (eptr->inputpacket.packet) {
 				free(eptr->inputpacket.packet);
@@ -5339,13 +5340,14 @@ void matoclserv_write(matoclserventry *eptr) {
 		}
 		pack->startptr+=i;
 		pack->bytesleft-=i;
+		metrics::Counter::increment(metrics::Counter::Master::CLIENT_TX_BYTES, i);
 		stats_bsent+=i;
 		if (pack->bytesleft>0) {
 			return;
 		}
 		free(pack->packet);
 		stats_psent++;
-		metrics::Counter::increment(metrics::Counter::CLIENT_TX_PACKETS);
+		metrics::Counter::increment(metrics::Counter::Master::CLIENT_TX_PACKETS);
 		eptr->outputhead = pack->next;
 		if (eptr->outputhead==NULL) {
 			eptr->outputtail = &(eptr->outputhead);

--- a/src/metarestore/CMakeLists.txt
+++ b/src/metarestore/CMakeLists.txt
@@ -20,7 +20,7 @@ add_library(metarestore ${METARESTORE_SOURCES} ${METARESTORE_MASTER_SOURCES} ${M
   ../master/restore.cc ../master/locks.cc ../master/task_manager.cc ../master/snapshot_task.cc
   ../master/metadata_loader.cc ../master/setgoal_task.cc ../master/settrashtime_task.cc)
 
-target_link_libraries(metarestore sfscommon)
+target_link_libraries(metarestore metrics sfscommon)
 if(JUDY_LIBRARY)
   target_link_libraries(metarestore ${JUDY_LIBRARY})
 endif()

--- a/src/metrics/CMakeLists.txt
+++ b/src/metrics/CMakeLists.txt
@@ -16,11 +16,10 @@
 #  along with SaunaFS  If not, see <http://www.gnu.org/licenses/>.
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
-
 collect_sources(METRICS)
 
 add_library(metrics ${METRICS_SOURCES})
 
-if (PROMETHEUS_CPP_ENABLE_PULL)
+if (ENABLE_PROMETHEUS)
   target_link_libraries(metrics slogger prometheus-cpp::pull)
 endif()

--- a/src/metrics/master.cc
+++ b/src/metrics/master.cc
@@ -1,0 +1,187 @@
+/*
+
+   Copyright 2024 Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "metrics/master.h"
+#include "metrics.h"
+#include "metrics/utils.h"
+
+#ifdef HAVE_PROMETHEUS
+using namespace metrics;
+
+Master::Master(std::shared_ptr<prometheus::Registry> &registry) {
+	// clang-format off
+	// NOLINTBEGIN(cppcoreguidelines-prefer-member-initializer)
+	packetClientCounter = &setupFamily(
+		"metadata_observed_packets_client_total",
+		"Number of observed packets from and for client", registry);
+	byteClientCounter = &setupFamily(
+		"metadata_observed_bytes_client_total",
+		"Number of observed bytes from and for client", registry);
+	filesystemCounter = &setupFamily(
+		"metadata_stats_total",
+		"Number of observed filesystem operations", registry);
+	chunkCounter= &setupFamily(
+		"metadata_chunk_operations_total",
+		"Number of chunk operations", registry);
+	// NOLINTEND(cppcoreguidelines-prefer-member-initializer)
+
+	// A very hacky way to allow compile time checking if metrics have been
+	// set. Any enum value not used will throw a compile time error.
+	using Master = Counter::Master;
+	Master start = Master::KEY_START;
+	switch (start) {
+		case Master::KEY_START:
+			[[fallthrough]];
+		case Master::CHUNK_DELETE:
+			masterCounters[static_cast<unsigned int>(Master::CHUNK_DELETE)] =
+				Counter(
+					{{"chunk", "operations"}, {"operation", "delete"}},
+					chunkCounter);
+			[[fallthrough]];
+		case Master::CHUNK_REPLICATE:
+			masterCounters[static_cast<unsigned int>(Master::CHUNK_REPLICATE)] =
+				Counter(
+					{{"chunk", "operations"}, {"operation", "replicate"}},
+					chunkCounter);
+			[[fallthrough]];
+		case Master::FS_STATFS:
+			masterCounters[static_cast<unsigned int>(Master::FS_STATFS)] =
+				Counter(
+					{{"filesystem", "operations"}, {"operation", "STATFS"}},
+					filesystemCounter);
+			[[fallthrough]];
+		case Master::FS_GETATTR:
+			masterCounters[static_cast<unsigned int>(Master::FS_GETATTR)] =
+				Counter(
+					{{"filesystem", "operations"}, {"operation", "GETATTR"}},
+					filesystemCounter);
+			[[fallthrough]];
+		case Master::FS_SETATTR:
+			masterCounters[static_cast<unsigned int>(Master::FS_SETATTR)] =
+				Counter(
+					{{"filesystem", "operations"}, {"operation", "SETATTR"}},
+					filesystemCounter);
+			[[fallthrough]];
+		case Master::FS_LOOKUP:
+			masterCounters[static_cast<unsigned int>(Master::FS_LOOKUP)] =
+				Counter(
+					{{"filesystem", "operations"}, {"operation", "LOOKUP"}},
+					filesystemCounter);
+			[[fallthrough]];
+		case Master::FS_MKDIR:
+			masterCounters[static_cast<unsigned int>(Master::FS_MKDIR)] =
+				Counter(
+					{{"filesystem", "operations"}, {"operation", "MKDIR"}},
+					filesystemCounter);
+			[[fallthrough]];
+		case Master::FS_RMDIR:
+			masterCounters[static_cast<unsigned int>(Master::FS_RMDIR)] =
+				Counter(
+					{{"filesystem", "operations"}, {"operation", "RMDIR"}},
+					filesystemCounter);
+			[[fallthrough]];
+		case Master::FS_SYMLINK:
+			masterCounters[static_cast<unsigned int>(Master::FS_SYMLINK)] =
+				Counter(
+					{{"filesystem", "operations"}, {"operation", "SYMLINK"}},
+					filesystemCounter);
+			[[fallthrough]];
+		case Master::FS_READLINK:
+			masterCounters[static_cast<unsigned int>(Master::FS_READLINK)] =
+				Counter(
+					{{"filesystem", "operations"}, {"operation", "READLINK"}},
+					filesystemCounter);
+			[[fallthrough]];
+		case Master::FS_MKNOD:
+			masterCounters[static_cast<unsigned int>(Master::FS_MKNOD)] =
+				Counter(
+					{{"filesystem", "operations"}, {"operation", "MKNOD"}},
+					filesystemCounter);
+			[[fallthrough]];
+		case Master::FS_UNLINK:
+			masterCounters[static_cast<unsigned int>(Master::FS_UNLINK)] =
+				Counter(
+					{{"filesystem", "operations"}, {"operation", "UNLINK"}},
+					filesystemCounter);
+			[[fallthrough]];
+		case Master::FS_RENAME:
+			masterCounters[static_cast<unsigned int>(Master::FS_RENAME)] =
+				Counter(
+					{{"filesystem", "operations"}, {"operation", "RENAME"}},
+					filesystemCounter);
+			[[fallthrough]];
+		case Master::FS_LINK:
+			masterCounters[static_cast<unsigned int>(Master::FS_LINK)] =
+				Counter(
+					{{"filesystem", "operations"}, {"operation", "LINK"}},
+					filesystemCounter);
+			[[fallthrough]];
+		case Master::FS_READDIR:
+			masterCounters[static_cast<unsigned int>(Master::FS_READDIR)] = Counter(
+				{{"filesystem", "operations"}, {"operation", "READDIR"}},
+				filesystemCounter);
+			[[fallthrough]];
+		case Master::FS_OPEN:
+			masterCounters[static_cast<unsigned int>(Master::FS_OPEN)] =
+				Counter(
+					{{"filesystem", "operations"}, {"operation", "OPEN"}},
+					filesystemCounter);
+			[[fallthrough]];
+		case Master::FS_READ:
+			masterCounters[static_cast<unsigned int>(Master::FS_READ)] =
+				Counter(
+					{{"filesystem", "operations"}, {"operation", "READ"}},
+					filesystemCounter);
+			[[fallthrough]];
+		case Master::FS_WRITE:
+			masterCounters[static_cast<unsigned int>(Master::FS_WRITE)] =
+				Counter(
+					{{"filesystem", "operations"}, {"operation", "WRITE"}},
+					filesystemCounter);
+			[[fallthrough]];
+		case Master::CLIENT_RX_PACKETS:
+			masterCounters[static_cast<unsigned int>(Master::CLIENT_RX_PACKETS)] =
+				Counter(
+					{{"protocol", "tcp"}, {"direction", "rx"}},
+					packetClientCounter);
+			[[fallthrough]];
+		case Master::CLIENT_TX_PACKETS:
+			masterCounters[static_cast<unsigned int>(Master::CLIENT_TX_PACKETS)] =
+				Counter(
+					{{"protocol", "tcp"}, {"direction", "tx"}},
+					packetClientCounter);
+			[[fallthrough]];
+		case Master::CLIENT_RX_BYTES:
+			masterCounters[static_cast<unsigned int>(Master::CLIENT_RX_BYTES)] =
+				Counter(
+					{{"protocol", "tcp"}, {"direction", "rx"}},
+					byteClientCounter);
+			[[fallthrough]];
+		case Master::CLIENT_TX_BYTES:
+			masterCounters[static_cast<unsigned int>(Master::CLIENT_TX_BYTES)] =
+				Counter(
+					{{"protocol", "tcp"}, {"direction", "tx"}},
+					byteClientCounter);
+			[[fallthrough]];
+		case Master::KEY_END:
+			break;
+	}
+	// clang-format on
+}
+#endif

--- a/src/metrics/master.h
+++ b/src/metrics/master.h
@@ -1,0 +1,43 @@
+/*
+
+   Copyright 2024 Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#include "metrics/metrics.h"
+
+#ifdef HAVE_PROMETHEUS
+#include <prometheus/counter.h>
+#include <prometheus/registry.h>
+
+namespace metrics {
+
+struct Master {
+	Master() = default;
+	Master(std::shared_ptr<prometheus::Registry>& registry);
+
+	// Metric(s)
+	CounterFamily *packetClientCounter{nullptr};
+	CounterFamily *byteClientCounter{nullptr};
+	CounterFamily *filesystemCounter{nullptr};
+	CounterFamily *chunkCounter{nullptr};
+
+	// Master Counters
+	std::array<Counter, static_cast<unsigned int>(Counter::Master::KEY_END) + 1> masterCounters;
+};
+}
+#endif

--- a/src/metrics/metrics.cc
+++ b/src/metrics/metrics.cc
@@ -17,6 +17,20 @@
    along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
  */
 
+// This library provides a means of manipulating Prometheus metrics safely and
+// efficiently.
+// The two key restraints in the design are:
+// 1. Prefer compile time costs/safety over initialization time costs/safety,
+// and avoid runtime costs except in accessing the metrics themselves (but
+// minimize them).
+// 2. Do not allow dynamic dimensional data on runtime (i.e, calling Add after
+// initialization)
+//
+// This should allow placing metric gathering functions pretty much everywhere,
+// without worry for performance impact. To do this, it uses a lookup table
+// using enums instead of a map. See master.cc and master.h for an example
+// implementation for adding new metrics.
+
 #ifdef HAVE_PROMETHEUS
 #include <prometheus/counter.h>
 #include <prometheus/detail/builder.h>
@@ -30,16 +44,20 @@
 #endif
 
 #include "metrics.h"
+#include "metrics/master.h"
 #include "slogger/slogger.h"
+
+
+constexpr auto THREAD_SLEEP_TIME_MS = 100;
 
 namespace metrics {
 
 std::unique_ptr<std::jthread>
-    metrics_main_thread;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+    gMetricsMainThread;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 void destroy() {
-	if (metrics_main_thread != nullptr) {
-		metrics_main_thread->request_stop();
+	if (gMetricsMainThread != nullptr) {
+		gMetricsMainThread->request_stop();
 	}
 }
 
@@ -52,73 +70,41 @@ void init(const char* /* unused */) {
 }
 #else
 
-constexpr auto THREAD_SLEEP_TIME_MS = 100;
-
-prometheus::Family<prometheus::Counter> &setup_family(
-    const char *name, const char *help,
-    std::shared_ptr<prometheus::Registry> &registry) {
-	return prometheus::BuildCounter().Name(name).Help(help).Register(*registry);
-}
-
-class Counters {
+class PrometheusMetrics {
 public:
-	Counters() {
-		registry = std::make_shared<prometheus::Registry>();
-		// NOLINTBEGIN(cppcoreguidelines-prefer-member-initializer)
-		packet_counter = &setup_family(
-		    "observed_packets_total_client",
-		    "Number of observed packets from and for client", registry);
-		// NOLINTEND(cppcoreguidelines-prefer-member-initializer)
-
-		// A very hacky way to allow compile time checking if metrics have been
-		// set. Any enum value not used will throw a compile time error.
-		Counter::Key start = Counter::KEY_START;
-		switch (start) {
-		case Counter::KEY_START:
-		case Counter::CLIENT_RX_PACKETS:
-			counters[Counter::CLIENT_RX_PACKETS] = Counter(
-			    {{"protocol", "tcp"}, {"direction", "rx"}}, packet_counter);
-			[[fallthrough]];
-		case Counter::CLIENT_TX_PACKETS:
-			counters[Counter::CLIENT_TX_PACKETS] = Counter(
-			    {{"protocol", "tcp"}, {"direction", "tx"}}, packet_counter);
-		case Counter::KEY_END:
-			break;
-		}
+	PrometheusMetrics() : registry(std::make_shared<prometheus::Registry>()) {
+		master = Master(registry);
 	}
 
-	std::shared_ptr<prometheus::Registry> get_registry() {
+	std::shared_ptr<prometheus::Registry> getRegistry() {
 		return registry;
 	}
 
-	inline Counter& get(Counter::Key type) {
-		// Completely safe, as all values are defined
-		return counters[type]; // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
-	}
+	// Master metrics
+	Master master; // NOLINT(cppcoreguidelines-non-private-member-variables-in-classes)
 
 private:
-	// Registry, used by packet_counter and counters
+	// Registry
 	std::shared_ptr<prometheus::Registry> registry;
-
-	// Metric(s)
-	prometheus::Family<prometheus::Counter> *packet_counter;
-
-	// All counters
-	std::array<Counter, Counter::Key::KEY_END + 1> counters;
 };
-Counters counters;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+PrometheusMetrics gPrometheusMetrics;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
-void Counter::increment(Key key, double n) {
-	auto counter = counters.get(key);
+template <typename T>
+void Counter::increment(T key, double n) {
+	// Safe as all values are constructed at specific keys, however a check
+	// needs to be made whether the actual counter initialized or not (for
+	// whatever reason)
+	auto counterKey = static_cast<unsigned int>(key);
+	auto counter = gPrometheusMetrics.master.masterCounters[counterKey]; // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
 	if (counter.counter_ != nullptr) { counter.counter_->Increment(n); }
 }
 
-void prometheus_loop(const std::stop_token& stop, const char* host) {
+void prometheusLoop(const std::stop_token& stop, const char* host) {
 	try {
 		// create an http server
 		prometheus::Exposer exposer{host};
 
-		exposer.RegisterCollectable(counters.get_registry());
+		exposer.RegisterCollectable(gPrometheusMetrics.getRegistry());
 		safs::log_info("started prometheus server");
 
 		while (!stop.stop_requested()) {
@@ -130,8 +116,10 @@ void prometheus_loop(const std::stop_token& stop, const char* host) {
 }
 
 void init(const char* host) {
-	metrics_main_thread = std::make_unique<std::jthread>(std::jthread(prometheus_loop, host));
+	gMetricsMainThread = std::make_unique<std::jthread>(std::jthread(prometheusLoop, host));
 }
 
 }
 #endif
+template void metrics::Counter::increment<metrics::Counter::Master>
+	(metrics::Counter::Master key, double n);

--- a/src/metrics/metrics.h
+++ b/src/metrics/metrics.h
@@ -23,23 +23,50 @@
 #include <prometheus/exposer.h>
 #include <prometheus/registry.h>
 #include <prometheus/family.h>
+
+using CounterFamily = prometheus::Family<prometheus::Counter>;
+
 #endif
 
 namespace metrics {
 
 class Counter {
 public:
-	enum Key {
-		KEY_START = 0,
-		CLIENT_RX_PACKETS,
-		CLIENT_TX_PACKETS,
-		KEY_END,
-	};
+enum class Master : unsigned int {
+	KEY_START = 0,      // Used internally, has no effect
+	CHUNK_DELETE,       // Chunk deletion operations
+	CHUNK_REPLICATE,    // Chunk replication operations
+	FS_STATFS,          // Filesystem STATFS operations
+	FS_GETATTR,         // Filesystem GETATTR operations
+	FS_SETATTR,         // Filesystem SETATTR operations
+	FS_LOOKUP,          // Filesystem LOOKUP operations
+	FS_MKDIR,           // Filesystem MKDIR operations
+	FS_RMDIR,           // Filesystem RMDIR operations
+	FS_SYMLINK,         // Filesystem SYMLINK operations
+	FS_READLINK,        // Filesystem READLINK operations
+	FS_MKNOD,           // Filesystem MKNOD operations
+	FS_UNLINK,          // Filesystem UNLINK operations
+	FS_RENAME,          // Filesystem RENAME operations
+	FS_LINK,            // Filesystem LINK operations
+	FS_READDIR,         // Filesystem READDIR operations
+	FS_OPEN,            // Filesystem OPEN operations
+	FS_READ,            // Filesystem READ operations
+	FS_WRITE,           // Filesystem WRITE operations
+	CLIENT_RX_PACKETS,  // Packets (i.e messages) received from
+	                    // client
+	CLIENT_TX_PACKETS,  // Packets (i.e messages) sent to client
+	CLIENT_RX_BYTES,    // Bytes received from client
+	CLIENT_TX_BYTES,    // Bytes sent to client
+	KEY_END,            // Used internally, has no effect
+};
+
 #ifdef HAVE_PROMETHEUS
 	Counter() : counter_(nullptr) {};
-	Counter(const prometheus::Labels &labels, prometheus::Family<prometheus::Counter> *family) : counter_(&family->Add(labels)) {};
+	Counter(const prometheus::Labels &labels, CounterFamily *family) :
+		counter_(&family->Add(labels)) {};
 
-	static void increment(Key key, double n = 1);
+	template <typename T>
+	static void increment(T key, double n = 1);
 
 private:
 	prometheus::Counter* counter_;
@@ -47,11 +74,8 @@ private:
 	// Dummy methods for packages without prometheus
 	explicit Counter() = default;
 
-	static void increment(Key /*unused*/, double  /*unused*/= 1) {
-	}
-
-	static inline Counter get(Counter::Key  /*type*/) {
-		return Counter();
+	template <typename T>
+	static void increment(T /*unused*/, double  /*unused*/= 1) {
 	}
 #endif
 };

--- a/src/metrics/utils.h
+++ b/src/metrics/utils.h
@@ -1,0 +1,30 @@
+/*
+
+   Copyright 2024 Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#ifdef HAVE_PROMETHEUS
+#include <prometheus/counter.h>
+#include <prometheus/family.h>
+
+inline prometheus::Family<prometheus::Counter> &setupFamily(
+    const char *name, const char *help,
+    std::shared_ptr<prometheus::Registry> &registry) {
+	return prometheus::BuildCounter().Name(name).Help(help).Register(*registry);
+}
+#endif

--- a/tests/test_suites/SanityChecks/test_prometheus.sh
+++ b/tests/test_suites/SanityChecks/test_prometheus.sh
@@ -2,9 +2,9 @@ if ! ldd $(whereis sfsmaster | awk '{print $2}') | grep prometheus; then
 	echo "Prometheus client isn't linked with master, skipping test..."
 	test_end
 fi
-expected_client_received_initial='observed_packets_total_client{direction="rx",protocol="tcp"}'
-expected_client_sent_initial='observed_packets_total_client{direction="tx",protocol="tcp"}'
-prometheus_host="localhost:8080"
+expected_client_received_initial='metadata_observed_packets_client_total{direction="rx",protocol="tcp"}'
+expected_client_sent_initial='metadata_observed_packets_client_total{direction="tx",protocol="tcp"}'
+prometheus_host="localhost:45678"
 
 USE_RAMDISK=YES \
 	MASTERSERVERS=1 \
@@ -14,10 +14,11 @@ USE_RAMDISK=YES \
 	MASTER_EXTRA_CONFIG="ENABLE_PROMETHEUS = 1|PROMETHEUS_HOST = ${prometheus_host}" \
 	setup_local_empty_saunafs info
 
-
+curl --fail "${prometheus_host}/metrics"
+curl --fail "${prometheus_host}/metrics"
 # Why are these at 1 when master is started with no clients?
-expect_equals 1 $(grep "${expected_client_received_initial}" <<< "$(curl --fail "${prometheus_host}/metrics")" | awk '{print $2}' )
-expect_equals 1 $(grep "${expected_client_sent_initial}" <<< "$(curl --fail "${prometheus_host}/metrics")" | awk '{print $2}' )
+expect_equals 1 $(grep "${expected_client_received_initial}" <<< "$(curl --fail "${prometheus_host}/metrics")" | awk '{print $2}')
+expect_equals 1 $(grep "${expected_client_sent_initial}" <<< "$(curl --fail "${prometheus_host}/metrics")" | awk '{print $2}')
 
 # First 4 bytes: type ANTOAN_PING (check src/protocol/SFSCommunication.h)
 # Second 4 bytes: byte length of data
@@ -26,4 +27,4 @@ expect_equals 1 $(grep "${expected_client_sent_initial}" <<< "$(curl --fail "${p
 # open for a while, sending ANTOAN_NOP)
 echo -e "\x00\x00\x00\x03\x00\x00\x00\x04\x00\x00\x00\x01" | nc -q 0 127.0.0.1 ${saunafs_info_[matocl]}
 
-expect_equals 2 $(grep "${expected_client_received_initial}" <<< "$(curl --fail "${prometheus_host}/metrics")" | awk '{print $2}' )
+expect_equals 2 $(grep "${expected_client_received_initial}" <<< "$(curl --fail "${prometheus_host}/metrics")" | awk '{print $2}')

--- a/tests/test_suites/SanityChecks/test_prometheus.sh
+++ b/tests/test_suites/SanityChecks/test_prometheus.sh
@@ -1,11 +1,8 @@
-if ! ldd $(whereis sfsmaster | awk '{print $2}') | grep prometheus; then
-	echo "Prometheus client isn't linked with master, skipping test..."
-	test_end
-fi
 expected_client_received_initial='metadata_observed_packets_client_total{direction="rx",protocol="tcp"}'
 expected_client_sent_initial='metadata_observed_packets_client_total{direction="tx",protocol="tcp"}'
-prometheus_host="localhost:45678"
-
+declare port
+get_next_port_number port
+prometheus_host="localhost:${port}"
 USE_RAMDISK=YES \
 	MASTERSERVERS=1 \
 	CHUNKSERVERS=0 \
@@ -14,11 +11,10 @@ USE_RAMDISK=YES \
 	MASTER_EXTRA_CONFIG="ENABLE_PROMETHEUS = 1|PROMETHEUS_HOST = ${prometheus_host}" \
 	setup_local_empty_saunafs info
 
-curl --fail "${prometheus_host}/metrics"
-curl --fail "${prometheus_host}/metrics"
+
 # Why are these at 1 when master is started with no clients?
-expect_equals 1 $(grep "${expected_client_received_initial}" <<< "$(curl --fail "${prometheus_host}/metrics")" | awk '{print $2}')
-expect_equals 1 $(grep "${expected_client_sent_initial}" <<< "$(curl --fail "${prometheus_host}/metrics")" | awk '{print $2}')
+expect_equals 1 $(grep "${expected_client_received_initial}" <<< "$(curl --fail "${prometheus_host}/metrics")" | awk '{print $2}' )
+expect_equals 1 $(grep "${expected_client_sent_initial}" <<< "$(curl --fail "${prometheus_host}/metrics")" | awk '{print $2}' )
 
 # First 4 bytes: type ANTOAN_PING (check src/protocol/SFSCommunication.h)
 # Second 4 bytes: byte length of data
@@ -27,4 +23,4 @@ expect_equals 1 $(grep "${expected_client_sent_initial}" <<< "$(curl --fail "${p
 # open for a while, sending ANTOAN_NOP)
 echo -e "\x00\x00\x00\x03\x00\x00\x00\x04\x00\x00\x00\x01" | nc -q 0 127.0.0.1 ${saunafs_info_[matocl]}
 
-expect_equals 2 $(grep "${expected_client_received_initial}" <<< "$(curl --fail "${prometheus_host}/metrics")" | awk '{print $2}')
+expect_equals 2 $(grep "${expected_client_received_initial}" <<< "$(curl --fail "${prometheus_host}/metrics")" | awk '{print $2}' )

--- a/tests/test_suites/ShortSystemTests/test_prometheus_metadata.sh
+++ b/tests/test_suites/ShortSystemTests/test_prometheus_metadata.sh
@@ -1,0 +1,37 @@
+declare port
+get_next_port_number port
+prometheus_host="localhost:${port}"
+USE_RAMDISK=YES \
+	MASTERSERVERS=1 \
+	MOUNTS=1 \
+	CHUNKSERVERS=3
+	MASTER_EXTRA_CONFIG="ENABLE_PROMETHEUS = 1|PROMETHEUS_HOST = ${prometheus_host}" \
+	SFSEXPORTS_EXTRA_OPTIONS="allcanchangequota,ignoregid" \
+	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER,symlinkcachetimeout=0" \
+	setup_local_empty_saunafs info
+
+# Check if metrics is up
+curl --fail "${prometheus_host}/metrics"
+
+cd "${info[mount0]}"
+metadata_generate_all
+# Do some reading and linking
+echo "foo" > bar
+ln -s bar bar_ln
+cat bar
+readlink bar_ln
+
+# Check if any value is zero
+input_data=$(grep -E 'metadata_stats_total\{filesystem="operations",operation="[A-Z]+"\}' <<< "$(curl --fail "${prometheus_host}/metrics")")
+echo "$input_data" | while read -r line; do
+	echo "${line}"
+	# BUG: Setting symlinkcachetimeout to 0, it still uses client cache
+	if grep -q "READLINK" <<< "$line"; then
+		continue
+	fi
+	# Extract the numeric value from each line
+	value=$(echo "$line" | awk '{print $NF}')
+
+	# Check if the value is greater than zero
+	expect_less_than 0 "$value"
+done

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -8,7 +8,8 @@
     "boost-system",
     "fmt",
     "gtest",
-    "spdlog"
+    "spdlog",
+    "prometheus-cpp"
   ],
   "overrides": [
     {
@@ -318,6 +319,10 @@
     {
       "name": "zstd",
       "version": "1.5.6"
+    },
+    {
+      "name": "prometheus-cpp",
+      "version": "1.3.0"
     }
   ]
 }


### PR DESCRIPTION
This commit finishes adding metric data from master chartsdata. Since all the chartsdata was counters in Prometheus terminology, there was no need to add other types, however a a small refactor was needed to accomodate master metrics and in the future other service metrics. Notably removed was CPU usage and memory, since there are better ways to gather this data, including with a prometheus server itself (which will scrape this data).

This commit deprecates master chartsdata, and is the first step in deprecating the CGI monitoring