### PR TITLE
chore: add codespell support and make it fix few typos

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -3,5 +3,5 @@
 skip = .git*,*.pdf,*.svg,*.css,.codespellrc,external
 check-hidden = true
 # Words with mixed casing
-ignore-regex = \b[A-Z]*[a-z]+[A-Z][A-Za-z]*\b
+ignore-regex = \b[A-Z]*[a-z]+[A-Z][A-Za-z]*\b|/mnt/[a-z0-9]+|.*\bcodespell-ignore\b.*
 ignore-words-list = oce,nd,inout,thid

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,7 @@
+[codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = .git*,*.pdf,*.svg,*.css,.codespellrc,external
+check-hidden = true
+# Words with mixed casing
+ignore-regex = \b[A-Z]*[a-z]+[A-Z][A-Za-z]*\b
+ignore-words-list = oce,nd,inout,thid

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,25 @@
+# Codespell configuration is within .codespellrc
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/NEWS
+++ b/NEWS
@@ -174,7 +174,7 @@ This file lists noteworthy changes in SaunaFS.
  - (master) reimplement directory entry cache for faster lookups
  - (master) add whole-path lookups
  - (master, chunkserver) add chunkserver load awareness
- - (mount) add readahead to improve sequential read perfromance
+ - (mount) add readahead to improve sequential read performance
  - (mount) add secondary groups support
  - (tools) add correct-only flag to filerepair
  - (tools) add -s and -i options to snapshot command
@@ -282,10 +282,10 @@ This file lists noteworthy changes in SaunaFS.
   - (master) High availability provided by shadow master servers
   - (mount, chunkserver) CRC algorithm replaced with a 3 times faster implementation
   - (mount, master) Support for quotas (for users and groups)
-  - (mount, master) Support for posix access contol lists (requires additional OS support)
+  - (mount, master) Support for posix access control lists (requires additional OS support)
   - (mount, master) Support for global I/O limiting (bandwidth limiting)
   - (mount) Support for per-mountpoint I/O limiting (bandwidth limiting)
-  - (adm) New package lizardfs-adm with a lizardfs-probe command-line tool which can be used to query the installation for variuos parameteres
+  - (adm) New package lizardfs-adm with a lizardfs-probe command-line tool which can be used to query the installation for various parameters
   - (master) New mechanism of storing metadata backup files which improves performance of the hourly metadata dumps
   - (all) A comprehensive test suite added
   - (all) Multiple bugfixes
@@ -391,7 +391,7 @@ This file lists noteworthy changes in SaunaFS.
   - (daemon) fixed return values (return non zero on error)
   - (cs) fixed chunk testing bug (any error during chunk opening caused assigning whole disk as damaged)
   - (cs,metalogger) added resolving master name when connection failed (patch contributed by Davies Liu)
-  - (mount) added creating new session when prevoius is lost (inspired by Davies Liu)
+  - (mount) added creating new session when previous is lost (inspired by Davies Liu)
   - (cs) added for unused chunks week delay before deletion (inspired by Davies Liu)
   - (cgi) added switching between name and IP in 'path' column in 'Disks' table (inspired by Davies Liu)
   - (master) do not update ctime when goal, trashtime or extra attributes are not changing
@@ -400,7 +400,7 @@ This file lists noteworthy changes in SaunaFS.
 
   - (metalogger) added sending metadata after metalogger startup
   - (master,metalogger) added sending two change logs together with metadata
-  - (metarestore) imporved merging change logs
+  - (metarestore) improved merging change logs
   - (all) added a lot of assertions (mainly NULL pointers, and unsuccessful thread functions)
   - (all) fixed some minor bugs and potential race conditions (makes valgrind happy)
   - (cs) added ability to use read-only disks in "marked for removal" mode (to retrieve missing chunks from damaged disks)
@@ -435,7 +435,7 @@ This file lists noteworthy changes in SaunaFS.
   - (metarestore) fixed bugs in "REPAIR" and "SNAPSHOT" entries
   - (master) fixed bug in "snapshot" command ("mfsmakesnapshot dir dir/" caused master to hung-up)
   - (master) preserving atime and mtime during "snapshot" operation (makes "snapshot" to work more like "cp -Rp" than "cp -R")
-  - (cs) ommit "marked for removal" disks during chunk test loop
+  - (cs) omit "marked for removal" disks during chunk test loop
 
 * MooseFS 1.6.14 (2010-03-19)
 

--- a/cmake/FindSocket.cmake
+++ b/cmake/FindSocket.cmake
@@ -10,7 +10,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# This is for finding berkley socket functions
+# This is for finding berkeley socket functions
 # it specifically looks for socket()
 
 # brought from: https://raw.github.com/cjdelisle/cjdns/master/cmake/modules/FindSocket.cmake

--- a/create-deb-package.sh
+++ b/create-deb-package.sh
@@ -8,7 +8,7 @@ git diff --cached --exit-code > /dev/null 2>&1
 staged=$?
 
 if [[ $unstaged != 0 ]] || [[ $staged != 0 ]]; then
-	echo "WARNING: You have uncommited changes. They will NOT be included in the build."
+	echo "WARNING: You have uncommitted changes. They will NOT be included in the build."
 	read -n 1 -s -r -p "Press any key to continue"
 	echo
 fi

--- a/doc/saunafs-uraft.cfg.5.adoc
+++ b/doc/saunafs-uraft.cfg.5.adoc
@@ -57,7 +57,7 @@ election algorithm.
 heartbeat messages.
 
 *LOCAL_MASTER_CHECK_PERIOD*:: *[advanced]* period in milliseconds between
-checking wheter local master is alive.
+checking whether local master is alive.
 
 == REPORTING BUGS
 

--- a/doc/sfschunkserver.8.adoc
+++ b/doc/sfschunkserver.8.adoc
@@ -65,7 +65,7 @@ or *kill*. Default action is *restart*.
 == FILES
 
 *sfschunkserver.cfg*:: configuration file for SaunaFS chunkserver process;
-refer to *sfschunkserver.cfg*(5) manual for defails
+refer to *sfschunkserver.cfg*(5) manual for details
 
 *sfshdd.cfg*:: list of directories (mountpoints) used for SaunaFS storage (one
 per line; directory prefixed by *** character causes given directory to be

--- a/doc/sfschunkserver.cfg.5.adoc
+++ b/doc/sfschunkserver.cfg.5.adoc
@@ -122,7 +122,7 @@ the value is aligned down to 64 KiB)
 
 *MAX_READ_BEHIND_KB*:: try to fix out-of-order read requests; the value tells
 how much of skipped data to read if an offset of some read operation is greater
-than the offset where the previos operation finished (default is 0, i.e. don't
+than the offset where the previous operation finished (default is 0, i.e. don't
 read any skipped data; the value is aligned down to 64 KiB)
 
 *PERFORM_FSYNC*:: call fsync() after a chunk is modified (default is 1, i.e.

--- a/doc/sfsmaster.cfg.5.adoc
+++ b/doc/sfsmaster.cfg.5.adoc
@@ -192,7 +192,7 @@ list of open files) should be sustained in the master server after connection
 with the client was lost. Values between 60 and 604800 (one week) are accepted.
 (default is 86400)
 
-*USE_BDB_FOR_NAME_STORAGE*:: When this option is set to 1 Berkley DB is used
+*USE_BDB_FOR_NAME_STORAGE*:: When this option is set to 1 Berkeley DB is used
 for storing file/directory names in file (DATA_PATH/name_storage.db). By
 default all strings are kept in system memory. (default is 0)
 

--- a/doc/sfsmetalogger.8.adoc
+++ b/doc/sfsmetalogger.8.adoc
@@ -54,7 +54,7 @@ is the one of *start*, *stop*, *restart*, *reload*, *test*, *isalive* or *kill*.
 
 *sfsmetalogger.cfg*::
 configuration file for SaunaFS metalogger process; refer to *sfsmetalogger.cfg*(5) manual for
-defails
+details
 
 *sfsmetalogger.lock*::
 PID file of running SaunaFS metalogger process

--- a/src/cgi/cgiserv.py.in
+++ b/src/cgi/cgiserv.py.in
@@ -17,7 +17,7 @@ import socket
 import select
 
 """Http server based on recipes 511453,511454 from code.activestate.com by Pierre Quentel"""
-"""Added support for indexes, access tests, proper handle of SystemExit exception, fixed couple of errors and vulnerbilities, getopt, lockfiles, daemonize etc. by Jakub Kruszona-Zawadzki"""
+"""Added support for indexes, access tests, proper handle of SystemExit exception, fixed couple of errors and vulnerabilities, getopt, lockfiles, daemonize etc. by Jakub Kruszona-Zawadzki"""
 
  ######################## ! DEPRECATION WARNING ! #########################
  #                                                                        #

--- a/src/cgi/saunafs-cgiserver.py.in
+++ b/src/cgi/saunafs-cgiserver.py.in
@@ -15,7 +15,7 @@ import urllib.parse
 
 # Http server based on recipes 511453,511454 from code.activestate.com by
 # Pierre Quentel Added support for indexes, access tests, proper handle of
-# SystemExit exception, fixed couple of errors and vulnerbilities, getopt,
+# SystemExit exception, fixed couple of errors and vulnerabilities, getopt,
 # lockfiles, daemonize etc. by Jakub Kruszona-Zawadzki
 
 # The dictionary holding one client handler for each connected client

--- a/src/cgi/sfs.cgi.in
+++ b/src/cgi/sfs.cgi.in
@@ -1214,7 +1214,7 @@ if "CH" in sectionset:
         out.append("""<br/>""")
         add_repl_del_state(out, "replicat", replication)
         out.append("""<br/>""")
-        add_repl_del_state(out, "delet", deletion)
+        add_repl_del_state(out, "delet", deletion)  # pragma: codespell-ignore
         print("\n".join(out))
     except Exception:
         print("""<table class="FR" cellspacing="0" summary="Exception">""")

--- a/src/chunkserver/chunkserver-common/cmr_disk.cc
+++ b/src/chunkserver/chunkserver-common/cmr_disk.cc
@@ -46,7 +46,7 @@ void CmrDisk::createPathsAndSubfolders() {
 	if (ret) {
 		safs_pretty_syslog(LOG_INFO,
 		                   "Folders structures for disk %s "
-		                   "auto-generated succesfully",
+		                   "auto-generated successfully",
 		                   getPaths().c_str());
 	}
 }

--- a/src/chunkserver/chunkserver-common/default_disk_manager.cc
+++ b/src/chunkserver/chunkserver-common/default_disk_manager.cc
@@ -259,7 +259,7 @@ IDisk *DefaultDiskManager::getDiskForNewChunk(
 	}
 
 	if (bestDisk != DiskNotFound) {
-		// Lower the probability of being choosen again
+		// Lower the probability of being chosen again
 		bestDisk->setCarry(bestDisk->carry() - 1.0);
 		return bestDisk;
 	}

--- a/src/chunkserver/chunkserver-common/disk_interface.h
+++ b/src/chunkserver/chunkserver-common/disk_interface.h
@@ -75,7 +75,7 @@ public:
 	/// This information is usually sent to master.
 	virtual DiskInfo toDiskInfo() const = 0;
 
-	/// Retrives the paths in the format [*]metaPath[ | dataPath].
+	/// Retrieves the paths in the format [*]metaPath[ | dataPath].
 	/// [] means optional, depending on current configuration.
 	virtual std::string getPaths() const = 0;
 

--- a/src/chunkserver/chunkserver-common/disk_utils.h
+++ b/src/chunkserver/chunkserver-common/disk_utils.h
@@ -15,7 +15,7 @@ constexpr uint8_t kLastErrorSize = 30;
 constexpr uint32_t kSecondsInOneMinute = 60;
 constexpr uint32_t kMinutesInOneHour = 60;
 
-/// Number of bytes which should be addded to each disk's used space
+/// Number of bytes which should be added to each disk's used space
 inline uint64_t gLeaveFree;
 
 /// Default value for HDD_LEAVE_SPACE_DEFAULT

--- a/src/chunkserver/chunkserver-common/disk_with_fd.h
+++ b/src/chunkserver/chunkserver-common/disk_with_fd.h
@@ -54,7 +54,7 @@ public:
 	/// Returns a DiskInfo object from the information inside this Disk
 	DiskInfo toDiskInfo() const override;
 
-	/// Retrives the paths in the format [*]metaPath[ | dataPath]
+	/// Retrieves the paths in the format [*]metaPath[ | dataPath]
 	///
 	/// [] means optional, depending on current configuration.
 	std::string getPaths() const override;

--- a/src/chunkserver/chunkserver-common/hdd_stats.h
+++ b/src/chunkserver/chunkserver-common/hdd_stats.h
@@ -114,7 +114,7 @@ private:
 	uint64_t dataSize_;          ///< Size of the IO operation
 	IDisk *disk_;                 ///< Disk for this operation
 	StatsUpdateFunc updateFunc_; ///< Delegate function to call at destruction
-	bool success_ = true;        ///< Tells if the operation succeded
+	bool success_ = true;        ///< Tells if the operation succeeded
 };
 
 /// Concrete updater for write operations

--- a/src/chunkserver/chunkserver_entry.h
+++ b/src/chunkserver/chunkserver_entry.h
@@ -97,7 +97,7 @@ struct ChunkserverEntry {
 	enum class State : uint8_t {
 		Idle,        // idle connection, new or used previously
 		Read,        // after CLTOCS_READ, but didn't send all of the
-		             // CSTOCL_READ_(DATA|STAUS)
+		             // CSTOCL_READ_(DATA|STATUS)
 		GetBlock,    // after CSTOCS_GET_CHUNK_BLOCKS, but didn't send response
 		WriteLast,   // ready for writing data; data not forwarded to other CSs
 		Connecting,  // connecting to other chunkserver to form a writing chain
@@ -166,7 +166,7 @@ struct ChunkserverEntry {
 	uint32_t size = 0; ///< R: Size of the current operation.
 
 	/// Pointer to the concrete serializer singleton.
-	/// Serializers coud be of type:
+	/// Serializers could be of type:
 	/// - LegacyMessageSerializer: for legacy messages
 	/// - SaunaFsMessageSerializer: for new messages
 	MessageSerializer* messageSerializer = nullptr; // R+W

--- a/src/chunkserver/hddspacemgr.cc
+++ b/src/chunkserver/hddspacemgr.cc
@@ -747,7 +747,7 @@ int hddRead(uint64_t chunkId, uint32_t version, ChunkPartType chunkType,
 		OutputBuffer tmp(kHddBlockSize);
 		status = hddReadCrcAndBlock(chunk, block, &tmp);
 
-		if (status == SAUNAFS_STATUS_OK) {  // Succesful read of the full block
+		if (status == SAUNAFS_STATUS_OK) {  // Successful read of the full block
 			status = hddCheckCrcForFullBlock(chunk, block, &tmp, true);
 
 			if (status == SAUNAFS_STATUS_OK) {  // CRC is OK or check disabled
@@ -1616,7 +1616,7 @@ static int hddInternalDuplicateTruncate(uint64_t chunkId, uint32_t chunkVersion,
 		crcDataDup = gOpenChunks.getResource(dupChunk->metaFD()).crcData();
 	}
 
-	// Seek to the beggining of data block on both chunks
+	// Seek to the beginning of data block on both chunks
 	if (!dupDisk->isZonedDevice()) {
 		dupDisk->lseekData(dupChunk, dupChunk->getBlockOffset(0), SEEK_SET);
 	}

--- a/src/chunkserver/hddspacemgr.h
+++ b/src/chunkserver/hddspacemgr.h
@@ -82,7 +82,7 @@ int hddChunkGetNumberOfBlocks(uint64_t chunkId, ChunkPartType chunkType,
 // chunkNewVersion>0 && length==0xFFFFFFFF && chunkIdCopy==0   -> change version
 // chunkNewVersion>0 && length==0xFFFFFFFF && chunkIdCopy>0     -> duplicate
 // chunkNewVersion>0 && length<=SFSCHUNKSIZE && chunkIdCopy==0  -> truncate
-// chunkNewVersion>0 && length<=SFSCHUNKSIZE && chunkIdCopy>0   -> dup and trun
+// chunkNewVersion>0 && length<=SFSCHUNKSIZE && chunkIdCopy>0   -> dup and turn
 // chunkNewVersion==0 && length==0                              -> delete
 // chunkNewVersion==0 && length==1                              -> create
 // chunkNewVersion==0 && length==2                              -> test
@@ -103,7 +103,7 @@ int hddInit();
 // Chunk low-level operations
 // The following functions shouldn't be used, unless for specific implementation
 // i.e. \see ChunkFileCreator
-// In most cases functions above are prefered.
+// In most cases functions above are preferred.
 
 /// Deletes the chunk from the registry and from the disk's testlist in a
 /// thread-safe way.

--- a/src/common/chunk_copies_calculator_unittest.cc
+++ b/src/common/chunk_copies_calculator_unittest.cc
@@ -39,14 +39,14 @@ TEST(ChunkCopiesCalculator, addPart) {
 	cccp.addPart(slice_traits::xors::ChunkPartType(3, 2), MediaLabel("B"));
 	cccp.addPart(slice_traits::xors::ChunkPartType(3, 1), MediaLabel("B"));
 	cccp.addPart(slice_traits::xors::ChunkPartType(3, 0), MediaLabel("A"));
-	Goal &avalible = cccp.getAvailable();
-	avalible.setName("goalname");
+	Goal &available = cccp.getAvailable();
+	available.setName("goalname");
 
-	ASSERT_EQ(avalible, goal);
+	ASSERT_EQ(available, goal);
 
 	cccp.addPart(slice_traits::xors::ChunkPartType(3, 0), MediaLabel("A"));
 
-	ASSERT_NE(avalible, goal);
+	ASSERT_NE(available, goal);
 }
 
 TEST(ChunkCopiesCalculator, removePart) {
@@ -56,10 +56,10 @@ TEST(ChunkCopiesCalculator, removePart) {
 	cccp.addPart(slice_traits::xors::ChunkPartType(3, 2), MediaLabel("B"));
 	cccp.addPart(slice_traits::xors::ChunkPartType(3, 1), MediaLabel("B"));
 	cccp.addPart(slice_traits::xors::ChunkPartType(3, 0), MediaLabel("A"));
-	Goal &avalible = cccp.getAvailable();
-	avalible.setName("goalname");
+	Goal &available = cccp.getAvailable();
+	available.setName("goalname");
 
-	ASSERT_EQ(avalible, goal);
+	ASSERT_EQ(available, goal);
 
 	cccp.removePart(sneakyPartType(kXor3), 0, MediaLabel("A"));
 	cccp.removePart(sneakyPartType(kXor3), 1, MediaLabel("B"));
@@ -171,8 +171,8 @@ TEST(ChunkCopiesCalculator, optimize) {
 	cccp.addPart(slice_traits::xors::ChunkPartType(5, 4), MediaLabel("X"));
 	cccp.addPart(slice_traits::xors::ChunkPartType(5, 5), MediaLabel("A"));
 
-	Goal &avalible = cccp.getAvailable();
-	avalible.setName("goalname");
+	Goal &available = cccp.getAvailable();
+	available.setName("goalname");
 
 	cccp.optimize();
 	int cost = cccp.countPartsToRecover();
@@ -187,8 +187,8 @@ TEST(ChunkCopiesCalculator, updateRedundancyLevel) {
 	cccp.addPart(slice_traits::xors::ChunkPartType(3, 2), MediaLabel("B"));
 	cccp.addPart(slice_traits::xors::ChunkPartType(3, 1), MediaLabel("B"));
 	cccp.addPart(slice_traits::xors::ChunkPartType(3, 0), MediaLabel("A"));
-	Goal &avalible = cccp.getAvailable();
-	avalible.setName("goalname");
+	Goal &available = cccp.getAvailable();
+	available.setName("goalname");
 
 	cccp.evalRedundancyLevel();
 	ASSERT_EQ(ChunksAvailabilityState::State::kSafe, cccp.getState());
@@ -244,8 +244,8 @@ TEST(ChunkCopiesCalculator, canRemoveExtraPartsFromSlice) {
 	cccp.addPart(slice_traits::xors::ChunkPartType(5, 4), MediaLabel("A"));
 	cccp.addPart(slice_traits::xors::ChunkPartType(5, 5), MediaLabel("C"));
 
-	Goal &avalible = cccp.getAvailable();
-	avalible.setName("goalname");
+	Goal &available = cccp.getAvailable();
+	available.setName("goalname");
 
 	cccp.optimize();
 	// goalname: $xor5 {C A A B B C}
@@ -287,8 +287,8 @@ TEST(ChunkCopiesCalculator, getLabelsToRecover) {
 	cccp.addPart(slice_traits::xors::ChunkPartType(4, 2), MediaLabel("A"));
 	cccp.addPart(slice_traits::xors::ChunkPartType(4, 3), MediaLabel("C"));
 
-	Goal &avalible = cccp.getAvailable();
-	avalible.setName("goalname");
+	Goal &available = cccp.getAvailable();
+	available.setName("goalname");
 
 	cccp.optimize();
 	//goalname: $xor4 {A B A C B}
@@ -323,8 +323,8 @@ TEST(ChunkCopiesCalculator, getRemovePool) {
 
 	cccp.evalRedundancyLevel();
 
-	Goal &avalible = cccp.getAvailable();
-	avalible.setName("goalname");
+	Goal &available = cccp.getAvailable();
+	available.setName("goalname");
 
 	cccp.updateRedundancyLevel(sneakyPartType(kXor4));
 	ASSERT_EQ(ChunksAvailabilityState::State::kSafe, cccp.getState());
@@ -368,8 +368,8 @@ TEST(ChunkCopiesCalculator, countPartsToMove) {
 	cccp.addPart(slice_traits::xors::ChunkPartType(4, 4), MediaLabel("A"));
 	cccp.addPart(slice_traits::xors::ChunkPartType(4, 4), MediaLabel("C"));
 
-	Goal &avalible = cccp.getAvailable();
-	avalible.setName("goalname");
+	Goal &available = cccp.getAvailable();
+	available.setName("goalname");
 
 	cccp.updateRedundancyLevel(sneakyPartType(kXor4));
 

--- a/src/common/compact_vector.h
+++ b/src/common/compact_vector.h
@@ -173,7 +173,7 @@ private:
 /*! \brief Compact vector storage class for 64 bit system
  *
  * On 64 bit system there is a limit on where memory can be allocated in user space.
- * Also current processors have build-in hardware limit on how much memory can be addressed.
+ * Also current processors have built-in hardware limit on how much memory can be addressed.
  * User space limit by OS:
  *   - Linux   128 TB
  *   - Windows 8 TB

--- a/src/common/hashfn.h
+++ b/src/common/hashfn.h
@@ -32,7 +32,7 @@
 /* fast integer hash functions by Thomas Wang */
 /* all of them pass the avalanche test */
 
-/* They are not mutch better in standard collision test than stupid "X*prime"
+/* They are not much better in standard collision test than stupid "X*prime"
  * functions, but calculation times are similar, so it should be safer to use
  * this functions */
 

--- a/src/common/id_pool.h
+++ b/src/common/id_pool.h
@@ -32,7 +32,7 @@ namespace detail {
 /*! \brief Helper class for IdPool.
  *
  * This class is almost typical bit pool. The only difference is that
- * when pool is full or empty underlaying vector storage releases all data.
+ * when pool is full or empty underlying vector storage releases all data.
  */
 template<typename V,typename S>
 class IdPoolBlock {

--- a/src/common/io_limits_database.h
+++ b/src/common/io_limits_database.h
@@ -52,7 +52,7 @@ class IoLimitsDatabase {
 public:
 	typedef std::string GroupId;
 
-	// An exception that is thrown if a user requestes an assignment for a group
+	// An exception that is thrown if a user requests an assignment for a group
 	// that cannot be served
 	SAUNAFS_CREATE_EXCEPTION_CLASS_MSG(InvalidGroupIdException, Exception,
 			"invalid group id");

--- a/src/common/linear_assignment_cache.h
+++ b/src/common/linear_assignment_cache.h
@@ -120,7 +120,7 @@ public:
 	 * @brief Calculate hash of a part.
 	 *
 	 * Hash of a part is P(```kBasePart_```) mod ```kModPart_```. P is a
-	 * polynomial whose coeficients are values dependant on each (labelId,
+	 * polynomial whose coefficients are values dependent on each (labelId,
 	 * copies) pair of the part.
 	 *
 	 * @param part Part to be calculated hash.
@@ -141,11 +141,11 @@ public:
 	 * @brief Calculate hash of a slice starting from a given hash.
 	 *
 	 * Hash of a part is Q(```kBaseSlice_```) mod ```kModSlice_```. Q is a
-	 * polynomial whose coeficients are the hashed of each of the parts in the
+	 * polynomial whose coefficients are the hashed of each of the parts in the
 	 * slice.
 	 *
 	 * @param startingHash Could be the ```kInitialStartingHash_``` or some hash
-	 * calculation from a previos slice.
+	 * calculation from a previous slice.
 	 * @param slice Slice to be calculated hash.
 	 * @return Hash of the given slice starting from the provided hash.
 	 */

--- a/src/data/saunafs-uraft.cfg
+++ b/src/data/saunafs-uraft.cfg
@@ -38,7 +38,7 @@
 ## Maximum election timeout (ms)
 # ELECTION_TIMEOUT_MAX = 600
 
-## Period between hearbeat messages (ms)
+## Period between heartbeat messages (ms)
 # HEARTBEAT_PERIOD = 20
 
 ## How often uRaft checks if local master is alive (ms)

--- a/src/data/saunafs-uraft.cfg
+++ b/src/data/saunafs-uraft.cfg
@@ -6,7 +6,7 @@
 #                                                              #
 ################################################################
 
-## uRaft default udp port used for comunication between nodes
+## uRaft default udp port used for communication between nodes
 ##
 # URAFT_PORT = 9427
 

--- a/src/data/sfschunkserver.cfg.in
+++ b/src/data/sfschunkserver.cfg.in
@@ -134,7 +134,7 @@
 
 ## Try to fix out-of-order read requests; the value tells how much of
 ## skipped data to read if an offset of some read operation is greater than
-## the offset where the previos operation finished
+## the offset where the previous operation finished
 ## (Default: 0), i.e. don't read any skipped data; the value is aligned down to 64 KiB.
 # MAX_READ_BEHIND_KB = 0
 

--- a/src/data/sfsmaster.cfg.in
+++ b/src/data/sfsmaster.cfg.in
@@ -249,7 +249,7 @@
 # deprecated:
 # CHUNKS_DEL_LIMIT - use CHUNKS_SOFT_DEL_LIMIT instead
 
-## Use Berkley DB for file/directory name storage (Boolean, 0 or 1).
+## Use Berkeley DB for file/directory name storage (Boolean, 0 or 1).
 ## By default system memory is used for storing file/directory names.
 ## With this option enabled Berkeley DB is used for storing
 ## names in file (@DATA_PATH@/name_storage.db)

--- a/src/main/main.cc
+++ b/src/main/main.cc
@@ -569,7 +569,7 @@ FileLock::LockStatus FileLock::wdlock(RunMode runmode, uint32_t timeout) {
 		}
 		if (runmode==RunMode::kReload) {
 			/*
-			 * FIXME: buissiness logic should not be in file locking function.
+			 * FIXME: business logic should not be in file locking function.
 			 */
 			if (kill(ownerpid,SIGHUP)<0) {
 				safs_pretty_errlog(LOG_ERR,
@@ -582,7 +582,7 @@ FileLock::LockStatus FileLock::wdlock(RunMode runmode, uint32_t timeout) {
 		}
 		if (runmode==RunMode::kKill) {
 			/*
-			 * FIXME: buissiness logic should not be in file locking function.
+			 * FIXME: business logic should not be in file locking function.
 			 */
 #ifdef ENABLE_EXIT_ON_USR1
 			if (kill(ownerpid,SIGUSR1)<0) {
@@ -597,7 +597,7 @@ FileLock::LockStatus FileLock::wdlock(RunMode runmode, uint32_t timeout) {
 		} else {
 			sassert((runmode == RunMode::kStop) || (runmode == RunMode::kRestart));
 			/*
-			 * FIXME: buissiness logic should not be in file locking function.
+			 * FIXME: business logic should not be in file locking function.
 			 */
 			if (kill(ownerpid,SIGTERM)<0) {
 				safs_pretty_errlog(LOG_ERR,

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -249,7 +249,7 @@ bool fsnodes_isancestor(FSNodeDirectory *ancestor, FSNode *node) {
  * or \param ancestor is ancestor of \param node.
  */
 bool fsnodes_isancestor_or_node_reserved_or_trash(FSNodeDirectory *ancestor, FSNode *node) {
-	// Return true if file is reservered:
+	// Return true if file is reserved:
 	if (node && (node->type == FSNode::kReserved || node->type == FSNode::kTrash)) {
 		return true;
 	}
@@ -1422,7 +1422,7 @@ uint8_t fsnodes_undel(uint32_t ts, FSNodeFile *node) {
 			}
 		}
 	}
-	if (partleng == 0) {  // last part canot be empty - it's the name of undeleted file
+	if (partleng == 0) {  // last part cannot be empty - it's the name of undeleted file
 		return SAUNAFS_ERROR_CANTCREATEPATH;
 	}
 	if (partleng == dots && partleng <= 2) {  // '.' or '..' in path

--- a/src/master/filesystem_operations.h
+++ b/src/master/filesystem_operations.h
@@ -76,7 +76,7 @@ uint8_t fs_repair(uint32_t rootinode, uint8_t sesflags, uint32_t inode, uint32_t
 /*! \brief Perform a flock operation on filesystem
  * Possible operations:
  * - unlock
- * - shared/exlusive blocking/nonblocking lock
+ * - shared/exclusive blocking/nonblocking lock
  * - handle interrupt
  */
 int fs_flock_op(const FsContext &context, uint32_t inode, uint64_t owner, uint32_t sessionid,
@@ -86,7 +86,7 @@ int fs_flock_op(const FsContext &context, uint32_t inode, uint64_t owner, uint32
 /*! \brief Perform a posix lock operation on filesystem
  * Possible operations:
  * - unlock
- * - shared/exlusive blocking/nonblocking lock
+ * - shared/exclusive blocking/nonblocking lock
  * - handle interrupt
  */
 int fs_posixlock_op(const FsContext &context, uint32_t inode, uint64_t start,

--- a/src/master/fs_context.h
+++ b/src/master/fs_context.h
@@ -251,7 +251,7 @@ public:
 	}
 
 	/**
-	 * Returns timestap.
+	 * Returns timestamp.
 	 * This is a timestamp of any operations performed in this context.
 	 */
 	uint32_t ts() const {

--- a/src/master/matomlserv.cc
+++ b/src/master/matomlserv.cc
@@ -94,7 +94,7 @@ static int lsock;
 static int32_t lsockpdescpos;
 static bool gExiting = false;
 
-/// Miminal period (in seconds) between two metadata save processes requested by shadow masters
+/// Minimal period (in seconds) between two metadata save processes requested by shadow masters
 static uint32_t gMinMetadataSaveRequestPeriod_s;
 
 /// Timestamp of the last metadata save request

--- a/src/master/metadata_loader.h
+++ b/src/master/metadata_loader.h
@@ -88,7 +88,7 @@ struct MetadataSection {
 	/// Whether to load the section asynchronously or not (default: true).
 	bool asyncLoad;
 
-	/// Whether the section is legacy and wont be loaded by default (default: false).
+	/// Whether the section is legacy and won't be loaded by default (default: false).
 	bool isLegacy;
 };
 

--- a/src/master/personality.cc
+++ b/src/master/personality.cc
@@ -111,7 +111,7 @@ void personality_reload(void) {
 				promoteToMaster();
 			} else {
 				safs_pretty_syslog(LOG_ERR,
-						"trying to preform forbidden personality change from Master to Shadow");
+						"trying to perform forbidden personality change from Master to Shadow");
 			}
 		}
 	} catch (const ConfigurationException& e) {

--- a/src/master/restore.cc
+++ b/src/master/restore.cc
@@ -835,7 +835,7 @@ int restore_line(const char* filename, uint64_t lv, const char* line) {
 				status = do_append(filename,lv,ts,ptr+6);
 			} else if (strncmp(ptr,"ACQUIRE",7)==0) {
 				status = do_acquire(filename,lv,ts,ptr+7);
-			} else if (strncmp(ptr,"AQUIRE",6)==0) {
+			} else if (strncmp(ptr,"AQUIRE",6)==0) { // pragma: codespell-ignore
 				status = do_acquire(filename,lv,ts,ptr+6);
 			}
 			break;

--- a/src/master/snapshot_task.h
+++ b/src/master/snapshot_task.h
@@ -34,7 +34,7 @@
  *
  * This class uses new approach to executing snapshots.
  * Each snapshot request is split into clone tasks.
- * Clone task is responsible for snapshoting only one inode.
+ * Clone task is responsible for snapshotting only one inode.
  * In the case of cloning directory inode new clone tasks can be enqueued
  * with child inodes.
  *

--- a/src/mount/io_limit_group.h
+++ b/src/mount/io_limit_group.h
@@ -31,7 +31,7 @@
 
 SAUNAFS_CREATE_EXCEPTION_CLASS(GetIoLimitGroupIdException, Exception);
 
-// parse 'is' assuming that it conains /proc/*/cgroup - formatted data
+// parse 'is' assuming that it contains /proc/*/cgroup - formatted data
 IoLimitGroupId getIoLimitGroupId(std::istream& is, const std::string& subsystem);
 
 // parse /proc/pid/cgroup

--- a/src/mount/option_casing_normalization.h
+++ b/src/mount/option_casing_normalization.h
@@ -29,7 +29,7 @@
  */
 void normalize_argument_casing(char *arg) {
 	// A single argument looks like this: arg1=val1,arg2=val2,...,argn=valn
-	// So, case change should be applied at the begining and between a comma
+	// So, case change should be applied at the beginning and between a comma
 	// appearance and the next equal sign
 
 	std::string argument(arg);

--- a/src/mount/polonaise/options.cc
+++ b/src/mount/polonaise/options.cc
@@ -127,7 +127,7 @@ void parse_command_line(int argc, char** argv, Setup& setup) {
 				"size of direntry cache in number of elements")
 			("entry-cache-timeout",
 				po::value<double>(&setup.entry_cache_timeout)->default_value((unsigned)SaunaClient::FsInitParams::kDefaultEntryCacheTimeout),
-				"timeout for enty cache")
+				"timeout for entry cache")
 			("attr-cache-timeout",
 				po::value<double>(&setup.attr_cache_timeout)->default_value((unsigned)SaunaClient::FsInitParams::kDefaultAttrCacheTimeout),
 				"timeout for attribute cache")

--- a/src/mount/polonaise/options.cc
+++ b/src/mount/polonaise/options.cc
@@ -103,7 +103,7 @@ void parse_command_line(int argc, char** argv, Setup& setup) {
 				"password for saunafs instance")
 			("io-retries",
 				po::value<uint32_t>(&setup.io_retries)->default_value((unsigned)SaunaClient::FsInitParams::kDefaultIoRetries),
-				"number of retries for I/O failres")
+				"number of retries for I/O failures")
 			("write-buffer-size",
 				po::value<uint32_t>(&setup.write_buffer_size)->default_value((unsigned)SaunaClient::FsInitParams::kDefaultWriteCacheSize),
 				"size of global write buffer in MiB")

--- a/src/nfs-ganesha/ds.c
+++ b/src/nfs-ganesha/ds.c
@@ -84,7 +84,7 @@ static void dsh_release(struct fsal_ds_handle *const dataServerHandle) {
 /**
  * @brief Open a file from DataServerHandle.
  *
- * Auxiliar function to open files in the syscalls related with Data Server.
+ * Auxiliary function to open files in the syscalls related with Data Server.
  *
  * @param[in] export         Handle to release
  * @param[in] dataServer     Data Server handle

--- a/src/nfs-ganesha/main.c
+++ b/src/nfs-ganesha/main.c
@@ -60,7 +60,7 @@ struct SaunaFSModule SaunaFS = {
                  .acl_support = 0,
 #endif
                  .cansettime = true,
-                 .homogenous = true,
+                 .homogenous = true,  // pragma: codespell-ignore
                  .supported_attrs = SAUNAFS_SUPPORTED_ATTRS,
                  .maxread = (uint64_t)FSAL_MAXIOSIZE,
                  .maxwrite = (uint64_t)FSAL_MAXIOSIZE,

--- a/src/protocol/SFSCommunication.h
+++ b/src/protocol/SFSCommunication.h
@@ -234,7 +234,7 @@ enum class SugidClearMode {
 #define SAUNAFS_LOCK_INTERRUPT 8
 #define SAUNAFS_LOCK_NONBLOCK 16
 
-// flags: "flags" fileld in "CLTOMA_FUSE_AQUIRE"
+// flags: "flags" field in "CLTOMA_FUSE_AQUIRE"
 #define WANT_READ 1
 #define WANT_WRITE 2
 #define AFTER_CREATE 4

--- a/src/tools/set_trashtime.cc
+++ b/src/tools/set_trashtime.cc
@@ -174,7 +174,7 @@ static int gene_set_trashtime_run(int argc, char **argv, int rflag) {
 	} else {
 		fprintf(
 		    stderr,
-		    "trashtime should be given as number of seconds optionally folowed by '-' or '+'\n");
+		    "trashtime should be given as number of seconds optionally followed by '-' or '+'\n");
 		set_trashtime_usage();
 		return 1;
 	}

--- a/src/unittests/mocks/module_mock.h
+++ b/src/unittests/mocks/module_mock.h
@@ -66,7 +66,7 @@ public:
 	bool waitForSignal(std::chrono::duration<Rep, Period> timeout);
 
 	/*
-	 * Starts a tread which manages the network communication with this mock
+	 * Starts a thread which manages the network communication with this mock
 	 */
 	void init();
 

--- a/src/unittests/plan_tester.cc
+++ b/src/unittests/plan_tester.cc
@@ -36,7 +36,7 @@ namespace unittests {
  * \param data Vector with chunkserver data.
  * \param offset Offset with position of data in \param data vector that should be read.
  * \param size Size of data to read.
- * \return 0 on succes
+ * \return 0 on success
  *         -1 on failure
  */
 int ReadPlanTester::readDataFromChunkServer(std::vector<uint8_t> &output, int output_offset,
@@ -59,7 +59,7 @@ int ReadPlanTester::readDataFromChunkServer(std::vector<uint8_t> &output, int ou
  * \param write_buffer_offset Offset where data should be stored in output_buffer_ vector.
  * \param available_data Map with data for each chunk part type.
  * \param op Structure describing requested read operation.
- * \return 0 on succes
+ * \return 0 on success
  *         -1 on failure
  */
 int ReadPlanTester::startReadOperation(int write_buffer_offset,

--- a/src/uraft/uraftcontroller.cc
+++ b/src/uraft/uraftcontroller.cc
@@ -370,7 +370,7 @@ bool uRaftController::runCommand(const std::vector<std::string> &cmd, std::strin
  * Reads data from file descriptor and store them in string (with timeout).
  * \param fd file descriptor to read
  * \param result string with read data.
- * \param timoeut time (ms) after which we stop reading data.
+ * \param timeout time (ms) after which we stop reading data.
  * \return -1 error
  *         0  timeout did occur
  *         1  no error

--- a/src/uraft/uraftcontroller.h
+++ b/src/uraft/uraftcontroller.h
@@ -7,7 +7,7 @@
 #include "common/time_utils.h"
 #include "uraftstatus.h"
 
-/*! \brief Managament of SaunaFS metadata server based on uRaft algorithm.
+/*! \brief Management of SaunaFS metadata server based on uRaft algorithm.
  *
  * This class manages local SaunaFS master/shadow server. This is done using
  * base class uRaft for selection of leader. We get informed on leader change by call

--- a/tests/saunafs-tests.cc
+++ b/tests/saunafs-tests.cc
@@ -39,7 +39,7 @@ std::string tempDirForAllTests() {
 // but it does not need to outlive the test environment
 // it has to be in a separate folder due to
 // sticky bit in /tmp
-// It cannot be in TEMP_DIR, becaue the folder is cleaned
+// It cannot be in TEMP_DIR, because the folder is cleaned
 // after every test.
 std::string testErrFilePath() {
 	return tempDirForAllTests() + "/test_err";
@@ -49,7 +49,7 @@ std::string testErrFilePath() {
 
 class BashTestEnvironment : public ::testing::Environment {
 	virtual void SetUp() {
-		// remove prevoius temp dir
+		// remove previous temp dir
 		std::string tempForAllTests = tempDirForAllTests();
 		if (boost::filesystem::exists(tempForAllTests)) {
 			boost::filesystem::remove_all(tempForAllTests);
@@ -60,7 +60,7 @@ class BashTestEnvironment : public ::testing::Environment {
 		boost::filesystem::permissions(tempForAllTests, perms);
 	}
 	virtual void TearDown() {
-		// remove prevoius temp dir
+		// remove previous temp dir
 		std::string tempForAllTests = tempDirForAllTests();
 		if (boost::filesystem::exists(tempForAllTests)) {
 			boost::filesystem::remove_all(tempForAllTests);

--- a/tests/setup_machine.sh
+++ b/tests/setup_machine.sh
@@ -37,7 +37,7 @@ fi
 
 if grep -q 'saunafstest_loop' /etc/fstab; then
 	if [[ "${1}" != "setup-force" ]]; then
-		echo 'The machine is at least partialy configured'
+		echo 'The machine is at least partially configured'
 		echo 'Run revert-setup-machine.sh to revert the current configuration'
 		exit 1
 	fi

--- a/tests/test_suites/LongManualTests/test_advanced_readahead_parameters.sh
+++ b/tests/test_suites/LongManualTests/test_advanced_readahead_parameters.sh
@@ -1,5 +1,5 @@
 # Goal of test:
-# Verify that combinations of different readahead parameters succesfully manage to read a file in different patterns.
+# Verify that combinations of different readahead parameters successfully manage to read a file in different patterns.
 #
 assert_program_installed fio
 

--- a/tests/test_suites/ShortFailingTests/test_cgi_validate_html.sh
+++ b/tests/test_suites/ShortFailingTests/test_cgi_validate_html.sh
@@ -36,7 +36,7 @@ traverse_cgi() {
 	mkdir -p "$dir"
 	if wget --version | awk 'NR==1 && $3 < 1.14 {exit 1}' ; then
 		# Optimization for newer wgets -- don't download pages with two tabs open.
-		# This is achieved by filtering out URLs with '|' charecters (like in secions=IN|CS|MO).
+		# This is achieved by filtering out URLs with '|' characters (like in sections=IN|CS|MO).
 		filter="--reject-regex=%7C"
 	fi
 	wget -l2 --directory-prefix="$dir" $filter -r -q "${info[cgi_url]}"

--- a/tests/test_suites/ShortSystemTests/test_auto_recovery_xor_repair.sh
+++ b/tests/test_suites/ShortSystemTests/test_auto_recovery_xor_repair.sh
@@ -110,7 +110,7 @@ saunafs_wait_for_ready_chunkservers 4
 # chunk 0 [0 copies] - one xor part (id: 5, ver: 2), two xor parts (id: 5 ver: 1)
 # chunk 1 [1 copy  ] - three xor parts (id: 6, ver: 1)
 # chunk 2 [0 copies] - one xor part (id: 3, ver: 1)
-# chunk 3 [1 copy  ] - one std chunk with (id: 4 ver: 1) (from snaphot)
+# chunk 3 [1 copy  ] - one std chunk with (id: 4 ver: 1) (from snapshot)
 checkfile=$(saunafs checkfile dir/file)
 assert_awk_finds '/chunks with 0 copies: *2$/' "$checkfile"
 assert_awk_finds '/chunks with 1 copy: *2$/' "$checkfile"

--- a/tests/test_suites/ShortSystemTests/test_custom_goals_missing_server.sh
+++ b/tests/test_suites/ShortSystemTests/test_custom_goals_missing_server.sh
@@ -27,7 +27,7 @@ for goal in g{2..3}_{1..8}; do
 	saunafs setgoal "$goal" "$file"
 	FILE_SIZE=1K file-generate "$file"
 
-	# Now verify if the file has exactly the requied number of copies of its chunk
+	# Now verify if the file has exactly the required number of copies of its chunk
 	fileinfo=$(saunafs fileinfo "$file")
 	expected_copies=${goal:1:1}
 	actual_copies=$(echo "$fileinfo" | grep copy | wc -l)

--- a/tests/test_suites/ShortSystemTests/test_custom_goals_when_creating_new_chunks.sh
+++ b/tests/test_suites/ShortSystemTests/test_custom_goals_when_creating_new_chunks.sh
@@ -13,7 +13,7 @@ USE_RAMDISK=YES \
 	setup_local_empty_saunafs info
 
 # For each goal, define all possible lists of labels. Each list is sorted alphabetically,
-# lists are separated using pipes, lables in a single list using commas.
+# lists are separated using pipes, labels in a single list using commas.
 expected_labels[1]="cn|de|us"
 expected_labels[2]="cn,de|cn,us|de,de|de,us|us,us"
 expected_labels[3]="cn,de,de|cn,de,us|cn,us,us|de,de,us|de,us,us"
@@ -35,7 +35,7 @@ expected_labels[18]="cn,de,us|cn,us,us|de,de,us|de,us,us"
 expected_labels[19]="cn,de,us|de,de,us|de,us,us"
 expected_labels[20]="cn,de,us,us|cn,de,de,us"
 
-# For a given file, prints lables of chunkservers where the file's chunks are placed, eg. de,us,us
+# For a given file, prints labels of chunkservers where the file's chunks are placed, eg. de,us,us
 get_file_labels() {
 	local fileinfo_to_labels="`
 			`/copy .*:(${info[chunkserver0_port]}|${info[chunkserver1_port]}):.*\$/ {print \"de\"} `

--- a/tests/test_suites/ShortSystemTests/test_ec_overwriting.sh
+++ b/tests/test_suites/ShortSystemTests/test_ec_overwriting.sh
@@ -18,7 +18,7 @@ FILE_SIZE=${file_size_mb}M file-generate "$tmpf"
 # Create a file on SaunaFS filesystem with random data
 dd if=/dev/urandom of="$dir/file" bs=1MiB count=$file_size_mb
 
-# Overwirte the file using data from the temporary file
+# Overwrite the file using data from the temporary file
 # Use 20 parallel threads, each of them overwrites a random 1 KB block
 seq 0 $((file_size_mb*1024-1)) | shuf | xargs -P20 -IXX \
 		dd if="$tmpf" of="$dir/file" bs=1K count=1 seek=XX skip=XX conv=notrunc 2>/dev/null

--- a/tests/test_suites/ShortSystemTests/test_long_readdir.sh
+++ b/tests/test_suites/ShortSystemTests/test_long_readdir.sh
@@ -9,7 +9,7 @@ file_names() {
 	local N=30000
 	seq 1 $N
 	seq 1 $N | sed -e "s/^/dir_/"
-	seq 1 $N | sed -e "s/^/a bit longer name of a direcotry /"
+	seq 1 $N | sed -e "s/^/a bit longer name of a directory /"
 	seq 1 $N | sed -e "s/^/$(yes loooooong | tr '\n' '_' | head -c 245)_/"
 }
 

--- a/tests/test_suites/ShortSystemTests/test_metadata_save_request_min_period.sh
+++ b/tests/test_suites/ShortSystemTests/test_metadata_save_request_min_period.sh
@@ -35,7 +35,7 @@ saunafs_master_n 1 stop
 touch "${info[mount0]}"/file2
 sed -i 's/file2/fool2/g' "${info[master_data_path]}"/changelog.sfs
 
-# Start the shadow master again; it shouldn't synchonize within first seconds because of
+# Start the shadow master again; it shouldn't synchronize within first seconds because of
 # METADATA_SAVE_REQUEST_MIN_PERIOD. Let's verify if the synchronization needs at least 7 seconds.
 saunafs_master_n 1 start
 sleep $(timeout_rescale_seconds 7)

--- a/tests/tools/assert.sh
+++ b/tests/tools/assert.sh
@@ -137,7 +137,7 @@ assert_template_eventually_() {
 	local command=$1
 	local timeout=$(rescale_timeout_for_assert_eventually_ "${2:-}")
 	if ! wait_for "$command" "$timeout"; then
-		$FAIL_FUNCTION "'$command' didn't succedd within $timeout"
+		$FAIL_FUNCTION "'$command' didn't succeed within $timeout"
 	fi
 }
 

--- a/tests/tools/config.sh
+++ b/tests/tools/config.sh
@@ -61,7 +61,7 @@ if ! touch "$TEMP_DIR/check_tmp_dir" || ! rm "$TEMP_DIR/check_tmp_dir"; then
 	exit 1
 fi
 
-# This function shold be called just after test_fail is able to work
+# This function should be called just after test_fail is able to work
 check_configuration() {
 	for prog in \
 		$SAUNAFS_ROOT/sbin/{sfsmaster,sfschunkserver} \

--- a/tests/tools/saunafs.sh
+++ b/tests/tools/saunafs.sh
@@ -307,7 +307,7 @@ create_magic_debug_log_entry_() {
 	fi | sed -e 's/,$//'
 }
 
-# Sometimes use Berkley DB name storage
+# Sometimes use Berkeley DB name storage
 create_bdb_name_storage_entry_() {
 	if (($RANDOM % 2)); then
 		echo "USE_BDB_FOR_NAME_STORAGE = 0"

--- a/tests/tools/test.sh
+++ b/tests/tools/test.sh
@@ -9,7 +9,7 @@ test_add_failure() {
 		return
 	fi
 	local message="[$(date +"%F %T")] $*"
-	# Env. valiable ERROR_FILE can be used to store error messages in a file
+	# Env. variable ERROR_FILE can be used to store error messages in a file
 	echo "$message" | tee -a "${ERROR_FILE:-/dev/null}" >> "$test_result_file"
 	# Print bold red message to the console
 	tput setaf 1

--- a/tests/tools/valgrind.sh
+++ b/tests/tools/valgrind.sh
@@ -78,13 +78,13 @@ valgrind_enable() {
 			valgrind_command+="$(getHelgrindOptions)"
 		fi
 
-		# Supressions files for known false positives
+		# Suppressions files for known false positives
 		valgrind_command+=" --suppressions=$SOURCE_DIR/tests/tools/valgrind-${valgrind_tool_}.supp"
 
 		# Valgrind error messages will be written here.
 		valgrind_command+=" --log-file=${ERROR_DIR}/valgrind__\${1}_%p.log"
 
-		# Valgrind errors will generate suppresions:
+		# Valgrind errors will generate suppressions:
 		valgrind_command+=" --gen-suppressions=all"
 
 		# Valgrind will show filepaths with module subdirectories on errors:

--- a/utils/wireshark/plugins/saunafs/make_dissector.py
+++ b/utils/wireshark/plugins/saunafs/make_dissector.py
@@ -286,7 +286,7 @@ for line in sys.stdin:
                 break
             (name, condition, typestr) = re.match(regex, arg).group(1, 2, 3)
             assert condition is not None or type is not None
-            # Condition, ie. somthing like version==3 or rver==0x55:8
+            # Condition, ie. something like version==3 or rver==0x55:8
             if condition:
                 variant.add_condition(name, condition)
                 condition_added = True


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .  It detects (and can be used to fix) commonly made typos.  There is a good number of them found in this codebase.

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.