### PR TITLE
fix(build): suppress warnings in manpage generation

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -53,7 +53,10 @@ set(MANPAGES
     sfsmetarestore.8
 )
 
-set(INSTALLED_MANPAGES)
+# Create custom directory to store the a2x logs
+set(A2X_LOGS_DIR ${CMAKE_CURRENT_BINARY_DIR}/a2x)
+execute_process(COMMAND mkdir -p ${A2X_LOGS_DIR})
+
 foreach(MANPAGE ${MANPAGES})
   get_filename_component(MANPAGE_SRC ${CMAKE_CURRENT_SOURCE_DIR}/${MANPAGE}.adoc ABSOLUTE)
   set(GENERATED_MANPAGE_PATH ${CMAKE_CURRENT_BINARY_DIR}/${MANPAGE})
@@ -66,7 +69,9 @@ foreach(MANPAGE ${MANPAGES})
     set(MANPAGE_SRC_SYMLINK ${CMAKE_CURRENT_BINARY_DIR}/${MANPAGE}.txt)
     add_custom_command(OUTPUT ${GENERATED_MANPAGE_PATH}
         COMMAND ln -s -f ${MANPAGE_SRC} ${MANPAGE_SRC_SYMLINK}
-        COMMAND a2x ${ASCIIDOC_VERBOSE} -L -f manpage ${MANPAGE_SRC_SYMLINK}
+        # Grepping out 'invalid escape sequence' warnings due to asciidoc bug
+        COMMAND a2x ${ASCIIDOC_VERBOSE} -L -f manpage ${MANPAGE_SRC_SYMLINK} 2>&1
+            | grep -v 'invalid escape sequence' | tee ${A2X_LOGS_DIR}/${MANPAGE}.log
         DEPENDS ${MANPAGE_SRC})
     set(GENERATED_MANPAGES ${GENERATED_MANPAGES} ${GENERATED_MANPAGE_PATH})
   endif()

--- a/tests/test_suites/SanityChecks/test_generate_manpages.sh
+++ b/tests/test_suites/SanityChecks/test_generate_manpages.sh
@@ -1,0 +1,27 @@
+assert_program_installed a2x
+timeout_set 2 minutes
+
+# Clone the 'dev' branch from the SaunaFS repository
+git clone --branch dev https://github.com/leil-io/saunafs.git "${TEMP_DIR}/saunafs"
+
+# Change to the temporary directory
+cd "${TEMP_DIR}/saunafs"
+
+# Check if the feature branch exists and check it out if it does
+if git ls-remote --heads origin fix-warnings-build-doc | \
+	grep -q "fix-warnings-build-doc"; then
+	git checkout fix-warnings-build-doc
+fi
+
+# Run the build process and capture the output
+cmake -B ./build
+make -C ./build/doc 2>&1 | tee "${TEMP_DIR}/build-doc.log"
+
+# Check for the presence of 'SyntaxWarning: invalid escape sequence' lines
+pattern="SyntaxWarning: invalid escape sequence"
+if grep -q "${pattern}" "${TEMP_DIR}/build-doc.log"; then
+	echo "Test failed: 'SyntaxWarning: invalid escape sequence' found in a2x output"
+	exit 1
+else
+	echo "Test passed: No 'SyntaxWarning: invalid escape sequence' found in a2x output"
+fi


### PR DESCRIPTION
This commit redirects annoying `SyntaxWarning` lines to reduce unnecessary noise in build logs, making them cleaner and easier to debug.

Additionally, a test was added to ensure new `a2x` warnings, such as `SyntaxWarning`, do not return in future builds.