### PR TITLE
Build saunafs using clang

### DIFF
--- a/src/master/chunks.cc
+++ b/src/master/chunks.cc
@@ -2634,7 +2634,7 @@ void chunk_jobs_process_bit(void) {
 
 #endif
 
-constexpr uint32_t kSerializedChunkSizeNoLockId = 16;
+[[maybe_unused]] constexpr uint32_t kSerializedChunkSizeNoLockId = 16;
 constexpr uint32_t kSerializedChunkSizeWithLockId = 20;
 #define CHUNKCNT 1000
 

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -46,7 +46,7 @@
 
 std::array<uint32_t, FsStats::Size> gFsStatsArray = {{}};
 
-static const char kAclXattrs[] = "system.richacl";
+[[maybe_unused]] static const char kAclXattrs[] = "system.richacl";
 
 void fs_retrieve_stats(std::array<uint32_t, FsStats::Size> &output_stats) {
 	output_stats = gFsStatsArray;

--- a/src/master/filesystem_store.cc
+++ b/src/master/filesystem_store.cc
@@ -52,8 +52,8 @@
 
 
 // TODO (Baldor): Review the need for these constants below
-constexpr uint8_t kMetadataVersionLegacy = 0x15;
-constexpr uint8_t kMetadataVersionSaunaFS = 0x16;
+[[maybe_unused]] constexpr uint8_t kMetadataVersionLegacy = 0x15;
+[[maybe_unused]] constexpr uint8_t kMetadataVersionSaunaFS = 0x16;
 constexpr uint8_t kMetadataVersionWithSections = 0x20;
 constexpr uint8_t kMetadataVersionWithLockIds = 0x29;
 constexpr int8_t kOpSuccess = 0;
@@ -1316,8 +1316,10 @@ void fs_load_changelog(const std::string &path) {
 #endif
 
 bool isNewMetadataFile([[maybe_unused]]const uint8_t *headerPtr) {
-	static constexpr std::string_view kMetadataHeaderNew(SFSSIGNATURE "M NEW");
-	static constexpr std::string_view kMetadataHeaderOld(SAUSIGNATURE "M NEW");
+	[[maybe_unused]] static constexpr std::string_view kMetadataHeaderNew(
+	    SFSSIGNATURE "M NEW");
+	[[maybe_unused]] static constexpr std::string_view kMetadataHeaderOld(
+	    SAUSIGNATURE "M NEW");
 	[[maybe_unused]]static constexpr uint8_t kMetadataHeaderSize = 8;
 #ifndef METARESTORE
 	if (metadataserver::isMaster()) {  // special case - create new file system

--- a/src/master/matotsserv.cc
+++ b/src/master/matotsserv.cc
@@ -32,5 +32,5 @@
 #include "protocol/input_packet.h"
 
 /// Maximum allowed length of a network packet
-static constexpr uint32_t kMaxPacketSize = 500000000;
+[[maybe_unused]] static constexpr uint32_t kMaxPacketSize = 500000000;
 

--- a/src/metrics/metrics.cc
+++ b/src/metrics/metrics.cc
@@ -32,8 +32,6 @@
 #include "metrics.h"
 #include "slogger/slogger.h"
 
-constexpr auto THREAD_SLEEP_TIME_MS = 100;
-
 namespace metrics {
 
 std::unique_ptr<std::jthread>
@@ -53,6 +51,8 @@ void init(const char* /* unused */) {
 }
 }
 #else
+
+constexpr auto THREAD_SLEEP_TIME_MS = 100;
 
 prometheus::Family<prometheus::Counter> &setup_family(
     const char *name, const char *help,

--- a/src/mount/client/sauna_client_c_linkage.h
+++ b/src/mount/client/sauna_client_c_linkage.h
@@ -59,33 +59,44 @@ int saunafs_releasedir(SaunaClient::Inode ino, uint64_t opendirSessionID);
 int saunafs_setattr(SaunaClient::Context &ctx, SaunaClient::Inode ino,
 	             struct stat *stbuf, int to_set, SaunaClient::AttrReply &attr_reply);
 
-std::pair<int, ReadCache::Result> saunafs_read(SaunaClient::Context &ctx, SaunaClient::Inode ino,
-	                                         size_t size, off_t off, SaunaClient::FileInfo* fi);
+int saunafs_read(SaunaClient::Context &ctx, SaunaClient::Inode ino, size_t size,
+                 off_t off, SaunaClient::FileInfo *fi, ReadCache::Result &result);
 
-std::pair<int, std::vector<uint8_t>> saunafs_read_special_inode(SaunaClient::Context &ctx,
-	                    SaunaClient::Inode ino, size_t size, off_t off, SaunaClient::FileInfo* fi);
+int saunafs_read_special_inode(SaunaClient::Context &ctx,
+                               SaunaClient::Inode ino, size_t size, off_t off,
+                               SaunaClient::FileInfo *fi,
+                               std::vector<uint8_t> &special_inode);
 
-std::pair<int, std::vector<SaunaClient::DirEntry>> saunafs_readdir(SaunaClient::Context &ctx,
-	                    uint64_t opendirSessionID, SaunaClient::Inode ino, off_t off, size_t max_entries);
+int saunafs_readdir(SaunaClient::Context &ctx, uint64_t opendirSessionID,
+                    SaunaClient::Inode ino, off_t off, size_t max_entries,
+                    std::vector<SaunaClient::DirEntry> &entries);
 
 int saunafs_readlink(SaunaClient::Context &ctx, SaunaClient::Inode ino, std::string &link);
 
-std::pair<int, std::vector<NamedInodeEntry>> saunafs_readreserved(SaunaClient::Context &ctx,
-	                    SaunaClient::NamedInodeOffset off, SaunaClient::NamedInodeOffset max_entries);
+int saunafs_readreserved(SaunaClient::Context &ctx,
+                         SaunaClient::NamedInodeOffset off,
+                         SaunaClient::NamedInodeOffset max_entries,
+                         std::vector<NamedInodeEntry> &inode_entries);
 
-std::pair<int, std::vector<NamedInodeEntry>> saunafs_readtrash(SaunaClient::Context &ctx,
-	                    SaunaClient::NamedInodeOffset off, SaunaClient::NamedInodeOffset max_entries);
+int saunafs_readtrash(SaunaClient::Context &ctx,
+                      SaunaClient::NamedInodeOffset off,
+                      SaunaClient::NamedInodeOffset max_entries,
+                      std::vector<NamedInodeEntry> &trash_entries);
 
-std::pair<int, ssize_t> saunafs_write(SaunaClient::Context &ctx, SaunaClient::Inode ino,
-	                               const char *buf, size_t size, off_t off, SaunaClient::FileInfo* fi);
+int saunafs_write(SaunaClient::Context &ctx, SaunaClient::Inode ino,
+                  const char *buf, size_t size, off_t off,
+                  SaunaClient::FileInfo *fi, ssize_t &bytes_written);
+
 int saunafs_flush(SaunaClient::Context &ctx, SaunaClient::Inode ino, SaunaClient::FileInfo* fi);
 int saunafs_fsync(SaunaClient::Context &ctx, SaunaClient::Inode ino, int datasync, SaunaClient::FileInfo* fi);
 bool saunafs_isSpecialInode(SaunaClient::Inode ino);
 int saunafs_update_groups(SaunaClient::Context &ctx);
-std::pair<int, SaunaClient::JobId> saunafs_makesnapshot(SaunaClient::Context &ctx, SaunaClient::Inode ino,
-	                                                  SaunaClient::Inode dst_parent,
-	                                                  const std::string &dst_name,
-	                                                  bool can_overwrite);
+
+int saunafs_makesnapshot(SaunaClient::Context &ctx, SaunaClient::Inode ino,
+                         SaunaClient::Inode dst_parent,
+                         const std::string &dst_name, bool can_overwrite,
+                         SaunaClient::JobId &job_id);
+
 int saunafs_getgoal(SaunaClient::Context &ctx, SaunaClient::Inode ino, std::string &goal);
 int saunafs_setgoal(SaunaClient::Context &ctx, SaunaClient::Inode ino,
 	             const std::string &goal_name, uint8_t smode);
@@ -100,14 +111,20 @@ int saunafs_getxattr(SaunaClient::Context ctx, SaunaClient::Inode ino, const cha
 int saunafs_listxattr(SaunaClient::Context ctx, SaunaClient::Inode ino, size_t size,
 	               SaunaClient::XattrReply &xattr_reply);
 int saunafs_removexattr(SaunaClient::Context ctx, SaunaClient::Inode ino, const char *name);
-std::pair<int,std::vector<ChunkWithAddressAndLabel>> saunafs_getchunksinfo(SaunaClient::Context &ctx,
-	             SaunaClient::Inode ino, uint32_t chunk_index, uint32_t chunk_count);
-std::pair<int,std::vector<ChunkserverListEntry>> saunafs_getchunkservers();
+
+int saunafs_getchunksinfo(SaunaClient::Context &ctx, SaunaClient::Inode ino,
+                          uint32_t chunk_index, uint32_t chunk_count,
+                          std::vector<ChunkWithAddressAndLabel> &chunks);
+
+int saunafs_getchunkservers(std::vector<ChunkserverListEntry> &chunkservers);
 
 int saunafs_getlk(SaunaClient::Context &ctx, SaunaClient::Inode ino, SaunaClient::FileInfo *fi,
 	  safs_locks::FlockWrapper &lock);
-std::pair<int, uint32_t> saunafs_setlk_send(SaunaClient::Context &ctx, SaunaClient::Inode ino,
-	                            SaunaClient::FileInfo *fi, safs_locks::FlockWrapper &lock);
+
+int saunafs_setlk_send(SaunaClient::Context &ctx, SaunaClient::Inode ino,
+                       SaunaClient::FileInfo *fi,
+                       safs_locks::FlockWrapper &lock, uint32_t &reqid);
+
 int saunafs_setlk_recv();
 int saunafs_setlk_interrupt(const safs_locks::InterruptData &data);
 

--- a/src/mount/global_io_limiter_unittest.cc
+++ b/src/mount/global_io_limiter_unittest.cc
@@ -330,7 +330,7 @@ TEST(LimiterProxyTests, ManyMountsSummaryThroughput) {
 
 		// Run N threads using LimiterProxy, each performing M subsequent reads
 		for (int i  = 0; i < N; i++) {
-			asyncs.push_back(std::async(std::launch::async, [&proxyLimiter, M, &deadline, &mutex,
+			asyncs.push_back(std::async(std::launch::async, [&proxyLimiter, &deadline, &mutex,
 					&someoneCompleted, &completed, &expectedToBeCompleted]() {
 						for (auto i = 0; i < M; ++i) {
 							ASSERT_EQ(SAUNAFS_STATUS_OK, proxyLimiter.waitForRead(

--- a/src/mount/sauna_client.cc
+++ b/src/mount/sauna_client.cc
@@ -1815,7 +1815,7 @@ std::vector<DirEntry> readdir(Context &ctx, uint64_t fh, Inode ino, off_t off, s
 	/* Scope for lock guard. */ {
 		std::lock_guard<std::mutex> sessions_guard(gReaddirMutex);
 		ReaddirSessions::iterator sessionIt = gReaddirSessions.find(fh);
-		sassert(sessionIt != gReaddirSessions.end());
+		sassert(sessionIt != gReaddirSessions.end() || gReaddirSessions.empty());
 		readdirSession = &sessionIt->second;
 	}
 	do {

--- a/src/unittests/plan_tester.cc
+++ b/src/unittests/plan_tester.cc
@@ -139,10 +139,8 @@ void ReadPlanTester::checkPlan(const std::unique_ptr<ReadPlan> &plan, uint8_t *b
 		}
 	}
 
-	int post_size = 0;
 	for (const auto &post : plan->postprocess_operations) {
 		assert(post.first >= 0);
-		post_size += post.first;
 	}
 
 	plan->buffer_start = buffer_start;

--- a/tests/setup_machine.sh
+++ b/tests/setup_machine.sh
@@ -65,6 +65,7 @@ common_packages=(
 	bash-completion
 	bc
 	ccache
+	clang
 	cmake
 	curl
 	dbench

--- a/tests/test_suites/LongSystemTests/test_build_saunafs_using_clang.sh
+++ b/tests/test_suites/LongSystemTests/test_build_saunafs_using_clang.sh
@@ -1,0 +1,27 @@
+timeout_set 20 minutes
+assert_program_installed git
+assert_program_installed cmake
+assert_program_installed make
+assert_program_installed clang
+
+MINIMUM_PARALLEL_JOBS=4
+MAXIMUM_PARALLEL_JOBS=16
+PARALLEL_JOBS=$(get_nproc_clamped_between ${MINIMUM_PARALLEL_JOBS} ${MAXIMUM_PARALLEL_JOBS})
+
+# Clone the repository
+git clone --branch dev https://github.com/leil-io/saunafs.git "${TEMP_DIR}/saunafs"
+
+# Change to the temporary directory
+cd "${TEMP_DIR}/saunafs"
+
+# Check if the feature branch exists and check it out if it does
+feature_branch="build-saunafs-using-clang"
+if git ls-remote --heads origin "${feature_branch}" | \
+	grep -q "${feature_branch}"; then
+	git checkout "${feature_branch}"
+fi
+
+assert_success cmake -B ./build -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+	-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
+	-DENABLE_TESTS=ON -DENABLE_NFS_GANESHA=ON -DENABLE_CLIENT_LIB=ON
+assert_success make -C ./build -j${PARALLEL_JOBS}


### PR DESCRIPTION
This pull request ensures that the SaunaFS project can be successfully built with Clang by addressing compatibility issues and suppressing C-linkage errors in the Client API.

**Summary of Changes:**

- Replaced the use of C++-specific types (`std::pair`, `std::vector`) in Client API functions.

- Refactored these functions to return an integer exit code and use references for variable updates.

- Added a Clang build test to validate compatibility and prevent regressions.

- Fix GCC-specific pragmas in Clang builds.

- Removed unused variable assignments in tests to avoid unnecessary warnings.

**Testing:**

- Added a test to validate the SaunaFS build process with Clang.

- Verified the build with both Clang and GCC to ensure no regressions.