### PR TITLE
fix(client): Fix client using localhost for chunkservers

### DIFF
--- a/src/chunkserver/masterconn.cc
+++ b/src/chunkserver/masterconn.cc
@@ -484,6 +484,9 @@ int masterconn_initconnect(masterconn *eptr) {
 		}
 		eptr->bindip = bip;
 		if (tcpresolve(MasterHost,MasterPort,&mip,&mport,0)>=0) {
+			if (isLoopbackAddress(mip)) {
+				safs::log_warn("Chunkserver loopback IP addresses are experimental; consider assigning an IP address to chunkserver (via /etc/hosts or some other way)");
+			}
 				eptr->masterip = mip;
 				eptr->masterport = mport;
 				eptr->masteraddrvalid = 1;
@@ -762,6 +765,9 @@ void masterconn_reload(void) {
 			eptr->mode = KILL;
 		}
 		if (tcpresolve(MasterHost,MasterPort,&mip,&mport,0)>=0) {
+			if (isLoopbackAddress(mip)) {
+				safs::log_warn("Chunkserver loopback IP addresses are experimental; consider a non-loopback IP address to chunkserver (via /etc/hosts or some other way)");
+			}
 			if (eptr->masterip != mip || eptr->masterport != mport) {
 				eptr->masterip = mip;
 				eptr->masterport = mport;

--- a/src/common/network_address.h
+++ b/src/common/network_address.h
@@ -28,6 +28,10 @@
 #include "common/human_readable_format.h"
 #include "common/serialization.h"
 
+inline bool isLoopbackAddress(uint32_t address) {
+	return ((address & 0xFF000000) == 0x7F000000); // ip in range (127.0.0.0...127.255.255.255)
+}
+
 struct NetworkAddress {
 	uint32_t ip;
 	uint16_t port;

--- a/src/master/matocsserv.cc
+++ b/src/master/matocsserv.cc
@@ -1038,6 +1038,9 @@ void matocsserv_register_host(matocsserventry *eptr, uint32_t version, uint32_t 
 		free(eptr->servstrip);
 	}
 	eptr->servstrip = matocsserv_makestrip(eptr->servip);
+	if (isLoopbackAddress(eptr->servip)) {
+		safs::log_warn("Chunkserver loopback IP addresses are experimental; consider assigning a non-loopback IP address to chunkserver (via /etc/hosts or some other way)");
+	}
 	if (csdb_new_connection(eptr->servip,eptr->servport,eptr)<0) {
 		safs_pretty_syslog(LOG_WARNING,"chunk-server already connected !!!");
 		eptr->mode=KILL;

--- a/src/mount/mastercomm.cc
+++ b/src/mount/mastercomm.cc
@@ -59,7 +59,9 @@
 #include "protocol/SFSCommunication.h"
 #include "protocol/packet.h"
 
-const uint32_t localhost = 0x7F000001;
+bool isLoopbackAddress(uint32_t ip) {	
+	return ((ip & 0xFF000000) == 0x7F000000); // ip in range (127.0.0.0...127.255.255.255)
+}
 
 struct threc {
 	pthread_t thid;

--- a/src/mount/mastercomm.cc
+++ b/src/mount/mastercomm.cc
@@ -2253,7 +2253,7 @@ uint8_t fs_sauwritechunk(uint32_t inode, uint32_t chunkIndex, uint32_t &lockId,
 	for (auto& server : chunkservers) {
 		// If 127.0.0.1, let's assume it's the same as master
 		if (server.address.ip == localhost) {
-			server.address.ip=masterip;
+			server.address.ip = masterip;
 			safs::log_debug("changing chunkserver ip address 127.0.0.1 to {}", htonl(masterip));
 		}
 	}

--- a/src/mount/mastercomm.cc
+++ b/src/mount/mastercomm.cc
@@ -22,6 +22,7 @@
 #include "mount/mastercomm.h"
 
 #include <limits.h>
+#include <netinet/in.h>
 #include <pthread.h>
 #include <signal.h>
 #include <stdio.h>
@@ -57,6 +58,8 @@
 #include "protocol/matocl.h"
 #include "protocol/SFSCommunication.h"
 #include "protocol/packet.h"
+
+const uint32_t localhost = 0x7F000001;
 
 struct threc {
 	pthread_t thid;
@@ -2143,6 +2146,13 @@ uint8_t fs_saureadchunk(std::vector<ChunkTypeWithAddress> &chunkservers, uint64_
 		setDisconnect(true);
 		return SAUNAFS_ERROR_IO;
 	}
+	for (auto& server : chunkservers) {
+		// If 127.0.0.1, let's assume it's the same as master
+		if (server.address.ip == localhost) {
+			server.address.ip=masterip;
+			safs::log_debug("changing chunkserver ip address 127.0.0.1 to {}", htonl(masterip));
+		}
+	}
 	return SAUNAFS_STATUS_OK;
 }
 
@@ -2237,6 +2247,13 @@ uint8_t fs_sauwritechunk(uint32_t inode, uint32_t chunkIndex, uint32_t &lockId,
 				"(length:%zu), %s", message.size(), ex.what());
 		setDisconnect(true);
 		return SAUNAFS_ERROR_IO;
+	}
+	for (auto& server : chunkservers) {
+		// If 127.0.0.1, let's assume it's the same as master
+		if (server.address.ip == localhost) {
+			server.address.ip=masterip;
+			safs::log_debug("changing chunkserver ip address 127.0.0.1 to {}", htonl(masterip));
+		}
 	}
 
 	return SAUNAFS_STATUS_OK;
@@ -3253,5 +3270,12 @@ uint8_t fs_getchunkservers(std::vector<ChunkserverListEntry> &chunkservers) {
 
 	chunkservers.clear();
 	matocl::cservList::deserialize(message, message_id, chunkservers);
+	for (auto& server : chunkservers) {
+		// If 127.0.0.1, let's assume chunkserver is the same as master host
+		if (server.servip == localhost) {
+			server.servip = masterip;
+			safs::log_debug("changing chunkserver ip address 127.0.0.1 to {}", htonl(masterip));
+		}
+	}
 	return SAUNAFS_STATUS_OK;
 }

--- a/src/mount/mastercomm.cc
+++ b/src/mount/mastercomm.cc
@@ -59,10 +59,6 @@
 #include "protocol/SFSCommunication.h"
 #include "protocol/packet.h"
 
-bool isLoopbackAddress(uint32_t ip) {	
-	return ((ip & 0xFF000000) == 0x7F000000); // ip in range (127.0.0.0...127.255.255.255)
-}
-
 struct threc {
 	pthread_t thid;
 	std::mutex mutex;
@@ -2149,10 +2145,11 @@ uint8_t fs_saureadchunk(std::vector<ChunkTypeWithAddress> &chunkservers, uint64_
 		return SAUNAFS_ERROR_IO;
 	}
 	for (auto& server : chunkservers) {
-		// If 127.0.0.1, let's assume it's the same as master
-		if (server.address.ip == localhost) {
-			server.address.ip=masterip;
-			safs::log_debug("changing chunkserver ip address 127.0.0.1 to {}", htonl(masterip));
+		if (isLoopbackAddress(server.address.ip)) {
+			safs::log_debug("Changing chunkserver ip address {} to {}",
+				  htonl(server.address.ip),
+				  htonl(masterip));
+			server.address.ip = masterip;
 		}
 	}
 	return SAUNAFS_STATUS_OK;
@@ -2252,9 +2249,11 @@ uint8_t fs_sauwritechunk(uint32_t inode, uint32_t chunkIndex, uint32_t &lockId,
 	}
 	for (auto& server : chunkservers) {
 		// If 127.0.0.1, let's assume it's the same as master
-		if (server.address.ip == localhost) {
+		if (isLoopbackAddress(server.address.ip)) {
+			safs::log_debug("fs_sauwritechunk: Changing chunkserver ip address {} to {}",
+				  htonl(server.address.ip),
+				  htonl(masterip));
 			server.address.ip = masterip;
-			safs::log_debug("changing chunkserver ip address 127.0.0.1 to {}", htonl(masterip));
 		}
 	}
 
@@ -3274,9 +3273,12 @@ uint8_t fs_getchunkservers(std::vector<ChunkserverListEntry> &chunkservers) {
 	matocl::cservList::deserialize(message, message_id, chunkservers);
 	for (auto& server : chunkservers) {
 		// If 127.0.0.1, let's assume chunkserver is the same as master host
-		if (server.servip == localhost) {
+		if (isLoopbackAddress(server.servip)) {
 			server.servip = masterip;
-			safs::log_debug("changing chunkserver ip address 127.0.0.1 to {}", htonl(masterip));
+			safs::log_debug("fs_getchunkservers: changing chunkserver ip address {} to {}",
+				  htonl(server.servip),
+				  htonl(masterip));
+			safs::log_warn("localhost chunkserver ip addresses are experimental, consider assigning an IP address to chunkserver (via /etc/hosts or some other way)");
 		}
 	}
 	return SAUNAFS_STATUS_OK;


### PR DESCRIPTION
When master gives information regarding chunks and chunkservers, it may give the localhost ip addresses of chunkserver to client, causing the client to search for the chunks on their localhost. This commit fixes that by interpreting localhost from master to mean the master IP address.