### PR TITLE
perf(uraft): Reduce CPU usage on non-leader nodes

### DIFF
--- a/src/uraft/uraftcontroller.cc
+++ b/src/uraft/uraftcontroller.cc
@@ -230,8 +230,8 @@ void uRaftController::checkNodeStatus(const boost::system::error_code &error) {
 			node_alive_ = is_alive;
 		}
 
-		if (!isFloatingIpAlive()) {
-			if (state_.president) {
+		if (state_.president) {
+			if (!isFloatingIpAlive()) {
 				syslog(LOG_ERR, "Floating IP is not alive. Demoting leader.");
 				demoteLeader(); // Demote current leader and trigger a new election
 				nodeDemote();   // Restart metadata server and sync metadata version


### PR DESCRIPTION
This commit ensures that periodic validation of floating IP status is performed only on the leader node, reducing CPU usage on non-leader nodes.