### PR TITLE
feat(uraft): Add mechanism to recover floating IP

### DIFF
--- a/doc/saunafs-uraft-helper.8.adoc
+++ b/doc/saunafs-uraft-helper.8.adoc
@@ -14,7 +14,7 @@ saunafs-uraft-helper
 
 *saunafs-uraft-helper* is a helper script, used internally by *saunafs-uraft*
 to manage nodes. The script should implement the following operations: isalive
-metadata-version quick-stop promote demote assign-ip drop-ip
+metadata-version quick-stop promote demote assign-ip drop-ip is-floating-ip-alive
 
 Except from *isalive*, this script should not be used on its own. If anyone
 needs special actions to be taken during *saunafs-uraft* management stages

--- a/src/uraft/saunafs-uraft-helper.in
+++ b/src/uraft/saunafs-uraft-helper.in
@@ -151,6 +151,30 @@ saunafs_metadata_version() {
 	esac
 }
 
+is_ip_present() {
+	local ip="${1}"
+	local iface="${2:-}"
+	local -a ip_command_extra_args=()
+	if [ -n "${iface}" ]; then
+		ip_command_extra_args+=("dev" "${iface}")
+	fi
+	ip addr show "${ip_command_extra_args[@]}" | grep -wq -m1 "${ip}"
+}
+
+saunafs_is_floating_ip_present() {
+	load_config
+	if is_ip_present "${ipaddr}" "${iface}"; then
+		echo -n alive
+		return 0
+	fi
+	if [ -n "${ipaddr2}" ] && is_ip_present "${ipaddr2}" "${iface2}"; then
+		echo -n alive
+		return 0
+	fi
+	echo -n dead
+	return 1
+}
+
 saunafs_isalive() {
 	saunafs_master isalive
 	if [[ $? == 0 ]] ; then
@@ -196,6 +220,7 @@ print_help() {
 	echo "assign-ip"
 	echo "drop-ip"
 	echo "dead"
+	echo "is-floating-ip-alive"
 }
 
 case "$1" in
@@ -207,6 +232,7 @@ case "$1" in
 	assign-ip)         saunafs_assign_ip;;
 	drop-ip)           saunafs_drop_ip;;
 	dead)              saunafs_dead;;
+	is-floating-ip-alive) saunafs_is_floating_ip_present;;
 	*)                 print_help;;
 
 esac

--- a/src/uraft/uraftcontroller.h
+++ b/src/uraft/uraftcontroller.h
@@ -54,6 +54,9 @@ public:
 	//! called by uRaft with new leader id.
 	virtual void     nodeLeader(int id);
 
+	//! called to check if floating ip is alive.
+	bool isFloatingIpAlive();
+
 protected:
 	void  checkCommandStatus(const boost::system::error_code &error);
 	void  checkNodeStatus(const boost::system::error_code &error);


### PR DESCRIPTION
Previously, the loss of the uRaft floating IP caused SaunaFS services to stop. Consequently, the cluster was unable to recover and it was required a manual restart of the uraft service to bring back the floating IP.

This commit introduces a recovery mechanism that allows SaunaFS to regain the floating IP after unexpected failures.

The key changes are:
- Added `saunafs_is_floating_ip_present()` in `saunafs-uraft-helper` to check the current state of the floating IP.
- Added `isFloatingIpAlive()` in uRaft to check the floating IP status by invoking a helper script function.
- Introduced logic to demote the current leader if the floating IP is lost and ensure metadata synchronization between shadow servers and the newly elected leader. It avoids having split brain scenarios.