### PR TITLE
fix: Fix CLang compilation

### DIFF
--- a/src/master/filesystem_node_types.h
+++ b/src/master/filesystem_node_types.h
@@ -330,16 +330,6 @@ struct FSNodeDirectory : public FSNode {
 		return entries.end();
 	}
 
-	/*! \brief Find directory entry with given node.
-	 *
-	 * \param node Node to find.
-	 * \return If node is found returns iterator pointing to directory entry containing node,
-	 *         otherwise entries.end().
-	 */
-	const_iterator find(const FSNode *node) const {
-		return find(node);
-	}
-
 	iterator find_nth(EntriesContainer::size_type nth) {
 		return entries.find_nth(nth);
 	}


### PR DESCRIPTION
CLang compiler was detecting one of the ```find``` functions in the
```FSNodeDirectory``` as recursive, which was causing the CLang build
to fail. This commit removes that function, which was not used in
the rest of the code and it is also simple.

Signed-off-by: Dave <dave@leil.io>