### PR TITLE
refactor: Minor logging changes

### DIFF
--- a/src/mount/sauna_client.cc
+++ b/src/mount/sauna_client.cc
@@ -911,7 +911,7 @@ AttrReply getattr(Context &ctx, Inode ino) {
 	maxfleng = write_data_getmaxfleng(ino);
 	if (usedircache && gDirEntryCache.lookup(ctx,ino,attr)) {
 		if (debug_mode) {
-			safs::log_debug("getattr: sending data from dircache\n");
+			safs::log_debug("getattr: sending data from dircache");
 		}
 		stats_inc(OP_DIRCACHE_GETATTR);
 		status = SAUNAFS_STATUS_OK;
@@ -2076,7 +2076,7 @@ EntryParam create(Context &ctx, Inode parent, const char *name, mode_t mode,
 		fi->keep_cache = (mattr&MATTR_ALLOWDATACACHE)?1:0;
 	}
 	if (debug_mode) {
-		safs::log_debug("create ({}) ok -> keep cache: {}\n", inode, (int)fi->keep_cache);
+		safs::log_debug("create ({}) ok -> keep cache: {}", inode, (int)fi->keep_cache);
 	}
 	gDirEntryCache.lockAndInvalidateParent(ctx, parent);
 	e.ino = inode;
@@ -2146,7 +2146,7 @@ void open(Context &ctx, Inode ino, FileInfo *fi) {
 		fi->keep_cache = (mattr&MATTR_ALLOWDATACACHE)?1:0;
 	}
 	if (debug_mode) {
-		safs::log_debug("open ({}) ok -> keep cache: {}\n", ino, (int)fi->keep_cache);
+		safs::log_debug("open ({}) ok -> keep cache: {}", ino, (int)fi->keep_cache);
 	}
 	fi->direct_io = gDirectIo;
 	oplog_printf(ctx, "open (%lu): OK (%lu,%lu)",

--- a/src/mount/sauna_client.h
+++ b/src/mount/sauna_client.h
@@ -62,6 +62,8 @@ struct FsInitParams {
 	static constexpr unsigned kDefaultReportReservedPeriod = 60;
 	static constexpr const char *kDefaultUmaskDir = "002"; // means rwxrwxr-x permissions mask, 775 default permissions
 	static constexpr const char *kDefaultUmaskFile = "002"; // means rwxrwxr-x permissions mask, 775 default permissions
+	static constexpr const char *kDefaultLogLevel = "warn";
+	static constexpr const char *kDefaultLogFlushLevel = "err";
 #else
 	static constexpr unsigned kDefaultReportReservedPeriod = 30;
 #endif

--- a/src/slogger/slogger.cc
+++ b/src/slogger/slogger.cc
@@ -70,9 +70,6 @@ bool safs::add_log_file(const char *path, log_level::LogLevel level, int max_fil
 		logger->set_level((spdlog::level::level_enum)level);
 		// Format: DATE TIME [LEVEL] [PID:TID] : MESSAGE
 		logger->set_pattern("%D %H:%M:%S.%e [%l] [%P:%t] : %v");
-#ifdef _WIN32
-		logger->flush_on(spdlog::level::err);
-#endif
 		return true;
 	} catch (const spdlog::spdlog_ex &e) {
 		safs_pretty_syslog(LOG_ERR, "Adding %s log file failed: %s", path, e.what());


### PR DESCRIPTION
This PR contains two relativetly unrelated changes:
- remove extra endline in some mount debug in some log_debug calls in the mount code. These were the only ones doing it and the log_debug already added a newline after the message, so an empty line was generated.
- support new log options in Windows Client. This change includes removing the automatic flush level at err and defining the default value of the new added options (sfsloglevel and sfslogflushlevel) in the default place. These changes only affect Windows Client code.