### PR TITLE
build: Require Judy for building

### DIFF
--- a/cmake/Libraries.cmake
+++ b/cmake/Libraries.cmake
@@ -137,7 +137,7 @@ endif()
 
 # Find Judy
 
-find_package(Judy)
+find_package(Judy REQUIRED)
 if(JUDY_FOUND)
   set(SAUNAFS_HAVE_JUDY YES)
   set(SAUNAFS_HAVE_WORKING_JUDY1 ${JUDY_HAVE_WORKING_JUDY1})


### PR DESCRIPTION
If Judy is not present, the master could take a very long time to load (depending on FREE section size). This fixes that by requiring Judy for building.

Fixes #239