### PR TITLE
fix(uRaft): Recover from floatting IP drop (#195)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,7 +11,7 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 
 # Tab indentation for shell scripts, Dockerfiles and Makefiles
-[{*.{bash,sh},Dockerfile,Dockerfile.*,Makefile,*.mk}]
+[{*.{bash,sh},Dockerfile,Dockerfile.*,Makefile,*.mk,*.in}]
 indent_style = tab
 # Unsupported in some editors
 keep_padding = true

--- a/src/uraft/main.cc
+++ b/src/uraft/main.cc
@@ -43,7 +43,7 @@ void parseOptions(int argc, char **argv, uRaftController::Options &opt, bool &ma
 	("LOCAL_MASTER_MATOCL_PORT", po::value<int>()->default_value(9421), "local master matocl port")
 	("LOCAL_MASTER_CHECK_PERIOD", po::value<int>()->default_value(250), "local master check status period")
 	("URAFT_ELECTOR_MODE", po::value<int>()->default_value(0), "run in elector mode")
-	("URAFT_GETVERSION_TIMEOUT", po::value<int>()->default_value(50), "getversion timeout (ms)")
+	("URAFT_GETVERSION_TIMEOUT", po::value<int>()->default_value(200), "getversion timeout (ms)")
 	("URAFT_PROMOTE_TIMEOUT", po::value<int>()->default_value(1000000000), "promote timeout (ms)")
 	("URAFT_DEMOTE_TIMEOUT", po::value<int>()->default_value(1000000000), "demote timeout (ms)")
 	("URAFT_DEAD_HANDLER_TIMEOUT", po::value<int>()->default_value(1000000000), "metadata server dead handler timeout (ms)")

--- a/src/uraft/saunafs-uraft-helper.in
+++ b/src/uraft/saunafs-uraft-helper.in
@@ -151,13 +151,47 @@ saunafs_metadata_version() {
 	esac
 }
 
-saunafs_isalive() {
-	saunafs_master isalive
-	if [[ $? == 0 ]] ; then
-		echo -n alive
-	else
-		echo -n dead
+have_master_role() {
+	local local_status="$(saunafs_admin metadataserver-status --porcelain "${matocl_host}" "${matocl_port}")"
+	[ "$(awk '{print $1}' <<< "${local_status}" 2>/dev/null)" == "master" ]
+}
+
+is_ip_present() {
+	local ip="${1}"
+	local iface="${2:-}"
+	local -a ip_command_extra_args=()
+	if [ -n "${iface}" ]; then
+		ip_command_extra_args+=("dev" "${iface}")
 	fi
+	ip addr show "${ip_command_extra_args[@]}" | grep -wq -m1 "${ip}"
+}
+
+is_floating_ip_present() {
+	if is_ip_present "${ipaddr}" "${iface}"; then
+		return 0
+	fi
+	if [ -n "${ipaddr2}" ] && is_ip_present "${ipaddr2}" "${iface2}"; then
+		return 0
+	fi
+	return 1
+}
+
+saunafs_isalive() {
+	# First, check if Saunafs master reports being alive
+	if ! saunafs_master isalive; then
+		echo -n 'dead'
+		return
+	fi
+
+	load_config
+
+	if ! is_floating_ip_present && have_master_role; then
+		echo -n 'non-floating'
+		return
+	fi
+
+	# If everything is okay, we are alive
+	echo -n 'alive'
 }
 
 saunafs_assign_ip() {


### PR DESCRIPTION
When the floating IP was lost by accident, the uRaft was not able to detect it. This commit allows the HA to react in such a case.