### PR TITLE
feat(chunkserver): Reduce strings RAM usage

### DIFF
--- a/src/chunkserver/chunk_unittest.cc
+++ b/src/chunkserver/chunk_unittest.cc
@@ -69,21 +69,27 @@ TEST_F(ChunkTests, GetFileName) {
 
 	standardChunk.setId(0x123456);
 	standardChunk.setOwner(&disk);
+	standardChunk.setVersion(0xabcd);
+	standardChunk.updateFilenamesFromVersion(0xabcd);
 	EXPECT_EQ("/mnt/chunks12/"
 	          "chunk_0000000000123456_0000ABCD" CHUNK_METADATA_FILE_EXTENSION,
-	          standardChunk.generateMetadataFilenameForVersion(0xabcd));
+	          standardChunk.fullMetaFilename());
 
 	chunk_1_of_3.setId(0x8765430d);
 	chunk_1_of_3.setOwner(&disk);
+	chunk_1_of_3.setVersion(0x654321);
+	chunk_1_of_3.updateFilenamesFromVersion(0x654321);
 	EXPECT_EQ("/mnt/chunks65/chunk_xor_1_of_3_000000008765430D_00654321"
 	          CHUNK_METADATA_FILE_EXTENSION,
-	          chunk_1_of_3.generateMetadataFilenameForVersion(0x654321));
+	          chunk_1_of_3.fullMetaFilename());
 
 	chunk_p_of_3.setId(0x1234567890abcdef);
 	chunk_p_of_3.setOwner(&disk);
