### PR TITLE
test: Add tests for ENOSPC handling in Ganesha

### DIFF
--- a/src/errors/sfserr.cc
+++ b/src/errors/sfserr.cc
@@ -60,6 +60,8 @@ int saunafs_error_conv(uint8_t status) {
 			return ENOTEMPTY;
 		case SAUNAFS_ERROR_IO:
 			return EIO;
+		case SAUNAFS_ERROR_NOSPACE:
+			return ENOSPC;
 		case SAUNAFS_ERROR_EROFS:
 			return EROFS;
 		case SAUNAFS_ERROR_QUOTA:

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_allocate_large_file.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_allocate_large_file.sh
@@ -1,0 +1,71 @@
+#
+# To run this test you need to add the following lines to /etc/sudoers.d/saunafstest:
+#
+# saunafstest ALL = NOPASSWD: /bin/mount, /bin/umount, /bin/pkill, /bin/mkdir, /bin/touch
+# saunafstest ALL = NOPASSWD: /usr/bin/ganesha.nfsd
+#
+# The path for the Ganesha daemon should match the installation folder inside the test.
+#
+
+timeout_set 2 minutes
+
+CHUNKSERVERS=3 \
+	USE_RAMDISK=YES \
+	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER,sfsioretries=10" \
+	CHUNKSERVER_EXTRA_CONFIG="READ_AHEAD_KB = 1024|MAX_READ_BEHIND_KB = 2048"
+	setup_local_empty_saunafs info
+
+test_error_cleanup() {
+	sudo umount -l ${TEMP_DIR}/mnt/ganesha
+	sudo pkill -9 ganesha.nfsd
+}
+
+mkdir -p ${TEMP_DIR}/mnt/ganesha
+
+create_ganesha_pid_file
+
+cd ${info[mount0]}
+
+cat <<EOF > ${info[mount0]}/ganesha.conf
+NFS_KRB5 {
+	Active_krb5=false;
+}
+NFSV4 {
+	Grace_Period = 5;
+}
+EXPORT {
+	Attr_Expiration_Time = 10;
+	Export_Id = 2;
+	Path = /;
+	Pseudo = /;
+	Access_Type = RW;
+	FSAL {
+		Name = SaunaFS;
+		hostname = localhost;
+		port = ${saunafs_info_[matocl]};
+		# How often to retry to connect
+		io_retries = 10;
+		cache_expiration_time_ms = 2500;
+	}
+	Protocols = 4;
+	CLIENT {
+		Clients = localhost;
+	}
+}
+EOF
+
+# This test logs the output to a file to avoid verbose output
+sudo /usr/bin/ganesha.nfsd -f ${info[mount0]}/ganesha.conf -L /tmp/ganesha.log
+
+check_rpc_service
+sudo mount -vvvv localhost:/ $TEMP_DIR/mnt/ganesha
+
+# Create a file larger than the RAMDISK available space (2G) and upload it
+fallocate -l 3G $TEMP_DIR/mnt/ganesha/largefile
+ls -lh $TEMP_DIR/mnt/ganesha/largefile
+
+# Write data to the allocated file to trigger actual space allocation
+assert_failure dd if=/dev/urandom of=$TEMP_DIR/mnt/ganesha/largefile bs=1M count=3072
+ls -lh $TEMP_DIR/mnt/ganesha/largefile
+
+test_error_cleanup || true

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_append_data_until_exhausting_space.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_append_data_until_exhausting_space.sh
@@ -1,0 +1,70 @@
+#
+# To run this test you need to add the following lines to /etc/sudoers.d/saunafstest:
+#
+# saunafstest ALL = NOPASSWD: /bin/mount, /bin/umount, /bin/pkill, /bin/mkdir, /bin/touch
+# saunafstest ALL = NOPASSWD: /usr/bin/ganesha.nfsd
+#
+# The path for the Ganesha daemon should match the installation folder inside the test.
+#
+
+timeout_set 2 minutes
+
+CHUNKSERVERS=3 \
+	USE_RAMDISK=YES \
+	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER,sfsioretries=10" \
+	CHUNKSERVER_EXTRA_CONFIG="READ_AHEAD_KB = 1024|MAX_READ_BEHIND_KB = 2048"
+	setup_local_empty_saunafs info
+
+test_error_cleanup() {
+	sudo umount -l ${TEMP_DIR}/mnt/ganesha
+	sudo pkill -9 ganesha.nfsd
+}
+
+mkdir -p ${TEMP_DIR}/mnt/ganesha
+
+create_ganesha_pid_file
+
+cd ${info[mount0]}
+
+cat <<EOF > ${info[mount0]}/ganesha.conf
+NFS_KRB5 {
+	Active_krb5=false;
+}
+NFSV4 {
+	Grace_Period = 5;
+}
+EXPORT {
+	Attr_Expiration_Time = 10;
+	Export_Id = 2;
+	Path = /;
+	Pseudo = /;
+	Access_Type = RW;
+	FSAL {
+		Name = SaunaFS;
+		hostname = localhost;
+		port = ${saunafs_info_[matocl]};
+		# How often to retry to connect
+		io_retries = 10;
+		cache_expiration_time_ms = 2500;
+	}
+	Protocols = 4;
+	CLIENT {
+		Clients = localhost;
+	}
+}
+EOF
+
+sudo /usr/bin/ganesha.nfsd -f ${info[mount0]}/ganesha.conf
+
+check_rpc_service
+sudo mount -vvvv localhost:/ $TEMP_DIR/mnt/ganesha
+
+# Append data until exhausting the available space should fail
+while true; do
+	if ! dd if=/dev/urandom of=$TEMP_DIR/mnt/ganesha/largefile bs=1M count=1 \
+		oflag=append conv=notrunc status=none; then
+		break
+	fi
+done
+
+test_error_cleanup || true

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_copy_file_without_enough_space.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_copy_file_without_enough_space.sh
@@ -1,0 +1,67 @@
+#
+# To run this test you need to add the following lines to /etc/sudoers.d/saunafstest:
+#
+# saunafstest ALL = NOPASSWD: /bin/mount, /bin/umount, /bin/pkill, /bin/mkdir, /bin/touch
+# saunafstest ALL = NOPASSWD: /usr/bin/ganesha.nfsd
+#
+# The path for the Ganesha daemon should match the installation folder inside the test.
+#
+
+timeout_set 2 minutes
+
+CHUNKSERVERS=3 \
+	USE_RAMDISK=YES \
+	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER,sfsioretries=10" \
+	CHUNKSERVER_EXTRA_CONFIG="READ_AHEAD_KB = 1024|MAX_READ_BEHIND_KB = 2048"
+	setup_local_empty_saunafs info
+
+test_error_cleanup() {
+	sudo umount -l ${TEMP_DIR}/mnt/ganesha
+	sudo pkill -9 ganesha.nfsd
+}
+
+mkdir -p ${TEMP_DIR}/mnt/ganesha
+
+create_ganesha_pid_file
+
+cd ${info[mount0]}
+
+cat <<EOF > ${info[mount0]}/ganesha.conf
+NFS_KRB5 {
+	Active_krb5=false;
+}
+NFSV4 {
+	Grace_Period = 5;
+}
+EXPORT {
+	Attr_Expiration_Time = 10;
+	Export_Id = 2;
+	Path = /;
+	Pseudo = /;
+	Access_Type = RW;
+	FSAL {
+		Name = SaunaFS;
+		hostname = localhost;
+		port = ${saunafs_info_[matocl]};
+		# How often to retry to connect
+		io_retries = 10;
+		cache_expiration_time_ms = 2500;
+	}
+	Protocols = 4;
+	CLIENT {
+		Clients = localhost;
+	}
+}
+EOF
+
+# This test logs the output to a file to avoid verbose output
+sudo /usr/bin/ganesha.nfsd -f ${info[mount0]}/ganesha.conf -L /tmp/ganesha.log
+
+check_rpc_service
+sudo mount -vvvv localhost:/ $TEMP_DIR/mnt/ganesha
+
+# Create a file larger than the RAMDISK available space (2G) and upload it
+assert_failure dd if=/dev/urandom of=$TEMP_DIR/mnt/ganesha/largefile bs=1M count=3072
+
+ls -lh $TEMP_DIR/mnt/ganesha/largefile
+test_error_cleanup || true

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_truncate_file_to_big_size.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_truncate_file_to_big_size.sh
@@ -1,0 +1,74 @@
+#
+# To run this test you need to add the following lines to /etc/sudoers.d/saunafstest:
+#
+# saunafstest ALL = NOPASSWD: /bin/mount, /bin/umount, /bin/pkill, /bin/mkdir, /bin/touch
+# saunafstest ALL = NOPASSWD: /usr/bin/ganesha.nfsd
+#
+# The path for the Ganesha daemon should match the installation folder inside the test.
+#
+
+timeout_set 2 minutes
+
+CHUNKSERVERS=3 \
+	USE_RAMDISK=YES \
+	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER,sfsioretries=10" \
+	CHUNKSERVER_EXTRA_CONFIG="READ_AHEAD_KB = 1024|MAX_READ_BEHIND_KB = 2048"
+	setup_local_empty_saunafs info
+
+test_error_cleanup() {
+	sudo umount -l ${TEMP_DIR}/mnt/ganesha
+	sudo pkill -9 ganesha.nfsd
+}
+
+mkdir -p ${TEMP_DIR}/mnt/ganesha
+
+create_ganesha_pid_file
+
+cd ${info[mount0]}
+
+cat <<EOF > ${info[mount0]}/ganesha.conf
+NFS_KRB5 {
+	Active_krb5=false;
+}
+NFSV4 {
+	Grace_Period = 5;
+}
+EXPORT {
+	Attr_Expiration_Time = 10;
+	Export_Id = 2;
+	Path = /;
+	Pseudo = /;
+	Access_Type = RW;
+	FSAL {
+		Name = SaunaFS;
+		hostname = localhost;
+		port = ${saunafs_info_[matocl]};
+		# How often to retry to connect
+		io_retries = 10;
+		cache_expiration_time_ms = 2500;
+	}
+	Protocols = 4;
+	CLIENT {
+		Clients = localhost;
+	}
+}
+EOF
+
+# This test logs the output to a file to avoid verbose output
+sudo /usr/bin/ganesha.nfsd -f ${info[mount0]}/ganesha.conf -L /tmp/ganesha.log
+
+check_rpc_service
+sudo mount -vvvv localhost:/ $TEMP_DIR/mnt/ganesha
+
+# Create a file of 200M
+dd if=/dev/urandom of=$TEMP_DIR/mnt/ganesha/largefile bs=1M count=200 status=none
+
+# Truncate the file to 3G, a size bigger than the RAMDISK available space
+truncate -s 3G $TEMP_DIR/mnt/ganesha/largefile
+ls -lh $TEMP_DIR/mnt/ganesha/largefile
+
+# Write data to the truncated file to trigger actual space allocation
+assert_failure dd if=/dev/urandom of=$TEMP_DIR/mnt/ganesha/largefile bs=1M \
+	seek=200 count=3072
+
+test_error_cleanup || true


### PR DESCRIPTION
These changes address issue #233 by adding tests to verify how the NFS client handles ENOSPC (no space left on device) errors.

The following tests validate various ENOSPC scenarios:
- **Allocate large file**: Verifies that allocating a file larger than the available space fails.

- **File append**: Verifies that appending data until space is exhausted fails.

- **Copy large file**: Verifies that copying a file exceeding available space fails.

- **File truncation**: Verifies that truncating a file beyond available space fails.

Additionally, error conversion now maps `SAUNAFS_ERROR_NOSPACE` to `ENOSPC` in the error handler for consistency.