### PR TITLE
feat: Use quota in volume size option

### DIFF
--- a/doc/sfsmount.1.adoc
+++ b/doc/sfsmount.1.adoc
@@ -228,14 +228,18 @@ huge amount of virtual memory. This can influence performance by reducing
 memory fragmentation and improving cache locality, but it may also lead to
 contention and reduced parallelism in multi-threaded applications.
 Use it in constrained memory environments, recommended values are 4 or 8.
-(default is 0: disabled or let glibc decide)
+(default is 0: disabled or let glibc decide).
 
 *-o sfslognotificationarea=*'0|1'::  
 Enable/disable logging to Linux notification area (default: 0).
 
 *-o sfsmessagesuppressionperiod=*'N'::
 Set period of message suppression in seconds for logging on notification area 
-(default: 10)
+(default: 10).
+
+*-o usequotainvolumesize=*'0|1'::
+When set to 1, use the user and group specific quota hard limit to calculate
+the volume size (default: 0).
 
 General mount options (see *mount*(8) manual):
 

--- a/doc/sfsmount.1.adoc
+++ b/doc/sfsmount.1.adoc
@@ -237,6 +237,10 @@ Enable/disable logging to Linux notification area (default: 0).
 Set period of message suppression in seconds for logging on notification area 
 (default: 10).
 
+*-o statfscachetimeout=*'MSEC'::
+Set statfs cache timeout in milliseconds. When equal to 0 the cache is 
+disabled (default: 0).
+
 *-o usequotainvolumesize=*'0|1'::
 When set to 1, use the user and group specific quota hard limit to calculate
 the volume size (default: 0).

