### PR TITLE
Refactor chunkserverentry use std list and smart pointers

### DIFF
--- a/src/chunkserver/network_worker_thread.cc
+++ b/src/chunkserver/network_worker_thread.cc
@@ -153,8 +153,6 @@ std::unique_ptr<PacketStruct> worker_create_detached_packet_with_output_buffer(
 ChunkserverEntry::~ChunkserverEntry() {
 	if (sock >= 0) { tcpclose(sock); }
 	if (fwdSocket >= 0) { tcpclose(fwdSocket); }
-
-	outputPackets.clear();
 }
 
 void ChunkserverEntry::attachPacket(std::unique_ptr<PacketStruct> &&packet) {

--- a/src/chunkserver/network_worker_thread.cc
+++ b/src/chunkserver/network_worker_thread.cc
@@ -205,7 +205,6 @@ uint8_t *worker_create_attached_packet(ChunkserverEntry *eptr, uint32_t type,
 	put32bit(&ptr, type);
 	put32bit(&ptr, size);
 	outPacket->startPtr = outPacket->packet;
-	outPacket->next = nullptr;
 	eptr->attachPacket(std::move(outPacket));
 
 	return ptr;

--- a/src/chunkserver/network_worker_thread.cc
+++ b/src/chunkserver/network_worker_thread.cc
@@ -1494,11 +1494,12 @@ void worker_write(ChunkserverEntry *eptr) {
 	TRACETHIS();
 	PacketStruct *pack = nullptr;
 	int32_t bytesWritten;
+
 	for (;;) {
+		if (eptr->outputPackets.empty()) { return; }
+
 		pack = eptr->outputPackets.front().get();
-		if (pack == nullptr) {
-			return;
-		}
+
 		if (pack->outputBuffer) {
 			size_t bytesInBufferBefore = pack->outputBuffer->bytesInABuffer();
 			OutputBuffer::WriteStatus ret = pack->outputBuffer->writeOutToAFileDescriptor(eptr->sock);

--- a/src/chunkserver/network_worker_thread.h
+++ b/src/chunkserver/network_worker_thread.h
@@ -25,6 +25,7 @@
 #include <atomic>
 #include <cstdint>
 #include <list>
+#include <memory>
 #include <mutex>
 #include <set>
 #include <vector>
@@ -106,8 +107,8 @@ struct ChunkserverEntry {
 	int32_t pDescPos = -1;  ///< Position in the poll descriptors array
 	int32_t fwdPDescPos = -1;  ///< Position in poll descriptors for fwdSocket
 	uint32_t lastActivity = 0; ///< Last activity time
-	uint8_t headerBuffer[PacketHeader::kSize];  ///< buffer for packet header
-	uint8_t fwdHeaderBuffer[PacketHeader::kSize];  ///< buffer for fwd packet header
+	uint8_t headerBuffer[PacketHeader::kSize]{};  ///< buffer for packet header
+	uint8_t fwdHeaderBuffer[PacketHeader::kSize]{};  ///< fwd packet header buff
 	/// Stores the data of the incoming packet for processing
 	PacketStruct inputPacket;
 	uint8_t *fwdStartPtr = nullptr; ///< used for forwarding inputpacket data
@@ -115,10 +116,8 @@ struct ChunkserverEntry {
 	PacketStruct fwdInputPacket; ///< used for receiving status from fwdSocket
 	std::vector<uint8_t> fwdInitPacket; ///< used only for write initialization
 
-	/// Pointer to the head of the output packets list
-	PacketStruct *outputHead = nullptr;
-	/// Pointer to the tail of the output packets list
-	PacketStruct **outputTail = &outputHead;
+	/// List of output packets waiting to be sent to the clients
+	std::list<std::unique_ptr<PacketStruct>> outputPackets;
 
 	/* write */
 	uint32_t writeJobId = 0; ///< ID of the current write job being processed
@@ -139,8 +138,9 @@ struct ChunkserverEntry {
 	uint16_t getBlocksJobResult = 0; ///< Result of the get blocks job
 
 	/* common for read and write but meaning is different !!! */
-	void *readPacket = nullptr;
-	void *writePacket = nullptr;
+	std::unique_ptr<PacketStruct> readPacket = nullptr;
+	std::unique_ptr<PacketStruct> writePacket =
+	    std::make_unique<PacketStruct>();
 
 	uint8_t isChunkOpen = 0;
 	uint64_t chunkId = 0; // R+W
@@ -164,9 +164,25 @@ struct ChunkserverEntry {
 		inputPacket.packet = nullptr;
 	}
 
-	ChunkserverEntry(const ChunkserverEntry&) = delete;
-	ChunkserverEntry(ChunkserverEntry&&) = default;
-	ChunkserverEntry& operator=(const ChunkserverEntry&) = delete;
+	// Disallow copying and moving to avoid misuse.
+	ChunkserverEntry(const ChunkserverEntry &) = delete;
+	ChunkserverEntry &operator=(const ChunkserverEntry &) = delete;
+	ChunkserverEntry(ChunkserverEntry &&) = delete;
+	ChunkserverEntry &operator=(ChunkserverEntry &&) = delete;
+
+	~ChunkserverEntry() = default;
+
+	/// Attaches a packet to the output packet list (taking ownership).
+	inline void attachPacket(std::unique_ptr<PacketStruct> &&packet);
+	/// Releases the packet resources, primarily the packet buffer.
+	/// This function should be used until the code is refactored to use RAII.
+	inline void releasePacketResources(std::unique_ptr<PacketStruct> &packet);
+	/// Preserves the inputPacket buffer into writePacket (to avoid copying it).
+	/// Used for write operations, where the data comes from the network.
+	inline void preserveInputPacket();
+	/// Releases the preserved packet resources.
+	static inline void deletePreservedPacket(
+	    std::unique_ptr<PacketStruct> &packet);
 };
 
 class NetworkWorkerThread {

--- a/src/chunkserver/network_worker_thread.h
+++ b/src/chunkserver/network_worker_thread.h
@@ -45,7 +45,6 @@
  * and an optional output buffer for writing data.
  */
 struct PacketStruct {
-	PacketStruct *next = nullptr;
 	uint8_t *startPtr = nullptr;
 	uint32_t bytesLeft = 0;
 	uint8_t *packet = nullptr;


### PR DESCRIPTION
Partial refactor of ChunkserverEntry related structs.
Main goals:
- Avoid C-like linked lists and use std::list.
- Simplified memory management (malloc and free was used before).
- Reuse of already allocated memory.
- Use of move semantics.
- Simplified destruction and cleanup.
- Shorter code.
- Remove void* and casts.