### PR TITLE
test(all): Add new basic helgrind test

### DIFF
--- a/src/mount/mastercomm.cc
+++ b/src/mount/mastercomm.cc
@@ -72,6 +72,10 @@ struct threc {
 
 	uint32_t packetId;      // thread number
 	threc *next;
+
+	~threc() {
+		pthread_mutex_destroy(mutex.native_handle());
+	}
 };
 
 #define DEFAULT_OUTPUT_BUFFSIZE 0x1000
@@ -1313,8 +1317,10 @@ void fs_term(void) {
 	std::unique_lock<std::mutex> rec_lock(recMutex);
 	for (tr = threchead ; tr ; tr = trn) {
 		trn = tr->next;
+		tr->mutex.lock();  // Make helgrind happy
 		tr->outputBuffer.clear();
 		tr->inputBuffer.clear();
+		tr->mutex.unlock();
 		delete tr;
 	}
 	threchead = nullptr;

--- a/src/mount/readdata.h
+++ b/src/mount/readdata.h
@@ -217,6 +217,12 @@ struct ReadRecord {
 	      readahead_adviser(gCacheExpirationTime_ms, gReadaheadMaxWindowSize),
 	      inode(inode) {}
 
+	~ReadRecord() {
+		mutex.lock();  // Make helgrind happy
+		mutex.unlock();
+		pthread_mutex_destroy(mutex.native_handle());
+	}
+
 	void resetSuggestedReadaheadReqs() {
 		suggestedReadaheadReqs_ = 0;
 	}

--- a/src/mount/sauna_client.cc
+++ b/src/mount/sauna_client.cc
@@ -1960,6 +1960,8 @@ static finfo* fs_newfileinfo(uint8_t accmode, uint32_t inode) {
 void remove_file_info(FileInfo *f) {
 	finfo* fileinfo = (finfo*)(f->fh);
 	PthreadMutexWrapper lock(fileinfo->lock);
+	fileinfo->use_flocks = false;
+	fileinfo->use_posixlocks = false;
 	if (fileinfo->mode == IO_READONLY || fileinfo->mode == IO_READ) {
 		read_data_end(static_cast<ReadRecord *>(fileinfo->data));
 	} else if (fileinfo->mode == IO_WRITEONLY || fileinfo->mode == IO_WRITE) {
@@ -2171,9 +2173,7 @@ void release(Inode ino, FileInfo *fi) {
 	if (fileinfo != NULL){
 		if (fileinfo->use_flocks) {
 			fs_flock_send(ino, fi->lock_owner, 0, safs_locks::kRelease);
-			fileinfo->use_flocks = false;
 		}
-		fileinfo->use_posixlocks = false;
 		remove_file_info(fi);
 	}
 	fs_release(ino);

--- a/tests/test_suites/SanityChecks/test_helgrind_basic.sh
+++ b/tests/test_suites/SanityChecks/test_helgrind_basic.sh
@@ -1,0 +1,54 @@
+timeout_set 45 seconds
+valgrind_enable "helgrind"
+
+CHUNKSERVERS=3 \
+	DISK_PER_CHUNKSERVER=2 \
+	USE_RAMDISK=YES \
+	MASTER_CUSTOM_GOALS="10 ec21: \$ec(2,1)" \
+	# increased timeouts due to expected slowdown by helgrind
+	MOUNT_EXTRA_CONFIG="sfschunkserverwavereadto=5000,`
+		`sfschunkservertotalreadto=20000,maxreadaheadrequests=2,`
+		`cacheexpirationtime=60000" \
+	AUTO_SHADOW_MASTER="NO" \
+	setup_local_empty_saunafs info
+
+number_of_files=4
+file_size=$((1024 * 1024 * 8))
+goals="ec21"
+
+function generateFiles() {
+	for goal in ${goals}; do
+		mkdir ${goal}
+		saunafs setgoal ${goal} ${goal}
+
+		echo "Writing ${number_of_files} files with goal ${goal}"
+		for i in $(seq 1 ${number_of_files}); do
+			FILE_SIZE=${file_size} assert_success file-generate "${goal}/file${i}" &
+		done
+	done
+
+	wait
+
+	echo "Files written"
+}
+
+function validateFiles() {
+	for goal in ${goals}; do
+		echo "Validating ${number_of_files} files with goal ${goal}"
+		for i in $(seq 1 ${number_of_files}); do
+			assert_success file-validate "${goal}/file${i}" &
+		done
+	done
+
+	wait
+
+	echo "Files validated"
+}
+
+cd "${info[mount0]}"
+
+generateFiles
+
+drop_caches
+
+validateFiles

--- a/tests/tools/valgrind-helgrind.supp
+++ b/tests/tools/valgrind-helgrind.supp
@@ -11,84 +11,40 @@
 }
 
 {
-   generic_placeholder_start_thread
-   # Must be replaced by more specific suppresions
+   # fuse_session_loop_mt is called only once at starting time, therefore only exits once. 
+   # Looks like related to fuse and not to our client.
+   fuse_session_loop_mt_exit
    Helgrind:Race
+   fun:fuse_session_exit
    ...
+   fun:fuse_session_loop_mt
+   ...
+}
+
+{
+   # fuse_session_new is called only once at starting time. 
+   # Looks like related to fuse and not to our client.
+   fuse_session_new_initialization
+   Helgrind:Race
+   obj:*
+   obj:*
+   obj:*
+   obj:*
    fun:start_thread
    fun:clone
 }
 
 {
-   generic_placeholder_deallocate
-   # Must be replaced by more specific suppresions
+   # False positive about std::to_string calls when naming the read/write worker threads.
+   to_string_in_workers_names
    Helgrind:Race
    ...
-   fun:deallocate
+   fun:operator<<
+   fun:to_string<short unsigned int>
+   fun:*worker*
    ...
-}
-
-{
-   generic_placeholder_fs_term
-   # Must be classified
-   Helgrind:Race
-   ...
-   fun:_Z7fs_termv
-   fun:_ZN11SaunaClient7fs_termEv
-   ...
-}
-
-{
-   generic_placeholder_fuse_session_exit
-   # Must be classified
-   Helgrind:Race
-   ...
-   fun:fuse_session_exit
-   ...
-}
-
-{
-   generic_placeholder_read_data_delayed_ops
-   # Must be classified
-   Helgrind:Race
-   ...
-   fun:_Z21read_data_delayed_opsPv
-   ...
-}
-
-{
-   generic_placeholder_Unwind_RaiseException
-   # Must be replaced by more specific suppresions
-   Helgrind:Race
-   ...
-   fun:_Unwind_RaiseException
-   ...
-}
-
-{
-   generic_placeholder_Unwind_SetGR
-   # Must be replaced by more specific suppresions
-   Helgrind:Race
-   fun:_Unwind_SetGR
-   ...
-}
-
-{
-   generic_placeholder_ReadCache
-   # Must be replaced by more specific suppresions
-   Helgrind:Race
-   ...
-   fun:_ZN9ReadCache*
-   ...
-}
-
-{
-   generic_placeholder_ipToString
-   # Must be replaced by more specific suppresions
-   Helgrind:Race
-   ...
-   fun:_Z10ipToString*
-   ...
+   fun:start_thread
+   fun:clone
 }
 
 # MAIN LOOP (used in metadata servers and chunkservers)

--- a/tests/tools/valgrind-helgrind.supp
+++ b/tests/tools/valgrind-helgrind.supp
@@ -1,12 +1,114 @@
 # MOUNT
 
 {
-   fuse_session_loop_mt initialization
+   fuse_session_loop_mt_initialization
    # fuse_session_loop_mt is called only once at starting time. Looks like
    # related to fuse and not to our client.
    Helgrind:PthAPIerror
    ...
    fun:fuse_session_loop_mt
-   fun:fuse_session_loop_mt
    ...
+}
+
+{
+   generic_placeholder_start_thread
+   # Must be replaced by more specific suppresions
+   Helgrind:Race
+   ...
+   fun:start_thread
+   fun:clone
+}
+
+{
+   generic_placeholder_deallocate
+   # Must be replaced by more specific suppresions
+   Helgrind:Race
+   ...
+   fun:deallocate
+   ...
+}
+
+{
+   generic_placeholder_fs_term
+   # Must be classified
+   Helgrind:Race
+   ...
+   fun:_Z7fs_termv
+   fun:_ZN11SaunaClient7fs_termEv
+   ...
+}
+
+{
+   generic_placeholder_fuse_session_exit
+   # Must be classified
+   Helgrind:Race
+   ...
+   fun:fuse_session_exit
+   ...
+}
+
+{
+   generic_placeholder_read_data_delayed_ops
+   # Must be classified
+   Helgrind:Race
+   ...
+   fun:_Z21read_data_delayed_opsPv
+   ...
+}
+
+{
+   generic_placeholder_Unwind_RaiseException
+   # Must be replaced by more specific suppresions
+   Helgrind:Race
+   ...
+   fun:_Unwind_RaiseException
+   ...
+}
+
+{
+   generic_placeholder_Unwind_SetGR
+   # Must be replaced by more specific suppresions
+   Helgrind:Race
+   fun:_Unwind_SetGR
+   ...
+}
+
+{
+   generic_placeholder_ReadCache
+   # Must be replaced by more specific suppresions
+   Helgrind:Race
+   ...
+   fun:_ZN9ReadCache*
+   ...
+}
+
+{
+   generic_placeholder_ipToString
+   # Must be replaced by more specific suppresions
+   Helgrind:Race
+   ...
+   fun:_Z10ipToString*
+   ...
+}
+
+# MAIN LOOP (used in metadata servers and chunkservers)
+
+{
+   # False positive about gPollTimeout (not atomic to avoid not needed overhead)
+   poll_timeout_loading
+   Helgrind:Race
+   fun:_Z27eventloop_load_poll_timeoutv
+   fun:_Z13eventloop_runv
+   fun:main
+}
+
+# CHUNKSERVER
+
+{
+   # False positive about gPollTimeout (not atomic to avoid not needed overhead)
+   poll_timeout_in_network_worker_threads
+   Helgrind:Race
+   fun:_ZN19NetworkWorkerThreadclEv
+   ...
+   fun:start_thread
 }

--- a/tests/tools/valgrind.sh
+++ b/tests/tools/valgrind.sh
@@ -31,7 +31,7 @@ getHelgrindOptions() {
 	options+=" --track-lockorders=yes"
 	options+=" --read-var-info=no"
 	# Possible values: full, approx, none
-	options+=" --history-level=none"
+	options+=" --history-level=full"
 	options+=" --delta-stacktrace=yes"
 	options+=" --free-is-write=yes"
 	options+=" --cmp-race-err-addrs=yes"


### PR DESCRIPTION
The threading safety was not checked explicitely in our tests. Threading issues can cause non-deterministic runtime errors that are hard to reproduce and debug. We use multiple threads so far in the chunkservers and clients.

This change introduces a basic test using helgrind (from valgrind). The idea is to gradually add complexity to this test and create others (more specific) when needed.

Some extra commits were added for already detected warnings.