### PR TITLE
test: Improve Ganesha test for master failover

### DIFF
--- a/tests/run-test.sh
+++ b/tests/run-test.sh
@@ -66,7 +66,7 @@ stop_ganesha() {
 	fi
 
 	# Check if ganesha daemon is still running
-	if pgrep ganesha.nfsd > /dev/null; then
+	if ps aux | grep [g]anesha > /dev/null; then
 		# Start a new ganesha daemon to remove the hanging one
 		sudo /usr/bin/ganesha.nfsd -L /var/log/ganesha.log
 		sleep 2


### PR DESCRIPTION
This test occasionally failed during master failover when the NFS client performed operations like file copy and checksum validation. Additionally, the test previously read from the OS cache instead of the NFS mount, leading to data corruption and mount unavailability.

This commit improves test reliability by increasing `io_retries` for a more robust recovery mechanism in the SaunaFS client. It also extends the grace period and lease lifetime to give Ganesha more time to recover. Finally, reading checksum through NFS was modified to use `dd` with the `iflag=direct` to read the file directly from the disk, bypassing the OS cache and preventing cache-related issues.