### PR TITLE
fix(tests): Fix call to timeout_rescale

### DIFF
--- a/tests/tools/assert.sh
+++ b/tests/tools/assert.sh
@@ -198,7 +198,7 @@ rescale_timeout_for_assert_eventually_() {
 	if [[ -n "$1" ]]; then
 		timeout_rescale "$1"
 	else
-		timeout_rescale $ASSERT_TIMEOUT
+		timeout_rescale "${ASSERT_TIMEOUT}"
 	fi
 }
 


### PR DESCRIPTION
The previous call was expanding to two arguments, possibly causing non-deterministic errors in some tests.