### PR TITLE
test(mount): Add test for ignoreflush option

### DIFF
--- a/doc/sfsmount.1.adoc
+++ b/doc/sfsmount.1.adoc
@@ -213,10 +213,10 @@ Equivalent to *--nostdopts* (*-n*) option for use in fstab.
 *-o nonempty*::
 Equivalent to *--nonempty* option for use in fstab.
 
-*-o sfsignoreflush*::
+*-o sfsignoreflush*'0|1'::
 Advanced: use with caution. Ignore flush usual behavior by replying SUCCESS to it
 immediately. Targets fast creation of small files, but may cause data loss
-during crashes when allegedly flushed data is still being processed.
+during crashes when allegedly flushed data is still being processed (default: 0).
 
 *-o sfsdirectio=*'0|1'::
 Whether to use FUSE DirectIO. This may improve performance when reading large

--- a/src/mount/fuse/mount_config.cc
+++ b/src/mount/fuse/mount_config.cc
@@ -92,7 +92,7 @@ struct fuse_opt gSfsOptsStage2[] = {
 	SFS_OPT("bandwidthoveruse=%lf", bandwidthoveruse, 1),
 	SFS_OPT("sfsdirentrycachesize=%u", direntrycachesize, 0),
 	SFS_OPT("nostdmountoptions", nostdmountoptions, 1),
-	SFS_OPT("sfsignoreflush", ignoreflush, 1),
+	SFS_OPT("sfsignoreflush=%d", ignoreflush, 0),
 
 	SFS_OPT("enablefilelocks=%u", filelocks, 0),
 	SFS_OPT("nonempty", nonemptymount, 1),
@@ -168,9 +168,10 @@ void usage(const char *progname) {
 "    -o sfswriteworkers=N        define number of write workers (default: %u)\n"
 "    -o sfswritewindowsize=N     define write window size (in blocks) for "
 				"each chunk (default: %u)\n"
-"    -o sfsignoreflush           Advanced: use with caution. Ignore flush usual "
+"    -o sfsignoreflush=0|1       Advanced: use with caution. Ignore flush usual "
 				"behavior by replying SUCCESS to it immediately. Targets fast "
-				"creation of small files, but may cause data loss during crashes.\n"
+				"creation of small files, but may cause data loss during crashes "
+				"(default: %d)\n"
 "\n"
 "Other options:\n"
 "    -m   --meta                 equivalent to '-o sfsmeta'\n"
@@ -248,6 +249,7 @@ void usage(const char *progname) {
 		SaunaClient::FsInitParams::kDefaultCachePerInodePercentage,
 		SaunaClient::FsInitParams::kDefaultWriteWorkers,
 		SaunaClient::FsInitParams::kDefaultWriteWindowSize,
+		SaunaClient::FsInitParams::kDefaultIgnoreFlush,
 		SaunaClient::FsInitParams::kDefaultUseRwLock,
 		SaunaClient::FsInitParams::kDefaultMkdirCopySgid,
 		sugidClearModeString(SaunaClient::FsInitParams::kDefaultSugidClearMode),

--- a/src/mount/writedata.cc
+++ b/src/mount/writedata.cc
@@ -215,7 +215,6 @@ static InodeDataMap inodedataMap;
 
 static uint32_t gWriteWindowSize;
 static uint32_t gChunkserverTimeout_ms;
-static std::atomic<bool> gIgnoreFlush;
 
 // percentage of the free cache (1% - 100%) which can be used by one inode
 static uint32_t gCachePerInodePercentage;

--- a/tests/test_suites/SanityChecks/test_mount_tweaks.sh
+++ b/tests/test_suites/SanityChecks/test_mount_tweaks.sh
@@ -6,8 +6,8 @@
 #
 MOUNTS=2 \
   USE_RAMDISK=YES \
-  MOUNT_0_EXTRA_CONFIG="sfsdirectio=0" \
-  MOUNT_1_EXTRA_CONFIG="sfsdirectio=1,sfsignoreflush" \
+  MOUNT_0_EXTRA_CONFIG="sfsdirectio=0,sfsignoreflush=0" \
+  MOUNT_1_EXTRA_CONFIG="sfsdirectio=1,sfsignoreflush=1" \
   setup_local_empty_saunafs info
 
 expect_equals "false" "$(cat ${info[mount0]}/.saunafs_tweaks | grep -i directio | awk '{print $2}')"

--- a/tests/test_suites/ShortSystemTests/test_ignore_flush.sh
+++ b/tests/test_suites/ShortSystemTests/test_ignore_flush.sh
@@ -1,0 +1,56 @@
+CHUNKSERVERS=5 \
+	MOUNTS=2 \
+	MOUNT_0_EXTRA_CONFIG="sfscachemode=NEVER`
+			`|sfsignoreflush=1`
+			`|sfsioretries=5" \
+	MOUNT_1_EXTRA_CONFIG="sfscachemode=NEVER`
+			`|sfsignoreflush=0`
+			`|sfsioretries=5" \
+	MASTER_CUSTOM_GOALS="10 ec_3_2: \$ec(3,2)" \
+	USE_RAMDISK=YES \
+	setup_local_empty_saunafs info
+
+get_checksum() {
+	sha256sum $1 | awk '{ print $1 }'
+}
+
+dir="${info[mount0]}/dir1"
+dir2="${info[mount1]}/dir2"
+
+mkdir "$dir" "$dir2"
+
+saunafs setgoal ec_3_2 "$dir" "$dir2"
+
+# stop three chunkservers for invalidating the writing of a ec_3_2 file
+for i in {0..2}; do
+	saunafs_chunkserver_daemon $i stop
+done
+
+assert_success dd if=/dev/zero of=${dir}/file1 bs=1M count=1 oflag=direct
+assert_failure dd if=/dev/zero of=${dir2}/file2 bs=1M count=1 oflag=direct
+
+# now test that with only two chunkservers stopped, 
+# writing the ec_3_2 files is possible
+saunafs_chunkserver_daemon 0 start
+
+dd if=/dev/urandom of=/tmp/tmpfile1 bs=1M count=100
+dd if=/dev/urandom of=/tmp/tmpfile2 bs=1M count=100
+
+checksum_tmp_file1=$(get_checksum /tmp/tmpfile1)
+checksum_tmp_file2=$(get_checksum /tmp/tmpfile2)
+
+echo "Copying files from /tmp to $dir and $dir2"
+assert_success dd if=/tmp/tmpfile1 of=${dir}/tmpfile1 oflag=direct bs=1M count=100
+assert_success dd if=/tmp/tmpfile2 of=${dir2}/tmpfile2 oflag=direct bs=1M count=100
+
+echo "Compare files to ensure they are identical"
+assert_success cmp /tmp/tmpfile1 ${dir}/tmpfile1
+assert_success cmp /tmp/tmpfile2 ${dir2}/tmpfile2
+
+echo "Get the md5sum of the files"
+checksum_dir_file1=$(get_checksum ${dir}/tmpfile1)
+checksum_dir_file2=$(get_checksum ${dir2}/tmpfile2)
+
+echo "Compare md5sums to ensure they are identical"
+assert_equals $checksum_tmp_file1 $checksum_dir_file1
+assert_equals $checksum_tmp_file2 $checksum_dir_file2


### PR DESCRIPTION
This change adds a test for checking the sfsignoreflush option when a possible write process could fail during the flush operation. This way it is possible to check that when sfsignoreflush is on, some writing errors can be ignored.



This PR should be merged after: [#228](https://github.com/leil-io/saunafs/pull/228) 