### PR TITLE
feat(mount): Add option for open files on Windows

### DIFF
--- a/src/mount/acquired_files_last_time_used.h
+++ b/src/mount/acquired_files_last_time_used.h
@@ -1,0 +1,96 @@
+/*
+   Copyright 2013-2017 Skytechnology sp. z o.o.
+   Copyright 2023      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "common/platform.h"
+
+#include <ctime>
+#include <map>
+#include <mutex>
+#include <set>
+#include <stdexcept>
+
+inline uint32_t gCleanAcquiredFilesPeriod;
+inline uint32_t gCleanAcquiredFilesTimeout;
+
+// Define the AcquiredFileLastTimeUsed struct
+struct AcquiredFileLastTimeUsed {
+	uint32_t inode;
+	uint32_t lastTimeUsed;
+
+	// Constructor
+	AcquiredFileLastTimeUsed(uint32_t inode, uint32_t lastTimeUsed)
+	    : inode(inode), lastTimeUsed(lastTimeUsed) {}
+};
+
+struct CompareByLastTimeUsed {
+	bool operator()(const AcquiredFileLastTimeUsed &acquiredFile1,
+	                const AcquiredFileLastTimeUsed &acquiredFile2) const {
+		return acquiredFile1.lastTimeUsed < acquiredFile2.lastTimeUsed ||
+		       (acquiredFile1.lastTimeUsed == acquiredFile2.lastTimeUsed &&
+		        acquiredFile1.inode < acquiredFile2.inode);
+	}
+};
+
+using AcquiredFilesLastTimeUsed =
+    std::set<AcquiredFileLastTimeUsed, CompareByLastTimeUsed>;
+using InodeToFileMap = std::map<uint32_t, AcquiredFilesLastTimeUsed::iterator>;
+
+inline AcquiredFilesLastTimeUsed acquiredFilesLastTimeUsed;
+inline InodeToFileMap inodeToFileMap;
+
+// Function to return the least value according to the custom comparator
+inline AcquiredFileLastTimeUsed getOldestAcquiredFile() {
+	if (!acquiredFilesLastTimeUsed.empty()) {
+		return *acquiredFilesLastTimeUsed
+		            .begin();  // The first element is the least according to
+		                       // the comparator
+	}
+	throw std::runtime_error("Acquired Files With Last Time Used Set is empty");
+}
+
+// Function to add/update a new AcquiredFileLastTimeUsed
+inline void addOrUpdateAcquiredFileLastTimeUsed(
+    uint32_t inode, uint32_t lastTimeUsed = time(nullptr)) {
+	auto it = inodeToFileMap.find(inode);
+	if (it != inodeToFileMap.end()) {
+		// Update existing entry
+		AcquiredFileLastTimeUsed updatedFile = *(it->second);
+		updatedFile.lastTimeUsed = lastTimeUsed;
+		acquiredFilesLastTimeUsed.erase(it->second);
+		auto newIt = acquiredFilesLastTimeUsed.insert(updatedFile).first;
+		inodeToFileMap[inode] = newIt;
+	} else {
+		// Add new entry
+		AcquiredFileLastTimeUsed newFile(inode, lastTimeUsed);
+		auto insertionResult = acquiredFilesLastTimeUsed.insert(newFile);
+		auto newIt = insertionResult.first;
+		inodeToFileMap[inode] = newIt;
+	}
+}
+
+// Function to remove an AcquiredFileLastTimeUsed
+inline void removeAcquiredFileLastTimeUsed(uint32_t inode) {
+	auto it = inodeToFileMap.find(inode);
+	if (it != inodeToFileMap.end()) {
+		acquiredFilesLastTimeUsed.erase(it->second);
+		inodeToFileMap.erase(it);
+	}
+}

--- a/src/mount/mastercomm.h
+++ b/src/mount/mastercomm.h
@@ -31,6 +31,9 @@
 #include "common/chunk_type_with_address.h"
 #include "mount/group_cache.h"
 #include "mount/sauna_client.h"
+#ifdef _WIN32
+#include "mount/acquired_files_last_time_used.h"
+#endif
 #include "protocol/packet.h"
 #include "protocol/lock_info.h"
 #include "protocol/directory_entry.h"
@@ -39,6 +42,11 @@
 #ifdef _WIN32
 inline std::atomic_bool gIsDisconnectedFromMaster;
 #endif
+
+inline std::mutex acquiredFileMutex;
+// <inode, cnt> and sorted by inode
+using AcquiredFileMap = std::map<uint32_t, uint32_t>;
+inline AcquiredFileMap acquiredFiles;
 
 void fs_getmasterlocation(uint8_t loc[14]);
 uint32_t fs_getsrcip(void);

--- a/src/mount/sauna_client.h
+++ b/src/mount/sauna_client.h
@@ -83,6 +83,8 @@ struct FsInitParams {
 	static constexpr bool     kDefaultIgnoreFlush = false;
 #ifdef _WIN32
 	static constexpr unsigned kDefaultWriteCacheSize = 50;
+	static constexpr unsigned kDefaultCleanAcquiredFilesPeriod = 0;
+	static constexpr unsigned kDefaultCleanAcquiredFilesTimeout = 0;
 #else
 	static constexpr unsigned kDefaultWriteCacheSize = 0;
 #endif
@@ -148,6 +150,8 @@ struct FsInitParams {
 	             acl_cache_timeout(kDefaultAclCacheTimeout), acl_cache_size(kDefaultAclCacheSize),
 #ifdef _WIN32
 	             mounting_uid(USE_LOCAL_ID), mounting_gid(USE_LOCAL_ID),
+	             clean_acquired_files_period(kDefaultCleanAcquiredFilesPeriod), 
+	             clean_acquired_files_timeout(kDefaultCleanAcquiredFilesTimeout),
 #endif
 	             ignore_flush(kDefaultIgnoreFlush), verbose(kDefaultVerbose), direct_io(kDirectIO) {
 	}
@@ -181,6 +185,8 @@ struct FsInitParams {
 	             acl_cache_timeout(kDefaultAclCacheTimeout), acl_cache_size(kDefaultAclCacheSize),
 #ifdef _WIN32
 	             mounting_uid(USE_LOCAL_ID), mounting_gid(USE_LOCAL_ID),
+				 clean_acquired_files_period(kDefaultCleanAcquiredFilesPeriod), 
+				 clean_acquired_files_timeout(kDefaultCleanAcquiredFilesTimeout),
 #endif
 	             ignore_flush(kDefaultIgnoreFlush), verbose(kDefaultVerbose), direct_io(kDirectIO) {
 	}
@@ -232,6 +238,8 @@ struct FsInitParams {
 	int mounting_uid;
 	int mounting_gid;
 	std::unordered_set<uint32_t> allowed_users;
+	unsigned clean_acquired_files_period;
+	unsigned clean_acquired_files_timeout;
 #endif
 
 	bool ignore_flush;


### PR DESCRIPTION
This change enables the corresponding options to be used on the Windows client for cleaning open unused files by external applications using our filesystem.