### PR TITLE
Fix file by inode test

### DIFF
--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -1986,9 +1986,10 @@ void matoclserv_fuse_access(matoclserventry *eptr,const uint8_t *data,uint32_t l
 	gid = get32bit(&data);
 	modemask = get8bit(&data);
 	status = matoclserv_check_group_cache(eptr, gid);
-	if (status == SAUNAFS_STATUS_OK && inode != SPECIAL_INODE_PATH_BY_INODE) {
+	if (status == SAUNAFS_STATUS_OK && inode != SPECIAL_INODE_PATH_BY_INODE &&
+	    inode != SPECIAL_INODE_FILE_BY_INODE) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = fs_access(context,inode,modemask);
+		status = fs_access(context, inode, modemask);
 	}
 	ptr = matoclserv_createpacket(eptr,MATOCL_FUSE_ACCESS,5);
 	put32bit(&ptr,msgid);

--- a/src/mount/sauna_client.cc
+++ b/src/mount/sauna_client.cc
@@ -1717,7 +1717,8 @@ void opendir(Context &ctx, Inode ino) {
 	if (debug_mode) {
 		oplog_printf(ctx, "opendir (%lu) ...", (unsigned long int)ino);
 	}
-	if (ino != SPECIAL_INODE_PATH_BY_INODE && IS_SPECIAL_INODE(ino)) {
+	if (ino != SPECIAL_INODE_PATH_BY_INODE &&
+	    ino != SPECIAL_INODE_FILE_BY_INODE && IS_SPECIAL_INODE(ino)) {
 		oplog_printf(ctx, "opendir (%lu): %s", (unsigned long int)ino,
 		             saunafs_error_string(SAUNAFS_ERROR_ENOTDIR));
 		throw RequestException(SAUNAFS_ERROR_ENOTDIR);

--- a/tests/test_suites/ShortSystemTests/test_files_by_inode_permissions.sh
+++ b/tests/test_suites/ShortSystemTests/test_files_by_inode_permissions.sh
@@ -32,6 +32,6 @@ assert_success dd if=/dev/random of="$INODE_PATH/6" bs=1 count=1
 assert_success printf "#/bin/bash\necho 'Hello!\n' > /dev/null" > "$INODE_PATH/7"
 assert_success "$INODE_PATH/7"
 
-# ls on .saunafs_file_by_inode should fail, or we can end up
-# with very long listing.
-assert_failure ls $INODE_PATH
+# ls on .saunafs_file_by_inode should pass, as it is treated
+# a directory by its definition.
+assert_success ls $INODE_PATH


### PR DESCRIPTION
Previous version of the test checking the file by inode special file
functionality was not properly considering this file as a directory
as it was defined. This change fixes this.

This change should be added after https://github.com/leil-io/saunafs/pull/265