### PR TITLE
fix: Fixes on sfsappendchunks + test

### DIFF
--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -1156,19 +1156,7 @@ uint8_t fsnodes_appendchunks(uint32_t ts, FSNodeFile *dst, FSNodeFile *src) {
 	fsnodes_get_stats(dst, &psr);
 
 	uint32_t result_chunks = src_chunks + dst_chunks;
-
-	if (result_chunks > dst->chunks.size()) {
-		uint32_t new_size;
-		if (result_chunks <= 8) {
-			new_size = result_chunks;
-		} else if (result_chunks <= 64) {
-			new_size = ((result_chunks - 1) & 0xFFFFFFF8) + 8;
-		} else {
-			new_size = ((result_chunks - 1) & 0xFFFFFFC0) + 64;
-		}
-		assert(new_size >= result_chunks);
-		dst->chunks.resize(new_size, 0);
-	}
+	dst->chunks.resize(result_chunks, 0);
 
 	std::copy(src->chunks.begin(), src->chunks.begin() + src_chunks, dst->chunks.begin() + dst_chunks);
 

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -1183,7 +1183,8 @@ uint8_t fsnodes_appendchunks(uint32_t ts, FSNodeFile *dst, FSNodeFile *src) {
 		}
 	}
 
-	uint64_t length = (dst_chunks << SFSCHUNKBITS) + src->length;
+	uint64_t length =
+	    (static_cast<uint64_t>(dst_chunks) << SFSCHUNKBITS) + src->length;
 	if (dst->type == FSNode::kTrash) {
 		gMetadata->trashspace -= dst->length;
 		gMetadata->trashspace += length;

--- a/tests/test_suites/SanityChecks/test_sfstools.sh
+++ b/tests/test_suites/SanityChecks/test_sfstools.sh
@@ -58,3 +58,9 @@ sfssetquota -d 1000000 2000 1000000 2000 dir
 
 quota=$(sfsrepquota -d dir)
 assert_equals "$quota" "$(saunafs repquota -d dir)"
+
+# Create a 25 chunks file and make a 4x snapshot of it
+FILE_SIZE=1600M file-generate test3
+sfsappendchunks 4xtest3 test3 test3 test3 test3
+assert_equals $((4*25)) $(sfsfileinfo 4xtest3 | grep "chunk" | wc -l)
+assert_equals $((4*25*64*1024*1024)) $(sfsdirinfo 4xtest3 | grep "length:" | awk '{print $2}')


### PR DESCRIPTION
When appending chunks of relatively big files to some destination file
the resulting size could be wrong. This issue was caused by an overflow
when calculating new size of the destination file.

The previous version of the code was using a legacy (C-like) approach
to enlarge the chunk list of the resulting file of appending chunks. It
was increasing one by one when too small, then eight by eight then 64
at a time, and having at as many as needed.

This approach had a downside, which is that the real number of chunks
of that file was not shown correctly when using fileinfo tool, and
extra chunks were appearing without data, which might be confusing. It
was also not fulfilling any purpose, motivation for that change was
reducing the malloc calls when requesting memory for new chunks, but
the vector's resize manages to perform this already quite efficient.

This PR also improves sfstools test to check the prevous two issues.

Signed-off-by: Dave <dave@leil.io>