### PR TITLE
feat(mount): New chunk-based write algorithm

### DIFF
--- a/doc/sfsmount.1.adoc
+++ b/doc/sfsmount.1.adoc
@@ -218,13 +218,14 @@ Equivalent to *--nostdopts* (*-n*) option for use in fstab.
 *-o nonempty*::
 Equivalent to *--nonempty* option for use in fstab.
 
-*-o sfsuseoldwritealgorithm*::
-Use legacy write algorithm. Though new algorithm is faster in most cases, old
-algorithm may prove useful in some scenarios.
+*-o sfsuseinodebasedwritealgorithm=*'0|1'::
+Use inode based write algorithm when set to 1. Use chunk based write algorithm
+when set to 0. Though chunk based algorithm is faster in most cases, inode
+based algorithm may prove useful in some scenarios (default: 0).
 
-*-o sfsignoreflush*'0|1'::
-Advanced: use with caution. Ignore flush usual behavior by replying SUCCESS to it
-immediately. Targets fast creation of small files, but may cause data loss
+*-o sfsignoreflush=*'0|1'::
+Advanced: use with caution. Ignore flush usual behavior by replying SUCCESS to
+it immediately. Targets fast creation of small files, but may cause data loss
 during crashes when allegedly flushed data is still being processed (default: 0).
 
 *-o sfsdirectio=*'0|1'::

--- a/doc/sfsmount.1.adoc
+++ b/doc/sfsmount.1.adoc
@@ -218,6 +218,10 @@ Equivalent to *--nostdopts* (*-n*) option for use in fstab.
 *-o nonempty*::
 Equivalent to *--nonempty* option for use in fstab.
 
+*-o sfsuseoldwritealgorithm*::
+Use legacy write algorithm. Though new algorithm is faster in most cases, old
+algorithm may prove useful in some scenarios.
+
 *-o sfsignoreflush*'0|1'::
 Advanced: use with caution. Ignore flush usual behavior by replying SUCCESS to it
 immediately. Targets fast creation of small files, but may cause data loss

--- a/doc/sfsmount.1.adoc
+++ b/doc/sfsmount.1.adoc
@@ -127,6 +127,9 @@ Set directory entry cache timeout in seconds (default: 1.0).
 *-o sfswritecachesize=*'N'::
 Specify write cache size in MiB (in range: 16..2048 - default: 128).
 
+*-o sfschunkserverwavewriteto=*'MSEC'::
+Set timeout for executing each wave of a write operation in milliseconds (default: 50).
+
 *-o sfscacheperinodepercentage=*'N'::
 Specify what part of the write cache non occupied by other inodes can a single
 inode occupy (measured in %). E.g. When N=75 and the inode X uses 10 MiB, and

