### PR TITLE
chore(master): Update includes

### DIFF
--- a/src/main/main.cc
+++ b/src/main/main.cc
@@ -19,18 +19,13 @@
  */
 
 #include "common/platform.h"
+
 #include "init.h"
 
-#include <errno.h>
 #include <fcntl.h>
 #include <grp.h>
-#include <ios>
 #include <malloc.h>
 #include <pwd.h>
-#include <signal.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <strings.h>
 #include <sys/resource.h>
 #include <sys/stat.h>
@@ -38,27 +33,27 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <syslog.h>
-#include <time.h>
 #include <unistd.h>
-#include <algorithm>
-#include <atomic>
+#include <cerrno>
+#include <csignal>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
 #include <fstream>
+#include <ios>
 #include <iostream>
-#include <list>
-#include <memory>
 
-#include "config/cfg.h"
 #include "common/crc.h"
 #include "common/cwrap.h"
 #include "common/event_loop.h"
-#include "common/exceptions.h"
 #include "common/exit_status.h"
 #include "common/main.h"
 #include "common/massert.h"
 #include "common/setup.h"
-#include "common/time_utils.h"
 #include "common/version.h"
-#include "protocol/SFSCommunication.h"
+#include "config/cfg.h"
 #include "slogger/slogger.h"
 
 #if defined(SAUNAFS_HAVE_MLOCKALL)

--- a/src/master/changelog.cc
+++ b/src/master/changelog.cc
@@ -19,18 +19,17 @@
  */
 
 #include "common/platform.h"
+
 #include "master/changelog.h"
 
-#include <stdarg.h>
-#include <stdio.h>
 #include <syslog.h>
 #include <unistd.h>
+#include <cstdio>
 
-#include "config/cfg.h"
+#include <common/exceptions.h>
 #include "common/event_loop.h"
-#include "common/main.h"
-#include "common/metadata.h"
 #include "common/rotate_files.h"
+#include "config/cfg.h"
 #include "slogger/slogger.h"
 
 /// Base name of a changelog file.

--- a/src/master/changelog.h
+++ b/src/master/changelog.h
@@ -22,9 +22,8 @@
 
 #include "common/platform.h"
 
-#include <inttypes.h>
+#include <cstdint>
 #include <string>
-
 
 constexpr uint32_t kMaxLogLineSize = 200000;
 

--- a/src/master/chartsdata.cc
+++ b/src/master/chartsdata.cc
@@ -19,21 +19,20 @@
  */
 
 #include "common/platform.h"
+
 #include "master/chartsdata.h"
 
-#include <errno.h>
 #include <fcntl.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <syslog.h>
-#include <time.h>
 #include <unistd.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
 
 #include "common/charts.h"
 #include "common/event_loop.h"
 #include "master/chunks.h"
-#include "master/filesystem.h"
 #include "master/filesystem_operations.h"
 #include "master/matoclserv.h"
 

--- a/src/master/chartsdata.h
+++ b/src/master/chartsdata.h
@@ -22,7 +22,7 @@
 
 #include "common/platform.h"
 
-#include <inttypes.h>
+#include <cstdint>
 
 uint64_t chartsdata_memusage(void);
 int chartsdata_init (void);

--- a/src/master/chunk_goal_counters.cc
+++ b/src/master/chunk_goal_counters.cc
@@ -19,6 +19,7 @@
  */
 
 #include "common/platform.h"
+
 #include "master/chunk_goal_counters.h"
 
 #include "common/goal.h"

--- a/src/master/chunk_goal_counters_unittest.cc
+++ b/src/master/chunk_goal_counters_unittest.cc
@@ -19,13 +19,13 @@
  */
 
 #include "common/platform.h"
-#include "common/goal.h"
-#include "master/chunk_goal_counters.h"
-#include "master/goal_cache.h"
-#include "master/goal_config_loader.h"
 
 #include <algorithm>
 #include <map>
+
+#include "common/goal.h"
+#include "master/chunk_goal_counters.h"
+#include "master/goal_cache.h"
 
 #include <gtest/gtest.h>
 

--- a/src/master/chunks.cc
+++ b/src/master/chunks.cc
@@ -19,20 +19,21 @@
  */
 
 #include "common/platform.h"
+
 #include "master/chunks.h"
 
 #include <fcntl.h>
-#include <inttypes.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <syslog.h>
 #include <unistd.h>
-#include <unordered_map>
 #include <algorithm>
+#include <cinttypes>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <deque>
+#include <unordered_map>
 
 #include "common/chunk_copies_calculator.h"
 #include "common/chunk_version_with_todel_flag.h"
@@ -60,7 +61,7 @@
 #include "protocol/SFSCommunication.h"
 
 #ifdef METARESTORE
-#  include <time.h>
+#  include <ctime>
 #else
 #  include "config/cfg.h"
 #  include "common/main.h"

--- a/src/master/chunks.h
+++ b/src/master/chunks.h
@@ -22,7 +22,6 @@
 
 #include "common/platform.h"
 
-#include <cinttypes>
 #include <cstdio>
 
 #include "common/chunk_part_type.h"

--- a/src/master/chunkserver_db.cc
+++ b/src/master/chunkserver_db.cc
@@ -19,15 +19,16 @@
    along with SaunaFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "master/chunkserver_db.h"
 #include "common/platform.h"
 