+	chunk_p_of_3.setVersion(0x12345678);
+	chunk_p_of_3.updateFilenamesFromVersion(0x12345678);
 	EXPECT_EQ("/mnt/chunksAB/chunk_xor_parity_of_3_1234567890ABCDEF_12345678"
 	          CHUNK_METADATA_FILE_EXTENSION,
-	          chunk_p_of_3.generateMetadataFilenameForVersion(0x12345678));
+	          chunk_p_of_3.fullMetaFilename());
 }
 
 TEST_F(ChunkTests, GetSubfolderName) {

--- a/src/chunkserver/chunkserver-common/chunk_interface.h
+++ b/src/chunkserver/chunkserver-common/chunk_interface.h
@@ -84,13 +84,19 @@ public:
 	/// Virtual destructor needed for correct polymorphism
 	virtual ~IChunk() = default;
 
+	/// Returns the full path to the metadata file.
+	virtual std::string fullMetaFilename() const = 0;
+
 	/// Getter for the name of the metadata file.
-	virtual std::string metaFilename() const = 0;
+	virtual const std::string &metaFilename() const = 0;
 	/// Setter for the name of the metadata file.
 	virtual void setMetaFilename(const std::string& _metaFilename) = 0;
 
+	/// Returns the full path to the data file.
+	virtual std::string fullDataFilename() const = 0;
+
 	/// Getter for the name of the data file.
-	virtual std::string dataFilename() const = 0;
+	virtual const std::string &dataFilename() const = 0;
 	/// Setter for the name of the data file.
 	virtual void setDataFilename(const std::string &_dataFilename) = 0;
 

--- a/src/chunkserver/chunkserver-common/chunk_with_fd.cc
+++ b/src/chunkserver/chunkserver-common/chunk_with_fd.cc
@@ -8,13 +8,23 @@
 FDChunk::FDChunk(uint64_t chunkId, ChunkPartType type, ChunkState state)
     : id_(chunkId), type_(type), state_(state) {}
 
-std::string FDChunk::metaFilename() const { return metaFilename_; }
+std::string FDChunk::fullMetaFilename() const {
+	return owner_->metaPath() + Subfolder::getSubfolderNameGivenChunkId(id_) +
+	       "/" + metaFilename_;
+}
+
+const std::string &FDChunk::metaFilename() const { return metaFilename_; }
 
 void FDChunk::setMetaFilename(const std::string &_metaFilename) {
 	metaFilename_ = _metaFilename;
 }
 
-std::string FDChunk::dataFilename() const { return dataFilename_; }
+std::string FDChunk::fullDataFilename() const {
+	return owner_->dataPath() + Subfolder::getSubfolderNameGivenChunkId(id_) +
+	       "/" + dataFilename_;
+}
+
+const std::string &FDChunk::dataFilename() const { return dataFilename_; }
 
 void FDChunk::setDataFilename(const std::string &_dataFilename) {
 	dataFilename_ = _dataFilename;
@@ -33,8 +43,7 @@ std::string FDChunk::generateMetadataFilenameForVersion(
 std::string FDChunk::generateFilenameForVersion(uint32_t _version,
                                                 bool isForMetadata) const {
 	std::stringstream result;
-	result << (isForMetadata ? owner_->metaPath() : owner_->dataPath());
-	result << Subfolder::getSubfolderNameGivenChunkId(id_) << "/chunk_";
+	result << "chunk_";
 
 	if (slice_traits::isXor(type_)) {
 		if (slice_traits::xors::isXorParity(type_)) {

--- a/src/chunkserver/chunkserver-common/chunk_with_fd.h
+++ b/src/chunkserver/chunkserver-common/chunk_with_fd.h
@@ -59,13 +59,19 @@ public:
 	/// Virtual destructor needed for correct polymorphism
 	virtual ~FDChunk() = default;
 
+	/// Returns the full path to the metadata file.
+	std::string fullMetaFilename() const override;
+
 	/// Getter for the name of the metadata filename.
-	std::string metaFilename() const override;
+	const std::string &metaFilename() const override;
 	/// Setter for the name of the metadata filename.
 	void setMetaFilename(const std::string &_metaFilename) override;
 
+	/// Returns the full path to the data file.
+	std::string fullDataFilename() const override;
+
 	/// Getter for the name of the data filename.
-	std::string dataFilename() const override;
+	const std::string &dataFilename() const override;
 	/// Setter for the name of the data filename.
 	void setDataFilename(const std::string &_dataFilename) override;
 

--- a/src/chunkserver/chunkserver-common/disk_interface.h
+++ b/src/chunkserver/chunkserver-common/disk_interface.h
@@ -248,9 +248,9 @@ public:
 	virtual void setLastRefresh(uint32_t newLastRefresh) = 0;
 
 	/// Returns the path of the metadata directory
-	virtual std::string metaPath() const = 0;
+	virtual const std::string &metaPath() const = 0;
 	/// Returns the path of the data directory
-	virtual std::string dataPath() const = 0;
+	virtual const std::string &dataPath() const = 0;
 
 	/// Returns the reserved space in bytes defined by configuration
 	virtual uint64_t leaveFreeSpace() const = 0;

--- a/src/chunkserver/chunkserver-common/disk_with_fd.cc
+++ b/src/chunkserver/chunkserver-common/disk_with_fd.cc
@@ -241,14 +241,14 @@ int FDDisk::readChunkCrc(IChunk *chunk, uint32_t chunkVersion,
 	                                        chunk->getSignatureOffset())) {
 		const int errmem = errno;
 		safs_silent_errlog(LOG_WARNING, "readChunkCrc: file:%s - read error",
-		                   chunk->metaFilename().c_str());
+		                   chunk->fullMetaFilename().c_str());
 		errno = errmem;
 		return SAUNAFS_ERROR_IO;
 	}
 
 	if (!chunkSignature->hasValidSignatureId()) {
 		safs_pretty_syslog(LOG_WARNING, "readChunkCrc: file:%s - wrong header",
-		                   chunk->metaFilename().c_str());
+		                   chunk->fullMetaFilename().c_str());
 		errno = 0;
 		return SAUNAFS_ERROR_IO;
 	}
@@ -264,7 +264,7 @@ int FDDisk::readChunkCrc(IChunk *chunk, uint32_t chunkVersion,
 		    LOG_WARNING,
 		    "readChunkCrc: file:%s - wrong id/version/type in header "
 		    "(%016" PRIX64 "_%08" PRIX32 ", typeId %" PRIu8 ")",
-		    chunk->metaFilename().c_str(), chunkSignature->chunkId(),
+		    chunk->fullMetaFilename().c_str(), chunkSignature->chunkId(),
 		    chunkSignature->chunkVersion(),
 		    chunkSignature->chunkType().getId());
 		errno = 0;
@@ -284,7 +284,7 @@ int FDDisk::readChunkCrc(IChunk *chunk, uint32_t chunkVersion,
 			const int errmem = errno;
 			safs_silent_errlog(LOG_WARNING,
 			                   "readChunkCrc: file:%s - read error",
-			                   chunk->metaFilename().c_str());
+			                   chunk->fullMetaFilename().c_str());
 			errno = errmem;
 			updater.markReadAsFailed();
 			return SAUNAFS_ERROR_IO;
@@ -315,7 +315,7 @@ int FDDisk::fsyncFD(IChunk *chunk, bool isForMetadata) {
 	const auto fileDescriptor =
 	    isForMetadata ? chunk->metaFD() : chunk->dataFD();
 	const auto filename =
-	    isForMetadata ? chunk->metaFilename() : chunk->dataFilename();
+	    isForMetadata ? chunk->fullMetaFilename() : chunk->fullDataFilename();
 
 	if (filename.empty() || fileDescriptor < 0) {
 		return SAUNAFS_STATUS_OK;
@@ -440,13 +440,13 @@ void FDDisk::setLeaveFreeSpace(uint64_t newLeaveFreeSpace) {
 	leaveFreeSpace_ = newLeaveFreeSpace;
 }
 
-std::string FDDisk::dataPath() const { return dataPath_; }
+const std::string &FDDisk::dataPath() const { return dataPath_; }
 
 void FDDisk::setDataPath(const std::string &newDataPath) {
 	dataPath_ = newDataPath;
 }
 
-std::string FDDisk::metaPath() const { return metaPath_; }
+const std::string &FDDisk::metaPath() const { return metaPath_; }
 
 void FDDisk::setMetaPath(const std::string &newMetaPath) {
 	metaPath_ = newMetaPath;

--- a/src/chunkserver/chunkserver-common/disk_with_fd.h
+++ b/src/chunkserver/chunkserver-common/disk_with_fd.h
@@ -92,12 +92,12 @@ public:
 	int writeChunkHeader(IChunk *chunk) override;
 
 	/// Returns the path of the metadata directory
-	std::string metaPath() const override;
+	const std::string &metaPath() const override;
 	/// Sets the path of the metadata directory
 	void setMetaPath(const std::string &newMetaPath);
 
 	/// Returns the path of the data directory
-	std::string dataPath() const override;
+	const std::string &dataPath() const override;
 	/// Sets the path of the data directory
 	void setDataPath(const std::string &newDataPath);
 

--- a/src/chunkserver/chunkserver-common/hdd_utils.cc
+++ b/src/chunkserver/chunkserver-common/hdd_utils.cc
@@ -123,7 +123,7 @@ int chunkWriteCrc(IChunk *chunk) {
 			int errmem = errno;
 			safs_silent_errlog(LOG_WARNING,
 			                   "chunk_writecrc: file: %s - write error",
-			                   chunk->metaFilename().c_str());
+			                   chunk->fullMetaFilename().c_str());
 			errno = errmem;
 			updater.markWriteAsFailed();
 			return SAUNAFS_ERROR_IO;
@@ -157,7 +157,7 @@ int hddIOEnd(IChunk *chunk) {
 			// FIXME(hazeman): We are probably leaking fd here.
 			int errmem = errno;
 			safs_silent_errlog(LOG_WARNING, "hddIOEnd: file:%s - write error",
-			                   chunk->metaFilename().c_str());
+			                   chunk->fullMetaFilename().c_str());
 			errno = errmem;
 			return status;
 		}
@@ -170,7 +170,7 @@ int hddIOEnd(IChunk *chunk) {
 				int errmem = errno;
 				safs_silent_errlog(LOG_WARNING,
 				                   "hddIOEnd: file:%s - fsync error",
-				                   chunk->metaFilename().c_str());
+				                   chunk->fullMetaFilename().c_str());
 				errno = errmem;
 				return status;
 			}
@@ -238,7 +238,7 @@ int hddIOBegin(IChunk *chunk, int newFlag, uint32_t chunkVersion) {
 				if (chunk->metaFD() < 0 && errno != ENFILE) {
 					safs_silent_errlog(LOG_WARNING,
 					                   "hddIOBegin: file:%s - open error",
-					                   chunk->metaFilename().c_str());
+					                   chunk->fullMetaFilename().c_str());
 					return SAUNAFS_ERROR_IO;
 				} else if (chunk->metaFD() >= 0) {
 					gOpenChunks.acquire(chunk->metaFD(), OpenChunk(chunk));
@@ -255,7 +255,7 @@ int hddIOBegin(IChunk *chunk, int newFlag, uint32_t chunkVersion) {
 			if (chunk->metaFD() < 0) {
 				safs_silent_errlog(LOG_WARNING,
 				                   "hddIOBegin: file: %s - open error",
-				                   chunk->metaFilename().c_str());
+				                   chunk->fullMetaFilename().c_str());
 				return SAUNAFS_ERROR_IO;
 			}
 		}
@@ -274,7 +274,7 @@ int hddIOBegin(IChunk *chunk, int newFlag, uint32_t chunkVersion) {
 				gOpenChunks.release(chunk->metaFD(), eventloop_time());
 				safs_silent_errlog(LOG_WARNING,
 				                   "hddIOBegin: file:%s - read error",
-				                   chunk->metaFilename().c_str());
+				                   chunk->fullMetaFilename().c_str());
 				errno = errmem;
 				return status;
 			}

--- a/src/chunkserver/chunkserver-common/open_chunk.h
+++ b/src/chunkserver/chunkserver-common/open_chunk.h
@@ -83,7 +83,7 @@ public:
 			if (closeError) {
 				hddAddErrorAndPreserveErrno(chunk_);
 				safs_silent_errlog(LOG_WARNING,"open_chunk: file:%s - close error",
-				                   chunk_->metaFilename().c_str());
+				                   chunk_->fullMetaFilename().c_str());
 				hddReportDamagedChunk(chunk_->id(), chunk_->type());
 			}
 

--- a/src/chunkserver/hddspacemgr.cc
+++ b/src/chunkserver/hddspacemgr.cc
@@ -591,7 +591,7 @@ int hddReadCrcAndBlock(IChunk *chunk, uint16_t blockNumber,
 			safs_silent_errlog(LOG_WARNING,
 			                   "hddReadCrcAndBlock: file:%s"
 			                   " - read error on block: %d",
-			                   chunk->dataFilename().c_str(), blockNumber);
+			                   chunk->fullDataFilename().c_str(), blockNumber);
 			hddReportDamagedChunk(chunk->id(), chunk->type());
 			return SAUNAFS_ERROR_IO;
 		}
@@ -874,7 +874,7 @@ std::pair<int, IChunk *> hddInternalCreateChunk(uint64_t chunkId,
 			hddAddErrorAndPreserveErrno(chunk);
 			safs_silent_errlog(LOG_WARNING,
 			                   "create_newchunk: file:%s - write error",
-			                   chunk->metaFilename().c_str());
+			                   chunk->fullMetaFilename().c_str());
 			hddIOEnd(chunk);
 			disk->unlinkChunk(chunk);
 			hddDeleteChunkFromRegistry(chunk);
@@ -966,7 +966,7 @@ static int hddInternalTestChunk(uint64_t chunkId, uint32_t version,
 			hddAddErrorAndPreserveErrno(chunk);
 			safs_pretty_syslog(LOG_WARNING,
 			                   "testChunk: file:%s - crc error on block: %d",
-			                   chunk->metaFilename().c_str(), block);
+			                   chunk->fullMetaFilename().c_str(), block);
 			status = SAUNAFS_ERROR_CRC;
 			break;
 		}
