### PR TITLE
fix: Clarify error offset in file-validate

### DIFF
--- a/utils/data_generator.h
+++ b/utils/data_generator.h
@@ -117,7 +117,8 @@ public:
 				if (actual_buffer[i] != proper_buffer[i]) {
 					std::stringstream ss;
 					ss << "(inode " << file_information.st_ino << ")"
-							<< " data mismatch at offset " << i << ", seed " << seed_ << ". Expected/actual:\n";
+					   << " data mismatch at offset " << current_offset + i
+					   << ", seed " << seed_ << ". Expected/actual:\n";
 					for (size_t j = i; j < (size_t)bytes_read && j < i + 32; ++j) {
 						ss << std::hex << std::setfill('0') << std::setw(2)
 								<< static_cast<int>(static_cast<unsigned char>(proper_buffer[j]))


### PR DESCRIPTION
Current version of the code, when showing the error offset in a
file-validate check many times say a wrong offset inside the file. This
is because it is showing the error offset inside the buffer reading
from the checked file.

The real offset may be obtained from the expected data, but it would be
much easier to show it as a first result.