-#include "config/cfg.h"
-#include "common/integer_sequence.h"
-#include "common/saunafs_version.h"
-#include "master/matocsserv.h"
+#include "master/chunkserver_db.h"
 
 #include <unordered_map>
+
+#include "common/integer_sequence.h"
+#include "common/saunafs_version.h"
+#include "config/cfg.h"
+#include "master/matocsserv.h"
 
 struct csdb_hash {
 	std::size_t operator()(const std::pair<uint32_t, uint16_t> &key) const {

--- a/src/master/datacachemgr.cc
+++ b/src/master/datacachemgr.cc
@@ -19,10 +19,8 @@
  */
 
 #include "common/platform.h"
-#include "master/datacachemgr.h"
 
-#include <inttypes.h>
-#include <stdio.h>
+#include "master/datacachemgr.h"
 
 /*
   open(inode,sessionid) -> isset? (inode,sessionid)

--- a/src/master/datacachemgr.h
+++ b/src/master/datacachemgr.h
@@ -22,7 +22,7 @@
 
 #include "common/platform.h"
 
-#include <inttypes.h>
+#include <cstdint>
 
 int dcm_open(uint32_t inode,uint32_t sessionid);
 void dcm_access(uint32_t inode,uint32_t sessionid);

--- a/src/master/exports.cc
+++ b/src/master/exports.cc
@@ -19,28 +19,28 @@
  */
 
 #include "common/platform.h"
+
 #include "master/exports.h"
 
-#include <errno.h>
 #include <fcntl.h>
 #include <grp.h>
-#include <inttypes.h>
 #include <pwd.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <syslog.h>
 #include <unistd.h>
+#include <cerrno>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 
-#include "config/cfg.h"
 #include "common/cwrap.h"
 #include "common/datapack.h"
-#include "common/exceptions.h"
 #include "common/event_loop.h"
+#include "common/exceptions.h"
 #include "common/goal.h"
-#include "common/main.h"
 #include "common/massert.h"
 #include "common/md5.h"
+#include "config/cfg.h"
 #include "protocol/SFSCommunication.h"
 #include "slogger/slogger.h"
 

--- a/src/master/exports.h
+++ b/src/master/exports.h
@@ -22,7 +22,7 @@
 
 #include "common/platform.h"
 
-#include <inttypes.h>
+#include <cstdint>
 
 uint32_t exports_info_size(uint8_t versmode);
 void exports_info_data(uint8_t versmode, uint8_t *buff);

--- a/src/master/filesystem.cc
+++ b/src/master/filesystem.cc
@@ -19,14 +19,17 @@
  */
 
 #include "common/platform.h"
+
 #include "master/filesystem.h"
 
-#include "config/cfg.h"
+#include <fstream>
+
 #include "common/event_loop.h"
 #include "common/lockfile.h"
 #include "common/main.h"
 #include "common/metadata.h"
 #include "common/scoped_timer.h"
+#include "config/cfg.h"
 #include "master/changelog.h"
 #include "master/chunks.h"
 #include "master/datacachemgr.h"
@@ -38,11 +41,8 @@
 #include "master/filesystem_store.h"
 #include "master/goal_config_loader.h"
 #include "master/matoclserv.h"
-#include "master/matomlserv.h"
 #include "master/metadata_dumper.h"
 #include "master/restore.h"
-
-#include <fstream>
 
 FilesystemMetadata* gMetadata = nullptr;
 

--- a/src/master/filesystem.h
+++ b/src/master/filesystem.h
@@ -22,24 +22,23 @@
 
 #include "common/platform.h"
 
-#include <inttypes.h>
-#include <string.h>
 #include <cstdint>
 #include <map>
 
 #include "common/access_control_list.h"
-#include "common/attributes.h"
 #include "common/acl_type.h"
+#include "common/attributes.h"
+#include "common/chunk_with_address_and_label.h"
 #include "common/exception.h"
 #include "common/goal.h"
 #include "common/richacl.h"
 #include "master/checksum.h"
-#include "master/filesystem_node.h"
 #include "master/fs_context.h"
 #include "master/hstring.h"
 #include "master/metadata_dumper.h"
 #include "master/setgoal_task.h"
 #include "master/settrashtime_task.h"
+#include "protocol/directory_entry.h"
 #include "protocol/named_inode_entry.h"
 #include "protocol/quota.h"
 

--- a/src/master/filesystem_checksum.cc
+++ b/src/master/filesystem_checksum.cc
@@ -19,14 +19,14 @@
 */
 
 #include "common/platform.h"
+
 #include "master/filesystem_checksum.h"
 
 #include <cstdint>
 
 #include "common/event_loop.h"
 #include "common/hashfn.h"
-#include "common/platform.h"
-#include "master/filesystem_checksum_updater.h"
+#include "master/chunks.h"
 #include "master/filesystem_metadata.h"
 #include "master/filesystem_xattr.h"
 

--- a/src/master/filesystem_checksum.h
+++ b/src/master/filesystem_checksum.h
@@ -22,12 +22,8 @@
 
 #include "common/platform.h"
 
-#include "common/saunafs_version.h"
-#include "common/massert.h"
 #include "master/checksum.h"
-#include "master/filesystem_metadata.h"
 #include "master/filesystem_node_types.h"
-#include "master/personality.h"
 
 void fsnodes_checksum_add_to_background(FSNode *node);
 void fsnodes_update_checksum(FSNode *node);

--- a/src/master/filesystem_checksum_background_updater.cc
+++ b/src/master/filesystem_checksum_background_updater.cc
@@ -19,13 +19,10 @@
 */
 
 #include "common/platform.h"
+
 #include "master/filesystem_checksum_background_updater.h"
 
-#include "common/saunafs_version.h"
-#include "master/filesystem_checksum.h"
 #include "master/filesystem_metadata.h"
-#include "master/filesystem_operations.h"
-#include "master/personality.h"
 
 ChecksumBackgroundUpdater::ChecksumBackgroundUpdater()
 	: speedLimit_(0) {  // Not important, redefined in fs_read_config_file()

--- a/src/master/filesystem_checksum_background_updater.h
+++ b/src/master/filesystem_checksum_background_updater.h
@@ -22,6 +22,7 @@
 
 #include "common/platform.h"
 
+#include "common/massert.h"
 #include "master/filesystem_node_types.h"
 #include "master/filesystem_xattr.h"
 

--- a/src/master/filesystem_checksum_updater.cc
+++ b/src/master/filesystem_checksum_updater.cc
@@ -19,6 +19,7 @@
  */
 
 #include "common/platform.h"
+
 #include "master/filesystem_checksum_updater.h"
 
 #ifndef METARESTORE

--- a/src/master/filesystem_freenode.cc
+++ b/src/master/filesystem_freenode.cc
@@ -19,6 +19,7 @@
 */
 
 #include "common/platform.h"
+
 #include "master/filesystem_freenode.h"
 
 #include "master/filesystem_metadata.h"

--- a/src/master/filesystem_freenode.h
+++ b/src/master/filesystem_freenode.h
@@ -21,7 +21,8 @@
 #pragma once
 
 #include "common/platform.h"
-#include "master/filesystem_node_types.h"
+
+#include <cstdint>
 
 /*! \brief Get next free inode number.
  *

--- a/src/master/filesystem_metadata.h
+++ b/src/master/filesystem_metadata.h
@@ -23,16 +23,13 @@
 #include "common/platform.h"
 
 #include <map>
-#include <unordered_map>
 
 #include "common/special_inode_defs.h"
 #include "master/acl_storage.h"
-#include "master/chunks.h"
-#include "master/id_pool_detainer.h"
 #include "master/filesystem_checksum_background_updater.h"
-#include "master/filesystem_freenode.h"
 #include "master/filesystem_node_types.h"
 #include "master/filesystem_xattr.h"
+#include "master/id_pool_detainer.h"
 #include "master/locks.h"
 #include "master/metadata_dumper.h"
 #include "master/quota_database.h"

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -19,6 +19,7 @@
  */
 
 #include "common/platform.h"
+
 #include "filesystem_node.h"
 
 #include <cassert>

--- a/src/master/filesystem_node.h
+++ b/src/master/filesystem_node.h
@@ -21,8 +21,10 @@
 #pragma once
 
 #include "common/platform.h"
-#include "master/filesystem_node_types.h"
+
 #include "master/filesystem_metadata.h"
+#include "master/filesystem_node_types.h"
+#include "master/fs_context.h"
 #include "protocol/directory_entry.h"
 #include "protocol/named_inode_entry.h"
 

--- a/src/master/filesystem_node_types.h
+++ b/src/master/filesystem_node_types.h
@@ -25,13 +25,10 @@
 #include <array>
 #include <cstdint>
 #include <unordered_map>
-#include <memory>
 
-#include "common/access_control_list.h"
-#include "common/acl_type.h"
-#include "common/attributes.h"
 #include "common/goal.h"
 #include "common/compact_vector.h"
+#include "protocol/SFSCommunication.h"
 
 #if defined(SAUNAFS_HAVE_64BIT_JUDY) &&               \
     (!defined(DISABLE_JUDY_FOR_TRASHPATHCONTAINER) || \
@@ -47,7 +44,6 @@
 #include <ext/pb_ds/assoc_container.hpp>
 #include <ext/pb_ds/tree_policy.hpp>
 
-#include "master/fs_context.h"
 #include "master/hstring_storage.h"
 
 #define NODEHASHBITS (22)

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -20,6 +20,7 @@
  */
 
 #include "common/platform.h"
+
 #include "master/filesystem_operations.h"
 
 #include <cstdarg>

--- a/src/master/filesystem_operations.h
+++ b/src/master/filesystem_operations.h
@@ -27,7 +27,6 @@
 #include "common/goal.h"
 #include "master/fs_context.h"
 #include "master/locks.h"
-#include "master/setgoal_task.h"
 #include "protocol/lock_info.h"
 
 #define DEFAULT_GOAL 1

--- a/src/master/filesystem_periodic.cc
+++ b/src/master/filesystem_periodic.cc
@@ -19,10 +19,10 @@
  */
 
 #include "common/platform.h"
+
 #include "master/filesystem_periodic.h"
 
 #include <cstdint>
-#include <type_traits>
 
 #include "config/cfg.h"
 #include "common/event_loop.h"
@@ -32,6 +32,7 @@
 #  include "common/flat_map.h"
 #endif
 #include "common/loop_watchdog.h"
+#include "master/chunks.h"
 #include "master/filesystem_checksum.h"
 #include "master/filesystem_checksum_updater.h"
 #include "master/filesystem_metadata.h"

--- a/src/master/filesystem_quota.cc
+++ b/src/master/filesystem_quota.cc
@@ -19,12 +19,14 @@
 
 #include "common/platform.h"
 
+#include <master/filesystem_quota.h>
+
 #include <cassert>
 
 #include "common/event_loop.h"
-#include "common/small_vector.h"
 #include "master/filesystem_checksum_updater.h"
 #include "master/filesystem_metadata.h"
+#include "master/filesystem_node.h"
 #include "master/quota_database.h"
 
 template <class T>

--- a/src/master/filesystem_quota.h
+++ b/src/master/filesystem_quota.h
@@ -20,8 +20,11 @@
 
 #include "common/platform.h"
 
-#include "master/filesystem_freenode.h"
-#include "master/quota_database.h"
+#include <cstdint>
+#include <initializer_list>
+#include <utility>
+#include "protocol/quota.h"
+#include <master/filesystem_node_types.h>
 
 /*! \brief Test if resource change exceeds quota for users and groups.
  * \param uid User id.

--- a/src/master/filesystem_snapshot.cc
+++ b/src/master/filesystem_snapshot.cc
@@ -20,10 +20,9 @@
 #include "common/platform.h"
 
 #include "config/cfg.h"
-#include "common/main.h"
 #include "master/filesystem_checksum_updater.h"
 #include "master/filesystem_metadata.h"
-#include "master/filesystem_quota.h"
+#include "master/filesystem_node.h"
 #include "master/snapshot_task.h"
 #include "master/task_manager.h"
 

--- a/src/master/filesystem_snapshot.h
+++ b/src/master/filesystem_snapshot.h
@@ -21,8 +21,8 @@
 
 #include "common/platform.h"
 
-#include "master/filesystem.h"
 #include "master/fs_context.h"
+#include "master/hstring.h"
 
 void fs_read_snapshot_config_file();
 

--- a/src/master/filesystem_store.cc
+++ b/src/master/filesystem_store.cc
@@ -19,6 +19,7 @@
 */
 
 #include "common/platform.h"
+
 #include "master/filesystem_store.h"
 
 #include <algorithm>
@@ -29,13 +30,14 @@
 
 #include "common/cwrap.h"
 #include "common/event_loop.h"
+#include "common/memory_mapped_file.h"
 #include "common/metadata.h"
 #include "common/rotate_files.h"
 #include "common/saunafs_version.h"
 #include "common/setup.h"
-#include "common/memory_mapped_file.h"
 
 #include "master/changelog.h"
+#include "master/chunks.h"
 #include "master/filesystem.h"
 #include "master/filesystem_metadata.h"
 #include "master/filesystem_node.h"

--- a/src/master/filesystem_store.h
+++ b/src/master/filesystem_store.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "common/platform.h"
+
 #include "common/exceptions.h"
 
 SAUNAFS_CREATE_EXCEPTION_CLASS(MetadataException, Exception);

--- a/src/master/filesystem_store_acl.cc
+++ b/src/master/filesystem_store_acl.cc
@@ -19,6 +19,7 @@
 */
 
 #include "common/platform.h"
+
 #include "master/filesystem_store_acl.h"
 
 #include <cstdio>

--- a/src/master/filesystem_store_acl.h
+++ b/src/master/filesystem_store_acl.h
@@ -22,8 +22,6 @@
 
 #include <cstdio>
 
-#include "common/exceptions.h"
-#include "master/metadata_dumper.h"
 #include "master/metadata_loader.h"
 
 bool fs_load_legacy_acls(MetadataLoader::Options);

--- a/src/master/filesystem_xattr.cc
+++ b/src/master/filesystem_xattr.cc
@@ -20,9 +20,9 @@
 
 #include "common/platform.h"
 
-#include "common/hashfn.h"
-#include "master/filesystem_checksum.h"
-#include "master/filesystem_xattr.h"
+#include <common/hashfn.h>
+#include <master/filesystem_metadata.h>
+#include <master/filesystem_xattr.h>
 
 static uint64_t xattr_checksum(const xattr_data_entry *xde) {
 	if (!xde) {

--- a/src/master/fs_context.h
+++ b/src/master/fs_context.h
@@ -24,11 +24,9 @@
 #include <cassert>
 #include <cstdint>
 
-#include "common/small_vector.h"
 #include "common/special_inode_defs.h"
-#include "protocol/cltoma.h"
-#include "protocol/SFSCommunication.h"
 #include "master/personality.h"
+#include "protocol/cltoma.h"
 
 /**
  * A class which represents objects describing how to perform filesystem operations

--- a/src/master/get_servers_for_new_chunk.cc
+++ b/src/master/get_servers_for_new_chunk.cc
@@ -22,7 +22,6 @@
 
 #include "master/get_servers_for_new_chunk.h"
 
-#include "common/massert.h"
 #include "common/random.h"
 #include "master/chunks.h"
 #include "master/matocsserv.h"

--- a/src/master/get_servers_for_new_chunk.h
+++ b/src/master/get_servers_for_new_chunk.h
@@ -22,7 +22,6 @@
 #include "common/platform.h"
 
 #include <cstdint>
-#include <map>
 #include <vector>
 
 #include "common/goal.h"

--- a/src/master/get_servers_for_new_chunk_unittest.cc
+++ b/src/master/get_servers_for_new_chunk_unittest.cc
@@ -19,6 +19,7 @@
  */
 
 #include "common/platform.h"
+
 #include "common/media_label.h"
 #include "master/get_servers_for_new_chunk.h"
 

--- a/src/master/goal_cache.h
+++ b/src/master/goal_cache.h
@@ -19,7 +19,9 @@
  */
 
 #include "common/platform.h"
+
 #include "common/generic_lru_cache.h"
+#include "common/goal.h"
 #include "master/chunk_goal_counters.h"
 
 struct CountersHasher {

--- a/src/master/goal_config_loader.cc
+++ b/src/master/goal_config_loader.cc
@@ -19,10 +19,10 @@
  */
 
 #include "common/platform.h"
+
 #include "master/goal_config_loader.h"
 
-#include <iterator>
-#include <sstream>
+#include <list>
 #include <string>
 
 #include "common/exceptions.h"

--- a/src/master/goal_config_loader.h
+++ b/src/master/goal_config_loader.h
@@ -19,11 +19,11 @@
  */
 
 #pragma once
+
 #include "common/platform.h"
 
 #include <cctype>
 #include <cstring>
-#include <list>
 #include <map>
 
 #include "common/goal.h"

--- a/src/master/goal_config_loader_unittest.cc
+++ b/src/master/goal_config_loader_unittest.cc
@@ -19,6 +19,7 @@
  */
 
 #include "common/platform.h"
+
 #include "master/goal_config_loader.h"
 
 #include <gtest/gtest.h>

--- a/src/master/hstorage_init.cc
+++ b/src/master/hstorage_init.cc
@@ -20,8 +20,8 @@
 
 #include "common/platform.h"
 
-#include "config/cfg.h"
 #include "common/event_loop.h"
+#include "config/cfg.h"
 #include "master/hstring_memstorage.h"
 #ifdef SAUNAFS_HAVE_DB
   #include "master/hstring_bdbstorage.h"

--- a/src/master/hstring.h
+++ b/src/master/hstring.h
@@ -5,7 +5,6 @@
 #include <algorithm>
 #include <cassert>
 #include <cstdint>
-#include <memory>
 #include <string>
 
 /*! \brief String class keeping an additional field - precomputed hash.

--- a/src/master/hstring_bdbstorage.h
+++ b/src/master/hstring_bdbstorage.h
@@ -2,11 +2,9 @@
 
 #include "common/platform.h"
 
-#include "common/exception.h"
 #include "master/hstring_storage.h"
 
 #include <db.h>
-#include <vector>
 
 namespace hstorage {
 

--- a/src/master/hstring_memstorage.cc
+++ b/src/master/hstring_memstorage.cc
@@ -3,7 +3,6 @@
 #include <cassert>
 #include <cstdlib>
 #include <cstring>
-#include <algorithm>
 
 #include "master/hstring_memstorage.h"
 

--- a/src/master/hstring_storage.h
+++ b/src/master/hstring_storage.h
@@ -4,6 +4,8 @@
 
 #include "master/hstring.h"
 
+#include <memory>
+
 namespace hstorage {
 /*! \brief Class representing type of String storage
  *

--- a/src/master/id_pool_detainer.h
+++ b/src/master/id_pool_detainer.h
@@ -1,13 +1,14 @@
 #pragma once
 
 #include "common/platform.h"
+
 #include "common/id_pool.h"
 
 #if defined(SAUNAFS_HAVE_JUDY) && defined(SAUNAFS_HAVE_WORKING_JUDY1)
 #include <Judy.h>
 #include <iterator>
 #else
-#include <stdint.h>
+#include <cstdint>
 #include <algorithm>
 #include <deque>
 #endif

--- a/src/master/id_pool_detainer_unittest.cc
+++ b/src/master/id_pool_detainer_unittest.cc
@@ -1,4 +1,5 @@
 #include "common/platform.h"
+
 #include "master/id_pool_detainer.h"
 
 #include <gtest/gtest.h>

--- a/src/master/init.h
+++ b/src/master/init.h
@@ -23,10 +23,10 @@
 #include <sys/syslog.h>
 #include <vector>
 
-#include "config/cfg.h"
 #include "common/event_loop.h"
 #include "common/random.h"
 #include "common/run_tab.h"
+#include "config/cfg.h"
 #include "master/chartsdata.h"
 #include "master/datacachemgr.h"
 #include "master/exports.h"

--- a/src/master/itree.cc
+++ b/src/master/itree.cc
@@ -19,9 +19,10 @@
  */
 
 #include "common/platform.h"
+
 #include "master/itree.h"
 
-#include <stdlib.h>
+#include <cstdlib>
 
 #include "common/massert.h"
 

--- a/src/master/itree.h
+++ b/src/master/itree.h
@@ -22,7 +22,7 @@
 
 #include "common/platform.h"
 
-#include <inttypes.h>
+#include <cstdint>
 
 void* itree_rebalance(void *o);
 void* itree_add_interval(void *o,uint32_t f,uint32_t t,uint32_t id);

--- a/src/master/locks.cc
+++ b/src/master/locks.cc
@@ -19,12 +19,13 @@
  */
 
 #include "common/platform.h"
+
 #include "master/locks.h"
+
+#include <functional>
 
 #include "common/memory_mapped_file.h"
 #include "slogger/slogger.h"
-
-#include <functional>
 
 bool LockRanges::fits(const LockRange &range) const {
 	return findCollision(range) == nullptr;

--- a/src/master/locks.h
+++ b/src/master/locks.h
@@ -22,11 +22,11 @@
 
 #include "common/platform.h"
 
+#include <unordered_map>
+
 #include "common/compact_vector.h"
 #include "common/memory_mapped_file.h"
 #include "protocol/lock_info.h"
-
-#include <unordered_map>
 
 /*! \brief Representation of half-open interval [a, b) with it's type and owner */
 struct LockRange {

--- a/src/master/masterconn.cc
+++ b/src/master/masterconn.cc
@@ -19,40 +19,40 @@
  */
 
 #include "common/platform.h"
+
 #include "master/masterconn.h"
 
-#include <errno.h>
 #include <fcntl.h>
-#include <inttypes.h>
 #include <netinet/in.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/uio.h>
 #include <syslog.h>
-#include <time.h>
 #include <unistd.h>
+#include <cerrno>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
 #include <string>
 
-#include "config/cfg.h"
 #include "common/crc.h"
-#include "common/cwrap.h"
 #include "common/datapack.h"
 #include "common/event_loop.h"
-#include "common/saunafs_version.h"
 #include "common/loop_watchdog.h"
 #include "common/massert.h"
 #include "common/metadata.h"
 #include "common/rotate_files.h"
-#include "slogger/slogger.h"
+#include "common/saunafs_version.h"
 #include "common/sockets.h"
 #include "common/time_utils.h"
+#include "config/cfg.h"
 #include "master/changelog.h"
-#include "protocol/matoml.h"
 #include "protocol/SFSCommunication.h"
+#include "protocol/matoml.h"
 #include "protocol/mltoma.h"
+#include "slogger/slogger.h"
 
 #ifndef METALOGGER
 #include "master/filesystem.h"

--- a/src/master/masterconn.h
+++ b/src/master/masterconn.h
@@ -22,9 +22,6 @@
 
 #include "common/platform.h"
 
-#include <inttypes.h>
-#include <stdio.h>
-
 int masterconn_init(void);
 
 bool masterconn_is_connected();

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -19,7 +19,7 @@
  */
 
 #include "common/platform.h"
-#include "common/sessions_file.h"
+
 #include "master/matoclserv.h"
 
 #include <errno.h>
@@ -40,7 +40,6 @@
 #include <fstream>
 #include <memory>
 
-#include "config/cfg.h"
 #include "common/charts.h"
 #include "common/chunk_type_with_address.h"
 #include "common/chunk_with_address_and_label.h"
@@ -62,8 +61,10 @@
 #include "common/saunafs_statistics.h"
 #include "common/saunafs_version.h"
 #include "common/serialized_goal.h"
+#include "common/sessions_file.h"
 #include "common/sockets.h"
 #include "common/user_groups.h"
+#include "config/cfg.h"
 #include "master/changelog.h"
 #include "master/chartsdata.h"
 #include "master/chunks.h"
@@ -71,6 +72,7 @@
 #include "master/datacachemgr.h"
 #include "master/exports.h"
 #include "master/filesystem.h"
+#include "master/filesystem_node.h"
 #include "master/filesystem_operations.h"
 #include "master/filesystem_periodic.h"
 #include "master/filesystem_snapshot.h"

--- a/src/master/matoclserv.h
+++ b/src/master/matoclserv.h
@@ -22,7 +22,7 @@
 
 #include "common/platform.h"
 
-#include <inttypes.h>
+#include <cstdint>
 
 void matoclserv_stats(uint64_t stats[5]);
 /*

--- a/src/master/matocsserv.cc
+++ b/src/master/matocsserv.cc
@@ -19,50 +19,48 @@
  */
 
 #include "common/platform.h"
+
 #include "master/matocsserv.h"
 
-#include <errno.h>
-#include <inttypes.h>
 #include <netinet/in.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <sys/types.h>
 #include <sys/uio.h>
 #include <syslog.h>
-#include <time.h>
 #include <unistd.h>
 #include <algorithm>
+#include <cerrno>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
 #include <list>
-#include <set>
 #include <vector>
 
-#include "config/cfg.h"
 #include "common/counting_sort.h"
 #include "common/datapack.h"
 #include "common/event_loop.h"
 #include "common/goal.h"
-#include "common/hashfn.h"
-#include "common/saunafs_version.h"
 #include "common/loop_watchdog.h"
 #include "common/massert.h"
-#include "errors/sfserr.h"
 #include "common/output_packet.h"
 #include "common/random.h"
+#include "common/saunafs_version.h"
 #include "common/slice_traits.h"
-#include "slogger/slogger.h"
 #include "common/sockets.h"
 #include "common/time_utils.h"
+#include "config/cfg.h"
 #include "master/chunks.h"
 #include "master/chunkserver_db.h"
 #include "master/filesystem.h"
 #include "master/get_servers_for_new_chunk.h"
 #include "master/personality.h"
+#include "protocol/SFSCommunication.h"
 #include "protocol/cstoma.h"
 #include "protocol/input_packet.h"
 #include "protocol/matocs.h"
-#include "protocol/SFSCommunication.h"
 #include "protocol/packet.h"
+#include "slogger/slogger.h"
 
 #define MaxPacketSize 500000000
 

--- a/src/master/matocsserv.h
+++ b/src/master/matocsserv.h
@@ -22,11 +22,10 @@
 
 #include "common/platform.h"
 
-#include <inttypes.h>
+#include <cstdint>
 #include <vector>
 
 #include "common/chunk_part_type.h"
-#include "common/goal.h"
 #include "common/media_label.h"
 #include "master/get_servers_for_new_chunk.h"
 #include "protocol/chunkserver_list_entry.h"

--- a/src/master/matomlserv.cc
+++ b/src/master/matomlserv.cc
@@ -20,6 +20,7 @@
  */
 
 #include "common/platform.h"
+
 #include "master/matomlserv.h"
 
 #include <errno.h>
@@ -36,21 +37,21 @@
 #include <unistd.h>
 #include <set>
 
-#include "config/cfg.h"
 #include "common/crc.h"
 #include "common/datapack.h"
 #include "common/event_loop.h"
-#include "common/saunafs_version.h"
 #include "common/loop_watchdog.h"
 #include "common/massert.h"
 #include "common/metadata.h"
-#include "slogger/slogger.h"
+#include "common/saunafs_version.h"
 #include "common/sockets.h"
+#include "config/cfg.h"
 #include "master/filesystem.h"
 #include "master/personality.h"
-#include "protocol/matoml.h"
 #include "protocol/SFSCommunication.h"
+#include "protocol/matoml.h"
 #include "protocol/mltoma.h"
+#include "slogger/slogger.h"
 
 #define MaxPacketSize 1500000
 #define OLD_CHANGES_BLOCK_SIZE 5000

--- a/src/master/matomlserv.h
+++ b/src/master/matomlserv.h
@@ -22,7 +22,7 @@
 
 #include "common/platform.h"
 
-#include <inttypes.h>
+#include <cstdint>
 
 #include "common/metadataserver_list_entry.h"
 

--- a/src/master/matotsserv.cc
+++ b/src/master/matotsserv.cc
@@ -20,16 +20,7 @@
 
 #include "common/platform.h"
 
-
-#include <list>
-
-#include "common/event_loop.h"
-#include "common/media_label.h"
-#include "common/network_address.h"
-#include "common/output_packet.h"
-#include "common/sockets.h"
-#include "common/time_utils.h"
-#include "protocol/input_packet.h"
+#include <cstdint>
 
 /// Maximum allowed length of a network packet
 [[maybe_unused]] static constexpr uint32_t kMaxPacketSize = 500000000;

--- a/src/master/metadata_dumper.cc
+++ b/src/master/metadata_dumper.cc
@@ -19,14 +19,14 @@
  */
 
 #include "common/platform.h"
+
 #include "master/metadata_dumper.h"
 
-#include <string.h>
+#include <string>
 
 #include "common/massert.h"
 #include "common/metadata.h"
 #include "master/filesystem.h"
-#include "master/personality.h"
 
 static bool createPipe(int pipefds[2]) {
 	if (pipe(pipefds) != 0) {

--- a/src/master/metadata_dumper.h
+++ b/src/master/metadata_dumper.h
@@ -22,14 +22,12 @@
 
 #include "common/platform.h"
 
-#include <errno.h>
 #include <poll.h>
 #include <syslog.h>
 #include <unistd.h>
 #include <string>
 #include <vector>
 
-#include "slogger/slogger.h"
 #include "common/time_utils.h"
 
 class MetadataDumper {

--- a/src/master/metadata_loader.cc
+++ b/src/master/metadata_loader.cc
@@ -19,6 +19,7 @@
 #include "common/platform.h"
 
 #include "master/metadata_loader.h"
+
 #include "master/filesystem_store.h"
 
 bool MetadataLoader::loadSection(const MetadataSection &section,

--- a/src/master/personality.cc
+++ b/src/master/personality.cc
@@ -19,15 +19,15 @@
  */
 
 #include "common/platform.h"
+
 #include "personality.h"
 
 #include <algorithm>
 
-#include "config/cfg.h"
-#include "common/exceptions.h"
 #include "common/event_loop.h"
+#include "common/exceptions.h"
 #include "common/main.h"
-#include "common/massert.h"
+#include "config/cfg.h"
 #include "slogger/slogger.h"
 
 namespace metadataserver {

--- a/src/master/quota_database.cc
+++ b/src/master/quota_database.cc
@@ -19,6 +19,7 @@
  */
 
 #include "common/platform.h"
+
 #include "master/quota_database.h"
 
 void QuotaDatabase::remove(QuotaOwnerType owner_type, uint32_t owner_id, QuotaRigor rigor,

--- a/src/master/quota_database.h
+++ b/src/master/quota_database.h
@@ -23,7 +23,6 @@
 #include "common/platform.h"
 
 #include <cstdint>
-#include <memory>
 #include <unordered_map>
 
 #include "common/hashfn.h"

--- a/src/master/quota_database_unittest.cc
+++ b/src/master/quota_database_unittest.cc
@@ -19,6 +19,7 @@
  */
 
 #include "common/platform.h"
+
 #include "master/quota_database.h"
 
 #include <gtest/gtest.h>

--- a/src/master/recursive_remove_task.cc
+++ b/src/master/recursive_remove_task.cc
@@ -21,6 +21,9 @@
 
 #include "master/recursive_remove_task.h"
 
+#include "master/filesystem_node.h"
+#include "master/filesystem_operations.h"
+
 bool RemoveTask::isFinished() const {
 	return current_subtask_ == subtask_.end();
 }

--- a/src/master/recursive_remove_task.h
+++ b/src/master/recursive_remove_task.h
@@ -23,9 +23,8 @@
 
 #include <memory>
 
-#include "common/special_inode_defs.h"
-#include "master/filesystem_node.h"
-#include "master/filesystem_operations.h"
+#include "master/filesystem_node_types.h"
+#include "master/fs_context.h"
 #include "master/hstring.h"
 #include "master/task_manager.h"
 

--- a/src/master/restore.cc
+++ b/src/master/restore.cc
@@ -19,19 +19,20 @@
  */
 
 #include "common/platform.h"
+
 #include "master/restore.h"
 
-#include <inttypes.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 
-#include "protocol/SFSCommunication.h"
 #include "errors/saunafs_error_codes.h"
-#include "slogger/slogger.h"
 #include "master/filesystem.h"
-#include "master/filesystem_snapshot.h"
 #include "master/filesystem_operations.h"
+#include "master/filesystem_snapshot.h"
+#include "protocol/SFSCommunication.h"
+#include "slogger/slogger.h"
 
 #define EAT(clptr,fn,vno,c) { \
 	if (*(clptr)!=(c)) { \

--- a/src/master/restore.h
+++ b/src/master/restore.h
@@ -22,7 +22,7 @@
 
 #include "common/platform.h"
 
-#include <inttypes.h>
+#include <cstdint>
 
 enum class RestoreRigor { kIgnoreParseErrors, kDontIgnoreAnyErrors };
 

--- a/src/master/setgoal_task.h
+++ b/src/master/setgoal_task.h
@@ -21,8 +21,8 @@
 
 #include "common/platform.h"
 
+#include "master/filesystem_node_types.h"
 #include "master/task_manager.h"
-#include "master/filesystem_node.h"
 
 class SetGoalTask : public TaskManager::Task {
 public:

--- a/src/master/settrashtime_task.cc
+++ b/src/master/settrashtime_task.cc
@@ -23,6 +23,7 @@
 #include "master/settrashtime_task.h"
 
 #include "master/filesystem_checksum.h"
+#include "master/filesystem_node.h"
 #include "master/filesystem_operations.h"
 
 int SetTrashtimeTask::execute(uint32_t ts, intrusive_list<Task> &work_queue) {

--- a/src/master/settrashtime_task.h
+++ b/src/master/settrashtime_task.h
@@ -21,7 +21,7 @@
 
 #include "common/platform.h"
 
-#include "master/filesystem_node.h"
+#include "master/filesystem_node_types.h"
 #include "master/task_manager.h"
 
 class SetTrashtimeTask : public TaskManager::Task {

--- a/src/master/snapshot_task.cc
+++ b/src/master/snapshot_task.cc
@@ -21,8 +21,10 @@
 
 #include "master/snapshot_task.h"
 
+#include "master/chunks.h"
 #include "master/filesystem_checksum.h"
 #include "master/filesystem_metadata.h"
+#include "master/filesystem_node.h"
 #include "master/filesystem_operations.h"
 #include "master/filesystem_quota.h"
 

--- a/src/master/snapshot_task.h
+++ b/src/master/snapshot_task.h
@@ -22,13 +22,11 @@
 #include "common/platform.h"
 
 #include <cassert>
-#include <functional>
-#include <list>
 #include <string>
 
-#include "master/task_manager.h"
-#include "master/filesystem_node.h"
+#include "master/filesystem_node_types.h"
 #include "master/hstring.h"
+#include "master/task_manager.h"
 
 /*! \brief Implementation of Snapshot Task to work with Task Manager.
  *

--- a/src/master/task_manager.cc
+++ b/src/master/task_manager.cc
@@ -22,9 +22,6 @@
 #include "master/task_manager.h"
 
 #include "common/loop_watchdog.h"
-#include "master/filesystem_metadata.h"
-#include "master/filesystem_node.h"
-#include "protocol/SFSCommunication.h"
 
 void TaskManager::Job::finalize(int status) {
 	if (finish_callback_) {

--- a/src/master/task_manager.h
+++ b/src/master/task_manager.h
@@ -23,7 +23,6 @@
 
 #include <functional>
 #include <list>
-#include <memory>
 #include <string>
 
 #include "common/intrusive_list.h"

--- a/src/master/topology.cc
+++ b/src/master/topology.cc
@@ -19,23 +19,23 @@
  */
 
 #include "common/platform.h"
+
 #include "master/topology.h"
 
-#include <errno.h>
 #include <fcntl.h>
-#include <inttypes.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <syslog.h>
 #include <unistd.h>
+#include <cerrno>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 
-#include "config/cfg.h"
 #include "common/event_loop.h"
-#include "common/massert.h"
+#include "config/cfg.h"
 #include "errors/sfserr.h"
-#include "slogger/slogger.h"
 #include "master/itree.h"
+#include "slogger/slogger.h"
 
 static void *racktree;
 static char *TopologyFileName;

--- a/src/master/topology.h
+++ b/src/master/topology.h
@@ -22,7 +22,7 @@
 
 #include "common/platform.h"
 
-#include <inttypes.h>
+#include <cstdint>
 
 uint8_t topology_distance(uint32_t ip1,uint32_t ip2);
 int topology_init(void);


### PR DESCRIPTION
Previously, there were too many unused includes.

This commit removes the unneeded includes in the master files.
The includes were also sorted according clang-format, except for:

- common/platform.h is the first and should be in a separate group.
- If it is a .cc with associated .h, then the .h follows
  common/platform.h. Also in a separate group.
- Then the system libraries/dependencies (sorted by clang-format).
- Then the saunafs includes.