@@ -1048,7 +1048,7 @@ static int hddInternalDuplicate(uint64_t chunkId, uint32_t chunkVersion,
 		if (dupChunk->renameChunkFile(chunkNewVersion) < 0) {
 			hddAddErrorAndPreserveErrno(originalChunk);
 			safs_silent_errlog(LOG_WARNING, "duplicate: file:%s - rename error",
-			                   originalChunk->metaFilename().c_str());
+			                   originalChunk->fullMetaFilename().c_str());
 			hddDeleteChunkFromRegistry(dupChunk);
 			hddChunkRelease(originalChunk);
 			return SAUNAFS_ERROR_IO;
@@ -1067,7 +1067,7 @@ static int hddInternalDuplicate(uint64_t chunkId, uint32_t chunkVersion,
 		if (status != SAUNAFS_STATUS_OK) {
 			hddAddErrorAndPreserveErrno(originalChunk);
 			safs_silent_errlog(LOG_WARNING, "duplicate: file:%s - write error",
-			                   dupChunk->metaFilename().c_str());
+			                   dupChunk->fullMetaFilename().c_str());
 			hddDeleteChunkFromRegistry(dupChunk);
 			hddIOEnd(originalChunk);
 			hddChunkRelease(originalChunk);
@@ -1120,7 +1120,7 @@ static int hddInternalDuplicate(uint64_t chunkId, uint32_t chunkVersion,
 			hddAddErrorAndPreserveErrno(dupChunk);
 			safs_silent_errlog(LOG_WARNING,
 			                   "duplicate: file:%s - hdr write error",
-			                   dupChunk->metaFilename().c_str());
+			                   dupChunk->fullMetaFilename().c_str());
 			hddIOEnd(dupChunk);
 			dupDisk->unlinkChunk(dupChunk);
 			hddDeleteChunkFromRegistry(dupChunk);
@@ -1148,7 +1148,7 @@ static int hddInternalDuplicate(uint64_t chunkId, uint32_t chunkVersion,
 				hddAddErrorAndPreserveErrno(originalChunk);
 				safs_silent_errlog(LOG_WARNING,
 				                   "duplicate: file:%s - data read error",
-				                   dupChunk->metaFilename().c_str());
+				                   dupChunk->fullMetaFilename().c_str());
 				hddIOEnd(dupChunk);
 				dupDisk->unlinkChunk(dupChunk);
 				hddDeleteChunkFromRegistry(dupChunk);
@@ -1183,7 +1183,7 @@ static int hddInternalDuplicate(uint64_t chunkId, uint32_t chunkVersion,
 				hddAddErrorAndPreserveErrno(dupChunk);
 				safs_silent_errlog(LOG_WARNING,
 				                   "duplicate: file:%s - data write error",
-				                   dupChunk->metaFilename().c_str());
+				                   dupChunk->fullMetaFilename().c_str());
 				hddIOEnd(dupChunk);
 				dupDisk->unlinkChunk(dupChunk);
 				hddDeleteChunkFromRegistry(dupChunk);
@@ -1236,7 +1236,7 @@ int hddInternalUpdateVersion(IChunk *chunk, uint32_t version,
 		hddAddErrorAndPreserveErrno(chunk);
 		safs_silent_errlog(LOG_WARNING,
 		                   "hddInternalUpdateVersion: file:%s - rename error",
-		                   chunk->metaFilename().c_str());
+		                   chunk->fullMetaFilename().c_str());
 		return SAUNAFS_ERROR_IO;
 	}
 	status = hddIOBegin(chunk, 0, version);
@@ -1244,7 +1244,7 @@ int hddInternalUpdateVersion(IChunk *chunk, uint32_t version,
 		hddAddErrorAndPreserveErrno(chunk);
 		safs_silent_errlog(LOG_WARNING,
 		                   "hddInternalUpdateVersion: file:%s - open error",
-		                   chunk->metaFilename().c_str());
+		                   chunk->fullMetaFilename().c_str());
 		return status;
 	}
 	status = chunk->owner()->overwriteChunkVersion(chunk, newversion);
