### PR TITLE
fix(mount): Fix client race conditions

### DIFF
--- a/doc/sfsmount.1.adoc
+++ b/doc/sfsmount.1.adoc
@@ -157,10 +157,7 @@ operation in milliseconds (default: 2000).
 
 *-o cacheexpirationtime=*'MSEC'::
 Set timeout for read cache entries to be considered valid in milliseconds. 0
-disables cache (default: 0). Due to a bug, this can sometimes result in invalid
-data being returned if reading the mount point from multiple processes/threads
-and it's not disabled. Verify data being sent using a checksum if using this
-feature.
+disables cache (default: 1000).
 
 *-o readaheadmaxwindowsize=*'KB'::
 Set max value of readahead window per single descriptor in kibibytes (default: 16384).

--- a/src/mount/chunk_locator.h
+++ b/src/mount/chunk_locator.h
@@ -74,7 +74,7 @@ private:
 	uint32_t inode_;
 	uint32_t index_;
 
-	std::shared_ptr<const ChunkLocationInfo> cache_;
+	std::shared_ptr<const ChunkLocationInfo> cache_ = nullptr;
 	std::mutex mutex_;
 };
 

--- a/src/mount/chunk_reader.cc
+++ b/src/mount/chunk_reader.cc
@@ -28,9 +28,9 @@
 #include "common/time_utils.h"
 #include "mount/global_chunkserver_stats.h"
 
-ChunkReader::ChunkReader(ChunkConnector& connector, ReadChunkLocator& _locator, double bandwidth_overuse)
+ChunkReader::ChunkReader(ChunkConnector& connector, double bandwidth_overuse)
 		: connector_(connector),
-		  locator_(&_locator),
+		  locator_(std::make_unique<ReadChunkLocator>()),
 		  inode_(0),
 		  index_(0),
 		  planner_(bandwidth_overuse),

