### PR TITLE
ci: Update GitHub Actions to use latest versions

### DIFF
--- a/.github/workflows/run-unit-and-ganesha-tests.yml
+++ b/.github/workflows/run-unit-and-ganesha-tests.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Install nfs-ganesha v4.3 from Ubuntu repository
       run: |
@@ -23,7 +23,7 @@ jobs:
         sudo apt install -y nfs-common nfs-ganesha nfs-ganesha-vfs
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
 


### PR DESCRIPTION
The previous Github Actions workflow in charge of running Ganesha and Unit Tests showed some annoying warnings about using deprecated node versions.

This commit updates versions for `checkout` and `setup-python` actions to remove these warnings.

Key changes:
- Updated `actions/checkout` from v2 to v4.
- Updated `actions/setup-python` from v2 to v4.