### PR TITLE
feat: Reduce malloc virtual memory usage

### DIFF
--- a/cmake/EnvTests.cmake
+++ b/cmake/EnvTests.cmake
@@ -71,7 +71,7 @@ endif()
 check_functions("${REQUIRED_FUNCTIONS}" TRUE)
 
 set(OPTIONAL_FUNCTIONS strerror perror pread pwrite readv writev getrusage
-  setitimer posix_fadvise fallocate)
+  setitimer posix_fadvise fallocate mallopt)
 check_functions("${OPTIONAL_FUNCTIONS}" false)
 
 CHECK_LIBRARY_EXISTS(rt clock_gettime "time.h" SAUNAFS_HAVE_CLOCK_GETTIME)

--- a/config.h.in
+++ b/config.h.in
@@ -104,6 +104,7 @@
 #cmakedefine SAUNAFS_HAVE_SETITIMER
 #cmakedefine SAUNAFS_HAVE_STD_TO_STRING
 #cmakedefine SAUNAFS_HAVE_STD_STOULL
+#cmakedefine SAUNAFS_HAVE_MALLOPT
 
 /* [CMake] Optional functions #2 */
 #cmakedefine SAUNAFS_HAVE_DUP2

--- a/doc/sfschunkserver.cfg.5.adoc
+++ b/doc/sfschunkserver.cfg.5.adoc
@@ -37,6 +37,13 @@ sfschunkserver)
 *LOCK_MEMORY*:: whether to perform mlockall() to avoid swapping out
 sfschunkserver process (default is 0, i.e. no)
 
+*LIMIT_GLIBC_MALLOC_ARENAS*:: Linux only: limit glibc malloc arenas to given
+value - prevents from using huge amount of virtual memory. This can influence
+performance by reducing memory fragmentation and improving cache locality, but
+it may also lead to contention and reduced parallelism in multi-threaded
+applications. Use it in constrained memory environments, recommended values are
+4 or 8. (default is 0: disabled or let glibc decide)
+
 *NICE_LEVEL*:: nice level to run daemon with (default is -19 if possible; note:
 process must be started as root to increase priority)
 

--- a/doc/sfsmaster.cfg.5.adoc
+++ b/doc/sfsmaster.cfg.5.adoc
@@ -52,6 +52,13 @@ sfsmaster)
 *LOCK_MEMORY*:: whether to perform mlockall() to avoid swapping out sfsmaster
 process (default is 0, i.e. no)
 
+*LIMIT_GLIBC_MALLOC_ARENAS*:: Linux only: limit glibc malloc arenas to given
+value - prevents from using huge amount of virtual memory. This can influence
+performance by reducing memory fragmentation and improving cache locality, but
+it may also lead to contention and reduced parallelism in multi-threaded
+applications. Use it in constrained memory environments, recommended values are
+4 or 8. (default is 0: disabled or let glibc decide)
+
 *NICE_LEVEL*:: nice level to run daemon with (default is -19 if possible; note:
 process must be started as root to increase priority)
 

--- a/doc/sfsmetalogger.cfg.5.adoc
+++ b/doc/sfsmetalogger.cfg.5.adoc
@@ -36,6 +36,13 @@ name of process to place in syslog messages (default is sfsmetalogger)
 *LOCK_MEMORY*::
 whether to perform mlockall() to avoid swapping out sfsmetalogger process (default is 0, i.e. no)
 
+*LIMIT_GLIBC_MALLOC_ARENAS*:: Linux only: limit glibc malloc arenas to given
+value - prevents from using huge amount of virtual memory. This can influence
+performance by reducing memory fragmentation and improving cache locality, but
+it may also lead to contention and reduced parallelism in multi-threaded
+applications. Use it in constrained memory environments, recommended values are
+4 or 8. (default is 0: disabled or let glibc decide)
+
 *NICE_LEVEL*::
 nice level to run daemon with (default is -19 if possible; note: process must be started as root to
 increase priority)

--- a/src/data/sfschunkserver.cfg.in
+++ b/src/data/sfschunkserver.cfg.in
@@ -17,6 +17,14 @@
 ## (Default: 0)
 # LOCK_MEMORY = 0
 
+## Linux only: limit glibc malloc arenas to given value - prevents from using
+## huge amount of virtual memory. This can influence performance by reducing
+## memory fragmentation and improving cache locality, but it may also lead to
+## contention and reduced parallelism in multi-threaded applications.
+## Use it in constrained memory environments, recommended values are 4 or 8.
+## (default is 0: disabled or let glibc decide)
+# LIMIT_GLIBC_MALLOC_ARENAS = 0
+
 ## Nice level to run daemon with (default is -19 if possible).
 # NICE_LEVEL = -19
 

--- a/src/data/sfsmaster.cfg.in
+++ b/src/data/sfsmaster.cfg.in
@@ -27,6 +27,14 @@
 ## (Default: 0)
 # LOCK_MEMORY = 0
 
+## Linux only: limit glibc malloc arenas to given value - prevents from using
+## huge amount of virtual memory. This can influence performance by reducing
+## memory fragmentation and improving cache locality, but it may also lead to
+## contention and reduced parallelism in multi-threaded applications.
+## Use it in constrained memory environments, recommended values are 4 or 8.
+## (default is 0: disabled or let glibc decide)
+# LIMIT_GLIBC_MALLOC_ARENAS = 0
+
 ## Nice level to run daemon with, when possible to set.
 ## (Default: -19)
 # NICE_LEVEL = -19

--- a/src/data/sfsmetalogger.cfg.in
+++ b/src/data/sfsmetalogger.cfg.in
@@ -15,6 +15,14 @@
 ## (Default: 0)
 # LOCK_MEMORY = 0
 
