### PR TITLE
feat(tests): Add RPC service recovery function

### DIFF
--- a/tests/setup_machine.sh
+++ b/tests/setup_machine.sh
@@ -359,6 +359,7 @@ if [ ! -f /etc/sudoers.d/saunafstest ] || ! grep -q '# Ganesha' /etc/sudoers.d/s
 		saunafstest ALL = NOPASSWD: /tmp/SaunaFS-autotests/mnt/sfs0/bin/ganesha.nfsd
 		saunafstest ALL = NOPASSWD: /usr/bin/ganesha.nfsd
 		saunafstest ALL = NOPASSWD: /usr/bin/pkill -9 ganesha.nfsd
+		saunafstest ALL = NOPASSWD: /usr/bin/pkill -HUP rpcbind
 		saunafstest ALL = NOPASSWD: /usr/bin/mkdir -p /var/run/ganesha
 		saunafstest ALL = NOPASSWD: /usr/bin/touch /var/run/ganesha/ganesha.pid
 		saunafstest ALL = NOPASSWD: /usr/bin/mount, /usr/bin/umount

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_connectathon_nfs_suite.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_connectathon_nfs_suite.sh
@@ -7,7 +7,7 @@
 # The path for the Ganesha daemon should match the installation folder inside the test.
 #
 
-timeout_set 2 minutes
+timeout_set 3 minutes
 
 CHUNKSERVERS=5 \
 	USE_RAMDISK=YES \
