### PR TITLE
fix(pcqueue): Remove Helgrind warnings

### DIFF
--- a/src/common/pcqueue.cc
+++ b/src/common/pcqueue.cc
@@ -81,7 +81,6 @@ bool ProducerConsumerQueue::put(uint32_t jobId, uint32_t jobType, uint8_t *data,
 	queue_.emplace(jobId, jobType, data, length);
 	currentSize_ += length;
 
-	lock.unlock();
 	notEmpty_.notify_one();
 	return true;
 }
@@ -125,7 +124,6 @@ bool ProducerConsumerQueue::get(uint32_t *jobId, uint32_t *jobType,
 
 	queue_.pop();
 
-	lock.unlock();
 	notFull_.notify_one();
 	return true;
 }


### PR DESCRIPTION
The `ProducerConsumerQueue` class previously triggered Helgrind warnings due to condition variables being notified (`notify_one()`) without holding the associated mutex. This behavior could result in race conditions and undefined behavior.

This commit ensures that `notEmpty` and `notFull` condition variables are always notified while holding the mutex, guaranteeing thread safety and proper synchronization.