--- a/src/mount/fuse/main.cc
+++ b/src/mount/fuse/main.cc
@@ -263,6 +263,7 @@ static int mainloop(struct fuse_args *args, struct fuse_cmdline_opts *fuse_opts,
 	params.ignore_flush = gMountOptions.ignoreflush;
 	params.log_notifications_area = gMountOptions.lognotificationarea;
 	params.message_suppression_period = gMountOptions.messagesuppressionperiod;
+	params.use_quota_in_volume_size = gMountOptions.usequotainvolumesize;
 
 	if (!gMountOptions.meta) {
 		SaunaClient::fs_init(params);

--- a/src/mount/fuse/main.cc
+++ b/src/mount/fuse/main.cc
@@ -263,6 +263,7 @@ static int mainloop(struct fuse_args *args, struct fuse_cmdline_opts *fuse_opts,
 	params.ignore_flush = gMountOptions.ignoreflush;
 	params.log_notifications_area = gMountOptions.lognotificationarea;
 	params.message_suppression_period = gMountOptions.messagesuppressionperiod;
+	params.statfs_cache_timeout = gMountOptions.statfscachetimeout;
 	params.use_quota_in_volume_size = gMountOptions.usequotainvolumesize;
 
 	if (!gMountOptions.meta) {

--- a/src/mount/fuse/mount_config.cc
+++ b/src/mount/fuse/mount_config.cc
@@ -96,6 +96,7 @@ struct fuse_opt gSfsOptsStage2[] = {
 	SFS_OPT("limitglibcmallocarenas=%d", limitglibcmallocarenas, 0),
 	SFS_OPT("sfslognotificationarea=%d", lognotificationarea, 0),
 	SFS_OPT("sfsmessagesuppressionperiod=%u", messagesuppressionperiod, 0),
+	SFS_OPT("usequotainvolumesize=%d", usequotainvolumesize, 0),
 
 	SFS_OPT("enablefilelocks=%u", filelocks, 0),
 	SFS_OPT("nonempty", nonemptymount, 1),
@@ -244,6 +245,8 @@ void usage(const char *progname) {
 "    -o sfslognotificationarea=0|1  enable/disable logging to Linux notification area (default: %d)\n"
 "    -o sfsmessagesuppressionperiod=N  set period of message suppression in seconds for logging on "
 				"notification area (default: %u)\n"
+"    -o usequotainvolumesize=0|1  when set to 1, use the user and group specific quota hard "
+				"limit to calculate the volume size (default: %u)\n"
 "\n",
 		SaunaClient::FsInitParams::kDefaultCacheExpirationTime,
 		SaunaClient::FsInitParams::kDefaultReadaheadMaxWindowSize,
@@ -276,7 +279,8 @@ void usage(const char *progname) {
 		SaunaClient::FsInitParams::kDefaultSubfolder,
 		SaunaClient::FsInitParams::kDefaultLimitGlibcMallocArenas,
 		SaunaClient::FsInitParams::kDefaultLogNotificationArea,
-		SaunaClient::FsInitParams::kDefaultMessageSuppressionPeriod
+		SaunaClient::FsInitParams::kDefaultMessageSuppressionPeriod,
+		SaunaClient::FsInitParams::kDefaultUseQuotaInVolumeSize
 	);
 	printf(
 "CMODE can be set to:\n"

--- a/src/mount/fuse/mount_config.cc
+++ b/src/mount/fuse/mount_config.cc
@@ -96,6 +96,7 @@ struct fuse_opt gSfsOptsStage2[] = {
 	SFS_OPT("limitglibcmallocarenas=%d", limitglibcmallocarenas, 0),
 	SFS_OPT("sfslognotificationarea=%d", lognotificationarea, 0),
 	SFS_OPT("sfsmessagesuppressionperiod=%u", messagesuppressionperiod, 0),
+	SFS_OPT("statfscachetimeout=%d", statfscachetimeout, 0),
 	SFS_OPT("usequotainvolumesize=%d", usequotainvolumesize, 0),
 
 	SFS_OPT("enablefilelocks=%u", filelocks, 0),
@@ -245,6 +246,8 @@ void usage(const char *progname) {
 "    -o sfslognotificationarea=0|1  enable/disable logging to Linux notification area (default: %d)\n"
 "    -o sfsmessagesuppressionperiod=N  set period of message suppression in seconds for logging on "
 				"notification area (default: %u)\n"
+"    -o statfscachetimeout=MSEC  set statfs cache timeout in milliseconds. When equal to 0 "
+				"the cache is disabled (default: %u)\n"
 "    -o usequotainvolumesize=0|1  when set to 1, use the user and group specific quota hard "
 				"limit to calculate the volume size (default: %u)\n"
 "\n",
@@ -280,6 +283,7 @@ void usage(const char *progname) {
 		SaunaClient::FsInitParams::kDefaultLimitGlibcMallocArenas,
 		SaunaClient::FsInitParams::kDefaultLogNotificationArea,
 		SaunaClient::FsInitParams::kDefaultMessageSuppressionPeriod,
+		SaunaClient::FsInitParams::kDefaultStatfsCacheTo,
 		SaunaClient::FsInitParams::kDefaultUseQuotaInVolumeSize
 	);
 	printf(

--- a/src/mount/fuse/mount_config.h
+++ b/src/mount/fuse/mount_config.h
@@ -118,6 +118,7 @@ struct sfsopts_ {
 	unsigned limitglibcmallocarenas;
 	int lognotificationarea;
 	unsigned messagesuppressionperiod;
+	int statfscachetimeout;
 	int usequotainvolumesize;
 
 	sfsopts_()
@@ -177,6 +178,7 @@ struct sfsopts_ {
 		directio(SaunaClient::FsInitParams::kDirectIO),
 		ignoreflush(SaunaClient::FsInitParams::kDefaultIgnoreFlush),
 		limitglibcmallocarenas(SaunaClient::FsInitParams::kDefaultLimitGlibcMallocArenas),
+		statfscachetimeout(SaunaClient::FsInitParams::kDefaultStatfsCacheTo),
 		usequotainvolumesize(SaunaClient::FsInitParams::kDefaultUseQuotaInVolumeSize)
 	{ }
 };

--- a/src/mount/fuse/mount_config.h
+++ b/src/mount/fuse/mount_config.h
@@ -118,6 +118,7 @@ struct sfsopts_ {
 	unsigned limitglibcmallocarenas;
 	int lognotificationarea;
 	unsigned messagesuppressionperiod;
+	int usequotainvolumesize;
 
 	sfsopts_()
 		: masterhost(NULL),
@@ -175,7 +176,8 @@ struct sfsopts_ {
 		nonemptymount(SaunaClient::FsInitParams::kDefaultNonEmptyMounts),
 		directio(SaunaClient::FsInitParams::kDirectIO),
 		ignoreflush(SaunaClient::FsInitParams::kDefaultIgnoreFlush),
-		limitglibcmallocarenas(SaunaClient::FsInitParams::kDefaultLimitGlibcMallocArenas)
+		limitglibcmallocarenas(SaunaClient::FsInitParams::kDefaultLimitGlibcMallocArenas),
+		usequotainvolumesize(SaunaClient::FsInitParams::kDefaultUseQuotaInVolumeSize)
 	{ }
 };
 

--- a/src/mount/mastercomm.h
+++ b/src/mount/mastercomm.h
@@ -121,6 +121,8 @@ void fs_setlk_interrupt(const safs_locks::InterruptData &data);
 
 uint8_t fs_makesnapshot(uint32_t src_inode, uint32_t dst_parent, const std::string &dst_name,
 	                uint32_t uid, uint32_t gid, uint8_t can_overwrite, uint32_t &job_id);
+uint8_t fs_get_self_quota(uint32_t uid, uint32_t gid,
+                          std::vector<QuotaEntry> &quota_entries);
 uint8_t fs_getgoal(uint32_t inode, std::string &goal);
 uint8_t fs_setgoal(uint32_t inode, uint32_t uid, const std::string &goal_name, uint8_t smode);
 

--- a/src/mount/sauna_client.h
+++ b/src/mount/sauna_client.h
@@ -88,6 +88,7 @@ struct FsInitParams {
 	static constexpr bool     kDefaultIgnoreFlush = false;
 	static constexpr int      kDefaultLogNotificationArea = 0;
 	static constexpr unsigned kDefaultMessageSuppressionPeriod = 10;
+	static constexpr bool     kDefaultUseQuotaInVolumeSize = false;
 #ifdef _WIN32
 	static constexpr unsigned kDefaultWriteCacheSize = 50;
 	static constexpr unsigned kDefaultCleanAcquiredFilesPeriod = 0;
@@ -164,7 +165,7 @@ struct FsInitParams {
 	             enable_status_updater_thread(kDefaultEnableStatusUpdaterThread),
 	             ignore_utimens_update(kDefaultIgnoreUtimensUpdate),
 #endif
-	             ignore_flush(kDefaultIgnoreFlush), 
+	             ignore_flush(kDefaultIgnoreFlush), use_quota_in_volume_size(kDefaultUseQuotaInVolumeSize),
 	             verbose(kDefaultVerbose), 
 	             direct_io(kDirectIO),
 	             limit_glibc_malloc_arenas(kDefaultLimitGlibcMallocArenas),
@@ -207,11 +208,11 @@ struct FsInitParams {
 	             enable_status_updater_thread(kDefaultEnableStatusUpdaterThread),
 	             ignore_utimens_update(kDefaultIgnoreUtimensUpdate),
 #endif
-	             ignore_flush(kDefaultIgnoreFlush), 
-	             verbose(kDefaultVerbose), 
+	             ignore_flush(kDefaultIgnoreFlush), use_quota_in_volume_size(kDefaultUseQuotaInVolumeSize),
+	             verbose(kDefaultVerbose),
 	             direct_io(kDirectIO),
 	             limit_glibc_malloc_arenas(kDefaultLimitGlibcMallocArenas),
-	             log_notifications_area(kDefaultLogNotificationArea), 
+	             log_notifications_area(kDefaultLogNotificationArea),
 	             message_suppression_period(kDefaultMessageSuppressionPeriod) {
 
 	}
@@ -270,6 +271,7 @@ struct FsInitParams {
 #endif
 
 	bool ignore_flush;
+	bool use_quota_in_volume_size;
 	bool verbose;
 	bool direct_io;
 	unsigned limit_glibc_malloc_arenas;

--- a/src/mount/sauna_client.h
+++ b/src/mount/sauna_client.h
@@ -61,15 +61,6 @@ struct FsInitParams {
 	static constexpr const char *kDefaultSubfolder = DEFAULT_MOUNTED_SUBFOLDER;
 	static constexpr bool     kDefaultDoNotRememberPassword = false;
 	static constexpr bool     kDefaultDelayedInit = false;
-#ifdef _WIN32
-	static constexpr unsigned kDefaultReportReservedPeriod = 60;
-	static constexpr const char *kDefaultUmaskDir = "002"; // means rwxrwxr-x permissions mask, 775 default permissions
-	static constexpr const char *kDefaultUmaskFile = "002"; // means rwxrwxr-x permissions mask, 775 default permissions
-	static constexpr const char *kDefaultLogLevel = "warn";
-	static constexpr const char *kDefaultLogFlushLevel = "err";
-#else
-	static constexpr unsigned kDefaultReportReservedPeriod = 30;
-#endif
 	static constexpr unsigned kDefaultIoRetries = 30;
 	static constexpr unsigned kDefaultRoundTime = 200;
 	static constexpr unsigned kDefaultChunkserverConnectTo = 2000;
@@ -91,13 +82,22 @@ struct FsInitParams {
 	static constexpr unsigned kDefaultStatfsCacheTo = 0;
 	static constexpr bool     kDefaultUseQuotaInVolumeSize = false;
 #ifdef _WIN32
+	static constexpr unsigned kDefaultReportReservedPeriod = 60;
+	static constexpr const char *kDefaultUmaskDir = "002"; // means rwxrwxr-x permissions mask, 775 default permissions
+	static constexpr const char *kDefaultUmaskFile = "002"; // means rwxrwxr-x permissions mask, 775 default permissions
+	static constexpr const char *kDefaultLogLevel = "warn";
+	static constexpr const char *kDefaultLogFlushLevel = "err";
 	static constexpr unsigned kDefaultWriteCacheSize = 50;
 	static constexpr unsigned kDefaultCleanAcquiredFilesPeriod = 0;
 	static constexpr unsigned kDefaultCleanAcquiredFilesTimeout = 0;
 	static constexpr int      kDefaultEnableStatusUpdaterThread = 0;
 	static constexpr bool     kDefaultIgnoreUtimensUpdate = false;
+	static constexpr bool     kDefaultMkdirCopySgid = false;
 #else
+	static constexpr unsigned kDefaultReportReservedPeriod = 30;
 	static constexpr unsigned kDefaultWriteCacheSize = 0;
+	static constexpr unsigned kDefaultLimitGlibcMallocArenas = 0;
+	static constexpr bool     kDefaultMkdirCopySgid = true;
 #endif
 	static constexpr unsigned kDefaultCachePerInodePercentage = 25;
 	static constexpr unsigned kDefaultWriteWorkers = 10;
@@ -111,11 +111,6 @@ struct FsInitParams {
 	static constexpr unsigned kDefaultDirentryCacheSize = 100000;
 	static constexpr double   kDefaultEntryCacheTimeout = 0.0;
 	static constexpr double   kDefaultAttrCacheTimeout = 1.0;
-#ifdef __linux__
-	static constexpr bool     kDefaultMkdirCopySgid = true;
-#else
-	static constexpr bool     kDefaultMkdirCopySgid = false;
-#endif
 #if defined(DEFAULT_SUGID_CLEAR_MODE_EXT)
 	static constexpr SugidClearMode kDefaultSugidClearMode = SugidClearMode::kExt;
 #elif defined(DEFAULT_SUGID_CLEAR_MODE_BSD)
@@ -130,7 +125,6 @@ struct FsInitParams {
 	static constexpr unsigned kDefaultAclCacheSize = 1000;
 	static constexpr bool     kDefaultVerbose = false;
 	static constexpr bool     kDirectIO = false;
-	static constexpr unsigned kDefaultLimitGlibcMallocArenas = 0;
 	// Thank you, GCC 4.6, for no delegating constructors
 	FsInitParams()
 	             : bind_host(), host(), port(), meta(false), mountpoint(), subfolder(kDefaultSubfolder),
@@ -165,15 +159,14 @@ struct FsInitParams {
 	             clean_acquired_files_timeout(kDefaultCleanAcquiredFilesTimeout),
 	             enable_status_updater_thread(kDefaultEnableStatusUpdaterThread),
 	             ignore_utimens_update(kDefaultIgnoreUtimensUpdate),
+#else
+	             limit_glibc_malloc_arenas(kDefaultLimitGlibcMallocArenas),
 #endif
 	             ignore_flush(kDefaultIgnoreFlush), statfs_cache_timeout(kDefaultStatfsCacheTo),
 				 use_quota_in_volume_size(kDefaultUseQuotaInVolumeSize),
-	             verbose(kDefaultVerbose),
-	             direct_io(kDirectIO),
-	             limit_glibc_malloc_arenas(kDefaultLimitGlibcMallocArenas),
+	             verbose(kDefaultVerbose), direct_io(kDirectIO),
 	             log_notifications_area(kDefaultLogNotificationArea), 
 	             message_suppression_period(kDefaultMessageSuppressionPeriod) {
-
 	}
 
 	FsInitParams(const std::string &bind_host, const std::string &host, const std::string &port, const std::string &mountpoint)
@@ -209,15 +202,14 @@ struct FsInitParams {
 	             clean_acquired_files_timeout(kDefaultCleanAcquiredFilesTimeout),
 	             enable_status_updater_thread(kDefaultEnableStatusUpdaterThread),
 	             ignore_utimens_update(kDefaultIgnoreUtimensUpdate),
-#endif
+#else
+	             limit_glibc_malloc_arenas(kDefaultLimitGlibcMallocArenas),
+#endif 
 	             ignore_flush(kDefaultIgnoreFlush), statfs_cache_timeout(kDefaultStatfsCacheTo),
 				 use_quota_in_volume_size(kDefaultUseQuotaInVolumeSize),
-	             verbose(kDefaultVerbose),
-	             direct_io(kDirectIO),
-	             limit_glibc_malloc_arenas(kDefaultLimitGlibcMallocArenas),
+	             verbose(kDefaultVerbose), direct_io(kDirectIO),
 	             log_notifications_area(kDefaultLogNotificationArea),
 	             message_suppression_period(kDefaultMessageSuppressionPeriod) {
-
 	}
 
 	std::string bind_host;
@@ -271,6 +263,8 @@ struct FsInitParams {
 	unsigned clean_acquired_files_timeout;
 	unsigned enable_status_updater_thread;
 	unsigned ignore_utimens_update;
+#else
+	unsigned limit_glibc_malloc_arenas;
 #endif
 
 	bool ignore_flush;
@@ -278,7 +272,6 @@ struct FsInitParams {
 	bool use_quota_in_volume_size;
 	bool verbose;
 	bool direct_io;
-	unsigned limit_glibc_malloc_arenas;
 	int log_notifications_area;
 	unsigned message_suppression_period;
 

--- a/src/mount/sauna_client.h
+++ b/src/mount/sauna_client.h
@@ -88,6 +88,7 @@ struct FsInitParams {
 	static constexpr bool     kDefaultIgnoreFlush = false;
 	static constexpr int      kDefaultLogNotificationArea = 0;
 	static constexpr unsigned kDefaultMessageSuppressionPeriod = 10;
+	static constexpr unsigned kDefaultStatfsCacheTo = 0;
 	static constexpr bool     kDefaultUseQuotaInVolumeSize = false;
 #ifdef _WIN32
 	static constexpr unsigned kDefaultWriteCacheSize = 50;
@@ -165,8 +166,9 @@ struct FsInitParams {
 	             enable_status_updater_thread(kDefaultEnableStatusUpdaterThread),
 	             ignore_utimens_update(kDefaultIgnoreUtimensUpdate),
 #endif
-	             ignore_flush(kDefaultIgnoreFlush), use_quota_in_volume_size(kDefaultUseQuotaInVolumeSize),
-	             verbose(kDefaultVerbose), 
+	             ignore_flush(kDefaultIgnoreFlush), statfs_cache_timeout(kDefaultStatfsCacheTo),
+				 use_quota_in_volume_size(kDefaultUseQuotaInVolumeSize),
+	             verbose(kDefaultVerbose),
 	             direct_io(kDirectIO),
 	             limit_glibc_malloc_arenas(kDefaultLimitGlibcMallocArenas),
 	             log_notifications_area(kDefaultLogNotificationArea), 
@@ -208,7 +210,8 @@ struct FsInitParams {
 	             enable_status_updater_thread(kDefaultEnableStatusUpdaterThread),
 	             ignore_utimens_update(kDefaultIgnoreUtimensUpdate),
 #endif
-	             ignore_flush(kDefaultIgnoreFlush), use_quota_in_volume_size(kDefaultUseQuotaInVolumeSize),
+	             ignore_flush(kDefaultIgnoreFlush), statfs_cache_timeout(kDefaultStatfsCacheTo),
+				 use_quota_in_volume_size(kDefaultUseQuotaInVolumeSize),
 	             verbose(kDefaultVerbose),
 	             direct_io(kDirectIO),
 	             limit_glibc_malloc_arenas(kDefaultLimitGlibcMallocArenas),
@@ -271,6 +274,7 @@ struct FsInitParams {
 #endif
 
 	bool ignore_flush;
+	unsigned statfs_cache_timeout;
 	bool use_quota_in_volume_size;
 	bool verbose;
 	bool direct_io;

--- a/tests/test_suites/ShortSystemTests/test_use_quota_in_volume_size.sh
+++ b/tests/test_suites/ShortSystemTests/test_use_quota_in_volume_size.sh
@@ -1,0 +1,74 @@
+timeout_set 20 seconds
+
+CHUNKSERVERS=1 \
+	USE_RAMDISK=YES \
+	SFSEXPORTS_EXTRA_OPTIONS="allcanchangequota" \
+	MOUNT_EXTRA_CONFIG="usequotainvolumesize=1,statfscachetimeout=1" \
+	setup_local_empty_saunafs info
+
+get_mountpoint_total_space() {
+	df --block-size=1 | grep "${info[mount0]}" | awk '{print $2}'
+}
+
+get_mountpoint_available_space() {
+	df --block-size=1 | grep "${info[mount0]}" | awk '{print $4}'
+}
+
+cd "${info[mount0]}"
+
+user_limit_mb=512
+user_limit=$((user_limit_mb*1024*1024))
+current_total_space=$(get_mountpoint_total_space)
+assert_less_than ${user_limit} ${current_total_space}
+echo "OK: the total space is more than ${user_limit_mb}MiB"
+
+# Set the quota to 512MiB for current user (saunafstest)
+saunafs setquota -u $(id -u) 0 ${user_limit} 0 0 .
+assert_success dd if=/dev/zero of=file1 bs=1M count=$((user_limit_mb))
+assert_equals $(get_mountpoint_total_space) ${user_limit}
+echo "Ok: the total space is exactly ${user_limit_mb}MiB"
+# Check the available space is exactly zero
+assert_equals $(get_mountpoint_available_space) 0
+echo "Ok: the available space is exactly zero"
+
+# Check the quota is actually enforced
+assert_failure dd if=/dev/zero of=file1 bs=1M count=$((user_limit_mb+1))
+
+# Check the tweaks is working for UseQuotaInVolumeSize
+assert_equals $(cat .saunafs_tweaks | grep "UseQuotaInVolumeSize" | awk '{print $2}') "true"
+echo "UseQuotaInVolumeSize=false" | sudo tee ${info[mount0]}/.saunafs_tweaks
+current_total_space=$(get_mountpoint_total_space)
+assert_less_than ${user_limit} ${current_total_space}
+echo "OK: the total space is more than ${user_limit_mb}MiB"
+assert_equals $(cat .saunafs_tweaks | grep "UseQuotaInVolumeSize" | awk '{print $2}') "false"
+
+# Brought it back
+echo "UseQuotaInVolumeSize=true" | sudo tee ${info[mount0]}/.saunafs_tweaks
+
+# Check the tweaks is working for StatfsCacheTimeout
+assert_equals $(cat .saunafs_tweaks | grep "StatfsCacheTimeout" | awk '{print $2}') 1
+# Set the timeout to 5 seconds
+echo "StatfsCacheTimeout=5000" | sudo tee ${info[mount0]}/.saunafs_tweaks
+assert_equals $(cat .saunafs_tweaks | grep "StatfsCacheTimeout" | awk '{print $2}') 5000
+# Last statfs call should be still cached
+assert_equals ${current_total_space} $(get_mountpoint_total_space)
+echo "OK: the total space is the old one (cache is still valid)"
+
+# Wait for the cache to expire
+sleep 6
+assert_equals ${user_limit} $(get_mountpoint_total_space)
+echo "OK: the total space is exactly ${user_limit_mb}MiB (cache is expired)"
+echo "StatfsCacheTimeout=0" | sudo tee ${info[mount0]}/.saunafs_tweaks
+
+# Check the behavior for group quota
+saunafs setquota -u $(id -u) 0 $((2*user_limit)) 0 0 .
+saunafs setquota -g $(id -g) 0 $((2*user_limit)) 0 0 .
+assert_success sudo -nu saunafstest_0 dd if=/dev/zero of=file2 bs=1M count=$((user_limit_mb))
+sudo -nu saunafstest_0 chown saunafstest_0:$(id -g) file2
+
+# Available space should be 0 because of the group quota: file1 and file2
+# belong to the same group and there is no more space left for that group.
+
+# Check the available space is exactly zero
+assert_equals $(get_mountpoint_available_space) 0
+echo "Ok: the available space is exactly zero"


### PR DESCRIPTION
The following changes are proposed:
- introduce the option ```usequotainvolumesize``` to display the user specific quota instead of the storage total size. This option is also added to tweaks hidden file.
- introduce the option ```statfscachetimeout``` to tune the statfs output caching, it is disabled by default. This option is also added to tweaks hidden file.
- add a test to check the behavior of the option.
- a small refactor in sauna_client.h (a new option is added and it would be nice to pack it together).

Signed-off-by: Dave <dave@leil.io>