### PR TITLE
feat(admin): Add list-disk-groups command

### DIFF
--- a/src/admin/list_disk_groups_command.cc
+++ b/src/admin/list_disk_groups_command.cc
@@ -1,0 +1,98 @@
+/*
+   Copyright 2023 Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "common/platform.h"
+
+#include <yaml-cpp/yaml.h>
+#include <iostream>
+
+#include "admin/list_chunkservers_command.h"
+#include "admin/list_disk_groups_command.h"
+#include "common/saunafs_version.h"
+#include "common/serialization.h"
+#include "common/server_connection.h"
+
+std::string ListDiskGroupsCommand::name() const { return "list-disk-groups"; }
+
+void ListDiskGroupsCommand::usage() const {
+	std::cerr << name() << " <master ip> <master port>\n";
+	std::cerr << "    Prints disk groups configuration in chunkservers.\n";
+}
+
+void ListDiskGroupsCommand::run(const Options &options) const {
+	if (options.arguments().size() != 2) {
+		throw WrongUsageException(
+		    "Expected <master ip> and <master port> for " + name());
+	}
+
+	auto chunkservers = ListChunkserversCommand::getChunkserversList(
+	    options.argument(0), options.argument(1));
+
+	YAML::Emitter yaml;
+	yaml << YAML::BeginMap;  // start root map
+
+	yaml << YAML::Key << "chunkservers";
+	yaml << YAML::Value << YAML::BeginSeq;  // start chunkservers list
+
+	for (const auto &chunkserver : chunkservers) {
+		if (chunkserver.version == kDisconnectedChunkserverVersion) {
+			continue;  // skip disconnected chunkservers
+		}
+
+		std::vector<uint8_t> request;
+		std::vector<uint8_t> response;
+		serializeLegacyPacket(request, CLTOCS_ADMIN_LIST_DISK_GROUPS);
+
+		auto csAddress =
+		    NetworkAddress(chunkserver.servip, chunkserver.servport);
+		ServerConnection connection(csAddress);
+		response = connection.sendAndReceive(request,
+		                                     CSTOCL_ADMIN_LIST_DISK_GROUPS);
+
+		std::string info;
+
+		try {
+			deserializeAllLegacyPacketDataNoHeader(response, info);
+		} catch (const IncorrectDeserializationException &e) {
+			std::cerr << e.what() << "\n";
+			continue;
+		}
+
+		yaml << YAML::BeginMap;  // start chunkserver map
+		yaml << YAML::Key << "chunkserver";
+		yaml << YAML::Value << csAddress.toString();
+
+		static constexpr const char *kDiskGroupsKey = "disk_groups";
+		yaml << YAML::Key << kDiskGroupsKey;
+
+		YAML::Node diskGroups = YAML::Load(info);
+
+		if (diskGroups.IsMap() && diskGroups[kDiskGroupsKey]) {
+			yaml << YAML::Value << diskGroups[kDiskGroupsKey];
+		} else {
+			yaml << YAML::Value << info;
+		}
+
+		yaml << YAML::EndMap;  // end chunkserver map
+	}
+
+	yaml << YAML::EndSeq;  // end chunkservers list
+	yaml << YAML::EndMap;  // end root map
+
+	std::cout << yaml.c_str() << "\n";
+}

--- a/src/admin/list_disk_groups_command.h
+++ b/src/admin/list_disk_groups_command.h
@@ -1,0 +1,30 @@
+/*
+   Copyright 2023 Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "common/platform.h"
+
+#include "admin/saunafs_admin_command.h"
+
+class ListDiskGroupsCommand : public SaunaFsAdminCommand {
+public:
+	std::string name() const override;
+	void usage() const override;
+	void run(const Options& options) const override;
+};

--- a/src/admin/main.cc
+++ b/src/admin/main.cc
@@ -29,6 +29,7 @@
 #include "admin/list_chunkservers_command.h"
 #include "admin/list_defective_files_command.h"
 #include "admin/list_disks_command.h"
+#include "admin/list_disk_groups_command.h"
 #include "admin/list_goals_command.h"
 #include "admin/list_metadataservers_command.h"
 #include "admin/list_mounts_command.h"
@@ -58,6 +59,7 @@ int main(int argc, const char** argv) {
 			new ListChunkserversCommand(),
 			new ListDefectiveFilesCommand(),
 			new ListDisksCommand(),
+			new ListDiskGroupsCommand(),
 			new ListGoalsCommand(),
 			new ListMountsCommand(),
 			new ListMetadataserversCommand(),

--- a/src/chunkserver/chunkserver-common/default_disk_manager.h
+++ b/src/chunkserver/chunkserver-common/default_disk_manager.h
@@ -69,4 +69,8 @@ public:
 	/// Update the space usage of the disks.
 	/// No need to update the space usage here for this implementation.
 	void updateSpaceUsage() override {};
+
+	/// Gets the disk groups information.
+	/// Not supported by the default disk manager.
+	std::string getDiskGroupsInfo() override { return "Not supported"; }
 };

--- a/src/chunkserver/chunkserver-common/disk_manager_interface.h
+++ b/src/chunkserver/chunkserver-common/disk_manager_interface.h
@@ -57,4 +57,7 @@ public:
 
 	/// Update the space usage of the disks.
 	virtual void updateSpaceUsage() = 0;
+
+	/// Gets the disk groups information in YAML format
+	virtual std::string getDiskGroupsInfo() = 0;
 };

--- a/src/chunkserver/hddspacemgr.cc
+++ b/src/chunkserver/hddspacemgr.cc
@@ -189,6 +189,12 @@ void hddSerializeAllDiskInfosV2(uint8_t *buff) {
 	gDisksMutex.unlock();  //Locked by hddGetSerializedSizeOfAllDiskInfosV2
 }
 
+std::string hddGetDiskGroups() {
+	TRACETHIS();
+
+	return gDiskManager->getDiskGroupsInfo();
+}
+
 void hddDiskInfoRotateStats() {
 	TRACETHIS();
 

--- a/src/chunkserver/hddspacemgr.h
+++ b/src/chunkserver/hddspacemgr.h
@@ -41,6 +41,8 @@ void hddGetNewChunks(std::vector<ChunkWithVersionAndType>& chunks,
 uint32_t hddGetSerializedSizeOfAllDiskInfosV2();
 void hddSerializeAllDiskInfosV2(uint8_t *buff);
 
+std::string hddGetDiskGroups();
+
 const std::size_t kChunkBulkSize = 1000;
 using BulkFunction = std::function<void(std::vector<ChunkWithVersionAndType>&)>;
 /// Executes the callback for each bulk of at most \p kChunkBulkSize chunks.

--- a/src/chunkserver/network_worker_thread.cc
+++ b/src/chunkserver/network_worker_thread.cc
@@ -887,6 +887,22 @@ void worker_hdd_list_v2(csserventry *eptr, const uint8_t *data,
 	hddSerializeAllDiskInfosV2(ptr); // unlock
 }
 
+void worker_list_disk_groups(csserventry *eptr,
+                             [[maybe_unused]] const uint8_t *data,
+                             [[maybe_unused]] uint32_t length) {
+	TRACETHIS();
+
+	std::string diskGroups = hddGetDiskGroups();
+
+	// 4 bytes for the size of the string + 1 byte for the null character
+	static constexpr uint8_t kSerializedSizePlusNullChar = 5;
+
+	uint8_t *ptr = worker_create_attached_packet(
+	    eptr, CSTOCL_ADMIN_LIST_DISK_GROUPS,
+	    diskGroups.size() + kSerializedSizePlusNullChar);
+	serialize(&ptr, diskGroups);
+}
+
 void worker_chart(csserventry *eptr, const uint8_t *data, uint32_t length) {
 	TRACETHIS();
 	uint32_t chartid;
@@ -1021,6 +1037,9 @@ void worker_gotpacket(csserventry *eptr, uint32_t type, const uint8_t *data, uin
 			break;
 		case CLTOCS_HDD_LIST_V2:
 			worker_hdd_list_v2(eptr, data, length);
+			break;
+		case CLTOCS_ADMIN_LIST_DISK_GROUPS:
+			worker_list_disk_groups(eptr, data, length);
 			break;
 		case CLTOAN_CHART:
 			worker_chart(eptr, data, length);

--- a/src/protocol/SFSCommunication.h
+++ b/src/protocol/SFSCommunication.h
@@ -1751,3 +1751,11 @@ enum class SugidClearMode {
 // 0x0259
 #define CSTOCL_HDD_LIST_V2 (PROTO_BASE+601)
 // N*[ entrysize:16 path:NAME flags:8 errchunkid:64 errtime:32 used:64 total:64 chunkscount:32 bytesread:64 usecread:64 usecreadmax:64 byteswriten:64 usecwrite:64 usecwritemax:64]
+
+// 0x025D
+#define CLTOCS_ADMIN_LIST_DISK_GROUPS (PROTO_BASE + 602)
+/// -
+
+// 0x025E
+#define CSTOCL_ADMIN_LIST_DISK_GROUPS (PROTO_BASE + 603)
+/// config:STDSTRING


### PR DESCRIPTION
The saunafs-admin was extended to show the disk groups configuration from the chunkservers. The default disk manager does not support this feature yet and prints 'Not supported', but it is already available (and used) from the plugins by reimplementing the default behavior.