### PR TITLE
fix(mount): Fix case-insensitive test

### DIFF
--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -447,9 +447,7 @@ uint8_t fs_lookup(const FsContext &context, uint32_t parent, const HString &name
 		return SAUNAFS_ERROR_EINVAL;
 	}
 
-	auto parentNode = static_cast<FSNodeDirectory *>(wd);
-	parentNode->case_insensitive = context.sesflags() & SESFLAG_CASEINSENSITIVE;
-	FSNode *child = fsnodes_lookup(parentNode, name);
+	FSNode *child = fsnodes_lookup(static_cast<FSNodeDirectory*>(wd), name);
 	if (!child) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
@@ -960,6 +958,8 @@ uint8_t fs_mknod(const FsContext &context, uint32_t parent, const HString &name,
 	    fsnodes_quota_exceeded_dir(wd, {{QuotaResource::kInodes, 1}})) {
 		return SAUNAFS_ERROR_QUOTA;
 	}
+	static_cast<FSNodeDirectory *>(wd)->case_insensitive =
+	    context.sesflags() & SESFLAG_CASEINSENSITIVE;
 	p = fsnodes_create_node(ts, static_cast<FSNodeDirectory*>(wd), name, type, mode, umask, context.uid(), context.gid(), 0,
 	                        AclInheritance::kInheritAcl);
 	if (type == FSNode::kBlockDev || type == FSNode::kCharDev) {
@@ -1005,6 +1005,8 @@ uint8_t fs_mkdir(const FsContext &context, uint32_t parent, const HString &name,
 	    fsnodes_quota_exceeded_dir(wd, {{QuotaResource::kInodes, 1}})) {
 		return SAUNAFS_ERROR_QUOTA;
 	}
+	static_cast<FSNodeDirectory *>(wd)->case_insensitive =
+	    context.sesflags() & SESFLAG_CASEINSENSITIVE;
 	p = fsnodes_create_node(ts, static_cast<FSNodeDirectory *>(wd), name, FSNode::kDirectory, mode,
 	                        umask, context.uid(), context.gid(), copysgid, AclInheritance::kInheritAcl);
 	*inode = p->id;

--- a/tests/test_suites/ShortSystemTests/test_case_insensitive_filesystem.sh
+++ b/tests/test_suites/ShortSystemTests/test_case_insensitive_filesystem.sh
@@ -33,6 +33,7 @@ fi
 
 # test rename case insensitive new file to existing file
 touch file3
+sleep 1
 assert_equals "3" "$(ls . | wc -l)"
 mv file3 file1
 assert_equals "2" "$(ls . | wc -l)"
@@ -42,4 +43,37 @@ rm "fiLE1"
 assert_equals "1" "$(ls . | wc -l)"
 
 rm "foldeR1/fIlE2"
-assert_equals "0" "$(ls foldeR1/fIlE2 | wc -l)"
+assert_equals "0" "$(ls foldeR1/ | wc -l)"
+
+# test recursive case insensitive in directories
+mkdir folder2
+mkdir folder2/folder3
+mkdir folder2/folder3/folder4
+
+touch FOldER2/fOLdeR3/folDEr4/file4
+
+echo "data" > FOldER2/fOLdeR3/folDEr4/fIlE4
+
+assert_equals "data" "$(cat folder2/folder3/folder4/file4)"
+assert_equals "data" "$(cat folder2/folder3/folder4/fIlE4)"
+
+# test removing case insensitive in mountpoint
+cd ..
+saunafs_mount_unmount 0
+assert_success saunafs_master_daemon stop
+sleep 5
+SFSEXPORTS_EXTRA_OPTIONS=""
+number_of_mounts=1
+rm "$TEMP_DIR/saunafs/etc/sfsexports.cfg"
+create_sfsexports_cfg_ >"$TEMP_DIR/saunafs/etc/sfsexports.cfg"
+saunafs_master_daemon start
+saunafs_mount_start 0
+
+cd "${info[mount0]}"
+assert_equals "data" "$(cat folder2/folder3/folder4/file4)"
+assert_failure cat folder2/folder3/folder4/fIlE4
+
+touch file5
+echo "data" > file5
+assert_success cat file5
+assert_failure cat fiLE5


### PR DESCRIPTION
On the Windows client, the case-insensitive test was failing because the client was not correctly updating the case insensitive flag for a given directory. Also, the test had a line with an incorrect path when checking the proper deletion of files. This commit fixes those issues.