### PR TITLE
Fix readcache memory release

### DIFF
--- a/src/mount/readdata.h
+++ b/src/mount/readdata.h
@@ -32,7 +32,7 @@
 #include "mount/readdata_cache.h"
 
 inline std::atomic<uint32_t> gReadaheadMaxWindowSize;
-inline std::atomic<uint32_t> gCacheExpirationTime_ms;
+inline std::atomic<uint32_t> gOriginalCacheExpirationTime_ms;
 inline std::atomic<uint32_t> gMaxReadaheadRequests;
 
 enum class ReadaheadRequestState {

--- a/src/mount/readdata.h
+++ b/src/mount/readdata.h
@@ -210,14 +210,13 @@ struct ReadRecord {
 	std::atomic<uint8_t> refreshCounter = 0;
 	std::atomic<uint16_t> requestsNotDone = 0;
 	bool expired = false; //gMutex
-	std::atomic<bool> stopThread;
+	std::atomic<bool> stopThread{false};
 	std::thread garbageCollectorThread;
 
 	ReadRecord(uint32_t inode)
 	    : cache(gCacheExpirationTime_ms),
 	      readahead_adviser(gCacheExpirationTime_ms, gReadaheadMaxWindowSize),
 	      inode(inode),
-	      stopThread(false),
 	      garbageCollectorThread(&ReadRecord::readCacheGarbageCollectionThread, this) {}
 
 	~ReadRecord() {
@@ -248,6 +247,7 @@ struct ReadRecord {
 			std::this_thread::sleep_for(std::chrono::milliseconds(300));
 		}
 	}
+
 	void terminateThread() {
 		stopThread.store(true);
 		if (garbageCollectorThread.joinable()) {

--- a/src/mount/readdata.h
+++ b/src/mount/readdata.h
@@ -34,7 +34,6 @@
 inline std::atomic<uint32_t> gReadaheadMaxWindowSize;
 inline std::atomic<uint32_t> gCacheExpirationTime_ms;
 inline std::atomic<uint32_t> gMaxReadaheadRequests;
-inline std::atomic<uint64_t> gReadCacheMaxSize;
 
 enum class ReadaheadRequestState {
 	kInqueued,
@@ -220,12 +219,9 @@ struct ReadRecord {
 	      inode(inode),
 	      stopThread(false),
 	      garbageCollectorThread(&ReadRecord::readCacheGarbageCollectionThread, this) {}
-	
-	~ReadRecord() { 
-		terminateThread();
-	}
 
 	~ReadRecord() {
+		terminateThread();
 		mutex.lock();  // Make helgrind happy
 		mutex.unlock();
 		pthread_mutex_destroy(mutex.native_handle());

--- a/src/mount/readdata_cache.h
+++ b/src/mount/readdata_cache.h
@@ -24,7 +24,6 @@
 
 #include "common/small_vector.h"
 #include "common/time_utils.h"
-#include "mount/memory_info.h"
 
 #include <atomic>
 #include <cassert>
@@ -32,6 +31,7 @@
 #include <deque>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <numeric>
 
 #include <boost/intrusive/list.hpp>
@@ -315,7 +315,7 @@ public:
 		unsigned reserved_count = count;
 		auto it = lru_.begin();
 		expiration_time_ = gCacheExpirationTime_ms.load();
-		
+
 		std::vector<Entry *> entriesToErase;
 		while (!lru_.empty() && count-- > 0 && it != lru_.end()) {
 			if (it->done && it->expired(expiration_time_)) {

--- a/src/mount/readdata_cache.h
+++ b/src/mount/readdata_cache.h
@@ -291,14 +291,19 @@ public:
 
 	void collectGarbage(unsigned count = 1000000) {
 		unsigned reserved_count = count;
-		while (!lru_.empty() && count-- > 0) {
-			Entry *e = std::addressof(lru_.front());
-			if (e->expired(expiration_time_) && e->done) {
-				erase(entries_.iterator_to(*e));
-			} else {
-				break;
+		auto it = lru_.begin();
+		
+		std::vector<Entry *> entriesToErase;
+		while (!lru_.empty() && count-- > 0 && it != lru_.end()) {
+			if (it->done && it->expired(expiration_time_)) {
+				entriesToErase.push_back(std::addressof(*it));
 			}
+			it++;
 		}
+		for (auto e : entriesToErase) {
+			erase(entries_.iterator_to(*e));
+		}
+
 		clearReserved(reserved_count);
 	}
 

--- a/src/mount/sauna_client.cc
+++ b/src/mount/sauna_client.cc
@@ -206,14 +206,14 @@ bool isSpecialInode(Inode ino) {
 
 enum {IO_NONE,IO_READ,IO_WRITE,IO_READONLY,IO_WRITEONLY};
 
-typedef struct _finfo {
+struct finfo {
 	uint8_t mode;
 	void *data;
 	uint8_t use_flocks;
 	uint8_t use_posixlocks;
 	pthread_mutex_t lock;
 	pthread_mutex_t flushlock;
-} finfo;
+};
 
 static DirEntryCache gDirEntryCache;
 static unsigned gDirEntryCacheMaxSize = 100000;

--- a/tests/test_suites/ShortSystemTests/test_read_cache_low_level_parallel_reads.sh
+++ b/tests/test_suites/ShortSystemTests/test_read_cache_low_level_parallel_reads.sh
@@ -1,0 +1,21 @@
+timeout_set 3 minutes
+
+CHUNKSERVERS=1 \
+	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER`
+			`|cacheexpirationtime=10000`
+			`|readcachemaxsizepercentage=1`
+			`|sfschunkserverwavereadto=2000`
+			`|sfsioretries=50`
+			`|readaheadmaxwindowsize=5000`
+			`|sfschunkservertotalreadto=8000" \
+	setup_local_empty_saunafs info
+
+cd ${info[mount0]}
+
+num_jobs=18
+five_percent_ram_mb=$(awk '/MemTotal/ {print int($2 / 1024 * 0.05)}' /proc/meminfo)
+size_per_job=$(echo "${five_percent_ram_mb} / ${num_jobs}" | bc)
+echo "five_percent_ram_mb: ${five_percent_ram_mb}, num_jobs: ${num_jobs}, size_per_job: ${size_per_job}"
+
+fio --name=test_multiple_reads --directory=${info[mount0]} --size=${size_per_job}M --rw=write --ioengine=libaio --group_reporting --numjobs=${num_jobs} --bs=1M --direct=1 --iodepth=1
+fio --name=test_multiple_reads --directory=${info[mount0]} --size=${size_per_job}M --rw=read --ioengine=libaio --group_reporting --numjobs=${num_jobs} --bs=1M --direct=1 --iodepth=1


### PR DESCRIPTION
### Summary of Changes

- **test(mount): Add test for multi read low cache**
  - Added a test to ensure the system can handle multiple read processes with low read cache memory.

- **feat(mount): Add threads for read records garbage**
  - Introduced threads for each active read record to manage their own read cache garbage collection.

- **feat(mount): Add cache expiration time thread**
  - Added a thread to dynamically update the read cache expiration time for better handling of multiple parallel reads.

- **feat(mount): Fix window read cache suggested size**
  - Adjusted the read ahead window size distribution among read workers to balance the load during multiple parallel reads.

- **feat(mount): Add limitation to extra read requests**
  - Disabled additional read requests when read cache memory is almost full to prevent memory release issues.

- **update(mount): Update collectGarbage function**
  - Improved the `collectGarbage` function to ensure all expired and fully processed entries are released, enhancing read performance.

Note: In the performance benchmark that we've made there aren't no noticeable changes when enough memory is provided. 

Co-authored-by: Dave <dave@leil.io>