### PR TITLE
refactor: Minor changes in Windows Client testing

### DIFF
--- a/tests/tools/config.sh
+++ b/tests/tools/config.sh
@@ -49,6 +49,7 @@ chmod 777 "$TEMP_DIR"
 export PATH="$SAUNAFS_ROOT/sbin:$SAUNAFS_ROOT/bin:$PATH"
 if is_windows_system; then
 	export PATH="$(get_windows_homepath)/SaunaFS:/mnt/c/Windows/System32:$PATH"
+	export SAFS_MOUNT_COMMAND="sfsmount.exe"
 fi
 
 # Quick checks needed to call test_begin and test_fail

--- a/tests/tools/saunafs.sh
+++ b/tests/tools/saunafs.sh
@@ -642,8 +642,8 @@ windows_do_mount_() {
 	local user_id=$4
 	local group_id=$5
 	local mount_id=$6
-	local fuse_options=$(validate_and_append_fuse_options "${mount_id}" "sfsmount3.exe")
-	sfsmount3.exe -c ${mount_cfg} -D ${drive}: --uid $user_id --gid $group_id ${fuse_options} &
+	local fuse_options=$(validate_and_append_fuse_options "${mount_id}" "${SAFS_MOUNT_COMMAND}")
+	${SAFS_MOUNT_COMMAND} -c ${mount_cfg} -D ${drive}: --uid $user_id --gid $group_id ${fuse_options} &
 	disown $!
 
 	local counter=0
@@ -660,7 +660,7 @@ windows_do_mount_() {
 
 windows_do_umount_() {
 	sudo umount -l $2
-	sfsmount3.exe -u ${1}:
+	${SAFS_MOUNT_COMMAND} -u ${1}:
 }
 
 do_mount_() {
@@ -710,7 +710,7 @@ windows_prepare_mount_() {
 	saunafs_info_[mount${mount_id}]=$mount_dir
 	saunafs_info_[mount${mount_id}_cfg]=$mount_cfg
 	saunafs_info_[mntcall${mount_id}]=$mount_call
-	saunafs_info_[mnt${mount_id}_command]="sfsmount3.exe"
+	saunafs_info_[mnt${mount_id}_command]="${SAFS_MOUNT_COMMAND}"
 	saunafs_info_[umountcall${mount_id}]=$umount_call
 	saunafs_info_[mount_win_path${mount_id}]=${mount_big_dir_letter}:
 }

--- a/tests/tools/test.sh
+++ b/tests/tools/test.sh
@@ -157,7 +157,7 @@ windows_unmount_fs() {
 			break
 		fi
 	done
-	taskkill.exe /IM sfsmount3.exe /F &> /dev/null || true
+	taskkill.exe /IM ${SAFS_MOUNT_COMMAND} /F &> /dev/null || true
 }
 
 # Unmounts all SaunaFS testing mountpoints created in Unix-like OS's

--- a/tests/tools/timeout.sh
+++ b/tests/tools/timeout.sh
@@ -19,7 +19,7 @@ timeout_killer_thread() {
 		local value=$(($(date +%s -d "$value_string") - $(date +%s)))
 		local now_ts=$(date +%s)
 
-		# Triples test time in Windows environment
+		# Increase test time in Windows environment
 		if is_windows_system; then
 			multiplier=$((5 * $multiplier))
 		fi


### PR DESCRIPTION
Changes:
- change comment in timeout.sh to make it more general. Previous
comment was outdated.
- define SAFS_MOUNT_COMMAND also for Windows Client testing, and
substitute the sfsmount3.exe occurences.
- update the sfsmount3.exe for sfsmount.exe, because the Windows Client
CLI binary was renamed like this some time ago.