### PR TITLE
fix(tools): infinite recursion in sfstools.sh

### DIFF
--- a/src/tools/sfstools.sh
+++ b/src/tools/sfstools.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
 
-tool=$(basename $0)
-
-${tool/saunafs/saunafs } "$@"
+tool="$(basename $0)"
+exec saunafs "${tool#sfs}" "$@"

--- a/tests/test_suites/SanityChecks/test_sfstools.sh
+++ b/tests/test_suites/SanityChecks/test_sfstools.sh
@@ -1,0 +1,60 @@
+CHUNKSERVERS=4 \
+	SFSEXPORTS_EXTRA_OPTIONS="allcanchangequota" \
+	# MASTER_CUSTOM_GOALS="2 2: _" \
+	USE_RAMDISK=YES \
+	setup_local_empty_saunafs info
+
+cd "${info[mount0]}"
+
+touch test
+mkdir dir
+
+goal=$(sfsgetgoal dir)
+
+assert_equals "$goal" "dir: 1"
+
+goal=$(sfssetgoal 2 dir)
+
+assert_equals "$goal" "dir: 2"
+
+
+time=$(sfsgettrashtime test)
+assert_equals "$time" "test: 86400"
+sfssettrashtime 0 test
+time=$(sfsgettrashtime test)
+assert_equals "$time" "test: 0"
+
+attrs=$(sfsgeteattr test)
+assert_equals "$attrs" "test: -"
+sfsseteattr -f noattrcache test
+attrs=$(sfsgeteattr test)
+assert_equals "$attrs" "test: noattrcache"
+sfsdeleattr -f noattrcache test
+attrs=$(sfsgeteattr test)
+assert_equals "$attrs" "test: -"
+
+check=$(sfscheckfile test)
+assert_equals "$check" "test:"
+check=$(sfsfileinfo test)
+assert_equals "$check" "test:"
+
+echo "foo" > test
+echo "bar" > test2
+
+sfsappendchunks test2 test
+# We aren't checking the result, since it can take some time. Another test
+# should be check if it's working with (with the saunafs command)
+
+assert_equals "$(sfsdirinfo dir)" "$(saunafs dirinfo dir)"
+
+sfsfilerepair test
+
+sfsmakesnapshot dir dir_snapshot
+
+quota=$(sfsrepquota -d dir)
+assert_equals "$quota" "# User/Group ID/Directory; Bytes: current usage, soft limit, hard limit; Inodes: current usage, soft limit, hard limit;"
+
+sfssetquota -d 1000000 2000 1000000 2000 dir
+
+quota=$(sfsrepquota -d dir)
+assert_equals "$quota" "$(saunafs repquota -d dir)"


### PR DESCRIPTION
Fixes https://github.com/lizardfs/lizardfs/issues/886, requested in https://github.com/lizardfs/lizardfs/pull/887#issuecomment-2333801710
This commit is a port of that fix for LizardFS to SaunaFS.

An example error message was:

```console
$ LC_ALL=C bash -x /usr/bin/mfssetgoal --help
++ basename /usr/bin/mfssetgoal
+ tool=mfssetgoal
+ mfssetgoal --help
bash: warning: shell level (1000) too high, resetting to 1
```