### PR TITLE
feat(chunkserver): Get chunk to test from manager

### DIFF
--- a/src/chunkserver/chunkserver-common/default_disk_manager.h
+++ b/src/chunkserver/chunkserver-common/default_disk_manager.h
@@ -21,6 +21,7 @@
 #include "common/platform.h"
 
 #include "chunkserver-common/disk_manager_interface.h"
+#include "chunkserver-common/global_shared_resources.h"
 
 /**
  * \brief Default implementation of the disk manager interface.
@@ -77,7 +78,20 @@ public:
 	/// Selects the disk to use for GC.
 	IDisk *getDiskForGC() override;
 
+	/// Selects next chunk to test.
+	IChunk *getChunkToTest(uint32_t &elapsedTimeMs) override;
+
+	/// Reset the disk iterators used for tests.
+	/// Usually when gResetTester changes or after a reload.
+	void resetDiskIteratorForTests() override;
+
 private:
 	/// Next disk index for GC. Helps in the round-robin strategy.
 	uint32_t nextDiskIndexForGC_ = 0;
+
+	// Iterators used to select the disks for chunk testing.
+	using DisksIterator = std::vector<std::unique_ptr<IDisk>>::iterator;
+
+	DisksIterator diskItForTests_ = gDisks.begin();
+	DisksIterator previousDiskItForTests_ = gDisks.begin();
 };

--- a/src/chunkserver/chunkserver-common/disk_manager_interface.h
+++ b/src/chunkserver/chunkserver-common/disk_manager_interface.h
@@ -64,4 +64,10 @@ public:
 	/// Selects the disk to use for Garbage Collection (GC).
 	/// Could return DiskNotFound if the disks does not need GC.
 	virtual IDisk *getDiskForGC() = 0;
+
+	/// Selects the disk to use for a chunk test.
+	virtual IChunk *getChunkToTest(uint32_t &elapsedTimeMs) = 0;
+
+	/// Resets the helper disk iterator for tests.
+	virtual void resetDiskIteratorForTests() = 0;
 };

--- a/src/chunkserver/chunkserver-common/global_shared_resources.h
+++ b/src/chunkserver/chunkserver-common/global_shared_resources.h
@@ -14,6 +14,13 @@ inline IndexedResourcePool<OpenChunk> gOpenChunks;
 /// chunks to be tested.
 inline std::mutex gTestsMutex;
 
+/// Maximum frequency for chunk testing in milliseconds.
+constexpr uint32_t kMaxTestFreqMs = 1000U;
+
+/// Frequency for chunk testing in milliseconds.
+/// Can be changed via the configuration file (HDD_TEST_FREQ).
+inline std::atomic<unsigned> gHDDTestFreq_ms(10 * 1000);
+
 /// Global unordered_map of all chunks stored in this chunkserver.
 inline ChunkMap gChunksMap;
 


### PR DESCRIPTION
This commit adds and extension point for the disk managers to be asked about the next chunk to test. The default disk manager uses the same approach as before.

It is up to the disk manager plugins to provide custom implementation for this behavior.