--- a/src/mount/chunk_locator.h
+++ b/src/mount/chunk_locator.h
@@ -106,7 +106,7 @@ public:
 	}
 
 	void updateFileLength(uint64_t fileLength) {
-		locationInfo_. fileLength = fileLength;
+		locationInfo_.fileLength = fileLength;
 	}
 
 	const ChunkLocationInfo& locationInfo() const {

--- a/src/mount/chunk_locator.h
+++ b/src/mount/chunk_locator.h
@@ -80,7 +80,7 @@ private:
 
 class WriteChunkLocator {
 public:
-	WriteChunkLocator() : inode_(0), index_(0), lockId_(0) {}
+	WriteChunkLocator() {}
 
 	virtual ~WriteChunkLocator() {
 		try {
@@ -124,9 +124,9 @@ protected:
 			  lockId_(lockId) {
 	}
 
-	uint32_t inode_;
-	uint32_t index_;
-	uint32_t lockId_;
+	uint32_t inode_ = 0;
+	uint32_t index_ = 0;
+	uint32_t lockId_ = 0;
 	ChunkLocationInfo locationInfo_;
 };
 

--- a/src/mount/chunk_writer.cc
+++ b/src/mount/chunk_writer.cc
@@ -113,10 +113,6 @@ ChunkWriter::ChunkWriter(uint32_t chunkIndex,
                          ChunkConnector &connector, int dataChainFd)
 	: chunkserverStats_(chunkserverStats),
 	  connector_(connector),
-	  locator_(nullptr),
-	  idCounter_(0),
-	  acceptsNewOperations_(true),
-	  combinedStripeSize_(0),
 	  dataChainFd_(dataChainFd),
 	  chunkIndex_(chunkIndex) {
 }
@@ -664,7 +660,7 @@ void ChunkWriter::readBlocks(int block_index, int size, int block_from, int bloc
 	for (int index = block_index; index < block_index + size; ++index) {
 		assert(index < SFSBLOCKSINCHUNK);
 
-		WriteCacheBlock block(chunkIndex_,index, WriteCacheBlock::kReadBlock);
+		WriteCacheBlock block(chunkIndex_, index, WriteCacheBlock::kReadBlock);
 		memcpy(block.data(), buffer.data() + offset, SFSBLOCKSIZE);
 		block.from = block_from;
 		block.to = block_to;

--- a/src/mount/chunk_writer.h
+++ b/src/mount/chunk_writer.h
@@ -40,6 +40,7 @@ public:
 	/**
 	 * Constructor
 	 *
+	 * \param chunkIndex - index of the chunk within the inode the ChunkWriter will be writing.
 	 * \param stats - database which will be updated by the object when accessing servers
 	 * \param connector - object that will be used to create connection with chunkservers
 	 *        to write to them and read from them
@@ -176,10 +177,10 @@ private:
 
 	ChunkserverStats& chunkserverStats_;
 	ChunkConnector& connector_;
-	WriteChunkLocator* locator_;
-	uint32_t idCounter_;
-	bool acceptsNewOperations_;
-	int combinedStripeSize_;
+	WriteChunkLocator *locator_ = nullptr;
+	uint32_t idCounter_ = 0;
+	bool acceptsNewOperations_ = true;
+	int combinedStripeSize_ = 0;
 	int dataChainFd_;
 	int chunkSizeInBlocks_;
 	uint32_t chunkIndex_;

--- a/src/mount/chunk_writer.h
+++ b/src/mount/chunk_writer.h
@@ -40,15 +40,14 @@ public:
 	/**
 	 * Constructor
 	 *
-	 * \param chunkIndex - index of the chunk within the inode the ChunkWriter will be writing.
 	 * \param stats - database which will be updated by the object when accessing servers
 	 * \param connector - object that will be used to create connection with chunkservers
 	 *        to write to them and read from them
 	 * \param dataChainFd - end of pipe; if anything is written to it, ChunkWriter will break its
 	 *        poll call and look for some new data in write cache for the currently written chunk
 	 */
-	ChunkWriter(uint32_t chunkIndex, ChunkserverStats &stats,
-	            ChunkConnector &connector, int dataChainFd);
+	ChunkWriter(ChunkserverStats &stats, ChunkConnector &connector,
+	            int dataChainFd);
 	ChunkWriter(const ChunkWriter&) = delete;
 	~ChunkWriter();
 	ChunkWriter& operator=(const ChunkWriter&) = delete;
@@ -183,7 +182,6 @@ private:
 	int combinedStripeSize_ = 0;
 	int dataChainFd_;
 	int chunkSizeInBlocks_;
-	uint32_t chunkIndex_;
 
 	std::map<int, std::unique_ptr<WriteExecutor>> executors_;
 	std::list<WriteCacheBlock> journal_;

--- a/src/mount/chunk_writer.h
+++ b/src/mount/chunk_writer.h
@@ -46,7 +46,8 @@ public:
 	 * \param dataChainFd - end of pipe; if anything is written to it, ChunkWriter will break its
 	 *        poll call and look for some new data in write cache for the currently written chunk
 	 */
-	ChunkWriter(ChunkserverStats& stats, ChunkConnector& connector, int dataChainFd);
+	ChunkWriter(uint32_t chunkIndex, ChunkserverStats &stats,
+	            ChunkConnector &connector, int dataChainFd);
 	ChunkWriter(const ChunkWriter&) = delete;
 	~ChunkWriter();
 	ChunkWriter& operator=(const ChunkWriter&) = delete;
@@ -181,6 +182,7 @@ private:
 	int combinedStripeSize_;
 	int dataChainFd_;
 	int chunkSizeInBlocks_;
+	uint32_t chunkIndex_;
 
 	std::map<int, std::unique_ptr<WriteExecutor>> executors_;
 	std::list<WriteCacheBlock> journal_;

--- a/src/mount/fuse/main.cc
+++ b/src/mount/fuse/main.cc
@@ -244,6 +244,7 @@ static int mainloop(struct fuse_args *args, struct fuse_cmdline_opts *fuse_opts,
 	params.prefetch_xor_stripes = gMountOptions.prefetchxorstripes;
 	params.bandwidth_overuse = gMountOptions.bandwidthoveruse;
 	params.write_cache_size = gMountOptions.writecachesize;
+	params.write_wave_timeout_ms = gMountOptions.chunkserverwavewriteto;
 	params.write_workers = gMountOptions.writeworkers;
 	params.write_window_size = gMountOptions.writewindowsize;
 	params.chunkserver_write_timeout_ms = gMountOptions.chunkserverwriteto;

--- a/src/mount/fuse/main.cc
+++ b/src/mount/fuse/main.cc
@@ -261,6 +261,7 @@ static int mainloop(struct fuse_args *args, struct fuse_cmdline_opts *fuse_opts,
 	params.acl_cache_size = gMountOptions.aclcachesize;
 	params.debug_mode = gMountOptions.debug;
 	params.direct_io = gMountOptions.directio;
+	params.use_old_write_algorithm = gMountOptions.useoldwritealgorithm;
 	params.ignore_flush = gMountOptions.ignoreflush;
 	params.malloc_trim_period = gMountOptions.malloctrimperiod;
 	params.log_notifications_area = gMountOptions.lognotificationarea;

--- a/src/mount/fuse/main.cc
+++ b/src/mount/fuse/main.cc
@@ -261,7 +261,8 @@ static int mainloop(struct fuse_args *args, struct fuse_cmdline_opts *fuse_opts,
 	params.acl_cache_size = gMountOptions.aclcachesize;
 	params.debug_mode = gMountOptions.debug;
 	params.direct_io = gMountOptions.directio;
-	params.use_old_write_algorithm = gMountOptions.useoldwritealgorithm;
+	params.use_inode_based_write_algorithm =
+	    gMountOptions.useinodebasedwritealgorithm;
 	params.ignore_flush = gMountOptions.ignoreflush;
 	params.malloc_trim_period = gMountOptions.malloctrimperiod;
 	params.log_notifications_area = gMountOptions.lognotificationarea;

--- a/src/mount/fuse/mount_config.cc
+++ b/src/mount/fuse/mount_config.cc
@@ -56,6 +56,7 @@ struct fuse_opt gSfsOptsStage2[] = {
 	SFS_OPT("sfsmemlock", memlock, 1),
 #endif
 	SFS_OPT("sfswritecachesize=%u", writecachesize, 0),
+	SFS_OPT("sfschunkserverwavewriteto=%u", chunkserverwavewriteto, 0),
 	SFS_OPT("sfsaclcachesize=%u", aclcachesize, 0),
 	SFS_OPT("sfscacheperinodepercentage=%u", cachePerInodePercentage, 0),
 	SFS_OPT("sfswriteworkers=%u", writeworkers, 0),
@@ -185,6 +186,8 @@ void initialize_opts_name_values() {
 	gOptsNameValues["maxreadaheadrequests"] = std::to_string(gMountOptions.maxreadaheadrequests);
 	gOptsNameValues["sfsprefetchxorstripes"] = std::to_string(gMountOptions.prefetchxorstripes);
 	gOptsNameValues["sfschunkserverwriteto"] = std::to_string(gMountOptions.chunkserverwriteto);
+	gOptsNameValues["sfschunkserverwavewriteto"] =
+	    std::to_string(gMountOptions.chunkserverwavewriteto);
 	gOptsNameValues["symlinkcachetimeout"] = std::to_string(gMountOptions.symlinkcachetimeout);
 	gOptsNameValues["bandwidthoveruse"] = std::to_string(gMountOptions.bandwidthoveruse);
 	gOptsNameValues["sfsdirentrycachesize"] = std::to_string(gMountOptions.direntrycachesize);
@@ -257,6 +260,8 @@ void usage(const char *progname) {
 "Write related options:\n"
 "    -o sfschunkserverwriteto=MSEC  set chunkserver response timeout during "
 				"write operation in milliseconds (default: %u)\n"
+"    -o sfschunkserverwavewriteto=MSEC  set timeout for executing each wave "
+				"of a write operation in milliseconds (default: %u)\n"
 "    -o sfswritecachesize=N      define size of write cache in MiB (default: %u)\n"
 "    -o sfscacheperinodepercentage=P  define what part of the write cache non "
 				"occupied by other inodes can a single inode "
@@ -359,6 +364,7 @@ void usage(const char *progname) {
 		SaunaClient::FsInitParams::kDefaultBandwidthOveruse,
 		SaunaClient::FsInitParams::kDefaultReadCacheMaxSizePercentage,
 		SaunaClient::FsInitParams::kDefaultChunkserverWriteTo,
+		SaunaClient::FsInitParams::kDefaultWriteWaveTo,
 		SaunaClient::FsInitParams::kDefaultWriteCacheSize,
 		SaunaClient::FsInitParams::kDefaultCachePerInodePercentage,
 		SaunaClient::FsInitParams::kDefaultWriteWorkers,

--- a/src/mount/fuse/mount_config.cc
+++ b/src/mount/fuse/mount_config.cc
@@ -94,7 +94,7 @@ struct fuse_opt gSfsOptsStage2[] = {
 	SFS_OPT("bandwidthoveruse=%lf", bandwidthoveruse, 1),
 	SFS_OPT("sfsdirentrycachesize=%u", direntrycachesize, 0),
 	SFS_OPT("nostdmountoptions", nostdmountoptions, 1),
-	SFS_OPT("sfsuseoldwritealgorithm", useoldwritealgorithm, 1),
+	SFS_OPT("sfsuseinodebasedwritealgorithm=%d", useinodebasedwritealgorithm, 0),
 	SFS_OPT("sfsignoreflush=%d", ignoreflush, 0),
 	SFS_OPT("limitglibcmallocarenas=%d", limitglibcmallocarenas, 0),
 	SFS_OPT("malloctrimperiod=%d", malloctrimperiod, 0),
@@ -142,6 +142,8 @@ void initialize_opts_name_values() {
 	gOptsNameValues["sfscacheperinodepercentage"] =
 	    std::to_string(gMountOptions.cachePerInodePercentage);
 	gOptsNameValues["sfswriteworkers"] = std::to_string(gMountOptions.writeworkers);
+	gOptsNameValues["sfsuseinodebasedwritealgorithm"] =
+	    std::to_string(gMountOptions.useinodebasedwritealgorithm);
 	gOptsNameValues["sfsioretries (read)"] = std::to_string(gMountOptions.ioretries);
 	gOptsNameValues["sfsioretries (write)"] = std::to_string(gMountOptions.ioretries);
 	gOptsNameValues["sfswritewindowsize"] = std::to_string(gMountOptions.writewindowsize);
@@ -270,7 +272,9 @@ void usage(const char *progname) {
 "    -o sfswriteworkers=N        define number of write workers (default: %u)\n"
 "    -o sfswritewindowsize=N     define write window size (in blocks) for "
 				"each chunk (default: %u)\n"
-"    -o sfsuseoldwritealgorithm  use legacy write algorithm.\n"
+"    -o sfsuseinodebasedwritealgorithm=0|1  use inode based write algorithm when "
+				"set to 1. Use chunk based write algorithm when set to 0 "
+				"(default: %d)\n"
 "    -o sfsignoreflush=0|1       Advanced: use with caution. Ignore flush usual "
 				"behavior by replying SUCCESS to it immediately. Targets fast "
 				"creation of small files, but may cause data loss during crashes "
@@ -371,6 +375,7 @@ void usage(const char *progname) {
 		SaunaClient::FsInitParams::kDefaultCachePerInodePercentage,
 		SaunaClient::FsInitParams::kDefaultWriteWorkers,
 		SaunaClient::FsInitParams::kDefaultWriteWindowSize,
+		SaunaClient::FsInitParams::kDefaultUseInodeBasedWriteAlgorithm,
 		SaunaClient::FsInitParams::kDefaultIgnoreFlush,
 		SaunaClient::FsInitParams::kDefaultUseRwLock,
 		SaunaClient::FsInitParams::kDefaultMkdirCopySgid,

--- a/src/mount/fuse/mount_config.cc
+++ b/src/mount/fuse/mount_config.cc
@@ -94,6 +94,7 @@ struct fuse_opt gSfsOptsStage2[] = {
 	SFS_OPT("bandwidthoveruse=%lf", bandwidthoveruse, 1),
 	SFS_OPT("sfsdirentrycachesize=%u", direntrycachesize, 0),
 	SFS_OPT("nostdmountoptions", nostdmountoptions, 1),
+	SFS_OPT("sfsuseoldwritealgorithm", useoldwritealgorithm, 1),
 	SFS_OPT("sfsignoreflush=%d", ignoreflush, 0),
 	SFS_OPT("limitglibcmallocarenas=%d", limitglibcmallocarenas, 0),
 	SFS_OPT("malloctrimperiod=%d", malloctrimperiod, 0),
@@ -269,6 +270,7 @@ void usage(const char *progname) {
 "    -o sfswriteworkers=N        define number of write workers (default: %u)\n"
 "    -o sfswritewindowsize=N     define write window size (in blocks) for "
 				"each chunk (default: %u)\n"
+"    -o sfsuseoldwritealgorithm  use legacy write algorithm.\n"
 "    -o sfsignoreflush=0|1       Advanced: use with caution. Ignore flush usual "
 				"behavior by replying SUCCESS to it immediately. Targets fast "
 				"creation of small files, but may cause data loss during crashes "

--- a/src/mount/fuse/mount_config.h
+++ b/src/mount/fuse/mount_config.h
@@ -89,6 +89,7 @@ struct sfsopts_ {
 	int passwordask;
 	int donotrememberpassword;
 	unsigned writecachesize;
+	unsigned chunkserverwavewriteto;
 	unsigned cachePerInodePercentage;
 	unsigned writeworkers;
 	unsigned ioretries;
@@ -154,6 +155,7 @@ struct sfsopts_ {
 		passwordask(0),
 		donotrememberpassword(SaunaClient::FsInitParams::kDefaultDoNotRememberPassword),
 		writecachesize(SaunaClient::FsInitParams::kDefaultWriteCacheSize),
+		chunkserverwavewriteto(SaunaClient::FsInitParams::kDefaultWriteWaveTo),
 		cachePerInodePercentage(SaunaClient::FsInitParams::kDefaultCachePerInodePercentage),
 		writeworkers(SaunaClient::FsInitParams::kDefaultWriteWorkers),
 		ioretries(SaunaClient::FsInitParams::kDefaultIoRetries),

--- a/src/mount/fuse/mount_config.h
+++ b/src/mount/fuse/mount_config.h
@@ -115,7 +115,7 @@ struct sfsopts_ {
 	double bandwidthoveruse;
 	int nonemptymount;
 	bool directio;
-    int useoldwritealgorithm;
+    int useinodebasedwritealgorithm;
 	int ignoreflush;
 	unsigned limitglibcmallocarenas;
 	unsigned malloctrimperiod;
@@ -182,7 +182,7 @@ struct sfsopts_ {
 		bandwidthoveruse(SaunaClient::FsInitParams::kDefaultBandwidthOveruse),
 		nonemptymount(SaunaClient::FsInitParams::kDefaultNonEmptyMounts),
 		directio(SaunaClient::FsInitParams::kDirectIO),
-        useoldwritealgorithm(SaunaClient::FsInitParams::kDefaultUseOldWriteAlgorithm),
+        useinodebasedwritealgorithm(SaunaClient::FsInitParams::kDefaultUseInodeBasedWriteAlgorithm),
 		ignoreflush(SaunaClient::FsInitParams::kDefaultIgnoreFlush),
 		limitglibcmallocarenas(SaunaClient::FsInitParams::kDefaultLimitGlibcMallocArenas),
 		malloctrimperiod(SaunaClient::FsInitParams::kDefaultMallocTrimPeriod),

--- a/src/mount/fuse/mount_config.h
+++ b/src/mount/fuse/mount_config.h
@@ -115,6 +115,7 @@ struct sfsopts_ {
 	double bandwidthoveruse;
 	int nonemptymount;
 	bool directio;
+    int useoldwritealgorithm;
 	int ignoreflush;
 	unsigned limitglibcmallocarenas;
 	unsigned malloctrimperiod;
@@ -181,6 +182,7 @@ struct sfsopts_ {
 		bandwidthoveruse(SaunaClient::FsInitParams::kDefaultBandwidthOveruse),
 		nonemptymount(SaunaClient::FsInitParams::kDefaultNonEmptyMounts),
 		directio(SaunaClient::FsInitParams::kDirectIO),
+        useoldwritealgorithm(SaunaClient::FsInitParams::kDefaultUseOldWriteAlgorithm),
 		ignoreflush(SaunaClient::FsInitParams::kDefaultIgnoreFlush),
 		limitglibcmallocarenas(SaunaClient::FsInitParams::kDefaultLimitGlibcMallocArenas),
 		malloctrimperiod(SaunaClient::FsInitParams::kDefaultMallocTrimPeriod),

--- a/src/mount/readdata_cache.h
+++ b/src/mount/readdata_cache.h
@@ -427,7 +427,7 @@ public:
 		}
 		while (it != entries_.end()) {
 			// If the entry ends before the chunk, skip it
-			if (it->endOffset() < chunkStart) {
+			if (it->offset + it->requested_size < chunkStart) {
 				++it;
 				continue;
 			}

--- a/src/mount/sauna_client.cc
+++ b/src/mount/sauna_client.cc
@@ -3666,7 +3666,7 @@ void fs_init(FsInitParams &params) {
 			params.prefetch_xor_stripes,
 			std::max(params.bandwidth_overuse, 1.));
 
-	gUseOldWriteAlgorithm = params.use_old_write_algorithm;
+	gUseInodeBasedWriteAlgorithm = params.use_inode_based_write_algorithm;
 	write_data_init(
 	    params.write_cache_size, params.io_retries, params.write_workers,
 	    params.write_window_size, params.chunkserver_write_timeout_ms,

--- a/src/mount/sauna_client.cc
+++ b/src/mount/sauna_client.cc
@@ -3665,8 +3665,10 @@ void fs_init(FsInitParams &params) {
 			params.max_readahead_requests,
 			params.prefetch_xor_stripes,
 			std::max(params.bandwidth_overuse, 1.));
-	write_data_init(params.write_cache_size, params.io_retries, params.write_workers,
-			params.write_window_size, params.chunkserver_write_timeout_ms, params.cache_per_inode_percentage);
+	write_data_init(
+	    params.write_cache_size, params.io_retries, params.write_workers,
+	    params.write_window_size, params.chunkserver_write_timeout_ms,
+	    params.cache_per_inode_percentage, params.write_wave_timeout_ms);
 #ifdef _WIN32
 	set_debug_mode(params.debug_mode);
 #endif

--- a/src/mount/sauna_client.cc
+++ b/src/mount/sauna_client.cc
@@ -3665,6 +3665,8 @@ void fs_init(FsInitParams &params) {
 			params.max_readahead_requests,
 			params.prefetch_xor_stripes,
 			std::max(params.bandwidth_overuse, 1.));
+
+	gUseOldWriteAlgorithm = params.use_old_write_algorithm;
 	write_data_init(
 	    params.write_cache_size, params.io_retries, params.write_workers,
 	    params.write_window_size, params.chunkserver_write_timeout_ms,

--- a/src/mount/sauna_client.h
+++ b/src/mount/sauna_client.h
@@ -91,7 +91,6 @@ struct FsInitParams {
 	static constexpr const char *kDefaultUmaskFile = "002"; // means rwxrwxr-x permissions mask, 775 default permissions
 	static constexpr const char *kDefaultLogLevel = "warn";
 	static constexpr const char *kDefaultLogFlushLevel = "err";
-	static constexpr unsigned kDefaultWriteCacheSize = 50;
 	static constexpr unsigned kDefaultCleanAcquiredFilesPeriod = 0;
 	static constexpr unsigned kDefaultCleanAcquiredFilesTimeout = 0;
 	static constexpr int      kDefaultEnableStatusUpdaterThread = 0;
@@ -99,11 +98,12 @@ struct FsInitParams {
 	static constexpr bool     kDefaultMkdirCopySgid = false;
 #else
 	static constexpr unsigned kDefaultReportReservedPeriod = 30;
-	static constexpr unsigned kDefaultWriteCacheSize = 0;
 	static constexpr unsigned kDefaultLimitGlibcMallocArenas = 0;
 	static constexpr unsigned kDefaultMallocTrimPeriod = 0;
 	static constexpr bool     kDefaultMkdirCopySgid = true;
 #endif
+	static constexpr unsigned kDefaultWriteCacheSize = 128;
+
 	static constexpr unsigned kDefaultCachePerInodePercentage = 25;
 	static constexpr unsigned kDefaultWriteWorkers = 10;
 	static constexpr unsigned kDefaultWriteWindowSize = 15;

--- a/src/mount/sauna_client.h
+++ b/src/mount/sauna_client.h
@@ -96,14 +96,15 @@ struct FsInitParams {
 	static constexpr int      kDefaultEnableStatusUpdaterThread = 0;
 	static constexpr bool     kDefaultIgnoreUtimensUpdate = false;
 	static constexpr bool     kDefaultMkdirCopySgid = false;
+	static constexpr unsigned kDefaultWriteWaveTo = 10;
 #else
 	static constexpr unsigned kDefaultReportReservedPeriod = 30;
 	static constexpr unsigned kDefaultLimitGlibcMallocArenas = 0;
 	static constexpr unsigned kDefaultMallocTrimPeriod = 0;
 	static constexpr bool     kDefaultMkdirCopySgid = true;
+	static constexpr unsigned kDefaultWriteWaveTo = 50;
 #endif
 	static constexpr unsigned kDefaultWriteCacheSize = 128;
-
 	static constexpr unsigned kDefaultCachePerInodePercentage = 25;
 	static constexpr unsigned kDefaultWriteWorkers = 10;
 	static constexpr unsigned kDefaultWriteWindowSize = 15;
@@ -148,6 +149,7 @@ struct FsInitParams {
 	             prefetch_xor_stripes(kDefaultPrefetchXorStripes),
 	             bandwidth_overuse(kDefaultBandwidthOveruse),
 	             write_cache_size(kDefaultWriteCacheSize),
+	             write_wave_timeout_ms(kDefaultWriteWaveTo),
 	             write_workers(kDefaultWriteWorkers), write_window_size(kDefaultWriteWindowSize),
 	             chunkserver_write_timeout_ms(kDefaultChunkserverWriteTo),
 	             cache_per_inode_percentage(kDefaultCachePerInodePercentage),
@@ -193,6 +195,7 @@ struct FsInitParams {
 	             prefetch_xor_stripes(kDefaultPrefetchXorStripes),
 	             bandwidth_overuse(kDefaultBandwidthOveruse),
 	             write_cache_size(kDefaultWriteCacheSize),
+	             write_wave_timeout_ms(kDefaultWriteWaveTo),
 	             write_workers(kDefaultWriteWorkers), write_window_size(kDefaultWriteWindowSize),
 	             chunkserver_write_timeout_ms(kDefaultChunkserverWriteTo),
 	             cache_per_inode_percentage(kDefaultCachePerInodePercentage),
@@ -246,6 +249,7 @@ struct FsInitParams {
 	double bandwidth_overuse;
 
 	unsigned write_cache_size;
+	unsigned write_wave_timeout_ms;
 	unsigned write_workers;
 	unsigned write_window_size;
 	unsigned chunkserver_write_timeout_ms;

--- a/src/mount/sauna_client.h
+++ b/src/mount/sauna_client.h
@@ -104,6 +104,7 @@ struct FsInitParams {
 	static constexpr bool     kDefaultMkdirCopySgid = true;
 	static constexpr unsigned kDefaultWriteWaveTo = 50;
 #endif
+	static constexpr bool     kDefaultUseOldWriteAlgorithm = false;
 	static constexpr unsigned kDefaultWriteCacheSize = 128;
 	static constexpr unsigned kDefaultCachePerInodePercentage = 25;
 	static constexpr unsigned kDefaultWriteWorkers = 10;
@@ -169,6 +170,7 @@ struct FsInitParams {
 #else
 	             malloc_trim_period(kDefaultMallocTrimPeriod),
 #endif
+	             use_old_write_algorithm(kDefaultUseOldWriteAlgorithm),
 	             ignore_flush(kDefaultIgnoreFlush), statfs_cache_timeout(kDefaultStatfsCacheTo),
 	             use_quota_in_volume_size(kDefaultUseQuotaInVolumeSize),
 	             max_wait_retry_time(kDefaultMaxWaitRetryTime),
@@ -214,7 +216,8 @@ struct FsInitParams {
 	             ignore_utimens_update(kDefaultIgnoreUtimensUpdate),
 #else
 	             malloc_trim_period(kDefaultMallocTrimPeriod),
-#endif
+#endif 
+	             use_old_write_algorithm(kDefaultUseOldWriteAlgorithm),
 	             ignore_flush(kDefaultIgnoreFlush), statfs_cache_timeout(kDefaultStatfsCacheTo),
 	             use_quota_in_volume_size(kDefaultUseQuotaInVolumeSize),
 	             max_wait_retry_time(kDefaultMaxWaitRetryTime),
@@ -280,6 +283,7 @@ struct FsInitParams {
 	unsigned malloc_trim_period;
 #endif
 
+	bool use_old_write_algorithm;
 	bool ignore_flush;
 	unsigned statfs_cache_timeout;
 	bool use_quota_in_volume_size;

--- a/src/mount/sauna_client.h
+++ b/src/mount/sauna_client.h
@@ -104,7 +104,7 @@ struct FsInitParams {
 	static constexpr bool     kDefaultMkdirCopySgid = true;
 	static constexpr unsigned kDefaultWriteWaveTo = 50;
 #endif
-	static constexpr bool     kDefaultUseOldWriteAlgorithm = false;
+	static constexpr bool     kDefaultUseInodeBasedWriteAlgorithm = false;
 	static constexpr unsigned kDefaultWriteCacheSize = 128;
 	static constexpr unsigned kDefaultCachePerInodePercentage = 25;
 	static constexpr unsigned kDefaultWriteWorkers = 10;
@@ -170,7 +170,7 @@ struct FsInitParams {
 #else
 	             malloc_trim_period(kDefaultMallocTrimPeriod),
 #endif
-	             use_old_write_algorithm(kDefaultUseOldWriteAlgorithm),
+	             use_inode_based_write_algorithm(kDefaultUseInodeBasedWriteAlgorithm),
 	             ignore_flush(kDefaultIgnoreFlush), statfs_cache_timeout(kDefaultStatfsCacheTo),
 	             use_quota_in_volume_size(kDefaultUseQuotaInVolumeSize),
 	             max_wait_retry_time(kDefaultMaxWaitRetryTime),
@@ -217,7 +217,7 @@ struct FsInitParams {
 #else
 	             malloc_trim_period(kDefaultMallocTrimPeriod),
 #endif 
-	             use_old_write_algorithm(kDefaultUseOldWriteAlgorithm),
+	             use_inode_based_write_algorithm(kDefaultUseInodeBasedWriteAlgorithm),
 	             ignore_flush(kDefaultIgnoreFlush), statfs_cache_timeout(kDefaultStatfsCacheTo),
 	             use_quota_in_volume_size(kDefaultUseQuotaInVolumeSize),
 	             max_wait_retry_time(kDefaultMaxWaitRetryTime),
@@ -283,7 +283,7 @@ struct FsInitParams {
 	unsigned malloc_trim_period;
 #endif
 
-	bool use_old_write_algorithm;
+	bool use_inode_based_write_algorithm;
 	bool ignore_flush;
 	unsigned statfs_cache_timeout;
 	bool use_quota_in_volume_size;

--- a/src/mount/writedata.cc
+++ b/src/mount/writedata.cc
@@ -76,12 +76,12 @@ struct inodedata {
 	uint16_t writewaiting;
 	uint16_t lcnt;
 	uint32_t trycnt;
-	bool inqueue; // true it this inode is waiting in one of the queues or is being processed
+	bool inqueue;  // true it this inode is waiting in one of the queues or is being processed
 	uint32_t minimumBlocksToWrite;
 	std::list<WriteCacheBlock> dataChain;
-	int alterations_in_chain; // number of adherent blocks with different chunk ids in chain
-	std::condition_variable flushcond; // wait for !inqueue (flush)
-	std::condition_variable writecond; // wait for flushwaiting==0 (write)
+	int alterations_in_chain;  // number of adherent blocks with different chunk ids in chain
+	std::condition_variable flushcond;  // wait for !inqueue (flush)
+	std::condition_variable writecond;  // wait for flushwaiting==0 (write)
 	std::unique_ptr<WriteChunkLocator> locator;
 	int newDataInChainPipe[2];
 	bool workerWaitingForData;
@@ -89,17 +89,17 @@ struct inodedata {
 	Timer lastWriteToChunkservers;
 
 	inodedata(uint32_t inode)
-			: inode(inode),
-			  maxfleng(0),
-			  status(SAUNAFS_STATUS_OK),
-			  flushwaiting(0),
-			  writewaiting(0),
-			  lcnt(0),
-			  trycnt(0),
-			  inqueue(false),
-			  minimumBlocksToWrite(1),
-			  alterations_in_chain(),
-			  workerWaitingForData(false) {
+	    : inode(inode),
+	      maxfleng(0),
+	      status(SAUNAFS_STATUS_OK),
+	      flushwaiting(0),
+	      writewaiting(0),
+	      lcnt(0),
+	      trycnt(0),
+	      inqueue(false),
+	      minimumBlocksToWrite(1),
+	      alterations_in_chain(),
+	      workerWaitingForData(false) {
 #ifdef _WIN32
 		// We don't use inodeData->waitingworker and inodeData->pipe on Cygwin because
 		// Cygwin's implementation of mixed socket & pipe polling is very inefficient.
@@ -136,9 +136,7 @@ struct inodedata {
 	}
 
 	/* glock: UNUSED */
-	bool isDataChainPipeValid() const {
-		return newDataInChainPipe[0] >= 0;
-	}
+	bool isDataChainPipeValid() const { return newDataInChainPipe[0] >= 0; }
 
 	/*! Check if inode requires flushing all its data chain to chunkservers.
 	 *
@@ -149,33 +147,31 @@ struct inodedata {
 	 * glock: LOCKED
 	 */
 	bool requiresFlushing() const {
-		return (flushwaiting > 0
-				|| lastWriteToDataChain.elapsed_ms() >= kMaximumTimeInDataChainSinceLastWrite_ms
-				|| lastWriteToChunkservers.elapsed_ms() >= kMaximumTimeInDataChainSinceLastFlush_ms);
+		return (flushwaiting > 0 ||
+		        lastWriteToDataChain.elapsed_ms() >= kMaximumTimeInDataChainSinceLastWrite_ms ||
+		        lastWriteToChunkservers.elapsed_ms() >= kMaximumTimeInDataChainSinceLastFlush_ms);
 	}
 
 	void pushToChain(WriteCacheBlock &&block) {
 		dataChain.push_back(std::move(block));
-		if (dataChain.size() > 1 && dataChain.back().chunkIndex != std::next(dataChain.rbegin())->chunkIndex) {
+		if (dataChain.size() > 1 &&
+		    dataChain.back().chunkIndex != std::next(dataChain.rbegin())->chunkIndex) {
 			alterations_in_chain++;
 		}
 	}
 
 	void popFromChain() {
 		assert(dataChain.size() > 0);
-		if (dataChain.size() > 1 && dataChain.front().chunkIndex != std::next(dataChain.begin())->chunkIndex) {
+		if (dataChain.size() > 1 &&
+		    dataChain.front().chunkIndex != std::next(dataChain.begin())->chunkIndex) {
 			alterations_in_chain--;
 		}
 		dataChain.pop_front();
 	}
 
-	void registerAlterationsInChain(int delta) {
-		alterations_in_chain += delta;
-	}
+	void registerAlterationsInChain(int delta) { alterations_in_chain += delta; }
 
-	bool hasMultipleChunkIdsInChain() const {
-		return alterations_in_chain > 0;
-	}
+	bool hasMultipleChunkIdsInChain() const { return alterations_in_chain > 0; }
 
 private:
 	/*! Limit for \p lastWriteToChunkservers after which we force a flush.
@@ -198,9 +194,7 @@ struct DelayedQueueEntry {
 	static constexpr int kTicksPerSecond = 10;
 
 	DelayedQueueEntry(inodedata *inodeData, int32_t ticksLeft)
-			: inodeData(inodeData),
-			  ticksLeft(ticksLeft) {
-	}
+	    : inodeData(inodeData), ticksLeft(ticksLeft) {}
 };
 
 static std::atomic<uint32_t> maxretries;
@@ -231,26 +225,21 @@ static std::list<DelayedQueueEntry> delayedQueue;
 static ConnectionPool gChunkserverConnectionPool;
 static ChunkConnectorUsingPool gChunkConnector(gChunkserverConnectionPool);
 
-void write_cb_release_blocks(uint32_t count, Glock&) {
+void write_cb_release_blocks(uint32_t count, Glock &) {
 	freecacheblocks += count;
-	if (fcbwaiting > 0 && freecacheblocks > 0) {
-		fcbcond.notify_all();
-	}
+	if (fcbwaiting > 0 && freecacheblocks > 0) { fcbcond.notify_all(); }
 }
 
-void write_cb_acquire_blocks(uint32_t count, Glock&) {
-	freecacheblocks -= count;
-}
+void write_cb_acquire_blocks(uint32_t count, Glock &) { freecacheblocks -= count; }
 
-void write_cb_wait_for_block(inodedata* id, Glock& glock) {
+void write_cb_wait_for_block(inodedata *id, Glock &glock) {
 	LOG_AVG_TILL_END_OF_SCOPE0("write_cb_wait_for_block");
 	fcbwaiting++;
 	uint64_t dataChainSize = id->dataChain.size();
 	while (freecacheblocks <= 0
-			// dataChainSize / (dataChainSize + freecacheblocks) > gCachePerInodePercentage / 100
-			// really means "0 > 0"
-			|| dataChainSize * 100 > (dataChainSize + freecacheblocks) * gCachePerInodePercentage)
-	{
+	       // dataChainSize / (dataChainSize + freecacheblocks) > gCachePerInodePercentage / 100
+	       // really means "0 > 0"
+	       || dataChainSize * 100 > (dataChainSize + freecacheblocks) * gCachePerInodePercentage) {
 		fcbcond.wait(glock);
 	}
 	fcbwaiting--;
@@ -259,16 +248,12 @@ void write_cb_wait_for_block(inodedata* id, Glock& glock) {
 /* inode */
 
 inodedata *write_find_inodedata(uint32_t inode, Glock &) {
-	if (inodedataMap.contains(inode)) {
-		return inodedataMap[inode];
-	}
+	if (inodedataMap.contains(inode)) { return inodedataMap[inode]; }
 	return NULL;
 }
 
 inodedata *write_get_inodedata(uint32_t inode, Glock &) {
-	if (inodedataMap.contains(inode)) {
-		return inodedataMap[inode];
-	}
+	if (inodedataMap.contains(inode)) { return inodedataMap[inode]; }
 	auto id = new inodedata(inode);
 	inodedataMap[inode] = id;
 	return id;
@@ -276,9 +261,7 @@ inodedata *write_get_inodedata(uint32_t inode, Glock &) {
 
 void write_free_inodedata(inodedata *fid, Glock &) {
 	uint32_t inode = fid->inode;
-	if (!inodedataMap.contains(inode)) {
-		return;
-	}
+	if (!inodedataMap.contains(inode)) { return; }
 
 	auto id = inodedataMap[inode];
 	sassert(id == fid);
@@ -288,11 +271,11 @@ void write_free_inodedata(inodedata *fid, Glock &) {
 
 /* delayed queue */
 
-static void delayed_queue_put(inodedata* id, uint32_t seconds, Glock&) {
+static void delayed_queue_put(inodedata *id, uint32_t seconds, Glock &) {
 	delayedQueue.push_back(DelayedQueueEntry(id, seconds * DelayedQueueEntry::kTicksPerSecond));
 }
 
-static bool delayed_queue_remove(inodedata* id, Glock&) {
+static bool delayed_queue_remove(inodedata *id, Glock &) {
 	for (auto it = delayedQueue.begin(); it != delayedQueue.end(); ++it) {
 		if (it->inodeData == id) {
 			delayedQueue.erase(it);
@@ -302,7 +285,7 @@ static bool delayed_queue_remove(inodedata* id, Glock&) {
 	return false;
 }
 
-void* delayed_queue_worker(void*) {
+void *delayed_queue_worker(void *) {
 	pthread_setname_np(pthread_self(), "delQueueWriter");
 
 	for (;;) {
@@ -310,11 +293,9 @@ void* delayed_queue_worker(void*) {
 		Glock lock(gMutex);
 		auto it = delayedQueue.begin();
 		while (it != delayedQueue.end()) {
-			if (it->inodeData == NULL) {
-				return NULL;
-			}
+			if (it->inodeData == NULL) { return NULL; }
 			if (--it->ticksLeft <= 0) {
-				jobsQueue->put(0, 0, reinterpret_cast<uint8_t*>(it->inodeData), 0);
+				jobsQueue->put(0, 0, reinterpret_cast<uint8_t *>(it->inodeData), 0);
 				it = delayedQueue.erase(it);
 			} else {
 				++it;
@@ -328,25 +309,24 @@ void* delayed_queue_worker(void*) {
 
 /* queues */
 
-void write_delayed_enqueue(inodedata* id, uint32_t seconds, Glock& lock) {
+void write_delayed_enqueue(inodedata *id, uint32_t seconds, Glock &lock) {
 	if (seconds > 0) {
 		delayed_queue_put(id, seconds, lock);
 	} else {
-		jobsQueue->put(0, 0, reinterpret_cast<uint8_t*>(id), 0);
+		jobsQueue->put(0, 0, reinterpret_cast<uint8_t *>(id), 0);
 	}
 }
 
-void write_enqueue(inodedata* id, Glock&) {
-	jobsQueue->put(0, 0, reinterpret_cast<uint8_t*>(id), 0);
+void write_enqueue(inodedata *id, Glock &) {
+	jobsQueue->put(0, 0, reinterpret_cast<uint8_t *>(id), 0);
 }
 
-void write_job_delayed_end(inodedata* id, int status, int seconds, Glock &lock) {
+void write_job_delayed_end(inodedata *id, int status, int seconds, Glock &lock) {
 	LOG_AVG_TILL_END_OF_SCOPE0("write_job_delayed_end");
 	LOG_AVG_TILL_END_OF_SCOPE1("write_job_delayed_end#sec", seconds);
 	id->locator.reset();
 	if (status != SAUNAFS_STATUS_OK) {
-		safs::log_warn("error writing file number {}: {}", id->inode,
-		               saunafs_error_string(status));
+		safs::log_warn("error writing file number {}: {}", id->inode, saunafs_error_string(status));
 		id->status = status;
 	}
 	status = id->status;
@@ -354,10 +334,10 @@ void write_job_delayed_end(inodedata* id, int status, int seconds, Glock &lock) 
 		// Don't sleep if we have to write all the data immediately
 		seconds = 0;
 	}
-	if (!id->dataChain.empty() && status == SAUNAFS_STATUS_OK) { // still have some work to do
-		id->trycnt = 0; // on good write reset try counter
+	if (!id->dataChain.empty() && status == SAUNAFS_STATUS_OK) {  // still have some work to do
+		id->trycnt = 0;                                           // on good write reset try counter
 		write_delayed_enqueue(id, seconds, lock);
-	} else {        // no more work or error occurred
+	} else {  // no more work or error occurred
 		// if this is an error then release all data blocks
 		write_cb_release_blocks(id->dataChain.size(), lock);
 		id->dataChain.clear();
@@ -365,9 +345,7 @@ void write_job_delayed_end(inodedata* id, int status, int seconds, Glock &lock) 
 		// We don't reset maxfleng (id->maxfleng = 0;) for a while longer, to
 		// have its value ready to some quick cache responses in lookup and
 		// getattr syscalls
-		if (id->flushwaiting > 0) {
-			id->flushcond.notify_all();
-		}
+		if (id->flushwaiting > 0) { id->flushcond.notify_all(); }
 	}
 }
 
@@ -378,14 +356,14 @@ void write_job_end(inodedata *id, int status, Glock &lock) {
 class InodeChunkWriter {
 public:
 	InodeChunkWriter() : inodeData_(nullptr), chunkIndex_(0) {}
-	void processJob(inodedata* data);
+	void processJob(inodedata *data);
 
 private:
-	void processDataChain(ChunkWriter& writer);
-	void returnJournalToDataChain(std::list<WriteCacheBlock>&& journal, Glock&);
-	bool haveAnyBlockInCurrentChunk(Glock&);
-	bool haveBlockWorthWriting(uint32_t unfinishedOperationCount, Glock&);
-	inodedata* inodeData_;
+	void processDataChain(ChunkWriter &writer);
+	void returnJournalToDataChain(std::list<WriteCacheBlock> &&journal, Glock &);
+	bool haveAnyBlockInCurrentChunk(Glock &);
+	bool haveBlockWorthWriting(uint32_t unfinishedOperationCount, Glock &);
+	inodedata *inodeData_;
 	uint32_t chunkIndex_;
 	Timer wholeOperationTimer;
 
@@ -399,7 +377,7 @@ private:
 	static const uint32_t kMinTryCounterToShowWriteErrorMessage = 4;
 };
 
-void InodeChunkWriter::processJob(inodedata* inodeData) {
+void InodeChunkWriter::processJob(inodedata *inodeData) {
 	LOG_AVG_TILL_END_OF_SCOPE0("InodeChunkWriter::processJob");
 	inodeData_ = inodeData;
 
@@ -432,16 +410,13 @@ void InodeChunkWriter::processJob(inodedata* inodeData) {
 	ChunkWriter writer(globalChunkserverStats, gChunkConnector, inodeData_->newDataInChainPipe[0]);
 	wholeOperationTimer.reset();
 	std::unique_ptr<WriteChunkLocator> locator = std::move(inodeData_->locator);
-	if (!locator) {
-		locator.reset(new WriteChunkLocator());
-	}
+	if (!locator) { locator.reset(new WriteChunkLocator()); }
 
 	try {
 		try {
 			locator->locateAndLockChunk(inodeData_->inode, chunkIndex_);
 			Glock lock(gMutex);
-			inodeData_->maxfleng =
-			    std::max(inodeData_->maxfleng, locator->fileLength());
+			inodeData_->maxfleng = std::max(inodeData_->maxfleng, locator->fileLength());
 			lock.unlock();
 
 			// Optimization -- talk with chunkservers only if we have to write any data.
@@ -472,18 +447,18 @@ void InodeChunkWriter::processJob(inodedata* inodeData) {
 				canWait = false;
 			}
 			write_job_delayed_end(inodeData_, SAUNAFS_STATUS_OK, (canWait ? 1 : 0), lock);
-		} catch (Exception& e) {
+		} catch (Exception &e) {
 			std::string errorString = e.what();
-			addPathByInodeBasedNotificationMessage(
-				"Write error: " + std::string(e.what()), inodeData_->inode);
+			addPathByInodeBasedNotificationMessage("Write error: " + std::string(e.what()),
+			                                       inodeData_->inode);
 			Glock lock(gMutex);
 			if (e.status() != SAUNAFS_ERROR_LOCKED) {
 				inodeData_->trycnt++;
 				errorString += " (try counter: " + std::to_string(inodeData->trycnt) + ")";
 			} else if (inodeData_->trycnt == 0) {
 				// Set to nonzero to inform writers, that this task needs to wait a bit
-				// Don't increase -- SAUNAFS_ERROR_LOCKED means that chunk is locked by a different client
-				// and we have to wait until it is unlocked
+				// Don't increase -- SAUNAFS_ERROR_LOCKED means that chunk is locked by a different
+				// client and we have to wait until it is unlocked
 				inodeData_->trycnt = 1;
 			}
 			// Keep the lock
@@ -492,8 +467,8 @@ void InodeChunkWriter::processJob(inodedata* inodeData) {
 			returnJournalToDataChain(writer.releaseJournal(), lock);
 			lock.unlock();
 
-			safs::log_warn("write file error, inode: {}, index: {} - {}",
-			               inodeData_->inode, chunkIndex_, errorString.c_str());
+			safs::log_warn("write file error, inode: {}, index: {} - {}", inodeData_->inode,
+			               chunkIndex_, errorString.c_str());
 			if (inodeData_->trycnt >= maxretries) {
 				// Convert error to an unrecoverable error
 				throw UnrecoverableWriteException(e.message(), e.status());
@@ -502,34 +477,33 @@ void InodeChunkWriter::processJob(inodedata* inodeData) {
 				throw;
 			}
 		}
-	} catch (UnrecoverableWriteException& e) {
-		addPathByInodeBasedNotificationMessage(
-			"Write error: " + std::string(e.what()), inodeData_->inode);
+	} catch (UnrecoverableWriteException &e) {
+		addPathByInodeBasedNotificationMessage("Write error: " + std::string(e.what()),
+		                                       inodeData_->inode);
 		Glock lock(gMutex);
 		if (e.status() == SAUNAFS_ERROR_ENOENT) {
 			write_job_end(inodeData_, SAUNAFS_ERROR_EBADF, lock);
 		} else if (e.status() == SAUNAFS_ERROR_QUOTA) {
 			write_job_end(inodeData_, SAUNAFS_ERROR_QUOTA, lock);
-		} else if (e.status() == SAUNAFS_ERROR_NOSPACE || e.status() == SAUNAFS_ERROR_NOCHUNKSERVERS) {
+		} else if (e.status() == SAUNAFS_ERROR_NOSPACE ||
+		           e.status() == SAUNAFS_ERROR_NOCHUNKSERVERS) {
 			write_job_end(inodeData_, SAUNAFS_ERROR_NOSPACE, lock);
 		} else {
 			write_job_end(inodeData_, SAUNAFS_ERROR_IO, lock);
 		}
-	} catch (Exception& e) {
+	} catch (Exception &e) {
 		if (inodeData_->trycnt > kMinTryCounterToShowWriteErrorMessage) {
-			addPathByInodeBasedNotificationMessage(
-				"Write error: " + std::string(e.what()), inodeData_->inode);
+			addPathByInodeBasedNotificationMessage("Write error: " + std::string(e.what()),
+			                                       inodeData_->inode);
 		}
 		Glock lock(gMutex);
 		int waitTime = 1;
-		if (inodeData_->trycnt > 10) {
-			waitTime = std::min<int>(10, inodeData_->trycnt - 9);
-		}
+		if (inodeData_->trycnt > 10) { waitTime = std::min<int>(10, inodeData_->trycnt - 9); }
 		write_delayed_enqueue(inodeData_, waitTime, lock);
 	}
 }
 
-void InodeChunkWriter::processDataChain(ChunkWriter& writer) {
+void InodeChunkWriter::processDataChain(ChunkWriter &writer) {
 	LOG_AVG_TILL_END_OF_SCOPE0("InodeChunkWriter::processDataChain");
 	uint32_t maximumTime = kMaximumTime;
 	bool otherJobsAreWaiting = false;
@@ -551,8 +525,8 @@ void InodeChunkWriter::processDataChain(ChunkWriter& writer) {
 		// new if we've already sent 'gWriteWindowSize' blocks and didn't receive status from
 		// the chunkserver.
 		bool can_expect_next_block = true;
-		if (wholeOperationTimer.elapsed_s() + kTimeToFinishOperations < maximumTime
-				&& writer.acceptsNewOperations()) {
+		if (wholeOperationTimer.elapsed_s() + kTimeToFinishOperations < maximumTime &&
+		    writer.acceptsNewOperations()) {
 			Glock lock(gMutex);
 			// While there is any block worth sending, we add new write operation
 			while (haveBlockWorthWriting(writer.getUnfinishedOperationsCount(), lock)) {
@@ -586,8 +560,7 @@ void InodeChunkWriter::processDataChain(ChunkWriter& writer) {
 
 		Glock lock(gMutex);
 		writer.setChunkSizeInBlocks(
-		    std::min(inodeData_->maxfleng - chunkIndex_ * SFSCHUNKSIZE,
-		             (uint64_t)SFSCHUNKSIZE));
+		    std::min(inodeData_->maxfleng - chunkIndex_ * SFSCHUNKSIZE, (uint64_t)SFSCHUNKSIZE));
 		lock.unlock();
 		if (writer.startNewOperations(can_expect_next_block) > 0) {
 			lock.lock();
@@ -598,8 +571,8 @@ void InodeChunkWriter::processDataChain(ChunkWriter& writer) {
 			return;
 		} else if (wholeOperationTimer.elapsed_s() >= maximumTime) {
 			throw RecoverableWriteException(
-					"Timeout after " + std::to_string(wholeOperationTimer.elapsed_ms()) + " ms",
-					SAUNAFS_ERROR_TIMEOUT);
+			    "Timeout after " + std::to_string(wholeOperationTimer.elapsed_ms()) + " ms",
+			    SAUNAFS_ERROR_TIMEOUT);
 		}
 
 		writer.processOperations(gWriteWaveTimeout);
@@ -610,8 +583,10 @@ void InodeChunkWriter::returnJournalToDataChain(std::list<WriteCacheBlock> &&jou
 	if (!journal.empty()) {
 		write_cb_acquire_blocks(journal.size(), lock);
 		uint64_t prev_id = journal.front().chunkIndex;
-		int alterations = (!inodeData_->dataChain.empty()
-				&& journal.back().chunkIndex != inodeData_->dataChain.front().chunkIndex) ? 1 : 0;
+		int alterations = (!inodeData_->dataChain.empty() &&
+		                   journal.back().chunkIndex != inodeData_->dataChain.front().chunkIndex)
+		                      ? 1
+		                      : 0;
 		for (auto it = std::next(journal.begin()); it != journal.end(); ++it) {
 			if (it->chunkIndex != prev_id) {
 				alterations++;
@@ -626,7 +601,7 @@ void InodeChunkWriter::returnJournalToDataChain(std::list<WriteCacheBlock> &&jou
 /*
  * Check if there is any data in the same chunk waiting to be written.
  */
-bool InodeChunkWriter::haveAnyBlockInCurrentChunk(Glock&) {
+bool InodeChunkWriter::haveAnyBlockInCurrentChunk(Glock &) {
 	if (inodeData_->dataChain.empty()) {
 		return false;
 	} else {
@@ -640,11 +615,9 @@ bool InodeChunkWriter::haveAnyBlockInCurrentChunk(Glock&) {
  * These can be taken only if we are close to run out of tasks to do.
  * glock: LOCKED
  */
-bool InodeChunkWriter::haveBlockWorthWriting(uint32_t unfinishedOperationCount, Glock& lock) {
-	if (!haveAnyBlockInCurrentChunk(lock)) {
-		return false;
-	}
-	const auto& block = inodeData_->dataChain.front();
+bool InodeChunkWriter::haveBlockWorthWriting(uint32_t unfinishedOperationCount, Glock &lock) {
+	if (!haveAnyBlockInCurrentChunk(lock)) { return false; }
+	const auto &block = inodeData_->dataChain.front();
 	if (block.type != WriteCacheBlock::kWritableBlock) {
 		// Always write data, that was previously written
 		return true;
@@ -654,14 +627,13 @@ bool InodeChunkWriter::haveBlockWorthWriting(uint32_t unfinishedOperationCount, 
 	} else {
 		// Always start full blocks; start partial blocks only if we have to flush the data
 		// or the block won't be expanded (only the last one can be) to a full block
-		return (block.size() == SFSBLOCKSIZE
-				|| inodeData_->requiresFlushing()
-				|| inodeData_->dataChain.size() > 1);
+		return (block.size() == SFSBLOCKSIZE || inodeData_->requiresFlushing() ||
+		        inodeData_->dataChain.size() > 1);
 	}
 }
 
 /* main working thread | glock:UNLOCKED */
-void* write_worker(void*) {
+void *write_worker(void *) {
 	InodeChunkWriter inodeDataWriter;
 
 	static std::atomic_uint16_t writeWorkersCounter(0);
@@ -676,13 +648,11 @@ void* write_worker(void*) {
 			LOG_AVG_TILL_END_OF_SCOPE0("write_worker#idle");
 			jobsQueue->get(&z1, &z2, &data, &z3);
 		}
-		if (data == NULL) {
-			return NULL;
-		}
+		if (data == NULL) { return NULL; }
 
 		// process the job
 		LOG_AVG_TILL_END_OF_SCOPE0("write_worker#working");
-		inodeDataWriter.processJob((inodedata*) data);
+		inodeDataWriter.processJob((inodedata *)data);
 	}
 	return NULL;
 }
@@ -700,9 +670,7 @@ void write_data_init(uint32_t cachesize, uint32_t retries, uint32_t workers,
 	gChunkserverTimeout_ms = chunkserverTimeout_ms;
 	maxretries = retries;
 	gWriteWaveTimeout = waveTimeout;
-	if (cacheblockcount < 10) {
-		cacheblockcount = 10;
-	}
+	if (cacheblockcount < 10) { cacheblockcount = 10; }
 
 	freecacheblocks = cacheblockcount;
 	gCachePerInodePercentage = cachePerInodePercentage;
@@ -713,9 +681,7 @@ void write_data_init(uint32_t cachesize, uint32_t retries, uint32_t workers,
 	pthread_attr_setstacksize(&thattr, 0x100000);
 	pthread_create(&delayed_queue_worker_th, &thattr, delayed_queue_worker, NULL);
 	write_worker_th.resize(workers);
-	for (auto& th : write_worker_th) {
-		pthread_create(&th, &thattr, write_worker, NULL);
-	}
+	for (auto &th : write_worker_th) { pthread_create(&th, &thattr, write_worker, NULL); }
 	pthread_attr_destroy(&thattr);
 
 	gTweaks.registerVariable("WriteMaxRetries", maxretries, "sfsioretries (write)");
@@ -729,32 +695,25 @@ void write_data_term(void) {
 		Glock lock(gMutex);
 		delayed_queue_put(nullptr, 0, lock);
 	}
-	for (i = 0; i < write_worker_th.size(); i++) {
-		jobsQueue->put(0, 0, NULL, 0);
-	}
-	for (i = 0; i < write_worker_th.size(); i++) {
-		pthread_join(write_worker_th[i], NULL);
-	}
+	for (i = 0; i < write_worker_th.size(); i++) { jobsQueue->put(0, 0, NULL, 0); }
+	for (i = 0; i < write_worker_th.size(); i++) { pthread_join(write_worker_th[i], NULL); }
 	pthread_join(delayed_queue_worker_th, NULL);
 	jobsQueue.reset();
-	for (const auto &[_, id] : inodedataMap) {
-		delete id;
-	}
+	for (const auto &[_, id] : inodedataMap) { delete id; }
 	inodedataMap.clear();
 }
 
 /* glock: UNLOCKED */
-int write_block(inodedata *id, uint32_t chindx, uint16_t pos, uint32_t from, uint32_t to, const uint8_t *data) {
+int write_block(inodedata *id, uint32_t chindx, uint16_t pos, uint32_t from, uint32_t to,
+                const uint8_t *data) {
 	Glock lock(gMutex);
 	id->lastWriteToDataChain.reset();
 
 	// Try to expand the last block
 	if (!id->dataChain.empty()) {
-		auto& lastBlock = id->dataChain.back();
-		if (lastBlock.chunkIndex == chindx
-				&& lastBlock.blockIndex == pos
-				&& lastBlock.type == WriteCacheBlock::kWritableBlock
-				&& lastBlock.expand(from, to, data)) {
+		auto &lastBlock = id->dataChain.back();
+		if (lastBlock.chunkIndex == chindx && lastBlock.blockIndex == pos &&
+		    lastBlock.type == WriteCacheBlock::kWritableBlock && lastBlock.expand(from, to, data)) {
 			id->wakeUpWorkerIfNecessary();
 			return 0;
 		}
@@ -769,11 +728,10 @@ int write_block(inodedata *id, uint32_t chindx, uint16_t pos, uint32_t from, uin
 		// Consider some speedup if there are no errors and:
 		// - there is a lot of blocks in the write chain
 		// - there are at least two chunks in the write chain
-		if (id->trycnt == 0 && (id->dataChain.size() > id->minimumBlocksToWrite
-			|| id->dataChain.front().chunkIndex != id->dataChain.back().chunkIndex)) {
-			if (delayed_queue_remove(id, lock)) {
-				write_enqueue(id, lock);
-			}
+		if (id->trycnt == 0 &&
+		    (id->dataChain.size() > id->minimumBlocksToWrite ||
+		     id->dataChain.front().chunkIndex != id->dataChain.back().chunkIndex)) {
+			if (delayed_queue_remove(id, lock)) { write_enqueue(id, lock); }
 		}
 		id->wakeUpWorkerIfNecessary();
 	} else {
@@ -784,7 +742,7 @@ int write_block(inodedata *id, uint32_t chindx, uint16_t pos, uint32_t from, uin
 }
 
 /* glock: UNLOCKED */
-int write_blocks(inodedata *id, uint64_t offset, uint32_t size, const uint8_t* data) {
+int write_blocks(inodedata *id, uint64_t offset, uint32_t size, const uint8_t *data) {
 	LOG_AVG_TILL_END_OF_SCOPE0("write_blocks");
 	uint32_t chindx = offset >> SFSCHUNKBITS;
 	uint16_t pos = (offset & SFSCHUNKMASK) >> SFSBLOCKBITS;
@@ -812,53 +770,40 @@ int write_blocks(inodedata *id, uint64_t offset, uint32_t size, const uint8_t* d
 	return 0;
 }
 
-int write_data(void *vid, uint64_t offset, uint32_t size, const uint8_t *data,
-               size_t currentSize) {
+int write_data(void *vid, uint64_t offset, uint32_t size, const uint8_t *data, size_t currentSize) {
 	LOG_AVG_TILL_END_OF_SCOPE0("write_data");
 	int status;
-	inodedata *id = (inodedata*) vid;
-	if (id == NULL) {
-		return SAUNAFS_ERROR_IO;
-	}
+	inodedata *id = (inodedata *)vid;
+	if (id == NULL) { return SAUNAFS_ERROR_IO; }
 
 	Glock lock(gMutex);
 	status = id->status;
 	id->maxfleng = std::max(id->maxfleng, currentSize);
 	if (status == SAUNAFS_STATUS_OK) {
-		if (offset + size > id->maxfleng) {     // move fleng
+		if (offset + size > id->maxfleng) {  // move fleng
 			id->maxfleng = offset + size;
 		}
 		id->writewaiting++;
-		while (id->flushwaiting > 0) {
-			id->writecond.wait(lock);
-		}
+		while (id->flushwaiting > 0) { id->writecond.wait(lock); }
 		id->writewaiting--;
 	}
 	lock.unlock();
 
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	}
+	if (status != SAUNAFS_STATUS_OK) { return status; }
 
 	return write_blocks(id, offset, size, data);
 }
 
-static void write_data_flushwaiting_increase(inodedata *id, Glock&) {
-	id->flushwaiting++;
-}
+static void write_data_flushwaiting_increase(inodedata *id, Glock &) { id->flushwaiting++; }
 
-static void write_data_flushwaiting_decrease(inodedata *id, Glock&) {
+static void write_data_flushwaiting_decrease(inodedata *id, Glock &) {
 	id->flushwaiting--;
-	if (id->flushwaiting == 0 && id->writewaiting > 0) {
-		id->writecond.notify_all();
-	}
+	if (id->flushwaiting == 0 && id->writewaiting > 0) { id->writecond.notify_all(); }
 }
 
-static void write_data_lcnt_increase(inodedata *id, Glock&) {
-	id->lcnt++;
-}
+static void write_data_lcnt_increase(inodedata *id, Glock &) { id->lcnt++; }
 
-static void	write_data_lcnt_decrease_check_deleted(inodedata *id, Glock& lock, bool& isDeleted) {
+static void write_data_lcnt_decrease_check_deleted(inodedata *id, Glock &lock, bool &isDeleted) {
 	// As long as it is not freed, then we don't consider the inodedata deleted
 	isDeleted = false;
 	id->lcnt--;
@@ -868,50 +813,42 @@ static void	write_data_lcnt_decrease_check_deleted(inodedata *id, Glock& lock, b
 	}
 }
 
-inline void write_data_lcnt_decrease(inodedata *id, Glock& lock) {
+inline void write_data_lcnt_decrease(inodedata *id, Glock &lock) {
 	bool dummy_isDeleted;
 	write_data_lcnt_decrease_check_deleted(id, lock, dummy_isDeleted);
-	(void) dummy_isDeleted;
+	(void)dummy_isDeleted;
 }
 
-void* write_data_new(uint32_t inode) {
-	inodedata* id;
+void *write_data_new(uint32_t inode) {
+	inodedata *id;
 	Glock lock(gMutex);
 	id = write_get_inodedata(inode, lock);
-	if (id == NULL) {
-		return NULL;
-	}
+	if (id == NULL) { return NULL; }
 	write_data_lcnt_increase(id, lock);
 	return id;
 }
 
-static int write_data_flush(void* vid, Glock& lock) {
-	inodedata* id = (inodedata*) vid;
-	if (id == NULL) {
-		return SAUNAFS_ERROR_IO;
-	}
+static int write_data_flush(void *vid, Glock &lock) {
+	inodedata *id = (inodedata *)vid;
+	if (id == NULL) { return SAUNAFS_ERROR_IO; }
 
 	write_data_flushwaiting_increase(id, lock);
 	// If there are no errors (trycnt==0) and inode is waiting in the delayed queue, speed it up
-	if (id->trycnt == 0 && delayed_queue_remove(id, lock)) {
-		write_enqueue(id, lock);
-	}
+	if (id->trycnt == 0 && delayed_queue_remove(id, lock)) { write_enqueue(id, lock); }
 	// Wait for the data to be flushed
-	while (id->inqueue) {
-		id->flushcond.wait(lock);
-	}
+	while (id->inqueue) { id->flushcond.wait(lock); }
 	write_data_flushwaiting_decrease(id, lock);
 	return id->status;
 }
 
-int write_data_flush(void* vid) {
+int write_data_flush(void *vid) {
 	Glock lock(gMutex);
 	return write_data_flush(vid, lock);
 }
 
 uint64_t write_data_getmaxfleng(uint32_t inode) {
 	uint64_t maxfleng;
-	inodedata* id;
+	inodedata *id;
 	Glock lock(gMutex);
 	id = write_find_inodedata(inode, lock);
 	if (id) {
@@ -924,24 +861,20 @@ uint64_t write_data_getmaxfleng(uint32_t inode) {
 
 int write_data_flush_inode(uint32_t inode) {
 	Glock lock(gMutex);
-	inodedata* id = write_find_inodedata(inode, lock);
-	if (id == NULL) {
-		return 0;
-	}
+	inodedata *id = write_find_inodedata(inode, lock);
+	if (id == NULL) { return 0; }
 	return write_data_flush(id, lock);
 }
 
 int write_data_truncate(uint32_t inode, bool opened, uint32_t uid, uint32_t gid, uint64_t length,
-		Attributes& attr) {
+                        Attributes &attr) {
 	Glock lock(gMutex);
 
 	// 1. Flush writes but don't finish it completely - it'll be done at the end of truncate
-	inodedata* id = write_get_inodedata(inode, lock);
-	if (id == NULL) {
-		return SAUNAFS_ERROR_IO;
-	}
+	inodedata *id = write_get_inodedata(inode, lock);
+	if (id == NULL) { return SAUNAFS_ERROR_IO; }
 	write_data_lcnt_increase(id, lock);
-	write_data_flushwaiting_increase(id, lock); // this will block any writing to this inode
+	write_data_flushwaiting_increase(id, lock);  // this will block any writing to this inode
 
 	int err = write_data_flush(id, lock);
 	if (err != 0) {
@@ -961,13 +894,10 @@ int write_data_truncate(uint32_t inode, bool opened, uint32_t uid, uint32_t gid,
 	do {
 		status = fs_truncate(inode, opened, uid, gid, length, writeNeeded, attr, oldLength, lockId);
 		if (status != SAUNAFS_STATUS_OK) {
-			safs::log_info("truncate file {} to length {}: {} (try {}/{})",
-			               inode, length, saunafs_error_string(status),
-			               int(retries + 1), int(maxretries));
+			safs::log_info("truncate file {} to length {}: {} (try {}/{})", inode, length,
+			               saunafs_error_string(status), int(retries + 1), int(maxretries));
 		}
-		if (retries >= maxretries) {
-			break;
-		}
+		if (retries >= maxretries) { break; }
 		if (status == SAUNAFS_ERROR_LOCKED) {
 			sleep(1);
 		} else if (status == SAUNAFS_ERROR_CHUNKLOST || status == SAUNAFS_ERROR_NOTDONE) {
@@ -975,7 +905,8 @@ int write_data_truncate(uint32_t inode, bool opened, uint32_t uid, uint32_t gid,
 			retrySleepTime_us = std::min(2 * retrySleepTime_us, 60 * 1000000);
 			++retries;
 		}
-	} while (status == SAUNAFS_ERROR_LOCKED || status == SAUNAFS_ERROR_CHUNKLOST || status == SAUNAFS_ERROR_NOTDONE);
+	} while (status == SAUNAFS_ERROR_LOCKED || status == SAUNAFS_ERROR_CHUNKLOST ||
+	         status == SAUNAFS_ERROR_NOTDONE);
 	lock.lock();
 	if (status != 0 || !writeNeeded) {
 		// Something failed or we have nothing to do more (master server managed to do the truncate)
@@ -983,9 +914,7 @@ int write_data_truncate(uint32_t inode, bool opened, uint32_t uid, uint32_t gid,
 		write_data_flushwaiting_decrease(id, lock);
 		write_data_lcnt_decrease_check_deleted(id, lock, isDeleted);
 		if (status == SAUNAFS_STATUS_OK) {
-			if (!isDeleted) {
-				id->maxfleng = length;
-			}
+			if (!isDeleted) { id->maxfleng = length; }
 			return 0;
 		} else {
 			return status;
@@ -995,9 +924,9 @@ int write_data_truncate(uint32_t inode, bool opened, uint32_t uid, uint32_t gid,
 	// We have to write zeros in suitable region to update xor/ec parity parts.
 	// Let's calculate size of the region to be zeroed
 	uint64_t endOffset = std::min({
-		oldLength,                            // no further than to the end of the file
-		length + slice_traits::ec::kMaxDataCount * SFSBLOCKSIZE, // no more than the maximal stripe
-		(length + SFSCHUNKSIZE - 1) / SFSCHUNKSIZE * SFSCHUNKSIZE // no beyond the end of chunk
+	    oldLength,  // no further than to the end of the file
+	    length + slice_traits::ec::kMaxDataCount * SFSBLOCKSIZE,  // no more than the maximal stripe
+	    (length + SFSCHUNKSIZE - 1) / SFSCHUNKSIZE * SFSCHUNKSIZE  // no beyond the end of chunk
 	});
 
 	if (endOffset > length) {
@@ -1006,7 +935,8 @@ int write_data_truncate(uint32_t inode, bool opened, uint32_t uid, uint32_t gid,
 
 		// Something has to be written, so pass our lock to writing threads
 		sassert(id->dataChain.empty());
-		id->locator.reset(new TruncateWriteChunkLocator(inode, length / SFSCHUNKSIZE, lockId));
+		id->locator.reset(
+		    new TruncateWriteChunkLocator(inode, length / SFSCHUNKSIZE, lockId, endOffset));
 
 		// And now pass block of zeros to writing threads
 		std::vector<uint8_t> zeros(endOffset - length, 0);
@@ -1046,12 +976,10 @@ int write_data_truncate(uint32_t inode, bool opened, uint32_t uid, uint32_t gid,
 	return 0;
 }
 
-int write_data_end(void* vid) {
+int write_data_end(void *vid) {
 	Glock lock(gMutex);
-	inodedata* id = (inodedata*) vid;
-	if (id == NULL) {
-		return SAUNAFS_ERROR_IO;
-	}
+	inodedata *id = (inodedata *)vid;
+	if (id == NULL) { return SAUNAFS_ERROR_IO; }
 	int status = write_data_flush(id, lock);
 	write_data_lcnt_decrease(id, lock);
 	return status;
@@ -1094,10 +1022,8 @@ struct inodedata {
 	 */
 	bool requiresFlushing() {
 		return (flushwaiting > 0 ||
-		        lastWriteToDataChain.elapsed_ms() >=
-		            kMaximumTimeInDataChainSinceLastWrite_ms ||
-		        lastWriteToChunkservers.elapsed_ms() >=
-		            kMaximumTimeInDataChainSinceLastFlush_ms);
+		        lastWriteToDataChain.elapsed_ms() >= kMaximumTimeInDataChainSinceLastWrite_ms ||
+		        lastWriteToChunkservers.elapsed_ms() >= kMaximumTimeInDataChainSinceLastFlush_ms);
 	}
 
 	bool wasLastBlockRecentlyWritten() const {
@@ -1134,13 +1060,13 @@ struct ChunkData {
 	int newDataInChainPipe[2];
 	uint32_t minimumBlocksToWrite = 1;
 	std::list<WriteCacheBlock> dataChain;
-	bool inQueue = false;  // true if this chunk is waiting in one of the queues or is being processed
+	bool inQueue =
+	    false;  // true if this chunk is waiting in one of the queues or is being processed
 	bool workerWaitingForData = false;
 	std::unique_ptr<WriteChunkLocator> locator;
 	std::atomic<int> writesCount = 0;
 
-	ChunkData(uint32_t chunkIndex, inodedata *parent)
-	    : chunkIndex(chunkIndex), parent_(parent) {
+	ChunkData(uint32_t chunkIndex, inodedata *parent) : chunkIndex(chunkIndex), parent_(parent) {
 #ifdef _WIN32
 		// We don't use inodeData->waitingworker and inodeData->pipe on Cygwin because
 		// Cygwin's implementation of mixed socket & pipe polling is very inefficient.
@@ -1162,9 +1088,7 @@ struct ChunkData {
 	}
 
 	/* inodeLock: UNUSED */
-	bool isDataChainPipeValid() const {
-		return newDataInChainPipe[0] >= 0;
-	}
+	bool isDataChainPipeValid() const { return newDataInChainPipe[0] >= 0; }
 
 	/* inodeLock: LOCKED */
 	void wakeUpWorkerIfNecessary() {
@@ -1198,14 +1122,10 @@ struct ChunkData {
 	void updateParentStatus(int8_t status) { parent_->status = status; }
 
 	/* inodeLock: LOCKED */
-	int8_t getParentStatus() {
-		return parent_->status;
-	}
+	int8_t getParentStatus() { return parent_->status; }
 
 	/* inodeLock: LOCKED */
-	bool requiresFlushing() const {
-		return parent_->requiresFlushing();
-	}
+	bool requiresFlushing() const { return parent_->requiresFlushing(); }
 
 	/* inodeLock: LOCKED */
 	void clear() {
@@ -1214,12 +1134,10 @@ struct ChunkData {
 	}
 
 	/* inodeLock: UNUSED */
-	inline inodedata *getParent() const {
-		return parent_;
-	}
+	inline inodedata *getParent() const { return parent_; }
 
 private:
-	inodedata *parent_; // contains inode and other useful data
+	inodedata *parent_;  // contains inode and other useful data
 };
 
 struct DelayedQueueEntry {
@@ -1228,9 +1146,7 @@ struct DelayedQueueEntry {
 	static constexpr int kTicksPerSecond = 10;
 
 	DelayedQueueEntry(ChunkData *chunkData, int32_t ticksLeft)
-			: chunkData(chunkData),
-			  ticksLeft(ticksLeft) {
-	}
+	    : chunkData(chunkData), ticksLeft(ticksLeft) {}
 };
 
 static std::atomic<uint32_t> maxretries;
@@ -1277,12 +1193,10 @@ void write_cb_release_blocks(uint32_t count) {
 }
 
 /* globalLock: UNLOCKED*/
-void write_cb_acquire_blocks(uint32_t count) {
-	freecacheblocks -= count;
-}
+void write_cb_acquire_blocks(uint32_t count) { freecacheblocks -= count; }
 
 /* globalLock: UNLOCKED*/
-void write_cb_wait_for_block(inodedata* id) {
+void write_cb_wait_for_block(inodedata *id) {
 	LOG_AVG_TILL_END_OF_SCOPE0("write_cb_wait_for_block");
 	fcbwaiting++;
 	uint64_t totalCachedBlocks = id->totalCachedBlocks;
@@ -1290,8 +1204,8 @@ void write_cb_wait_for_block(inodedata* id) {
 	while (freecacheblocks <= 0
 	       // totalCachedBlocks / (totalCachedBlocks + freecacheblocks) >
 	       // gCachePerInodePercentage / 100 really means "0 > 0"
-	       || totalCachedBlocks * 100 > (totalCachedBlocks + freecacheblocks) *
-	                                        gCachePerInodePercentage) {
+	       || totalCachedBlocks * 100 >
+	              (totalCachedBlocks + freecacheblocks) * gCachePerInodePercentage) {
 		fcbcond.wait(fcbcondLock);
 	}
 	fcbwaiting--;
@@ -1300,16 +1214,12 @@ void write_cb_wait_for_block(inodedata* id) {
 /* inode */
 
 inodedata *write_find_inodedata(uint32_t inode, Lock &) {
-	if (inodedataMap.contains(inode)) {
-		return inodedataMap[inode];
-	}
+	if (inodedataMap.contains(inode)) { return inodedataMap[inode]; }
 	return NO_INODEDATA;
 }
 
 inodedata *write_get_inodedata(uint32_t inode, Lock &) {
-	if (inodedataMap.contains(inode)) {
-		return inodedataMap[inode];
-	}
+	if (inodedataMap.contains(inode)) { return inodedataMap[inode]; }
 	auto id = new inodedata(inode);
 	inodedataMap[inode] = id;
 	return id;
@@ -1317,9 +1227,7 @@ inodedata *write_get_inodedata(uint32_t inode, Lock &) {
 
 void write_free_inodedata(inodedata *fid, Lock &) {
 	uint32_t inode = fid->inode;
-	if (!inodedataMap.contains(inode)) {
-		return;
-	}
+	if (!inodedataMap.contains(inode)) { return; }
 
 	auto id = inodedataMap[inode];
 	sassert(id == fid);
@@ -1330,18 +1238,13 @@ void write_free_inodedata(inodedata *fid, Lock &) {
 /* chunk */
 
 /* inodeLock: LOCKED*/
-ChunkData *write_get_chunkdata(uint32_t chunkIndex, inodedata *id,
-                               Lock &inodeLock) {
+ChunkData *write_get_chunkdata(uint32_t chunkIndex, inodedata *id, Lock &inodeLock) {
 	auto chunkDataListIt =
 	    std::find_if(id->chunkDataList.begin(), id->chunkDataList.end(),
-	                 [&](ChunkDataPtr &chunkData) {
-		                 return chunkData->chunkIndex == chunkIndex;
-	                 });
-	if (chunkDataListIt != id->chunkDataList.end()) {
-		return chunkDataListIt->get();
-	}
+	                 [&](ChunkDataPtr &chunkData) { return chunkData->chunkIndex == chunkIndex; });
+	if (chunkDataListIt != id->chunkDataList.end()) { return chunkDataListIt->get(); }
 	id->chunkDataList.emplace_front(new ChunkData(chunkIndex, id));
-	auto& chunkData = id->chunkDataList.front();
+	auto &chunkData = id->chunkDataList.front();
 	id->emptyChunkDataList = false;
 	inodeLock.unlock();
 
@@ -1352,8 +1255,8 @@ ChunkData *write_get_chunkdata(uint32_t chunkIndex, inodedata *id,
 		globalLock.unlock();
 
 		inodeLock.lock();
-		chunkData->locator = std::make_unique<TruncateWriteChunkLocator>(
-		    id->inode, chunkIndex, lockid, endoffset);
+		chunkData->locator =
+		    std::make_unique<TruncateWriteChunkLocator>(id->inode, chunkIndex, lockid, endoffset);
 		inodeLock.unlock();
 		globalLock.lock();
 	}
@@ -1367,9 +1270,9 @@ void write_free_chunkdata(ChunkData *fChunkData, Lock &) {
 	inodedata *id = fChunkData->getParent();
 	sassert(!id->chunkDataList.empty());
 
-	auto chunkDataListIt = std::find_if(
-	    id->chunkDataList.begin(), id->chunkDataList.end(),
-	    [&](ChunkDataPtr &chunkData) { return chunkData.get() == fChunkData; });
+	auto chunkDataListIt =
+	    std::find_if(id->chunkDataList.begin(), id->chunkDataList.end(),
+	                 [&](ChunkDataPtr &chunkData) { return chunkData.get() == fChunkData; });
 	if (chunkDataListIt != id->chunkDataList.end()) {
 		id->chunkDataList.erase(chunkDataListIt);
 		id->emptyChunkDataList = id->chunkDataList.empty();
@@ -1380,12 +1283,12 @@ void write_free_chunkdata(ChunkData *fChunkData, Lock &) {
 
 /* globalLock: LOCKED*/
 static void delayed_queue_put(ChunkData *chunkData, uint32_t seconds, Lock &) {
-	delayedQueue.emplace_back(DelayedQueueEntry(
-	    chunkData, seconds * DelayedQueueEntry::kTicksPerSecond));
+	delayedQueue.emplace_back(
+	    DelayedQueueEntry(chunkData, seconds * DelayedQueueEntry::kTicksPerSecond));
 }
 
 /* globalLock: LOCKED*/
-static bool delayed_queue_remove(ChunkData* chunkData, Lock&) {
+static bool delayed_queue_remove(ChunkData *chunkData, Lock &) {
 	for (auto it = delayedQueue.begin(); it != delayedQueue.end(); ++it) {
 		if (it->chunkData == chunkData) {
 			delayedQueue.erase(it);
@@ -1399,21 +1302,20 @@ static bool delayed_queue_remove(ChunkData* chunkData, Lock&) {
 static std::vector<ChunkData *> delayed_queue_remove(inodedata *id, Lock &) {
 	std::vector<ChunkData *> removedChunkData;
 
-	auto it =
-	    std::remove_if(delayedQueue.begin(), delayedQueue.end(),
-	                   [&](const DelayedQueueEntry &entry) {
-		                   if (entry.chunkData->getParent() == id) {
-			                   removedChunkData.push_back(entry.chunkData);
-			                   return true;
-		                   }
-		                   return false;
-	                   });
+	auto it = std::remove_if(delayedQueue.begin(), delayedQueue.end(),
+	                         [&](const DelayedQueueEntry &entry) {
+		                         if (entry.chunkData->getParent() == id) {
+			                         removedChunkData.push_back(entry.chunkData);
+			                         return true;
+		                         }
+		                         return false;
+	                         });
 
 	delayedQueue.erase(it, delayedQueue.end());
 	return removedChunkData;
 }
 
-void* delayed_queue_worker(void*) {
+void *delayed_queue_worker(void *) {
 	pthread_setname_np(pthread_self(), "delQueueWriter");
 
 	for (;;) {
@@ -1421,9 +1323,7 @@ void* delayed_queue_worker(void*) {
 		Lock globalLock(gMutex);
 		auto it = delayedQueue.begin();
 		while (it != delayedQueue.end()) {
-			if (it->chunkData == NO_CHUNKDATA) {
-				return NULL;
-			}
+			if (it->chunkData == NO_CHUNKDATA) { return NULL; }
 			if (--it->ticksLeft <= 0) {
 				auto *data = reinterpret_cast<uint8_t *>(it->chunkData);
 				jobsQueue->put(0, 0, data, 0);
@@ -1441,27 +1341,25 @@ void* delayed_queue_worker(void*) {
 /* queues */
 
 /* globalLock: LOCKED*/
-void write_delayed_enqueue(ChunkData* chunkData, uint32_t seconds, Lock& globalLock) {
+void write_delayed_enqueue(ChunkData *chunkData, uint32_t seconds, Lock &globalLock) {
 	if (seconds > 0) {
 		delayed_queue_put(chunkData, seconds, globalLock);
 	} else {
-		jobsQueue->put(0, 0, reinterpret_cast<uint8_t*>(chunkData), 0);
+		jobsQueue->put(0, 0, reinterpret_cast<uint8_t *>(chunkData), 0);
 	}
 }
 
 void write_enqueue(ChunkData *chunkData, Lock &) {
-	jobsQueue->put(0, 0, reinterpret_cast<uint8_t*>(chunkData), 0);
+	jobsQueue->put(0, 0, reinterpret_cast<uint8_t *>(chunkData), 0);
 }
 
 /* globalLock: LOCKED*/
 void write_enqueue(std::vector<ChunkData *> &chunks, Lock &) {
-	for (auto chunk : chunks) {
-		jobsQueue->put(0, 0, reinterpret_cast<uint8_t *>(chunk), 0);
-	}
+	for (auto chunk : chunks) { jobsQueue->put(0, 0, reinterpret_cast<uint8_t *>(chunk), 0); }
 }
 
 /* globalLock: LOCKED*/
-void write_job_delayed_end(ChunkData* chunkData, int status, int seconds, Lock &globalLock) {
+void write_job_delayed_end(ChunkData *chunkData, int status, int seconds, Lock &globalLock) {
 	LOG_AVG_TILL_END_OF_SCOPE0("write_job_delayed_end");
 	LOG_AVG_TILL_END_OF_SCOPE1("write_job_delayed_end#sec", seconds);
 	inodedata *parent = chunkData->getParent();
@@ -1489,7 +1387,7 @@ void write_job_delayed_end(ChunkData* chunkData, int status, int seconds, Lock &
 		write_enqueue(chunkData, globalLock);
 	} else if (!chunkData->dataChain.empty() &&
 	           status == SAUNAFS_STATUS_OK) {  // still have some work to do
-		chunkData->tryCounter = 0;  // on good write reset try counter
+		chunkData->tryCounter = 0;             // on good write reset try counter
 		inodeLock.unlock();
 
 		globalLock.lock();
@@ -1506,9 +1404,7 @@ void write_job_delayed_end(ChunkData* chunkData, int status, int seconds, Lock &
 		inodeLock.unlock();
 
 		globalLock.lock();
-		if (parent->emptyChunkDataList) {
-			parent->flushcond.notify_all();
-		}
+		if (parent->emptyChunkDataList) { parent->flushcond.notify_all(); }
 	}
 }
 
@@ -1519,31 +1415,31 @@ void write_job_end(ChunkData *chunkData, int status, Lock &globalLock) {
 
 class ChunkJobWriter {
 public:
-	void processJob(ChunkData* chunkData);
+	void processJob(ChunkData *chunkData);
 
 private:
-	void processDataChain(ChunkWriter& writer);
+	void processDataChain(ChunkWriter &writer);
 
 	/*
-	* Returns pending operations to datachain.
-	* inodeLock: LOCKED
-	*/
-	void returnJournalToDataChain(std::list<WriteCacheBlock>&& journal, Lock&);
+	 * Returns pending operations to datachain.
+	 * inodeLock: LOCKED
+	 */
+	void returnJournalToDataChain(std::list<WriteCacheBlock> &&journal, Lock &);
 
 	/*
-	* Check if there is any data in the same chunk waiting to be written.
-	* inodeLock: LOCKED
-	*/
-	bool haveAnyBlockInCurrentChunk(Lock&);
+	 * Check if there is any data in the same chunk waiting to be written.
+	 * inodeLock: LOCKED
+	 */
+	bool haveAnyBlockInCurrentChunk(Lock &);
 
 	/*
-	* Check if there is any data worth sending to the chunkserver.
-	* We will avoid sending blocks of size different than SFSBLOCKSIZE.
-	* These can be taken only if we are close to run out of tasks to do.
-	* inodeLock: LOCKED
-	*/
-	bool haveBlockWorthWriting(uint32_t unfinishedOperationCount, Lock&);
-	ChunkData* chunkData_ = NO_CHUNKDATA;
+	 * Check if there is any data worth sending to the chunkserver.
+	 * We will avoid sending blocks of size different than SFSBLOCKSIZE.
+	 * These can be taken only if we are close to run out of tasks to do.
+	 * inodeLock: LOCKED
+	 */
+	bool haveBlockWorthWriting(uint32_t unfinishedOperationCount, Lock &);
+	ChunkData *chunkData_ = NO_CHUNKDATA;
 	uint32_t chunkIndex_ = 0;
 	Timer wholeOperationTimer;
 
@@ -1557,27 +1453,23 @@ private:
 	static const uint32_t kMinTryCounterToShowWriteErrorMessage = 4;
 };
 
-void ChunkJobWriter::processJob(ChunkData* chunkData) {
+void ChunkJobWriter::processJob(ChunkData *chunkData) {
 	LOG_AVG_TILL_END_OF_SCOPE0("ChunkJobWriter::processJob");
 	chunkData_ = chunkData;
 	chunkIndex_ = chunkData_->chunkIndex;
 	inodedata *parent = chunkData_->getParent();
 
 	/*  Process the job */
-	ChunkWriter writer(globalChunkserverStats, gChunkConnector,
-	                   chunkData_->newDataInChainPipe[0]);
+	ChunkWriter writer(globalChunkserverStats, gChunkConnector, chunkData_->newDataInChainPipe[0]);
 	wholeOperationTimer.reset();
 	std::unique_ptr<WriteChunkLocator> locator = std::move(chunkData_->locator);
-	if (!locator) {
-		locator.reset(new WriteChunkLocator());
-	}
+	if (!locator) { locator.reset(new WriteChunkLocator()); }
 
 	try {
 		try {
 			locator->locateAndLockChunk(parent->inode, chunkIndex_);
 			Lock inodeLock(parent->mutex);
-			parent->maxfleng =
-			    std::max(parent->maxfleng, locator->fileLength());
+			parent->maxfleng = std::max(parent->maxfleng, locator->fileLength());
 
 			// Optimization -- talk with chunkservers only if we have to write any data.
 			// Don't do this if we just have to release some previously unlocked lock.
@@ -1623,18 +1515,18 @@ void ChunkJobWriter::processJob(ChunkData* chunkData) {
 
 			Lock globalLock(gMutex);
 			write_job_delayed_end(chunkData_, SAUNAFS_STATUS_OK, (canWait ? 1 : 0), globalLock);
-		} catch (Exception& e) {
+		} catch (Exception &e) {
 			std::string errorString = e.what();
-			addPathByInodeBasedNotificationMessage(
-			    "Write error: " + std::string(e.what()), parent->inode);
+			addPathByInodeBasedNotificationMessage("Write error: " + std::string(e.what()),
+			                                       parent->inode);
 			Lock inodeLock(parent->mutex);
 			if (e.status() != SAUNAFS_ERROR_LOCKED) {
 				chunkData_->tryCounter++;
 				errorString += " (try counter: " + std::to_string(chunkData->tryCounter) + ")";
 			} else if (chunkData_->tryCounter == 0) {
 				// Set to nonzero to inform writers, that this task needs to wait a bit
-				// Don't increase -- SAUNAFS_ERROR_LOCKED means that chunk is locked by a different client
-				// and we have to wait until it is unlocked
+				// Don't increase -- SAUNAFS_ERROR_LOCKED means that chunk is locked by a different
+				// client and we have to wait until it is unlocked
 				chunkData_->tryCounter = 1;
 			}
 			// Keep the lock
@@ -1653,9 +1545,9 @@ void ChunkJobWriter::processJob(ChunkData* chunkData) {
 				throw;
 			}
 		}
-	} catch (UnrecoverableWriteException& e) {
-		addPathByInodeBasedNotificationMessage(
-		    "Write error: " + std::string(e.what()), parent->inode);
+	} catch (UnrecoverableWriteException &e) {
+		addPathByInodeBasedNotificationMessage("Write error: " + std::string(e.what()),
+		                                       parent->inode);
 		Lock globalLock(gMutex);
 		if (e.status() == SAUNAFS_ERROR_ENOENT) {
 			write_job_end(chunkData_, SAUNAFS_ERROR_EBADF, globalLock);
@@ -1667,10 +1559,10 @@ void ChunkJobWriter::processJob(ChunkData* chunkData) {
 		} else {
 			write_job_end(chunkData_, SAUNAFS_ERROR_IO, globalLock);
 		}
-	} catch (Exception& e) {
+	} catch (Exception &e) {
 		if (chunkData_->tryCounter > kMinTryCounterToShowWriteErrorMessage) {
-			addPathByInodeBasedNotificationMessage(
-			    "Write error: " + std::string(e.what()), parent->inode);
+			addPathByInodeBasedNotificationMessage("Write error: " + std::string(e.what()),
+			                                       parent->inode);
 		}
 		Lock globalLock(gMutex);
 		int waitTime = 1;
@@ -1681,7 +1573,7 @@ void ChunkJobWriter::processJob(ChunkData* chunkData) {
 	}
 }
 
-void ChunkJobWriter::processDataChain(ChunkWriter& writer) {
+void ChunkJobWriter::processDataChain(ChunkWriter &writer) {
 	LOG_AVG_TILL_END_OF_SCOPE0("ChunkJobWriter::processDataChain");
 	uint32_t maximumTime = kMaximumTime;
 	bool otherJobsAreWaiting = false;
@@ -1704,8 +1596,8 @@ void ChunkJobWriter::processDataChain(ChunkWriter& writer) {
 		// new if we've already sent 'gWriteWindowSize' blocks and didn't receive status from
 		// the chunkserver.
 		bool can_expect_next_block = true;
-		if (wholeOperationTimer.elapsed_s() + kTimeToFinishOperations < maximumTime
-				&& writer.acceptsNewOperations()) {
+		if (wholeOperationTimer.elapsed_s() + kTimeToFinishOperations < maximumTime &&
+		    writer.acceptsNewOperations()) {
 			Lock inodeLock(parent->mutex);
 			// While there is any block worth sending, we add new write operation
 			while (haveBlockWorthWriting(writer.getUnfinishedOperationsCount(), inodeLock)) {
@@ -1747,8 +1639,7 @@ void ChunkJobWriter::processDataChain(ChunkWriter& writer) {
 
 		Lock inodeLock(parent->mutex);
 		writer.setChunkSizeInBlocks(
-		    std::min(parent->maxfleng - chunkIndex_ * SFSCHUNKSIZE,
-		             (uint64_t)SFSCHUNKSIZE));
+		    std::min(parent->maxfleng - chunkIndex_ * SFSCHUNKSIZE, (uint64_t)SFSCHUNKSIZE));
 		inodeLock.unlock();
 		if (writer.startNewOperations(can_expect_next_block) > 0) {
 			inodeLock.lock();
@@ -1759,37 +1650,31 @@ void ChunkJobWriter::processDataChain(ChunkWriter& writer) {
 			return;
 		} else if (wholeOperationTimer.elapsed_s() >= maximumTime) {
 			throw RecoverableWriteException(
-					"Timeout after " + std::to_string(wholeOperationTimer.elapsed_ms()) + " ms",
-					SAUNAFS_ERROR_TIMEOUT);
+			    "Timeout after " + std::to_string(wholeOperationTimer.elapsed_ms()) + " ms",
+			    SAUNAFS_ERROR_TIMEOUT);
 		}
 
 		writer.processOperations(gWriteWaveTimeout);
 	}
 }
 
-void ChunkJobWriter::returnJournalToDataChain(
-    std::list<WriteCacheBlock> &&journal, Lock &inodeLock) {
+void ChunkJobWriter::returnJournalToDataChain(std::list<WriteCacheBlock> &&journal,
+                                              Lock &inodeLock) {
 	if (!journal.empty()) {
 		inodeLock.unlock();
 		write_cb_acquire_blocks(journal.size());
 		inodeLock.lock();
 
 		chunkData_->getParent()->totalCachedBlocks += journal.size();
-		chunkData_->dataChain.splice(chunkData_->dataChain.begin(),
-		                             std::move(journal));
+		chunkData_->dataChain.splice(chunkData_->dataChain.begin(), std::move(journal));
 	}
 }
 
-bool ChunkJobWriter::haveAnyBlockInCurrentChunk(Lock&) {
-	return !chunkData_->dataChain.empty();
-}
+bool ChunkJobWriter::haveAnyBlockInCurrentChunk(Lock &) { return !chunkData_->dataChain.empty(); }
 
-bool ChunkJobWriter::haveBlockWorthWriting(uint32_t unfinishedOperationCount,
-                                           Lock &inodeLock) {
-	if (!haveAnyBlockInCurrentChunk(inodeLock)) {
-		return false;
-	}
-	const auto& block = chunkData_->dataChain.front();
+bool ChunkJobWriter::haveBlockWorthWriting(uint32_t unfinishedOperationCount, Lock &inodeLock) {
+	if (!haveAnyBlockInCurrentChunk(inodeLock)) { return false; }
+	const auto &block = chunkData_->dataChain.front();
 	if (block.type != WriteCacheBlock::kWritableBlock) {
 		// Always write data, that was previously written
 		return true;
@@ -1799,14 +1684,13 @@ bool ChunkJobWriter::haveBlockWorthWriting(uint32_t unfinishedOperationCount,
 	} else {
 		// Always start full blocks; start partial blocks only if we have to flush the data
 		// or the block won't be expanded (only the last one can be) to a full block
-		return (block.size() == SFSBLOCKSIZE
-				|| chunkData_->requiresFlushing()
-				|| chunkData_->dataChain.size() > 1);
+		return (block.size() == SFSBLOCKSIZE || chunkData_->requiresFlushing() ||
+		        chunkData_->dataChain.size() > 1);
 	}
 }
 
 /* main working thread | globalLock:UNLOCKED */
-void* write_worker(void*) {
+void *write_worker(void *) {
 	ChunkJobWriter chunkJobWriter;
 
 	static std::atomic_uint16_t writeWorkersCounter(0);
@@ -1821,13 +1705,11 @@ void* write_worker(void*) {
 			LOG_AVG_TILL_END_OF_SCOPE0("write_worker#idle");
 			jobsQueue->get(&z1, &z2, &data, &z3);
 		}
-		if (data == NO_CHUNKDATA) {
-			return NULL;
-		}
+		if (data == NO_CHUNKDATA) { return NULL; }
 
 		// process the job
 		LOG_AVG_TILL_END_OF_SCOPE0("write_worker#working");
-		chunkJobWriter.processJob((ChunkData*) data);
+		chunkJobWriter.processJob((ChunkData *)data);
 	}
 	return NULL;
 }
@@ -1845,9 +1727,7 @@ void write_data_init(uint32_t cachesize, uint32_t retries, uint32_t workers,
 	gChunkserverTimeout_ms = chunkserverTimeout_ms;
 	maxretries = retries;
 	gWriteWaveTimeout = waveTimeout;
-	if (cacheblockcount < 10) {
-		cacheblockcount = 10;
-	}
+	if (cacheblockcount < 10) { cacheblockcount = 10; }
 
 	freecacheblocks = cacheblockcount;
 	gCachePerInodePercentage = cachePerInodePercentage;
@@ -1858,9 +1738,7 @@ void write_data_init(uint32_t cachesize, uint32_t retries, uint32_t workers,
 	pthread_attr_setstacksize(&thattr, 0x100000);
 	pthread_create(&delayed_queue_worker_th, &thattr, delayed_queue_worker, NULL);
 	write_worker_th.resize(workers);
-	for (auto& th : write_worker_th) {
-		pthread_create(&th, &thattr, write_worker, NULL);
-	}
+	for (auto &th : write_worker_th) { pthread_create(&th, &thattr, write_worker, NULL); }
 	pthread_attr_destroy(&thattr);
 
 	gTweaks.registerVariable("WriteMaxRetries", maxretries, "sfsioretries (write)");
@@ -1874,33 +1752,26 @@ void write_data_term(void) {
 		Lock globalLock(gMutex);
 		delayed_queue_put(NO_CHUNKDATA, 0, globalLock);
 	}
-	for (i = 0; i < write_worker_th.size(); i++) {
-		jobsQueue->put(0, 0, NO_CHUNKDATA, 0);
-	}
-	for (i = 0; i < write_worker_th.size(); i++) {
-		pthread_join(write_worker_th[i], NULL);
-	}
+	for (i = 0; i < write_worker_th.size(); i++) { jobsQueue->put(0, 0, NO_CHUNKDATA, 0); }
+	for (i = 0; i < write_worker_th.size(); i++) { pthread_join(write_worker_th[i], NULL); }
 	pthread_join(delayed_queue_worker_th, NULL);
 	jobsQueue.reset();
-	for (const auto &[_, id] : inodedataMap) {
-		delete id;
-	}
+	for (const auto &[_, id] : inodedataMap) { delete id; }
 	inodedataMap.clear();
 }
 
 /* inodeLock: UNLOCKED */
 /* globalLock: UNLOCKED */
-int write_block(ChunkData *chunkData, uint16_t pos, uint32_t from, uint32_t to,
-                const uint8_t *data, Lock &inodeLock) {
+int write_block(ChunkData *chunkData, uint16_t pos, uint32_t from, uint32_t to, const uint8_t *data,
+                Lock &inodeLock) {
 	inodedata *parent = chunkData->getParent();
 	parent->lastWriteToDataChain.reset();
 
 	// Try to expand the last block
 	if (!chunkData->dataChain.empty()) {
-		auto& lastBlock = chunkData->dataChain.back();
-		if (lastBlock.blockIndex == pos
-				&& lastBlock.type == WriteCacheBlock::kWritableBlock
-				&& lastBlock.expand(from, to, data)) {
+		auto &lastBlock = chunkData->dataChain.back();
+		if (lastBlock.blockIndex == pos && lastBlock.type == WriteCacheBlock::kWritableBlock &&
+		    lastBlock.expand(from, to, data)) {
 			chunkData->wakeUpWorkerIfNecessary();
 			return 0;
 		}
@@ -1912,8 +1783,8 @@ int write_block(ChunkData *chunkData, uint16_t pos, uint32_t from, uint32_t to,
 	write_cb_acquire_blocks(1);
 
 	inodeLock.lock();
-	chunkData->pushToChain(WriteCacheBlock(chunkData->chunkIndex, pos,
-	                                       WriteCacheBlock::kWritableBlock));
+	chunkData->pushToChain(
+	    WriteCacheBlock(chunkData->chunkIndex, pos, WriteCacheBlock::kWritableBlock));
 	sassert(chunkData->dataChain.back().expand(from, to, data));
 	Lock globalLock(gMutex, std::defer_lock);
 	if (chunkData->inQueue) {
@@ -1947,8 +1818,7 @@ int write_block(ChunkData *chunkData, uint16_t pos, uint32_t from, uint32_t to,
 }
 
 /* globalLock: UNLOCKED */
-int write_blocks(inodedata *id, uint64_t offset, uint32_t size,
-                 const uint8_t *data) {
+int write_blocks(inodedata *id, uint64_t offset, uint32_t size, const uint8_t *data) {
 	LOG_AVG_TILL_END_OF_SCOPE0("write_blocks");
 	uint32_t chindx = offset >> SFSCHUNKBITS;
 	uint16_t pos = (offset & SFSCHUNKMASK) >> SFSBLOCKBITS;
@@ -1983,68 +1853,54 @@ int write_blocks(inodedata *id, uint64_t offset, uint32_t size,
 	return 0;
 }
 
-int write_data(void *vid, uint64_t offset, uint32_t size, const uint8_t *data,
-               size_t currentSize) {
+int write_data(void *vid, uint64_t offset, uint32_t size, const uint8_t *data, size_t currentSize) {
 	LOG_AVG_TILL_END_OF_SCOPE0("write_data");
 	int status;
-	inodedata *id = (inodedata*) vid;
-	if (id == NO_INODEDATA) {
-		return SAUNAFS_ERROR_IO;
-	}
+	inodedata *id = (inodedata *)vid;
+	if (id == NO_INODEDATA) { return SAUNAFS_ERROR_IO; }
 
 	Lock inodeLock(id->mutex);
 	status = id->status;
 	id->maxfleng = std::max(id->maxfleng, currentSize);
 	if (status == SAUNAFS_STATUS_OK) {
-		if (offset + size > id->maxfleng) {     // move fleng
+		if (offset + size > id->maxfleng) {  // move fleng
 			id->maxfleng = offset + size;
 		}
 		id->writewaiting++;
-		while (id->flushwaiting > 0) {
-			id->writecond.wait(inodeLock);
-		}
+		while (id->flushwaiting > 0) { id->writecond.wait(inodeLock); }
 		id->writewaiting--;
 	}
 	inodeLock.unlock();
 
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	}
+	if (status != SAUNAFS_STATUS_OK) { return status; }
 
 	return write_blocks(id, offset, size, data);
 }
 
 /* inode: LOCKED */
-static void write_data_flushwaiting_increase(inodedata *id, Lock&) {
-	id->flushwaiting++;
-}
+static void write_data_flushwaiting_increase(inodedata *id, Lock &) { id->flushwaiting++; }
 
 /* inode: LOCKED */
-static void write_data_flushwaiting_decrease(inodedata *id, Lock&) {
+static void write_data_flushwaiting_decrease(inodedata *id, Lock &) {
 	id->flushwaiting--;
-	if (id->flushwaiting == 0 && id->writewaiting > 0) {
-		id->writecond.notify_all();
-	}
+	if (id->flushwaiting == 0 && id->writewaiting > 0) { id->writecond.notify_all(); }
 }
 
 /* inode: UNLOCKED */
-static void write_data_lcnt_increase(inodedata *id) {
-	id->lcnt++;
-}
+static void write_data_lcnt_increase(inodedata *id) { id->lcnt++; }
 
 /* inode: LOCKED */
-static void write_data_lcnt_decrease_check_deleted(inodedata *id,
-                                                   Lock &inodeLock,
+static void write_data_lcnt_decrease_check_deleted(inodedata *id, Lock &inodeLock,
                                                    bool &isDeleted) {
 	// As long as it is not freed, then we don't consider the inodedata deleted
 	isDeleted = false;
-	bool almostDone = (id->emptyChunkDataList) && (id->flushwaiting == 0) &&
-	    (id->writewaiting == 0);
+	bool almostDone =
+	    (id->emptyChunkDataList) && (id->flushwaiting == 0) && (id->writewaiting == 0);
 	inodeLock.unlock();
 
 	Lock globalLock(gMutex);
 	id->lcnt--;
-	if (id->lcnt == 0 && almostDone) {		
+	if (id->lcnt == 0 && almostDone) {
 		write_free_inodedata(id, globalLock);
 		isDeleted = true;
 		return;
@@ -2055,30 +1911,26 @@ static void write_data_lcnt_decrease_check_deleted(inodedata *id,
 }
 
 /* inode: LOCKED */
-inline void write_data_lcnt_decrease(inodedata *id, Lock& inodeLock) {
+inline void write_data_lcnt_decrease(inodedata *id, Lock &inodeLock) {
 	bool dummy_isDeleted;
 	write_data_lcnt_decrease_check_deleted(id, inodeLock, dummy_isDeleted);
-	(void) dummy_isDeleted;
+	(void)dummy_isDeleted;
 }
 
-void* write_data_new(uint32_t inode) {
-	inodedata* id;
+void *write_data_new(uint32_t inode) {
+	inodedata *id;
 	Lock globalLock(gMutex);
 	id = write_get_inodedata(inode, globalLock);
-	if (id == NO_INODEDATA) {
-		return NO_INODEDATA;
-	}
+	if (id == NO_INODEDATA) { return NO_INODEDATA; }
 
 	write_data_lcnt_increase(id);
 	return id;
 }
 
 /* globalLock: LOCKED */
-static int write_data_flush(void* vid, Lock& globalLock) {
-	inodedata* id = (inodedata*) vid;
-	if (id == NO_INODEDATA) {
-		return SAUNAFS_ERROR_IO;
-	}
+static int write_data_flush(void *vid, Lock &globalLock) {
+	inodedata *id = (inodedata *)vid;
+	if (id == NO_INODEDATA) { return SAUNAFS_ERROR_IO; }
 	globalLock.unlock();
 
 	Lock inodeLock(id->mutex);
@@ -2094,9 +1946,7 @@ static int write_data_flush(void* vid, Lock& globalLock) {
 	}
 
 	// Wait for the data to be flushed
-	while (!id->emptyChunkDataList) {
-		id->flushcond.wait(globalLock);
-	}
+	while (!id->emptyChunkDataList) { id->flushcond.wait(globalLock); }
 	globalLock.unlock();
 
 	inodeLock.lock();
@@ -2108,14 +1958,14 @@ static int write_data_flush(void* vid, Lock& globalLock) {
 	return id->status;
 }
 
-int write_data_flush(void* vid) {
+int write_data_flush(void *vid) {
 	Lock globalLock(gMutex);
 	return write_data_flush(vid, globalLock);
 }
 
 uint64_t write_data_getmaxfleng(uint32_t inode) {
 	uint64_t maxfleng;
-	inodedata* id;
+	inodedata *id;
 	Lock globalLock(gMutex);
 	id = write_find_inodedata(inode, globalLock);
 	if (id) {
@@ -2128,27 +1978,23 @@ uint64_t write_data_getmaxfleng(uint32_t inode) {
 
 int write_data_flush_inode(uint32_t inode) {
 	Lock globalLock(gMutex);
-	inodedata* id = write_find_inodedata(inode, globalLock);
-	if (id == NO_INODEDATA) {
-		return 0;
-	}
+	inodedata *id = write_find_inodedata(inode, globalLock);
+	if (id == NO_INODEDATA) { return 0; }
 	return write_data_flush(id, globalLock);
 }
 
-int write_data_truncate(uint32_t inode, bool opened, uint32_t uid, uint32_t gid,
-                        uint64_t length, Attributes &attr) {
+int write_data_truncate(uint32_t inode, bool opened, uint32_t uid, uint32_t gid, uint64_t length,
+                        Attributes &attr) {
 	Lock globalLock(gMutex);
 
 	// 1. Flush writes but don't finish it completely - it'll be done at the end of truncate
-	inodedata* id = write_get_inodedata(inode, globalLock);
+	inodedata *id = write_get_inodedata(inode, globalLock);
 	globalLock.unlock();
-	if (id == NO_INODEDATA) {
-		return SAUNAFS_ERROR_IO;
-	}
+	if (id == NO_INODEDATA) { return SAUNAFS_ERROR_IO; }
 
 	Lock inodeLock(id->mutex);
 	write_data_lcnt_increase(id);
-	write_data_flushwaiting_increase(id, inodeLock); // this will block any writing to this inode
+	write_data_flushwaiting_increase(id, inodeLock);  // this will block any writing to this inode
 	inodeLock.unlock();
 
 	globalLock.lock();
@@ -2171,13 +2017,10 @@ int write_data_truncate(uint32_t inode, bool opened, uint32_t uid, uint32_t gid,
 	do {
 		status = fs_truncate(inode, opened, uid, gid, length, writeNeeded, attr, oldLength, lockId);
 		if (status != SAUNAFS_STATUS_OK) {
-			safs::log_info("truncate file {} to length {}: {} (try {}/{})",
-			               inode, length, saunafs_error_string(status),
-			               int(retries + 1), int(maxretries));
+			safs::log_info("truncate file {} to length {}: {} (try {}/{})", inode, length,
+			               saunafs_error_string(status), int(retries + 1), int(maxretries));
 		}
-		if (retries >= maxretries) {
-			break;
-		}
+		if (retries >= maxretries) { break; }
 		if (status == SAUNAFS_ERROR_LOCKED) {
 			sleep(1);
 		} else if (status == SAUNAFS_ERROR_CHUNKLOST || status == SAUNAFS_ERROR_NOTDONE) {
@@ -2185,7 +2028,8 @@ int write_data_truncate(uint32_t inode, bool opened, uint32_t uid, uint32_t gid,
 			retrySleepTime_us = std::min(2 * retrySleepTime_us, 60 * 1000000);
 			++retries;
 		}
-	} while (status == SAUNAFS_ERROR_LOCKED || status == SAUNAFS_ERROR_CHUNKLOST || status == SAUNAFS_ERROR_NOTDONE);
+	} while (status == SAUNAFS_ERROR_LOCKED || status == SAUNAFS_ERROR_CHUNKLOST ||
+	         status == SAUNAFS_ERROR_NOTDONE);
 	inodeLock.lock();
 	if (status != 0 || !writeNeeded) {
 		// Something failed or we have nothing to do more (master server managed to do the truncate)
@@ -2193,9 +2037,7 @@ int write_data_truncate(uint32_t inode, bool opened, uint32_t uid, uint32_t gid,
 		write_data_flushwaiting_decrease(id, inodeLock);
 		write_data_lcnt_decrease_check_deleted(id, inodeLock, isDeleted);
 		if (status == SAUNAFS_STATUS_OK) {
-			if (!isDeleted) {
-				id->maxfleng = length;
-			}
+			if (!isDeleted) { id->maxfleng = length; }
 			return 0;
 		} else {
 			return status;
@@ -2205,9 +2047,9 @@ int write_data_truncate(uint32_t inode, bool opened, uint32_t uid, uint32_t gid,
 	// We have to write zeros in suitable region to update xor/ec parity parts.
 	// Let's calculate size of the region to be zeroed
 	uint64_t endOffset = std::min({
-		oldLength,                            // no further than to the end of the file
-		length + slice_traits::ec::kMaxDataCount * SFSBLOCKSIZE, // no more than the maximal stripe
-		(length + SFSCHUNKSIZE - 1) / SFSCHUNKSIZE * SFSCHUNKSIZE // no beyond the end of chunk
+	    oldLength,  // no further than to the end of the file
+	    length + slice_traits::ec::kMaxDataCount * SFSBLOCKSIZE,  // no more than the maximal stripe
+	    (length + SFSCHUNKSIZE - 1) / SFSCHUNKSIZE * SFSCHUNKSIZE  // no beyond the end of chunk
 	});
 
 	if (endOffset > length) {
@@ -2270,12 +2112,10 @@ int write_data_truncate(uint32_t inode, bool opened, uint32_t uid, uint32_t gid,
 	return 0;
 }
 
-int write_data_end(void* vid) {
+int write_data_end(void *vid) {
 	Lock globalLock(gMutex);
-	inodedata* id = (inodedata*) vid;
-	if (id == NO_INODEDATA) {
-		return SAUNAFS_ERROR_IO;
-	}
+	inodedata *id = (inodedata *)vid;
+	if (id == NO_INODEDATA) { return SAUNAFS_ERROR_IO; }
 	int status = write_data_flush(id, globalLock);
 	globalLock.unlock();
 
@@ -2290,13 +2130,13 @@ void write_data_init(uint32_t cachesize, uint32_t retries, uint32_t workers,
                      uint32_t writewindowsize, uint32_t chunkserverTimeout_ms,
                      uint32_t cachePerInodePercentage, uint32_t waveTimeout) {
 	if (gUseInodeBasedWriteAlgorithm) {
-		InodeBasedWriteAlgorithm::write_data_init(
-		    cachesize, retries, workers, writewindowsize, chunkserverTimeout_ms,
-		    cachePerInodePercentage, waveTimeout);
+		InodeBasedWriteAlgorithm::write_data_init(cachesize, retries, workers, writewindowsize,
+		                                          chunkserverTimeout_ms, cachePerInodePercentage,
+		                                          waveTimeout);
 	} else {
-		ChunkBasedWriteAlgorithm::write_data_init(
-		    cachesize, retries, workers, writewindowsize, chunkserverTimeout_ms,
-		    cachePerInodePercentage, waveTimeout);
+		ChunkBasedWriteAlgorithm::write_data_init(cachesize, retries, workers, writewindowsize,
+		                                          chunkserverTimeout_ms, cachePerInodePercentage,
+		                                          waveTimeout);
 	}
 }
 
@@ -2309,23 +2149,17 @@ void write_data_term(void) {
 }
 
 void *write_data_new(uint32_t inode) {
-	if (gUseInodeBasedWriteAlgorithm) {
-		return InodeBasedWriteAlgorithm::write_data_new(inode);
-	}
+	if (gUseInodeBasedWriteAlgorithm) { return InodeBasedWriteAlgorithm::write_data_new(inode); }
 	return ChunkBasedWriteAlgorithm::write_data_new(inode);
 }
 
 int write_data_end(void *vid) {
-	if (gUseInodeBasedWriteAlgorithm) {
-		return InodeBasedWriteAlgorithm::write_data_end(vid);
-	}
+	if (gUseInodeBasedWriteAlgorithm) { return InodeBasedWriteAlgorithm::write_data_end(vid); }
 	return ChunkBasedWriteAlgorithm::write_data_end(vid);
 }
 
 int write_data_flush(void *vid) {
-	if (gUseInodeBasedWriteAlgorithm) {
-		return InodeBasedWriteAlgorithm::write_data_flush(vid);
-	}
+	if (gUseInodeBasedWriteAlgorithm) { return InodeBasedWriteAlgorithm::write_data_flush(vid); }
 	return ChunkBasedWriteAlgorithm::write_data_flush(vid);
 }
 
@@ -2343,22 +2177,17 @@ int write_data_flush_inode(uint32_t inode) {
 	return ChunkBasedWriteAlgorithm::write_data_flush_inode(inode);
 }
 
-int write_data_truncate(uint32_t inode, bool opened, uint32_t uid, uint32_t gid,
-                        uint64_t length, Attributes &attr) {
+int write_data_truncate(uint32_t inode, bool opened, uint32_t uid, uint32_t gid, uint64_t length,
+                        Attributes &attr) {
 	if (gUseInodeBasedWriteAlgorithm) {
-		return InodeBasedWriteAlgorithm::write_data_truncate(inode, opened, uid,
-		                                                     gid, length, attr);
+		return InodeBasedWriteAlgorithm::write_data_truncate(inode, opened, uid, gid, length, attr);
 	}
-	return ChunkBasedWriteAlgorithm::write_data_truncate(inode, opened, uid,
-	                                                     gid, length, attr);
+	return ChunkBasedWriteAlgorithm::write_data_truncate(inode, opened, uid, gid, length, attr);
 }
 
-int write_data(void *vid, uint64_t offset, uint32_t size, const uint8_t *buff,
-               size_t currentSize) {
+int write_data(void *vid, uint64_t offset, uint32_t size, const uint8_t *buff, size_t currentSize) {
 	if (gUseInodeBasedWriteAlgorithm) {
-		return InodeBasedWriteAlgorithm::write_data(vid, offset, size, buff,
-		                                            currentSize);
+		return InodeBasedWriteAlgorithm::write_data(vid, offset, size, buff, currentSize);
 	}
-	return ChunkBasedWriteAlgorithm::write_data(vid, offset, size, buff,
-	                                            currentSize);
+	return ChunkBasedWriteAlgorithm::write_data(vid, offset, size, buff, currentSize);
 }

--- a/src/mount/writedata.cc
+++ b/src/mount/writedata.cc
@@ -66,7 +66,986 @@
 #define NO_INODEDATA nullptr
 #define NO_CHUNKDATA nullptr
 
-namespace {
+namespace OldWriteAlgorithm {
+
+struct inodedata {
+	uint32_t inode;
+	uint64_t maxfleng;
+	int status;
+	uint16_t flushwaiting;
+	uint16_t writewaiting;
+	uint16_t lcnt;
+	uint32_t trycnt;
+	bool inqueue; // true it this inode is waiting in one of the queues or is being processed
+	uint32_t minimumBlocksToWrite;
+	std::list<WriteCacheBlock> dataChain;
+	int alterations_in_chain; // number of adherent blocks with different chunk ids in chain
+	std::condition_variable flushcond; // wait for !inqueue (flush)
+	std::condition_variable writecond; // wait for flushwaiting==0 (write)
+	std::unique_ptr<WriteChunkLocator> locator;
+	int newDataInChainPipe[2];
+	bool workerWaitingForData;
+	Timer lastWriteToDataChain;
+	Timer lastWriteToChunkservers;
+
+	inodedata(uint32_t inode)
+			: inode(inode),
+			  maxfleng(0),
+			  status(SAUNAFS_STATUS_OK),
+			  flushwaiting(0),
+			  writewaiting(0),
+			  lcnt(0),
+			  trycnt(0),
+			  inqueue(false),
+			  minimumBlocksToWrite(1),
+			  alterations_in_chain(),
+			  workerWaitingForData(false) {
+#ifdef _WIN32
+		// We don't use inodeData->waitingworker and inodeData->pipe on Cygwin because
+		// Cygwin's implementation of mixed socket & pipe polling is very inefficient.
+		// On mingw platform pipes are unavailable.
+		newDataInChainPipe[0] = newDataInChainPipe[1] = -1;
+#else
+		if (pipe(newDataInChainPipe) < 0) {
+			safs_pretty_syslog(LOG_WARNING, "creating pipe error: %s", strerr(errno));
+			newDataInChainPipe[0] = -1;
+		}
+#endif
+	}
+
+	~inodedata() {
+		if (isDataChainPipeValid()) {
+			close(newDataInChainPipe[0]);
+			close(newDataInChainPipe[1]);
+		}
+	}
+
+	/* glock: LOCKED */
+	void wakeUpWorkerIfNecessary() {
+		/*
+		 * Write worker always looks for the first block in chain and we modify or add always the
+		 * last block in chain so it is necessary to wake up write worker only if the first block
+		 * is the last one, ie. dataChain.size() == 1.
+		 */
+		if (workerWaitingForData && dataChain.size() == 1 && isDataChainPipeValid()) {
+			if (write(newDataInChainPipe[1], " ", 1) != 1) {
+				safs_pretty_syslog(LOG_ERR, "write pipe error: %s", strerr(errno));
+			}
+			workerWaitingForData = false;
+		}
+	}
+
+	/* glock: UNUSED */
+	bool isDataChainPipeValid() const {
+		return newDataInChainPipe[0] >= 0;
+	}
+
+	/*! Check if inode requires flushing all its data chain to chunkservers.
+	 *
+	 * Returns true if anyone requested to flush the data by calling write_data_flush
+	 * or write_data_flush_inode or the data in data chain is too old to keep it longer in
+	 * our buffers. If this function returns false, we write only full stripes from data
+	 * chain to chunkservers.
+	 * glock: LOCKED
+	 */
+	bool requiresFlushing() const {
+		return (flushwaiting > 0
+				|| lastWriteToDataChain.elapsed_ms() >= kMaximumTimeInDataChainSinceLastWrite_ms
+				|| lastWriteToChunkservers.elapsed_ms() >= kMaximumTimeInDataChainSinceLastFlush_ms);
+	}
+
+	void pushToChain(WriteCacheBlock &&block) {
+		dataChain.push_back(std::move(block));
+		if (dataChain.size() > 1 && dataChain.back().chunkIndex != std::next(dataChain.rbegin())->chunkIndex) {
+			alterations_in_chain++;
+		}
+	}
+
+	void popFromChain() {
+		assert(dataChain.size() > 0);
+		if (dataChain.size() > 1 && dataChain.front().chunkIndex != std::next(dataChain.begin())->chunkIndex) {
+			alterations_in_chain--;
+		}
+		dataChain.pop_front();
+	}
+
+	void registerAlterationsInChain(int delta) {
+		alterations_in_chain += delta;
+	}
+
+	bool hasMultipleChunkIdsInChain() const {
+		return alterations_in_chain > 0;
+	}
+
+private:
+	/*! Limit for \p lastWriteToChunkservers after which we force a flush.
+	 *
+	 * Maximum time for data to be kept in data chain waiting for collecting a full stripe.
+	 */
+	static const uint32_t kMaximumTimeInDataChainSinceLastFlush_ms = 15000;
+
+	/*! Limit for \p lastWriteToDataChain after which we force a flush.
+	 *
+	 * Maximum time for data to be kept in data chain waiting for collecting a full stripe
+	 * if no new data is written into the data chain
+	 */
+	static const uint32_t kMaximumTimeInDataChainSinceLastWrite_ms = 5000;
+};
+
+struct DelayedQueueEntry {
+	inodedata *inodeData;
+	int32_t ticksLeft;
+	static constexpr int kTicksPerSecond = 10;
+
+	DelayedQueueEntry(inodedata *inodeData, int32_t ticksLeft)
+			: inodeData(inodeData),
+			  ticksLeft(ticksLeft) {
+	}
+};
+
+static std::atomic<uint32_t> maxretries;
+static std::atomic<uint32_t> gWaveTimeout;
+static std::mutex gMutex;
+typedef std::unique_lock<std::mutex> Glock;
+
+static std::condition_variable fcbcond;
+static uint32_t fcbwaiting = 0;
+static int64_t freecacheblocks;
+
+// <inode, respective inodedata> and sorted by inode
+using InodeDataMap = std::map<uint32_t, inodedata *>;
+static InodeDataMap inodedataMap;
+
+static uint32_t gWriteWindowSize;
+static uint32_t gChunkserverTimeout_ms;
+
+// percentage of the free cache (1% - 100%) which can be used by one inode
+static uint32_t gCachePerInodePercentage;
+
+static pthread_t delayed_queue_worker_th;
+static std::vector<pthread_t> write_worker_th;
+
+static std::unique_ptr<ProducerConsumerQueue> jobsQueue;
+static std::list<DelayedQueueEntry> delayedQueue;
+
+static ConnectionPool gChunkserverConnectionPool;
+static ChunkConnectorUsingPool gChunkConnector(gChunkserverConnectionPool);
+
+void write_cb_release_blocks(uint32_t count, Glock&) {
+	freecacheblocks += count;
+	if (fcbwaiting > 0 && freecacheblocks > 0) {
+		fcbcond.notify_all();
+	}
+}
+
+void write_cb_acquire_blocks(uint32_t count, Glock&) {
+	freecacheblocks -= count;
+}
+
+void write_cb_wait_for_block(inodedata* id, Glock& glock) {
+	LOG_AVG_TILL_END_OF_SCOPE0("write_cb_wait_for_block");
+	fcbwaiting++;
+	uint64_t dataChainSize = id->dataChain.size();
+	while (freecacheblocks <= 0
+			// dataChainSize / (dataChainSize + freecacheblocks) > gCachePerInodePercentage / 100
+			// really means "0 > 0"
+			|| dataChainSize * 100 > (dataChainSize + freecacheblocks) * gCachePerInodePercentage)
+	{
+		fcbcond.wait(glock);
+	}
+	fcbwaiting--;
+}
+
+/* inode */
+
+inodedata *write_find_inodedata(uint32_t inode, Glock &) {
+	if (inodedataMap.contains(inode)) {
+		return inodedataMap[inode];
+	}
+	return NULL;
+}
+
+inodedata *write_get_inodedata(uint32_t inode, Glock &) {
+	if (inodedataMap.contains(inode)) {
+		return inodedataMap[inode];
+	}
+	auto id = new inodedata(inode);
+	inodedataMap[inode] = id;
+	return id;
+}
+
+void write_free_inodedata(inodedata *fid, Glock &) {
+	uint32_t inode = fid->inode;
+	if (!inodedataMap.contains(inode)) {
+		return;
+	}
+
+	auto id = inodedataMap[inode];
+	sassert(id == fid);
+	delete id;
+	inodedataMap.erase(inode);
+}
+
+/* delayed queue */
+
+static void delayed_queue_put(inodedata* id, uint32_t seconds, Glock&) {
+	delayedQueue.push_back(DelayedQueueEntry(id, seconds * DelayedQueueEntry::kTicksPerSecond));
+}
+
+static bool delayed_queue_remove(inodedata* id, Glock&) {
+	for (auto it = delayedQueue.begin(); it != delayedQueue.end(); ++it) {
+		if (it->inodeData == id) {
+			delayedQueue.erase(it);
+			return true;
+		}
+	}
+	return false;
+}
+
+void* delayed_queue_worker(void*) {
+	pthread_setname_np(pthread_self(), "delQueueWriter");
+
+	for (;;) {
+		Timeout timeout(std::chrono::microseconds(1000000 / DelayedQueueEntry::kTicksPerSecond));
+		Glock lock(gMutex);
+		auto it = delayedQueue.begin();
+		while (it != delayedQueue.end()) {
+			if (it->inodeData == NULL) {
+				return NULL;
+			}
+			if (--it->ticksLeft <= 0) {
+				jobsQueue->put(0, 0, reinterpret_cast<uint8_t*>(it->inodeData), 0);
+				it = delayedQueue.erase(it);
+			} else {
+				++it;
+			}
+		}
+		lock.unlock();
+		usleep(timeout.remaining_us());
+	}
+	return NULL;
+}
+
+/* queues */
+
+void write_delayed_enqueue(inodedata* id, uint32_t seconds, Glock& lock) {
+	if (seconds > 0) {
+		delayed_queue_put(id, seconds, lock);
+	} else {
+		jobsQueue->put(0, 0, reinterpret_cast<uint8_t*>(id), 0);
+	}
+}
+
+void write_enqueue(inodedata* id, Glock&) {
+	jobsQueue->put(0, 0, reinterpret_cast<uint8_t*>(id), 0);
+}
+
+void write_job_delayed_end(inodedata* id, int status, int seconds, Glock &lock) {
+	LOG_AVG_TILL_END_OF_SCOPE0("write_job_delayed_end");
+	LOG_AVG_TILL_END_OF_SCOPE1("write_job_delayed_end#sec", seconds);
+	id->locator.reset();
+	if (status != SAUNAFS_STATUS_OK) {
+		safs_pretty_syslog(LOG_WARNING, "error writing file number %" PRIu32 ": %s", id->inode, saunafs_error_string(status));
+		id->status = status;
+	}
+	status = id->status;
+	if (id->requiresFlushing() > 0) {
+		// Don't sleep if we have to write all the data immediately
+		seconds = 0;
+	}
+	if (!id->dataChain.empty() && status == SAUNAFS_STATUS_OK) { // still have some work to do
+		id->trycnt = 0; // on good write reset try counter
+		write_delayed_enqueue(id, seconds, lock);
+	} else {        // no more work or error occurred
+		// if this is an error then release all data blocks
+		write_cb_release_blocks(id->dataChain.size(), lock);
+		id->dataChain.clear();
+		id->inqueue = false;
+		// We don't reset maxfleng (id->maxfleng = 0;) for a while longer, to
+		// have its value ready to some quick cache responses in lookup and
+		// getattr syscalls
+		if (id->flushwaiting > 0) {
+			id->flushcond.notify_all();
+		}
+	}
+}
+
+void write_job_end(inodedata *id, int status, Glock &lock) {
+	write_job_delayed_end(id, status, 0, lock);
+}
+
+class InodeChunkWriter {
+public:
+	InodeChunkWriter() : inodeData_(nullptr), chunkIndex_(0) {}
+	void processJob(inodedata* data);
+
+private:
+	void processDataChain(ChunkWriter& writer);
+	void returnJournalToDataChain(std::list<WriteCacheBlock>&& journal, Glock&);
+	bool haveAnyBlockInCurrentChunk(Glock&);
+	bool haveBlockWorthWriting(uint32_t unfinishedOperationCount, Glock&);
+	inodedata* inodeData_;
+	uint32_t chunkIndex_;
+	Timer wholeOperationTimer;
+
+	// Maximum time of writing one chunk
+	static const uint32_t kMaximumTime = 30;
+	static const uint32_t kMaximumTimeWhenJobsWaiting = 10;
+	// For the last 'kTimeToFinishOperations' seconds of maximumTime we won't start new operations
+	static const uint32_t kTimeToFinishOperations = 5;
+};
+
+void InodeChunkWriter::processJob(inodedata* inodeData) {
+	LOG_AVG_TILL_END_OF_SCOPE0("InodeChunkWriter::processJob");
+	inodeData_ = inodeData;
+
+	// First, choose index of some chunk to write
+	Glock lock(gMutex);
+	int status = inodeData_->status;
+	bool haveDataToWrite;
+	if (inodeData_->locator) {
+		// There is a chunk lock left by a previous unfinished job -- let's finish it!
+		chunkIndex_ = inodeData_->locator->chunkIndex();
+		haveDataToWrite = haveAnyBlockInCurrentChunk(lock);
+	} else if (!inodeData_->dataChain.empty()) {
+		// There is no unfinished job, but there is some data to write -- let's start a new job
+		chunkIndex_ = inodeData_->dataChain.front().chunkIndex;
+		haveDataToWrite = true;
+	} else {
+		// No data, no unfinished jobs -- something wrong!
+		// This should never happen, so the status doesn't really matter
+		safs_pretty_syslog(LOG_WARNING, "got inode with no data to write!!!");
+		haveDataToWrite = false;
+		status = SAUNAFS_ERROR_EINVAL;
+	}
+	if (status != SAUNAFS_STATUS_OK) {
+		write_job_end(inodeData_, status, lock);
+		return;
+	}
+	lock.unlock();
+
+	/*  Process the job */
+	ChunkWriter writer(globalChunkserverStats, gChunkConnector, inodeData_->newDataInChainPipe[0]);
+	wholeOperationTimer.reset();
+	std::unique_ptr<WriteChunkLocator> locator = std::move(inodeData_->locator);
+	if (!locator) {
+		locator.reset(new WriteChunkLocator());
+	}
+
+	try {
+		try {
+			locator->locateAndLockChunk(inodeData_->inode, chunkIndex_);
+			Glock lock(gMutex);
+			inodeData_->maxfleng =
+			    std::max(inodeData_->maxfleng, locator->fileLength());
+			lock.unlock();
+
+			// Optimization -- talk with chunkservers only if we have to write any data.
+			// Don't do this if we just have to release some previously unlocked lock.
+			if (haveDataToWrite) {
+				writer.init(locator.get(), gChunkserverTimeout_ms);
+				processDataChain(writer);
+				writer.finish(kTimeToFinishOperations * 1000);
+
+				lock.lock();
+				returnJournalToDataChain(writer.releaseJournal(), lock);
+				lock.unlock();
+			}
+			locator->unlockChunk();
+			read_inode_ops(inodeData_->inode);
+
+			lock.lock();
+			inodeData_->minimumBlocksToWrite = writer.getMinimumBlockCountWorthWriting();
+			bool canWait = !inodeData_->requiresFlushing();
+			if (!haveAnyBlockInCurrentChunk(lock)) {
+				// There is no need to wait if we have just finished writing some chunk.
+				// Let's immediately start writing the next chunk (if there is any).
+				canWait = false;
+			}
+			if (inodeData_->hasMultipleChunkIdsInChain()) {
+				// Don't wait if there is more than one chunk in the data chain -- the first chunk
+				// has to be flushed, because no more data will be added to it
+				canWait = false;
+			}
+			write_job_delayed_end(inodeData_, SAUNAFS_STATUS_OK, (canWait ? 1 : 0), lock);
+		} catch (Exception& e) {
+			std::string errorString = e.what();
+			Glock lock(gMutex);
+			if (e.status() != SAUNAFS_ERROR_LOCKED) {
+				inodeData_->trycnt++;
+				errorString += " (try counter: " + std::to_string(inodeData->trycnt) + ")";
+			} else if (inodeData_->trycnt == 0) {
+				// Set to nonzero to inform writers, that this task needs to wait a bit
+				// Don't increase -- SAUNAFS_ERROR_LOCKED means that chunk is locked by a different client
+				// and we have to wait until it is unlocked
+				inodeData_->trycnt = 1;
+			}
+			// Keep the lock
+			inodeData_->locator = std::move(locator);
+			// Move data left in the journal into front of the write cache
+			returnJournalToDataChain(writer.releaseJournal(), lock);
+			lock.unlock();
+
+			safs_pretty_syslog(LOG_WARNING, "write file error, inode: %" PRIu32 ", index: %" PRIu32 " - %s",
+					inodeData_->inode, chunkIndex_, errorString.c_str());
+			if (inodeData_->trycnt >= maxretries) {
+				// Convert error to an unrecoverable error
+				throw UnrecoverableWriteException(e.message(), e.status());
+			} else {
+				// This may be recoverable or unrecoverable error
+				throw;
+			}
+		}
+	} catch (UnrecoverableWriteException& e) {
+		Glock lock(gMutex);
+		if (e.status() == SAUNAFS_ERROR_ENOENT) {
+			write_job_end(inodeData_, SAUNAFS_ERROR_EBADF, lock);
+		} else if (e.status() == SAUNAFS_ERROR_QUOTA) {
+			write_job_end(inodeData_, SAUNAFS_ERROR_QUOTA, lock);
+		} else if (e.status() == SAUNAFS_ERROR_NOSPACE || e.status() == SAUNAFS_ERROR_NOCHUNKSERVERS) {
+			write_job_end(inodeData_, SAUNAFS_ERROR_NOSPACE, lock);
+		} else {
+			write_job_end(inodeData_, SAUNAFS_ERROR_IO, lock);
+		}
+	} catch (Exception& e) {
+		Glock lock(gMutex);
+		int waitTime = 1;
+		if (inodeData_->trycnt > 10) {
+			waitTime = std::min<int>(10, inodeData_->trycnt - 9);
+		}
+		write_delayed_enqueue(inodeData_, waitTime, lock);
+	}
+}
+
+void InodeChunkWriter::processDataChain(ChunkWriter& writer) {
+	LOG_AVG_TILL_END_OF_SCOPE0("InodeChunkWriter::processDataChain");
+	uint32_t maximumTime = kMaximumTime;
+	bool otherJobsAreWaiting = false;
+	while (true) {
+		bool newOtherJobsAreWaiting = !jobsQueue->isEmpty();
+		if (!otherJobsAreWaiting && newOtherJobsAreWaiting) {
+			// Some new jobs have just arrived in the queue -- we should finish faster.
+			maximumTime = kMaximumTimeWhenJobsWaiting;
+			// But we need at least 5 seconds to finish the operations that are in progress
+			uint32_t elapsedSeconds = wholeOperationTimer.elapsed_s();
+			if (elapsedSeconds + kTimeToFinishOperations >= maximumTime) {
+				maximumTime = elapsedSeconds + kTimeToFinishOperations;
+			}
+		}
+		otherJobsAreWaiting = newOtherJobsAreWaiting;
+
+		// If we have sent the previous message and have some time left, we can take
+		// another block from current chunk to process it simultaneously. We won't take anything
+		// new if we've already sent 'gWriteWindowSize' blocks and didn't receive status from
+		// the chunkserver.
+		bool can_expect_next_block = true;
+		if (wholeOperationTimer.elapsed_s() + kTimeToFinishOperations < maximumTime
+				&& writer.acceptsNewOperations()) {
+			Glock lock(gMutex);
+			// While there is any block worth sending, we add new write operation
+			while (haveBlockWorthWriting(writer.getUnfinishedOperationsCount(), lock)) {
+				// Remove block from cache and pass it to the writer
+				writer.addOperation(std::move(inodeData_->dataChain.front()));
+				inodeData_->popFromChain();
+				write_cb_release_blocks(1, lock);
+			}
+			if (inodeData_->requiresFlushing() && !haveAnyBlockInCurrentChunk(lock)) {
+				// No more data and some flushing is needed or required, so flush everything
+				writer.startFlushMode();
+			}
+			if (writer.getUnfinishedOperationsCount() < gWriteWindowSize) {
+				inodeData_->workerWaitingForData = true;
+			}
+			can_expect_next_block = haveAnyBlockInCurrentChunk(lock);
+		} else if (writer.acceptsNewOperations()) {
+			// We are running out of time...
+			Glock lock(gMutex);
+			if (!inodeData_->requiresFlushing()) {
+				// Nobody is waiting for the data to be flushed and the data in write chain
+				// isn't too old. Let's postpone any operations
+				// that didn't start yet and finish them in the next time slice for this chunk
+				writer.dropNewOperations();
+			} else {
+				// Somebody if waiting for a flush, so we have to finish writing everything.
+				writer.startFlushMode();
+			}
+			can_expect_next_block = haveAnyBlockInCurrentChunk(lock);
+		}
+
+		Glock lock(gMutex);
+		writer.setChunkSizeInBlocks(
+		    std::min(inodeData_->maxfleng - chunkIndex_ * SFSCHUNKSIZE,
+		             (uint64_t)SFSCHUNKSIZE));
+		lock.unlock();
+		if (writer.startNewOperations(can_expect_next_block) > 0) {
+			lock.lock();
+			inodeData_->lastWriteToChunkservers.reset();
+			lock.unlock();
+		}
+		if (writer.getPendingOperationsCount() == 0) {
+			return;
+		} else if (wholeOperationTimer.elapsed_s() >= maximumTime) {
+			throw RecoverableWriteException(
+					"Timeout after " + std::to_string(wholeOperationTimer.elapsed_ms()) + " ms",
+					SAUNAFS_ERROR_TIMEOUT);
+		}
+
+		writer.processOperations(gWaveTimeout);
+	}
+}
+
+void InodeChunkWriter::returnJournalToDataChain(std::list<WriteCacheBlock> &&journal, Glock &lock) {
+	if (!journal.empty()) {
+		write_cb_acquire_blocks(journal.size(), lock);
+		uint64_t prev_id = journal.front().chunkIndex;
+		int alterations = (!inodeData_->dataChain.empty()
+				&& journal.back().chunkIndex != inodeData_->dataChain.front().chunkIndex) ? 1 : 0;
+		for (auto it = std::next(journal.begin()); it != journal.end(); ++it) {
+			if (it->chunkIndex != prev_id) {
+				alterations++;
+				prev_id = it->chunkIndex;
+			}
+		}
+		inodeData_->dataChain.splice(inodeData_->dataChain.begin(), std::move(journal));
+		inodeData_->registerAlterationsInChain(alterations);
+	}
+}
+
+/*
+ * Check if there is any data in the same chunk waiting to be written.
+ */
+bool InodeChunkWriter::haveAnyBlockInCurrentChunk(Glock&) {
+	if (inodeData_->dataChain.empty()) {
+		return false;
+	} else {
+		return inodeData_->dataChain.front().chunkIndex == chunkIndex_;
+	}
+}
+
+/*
+ * Check if there is any data worth sending to the chunkserver.
+ * We will avoid sending blocks of size different than SFSBLOCKSIZE.
+ * These can be taken only if we are close to run out of tasks to do.
+ * glock: LOCKED
+ */
+bool InodeChunkWriter::haveBlockWorthWriting(uint32_t unfinishedOperationCount, Glock& lock) {
+	if (!haveAnyBlockInCurrentChunk(lock)) {
+		return false;
+	}
+	const auto& block = inodeData_->dataChain.front();
+	if (block.type != WriteCacheBlock::kWritableBlock) {
+		// Always write data, that was previously written
+		return true;
+	} else if (unfinishedOperationCount >= gWriteWindowSize) {
+		// Don't start new operations if there is already a lot of pending writes
+		return false;
+	} else {
+		// Always start full blocks; start partial blocks only if we have to flush the data
+		// or the block won't be expanded (only the last one can be) to a full block
+		return (block.size() == SFSBLOCKSIZE
+				|| inodeData_->requiresFlushing()
+				|| inodeData_->dataChain.size() > 1);
+	}
+}
+
+/* main working thread | glock:UNLOCKED */
+void* write_worker(void*) {
+	InodeChunkWriter inodeDataWriter;
+
+	static std::atomic_uint16_t writeWorkersCounter(0);
+	std::string threadName = "writeWorker " + std::to_string(writeWorkersCounter++);
+	pthread_setname_np(pthread_self(), threadName.c_str());
+
+	for (;;) {
+		// get next job
+		uint32_t z1, z2, z3;
+		uint8_t *data;
+		{
+			LOG_AVG_TILL_END_OF_SCOPE0("write_worker#idle");
+			jobsQueue->get(&z1, &z2, &data, &z3);
+		}
+		if (data == NULL) {
+			return NULL;
+		}
+
+		// process the job
+		LOG_AVG_TILL_END_OF_SCOPE0("write_worker#working");
+		inodeDataWriter.processJob((inodedata*) data);
+	}
+	return NULL;
+}
+
+/* API | glock: INITIALIZED,UNLOCKED */
+void write_data_init(uint32_t cachesize, uint32_t retries, uint32_t workers,
+                     uint32_t writewindowsize, uint32_t chunkserverTimeout_ms,
+                     uint32_t cachePerInodePercentage, uint32_t waveTimeout) {
+	uint64_t cachebytecount = uint64_t(cachesize) * 1024 * 1024;
+	uint64_t cacheblockcount = (cachebytecount / SFSBLOCKSIZE);
+	pthread_attr_t thattr;
+
+	gChunkConnector.setSourceIp(fs_getsrcip());
+	gWriteWindowSize = writewindowsize;
+	gChunkserverTimeout_ms = chunkserverTimeout_ms;
+	maxretries = retries;
+	gWaveTimeout = waveTimeout;
+	if (cacheblockcount < 10) {
+		cacheblockcount = 10;
+	}
+
+	freecacheblocks = cacheblockcount;
+	gCachePerInodePercentage = cachePerInodePercentage;
+
+	jobsQueue = std::make_unique<ProducerConsumerQueue>(0, deleterByType<inodedata>);
+
+	pthread_attr_init(&thattr);
+	pthread_attr_setstacksize(&thattr, 0x100000);
+	pthread_create(&delayed_queue_worker_th, &thattr, delayed_queue_worker, NULL);
+	write_worker_th.resize(workers);
+	for (auto& th : write_worker_th) {
+		pthread_create(&th, &thattr, write_worker, NULL);
+	}
+	pthread_attr_destroy(&thattr);
+
+	gTweaks.registerVariable("WriteMaxRetries", maxretries);
+	gTweaks.registerVariable("WriteWaveTimeout", gWaveTimeout);
+}
+
+void write_data_term(void) {
+	uint32_t i;
+
+	{
+		Glock lock(gMutex);
+		delayed_queue_put(nullptr, 0, lock);
+	}
+	for (i = 0; i < write_worker_th.size(); i++) {
+		jobsQueue->put(0, 0, NULL, 0);
+	}
+	for (i = 0; i < write_worker_th.size(); i++) {
+		pthread_join(write_worker_th[i], NULL);
+	}
+	pthread_join(delayed_queue_worker_th, NULL);
+	jobsQueue.reset();
+	for (const auto &[_, id] : inodedataMap) {
+		delete id;
+	}
+	inodedataMap.clear();
+}
+
+/* glock: UNLOCKED */
+int write_block(inodedata *id, uint32_t chindx, uint16_t pos, uint32_t from, uint32_t to, const uint8_t *data) {
+	Glock lock(gMutex);
+	id->lastWriteToDataChain.reset();
+
+	// Try to expand the last block
+	if (!id->dataChain.empty()) {
+		auto& lastBlock = id->dataChain.back();
+		if (lastBlock.chunkIndex == chindx
+				&& lastBlock.blockIndex == pos
+				&& lastBlock.type == WriteCacheBlock::kWritableBlock
+				&& lastBlock.expand(from, to, data)) {
+			id->wakeUpWorkerIfNecessary();
+			return 0;
+		}
+	}
+
+	// Didn't manage to expand an existing block, so allocate a new one
+	write_cb_wait_for_block(id, lock);
+	write_cb_acquire_blocks(1, lock);
+	id->pushToChain(WriteCacheBlock(chindx, pos, WriteCacheBlock::kWritableBlock));
+	sassert(id->dataChain.back().expand(from, to, data));
+	if (id->inqueue) {
+		// Consider some speedup if there are no errors and:
+		// - there is a lot of blocks in the write chain
+		// - there are at least two chunks in the write chain
+		if (id->trycnt == 0 && (id->dataChain.size() > id->minimumBlocksToWrite
+			|| id->dataChain.front().chunkIndex != id->dataChain.back().chunkIndex)) {
+			if (delayed_queue_remove(id, lock)) {
+				write_enqueue(id, lock);
+			}
+		}
+		id->wakeUpWorkerIfNecessary();
+	} else {
+		id->inqueue = true;
+		write_enqueue(id, lock);
+	}
+	return 0;
+}
+
+/* glock: UNLOCKED */
+int write_blocks(inodedata *id, uint64_t offset, uint32_t size, const uint8_t* data) {
+	LOG_AVG_TILL_END_OF_SCOPE0("write_blocks");
+	uint32_t chindx = offset >> SFSCHUNKBITS;
+	uint16_t pos = (offset & SFSCHUNKMASK) >> SFSBLOCKBITS;
+	uint32_t from = offset & SFSBLOCKMASK;
+	while (size > 0) {
+		if (size > SFSBLOCKSIZE - from) {
+			if (write_block(id, chindx, pos, from, SFSBLOCKSIZE, data) < 0) {
+				return SAUNAFS_ERROR_IO;
+			}
+			size -= (SFSBLOCKSIZE - from);
+			data += (SFSBLOCKSIZE - from);
+			from = 0;
+			pos++;
+			if (pos == SFSBLOCKSINCHUNK) {
+				pos = 0;
+				chindx++;
+			}
+		} else {
+			if (write_block(id, chindx, pos, from, from + size, data) < 0) {
+				return SAUNAFS_ERROR_IO;
+			}
+			size = 0;
+		}
+	}
+	return 0;
+}
+
+int write_data(void *vid, uint64_t offset, uint32_t size, const uint8_t *data,
+               size_t currentSize) {
+	LOG_AVG_TILL_END_OF_SCOPE0("write_data");
+	int status;
+	inodedata *id = (inodedata*) vid;
+	if (id == NULL) {
+		return SAUNAFS_ERROR_IO;
+	}
+
+	Glock lock(gMutex);
+	status = id->status;
+	id->maxfleng = std::max(id->maxfleng, currentSize);
+	if (status == SAUNAFS_STATUS_OK) {
+		if (offset + size > id->maxfleng) {     // move fleng
+			id->maxfleng = offset + size;
+		}
+		id->writewaiting++;
+		while (id->flushwaiting > 0) {
+			id->writecond.wait(lock);
+		}
+		id->writewaiting--;
+	}
+	lock.unlock();
+
+	if (status != SAUNAFS_STATUS_OK) {
+		return status;
+	}
+
+	return write_blocks(id, offset, size, data);
+}
+
+static void write_data_flushwaiting_increase(inodedata *id, Glock&) {
+	id->flushwaiting++;
+}
+
+static void write_data_flushwaiting_decrease(inodedata *id, Glock&) {
+	id->flushwaiting--;
+	if (id->flushwaiting == 0 && id->writewaiting > 0) {
+		id->writecond.notify_all();
+	}
+}
+
+static void write_data_lcnt_increase(inodedata *id, Glock&) {
+	id->lcnt++;
+}
+
+static void	write_data_lcnt_decrease_check_deleted(inodedata *id, Glock& lock, bool& isDeleted) {
+	// As long as it is not freed, then we don't consider the inodedata deleted
+	isDeleted = false;
+	id->lcnt--;
+	if (id->lcnt == 0 && !id->inqueue && id->flushwaiting == 0 && id->writewaiting == 0) {
+		write_free_inodedata(id, lock);
+		isDeleted = true;
+	}
+}
+
+inline void write_data_lcnt_decrease(inodedata *id, Glock& lock) {
+	bool dummy_isDeleted;
+	write_data_lcnt_decrease_check_deleted(id, lock, dummy_isDeleted);
+	(void) dummy_isDeleted;
+}
+
+void* write_data_new(uint32_t inode) {
+	inodedata* id;
+	Glock lock(gMutex);
+	id = write_get_inodedata(inode, lock);
+	if (id == NULL) {
+		return NULL;
+	}
+	write_data_lcnt_increase(id, lock);
+	return id;
+}
+
+static int write_data_flush(void* vid, Glock& lock) {
+	inodedata* id = (inodedata*) vid;
+	if (id == NULL) {
+		return SAUNAFS_ERROR_IO;
+	}
+
+	write_data_flushwaiting_increase(id, lock);
+	// If there are no errors (trycnt==0) and inode is waiting in the delayed queue, speed it up
+	if (id->trycnt == 0 && delayed_queue_remove(id, lock)) {
+		write_enqueue(id, lock);
+	}
+	// Wait for the data to be flushed
+	while (id->inqueue) {
+		id->flushcond.wait(lock);
+	}
+	write_data_flushwaiting_decrease(id, lock);
+	return id->status;
+}
+
+int write_data_flush(void* vid) {
+	Glock lock(gMutex);
+	return write_data_flush(vid, lock);
+}
+
+uint64_t write_data_getmaxfleng(uint32_t inode) {
+	uint64_t maxfleng;
+	inodedata* id;
+	Glock lock(gMutex);
+	id = write_find_inodedata(inode, lock);
+	if (id) {
+		maxfleng = id->maxfleng;
+	} else {
+		maxfleng = 0;
+	}
+	return maxfleng;
+}
+
+int write_data_flush_inode(uint32_t inode) {
+	Glock lock(gMutex);
+	inodedata* id = write_find_inodedata(inode, lock);
+	if (id == NULL) {
+		return 0;
+	}
+	return write_data_flush(id, lock);
+}
+
+int write_data_truncate(uint32_t inode, bool opened, uint32_t uid, uint32_t gid, uint64_t length,
+		Attributes& attr) {
+	Glock lock(gMutex);
+
+	// 1. Flush writes but don't finish it completely - it'll be done at the end of truncate
+	inodedata* id = write_get_inodedata(inode, lock);
+	if (id == NULL) {
+		return SAUNAFS_ERROR_IO;
+	}
+	write_data_lcnt_increase(id, lock);
+	write_data_flushwaiting_increase(id, lock); // this will block any writing to this inode
+
+	int err = write_data_flush(id, lock);
+	if (err != 0) {
+		write_data_flushwaiting_decrease(id, lock);
+		write_data_lcnt_decrease(id, lock);
+		return err;
+	}
+
+	// 2. Send the request to master
+	uint8_t status;
+	bool writeNeeded;
+	uint64_t oldLength;
+	uint32_t lockId;
+	lock.unlock();
+	int retrySleepTime_us = 200000;
+	uint32_t retries = 0;
+	do {
+		status = fs_truncate(inode, opened, uid, gid, length, writeNeeded, attr, oldLength, lockId);
+		if (status != SAUNAFS_STATUS_OK) {
+			safs_pretty_syslog(LOG_INFO, "truncate file %" PRIu32 " to length %" PRIu64 ": %s (try %d/%d)",
+					inode, length, saunafs_error_string(status), int(retries + 1), int(maxretries));
+		}
+		if (retries >= maxretries) {
+			break;
+		}
+		if (status == SAUNAFS_ERROR_LOCKED) {
+			sleep(1);
+		} else if (status == SAUNAFS_ERROR_CHUNKLOST || status == SAUNAFS_ERROR_NOTDONE) {
+			usleep(retrySleepTime_us);
+			retrySleepTime_us = std::min(2 * retrySleepTime_us, 60 * 1000000);
+			++retries;
+		}
+	} while (status == SAUNAFS_ERROR_LOCKED || status == SAUNAFS_ERROR_CHUNKLOST || status == SAUNAFS_ERROR_NOTDONE);
+	lock.lock();
+	if (status != 0 || !writeNeeded) {
+		// Something failed or we have nothing to do more (master server managed to do the truncate)
+		bool isDeleted = false;
+		write_data_flushwaiting_decrease(id, lock);
+		write_data_lcnt_decrease_check_deleted(id, lock, isDeleted);
+		if (status == SAUNAFS_STATUS_OK) {
+			if (!isDeleted) {
+				id->maxfleng = length;
+			}
+			return 0;
+		} else {
+			// status is now SFS status, so we cannot return any errno
+			throw UnrecoverableWriteException("fs_truncate failed", status);
+		}
+	}
+
+	// We have to write zeros in suitable region to update xor/ec parity parts.
+	// Let's calculate size of the region to be zeroed
+	uint64_t endOffset = std::min({
+		oldLength,                            // no further than to the end of the file
+		length + slice_traits::ec::kMaxDataCount * SFSBLOCKSIZE, // no more than the maximal stripe
+		(length + SFSCHUNKSIZE - 1) / SFSCHUNKSIZE * SFSCHUNKSIZE // no beyond the end of chunk
+	});
+
+	if (endOffset > length) {
+		// Make maxfleng big enough for the upcoming writes
+		id->maxfleng = endOffset;
+
+		// Something has to be written, so pass our lock to writing threads
+		sassert(id->dataChain.empty());
+		id->locator.reset(new TruncateWriteChunkLocator(inode, length / SFSCHUNKSIZE, lockId));
+
+		// And now pass block of zeros to writing threads
+		std::vector<uint8_t> zeros(endOffset - length, 0);
+		lock.unlock();
+		err = write_blocks(id, length, zeros.size(), zeros.data());
+		lock.lock();
+		if (err != 0) {
+			write_data_flushwaiting_decrease(id, lock);
+			write_data_lcnt_decrease(id, lock);
+			return err;
+		}
+
+		// Wait for writing threads to finish
+		err = write_data_flush(id, lock);
+		id->locator.reset();
+		if (err != 0) {
+			// unlock the chunk here?
+			write_data_flushwaiting_decrease(id, lock);
+			write_data_lcnt_decrease(id, lock);
+			return err;
+		}
+	}
+
+	id->maxfleng = length;
+	// Now we can tell the master server to finish the truncate operation and then unblock the inode
+	lock.unlock();
+	status = fs_truncateend(inode, uid, gid, length, lockId, attr);
+	write_data_flushwaiting_decrease(id, lock);
+	write_data_lcnt_decrease(id, lock);
+
+	if (status != SAUNAFS_STATUS_OK) {
+		// status is now SFS status, so we cannot return any errno
+		throw UnrecoverableWriteException("fs_truncateend failed", status);
+	}
+	return 0;
+}
+
+int write_data_end(void* vid) {
+	Glock lock(gMutex);
+	inodedata* id = (inodedata*) vid;
+	if (id == NULL) {
+		return SAUNAFS_ERROR_IO;
+	}
+	int status = write_data_flush(id, lock);
+	write_data_lcnt_decrease(id, lock);
+	return status;
+}
+
+}  // namespace OldWriteAlgorithm
+
+namespace NewWriteAlgorithm {
 
 struct ChunkData;
 
@@ -239,8 +1218,6 @@ struct DelayedQueueEntry {
 			  ticksLeft(ticksLeft) {
 	}
 };
-
-} // anonymous namespace
 
 static std::atomic<uint32_t> maxretries;
 static std::atomic<uint32_t> gWaveTimeout;
@@ -572,8 +1549,8 @@ void ChunkJobWriter::processJob(ChunkData* chunkData) {
 	inodedata *parent = chunkData_->getParent();
 
 	/*  Process the job */
-	ChunkWriter writer(chunkData_->chunkIndex, globalChunkserverStats,
-	                   gChunkConnector, chunkData_->newDataInChainPipe[0]);
+	ChunkWriter writer(globalChunkserverStats, gChunkConnector,
+	                   chunkData_->newDataInChainPipe[0]);
 	wholeOperationTimer.reset();
 	std::unique_ptr<WriteChunkLocator> locator = std::move(chunkData_->locator);
 	if (!locator) {
@@ -772,7 +1749,6 @@ void ChunkJobWriter::processDataChain(ChunkWriter& writer) {
 					SAUNAFS_ERROR_TIMEOUT);
 		}
 
-		// Let's sleep a bit shorter if we can't be woken up by the pipe to reduce the latency
 		writer.processOperations(gWaveTimeout);
 	}
 }
@@ -1290,4 +2266,82 @@ int write_data_end(void* vid) {
 	Lock inodeLock(id->mutex);
 	write_data_lcnt_decrease(id, inodeLock);
 	return status;
+}
+
+}  // namespace NewWriteAlgorithm
+
+void write_data_init(uint32_t cachesize, uint32_t retries, uint32_t workers,
+                     uint32_t writewindowsize, uint32_t chunkserverTimeout_ms,
+                     uint32_t cachePerInodePercentage, uint32_t waveTimeout) {
+	if (gUseOldWriteAlgorithm) {
+		OldWriteAlgorithm::write_data_init(
+		    cachesize, retries, workers, writewindowsize, chunkserverTimeout_ms,
+		    cachePerInodePercentage, waveTimeout);
+	} else {
+		NewWriteAlgorithm::write_data_init(
+		    cachesize, retries, workers, writewindowsize, chunkserverTimeout_ms,
+		    cachePerInodePercentage, waveTimeout);
+	}
+}
+
+void write_data_term(void) {
+	if (gUseOldWriteAlgorithm) {
+		OldWriteAlgorithm::write_data_term();
+	} else {
+		NewWriteAlgorithm::write_data_term();
+	}
+}
+
+void *write_data_new(uint32_t inode) {
+	if (gUseOldWriteAlgorithm) {
+		return OldWriteAlgorithm::write_data_new(inode);
+	}
+	return NewWriteAlgorithm::write_data_new(inode);
+}
+
+int write_data_end(void *vid) {
+	if (gUseOldWriteAlgorithm) {
+		return OldWriteAlgorithm::write_data_end(vid);
+	}
+	return NewWriteAlgorithm::write_data_end(vid);
+}
+
+int write_data_flush(void *vid) {
+	if (gUseOldWriteAlgorithm) {
+		return OldWriteAlgorithm::write_data_flush(vid);
+	}
+	return NewWriteAlgorithm::write_data_flush(vid);
+}
+
+uint64_t write_data_getmaxfleng(uint32_t inode) {
+	if (gUseOldWriteAlgorithm) {
+		return OldWriteAlgorithm::write_data_getmaxfleng(inode);
+	}
+	return NewWriteAlgorithm::write_data_getmaxfleng(inode);
+}
+
+int write_data_flush_inode(uint32_t inode) {
+	if (gUseOldWriteAlgorithm) {
+		return OldWriteAlgorithm::write_data_flush_inode(inode);
+	}
+	return NewWriteAlgorithm::write_data_flush_inode(inode);
+}
+
+int write_data_truncate(uint32_t inode, bool opened, uint32_t uid, uint32_t gid,
+                        uint64_t length, Attributes &attr) {
+	if (gUseOldWriteAlgorithm) {
+		return OldWriteAlgorithm::write_data_truncate(inode, opened, uid, gid,
+		                                              length, attr);
+	}
+	return NewWriteAlgorithm::write_data_truncate(inode, opened, uid, gid,
+	                                              length, attr);
+}
+
+int write_data(void *vid, uint64_t offset, uint32_t size, const uint8_t *buff,
+               size_t currentSize) {
+	if (gUseOldWriteAlgorithm) {
+		return OldWriteAlgorithm::write_data(vid, offset, size, buff,
+		                                     currentSize);
+	}
+	return NewWriteAlgorithm::write_data(vid, offset, size, buff, currentSize);
 }

--- a/src/mount/writedata.cc
+++ b/src/mount/writedata.cc
@@ -394,6 +394,9 @@ private:
 	static const uint32_t kMaximumTimeWhenJobsWaiting = 10;
 	// For the last 'kTimeToFinishOperations' seconds of maximumTime we won't start new operations
 	static const uint32_t kTimeToFinishOperations = 5;
+	// Minimum tries counter value before showing write error message on
+	// notifications area
+	static const uint32_t kMinTryCounterToShowWriteErrorMessage = 4;
 };
 
 void InodeChunkWriter::processJob(inodedata* inodeData) {
@@ -453,7 +456,7 @@ void InodeChunkWriter::processJob(inodedata* inodeData) {
 				lock.unlock();
 			}
 			locator->unlockChunk();
-			read_inode_ops(inodeData_->inode);
+			read_inode_reconnect_and_clear_cache(inodeData_->inode, chunkIndex_);
 
 			lock.lock();
 			inodeData_->minimumBlocksToWrite = writer.getMinimumBlockCountWorthWriting();
@@ -471,6 +474,8 @@ void InodeChunkWriter::processJob(inodedata* inodeData) {
 			write_job_delayed_end(inodeData_, SAUNAFS_STATUS_OK, (canWait ? 1 : 0), lock);
 		} catch (Exception& e) {
 			std::string errorString = e.what();
+			addPathByInodeBasedNotificationMessage(
+				"Write error: " + std::string(e.what()), inodeData_->inode);
 			Glock lock(gMutex);
 			if (e.status() != SAUNAFS_ERROR_LOCKED) {
 				inodeData_->trycnt++;
@@ -498,6 +503,8 @@ void InodeChunkWriter::processJob(inodedata* inodeData) {
 			}
 		}
 	} catch (UnrecoverableWriteException& e) {
+		addPathByInodeBasedNotificationMessage(
+			"Write error: " + std::string(e.what()), inodeData_->inode);
 		Glock lock(gMutex);
 		if (e.status() == SAUNAFS_ERROR_ENOENT) {
 			write_job_end(inodeData_, SAUNAFS_ERROR_EBADF, lock);
@@ -509,6 +516,10 @@ void InodeChunkWriter::processJob(inodedata* inodeData) {
 			write_job_end(inodeData_, SAUNAFS_ERROR_IO, lock);
 		}
 	} catch (Exception& e) {
+		if (inodeData_->trycnt > kMinTryCounterToShowWriteErrorMessage) {
+			addPathByInodeBasedNotificationMessage(
+				"Write error: " + std::string(e.what()), inodeData_->inode);
+		}
 		Glock lock(gMutex);
 		int waitTime = 1;
 		if (inodeData_->trycnt > 10) {
@@ -707,8 +718,8 @@ void write_data_init(uint32_t cachesize, uint32_t retries, uint32_t workers,
 	}
 	pthread_attr_destroy(&thattr);
 
-	gTweaks.registerVariable("WriteMaxRetries", maxretries);
-	gTweaks.registerVariable("WriteWaveTimeout", gWriteWaveTimeout);
+	gTweaks.registerVariable("WriteMaxRetries", maxretries, "sfsioretries (write)");
+	gTweaks.registerVariable("WriteWaveTimeout", gWriteWaveTimeout, "sfschunkserverwavewriteto");
 }
 
 void write_data_term(void) {

--- a/src/mount/writedata.cc
+++ b/src/mount/writedata.cc
@@ -2147,8 +2147,16 @@ int write_data_end(void *vid) {
 	int status = write_data_flush(id, globalLock);
 	globalLock.unlock();
 
-	Lock inodeLock(id->mutex);
-	write_data_lcnt_decrease(id, inodeLock);
+	bool almostDone = false;
+	{
+		Lock inodeLock(id->mutex);
+		almostDone = (id->emptyChunkDataList) && (id->flushwaiting == 0) && (id->writewaiting == 0);
+	}
+
+	globalLock.lock();
+	id->lcnt--;
+	if (id->lcnt == 0 && almostDone) { write_free_inodedata(id, globalLock); }
+
 	return status;
 }
 

--- a/src/mount/writedata.cc
+++ b/src/mount/writedata.cc
@@ -66,6 +66,8 @@
 
 namespace {
 
+struct ChunkData;
+
 struct inodedata {
 	uint32_t inode;
 	uint64_t maxfleng;
@@ -73,16 +75,10 @@ struct inodedata {
 	uint16_t flushwaiting;
 	uint16_t writewaiting;
 	uint16_t lcnt;
-	uint32_t trycnt;
-	bool inqueue; // true it this inode is waiting in one of the queues or is being processed
-	uint32_t minimumBlocksToWrite;
-	std::list<WriteCacheBlock> dataChain;
-	int alterations_in_chain; // number of adherent blocks with different chunk ids in chain
 	std::condition_variable flushcond; // wait for !inqueue (flush)
 	std::condition_variable writecond; // wait for flushwaiting==0 (write)
-	std::unique_ptr<WriteChunkLocator> locator;
-	int newDataInChainPipe[2];
-	bool workerWaitingForData;
+	std::atomic<ChunkData *> chunksDataFirst;
+	std::atomic<uint64_t> totalCachedBlocks;
 	Timer lastWriteToDataChain;
 	Timer lastWriteToChunkservers;
 
@@ -93,49 +89,8 @@ struct inodedata {
 			  flushwaiting(0),
 			  writewaiting(0),
 			  lcnt(0),
-			  trycnt(0),
-			  inqueue(false),
-			  minimumBlocksToWrite(1),
-			  alterations_in_chain(),
-			  workerWaitingForData(false) {
-#ifdef _WIN32
-		// We don't use inodeData->waitingworker and inodeData->pipe on Cygwin because
-		// Cygwin's implementation of mixed socket & pipe polling is very inefficient.
-		// On mingw platform pipes are unavailable.
-		newDataInChainPipe[0] = newDataInChainPipe[1] = -1;
-#else
-		if (pipe(newDataInChainPipe) < 0) {
-			safs_pretty_syslog(LOG_WARNING, "creating pipe error: %s", strerr(errno));
-			newDataInChainPipe[0] = -1;
-		}
-#endif
-	}
-
-	~inodedata() {
-		if (isDataChainPipeValid()) {
-			close(newDataInChainPipe[0]);
-			close(newDataInChainPipe[1]);
-		}
-	}
-
-	/* glock: LOCKED */
-	void wakeUpWorkerIfNecessary() {
-		/*
-		 * Write worker always looks for the first block in chain and we modify or add always the
-		 * last block in chain so it is necessary to wake up write worker only if the first block
-		 * is the last one, ie. dataChain.size() == 1.
-		 */
-		if (workerWaitingForData && dataChain.size() == 1 && isDataChainPipeValid()) {
-			if (write(newDataInChainPipe[1], " ", 1) != 1) {
-				safs_pretty_syslog(LOG_ERR, "write pipe error: %s", strerr(errno));
-			}
-			workerWaitingForData = false;
-		}
-	}
-
-	/* glock: UNUSED */
-	bool isDataChainPipeValid() const {
-		return newDataInChainPipe[0] >= 0;
+			  chunksDataFirst(nullptr),
+			  totalCachedBlocks(0) {
 	}
 
 	/*! Check if inode requires flushing all its data chain to chunkservers.
@@ -147,36 +102,15 @@ struct inodedata {
 	 * glock: LOCKED
 	 */
 	bool requiresFlushing() const {
-		return (flushwaiting > 0
-				|| lastWriteToDataChain.elapsed_ms() >= kMaximumTimeInDataChainSinceLastWrite_ms
-				|| lastWriteToChunkservers.elapsed_ms() >= kMaximumTimeInDataChainSinceLastFlush_ms);
+		return (flushwaiting > 0 ||
+		        lastWriteToDataChain.elapsed_ms() >=
+		            kMaximumTimeInDataChainSinceLastWrite_ms ||
+		        lastWriteToChunkservers.elapsed_ms() >=
+		            kMaximumTimeInDataChainSinceLastFlush_ms);
 	}
 
-	void pushToChain(WriteCacheBlock &&block) {
-		dataChain.push_back(std::move(block));
-		if (dataChain.size() > 1 && dataChain.back().chunkIndex != std::next(dataChain.rbegin())->chunkIndex) {
-			alterations_in_chain++;
-		}
-	}
-
-	void popFromChain() {
-		assert(dataChain.size() > 0);
-		if (dataChain.size() > 1 && dataChain.front().chunkIndex != std::next(dataChain.begin())->chunkIndex) {
-			alterations_in_chain--;
-		}
-		dataChain.pop_front();
-	}
-
-	void registerAlterationsInChain(int delta) {
-		alterations_in_chain += delta;
-	}
-
-	bool hasMultipleChunkIdsInChain() const {
-		return alterations_in_chain > 0;
-	}
-
-	bool wasLastBlockRecentlyWrittenAndTaken() const {
-		return dataChain.empty() && lastWriteToDataChain.elapsed_ms() < kVeryRecentWrite_ms;
+	bool wasLastBlockRecentlyWritten() const {
+		return lastWriteToDataChain.elapsed_ms() < kVeryRecentWrite_ms;
 	}
 
 private:
@@ -201,13 +135,112 @@ private:
 	static const uint32_t kVeryRecentWrite_ms = 5;
 };
 
+struct ChunkData {
+	uint32_t chunkIndex;
+	uint16_t tryCounter;
+	int newDataInChainPipe[2];
+	uint32_t minimumBlocksToWrite;
+	std::list<WriteCacheBlock> dataChain;
+	bool inQueue; // true it this chunk is waiting in one of the queues or is being processed
+	bool workerWaitingForData;
+	ChunkData *next; // for iterating through the chunkdata of an inode
+	std::unique_ptr<WriteChunkLocator> locator;
+	std::atomic<int> beingWritten;
+
+	ChunkData(uint32_t chunkIndex, inodedata *parent)
+	    : chunkIndex(chunkIndex),
+	      tryCounter(0),
+	      minimumBlocksToWrite(1),
+	      inQueue(false),
+	      workerWaitingForData(false),
+	      next(nullptr),
+	      beingWritten(0),
+	      parent_(parent) {
+#ifdef _WIN32
+		// We don't use inodeData->waitingworker and inodeData->pipe on Cygwin because
+		// Cygwin's implementation of mixed socket & pipe polling is very inefficient.
+		// On mingw platform pipes are unavailable.
+		newDataInChainPipe[0] = newDataInChainPipe[1] = -1;
+#else
+		if (pipe(newDataInChainPipe) < 0) {
+			safs_pretty_syslog(LOG_WARNING, "creating pipe error: %s", strerr(errno));
+			newDataInChainPipe[0] = -1;
+		}
+#endif
+	}
+
+	~ChunkData() {
+		if (isDataChainPipeValid()) {
+			close(newDataInChainPipe[0]);
+			close(newDataInChainPipe[1]);
+		}
+	}
+
+	/* glock: UNUSED */
+	bool isDataChainPipeValid() const {
+		return newDataInChainPipe[0] >= 0;
+	}
+
+	/* glock: LOCKED */
+	void wakeUpWorkerIfNecessary() {
+		/*
+		 * Write worker always looks for the first block in chain and we modify or add always the
+		 * last block in chain so it is necessary to wake up write worker only if the first block
+		 * is the last one, ie. dataChain.size() == 1.
+		 */
+		if (workerWaitingForData && dataChain.size() == 1 && isDataChainPipeValid()) {
+			if (write(newDataInChainPipe[1], " ", 1) != 1) {
+				safs_pretty_syslog(LOG_ERR, "write pipe error: %s", strerr(errno));
+			}
+			workerWaitingForData = false;
+		}
+	}
+
+	void pushToChain(WriteCacheBlock &&block) {
+		dataChain.push_back(std::move(block));
+		parent_->totalCachedBlocks++;
+	}
+
+	void popFromChain() {
+		assert(dataChain.size() > 0);
+		dataChain.pop_front();
+		parent_->totalCachedBlocks--;
+	}
+
+	void updateParentStatus(int8_t status) { parent_->status = status; }
+
+	int8_t getParentStatus() {
+		return parent_->status;
+	}
+
+	bool requiresFlushing() const {
+		return parent_->requiresFlushing();
+	}
+
+	void clear() {
+		parent_->totalCachedBlocks -= dataChain.size();
+		dataChain.clear();
+	}
+
+	bool parentIsDone() const {
+		return parent_->chunksDataFirst == nullptr;
+	}
+
+	void notifyParentFlushcond() { parent_->flushcond.notify_all(); }
+
+	inline inodedata *getParent() const { return parent_; }
+
+private:
+	inodedata *parent_; // contains inode and other useful data
+};
+
 struct DelayedQueueEntry {
-	inodedata *inodeData;
+	ChunkData *chunkData;
 	int32_t ticksLeft;
 	static constexpr int kTicksPerSecond = 10;
 
-	DelayedQueueEntry(inodedata *inodeData, int32_t ticksLeft)
-			: inodeData(inodeData),
+	DelayedQueueEntry(ChunkData *chunkData, int32_t ticksLeft)
+			: chunkData(chunkData),
 			  ticksLeft(ticksLeft) {
 	}
 };
@@ -226,6 +259,8 @@ static int64_t freecacheblocks;
 using InodeDataMap = std::map<uint32_t, inodedata *>;
 static InodeDataMap inodedataMap;
 
+// <inode, <lockid, endoffset>> and sorted by inode
+static std::map<uint32_t, std::pair<uint64_t, uint64_t>> truncateLocatorsData;
 static uint32_t gWriteWindowSize;
 static uint32_t gChunkserverTimeout_ms;
 
@@ -255,12 +290,12 @@ void write_cb_acquire_blocks(uint32_t count, Glock&) {
 void write_cb_wait_for_block(inodedata* id, Glock& glock) {
 	LOG_AVG_TILL_END_OF_SCOPE0("write_cb_wait_for_block");
 	fcbwaiting++;
-	uint64_t dataChainSize = id->dataChain.size();
+	uint64_t totalCachedBlocks = id->totalCachedBlocks;
 	while (freecacheblocks <= 0
-			// dataChainSize / (dataChainSize + freecacheblocks) > gCachePerInodePercentage / 100
-			// really means "0 > 0"
-			|| dataChainSize * 100 > (dataChainSize + freecacheblocks) * gCachePerInodePercentage)
-	{
+	       // totalCachedBlocks / (totalCachedBlocks + freecacheblocks) >
+	       // gCachePerInodePercentage / 100 really means "0 > 0"
+	       || totalCachedBlocks * 100 > (totalCachedBlocks + freecacheblocks) *
+	                                        gCachePerInodePercentage) {
 		fcbcond.wait(glock);
 	}
 	fcbwaiting--;
@@ -296,20 +331,76 @@ void write_free_inodedata(inodedata *fid, Glock &) {
 	inodedataMap.erase(inode);
 }
 
-/* delayed queue */
-
-static void delayed_queue_put(inodedata* id, uint32_t seconds, Glock&) {
-	delayedQueue.push_back(DelayedQueueEntry(id, seconds * DelayedQueueEntry::kTicksPerSecond));
+ChunkData *write_get_chunkdata(uint32_t chunk, inodedata *id) {
+	ChunkData *chunkData;
+	for (ChunkData *chunkData = id->chunksDataFirst; chunkData;
+	     chunkData = chunkData->next) {
+		if (chunkData->chunkIndex == chunk) {
+			return chunkData;
+		}
+	}
+	chunkData = new ChunkData(chunk, id);
+	chunkData->next = id->chunksDataFirst;
+	id->chunksDataFirst = chunkData;
+	Glock lock(gMutex);
+	auto it = truncateLocatorsData.find(id->inode);
+	if (it != truncateLocatorsData.end()) {
+		auto [lockid, endoffset] = it->second;
+		chunkData->locator.reset(
+		    new TruncateWriteChunkLocator(id->inode, chunk, lockid, endoffset));
+	}
+	return chunkData;
 }
 
-static bool delayed_queue_remove(inodedata* id, Glock&) {
+void write_free_chunkdata(ChunkData *fChunkData) {
+	inodedata *id = fChunkData->getParent();
+	ChunkData *cpyChunksDataFirst = id->chunksDataFirst;
+	ChunkData *chunkData, **chunkDataPtr = &(cpyChunksDataFirst);
+	sassert(id->chunksDataFirst != nullptr);
+	bool isFirst = true;
+	while ((chunkData = *chunkDataPtr)) {
+		if (chunkData == fChunkData) {
+			if (isFirst) {
+				id->chunksDataFirst = chunkData->next;
+			} else {
+				*chunkDataPtr = chunkData->next;
+			}
+			delete chunkData;
+			return;
+		}
+		chunkDataPtr = &(chunkData->next);
+		sassert(*chunkDataPtr != nullptr);
+		isFirst = false;
+	}
+}
+
+/* delayed queue */
+
+static void delayed_queue_put(ChunkData* chunkData, uint32_t seconds, Glock&) {
+	delayedQueue.push_back(DelayedQueueEntry(chunkData, seconds * DelayedQueueEntry::kTicksPerSecond));
+}
+
+static bool delayed_queue_remove(ChunkData* chunkData, Glock&) {
 	for (auto it = delayedQueue.begin(); it != delayedQueue.end(); ++it) {
-		if (it->inodeData == id) {
+		if (it->chunkData == chunkData) {
 			delayedQueue.erase(it);
 			return true;
 		}
 	}
 	return false;
+}
+
+static std::vector<ChunkData*> delayed_queue_remove(inodedata *id, Glock &) {
+	std::vector<ChunkData*> removedChunkData;
+	for (auto it = delayedQueue.begin(); it != delayedQueue.end();) {
+		if (it->chunkData->getParent() == id) {
+			removedChunkData.push_back(it->chunkData);
+			it = delayedQueue.erase(it);
+		} else {
+			it++;
+		}
+	}
+	return removedChunkData;
 }
 
 void* delayed_queue_worker(void*) {
@@ -320,11 +411,11 @@ void* delayed_queue_worker(void*) {
 		Glock lock(gMutex);
 		auto it = delayedQueue.begin();
 		while (it != delayedQueue.end()) {
-			if (it->inodeData == NULL) {
+			if (it->chunkData == NULL) {
 				return NULL;
 			}
 			if (--it->ticksLeft <= 0) {
-				auto *data = reinterpret_cast<uint8_t *>(it->inodeData);
+				auto *data = reinterpret_cast<uint8_t *>(it->chunkData);
 				jobsQueue->put(0, 0, data, 0);
 				it = delayedQueue.erase(it);
 			} else {
@@ -339,65 +430,74 @@ void* delayed_queue_worker(void*) {
 
 /* queues */
 
-void write_delayed_enqueue(inodedata* id, uint32_t seconds, Glock& lock) {
+void write_delayed_enqueue(ChunkData* chunkData, uint32_t seconds, Glock& lock) {
 	if (seconds > 0) {
-		delayed_queue_put(id, seconds, lock);
+		delayed_queue_put(chunkData, seconds, lock);
 	} else {
-		jobsQueue->put(0, 0, reinterpret_cast<uint8_t*>(id), 0);
+		jobsQueue->put(0, 0, reinterpret_cast<uint8_t*>(chunkData), 0);
 	}
 }
 
-void write_enqueue(inodedata* id, Glock&) {
-	jobsQueue->put(0, 0, reinterpret_cast<uint8_t*>(id), 0);
+void write_enqueue(ChunkData *chunkData, Glock &) {
+	jobsQueue->put(0, 0, reinterpret_cast<uint8_t*>(chunkData), 0);
 }
 
-void write_job_delayed_end(inodedata* id, int status, int seconds, Glock &lock) {
+void write_enqueue(std::vector<ChunkData *> &chunks, Glock &) {
+	for (auto chunk : chunks) {
+		jobsQueue->put(0, 0, reinterpret_cast<uint8_t *>(chunk), 0);
+	}
+}
+
+void write_job_delayed_end(ChunkData* chunkData, int status, int seconds, Glock &lock) {
 	LOG_AVG_TILL_END_OF_SCOPE0("write_job_delayed_end");
 	LOG_AVG_TILL_END_OF_SCOPE1("write_job_delayed_end#sec", seconds);
-	if (id->locator != nullptr && id->locator->shouldReset()) {
-		id->locator.reset();
+	inodedata *parent = chunkData->getParent();
+	if (chunkData->locator != nullptr && chunkData->locator->shouldReset()) {
+		chunkData->locator.reset();
 	}
 	if (status != SAUNAFS_STATUS_OK) {
-		safs_pretty_syslog(LOG_WARNING, "error writing file number %" PRIu32 ": %s", id->inode, saunafs_error_string(status));
-		id->status = status;
+		safs_pretty_syslog(LOG_WARNING, "error writing file number %" PRIu32 ": %s", parent->inode, saunafs_error_string(status));
+		chunkData->updateParentStatus(status);
 	}
-	status = id->status;
-	if (id->requiresFlushing() > 0) {
+	status = chunkData->getParentStatus();
+	if (chunkData->requiresFlushing() > 0) {
 		// Don't sleep if we have to write all the data immediately
 		seconds = 0;
 	}
-	if (!id->dataChain.empty() && status == SAUNAFS_STATUS_OK) { // still have some work to do
-		id->trycnt = 0; // on good write reset try counter
-		write_delayed_enqueue(id, seconds, lock);
+	if (chunkData->beingWritten) {
+		write_enqueue(chunkData, lock);
+	} else if (!chunkData->dataChain.empty() && status == SAUNAFS_STATUS_OK) { // still have some work to do
+		chunkData->tryCounter = 0; // on good write reset try counter
+		write_delayed_enqueue(chunkData, seconds, lock);
 	} else {        // no more work or error occurred
 		// if this is an error then release all data blocks
-		write_cb_release_blocks(id->dataChain.size(), lock);
-		id->dataChain.clear();
-		id->inqueue = false;
+		write_cb_release_blocks(chunkData->dataChain.size(), lock);
+		chunkData->clear();
 		// We don't reset maxfleng (id->maxfleng = 0;) for a while longer, to
 		// have its value ready to some quick cache responses in lookup and
 		// getattr syscalls
-		if (id->flushwaiting > 0) {
-			id->flushcond.notify_all();
+		write_free_chunkdata(chunkData);
+		if (parent->chunksDataFirst == nullptr) {
+			parent->flushcond.notify_all();
 		}
 	}
 }
 
-void write_job_end(inodedata *id, int status, Glock &lock) {
-	write_job_delayed_end(id, status, 0, lock);
+void write_job_end(ChunkData* chunkData, int status, Glock &lock) {
+	write_job_delayed_end(chunkData, status, 0, lock);
 }
 
-class InodeChunkWriter {
+class ChunkJobWriter {
 public:
-	InodeChunkWriter() : inodeData_(nullptr), chunkIndex_(0) {}
-	void processJob(inodedata* data);
+	ChunkJobWriter() : chunkData_(nullptr), chunkIndex_(0) {}
+	void processJob(ChunkData* chunkData);
 
 private:
 	void processDataChain(ChunkWriter& writer);
 	void returnJournalToDataChain(std::list<WriteCacheBlock>&& journal, Glock&);
 	bool haveAnyBlockInCurrentChunk(Glock&);
 	bool haveBlockWorthWriting(uint32_t unfinishedOperationCount, Glock&);
-	inodedata* inodeData_;
+	ChunkData* chunkData_;
 	uint32_t chunkIndex_;
 	Timer wholeOperationTimer;
 
@@ -411,54 +511,32 @@ private:
 	static const uint32_t kMinTryCounterToShowWriteErrorMessage = 4;
 };
 
-void InodeChunkWriter::processJob(inodedata* inodeData) {
-	LOG_AVG_TILL_END_OF_SCOPE0("InodeChunkWriter::processJob");
-	inodeData_ = inodeData;
-
-	// First, choose index of some chunk to write
-	Glock lock(gMutex);
-	int status = inodeData_->status;
-	bool haveDataToWrite;
-	if (inodeData_->locator) {
-		// There is a chunk lock left by a previous unfinished job -- let's finish it!
-		chunkIndex_ = inodeData_->locator->chunkIndex();
-		haveDataToWrite = haveAnyBlockInCurrentChunk(lock);
-	} else if (!inodeData_->dataChain.empty()) {
-		// There is no unfinished job, but there is some data to write -- let's start a new job
-		chunkIndex_ = inodeData_->dataChain.front().chunkIndex;
-		haveDataToWrite = true;
-	} else {
-		// No data, no unfinished jobs -- something wrong!
-		// This should never happen, so the status doesn't really matter
-		safs_pretty_syslog(LOG_WARNING, "got inode with no data to write!!!");
-		haveDataToWrite = false;
-		status = SAUNAFS_ERROR_EINVAL;
-	}
-	if (status != SAUNAFS_STATUS_OK) {
-		write_job_end(inodeData_, status, lock);
-		return;
-	}
-	lock.unlock();
+void ChunkJobWriter::processJob(ChunkData* chunkData) {
+	LOG_AVG_TILL_END_OF_SCOPE0("ChunkJobWriter::processJob");
+	chunkData_ = chunkData;
+	chunkIndex_ = chunkData_->chunkIndex;
+	inodedata *parent = chunkData_->getParent();
 
 	/*  Process the job */
-	ChunkWriter writer(globalChunkserverStats, gChunkConnector, inodeData_->newDataInChainPipe[0]);
+	ChunkWriter writer(chunkData_->chunkIndex, globalChunkserverStats,
+	                   gChunkConnector, chunkData_->newDataInChainPipe[0]);
 	wholeOperationTimer.reset();
-	std::unique_ptr<WriteChunkLocator> locator = std::move(inodeData_->locator);
+	std::unique_ptr<WriteChunkLocator> locator = std::move(chunkData_->locator);
 	if (!locator) {
 		locator.reset(new WriteChunkLocator());
 	}
 
 	try {
 		try {
-			locator->locateAndLockChunk(inodeData_->inode, chunkIndex_);
+			locator->locateAndLockChunk(parent->inode, chunkIndex_);
 			Glock lock(gMutex);
-			inodeData_->maxfleng =
-			    std::max(inodeData_->maxfleng, locator->fileLength());
+			parent->maxfleng =
+			    std::max(parent->maxfleng, locator->fileLength());
 			lock.unlock();
 
 			// Optimization -- talk with chunkservers only if we have to write any data.
 			// Don't do this if we just have to release some previously unlocked lock.
-			if (haveDataToWrite) {
+			if (haveAnyBlockInCurrentChunk(lock)) {
 				writer.init(locator.get(), gChunkserverTimeout_ms);
 				processDataChain(writer);
 				writer.finish(kTimeToFinishOperations * 1000);
@@ -467,54 +545,59 @@ void InodeChunkWriter::processJob(inodedata* inodeData) {
 				returnJournalToDataChain(writer.releaseJournal(), lock);
 				lock.unlock();
 			}
+
+			for (ChunkData *it = parent->chunksDataFirst; it;
+			     it = it->next) {
+				if (it->chunkIndex > chunkData_->chunkIndex) {
+					// set it to 0 in order to don't update master size of the
+					// file
+					locator->updateFileLength(0);
+					break;
+				}
+			}
 			locator->unlockChunk();
-			read_inode_reconnect_and_clear_cache(inodeData_->inode, chunkIndex_);
+			read_inode_reconnect_and_clear_cache(parent->inode, chunkIndex_);
 
 			lock.lock();
-			inodeData_->minimumBlocksToWrite = writer.getMinimumBlockCountWorthWriting();
-			bool canWait = !inodeData_->requiresFlushing();
+			chunkData_->minimumBlocksToWrite = writer.getMinimumBlockCountWorthWriting();
+			bool canWait = !chunkData_->requiresFlushing();
 			if (!haveAnyBlockInCurrentChunk(lock)) {
 				// There is no need to wait if we have just finished writing some chunk.
 				// Let's immediately start writing the next chunk (if there is any).
-				canWait = false;
-			}
-			if (inodeData_->hasMultipleChunkIdsInChain()) {
-				// Don't wait if there is more than one chunk in the data chain -- the first chunk
-				// has to be flushed, because no more data will be added to it
 				canWait = false;
 			}
 
 			if (!locator->shouldReset()) {
 				// In the case of a truncate operation that is not finished yet, we don't want to
 				// reset the locator, because it will be used later to lock the chunk again
-				inodeData_->locator = std::move(locator);
+				chunkData_->locator = std::move(locator);
 			}
 
-			write_job_delayed_end(inodeData_, SAUNAFS_STATUS_OK, (canWait ? 1 : 0), lock);
+			write_job_delayed_end(chunkData_, SAUNAFS_STATUS_OK, (canWait ? 1 : 0), lock);
 		} catch (Exception& e) {
 			std::string errorString = e.what();
 			addPathByInodeBasedNotificationMessage(
-			    "Write error: " + std::string(e.what()), inodeData_->inode);
+			    "Write error: " + std::string(e.what()), parent->inode);
 			Glock lock(gMutex);
 			if (e.status() != SAUNAFS_ERROR_LOCKED) {
-				inodeData_->trycnt++;
-				errorString += " (try counter: " + std::to_string(inodeData->trycnt) + ")";
-			} else if (inodeData_->trycnt == 0) {
+				chunkData_->tryCounter++;
+				errorString += " (try counter: " + std::to_string(chunkData->tryCounter) + ")";
+			} else if (chunkData_->tryCounter == 0) {
 				// Set to nonzero to inform writers, that this task needs to wait a bit
 				// Don't increase -- SAUNAFS_ERROR_LOCKED means that chunk is locked by a different client
 				// and we have to wait until it is unlocked
-				inodeData_->trycnt = 1;
+				chunkData_->tryCounter = 1;
 			}
 			// Keep the lock
-			inodeData_->locator = std::move(locator);
+			chunkData_->locator = std::move(locator);
 			// Move data left in the journal into front of the write cache
 			returnJournalToDataChain(writer.releaseJournal(), lock);
 			lock.unlock();
 
 			safs_pretty_syslog(LOG_WARNING, "write file error, inode: %" PRIu32 ", index: %" PRIu32 " - %s",
-					inodeData_->inode, chunkIndex_, errorString.c_str());
+					parent->inode, chunkIndex_, errorString.c_str());
 
-			if (inodeData_->trycnt >= maxretries) {
+			if (chunkData_->tryCounter >= maxretries) {
 				// Convert error to an unrecoverable error
 				throw UnrecoverableWriteException(e.message(), e.status());
 			} else {
@@ -524,35 +607,36 @@ void InodeChunkWriter::processJob(inodedata* inodeData) {
 		}
 	} catch (UnrecoverableWriteException& e) {
 		addPathByInodeBasedNotificationMessage(
-		    "Write error: " + std::string(e.what()), inodeData_->inode);
+		    "Write error: " + std::string(e.what()), parent->inode);
 		Glock lock(gMutex);
 		if (e.status() == SAUNAFS_ERROR_ENOENT) {
-			write_job_end(inodeData_, SAUNAFS_ERROR_EBADF, lock);
+			write_job_end(chunkData_, SAUNAFS_ERROR_EBADF, lock);
 		} else if (e.status() == SAUNAFS_ERROR_QUOTA) {
-			write_job_end(inodeData_, SAUNAFS_ERROR_QUOTA, lock);
+			write_job_end(chunkData_, SAUNAFS_ERROR_QUOTA, lock);
 		} else if (e.status() == SAUNAFS_ERROR_NOSPACE || e.status() == SAUNAFS_ERROR_NOCHUNKSERVERS) {
-			write_job_end(inodeData_, SAUNAFS_ERROR_NOSPACE, lock);
+			write_job_end(chunkData_, SAUNAFS_ERROR_NOSPACE, lock);
 		} else {
-			write_job_end(inodeData_, SAUNAFS_ERROR_IO, lock);
+			write_job_end(chunkData_, SAUNAFS_ERROR_IO, lock);
 		}
 	} catch (Exception& e) {
-		if (inodeData_->trycnt > kMinTryCounterToShowWriteErrorMessage) {
+		if (chunkData_->tryCounter > kMinTryCounterToShowWriteErrorMessage) {
 			addPathByInodeBasedNotificationMessage(
-			    "Write error: " + std::string(e.what()), inodeData_->inode);
+			    "Write error: " + std::string(e.what()), parent->inode);
 		}
 		Glock lock(gMutex);
 		int waitTime = 1;
-		if (inodeData_->trycnt > 10) {
-			waitTime = std::min<int>(10, inodeData_->trycnt - 9);
+		if (chunkData_->tryCounter > 10) {
+			waitTime = std::min<int>(10, chunkData_->tryCounter - 9);
 		}
-		write_delayed_enqueue(inodeData_, waitTime, lock);
+		write_delayed_enqueue(chunkData_, waitTime, lock);
 	}
 }
 
-void InodeChunkWriter::processDataChain(ChunkWriter& writer) {
-	LOG_AVG_TILL_END_OF_SCOPE0("InodeChunkWriter::processDataChain");
+void ChunkJobWriter::processDataChain(ChunkWriter& writer) {
+	LOG_AVG_TILL_END_OF_SCOPE0("ChunkJobWriter::processDataChain");
 	uint32_t maximumTime = kMaximumTime;
 	bool otherJobsAreWaiting = false;
+	inodedata *parent = chunkData_->getParent();
 	while (true) {
 		bool newOtherJobsAreWaiting = !jobsQueue->isEmpty();
 		if (!otherJobsAreWaiting && newOtherJobsAreWaiting) {
@@ -577,23 +661,24 @@ void InodeChunkWriter::processDataChain(ChunkWriter& writer) {
 			// While there is any block worth sending, we add new write operation
 			while (haveBlockWorthWriting(writer.getUnfinishedOperationsCount(), lock)) {
 				// Remove block from cache and pass it to the writer
-				writer.addOperation(std::move(inodeData_->dataChain.front()));
-				inodeData_->popFromChain();
+				writer.addOperation(std::move(chunkData_->dataChain.front()));
+				chunkData_->popFromChain();
 				write_cb_release_blocks(1, lock);
 			}
-			if (inodeData_->requiresFlushing() && !haveAnyBlockInCurrentChunk(lock)) {
+			if (chunkData_->requiresFlushing() && !haveAnyBlockInCurrentChunk(lock)) {
 				// No more data and some flushing is needed or required, so flush everything
 				writer.startFlushMode();
 			}
 			if (writer.getUnfinishedOperationsCount() < gWriteWindowSize) {
-				inodeData_->workerWaitingForData = true;
+				chunkData_->workerWaitingForData = true;
 			}
-			can_expect_next_block = haveAnyBlockInCurrentChunk(lock) ||
-			                        inodeData_->wasLastBlockRecentlyWrittenAndTaken();
+			can_expect_next_block =
+			    haveAnyBlockInCurrentChunk(lock) ||
+			    (parent->wasLastBlockRecentlyWritten() && !chunkData_->dataChain.empty());
 		} else if (writer.acceptsNewOperations()) {
 			// We are running out of time...
 			Glock lock(gMutex);
-			if (!inodeData_->requiresFlushing()) {
+			if (!chunkData_->requiresFlushing()) {
 				// Nobody is waiting for the data to be flushed and the data in write chain
 				// isn't too old. Let's postpone any operations
 				// that didn't start yet and finish them in the next time slice for this chunk
@@ -602,18 +687,19 @@ void InodeChunkWriter::processDataChain(ChunkWriter& writer) {
 				// Somebody if waiting for a flush, so we have to finish writing everything.
 				writer.startFlushMode();
 			}
-			can_expect_next_block = haveAnyBlockInCurrentChunk(lock) ||
-			                        inodeData_->wasLastBlockRecentlyWrittenAndTaken();
+			can_expect_next_block =
+			    haveAnyBlockInCurrentChunk(lock) ||
+			    (parent->wasLastBlockRecentlyWritten() && !chunkData_->dataChain.empty());
 		}
 
 		Glock lock(gMutex);
 		writer.setChunkSizeInBlocks(
-		    std::min(inodeData_->maxfleng - chunkIndex_ * SFSCHUNKSIZE,
+		    std::min(parent->maxfleng - chunkIndex_ * SFSCHUNKSIZE,
 		             (uint64_t)SFSCHUNKSIZE));
 		lock.unlock();
 		if (writer.startNewOperations(can_expect_next_block) > 0) {
 			lock.lock();
-			inodeData_->lastWriteToChunkservers.reset();
+			parent->lastWriteToChunkservers.reset();
 			lock.unlock();
 		}
 		if (writer.getPendingOperationsCount() == 0) {
@@ -625,36 +711,25 @@ void InodeChunkWriter::processDataChain(ChunkWriter& writer) {
 		}
 
 		// Let's sleep a bit shorter if we can't be woken up by the pipe to reduce the latency
-		writer.processOperations(inodeData_->isDataChainPipeValid() ? 50 : 10);
+		writer.processOperations(chunkData_->isDataChainPipeValid() ? 50 : 10);
 	}
 }
 
-void InodeChunkWriter::returnJournalToDataChain(std::list<WriteCacheBlock> &&journal, Glock &lock) {
+void ChunkJobWriter::returnJournalToDataChain(
+    std::list<WriteCacheBlock> &&journal, Glock &lock) {
 	if (!journal.empty()) {
 		write_cb_acquire_blocks(journal.size(), lock);
-		uint64_t prev_id = journal.front().chunkIndex;
-		int alterations = (!inodeData_->dataChain.empty()
-				&& journal.back().chunkIndex != inodeData_->dataChain.front().chunkIndex) ? 1 : 0;
-		for (auto it = std::next(journal.begin()); it != journal.end(); ++it) {
-			if (it->chunkIndex != prev_id) {
-				alterations++;
-				prev_id = it->chunkIndex;
-			}
-		}
-		inodeData_->dataChain.splice(inodeData_->dataChain.begin(), std::move(journal));
-		inodeData_->registerAlterationsInChain(alterations);
+		chunkData_->getParent()->totalCachedBlocks += journal.size();
+		chunkData_->dataChain.splice(chunkData_->dataChain.begin(),
+		                             std::move(journal));
 	}
 }
 
 /*
  * Check if there is any data in the same chunk waiting to be written.
  */
-bool InodeChunkWriter::haveAnyBlockInCurrentChunk(Glock&) {
-	if (inodeData_->dataChain.empty()) {
-		return false;
-	} else {
-		return inodeData_->dataChain.front().chunkIndex == chunkIndex_;
-	}
+bool ChunkJobWriter::haveAnyBlockInCurrentChunk(Glock&) {
+	return !chunkData_->dataChain.empty();
 }
 
 /*
@@ -663,11 +738,12 @@ bool InodeChunkWriter::haveAnyBlockInCurrentChunk(Glock&) {
  * These can be taken only if we are close to run out of tasks to do.
  * glock: LOCKED
  */
-bool InodeChunkWriter::haveBlockWorthWriting(uint32_t unfinishedOperationCount, Glock& lock) {
+bool ChunkJobWriter::haveBlockWorthWriting(uint32_t unfinishedOperationCount,
+                                           Glock &lock) {
 	if (!haveAnyBlockInCurrentChunk(lock)) {
 		return false;
 	}
-	const auto& block = inodeData_->dataChain.front();
+	const auto& block = chunkData_->dataChain.front();
 	if (block.type != WriteCacheBlock::kWritableBlock) {
 		// Always write data, that was previously written
 		return true;
@@ -678,14 +754,14 @@ bool InodeChunkWriter::haveBlockWorthWriting(uint32_t unfinishedOperationCount, 
 		// Always start full blocks; start partial blocks only if we have to flush the data
 		// or the block won't be expanded (only the last one can be) to a full block
 		return (block.size() == SFSBLOCKSIZE
-				|| inodeData_->requiresFlushing()
-				|| inodeData_->dataChain.size() > 1);
+				|| chunkData_->requiresFlushing()
+				|| chunkData_->dataChain.size() > 1);
 	}
 }
 
 /* main working thread | glock:UNLOCKED */
 void* write_worker(void*) {
-	InodeChunkWriter inodeDataWriter;
+	ChunkJobWriter chunkJobWriter;
 
 	static std::atomic_uint16_t writeWorkersCounter(0);
 	std::string threadName = "writeWorker " + std::to_string(writeWorkersCounter++);
@@ -705,7 +781,7 @@ void* write_worker(void*) {
 
 		// process the job
 		LOG_AVG_TILL_END_OF_SCOPE0("write_worker#working");
-		inodeDataWriter.processJob((inodedata*) data);
+		chunkJobWriter.processJob((ChunkData*) data);
 	}
 	return NULL;
 }
@@ -728,7 +804,7 @@ void write_data_init(uint32_t cachesize, uint32_t retries, uint32_t workers,
 	freecacheblocks = cacheblockcount;
 	gCachePerInodePercentage = cachePerInodePercentage;
 
-	jobsQueue = std::make_unique<ProducerConsumerQueue>(0, deleterByType<inodedata>);
+	jobsQueue = std::make_unique<ProducerConsumerQueue>(0, deleterByType<ChunkData>);
 
 	pthread_attr_init(&thattr);
 	pthread_attr_setstacksize(&thattr, 0x100000);
@@ -764,54 +840,59 @@ void write_data_term(void) {
 }
 
 /* glock: UNLOCKED */
-int write_block(inodedata *id, uint32_t chindx, uint16_t pos, uint32_t from, uint32_t to, const uint8_t *data) {
+int write_block(ChunkData* chunkData, uint16_t pos, uint32_t from, uint32_t to, const uint8_t *data) {
 	Glock lock(gMutex);
-	id->lastWriteToDataChain.reset();
+	inodedata *parent = chunkData->getParent();
+	parent->lastWriteToDataChain.reset();
 
 	// Try to expand the last block
-	if (!id->dataChain.empty()) {
-		auto& lastBlock = id->dataChain.back();
-		if (lastBlock.chunkIndex == chindx
-				&& lastBlock.blockIndex == pos
+	if (!chunkData->dataChain.empty()) {
+		auto& lastBlock = chunkData->dataChain.back();
+		if (lastBlock.blockIndex == pos
 				&& lastBlock.type == WriteCacheBlock::kWritableBlock
 				&& lastBlock.expand(from, to, data)) {
-			id->wakeUpWorkerIfNecessary();
+			chunkData->wakeUpWorkerIfNecessary();
 			return 0;
 		}
 	}
 
 	// Didn't manage to expand an existing block, so allocate a new one
-	write_cb_wait_for_block(id, lock);
+	write_cb_wait_for_block(parent, lock);
 	write_cb_acquire_blocks(1, lock);
-	id->pushToChain(WriteCacheBlock(chindx, pos, WriteCacheBlock::kWritableBlock));
-	sassert(id->dataChain.back().expand(from, to, data));
-	if (id->inqueue) {
+	chunkData->pushToChain(WriteCacheBlock(chunkData->chunkIndex, pos,
+	                                       WriteCacheBlock::kWritableBlock));
+	sassert(chunkData->dataChain.back().expand(from, to, data));
+	if (chunkData->inQueue) {
 		// Consider some speedup if there are no errors and:
 		// - there is a lot of blocks in the write chain
 		// - there are at least two chunks in the write chain
-		if (id->trycnt == 0 && (id->dataChain.size() > id->minimumBlocksToWrite
-			|| id->dataChain.front().chunkIndex != id->dataChain.back().chunkIndex)) {
-			if (delayed_queue_remove(id, lock)) {
-				write_enqueue(id, lock);
+		if (chunkData->tryCounter == 0 &&
+		    (chunkData->dataChain.size() > chunkData->minimumBlocksToWrite)) {
+			if (delayed_queue_remove(chunkData, lock)) {
+				write_enqueue(chunkData, lock);
 			}
 		}
-		id->wakeUpWorkerIfNecessary();
+		chunkData->wakeUpWorkerIfNecessary();
 	} else {
-		id->inqueue = true;
-		write_enqueue(id, lock);
+		chunkData->inQueue = true;
+		write_enqueue(chunkData, lock);
 	}
 	return 0;
 }
 
 /* glock: UNLOCKED */
-int write_blocks(inodedata *id, uint64_t offset, uint32_t size, const uint8_t* data) {
+int write_blocks(inodedata *id, uint64_t offset, uint32_t size,
+                 const uint8_t *data) {
 	LOG_AVG_TILL_END_OF_SCOPE0("write_blocks");
 	uint32_t chindx = offset >> SFSCHUNKBITS;
 	uint16_t pos = (offset & SFSCHUNKMASK) >> SFSBLOCKBITS;
 	uint32_t from = offset & SFSBLOCKMASK;
 	while (size > 0) {
+		ChunkData *chunkData = write_get_chunkdata(chindx, id);
+		chunkData->beingWritten++;
 		if (size > SFSBLOCKSIZE - from) {
-			if (write_block(id, chindx, pos, from, SFSBLOCKSIZE, data) < 0) {
+			if (write_block(chunkData, pos, from, SFSBLOCKSIZE, data) < 0) {
+				chunkData->beingWritten--;
 				return SAUNAFS_ERROR_IO;
 			}
 			size -= (SFSBLOCKSIZE - from);
@@ -823,11 +904,13 @@ int write_blocks(inodedata *id, uint64_t offset, uint32_t size, const uint8_t* d
 				chindx++;
 			}
 		} else {
-			if (write_block(id, chindx, pos, from, from + size, data) < 0) {
+			if (write_block(chunkData, pos, from, from + size, data) < 0) {
+				chunkData->beingWritten--;
 				return SAUNAFS_ERROR_IO;
 			}
 			size = 0;
 		}
+		chunkData->beingWritten--;
 	}
 	return 0;
 }
@@ -882,7 +965,8 @@ static void	write_data_lcnt_decrease_check_deleted(inodedata *id, Glock& lock, b
 	// As long as it is not freed, then we don't consider the inodedata deleted
 	isDeleted = false;
 	id->lcnt--;
-	if (id->lcnt == 0 && !id->inqueue && id->flushwaiting == 0 && id->writewaiting == 0) {
+	if (id->lcnt == 0 && id->chunksDataFirst == nullptr &&
+	    id->flushwaiting == 0 && id->writewaiting == 0) {
 		write_free_inodedata(id, lock);
 		isDeleted = true;
 	}
@@ -912,15 +996,17 @@ static int write_data_flush(void* vid, Glock& lock) {
 	}
 
 	write_data_flushwaiting_increase(id, lock);
-	// If there are no errors (trycnt==0) and inode is waiting in the delayed queue, speed it up
-	if (id->trycnt == 0 && delayed_queue_remove(id, lock)) {
-		write_enqueue(id, lock);
+	// If there are no errors (status == SAUNAFS_STATUS_OK) and inode is waiting in the delayed queue, speed it up
+	auto delayedEnqueuedChunkData = delayed_queue_remove(id, lock);
+	if (id->status == SAUNAFS_STATUS_OK && !delayedEnqueuedChunkData.empty()) {
+		write_enqueue(delayedEnqueuedChunkData, lock);
 	}
 	// Wait for the data to be flushed
-	while (id->inqueue) {
+	while (id->chunksDataFirst != nullptr) {
 		id->flushcond.wait(lock);
 	}
 	write_data_flushwaiting_decrease(id, lock);
+	id->maxfleng = 0;
 	return id->status;
 }
 
@@ -1025,9 +1111,8 @@ int write_data_truncate(uint32_t inode, bool opened, uint32_t uid, uint32_t gid,
 		id->maxfleng = endOffset;
 
 		// Something has to be written, so pass our lock to writing threads
-		sassert(id->dataChain.empty());
-		id->locator.reset(
-		    new TruncateWriteChunkLocator(inode, length / SFSCHUNKSIZE, lockId, endOffset));
+		sassert(id->totalCachedBlocks == 0);
+		truncateLocatorsData[id->inode] = {lockId, endOffset};
 
 		// And now pass block of zeros to writing threads
 		std::vector<uint8_t> zeros(endOffset - length, 0);
@@ -1035,6 +1120,7 @@ int write_data_truncate(uint32_t inode, bool opened, uint32_t uid, uint32_t gid,
 		err = write_blocks(id, length, zeros.size(), zeros.data());
 		lock.lock();
 		if (err != 0) {
+			truncateLocatorsData.erase(id->inode);
 			write_data_flushwaiting_decrease(id, lock);
 			write_data_lcnt_decrease(id, lock);
 			return err;
@@ -1042,7 +1128,8 @@ int write_data_truncate(uint32_t inode, bool opened, uint32_t uid, uint32_t gid,
 
 		// Wait for writing threads to finish
 		err = write_data_flush(id, lock);
-		id->locator.reset();
+
+		truncateLocatorsData.erase(id->inode);
 		if (err != 0) {
 			// unlock the chunk here?
 			write_data_flushwaiting_decrease(id, lock);

--- a/src/mount/writedata.cc
+++ b/src/mount/writedata.cc
@@ -243,6 +243,7 @@ struct DelayedQueueEntry {
 } // anonymous namespace
 
 static std::atomic<uint32_t> maxretries;
+static std::atomic<uint32_t> gWaveTimeout;
 static std::mutex gMutex;
 
 static std::mutex fcbcondMutex;
@@ -772,7 +773,7 @@ void ChunkJobWriter::processDataChain(ChunkWriter& writer) {
 		}
 
 		// Let's sleep a bit shorter if we can't be woken up by the pipe to reduce the latency
-		writer.processOperations(chunkData_->isDataChainPipeValid() ? 50 : 10);
+		writer.processOperations(gWaveTimeout);
 	}
 }
 
@@ -843,7 +844,8 @@ void* write_worker(void*) {
 
 /* API | globalLock: INITIALIZED,UNLOCKED */
 void write_data_init(uint32_t cachesize, uint32_t retries, uint32_t workers,
-		uint32_t writewindowsize, uint32_t chunkserverTimeout_ms, uint32_t cachePerInodePercentage) {
+                     uint32_t writewindowsize, uint32_t chunkserverTimeout_ms,
+                     uint32_t cachePerInodePercentage, uint32_t waveTimeout) {
 	uint64_t cachebytecount = uint64_t(cachesize) * 1024 * 1024;
 	uint64_t cacheblockcount = (cachebytecount / SFSBLOCKSIZE);
 	pthread_attr_t thattr;
@@ -852,6 +854,7 @@ void write_data_init(uint32_t cachesize, uint32_t retries, uint32_t workers,
 	gWriteWindowSize = writewindowsize;
 	gChunkserverTimeout_ms = chunkserverTimeout_ms;
 	maxretries = retries;
+	gWaveTimeout = waveTimeout;
 	if (cacheblockcount < 10) {
 		cacheblockcount = 10;
 	}
@@ -871,6 +874,7 @@ void write_data_init(uint32_t cachesize, uint32_t retries, uint32_t workers,
 	pthread_attr_destroy(&thattr);
 
 	gTweaks.registerVariable("WriteMaxRetries", maxretries, "sfsioretries (write)");
+	gTweaks.registerVariable("WriteWaveTimeout", gWaveTimeout, "sfschunkserverwavewriteto");
 }
 
 void write_data_term(void) {

--- a/src/mount/writedata.cc
+++ b/src/mount/writedata.cc
@@ -173,6 +173,10 @@ struct inodedata {
 
 	bool hasMultipleChunkIdsInChain() const { return alterations_in_chain > 0; }
 
+	bool wasLastBlockRecentlyWrittenAndTaken() const {
+		return dataChain.empty() && lastWriteToDataChain.elapsed_ms() < kVeryRecentWrite_ms;
+	}
+
 private:
 	/*! Limit for \p lastWriteToChunkservers after which we force a flush.
 	 *
@@ -186,6 +190,13 @@ private:
 	 * if no new data is written into the data chain
 	 */
 	static const uint32_t kMaximumTimeInDataChainSinceLastWrite_ms = 5000;
+
+	/*! Limit for considering the last write to data chain very recent.
+	 *
+	 * This is used to avoid writing a partial stripe to chunkservers when last block was full and
+	 * next one has not even started.
+	 */
+	static const uint32_t kVeryRecentWrite_ms = 5;
 };
 
 struct DelayedQueueEntry {
@@ -324,7 +335,9 @@ void write_enqueue(inodedata *id, Glock &) {
 void write_job_delayed_end(inodedata *id, int status, int seconds, Glock &lock) {
 	LOG_AVG_TILL_END_OF_SCOPE0("write_job_delayed_end");
 	LOG_AVG_TILL_END_OF_SCOPE1("write_job_delayed_end#sec", seconds);
-	id->locator.reset();
+	if (id->locator != nullptr && id->locator->shouldReset()) {
+		id->locator.reset();
+	}
 	if (status != SAUNAFS_STATUS_OK) {
 		safs::log_warn("error writing file number {}: {}", id->inode, saunafs_error_string(status));
 		id->status = status;
@@ -446,6 +459,13 @@ void InodeChunkWriter::processJob(inodedata *inodeData) {
 				// has to be flushed, because no more data will be added to it
 				canWait = false;
 			}
+
+			if (!locator->shouldReset()) {
+				// In the case of a truncate operation that is not finished yet, we don't want to
+				// reset the locator, because it will be used later to lock the chunk again
+				inodeData_->locator = std::move(locator);
+			}
+
 			write_job_delayed_end(inodeData_, SAUNAFS_STATUS_OK, (canWait ? 1 : 0), lock);
 		} catch (Exception &e) {
 			std::string errorString = e.what();
@@ -542,7 +562,8 @@ void InodeChunkWriter::processDataChain(ChunkWriter &writer) {
 			if (writer.getUnfinishedOperationsCount() < gWriteWindowSize) {
 				inodeData_->workerWaitingForData = true;
 			}
-			can_expect_next_block = haveAnyBlockInCurrentChunk(lock);
+			can_expect_next_block = haveAnyBlockInCurrentChunk(lock) ||
+			                        inodeData_->wasLastBlockRecentlyWrittenAndTaken();
 		} else if (writer.acceptsNewOperations()) {
 			// We are running out of time...
 			Glock lock(gMutex);
@@ -555,7 +576,8 @@ void InodeChunkWriter::processDataChain(ChunkWriter &writer) {
 				// Somebody if waiting for a flush, so we have to finish writing everything.
 				writer.startFlushMode();
 			}
-			can_expect_next_block = haveAnyBlockInCurrentChunk(lock);
+			can_expect_next_block = haveAnyBlockInCurrentChunk(lock) ||
+			                        inodeData_->wasLastBlockRecentlyWrittenAndTaken();
 		}
 
 		Glock lock(gMutex);
@@ -1380,7 +1402,7 @@ void write_job_delayed_end(ChunkData *chunkData, int status, int seconds, Lock &
 		// Don't sleep if we have to write all the data immediately
 		seconds = 0;
 	}
-	if (chunkData->writesCount > 0) {
+	if (chunkData->writesCount > 0 && status == SAUNAFS_STATUS_OK) {
 		inodeLock.unlock();
 
 		globalLock.lock();
@@ -1393,18 +1415,27 @@ void write_job_delayed_end(ChunkData *chunkData, int status, int seconds, Lock &
 		globalLock.lock();
 		write_delayed_enqueue(chunkData, seconds, globalLock);
 	} else {  // no more work or error occurred
+		bool somebodyIsWriting = chunkData->writesCount > 0;
 		// if this is an error then release all data blocks
 		write_cb_release_blocks(chunkData->dataChain.size());
 
 		chunkData->clear();
-		// We don't reset maxfleng (id->maxfleng = 0;) for a while longer, to
-		// have its value ready to some quick cache responses in lookup and
-		// getattr syscalls
-		write_free_chunkdata(chunkData, inodeLock);
+		if (!somebodyIsWriting) {
+			// We don't reset maxfleng (id->maxfleng = 0;) for a while longer, to
+			// have its value ready to some quick cache responses in lookup and
+			// getattr syscalls
+			write_free_chunkdata(chunkData, inodeLock);
+		}
 		inodeLock.unlock();
 
 		globalLock.lock();
-		if (parent->emptyChunkDataList) { parent->flushcond.notify_all(); }
+		if (parent->emptyChunkDataList || status != SAUNAFS_STATUS_OK) {
+			parent->flushcond.notify_all();
+		} else {// parent->emptyChunkDataList = false and status == SAUNAFS_STATUS_OK
+			if (somebodyIsWriting) {
+				write_enqueue(chunkData, globalLock);
+			}
+		}
 	}
 }
 
@@ -1481,15 +1512,6 @@ void ChunkJobWriter::processJob(ChunkData *chunkData) {
 
 				inodeLock.lock();
 				returnJournalToDataChain(writer.releaseJournal(), inodeLock);
-			}
-
-			for (auto const &it : parent->chunkDataList) {
-				if (it->chunkIndex > chunkData_->chunkIndex) {
-					// set it to 0 in order to don't update master size of the
-					// file
-					locator->updateFileLength(0);
-					break;
-				}
 			}
 			inodeLock.unlock();
 
@@ -1619,7 +1641,7 @@ void ChunkJobWriter::processDataChain(ChunkWriter &writer) {
 			}
 			can_expect_next_block =
 			    haveAnyBlockInCurrentChunk(inodeLock) ||
-			    (parent->wasLastBlockRecentlyWritten() && !chunkData_->dataChain.empty());
+			    (parent->wasLastBlockRecentlyWritten() && chunkData_->dataChain.empty());
 		} else if (writer.acceptsNewOperations()) {
 			// We are running out of time...
 			Lock inodeLock(parent->mutex);
@@ -1634,7 +1656,7 @@ void ChunkJobWriter::processDataChain(ChunkWriter &writer) {
 			}
 			can_expect_next_block =
 			    haveAnyBlockInCurrentChunk(inodeLock) ||
-			    (parent->wasLastBlockRecentlyWritten() && !chunkData_->dataChain.empty());
+			    (parent->wasLastBlockRecentlyWritten() && chunkData_->dataChain.empty());
 		}
 
 		Lock inodeLock(parent->mutex);
@@ -1849,6 +1871,10 @@ int write_blocks(inodedata *id, uint64_t offset, uint32_t size, const uint8_t *d
 			size = 0;
 		}
 		chunkData->writesCount--;
+
+		if (id->status != SAUNAFS_STATUS_OK) {
+			return id->status;
+		}
 	}
 	return 0;
 }
@@ -1946,12 +1972,13 @@ static int write_data_flush(void *vid, Lock &globalLock) {
 	}
 
 	// Wait for the data to be flushed
-	while (!id->emptyChunkDataList) { id->flushcond.wait(globalLock); }
+	while (!id->emptyChunkDataList && id->status == SAUNAFS_STATUS_OK) {
+		id->flushcond.wait(globalLock);
+	}
 	globalLock.unlock();
 
 	inodeLock.lock();
 	write_data_flushwaiting_decrease(id, inodeLock);
-	id->maxfleng = 0;
 	inodeLock.unlock();
 
 	globalLock.lock();
@@ -1969,6 +1996,7 @@ uint64_t write_data_getmaxfleng(uint32_t inode) {
 	Lock globalLock(gMutex);
 	id = write_find_inodedata(inode, globalLock);
 	if (id) {
+		Lock inodeLock(id->mutex);
 		maxfleng = id->maxfleng;
 	} else {
 		maxfleng = 0;

--- a/src/mount/writedata.cc
+++ b/src/mount/writedata.cc
@@ -66,7 +66,7 @@
 #define NO_INODEDATA nullptr
 #define NO_CHUNKDATA nullptr
 
-namespace OldWriteAlgorithm {
+namespace InodeBasedWriteAlgorithm {
 
 struct inodedata {
 	uint32_t inode;
@@ -107,7 +107,7 @@ struct inodedata {
 		newDataInChainPipe[0] = newDataInChainPipe[1] = -1;
 #else
 		if (pipe(newDataInChainPipe) < 0) {
-			safs_pretty_syslog(LOG_WARNING, "creating pipe error: %s", strerr(errno));
+			safs::log_warn("creating pipe error: {}", strerr(errno));
 			newDataInChainPipe[0] = -1;
 		}
 #endif
@@ -129,7 +129,7 @@ struct inodedata {
 		 */
 		if (workerWaitingForData && dataChain.size() == 1 && isDataChainPipeValid()) {
 			if (write(newDataInChainPipe[1], " ", 1) != 1) {
-				safs_pretty_syslog(LOG_ERR, "write pipe error: %s", strerr(errno));
+				safs::log_err("write pipe error: {}", strerr(errno));
 			}
 			workerWaitingForData = false;
 		}
@@ -204,7 +204,7 @@ struct DelayedQueueEntry {
 };
 
 static std::atomic<uint32_t> maxretries;
-static std::atomic<uint32_t> gWaveTimeout;
+static std::atomic<uint32_t> gWriteWaveTimeout;
 static std::mutex gMutex;
 typedef std::unique_lock<std::mutex> Glock;
 
@@ -345,7 +345,8 @@ void write_job_delayed_end(inodedata* id, int status, int seconds, Glock &lock) 
 	LOG_AVG_TILL_END_OF_SCOPE1("write_job_delayed_end#sec", seconds);
 	id->locator.reset();
 	if (status != SAUNAFS_STATUS_OK) {
-		safs_pretty_syslog(LOG_WARNING, "error writing file number %" PRIu32 ": %s", id->inode, saunafs_error_string(status));
+		safs::log_warn("error writing file number {}: {}", id->inode,
+		               saunafs_error_string(status));
 		id->status = status;
 	}
 	status = id->status;
@@ -414,7 +415,7 @@ void InodeChunkWriter::processJob(inodedata* inodeData) {
 	} else {
 		// No data, no unfinished jobs -- something wrong!
 		// This should never happen, so the status doesn't really matter
-		safs_pretty_syslog(LOG_WARNING, "got inode with no data to write!!!");
+		safs::log_warn("got inode with no data to write!!!");
 		haveDataToWrite = false;
 		status = SAUNAFS_ERROR_EINVAL;
 	}
@@ -486,8 +487,8 @@ void InodeChunkWriter::processJob(inodedata* inodeData) {
 			returnJournalToDataChain(writer.releaseJournal(), lock);
 			lock.unlock();
 
-			safs_pretty_syslog(LOG_WARNING, "write file error, inode: %" PRIu32 ", index: %" PRIu32 " - %s",
-					inodeData_->inode, chunkIndex_, errorString.c_str());
+			safs::log_warn("write file error, inode: {}, index: {} - {}",
+			               inodeData_->inode, chunkIndex_, errorString.c_str());
 			if (inodeData_->trycnt >= maxretries) {
 				// Convert error to an unrecoverable error
 				throw UnrecoverableWriteException(e.message(), e.status());
@@ -590,7 +591,7 @@ void InodeChunkWriter::processDataChain(ChunkWriter& writer) {
 					SAUNAFS_ERROR_TIMEOUT);
 		}
 
-		writer.processOperations(gWaveTimeout);
+		writer.processOperations(gWriteWaveTimeout);
 	}
 }
 
@@ -687,7 +688,7 @@ void write_data_init(uint32_t cachesize, uint32_t retries, uint32_t workers,
 	gWriteWindowSize = writewindowsize;
 	gChunkserverTimeout_ms = chunkserverTimeout_ms;
 	maxretries = retries;
-	gWaveTimeout = waveTimeout;
+	gWriteWaveTimeout = waveTimeout;
 	if (cacheblockcount < 10) {
 		cacheblockcount = 10;
 	}
@@ -707,7 +708,7 @@ void write_data_init(uint32_t cachesize, uint32_t retries, uint32_t workers,
 	pthread_attr_destroy(&thattr);
 
 	gTweaks.registerVariable("WriteMaxRetries", maxretries);
-	gTweaks.registerVariable("WriteWaveTimeout", gWaveTimeout);
+	gTweaks.registerVariable("WriteWaveTimeout", gWriteWaveTimeout);
 }
 
 void write_data_term(void) {
@@ -949,8 +950,9 @@ int write_data_truncate(uint32_t inode, bool opened, uint32_t uid, uint32_t gid,
 	do {
 		status = fs_truncate(inode, opened, uid, gid, length, writeNeeded, attr, oldLength, lockId);
 		if (status != SAUNAFS_STATUS_OK) {
-			safs_pretty_syslog(LOG_INFO, "truncate file %" PRIu32 " to length %" PRIu64 ": %s (try %d/%d)",
-					inode, length, saunafs_error_string(status), int(retries + 1), int(maxretries));
+			safs::log_info("truncate file {} to length {}: {} (try {}/{})",
+			               inode, length, saunafs_error_string(status),
+			               int(retries + 1), int(maxretries));
 		}
 		if (retries >= maxretries) {
 			break;
@@ -975,8 +977,7 @@ int write_data_truncate(uint32_t inode, bool opened, uint32_t uid, uint32_t gid,
 			}
 			return 0;
 		} else {
-			// status is now SFS status, so we cannot return any errno
-			throw UnrecoverableWriteException("fs_truncate failed", status);
+			return status;
 		}
 	}
 
@@ -1019,15 +1020,17 @@ int write_data_truncate(uint32_t inode, bool opened, uint32_t uid, uint32_t gid,
 	}
 
 	id->maxfleng = length;
-	// Now we can tell the master server to finish the truncate operation and then unblock the inode
+	// Now we can tell the master server to finish the truncate operation and
+	// then unblock the inode
 	lock.unlock();
 	status = fs_truncateend(inode, uid, gid, length, lockId, attr);
 	write_data_flushwaiting_decrease(id, lock);
 	write_data_lcnt_decrease(id, lock);
 
 	if (status != SAUNAFS_STATUS_OK) {
-		// status is now SFS status, so we cannot return any errno
-		throw UnrecoverableWriteException("fs_truncateend failed", status);
+		safs::log_warn("truncateend on file {} to length {}: {}", inode, length,
+		               saunafs_error_string(status));
+		return status;
 	}
 	return 0;
 }
@@ -1043,9 +1046,9 @@ int write_data_end(void* vid) {
 	return status;
 }
 
-}  // namespace OldWriteAlgorithm
+}  // namespace InodeBasedWriteAlgorithm
 
-namespace NewWriteAlgorithm {
+namespace ChunkBasedWriteAlgorithm {
 
 struct ChunkData;
 
@@ -1134,7 +1137,7 @@ struct ChunkData {
 		newDataInChainPipe[0] = newDataInChainPipe[1] = -1;
 #else
 		if (pipe(newDataInChainPipe) < 0) {
-			safs_pretty_syslog(LOG_WARNING, "creating pipe error: %s", strerr(errno));
+			safs::log_warn("creating pipe error: {}", strerr(errno));
 			newDataInChainPipe[0] = -1;
 		}
 #endif
@@ -1161,7 +1164,7 @@ struct ChunkData {
 		 */
 		if (workerWaitingForData && dataChain.size() == 1 && isDataChainPipeValid()) {
 			if (write(newDataInChainPipe[1], " ", 1) != 1) {
-				safs_pretty_syslog(LOG_ERR, "write pipe error: %s", strerr(errno));
+				safs::log_err("write pipe error: {}", strerr(errno));
 			}
 			workerWaitingForData = false;
 		}
@@ -1220,7 +1223,7 @@ struct DelayedQueueEntry {
 };
 
 static std::atomic<uint32_t> maxretries;
-static std::atomic<uint32_t> gWaveTimeout;
+static std::atomic<uint32_t> gWriteWaveTimeout;
 static std::mutex gMutex;
 
 static std::mutex fcbcondMutex;
@@ -1459,7 +1462,8 @@ void write_job_delayed_end(ChunkData* chunkData, int status, int seconds, Lock &
 	}
 
 	if (status != SAUNAFS_STATUS_OK) {
-		safs_pretty_syslog(LOG_WARNING, "error writing file number %" PRIu32 ": %s", parent->inode, saunafs_error_string(status));
+		safs::log_warn("error writing file number {}: {}", parent->inode,
+		               saunafs_error_string(status));
 		chunkData->updateParentStatus(status);
 	}
 	status = chunkData->getParentStatus();
@@ -1628,9 +1632,8 @@ void ChunkJobWriter::processJob(ChunkData* chunkData) {
 			returnJournalToDataChain(writer.releaseJournal(), inodeLock);
 			inodeLock.unlock();
 
-			safs_pretty_syslog(LOG_WARNING, "write file error, inode: %" PRIu32 ", index: %" PRIu32 " - %s",
-					parent->inode, chunkIndex_, errorString.c_str());
-
+			safs::log_warn("write file error, inode: {}, index: {} - {}", parent->inode,
+			               chunkIndex_, errorString.c_str());
 			if (chunkData_->tryCounter >= maxretries) {
 				// Convert error to an unrecoverable error
 				throw UnrecoverableWriteException(e.message(), e.status());
@@ -1749,7 +1752,7 @@ void ChunkJobWriter::processDataChain(ChunkWriter& writer) {
 					SAUNAFS_ERROR_TIMEOUT);
 		}
 
-		writer.processOperations(gWaveTimeout);
+		writer.processOperations(gWriteWaveTimeout);
 	}
 }
 
@@ -1830,7 +1833,7 @@ void write_data_init(uint32_t cachesize, uint32_t retries, uint32_t workers,
 	gWriteWindowSize = writewindowsize;
 	gChunkserverTimeout_ms = chunkserverTimeout_ms;
 	maxretries = retries;
-	gWaveTimeout = waveTimeout;
+	gWriteWaveTimeout = waveTimeout;
 	if (cacheblockcount < 10) {
 		cacheblockcount = 10;
 	}
@@ -1850,7 +1853,7 @@ void write_data_init(uint32_t cachesize, uint32_t retries, uint32_t workers,
 	pthread_attr_destroy(&thattr);
 
 	gTweaks.registerVariable("WriteMaxRetries", maxretries, "sfsioretries (write)");
-	gTweaks.registerVariable("WriteWaveTimeout", gWaveTimeout, "sfschunkserverwavewriteto");
+	gTweaks.registerVariable("WriteWaveTimeout", gWriteWaveTimeout, "sfschunkserverwavewriteto");
 }
 
 void write_data_term(void) {
@@ -2157,8 +2160,9 @@ int write_data_truncate(uint32_t inode, bool opened, uint32_t uid, uint32_t gid,
 	do {
 		status = fs_truncate(inode, opened, uid, gid, length, writeNeeded, attr, oldLength, lockId);
 		if (status != SAUNAFS_STATUS_OK) {
-			safs_pretty_syslog(LOG_INFO, "truncate file %" PRIu32 " to length %" PRIu64 ": %s (try %d/%d)",
-					inode, length, saunafs_error_string(status), int(retries + 1), int(maxretries));
+			safs::log_info("truncate file {} to length {}: {} (try {}/{})",
+			               inode, length, saunafs_error_string(status),
+			               int(retries + 1), int(maxretries));
 		}
 		if (retries >= maxretries) {
 			break;
@@ -2183,8 +2187,7 @@ int write_data_truncate(uint32_t inode, bool opened, uint32_t uid, uint32_t gid,
 			}
 			return 0;
 		} else {
-			// status is now SFS status, so we cannot return any errno
-			throw UnrecoverableWriteException("fs_truncate failed", status);
+			return status;
 		}
 	}
 
@@ -2238,7 +2241,8 @@ int write_data_truncate(uint32_t inode, bool opened, uint32_t uid, uint32_t gid,
 	}
 
 	id->maxfleng = length;
-	// Now we can tell the master server to finish the truncate operation and then unblock the inode
+	// Now we can tell the master server to finish the truncate operation and
+	// then unblock the inode
 	inodeLock.unlock();
 
 	status = fs_truncateend(inode, uid, gid, length, lockId, attr);
@@ -2248,8 +2252,9 @@ int write_data_truncate(uint32_t inode, bool opened, uint32_t uid, uint32_t gid,
 	write_data_lcnt_decrease(id, inodeLock);
 
 	if (status != SAUNAFS_STATUS_OK) {
-		// status is now SFS status, so we cannot return any errno
-		throw UnrecoverableWriteException("fs_truncateend failed", status);
+		safs::log_warn("truncateend on file {} to length {}: {}", inode, length,
+		               saunafs_error_string(status));
+		return status;
 	}
 	return 0;
 }
@@ -2268,80 +2273,81 @@ int write_data_end(void* vid) {
 	return status;
 }
 
-}  // namespace NewWriteAlgorithm
+}  // namespace ChunkBasedWriteAlgorithm
 
 void write_data_init(uint32_t cachesize, uint32_t retries, uint32_t workers,
                      uint32_t writewindowsize, uint32_t chunkserverTimeout_ms,
                      uint32_t cachePerInodePercentage, uint32_t waveTimeout) {
-	if (gUseOldWriteAlgorithm) {
-		OldWriteAlgorithm::write_data_init(
+	if (gUseInodeBasedWriteAlgorithm) {
+		InodeBasedWriteAlgorithm::write_data_init(
 		    cachesize, retries, workers, writewindowsize, chunkserverTimeout_ms,
 		    cachePerInodePercentage, waveTimeout);
 	} else {
-		NewWriteAlgorithm::write_data_init(
+		ChunkBasedWriteAlgorithm::write_data_init(
 		    cachesize, retries, workers, writewindowsize, chunkserverTimeout_ms,
 		    cachePerInodePercentage, waveTimeout);
 	}
 }
 
 void write_data_term(void) {
-	if (gUseOldWriteAlgorithm) {
-		OldWriteAlgorithm::write_data_term();
+	if (gUseInodeBasedWriteAlgorithm) {
+		InodeBasedWriteAlgorithm::write_data_term();
 	} else {
-		NewWriteAlgorithm::write_data_term();
+		ChunkBasedWriteAlgorithm::write_data_term();
 	}
 }
 
 void *write_data_new(uint32_t inode) {
-	if (gUseOldWriteAlgorithm) {
-		return OldWriteAlgorithm::write_data_new(inode);
+	if (gUseInodeBasedWriteAlgorithm) {
+		return InodeBasedWriteAlgorithm::write_data_new(inode);
 	}
-	return NewWriteAlgorithm::write_data_new(inode);
+	return ChunkBasedWriteAlgorithm::write_data_new(inode);
 }
 
 int write_data_end(void *vid) {
-	if (gUseOldWriteAlgorithm) {
-		return OldWriteAlgorithm::write_data_end(vid);
+	if (gUseInodeBasedWriteAlgorithm) {
+		return InodeBasedWriteAlgorithm::write_data_end(vid);
 	}
-	return NewWriteAlgorithm::write_data_end(vid);
+	return ChunkBasedWriteAlgorithm::write_data_end(vid);
 }
 
 int write_data_flush(void *vid) {
-	if (gUseOldWriteAlgorithm) {
-		return OldWriteAlgorithm::write_data_flush(vid);
+	if (gUseInodeBasedWriteAlgorithm) {
+		return InodeBasedWriteAlgorithm::write_data_flush(vid);
 	}
-	return NewWriteAlgorithm::write_data_flush(vid);
+	return ChunkBasedWriteAlgorithm::write_data_flush(vid);
 }
 
 uint64_t write_data_getmaxfleng(uint32_t inode) {
-	if (gUseOldWriteAlgorithm) {
-		return OldWriteAlgorithm::write_data_getmaxfleng(inode);
+	if (gUseInodeBasedWriteAlgorithm) {
+		return InodeBasedWriteAlgorithm::write_data_getmaxfleng(inode);
 	}
-	return NewWriteAlgorithm::write_data_getmaxfleng(inode);
+	return ChunkBasedWriteAlgorithm::write_data_getmaxfleng(inode);
 }
 
 int write_data_flush_inode(uint32_t inode) {
-	if (gUseOldWriteAlgorithm) {
-		return OldWriteAlgorithm::write_data_flush_inode(inode);
+	if (gUseInodeBasedWriteAlgorithm) {
+		return InodeBasedWriteAlgorithm::write_data_flush_inode(inode);
 	}
-	return NewWriteAlgorithm::write_data_flush_inode(inode);
+	return ChunkBasedWriteAlgorithm::write_data_flush_inode(inode);
 }
 
 int write_data_truncate(uint32_t inode, bool opened, uint32_t uid, uint32_t gid,
                         uint64_t length, Attributes &attr) {
-	if (gUseOldWriteAlgorithm) {
-		return OldWriteAlgorithm::write_data_truncate(inode, opened, uid, gid,
-		                                              length, attr);
+	if (gUseInodeBasedWriteAlgorithm) {
+		return InodeBasedWriteAlgorithm::write_data_truncate(inode, opened, uid,
+		                                                     gid, length, attr);
 	}
-	return NewWriteAlgorithm::write_data_truncate(inode, opened, uid, gid,
-	                                              length, attr);
+	return ChunkBasedWriteAlgorithm::write_data_truncate(inode, opened, uid,
+	                                                     gid, length, attr);
 }
 
 int write_data(void *vid, uint64_t offset, uint32_t size, const uint8_t *buff,
                size_t currentSize) {
-	if (gUseOldWriteAlgorithm) {
-		return OldWriteAlgorithm::write_data(vid, offset, size, buff,
-		                                     currentSize);
+	if (gUseInodeBasedWriteAlgorithm) {
+		return InodeBasedWriteAlgorithm::write_data(vid, offset, size, buff,
+		                                            currentSize);
 	}
-	return NewWriteAlgorithm::write_data(vid, offset, size, buff, currentSize);
+	return ChunkBasedWriteAlgorithm::write_data(vid, offset, size, buff,
+	                                            currentSize);
 }

--- a/src/mount/writedata.cc
+++ b/src/mount/writedata.cc
@@ -63,35 +63,33 @@
 #include "protocol/SFSCommunication.h"
 
 #define IDLE_CONNECTION_TIMEOUT 6
+#define NO_INODEDATA nullptr
+#define NO_CHUNKDATA nullptr
 
 namespace {
 
 struct ChunkData;
 
+using Lock = std::unique_lock<std::mutex>;
+using ChunkDataPtr = std::unique_ptr<ChunkData>;
+
 struct inodedata {
 	uint32_t inode;
-	uint64_t maxfleng;
-	int status;
-	uint16_t flushwaiting;
-	uint16_t writewaiting;
-	uint16_t lcnt;
-	std::condition_variable flushcond; // wait for !inqueue (flush)
-	std::condition_variable writecond; // wait for flushwaiting==0 (write)
-	std::atomic<ChunkData *> chunksDataFirst;
-	std::atomic<uint64_t> totalCachedBlocks;
-	Timer lastWriteToDataChain;
-	Timer lastWriteToChunkservers;
+	uint64_t maxfleng = 0;           // inodeLock
+	int status = SAUNAFS_STATUS_OK;  // inodeLock
+	uint16_t flushwaiting = 0;       // inodeLock
+	uint16_t writewaiting = 0;       // inodeLock
+	std::atomic<uint16_t> lcnt = 0;
+	std::condition_variable flushcond;  // wait for !inqueue (flush): using globalLock
+	std::condition_variable writecond;  // wait for flushwaiting==0 (write): using inodeLock
+	std::list<ChunkDataPtr> chunkDataList;
+	std::atomic_bool emptyChunkDataList = true;
+	std::atomic<uint64_t> totalCachedBlocks = 0;
+	std::mutex mutex;
+	Timer lastWriteToDataChain;     // inodeLock
+	Timer lastWriteToChunkservers;  // inodeLock
 
-	inodedata(uint32_t inode)
-			: inode(inode),
-			  maxfleng(0),
-			  status(SAUNAFS_STATUS_OK),
-			  flushwaiting(0),
-			  writewaiting(0),
-			  lcnt(0),
-			  chunksDataFirst(nullptr),
-			  totalCachedBlocks(0) {
-	}
+	inodedata(uint32_t inode) : inode(inode) {}
 
 	/*! Check if inode requires flushing all its data chain to chunkservers.
 	 *
@@ -99,9 +97,9 @@ struct inodedata {
 	 * or write_data_flush_inode or the data in data chain is too old to keep it longer in
 	 * our buffers. If this function returns false, we write only full stripes from data
 	 * chain to chunkservers.
-	 * glock: LOCKED
+	 * inodeLock: LOCKED
 	 */
-	bool requiresFlushing() const {
+	bool requiresFlushing() {
 		return (flushwaiting > 0 ||
 		        lastWriteToDataChain.elapsed_ms() >=
 		            kMaximumTimeInDataChainSinceLastWrite_ms ||
@@ -135,27 +133,21 @@ private:
 	static const uint32_t kVeryRecentWrite_ms = 5;
 };
 
+using InodeDataPtr = std::unique_ptr<inodedata>;
+
 struct ChunkData {
 	uint32_t chunkIndex;
-	uint16_t tryCounter;
+	uint16_t tryCounter = 0;
 	int newDataInChainPipe[2];
-	uint32_t minimumBlocksToWrite;
+	uint32_t minimumBlocksToWrite = 1;
 	std::list<WriteCacheBlock> dataChain;
-	bool inQueue; // true it this chunk is waiting in one of the queues or is being processed
-	bool workerWaitingForData;
-	ChunkData *next; // for iterating through the chunkdata of an inode
+	bool inQueue = false;  // true if this chunk is waiting in one of the queues or is being processed
+	bool workerWaitingForData = false;
 	std::unique_ptr<WriteChunkLocator> locator;
-	std::atomic<int> beingWritten;
+	std::atomic<int> writesCount = 0;
 
 	ChunkData(uint32_t chunkIndex, inodedata *parent)
-	    : chunkIndex(chunkIndex),
-	      tryCounter(0),
-	      minimumBlocksToWrite(1),
-	      inQueue(false),
-	      workerWaitingForData(false),
-	      next(nullptr),
-	      beingWritten(0),
-	      parent_(parent) {
+	    : chunkIndex(chunkIndex), parent_(parent) {
 #ifdef _WIN32
 		// We don't use inodeData->waitingworker and inodeData->pipe on Cygwin because
 		// Cygwin's implementation of mixed socket & pipe polling is very inefficient.
@@ -176,12 +168,12 @@ struct ChunkData {
 		}
 	}
 
-	/* glock: UNUSED */
+	/* inodeLock: UNUSED */
 	bool isDataChainPipeValid() const {
 		return newDataInChainPipe[0] >= 0;
 	}
 
-	/* glock: LOCKED */
+	/* inodeLock: LOCKED */
 	void wakeUpWorkerIfNecessary() {
 		/*
 		 * Write worker always looks for the first block in chain and we modify or add always the
@@ -196,39 +188,42 @@ struct ChunkData {
 		}
 	}
 
+	/* inodeLock: LOCKED */
 	void pushToChain(WriteCacheBlock &&block) {
-		dataChain.push_back(std::move(block));
+		dataChain.emplace_back(std::move(block));
 		parent_->totalCachedBlocks++;
 	}
 
+	/* inodeLock: LOCKED */
 	void popFromChain() {
 		assert(dataChain.size() > 0);
 		dataChain.pop_front();
 		parent_->totalCachedBlocks--;
 	}
 
+	/* inodeLock: LOCKED */
 	void updateParentStatus(int8_t status) { parent_->status = status; }
 
+	/* inodeLock: LOCKED */
 	int8_t getParentStatus() {
 		return parent_->status;
 	}
 
+	/* inodeLock: LOCKED */
 	bool requiresFlushing() const {
 		return parent_->requiresFlushing();
 	}
 
+	/* inodeLock: LOCKED */
 	void clear() {
 		parent_->totalCachedBlocks -= dataChain.size();
 		dataChain.clear();
 	}
 
-	bool parentIsDone() const {
-		return parent_->chunksDataFirst == nullptr;
+	/* inodeLock: UNUSED */
+	inline inodedata *getParent() const {
+		return parent_;
 	}
-
-	void notifyParentFlushcond() { parent_->flushcond.notify_all(); }
-
-	inline inodedata *getParent() const { return parent_; }
 
 private:
 	inodedata *parent_; // contains inode and other useful data
@@ -249,11 +244,11 @@ struct DelayedQueueEntry {
 
 static std::atomic<uint32_t> maxretries;
 static std::mutex gMutex;
-typedef std::unique_lock<std::mutex> Glock;
 
+static std::mutex fcbcondMutex;
 static std::condition_variable fcbcond;
-static uint32_t fcbwaiting = 0;
-static int64_t freecacheblocks;
+static std::atomic<uint32_t> fcbwaiting = 0;
+static std::atomic<int64_t> freecacheblocks;
 
 // <inode, respective inodedata> and sorted by inode
 using InodeDataMap = std::map<uint32_t, inodedata *>;
@@ -276,41 +271,50 @@ static std::list<DelayedQueueEntry> delayedQueue;
 static ConnectionPool gChunkserverConnectionPool;
 static ChunkConnectorUsingPool gChunkConnector(gChunkserverConnectionPool);
 
-void write_cb_release_blocks(uint32_t count, Glock&) {
+/* globalLock: UNLOCKED*/
+void write_cb_release_blocks(uint32_t count) {
 	freecacheblocks += count;
 	if (fcbwaiting > 0 && freecacheblocks > 0) {
-		fcbcond.notify_all();
+		Lock fcbcondLock(fcbcondMutex);
+		if (count == 1) {
+			fcbcond.notify_one();
+		} else {
+			fcbcond.notify_all();
+		}
 	}
 }
 
-void write_cb_acquire_blocks(uint32_t count, Glock&) {
+/* globalLock: UNLOCKED*/
+void write_cb_acquire_blocks(uint32_t count) {
 	freecacheblocks -= count;
 }
 
-void write_cb_wait_for_block(inodedata* id, Glock& glock) {
+/* globalLock: UNLOCKED*/
+void write_cb_wait_for_block(inodedata* id) {
 	LOG_AVG_TILL_END_OF_SCOPE0("write_cb_wait_for_block");
 	fcbwaiting++;
 	uint64_t totalCachedBlocks = id->totalCachedBlocks;
+	Lock fcbcondLock(fcbcondMutex);
 	while (freecacheblocks <= 0
 	       // totalCachedBlocks / (totalCachedBlocks + freecacheblocks) >
 	       // gCachePerInodePercentage / 100 really means "0 > 0"
 	       || totalCachedBlocks * 100 > (totalCachedBlocks + freecacheblocks) *
 	                                        gCachePerInodePercentage) {
-		fcbcond.wait(glock);
+		fcbcond.wait(fcbcondLock);
 	}
 	fcbwaiting--;
 }
 
 /* inode */
 
-inodedata *write_find_inodedata(uint32_t inode, Glock &) {
+inodedata *write_find_inodedata(uint32_t inode, Lock &) {
 	if (inodedataMap.contains(inode)) {
 		return inodedataMap[inode];
 	}
-	return NULL;
+	return NO_INODEDATA;
 }
 
-inodedata *write_get_inodedata(uint32_t inode, Glock &) {
+inodedata *write_get_inodedata(uint32_t inode, Lock &) {
 	if (inodedataMap.contains(inode)) {
 		return inodedataMap[inode];
 	}
@@ -319,7 +323,7 @@ inodedata *write_get_inodedata(uint32_t inode, Glock &) {
 	return id;
 }
 
-void write_free_inodedata(inodedata *fid, Glock &) {
+void write_free_inodedata(inodedata *fid, Lock &) {
 	uint32_t inode = fid->inode;
 	if (!inodedataMap.contains(inode)) {
 		return;
@@ -331,56 +335,65 @@ void write_free_inodedata(inodedata *fid, Glock &) {
 	inodedataMap.erase(inode);
 }
 
-ChunkData *write_get_chunkdata(uint32_t chunk, inodedata *id) {
-	ChunkData *chunkData;
-	for (ChunkData *chunkData = id->chunksDataFirst; chunkData;
-	     chunkData = chunkData->next) {
-		if (chunkData->chunkIndex == chunk) {
-			return chunkData;
-		}
+/* chunk */
+
+/* inodeLock: LOCKED*/
+ChunkData *write_get_chunkdata(uint32_t chunkIndex, inodedata *id,
+                               Lock &inodeLock) {
+	auto chunkDataListIt =
+	    std::find_if(id->chunkDataList.begin(), id->chunkDataList.end(),
+	                 [&](ChunkDataPtr &chunkData) {
+		                 return chunkData->chunkIndex == chunkIndex;
+	                 });
+	if (chunkDataListIt != id->chunkDataList.end()) {
+		return chunkDataListIt->get();
 	}
-	chunkData = new ChunkData(chunk, id);
-	chunkData->next = id->chunksDataFirst;
-	id->chunksDataFirst = chunkData;
-	Glock lock(gMutex);
+	id->chunkDataList.emplace_front(new ChunkData(chunkIndex, id));
+	auto& chunkData = id->chunkDataList.front();
+	id->emptyChunkDataList = false;
+	inodeLock.unlock();
+
+	Lock globalLock(gMutex);
 	auto it = truncateLocatorsData.find(id->inode);
 	if (it != truncateLocatorsData.end()) {
 		auto [lockid, endoffset] = it->second;
-		chunkData->locator.reset(
-		    new TruncateWriteChunkLocator(id->inode, chunk, lockid, endoffset));
+		globalLock.unlock();
+
+		inodeLock.lock();
+		chunkData->locator = std::make_unique<TruncateWriteChunkLocator>(
+		    id->inode, chunkIndex, lockid, endoffset);
+		inodeLock.unlock();
+		globalLock.lock();
 	}
-	return chunkData;
+	globalLock.unlock();
+	inodeLock.lock();
+	return chunkData.get();
 }
 
-void write_free_chunkdata(ChunkData *fChunkData) {
+/* inodeLock: LOCKED*/
+void write_free_chunkdata(ChunkData *fChunkData, Lock &) {
 	inodedata *id = fChunkData->getParent();
-	ChunkData *cpyChunksDataFirst = id->chunksDataFirst;
-	ChunkData *chunkData, **chunkDataPtr = &(cpyChunksDataFirst);
-	sassert(id->chunksDataFirst != nullptr);
-	bool isFirst = true;
-	while ((chunkData = *chunkDataPtr)) {
-		if (chunkData == fChunkData) {
-			if (isFirst) {
-				id->chunksDataFirst = chunkData->next;
-			} else {
-				*chunkDataPtr = chunkData->next;
-			}
-			delete chunkData;
-			return;
-		}
-		chunkDataPtr = &(chunkData->next);
-		sassert(*chunkDataPtr != nullptr);
-		isFirst = false;
+	sassert(!id->chunkDataList.empty());
+
+	auto chunkDataListIt = std::find_if(
+	    id->chunkDataList.begin(), id->chunkDataList.end(),
+	    [&](ChunkDataPtr &chunkData) { return chunkData.get() == fChunkData; });
+	if (chunkDataListIt != id->chunkDataList.end()) {
+		id->chunkDataList.erase(chunkDataListIt);
+		id->emptyChunkDataList = id->chunkDataList.empty();
 	}
 }
 
 /* delayed queue */
 
-static void delayed_queue_put(ChunkData* chunkData, uint32_t seconds, Glock&) {
-	delayedQueue.push_back(DelayedQueueEntry(chunkData, seconds * DelayedQueueEntry::kTicksPerSecond));
+/* globalLock: LOCKED*/
+static void delayed_queue_put(ChunkData *chunkData, uint32_t seconds, Lock &) {
+	delayedQueue.emplace_back(DelayedQueueEntry(
+	    chunkData, seconds * DelayedQueueEntry::kTicksPerSecond));
 }
 
-static bool delayed_queue_remove(ChunkData* chunkData, Glock&) {
+/* globalLock: LOCKED*/
+static bool delayed_queue_remove(ChunkData* chunkData, Lock&) {
 	for (auto it = delayedQueue.begin(); it != delayedQueue.end(); ++it) {
 		if (it->chunkData == chunkData) {
 			delayedQueue.erase(it);
@@ -390,16 +403,21 @@ static bool delayed_queue_remove(ChunkData* chunkData, Glock&) {
 	return false;
 }
 
-static std::vector<ChunkData*> delayed_queue_remove(inodedata *id, Glock &) {
-	std::vector<ChunkData*> removedChunkData;
-	for (auto it = delayedQueue.begin(); it != delayedQueue.end();) {
-		if (it->chunkData->getParent() == id) {
-			removedChunkData.push_back(it->chunkData);
-			it = delayedQueue.erase(it);
-		} else {
-			it++;
-		}
-	}
+/* globalLock: LOCKED*/
+static std::vector<ChunkData *> delayed_queue_remove(inodedata *id, Lock &) {
+	std::vector<ChunkData *> removedChunkData;
+
+	auto it =
+	    std::remove_if(delayedQueue.begin(), delayedQueue.end(),
+	                   [&](const DelayedQueueEntry &entry) {
+		                   if (entry.chunkData->getParent() == id) {
+			                   removedChunkData.push_back(entry.chunkData);
+			                   return true;
+		                   }
+		                   return false;
+	                   });
+
+	delayedQueue.erase(it, delayedQueue.end());
 	return removedChunkData;
 }
 
@@ -408,10 +426,10 @@ void* delayed_queue_worker(void*) {
 
 	for (;;) {
 		Timeout timeout(std::chrono::microseconds(1000000 / DelayedQueueEntry::kTicksPerSecond));
-		Glock lock(gMutex);
+		Lock globalLock(gMutex);
 		auto it = delayedQueue.begin();
 		while (it != delayedQueue.end()) {
-			if (it->chunkData == NULL) {
+			if (it->chunkData == NO_CHUNKDATA) {
 				return NULL;
 			}
 			if (--it->ticksLeft <= 0) {
@@ -422,7 +440,7 @@ void* delayed_queue_worker(void*) {
 				++it;
 			}
 		}
-		lock.unlock();
+		globalLock.unlock();
 		usleep(timeout.remaining_us());
 	}
 	return NULL;
@@ -430,31 +448,38 @@ void* delayed_queue_worker(void*) {
 
 /* queues */
 
-void write_delayed_enqueue(ChunkData* chunkData, uint32_t seconds, Glock& lock) {
+/* globalLock: LOCKED*/
+void write_delayed_enqueue(ChunkData* chunkData, uint32_t seconds, Lock& globalLock) {
 	if (seconds > 0) {
-		delayed_queue_put(chunkData, seconds, lock);
+		delayed_queue_put(chunkData, seconds, globalLock);
 	} else {
 		jobsQueue->put(0, 0, reinterpret_cast<uint8_t*>(chunkData), 0);
 	}
 }
 
-void write_enqueue(ChunkData *chunkData, Glock &) {
+void write_enqueue(ChunkData *chunkData, Lock &) {
 	jobsQueue->put(0, 0, reinterpret_cast<uint8_t*>(chunkData), 0);
 }
 
-void write_enqueue(std::vector<ChunkData *> &chunks, Glock &) {
+/* globalLock: LOCKED*/
+void write_enqueue(std::vector<ChunkData *> &chunks, Lock &) {
 	for (auto chunk : chunks) {
 		jobsQueue->put(0, 0, reinterpret_cast<uint8_t *>(chunk), 0);
 	}
 }
 
-void write_job_delayed_end(ChunkData* chunkData, int status, int seconds, Glock &lock) {
+/* globalLock: LOCKED*/
+void write_job_delayed_end(ChunkData* chunkData, int status, int seconds, Lock &globalLock) {
 	LOG_AVG_TILL_END_OF_SCOPE0("write_job_delayed_end");
 	LOG_AVG_TILL_END_OF_SCOPE1("write_job_delayed_end#sec", seconds);
 	inodedata *parent = chunkData->getParent();
+	globalLock.unlock();
+
+	Lock inodeLock(parent->mutex);
 	if (chunkData->locator != nullptr && chunkData->locator->shouldReset()) {
 		chunkData->locator.reset();
 	}
+
 	if (status != SAUNAFS_STATUS_OK) {
 		safs_pretty_syslog(LOG_WARNING, "error writing file number %" PRIu32 ": %s", parent->inode, saunafs_error_string(status));
 		chunkData->updateParentStatus(status);
@@ -464,41 +489,69 @@ void write_job_delayed_end(ChunkData* chunkData, int status, int seconds, Glock 
 		// Don't sleep if we have to write all the data immediately
 		seconds = 0;
 	}
-	if (chunkData->beingWritten) {
-		write_enqueue(chunkData, lock);
-	} else if (!chunkData->dataChain.empty() && status == SAUNAFS_STATUS_OK) { // still have some work to do
-		chunkData->tryCounter = 0; // on good write reset try counter
-		write_delayed_enqueue(chunkData, seconds, lock);
-	} else {        // no more work or error occurred
+	if (chunkData->writesCount > 0) {
+		inodeLock.unlock();
+
+		globalLock.lock();
+		write_enqueue(chunkData, globalLock);
+	} else if (!chunkData->dataChain.empty() &&
+	           status == SAUNAFS_STATUS_OK) {  // still have some work to do
+		chunkData->tryCounter = 0;  // on good write reset try counter
+		inodeLock.unlock();
+
+		globalLock.lock();
+		write_delayed_enqueue(chunkData, seconds, globalLock);
+	} else {  // no more work or error occurred
 		// if this is an error then release all data blocks
-		write_cb_release_blocks(chunkData->dataChain.size(), lock);
+		write_cb_release_blocks(chunkData->dataChain.size());
+
 		chunkData->clear();
 		// We don't reset maxfleng (id->maxfleng = 0;) for a while longer, to
 		// have its value ready to some quick cache responses in lookup and
 		// getattr syscalls
-		write_free_chunkdata(chunkData);
-		if (parent->chunksDataFirst == nullptr) {
+		write_free_chunkdata(chunkData, inodeLock);
+		inodeLock.unlock();
+
+		globalLock.lock();
+		if (parent->emptyChunkDataList) {
 			parent->flushcond.notify_all();
 		}
 	}
 }
 
-void write_job_end(ChunkData* chunkData, int status, Glock &lock) {
-	write_job_delayed_end(chunkData, status, 0, lock);
+/* globalLock: LOCKED*/
+void write_job_end(ChunkData *chunkData, int status, Lock &globalLock) {
+	write_job_delayed_end(chunkData, status, 0, globalLock);
 }
 
 class ChunkJobWriter {
 public:
-	ChunkJobWriter() : chunkData_(nullptr), chunkIndex_(0) {}
 	void processJob(ChunkData* chunkData);
 
 private:
 	void processDataChain(ChunkWriter& writer);
-	void returnJournalToDataChain(std::list<WriteCacheBlock>&& journal, Glock&);
-	bool haveAnyBlockInCurrentChunk(Glock&);
-	bool haveBlockWorthWriting(uint32_t unfinishedOperationCount, Glock&);
-	ChunkData* chunkData_;
-	uint32_t chunkIndex_;
+
+	/*
+	* Returns pending operations to datachain.
+	* inodeLock: LOCKED
+	*/
+	void returnJournalToDataChain(std::list<WriteCacheBlock>&& journal, Lock&);
+
+	/*
+	* Check if there is any data in the same chunk waiting to be written.
+	* inodeLock: LOCKED
+	*/
+	bool haveAnyBlockInCurrentChunk(Lock&);
+
+	/*
+	* Check if there is any data worth sending to the chunkserver.
+	* We will avoid sending blocks of size different than SFSBLOCKSIZE.
+	* These can be taken only if we are close to run out of tasks to do.
+	* inodeLock: LOCKED
+	*/
+	bool haveBlockWorthWriting(uint32_t unfinishedOperationCount, Lock&);
+	ChunkData* chunkData_ = NO_CHUNKDATA;
+	uint32_t chunkIndex_ = 0;
 	Timer wholeOperationTimer;
 
 	// Maximum time of writing one chunk
@@ -529,25 +582,23 @@ void ChunkJobWriter::processJob(ChunkData* chunkData) {
 	try {
 		try {
 			locator->locateAndLockChunk(parent->inode, chunkIndex_);
-			Glock lock(gMutex);
+			Lock inodeLock(parent->mutex);
 			parent->maxfleng =
 			    std::max(parent->maxfleng, locator->fileLength());
-			lock.unlock();
 
 			// Optimization -- talk with chunkservers only if we have to write any data.
 			// Don't do this if we just have to release some previously unlocked lock.
-			if (haveAnyBlockInCurrentChunk(lock)) {
+			if (haveAnyBlockInCurrentChunk(inodeLock)) {
+				inodeLock.unlock();
 				writer.init(locator.get(), gChunkserverTimeout_ms);
 				processDataChain(writer);
 				writer.finish(kTimeToFinishOperations * 1000);
 
-				lock.lock();
-				returnJournalToDataChain(writer.releaseJournal(), lock);
-				lock.unlock();
+				inodeLock.lock();
+				returnJournalToDataChain(writer.releaseJournal(), inodeLock);
 			}
 
-			for (ChunkData *it = parent->chunksDataFirst; it;
-			     it = it->next) {
+			for (auto const &it : parent->chunkDataList) {
 				if (it->chunkIndex > chunkData_->chunkIndex) {
 					// set it to 0 in order to don't update master size of the
 					// file
@@ -555,13 +606,15 @@ void ChunkJobWriter::processJob(ChunkData* chunkData) {
 					break;
 				}
 			}
+			inodeLock.unlock();
+
 			locator->unlockChunk();
 			read_inode_reconnect_and_clear_cache(parent->inode, chunkIndex_);
 
-			lock.lock();
+			inodeLock.lock();
 			chunkData_->minimumBlocksToWrite = writer.getMinimumBlockCountWorthWriting();
 			bool canWait = !chunkData_->requiresFlushing();
-			if (!haveAnyBlockInCurrentChunk(lock)) {
+			if (!haveAnyBlockInCurrentChunk(inodeLock)) {
 				// There is no need to wait if we have just finished writing some chunk.
 				// Let's immediately start writing the next chunk (if there is any).
 				canWait = false;
@@ -573,12 +626,15 @@ void ChunkJobWriter::processJob(ChunkData* chunkData) {
 				chunkData_->locator = std::move(locator);
 			}
 
-			write_job_delayed_end(chunkData_, SAUNAFS_STATUS_OK, (canWait ? 1 : 0), lock);
+			inodeLock.unlock();
+
+			Lock globalLock(gMutex);
+			write_job_delayed_end(chunkData_, SAUNAFS_STATUS_OK, (canWait ? 1 : 0), globalLock);
 		} catch (Exception& e) {
 			std::string errorString = e.what();
 			addPathByInodeBasedNotificationMessage(
 			    "Write error: " + std::string(e.what()), parent->inode);
-			Glock lock(gMutex);
+			Lock inodeLock(parent->mutex);
 			if (e.status() != SAUNAFS_ERROR_LOCKED) {
 				chunkData_->tryCounter++;
 				errorString += " (try counter: " + std::to_string(chunkData->tryCounter) + ")";
@@ -591,8 +647,8 @@ void ChunkJobWriter::processJob(ChunkData* chunkData) {
 			// Keep the lock
 			chunkData_->locator = std::move(locator);
 			// Move data left in the journal into front of the write cache
-			returnJournalToDataChain(writer.releaseJournal(), lock);
-			lock.unlock();
+			returnJournalToDataChain(writer.releaseJournal(), inodeLock);
+			inodeLock.unlock();
 
 			safs_pretty_syslog(LOG_WARNING, "write file error, inode: %" PRIu32 ", index: %" PRIu32 " - %s",
 					parent->inode, chunkIndex_, errorString.c_str());
@@ -608,27 +664,28 @@ void ChunkJobWriter::processJob(ChunkData* chunkData) {
 	} catch (UnrecoverableWriteException& e) {
 		addPathByInodeBasedNotificationMessage(
 		    "Write error: " + std::string(e.what()), parent->inode);
-		Glock lock(gMutex);
+		Lock globalLock(gMutex);
 		if (e.status() == SAUNAFS_ERROR_ENOENT) {
-			write_job_end(chunkData_, SAUNAFS_ERROR_EBADF, lock);
+			write_job_end(chunkData_, SAUNAFS_ERROR_EBADF, globalLock);
 		} else if (e.status() == SAUNAFS_ERROR_QUOTA) {
-			write_job_end(chunkData_, SAUNAFS_ERROR_QUOTA, lock);
-		} else if (e.status() == SAUNAFS_ERROR_NOSPACE || e.status() == SAUNAFS_ERROR_NOCHUNKSERVERS) {
-			write_job_end(chunkData_, SAUNAFS_ERROR_NOSPACE, lock);
+			write_job_end(chunkData_, SAUNAFS_ERROR_QUOTA, globalLock);
+		} else if (e.status() == SAUNAFS_ERROR_NOSPACE ||
+		           e.status() == SAUNAFS_ERROR_NOCHUNKSERVERS) {
+			write_job_end(chunkData_, SAUNAFS_ERROR_NOSPACE, globalLock);
 		} else {
-			write_job_end(chunkData_, SAUNAFS_ERROR_IO, lock);
+			write_job_end(chunkData_, SAUNAFS_ERROR_IO, globalLock);
 		}
 	} catch (Exception& e) {
 		if (chunkData_->tryCounter > kMinTryCounterToShowWriteErrorMessage) {
 			addPathByInodeBasedNotificationMessage(
 			    "Write error: " + std::string(e.what()), parent->inode);
 		}
-		Glock lock(gMutex);
+		Lock globalLock(gMutex);
 		int waitTime = 1;
 		if (chunkData_->tryCounter > 10) {
 			waitTime = std::min<int>(10, chunkData_->tryCounter - 9);
 		}
-		write_delayed_enqueue(chunkData_, waitTime, lock);
+		write_delayed_enqueue(chunkData_, waitTime, globalLock);
 	}
 }
 
@@ -657,15 +714,19 @@ void ChunkJobWriter::processDataChain(ChunkWriter& writer) {
 		bool can_expect_next_block = true;
 		if (wholeOperationTimer.elapsed_s() + kTimeToFinishOperations < maximumTime
 				&& writer.acceptsNewOperations()) {
-			Glock lock(gMutex);
+			Lock inodeLock(parent->mutex);
 			// While there is any block worth sending, we add new write operation
-			while (haveBlockWorthWriting(writer.getUnfinishedOperationsCount(), lock)) {
+			while (haveBlockWorthWriting(writer.getUnfinishedOperationsCount(), inodeLock)) {
 				// Remove block from cache and pass it to the writer
 				writer.addOperation(std::move(chunkData_->dataChain.front()));
 				chunkData_->popFromChain();
-				write_cb_release_blocks(1, lock);
+				inodeLock.unlock();
+
+				write_cb_release_blocks(1);
+
+				inodeLock.lock();
 			}
-			if (chunkData_->requiresFlushing() && !haveAnyBlockInCurrentChunk(lock)) {
+			if (chunkData_->requiresFlushing() && !haveAnyBlockInCurrentChunk(inodeLock)) {
 				// No more data and some flushing is needed or required, so flush everything
 				writer.startFlushMode();
 			}
@@ -673,11 +734,11 @@ void ChunkJobWriter::processDataChain(ChunkWriter& writer) {
 				chunkData_->workerWaitingForData = true;
 			}
 			can_expect_next_block =
-			    haveAnyBlockInCurrentChunk(lock) ||
+			    haveAnyBlockInCurrentChunk(inodeLock) ||
 			    (parent->wasLastBlockRecentlyWritten() && !chunkData_->dataChain.empty());
 		} else if (writer.acceptsNewOperations()) {
 			// We are running out of time...
-			Glock lock(gMutex);
+			Lock inodeLock(parent->mutex);
 			if (!chunkData_->requiresFlushing()) {
 				// Nobody is waiting for the data to be flushed and the data in write chain
 				// isn't too old. Let's postpone any operations
@@ -688,19 +749,19 @@ void ChunkJobWriter::processDataChain(ChunkWriter& writer) {
 				writer.startFlushMode();
 			}
 			can_expect_next_block =
-			    haveAnyBlockInCurrentChunk(lock) ||
+			    haveAnyBlockInCurrentChunk(inodeLock) ||
 			    (parent->wasLastBlockRecentlyWritten() && !chunkData_->dataChain.empty());
 		}
 
-		Glock lock(gMutex);
+		Lock inodeLock(parent->mutex);
 		writer.setChunkSizeInBlocks(
 		    std::min(parent->maxfleng - chunkIndex_ * SFSCHUNKSIZE,
 		             (uint64_t)SFSCHUNKSIZE));
-		lock.unlock();
+		inodeLock.unlock();
 		if (writer.startNewOperations(can_expect_next_block) > 0) {
-			lock.lock();
+			inodeLock.lock();
 			parent->lastWriteToChunkservers.reset();
-			lock.unlock();
+			inodeLock.unlock();
 		}
 		if (writer.getPendingOperationsCount() == 0) {
 			return;
@@ -716,31 +777,25 @@ void ChunkJobWriter::processDataChain(ChunkWriter& writer) {
 }
 
 void ChunkJobWriter::returnJournalToDataChain(
-    std::list<WriteCacheBlock> &&journal, Glock &lock) {
+    std::list<WriteCacheBlock> &&journal, Lock &inodeLock) {
 	if (!journal.empty()) {
-		write_cb_acquire_blocks(journal.size(), lock);
+		inodeLock.unlock();
+		write_cb_acquire_blocks(journal.size());
+		inodeLock.lock();
+
 		chunkData_->getParent()->totalCachedBlocks += journal.size();
 		chunkData_->dataChain.splice(chunkData_->dataChain.begin(),
 		                             std::move(journal));
 	}
 }
 
-/*
- * Check if there is any data in the same chunk waiting to be written.
- */
-bool ChunkJobWriter::haveAnyBlockInCurrentChunk(Glock&) {
+bool ChunkJobWriter::haveAnyBlockInCurrentChunk(Lock&) {
 	return !chunkData_->dataChain.empty();
 }
 
-/*
- * Check if there is any data worth sending to the chunkserver.
- * We will avoid sending blocks of size different than SFSBLOCKSIZE.
- * These can be taken only if we are close to run out of tasks to do.
- * glock: LOCKED
- */
 bool ChunkJobWriter::haveBlockWorthWriting(uint32_t unfinishedOperationCount,
-                                           Glock &lock) {
-	if (!haveAnyBlockInCurrentChunk(lock)) {
+                                           Lock &inodeLock) {
+	if (!haveAnyBlockInCurrentChunk(inodeLock)) {
 		return false;
 	}
 	const auto& block = chunkData_->dataChain.front();
@@ -759,7 +814,7 @@ bool ChunkJobWriter::haveBlockWorthWriting(uint32_t unfinishedOperationCount,
 	}
 }
 
-/* main working thread | glock:UNLOCKED */
+/* main working thread | globalLock:UNLOCKED */
 void* write_worker(void*) {
 	ChunkJobWriter chunkJobWriter;
 
@@ -775,7 +830,7 @@ void* write_worker(void*) {
 			LOG_AVG_TILL_END_OF_SCOPE0("write_worker#idle");
 			jobsQueue->get(&z1, &z2, &data, &z3);
 		}
-		if (data == NULL) {
+		if (data == NO_CHUNKDATA) {
 			return NULL;
 		}
 
@@ -786,7 +841,7 @@ void* write_worker(void*) {
 	return NULL;
 }
 
-/* API | glock: INITIALIZED,UNLOCKED */
+/* API | globalLock: INITIALIZED,UNLOCKED */
 void write_data_init(uint32_t cachesize, uint32_t retries, uint32_t workers,
 		uint32_t writewindowsize, uint32_t chunkserverTimeout_ms, uint32_t cachePerInodePercentage) {
 	uint64_t cachebytecount = uint64_t(cachesize) * 1024 * 1024;
@@ -822,11 +877,11 @@ void write_data_term(void) {
 	uint32_t i;
 
 	{
-		Glock lock(gMutex);
-		delayed_queue_put(nullptr, 0, lock);
+		Lock globalLock(gMutex);
+		delayed_queue_put(NO_CHUNKDATA, 0, globalLock);
 	}
 	for (i = 0; i < write_worker_th.size(); i++) {
-		jobsQueue->put(0, 0, nullptr, 0);
+		jobsQueue->put(0, 0, NO_CHUNKDATA, 0);
 	}
 	for (i = 0; i < write_worker_th.size(); i++) {
 		pthread_join(write_worker_th[i], NULL);
@@ -839,9 +894,10 @@ void write_data_term(void) {
 	inodedataMap.clear();
 }
 
-/* glock: UNLOCKED */
-int write_block(ChunkData* chunkData, uint16_t pos, uint32_t from, uint32_t to, const uint8_t *data) {
-	Glock lock(gMutex);
+/* inodeLock: UNLOCKED */
+/* globalLock: UNLOCKED */
+int write_block(ChunkData *chunkData, uint16_t pos, uint32_t from, uint32_t to,
+                const uint8_t *data, Lock &inodeLock) {
 	inodedata *parent = chunkData->getParent();
 	parent->lastWriteToDataChain.reset();
 
@@ -855,44 +911,62 @@ int write_block(ChunkData* chunkData, uint16_t pos, uint32_t from, uint32_t to, 
 			return 0;
 		}
 	}
+	inodeLock.unlock();
 
 	// Didn't manage to expand an existing block, so allocate a new one
-	write_cb_wait_for_block(parent, lock);
-	write_cb_acquire_blocks(1, lock);
+	write_cb_wait_for_block(parent);
+	write_cb_acquire_blocks(1);
+
+	inodeLock.lock();
 	chunkData->pushToChain(WriteCacheBlock(chunkData->chunkIndex, pos,
 	                                       WriteCacheBlock::kWritableBlock));
 	sassert(chunkData->dataChain.back().expand(from, to, data));
+	Lock globalLock(gMutex, std::defer_lock);
 	if (chunkData->inQueue) {
 		// Consider some speedup if there are no errors and:
 		// - there is a lot of blocks in the write chain
 		// - there are at least two chunks in the write chain
 		if (chunkData->tryCounter == 0 &&
 		    (chunkData->dataChain.size() > chunkData->minimumBlocksToWrite)) {
-			if (delayed_queue_remove(chunkData, lock)) {
-				write_enqueue(chunkData, lock);
+			inodeLock.unlock();
+
+			globalLock.lock();
+			if (delayed_queue_remove(chunkData, globalLock)) {
+				write_enqueue(chunkData, globalLock);
 			}
+			globalLock.unlock();
+
+			inodeLock.lock();
 		}
 		chunkData->wakeUpWorkerIfNecessary();
 	} else {
 		chunkData->inQueue = true;
-		write_enqueue(chunkData, lock);
+		inodeLock.unlock();
+
+		globalLock.lock();
+		write_enqueue(chunkData, globalLock);
+		globalLock.unlock();
+
+		inodeLock.lock();
 	}
 	return 0;
 }
 
-/* glock: UNLOCKED */
+/* globalLock: UNLOCKED */
 int write_blocks(inodedata *id, uint64_t offset, uint32_t size,
                  const uint8_t *data) {
 	LOG_AVG_TILL_END_OF_SCOPE0("write_blocks");
 	uint32_t chindx = offset >> SFSCHUNKBITS;
 	uint16_t pos = (offset & SFSCHUNKMASK) >> SFSBLOCKBITS;
 	uint32_t from = offset & SFSBLOCKMASK;
+	Lock inodeLock(id->mutex);
 	while (size > 0) {
-		ChunkData *chunkData = write_get_chunkdata(chindx, id);
-		chunkData->beingWritten++;
+		ChunkData *chunkData = write_get_chunkdata(chindx, id, inodeLock);
+		chunkData->writesCount++;
+
 		if (size > SFSBLOCKSIZE - from) {
-			if (write_block(chunkData, pos, from, SFSBLOCKSIZE, data) < 0) {
-				chunkData->beingWritten--;
+			if (write_block(chunkData, pos, from, SFSBLOCKSIZE, data, inodeLock) < 0) {
+				chunkData->writesCount--;
 				return SAUNAFS_ERROR_IO;
 			}
 			size -= (SFSBLOCKSIZE - from);
@@ -904,13 +978,13 @@ int write_blocks(inodedata *id, uint64_t offset, uint32_t size,
 				chindx++;
 			}
 		} else {
-			if (write_block(chunkData, pos, from, from + size, data) < 0) {
-				chunkData->beingWritten--;
+			if (write_block(chunkData, pos, from, from + size, data, inodeLock) < 0) {
+				chunkData->writesCount--;
 				return SAUNAFS_ERROR_IO;
 			}
 			size = 0;
 		}
-		chunkData->beingWritten--;
+		chunkData->writesCount--;
 	}
 	return 0;
 }
@@ -920,11 +994,11 @@ int write_data(void *vid, uint64_t offset, uint32_t size, const uint8_t *data,
 	LOG_AVG_TILL_END_OF_SCOPE0("write_data");
 	int status;
 	inodedata *id = (inodedata*) vid;
-	if (id == NULL) {
+	if (id == NO_INODEDATA) {
 		return SAUNAFS_ERROR_IO;
 	}
 
-	Glock lock(gMutex);
+	Lock inodeLock(id->mutex);
 	status = id->status;
 	id->maxfleng = std::max(id->maxfleng, currentSize);
 	if (status == SAUNAFS_STATUS_OK) {
@@ -933,11 +1007,11 @@ int write_data(void *vid, uint64_t offset, uint32_t size, const uint8_t *data,
 		}
 		id->writewaiting++;
 		while (id->flushwaiting > 0) {
-			id->writecond.wait(lock);
+			id->writecond.wait(inodeLock);
 		}
 		id->writewaiting--;
 	}
-	lock.unlock();
+	inodeLock.unlock();
 
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
@@ -946,80 +1020,110 @@ int write_data(void *vid, uint64_t offset, uint32_t size, const uint8_t *data,
 	return write_blocks(id, offset, size, data);
 }
 
-static void write_data_flushwaiting_increase(inodedata *id, Glock&) {
+/* inode: LOCKED */
+static void write_data_flushwaiting_increase(inodedata *id, Lock&) {
 	id->flushwaiting++;
 }
 
-static void write_data_flushwaiting_decrease(inodedata *id, Glock&) {
+/* inode: LOCKED */
+static void write_data_flushwaiting_decrease(inodedata *id, Lock&) {
 	id->flushwaiting--;
 	if (id->flushwaiting == 0 && id->writewaiting > 0) {
 		id->writecond.notify_all();
 	}
 }
 
-static void write_data_lcnt_increase(inodedata *id, Glock&) {
+/* inode: UNLOCKED */
+static void write_data_lcnt_increase(inodedata *id) {
 	id->lcnt++;
 }
 
-static void	write_data_lcnt_decrease_check_deleted(inodedata *id, Glock& lock, bool& isDeleted) {
+/* inode: LOCKED */
+static void write_data_lcnt_decrease_check_deleted(inodedata *id,
+                                                   Lock &inodeLock,
+                                                   bool &isDeleted) {
 	// As long as it is not freed, then we don't consider the inodedata deleted
 	isDeleted = false;
+	bool almostDone = (id->emptyChunkDataList) && (id->flushwaiting == 0) &&
+	    (id->writewaiting == 0);
+	inodeLock.unlock();
+
+	Lock globalLock(gMutex);
 	id->lcnt--;
-	if (id->lcnt == 0 && id->chunksDataFirst == nullptr &&
-	    id->flushwaiting == 0 && id->writewaiting == 0) {
-		write_free_inodedata(id, lock);
+	if (id->lcnt == 0 && almostDone) {		
+		write_free_inodedata(id, globalLock);
 		isDeleted = true;
+		return;
 	}
+	globalLock.unlock();
+
+	inodeLock.lock();
 }
 
-inline void write_data_lcnt_decrease(inodedata *id, Glock& lock) {
+/* inode: LOCKED */
+inline void write_data_lcnt_decrease(inodedata *id, Lock& inodeLock) {
 	bool dummy_isDeleted;
-	write_data_lcnt_decrease_check_deleted(id, lock, dummy_isDeleted);
+	write_data_lcnt_decrease_check_deleted(id, inodeLock, dummy_isDeleted);
 	(void) dummy_isDeleted;
 }
 
 void* write_data_new(uint32_t inode) {
 	inodedata* id;
-	Glock lock(gMutex);
-	id = write_get_inodedata(inode, lock);
-	if (id == NULL) {
-		return NULL;
+	Lock globalLock(gMutex);
+	id = write_get_inodedata(inode, globalLock);
+	if (id == NO_INODEDATA) {
+		return NO_INODEDATA;
 	}
-	write_data_lcnt_increase(id, lock);
+
+	write_data_lcnt_increase(id);
 	return id;
 }
 
-static int write_data_flush(void* vid, Glock& lock) {
+/* globalLock: LOCKED */
+static int write_data_flush(void* vid, Lock& globalLock) {
 	inodedata* id = (inodedata*) vid;
-	if (id == NULL) {
+	if (id == NO_INODEDATA) {
 		return SAUNAFS_ERROR_IO;
 	}
+	globalLock.unlock();
 
-	write_data_flushwaiting_increase(id, lock);
-	// If there are no errors (status == SAUNAFS_STATUS_OK) and inode is waiting in the delayed queue, speed it up
-	auto delayedEnqueuedChunkData = delayed_queue_remove(id, lock);
+	Lock inodeLock(id->mutex);
+	write_data_flushwaiting_increase(id, inodeLock);
+	inodeLock.unlock();
+
+	globalLock.lock();
+	// If there are no errors (status == SAUNAFS_STATUS_OK) and inode is waiting
+	// in the delayed queue, speed it up
+	auto delayedEnqueuedChunkData = delayed_queue_remove(id, globalLock);
 	if (id->status == SAUNAFS_STATUS_OK && !delayedEnqueuedChunkData.empty()) {
-		write_enqueue(delayedEnqueuedChunkData, lock);
+		write_enqueue(delayedEnqueuedChunkData, globalLock);
 	}
+
 	// Wait for the data to be flushed
-	while (id->chunksDataFirst != nullptr) {
-		id->flushcond.wait(lock);
+	while (!id->emptyChunkDataList) {
+		id->flushcond.wait(globalLock);
 	}
-	write_data_flushwaiting_decrease(id, lock);
+	globalLock.unlock();
+
+	inodeLock.lock();
+	write_data_flushwaiting_decrease(id, inodeLock);
 	id->maxfleng = 0;
+	inodeLock.unlock();
+
+	globalLock.lock();
 	return id->status;
 }
 
 int write_data_flush(void* vid) {
-	Glock lock(gMutex);
-	return write_data_flush(vid, lock);
+	Lock globalLock(gMutex);
+	return write_data_flush(vid, globalLock);
 }
 
 uint64_t write_data_getmaxfleng(uint32_t inode) {
 	uint64_t maxfleng;
 	inodedata* id;
-	Glock lock(gMutex);
-	id = write_find_inodedata(inode, lock);
+	Lock globalLock(gMutex);
+	id = write_find_inodedata(inode, globalLock);
 	if (id) {
 		maxfleng = id->maxfleng;
 	} else {
@@ -1029,30 +1133,37 @@ uint64_t write_data_getmaxfleng(uint32_t inode) {
 }
 
 int write_data_flush_inode(uint32_t inode) {
-	Glock lock(gMutex);
-	inodedata* id = write_find_inodedata(inode, lock);
-	if (id == NULL) {
+	Lock globalLock(gMutex);
+	inodedata* id = write_find_inodedata(inode, globalLock);
+	if (id == NO_INODEDATA) {
 		return 0;
 	}
-	return write_data_flush(id, lock);
+	return write_data_flush(id, globalLock);
 }
 
-int write_data_truncate(uint32_t inode, bool opened, uint32_t uid, uint32_t gid, uint64_t length,
-		Attributes& attr) {
-	Glock lock(gMutex);
+int write_data_truncate(uint32_t inode, bool opened, uint32_t uid, uint32_t gid,
+                        uint64_t length, Attributes &attr) {
+	Lock globalLock(gMutex);
 
 	// 1. Flush writes but don't finish it completely - it'll be done at the end of truncate
-	inodedata* id = write_get_inodedata(inode, lock);
-	if (id == NULL) {
+	inodedata* id = write_get_inodedata(inode, globalLock);
+	globalLock.unlock();
+	if (id == NO_INODEDATA) {
 		return SAUNAFS_ERROR_IO;
 	}
-	write_data_lcnt_increase(id, lock);
-	write_data_flushwaiting_increase(id, lock); // this will block any writing to this inode
 
-	int err = write_data_flush(id, lock);
+	Lock inodeLock(id->mutex);
+	write_data_lcnt_increase(id);
+	write_data_flushwaiting_increase(id, inodeLock); // this will block any writing to this inode
+	inodeLock.unlock();
+
+	globalLock.lock();
+	int err = write_data_flush(id, globalLock);
+	globalLock.unlock();
 	if (err != 0) {
-		write_data_flushwaiting_decrease(id, lock);
-		write_data_lcnt_decrease(id, lock);
+		inodeLock.lock();
+		write_data_flushwaiting_decrease(id, inodeLock);
+		write_data_lcnt_decrease(id, inodeLock);
 		return err;
 	}
 
@@ -1061,7 +1172,6 @@ int write_data_truncate(uint32_t inode, bool opened, uint32_t uid, uint32_t gid,
 	bool writeNeeded;
 	uint64_t oldLength;
 	uint32_t lockId;
-	lock.unlock();
 	int retrySleepTime_us = 200000;
 	uint32_t retries = 0;
 	do {
@@ -1081,12 +1191,12 @@ int write_data_truncate(uint32_t inode, bool opened, uint32_t uid, uint32_t gid,
 			++retries;
 		}
 	} while (status == SAUNAFS_ERROR_LOCKED || status == SAUNAFS_ERROR_CHUNKLOST || status == SAUNAFS_ERROR_NOTDONE);
-	lock.lock();
+	inodeLock.lock();
 	if (status != 0 || !writeNeeded) {
 		// Something failed or we have nothing to do more (master server managed to do the truncate)
 		bool isDeleted = false;
-		write_data_flushwaiting_decrease(id, lock);
-		write_data_lcnt_decrease_check_deleted(id, lock, isDeleted);
+		write_data_flushwaiting_decrease(id, inodeLock);
+		write_data_lcnt_decrease_check_deleted(id, inodeLock, isDeleted);
 		if (status == SAUNAFS_STATUS_OK) {
 			if (!isDeleted) {
 				id->maxfleng = length;
@@ -1112,38 +1222,50 @@ int write_data_truncate(uint32_t inode, bool opened, uint32_t uid, uint32_t gid,
 
 		// Something has to be written, so pass our lock to writing threads
 		sassert(id->totalCachedBlocks == 0);
+		inodeLock.unlock();
+
+		globalLock.lock();
 		truncateLocatorsData[id->inode] = {lockId, endOffset};
+		globalLock.unlock();
 
 		// And now pass block of zeros to writing threads
 		std::vector<uint8_t> zeros(endOffset - length, 0);
-		lock.unlock();
 		err = write_blocks(id, length, zeros.size(), zeros.data());
-		lock.lock();
+
+		inodeLock.lock();
 		if (err != 0) {
 			truncateLocatorsData.erase(id->inode);
-			write_data_flushwaiting_decrease(id, lock);
-			write_data_lcnt_decrease(id, lock);
+			write_data_flushwaiting_decrease(id, inodeLock);
+			write_data_lcnt_decrease(id, inodeLock);
 			return err;
 		}
+		inodeLock.unlock();
 
+		globalLock.lock();
 		// Wait for writing threads to finish
-		err = write_data_flush(id, lock);
+		err = write_data_flush(id, globalLock);
 
 		truncateLocatorsData.erase(id->inode);
+		globalLock.unlock();
+
+		inodeLock.lock();
 		if (err != 0) {
 			// unlock the chunk here?
-			write_data_flushwaiting_decrease(id, lock);
-			write_data_lcnt_decrease(id, lock);
+			write_data_flushwaiting_decrease(id, inodeLock);
+			write_data_lcnt_decrease(id, inodeLock);
 			return err;
 		}
 	}
 
 	id->maxfleng = length;
 	// Now we can tell the master server to finish the truncate operation and then unblock the inode
-	lock.unlock();
+	inodeLock.unlock();
+
 	status = fs_truncateend(inode, uid, gid, length, lockId, attr);
-	write_data_flushwaiting_decrease(id, lock);
-	write_data_lcnt_decrease(id, lock);
+
+	inodeLock.lock();
+	write_data_flushwaiting_decrease(id, inodeLock);
+	write_data_lcnt_decrease(id, inodeLock);
 
 	if (status != SAUNAFS_STATUS_OK) {
 		// status is now SFS status, so we cannot return any errno
@@ -1153,12 +1275,15 @@ int write_data_truncate(uint32_t inode, bool opened, uint32_t uid, uint32_t gid,
 }
 
 int write_data_end(void* vid) {
-	Glock lock(gMutex);
+	Lock globalLock(gMutex);
 	inodedata* id = (inodedata*) vid;
-	if (id == NULL) {
+	if (id == NO_INODEDATA) {
 		return SAUNAFS_ERROR_IO;
 	}
-	int status = write_data_flush(id, lock);
-	write_data_lcnt_decrease(id, lock);
+	int status = write_data_flush(id, globalLock);
+	globalLock.unlock();
+
+	Lock inodeLock(id->mutex);
+	write_data_lcnt_decrease(id, inodeLock);
 	return status;
 }

--- a/src/mount/writedata.h
+++ b/src/mount/writedata.h
@@ -27,6 +27,8 @@
 
 #include "common/attributes.h"
 
+inline bool gUseOldWriteAlgorithm;
+
 void write_data_init(uint32_t cachesize, uint32_t retries, uint32_t workers,
                      uint32_t writewindowsize, uint32_t chunkserverTimeout_ms,
                      uint32_t cachePerInodePercentage, uint32_t waveTimeout);

--- a/src/mount/writedata.h
+++ b/src/mount/writedata.h
@@ -28,8 +28,8 @@
 #include "common/attributes.h"
 
 void write_data_init(uint32_t cachesize, uint32_t retries, uint32_t workers,
-		uint32_t writewindowsize, uint32_t chunkserverTimeout_ms,
-		uint32_t cachePerInodePercentage);
+                     uint32_t writewindowsize, uint32_t chunkserverTimeout_ms,
+                     uint32_t cachePerInodePercentage, uint32_t waveTimeout);
 void write_data_term(void);
 void* write_data_new(uint32_t inode);
 int write_data_end(void *vid);

--- a/src/mount/writedata.h
+++ b/src/mount/writedata.h
@@ -27,7 +27,7 @@
 
 #include "common/attributes.h"
 
-inline bool gUseOldWriteAlgorithm;
+inline bool gUseInodeBasedWriteAlgorithm;
 
 void write_data_init(uint32_t cachesize, uint32_t retries, uint32_t workers,
                      uint32_t writewindowsize, uint32_t chunkserverTimeout_ms,

--- a/src/mount/writedata.h
+++ b/src/mount/writedata.h
@@ -39,6 +39,5 @@ int write_data_flush(void *vid);
 uint64_t write_data_getmaxfleng(uint32_t inode);
 int write_data_flush_inode(uint32_t inode);
 int write_data_truncate(uint32_t inode, bool opened, uint32_t uid, uint32_t gid, uint64_t length,
-		Attributes& attr);
-int write_data(void *vid, uint64_t offset, uint32_t size, const uint8_t *buff,
-               size_t currentSize);
+                        Attributes &attr);
+int write_data(void *vid, uint64_t offset, uint32_t size, const uint8_t *buff, size_t currentSize);

--- a/tests/test_suites/SanityChecks/test_quota_size.sh
+++ b/tests/test_suites/SanityChecks/test_quota_size.sh
@@ -2,7 +2,7 @@ timeout_set 45 seconds
 
 USE_RAMDISK=YES \
 	SFSEXPORTS_EXTRA_OPTIONS="allcanchangequota,ignoregid" \
-	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER" \
+	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER|sfsuseinodebasedwritealgorithm=1" \
 	setup_local_empty_saunafs info
 
 cd "${info[mount0]}"

--- a/tests/test_suites/ShortSystemTests/test_client_crash_during_write.sh
+++ b/tests/test_suites/ShortSystemTests/test_client_crash_during_write.sh
@@ -1,0 +1,37 @@
+# Test filesystem consistency after client crash
+
+CHUNKSERVERS=4 \
+	USE_RAMDISK=YES \
+	MOUNTS=1 \
+	setup_local_empty_saunafs info
+
+FILE_NAME="${info[mount0]}/crash_test_file"
+
+# Start write operation
+( dd if=/dev/urandom of=${FILE_NAME} bs=1M count=1024 status=none ) &
+
+# Allow write to start
+sleep 1
+
+# Simulate client crash
+MOUNT_PID=$(pgrep -f "sfsmount.*${info[mount0]}")
+pgrep -fa "sfsmount.*${info[mount0]}"
+# Write operation crashes here
+kill -9 ${MOUNT_PID}
+
+sleep 1
+umount "${info[mount0]}"
+
+echo "Client process killed to simulate crash."
+
+# Restart client
+saunafs_mount_start 0
+
+ACTUAL_SIZE=$(stat -c %s ${FILE_NAME})
+
+# Verify file exists, something was written
+if [ ${ACTUAL_SIZE} -gt 0 ]; then
+	echo "File exists after client restart."
+else
+	test_add_failure "File missing after client restart."
+fi

--- a/tests/test_suites/ShortSystemTests/test_concurrent_overlapping_writes.sh
+++ b/tests/test_suites/ShortSystemTests/test_concurrent_overlapping_writes.sh
@@ -1,0 +1,47 @@
+# Test concurrent overlapping writes to the same file
+timeout_set 2 minutes
+
+CHUNKSERVERS=4 \
+	USE_RAMDISK=YES \
+	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER" \
+	setup_local_empty_saunafs info
+
+cd "${info[mount0]}"
+
+# Define number of concurrent writers
+NUM_WRITERS=10
+# Define block size
+BS=1024
+# Define overlapping regions
+# All writers write to overlapping regions starting at offset 16M
+SLICE_SIZE=$((16 * 1024))
+LENGTH=$((2 * SLICE_SIZE))
+
+# Function for a writer process
+write_overlap() {
+	local id=$1
+	local offset=$2
+	local length=$3
+	local pattern=$(printf "%02d" ${id})
+	# Write the pattern to the file at the specified offset
+	yes "${pattern}" | tr -d '\n' | head -c $((length * BS)) | dd of=concurrent_file bs=${BS} count=${length} seek=${offset} conv=notrunc status=none
+}
+
+
+# Start concurrent writes
+for i in $(seq 1 ${NUM_WRITERS}); do
+	write_overlap ${i} $((SLICE_SIZE * i)) $((LENGTH)) &
+done
+
+wait
+
+# Read back the overlapping region
+dd if=concurrent_file bs=${BS} skip=$((SLICE_SIZE)) count=$((SLICE_SIZE * 11)) status=none > read_back_data
+
+# Since multiple writes overlapped, the final data should correspond to a mix of the 10 patterns
+unique_patterns=$(tr -d '\n' < read_back_data | fold -w2 | sort | uniq)
+if [ $(echo "${unique_patterns}" | wc -l) -le 10 ]; then
+	echo "Test passed: Overlapping writes resulted in consistent data."
+else
+	test_add_failure "Data corruption detected in overlapping writes."
+fi

--- a/tests/test_suites/ShortSystemTests/test_cross_boundary_writes.sh
+++ b/tests/test_suites/ShortSystemTests/test_cross_boundary_writes.sh
@@ -1,0 +1,71 @@
+# Test writes that cross block and chunk boundaries.
+
+CHUNKSERVERS=4 \
+	USE_RAMDISK=YES \
+	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER" \
+	setup_local_empty_saunafs info
+
+cd "${info[mount0]}"
+FILE_NAME="boundary_test_file"
+FILE_NAME_SAVED="${FILE_NAME}_saved"
+
+# Get block and chunk sizes.
+BLOCK_SIZE=${SAUNAFS_BLOCK_SIZE}
+CHUNK_SIZE=${SAUNAFS_CHUNK_SIZE}
+
+# Create a file large enough to span multiple chunks.
+SIZE=$((CHUNK_SIZE * 2 + BLOCK_SIZE * 2))
+FILE_SIZE=${SIZE} file-generate ${FILE_NAME}
+FILE_SIZE=${SIZE} file-generate ${FILE_NAME_SAVED}
+
+# Corrupt the data in different places
+BLOCK_GAP=128
+BLOCK_WRITE_BEGIN=$((BLOCK_SIZE - BLOCK_GAP))
+# note that: BLOCK_WRITE_BEGIN = 128 * (2^9 - 1) = 128 * 511, the first
+# write crosses a block boundary
+dd if=/dev/urandom of=${FILE_NAME} bs=$((BLOCK_WRITE_BEGIN / BLOCK_GAP)) \
+	count=10 seek=$((BLOCK_GAP)) conv=notrunc status=none
+
+CHUNK_GAP=1024
+CHUNK_WRITE_BEGIN=$((CHUNK_SIZE - CHUNK_GAP))
+# note that: CHUNK_WRITE_BEGIN = 1024 * (BLOCK_SIZE - 1) = 1024 * 65535, the 
+# first write crosses a chunk boundary
+dd if=/dev/urandom of=${FILE_NAME} bs=$((CHUNK_WRITE_BEGIN / CHUNK_GAP)) \
+	count=10 seek=$((CHUNK_GAP)) conv=notrunc status=none
+
+# note that: SIZE = 2050 * BLOCK_SIZE
+UNALIGNED_BS=2050
+# It will write using unaligned block size the end of the file
+dd if=/dev/urandom of=${FILE_NAME} bs=$((UNALIGNED_BS)) count=50 \
+	seek=$((BLOCK_SIZE - 50)) conv=notrunc status=none
+
+# Verify file is broken
+assert_failure file-validate ${FILE_NAME}
+
+# Though readable
+assert_success pv ${FILE_NAME} > /dev/null
+
+# Fix the file
+# Fix the cross-block-boundary write
+dd if=${FILE_NAME_SAVED} of=${FILE_NAME} bs=$((BLOCK_WRITE_BEGIN / BLOCK_GAP)) \
+	count=10 seek=$((BLOCK_GAP)) skip=$((BLOCK_GAP)) conv=notrunc status=none
+
+# Fix the chunk-block-boundary write
+dd if=${FILE_NAME_SAVED} of=${FILE_NAME} bs=$((CHUNK_WRITE_BEGIN / CHUNK_GAP)) \
+	count=10 seek=$((CHUNK_GAP)) skip=$((CHUNK_GAP)) conv=notrunc status=none
+
+# Fix the unaligned block size write
+dd if=${FILE_NAME_SAVED} of=${FILE_NAME} bs=$((UNALIGNED_BS)) count=50 \
+	seek=$((BLOCK_SIZE - 50)) skip=$((BLOCK_SIZE - 50)) conv=notrunc status=none
+
+# Verify file size
+ACTUAL_SIZE=$(stat -c %s ${FILE_NAME})
+
+if [ ${ACTUAL_SIZE} -ne ${SIZE} ]; then
+	test_add_failure "File size mismatch after cross-boundary writes. Expected ${SIZE}, got ${ACTUAL_SIZE}."
+else
+	echo "File size is correct after cross-boundary writes."
+fi
+
+# Verify file is fixed
+assert_success file-validate ${FILE_NAME}

--- a/tests/test_suites/ShortSystemTests/test_ec_small_parallel_writing.sh
+++ b/tests/test_suites/ShortSystemTests/test_ec_small_parallel_writing.sh
@@ -1,0 +1,42 @@
+if is_windows_system; then
+	timeout_set 5 minutes
+else
+	timeout_set 3 minutes
+fi
+
+
+CHUNKSERVERS=4 \
+	MOUNTS=10 \
+	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER" \
+	MASTER_CUSTOM_GOALS="10 ec_3_1: \$ec(3,1)" \
+	USE_RAMDISK=YES \
+	setup_local_empty_saunafs info
+
+# Create an empty file on the SaunaFS filesystem with ec_3_1 goal
+file="${info[mount0]}/file"
+touch "$file"
+saunafs setgoal ec_3_1 "$file"
+
+# Create a temporary file with 25 megabytes of generated data
+tmpf=$RAMDISK_DIR/tmpf
+FILE_SIZE=64K file-generate "$tmpf"
+
+# Run 10 tasks, each of them will copy every tenth kilobyte from the temporary file to the file
+# on SaunaFS using 5 concurrent writers and a dedicated mountpoint
+for i in {0..9}; do
+	(
+		file="${info[mount${i}]}/file"
+		seq $i 10 $((64*1024-1)) | shuf | expect_success xargs -P5 -IXX \
+				dd if="$tmpf" of="$file" bs=1 count=1 seek=XX skip=XX conv=notrunc 2>/dev/null
+	) &
+done
+wait
+
+# Validate the result
+MESSAGE="Data is corrupted after writing" expect_success file-validate "$file"
+
+# Validate the parity part
+csid=$(find_first_chunkserver_with_chunks_matching 'chunk_ec2_1_of_3*')
+saunafs_chunkserver_daemon $csid stop
+
+MESSAGE="Parity is corrupted after writing" expect_success file-validate "$file"

--- a/tests/test_suites/ShortSystemTests/test_exception_handling_in_writes.sh
+++ b/tests/test_suites/ShortSystemTests/test_exception_handling_in_writes.sh
@@ -1,0 +1,20 @@
+# Test exception handling during writes
+
+CHUNKSERVERS=4 \
+    USE_RAMDISK=YES \
+    setup_local_empty_saunafs info
+
+cd "${info[mount0]}"
+
+# Create read-only file
+FILE_NAME="exception_test_file"
+touch ${FILE_NAME}
+chmod 444 ${FILE_NAME}
+
+# Attempt to write
+assert_failure dd if=/dev/urandom of=${FILE_NAME} bs=1M count=1 conv=notrunc status=none
+
+echo "File is read-only, write failed as expected."
+
+# Check locks released
+assert_success rm ${FILE_NAME} <<< y

--- a/tests/test_suites/ShortSystemTests/test_lock_contention_stress.sh
+++ b/tests/test_suites/ShortSystemTests/test_lock_contention_stress.sh
@@ -1,0 +1,31 @@
+# Stress test write locking mechanism
+
+CHUNKSERVERS=4 \
+	USE_RAMDISK=YES \
+	setup_local_empty_saunafs info
+
+cd "${info[mount0]}"
+
+# Create file.
+FILE_NAME="lock_stress_file"
+FILE_NAME_CPY="lock_stress_file_cpy"
+NUM_PROCESSES=400
+KILOBYTES_PER_PROCESS=100
+FILE_SIZE=$((NUM_PROCESSES * KILOBYTES_PER_PROCESS * 1024)) file-generate ${FILE_NAME}
+
+# High concurrency writes
+
+for i in $(seq 1 ${NUM_PROCESSES}); do
+	(
+		OFFSET=$(((i - 1) * KILOBYTES_PER_PROCESS))
+		dd if=${FILE_NAME} of=${FILE_NAME_CPY} bs=1K count=${KILOBYTES_PER_PROCESS} \
+			seek=${OFFSET} skip=${OFFSET} conv=notrunc status=none
+	) &
+done
+
+wait
+
+echo "All concurrent writes completed."
+
+# Validate copy file
+assert_success file-validate ${FILE_NAME_CPY}

--- a/tests/test_suites/ShortSystemTests/test_mixed_types_parallel_writes.sh
+++ b/tests/test_suites/ShortSystemTests/test_mixed_types_parallel_writes.sh
@@ -1,0 +1,44 @@
+timeout_set 2 minutes
+
+CHUNKSERVERS=4 \
+	MOUNTS=4 \
+	MOUNT_0_EXTRA_CONFIG="sfscachemode=NEVER`
+			`|sfsuseinodebasedwritealgorithm=0" \
+	MOUNT_1_EXTRA_CONFIG="sfscachemode=NEVER`
+			`|sfsuseinodebasedwritealgorithm=1" \
+	MOUNT_2_EXTRA_CONFIG="sfscachemode=NEVER`
+			`|sfsuseinodebasedwritealgorithm=0" \
+	MOUNT_3_EXTRA_CONFIG="sfscachemode=NEVER`
+			`|sfsuseinodebasedwritealgorithm=1" \
+	MASTER_CUSTOM_GOALS="10 ec_3_1: \$ec(3,1)" \
+	USE_RAMDISK=YES \
+	setup_local_empty_saunafs info
+
+# Create an empty file on the SaunaFS filesystem with ec_3_1 goal
+file="${info[mount0]}/file"
+touch "${file}"
+saunafs setgoal ec_3_1 "${file}"
+
+# Create a temporary file with 16 megabytes of generated data
+tmpf="${RAMDISK_DIR}/tmpf"
+FILE_SIZE=16M file-generate "${tmpf}"
+
+# Run 4 tasks, each of them will copy every tenth kilobyte from the temporary file to the file
+# on SaunaFS using 5 concurrent writers and a dedicated mountpoint
+for i in {0..3}; do
+	(
+		file="${info[mount${i}]}/file"
+		seq $i 4 $((16*1024-1)) | shuf | expect_success xargs -P5 -IXX \
+				dd if="${tmpf}" of="${file}" bs=1K count=1 seek=XX skip=XX conv=notrunc 2>/dev/null
+	) &
+done
+wait
+
+# Validate the result
+MESSAGE="Data is corrupted after writing" expect_success file-validate "${file}"
+
+# Validate the parity part
+csid=$(find_first_chunkserver_with_chunks_matching 'chunk_ec2_1_of_3*')
+saunafs_chunkserver_daemon ${csid} stop
+
+MESSAGE="Parity is corrupted after writing" expect_success file-validate "${file}"

--- a/tests/test_suites/ShortSystemTests/test_network_partition_during_writes.sh
+++ b/tests/test_suites/ShortSystemTests/test_network_partition_during_writes.sh
@@ -1,0 +1,129 @@
+# Test client behavior during network partition
+timeout_set 2 minute
+
+CHUNKSERVERS=4 \
+	MASTER_CUSTOM_GOALS="10 ec_3_1: \$ec(3,1)" \
+	setup_local_empty_saunafs info
+
+mkdir "${info[mount0]}/dir"
+saunafs settrashtime 0 "${info[mount0]}/dir"
+
+FILE_SIZE_MB=1024
+FILE_NAME="${info[mount0]}/dir/network_test_file"
+FILE_NAME_CPY="${FILE_NAME}_cpy"
+touch ${FILE_NAME} ${FILE_NAME_CPY}
+saunafs setgoal ec_3_1 ${FILE_NAME} ${FILE_NAME_CPY}
+
+# Create a file with FILE_SIZE_MB MB of generated data
+FILE_SIZE=${FILE_SIZE_MB}M file-generate ${FILE_NAME}
+
+# Let's try only stopping the master
+# Start cpy operation
+( dd if=${FILE_NAME} of=${FILE_NAME_CPY} bs=1M count=${FILE_SIZE_MB} status=none ) &
+
+# Allow write to start
+sleep 0.2
+
+# Simulate network partition by stopping master
+echo "Stopping master to simulate network partition."
+saunafs_master_daemon stop
+
+# Sleep for a while to ensure the write tries to complete
+# After a few second wake up the master
+sleep 10
+
+saunafs_master_daemon restart
+echo "Done simulating network partition."
+
+# Wait for write to complete
+wait
+
+if [ $? -eq 0 ]; then
+    echo "Write succeeded during network partition."
+else
+    test_add_failure "Write failed unexpectedly during network partition."
+fi
+
+assert_success file-validate ${FILE_NAME_CPY}
+echo "Write continues after master crashed and restarted: OK"
+
+# Cleanup
+rm ${FILE_NAME_CPY}
+
+# Let's try only stopping the chunkservers
+# Start cpy operation
+( dd if=${FILE_NAME} of=${FILE_NAME_CPY} bs=1M count=${FILE_SIZE_MB} status=none ) &
+
+# Allow write to start
+sleep 0.2
+
+# Simulate chunkserver failures
+for i in {0..3}; do
+	echo "Chunkserver ${i} stopped."
+	saunafs_chunkserver_daemon ${i} stop
+done
+
+# Sleep for a while to ensure the write tries to complete
+# After a few second wake up the CSs
+sleep 10
+
+# Restart chunkservers
+for i in {0..3}; do
+	echo "Chunkserver ${i} started."
+	saunafs_chunkserver_daemon ${i} start
+done
+echo "Done simulating network partition."
+
+# Wait for write to complete
+wait
+
+if [ $? -eq 0 ]; then
+    echo "Write succeeded during network partition."
+else
+    test_add_failure "Write failed unexpectedly during network partition."
+fi
+
+assert_success file-validate ${FILE_NAME_CPY}
+echo "Write continues after chunkservers crashed and restarted: OK"
+
+# Cleanup
+rm ${FILE_NAME_CPY}
+
+# Let's try stopping the chunkservers and master
+# Start cpy operation
+( dd if=${FILE_NAME} of=${FILE_NAME_CPY} bs=1M count=${FILE_SIZE_MB} status=none ) &
+
+# Allow write to start
+sleep 0.2
+
+# Simulate master and chunkserver failures
+echo "Stopping master to simulate network partition."
+saunafs_master_daemon stop
+for i in {0..3}; do
+	echo "Chunkserver ${i} stopped."
+	saunafs_chunkserver_daemon ${i} stop
+done
+
+# Sleep for a while to ensure the write tries to complete
+# After a few second wake up the CSs
+sleep 10
+
+# Restart chunkservers and master
+for i in {0..3}; do
+	echo "Chunkserver ${i} started."
+	saunafs_chunkserver_daemon ${i} start
+done
+saunafs_master_daemon restart
+echo "Done simulating network partition."
+
+# Wait for write to complete
+wait
+
+if [ $? -eq 0 ]; then
+    echo "Write succeeded during network partition."
+else
+    test_add_failure "Write failed unexpectedly during network partition."
+fi
+
+assert_success file-validate ${FILE_NAME_CPY}
+echo "Write continues after chunkservers and master crashed and restarted: OK"

--- a/tests/test_suites/ShortSystemTests/test_quota_dir_size.sh
+++ b/tests/test_suites/ShortSystemTests/test_quota_dir_size.sh
@@ -2,7 +2,7 @@ timeout_set 45 seconds
 
 USE_RAMDISK=YES \
 	SFSEXPORTS_EXTRA_OPTIONS="allcanchangequota,ignoregid" \
-	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER" \
+	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER|sfsuseinodebasedwritealgorithm=1" \
 	setup_local_empty_saunafs info
 
 cd "${info[mount0]}"

--- a/tests/test_suites/ShortSystemTests/test_quota_in_volume_size.sh
+++ b/tests/test_suites/ShortSystemTests/test_quota_in_volume_size.sh
@@ -3,7 +3,7 @@ timeout_set 40 seconds
 CHUNKSERVERS=1 \
 	USE_RAMDISK=YES \
 	SFSEXPORTS_EXTRA_OPTIONS="allcanchangequota" \
-	MOUNT_EXTRA_CONFIG="usequotainvolumesize=1,statfscachetimeout=1,sfsreportreservedperiod=1" \
+	MOUNT_EXTRA_CONFIG="usequotainvolumesize=1,statfscachetimeout=1,sfsreportreservedperiod=1,sfsuseinodebasedwritealgorithm=1" \
 	setup_local_empty_saunafs info
 
 get_mountpoint_total_space() {

--- a/tests/test_suites/ShortSystemTests/test_write_algorithm_switching.sh
+++ b/tests/test_suites/ShortSystemTests/test_write_algorithm_switching.sh
@@ -1,0 +1,28 @@
+# Test switching between inode and chunk-based write algorithms
+
+CHUNKSERVERS=1 \
+	USE_RAMDISK=YES \
+	setup_local_empty_saunafs info
+
+# Generate original file
+FILE_NAME="${info[mount0]}/original_file"
+FILE_CPY="${FILE_NAME}_cpy"
+FILE_SIZE=10M file-generate ${FILE_NAME}
+
+# Write initial data using default: chunk-based algorithm
+dd if=${FILE_NAME} of=${FILE_CPY} bs=1M count=5 conv=notrunc status=none
+
+# Switch to inode-based algorithm.
+saunafs_mount_unmount 0
+echo "sfsuseinodebasedwritealgorithm=1" >> "${info[mount0_cfg]}"
+saunafs_mount_start 0
+
+# Continue writing.
+dd if=${FILE_NAME} of=${FILE_CPY} bs=1M count=5 seek=5 skip=5 conv=notrunc status=none
+
+# Verify data integrity.
+if file-validate ${FILE_CPY}; then
+	echo "Data integrity maintained after algorithm switch."
+else
+	test_add_failure "Data corruption after algorithm switch."
+fi


### PR DESCRIPTION
This PR targets the following issues:
- low performance in single thread writes.
- [Windows] stop/freeze of writes when multiple copies are performed at the same time.
- [Windows] decrease of performance sometimes when the number of writing threads increases.

It also adds a new parameter for tuning the write wave timeout (```sfschunkserverwavewriteto```). Another one, for chosing which write algorithm to use, was also added (```sfsuseoldwritealgorithm```).

The changes performed are following:
- create ```ChunkData``` struct to represent and gather the data of the pending write operation on a chunk. This struct contains many fields from the inodedata, since it is taking over such responsabilities. The use of this new structure is the main reason of the wide changes in the writedata.cc file.
- change of the approach in the write jobs queue: each entry, instead of being an ```inodedata``` one, it is a ```ChunkData``` one.
- minor changes in other classes (```WriteChunkLocator``` and ```ChunkWriter```).

A test on very small parallel random writings was added. I've also checked that there are no new data races conditions added by this changes.