+## Linux only: limit glibc malloc arenas to given value - prevents from using
+## huge amount of virtual memory. This can influence performance by reducing
+## memory fragmentation and improving cache locality, but it may also lead to
+## contention and reduced parallelism in multi-threaded applications.
+## Use it in constrained memory environments, recommended values are 4 or 8.
+## (default is 0: disabled or let glibc decide)
+# LIMIT_GLIBC_MALLOC_ARENAS = 0
+
 ## Nice level to run daemon with, when possible to set.
 ## (Default: -19)
 # NICE_LEVEL = -19

--- a/tests/test_suites/ShortSystemTests/test_limit_glibc_malloc_arenas.sh
+++ b/tests/test_suites/ShortSystemTests/test_limit_glibc_malloc_arenas.sh
@@ -1,0 +1,88 @@
+timeout_set "2 minutes"
+
+CHUNKSERVERS=3 \
+	MASTER_CUSTOM_GOALS="1 ec21: \$ec(2,1)" \
+	AUTO_SHADOW_MASTER="NO" \
+	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER" \
+	CHUNKSERVER_EXTRA_CONFIG="MAGIC_DEBUG_LOG = $TEMP_DIR/log|LOG_FLUSH_ON=DEBUG" \
+	MASTER_EXTRA_CONFIG="MAGIC_DEBUG_LOG = $TEMP_DIR/log|LOG_FLUSH_ON=DEBUG" \
+	setup_local_empty_saunafs info
+
+cd "${info[mount0]}"
+
+# Generates some files in parallel
+function generateAndValidateFiles() {
+	echo "Generating the files"
+
+	for file in $(seq 1 100); do
+		size=$((file * 1024))
+		FILE_SIZE=${size} assert_success file-generate "file.${file}" &
+	done
+
+	wait
+}
+
+function getActualArenaLimitFromLog() {
+	grep -ioP '(?<=Setting glibc malloc arena max to )[0-9]+' "${TEMP_DIR}/log" | tail -n 1
+}
+
+function getVirtualMemoryForPid() {
+	pid=${1}
+	ps -o vsz= -p ${pid}
+}
+
+# Generate some files to populate the filesystem
+generateAndValidateFiles
+
+# Master is consuming more memory after restart, so the comparison is not fair.
+# This restart makes the later comparison in better conditions.
+saunafs_master_daemon restart
+saunafs_wait_for_all_ready_chunkservers
+
+arenas=2
+
+### Test the limit in the first chunkserver ###
+
+# Get initial values
+cs0Pid=$(saunafs_chunkserver_daemon 0 test 2>&1 | tr -d '\0' | awk '{print $NF}')
+virtualMemoryCS0=$(getVirtualMemoryForPid ${cs0Pid})
+echo "CS0 PID: ${cs0Pid} - Virtual memory: ${virtualMemoryCS0}"
+
+# Edit the configuration to set the limit and restart
+echo "LIMIT_GLIBC_MALLOC_ARENAS = ${arenas}" >> "${info[chunkserver0_cfg]}"
+saunafs_chunkserver_daemon 0 restart
+saunafs_wait_for_all_ready_chunkservers
+
+# Check if the limit was set
+effectiveArenaLimit=$(getActualArenaLimitFromLog)
+assert_equals ${arenas} ${effectiveArenaLimit}
+echo "Arena limit set to ${effectiveArenaLimit} for chunkserver 0"
+
+# Check if the memory usage decreased
+cs0PidAfter=$(saunafs_chunkserver_daemon 0 test 2>&1 | tr -d '\0' | awk '{print $NF}')
+virtualMemoryCS0After=$(getVirtualMemoryForPid ${cs0PidAfter})
+echo "CS0 PID: ${cs0PidAfter} - Virtual memory: ${virtualMemoryCS0After}"
+assert_less_than ${virtualMemoryCS0After} ${virtualMemoryCS0}
+
+### Test the limit in the master ###
+
+# Get initial values
+master0Pid=$(saunafs_master_n 0 test 2>&1 | tr -d '\0' | awk '{print $NF}')
+virtualMemoryMaster0=$(getVirtualMemoryForPid ${master0Pid})
+echo "Master0 PID: ${master0Pid} - Virtual memory: ${virtualMemoryMaster0}"
+
+# Edit the configuration to set the limit and restart
+echo "LIMIT_GLIBC_MALLOC_ARENAS = ${arenas}" >> "${info[master0_cfg]}"
+saunafs_master_daemon restart
+saunafs_wait_for_all_ready_chunkservers
+
+# Check if the limit was set
+effectiveArenaLimit=$(getActualArenaLimitFromLog)
+assert_equals ${arenas} ${effectiveArenaLimit}
+echo "Arena limit set to ${effectiveArenaLimit} for master 0"
+
+# Check if the memory usage decreased
+master0PidAfter=$(saunafs_master_n 0 test 2>&1 | tr -d '\0' | awk '{print $NF}')
+virtualMemoryMaster0After=$(getVirtualMemoryForPid ${master0PidAfter})
+echo "Master0 PID: ${master0PidAfter} - Virtual memory: ${virtualMemoryMaster0After}"
+assert_less_than ${virtualMemoryMaster0After} ${virtualMemoryMaster0}


### PR DESCRIPTION
The new option LIMIT_GLIBC_MALLOC_ARENAS allows to tune (from configuration) the number of arenas used by malloc in environments with glibc. Setting it to a small positive number like 4 or 8, reduce the virtual memory used by the application, at the cost of possible performance drop for multi-threading (due to contention).

The default is 0, which means disabled (lets glibc decide the values). The options is meant to be used in environments with limited RAM.

So far, the new variable is only used in the daemons: metadata, metalogger and chunkservers.