@@ -1252,7 +1252,7 @@ int hddInternalUpdateVersion(IChunk *chunk, uint32_t version,
 		hddAddErrorAndPreserveErrno(chunk);
 		safs_silent_errlog(LOG_WARNING,
 		                   "hddInternalUpdateVersion: file:%s - write error",
-		                   chunk->metaFilename().c_str());
+		                   chunk->fullMetaFilename().c_str());
 		hddIOEnd(chunk);
 		return SAUNAFS_ERROR_IO;
 	}
@@ -1316,7 +1316,7 @@ static int hddInternalTruncate(uint64_t chunkId, ChunkPartType chunkType,
 		hddAddErrorAndPreserveErrno(chunk);
 		safs_silent_errlog(LOG_WARNING,
 		                   "truncate: file:%s - rename error",
-		                   chunk->metaFilename().c_str());
+		                   chunk->fullMetaFilename().c_str());
 		hddChunkRelease(chunk);
 		return SAUNAFS_ERROR_IO;
 	}
@@ -1333,7 +1333,7 @@ static int hddInternalTruncate(uint64_t chunkId, ChunkPartType chunkType,
 		hddAddErrorAndPreserveErrno(chunk);
 		safs_silent_errlog(LOG_WARNING,
 		                   "truncate: file:%s - write error",
-		                   chunk->metaFilename().c_str());
+		                   chunk->fullMetaFilename().c_str());
 		hddIOEnd(chunk);
 		hddChunkRelease(chunk);
 		return SAUNAFS_ERROR_IO;
