### PR TITLE
fix(tests): Allow to change tests data path

### DIFF
--- a/tests/ci_build/run-ganesha-tests.sh
+++ b/tests/ci_build/run-ganesha-tests.sh
@@ -27,4 +27,5 @@ echo ": \${SAUNAFS_ROOT:=${SAUNAFS_ROOT}}" | sudo tee -a /etc/saunafs_tests.conf
 sudo ln -sf ${SAUNAFS_ROOT}/lib/ganesha/libfsalsaunafs.so /usr/lib/ganesha/libfsalsaunafs.so
 sudo mkdir -p /usr/lib/x86_64-linux-gnu/ganesha
 sudo ln -sf ${SAUNAFS_ROOT}/lib/ganesha/libfsalsaunafs.so /usr/lib/x86_64-linux-gnu/ganesha/libfsalsaunafs.so
-sudo "${SAUNAFS_ROOT}/bin/saunafs-tests" --gtest_color=yes --gtest_filter="${test_filter}" --gtest_output=xml:"${TEST_OUTPUT_DIR}/ganesha_test_results.xml"
+export SFS_TEST_WORKSPACE="${WORKSPACE}"
+sudo --preserve-env=SFS_TEST_WORKSPACE "${SAUNAFS_ROOT}/bin/saunafs-tests" --gtest_color=yes --gtest_filter="${test_filter}" --gtest_output=xml:"${TEST_OUTPUT_DIR}/ganesha_test_results.xml"

--- a/tests/ci_build/run-sanity-check.sh
+++ b/tests/ci_build/run-sanity-check.sh
@@ -33,4 +33,5 @@ rm -rf /mnt/ramdisk/* || true
 export PATH="${SAUNAFS_ROOT}/bin:${PATH}"
 sudo sed -E -i '\,.*:\s+\$\{SAUNAFS_ROOT\s*:=.*,d' /etc/saunafs_tests.conf || true
 echo ": \${SAUNAFS_ROOT:=${SAUNAFS_ROOT}}" | sudo tee -a /etc/saunafs_tests.conf >/dev/null || true
-sudo "${SAUNAFS_ROOT}/bin/saunafs-tests" --gtest_color=yes --gtest_output=xml:"${TEST_OUTPUT_DIR}/sanity_test_results.xml" "${test_extra_args[@]}"
+export SFS_TEST_WORKSPACE="${WORKSPACE}"
+sudo --preserve-env=SFS_TEST_WORKSPACE "${SAUNAFS_ROOT}/bin/saunafs-tests" --gtest_color=yes --gtest_output=xml:"${TEST_OUTPUT_DIR}/sanity_test_results.xml" "${test_extra_args[@]}"

--- a/tests/saunafs-tests.cc
+++ b/tests/saunafs-tests.cc
@@ -74,8 +74,13 @@ const ::testing::Environment* gBashEnvironment = ::testing::AddGlobalTestEnviron
 class BashTestingSuite : public testing::Test {
 protected:
 	void run_test_case(std::string suite, std::string testCase) {
-		std::string runScript = TO_STRING(TEST_DATA_PATH) "/run-test.sh";
-		std::string testFile = TO_STRING(TEST_DATA_PATH) "/test_suites/" + suite + "/" + testCase + ".sh";
+		std::string testDataPath = TO_STRING(TEST_DATA_PATH);
+		std::string workspace = std::getenv("SFS_TEST_WORKSPACE");
+		if (!workspace.empty()) {
+			testDataPath = workspace + "/tests";
+		}
+		std::string runScript = testDataPath + "/run-test.sh";
+		std::string testFile = testDataPath + "/test_suites/" + suite + "/" + testCase + ".sh";
 		std::string errorFile = testErrFilePath();
 		std::string environment = "ERROR_FILE=" + errorFile;
 		environment += " TEST_SUITE_NAME=" + suite;


### PR DESCRIPTION
When the binary for tests was moved to a different path it could not find the tests bash script. 
This commit adds an environment variable to allow the path change in run time.