--- a/src/mount/chunk_reader.h
+++ b/src/mount/chunk_reader.h
@@ -40,7 +40,7 @@
 
 class ChunkReader {
 public:
-	ChunkReader(ChunkConnector& connector, ReadChunkLocator& _locator, double bandwidth_overuse);
+	ChunkReader(ChunkConnector& connector, double bandwidth_overuse);
 
 	/**
 	 * Uses a locator to locate the chunk and chooses chunkservers to read from.
@@ -80,7 +80,7 @@ public:
 
 private:
 	ChunkConnector& connector_;
-	ReadChunkLocator *locator_;
+	std::unique_ptr<ReadChunkLocator> locator_;
 	uint32_t inode_;
 	uint32_t index_;
 	std::shared_ptr<const ChunkLocationInfo> location_;

--- a/src/mount/masterproxy.cc
+++ b/src/mount/masterproxy.cc
@@ -35,7 +35,7 @@
 
 static int lsock = -1;
 static pthread_t proxythread;
-static uint8_t terminate;
+static std::atomic<uint8_t> terminate;
 
 static uint32_t proxyhost;
 static uint16_t proxyport;

--- a/src/mount/sauna_client.h
+++ b/src/mount/sauna_client.h
@@ -71,7 +71,7 @@ struct FsInitParams {
 	static constexpr unsigned kDefaultChunkserverReadTo = 2000;
 	static constexpr unsigned kDefaultChunkserverWaveReadTo = 500;
 	static constexpr unsigned kDefaultChunkserverTotalReadTo = 2000;
-	static constexpr unsigned kDefaultCacheExpirationTime = 0;
+	static constexpr unsigned kDefaultCacheExpirationTime = 1000;
 	static constexpr unsigned kDefaultReadaheadMaxWindowSize = 65536;
 	static constexpr unsigned kDefaultReadCacheMaxSize = 16384;
 	static constexpr unsigned kDefaultReadWorkers = 30;

--- a/src/mount/writedata.cc
+++ b/src/mount/writedata.cc
@@ -580,12 +580,15 @@ void InodeChunkWriter::processDataChain(ChunkWriter& writer) {
 			can_expect_next_block = haveAnyBlockInCurrentChunk(lock);
 		}
 
+		Glock lock(gMutex);
 		writer.setChunkSizeInBlocks(
 		    std::min(inodeData_->maxfleng - chunkIndex_ * SFSCHUNKSIZE,
 		             (uint64_t)SFSCHUNKSIZE));
+		lock.unlock();
 		if (writer.startNewOperations(can_expect_next_block) > 0) {
-			Glock lock(gMutex);
+			lock.lock();
 			inodeData_->lastWriteToChunkservers.reset();
+			lock.unlock();
 		}
 		if (writer.getPendingOperationsCount() == 0) {
 			return;

--- a/tests/test_suites/SanityChecks/test_options_random_casing.sh
+++ b/tests/test_suites/SanityChecks/test_options_random_casing.sh
@@ -10,7 +10,7 @@ CHUNKSERVERS=1 \
 cd "${info[mount0]}"
 
 # Expected values are current defaults
-assert_equals $(cat .saunafs_tweaks | egrep CacheExpirationTime | awk '{print $2}') 0
+assert_equals $(cat .saunafs_tweaks | egrep CacheExpirationTime | awk '{print $2}') 1000
 assert_equals $(cat .saunafs_tweaks | egrep WriteMaxRetries | awk '{print $2}') 30
 assert_equals $(cat .saunafs_tweaks | egrep MaxReadaheadRequests | awk '{print $2}') 5
 assert_equals $(cat .saunafs_tweaks | egrep ReadWaveTimeout | awk '{print $2}') 500

--- a/tests/test_suites/ShortSystemTests/test_many_parallel_reads.sh
+++ b/tests/test_suites/ShortSystemTests/test_many_parallel_reads.sh
@@ -1,0 +1,61 @@
+timeout_set 2 minutes
+
+CHUNKSERVERS=12 \
+    USE_RAMDISK=YES \
+    MOUNT_EXTRA_CONFIG="readaheadmaxwindowsize=256,maxreadaheadrequests=30,readworkers=100" \
+    MASTER_CUSTOM_GOALS="8 ec_8_4: \$ec(8,4)"
+    setup_local_empty_saunafs info
+
+cd ${info[mount0]}
+
+output_dir="random_files"
+mkdir -p "${output_dir}"
+touch control.files.saunafs
+
+saunafs setgoal -r ec_8_4 "${output_dir}"
+saunafs setgoal ec_8_4 control.files.saunafs
+
+# Generate 50 files
+for i in {1..50}; do
+    size=$(shuf -i 5000000-35000000 -n 1)
+    FILE_SIZE=${size} BLOCK_SIZE=65536 file-generate "${output_dir}/file_${i}"
+    echo $(pwd)/${output_dir}/file_${i} >> control.files.saunafs
+done
+
+echo "Dropping cache"
+drop_caches
+
+echo "Calculating parallel checksums"
+cat control.files.saunafs | while read -e line;
+do
+    md5sum "${line}" > $(mktemp /tmp/tmp.XXXXXXXXX.md5sum) &
+done
+
+# Progress bar
+while pgrep md5sum > /dev/null; do
+    echo -n "$(pgrep md5sum | wc -l)..."
+    sleep 1
+done
+
+sync
+
+# Check how many threads created output
+echo ""
+ls /tmp/tmp.*.md5sum | wc -l
+
+# Generate one md5sum file
+cat /tmp/tmp.*.md5sum > /tmp/parallel.md5sum.result.v2
+
+# Clean up
+rm /tmp/tmp.*.md5sum
+
+echo "Dropping cache"
+drop_caches
+
+echo "Checking ... by reading single threaded md5sums"
+assert_equals $(md5sum --check /tmp/parallel.md5sum.result.v2 | egrep "FAILED" | wc -l) 0
+
+echo "Validating files"
+for i in {1..50}; do
+    assert_success file-validate "${output_dir}/file_${i}" &
+done


### PR DESCRIPTION
This PR targets getting rid of race conditions in the client side
with the help of helgring (valgrind suite). Though it does not remove
all of the issues pointed out by helgrind, it does fixes many of them.

This PR also fixes the issue with the many parallel readings, thus 
bringing back the default values of the cacheexpirationtime parameter.

List of changes:
- check the status of the entries in result (ReadCache::Result) before returning
it in the request function.
- rename operations manager mutex to gReadaheadRequestsContainerMutex
and restrict its use to the cases when the container is used.
- add mutex per ReadRecord to protect its readaheadRequests,
readahead_adviser and cache.
- add mutex per read cache's Entry to protect its members, specially
the buffer and the timer.
- fix issue that may cause crash in the client related with the proper release
of the entries.
- remove ReadRecord's locator and replace it by creating locators per
ChunkReader.
- protect terminate variable from masterproxy.
- protect inodedata's maxfleng access in writedata.

Add some extra test?: helgrind seems to keep pointing at issues that we can't solve
Performance tests: performance did not show any difference.