### PR TITLE
fix(uraft): Fix missing floating ip address

### DIFF
--- a/src/uraft/main.cc
+++ b/src/uraft/main.cc
@@ -48,7 +48,8 @@ void parseOptions(int argc, char **argv, uRaftController::Options &opt, bool &ma
 	("URAFT_DEMOTE_TIMEOUT", po::value<int>()->default_value(1000000000), "demote timeout (ms)")
 	("URAFT_DEAD_HANDLER_TIMEOUT", po::value<int>()->default_value(1000000000), "metadata server dead handler timeout (ms)")
 	("URAFT_CHECK_CMD_PERIOD", po::value<int>()->default_value(100), "check command status period(ms)")
-	("URAFT_STATUS_PORT", po::value<int>()->default_value(9428), "node status port");
+	("URAFT_STATUS_PORT", po::value<int>()->default_value(9428), "node status port")
+	("URAFT_FLOATING_IP", po::value<std::string>(), "uraft floating ip address");
 
 	po::options_description cmdline_options;
 	cmdline_options.add(generic).add(config).add(hidden);
@@ -110,6 +111,9 @@ void parseOptions(int argc, char **argv, uRaftController::Options &opt, bool &ma
 	opt.local_master_server       = vm["LOCAL_MASTER_ADDRESS"].as<std::string>();
 	opt.local_master_port         = vm["LOCAL_MASTER_MATOCL_PORT"].as<int>();
 	opt.check_cmd_status_period   = vm["URAFT_CHECK_CMD_PERIOD"].as<int>();
+	if (opt.elector_mode == 0) {
+		opt.floating_ip           = vm["URAFT_FLOATING_IP"].as<std::string>();
+	}
 	make_daemon                   = vm["start-daemon"].as<bool>();
 
 	if (vm.count("id")) {
@@ -218,6 +222,11 @@ int main(int argc, char **argv) {
 	if (make_daemon && !daemonize()) {
 		syslog(LOG_ERR, "Unable to switch to daemon mode");
 		return EXIT_FAILURE;
+	}
+
+	if (!opt.floating_ip.empty()) {
+		syslog(LOG_INFO, "Setting URAFT_FLOATING_IP to %s", opt.floating_ip.c_str());
+		setenv("URAFT_FLOATING_IP", opt.floating_ip.c_str(), 0);
 	}
 
 	boost::asio::io_service  io_service;

--- a/src/uraft/saunafs-uraft-helper.in
+++ b/src/uraft/saunafs-uraft-helper.in
@@ -155,6 +155,11 @@ saunafs_isalive() {
 	saunafs_master isalive
 	if [[ $? == 0 ]] ; then
 		echo -n alive
+		if ! ip addr | grep -w -q "${URAFT_FLOATING_IP}"; then
+			log "floating ip address ${URAFT_FLOATING_IP} was lost, adding it again..."
+			load_config
+			saunafs_assign_ip
+		fi
 	else
 		echo -n dead
 	fi

--- a/src/uraft/uraftcontroller.h
+++ b/src/uraft/uraftcontroller.h
@@ -30,6 +30,7 @@ public:
 		int         promote_timeout;          //!< Time after which we kill promote script. //
 		int         demote_timeout;           //!< Time after which we kill demote script. //
 		int         dead_handler_timeout;     //!< Time after which we kill dead script. //
+		std::string floating_ip;        //!< Floating IP addresss used by uraft. //
 	};
 
 public:


### PR DESCRIPTION
If something removes the floating ip address from the device, saunafs-uraft will not bring it back. For example, on Ubuntu systems, if systemd-networkd is restarted, it will reapply netplan config, which inadvertently remove the floating ip address, and uraft has no way of adding this back.

This fix adds a way for uraft to bring the IP address back. First by exporting the IP address as an environment variable in the main program, and then by using in the script to query iproute2 for the IP address, and add it when it's missing.

Note that if two IP addresses with different subnet masks are added, then it won't re-add the IP address with the correct subnet mask.