### PR TITLE
feat(master, chukserver): Make poll timeout configurable

### DIFF
--- a/doc/sfschunkserver.cfg.5.adoc
+++ b/doc/sfschunkserver.cfg.5.adoc
@@ -110,6 +110,11 @@ them (default is 16)
 *BGJOBSCNT_PER_NETWORK_WORKER*:: maximum number of jobs that each network worker
 may use for disk operations (default is 1000)
 
+*POLL_TIMEOUT_MS*:: Maximum amount of time in milliseconds that the polling
+operation will wait for events. In the chunkservers, the same value is applied
+for the events loop and for the network worker threads. Smaller values could
+reduce latency at the cost of CPU usage (default: 50)
+
 *READ_AHEAD_KB*:: additional number of kilobytes which should be passed to
 posix_fadvise(POSIX_FADV_WILLNEED) before reading data from a chunk (default is
 0, i.e. use posix_fadvise only with the amount of data that is really needed;

--- a/doc/sfsmaster.cfg.5.adoc
+++ b/doc/sfsmaster.cfg.5.adoc
@@ -243,6 +243,11 @@ EC goals to land in the chunkservers with higher percentage of available space.
 Could cause parities landing always in the same chunkservers if the cluster is
 not well balanced. (default: 1)
 
+*POLL_TIMEOUT_MS*:: Maximum amount of time in milliseconds that the polling
+operation will wait for events. The value is applied for the polling in the
+events loop. Smaller values could reduce latency at the cost of CPU usage
+(default: 50)
+
 *ENABLE_PROMETHEUS*:: Whether to enable Prometheus support and metric
 collection. Note that this requires compiling with Prometheus support. Set to
 either 1 to enable, or 0 to disable (default is 0)

--- a/src/chunkserver/hddspacemgr.cc
+++ b/src/chunkserver/hddspacemgr.cc
@@ -77,6 +77,7 @@
 #include "chunkserver-common/subfolder.h"
 #include "chunkserver/chartsdata.h"
 #include "chunkserver/chunk_filename_parser.h"
+#include "chunkserver/network_worker_thread.h"
 #include "common/cfg.h"
 #include "common/chunk_version_with_todel_flag.h"
 #include "common/crc.h"

--- a/src/chunkserver/network_worker_thread.cc
+++ b/src/chunkserver/network_worker_thread.cc
@@ -1562,7 +1562,7 @@ void NetworkWorkerThread::operator()() {
 
 	while (!doTerminate) {
 		preparePollFds();
-		int i = poll(pdesc.data(), pdesc.size(), 50);
+		int i = poll(pdesc.data(), pdesc.size(), gPollTimeout);
 		if (i < 0) {
 			if (errno == EAGAIN) {
 				safs_pretty_syslog(LOG_WARNING, "poll returned EAGAIN");

--- a/src/common/event_loop.h
+++ b/src/common/event_loop.h
@@ -47,6 +47,11 @@ enum class ExitingStatus {
 extern ExitingStatus gExitingStatus;
 extern bool gReloadRequested;
 
+constexpr int kDefaultPollTimeout = 50;
+inline int gPollTimeout = kDefaultPollTimeout;
+
+void eventloop_load_poll_timeout();
+
 void eventloop_destructregister (void (*fun)(void));
 void eventloop_canexitregister (int (*fun)(void));
 void eventloop_wantexitregister (void (*fun)(void));

--- a/src/data/sfschunkserver.cfg.in
+++ b/src/data/sfschunkserver.cfg.in
@@ -119,6 +119,13 @@
 ## (Default: 1000)
 # BGJOBSCNT_PER_NETWORK_WORKER = 1000
 
+## Maximum amount of time in milliseconds that the polling operation will wait
+## for events. In the chunkservers, the same value is applied for the events
+## loop and for the network worker threads. Smaller values could reduce latency
+## at the cost of CPU usage.
+## (Default: 50)
+# POLL_TIMEOUT_MS = 50
+
 ## additional number of kilobytes which should be passed to
 ## posix_fadvise(POSIX_FADV_WILLNEED) before reading data from a chunk
 ## (Default: 0), i.e. use posix_fadvise only with the amount of data that is

--- a/src/data/sfsmaster.cfg.in
+++ b/src/data/sfsmaster.cfg.in
@@ -241,7 +241,7 @@
 ## (Default: 3600)
 # METADATA_DUMP_PERIOD_SECONDS = 3600
 
-## Interval for periodically cleaning of reserved files, in milliseconds. If set to 0, the reserved files 
+## Interval for periodically cleaning of reserved files, in milliseconds. If set to 0, the reserved files
 ## deletion is disabled.
 ## (Default: 0)
 # EMPTY_RESERVED_FILES_PERIOD_MSECONDS = 0
@@ -276,6 +276,12 @@
 ## landing always in the same chunkservers if the cluster is not well balanced.
 ## (Default: 1)
 # PRIORITIZE_DATA_PARTS = 1
+
+## Maximum amount of time in milliseconds that the polling operation will wait
+## for events. The value is applied for the polling in the events loop. Smaller
+## values could reduce latency at the cost of CPU usage.
+## (Default: 50)
+# POLL_TIMEOUT_MS = 50
 
 ## Minimum number of required redundant chunk parts that can be lost before
 ## chunk becomes endangered

--- a/tests/test_suites/ShortSystemTests/test_poll_timeout.sh
+++ b/tests/test_suites/ShortSystemTests/test_poll_timeout.sh
@@ -1,0 +1,88 @@
+timeout_set "3 minutes"
+
+CHUNKSERVERS=3 \
+	MASTER_CUSTOM_GOALS="1 ec21: \$ec(2,1)" \
+	AUTO_SHADOW_MASTER="NO" \
+	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER" \
+	CHUNKSERVER_EXTRA_CONFIG="MAGIC_DEBUG_LOG = $TEMP_DIR/log|LOG_FLUSH_ON=DEBUG" \
+	MASTER_EXTRA_CONFIG="MAGIC_DEBUG_LOG = $TEMP_DIR/log|LOG_FLUSH_ON=DEBUG" \
+	setup_local_empty_saunafs info
+
+cd "${info[mount0]}"
+
+# Generate and validate some files in parallel
+function generateAndValidateFiles() {
+	echo "Generating and validating the files"
+
+	for file in $(seq 1 20); do
+		size=$((file * 1024 * 1024))
+		FILE_SIZE=${size} assert_success file-generate "file.${file}" &
+	done
+
+	wait
+
+	for file in $(seq 1 20); do
+		assert_success file-validate "file.${file}" &
+	done
+
+	wait
+}
+
+function getActualPollTimeoutFromLog() {
+	grep -ioP '(?<=poll timeout set to )[0-9]+' "${TEMP_DIR}/log" | tail -n 1
+}
+
+lastChunkserver=2
+
+# Add default timeout to master and chunkservers cfgs
+defaultTimeout=50
+
+for cs in $(seq 0 ${lastChunkserver}); do
+	echo "POLL_TIMEOUT_MS = ${defaultTimeout}" >> "${info[chunkserver${cs}_cfg]}"
+	saunafs_chunkserver_daemon ${cs} restart
+done
+
+echo "POLL_TIMEOUT_MS = ${defaultTimeout}" >> "${info[master0_cfg]}"
+
+previousMasterTimeout=${defaultTimeout}
+previousChunkserverTimeout=${defaultTimeout}
+
+function applyTimeouts() {
+	local masterTimeout=$1
+	local chunkserverTimeout=$2
+
+	echo "Timeouts: Master=${masterTimeout}, Chunkservers=${chunkserverTimeout}"
+
+	for cs in $(seq 0 ${lastChunkserver}); do
+		sed -i "s/POLL_TIMEOUT_MS = ${previousChunkserverTimeout}/POLL_TIMEOUT_MS = ${chunkserverTimeout}/" \
+		    "${info[chunkserver${cs}_cfg]}"
+		saunafs_chunkserver_daemon ${cs} restart
+	done
+
+	saunafs_wait_for_all_ready_chunkservers
+
+	lastTimeout=$(getActualPollTimeoutFromLog)
+	assert_equals "${chunkserverTimeout}" "${lastTimeout}"
+
+	sed -i "s/POLL_TIMEOUT_MS = ${previousMasterTimeout}/POLL_TIMEOUT_MS = ${masterTimeout}/" \
+	    "${info[master0_cfg]}"
+	saunafs_master_daemon restart
+
+	saunafs_wait_for_all_ready_chunkservers
+
+	lastTimeout=$(getActualPollTimeoutFromLog)
+	assert_equals "${masterTimeout}" "${lastTimeout}"
+
+	previousChunkserverTimeout=${chunkserverTimeout}
+	previousMasterTimeout=${masterTimeout}
+}
+
+# Check different combinations of timeouts (from almost non-blocking to big wait)
+timeouts=(10 25 75 100)
+
+for masterTimeout in "${timeouts[@]}"; do
+	for chunkserverTimeout in "${timeouts[@]}"; do
+		applyTimeouts "${masterTimeout}" "${chunkserverTimeout}"
+		generateAndValidateFiles
+	done
+done


### PR DESCRIPTION
A poll timeout of 50 ms could introduce latency if the events occur more frequently. This commit makes the timeout configurable to easy test with different values to find optimal balance between timeout and CPU usage.