### PR TITLE
test: Use clang19 for running test_build_saunafs_using_clang

### DIFF
--- a/tests/setup_machine.sh
+++ b/tests/setup_machine.sh
@@ -157,6 +157,7 @@ apt_packages=(
 	libnfsidmap-dev
 	libnsl-dev
 	libsqlite3-dev
+	software-properties-common
 )
 noble_packages=(
 	prometheus-cpp-dev
@@ -250,6 +251,22 @@ case "${release}" in
 		echo "Installation of required packages SKIPPED, '${release}' isn't supported by this script"
 		;;
 esac
+
+case "${release}" in
+	LinuxMint/*|Ubuntu/*|Debian/*)
+		# Setup latest clang/llvm
+		wget https://apt.llvm.org/llvm.sh
+		echo "3080a6f961db6559698ea7692f0d5efa5ad9fde9ac6cf0758cfab134509b5bd6 llvm.sh" | sha256sum --check --status
+		chmod +x ./llvm.sh
+		./llvm.sh 19
+		rm llvm.sh
+		;;
+	*)
+		set +x
+		echo "Installation of clang19 SKIPPED, only in apt systems clang19 is installed automatically"
+		set -x
+esac
+
 gpg2 --list-keys
 #setup gtest from sources
 : "${GTEST_ROOT:=/usr/local}"

--- a/tests/test_suites/LongSystemTests/test_build_saunafs_using_clang.sh
+++ b/tests/test_suites/LongSystemTests/test_build_saunafs_using_clang.sh
@@ -22,6 +22,6 @@ if git ls-remote --heads origin "${feature_branch}" | \
 fi
 
 assert_success cmake -B ./build -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-	-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
+	-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++-19 \
 	-DENABLE_TESTS=ON -DENABLE_NFS_GANESHA=ON -DENABLE_CLIENT_LIB=ON
 assert_success make -C ./build -j${PARALLEL_JOBS}


### PR DESCRIPTION
Earlier versions of clang had trouble compiling due to the __cp_concepts
value being lower 202002L. This was updated in clang19, however most
major distributions do not ship it yet.

The commit uses a script to setup repositories for llvm toolchains and
installs the latest version from clang.

See here for more information: https://github.com/clangd/clangd/issues/2200