### PR TITLE
feat(chunkserver): Stat chunks at scan optionally

### DIFF
--- a/doc/sfschunkserver.cfg.5.adoc
+++ b/doc/sfschunkserver.cfg.5.adoc
@@ -128,6 +128,12 @@ read any skipped data; the value is aligned down to 64 KiB)
 *PERFORM_FSYNC*:: call fsync() after a chunk is modified (default is 1, i.e.
 enabled)
 
+*STAT_CHUNKS_AT_DISK_SCAN*:: verify that chunk metadata and data parts exists at
+scan time. If set to 1, the data part is also checked to be multiple of
+SFSBLOCKSIZE. Disabling this option accelerates the scan process, but does not
+check the chunk files. Warning: use it with caution, only in scenarios where a
+fast chunkserver restart is needed.(default is 1, i.e. enabled)
+
 *REPLICATION_TOTAL_TIMEOUT_MS*:: total timeout for single replication
 operation. Replications that take longer than that are considered failed and
 are immediately aborted (default: 60000)

--- a/src/admin/dump_config_command.cc
+++ b/src/admin/dump_config_command.cc
@@ -167,6 +167,7 @@ const static std::unordered_map<std::string, std::string> defaultOptionsCS = {
     {"BGJOBSCNT_PER_NETWORK_WORKER", "1000"},
     {"MAX_READ_BEHIND_KB", "0"},
     {"PERFORM_FSYNC", "1"},
+    {"STAT_CHUNKS_AT_DISK_SCAN", "1"},
     {"REPLICATION_TOTAL_TIMEOUT_MS", "60000"},
     {"REPLICATION_CONNECTION_TIMEOUT_MS", "1000"},
     {"REPLICATION_WAVE_TIMEOUT_MS", "500"},

--- a/src/chunkserver/chunkserver-common/cmr_disk.cc
+++ b/src/chunkserver/chunkserver-common/cmr_disk.cc
@@ -87,7 +87,9 @@ int CmrDisk::updateChunkAttributes(IChunk *chunk, bool isFromScan) {
 	assert(chunk);
 	TRACETHIS1(chunk->id());
 
-	(void)isFromScan;  // Not needed for conventional disks
+	if (isFromScan && !gStatChunksAtDiskScan) {
+		return SAUNAFS_STATUS_OK;
+	}
 
 	struct stat metaStat {};
 	if (stat(chunk->metaFilename().c_str(), &metaStat) < 0) {

--- a/src/chunkserver/chunkserver-common/global_shared_resources.h
+++ b/src/chunkserver/chunkserver-common/global_shared_resources.h
@@ -56,6 +56,8 @@ inline std::vector<std::unique_ptr<CondVarWithWaitCount>> gFreeCondVars;
 /// started yet, but it's a _very_ unlikely situation.
 inline std::atomic_int gScansInProgress(0);
 
+inline std::atomic_bool gStatChunksAtDiskScan{true};
+
 inline std::atomic_bool gPerformFsync(true);
 
 inline std::atomic_bool gCheckCrcWhenWriting{true};

--- a/src/chunkserver/hddspacemgr.cc
+++ b/src/chunkserver/hddspacemgr.cc
@@ -2483,6 +2483,16 @@ void hddReload(void) {
 
 	gAdviseNoCache = cfg_getuint32("HDD_ADVISE_NO_CACHE", 0);
 	gPerformFsync = cfg_getuint32("PERFORM_FSYNC", 1);
+
+	gStatChunksAtDiskScan = cfg_getuint8("STAT_CHUNKS_AT_DISK_SCAN", 1) != 0U;
+	if (!gStatChunksAtDiskScan) {
+		safs::log_warn(
+		    "hdd space manager: STAT_CHUNKS_AT_DISK_SCAN = {} (disabled): the "
+		    "chunk data files will not be checked at scan time, make sure they "
+		    "have not changed.",
+		    static_cast<uint8_t>(gStatChunksAtDiskScan));
+	}
+
 	gHDDTestFreq_ms =
 	    cfg_ranged_get("HDD_TEST_FREQ", 10., 0.001, 1000000.) * 1000;
 	gCheckCrcWhenReading = cfg_getuint8("HDD_CHECK_CRC_WHEN_READING", 1) != 0U;
@@ -2583,6 +2593,15 @@ int hddInit() {
 	initializeEmptyBlockCrcForDisks();
 
 	gPerformFsync = cfg_getuint32("PERFORM_FSYNC", 1);
+
+	gStatChunksAtDiskScan = cfg_getuint8("STAT_CHUNKS_AT_DISK_SCAN", 1) != 0U;
+	if (!gStatChunksAtDiskScan) {
+		safs::log_warn(
+		    "hdd space manager: STAT_CHUNKS_AT_DISK_SCAN = {} (disabled): the "
+		    "chunk data files will not be checked at scan time, make sure they "
+		    "have not changed.",
+		    static_cast<uint8_t>(gStatChunksAtDiskScan));
+	}
 
 	int64_t leaveSpaceDefaultDefaultValue =
 	    cfg_parse_size(disk::gLeaveSpaceDefaultDefaultStrValue);

--- a/src/data/sfschunkserver.cfg.in
+++ b/src/data/sfschunkserver.cfg.in
@@ -142,6 +142,14 @@
 ## (Default: 1), i.e. enabled.
 #PERFORM_FSYNC = 1
 
+## Verify that chunk metadata and data parts exists at scan time. If set to 1,
+## the data part is also checked to be multiple of SFSBLOCKSIZE. Disabling this
+## option accelerates the scan process, but does not check the chunk data files.
+## Warning: use it with caution, only in scenarios where a fast chunkserver
+## restart is needed.
+## (Default: 1), i.e. enabled.
+# STAT_CHUNKS_AT_DISK_SCAN = 1
+
 ## [ADVANCED] The DiskManager is responsible for assigning each chunk to a
 ## specific disk. By default the chunks are distributed in a balanced way among
 ## all the available disks. This variable can be changed to select a custom

--- a/tests/test_suites/ShortSystemTests/test_chunkserver_stat_chunks_at_disk_scan.sh
+++ b/tests/test_suites/ShortSystemTests/test_chunkserver_stat_chunks_at_disk_scan.sh
@@ -1,0 +1,51 @@
+CHUNKSERVERS=3 \
+	DISK_PER_CHUNKSERVER=2 \
+	USE_RAMDISK=YES \
+	CHUNKSERVER_EXTRA_CONFIG="MAGIC_DEBUG_LOG = $TEMP_DIR/log|LOG_FLUSH_ON=INFO" \
+	AUTO_SHADOW_MASTER="NO" \
+	MASTER_CUSTOM_GOALS="10 ec21: \$ec(2,1)" \
+	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER" \
+	setup_local_empty_saunafs info
+
+lastChunkserver=2
+number_of_files=100
+goals="2 ec21"
+
+function generateFiles() {
+	for goal in ${goals}; do
+		mkdir ${goal}
+		saunafs setgoal ${goal} ${goal}
+
+		echo "Writing ${number_of_files} small files with goal ${goal}"
+		for i in $(seq 1 ${number_of_files}); do
+			FILE_SIZE=1024 assert_success file-generate "${goal}/file${i}"
+		done
+	done
+}
+
+function validateFiles() {
+	for goal in ${goals}; do
+		echo "Validating ${number_of_files} small files with goal ${goal}"
+		for i in $(seq 1 ${number_of_files}); do
+			assert_success file-validate "${goal}/file${i}"
+		done
+	done
+}
+
+cd "${info[mount0]}"
+
+generateFiles
+
+# Disable stat on chunk files at scan time
+for cs in $(seq 0 ${lastChunkserver}); do
+	echo "STAT_CHUNKS_AT_DISK_SCAN = 0" >> "${info[chunkserver${cs}_cfg]}"
+	saunafs_chunkserver_daemon ${cs} restart
+done
+saunafs_wait_for_all_ready_chunkservers
+
+# Check that all chunkserver have the stat disabled
+assert_equals 3 $(grep -i "STAT_CHUNKS_AT_DISK_SCAN = 0" "${TEMP_DIR}/log" | wc -l)
+
+drop_caches
+
+validateFiles


### PR DESCRIPTION
Scanning disks with millions of chunks can take a considerable time. At scan time, by default, the chunkserver performs an stat operation on the metadata and data files of each chunk. This check is good, but makes the scan process very slow.

This change adds the configuration option STAT_CHUNKS_AT_DISK_SCAN to optionally disable this behavior. The scan time with this option disabled is around 40 times faster.