### PR TITLE
feat(mount): Add ignore utimens data for Windows

### DIFF
--- a/src/mount/sauna_client.cc
+++ b/src/mount/sauna_client.cc
@@ -3435,6 +3435,7 @@ void init(int debug_mode_, int keep_cache_, double direntry_cache_timeout_, unsi
 		double acl_cache_timeout_, unsigned acl_cache_size_, bool direct_io
 #ifdef _WIN32
 		, int mounting_uid_, int mounting_gid_, std::unordered_set<uint32_t> &allowed_users_
+		, bool ignore_utimens_update_
 #endif
 		, bool ignore_flush_
 		) {
@@ -3442,6 +3443,7 @@ void init(int debug_mode_, int keep_cache_, double direntry_cache_timeout_, unsi
 	mounting_uid = mounting_uid_;
 	mounting_gid = mounting_gid_;
 	allowed_users = allowed_users_;
+	gIgnoreUtimensUpdate = ignore_utimens_update_;
 #endif
 	gIgnoreFlush = ignore_flush_;
 	debug_mode = debug_mode_;
@@ -3476,6 +3478,9 @@ void init(int debug_mode_, int keep_cache_, double direntry_cache_timeout_, unsi
 
 	gTweaks.registerVariable("DirectIO", gDirectIo);
 	gTweaks.registerVariable("IgnoreFlush", gIgnoreFlush);
+#ifdef _WIN32
+	gTweaks.registerVariable("IgnoreUtimens", gIgnoreUtimensUpdate);
+#endif
 	gTweaks.registerVariable("AclCacheMaxTime", acl_cache->maxTime_ms);
 	gTweaks.registerVariable("AclCacheHit", acl_cache->cacheHit);
 	gTweaks.registerVariable("AclCacheExpired", acl_cache->cacheExpired);
@@ -3540,6 +3545,7 @@ void fs_init(FsInitParams &params) {
 		params.acl_cache_timeout, params.acl_cache_size, params.direct_io
 #ifdef _WIN32
 		, params.mounting_uid, params.mounting_gid, params.allowed_users
+		, params.ignore_utimens_update
 #endif
 		, params.ignore_flush
 		);

--- a/src/mount/sauna_client.h
+++ b/src/mount/sauna_client.h
@@ -50,6 +50,9 @@ namespace SaunaClient {
 typedef uint32_t Inode;
 typedef uint32_t JobId;
 typedef uint32_t NamedInodeOffset;
+#ifdef _WIN32
+inline std::atomic<bool> gIgnoreUtimensUpdate = false;
+#endif
 
 void update_readdir_session(uint64_t sessId, uint64_t entryIno);
 void drop_readdir_session(uint64_t opendirSessionID);
@@ -88,6 +91,7 @@ struct FsInitParams {
 	static constexpr unsigned kDefaultCleanAcquiredFilesPeriod = 0;
 	static constexpr unsigned kDefaultCleanAcquiredFilesTimeout = 0;
 	static constexpr int      kDefaultEnableStatusUpdaterThread = 0;
+	static constexpr bool     kDefaultIgnoreUtimensUpdate = false;
 #else
 	static constexpr unsigned kDefaultWriteCacheSize = 0;
 #endif
@@ -156,6 +160,7 @@ struct FsInitParams {
 	             clean_acquired_files_period(kDefaultCleanAcquiredFilesPeriod), 
 	             clean_acquired_files_timeout(kDefaultCleanAcquiredFilesTimeout),
 	             enable_status_updater_thread(kDefaultEnableStatusUpdaterThread),
+	             ignore_utimens_update(kDefaultIgnoreUtimensUpdate),
 #endif
 	             ignore_flush(kDefaultIgnoreFlush), verbose(kDefaultVerbose), direct_io(kDirectIO) {
 	}
@@ -189,9 +194,10 @@ struct FsInitParams {
 	             acl_cache_timeout(kDefaultAclCacheTimeout), acl_cache_size(kDefaultAclCacheSize),
 #ifdef _WIN32
 	             mounting_uid(USE_LOCAL_ID), mounting_gid(USE_LOCAL_ID),
-				 clean_acquired_files_period(kDefaultCleanAcquiredFilesPeriod), 
-				 clean_acquired_files_timeout(kDefaultCleanAcquiredFilesTimeout),
-				 enable_status_updater_thread(kDefaultEnableStatusUpdaterThread),
+	             clean_acquired_files_period(kDefaultCleanAcquiredFilesPeriod), 
+	             clean_acquired_files_timeout(kDefaultCleanAcquiredFilesTimeout),
+	             enable_status_updater_thread(kDefaultEnableStatusUpdaterThread),
+	             ignore_utimens_update(kDefaultIgnoreUtimensUpdate),
 #endif
 	             ignore_flush(kDefaultIgnoreFlush), verbose(kDefaultVerbose), direct_io(kDirectIO) {
 	}
@@ -246,6 +252,7 @@ struct FsInitParams {
 	unsigned clean_acquired_files_period;
 	unsigned clean_acquired_files_timeout;
 	unsigned enable_status_updater_thread;
+	unsigned ignore_utimens_update;
 #endif
 
 	bool ignore_flush;


### PR DESCRIPTION
This change adds the needed changes for implementing an option for ignoring the execution of metadata timestamps update syscalls on the Windows client.