@@ -24,15 +24,7 @@ test_error_cleanup() {
 mkdir -p ${TEMP_DIR}/mnt/ganesha
 mkdir -p ${info[mount0]}/data
 
-# Create PID file for Ganesha
-PID_FILE=/var/run/ganesha/ganesha.pid
-if [ ! -f ${PID_FILE} ]; then
-	echo "ganesha.pid doesn't exists, creating it...";
-	sudo mkdir -p /var/run/ganesha;
-	sudo touch ${PID_FILE};
-else
-	echo "ganesha.pid already exists";
-fi
+create_ganesha_pid_file
 
 cd ${info[mount0]}
 
@@ -70,8 +62,8 @@ SaunaFS {
 EOF
 
 sudo /usr/bin/ganesha.nfsd -f ${info[mount0]}/ganesha.conf
-assert_eventually 'showmount -e localhost'
 
+check_rpc_service
 sudo mount -vvvv localhost:/data $TEMP_DIR/mnt/ganesha
 
 # Run connectathon nfs suite

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_copy_file.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_copy_file.sh
@@ -7,7 +7,7 @@
 # The path for the Ganesha daemon should match the installation folder inside the test.
 #
 
-timeout_set 45 seconds
+timeout_set 2 minutes
 
 CHUNKSERVERS=5 \
 	USE_RAMDISK=YES \
@@ -23,15 +23,7 @@ test_error_cleanup() {
 
 mkdir -p ${TEMP_DIR}/mnt/ganesha
 
-# Create PID file for Ganesha
-PID_FILE=/var/run/ganesha/ganesha.pid
-if [ ! -f ${PID_FILE} ]; then
-	echo "ganesha.pid doesn't exists, creating it...";
-	sudo mkdir -p /var/run/ganesha;
-	sudo touch ${PID_FILE};
-else
-	echo "ganesha.pid already exists";
-fi
+create_ganesha_pid_file
 
 cd ${info[mount0]}
 
@@ -65,8 +57,8 @@ EXPORT
 EOF
 
 sudo /usr/bin/ganesha.nfsd -f ${info[mount0]}/ganesha.conf -L /tmp/ganesha.log
-assert_eventually 'showmount -e localhost'
 
+check_rpc_service
 sudo mount -vvvv localhost:/ $TEMP_DIR/mnt/ganesha
 
 cd $TEMP_DIR/mnt/ganesha

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_file_corruption_on_master_failover.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_file_corruption_on_master_failover.sh
@@ -32,15 +32,7 @@ get_checksum_with_direct_io() {
 
 mkdir -p "${TEMP_DIR}/mnt/ganesha"
 
-# Create PID file for Ganesha
-PID_FILE=/var/run/ganesha/ganesha.pid
-if [ ! -f ${PID_FILE} ]; then
-	echo "ganesha.pid doesn't exists, creating it...";
-	sudo mkdir -p /var/run/ganesha;
-	sudo touch "${PID_FILE}";
-else
-	echo "ganesha.pid already exists";
-fi
+create_ganesha_pid_file
 
 cd "${info[mount0]}"
 
@@ -77,8 +69,8 @@ EOF
 head -c 3G /dev/urandom | tee "${TEMP_DIR}/test_file" > /dev/null
 
 sudo /usr/bin/ganesha.nfsd -f "${info[mount0]}/ganesha.conf"
-assert_eventually 'showmount -e localhost'
 
+check_rpc_service
 sudo mount -vvvv localhost:/ "${TEMP_DIR}/mnt/ganesha"
 
 # Restart master server after 15 seconds

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_fio_random_mix_reads_writes.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_fio_random_mix_reads_writes.sh
@@ -11,7 +11,7 @@
 #
 assert_program_installed fio
 
-timeout_set 45 seconds
+timeout_set 2 minutes
 
 CHUNKSERVERS=5 \
 	USE_RAMDISK=YES \
@@ -27,15 +27,7 @@ test_error_cleanup() {
 
 mkdir -p ${TEMP_DIR}/mnt/ganesha
 
-# Create PID file for Ganesha
-PID_FILE=/var/run/ganesha/ganesha.pid
-if [ ! -f ${PID_FILE} ]; then
-	echo "ganesha.pid doesn't exists, creating it...";
-	sudo mkdir -p /var/run/ganesha;
-	sudo touch ${PID_FILE};
-else
-	echo "ganesha.pid already exists";
-fi
+create_ganesha_pid_file
 
 cd ${info[mount0]}
 
@@ -74,7 +66,7 @@ EOF
 
 sudo /usr/bin/ganesha.nfsd -f ${info[mount0]}/ganesha.conf
 
-assert_eventually 'showmount -e localhost'
+check_rpc_service
 sudo mount -vvvv localhost:/ $TEMP_DIR/mnt/ganesha
 
 echo ""

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_fio_random_reads.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_fio_random_reads.sh
@@ -11,7 +11,7 @@
 #
 assert_program_installed fio
 
-timeout_set 45 seconds
+timeout_set 2 minutes
 
 CHUNKSERVERS=5 \
 	USE_RAMDISK=YES \
@@ -27,15 +27,7 @@ test_error_cleanup() {
 
 mkdir -p ${TEMP_DIR}/mnt/ganesha
 
-# Create PID file for Ganesha
-PID_FILE=/var/run/ganesha/ganesha.pid
-if [ ! -f ${PID_FILE} ]; then
-	echo "ganesha.pid doesn't exists, creating it...";
-	sudo mkdir -p /var/run/ganesha;
-	sudo touch ${PID_FILE};
-else
-	echo "ganesha.pid already exists";
-fi
+create_ganesha_pid_file
 
 cd ${info[mount0]}
 
@@ -74,7 +66,7 @@ EOF
 
 sudo /usr/bin/ganesha.nfsd -f ${info[mount0]}/ganesha.conf
 
-assert_eventually 'showmount -e localhost'
+check_rpc_service
 sudo mount -vvvv localhost:/ $TEMP_DIR/mnt/ganesha
 
 echo ""

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_fio_random_writes.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_fio_random_writes.sh
@@ -11,7 +11,7 @@
 #
 assert_program_installed fio
 
-timeout_set 45 seconds
+timeout_set 2 minutes
 
 CHUNKSERVERS=5 \
 	USE_RAMDISK=YES \
@@ -27,15 +27,7 @@ test_error_cleanup() {
 
 mkdir -p ${TEMP_DIR}/mnt/ganesha
 
-# Create PID file for Ganesha
-PID_FILE=/var/run/ganesha/ganesha.pid
-if [ ! -f ${PID_FILE} ]; then
-	echo "ganesha.pid doesn't exists, creating it...";
-	sudo mkdir -p /var/run/ganesha;
-	sudo touch ${PID_FILE};
-else
-	echo "ganesha.pid already exists";
-fi
+create_ganesha_pid_file
 
 cd ${info[mount0]}
 
@@ -74,7 +66,7 @@ EOF
 
 sudo /usr/bin/ganesha.nfsd -f ${info[mount0]}/ganesha.conf
 
-assert_eventually 'showmount -e localhost'
+check_rpc_service
 sudo mount -vvvv localhost:/ $TEMP_DIR/mnt/ganesha
 
 echo ""

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_fio_sequential_mix_reads_writes.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_fio_sequential_mix_reads_writes.sh
@@ -12,7 +12,7 @@
 
 assert_program_installed fio
 
-timeout_set 45 seconds
+timeout_set 2 minutes
 
 CHUNKSERVERS=5 \
 	USE_RAMDISK=YES \
@@ -28,15 +28,7 @@ test_error_cleanup() {
 
 mkdir -p ${TEMP_DIR}/mnt/ganesha
 
-# Create PID file for Ganesha
-PID_FILE=/var/run/ganesha/ganesha.pid
-if [ ! -f ${PID_FILE} ]; then
-	echo "ganesha.pid doesn't exists, creating it...";
-	sudo mkdir -p /var/run/ganesha;
-	sudo touch ${PID_FILE};
-else
-	echo "ganesha.pid already exists";
-fi
+create_ganesha_pid_file
 
 cd ${info[mount0]}
 
@@ -75,7 +67,7 @@ EOF
 
 sudo /usr/bin/ganesha.nfsd -f ${info[mount0]}/ganesha.conf
 
-assert_eventually 'showmount -e localhost'
+check_rpc_service
 sudo mount -vvvv localhost:/ $TEMP_DIR/mnt/ganesha
 
 echo ""

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_fio_sequential_reads.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_fio_sequential_reads.sh
@@ -12,7 +12,7 @@
 
 assert_program_installed fio
 
-timeout_set 45 seconds
+timeout_set 2 minutes
 
 CHUNKSERVERS=5 \
 	USE_RAMDISK=YES \
@@ -28,15 +28,7 @@ test_error_cleanup() {
 
 mkdir -p ${TEMP_DIR}/mnt/ganesha
 
-# Create PID file for Ganesha
-PID_FILE=/var/run/ganesha/ganesha.pid
-if [ ! -f ${PID_FILE} ]; then
-	echo "ganesha.pid doesn't exists, creating it...";
-	sudo mkdir -p /var/run/ganesha;
-	sudo touch ${PID_FILE};
-else
-	echo "ganesha.pid already exists";
-fi
+create_ganesha_pid_file
 
 cd ${info[mount0]}
 
@@ -75,7 +67,7 @@ EOF
 
 sudo /usr/bin/ganesha.nfsd -f ${info[mount0]}/ganesha.conf
 
-assert_eventually 'showmount -e localhost'
+check_rpc_service
 sudo mount -vvvv localhost:/ $TEMP_DIR/mnt/ganesha
 
 echo ""

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_fio_sequential_writes.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_fio_sequential_writes.sh
@@ -12,7 +12,7 @@
 
 assert_program_installed fio
 
-timeout_set 45 seconds
+timeout_set 2 minutes
 
 CHUNKSERVERS=5 \
 	USE_RAMDISK=YES \
@@ -29,15 +29,7 @@ test_error_cleanup() {
 mkdir -p ${TEMP_DIR}/mnt/ganesha
 mkdir -p ${info[mount0]}/data
 
-# Create PID file for Ganesha
-PID_FILE=/var/run/ganesha/ganesha.pid
-if [ ! -f ${PID_FILE} ]; then
-	echo "ganesha.pid doesn't exists, creating it...";
-	sudo mkdir -p /var/run/ganesha;
-	sudo touch ${PID_FILE};
-else
-	echo "ganesha.pid already exists";
-fi
+create_ganesha_pid_file
 
 cd ${info[mount0]}
 
@@ -76,7 +68,7 @@ EOF
 
 sudo /usr/bin/ganesha.nfsd -f ${info[mount0]}/ganesha.conf
 
-assert_eventually 'showmount -e localhost'
+check_rpc_service
 sudo mount -vvvv localhost:/data $TEMP_DIR/mnt/ganesha
 
 echo ""

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_multi_export.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_multi_export.sh
@@ -7,7 +7,7 @@
 # The path for the Ganesha daemon should match the installation folder inside the test.
 #
 
-timeout_set 45 seconds
+timeout_set 2 minutes
 
 CHUNKSERVERS=5 \
 	USE_RAMDISK=YES \
@@ -28,15 +28,7 @@ cd ${info[mount0]}
 mkdir $TEMP_DIR/mnt/nfs{1,2,97,99}
 mkdir ganesha
 
-# Create PID file for Ganesha
-PID_FILE=/var/run/ganesha/ganesha.pid
-if [ ! -f ${PID_FILE} ]; then
-	echo "ganesha.pid doesn't exists, creating it...";
-	sudo mkdir -p /var/run/ganesha;
-	sudo touch ${PID_FILE};
-else
-	echo "ganesha.pid already exists";
-fi
+create_ganesha_pid_file
 
 cat <<EOF > ${info[mount0]}/ganesha.conf
 EXPORT
@@ -110,7 +102,8 @@ touch ${info[mount0]}/export1/test1
 touch ${info[mount0]}/export2/test2
 
 sudo /usr/bin/ganesha.nfsd -f ${info[mount0]}/ganesha.conf
-assert_eventually 'showmount -e localhost'
+
+check_rpc_service
 
 for x in 1 2 99; do
 	sudo mount -o v4.1 localhost:/e${x} ${TEMP_DIR}/mnt/nfs${x}

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_vs_linux_client_dd_read.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_vs_linux_client_dd_read.sh
@@ -11,7 +11,7 @@
 # with dd tool.
 #
 
-timeout_set 45 seconds
+timeout_set 2 minutes
 
 CHUNKSERVERS=5 \
 	USE_RAMDISK=YES \
@@ -27,15 +27,7 @@ test_error_cleanup() {
 
 mkdir -p ${TEMP_DIR}/mnt/ganesha
 
-# Create PID file for Ganesha
-PID_FILE=/var/run/ganesha/ganesha.pid
-if [ ! -f ${PID_FILE} ]; then
-	echo "ganesha.pid doesn't exists, creating it...";
-	sudo mkdir -p /var/run/ganesha;
-	sudo touch ${PID_FILE};
-else
-	echo "ganesha.pid already exists";
-fi
+create_ganesha_pid_file
 
 cd ${info[mount0]}
 
@@ -74,7 +66,7 @@ EOF
 
 sudo /usr/bin/ganesha.nfsd -f ${info[mount0]}/ganesha.conf
 
-assert_eventually 'showmount -e localhost'
+check_rpc_service
 sudo mount -vvvv localhost:/ $TEMP_DIR/mnt/ganesha
 
 # Generate the file to be read

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_vs_linux_client_dd_write.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_vs_linux_client_dd_write.sh
@@ -11,7 +11,7 @@
 # with dd tool.
 #
 
-timeout_set 45 seconds
+timeout_set 2 minutes
 
 CHUNKSERVERS=5 \
 	USE_RAMDISK=YES \
@@ -28,15 +28,7 @@ test_error_cleanup() {
 mkdir -p ${TEMP_DIR}/mnt/ganesha
 mkdir -p ${info[mount0]}/linux
 
-# Create PID file for Ganesha
-PID_FILE=/var/run/ganesha/ganesha.pid
-if [ ! -f ${PID_FILE} ]; then
-	echo "ganesha.pid doesn't exists, creating it...";
-	sudo mkdir -p /var/run/ganesha;
-	sudo touch ${PID_FILE};
-else
-	echo "ganesha.pid already exists";
-fi
+create_ganesha_pid_file
 
 cd ${info[mount0]}
 
@@ -75,7 +67,7 @@ EOF
 
 sudo /usr/bin/ganesha.nfsd -f ${info[mount0]}/ganesha.conf
 
-assert_eventually 'showmount -e localhost'
+check_rpc_service
 sudo mount -vvvv localhost:/ $TEMP_DIR/mnt/ganesha
 
 echo ""

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_vs_linux_client_random_mix_rw.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_vs_linux_client_random_mix_rw.sh
@@ -12,7 +12,7 @@
 #
 assert_program_installed fio
 
-timeout_set 45 seconds
+timeout_set 2 minutes
 
 CHUNKSERVERS=5 \
 	USE_RAMDISK=YES \
@@ -29,15 +29,7 @@ test_error_cleanup() {
 mkdir -p ${TEMP_DIR}/mnt/ganesha
 mkdir -p ${info[mount0]}/linux
 
-# Create PID file for Ganesha
-PID_FILE=/var/run/ganesha/ganesha.pid
-if [ ! -f ${PID_FILE} ]; then
-	echo "ganesha.pid doesn't exists, creating it...";
-	sudo mkdir -p /var/run/ganesha;
-	sudo touch ${PID_FILE};
-else
-	echo "ganesha.pid already exists";
-fi
+create_ganesha_pid_file
 
 cd ${info[mount0]}
 
@@ -76,7 +68,7 @@ EOF
 
 sudo /usr/bin/ganesha.nfsd -f ${info[mount0]}/ganesha.conf
 
-assert_eventually 'showmount -e localhost'
+check_rpc_service
 sudo mount -vvvv localhost:/ $TEMP_DIR/mnt/ganesha
 
 echo ""

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_vs_linux_client_sequential_read.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_vs_linux_client_sequential_read.sh
@@ -12,7 +12,7 @@
 #
 assert_program_installed fio
 
-timeout_set 45 seconds
+timeout_set 2 minutes
 
 CHUNKSERVERS=5 \
 	USE_RAMDISK=YES \
@@ -29,15 +29,7 @@ test_error_cleanup() {
 mkdir -p ${TEMP_DIR}/mnt/ganesha
 mkdir -p ${info[mount0]}/linux
 
-# Create PID file for Ganesha
-PID_FILE=/var/run/ganesha/ganesha.pid
-if [ ! -f ${PID_FILE} ]; then
-	echo "ganesha.pid doesn't exists, creating it...";
-	sudo mkdir -p /var/run/ganesha;
-	sudo touch ${PID_FILE};
-else
-	echo "ganesha.pid already exists";
-fi
+create_ganesha_pid_file
 
 cd ${info[mount0]}
 
@@ -76,7 +68,7 @@ EOF
 
 sudo /usr/bin/ganesha.nfsd -f ${info[mount0]}/ganesha.conf
 
-assert_eventually 'showmount -e localhost'
+check_rpc_service
 sudo mount -vvvv localhost:/ $TEMP_DIR/mnt/ganesha
 
 echo ""

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_vs_linux_client_sequential_write.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_vs_linux_client_sequential_write.sh
@@ -12,7 +12,7 @@
 #
 assert_program_installed fio
 
-timeout_set 45 seconds
+timeout_set 2 minutes
 
 CHUNKSERVERS=5 \
 	USE_RAMDISK=YES \
@@ -29,15 +29,7 @@ test_error_cleanup() {
 mkdir -p ${TEMP_DIR}/mnt/ganesha
 mkdir -p ${info[mount0]}/linux
 
-# Create PID file for Ganesha
-PID_FILE=/var/run/ganesha/ganesha.pid
-if [ ! -f ${PID_FILE} ]; then
-	echo "ganesha.pid doesn't exists, creating it...";
-	sudo mkdir -p /var/run/ganesha;
-	sudo touch ${PID_FILE};
-else
-	echo "ganesha.pid already exists";
-fi
+create_ganesha_pid_file
 
 cd ${info[mount0]}
 
@@ -76,7 +68,7 @@ EOF
 
 sudo /usr/bin/ganesha.nfsd -f ${info[mount0]}/ganesha.conf
 
-assert_eventually 'showmount -e localhost'
+check_rpc_service
 sudo mount -vvvv localhost:/ $TEMP_DIR/mnt/ganesha
 
 echo ""

--- a/tests/tools/ganesha.sh
+++ b/tests/tools/ganesha.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+# Function to retry the specified command up to a maximum number of attempts
+# with a delay of 5 seconds between each attempt
+retry_command_with_attempts() {
+	local max_attempts=$1
+	local attempt=1
+	local delay=5
+	shift
+	while (( attempt <= max_attempts )); do
+		if "$@"; then
+			return 0
+		fi
+		echo "Attempt $attempt failed! Retrying in $delay seconds..."
+		sleep $delay
+		attempt=$(( attempt + 1 ))
+	done
+
+	echo "All attempts failed!"
+	return 1
+}
+
+# Create PID file for Ganesha
+create_ganesha_pid_file() {
+	PID_FILE=/var/run/ganesha/ganesha.pid
+	if [ ! -f ${PID_FILE} ]; then
+		echo "ganesha.pid doesn't exists, creating it..."
+		sudo mkdir -p /var/run/ganesha
+		sudo touch "${PID_FILE}"
+	fi
+}
+
+# Function to check RPC service availability
+check_and_recover_rpc_service() {
+	# if NFS service is available, RPC is already running
+	if [ showmount -e localhost ]; then
+		echo "RPC service is now available"
+		return 0
+	fi
+
+	rpcbind_pid=$(pidof rpcbind)
+
+	# Check if rpcbind is running and restart it
+	if [ -n "$rpcbind_pid" ]; then
+		echo "RPC service is unavailable"
+		sudo pkill -HUP rpcbind
+	fi
+
+	return 1
+}
+
+check_rpc_service() {
+	if ! retry_command_with_attempts 5 showmount -e localhost; then
+		# If NFS service is not available, try to recover RPC service
+		retry_command_with_attempts 5 check_and_recover_rpc_service
+	fi
+}

--- a/tests/tools/test_main.sh
+++ b/tests/tools/test_main.sh
@@ -31,3 +31,4 @@ done
 . tools/color.sh
 . tools/continuous_test.sh
 . tools/logs.sh
+. tools/ganesha.sh


### PR DESCRIPTION
Previously, Ganesha tests failed when RPC became unavailable during the test suite execution. There was also some logic repeated across the suite, such as the creation of Ganesha PID file.

Key changes:
- Introduced a recovery mechanism for the RPC service to handle failures during the test suite execution.
- Refactored the Ganesha PID file creation by encapsulating the logic into a new `create_ganesha_pid_file` function, which is now used across all suite to avoid redundancy.