### PR TITLE
fix(mount): Fix tcptoread-write error message

### DIFF
--- a/src/common/sockets.h
+++ b/src/common/sockets.h
@@ -41,6 +41,7 @@
 #define TCPENOTSUP ENOTSUP
 #define TCPEINVAL EINVAL
 #define TCPETIMEDOUT ETIMEDOUT
+#define TCPNORESPONSE EIO
 #endif
 
 #include <vector>

--- a/src/mount/mastercomm.cc
+++ b/src/mount/mastercomm.cc
@@ -671,10 +671,12 @@ int fs_connect(bool verbose) {
 		return -1;
 	}
 	if (tcptoread(fd,regbuff,8,1000)!=8) {
+		int tcplasterr = tcpgetlasterror();
+		const auto* errorMessage = (tcplasterr != 0) ? strerr(tcplasterr) : strerr(TCPNORESPONSE);
 		if (verbose) {
-			fprintf(stderr,"error receiving data from sfsmaster: %s\n",strerr(tcpgetlasterror()));
+			fprintf(stderr,"error receiving data from sfsmaster: %s\n", errorMessage);
 		} else {
-			safs_pretty_syslog(LOG_WARNING,"error receiving data from sfsmaster: %s",strerr(tcpgetlasterror()));
+			safs_pretty_syslog(LOG_WARNING,"error receiving data from sfsmaster: %s", errorMessage);
 		}
 		tcpclose(fd);
 		fd=-1;


### PR DESCRIPTION
When trying to start client connection to master, sometimes error receiving data from master was shown as successful, which is not correct. This change improves readability of error by specifying a type of it when logging error message from client.