### PR TITLE
fix(tests): Reserve one core in build tests

### DIFF
--- a/tests/test_suites/LongSystemTests/test_build_and_rsync.sh
+++ b/tests/test_suites/LongSystemTests/test_build_and_rsync.sh
@@ -25,7 +25,7 @@ test_worker() {
 
 CHUNKSERVERS=3 \
 	MOUNTS=1 \
-	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER|cacheexpirationtime=0" \
+	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER|cacheexpirationtime=0|sfsdirentrycacheto=0" \
 	setup_local_empty_saunafs info
 
 cd "${info[mount0]}"

--- a/tests/test_suites/LongSystemTests/test_build_and_rsync.sh
+++ b/tests/test_suites/LongSystemTests/test_build_and_rsync.sh
@@ -6,6 +6,7 @@ assert_program_installed rsync
 MINIMUM_PARALLEL_JOBS=5
 MAXIMUM_PARALLEL_JOBS=16
 PARALLEL_JOBS=$(get_nproc_clamped_between ${MINIMUM_PARALLEL_JOBS} ${MAXIMUM_PARALLEL_JOBS})
+EFFECTIVE_JOBS=$(get_nicer_effective_jobs ${PARALLEL_JOBS})
 
 test_worker() {
 	export MESSAGE="Testing directory $1"
@@ -14,7 +15,7 @@ test_worker() {
 	mkdir saunafs/build
 	cd saunafs/build
 	assert_success cmake .. -G 'Unix Makefiles' -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=../install
-	assert_success make -j${PARALLEL_JOBS} install
+	assert_success make -j${EFFECTIVE_JOBS} install
 	cd ../..
 	assertlocal_success rsync -a saunafs/ copy_saunafs
 	find saunafs -type f | while read file; do

--- a/tests/test_suites/LongSystemTests/test_build_saunafs.sh
+++ b/tests/test_suites/LongSystemTests/test_build_saunafs.sh
@@ -3,7 +3,7 @@ assert_program_installed git
 assert_program_installed cmake
 
 CHUNKSERVERS=8 \
-	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER|cacheexpirationtime=0" \
+	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER|cacheexpirationtime=0|sfsdirentrycacheto=0" \
 	CHUNKSERVER_EXTRA_CONFIG="READ_AHEAD_KB = 1024|MAX_READ_BEHIND_KB = 2048"
 	setup_local_empty_saunafs info
 

--- a/tests/test_suites/LongSystemTests/test_build_saunafs.sh
+++ b/tests/test_suites/LongSystemTests/test_build_saunafs.sh
@@ -10,6 +10,7 @@ CHUNKSERVERS=8 \
 MINIMUM_PARALLEL_JOBS=4
 MAXIMUM_PARALLEL_JOBS=16
 PARALLEL_JOBS=$(get_nproc_clamped_between ${MINIMUM_PARALLEL_JOBS} ${MAXIMUM_PARALLEL_JOBS})
+EFFECTIVE_JOBS=$(get_nicer_effective_jobs ${PARALLEL_JOBS})
 
 cd ${info[mount0]}
 
@@ -25,4 +26,4 @@ cd saunafs
 mkdir -p build
 cd build
 assert_success cmake .. -G 'Unix Makefiles' -DCMAKE_BUILD_TYPE=RelWithDebInfo
-assert_success make -j${PARALLEL_JOBS}
+assert_success make -j${EFFECTIVE_JOBS}

--- a/tests/test_suites/LongSystemTests/test_build_while_auto_recovery.sh
+++ b/tests/test_suites/LongSystemTests/test_build_while_auto_recovery.sh
@@ -12,6 +12,7 @@ CHUNKSERVERS=3 \
 MINIMUM_PARALLEL_JOBS=5
 MAXIMUM_PARALLEL_JOBS=16
 PARALLEL_JOBS=$(get_nproc_clamped_between ${MINIMUM_PARALLEL_JOBS} ${MAXIMUM_PARALLEL_JOBS})
+EFFECTIVE_JOBS=$(get_nicer_effective_jobs ${PARALLEL_JOBS})
 
 master_kill_loop() {
 	while true; do
@@ -31,4 +32,4 @@ saunafs setgoal -r 2 saunafs
 mkdir saunafs/build
 cd saunafs/build
 assert_success cmake .. -G 'Unix Makefiles' -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../install
-assert_success make -j${PARALLEL_JOBS} install
+assert_success make -j${EFFECTIVE_JOBS} install

--- a/tests/test_suites/LongSystemTests/test_build_while_auto_recovery.sh
+++ b/tests/test_suites/LongSystemTests/test_build_while_auto_recovery.sh
@@ -6,7 +6,7 @@ CHUNKSERVERS=3 \
 	MOUNTS=1 \
 	CHUNKSERVER_EXTRA_CONFIG="MASTER_RECONNECTION_DELAY = 1" \
 	MASTER_EXTRA_CONFIG="AUTO_RECOVERY = 1"\
-	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER|cacheexpirationtime=0" \
+	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER|cacheexpirationtime=0|sfsdirentrycacheto=0" \
 	setup_local_empty_saunafs info
 
 MINIMUM_PARALLEL_JOBS=5

--- a/tests/test_suites/LongSystemTests/test_build_while_changing_master.sh
+++ b/tests/test_suites/LongSystemTests/test_build_while_changing_master.sh
@@ -12,6 +12,7 @@ MASTERSERVERS=$metaservers_nr \
 MINIMUM_PARALLEL_JOBS=5
 MAXIMUM_PARALLEL_JOBS=16
 PARALLEL_JOBS=$(get_nproc_clamped_between ${MINIMUM_PARALLEL_JOBS} ${MAXIMUM_PARALLEL_JOBS})
+EFFECTIVE_JOBS=$(get_nicer_effective_jobs ${PARALLEL_JOBS})
 
 assert_program_installed git
 assert_program_installed cmake
@@ -60,4 +61,4 @@ saunafs setgoal -r 2 saunafs
 mkdir saunafs/build
 cd saunafs/build
 assert_success cmake .. -G 'Unix Makefiles' -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=../install
-assert_success make -j${PARALLEL_JOBS} install
+assert_success make -j${EFFECTIVE_JOBS} install

--- a/tests/test_suites/LongSystemTests/test_build_while_changing_master.sh
+++ b/tests/test_suites/LongSystemTests/test_build_while_changing_master.sh
@@ -5,7 +5,7 @@ MASTERSERVERS=$metaservers_nr \
 	CHUNKSERVERS=2 \
 	CHUNKSERVER_EXTRA_CONFIG="MASTER_RECONNECTION_DELAY = 1" \
 	SFSEXPORTS_EXTRA_OPTIONS="allcanchangequota" \
-	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER|cacheexpirationtime=0" \
+	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER|cacheexpirationtime=0|sfsdirentrycacheto=0" \
 	MASTER_EXTRA_CONFIG="MAGIC_AUTO_FILE_REPAIR = 1" \
 	setup_local_empty_saunafs info
 
@@ -21,7 +21,7 @@ master_kill_loop() {
 	# Start shadow masters
 	for ((shadow_id=1 ; shadow_id<metaservers_nr; ++shadow_id)); do
 		saunafs_master_n $shadow_id start
-		assert_eventually "saunafs_shadow_synchronized $shadow_id"
+		assert_eventually "saunafs_shadow_synchronized $shadow_id" "30 seconds"
 	done
 
 	loop_nr=0
@@ -35,7 +35,7 @@ master_kill_loop() {
 		loop_nr=$((loop_nr + 1))
 
 		# Kill the previous master
-		assert_eventually "saunafs_shadow_synchronized $new_master_id"
+		assert_eventually "saunafs_shadow_synchronized $new_master_id" "30 seconds"
 		saunafs_stop_master_without_saving_metadata
 		saunafs_make_conf_for_shadow $prev_master_id
 
@@ -46,7 +46,7 @@ master_kill_loop() {
 		# Demote previous master to shadow
 		saunafs_make_conf_for_shadow $prev_master_id
 		saunafs_master_n $prev_master_id start
-		assert_eventually "saunafs_shadow_synchronized $prev_master_id"
+		assert_eventually "saunafs_shadow_synchronized $prev_master_id" "30 seconds"
 
 		saunafs_wait_for_all_ready_chunkservers
 	done

--- a/tests/tools/system.sh
+++ b/tests/tools/system.sh
@@ -27,3 +27,15 @@ get_nproc_clamped_between() {
 	local procs_num=$(nproc)
 	echo $(( (procs_num < minimum) ? minimum : (maximum < procs_num) ? maximum : procs_num ))
 }
+
+# Reserves one core for other tasks
+get_nicer_effective_jobs() {
+	local original_jobs=${1}
+	local procs_num=$(nproc)
+
+	if [ "${procs_num}" -eq "${original_jobs}" ]; then
+		echo $((procs_num - 1))
+	else
+		echo "${original_jobs}"
+	fi
+}


### PR DESCRIPTION
The build tests inside the saunafs mount point were using all available cores (clamped to 16). In the meantime other tasks need the processor. Sometimes these other tasks are timing out.

This change ensures that there is at least one core to do these other tasks.