### PR TITLE
feat(master): Add option to toggle data parts priority

### DIFF
--- a/doc/sfsmaster.cfg.5.adoc
+++ b/doc/sfsmaster.cfg.5.adoc
@@ -238,6 +238,11 @@ chunkserver disk usage to determine most fitting chunkserver. Heavy loaded
 chunkservers will be picked for operations less frequently. (default is 0,
 correct values are in range from 0 to 0.5)
 
+*PRIORITIZE_DATA_PARTS*:: When set, master server will prioritize data parts in
+EC goals to land in the chunkservers with higher percentage of available space.
+Could cause parities landing always in the same chunkservers if the cluster is
+not well balanced. (default: 1)
+
 *ENABLE_PROMETHEUS*:: Whether to enable Prometheus support and metric
 collection. Note that this requires compiling with Prometheus support. Set to
 either 1 to enable, or 0 to disable (default is 0)

--- a/src/admin/dump_config_command.cc
+++ b/src/admin/dump_config_command.cc
@@ -128,6 +128,7 @@ const static std::unordered_map<std::string, std::string> defaultOptionsMaster =
     {"SNAPSHOT_INITIAL_BATCH_SIZE", "1000"},
     {"SNAPSHOT_INITIAL_BATCH_SIZE_LIMIT", "10000"},
     {"FILE_TEST_LOOP_MIN_TIME", "3600"},
+    {"PRIORITIZE_DATA_PARTS", "1"},
 };
 
 const static std::unordered_map<std::string, std::string> defaultOptionsShadow = {

--- a/src/data/sfsmaster.cfg.in
+++ b/src/data/sfsmaster.cfg.in
@@ -271,6 +271,12 @@
 ## (Default: 0, Valid range: [0, 0.5])
 # LOAD_FACTOR_PENALTY = 0
 
+## When set, master server will prioritize data parts in EC goals to land in the
+## chunkservers with higher percentage of available space. Could cause parities
+## landing always in the same chunkservers if the cluster is not well balanced.
+## (Default: 1)
+# PRIORITIZE_DATA_PARTS = 1
+
 ## Minimum number of required redundant chunk parts that can be lost before
 ## chunk becomes endangered
 ## (Default: 0)

--- a/tests/test_suites/ShortSystemTests/test_ec_prioritize_data_parts.sh
+++ b/tests/test_suites/ShortSystemTests/test_ec_prioritize_data_parts.sh
@@ -1,0 +1,61 @@
+timeout_set 1 minute
+
+CHUNKSERVERS=4 \
+	DISK_PER_CHUNKSERVER=1 \
+	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER" \
+	MASTER_CUSTOM_GOALS="10 ec_3_1: \$ec(3,1)" \
+	USE_RAMDISK=YES \
+	setup_local_empty_saunafs info
+
+# Get the chunkservers that have parity parts for the given file
+function getChunkserversWithParities() {
+	local file="${1}"
+	saunafs fileinfo "${file}" \
+		| grep "part 4/4 of ec(3,1)" \
+		| awk '{print $3}' | sort -u
+}
+
+dir="${info[mount0]}/dir"
+mkdir "${dir}"
+saunafs setgoal ec_3_1 "${dir}"
+
+# Make the last chunkserver have less available space and restart it
+sed -i s/"HDD_LEAVE_SPACE_DEFAULT = 128MiB"/"HDD_LEAVE_SPACE_DEFAULT = 1024MiB"/g \
+       "${info[chunkserver3_cfg]}"
+saunafs_chunkserver_daemon 3 stop
+saunafs_chunkserver_daemon 3 start
+saunafs_wait_for_all_ready_chunkservers
+
+# Create a file using goal ec_3_1
+dd if=/dev/zero of="${dir}/file" bs=1MiB count=512 &> /dev/null
+
+# Count how many chunkservers received parity parts
+chunkservers_with_parities=$(getChunkserversWithParities "${dir}/file")
+echo "Chunkservers with parity parts:"
+echo "${chunkservers_with_parities}"
+parity_chunkservers=$(echo "${chunkservers_with_parities}" | wc -l)
+echo "Parity chunkservers: ${parity_chunkservers}"
+
+# As chunkserver 3 has less available space, it should receive all parity parts
+assert_equals 1 ${parity_chunkservers}
+
+# Disable prioritizing data parts in the master and reload it
+echo "PRIORITIZE_DATA_PARTS = 0" >> "${info[master_cfg]}"
+saunafs_master_daemon reload
+
+# Give the master some time to reload
+sleep 3
+
+# Recreate the file
+rm "${dir}/file"
+dd if=/dev/zero of="${dir}/file" bs=1MiB count=512 &> /dev/null
+
+# Count how many chunkservers received parity parts this time
+chunkservers_with_parities=$(getChunkserversWithParities "${dir}/file")
+echo "Chunkservers with parity parts:"
+echo "${chunkservers_with_parities}"
+parity_chunkservers=$(echo "${chunkservers_with_parities}" | wc -l)
+echo "Parity chunkservers: ${parity_chunkservers}"
+
+# Parities should be distributed among all chunkservers
+assert_less_than 1 ${parity_chunkservers}


### PR DESCRIPTION
Originally, the master server was placing the data parts in the chunkservers with higher available space factor. Then, the parity parts were placed in the remaining chunkservers.

If the cluster is not balanced (some chunkservers have more space than others), then almost all parities land in the same chunkservers. This causes that reading is always issued to the chunkservers with data parts, so the chunkservers with parity parts are barely used when reading.

This commit introduces the configuration variable PRIORITIZE_DATA_PARTS to control this behavior. The default value is 1 (active), which is the same as it was before.