### PR TITLE
fix(mount): Fix IIS permissions mess

### DIFF
--- a/src/mount/sauna_client.cc
+++ b/src/mount/sauna_client.cc
@@ -233,7 +233,7 @@ uint8_t get_session_flags() { return session_flags; }
 bool isMasterDisconnected() { return gIsDisconnectedFromMaster.load(); }
 
 #define LOCAL_USERS_THRESHOLD 0x30000
-#define IIS_USER 17
+std::unordered_set<uint32_t> allowed_users;
 static int32_t mounting_uid = USE_LOCAL_ID;
 static int32_t mounting_gid = USE_LOCAL_ID;
 uint32_t winfsp_uid = 0;
@@ -243,13 +243,13 @@ std::mutex winfsp_context_mutex;
 void update_last_winfsp_context(const uint32_t uid, const uint32_t gid) {
 	std::lock_guard<std::mutex> winfsp_context_lock(winfsp_context_mutex);
 
-	if (uid > LOCAL_USERS_THRESHOLD || uid == IIS_USER) {
+	if (uid > LOCAL_USERS_THRESHOLD || allowed_users.contains(uid)) {
 		if (debug_mode && winfsp_uid != uid) {
 			safs::log_debug("set WinFSP user id to {}", uid);
 		}
 		winfsp_uid = uid;
 	}
-	if (gid > LOCAL_USERS_THRESHOLD || gid == IIS_USER) {
+	if (gid > LOCAL_USERS_THRESHOLD || allowed_users.contains(gid)) {
 		if (debug_mode && winfsp_gid != gid) {
 			safs::log_debug("set WinFSP group id to {}", uid);
 		}
@@ -3392,13 +3392,14 @@ void init(int debug_mode_, int keep_cache_, double direntry_cache_timeout_, unsi
 		SugidClearMode sugid_clear_mode_, bool use_rwlock_,
 		double acl_cache_timeout_, unsigned acl_cache_size_, bool direct_io
 #ifdef _WIN32
-		, int mounting_uid_, int mounting_gid_
+		, int mounting_uid_, int mounting_gid_, std::unordered_set<uint32_t> &allowed_users_
 #endif
 		, bool ignore_flush_
 		) {
 #ifdef _WIN32
 	mounting_uid = mounting_uid_;
 	mounting_gid = mounting_gid_;
+	allowed_users = allowed_users_;
 #endif
 	ignore_flush = ignore_flush_;
 	debug_mode = debug_mode_;
@@ -3494,7 +3495,7 @@ void fs_init(FsInitParams &params) {
 		params.sugid_clear_mode, params.use_rw_lock,
 		params.acl_cache_timeout, params.acl_cache_size, params.direct_io
 #ifdef _WIN32
-		, params.mounting_uid, params.mounting_gid
+		, params.mounting_uid, params.mounting_gid, params.allowed_users
 #endif
 		, params.ignore_flush
 		);

--- a/src/mount/sauna_client.h
+++ b/src/mount/sauna_client.h
@@ -27,6 +27,7 @@
 #include <unistd.h>
 
 #include <string>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -226,6 +227,7 @@ struct FsInitParams {
 #ifdef _WIN32
 	int mounting_uid;
 	int mounting_gid;
+	std::unordered_set<uint32_t> allowed_users;
 #endif
 
 	bool ignore_flush;


### PR DESCRIPTION
This PR aims to provide the expected behavior of our system while
dealing with the IIS tool. This tool apparently uses a very specific
user (17) to access the underlaying files. The user 17 was not expected
to perform these kinds of operations, thus causing the permission denied
errors. Solution was to make a breach at some checks to allow it.