### PR TITLE
feat: Speedup unlink operation for big directories

### DIFF
--- a/src/master/filesystem_checksum.cc
+++ b/src/master/filesystem_checksum.cc
@@ -41,8 +41,9 @@ static uint64_t fsnodes_checksum(FSNode *node, bool full_update = false) {
 	case FSNode::kDirectory:
 		if (full_update) {
 			static_cast<FSNodeDirectory*>(node)->entries_hash = 0;
-			for(const auto &entry : *static_cast<FSNodeDirectory*>(node)) {
-				static_cast<FSNodeDirectory*>(node)->entries_hash ^= entry.first.hash();
+			for (const auto &entry : *static_cast<FSNodeDirectory *>(node)) {
+				static_cast<FSNodeDirectory *>(node)->entries_hash ^=
+				    entry.first->hash();
 			}
 
 			// Case insensitive
@@ -51,7 +52,7 @@ static uint64_t fsnodes_checksum(FSNode *node, bool full_update = false) {
 				for (const auto &entry :
 				     static_cast<FSNodeDirectory *>(node)->lowerCaseEntries) {
 					static_cast<FSNodeDirectory *>(node)
-					    ->lowerCaseEntriesHash ^= entry.first.hash();
+					    ->lowerCaseEntriesHash ^= entry.first->hash();
 				}
 			}
 		}

--- a/src/master/filesystem_dump.cc
+++ b/src/master/filesystem_dump.cc
@@ -130,11 +130,11 @@ void fs_dumpnodes() {
 
 void fs_dumpedgelist(FSNodeDirectory *parent) {
 	for (const auto &entry : parent->entries) {
-		fs_dumpedge(parent, entry.second, (std::string)entry.first);
+		fs_dumpedge(parent, entry.second, (std::string)(*entry.first));
 	}
 	if (parent->case_insensitive) {
 		for (const auto &entry : parent->lowerCaseEntries) {
-			fs_dumpedge(parent, entry.second, (std::string)entry.first);
+			fs_dumpedge(parent, entry.second, (std::string)(*entry.first));
 		}
 	}
 }

--- a/src/master/filesystem_periodic.cc
+++ b/src/master/filesystem_periodic.cc
@@ -107,10 +107,10 @@ static std::string get_node_info(FSNode *node) {
 	} else if (node->type == FSNode::kFile) {
 		name = "file " + std::to_string(node->id) + ": ";
 		bool first = true;
-		for (const auto parent_inode : node->parent) {
+		for (const auto &[parentId, _] : node->parent) {
 			std::string path;
 			FSNodeDirectory *parent =
-			        fsnodes_id_to_node_verify<FSNodeDirectory>(parent_inode);
+			    fsnodes_id_to_node_verify<FSNodeDirectory>(parentId);
 			fsnodes_getpath(parent, node, path);
 			if (!first) {
 				name += "|" + path;
@@ -124,7 +124,8 @@ static std::string get_node_info(FSNode *node) {
 		std::string path;
 		FSNodeDirectory *parent = nullptr;
 		if (!node->parent.empty()) {
-			parent = fsnodes_id_to_node_verify<FSNodeDirectory>(node->parent.front());
+			parent = fsnodes_id_to_node_verify<FSNodeDirectory>(
+			    node->parent.front().first);
 		}
 		fsnodes_getpath(parent, node, path);
 		name += path;
@@ -416,11 +417,23 @@ void fs_process_file_test() {
 				     static_cast<FSNodeDirectory *>(f)->entries) {
 					FSNode *node = entry.second;
 
-					if (!node ||
-					    std::find(node->parent.begin(), node->parent.end(),
-					              f->id) == node->parent.end()) {
+					if (!node) {
+						// the node points to invalid memory
 						node_error_flag |=
 						        static_cast<int>(kStructureError);
+					} else {
+						auto parentInChildPtr = std::find_if(
+						    node->parent.begin(), node->parent.end(),
+						    [f](const std::pair<uint32_t,
+						                        const hstorage::Handle *> &p) {
+							    return p.first == f->id;
+						    });
+						// the node doesn't have a parent entry pointing to the
+						// current directory
+						if (parentInChildPtr == node->parent.end()) {
+							node_error_flag |=
+							    static_cast<int>(kStructureError);
+						}
 					}
 				}
 			}

--- a/src/master/filesystem_store.cc
+++ b/src/master/filesystem_store.cc
@@ -50,6 +50,25 @@
 #include "master/restore.h"
 #include "metrics/metrics.h"
 
+constexpr uint16_t kEdgeNameMaxSize = 65535;
+constexpr uint8_t kEdgeHeaderSize =
+    sizeof(FSNode::id) + sizeof(FSNode::id) + sizeof(kEdgeNameMaxSize);
+uint8_t gEdgeStoreBuffer[kEdgeHeaderSize + kEdgeNameMaxSize];
+
+constexpr uint8_t kNodeHeaderSize =
+    sizeof(FSNode::type) + sizeof(FSNode::id) + sizeof(FSNode::goal) +
+    sizeof(FSNode::mode) + sizeof(FSNode::uid) + sizeof(FSNode::gid) +
+    sizeof(FSNode::atime) + sizeof(FSNode::mtime) + sizeof(FSNode::ctime) +
+    sizeof(FSNode::trashtime);
+// FSNodeFile is the longer type of FSNode, so we use it as the buffer size
+constexpr uint8_t kFileSpecificHeaderSize =
+    sizeof(FSNodeFile::length) + sizeof(uint32_t) + sizeof(uint16_t);
+constexpr uint32_t kChunksBucketSize = 65536;
+constexpr uint16_t kMaxSessionSize = 65535;
+constexpr uint32_t kFileSpecificExtraSize =
+    sizeof(uint64_t) * kChunksBucketSize + sizeof(uint32_t) * kMaxSessionSize;
+uint8_t gNodeStoreBuffer[kNodeHeaderSize + kFileSpecificHeaderSize +
+                         kFileSpecificExtraSize];
 
 // TODO (Baldor): Review the need for these constants below
 [[maybe_unused]] constexpr uint8_t kMetadataVersionLegacy = 0x15;
@@ -248,20 +267,21 @@ void fs_storeedge(FSNodeDirectory *parent, FSNode *child,
 	uint8_t uedgebuff[4 + 4 + 2 + 65535];
 	uint8_t *ptr;
 	if (child == nullptr) {  // last edge
-		memset(uedgebuff, 0, 4 + 4 + 2);
-		if (fwrite(uedgebuff, 1, 4 + 4 + 2, fd) != (size_t)(4 + 4 + 2)) {
+		memset(gEdgeStoreBuffer, 0, kEdgeHeaderSize);
+		if (fwrite(gEdgeStoreBuffer, 1, kEdgeHeaderSize, fd) !=
+		    (size_t)(kEdgeHeaderSize)) {
 			safs_pretty_syslog(LOG_NOTICE, "fwrite error");
 			return;
 		}
 		return;
 	}
-	ptr = uedgebuff;
+	ptr = gEdgeStoreBuffer;
 	put32bit(&ptr, (parent == nullptr) ? 0 : parent->id);
 	put32bit(&ptr, child->id);
 	put16bit(&ptr, name.length());
 	memcpy(ptr, name.c_str(), name.length());
-	if (fwrite(uedgebuff, 1, 4 + 4 + 2 + name.length(), fd) !=
-	    (size_t)(4 + 4 + 2 + name.length())) {
+	if (fwrite(gEdgeStoreBuffer, 1, kEdgeHeaderSize + name.length(), fd) !=
+	    (size_t)(kEdgeHeaderSize + name.length())) {
 		safs_pretty_syslog(LOG_NOTICE, "fwrite error");
 		return;
 	}
@@ -442,7 +462,7 @@ void fs_storenode(FSNode *f, FILE *fd) {
 		fputc(0, fd);
 		return;
 	}
-	ptr = unodebuff;
+	ptr = gNodeStoreBuffer;
 	put8bit(&ptr, f->type);
 	put32bit(&ptr, f->id);
 	put8bit(&ptr, f->goal);
@@ -460,8 +480,8 @@ void fs_storenode(FSNode *f, FILE *fd) {
 	case FSNode::kDirectory:
 	case FSNode::kSocket:
 	case FSNode::kFifo:
-		if (fwrite(unodebuff, 1, 1 + 4 + 1 + 2 + 4 + 4 + 4 + 4 + 4 + 4, fd) !=
-		    (size_t)(1 + 4 + 1 + 2 + 4 + 4 + 4 + 4 + 4 + 4)) {
+		if (fwrite(gNodeStoreBuffer, 1, kNodeHeaderSize, fd) !=
+		    (size_t)(kNodeHeaderSize)) {
 			safs_pretty_syslog(LOG_NOTICE, "fwrite error");
 			return;
 		}
@@ -469,8 +489,8 @@ void fs_storenode(FSNode *f, FILE *fd) {
 	case FSNode::kBlockDev:
 	case FSNode::kCharDev:
 		put32bit(&ptr, static_cast<FSNodeDevice *>(f)->rdev);
-		if (fwrite(unodebuff, 1, 1 + 4 + 1 + 2 + 4 + 4 + 4 + 4 + 4 + 4 + 4,
-		           fd) != (size_t)(1 + 4 + 1 + 2 + 4 + 4 + 4 + 4 + 4 + 4 + 4)) {
+		if (fwrite(gNodeStoreBuffer, 1, kNodeHeaderSize + 4, fd) !=
+		    (size_t)(kNodeHeaderSize + 4)) {
 			safs_pretty_syslog(LOG_NOTICE, "fwrite error");
 			return;
 		}
@@ -478,8 +498,8 @@ void fs_storenode(FSNode *f, FILE *fd) {
 	case FSNode::kSymlink:
 		name = (std::string) static_cast<FSNodeSymlink *>(f)->path;
 		put32bit(&ptr, name.length());
-		if (fwrite(unodebuff, 1, 1 + 4 + 1 + 2 + 4 + 4 + 4 + 4 + 4 + 4 + 4,
-		           fd) != (size_t)(1 + 4 + 1 + 2 + 4 + 4 + 4 + 4 + 4 + 4 + 4)) {
+		if (fwrite(gNodeStoreBuffer, 1, kNodeHeaderSize + 4, fd) !=
+		    (size_t)(kNodeHeaderSize + 4)) {
 			safs_pretty_syslog(LOG_NOTICE, "fwrite error");
 			return;
 		}
@@ -495,28 +515,30 @@ void fs_storenode(FSNode *f, FILE *fd) {
 		put64bit(&ptr, node_file->length);
 		ch = node_file->chunkCount();
 		put32bit(&ptr, ch);
-		sessionids = std::min<int>(node_file->sessionid.size(), 65535);
+		sessionids =
+		    std::min<int>(node_file->sessionid.size(), kMaxSessionSize);
 		put16bit(&ptr, sessionids);
 
-		if (fwrite(unodebuff, 1,
-		           1 + 4 + 1 + 2 + 4 + 4 + 4 + 4 + 4 + 4 + 8 + 4 + 2, fd) !=
-		    (size_t)(1 + 4 + 1 + 2 + 4 + 4 + 4 + 4 + 4 + 4 + 8 + 4 + 2)) {
+		if (fwrite(gNodeStoreBuffer, 1,
+		           kNodeHeaderSize + kFileSpecificHeaderSize,
+		           fd) != (size_t)(kNodeHeaderSize + kFileSpecificHeaderSize)) {
 			safs_pretty_syslog(LOG_NOTICE, "fwrite error");
 			return;
 		}
 
 		indx = 0;
-		while (ch > 65536) {
+		while (ch > kChunksBucketSize) {
 			chptr = ptr;
-			for (i = 0; i < 65536; i++) {
+			for (i = 0; i < kChunksBucketSize; i++) {
 				put64bit(&chptr, node_file->chunks[indx]);
 				indx++;
 			}
-			if (fwrite(ptr, 1, 8 * 65536, fd) != (size_t)(8 * 65536)) {
+			if (fwrite(ptr, 1, 8 * kChunksBucketSize, fd) !=
+			    (size_t)(8 * kChunksBucketSize)) {
 				safs_pretty_syslog(LOG_NOTICE, "fwrite error");
 				return;
 			}
-			ch -= 65536;
+			ch -= kChunksBucketSize;
 		}
 
 		chptr = ptr;
@@ -527,7 +549,7 @@ void fs_storenode(FSNode *f, FILE *fd) {
 
 		sessionids = 0;
 		for (const auto &sid : node_file->sessionid) {
-			if (sessionids >= 65535) {
+			if (sessionids >= kMaxSessionSize) {
 				break;
 			}
 			put32bit(&chptr, sid);

--- a/src/master/recursive_remove_task.cc
+++ b/src/master/recursive_remove_task.cc
@@ -65,7 +65,7 @@ int RemoveTask::execute(uint32_t ts, intrusive_list<Task> &work_queue) {
 			  static_cast<const FSNodeDirectory*>(child)->entries.size());
 		for (const auto &entry :
 				static_cast<FSNodeDirectory*>(child)->entries) {
-			subtasks.push_back(static_cast<HString>(entry.first));
+			subtasks.push_back(static_cast<HString>(*entry.first));
 		}
 		auto task = new RemoveTask(std::move(subtasks),
 					    child->id, context_);

--- a/src/master/snapshot_task.cc
+++ b/src/master/snapshot_task.cc
@@ -169,7 +169,7 @@ void SnapshotTask::cloneDirectoryData(const FSNodeDirectory *src_node, FSNodeDir
 	data.reserve(src_node->entries.size());
 	for (const auto &entry : src_node->entries) {
 		auto local_id = entry.second->id;
-		data.emplace_back(std::move(local_id), (HString)entry.first);
+		data.emplace_back(std::move(local_id), (HString)(*entry.first));
 	}
 	if (!data.empty()) {
 		auto task = new SnapshotTask(std::move(data), orig_inode_,


### PR DESCRIPTION
This PR mainly targets the unlink operation performance on big directories. The key change was to replace the O(n) [n = number of entries in the directory] previous implementation of getChildName to other one that behaves O(1) for non-hardlinked files.

There are some other side changes:
- modify the big session metadata benchmark to show results per every chunk of files (not yet configurable).
- speedup the dumping of metadata due to now creating the buffer to store nodes and edges every time. These buffers were not small.
- increase the size of the chunk hash table used in master to make their linked lists shorter. This change targets speeding up the traversing of those linked lists.