### PR TITLE
feat(mound): Add ignoreflush to tweaks variables

### DIFF
--- a/src/mount/sauna_client.cc
+++ b/src/mount/sauna_client.cc
@@ -215,7 +215,7 @@ static unsigned gDirEntryCacheMaxSize = 100000;
 
 static int debug_mode = 0;
 static int usedircache = 1;
-static bool ignore_flush = false;
+static std::atomic<bool> gIgnoreFlush = false;
 static int keep_cache = 0;
 static double direntry_cache_timeout = 0.1;
 static double entry_cache_timeout = 0.0;
@@ -2408,7 +2408,7 @@ BytesWritten write(Context &ctx, Inode ino, const char *buf, size_t size, off_t 
 }
 
 void flush(Context &ctx, Inode ino, FileInfo* fi) {
-	if (ignore_flush) {
+	if (gIgnoreFlush) {
 		oplog_printf(ctx, "flush (%lu): OK",
 				(unsigned long int)ino);
 		return;
@@ -3411,7 +3411,7 @@ void init(int debug_mode_, int keep_cache_, double direntry_cache_timeout_, unsi
 	mounting_gid = mounting_gid_;
 	allowed_users = allowed_users_;
 #endif
-	ignore_flush = ignore_flush_;
+	gIgnoreFlush = ignore_flush_;
 	debug_mode = debug_mode_;
 	keep_cache = keep_cache_;
 	direntry_cache_timeout = direntry_cache_timeout_;
@@ -3443,6 +3443,7 @@ void init(int debug_mode_, int keep_cache_, double direntry_cache_timeout_, unsi
 			getAcl));
 
 	gTweaks.registerVariable("DirectIO", gDirectIo);
+	gTweaks.registerVariable("IgnoreFlush", gIgnoreFlush);
 	gTweaks.registerVariable("AclCacheMaxTime", acl_cache->maxTime_ms);
 	gTweaks.registerVariable("AclCacheHit", acl_cache->cacheHit);
 	gTweaks.registerVariable("AclCacheExpired", acl_cache->cacheExpired);

--- a/src/mount/writedata.cc
+++ b/src/mount/writedata.cc
@@ -215,6 +215,7 @@ static InodeDataMap inodedataMap;
 
 static uint32_t gWriteWindowSize;
 static uint32_t gChunkserverTimeout_ms;
+static std::atomic<bool> gIgnoreFlush;
 
 // percentage of the free cache (1% - 100%) which can be used by one inode
 static uint32_t gCachePerInodePercentage;

--- a/tests/test_suites/SanityChecks/test_mount_tweaks.sh
+++ b/tests/test_suites/SanityChecks/test_mount_tweaks.sh
@@ -7,15 +7,21 @@
 MOUNTS=2 \
   USE_RAMDISK=YES \
   MOUNT_0_EXTRA_CONFIG="sfsdirectio=0" \
-  MOUNT_1_EXTRA_CONFIG="sfsdirectio=1" \
+  MOUNT_1_EXTRA_CONFIG="sfsdirectio=1,sfsignoreflush" \
   setup_local_empty_saunafs info
 
 expect_equals "false" "$(cat ${info[mount0]}/.saunafs_tweaks | grep -i directio | awk '{print $2}')"
+expect_equals "false" "$(cat ${info[mount0]}/.saunafs_tweaks | grep -i ignoreflush | awk '{print $2}')"
 expect_equals "true" "$(cat ${info[mount1]}/.saunafs_tweaks | grep -i directio | awk '{print $2}')"
+expect_equals "true" "$(cat ${info[mount1]}/.saunafs_tweaks | grep -i ignoreflush | awk '{print $2}')"
 
-# Modify the DirectIO option on the fly
+# Modify the options on the fly from tweaks file
 echo "DirectIO=true" | sudo tee ${info[mount0]}/.saunafs_tweaks
+echo "IgnoreFlush=true" | sudo tee ${info[mount0]}/.saunafs_tweaks
 echo "DirectIO=false" | sudo tee ${info[mount1]}/.saunafs_tweaks
+echo "IgnoreFlush=false" | sudo tee ${info[mount1]}/.saunafs_tweaks
 
 expect_equals "true" "$(cat ${info[mount0]}/.saunafs_tweaks | grep -i directio | awk '{print $2}')"
+expect_equals "true" "$(cat ${info[mount0]}/.saunafs_tweaks | grep -i ignoreflush | awk '{print $2}')"
 expect_equals "false" "$(cat ${info[mount1]}/.saunafs_tweaks | grep -i directio | awk '{print $2}')"
+expect_equals "false" "$(cat ${info[mount1]}/.saunafs_tweaks | grep -i ignoreflush | awk '{print $2}')"


### PR DESCRIPTION
This change allows the users to modify the sfsignoreflush option during runtime execution of the client.