### PR TITLE
build: Move cpack to another script

### DIFF
--- a/tests/ci_build/run-cpack.sh
+++ b/tests/ci_build/run-cpack.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+PROJECT_DIR="$(readlink -f "$(dirname "${BASH_SOURCE[0]}")/../..")"
+build_dir="${PROJECT_DIR}/build/saunafs-release"
+
+if [ -f "${build_dir}/CPackConfig.cmake" ]; then
+	nice cpack -B "${build_dir}" --config "${build_dir}/CPackConfig.cmake" -j "$(nproc)"
+else
+	warn "No CPack configuration found in ${build_dir}. Skipping packaging."
+fi


### PR DESCRIPTION
The cpack was creating long delays on builds that did not require it.

This commit fixes this and another quirks:
- Move cpack command to a different script.
- Remove WORKSPACE variable as conflicting with Jenkins environment.
- Set the same build type on coverage than in test.
- Allow for additional arguments to make from the command line.