@@ -1356,7 +1356,7 @@ static int hddInternalTruncate(uint64_t chunkId, ChunkPartType chunkType,
 			hddAddErrorAndPreserveErrno(chunk);
 			safs_silent_errlog(LOG_WARNING,
 			                   "truncate: file:%s - ftruncate error",
-			                   chunk->dataFilename().c_str());
+			                   chunk->fullDataFilename().c_str());
 			hddIOEnd(chunk);
 			hddChunkRelease(chunk);
 			return SAUNAFS_ERROR_IO;
@@ -1372,7 +1372,7 @@ static int hddInternalTruncate(uint64_t chunkId, ChunkPartType chunkType,
 				hddAddErrorAndPreserveErrno(chunk);
 				safs_silent_errlog(LOG_WARNING,
 				    "truncate: file:%s - ftruncate error",
-				    chunk->metaFilename().c_str());
+				    chunk->fullMetaFilename().c_str());
 				hddIOEnd(chunk);
 				hddChunkRelease(chunk);
 				return SAUNAFS_ERROR_IO;
@@ -1384,7 +1384,7 @@ static int hddInternalTruncate(uint64_t chunkId, ChunkPartType chunkType,
 			hddAddErrorAndPreserveErrno(chunk);
 			safs_silent_errlog(LOG_WARNING,
 			                   "truncate: file:%s - ftruncate error",
-			                   chunk->dataFilename().c_str());
+			                   chunk->fullDataFilename().c_str());
 			hddIOEnd(chunk);
 			hddChunkRelease(chunk);
 			return SAUNAFS_ERROR_IO;
