### PR TITLE
tests: Small fixes on read tests

### DIFF
--- a/tests/test_suites/ShortSystemTests/test_read_cache_low_level_percentage.sh
+++ b/tests/test_suites/ShortSystemTests/test_read_cache_low_level_percentage.sh
@@ -1,11 +1,17 @@
 timeout_set 2 minutes
 
+if is_windows_system; then
+	ioretries=15
+else
+	ioretries=14
+fi
+
 MOUNT_EXTRA_CONFIG="sfscachemode=NEVER`
 		`|readcachemaxsizepercentage=1`
 		`|maxreadaheadrequests=0`
-		`|sfsioretries=14`
+		`|sfsioretries=${ioretries}`
 		`|cacheexpirationtime=10000" \
-    setup_local_empty_saunafs info
+	setup_local_empty_saunafs info
 
 cd "${info[mount0]}"
 

--- a/tests/test_suites/ShortSystemTests/test_read_corrupted_files.sh
+++ b/tests/test_suites/ShortSystemTests/test_read_corrupted_files.sh
@@ -4,7 +4,7 @@ assert_program_installed pv
 
 USE_RAMDISK=YES \
 	CHUNKSERVERS=5 \
-    MOUNT_EXTRA_CONFIG="sfscachemode=NEVER`
+	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER`
 			`|readcachemaxsizepercentage=1`
 			`|sfsioretries=1`
 			`|maxreadaheadrequests=0`
@@ -44,12 +44,12 @@ max_iterations=$((max_memory_mb / (file_size_mb * 50)))
 
 # Limit the iterations for large memory systems
 if [ $iterations -gt $max_iterations ]; then
-  iterations=$max_iterations
+	iterations=$max_iterations
 fi
 
 # Read the file in a loop
 for ((i=0; i<iterations; i++)); do
-  assert_failure pv -B ${SAUNAFS_BLOCK_SIZE} -E -Z ${SAUNAFS_BLOCK_SIZE} -Y ${dir}/file &> /dev/null
+	assert_failure pv -B ${SAUNAFS_BLOCK_SIZE} -E -Z ${SAUNAFS_BLOCK_SIZE} -Y ${dir}/file &> /dev/null
 done
 
 sleep 10


### PR DESCRIPTION
Changes:
- use tab instead of space for indentation
- make the test_read_cache_low_level_percentage a bit more loose for
Windows testing.