### PR TITLE
test: Apply multiplier regardless if Valgrind enabled or not

### DIFF
--- a/tests/tools/assert.sh
+++ b/tests/tools/assert.sh
@@ -3,6 +3,9 @@
 # * assert_some_condition -- adds error to the test results and immediately stops the test
 # * assertlocal_some_condition -- adds error to the results and exits current subshell
 
+DEFAULT_ASSERT_TIMEOUT="15 seconds"
+: "${ASSERT_TIMEOUT:=$DEFAULT_ASSERT_TIMEOUT}"
+
 # (assert|assertlocal|expect)_program_installed <program>...
 assert_template_program_installed_() {
 	for program in "$@"; do
@@ -195,11 +198,7 @@ rescale_timeout_for_assert_eventually_() {
 	if [[ -n "$1" ]]; then
 		timeout_rescale "$1"
 	else
-		if valgrind_enabled; then
-			echo 60 seconds
-		else
-			echo 15 seconds
-		fi
+		timeout_rescale $ASSERT_TIMEOUT
 	fi
 }
 

--- a/tests/tools/timeout.sh
+++ b/tests/tools/timeout.sh
@@ -81,26 +81,17 @@ timeout_get_multiplier() {
 	cat "$test_timeout_multiplier_file"
 }
 
-# takes as parameter timeout (e.g. '1 minute') and rescales it by valgrind multiplier
+# takes as parameter timeout (e.g. '1 minute') and rescales it by multiplier
 # prints result in seconds to standard output (e.g. '900 seconds')
 timeout_rescale() {
-	if valgrind_enabled; then
-		local multiplier=$(timeout_get_multiplier)
-		local value=$(($(date +%s -d "$1") - $(date +%s)))
-
-		echo $((value * multiplier)) seconds
-	else
-		echo "$1"
-	fi
+	local multiplier=$(timeout_get_multiplier)
+	local value=$(($(date +%s -d "$1") - $(date +%s)))
+	echo $((value * multiplier)) seconds
 }
 
-# takes as parameter timeout in seconds (e.g. '60') and rescales it by valgrind multiplier
+# takes as parameter timeout in seconds (e.g. '60') and rescales it by multiplier
 # prints result to standard output (e.g. '900')
 timeout_rescale_seconds() {
-	if valgrind_enabled; then
-		local multiplier=$(timeout_get_multiplier)
-		echo $(($1 * multiplier))
-	else
-		echo "$1"
-	fi
+	local multiplier=$(timeout_get_multiplier)
+	echo $(($1 * multiplier))
 }


### PR DESCRIPTION
Some functions were only applying the multiplier if Valgrind was enabled. This fixes that by ensuring it's applied regardless of that

It also applies the multiplier to the default timeout of 15 seconds in assert functions, with it being adjustable through an environment variable.