@@ -1410,7 +1410,7 @@ static int hddInternalTruncate(uint64_t chunkId, ChunkPartType chunkType,
 					hddAddErrorAndPreserveErrno(chunk);
 					safs_silent_errlog(LOG_WARNING,
 					                   "truncate: file:%s - read error",
-					                   chunk->metaFilename().c_str());
+					                   chunk->fullMetaFilename().c_str());
 					hddIOEnd(chunk);
 					hddChunkRelease(chunk);
 					updater.markReadAsFailed();
@@ -1461,7 +1461,7 @@ static int hddInternalTruncate(uint64_t chunkId, ChunkPartType chunkType,
 						hddAddErrorAndPreserveErrno(chunk);
 						safs_silent_errlog(LOG_WARNING,
 						    "truncate: file:%s - data write error",
-						    chunk->metaFilename().c_str());
+						    chunk->fullMetaFilename().c_str());
 						hddIOEnd(chunk);
 						hddChunkRelease(chunk);
 						updater.markWriteAsFailed();
@@ -1556,7 +1556,7 @@ static int hddInternalDuplicateTruncate(uint64_t chunkId, uint32_t chunkVersion,
 			hddAddErrorAndPreserveErrno(originalChunk);
 			safs_silent_errlog(LOG_WARNING,
 			                   "duptrunc: file:%s - rename error",
-			                   originalChunk->metaFilename().c_str());
+			                   originalChunk->fullMetaFilename().c_str());
 			hddDeleteChunkFromRegistry(dupChunk);
 			hddChunkRelease(originalChunk);
 			return SAUNAFS_ERROR_IO;
