### PR TITLE
chore(chunkserver): Apply pending readability refactor

### DIFF
--- a/src/chunkserver/chunkserver_entry.h
+++ b/src/chunkserver/chunkserver_entry.h
@@ -47,6 +47,9 @@ constexpr uint32_t kIOAlignedPacketSize = disk::kIoBlockSize + SFSBLOCKSIZE;
 constexpr uint32_t kIOAlignedOffset =
     disk::kIoBlockSize - cltocs::writeData::kPrefixSize;
 
+// Alias for better readability
+#define kInvalidPacket nullptr
+
 /**
  * @brief Encapsulates the data associated with a packet.
  *
@@ -109,6 +112,13 @@ struct ChunkserverEntry {
 		Closed      // ready to be deleted
 	};
 
+	// Some constants to improve readability
+	static constexpr int kInvalidSocket = -1;
+	static constexpr int kInitConnectionOK = 0;
+	static constexpr int kInitConnectionFailed = -1;
+	static constexpr uint32_t kGenerateChartExpectedPacketSize =
+	    sizeof(uint32_t);
+
 	void* workerJobPool; // Job pool assigned to a given network worker thread
 
 	ChunkserverEntry::State state = ChunkserverEntry::State::Idle;
@@ -116,7 +126,7 @@ struct ChunkserverEntry {
 	ChunkserverEntry::Mode fwdMode = ChunkserverEntry::Mode::Header;
 
 	int sock;
-	int fwdSocket = -1; ///< forwarding socket for writing
+	int fwdSocket = kInvalidSocket; ///< forwarding socket for writing
 	uint64_t connectStartTimeUSec = 0; ///< for timeout and retry (usec)
 	uint8_t connectRetryCounter = 0; ///< for timeout and retry
 	NetworkAddress fwdServer; // the next server in write chain

--- a/src/chunkserver/network_worker_thread.cc
+++ b/src/chunkserver/network_worker_thread.cc
@@ -59,7 +59,10 @@ NetworkWorkerThread::NetworkWorkerThread(uint32_t nrOfBgjobsWorkers,
 	TRACETHIS();
 	eassert(pipe(notify_pipe) != -1);
 #ifdef F_SETPIPE_SZ
-	eassert(fcntl(notify_pipe[1], F_SETPIPE_SZ, 4096 * 32));
+	// Increase the pipe size to 128 KiB to handle a larger number of jobs
+	// without backpressure. On modern linux, the default pipe size is 64 KiB.
+	static constexpr int kPageAlignedPipeSize = 4096 * 32;
+	eassert(fcntl(notify_pipe[1], F_SETPIPE_SZ, kPageAlignedPipeSize));
 #endif
 	bgJobPool_ =
 	    job_pool_new(nrOfBgjobsWorkers, bgjobsCount, &bgJobPoolWakeUpFd_);


### PR DESCRIPTION
This commit applies old PR suggestions to improve the readability of the ChunkserverEntry struct and the NetworkWorkerThread class:

- Replace old magic constants by using named constants.
- Give more context about selected constants.