### PR TITLE
Fix service uraft restart on failure

### DIFF
--- a/rpm/service-files/saunafs-uraft.service
+++ b/rpm/service-files/saunafs-uraft.service
@@ -10,7 +10,8 @@ PIDFile=/var/run/saunafs-uraft.pid
 TimeoutSec=0
 ExecStart=/usr/sbin/saunafs-uraft
 ExecStopPost=/usr/sbin/saunafs-uraft-helper demote
-Restart=no
+Restart=on-failure
+RestartSec=60
 User=saunafs
 
 [Install]


### PR DESCRIPTION
Current saunafs-uarft binary is deploying a service file `saunafs-uraft.service` that if service fails, it doesn't allow to be automatically reloaded.