@@ -1576,7 +1576,7 @@ static int hddInternalDuplicateTruncate(uint64_t chunkId, uint32_t chunkVersion,
 			hddAddErrorAndPreserveErrno(originalChunk);
 			safs_silent_errlog(LOG_WARNING,
 			                   "duptrunc: file:%s - write error",
-			                   dupChunk->metaFilename().c_str());
+			                   dupChunk->fullMetaFilename().c_str());
 			hddDeleteChunkFromRegistry(dupChunk);
 			hddIOEnd(originalChunk);
 			hddChunkRelease(originalChunk);
@@ -1646,7 +1646,7 @@ static int hddInternalDuplicateTruncate(uint64_t chunkId, uint32_t chunkVersion,
 					hddAddErrorAndPreserveErrno(originalChunk);
 					safs_silent_errlog(LOG_WARNING,
 					    "duptrunc: file:%s - data read error",
-					    originalChunk->metaFilename().c_str());
+					    originalChunk->fullMetaFilename().c_str());
 					hddIOEnd(dupChunk);
 					dupDisk->unlinkChunk(dupChunk);
 					hddDeleteChunkFromRegistry(dupChunk);
@@ -1683,7 +1683,7 @@ static int hddInternalDuplicateTruncate(uint64_t chunkId, uint32_t chunkVersion,
 					hddAddErrorAndPreserveErrno(dupChunk);
 					safs_silent_errlog(LOG_WARNING,
 					    "duptrunc: file:%s - data write error",
-					    dupChunk->metaFilename().c_str());
+					    dupChunk->fullMetaFilename().c_str());
 					hddIOEnd(dupChunk);
 					dupDisk->unlinkChunk(dupChunk);
 					hddDeleteChunkFromRegistry(dupChunk);
@@ -1708,7 +1708,7 @@ static int hddInternalDuplicateTruncate(uint64_t chunkId, uint32_t chunkVersion,
 			hddAddErrorAndPreserveErrno(dupChunk);
 			safs_silent_errlog(LOG_WARNING,
 			                   "duptrunc: file:%s - ftruncate error",
-			                   dupChunk->metaFilename().c_str());
+			                   dupChunk->fullMetaFilename().c_str());
 			hddIOEnd(dupChunk);
 			dupDisk->unlinkChunk(dupChunk);
 			hddDeleteChunkFromRegistry(dupChunk);
@@ -1733,7 +1733,7 @@ static int hddInternalDuplicateTruncate(uint64_t chunkId, uint32_t chunkVersion,
 						hddAddErrorAndPreserveErrno(originalChunk);
 						safs_silent_errlog(LOG_WARNING,
 						    "duptrunc: file:%s - data read error",
-						    originalChunk->metaFilename().c_str());
+						    originalChunk->fullMetaFilename().c_str());
 						hddIOEnd(dupChunk);
 						dupDisk->unlinkChunk(dupChunk);
 						hddDeleteChunkFromRegistry(dupChunk);
@@ -1770,7 +1770,7 @@ static int hddInternalDuplicateTruncate(uint64_t chunkId, uint32_t chunkVersion,
 						hddAddErrorAndPreserveErrno(dupChunk);
 						safs_silent_errlog(LOG_WARNING,
 						    "duptrunc: file:%s - data write error",
-						    dupChunk->metaFilename().c_str());
+						    dupChunk->fullMetaFilename().c_str());
 						hddIOEnd(dupChunk);
 						dupDisk->unlinkChunk(dupChunk);
 						hddDeleteChunkFromRegistry(dupChunk);
@@ -1795,7 +1795,7 @@ static int hddInternalDuplicateTruncate(uint64_t chunkId, uint32_t chunkVersion,
 						hddAddErrorAndPreserveErrno(originalChunk);
 						safs_silent_errlog(LOG_WARNING,
 						    "duptrunc: file:%s - data read error",
-						    originalChunk->metaFilename().c_str());
+						    originalChunk->fullMetaFilename().c_str());
 						hddIOEnd(dupChunk);
 						dupDisk->unlinkChunk(dupChunk);
 						hddDeleteChunkFromRegistry(dupChunk);
