### PR TITLE
fix: Fix test_auto_recovery_incversion (Windows client tests)

### DIFF
--- a/tests/test_suites/ShortSystemTests/test_auto_recovery_incversion.sh
+++ b/tests/test_suites/ShortSystemTests/test_auto_recovery_incversion.sh
@@ -28,6 +28,10 @@ assert_success rm "$chunk"
 truncate -s 1 dir/file
 assert_awk_finds '/INCVERSION/' "$(cat "${info[master_data_path]}"/changelog.sfs)"
 echo b > something_more  # To make sure that after INCVERSION we are able to apply other changes
+if is_windows_system; then
+	# On Windows, we need to wait for the metadata to be dumped
+	sleep 0.5
+fi
 metadata=$(metadata_print)
 
 # Simulate crash of the master


### PR DESCRIPTION
This commit adds a small sleep right before printing the metadata to
allow the master to dump metadata. This process seems to be slower on
Windows (WSL1) testing, which is why it is needed.