### PR TITLE
test: Add new tests to GaneshaTests suite

### DIFF
--- a/tests/setup_machine.sh
+++ b/tests/setup_machine.sh
@@ -83,7 +83,9 @@ common_packages=(
 	nfs4-acl-tools
 	pkg-config
 	pylint
+	python3-gssapi      # required by Ganesha -> pynfs suite
 	python3-pip
+	python3-ply         # required by Ganesha -> pynfs suite
 	python3-setuptools
 	python3-wheel
 	psmisc
@@ -111,6 +113,7 @@ common_packages=(
 apt_packages=(
 	build-essential
 	iproute2
+	iozone3             # required by Ganesha -> iozone suite
 	libblkid-dev
 	libboost-filesystem-dev
 	libboost-iostreams-dev
@@ -175,6 +178,7 @@ dnf_packages=(
 	gperftools-libs
 	gtest-devel
 	iproute
+	iozone              # required by Ganesha -> iozone suite
 	isa-l-devel
 	Judy-devel
 	kernel-devel

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_dbench.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_dbench.sh
@@ -1,0 +1,61 @@
+assert_program_installed dbench
+
+timeout_set 3 minutes
+
+CHUNKSERVERS=3 \
+	setup_local_empty_saunafs info
+
+test_error_cleanup() {
+	cd ${TEMP_DIR}
+	sudo umount -l ${TEMP_DIR}/mnt/ganesha
+	sudo pkill -9 ganesha.nfsd
+}
+
+mkdir -p ${TEMP_DIR}/mnt/ganesha
+
+create_ganesha_pid_file
+
+cd ${info[mount0]}
+
+cat <<EOF > ${info[mount0]}/ganesha.conf
+NFS_KRB5 {
+	Active_krb5=false;
+}
+NFSV4 {
+	Grace_Period = 5;
+}
+EXPORT
+{
+	Attr_Expiration_Time = 10;
+	Export_Id = 2;
+	Path = /;
+	Pseudo = /;
+	Access_Type = RW;
+	FSAL {
+		Name = SaunaFS;
+		hostname = localhost;
+		port = ${saunafs_info_[matocl]};
+		# How often to retry to connect
+		io_retries = 15;
+		cache_expiration_time_ms = 2500;
+	}
+	Protocols = 4;
+	CLIENT {
+		Clients = localhost;
+	}
+}
+EOF
+
+sudo /usr/bin/ganesha.nfsd -f ${info[mount0]}/ganesha.conf
+
+check_rpc_service
+sudo mount -vvvv localhost:/ ${TEMP_DIR}/mnt/ganesha
+
+cd ${TEMP_DIR}/mnt/ganesha
+
+dbench -s -S -t 60 1
+if [[ ${PIPESTATUS[0]} != 0 ]]; then
+	test_fail "dbench failed"
+fi
+
+test_error_cleanup || true

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_iozone.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_iozone.sh
@@ -1,0 +1,61 @@
+assert_program_installed iozone
+
+timeout_set 3 minutes
+
+CHUNKSERVERS=3 \
+	USE_RAMDISK=YES \
+	setup_local_empty_saunafs info
+
+test_error_cleanup() {
+	cd ${TEMP_DIR}
+	sudo umount -l ${TEMP_DIR}/mnt/ganesha
+	sudo pkill -9 ganesha.nfsd
+}
+
+mkdir -p ${TEMP_DIR}/mnt/ganesha
+
+create_ganesha_pid_file
+
+cd ${info[mount0]}
+
+cat <<EOF > ${info[mount0]}/ganesha.conf
+NFS_KRB5 {
+	Active_krb5=false;
+}
+NFSV4 {
+	Grace_Period = 5;
+	Lease_Lifetime = 5;
+}
+EXPORT
+{
+	Attr_Expiration_Time = 0;
+	Export_Id = 99;
+	Path = /;
+	Pseudo = /;
+	Access_Type = RW;
+	FSAL {
+		Name = SaunaFS;
+		hostname = localhost;
+		port = ${saunafs_info_[matocl]};
+		# How often to retry to connect
+		io_retries = 5;
+		cache_expiration_time_ms = 2500;
+	}
+	Protocols = 4;
+	CLIENT {
+		Clients = localhost;
+	}
+}
+EOF
+
+sudo /usr/bin/ganesha.nfsd -f ${info[mount0]}/ganesha.conf
+
+check_rpc_service
+sudo mount -vvvv localhost:/ ${TEMP_DIR}/mnt/ganesha
+
+cd ${TEMP_DIR}/mnt/ganesha
+
+echo "Running iozone Test..."
+iozone -a -f ${TEMP_DIR}/iozone.tmp
+
+test_error_cleanup || true

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_pynfs.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_pynfs.sh
@@ -1,0 +1,59 @@
+timeout_set 5 minutes
+
+CHUNKSERVERS=3 \
+	USE_RAMDISK=YES \
+	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER" \
+	CHUNKSERVER_EXTRA_CONFIG="READ_AHEAD_KB = 1024|MAX_READ_BEHIND_KB = 2048"
+	setup_local_empty_saunafs info
+
+create_ganesha_pid_file
+
+cd ${info[mount0]}
+
+cat <<EOF > ${info[mount0]}/ganesha.conf
+NFS_KRB5 {
+	Active_krb5=false;
+}
+NFSV4 {
+	Grace_Period = 5;
+	Lease_Lifetime = 5;
+}
+EXPORT
+{
+	Attr_Expiration_Time = 0;
+	Export_Id = 99;
+	Path = /;
+	Pseudo = /;
+	Access_Type = RW;
+	FSAL {
+		Name = SaunaFS;
+		hostname = localhost;
+		port = ${saunafs_info_[matocl]};
+		# How often to retry to connect
+		io_retries = 5;
+		cache_expiration_time_ms = 2500;
+	}
+	Protocols = 4;
+	CLIENT {
+		Clients = localhost;
+	}
+}
+EOF
+
+sudo /usr/bin/ganesha.nfsd -f ${info[mount0]}/ganesha.conf
+
+check_rpc_service
+
+# Run pynfs suite
+cd ${TEMP_DIR}
+
+git clone git://linux-nfs.org/~bfields/pynfs.git
+cd pynfs && yes | python3 setup.py build > /${TEMP_DIR}/output_tempfile.txt
+echo $?
+
+cd ${TEMP_DIR}/pynfs/nfs4.1
+
+# Testing export localhost:/ for NFS v4.1
+./testserver.py localhost:/ --verbose --maketree --showomit --rundeps all ganesha
+
+sudo pkill -9 ganesha.nfsd

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_small_files.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_small_files.sh
@@ -1,0 +1,67 @@
+timeout_set 3 minutes
+
+CHUNKSERVERS=3 \
+	setup_local_empty_saunafs info
+
+test_error_cleanup() {
+	cd ${TEMP_DIR}
+	sudo umount -l ${TEMP_DIR}/mnt/ganesha
+	sudo pkill -9 ganesha.nfsd
+}
+
+mkdir -p ${TEMP_DIR}/mnt/ganesha
+
+create_ganesha_pid_file
+
+cd ${info[mount0]}
+
+cat <<EOF > ${info[mount0]}/ganesha.conf
+NFS_KRB5 {
+	Active_krb5=false;
+}
+NFSV4 {
+	Grace_Period = 5;
+	Lease_Lifetime = 5;
+}
+EXPORT
+{
+	Attr_Expiration_Time = 0;
+	Export_Id = 99;
+	Path = /;
+	Pseudo = /;
+	Access_Type = RW;
+	FSAL {
+		Name = SaunaFS;
+		hostname = localhost;
+		port = ${saunafs_info_[matocl]};
+		# How often to retry to connect
+		io_retries = 5;
+		cache_expiration_time_ms = 2500;
+	}
+	Protocols = 4;
+	CLIENT {
+		Clients = localhost;
+	}
+}
+EOF
+
+sudo /usr/bin/ganesha.nfsd -f ${info[mount0]}/ganesha.conf
+
+check_rpc_service
+sudo mount -vvvv localhost:/ ${TEMP_DIR}/mnt/ganesha
+
+cd ${TEMP_DIR}
+
+# Clone the small file test repo
+git clone https://github.com/distributed-system-analysis/smallfile.git
+cd smallfile
+
+# Run the small file test for each operation
+operations="create read chmod stat append rename delete-renamed mkdir rmdir"
+
+for operation in ${operations}; do
+	./smallfile_cli.py --files 200 --threads 20 --file-size 64 --hash-into-dirs Y \
+	--top ${TEMP_DIR}/mnt/ganesha --operation ${operation}
+done
+
+test_error_cleanup || true


### PR DESCRIPTION
This commit adds new tests to the GaneshaTests suite to validate NFS Ganesha functionality under various workloads:

- dbench: Generates workloads to test filesystem performance.
- iozone: Benchmarks filesystem I/O performance.
- pynfs: Tests NFS protocol compliance using a Python-based suite. See git://linux-nfs.org/~bfields/pynfs.git
- smallfile: Simulates workloads involving small file operations. See https://github.com/distributed-system-analysis/smallfile.git

These tests enhance the test coverage for NFS Ganesha by verifying its stability, compliance, and performance across different scenarios.

Signed-off-by: Crash crash@leil.io