@@ -1832,7 +1832,7 @@ static int hddInternalDuplicateTruncate(uint64_t chunkId, uint32_t chunkVersion,
 						hddAddErrorAndPreserveErrno(dupChunk);
 						safs_silent_errlog(LOG_WARNING,
 						    "duptrunc: file:%s - data write error",
-						    dupChunk->metaFilename().c_str());
+						    dupChunk->fullMetaFilename().c_str());
 						hddIOEnd(dupChunk);
 						dupDisk->unlinkChunk(dupChunk);
 						hddDeleteChunkFromRegistry(dupChunk);
@@ -1859,7 +1859,7 @@ static int hddInternalDuplicateTruncate(uint64_t chunkId, uint32_t chunkVersion,
 					hddAddErrorAndPreserveErrno(originalChunk);
 					safs_silent_errlog(LOG_WARNING,
 					    "duptrunc: file:%s - data read error",
-					    originalChunk->metaFilename().c_str());
+					    originalChunk->fullMetaFilename().c_str());
 					hddIOEnd(dupChunk);
 					dupDisk->unlinkChunk(dupChunk);
 					hddDeleteChunkFromRegistry(dupChunk);
@@ -1903,7 +1903,7 @@ static int hddInternalDuplicateTruncate(uint64_t chunkId, uint32_t chunkVersion,
 					hddAddErrorAndPreserveErrno(dupChunk);
 					safs_silent_errlog(LOG_WARNING,
 					    "duptrunc: file:%s - data write error",
-					    dupChunk->metaFilename().c_str());
+					    dupChunk->fullMetaFilename().c_str());
 					hddIOEnd(dupChunk);
 					dupDisk->unlinkChunk(dupChunk);
 					hddDeleteChunkFromRegistry(dupChunk);
@@ -1931,7 +1931,7 @@ static int hddInternalDuplicateTruncate(uint64_t chunkId, uint32_t chunkVersion,
 				hddAddErrorAndPreserveErrno(dupChunk);
 				safs_silent_errlog(LOG_WARNING,
 				                   "duptrunc: file:%s - hdr write error",
-				                   dupChunk->metaFilename().c_str());
+				                   dupChunk->fullMetaFilename().c_str());
 				hddIOEnd(dupChunk);
 				dupDisk->unlinkChunk(dupChunk);
 				hddDeleteChunkFromRegistry(dupChunk);
@@ -1985,7 +1985,7 @@ int hddInternalDelete(IChunk *chunk, uint32_t version) {
 		hddAddErrorAndPreserveErrno(chunk);
 		safs_silent_errlog(LOG_WARNING,
 		                   "hddInternalDelete: file: %s - unlink error",
-		                   chunk->metaFilename().c_str());
+		                   chunk->fullMetaFilename().c_str());
 		if (err == ENOENT) {
 			hddDeleteChunkFromRegistry(chunk);
 		} else {
@@ -2147,7 +2147,7 @@ void hddTesterThread() {
 				                   "%s: tested (OK)",
 				                   chunkId, version,
 				                   chunkType.toString().c_str(),
-				                   chunk->dataFilename().c_str());
+				                   chunk->fullDataFilename().c_str());
 			}
 		}
 
@@ -2214,7 +2214,7 @@ static inline void hddAddChunkFromDiskScan(IDisk *disk,
 
 	chunk->setVersion(version);
 	chunk->updateFilenamesFromVersion(version);
-	sassert(chunk->metaFilename() == fullname);
+	sassert(chunk->fullMetaFilename() == fullname);
 
 	{
 		disk->updateChunkAttributes(chunk, true);
@@ -2464,7 +2464,7 @@ void hddTerminate(void) {
 				if (chunkWriteCrc(chunk) != SAUNAFS_STATUS_OK) {
 					safs_silent_errlog(LOG_WARNING,
 					                   "hddTerminate: file: %s - write error",
-					                   chunk->metaFilename().c_str());
+					                   chunk->fullMetaFilename().c_str());
 				}
 			}
 			gOpenChunks.purge(chunk->metaFD());


### PR DESCRIPTION
The previous version was caching the complete paths to the meta and data parts for each chunk, consuming a considerable amount of RAM.

This change only caches the basenames and uses the owner's meta and data paths to construct the final path.