### PR TITLE
refactor(common): Replace raw queue with PCQueue

### DIFF
--- a/src/common/pcqueue.cc
+++ b/src/common/pcqueue.cc
@@ -19,276 +19,139 @@
  */
 
 #include "common/platform.h"
-#include "common/pcqueue.h"
+#include "pcqueue.h"
 
-#include <errno.h>
-#include <inttypes.h>
-#include <pthread.h>
-#include <stdlib.h>
-
-#include "common/massert.h"
+#include <cerrno>
+#include <cstdlib>
 #include "devtools/TracePrinter.h"
-#include "errors/sfserr.h"
+#include <pthread.h>
 
-typedef struct _qentry {
-	uint32_t id;
-	uint32_t op;
-	uint8_t *data;
-	uint32_t leng;
-	struct _qentry *next;
-} qentry;
-
-typedef struct _queue {
-	qentry *head,**tail;
-	uint32_t elements;
-	uint32_t size;
-	uint32_t maxsize;
-	uint32_t freewaiting;
-	uint32_t fullwaiting;
-	pthread_cond_t waitfree,waitfull;
-	pthread_mutex_t lock;
-} queue;
-
-void* queue_new(uint32_t size) {
+ProducerConsumerQueue::ProducerConsumerQueue(uint32_t maxSize, Deleter deleter)
+    : maxSize_(maxSize), currentSize_(0), deleter_(deleter) {
 	TRACETHIS();
-	queue *q;
-	q = (queue*)malloc(sizeof(queue));
-	passert(q);
-	q->head = NULL;
-	q->tail = &(q->head);
-	q->elements = 0;
-	q->size = 0;
-	q->maxsize = size;
-	q->freewaiting = 0;
-	q->fullwaiting = 0;
-	if (size) {
-		zassert(pthread_cond_init(&(q->waitfull),NULL));
+}
+
+ProducerConsumerQueue::~ProducerConsumerQueue() {
+	TRACETHIS();
+	std::lock_guard<std::mutex> lock(mutex_);
+	while (!queue_.empty()) {
+		auto &entry = queue_.front();
+		deleter_(entry.data);
+		queue_.pop();
 	}
-	zassert(pthread_cond_init(&(q->waitfree),NULL));
-	zassert(pthread_mutex_init(&(q->lock),NULL));
-	return q;
 }
 
-void queue_delete(void *que, void (*deleter)(uint8_t *)) {
+bool ProducerConsumerQueue::isEmpty() const {
 	TRACETHIS();
-	queue *q = (queue*)que;
-	qentry *qe,*qen;
-	zassert(pthread_mutex_lock(&(q->lock)));
-	sassert(q->freewaiting==0);
-	sassert(q->fullwaiting==0);
-	for (qe = q->head ; qe ; qe = qen) {
-		qen = qe->next;
-		deleter(qe->data);
-		free(qe);
+	std::lock_guard<std::mutex> lock(mutex_);
+	return queue_.empty();
+}
+
+bool ProducerConsumerQueue::isFull() const {
+	TRACETHIS();
+	std::lock_guard<std::mutex> lock(mutex_);
+	return maxSize_ > 0 && currentSize_ >= maxSize_;
+}
+
+uint32_t ProducerConsumerQueue::sizeLeft() const {
+	TRACETHIS();
+	std::lock_guard<std::mutex> lock(mutex_);
+	return maxSize_ > 0 ? maxSize_ - currentSize_ : UINT32_MAX;
+}
+
+uint32_t ProducerConsumerQueue::elements() const {
+	TRACETHIS();
+	std::lock_guard<std::mutex> lock(mutex_);
+	return queue_.size();
+}
+
+bool ProducerConsumerQueue::put(uint32_t jobId, uint32_t jobType, uint8_t *data,
+                                uint32_t length) {
+	TRACETHIS();
+	std::unique_lock<std::mutex> lock(mutex_);
+	notFull_.wait(lock, [this, length] {
+		return maxSize_ == 0 || currentSize_ + length <= maxSize_;
+	});
+
+	if (maxSize_ > 0 && length > maxSize_) {
+		errno = EDEADLK;
+		return false;
 	}
-	zassert(pthread_mutex_unlock(&(q->lock)));
-	zassert(pthread_mutex_destroy(&(q->lock)));
-	zassert(pthread_cond_destroy(&(q->waitfree)));
-	if (q->maxsize) {
-		zassert(pthread_cond_destroy(&(q->waitfull)));
-	}
-	free(q);
+
+	queue_.emplace(jobId, jobType, data, length);
+	currentSize_ += length;
+
+	lock.unlock();
+	notEmpty_.notify_one();
+	return true;
 }
 
-int queue_isempty(void *que) {
+bool ProducerConsumerQueue::tryPut(uint32_t jobId, uint32_t jobType,
+                                   uint8_t *data, uint32_t length) {
 	TRACETHIS();
-	queue *q = (queue*)que;
-	int r;
-	zassert(pthread_mutex_lock(&(q->lock)));
-	r=(q->elements==0)?1:0;
-	zassert(pthread_mutex_unlock(&(q->lock)));
-	return r;
-}
-
-uint32_t queue_elements(void *que) {
-	TRACETHIS();
-	queue *q = (queue*)que;
-	uint32_t r;
-	zassert(pthread_mutex_lock(&(q->lock)));
-	r=q->elements;
-	zassert(pthread_mutex_unlock(&(q->lock)));
-	return r;
-}
-
-int queue_isfull(void *que) {
-	TRACETHIS();
-	queue *q = (queue*)que;
-	int r;
-	zassert(pthread_mutex_lock(&(q->lock)));
-	r = (q->maxsize>0 && q->maxsize<=q->size)?1:0;
-	zassert(pthread_mutex_unlock(&(q->lock)));
-	return r;
-}
-
-uint32_t queue_sizeleft(void *que) {
-	TRACETHIS();
-	queue *q = (queue*)que;
-	uint32_t r;
-	zassert(pthread_mutex_lock(&(q->lock)));
-	if (q->maxsize>0) {
-		r = q->maxsize-q->size;
-	} else {
-		r = 0xFFFFFFFF;
-	}
-	zassert(pthread_mutex_unlock(&(q->lock)));
-	return r;
-}
-
-int queue_put(void *que,uint32_t id,uint32_t op,uint8_t *data,uint32_t leng) {
-	TRACETHIS();
-	queue *q = (queue*)que;
-	qentry *qe;
-	qe = (qentry*) malloc(sizeof(qentry));
-	passert(qe);
-	qe->id = id;
-	qe->op = op;
-	qe->data = data;
-	qe->leng = leng;
-	qe->next = NULL;
-	zassert(pthread_mutex_lock(&(q->lock)));
-	if (q->maxsize) {
-		if (leng>q->maxsize) {
-			zassert(pthread_mutex_unlock(&(q->lock)));
-			free(qe);
+	std::lock_guard<std::mutex> lock(mutex_);
+	if (maxSize_ > 0) {
+		if (length > maxSize_) {
 			errno = EDEADLK;
-			return -1;
+			return false;
 		}
-		while (q->size+leng>q->maxsize) {
-			q->fullwaiting++;
-			zassert(pthread_cond_wait(&(q->waitfull),&(q->lock)));
-		}
-	}
-	q->elements++;
-	q->size += leng;
-	*(q->tail) = qe;
-	q->tail = &(qe->next);
-	if (q->freewaiting>0) {
-		zassert(pthread_cond_signal(&(q->waitfree)));
-		q->freewaiting--;
-	}
-	zassert(pthread_mutex_unlock(&(q->lock)));
-	return 0;
-}
 
-int queue_tryput(void *que,uint32_t id,uint32_t op,uint8_t *data,uint32_t leng) {
-	TRACETHIS();
-	queue *q = (queue*)que;
-	qentry *qe;
-	zassert(pthread_mutex_lock(&(q->lock)));
-	if (q->maxsize) {
-		if (leng>q->maxsize) {
-			zassert(pthread_mutex_unlock(&(q->lock)));
-			errno = EDEADLK;
-			return -1;
-		}
-		if (q->size+leng>q->maxsize) {
-			zassert(pthread_mutex_unlock(&(q->lock)));
+		if (currentSize_ + length > maxSize_) {
 			errno = EBUSY;
-			return -1;
+			return false;
 		}
 	}
-	qe = (qentry*) malloc(sizeof(qentry));
-	passert(qe);
-	qe->id = id;
-	qe->op = op;
-	qe->data = data;
-	qe->leng = leng;
-	qe->next = NULL;
-	q->elements++;
-	q->size += leng;
-	*(q->tail) = qe;
-	q->tail = &(qe->next);
-	if (q->freewaiting>0) {
-		zassert(pthread_cond_signal(&(q->waitfree)));
-		q->freewaiting--;
-	}
-	zassert(pthread_mutex_unlock(&(q->lock)));
-	return 0;
+
+	queue_.emplace(jobId, jobType, data, length);
+	currentSize_ += length;
+
+	notEmpty_.notify_one();
+	return true;
 }
 
-int queue_get(void *que,uint32_t *id,uint32_t *op,uint8_t **data,uint32_t *leng) {
+bool ProducerConsumerQueue::get(uint32_t *jobId, uint32_t *jobType,
+                                uint8_t **data, uint32_t *length) {
 	TRACETHIS();
-	queue *q = (queue*)que;
-	qentry *qe;
-	zassert(pthread_mutex_lock(&(q->lock)));
-	while (q->elements==0) {
-		q->freewaiting++;
-		zassert(pthread_cond_wait(&(q->waitfree),&(q->lock)));
-	}
-	qe = q->head;
-	q->head = qe->next;
-	if (q->head==NULL) {
-		q->tail = &(q->head);
-	}
-	q->elements--;
-	q->size -= qe->leng;
-	if (q->fullwaiting>0) {
-		zassert(pthread_cond_signal(&(q->waitfull)));
-		q->fullwaiting--;
-	}
-	zassert(pthread_mutex_unlock(&(q->lock)));
-	if (id) {
-		*id = qe->id;
-	}
-	if (op) {
-		*op = qe->op;
-	}
-	if (data) {
-		*data = qe->data;
-	}
-	if (leng) {
-		*leng = qe->leng;
-	}
-	free(qe);
-	return 0;
+	std::unique_lock<std::mutex> lock(mutex_);
+	notEmpty_.wait(lock, [this] { return !queue_.empty(); });
+
+	auto &entry = queue_.front();
+	currentSize_ -= entry.length;
+
+	if (jobId) { *jobId = entry.jobId; }
+	if (jobType) { *jobType = entry.jobType; }
+	if (data) { *data = entry.data; }
+	if (length) { *length = entry.length; }
+
+	queue_.pop();
+
+	lock.unlock();
+	notFull_.notify_one();
+	return true;
 }
 
-int queue_tryget(void *que,uint32_t *id,uint32_t *op,uint8_t **data,uint32_t *leng) {
+bool ProducerConsumerQueue::tryGet(uint32_t *jobId, uint32_t *jobType,
+                                   uint8_t **data, uint32_t *length) {
 	TRACETHIS();
-	queue *q = (queue*)que;
-	qentry *qe;
-	zassert(pthread_mutex_lock(&(q->lock)));
-	if (q->elements==0) {
-		zassert(pthread_mutex_unlock(&(q->lock)));
-		if (id) {
-			*id=0;
-		}
-		if (op) {
-			*op=0;
-		}
-		if (data) {
-			*data=NULL;
-		}
-		if (leng) {
-			*leng=0;
-		}
+	std::lock_guard<std::mutex> lock(mutex_);
+	if (queue_.empty()) {
+		if (jobId) { *jobId = 0; }
+		if (jobType) { *jobType = 0; }
+		if (data) { *data = nullptr; }
+		if (length) { *length = 0; }
 		errno = EBUSY;
-		return -1;
+		return false;
 	}
-	qe = q->head;
-	q->head = qe->next;
-	if (q->head==NULL) {
-		q->tail = &(q->head);
-	}
-	q->elements--;
-	q->size -= qe->leng;
-	if (q->fullwaiting>0) {
-		zassert(pthread_cond_signal(&(q->waitfull)));
-		q->fullwaiting--;
-	}
-	zassert(pthread_mutex_unlock(&(q->lock)));
-	if (id) {
-		*id = qe->id;
-	}
-	if (op) {
-		*op = qe->op;
-	}
-	if (data) {
-		*data = qe->data;
-	}
-	if (leng) {
-		*leng = qe->leng;
-	}
-	free(qe);
-	return 0;
+
+	auto &entry = queue_.front();
+	currentSize_ -= entry.length;
+
+	if (jobId) { *jobId = entry.jobId; }
+	if (jobType) { *jobType = entry.jobType; }
+	if (data) { *data = entry.data; }
+	if (length) { *length = entry.length; }
+
+	queue_.pop();
+	notFull_.notify_one();
+	return true;
 }

--- a/src/common/pcqueue.h
+++ b/src/common/pcqueue.h
@@ -22,24 +22,180 @@
 
 #include "common/platform.h"
 
-#include <inttypes.h>
-
-inline void queue_deleter_dummy(uint8_t *) {
-}
+#include <condition_variable>
+#include <cstdint>
+#include <functional>
+#include <mutex>
+#include <queue>
 
 template<typename T>
-void queue_deleter_delete(uint8_t *p) {
+void deleterByType(uint8_t *p) {
 	delete ((T*)p);
 }
 
+inline void deleterDummy(uint8_t * /*unused*/) {}
 
-void* queue_new(uint32_t size);
-void queue_delete(void *que, void(*deleter)(uint8_t *) = queue_deleter_dummy);
-int queue_isempty(void *que);
-uint32_t queue_elements(void *que);
-int queue_isfull(void *que);
-uint32_t queue_sizeleft(void *que);
-int queue_put(void *que,uint32_t id,uint32_t op,uint8_t *data,uint32_t leng);
-int queue_tryput(void *que,uint32_t id,uint32_t op,uint8_t *data,uint32_t leng);
-int queue_get(void *que,uint32_t *id,uint32_t *op,uint8_t **data,uint32_t *leng);
-int queue_tryget(void *que,uint32_t *id,uint32_t *op,uint8_t **data,uint32_t *leng);
+/// @class ProducerConsumerQueue
+/// @brief A thread-safe queue for producer-consumer scenarios.
+///
+/// This class provides a thread-safe queue implementation that allows multiple
+/// producers and consumers to add and remove items concurrently. It uses a
+/// mutex and condition variables to ensure thread safety and to manage the
+/// queue's state.
+///
+/// This class is particularly useful in scenarios where you need to decouple
+/// the production and consumption of data, such as:
+/// * Multi-threaded applications where one or more threads are generating data
+///   and one or more threads are processing that data.
+/// * Asynchronous applications where one or more tasks are scheduled and
+///   another module processes the tasks.
+///
+/// // Example usage:
+/// ProducerConsumerQueue queue(10, deleterByType<YourDataType>);
+///
+/// // Producer thread
+/// std::thread producer([&queue]() {
+///     for (int i = 0; i < 100; ++i) {
+///         auto data = new YourDataType();
+///         // Initialize data...
+///         queue.put(i, 0, reinterpret_cast<uint8_t*>(data), sizeof(YourDataType));
+///     }
+/// });
+///
+/// // Consumer thread
+/// std::thread consumer([&queue]() {
+///     for (int i = 0; i < 100; ++i) {
+///         uint32_t jobId, jobType, length;
+///         uint8_t* data;
+///         queue.get(&jobId, &jobType, &data, &length);
+///         auto yourData = reinterpret_cast<YourDataType*>(data);
+///         // Process data...
+///         delete yourData;
+///     }
+/// });
+///
+/// producer.join();
+/// consumer.join();
+class ProducerConsumerQueue {
+public:
+	using Deleter = std::function<void(uint8_t*)>;
+
+	/// @brief Constructs a ProducerConsumerQueue with a specified maximum size
+	/// and deleter.
+	///
+	/// @param maxSize The maximum number of elements the queue can hold.
+	/// Default is 0 (unlimited).
+	/// @param deleter A callable type that defines how to delete the data
+	/// stored in the queue. Default is deleterDummy.
+	explicit ProducerConsumerQueue(uint32_t maxSize = 0,
+	                               Deleter deleter = deleterDummy);
+
+	/// @brief Destructor for the ProducerConsumerQueue.
+	~ProducerConsumerQueue();
+
+	/// @brief Checks if the queue is empty.
+	///
+	/// @return true if the queue is empty, false otherwise.
+	bool isEmpty() const;
+
+	/// @brief Checks if the queue is full.
+	///
+	/// @return true if the queue is full, false otherwise.
+	bool isFull() const;
+
+	/// @brief Returns the number of elements that can still be added to the
+	/// queue.
+	///
+	/// @return The number of elements that can still be added to the queue.
+	uint32_t sizeLeft() const;
+
+	/// @brief Returns the number of elements currently in the queue.
+	///
+	/// @return The number of elements currently in the queue.
+	uint32_t elements() const;
+
+	/// @brief Adds an element to the queue.
+	///
+	/// @param jobId The job ID associated with the element.
+	/// @param jobType The job type associated with the element.
+	/// @param data A pointer to the data to be added.
+	/// @param length The length of the data to be added.
+	/// @return true if the element was added successfully, false otherwise.
+	bool put(uint32_t jobId, uint32_t jobType, uint8_t *data, uint32_t length);
+
+	/// @brief Tries to add an element to the queue without blocking.
+	///
+	/// @param jobId The job ID associated with the element.
+	/// @param jobType The job type associated with the element.
+	/// @param data A pointer to the data to be added.
+	/// @param length The length of the data to be added.
+	/// @return true if the element was added successfully, false otherwise.
+	bool tryPut(uint32_t jobId, uint32_t jobType, uint8_t *data,
+	            uint32_t length);
+
+	/// @brief Removes an element from the queue.
+	///
+	/// @param jobId A pointer to store the job ID of the removed element.
+	/// @param jobType A pointer to store the job type of the removed element.
+	/// @param data A pointer to store the data of the removed element.
+	/// @param length A pointer to store the length of the data of the removed
+	/// element.
+	/// @return true if an element was removed successfully, false otherwise.
+	bool get(uint32_t *jobId, uint32_t *jobType, uint8_t **data,
+	         uint32_t *length);
+
+	/// @brief Tries to remove an element from the queue without blocking.
+	///
+	/// @param jobId A pointer to store the job ID of the removed element.
+	/// @param jobType A pointer to store the job type of the removed element.
+	/// @param data A pointer to store the data of the removed element.
+	/// @param length A pointer to store the length of the data of the removed
+	/// element.
+	/// @return true if an element was removed successfully, false otherwise.
+	bool tryGet(uint32_t *jobId, uint32_t *jobType, uint8_t **data,
+	            uint32_t *length);
+
+private:
+	/// @brief Represents an entry in the queue.
+	struct QueueEntry {
+		uint32_t jobId;    ///< The job ID associated with the entry.
+		uint32_t jobType;  ///< The job type associated with the entry.
+		uint8_t *data;     ///< A pointer to the data of the entry.
+		uint32_t length;   ///< The length of the data of the entry.
+
+		/// @brief Constructs a QueueEntry with the specified parameters.
+		///
+		/// @param jobId The job ID associated with the entry.
+		/// @param jobType The job type associated with the entry.
+		/// @param data A pointer to the data of the entry.
+		/// @param length The length of the data of the entry.
+		QueueEntry(uint32_t jobId, uint32_t jobType, uint8_t *data,
+		           uint32_t length)
+		    : jobId(jobId), jobType(jobType), data(data), length(length) {}
+
+		// Remove unneeded constructors and assignment operators to avoid misuse
+		QueueEntry() = delete;
+		QueueEntry(const QueueEntry &) = delete;
+		QueueEntry &operator=(const QueueEntry &) = delete;
+		QueueEntry(QueueEntry &&) = delete;
+		QueueEntry &operator=(QueueEntry &&) = delete;
+
+		/// @brief Destructor for the QueueEntry.
+		~QueueEntry() = default;
+	};
+
+	///< The underlying queue storing the entries.
+	std::queue<QueueEntry> queue_;
+	///< The maximum number of elements the queue can hold.
+	uint32_t maxSize_;
+	///< The current number of elements in the queue.
+	uint32_t currentSize_;
+	///< Mutex for synchronizing access to the queue.
+	mutable std::mutex mutex_;
+	///< Condition variable to signal when the queue is not full.
+	std::condition_variable notFull_;
+	///< Condition variable to signal when the queue is not empty.
+	std::condition_variable notEmpty_;
+	///< The deleter function used to delete the data stored in the queue.
+	Deleter deleter_;
+};

--- a/src/common/pcqueue_unittest.cc
+++ b/src/common/pcqueue_unittest.cc
@@ -1,0 +1,200 @@
+/*
+   Copyright 2024      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "common/pcqueue.h"
+#include <gtest/gtest.h>
+#include <thread>
+#include <vector>
+
+// Custom deleter for testing
+void customDeleter(uint8_t *data) { delete[] data; }
+
+const int kMaxSize = 10;
+const int kMaxLength = 10;
+const int kMaxQueueSize = 100;
+
+// Test adding and removing a single element
+TEST(ProducerConsumerQueueTests, SingleElement) {
+	ProducerConsumerQueue queue(kMaxSize, customDeleter);
+	auto *data = new uint8_t[kMaxLength];
+	EXPECT_TRUE(queue.put(1, 1, data, kMaxLength));
+
+	uint32_t jobId = 0;
+	uint32_t jobType = 0;
+	uint32_t length = 0;
+	uint8_t *retrievedData = nullptr;
+
+	EXPECT_TRUE(queue.get(&jobId, &jobType, &retrievedData, &length));
+	EXPECT_EQ(jobId, 1);
+	EXPECT_EQ(jobType, 1);
+	EXPECT_EQ(length, kMaxLength);
+	EXPECT_EQ(retrievedData, data);
+}
+
+// Test adding and removing multiple elements
+TEST(ProducerConsumerQueueTests, MultipleElements) {
+	ProducerConsumerQueue queue(kMaxQueueSize, customDeleter);
+	for (int i = 0; i < kMaxSize; ++i) {
+		auto *data = new uint8_t[kMaxLength];
+		EXPECT_TRUE(queue.put(i, i, data, kMaxLength));
+	}
+
+	for (int i = 0; i < kMaxSize; ++i) {
+		uint32_t jobId = 0;
+		uint32_t jobType = 0;
+		uint32_t length = 0;
+		uint8_t *retrievedData = nullptr;
+
+		EXPECT_TRUE(queue.get(&jobId, &jobType, &retrievedData, &length));
+		EXPECT_EQ(jobId, i);
+		EXPECT_EQ(jobType, i);
+		EXPECT_EQ(length, kMaxLength);
+	}
+}
+
+// Test behavior when the queue is full
+TEST(ProducerConsumerQueueTests, QueueFull) {
+	ProducerConsumerQueue queue(2, customDeleter);
+	auto *data1 = new uint8_t[kMaxLength];
+	auto *data2 = new uint8_t[kMaxLength];
+	auto *data3 = new uint8_t[kMaxLength];
+	EXPECT_TRUE(queue.put(1, 1, data1, 1));
+	EXPECT_TRUE(queue.put(2, 2, data2, 1));
+	EXPECT_FALSE(queue.tryPut(3, 3, data3, kMaxLength));
+	delete[] data3;
+}
+
+// Test behavior when the queue is empty
+TEST(ProducerConsumerQueueTests, QueueEmpty) {
+	ProducerConsumerQueue queue(kMaxSize, customDeleter);
+	uint32_t jobId = 0;
+	uint32_t jobType = 0;
+	uint32_t length = 0;
+	uint8_t *retrievedData = nullptr;
+	EXPECT_FALSE(queue.tryGet(&jobId, &jobType, &retrievedData, &length));
+}
+
+// Test concurrent access by multiple producer threads
+TEST(ProducerConsumerQueueTests, MultipleProducers) {
+	const int kMaxProducersSize = 10;
+	const int kMaxInsertionsPerThread = 10;
+
+	ProducerConsumerQueue queue(kMaxQueueSize, customDeleter);
+	std::vector<std::thread> producers;
+	producers.reserve(kMaxProducersSize);
+
+	for (int i = 0; i < kMaxProducersSize; ++i) {
+		producers.emplace_back([&queue, i]() {
+			for (int j = 0; j < kMaxInsertionsPerThread; ++j) {
+				auto *data = new uint8_t[kMaxLength];
+				queue.put(i * kMaxSize + j, i, data, 1);
+			}
+		});
+	}
+
+	for (auto &producer : producers) { producer.join(); }
+	EXPECT_EQ(queue.elements(), kMaxQueueSize);
+}
+
+// Test concurrent access by multiple consumer threads
+TEST(ProducerConsumerQueueTests, MultipleConsumers) {
+	const int kMaxConsumersSize = 10;
+	const int kMaxRemovalsPerThread = 10;
+
+	ProducerConsumerQueue queue(kMaxQueueSize, customDeleter);
+	for (int i = 0; i < kMaxQueueSize; ++i) {
+		auto *data = new uint8_t[kMaxLength];
+		queue.put(i, i, data, 1);
+	}
+
+	std::vector<std::thread> consumers;
+	consumers.reserve(kMaxConsumersSize);
+
+	for (int i = 0; i < kMaxConsumersSize; ++i) {
+		consumers.emplace_back([&queue]() {
+			for (int j = 0; j < kMaxRemovalsPerThread; ++j) {
+				uint32_t jobId = 0;
+				uint32_t jobType = 0;
+				uint32_t length = 0;
+				uint8_t *retrievedData = nullptr;
+				queue.get(&jobId, &jobType, &retrievedData, &length);
+			}
+		});
+	}
+
+	for (auto &consumer : consumers) { consumer.join(); }
+	EXPECT_TRUE(queue.isEmpty());
+}
+
+// Test concurrent access by both producer and consumer threads
+TEST(ProducerConsumerQueueTests, ProducersAndConsumers) {
+	const int kMaxProducersSize = 10;
+	const int kMaxConsumersSize = 10;
+	const int kMaxInsertionsPerThread = 10;
+	const int kMaxRemovalsPerThread = 10;
+
+	ProducerConsumerQueue queue(kMaxQueueSize, customDeleter);
+	std::vector<std::thread> producers;
+	producers.reserve(kMaxProducersSize);
+
+	std::vector<std::thread> consumers;
+	consumers.reserve(kMaxConsumersSize);
+
+	for (int i = 0; i < kMaxProducersSize; ++i) {
+		producers.emplace_back([&queue, i]() {
+			for (int j = 0; j < kMaxInsertionsPerThread; ++j) {
+				auto *data = new uint8_t[kMaxLength];
+				queue.put(i * kMaxProducersSize + j, i, data, kMaxLength);
+			}
+		});
+	}
+
+	for (int i = 0; i < kMaxConsumersSize; ++i) {
+		consumers.emplace_back([&queue]() {
+			for (int j = 0; j < kMaxRemovalsPerThread; ++j) {
+				uint32_t jobId = 0;
+				uint32_t jobType = 0;
+				uint32_t length = 0;
+				uint8_t *retrievedData = nullptr;
+				queue.get(&jobId, &jobType, &retrievedData, &length);
+			}
+		});
+	}
+
+	for (auto &producer : producers) { producer.join(); }
+	for (auto &consumer : consumers) { consumer.join(); }
+
+	EXPECT_TRUE(queue.isEmpty());
+}
+
+// Test using a custom deleter
+TEST(ProducerConsumerQueueTests, CustomDeleter) {
+	bool deleterCalled = false;
+	auto customDeleter = [&deleterCalled](uint8_t *data) {
+		deleterCalled = true;
+		delete[] data;
+	};
+
+	{
+		ProducerConsumerQueue queue(kMaxSize, customDeleter);
+		auto *data = new uint8_t[kMaxLength];
+		queue.put(1, 1, data, kMaxLength);
+	}
+
+	EXPECT_TRUE(deleterCalled);
+}


### PR DESCRIPTION
This commit replaces previous C-based pcqueue with a modern PCQueue class to improve resource management and maintainability. This refactor transitions from C-style manual memory management to smart pointers and modern C++ synchronization primitives like `std::condition_variable` and `std::mutex` to ensure thread-safe concurrent access.