### PR TITLE
fix(mount): Set default cacheExpirationTime to 0

### DIFF
--- a/doc/sfsmount.1.adoc
+++ b/doc/sfsmount.1.adoc
@@ -157,7 +157,10 @@ operation in milliseconds (default: 2000).
 
 *-o cacheexpirationtime=*'MSEC'::
 Set timeout for read cache entries to be considered valid in milliseconds. 0
-disables cache (default: 0).
+disables cache (default: 0). Due to a bug, this can sometimes result in invalid
+data being returned if reading the mount point from multiple processes/threads
+and it's not disabled. Verify data being sent using a checksum if using this
+feature.
 
 *-o readaheadmaxwindowsize=*'KB'::
 Set max value of readahead window per single descriptor in kibibytes (default: 16384).

--- a/src/mount/sauna_client.h
+++ b/src/mount/sauna_client.h
@@ -71,7 +71,7 @@ struct FsInitParams {
 	static constexpr unsigned kDefaultChunkserverReadTo = 2000;
 	static constexpr unsigned kDefaultChunkserverWaveReadTo = 500;
 	static constexpr unsigned kDefaultChunkserverTotalReadTo = 2000;
-	static constexpr unsigned kDefaultCacheExpirationTime = 1000;
+	static constexpr unsigned kDefaultCacheExpirationTime = 0;
 	static constexpr unsigned kDefaultReadaheadMaxWindowSize = 65536;
 	static constexpr unsigned kDefaultReadCacheMaxSize = 16384;
 	static constexpr unsigned kDefaultReadWorkers = 30;

--- a/tests/test_suites/SanityChecks/test_options_random_casing.sh
+++ b/tests/test_suites/SanityChecks/test_options_random_casing.sh
@@ -10,7 +10,7 @@ CHUNKSERVERS=1 \
 cd "${info[mount0]}"
 
 # Expected values are current defaults
-assert_equals $(cat .saunafs_tweaks | egrep CacheExpirationTime | awk '{print $2}') 1000
+assert_equals $(cat .saunafs_tweaks | egrep CacheExpirationTime | awk '{print $2}') 0
 assert_equals $(cat .saunafs_tweaks | egrep WriteMaxRetries | awk '{print $2}') 30
 assert_equals $(cat .saunafs_tweaks | egrep MaxReadaheadRequests | awk '{print $2}') 5
 assert_equals $(cat .saunafs_tweaks | egrep ReadWaveTimeout | awk '{print $2}') 500


### PR DESCRIPTION
This is a temporary mitigation for #179, it does not fix it.