### PR TITLE
feat(chunkserver): Make configurable masterconn workers

### DIFF
--- a/doc/sfschunkserver.cfg.5.adoc
+++ b/doc/sfschunkserver.cfg.5.adoc
@@ -51,6 +51,10 @@ the master server after disconnection (default is 5)
 *MASTER_TIMEOUT*:: timeout (in seconds) for the master server connection
 (default is 60, minimum is 0.01)
 
+*MASTER_NR_OF_WORKERS*:: number of threads that the connection to master may use
+to process operations on chunks, like create, duplicate, replicate and truncate
+(default is 10, minimum is 2)
+
 *BIND_HOST*:: local address to use for connecting with the master server
 (default is ***, i.e. default local address)
 

--- a/src/data/sfschunkserver.cfg.in
+++ b/src/data/sfschunkserver.cfg.in
@@ -43,6 +43,11 @@
 ## (Default: 60)
 # MASTER_TIMEOUT = 60
 
+## Number of threads that the connection to master may use to process operations
+## on chunks, like create, duplicate, replicate and truncate.
+(Default: 10, Minimum: 2)
+# MASTER_NR_OF_WORKERS = 10
+
 ## IP address to listen on for client (sfsmount) connections:
 # CSSERV_LISTEN_HOST = *
 

--- a/tests/test_suites/ShortSystemTests/test_chunkserver_masterconn_workers.sh
+++ b/tests/test_suites/ShortSystemTests/test_chunkserver_masterconn_workers.sh
@@ -1,0 +1,67 @@
+CHUNKSERVERS=3 \
+	USE_RAMDISK=YES \
+	MASTER_CUSTOM_GOALS="1 ec21: \$ec(2,1)" \
+	AUTO_SHADOW_MASTER="NO" \
+	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER" \
+	CHUNKSERVER_EXTRA_CONFIG="MAGIC_DEBUG_LOG = $TEMP_DIR/log|LOG_FLUSH_ON=INFO" \
+	setup_local_empty_saunafs info
+
+cd "${info[mount0]}"
+
+# Generate and validate some files in parallel
+function generateAndValidateFiles() {
+	for file in $(seq 1 20); do
+		size=$((file * 1024 * 1024))
+		FILE_SIZE=${size} assert_success file-generate "file.${file}" &
+	done
+
+	wait
+
+	for file in $(seq 1 20); do
+		assert_success file-validate "file.${file}" &
+	done
+
+	wait
+}
+
+function getActualWorkers() {
+	grep -oP '(?<=master connection: )[0-9]+' "${TEMP_DIR}/log" | tail -n 1
+}
+
+lastChunkserver=2
+
+# Minimum workers
+minimumWorkers=2
+
+## Set number of workers to 0 by configuration in all chunkservers and restart
+for cs in $(seq 0 ${lastChunkserver}); do
+	echo "MASTER_NR_OF_WORKERS = 0" >> "${info[chunkserver${cs}_cfg]}"
+	saunafs_chunkserver_daemon ${cs} restart
+done
+
+saunafs_wait_for_all_ready_chunkservers
+
+## Check that the system is still able to write and read files
+generateAndValidateFiles
+
+## Even if set to 0, the minimum number of workers is 2 in the code
+actualWorkers=$(getActualWorkers)
+assert_equals "${minimumWorkers}" "${actualWorkers}"
+
+# High number of workers
+highWorkers=50
+
+## Substitute the number of workers to be 50 in all chunkservers and restart
+for cs in $(seq 0 ${lastChunkserver}); do
+	sed -i 's/MASTER_NR_OF_WORKERS = 0/MASTER_NR_OF_WORKERS = 50/' \
+		"${info[chunkserver${cs}_cfg]}"
+	saunafs_chunkserver_daemon ${cs} restart
+done
+
+saunafs_wait_for_all_ready_chunkservers
+
+## Check that the system is still able to write and read files
+generateAndValidateFiles
+
+actualWorkers=$(getActualWorkers)
+assert_equals "${highWorkers}" "${actualWorkers}"


### PR DESCRIPTION
Previously the master connection had a fixed amount of 10 worker threads  in the jobs pool. This commit makes it configurable, to be able to adapt it to the expected workload.

For instance, a chunkserver handling a small number of disks may have a lower value.