### PR TITLE
feat(chunkserver): Add IDiskManager::getDiskForGC

### DIFF
--- a/src/chunkserver/chunkserver-common/default_disk_manager.h
+++ b/src/chunkserver/chunkserver-common/default_disk_manager.h
@@ -73,4 +73,11 @@ public:
 	/// Gets the disk groups information.
 	/// Not supported by the default disk manager.
 	std::string getDiskGroupsInfo() override { return "Not supported"; }
+
+	/// Selects the disk to use for GC.
+	IDisk *getDiskForGC() override;
+
+private:
+	/// Next disk index for GC. Helps in the round-robin strategy.
+	uint32_t nextDiskIndexForGC_ = 0;
 };

--- a/src/chunkserver/chunkserver-common/disk_manager_interface.h
+++ b/src/chunkserver/chunkserver-common/disk_manager_interface.h
@@ -60,4 +60,8 @@ public:
 
 	/// Gets the disk groups information in YAML format
 	virtual std::string getDiskGroupsInfo() = 0;
+
+	/// Selects the disk to use for Garbage Collection (GC).
+	/// Could return DiskNotFound if the disks does not need GC.
+	virtual IDisk *getDiskForGC() = 0;
 };

--- a/src/common/unique_queue.h
+++ b/src/common/unique_queue.h
@@ -56,6 +56,12 @@ public:
 			return element;
 		}
 	}
+
+	size_t size() {
+		std::lock_guard lock(mutex_);
+		return queue_.size();
+	}
+
 private:
 	typedef std::set<T> Set;
 	typedef std::queue<typename Set::iterator> Queue;


### PR DESCRIPTION
This commit adds and extension point for the disk managers to be asked about the next disk for garbage collection (GC). The default disk manager returns the next zoned device in a round-robin approach.

It is up to the disk manager plugins to provide custom implementation for this behavior.