### PR TITLE
chore(mds): Refactor the master's masterconn

### DIFF
--- a/src/master/masterconn.cc
+++ b/src/master/masterconn.cc
@@ -160,16 +160,6 @@ static void* download_hook;
 
 static uint64_t lastLogVersion = 0;
 
-static uint32_t stats_bytesout=0;
-static uint32_t stats_bytesin=0;
-
-void masterconn_stats(uint32_t *bin,uint32_t *bout) {
-	*bin = stats_bytesin;
-	*bout = stats_bytesout;
-	stats_bytesin = 0;
-	stats_bytesout = 0;
-}
-
 uint8_t *masterconn_createpacket(MasterConn *eptr, uint32_t type,
                                  uint32_t size) {
 	auto outpacket = std::make_unique<PacketStruct>();
@@ -838,7 +828,7 @@ void masterconn_read(MasterConn *eptr) {
 			}
 			return;
 		}
-		stats_bytesin+=i;
+
 		eptr->inputPacket.startPtr+=i;
 		eptr->inputPacket.bytesLeft-=i;
 
@@ -910,7 +900,6 @@ void masterconn_write(MasterConn *eptr) {
 			return;
 		}
 
-		stats_bytesout += writtenBytes;
 		pack->startPtr += writtenBytes;
 		pack->bytesLeft -= writtenBytes;
 

--- a/src/master/masterconn.cc
+++ b/src/master/masterconn.cc
@@ -61,83 +61,91 @@
 #include "master/restore.h"
 #endif /* #ifndef METALOGGER */
 
-#define MaxPacketSize 1500000
+/// Block size for metadata download (1 MB).
+constexpr uint32_t kMetadataDownloadBlocksize = 1000000U;
 
-#define META_DL_BLOCK 1000000
+/// Safety measure about expected max packet size.
+constexpr uint32_t kMaxPacketSize = 1500000U;
 
-// mode
-enum {FREE,CONNECTING,HEADER,DATA,KILL};
-
-enum class MasterConnectionState {
-	kNone,
-	kSynchronized,
-	kDownloading,
-	kDumpRequestPending,
-	kLimbo /*!< Got response from master regarding its inability to dump metadata. */
-};
-
-struct packetstruct {
-	struct packetstruct *next;
-	uint8_t *startptr;
-	uint32_t bytesleft;
+struct PacketStruct {
+	struct PacketStruct *next;
+	uint8_t *startPtr;
+	uint32_t bytesLeft;
 	uint8_t *packet;
 };
 
-struct masterconn {
-	int mode;
-	int sock;
-	uint32_t version; // version of the master server; known by shadow masters after registration
-	int32_t pdescpos;
-	uint32_t lastread,lastwrite;
-	uint8_t hdrbuff[8];
-	packetstruct inputpacket;
-	packetstruct *outputhead,**outputtail;
-	uint32_t bindip;
-	uint32_t masterip;
-	uint16_t masterport;
-	uint8_t masteraddrvalid;
+/// Represents a connection to the master server.
+/// Holds the connection state and the data that is being sent or received.
+struct MasterConn {
+	static constexpr uint8_t kHeaderSize = 8;
+	static constexpr uint8_t kChangeLogApplyErrorTimeout = 10;
+	static constexpr int kInvalidFD = -1;
+	static constexpr uint32_t kInvalidMasterVersion = 0;
 
-	uint8_t downloadretrycnt;
-	uint8_t downloading;
-	int metafd;     // using standard unix I/O because this is binary file
-	uint64_t filesize;
-	uint64_t dloffset;
-	uint64_t dlstartuts;
-	void* sessionsdownloadinit_handle;
-	void* metachanges_flush_handle;
-	MasterConnectionState state;
-	uint8_t error_status;
-	Timeout changelog_apply_error_packet_time;
-	masterconn()
-			: mode(),
-			  sock(),
-			  version(),
-			  pdescpos(),
-			  lastread(),
-			  lastwrite(),
-			  hdrbuff(),
-			  inputpacket(),
-			  outputhead(),
-			  outputtail(),
-			  bindip(),
-			  masterip(),
-			  masterport(),
-			  masteraddrvalid(),
-			  downloadretrycnt(),
-			  downloading(),
-			  metafd(),
-			  filesize(),
-			  dloffset(),
-			  dlstartuts(),
-			  sessionsdownloadinit_handle(),
-			  metachanges_flush_handle(),
-			  state(),
-			  error_status(),
-			  changelog_apply_error_packet_time(std::chrono::seconds(10)) {
-	}
+	enum class Mode : uint8_t {
+		Free,        ///< Connection is not in use.
+		Connecting,  ///< Connection is being established.
+		Header,      ///< Header is being read.
+		Data,        ///< Data is being read.
+		Kill         ///< Connection is being closed.
+	};
+
+	enum class State : uint8_t {
+		/// Initial state.
+		kNone,
+		/// Metadata was downloaded and we have the same version as the master.
+		kSynchronized,
+		/// Downloading metadata from the master.
+		kDownloading,
+		/// Waiting for the master to produce up-to-date metadata image.
+		kDumpRequestPending,
+		/// Got response from master regarding its inability to dump metadata.
+		kLimbo
+	};
+
+	Mode mode{};  ///< Current connection mode.
+	State state{State::kNone};  ///< Current synchonization state.
+
+	int sock{kInvalidFD};  ///< Socket descriptor.
+	int32_t pollDescPos{};  ///< Position in the poll descriptors array.
+	uint32_t lastRead{};  ///< Timestamp of the last read operation.
+	uint32_t lastWrite{};  ///< Timestamp of the last write operation.
+
+	/// Master version in the other end. Known after registration.
+	uint32_t masterVersion{kInvalidMasterVersion};
+
+	std::array<uint8_t, kHeaderSize> headerBuffer{};  ///< Buffer for headers.
+	PacketStruct inputPacket{};  ///< Structure for the input packet.
+	// To be replaced by a container.
+	PacketStruct *outputHead{};  ///< Head of the output packet queue.
+	PacketStruct **outputTail{};  ///< Tail of the output packet queue.
+
+	uint32_t bindIP{};  ///< IP address to bind the socket.
+	uint32_t masterIP{};  ///< IP address of the master server.
+	uint16_t masterPort{};  ///< Port of the master server.
+	uint8_t isMasterAddressValid{};  /// Known after (re)connections.
+
+	uint8_t downloadRetryCnt{};  ///< Retry count for downloads.
+	/// Number of the file being downloaded (metadata, changelogs, sessions).
+	/// 0 if no download is in progress.
+	uint8_t downloadingFileNum{};
+	int downloadFD{kInvalidFD};  ///< FD for the file being downloaded.
+	uint64_t fileSize{};  ///< Size of the file being downloaded.
+	uint64_t downloadOffset{};  ///< Offset for the download.
+	uint64_t downloadStartTimeInMicroSeconds{};  ///< Download start time.
+
+	/// Callback to download sessions periodically.
+	void* sessionsDownloadInitHandle{};
+	/// Callback to flush the changelog file(s) periodically.
+	void* changelogFlushHandle{};
+
+	uint8_t errorStatus{};  ///< Error status for mltoma::changelogApplyError.
+	/// Timeout for mltoma::changelogApplyError packets.
+	Timeout changelogApplyErrorTimeout{
+	    std::chrono::seconds(kChangeLogApplyErrorTimeout)};
 };
 
-static masterconn *masterconnsingleton=NULL;
+static MasterConn *gMasterConn = nullptr;
 
 // from config
 static uint32_t BackMetaCopies;
@@ -148,7 +156,7 @@ static uint32_t Timeout;
 static void* reconnect_hook;
 #ifdef METALOGGER
 static void* download_hook;
-#endif /* #ifndef METALOGGER */
+#endif /* #ifdef METALOGGER */
 static uint64_t lastlogversion=0;
 
 static uint32_t stats_bytesout=0;
@@ -240,50 +248,50 @@ void masterconn_findlastlogversion(void) {
 }
 #endif /* #ifdef METALOGGER */
 
-uint8_t* masterconn_createpacket(masterconn *eptr,uint32_t type,uint32_t size) {
-	packetstruct *outpacket;
+uint8_t* masterconn_createpacket(MasterConn *eptr,uint32_t type,uint32_t size) {
+	PacketStruct *outpacket;
 	uint8_t *ptr;
 	uint32_t psize;
 
-	outpacket=(packetstruct*)malloc(sizeof(packetstruct));
+	outpacket=(PacketStruct*)malloc(sizeof(PacketStruct));
 	passert(outpacket);
 	psize = size+8;
 	outpacket->packet= (uint8_t*) malloc(psize);
 	passert(outpacket->packet);
-	outpacket->bytesleft = psize;
+	outpacket->bytesLeft = psize;
 	ptr = outpacket->packet;
 	put32bit(&ptr,type);
 	put32bit(&ptr,size);
-	outpacket->startptr = (uint8_t*)(outpacket->packet);
+	outpacket->startPtr = (uint8_t*)(outpacket->packet);
 	outpacket->next = NULL;
-	*(eptr->outputtail) = outpacket;
-	eptr->outputtail = &(outpacket->next);
+	*(eptr->outputTail) = outpacket;
+	eptr->outputTail = &(outpacket->next);
 	return ptr;
 }
 
-void masterconn_createpacket(masterconn *eptr, std::vector<uint8_t> data) {
-	packetstruct *outpacket = (packetstruct*) malloc(sizeof(packetstruct));
+void masterconn_createpacket(MasterConn *eptr, std::vector<uint8_t> data) {
+	PacketStruct *outpacket = (PacketStruct*) malloc(sizeof(PacketStruct));
 	passert(outpacket);
 	outpacket->packet = (uint8_t*) malloc(data.size());
 	passert(outpacket->packet);
 	memcpy(outpacket->packet, data.data(), data.size());
-	outpacket->bytesleft = data.size();
-	outpacket->startptr = outpacket->packet;
+	outpacket->bytesLeft = data.size();
+	outpacket->startPtr = outpacket->packet;
 	outpacket->next = nullptr;
-	*(eptr->outputtail) = outpacket;
-	eptr->outputtail = &(outpacket->next);
+	*(eptr->outputTail) = outpacket;
+	eptr->outputTail = &(outpacket->next);
 }
 
-void masterconn_sendregister(masterconn *eptr) {
+void masterconn_sendregister(MasterConn *eptr) {
 	uint8_t *buff;
 
-	eptr->downloading=0;
-	eptr->metafd=-1;
+	eptr->downloadingFileNum = 0;
+	eptr->downloadFD = MasterConn::kInvalidFD;
 
 #ifndef METALOGGER
 	// shadow master registration
 	uint64_t metadataVersion = 0;
-	if (eptr->state == MasterConnectionState::kSynchronized) {
+	if (eptr->state == MasterConn::State::kSynchronized) {
 		metadataVersion = fs_getversion();
 	}
 	auto request = mltoma::registerShadow::build(SAUNAFS_VERSHEX, Timeout * 1000, metadataVersion);
@@ -309,7 +317,7 @@ void masterconn_sendregister(masterconn *eptr) {
 	}
 }
 
-void masterconn_send_metalogger_config(masterconn *eptr) {
+void masterconn_send_metalogger_config(MasterConn *eptr) {
 	std::string config = cfg_yaml_string();
 	auto request = mltoma::dumpConfiguration::build(config);
 	masterconn_createpacket(eptr, std::move(request));
@@ -333,15 +341,15 @@ namespace {
 #endif /* #else #ifdef METALOGGER */
 }
 
-void masterconn_kill_session(masterconn* eptr) {
-	if (eptr->mode != FREE) {
-		eptr->mode = KILL;
+void masterconn_kill_session(MasterConn* eptr) {
+	if (eptr->mode != MasterConn::Mode::Free) {
+		eptr->mode = MasterConn::Mode::Kill;
 	}
 }
 
-void masterconn_force_metadata_download(masterconn* eptr) {
+void masterconn_force_metadata_download(MasterConn* eptr) {
 #ifndef METALOGGER
-	eptr->state = MasterConnectionState::kNone;
+	eptr->state = MasterConn::State::kNone;
 	fs_unload();
 	restore_reset();
 #endif
@@ -349,27 +357,27 @@ void masterconn_force_metadata_download(masterconn* eptr) {
 	masterconn_kill_session(eptr);
 }
 
-void masterconn_request_metadata_dump(masterconn* eptr) {
-	masterconn_createpacket(eptr, mltoma::changelogApplyError::build(eptr->error_status));
-	eptr->state = MasterConnectionState::kDumpRequestPending;
-	eptr->changelog_apply_error_packet_time.reset();
+void masterconn_request_metadata_dump(MasterConn* eptr) {
+	masterconn_createpacket(eptr, mltoma::changelogApplyError::build(eptr->errorStatus));
+	eptr->state = MasterConn::State::kDumpRequestPending;
+	eptr->changelogApplyErrorTimeout.reset();
 }
 
-void masterconn_handle_changelog_apply_error(masterconn* eptr, uint8_t status) {
-	if (eptr->version <= saunafsVersion(2, 5, 0)) {
+void masterconn_handle_changelog_apply_error(MasterConn* eptr, uint8_t status) {
+	if (eptr->masterVersion <= saunafsVersion(2, 5, 0)) {
 		safs_pretty_syslog(LOG_NOTICE, "Dropping in-memory metadata and starting download from master");
 		masterconn_force_metadata_download(eptr);
 	} else {
 		safs_pretty_syslog(LOG_NOTICE, "Waiting for master to produce up-to-date metadata image");
-		eptr->error_status = status;
+		eptr->errorStatus = status;
 		masterconn_request_metadata_dump(eptr);
 	}
 }
 
 #ifndef METALOGGER
-void masterconn_int_send_matoclport(masterconn* eptr) {
+void masterconn_int_send_matoclport(MasterConn* eptr) {
 	static std::string previousPort = "";
-	if (eptr->version < SAUNAFS_VERSION(2, 5, 5)) {
+	if (eptr->masterVersion < SAUNAFS_VERSION(2, 5, 5)) {
 		return;
 	}
 	std::string portStr = cfg_getstring("MATOCL_LISTEN_PORT", "9421");
@@ -384,21 +392,21 @@ void masterconn_int_send_matoclport(masterconn* eptr) {
 	masterconn_createpacket(eptr, mltoma::matoclport::build(port));
 }
 
-void masterconn_registered(masterconn *eptr, const uint8_t *data, uint32_t length) {
+void masterconn_registered(MasterConn *eptr, const uint8_t *data, uint32_t length) {
 	PacketVersion responseVersion;
 	deserializePacketVersionNoHeader(data, length, responseVersion);
 	if (responseVersion == matoml::registerShadow::kStatusPacketVersion) {
 		uint8_t status;
 		matoml::registerShadow::deserialize(data, length, status);
 		safs_pretty_syslog(LOG_NOTICE, "Cannot register to master: %s", saunafs_error_string(status));
-		eptr->mode = KILL;
+		eptr->mode = MasterConn::Mode::Kill;
 	} else if (responseVersion == matoml::registerShadow::kResponsePacketVersion) {
 		uint32_t masterVersion;
 		uint64_t masterMetadataVersion;
 		matoml::registerShadow::deserialize(data, length, masterVersion, masterMetadataVersion);
-		eptr->version = masterVersion;
+		eptr->masterVersion = masterVersion;
 		masterconn_int_send_matoclport(eptr);
-		if ((eptr->state == MasterConnectionState::kSynchronized) && (fs_getversion() != masterMetadataVersion)) {
+		if ((eptr->state == MasterConn::State::kSynchronized) && (fs_getversion() != masterMetadataVersion)) {
 			masterconn_force_metadata_download(eptr);
 		}
 	} else {
@@ -407,7 +415,7 @@ void masterconn_registered(masterconn *eptr, const uint8_t *data, uint32_t lengt
 }
 #endif
 
-void masterconn_metachanges_log(masterconn *eptr,const uint8_t *data,uint32_t length) {
+void masterconn_metachanges_log(MasterConn *eptr,const uint8_t *data,uint32_t length) {
 	if ((length == 1) && (data[0] == FORCE_LOG_ROTATE)) {
 #ifdef METALOGGER
 		// In metalogger rotates are forced by the master server. Shadow masters rotate changelogs
@@ -418,17 +426,17 @@ void masterconn_metachanges_log(masterconn *eptr,const uint8_t *data,uint32_t le
 	}
 	if (length<10) {
 		safs_pretty_syslog(LOG_NOTICE,"MATOML_METACHANGES_LOG - wrong size (%" PRIu32 "/9+data)",length);
-		eptr->mode = KILL;
+		eptr->mode = MasterConn::Mode::Kill;
 		return;
 	}
 	if (data[0]!=0xFF) {
 		safs_pretty_syslog(LOG_NOTICE,"MATOML_METACHANGES_LOG - wrong packet");
-		eptr->mode = KILL;
+		eptr->mode = MasterConn::Mode::Kill;
 		return;
 	}
 	if (data[length-1]!='\0') {
 		safs_pretty_syslog(LOG_NOTICE,"MATOML_METACHANGES_LOG - invalid string");
-		eptr->mode = KILL;
+		eptr->mode = MasterConn::Mode::Kill;
 		return;
 	}
 
@@ -443,7 +451,7 @@ void masterconn_metachanges_log(masterconn *eptr,const uint8_t *data,uint32_t le
 	}
 
 #ifndef METALOGGER
-	if (eptr->state == MasterConnectionState::kSynchronized) {
+	if (eptr->state == MasterConn::State::kSynchronized) {
 		std::string buf(": ");
 		buf.append(changelogEntry);
 		static char const network[] = "network";
@@ -461,47 +469,45 @@ void masterconn_metachanges_log(masterconn *eptr,const uint8_t *data,uint32_t le
 	lastlogversion = version;
 }
 
-void masterconn_end_session(masterconn *eptr, const uint8_t* data, uint32_t length) {
+void masterconn_end_session(MasterConn *eptr, const uint8_t* data, uint32_t length) {
 	matoml::endSession::deserialize(data, length); // verify the empty packet
 	safs_pretty_syslog(LOG_NOTICE, "Master server is terminating; closing the connection...");
 	masterconn_kill_session(eptr);
 }
 
-int masterconn_download_end(masterconn *eptr) {
-	eptr->downloading=0;
+int masterconn_download_end(MasterConn *eptr) {
+	eptr->downloadingFileNum=0;
 	masterconn_createpacket(eptr,MLTOMA_DOWNLOAD_END,0);
-	if (eptr->metafd>=0) {
-		if (close(eptr->metafd)<0) {
+	if (eptr->downloadFD>=0) {
+		if (close(eptr->downloadFD)<0) {
 			safs_silent_errlog(LOG_NOTICE,"error closing metafile");
-			eptr->metafd=-1;
+			eptr->downloadFD = MasterConn::kInvalidFD;
 			return -1;
 		}
-		eptr->metafd=-1;
+		eptr->downloadFD = MasterConn::kInvalidFD;
 	}
 	return 0;
 }
 
-void masterconn_download_init(masterconn *eptr,uint8_t filenum) {
+void masterconn_download_init(MasterConn *eptr,uint8_t filenum) {
 	uint8_t *ptr;
-//      syslog(LOG_NOTICE,"download_init %d",filenum);
-	if ((eptr->mode==HEADER || eptr->mode==DATA) && eptr->downloading==0) {
-//              syslog(LOG_NOTICE,"sending packet");
+	if ((eptr->mode==MasterConn::Mode::Header || eptr->mode==MasterConn::Mode::Data) && eptr->downloadingFileNum==0) {
 		ptr = masterconn_createpacket(eptr,MLTOMA_DOWNLOAD_START,1);
 		put8bit(&ptr,filenum);
-		eptr->downloading=filenum;
+		eptr->downloadingFileNum = filenum;
 		if (filenum == DOWNLOAD_METADATA_SFS) {
-			masterconnsingleton->state = MasterConnectionState::kDownloading;
+			gMasterConn->state = MasterConn::State::kDownloading;
 		}
 	}
 }
 
 void masterconn_metadownloadinit() {
-	masterconn_download_init(masterconnsingleton, DOWNLOAD_METADATA_SFS);
+	masterconn_download_init(gMasterConn, DOWNLOAD_METADATA_SFS);
 }
 
 void masterconn_sessionsdownloadinit(void) {
-	if (masterconnsingleton->state == MasterConnectionState::kSynchronized) {
-		masterconn_download_init(masterconnsingleton, DOWNLOAD_SESSIONS_SFS);
+	if (gMasterConn->state == MasterConn::State::kSynchronized) {
+		masterconn_download_init(gMasterConn, DOWNLOAD_SESSIONS_SFS);
 	}
 }
 
@@ -515,16 +521,16 @@ int masterconn_metadata_check(const std::string& name) {
 	}
 }
 
-void masterconn_download_next(masterconn *eptr) {
+void masterconn_download_next(MasterConn *eptr) {
 	uint8_t *ptr;
 	uint8_t filenum;
 	int64_t dltime;
-	if (eptr->dloffset>=eptr->filesize) {   // end of file
-		filenum = eptr->downloading;
+	if (eptr->downloadOffset>=eptr->fileSize) {   // end of file
+		filenum = eptr->downloadingFileNum;
 		if (masterconn_download_end(eptr)<0) {
 			return;
 		}
-		dltime = eventloop_utime()-eptr->dlstartuts;
+		dltime = eventloop_utime()-eptr->downloadStartTimeInMicroSeconds;
 		if (dltime<=0) {
 			dltime=1;
 		}
@@ -535,8 +541,8 @@ void masterconn_download_next(masterconn *eptr) {
 				(filenum == DOWNLOAD_SESSIONS_SFS) ? "sessions" :
 				(filenum == DOWNLOAD_CHANGELOG_SFS) ? changelogFilename_1.c_str() :
 				(filenum == DOWNLOAD_CHANGELOG_SFS_1) ? changelogFilename_2.c_str() : "???",
-				eptr->filesize, dltime/1000000, (uint32_t)(dltime%1000000),
-				(double)(eptr->filesize) / (double)(dltime));
+				eptr->fileSize, dltime/1000000, (uint32_t)(dltime%1000000),
+				(double)(eptr->fileSize) / (double)(dltime));
 		if (filenum == DOWNLOAD_METADATA_SFS) {
 			if (masterconn_metadata_check(metadataTmpFilename) == 0) {
 				if (BackMetaCopies>0) {
@@ -566,12 +572,12 @@ void masterconn_download_next(masterconn *eptr) {
 				 * We can have other state if we are synchronized or we got changelog apply error
 				 * during independent sessions download session.
 				 */
-				if (eptr->state == MasterConnectionState::kDownloading) {
+				if (eptr->state == MasterConn::State::kDownloading) {
 					try {
 						fs_loadall();
 						lastlogversion = fs_getversion() - 1;
 						safs_pretty_syslog(LOG_NOTICE, "synced at version = %" PRIu64, lastlogversion);
-						eptr->state = MasterConnectionState::kSynchronized;
+						eptr->state = MasterConn::State::kSynchronized;
 					} catch (Exception& ex) {
 						safs_pretty_syslog(LOG_WARNING, "can't load downloaded metadata and changelogs: %s",
 								ex.what());
@@ -585,30 +591,30 @@ void masterconn_download_next(masterconn *eptr) {
 					}
 				}
 #else /* #ifndef METALOGGER */
-				eptr->state = MasterConnectionState::kSynchronized;
+				eptr->state = MasterConn::State::kSynchronized;
 #endif /* #else #ifndef METALOGGER */
 			}
 		}
 	} else {        // send request for next data packet
 		ptr = masterconn_createpacket(eptr,MLTOMA_DOWNLOAD_DATA,12);
-		put64bit(&ptr,eptr->dloffset);
-		if (eptr->filesize-eptr->dloffset>META_DL_BLOCK) {
-			put32bit(&ptr,META_DL_BLOCK);
+		put64bit(&ptr,eptr->downloadOffset);
+		if (eptr->fileSize-eptr->downloadOffset>kMetadataDownloadBlocksize) {
+			put32bit(&ptr,kMetadataDownloadBlocksize);
 		} else {
-			put32bit(&ptr,eptr->filesize-eptr->dloffset);
+			put32bit(&ptr,eptr->fileSize-eptr->downloadOffset);
 		}
 	}
 }
 
-void masterconn_download_start(masterconn *eptr,const uint8_t *data,uint32_t length) {
+void masterconn_download_start(MasterConn *eptr,const uint8_t *data,uint32_t length) {
 	if (length!=1 && length!=8) {
 		safs_pretty_syslog(LOG_NOTICE,"MATOML_DOWNLOAD_START - wrong size (%" PRIu32 "/1|8)",length);
-		eptr->mode = KILL;
+		eptr->mode = MasterConn::Mode::Kill;
 		return;
 	}
 	passert(data);
 	if (length==1) {
-		eptr->downloading=0;
+		eptr->downloadingFileNum=0;
 		safs_pretty_syslog(LOG_NOTICE,"download start error");
 		return;
 	}
@@ -616,23 +622,23 @@ void masterconn_download_start(masterconn *eptr,const uint8_t *data,uint32_t len
 	// We are a shadow master and we are going to do some changes in the data dir right now
 	fs_erase_message_from_lockfile();
 #endif
-	eptr->filesize = get64bit(&data);
-	eptr->dloffset = 0;
-	eptr->downloadretrycnt = 0;
-	eptr->dlstartuts = eventloop_utime();
-	if (eptr->downloading == DOWNLOAD_METADATA_SFS) {
-		eptr->metafd = open(metadataTmpFilename.c_str(), O_WRONLY | O_TRUNC | O_CREAT, 0666);
-	} else if (eptr->downloading == DOWNLOAD_SESSIONS_SFS) {
-		eptr->metafd = open(sessionsTmpFilename.c_str(), O_WRONLY | O_TRUNC | O_CREAT, 0666);
-	} else if ((eptr->downloading == DOWNLOAD_CHANGELOG_SFS)
-			|| (eptr->downloading == DOWNLOAD_CHANGELOG_SFS_1)) {
-		eptr->metafd = open(changelogTmpFilename.c_str(), O_WRONLY | O_TRUNC | O_CREAT, 0666);
+	eptr->fileSize = get64bit(&data);
+	eptr->downloadOffset = 0;
+	eptr->downloadRetryCnt = 0;
+	eptr->downloadStartTimeInMicroSeconds = eventloop_utime();
+	if (eptr->downloadingFileNum == DOWNLOAD_METADATA_SFS) {
+		eptr->downloadFD = open(metadataTmpFilename.c_str(), O_WRONLY | O_TRUNC | O_CREAT, 0666);
+	} else if (eptr->downloadingFileNum == DOWNLOAD_SESSIONS_SFS) {
+		eptr->downloadFD = open(sessionsTmpFilename.c_str(), O_WRONLY | O_TRUNC | O_CREAT, 0666);
+	} else if ((eptr->downloadingFileNum == DOWNLOAD_CHANGELOG_SFS)
+			|| (eptr->downloadingFileNum == DOWNLOAD_CHANGELOG_SFS_1)) {
+		eptr->downloadFD = open(changelogTmpFilename.c_str(), O_WRONLY | O_TRUNC | O_CREAT, 0666);
 	} else {
 		safs_pretty_syslog(LOG_NOTICE,"unexpected MATOML_DOWNLOAD_START packet");
-		eptr->mode = KILL;
+		eptr->mode = MasterConn::Mode::Kill;
 		return;
 	}
-	if (eptr->metafd<0) {
+	if (eptr->downloadFD<0) {
 		safs_silent_errlog(LOG_NOTICE,"error opening metafile");
 		masterconn_download_end(eptr);
 		return;
@@ -640,19 +646,19 @@ void masterconn_download_start(masterconn *eptr,const uint8_t *data,uint32_t len
 	masterconn_download_next(eptr);
 }
 
-void masterconn_download_data(masterconn *eptr,const uint8_t *data,uint32_t length) {
+void masterconn_download_data(MasterConn *eptr,const uint8_t *data,uint32_t length) {
 	uint64_t offset;
 	uint32_t leng;
 	uint32_t crc;
 	ssize_t ret;
-	if (eptr->metafd<0) {
+	if (eptr->downloadFD<0) {
 		safs_pretty_syslog(LOG_NOTICE,"MATOML_DOWNLOAD_DATA - file not opened");
-		eptr->mode = KILL;
+		eptr->mode = MasterConn::Mode::Kill;
 		return;
 	}
 	if (length<16) {
 		safs_pretty_syslog(LOG_NOTICE,"MATOML_DOWNLOAD_DATA - wrong size (%" PRIu32 "/16+data)",length);
-		eptr->mode = KILL;
+		eptr->mode = MasterConn::Mode::Kill;
 		return;
 	}
 	passert(data);
@@ -661,86 +667,86 @@ void masterconn_download_data(masterconn *eptr,const uint8_t *data,uint32_t leng
 	crc = get32bit(&data);
 	if (leng+16!=length) {
 		safs_pretty_syslog(LOG_NOTICE,"MATOML_DOWNLOAD_DATA - wrong size (%" PRIu32 "/16+%" PRIu32 ")",length,leng);
-		eptr->mode = KILL;
+		eptr->mode = MasterConn::Mode::Kill;
 		return;
 	}
-	if (offset!=eptr->dloffset) {
-		safs_pretty_syslog(LOG_NOTICE,"MATOML_DOWNLOAD_DATA - unexpected file offset (%" PRIu64 "/%" PRIu64 ")",offset,eptr->dloffset);
-		eptr->mode = KILL;
+	if (offset!=eptr->downloadOffset) {
+		safs_pretty_syslog(LOG_NOTICE,"MATOML_DOWNLOAD_DATA - unexpected file offset (%" PRIu64 "/%" PRIu64 ")",offset,eptr->downloadOffset);
+		eptr->mode = MasterConn::Mode::Kill;
 		return;
 	}
-	if (offset+leng>eptr->filesize) {
-		safs_pretty_syslog(LOG_NOTICE,"MATOML_DOWNLOAD_DATA - unexpected file size (%" PRIu64 "/%" PRIu64 ")",offset+leng,eptr->filesize);
-		eptr->mode = KILL;
+	if (offset+leng>eptr->fileSize) {
+		safs_pretty_syslog(LOG_NOTICE,"MATOML_DOWNLOAD_DATA - unexpected file size (%" PRIu64 "/%" PRIu64 ")",offset+leng,eptr->fileSize);
+		eptr->mode = MasterConn::Mode::Kill;
 		return;
 	}
 #ifdef SAUNAFS_HAVE_PWRITE
-	ret = pwrite(eptr->metafd,data,leng,offset);
+	ret = pwrite(eptr->downloadFD,data,leng,offset);
 #else /* SAUNAFS_HAVE_PWRITE */
 	lseek(eptr->metafd,offset,SEEK_SET);
 	ret = write(eptr->metafd,data,leng);
 #endif /* SAUNAFS_HAVE_PWRITE */
 	if (ret!=(ssize_t)leng) {
 		safs_silent_errlog(LOG_NOTICE,"error writing metafile");
-		if (eptr->downloadretrycnt>=5) {
+		if (eptr->downloadRetryCnt>=5) {
 			masterconn_download_end(eptr);
 		} else {
-			eptr->downloadretrycnt++;
+			eptr->downloadRetryCnt++;
 			masterconn_download_next(eptr);
 		}
 		return;
 	}
 	if (crc!=mycrc32(0,data,leng)) {
 		safs_pretty_syslog(LOG_NOTICE,"metafile data crc error");
-		if (eptr->downloadretrycnt>=5) {
+		if (eptr->downloadRetryCnt>=5) {
 			masterconn_download_end(eptr);
 		} else {
-			eptr->downloadretrycnt++;
+			eptr->downloadRetryCnt++;
 			masterconn_download_next(eptr);
 		}
 		return;
 	}
-	if (fsync(eptr->metafd)<0) {
+	if (fsync(eptr->downloadFD)<0) {
 		safs_silent_errlog(LOG_NOTICE,"error syncing metafile");
-		if (eptr->downloadretrycnt>=5) {
+		if (eptr->downloadRetryCnt>=5) {
 			masterconn_download_end(eptr);
 		} else {
-			eptr->downloadretrycnt++;
+			eptr->downloadRetryCnt++;
 			masterconn_download_next(eptr);
 		}
 		return;
 	}
-	eptr->dloffset+=leng;
-	eptr->downloadretrycnt=0;
+	eptr->downloadOffset+=leng;
+	eptr->downloadRetryCnt=0;
 	masterconn_download_next(eptr);
 }
 
-void masterconn_changelog_apply_error(masterconn *eptr, const uint8_t *data, uint32_t length) {
+void masterconn_changelog_apply_error(MasterConn *eptr, const uint8_t *data, uint32_t length) {
 	uint8_t status;
 	matoml::changelogApplyError::deserialize(data, length, status);
 	safs_silent_syslog(LOG_DEBUG, "master.matoml_changelog_apply_error status: %u", status);
 	if (status == SAUNAFS_STATUS_OK) {
 		masterconn_force_metadata_download(eptr);
 	} else if (status == SAUNAFS_ERROR_DELAYED) {
-		eptr->state = MasterConnectionState::kLimbo;
+		eptr->state = MasterConn::State::kLimbo;
 		safs_pretty_syslog(LOG_NOTICE, "Master temporarily refused to produce a new metadata image");
 	} else {
-		eptr->state = MasterConnectionState::kLimbo;
+		eptr->state = MasterConn::State::kLimbo;
 		safs_pretty_syslog(LOG_NOTICE, "Master failed to produce a new metadata image: %s", saunafs_error_string(status));
 	}
 }
 
-void masterconn_beforeclose(masterconn *eptr) {
-	if (eptr->metafd>=0) {
-		close(eptr->metafd);
-		eptr->metafd=-1;
+void masterconn_beforeclose(MasterConn *eptr) {
+	if (eptr->downloadFD>=0) {
+		close(eptr->downloadFD);
+		eptr->downloadFD = MasterConn::kInvalidFD;
 		unlink(metadataTmpFilename.c_str());
 		unlink(sessionsTmpFilename.c_str());
 		unlink(changelogTmpFilename.c_str());
 	}
 }
 
-void masterconn_gotpacket(masterconn *eptr,uint32_t type,const uint8_t *data,uint32_t length) {
+void masterconn_gotpacket(MasterConn *eptr,uint32_t type,const uint8_t *data,uint32_t length) {
 	try {
 		switch (type) {
 			case ANTOAN_NOP:
@@ -771,29 +777,29 @@ void masterconn_gotpacket(masterconn *eptr,uint32_t type,const uint8_t *data,uin
 				break;
 			default:
 				safs_pretty_syslog(LOG_NOTICE,"got unknown message (type:%" PRIu32 ")",type);
-				eptr->mode = KILL;
+				eptr->mode = MasterConn::Mode::Kill;
 				break;
 		}
 	} catch (IncorrectDeserializationException& ex) {
 		safs_pretty_syslog(LOG_NOTICE, "Packet 0x%" PRIX32 " - can't deserialize: %s", type, ex.what());
-		eptr->mode = KILL;
+		eptr->mode = MasterConn::Mode::Kill;
 	}
 }
 
 void masterconn_term(void) {
-	if (!masterconnsingleton) {
+	if (!gMasterConn) {
 		return;
 	}
-	packetstruct *pptr,*paptr;
-	masterconn *eptr = masterconnsingleton;
+	PacketStruct *pptr,*paptr;
+	MasterConn *eptr = gMasterConn;
 
-	if (eptr->mode!=FREE) {
+	if (eptr->mode!=MasterConn::Mode::Free) {
 		tcpclose(eptr->sock);
-		if (eptr->mode!=CONNECTING) {
-			if (eptr->inputpacket.packet) {
-				free(eptr->inputpacket.packet);
+		if (eptr->mode!=MasterConn::Mode::Connecting) {
+			if (eptr->inputPacket.packet) {
+				free(eptr->inputPacket.packet);
 			}
-			pptr = eptr->outputhead;
+			pptr = eptr->outputHead;
 			while (pptr) {
 				if (pptr->packet) {
 					free(pptr->packet);
@@ -805,20 +811,20 @@ void masterconn_term(void) {
 		}
 	}
 
-	delete masterconnsingleton;
-	masterconnsingleton = NULL;
+	delete gMasterConn;
+	gMasterConn = NULL;
 }
 
-void masterconn_connected(masterconn *eptr) {
+void masterconn_connected(MasterConn *eptr) {
 	tcpnodelay(eptr->sock);
-	eptr->mode=HEADER;
-	eptr->version = 0;
-	eptr->inputpacket.next = NULL;
-	eptr->inputpacket.bytesleft = 8;
-	eptr->inputpacket.startptr = eptr->hdrbuff;
-	eptr->inputpacket.packet = NULL;
-	eptr->outputhead = NULL;
-	eptr->outputtail = &(eptr->outputhead);
+	eptr->mode = MasterConn::Mode::Header;
+	eptr->masterVersion = MasterConn::kInvalidMasterVersion;
+	eptr->inputPacket.next = NULL;
+	eptr->inputPacket.bytesLeft = 8;
+	eptr->inputPacket.startPtr = eptr->headerBuffer.data();
+	eptr->inputPacket.packet = NULL;
+	eptr->outputHead = NULL;
+	eptr->outputTail = &(eptr->outputHead);
 
 	masterconn_sendregister(eptr);
 #ifdef METALOGGER
@@ -826,26 +832,26 @@ void masterconn_connected(masterconn *eptr) {
 #endif
 	if (lastlogversion==0) {
 		masterconn_metadownloadinit();
-	} else if (eptr->state == MasterConnectionState::kDumpRequestPending) {
+	} else if (eptr->state == MasterConn::State::kDumpRequestPending) {
 		masterconn_request_metadata_dump(eptr);
 	}
-	eptr->lastread = eptr->lastwrite = eventloop_time();
+	eptr->lastRead = eptr->lastWrite = eventloop_time();
 }
 
-int masterconn_initconnect(masterconn *eptr) {
+int masterconn_initconnect(MasterConn *eptr) {
 	int status;
-	if (eptr->masteraddrvalid==0) {
+	if (eptr->isMasterAddressValid==0) {
 		uint32_t mip,bip;
 		uint16_t mport;
 		if (tcpresolve(BindHost.c_str(), NULL, &bip, NULL, 1)>=0) {
-			eptr->bindip = bip;
+			eptr->bindIP = bip;
 		} else {
-			eptr->bindip = 0;
+			eptr->bindIP = 0;
 		}
 		if (tcpresolve(MasterHost.c_str(), MasterPort.c_str(), &mip, &mport, 0)>=0) {
-			eptr->masterip = mip;
-			eptr->masterport = mport;
-			eptr->masteraddrvalid = 1;
+			eptr->masterIP = mip;
+			eptr->masterPort = mport;
+			eptr->isMasterAddressValid = 1;
 		} else {
 			safs_pretty_syslog(LOG_WARNING,
 					"can't resolve master host/port (%s:%s)",
@@ -861,61 +867,61 @@ int masterconn_initconnect(masterconn *eptr) {
 	if (tcpnonblock(eptr->sock)<0) {
 		safs_pretty_errlog(LOG_WARNING,"set nonblock, error");
 		tcpclose(eptr->sock);
-		eptr->sock = -1;
+		eptr->sock = MasterConn::kInvalidFD;
 		return -1;
 	}
-	if (eptr->bindip>0) {
-		if (tcpnumbind(eptr->sock,eptr->bindip,0)<0) {
+	if (eptr->bindIP>0) {
+		if (tcpnumbind(eptr->sock,eptr->bindIP,0)<0) {
 			safs_pretty_errlog(LOG_WARNING,"can't bind socket to given ip");
 			tcpclose(eptr->sock);
-			eptr->sock = -1;
+			eptr->sock = MasterConn::kInvalidFD;
 			return -1;
 		}
 	}
-	status = tcpnumconnect(eptr->sock,eptr->masterip,eptr->masterport);
+	status = tcpnumconnect(eptr->sock,eptr->masterIP,eptr->masterPort);
 	if (status<0) {
 		safs_pretty_errlog(LOG_WARNING,"connect failed, error");
 		tcpclose(eptr->sock);
-		eptr->sock = -1;
-		eptr->masteraddrvalid = 0;
+		eptr->sock = MasterConn::kInvalidFD;
+		eptr->isMasterAddressValid = 0;
 		return -1;
 	}
 	if (status==0) {
 		safs_pretty_syslog(LOG_NOTICE,"connected to Master immediately");
 		masterconn_connected(eptr);
 	} else {
-		eptr->mode = CONNECTING;
+		eptr->mode = MasterConn::Mode::Connecting;
 		safs_pretty_syslog_attempt(LOG_NOTICE,"connecting to Master");
 	}
 	return 0;
 }
 
-void masterconn_connecttest(masterconn *eptr) {
+void masterconn_connecttest(MasterConn *eptr) {
 	int status;
 
 	status = tcpgetstatus(eptr->sock);
 	if (status) {
 		safs_silent_errlog(LOG_WARNING,"connection failed, error");
 		tcpclose(eptr->sock);
-		eptr->sock = -1;
-		eptr->mode = FREE;
-		eptr->masteraddrvalid = 0;
-		eptr->version = 0;
+		eptr->sock = MasterConn::kInvalidFD;
+		eptr->mode = MasterConn::Mode::Free;
+		eptr->isMasterAddressValid = 0;
+		eptr->masterVersion = MasterConn::kInvalidMasterVersion;
 	} else {
 		safs_pretty_syslog(LOG_NOTICE,"connected to Master");
 		masterconn_connected(eptr);
 	}
 }
 
-void masterconn_read(masterconn *eptr) {
+void masterconn_read(MasterConn *eptr) {
 	SignalLoopWatchdog watchdog;
 	int32_t i;
 	uint32_t type,size;
 	const uint8_t *ptr;
 
 	watchdog.start();
-	while (eptr->mode != KILL) {
-		i=read(eptr->sock,eptr->inputpacket.startptr,eptr->inputpacket.bytesleft);
+	while (eptr->mode != MasterConn::Mode::Kill) {
+		i=read(eptr->sock,eptr->inputPacket.startPtr,eptr->inputPacket.bytesLeft);
 		if (i==0) {
 			safs_pretty_syslog(LOG_NOTICE,"connection was reset by Master");
 			masterconn_kill_session(eptr);
@@ -929,48 +935,48 @@ void masterconn_read(masterconn *eptr) {
 			return;
 		}
 		stats_bytesin+=i;
-		eptr->inputpacket.startptr+=i;
-		eptr->inputpacket.bytesleft-=i;
+		eptr->inputPacket.startPtr+=i;
+		eptr->inputPacket.bytesLeft-=i;
 
-		if (eptr->inputpacket.bytesleft>0) {
+		if (eptr->inputPacket.bytesLeft>0) {
 			return;
 		}
 
-		if (eptr->mode==HEADER) {
-			ptr = eptr->hdrbuff+4;
+		if (eptr->mode==MasterConn::Mode::Header) {
+			ptr = eptr->headerBuffer.data() + 4;
 			size = get32bit(&ptr);
 
 			if (size>0) {
-				if (size>MaxPacketSize) {
-					safs_pretty_syslog(LOG_WARNING,"Master packet too long (%" PRIu32 "/%u)",size,MaxPacketSize);
+				if (size>kMaxPacketSize) {
+					safs_pretty_syslog(LOG_WARNING,"Master packet too long (%" PRIu32 "/%u)",size,kMaxPacketSize);
 					masterconn_kill_session(eptr);
 					return;
 				}
-				eptr->inputpacket.packet = (uint8_t*) malloc(size);
-				passert(eptr->inputpacket.packet);
-				eptr->inputpacket.bytesleft = size;
-				eptr->inputpacket.startptr = eptr->inputpacket.packet;
-				eptr->mode = DATA;
+				eptr->inputPacket.packet = (uint8_t*) malloc(size);
+				passert(eptr->inputPacket.packet);
+				eptr->inputPacket.bytesLeft = size;
+				eptr->inputPacket.startPtr = eptr->inputPacket.packet;
+				eptr->mode = MasterConn::Mode::Data;
 				continue;
 			}
-			eptr->mode = DATA;
+			eptr->mode = MasterConn::Mode::Data;
 		}
 
-		if (eptr->mode==DATA) {
-			ptr = eptr->hdrbuff;
+		if (eptr->mode==MasterConn::Mode::Data) {
+			ptr = eptr->headerBuffer.data();
 			type = get32bit(&ptr);
 			size = get32bit(&ptr);
 
-			eptr->mode=HEADER;
-			eptr->inputpacket.bytesleft = 8;
-			eptr->inputpacket.startptr = eptr->hdrbuff;
+			eptr->mode=MasterConn::Mode::Header;
+			eptr->inputPacket.bytesLeft = 8;
+			eptr->inputPacket.startPtr = eptr->headerBuffer.data();
 
-			masterconn_gotpacket(eptr,type,eptr->inputpacket.packet,size);
+			masterconn_gotpacket(eptr,type,eptr->inputPacket.packet,size);
 
-			if (eptr->inputpacket.packet) {
-				free(eptr->inputpacket.packet);
+			if (eptr->inputPacket.packet) {
+				free(eptr->inputPacket.packet);
 			}
-			eptr->inputpacket.packet=NULL;
+			eptr->inputPacket.packet=NULL;
 		}
 
 		if (watchdog.expired()) {
@@ -979,35 +985,35 @@ void masterconn_read(masterconn *eptr) {
 	}
 }
 
-void masterconn_write(masterconn *eptr) {
+void masterconn_write(MasterConn *eptr) {
 	SignalLoopWatchdog watchdog;
-	packetstruct *pack;
+	PacketStruct *pack;
 	int32_t i;
 
 	watchdog.start();
 	for (;;) {
-		pack = eptr->outputhead;
+		pack = eptr->outputHead;
 		if (pack==NULL) {
 			return;
 		}
-		i=write(eptr->sock,pack->startptr,pack->bytesleft);
+		i=write(eptr->sock,pack->startPtr,pack->bytesLeft);
 		if (i<0) {
 			if (errno!=EAGAIN) {
 				safs_silent_errlog(LOG_NOTICE,"write to Master error");
-				eptr->mode = KILL;
+				eptr->mode = MasterConn::Mode::Kill;
 			}
 			return;
 		}
 		stats_bytesout+=i;
-		pack->startptr+=i;
-		pack->bytesleft-=i;
-		if (pack->bytesleft>0) {
+		pack->startPtr+=i;
+		pack->bytesLeft-=i;
+		if (pack->bytesLeft>0) {
 			return;
 		}
 		free(pack->packet);
-		eptr->outputhead = pack->next;
-		if (eptr->outputhead==NULL) {
-			eptr->outputtail = &(eptr->outputhead);
+		eptr->outputHead = pack->next;
+		if (eptr->outputHead==NULL) {
+			eptr->outputTail = &(eptr->outputHead);
 		}
 		free(pack);
 
@@ -1018,85 +1024,85 @@ void masterconn_write(masterconn *eptr) {
 }
 
 void masterconn_wantexit(void) {
-	if (masterconnsingleton) {
-		masterconn_kill_session(masterconnsingleton);
+	if (gMasterConn) {
+		masterconn_kill_session(gMasterConn);
 	}
 }
 
 int masterconn_canexit(void) {
-	return !masterconnsingleton || masterconnsingleton->mode == FREE;
+	return !gMasterConn || gMasterConn->mode == MasterConn::Mode::Free;
 }
 
 void masterconn_desc(std::vector<pollfd> &pdesc) {
-	if (!masterconnsingleton) {
+	if (!gMasterConn) {
 		return;
 	}
-	masterconn *eptr = masterconnsingleton;
+	MasterConn *eptr = gMasterConn;
 
-	eptr->pdescpos = -1;
-	if (eptr->mode==FREE || eptr->sock<0) {
+	eptr->pollDescPos = -1;
+	if (eptr->mode==MasterConn::Mode::Free || eptr->sock<0) {
 		return;
 	}
-	if (eptr->mode==HEADER || eptr->mode==DATA) {
+	if (eptr->mode==MasterConn::Mode::Header || eptr->mode==MasterConn::Mode::Data) {
 		pdesc.push_back({eptr->sock,POLLIN,0});
-		eptr->pdescpos = pdesc.size() - 1;
+		eptr->pollDescPos = pdesc.size() - 1;
 	}
-	if (((eptr->mode==HEADER || eptr->mode==DATA) && eptr->outputhead!=NULL) || eptr->mode==CONNECTING) {
-		if (eptr->pdescpos>=0) {
-			pdesc[eptr->pdescpos].events |= POLLOUT;
+	if (((eptr->mode==MasterConn::Mode::Header || eptr->mode==MasterConn::Mode::Data) && eptr->outputHead!=NULL) || eptr->mode==MasterConn::Mode::Connecting) {
+		if (eptr->pollDescPos>=0) {
+			pdesc[eptr->pollDescPos].events |= POLLOUT;
 		} else {
 			pdesc.push_back({eptr->sock,POLLOUT,0});
-			eptr->pdescpos = pdesc.size() - 1;
+			eptr->pollDescPos = pdesc.size() - 1;
 		}
 	}
 }
 
 void masterconn_serve(const std::vector<pollfd> &pdesc) {
-	if (!masterconnsingleton) {
+	if (!gMasterConn) {
 		return;
 	}
 	uint32_t now=eventloop_time();
-	packetstruct *pptr,*paptr;
-	masterconn *eptr = masterconnsingleton;
+	PacketStruct *pptr,*paptr;
+	MasterConn *eptr = gMasterConn;
 
-	if (eptr->pdescpos>=0 && (pdesc[eptr->pdescpos].revents & (POLLHUP | POLLERR))) {
-		if (eptr->mode==CONNECTING) {
+	if (eptr->pollDescPos>=0 && (pdesc[eptr->pollDescPos].revents & (POLLHUP | POLLERR))) {
+		if (eptr->mode==MasterConn::Mode::Connecting) {
 			masterconn_connecttest(eptr);
 		} else {
-			eptr->mode = KILL;
+			eptr->mode = MasterConn::Mode::Kill;
 		}
 	}
-	if (eptr->mode==CONNECTING) {
-		if (eptr->sock>=0 && eptr->pdescpos>=0 && (pdesc[eptr->pdescpos].revents & POLLOUT)) { // FD_ISSET(eptr->sock,wset)) {
+	if (eptr->mode==MasterConn::Mode::Connecting) {
+		if (eptr->sock>=0 && eptr->pollDescPos>=0 && (pdesc[eptr->pollDescPos].revents & POLLOUT)) { // FD_ISSET(eptr->sock,wset)) {
 			masterconn_connecttest(eptr);
 		}
 	} else {
-		if (eptr->pdescpos>=0) {
-			if ((eptr->mode==HEADER || eptr->mode==DATA) && (pdesc[eptr->pdescpos].revents & POLLIN)) { // FD_ISSET(eptr->sock,rset)) {
-				eptr->lastread = now;
+		if (eptr->pollDescPos>=0) {
+			if ((eptr->mode==MasterConn::Mode::Header || eptr->mode==MasterConn::Mode::Data) && (pdesc[eptr->pollDescPos].revents & POLLIN)) { // FD_ISSET(eptr->sock,rset)) {
+				eptr->lastRead = now;
 				masterconn_read(eptr);
 			}
-			if ((eptr->mode==HEADER || eptr->mode==DATA) && (pdesc[eptr->pdescpos].revents & POLLOUT)) { // FD_ISSET(eptr->sock,wset)) {
-				eptr->lastwrite = now;
+			if ((eptr->mode==MasterConn::Mode::Header || eptr->mode==MasterConn::Mode::Data) && (pdesc[eptr->pollDescPos].revents & POLLOUT)) { // FD_ISSET(eptr->sock,wset)) {
+				eptr->lastWrite = now;
 				masterconn_write(eptr);
 			}
-			if ((eptr->mode==HEADER || eptr->mode==DATA) && eptr->lastread+Timeout<now) {
-				eptr->mode = KILL;
+			if ((eptr->mode==MasterConn::Mode::Header || eptr->mode==MasterConn::Mode::Data) && eptr->lastRead+Timeout<now) {
+				eptr->mode = MasterConn::Mode::Kill;
 			}
-			if ((eptr->mode==HEADER || eptr->mode==DATA) && eptr->lastwrite+(Timeout/3)<now && eptr->outputhead==NULL) {
+			if ((eptr->mode==MasterConn::Mode::Header || eptr->mode==MasterConn::Mode::Data) && eptr->lastWrite+(Timeout/3)<now && eptr->outputHead==NULL) {
 				masterconn_createpacket(eptr,ANTOAN_NOP,0);
 			}
 		}
 	}
-	if (eptr->mode == KILL) {
+	if (eptr->mode == MasterConn::Mode::Kill) {
 		masterconn_beforeclose(eptr);
 		tcpclose(eptr->sock);
-		eptr->sock = -1;
-		if (eptr->inputpacket.packet) {
-			free(eptr->inputpacket.packet);
-			eptr->inputpacket.packet = NULL;
+		eptr->sock = MasterConn::kInvalidFD;
+		if (eptr->inputPacket.packet) {
+			free(eptr->inputPacket.packet);
+			eptr->inputPacket.packet = NULL;
 		}
-		pptr = eptr->outputhead;
+		pptr = eptr->outputHead;
 		while (pptr) {
 			if (pptr->packet) {
 				free(pptr->packet);
@@ -1105,43 +1111,42 @@ void masterconn_serve(const std::vector<pollfd> &pdesc) {
 			pptr = pptr->next;
 			free(paptr);
 		}
-		eptr->outputhead = NULL;
-		eptr->mode = FREE;
-		eptr->version = 0;
+		eptr->outputHead = NULL;
+		eptr->mode = MasterConn::Mode::Free;
+		eptr->masterVersion = MasterConn::kInvalidMasterVersion;
 	}
 }
 
 void masterconn_reconnect(void) {
-	if (!masterconnsingleton) {
+	if (!gMasterConn) {
 		return;
 	}
-	masterconn *eptr = masterconnsingleton;
-	if (eptr->mode == FREE && gExitingStatus == ExitingStatus::kRunning) {
+	MasterConn *eptr = gMasterConn;
+	if (eptr->mode == MasterConn::Mode::Free && gExitingStatus == ExitingStatus::kRunning) {
 		masterconn_initconnect(eptr);
 	}
-	if ((eptr->mode == HEADER || eptr->mode == DATA) && eptr->state == MasterConnectionState::kLimbo) {
-		if (eptr->changelog_apply_error_packet_time.expired()) {
+	if ((eptr->mode == MasterConn::Mode::Header || eptr->mode == MasterConn::Mode::Data) && eptr->state == MasterConn::State::kLimbo) {
+		if (eptr->changelogApplyErrorTimeout.expired()) {
 			masterconn_request_metadata_dump(eptr);
 		}
 	}
 }
 
 void masterconn_become_master() {
-	if (!masterconnsingleton) {
+	if (!gMasterConn) {
 		return;
 	}
-	masterconn *eptr = masterconnsingleton;
-	eventloop_timeunregister(eptr->sessionsdownloadinit_handle);
-	eventloop_timeunregister(eptr->metachanges_flush_handle);
+	MasterConn *eptr = gMasterConn;
+	eventloop_timeunregister(eptr->sessionsDownloadInitHandle);
+	eventloop_timeunregister(eptr->changelogFlushHandle);
 	masterconn_term();
-	return;
 }
 
 void masterconn_reload(void) {
-	if (!masterconnsingleton) {
+	if (!gMasterConn) {
 		return;
 	}
-	masterconn *eptr = masterconnsingleton;
+	MasterConn *eptr = gMasterConn;
 	uint32_t ReconnectionDelay;
 
 	std::string newMasterHost = cfg_getstring("MASTER_HOST","sfsmaster");
@@ -1152,9 +1157,9 @@ void masterconn_reload(void) {
 		MasterHost = newMasterHost;
 		MasterPort = newMasterPort;
 		BindHost = newBindHost;
-		eptr->masteraddrvalid = 0;
-		if (eptr->mode != FREE) {
-			eptr->mode = KILL;
+		eptr->isMasterAddressValid = 0;
+		if (eptr->mode != MasterConn::Mode::Free) {
+			eptr->mode = MasterConn::Mode::Kill;
 		}
 	}
 
@@ -1186,7 +1191,7 @@ void masterconn_reload(void) {
 #endif /* #ifndef METALOGGER */
 
 #ifndef METALOGGER
-	masterconn_int_send_matoclport(masterconnsingleton);
+	masterconn_int_send_matoclport(gMasterConn);
 #endif /* #ifndef METALOGGER */
 }
 
@@ -1197,7 +1202,7 @@ int masterconn_init(void) {
 		return 0;
 	}
 #endif /* #ifndef METALOGGER */
-	masterconn *eptr;
+	MasterConn *eptr;
 
 	ReconnectionDelay = cfg_getuint32("MASTER_RECONNECTION_DELAY", 1);
 	MasterHost = cfg_getstring("MASTER_HOST","sfsmaster");
@@ -1223,16 +1228,16 @@ int masterconn_init(void) {
 	}
 #endif /* #ifdef METALOGGER */
 
-	eptr = masterconnsingleton = new masterconn();
+	eptr = gMasterConn = new MasterConn();
 	passert(eptr);
 
-	eptr->masteraddrvalid = 0;
-	eptr->mode = FREE;
-	eptr->pdescpos = -1;
-	eptr->metafd = -1;
-	eptr->version = 0;
-	eptr->sock  = -1;
-	eptr->state = MasterConnectionState::kNone;
+	eptr->isMasterAddressValid = 0;
+	eptr->mode = MasterConn::Mode::Free;
+	eptr->pollDescPos = -1;
+	eptr->downloadFD = MasterConn::kInvalidFD;
+	eptr->masterVersion = MasterConn::kInvalidMasterVersion;
+	eptr->sock  = MasterConn::kInvalidFD;
+	eptr->state = MasterConn::State::kNone;
 #ifdef METALOGGER
 	gMetadataBackend->changelogsMigrateFrom_1_6_29("changelog_ml");
 	masterconn_findlastlogversion();
@@ -1252,15 +1257,15 @@ int masterconn_init(void) {
 #ifndef METALOGGER
 	metadataserver::registerFunctionCalledOnPromotion(masterconn_become_master);
 #endif
-	eptr->sessionsdownloadinit_handle = eventloop_timeregister(TIMEMODE_RUN_LATE,60,0,masterconn_sessionsdownloadinit);
-	eptr->metachanges_flush_handle = eventloop_timeregister(TIMEMODE_RUN_LATE,1,0,changelog_flush);
+	eptr->sessionsDownloadInitHandle = eventloop_timeregister(TIMEMODE_RUN_LATE,60,0,masterconn_sessionsdownloadinit);
+	eptr->changelogFlushHandle = eventloop_timeregister(TIMEMODE_RUN_LATE,1,0,changelog_flush);
 	return 0;
 }
 
 bool masterconn_is_connected() {
-	masterconn *eptr = masterconnsingleton;
+	MasterConn *eptr = gMasterConn;
 	return (eptr != nullptr
-			&& (eptr->mode == HEADER || eptr->mode == DATA) // socket is connected
-			&& eptr->version > 0 // registration was successful
+			&& (eptr->mode == MasterConn::Mode::Header || eptr->mode == MasterConn::Mode::Data) // socket is connected
+			&& eptr->masterVersion > MasterConn::kInvalidMasterVersion // registration was successful
 	);
 }

--- a/src/master/masterconn.cc
+++ b/src/master/masterconn.cc
@@ -105,7 +105,7 @@ struct MasterConn {
 	};
 
 	Mode mode{};  ///< Current connection mode.
-	State state{State::kNone};  ///< Current synchonization state.
+	State state{State::kNone};  ///< Current synchronization state.
 
 	int sock{kInvalidFD};  ///< Socket descriptor.
 	int32_t pollDescPos{};  ///< Position in the poll descriptors array.

--- a/src/master/masterconn.cc
+++ b/src/master/masterconn.cc
@@ -65,12 +65,7 @@
 #include "master/restore.h"
 #endif /* #ifndef METALOGGER */
 
-/// Block size for metadata download (1 MB).
-constexpr uint32_t kMetadataDownloadBlocksize = 1000000U;
-
-/// Safety measure about expected max packet size.
-constexpr uint32_t kMaxPacketSize = 1500000U;
-
+/// Structure for the packet being sent or received.
 struct PacketStruct {
 	uint8_t *startPtr{};
 	uint32_t bytesLeft{0};
@@ -79,10 +74,15 @@ struct PacketStruct {
 
 /// Represents a connection to the master server.
 /// Holds the connection state and the data that is being sent or received.
+/// In charge of downloading metadata, sessions and changelogs.
 struct MasterConn {
 	// Useful constants.
-	static constexpr uint8_t kHeaderSize = 8;
-	static constexpr uint8_t kPacketTypeSize = 4;
+	/// Block size for metadata download (1 MB).
+	static constexpr uint32_t kMetadataDownloadBlocksize = 1000000U;
+	/// Safety measure about expected max packet size.
+	static constexpr uint32_t kMaxPacketSize = 1500000U;
+	static constexpr uint8_t kHeaderSize = 8;  ///< Packet type + size.
+	static constexpr uint8_t kPacketTypeSize = 4;  ///< sizeof(uint32_t).
 	static constexpr uint8_t kChangeLogApplyErrorTimeout = 10;
 	static constexpr int kInvalidFD = -1;
 	static constexpr int kInvalidPollDescPos = -1;
@@ -329,8 +329,6 @@ void MasterConn::createPacket(std::vector<uint8_t> data) {
 }
 
 void MasterConn::sendRegister() {
-	uint8_t *buff;
-
 	downloadingFileNum = 0;
 	downloadFD = kInvalidFD;
 
@@ -346,7 +344,7 @@ void MasterConn::sendRegister() {
 #endif
 
 	if (lastLogVersion>0) {
-		buff = createPacket(MLTOMA_REGISTER, 1 + 4 + 2 + 8);
+		auto *buff = createPacket(MLTOMA_REGISTER, 1 + 4 + 2 + 8);
 		put8bit(&buff,2);
 		put16bit(&buff,SAUNAFS_PACKAGE_VERSION_MAJOR);
 		put8bit(&buff,SAUNAFS_PACKAGE_VERSION_MINOR);
@@ -354,7 +352,7 @@ void MasterConn::sendRegister() {
 		put16bit(&buff,cfgMasterTimeout);
 		put64bit(&buff,lastLogVersion);
 	} else {
-		buff = createPacket(MLTOMA_REGISTER, 1 + 4 + 2);
+		auto *buff = createPacket(MLTOMA_REGISTER, 1 + 4 + 2);
 		put8bit(&buff,1);
 		put16bit(&buff,SAUNAFS_PACKAGE_VERSION_MAJOR);
 		put8bit(&buff,SAUNAFS_PACKAGE_VERSION_MINOR);
@@ -377,7 +375,7 @@ void MasterConn::killSession() {
 
 void MasterConn::forceMetadataDownload() {
 #ifndef METALOGGER
-	state = MasterConn::State::kNone;
+	state = State::kNone;
 	fs_unload();
 	restore_reset();
 #endif
@@ -477,7 +475,7 @@ void MasterConn::metachangesLog(const uint8_t *data,uint32_t length) {
 	const char* changelogEntry = reinterpret_cast<const char*>(data);
 
 	if ((lastLogVersion > 0) && (version != (lastLogVersion + 1))) {
-		safs::log_warn("some changes lost: [{}}-{}}], download metadata again", lastLogVersion, version - 1);
+		safs::log_warn("some changes lost: [{}-{}], download metadata again", lastLogVersion, version - 1);
 		handleChangelogApplyError(SAUNAFS_ERROR_METADATAVERSIONMISMATCH);
 		return;
 	}
@@ -618,12 +616,12 @@ void MasterConn::downloadNext() {
 				 * We can have other state if we are synchronized or we got changelog apply error
 				 * during independent sessions download session.
 				 */
-				if (state == MasterConn::State::kDownloading) {
+				if (state == State::kDownloading) {
 					try {
 						fs_loadall();
 						lastLogVersion = fs_getversion() - 1;
 						safs::log_info("synced at version = {}", lastLogVersion);
-						state = MasterConn::State::kSynchronized;
+						state = State::kSynchronized;
 					} catch (Exception& ex) {
 						safs::log_warn("can't load downloaded metadata and changelogs: {}",
 								ex.what());
@@ -637,7 +635,7 @@ void MasterConn::downloadNext() {
 					}
 				}
 #else /* #ifndef METALOGGER */
-				state = MasterConn::State::kSynchronized;
+				state = State::kSynchronized;
 #endif /* #else #ifndef METALOGGER */
 			}
 		}
@@ -677,16 +675,19 @@ void MasterConn::downloadStart(const uint8_t *data, uint32_t length) {
 	downloadRetryCnt = 0;
 	downloadStartTimeInMicroSeconds = eventloop_utime();
 
+	static constexpr mode_t kFilePermissions = 0666;
+	static constexpr int kFileFlags = O_WRONLY | O_TRUNC | O_CREAT;
+
 	if (downloadingFileNum == DOWNLOAD_METADATA_SFS) {
-		downloadFD = ::open(getMetadataTmpFilename().c_str(),
-		                    O_WRONLY | O_TRUNC | O_CREAT, 0666);
+		downloadFD = ::open(getMetadataTmpFilename().c_str(), kFileFlags,
+		                    kFilePermissions);
 	} else if (downloadingFileNum == DOWNLOAD_SESSIONS_SFS) {
-		downloadFD = ::open(getSessionsTmpFilename().c_str(),
-		                    O_WRONLY | O_TRUNC | O_CREAT, 0666);
+		downloadFD = ::open(getSessionsTmpFilename().c_str(), kFileFlags,
+		                    kFilePermissions);
 	} else if ((downloadingFileNum == DOWNLOAD_CHANGELOG_SFS) ||
 	           (downloadingFileNum == DOWNLOAD_CHANGELOG_SFS_1)) {
-		downloadFD = ::open(getChangelogTmpFilename().c_str(),
-		                    O_WRONLY | O_TRUNC | O_CREAT, 0666);
+		downloadFD = ::open(getChangelogTmpFilename().c_str(), kFileFlags,
+		                    kFilePermissions);
 	} else {
 		safs::log_info("unexpected MATOML_DOWNLOAD_START packet");
 		mode = Mode::Kill;
@@ -710,13 +711,13 @@ void MasterConn::downloadData(const uint8_t *data,uint32_t length) {
 
 	if (downloadFD < 0) {
 		safs::log_info("MATOML_DOWNLOAD_DATA - file not opened");
-		mode = MasterConn::Mode::Kill;
+		mode = Mode::Kill;
 		return;
 	}
 
 	if (length<16) {
 		safs::log_info("MATOML_DOWNLOAD_DATA - wrong size ({}/16+data)", length);
-		mode = MasterConn::Mode::Kill;
+		mode = Mode::Kill;
 		return;
 	}
 
@@ -727,31 +728,31 @@ void MasterConn::downloadData(const uint8_t *data,uint32_t length) {
 
 	if (leng+16!=length) {
 		safs::log_info("MATOML_DOWNLOAD_DATA - wrong size ({}/16+{})", length, leng);
-		mode = MasterConn::Mode::Kill;
+		mode = Mode::Kill;
 		return;
 	}
 
 	if (offset != downloadOffset) {
 		safs::log_info("MATOML_DOWNLOAD_DATA - unexpected file offset ({}/{})", offset, downloadOffset);
-		mode = MasterConn::Mode::Kill;
+		mode = Mode::Kill;
 		return;
 	}
 
 	if (offset + leng > fileSize) {
 		safs::log_info("MATOML_DOWNLOAD_DATA - unexpected file size ({}/{})", offset + leng, fileSize);
-		mode = MasterConn::Mode::Kill;
+		mode = Mode::Kill;
 		return;
 	}
 
 #ifdef SAUNAFS_HAVE_PWRITE
-	ret = ::pwrite(downloadFD,data,leng,offset);
+	ret = ::pwrite(downloadFD, data, leng, offset);
 #else /* SAUNAFS_HAVE_PWRITE */
-	::lseek(metafd,offset,SEEK_SET);
-	ret = ::write(metafd,data,leng);
+	::lseek(downloadFD, offset, SEEK_SET);
+	ret = ::write(downloadFD, data, leng);
 #endif /* SAUNAFS_HAVE_PWRITE */
 
-	if (ret!=(ssize_t)leng) {
-		safs_silent_errlog(LOG_NOTICE,"error writing metafile");
+	if (ret != (ssize_t)leng) {
+		safs_silent_errlog(LOG_NOTICE, "error writing metafile");
 		if (downloadRetryCnt >= 5) {
 			downloadEnd();
 		} else {
@@ -975,29 +976,30 @@ void MasterConn::connectTest() {
 
 void MasterConn::readFromSocket() {
 	SignalLoopWatchdog watchdog;
-	int32_t i;
-	uint32_t type,size;
-	const uint8_t *ptr;
+	int32_t readBytes{};
+	uint32_t type{};
+	uint32_t size{};
+	const uint8_t *ptr{};
 
 	watchdog.start();
 
-	while (mode != MasterConn::Mode::Kill) {
-		i = ::read(sock, inputPacket.startPtr, inputPacket.bytesLeft);
-		if (i==0) {
+	while (mode != Mode::Kill) {
+		readBytes = ::read(sock, inputPacket.startPtr, inputPacket.bytesLeft);
+		if (readBytes == 0) {
 			safs::log_info("connection was reset by Master");
 			killSession();
 			return;
 		}
-		if (i<0) {
-			if (errno!=EAGAIN) {
+		if (readBytes < 0) {
+			if (errno != EAGAIN) {
 				safs_silent_errlog(LOG_NOTICE, "read from Master error");
 				killSession();
 			}
 			return;
 		}
 
-		inputPacket.startPtr += i;
-		inputPacket.bytesLeft -= i;
+		inputPacket.startPtr += readBytes;
+		inputPacket.bytesLeft -= readBytes;
 
 		if (inputPacket.bytesLeft > 0) { return; }
 
@@ -1007,7 +1009,8 @@ void MasterConn::readFromSocket() {
 
 			if (size > 0) {
 				if (size > kMaxPacketSize) {
-					safs::log_warn("Master packet too long ({}/{})", size, kMaxPacketSize);
+					safs::log_warn("Master packet too long ({}/{})", size,
+					               kMaxPacketSize);
 					killSession();
 					return;
 				}
@@ -1164,8 +1167,8 @@ void MasterConn::reconnect() {
 }
 
 void MasterConn::becomeMaster() {
-	eventloop_timeunregister(sessionsDownloadInitHandle);
-	eventloop_timeunregister(changelogFlushHandle);
+	eventloop_timeunregister(this->sessionsDownloadInitHandle);
+	eventloop_timeunregister(this->changelogFlushHandle);
 }
 
 void MasterConn::loadConfig() {

--- a/src/master/masterconn.cc
+++ b/src/master/masterconn.cc
@@ -29,6 +29,7 @@
 #include <sys/uio.h>
 #include <syslog.h>
 #include <unistd.h>
+#include <algorithm>
 #include <cerrno>
 #include <cstdint>
 #include <cstdio>
@@ -49,6 +50,7 @@
 #include "common/sockets.h"
 #include "common/time_utils.h"
 #include "config/cfg.h"
+#include "errors/saunafs_error_codes.h"
 #include "master/changelog.h"
 #include "master/metadata_backend_common.h"
 #include "master/metadata_backend_interface.h"
@@ -62,6 +64,24 @@
 #include "master/personality.h"
 #include "master/restore.h"
 #endif /* #ifndef METALOGGER */
+
+namespace {
+#ifdef METALOGGER
+const std::string metadataFilename = kMetadataMlFilename;
+const std::string metadataTmpFilename = kMetadataMlTmpFilename;
+const std::string changelogFilename = kChangelogMlFilename;
+const std::string changelogTmpFilename = kChangelogMlTmpFilename;
+const std::string sessionsFilename = kSessionsMlFilename;
+const std::string sessionsTmpFilename = kSessionsMlTmpFilename;
+#else  /* #ifdef METALOGGER */
+const std::string metadataFilename = kMetadataFilename;
+const std::string metadataTmpFilename = kMetadataTmpFilename;
+const std::string changelogFilename = kChangelogFilename;
+const std::string changelogTmpFilename = kChangelogTmpFilename;
+const std::string sessionsFilename = kSessionsFilename;
+const std::string sessionsTmpFilename = kSessionsTmpFilename;
+#endif /* #else #ifdef METALOGGER */
+}  // namespace
 
 /// Block size for metadata download (1 MB).
 constexpr uint32_t kMetadataDownloadBlocksize = 1000000U;
@@ -78,10 +98,17 @@ struct PacketStruct {
 /// Represents a connection to the master server.
 /// Holds the connection state and the data that is being sent or received.
 struct MasterConn {
+	// Useful constants.
 	static constexpr uint8_t kHeaderSize = 8;
+	static constexpr uint8_t kPacketTypeSize = 4;
 	static constexpr uint8_t kChangeLogApplyErrorTimeout = 10;
 	static constexpr int kInvalidFD = -1;
+	static constexpr int kInvalidPollDescPos = -1;
 	static constexpr uint32_t kInvalidMasterVersion = 0;
+
+	static constexpr uint32_t kMaxMasterTimeout = 65536;
+	static constexpr uint32_t kMinMasterTimeout = 10;
+	static constexpr uint32_t kMaxBackMetaCopies = 100;
 
 	enum class Mode : uint8_t {
 		Free,        ///< Connection is not in use.
@@ -104,11 +131,11 @@ struct MasterConn {
 		kLimbo
 	};
 
-	Mode mode{};  ///< Current connection mode.
+	Mode mode{Mode::Free};  ///< Current connection mode.
 	State state{State::kNone};  ///< Current synchronization state.
 
 	int sock{kInvalidFD};  ///< Socket descriptor.
-	int32_t pollDescPos{};  ///< Position in the poll descriptors array.
+	int32_t pollDescPos{kInvalidFD};  ///< Position in the poll desc. array.
 	uint32_t lastRead{};  ///< Timestamp of the last read operation.
 	uint32_t lastWrite{};  ///< Timestamp of the last write operation.
 
@@ -123,7 +150,7 @@ struct MasterConn {
 	uint32_t bindIP{};  ///< IP address to bind the socket.
 	uint32_t masterIP{};  ///< IP address of the master server.
 	uint16_t masterPort{};  ///< Port of the master server.
-	uint8_t isMasterAddressValid{};  /// Known after (re)connections.
+	uint8_t isMasterAddressValid{0};  /// Known after (re)connections.
 
 	uint8_t downloadRetryCnt{};  ///< Retry count for downloads.
 	/// Number of the file being downloaded (metadata, changelogs, sessions).
@@ -143,25 +170,81 @@ struct MasterConn {
 	/// Timeout for mltoma::changelogApplyError packets.
 	Timeout changelogApplyErrorTimeout{
 	    std::chrono::seconds(kChangeLogApplyErrorTimeout)};
+
+	uint64_t lastLogVersion = 0;
+
+	// from config
+	uint32_t BackMetaCopies;
+	std::string MasterHost;
+	std::string MasterPort;
+	std::string BindHost;
+	uint32_t masterTimeout;
+
+	// Callbacks
+	void *reconnect_hook;
+#ifdef METALOGGER
+	void *download_hook;
+#endif /* #ifdef METALOGGER */
+
+	// Configuration
+
+	void loadConfig();
+	void reload();
+	void sendMetaloggerConfig();
+
+	// Connection and network packets
+
+	uint8_t *createPacket(uint32_t type, uint32_t size);
+	void createPacket(std::vector<uint8_t> data);
+	void gotPacket(uint32_t type,const uint8_t *data,uint32_t length);
+
+	int initConnect();
+	void onConnected();
+	void sendRegister();
+	void onRegistered(const uint8_t *data, uint32_t length);
+	void connectTest();
+	void reconnect();
+	void sendMatoClPort();
+
+	// Metadata and sessions download
+
+	void downloadNext();
+	void downloadData(const uint8_t *data, uint32_t length);
+	void forceMetadataDownload();
+	int downloadEnd();
+	void downloadInit(uint8_t filenum);
+	void downloadStart(const uint8_t *data, uint32_t length);
+	void requestMetadataDump();
+	int metadataCheck(const std::string& name);
+
+	// Changelogs
+
+	void metachangesLog(const uint8_t *data, uint32_t length);
+	void changelogApplyError(const uint8_t *data, uint32_t length);
+	void handleChangelogApplyError(uint8_t status);
+
+	// IO and polling
+
+	void readFromSocket();
+	void writeToSocket();
+	void pollDesc(std::vector<pollfd> &pdesc);
+	void serve(const std::vector<pollfd> &pdesc);
+
+	// Promotion
+
+	void becomeMaster();
+
+	// Shutting down
+
+	void endSession(const uint8_t* data, uint32_t length);
+	void killSession();
+	void beforeClose();
+	void terminate();
 };
 
 static MasterConn *gMasterConn = nullptr;
 
-// from config
-static uint32_t BackMetaCopies;
-static std::string MasterHost;
-static std::string MasterPort;
-static std::string BindHost;
-static uint32_t Timeout;
-static void* reconnect_hook;
-#ifdef METALOGGER
-static void* download_hook;
-#endif /* #ifdef METALOGGER */
-
-static uint64_t lastLogVersion = 0;
-
-uint8_t *masterconn_createpacket(MasterConn *eptr, uint32_t type,
-                                 uint32_t size) {
+uint8_t *MasterConn::createPacket(uint32_t type, uint32_t size) {
 	auto outpacket = std::make_unique<PacketStruct>();
 	passert(outpacket.get());
 	uint32_t psize = size + MasterConn::kHeaderSize;
@@ -172,121 +255,106 @@ uint8_t *masterconn_createpacket(MasterConn *eptr, uint32_t type,
 	put32bit(&ptr,type);
 	put32bit(&ptr,size);
 	outpacket->startPtr = outpacket->packet.data();
-	eptr->outputQueue.push(std::move(outpacket));
+	outputQueue.push(std::move(outpacket));
 
 	return ptr;
 }
 
-void masterconn_createpacket(MasterConn *eptr, std::vector<uint8_t> data) {
+void MasterConn::createPacket(std::vector<uint8_t> data) {
 	auto outpacket = std::make_unique<PacketStruct>();
 	passert(outpacket);
 	outpacket->packet = std::move(data);
 	passert(outpacket->packet.data());
 	outpacket->bytesLeft = outpacket->packet.size();
 	outpacket->startPtr = outpacket->packet.data();
-	eptr->outputQueue.push(std::move(outpacket));
+	outputQueue.push(std::move(outpacket));
 }
 
-void masterconn_sendregister(MasterConn *eptr) {
+void MasterConn::sendRegister() {
 	uint8_t *buff;
 
-	eptr->downloadingFileNum = 0;
-	eptr->downloadFD = MasterConn::kInvalidFD;
+	downloadingFileNum = 0;
+	downloadFD = kInvalidFD;
 
 #ifndef METALOGGER
 	// shadow master registration
 	uint64_t metadataVersion = 0;
-	if (eptr->state == MasterConn::State::kSynchronized) {
+	if (state == State::kSynchronized) {
 		metadataVersion = fs_getversion();
 	}
-	auto request = mltoma::registerShadow::build(SAUNAFS_VERSHEX, Timeout * 1000, metadataVersion);
-	masterconn_createpacket(eptr, std::move(request));
+	auto request = mltoma::registerShadow::build(SAUNAFS_VERSHEX, masterTimeout * 1000, metadataVersion);
+	createPacket(std::move(request));
 	return;
 #endif
 
 	if (lastLogVersion>0) {
-		buff = masterconn_createpacket(eptr,MLTOMA_REGISTER,1+4+2+8);
+		buff = createPacket(MLTOMA_REGISTER, 1 + 4 + 2 + 8);
 		put8bit(&buff,2);
 		put16bit(&buff,SAUNAFS_PACKAGE_VERSION_MAJOR);
 		put8bit(&buff,SAUNAFS_PACKAGE_VERSION_MINOR);
 		put8bit(&buff,SAUNAFS_PACKAGE_VERSION_MICRO);
-		put16bit(&buff,Timeout);
+		put16bit(&buff,masterTimeout);
 		put64bit(&buff,lastLogVersion);
 	} else {
-		buff = masterconn_createpacket(eptr,MLTOMA_REGISTER,1+4+2);
+		buff = createPacket(MLTOMA_REGISTER, 1 + 4 + 2);
 		put8bit(&buff,1);
 		put16bit(&buff,SAUNAFS_PACKAGE_VERSION_MAJOR);
 		put8bit(&buff,SAUNAFS_PACKAGE_VERSION_MINOR);
 		put8bit(&buff,SAUNAFS_PACKAGE_VERSION_MICRO);
-		put16bit(&buff,Timeout);
+		put16bit(&buff,masterTimeout);
 	}
 }
 
-void masterconn_send_metalogger_config(MasterConn *eptr) {
+void MasterConn::sendMetaloggerConfig() {
 	std::string config = cfg_yaml_string();
 	auto request = mltoma::dumpConfiguration::build(config);
-	masterconn_createpacket(eptr, std::move(request));
+	createPacket(std::move(request));
 }
 
-namespace {
-#ifdef METALOGGER
-	const std::string metadataFilename = kMetadataMlFilename;
-	const std::string metadataTmpFilename = kMetadataMlTmpFilename;
-	const std::string changelogFilename = kChangelogMlFilename;
-	const std::string changelogTmpFilename = kChangelogMlTmpFilename;
-	const std::string sessionsFilename = kSessionsMlFilename;
-	const std::string sessionsTmpFilename = kSessionsMlTmpFilename;
-#else /* #ifdef METALOGGER */
-	const std::string metadataFilename = kMetadataFilename;
-	const std::string metadataTmpFilename = kMetadataTmpFilename;
-	const std::string changelogFilename = kChangelogFilename;
-	const std::string changelogTmpFilename = kChangelogTmpFilename;
-	const std::string sessionsFilename = kSessionsFilename;
-	const std::string sessionsTmpFilename = kSessionsTmpFilename;
-#endif /* #else #ifdef METALOGGER */
-}
-
-void masterconn_kill_session(MasterConn* eptr) {
-	if (eptr->mode != MasterConn::Mode::Free) {
-		eptr->mode = MasterConn::Mode::Kill;
+void MasterConn::killSession() {
+	if (mode != Mode::Free) {
+		mode = Mode::Kill;
 	}
 }
 
-void masterconn_force_metadata_download(MasterConn* eptr) {
+void MasterConn::forceMetadataDownload() {
 #ifndef METALOGGER
-	eptr->state = MasterConn::State::kNone;
+	state = MasterConn::State::kNone;
 	fs_unload();
 	restore_reset();
 #endif
 	lastLogVersion = 0;
-	masterconn_kill_session(eptr);
+	killSession();
 }
 
-void masterconn_request_metadata_dump(MasterConn* eptr) {
-	masterconn_createpacket(eptr, mltoma::changelogApplyError::build(eptr->errorStatus));
-	eptr->state = MasterConn::State::kDumpRequestPending;
-	eptr->changelogApplyErrorTimeout.reset();
+void MasterConn::requestMetadataDump() {
+	createPacket(mltoma::changelogApplyError::build(errorStatus));
+	state = State::kDumpRequestPending;
+	changelogApplyErrorTimeout.reset();
 }
 
-void masterconn_handle_changelog_apply_error(MasterConn* eptr, uint8_t status) {
-	if (eptr->masterVersion <= saunafsVersion(2, 5, 0)) {
+void MasterConn::handleChangelogApplyError(uint8_t status) {
+	if (masterVersion <= saunafsVersion(2, 5, 0)) {
 		safs_pretty_syslog(LOG_NOTICE, "Dropping in-memory metadata and starting download from master");
-		masterconn_force_metadata_download(eptr);
+		forceMetadataDownload();
 	} else {
 		safs_pretty_syslog(LOG_NOTICE, "Waiting for master to produce up-to-date metadata image");
-		eptr->errorStatus = status;
-		masterconn_request_metadata_dump(eptr);
+		errorStatus = status;
+		requestMetadataDump();
 	}
 }
 
 #ifndef METALOGGER
-void masterconn_int_send_matoclport(MasterConn* eptr) {
-	static std::string previousPort = "";
-	if (eptr->masterVersion < SAUNAFS_VERSION(2, 5, 5)) {
+void MasterConn::sendMatoClPort() {
+	static std::string previousPort;
+
+	if (masterVersion < SAUNAFS_VERSION(2, 5, 5)) {
 		return;
 	}
+
 	std::string portStr = cfg_getstring("MATOCL_LISTEN_PORT", "9421");
 	static uint16_t port = 0;
+
 	if (portStr != previousPort) {
 		if (tcpresolve(nullptr, portStr.c_str(), nullptr, &port, false) < 0) {
 			safs_pretty_syslog(LOG_WARNING, "Cannot resolve MATOCL_LISTEN_PORT: %s", portStr.c_str());
@@ -294,25 +362,26 @@ void masterconn_int_send_matoclport(MasterConn* eptr) {
 		}
 		previousPort = portStr;
 	}
-	masterconn_createpacket(eptr, mltoma::matoclport::build(port));
+
+	createPacket(mltoma::matoclport::build(port));
 }
 
-void masterconn_registered(MasterConn *eptr, const uint8_t *data, uint32_t length) {
-	PacketVersion responseVersion;
+void MasterConn::onRegistered(const uint8_t *data, uint32_t length) {
+	PacketVersion responseVersion{};
 	deserializePacketVersionNoHeader(data, length, responseVersion);
 	if (responseVersion == matoml::registerShadow::kStatusPacketVersion) {
-		uint8_t status;
+		uint8_t status{};
 		matoml::registerShadow::deserialize(data, length, status);
 		safs_pretty_syslog(LOG_NOTICE, "Cannot register to master: %s", saunafs_error_string(status));
-		eptr->mode = MasterConn::Mode::Kill;
+		mode = Mode::Kill;
 	} else if (responseVersion == matoml::registerShadow::kResponsePacketVersion) {
-		uint32_t masterVersion;
-		uint64_t masterMetadataVersion;
-		matoml::registerShadow::deserialize(data, length, masterVersion, masterMetadataVersion);
-		eptr->masterVersion = masterVersion;
-		masterconn_int_send_matoclport(eptr);
-		if ((eptr->state == MasterConn::State::kSynchronized) && (fs_getversion() != masterMetadataVersion)) {
-			masterconn_force_metadata_download(eptr);
+		uint32_t incommingMasterVersion{};
+		uint64_t masterMetadataVersion{};
+		matoml::registerShadow::deserialize(data, length, incommingMasterVersion, masterMetadataVersion);
+		masterVersion = incommingMasterVersion;
+		sendMatoClPort();
+		if ((state == State::kSynchronized) && (fs_getversion() != masterMetadataVersion)) {
+			forceMetadataDownload();
 		}
 	} else {
 		safs_pretty_syslog(LOG_NOTICE, "Unknown register response: #%u", unsigned(responseVersion));
@@ -320,7 +389,7 @@ void masterconn_registered(MasterConn *eptr, const uint8_t *data, uint32_t lengt
 }
 #endif
 
-void masterconn_metachanges_log(MasterConn *eptr,const uint8_t *data,uint32_t length) {
+void MasterConn::metachangesLog(const uint8_t *data,uint32_t length) {
 	if ((length == 1) && (data[0] == FORCE_LOG_ROTATE)) {
 #ifdef METALOGGER
 		// In metalogger rotates are forced by the master server. Shadow masters rotate changelogs
@@ -331,17 +400,17 @@ void masterconn_metachanges_log(MasterConn *eptr,const uint8_t *data,uint32_t le
 	}
 	if (length<10) {
 		safs_pretty_syslog(LOG_NOTICE,"MATOML_METACHANGES_LOG - wrong size (%" PRIu32 "/9+data)",length);
-		eptr->mode = MasterConn::Mode::Kill;
+		mode = Mode::Kill;
 		return;
 	}
 	if (data[0]!=0xFF) {
 		safs_pretty_syslog(LOG_NOTICE,"MATOML_METACHANGES_LOG - wrong packet");
-		eptr->mode = MasterConn::Mode::Kill;
+		mode = Mode::Kill;
 		return;
 	}
 	if (data[length-1]!='\0') {
 		safs_pretty_syslog(LOG_NOTICE,"MATOML_METACHANGES_LOG - invalid string");
-		eptr->mode = MasterConn::Mode::Kill;
+		mode = Mode::Kill;
 		return;
 	}
 
@@ -351,12 +420,12 @@ void masterconn_metachanges_log(MasterConn *eptr,const uint8_t *data,uint32_t le
 
 	if ((lastLogVersion > 0) && (version != (lastLogVersion + 1))) {
 		safs_pretty_syslog(LOG_WARNING, "some changes lost: [%" PRIu64 "-%" PRIu64 "], download metadata again",lastLogVersion,version-1);
-		masterconn_handle_changelog_apply_error(eptr, SAUNAFS_ERROR_METADATAVERSIONMISMATCH);
+		handleChangelogApplyError(SAUNAFS_ERROR_METADATAVERSIONMISMATCH);
 		return;
 	}
 
 #ifndef METALOGGER
-	if (eptr->state == MasterConn::State::kSynchronized) {
+	if (state == State::kSynchronized) {
 		std::string buf(": ");
 		buf.append(changelogEntry);
 		static char const network[] = "network";
@@ -365,7 +434,7 @@ void masterconn_metachanges_log(MasterConn *eptr,const uint8_t *data,uint32_t le
 				RestoreRigor::kDontIgnoreAnyErrors)) != SAUNAFS_STATUS_OK) {
 			safs_pretty_syslog(LOG_WARNING, "malformed changelog sent by the master server, can't apply it. status: %s",
 					saunafs_error_string(status));
-			masterconn_handle_changelog_apply_error(eptr, status);
+			handleChangelogApplyError(status);
 			return;
 		}
 	}
@@ -374,49 +443,42 @@ void masterconn_metachanges_log(MasterConn *eptr,const uint8_t *data,uint32_t le
 	lastLogVersion = version;
 }
 
-void masterconn_end_session(MasterConn *eptr, const uint8_t* data, uint32_t length) {
+void MasterConn::endSession(const uint8_t* data, uint32_t length) {
 	matoml::endSession::deserialize(data, length); // verify the empty packet
 	safs_pretty_syslog(LOG_NOTICE, "Master server is terminating; closing the connection...");
-	masterconn_kill_session(eptr);
+	killSession();
 }
 
-int masterconn_download_end(MasterConn *eptr) {
-	eptr->downloadingFileNum=0;
-	masterconn_createpacket(eptr,MLTOMA_DOWNLOAD_END,0);
-	if (eptr->downloadFD>=0) {
-		if (close(eptr->downloadFD)<0) {
+int MasterConn::downloadEnd() {
+	downloadingFileNum = 0;
+	createPacket(MLTOMA_DOWNLOAD_END, 0);
+
+	if (downloadFD >= 0) {
+		if (::close(downloadFD) < 0) {
 			safs_silent_errlog(LOG_NOTICE,"error closing metafile");
-			eptr->downloadFD = MasterConn::kInvalidFD;
+			downloadFD = kInvalidFD;
 			return -1;
 		}
-		eptr->downloadFD = MasterConn::kInvalidFD;
+
+		downloadFD = kInvalidFD;
 	}
+
 	return 0;
 }
 
-void masterconn_download_init(MasterConn *eptr,uint8_t filenum) {
-	uint8_t *ptr;
-	if ((eptr->mode==MasterConn::Mode::Header || eptr->mode==MasterConn::Mode::Data) && eptr->downloadingFileNum==0) {
-		ptr = masterconn_createpacket(eptr,MLTOMA_DOWNLOAD_START,1);
-		put8bit(&ptr,filenum);
-		eptr->downloadingFileNum = filenum;
+void MasterConn::downloadInit(uint8_t filenum) {
+	if ((mode == Mode::Header || mode == Mode::Data) && downloadingFileNum == 0) {
+		auto *ptr = createPacket(MLTOMA_DOWNLOAD_START, 1);
+		put8bit(&ptr, filenum);
+		downloadingFileNum = filenum;
+
 		if (filenum == DOWNLOAD_METADATA_SFS) {
-			gMasterConn->state = MasterConn::State::kDownloading;
+			state = State::kDownloading;
 		}
 	}
 }
 
-void masterconn_metadownloadinit() {
-	masterconn_download_init(gMasterConn, DOWNLOAD_METADATA_SFS);
-}
-
-void masterconn_sessionsdownloadinit(void) {
-	if (gMasterConn->state == MasterConn::State::kSynchronized) {
-		masterconn_download_init(gMasterConn, DOWNLOAD_SESSIONS_SFS);
-	}
-}
-
-int masterconn_metadata_check(const std::string& name) {
+int MasterConn::metadataCheck(const std::string& name) {
 	try {
 		gMetadataBackend->getVersion(name);
 		return 0;
@@ -426,16 +488,17 @@ int masterconn_metadata_check(const std::string& name) {
 	}
 }
 
-void masterconn_download_next(MasterConn *eptr) {
+void MasterConn::downloadNext() {
 	uint8_t *ptr;
 	uint8_t filenum;
 	int64_t dltime;
-	if (eptr->downloadOffset>=eptr->fileSize) {   // end of file
-		filenum = eptr->downloadingFileNum;
-		if (masterconn_download_end(eptr)<0) {
+
+	if (downloadOffset >= fileSize) {   // end of file
+		filenum = downloadingFileNum;
+		if (downloadEnd() < 0) {
 			return;
 		}
-		dltime = eventloop_utime()-eptr->downloadStartTimeInMicroSeconds;
+		dltime = eventloop_utime() - downloadStartTimeInMicroSeconds;
 		if (dltime<=0) {
 			dltime=1;
 		}
@@ -446,10 +509,10 @@ void masterconn_download_next(MasterConn *eptr) {
 				(filenum == DOWNLOAD_SESSIONS_SFS) ? "sessions" :
 				(filenum == DOWNLOAD_CHANGELOG_SFS) ? changelogFilename_1.c_str() :
 				(filenum == DOWNLOAD_CHANGELOG_SFS_1) ? changelogFilename_2.c_str() : "???",
-				eptr->fileSize, dltime/1000000, (uint32_t)(dltime%1000000),
-				(double)(eptr->fileSize) / (double)(dltime));
+				fileSize, dltime/1000000, (uint32_t)(dltime%1000000),
+				(double)(fileSize) / (double)(dltime));
 		if (filenum == DOWNLOAD_METADATA_SFS) {
-			if (masterconn_metadata_check(metadataTmpFilename) == 0) {
+			if (metadataCheck(metadataTmpFilename) == 0) {
 				if (BackMetaCopies>0) {
 					rotateFiles(metadataFilename, BackMetaCopies, 1);
 				}
@@ -457,19 +520,19 @@ void masterconn_download_next(MasterConn *eptr) {
 					safs_pretty_syslog(LOG_NOTICE,"can't rename downloaded metadata - do it manually before next download");
 				}
 			}
-			masterconn_download_init(eptr, DOWNLOAD_CHANGELOG_SFS);
+			downloadInit(DOWNLOAD_CHANGELOG_SFS);
 		} else if (filenum == DOWNLOAD_CHANGELOG_SFS) {
-			if (rename(changelogTmpFilename.c_str(), changelogFilename_1.c_str()) < 0) {
+			if (::rename(changelogTmpFilename.c_str(), changelogFilename_1.c_str()) < 0) {
 				safs_pretty_syslog(LOG_NOTICE,"can't rename downloaded changelog - do it manually before next download");
 			}
-			masterconn_download_init(eptr, DOWNLOAD_CHANGELOG_SFS_1);
+			downloadInit(DOWNLOAD_CHANGELOG_SFS_1);
 		} else if (filenum == DOWNLOAD_CHANGELOG_SFS_1) {
-			if (rename(changelogTmpFilename.c_str(), changelogFilename_2.c_str()) < 0) {
+			if (::rename(changelogTmpFilename.c_str(), changelogFilename_2.c_str()) < 0) {
 				safs_pretty_syslog(LOG_NOTICE,"can't rename downloaded changelog - do it manually before next download");
 			}
-			masterconn_download_init(eptr, DOWNLOAD_SESSIONS_SFS);
+			downloadInit(DOWNLOAD_SESSIONS_SFS);
 		} else if (filenum == DOWNLOAD_SESSIONS_SFS) {
-			if (rename(sessionsTmpFilename.c_str(), sessionsFilename.c_str()) < 0) {
+			if (::rename(sessionsTmpFilename.c_str(), sessionsFilename.c_str()) < 0) {
 				safs_pretty_syslog(LOG_NOTICE,"can't rename downloaded sessions - do it manually before next download");
 			} else {
 #ifndef METALOGGER
@@ -477,12 +540,12 @@ void masterconn_download_next(MasterConn *eptr) {
 				 * We can have other state if we are synchronized or we got changelog apply error
 				 * during independent sessions download session.
 				 */
-				if (eptr->state == MasterConn::State::kDownloading) {
+				if (state == MasterConn::State::kDownloading) {
 					try {
 						fs_loadall();
 						lastLogVersion = fs_getversion() - 1;
 						safs_pretty_syslog(LOG_NOTICE, "synced at version = %" PRIu64, lastLogVersion);
-						eptr->state = MasterConn::State::kSynchronized;
+						state = MasterConn::State::kSynchronized;
 					} catch (Exception& ex) {
 						safs_pretty_syslog(LOG_WARNING, "can't load downloaded metadata and changelogs: %s",
 								ex.what());
@@ -492,166 +555,186 @@ void masterconn_download_next(MasterConn *eptr) {
 							// all will be good
 							status = SAUNAFS_ERROR_CHANGELOGINCONSISTENT;
 						}
-						masterconn_handle_changelog_apply_error(eptr, status);
+						handleChangelogApplyError(status);
 					}
 				}
 #else /* #ifndef METALOGGER */
-				eptr->state = MasterConn::State::kSynchronized;
+				state = MasterConn::State::kSynchronized;
 #endif /* #else #ifndef METALOGGER */
 			}
 		}
 	} else {        // send request for next data packet
-		ptr = masterconn_createpacket(eptr,MLTOMA_DOWNLOAD_DATA,12);
-		put64bit(&ptr,eptr->downloadOffset);
-		if (eptr->fileSize-eptr->downloadOffset>kMetadataDownloadBlocksize) {
-			put32bit(&ptr,kMetadataDownloadBlocksize);
+		ptr = createPacket(MLTOMA_DOWNLOAD_DATA, 12);
+		put64bit(&ptr, downloadOffset);
+		if (fileSize - downloadOffset > kMetadataDownloadBlocksize) {
+			put32bit(&ptr, kMetadataDownloadBlocksize);
 		} else {
-			put32bit(&ptr,eptr->fileSize-eptr->downloadOffset);
+			put32bit(&ptr, fileSize - downloadOffset);
 		}
 	}
 }
 
-void masterconn_download_start(MasterConn *eptr,const uint8_t *data,uint32_t length) {
-	if (length!=1 && length!=8) {
+void MasterConn::downloadStart(const uint8_t *data, uint32_t length) {
+	if (length != 1 && length != 8) {
 		safs_pretty_syslog(LOG_NOTICE,"MATOML_DOWNLOAD_START - wrong size (%" PRIu32 "/1|8)",length);
-		eptr->mode = MasterConn::Mode::Kill;
+		mode = Mode::Kill;
 		return;
 	}
+
 	passert(data);
-	if (length==1) {
-		eptr->downloadingFileNum=0;
+
+	if (length == 1) {
+		downloadingFileNum = 0;
 		safs_pretty_syslog(LOG_NOTICE,"download start error");
 		return;
 	}
+
 #ifndef METALOGGER
 	// We are a shadow master and we are going to do some changes in the data dir right now
 	fs_erase_message_from_lockfile();
 #endif
-	eptr->fileSize = get64bit(&data);
-	eptr->downloadOffset = 0;
-	eptr->downloadRetryCnt = 0;
-	eptr->downloadStartTimeInMicroSeconds = eventloop_utime();
-	if (eptr->downloadingFileNum == DOWNLOAD_METADATA_SFS) {
-		eptr->downloadFD = open(metadataTmpFilename.c_str(), O_WRONLY | O_TRUNC | O_CREAT, 0666);
-	} else if (eptr->downloadingFileNum == DOWNLOAD_SESSIONS_SFS) {
-		eptr->downloadFD = open(sessionsTmpFilename.c_str(), O_WRONLY | O_TRUNC | O_CREAT, 0666);
-	} else if ((eptr->downloadingFileNum == DOWNLOAD_CHANGELOG_SFS)
-			|| (eptr->downloadingFileNum == DOWNLOAD_CHANGELOG_SFS_1)) {
-		eptr->downloadFD = open(changelogTmpFilename.c_str(), O_WRONLY | O_TRUNC | O_CREAT, 0666);
+
+	fileSize = get64bit(&data);
+	downloadOffset = 0;
+	downloadRetryCnt = 0;
+	downloadStartTimeInMicroSeconds = eventloop_utime();
+
+	if (downloadingFileNum == DOWNLOAD_METADATA_SFS) {
+		downloadFD = ::open(metadataTmpFilename.c_str(), O_WRONLY | O_TRUNC | O_CREAT, 0666);
+	} else if (downloadingFileNum == DOWNLOAD_SESSIONS_SFS) {
+		downloadFD = ::open(sessionsTmpFilename.c_str(), O_WRONLY | O_TRUNC | O_CREAT, 0666);
+	} else if ((downloadingFileNum == DOWNLOAD_CHANGELOG_SFS)
+			|| (downloadingFileNum == DOWNLOAD_CHANGELOG_SFS_1)) {
+		downloadFD = ::open(changelogTmpFilename.c_str(), O_WRONLY | O_TRUNC | O_CREAT, 0666);
 	} else {
 		safs_pretty_syslog(LOG_NOTICE,"unexpected MATOML_DOWNLOAD_START packet");
-		eptr->mode = MasterConn::Mode::Kill;
+		mode = Mode::Kill;
 		return;
 	}
-	if (eptr->downloadFD<0) {
+
+	if (downloadFD < 0) {
 		safs_silent_errlog(LOG_NOTICE,"error opening metafile");
-		masterconn_download_end(eptr);
+		downloadEnd();
 		return;
 	}
-	masterconn_download_next(eptr);
+
+	downloadNext();
 }
 
-void masterconn_download_data(MasterConn *eptr,const uint8_t *data,uint32_t length) {
+void MasterConn::downloadData(const uint8_t *data,uint32_t length) {
 	uint64_t offset;
 	uint32_t leng;
 	uint32_t crc;
 	ssize_t ret;
-	if (eptr->downloadFD<0) {
+
+	if (downloadFD < 0) {
 		safs_pretty_syslog(LOG_NOTICE,"MATOML_DOWNLOAD_DATA - file not opened");
-		eptr->mode = MasterConn::Mode::Kill;
+		mode = MasterConn::Mode::Kill;
 		return;
 	}
+
 	if (length<16) {
 		safs_pretty_syslog(LOG_NOTICE,"MATOML_DOWNLOAD_DATA - wrong size (%" PRIu32 "/16+data)",length);
-		eptr->mode = MasterConn::Mode::Kill;
+		mode = MasterConn::Mode::Kill;
 		return;
 	}
+
 	passert(data);
 	offset = get64bit(&data);
 	leng = get32bit(&data);
 	crc = get32bit(&data);
+
 	if (leng+16!=length) {
 		safs_pretty_syslog(LOG_NOTICE,"MATOML_DOWNLOAD_DATA - wrong size (%" PRIu32 "/16+%" PRIu32 ")",length,leng);
-		eptr->mode = MasterConn::Mode::Kill;
+		mode = MasterConn::Mode::Kill;
 		return;
 	}
-	if (offset!=eptr->downloadOffset) {
-		safs_pretty_syslog(LOG_NOTICE,"MATOML_DOWNLOAD_DATA - unexpected file offset (%" PRIu64 "/%" PRIu64 ")",offset,eptr->downloadOffset);
-		eptr->mode = MasterConn::Mode::Kill;
+
+	if (offset != downloadOffset) {
+		safs_pretty_syslog(LOG_NOTICE,"MATOML_DOWNLOAD_DATA - unexpected file offset (%" PRIu64 "/%" PRIu64 ")",offset,downloadOffset);
+		mode = MasterConn::Mode::Kill;
 		return;
 	}
-	if (offset+leng>eptr->fileSize) {
-		safs_pretty_syslog(LOG_NOTICE,"MATOML_DOWNLOAD_DATA - unexpected file size (%" PRIu64 "/%" PRIu64 ")",offset+leng,eptr->fileSize);
-		eptr->mode = MasterConn::Mode::Kill;
+
+	if (offset + leng > fileSize) {
+		safs_pretty_syslog(LOG_NOTICE,"MATOML_DOWNLOAD_DATA - unexpected file size (%" PRIu64 "/%" PRIu64 ")",offset+leng,fileSize);
+		mode = MasterConn::Mode::Kill;
 		return;
 	}
+
 #ifdef SAUNAFS_HAVE_PWRITE
-	ret = pwrite(eptr->downloadFD,data,leng,offset);
+	ret = ::pwrite(downloadFD,data,leng,offset);
 #else /* SAUNAFS_HAVE_PWRITE */
-	lseek(eptr->metafd,offset,SEEK_SET);
-	ret = write(eptr->metafd,data,leng);
+	::lseek(metafd,offset,SEEK_SET);
+	ret = ::write(metafd,data,leng);
 #endif /* SAUNAFS_HAVE_PWRITE */
+
 	if (ret!=(ssize_t)leng) {
 		safs_silent_errlog(LOG_NOTICE,"error writing metafile");
-		if (eptr->downloadRetryCnt>=5) {
-			masterconn_download_end(eptr);
+		if (downloadRetryCnt >= 5) {
+			downloadEnd();
 		} else {
-			eptr->downloadRetryCnt++;
-			masterconn_download_next(eptr);
+			downloadRetryCnt++;
+			downloadNext();
 		}
 		return;
 	}
-	if (crc!=mycrc32(0,data,leng)) {
+
+	if (crc != mycrc32(0,data,leng)) {
 		safs_pretty_syslog(LOG_NOTICE,"metafile data crc error");
-		if (eptr->downloadRetryCnt>=5) {
-			masterconn_download_end(eptr);
+		if (downloadRetryCnt >= 5) {
+			downloadEnd();
 		} else {
-			eptr->downloadRetryCnt++;
-			masterconn_download_next(eptr);
+			downloadRetryCnt++;
+			downloadNext();
 		}
 		return;
 	}
-	if (fsync(eptr->downloadFD)<0) {
+
+	if (::fsync(downloadFD) < 0) {
 		safs_silent_errlog(LOG_NOTICE,"error syncing metafile");
-		if (eptr->downloadRetryCnt>=5) {
-			masterconn_download_end(eptr);
+		if (downloadRetryCnt >= 5) {
+			downloadEnd();
 		} else {
-			eptr->downloadRetryCnt++;
-			masterconn_download_next(eptr);
+			downloadRetryCnt++;
+			downloadNext();
 		}
 		return;
 	}
-	eptr->downloadOffset+=leng;
-	eptr->downloadRetryCnt=0;
-	masterconn_download_next(eptr);
+
+	downloadOffset+=leng;
+	downloadRetryCnt=0;
+
+	downloadNext();
 }
 
-void masterconn_changelog_apply_error(MasterConn *eptr, const uint8_t *data, uint32_t length) {
-	uint8_t status;
+void MasterConn::changelogApplyError(const uint8_t *data, uint32_t length) {
+	uint8_t status{};
 	matoml::changelogApplyError::deserialize(data, length, status);
 	safs_silent_syslog(LOG_DEBUG, "master.matoml_changelog_apply_error status: %u", status);
+
 	if (status == SAUNAFS_STATUS_OK) {
-		masterconn_force_metadata_download(eptr);
+		forceMetadataDownload();
 	} else if (status == SAUNAFS_ERROR_DELAYED) {
-		eptr->state = MasterConn::State::kLimbo;
+		state = State::kLimbo;
 		safs_pretty_syslog(LOG_NOTICE, "Master temporarily refused to produce a new metadata image");
 	} else {
-		eptr->state = MasterConn::State::kLimbo;
+		state = State::kLimbo;
 		safs_pretty_syslog(LOG_NOTICE, "Master failed to produce a new metadata image: %s", saunafs_error_string(status));
 	}
 }
 
-void masterconn_beforeclose(MasterConn *eptr) {
-	if (eptr->downloadFD>=0) {
-		close(eptr->downloadFD);
-		eptr->downloadFD = MasterConn::kInvalidFD;
-		unlink(metadataTmpFilename.c_str());
-		unlink(sessionsTmpFilename.c_str());
-		unlink(changelogTmpFilename.c_str());
+void MasterConn::beforeClose() {
+	if (downloadFD >= 0) {
+		::close(downloadFD);
+		downloadFD = MasterConn::kInvalidFD;
+		::unlink(metadataTmpFilename.c_str());
+		::unlink(sessionsTmpFilename.c_str());
+		::unlink(changelogTmpFilename.c_str());
 	}
 }
 
-void masterconn_gotpacket(MasterConn *eptr,uint32_t type,const uint8_t *data,uint32_t length) {
+void MasterConn::gotPacket(uint32_t type,const uint8_t *data,uint32_t length) {
 	try {
 		switch (type) {
 			case ANTOAN_NOP:
@@ -662,90 +745,86 @@ void masterconn_gotpacket(MasterConn *eptr,uint32_t type,const uint8_t *data,uin
 				break;
 #ifndef METALOGGER
 			case SAU_MATOML_REGISTER_SHADOW:
-				masterconn_registered(eptr,data,length);
-				break;
+			    onRegistered(data, length);
+			    break;
 #endif
 			case MATOML_METACHANGES_LOG:
-				masterconn_metachanges_log(eptr,data,length);
+				metachangesLog(data,length);
 				break;
 			case SAU_MATOML_END_SESSION:
-				masterconn_end_session(eptr,data,length);
-				break;
+			    endSession(data, length);
+			    break;
 			case MATOML_DOWNLOAD_START:
-				masterconn_download_start(eptr,data,length);
-				break;
+			    downloadStart(data, length);
+			    break;
 			case MATOML_DOWNLOAD_DATA:
-				masterconn_download_data(eptr,data,length);
-				break;
+			    downloadData(data, length);
+			    break;
 			case SAU_MATOML_CHANGELOG_APPLY_ERROR:
-				masterconn_changelog_apply_error(eptr, data, length);
+				changelogApplyError(data, length);
 				break;
 			default:
 				safs_pretty_syslog(LOG_NOTICE,"got unknown message (type:%" PRIu32 ")",type);
-				eptr->mode = MasterConn::Mode::Kill;
+				mode = Mode::Kill;
 				break;
 		}
 	} catch (IncorrectDeserializationException& ex) {
 		safs_pretty_syslog(LOG_NOTICE, "Packet 0x%" PRIX32 " - can't deserialize: %s", type, ex.what());
-		eptr->mode = MasterConn::Mode::Kill;
+		mode = Mode::Kill;
 	}
 }
 
-void masterconn_term(void) {
-	if (!gMasterConn) { return; }
+void MasterConn::terminate() {
+	if (mode != Mode::Free) {
+		tcpclose(sock);
 
-	MasterConn *eptr = gMasterConn;
+		if (mode != Mode::Connecting) {
+			inputPacket.packet.clear();
 
-	if (eptr->mode != MasterConn::Mode::Free) {
-		tcpclose(eptr->sock);
-
-		if (eptr->mode != MasterConn::Mode::Connecting) {
-			eptr->inputPacket.packet.clear();
-
-			while(!eptr->outputQueue.empty()) {
-				eptr->outputQueue.pop();
+			while(!outputQueue.empty()) {
+				outputQueue.pop();
 			}
 		}
 	}
-
-	delete gMasterConn;
-	gMasterConn = nullptr;
 }
 
-void masterconn_connected(MasterConn *eptr) {
-	tcpnodelay(eptr->sock);
-	eptr->mode = MasterConn::Mode::Header;
-	eptr->masterVersion = MasterConn::kInvalidMasterVersion;
-	eptr->inputPacket.bytesLeft = MasterConn::kHeaderSize;
-	eptr->inputPacket.startPtr = eptr->headerBuffer.data();
-	eptr->outputQueue = std::queue<std::unique_ptr<PacketStruct>>();
+void MasterConn::onConnected() {
+	tcpnodelay(sock);
+	mode = Mode::Header;
+	masterVersion = kInvalidMasterVersion;
+	inputPacket.bytesLeft = kHeaderSize;
+	inputPacket.startPtr = headerBuffer.data();
+	outputQueue = std::queue<std::unique_ptr<PacketStruct>>();
 
-	masterconn_sendregister(eptr);
+	sendRegister();
+
 #ifdef METALOGGER
-	masterconn_send_metalogger_config(eptr);
+	sendMetaloggerConfig();
 #endif
-	if (lastLogVersion==0) {
-		masterconn_metadownloadinit();
-	} else if (eptr->state == MasterConn::State::kDumpRequestPending) {
-		masterconn_request_metadata_dump(eptr);
+
+	if (lastLogVersion == 0) {
+		downloadInit(DOWNLOAD_METADATA_SFS);
+	} else if (state == State::kDumpRequestPending) {
+		requestMetadataDump();
 	}
-	eptr->lastRead = eptr->lastWrite = eventloop_time();
+
+	lastRead = lastWrite = eventloop_time();
 }
 
-int masterconn_initconnect(MasterConn *eptr) {
+int MasterConn::initConnect() {
 	int status;
-	if (eptr->isMasterAddressValid==0) {
+	if (isMasterAddressValid == 0) {
 		uint32_t mip,bip;
 		uint16_t mport;
 		if (tcpresolve(BindHost.c_str(), NULL, &bip, NULL, 1)>=0) {
-			eptr->bindIP = bip;
+			bindIP = bip;
 		} else {
-			eptr->bindIP = 0;
+			bindIP = 0;
 		}
 		if (tcpresolve(MasterHost.c_str(), MasterPort.c_str(), &mip, &mport, 0)>=0) {
-			eptr->masterIP = mip;
-			eptr->masterPort = mport;
-			eptr->isMasterAddressValid = 1;
+			masterIP = mip;
+			masterPort = mport;
+			isMasterAddressValid = 1;
 		} else {
 			safs_pretty_syslog(LOG_WARNING,
 					"can't resolve master host/port (%s:%s)",
@@ -753,123 +832,128 @@ int masterconn_initconnect(MasterConn *eptr) {
 			return -1;
 		}
 	}
-	eptr->sock=tcpsocket();
-	if (eptr->sock<0) {
+
+	sock = tcpsocket();
+
+	if (sock < 0) {
 		safs_pretty_errlog(LOG_WARNING,"create socket, error");
 		return -1;
 	}
-	if (tcpnonblock(eptr->sock)<0) {
+
+	if (tcpnonblock(sock) < 0) {
 		safs_pretty_errlog(LOG_WARNING,"set nonblock, error");
-		tcpclose(eptr->sock);
-		eptr->sock = MasterConn::kInvalidFD;
+		tcpclose(sock);
+		sock = kInvalidFD;
 		return -1;
 	}
-	if (eptr->bindIP>0) {
-		if (tcpnumbind(eptr->sock,eptr->bindIP,0)<0) {
+
+	if (bindIP > 0) {
+		if (tcpnumbind(sock, bindIP, 0) < 0) {
 			safs_pretty_errlog(LOG_WARNING,"can't bind socket to given ip");
-			tcpclose(eptr->sock);
-			eptr->sock = MasterConn::kInvalidFD;
+			tcpclose(sock);
+			sock = kInvalidFD;
 			return -1;
 		}
 	}
-	status = tcpnumconnect(eptr->sock,eptr->masterIP,eptr->masterPort);
-	if (status<0) {
+
+	status = tcpnumconnect(sock, masterIP, masterPort);
+
+	if (status < 0) {
 		safs_pretty_errlog(LOG_WARNING,"connect failed, error");
-		tcpclose(eptr->sock);
-		eptr->sock = MasterConn::kInvalidFD;
-		eptr->isMasterAddressValid = 0;
+		tcpclose(sock);
+		sock = kInvalidFD;
+		isMasterAddressValid = 0;
 		return -1;
 	}
-	if (status==0) {
+
+	if (status == 0) {
 		safs_pretty_syslog(LOG_NOTICE,"connected to Master immediately");
-		masterconn_connected(eptr);
+		onConnected();
 	} else {
-		eptr->mode = MasterConn::Mode::Connecting;
+		mode = Mode::Connecting;
 		safs_pretty_syslog_attempt(LOG_NOTICE,"connecting to Master");
 	}
+
 	return 0;
 }
 
-void masterconn_connecttest(MasterConn *eptr) {
-	int status;
+void MasterConn::connectTest() {
+	auto status = tcpgetstatus(sock);
 
-	status = tcpgetstatus(eptr->sock);
-	if (status) {
-		safs_silent_errlog(LOG_WARNING,"connection failed, error");
-		tcpclose(eptr->sock);
-		eptr->sock = MasterConn::kInvalidFD;
-		eptr->mode = MasterConn::Mode::Free;
-		eptr->isMasterAddressValid = 0;
-		eptr->masterVersion = MasterConn::kInvalidMasterVersion;
+	if (status != SAUNAFS_STATUS_OK) {
+		safs::log_warn("connection failed, error");
+		tcpclose(sock);
+		sock = kInvalidFD;
+		mode = Mode::Free;
+		isMasterAddressValid = 0;
+		masterVersion = kInvalidMasterVersion;
 	} else {
-		safs_pretty_syslog(LOG_NOTICE,"connected to Master");
-		masterconn_connected(eptr);
+		safs::log_info("connected to Master");
+		onConnected();
 	}
 }
 
-void masterconn_read(MasterConn *eptr) {
+void MasterConn::readFromSocket() {
 	SignalLoopWatchdog watchdog;
 	int32_t i;
 	uint32_t type,size;
 	const uint8_t *ptr;
 
 	watchdog.start();
-	while (eptr->mode != MasterConn::Mode::Kill) {
-		i=read(eptr->sock,eptr->inputPacket.startPtr,eptr->inputPacket.bytesLeft);
+
+	while (mode != MasterConn::Mode::Kill) {
+		i = ::read(sock, inputPacket.startPtr, inputPacket.bytesLeft);
 		if (i==0) {
 			safs_pretty_syslog(LOG_NOTICE,"connection was reset by Master");
-			masterconn_kill_session(eptr);
+			killSession();
 			return;
 		}
 		if (i<0) {
 			if (errno!=EAGAIN) {
 				safs_silent_errlog(LOG_NOTICE,"read from Master error");
-				masterconn_kill_session(eptr);
+				killSession();
 			}
 			return;
 		}
 
-		eptr->inputPacket.startPtr+=i;
-		eptr->inputPacket.bytesLeft-=i;
+		inputPacket.startPtr += i;
+		inputPacket.bytesLeft -= i;
 
-		if (eptr->inputPacket.bytesLeft>0) {
-			return;
-		}
+		if (inputPacket.bytesLeft > 0) { return; }
 
-		if (eptr->mode==MasterConn::Mode::Header) {
-			ptr = eptr->headerBuffer.data() + 4;
+		if (mode == Mode::Header) {
+			ptr = headerBuffer.data() + kPacketTypeSize;
 			size = get32bit(&ptr);
 
-			if (size>0) {
-				if (size>kMaxPacketSize) {
+			if (size > 0) {
+				if (size > kMaxPacketSize) {
 					safs_pretty_syslog(LOG_WARNING,"Master packet too long (%" PRIu32 "/%u)",size,kMaxPacketSize);
-					masterconn_kill_session(eptr);
+					killSession();
 					return;
 				}
 
-				eptr->inputPacket.packet.resize(size);
-				passert(eptr->inputPacket.packet.data());
-				eptr->inputPacket.bytesLeft = size;
-				eptr->inputPacket.startPtr = eptr->inputPacket.packet.data();
-				eptr->mode = MasterConn::Mode::Data;
+				inputPacket.packet.resize(size);
+				passert(inputPacket.packet.data());
+				inputPacket.bytesLeft = size;
+				inputPacket.startPtr = inputPacket.packet.data();
+				mode = Mode::Data;
 				continue;
 			}
-			eptr->mode = MasterConn::Mode::Data;
+
+			mode = Mode::Data;
 		}
 
-		if (eptr->mode==MasterConn::Mode::Data) {
-			ptr = eptr->headerBuffer.data();
+		if (mode == Mode::Data) {
+			ptr = headerBuffer.data();
 			type = get32bit(&ptr);
 			size = get32bit(&ptr);
 
-			eptr->mode=MasterConn::Mode::Header;
-			eptr->inputPacket.bytesLeft = MasterConn::kHeaderSize;
-			eptr->inputPacket.startPtr = eptr->headerBuffer.data();
+			mode = Mode::Header;
+			inputPacket.bytesLeft = kHeaderSize;
+			inputPacket.startPtr = headerBuffer.data();
 
-			masterconn_gotpacket(eptr, type, eptr->inputPacket.packet.data(),
-			                     size);
-
-			eptr->inputPacket.packet.clear();
+			gotPacket(type, inputPacket.packet.data(), size);
+			inputPacket.packet.clear();
 		}
 
 		if (watchdog.expired()) {
@@ -878,7 +962,7 @@ void masterconn_read(MasterConn *eptr) {
 	}
 }
 
-void masterconn_write(MasterConn *eptr) {
+void MasterConn::writeToSocket() {
 	SignalLoopWatchdog watchdog;
 	PacketStruct *pack = nullptr;
 	int32_t writtenBytes = 0;
@@ -886,16 +970,16 @@ void masterconn_write(MasterConn *eptr) {
 	watchdog.start();
 
 	for (;;) {
-		if (eptr->outputQueue.empty()) { return; }
+		if (outputQueue.empty()) { return; }
 
-		pack = eptr->outputQueue.front().get();
+		pack = outputQueue.front().get();
 
-		writtenBytes = ::write(eptr->sock, pack->startPtr, pack->bytesLeft);
+		writtenBytes = ::write(sock, pack->startPtr, pack->bytesLeft);
 
 		if (writtenBytes < 0) {
 			if (errno != EAGAIN) {
 				safs_silent_errlog(LOG_NOTICE, "write to Master error");
-				eptr->mode = MasterConn::Mode::Kill;
+				mode = Mode::Kill;
 			}
 			return;
 		}
@@ -905,7 +989,7 @@ void masterconn_write(MasterConn *eptr) {
 
 		if (pack->bytesLeft > 0) { return; }
 
-		eptr->outputQueue.pop();
+		outputQueue.pop();
 
 		if (watchdog.expired()) {
 			break;
@@ -913,130 +997,109 @@ void masterconn_write(MasterConn *eptr) {
 	}
 }
 
-void masterconn_wantexit(void) {
-	if (gMasterConn) {
-		masterconn_kill_session(gMasterConn);
-	}
-}
+void MasterConn::pollDesc(std::vector<pollfd> &pdesc) {
+	pollDescPos = kInvalidPollDescPos;
 
-int masterconn_canexit(void) {
-	return !gMasterConn || gMasterConn->mode == MasterConn::Mode::Free;
-}
-
-void masterconn_desc(std::vector<pollfd> &pdesc) {
-	if (!gMasterConn) {
-		return;
-	}
-	MasterConn *eptr = gMasterConn;
-
-	eptr->pollDescPos = -1;
-	if (eptr->mode==MasterConn::Mode::Free || eptr->sock<0) {
+	if (mode == Mode::Free || sock < 0) {
 		return;
 	}
 
-	if (eptr->mode==MasterConn::Mode::Header || eptr->mode==MasterConn::Mode::Data) {
-		pdesc.push_back({eptr->sock,POLLIN,0});
-		eptr->pollDescPos = pdesc.size() - 1;
+	if (mode == Mode::Header || mode == Mode::Data) {
+		pdesc.push_back({sock, POLLIN, 0});
+		pollDescPos = static_cast<int32_t>(pdesc.size() - 1);
 	}
 
-	if (((eptr->mode == MasterConn::Mode::Header ||
-	      eptr->mode == MasterConn::Mode::Data) &&
-	     !eptr->outputQueue.empty()) ||
-	    (eptr->mode == MasterConn::Mode::Connecting)) {
-		if (eptr->pollDescPos >= 0) {
-			pdesc[eptr->pollDescPos].events |= POLLOUT;
+	if (((mode == Mode::Header || mode == Mode::Data) &&
+	     !outputQueue.empty()) ||
+	    (mode == Mode::Connecting)) {
+		if (pollDescPos >= 0) {
+			pdesc[pollDescPos].events |= POLLOUT;
 		} else {
-			pdesc.push_back({eptr->sock, POLLOUT, 0});
-			eptr->pollDescPos = pdesc.size() - 1;
+			pdesc.push_back({sock, POLLOUT, 0});
+			pollDescPos = static_cast<int32_t>(pdesc.size() - 1);
 		}
 	}
 }
 
-void masterconn_serve(const std::vector<pollfd> &pdesc) {
-	if (!gMasterConn) { return; }
-
+void MasterConn::serve(const std::vector<pollfd> &pdesc) {
 	uint32_t now = eventloop_time();
-	MasterConn *eptr = gMasterConn;
 
-	if (eptr->pollDescPos>=0 && (pdesc[eptr->pollDescPos].revents & (POLLHUP | POLLERR))) {
-		if (eptr->mode==MasterConn::Mode::Connecting) {
-			masterconn_connecttest(eptr);
+	if (pollDescPos>=0 && (pdesc[pollDescPos].revents & (POLLHUP | POLLERR))) {
+		if (mode == Mode::Connecting) {
+			connectTest();
 		} else {
-			eptr->mode = MasterConn::Mode::Kill;
+			mode = Mode::Kill;
 		}
 	}
 
-	if (eptr->mode==MasterConn::Mode::Connecting) {
-		if (eptr->sock>=0 && eptr->pollDescPos>=0 && (pdesc[eptr->pollDescPos].revents & POLLOUT)) { // FD_ISSET(eptr->sock,wset)) {
-			masterconn_connecttest(eptr);
+	if (mode == Mode::Connecting) {
+		if (sock >= 0 && pollDescPos >= 0 && (pdesc[pollDescPos].revents & POLLOUT)) { // FD_ISSET(eptr->sock,wset)) {
+			connectTest();
 		}
 	} else {
-		if (eptr->pollDescPos>=0) {
-			if ((eptr->mode==MasterConn::Mode::Header || eptr->mode==MasterConn::Mode::Data) && (pdesc[eptr->pollDescPos].revents & POLLIN)) { // FD_ISSET(eptr->sock,rset)) {
-				eptr->lastRead = now;
-				masterconn_read(eptr);
+		if (pollDescPos >= 0) {
+			if ((mode == Mode::Header || mode == Mode::Data) && (pdesc[pollDescPos].revents & POLLIN)) { // FD_ISSET(eptr->sock,rset)) {
+				lastRead = now;
+				readFromSocket();
 			}
-			if ((eptr->mode==MasterConn::Mode::Header || eptr->mode==MasterConn::Mode::Data) && (pdesc[eptr->pollDescPos].revents & POLLOUT)) { // FD_ISSET(eptr->sock,wset)) {
-				eptr->lastWrite = now;
-				masterconn_write(eptr);
+			if ((mode == Mode::Header || mode == Mode::Data) && (pdesc[pollDescPos].revents & POLLOUT)) { // FD_ISSET(eptr->sock,wset)) {
+				lastWrite = now;
+				writeToSocket();
 			}
-			if ((eptr->mode==MasterConn::Mode::Header || eptr->mode==MasterConn::Mode::Data) && eptr->lastRead+Timeout<now) {
-				eptr->mode = MasterConn::Mode::Kill;
+			if ((mode == Mode::Header || mode == Mode::Data) && lastRead + masterTimeout < now) {
+				mode = Mode::Kill;
 			}
-			if ((eptr->mode==MasterConn::Mode::Header || eptr->mode==MasterConn::Mode::Data) && eptr->lastWrite+(Timeout/3)<now && eptr->outputQueue.empty()) {
-				masterconn_createpacket(eptr,ANTOAN_NOP,0);
+			if ((mode == Mode::Header || mode == Mode::Data) && lastWrite + (masterTimeout / 3) < now && outputQueue.empty()) {
+				createPacket(ANTOAN_NOP, 0);
 			}
 		}
 	}
 
-	if (eptr->mode == MasterConn::Mode::Kill) {
-		masterconn_beforeclose(eptr);
-		tcpclose(eptr->sock);
-		eptr->sock = MasterConn::kInvalidFD;
+	if (mode == Mode::Kill) {
+		beforeClose();
+		tcpclose(sock);
+		sock = kInvalidFD;
 
-		eptr->inputPacket.packet.clear();
+		inputPacket.packet.clear();
 
-		while (!eptr->outputQueue.empty()) {
-			eptr->outputQueue.pop();
+		while (!outputQueue.empty()) {
+			outputQueue.pop();
 		}
 
-		eptr->mode = MasterConn::Mode::Free;
-		eptr->masterVersion = MasterConn::kInvalidMasterVersion;
+		mode = Mode::Free;
+		masterVersion = kInvalidMasterVersion;
 	}
 }
 
-void masterconn_reconnect(void) {
-	if (!gMasterConn) {
-		return;
+void MasterConn::reconnect() {
+	if (mode == Mode::Free && gExitingStatus == ExitingStatus::kRunning) {
+		initConnect();
 	}
-	MasterConn *eptr = gMasterConn;
-	if (eptr->mode == MasterConn::Mode::Free && gExitingStatus == ExitingStatus::kRunning) {
-		masterconn_initconnect(eptr);
-	}
-	if ((eptr->mode == MasterConn::Mode::Header || eptr->mode == MasterConn::Mode::Data) && eptr->state == MasterConn::State::kLimbo) {
-		if (eptr->changelogApplyErrorTimeout.expired()) {
-			masterconn_request_metadata_dump(eptr);
+
+	if ((mode == Mode::Header || mode == Mode::Data) && state == State::kLimbo) {
+		if (changelogApplyErrorTimeout.expired()) {
+			requestMetadataDump();
 		}
 	}
 }
 
-void masterconn_become_master() {
-	if (!gMasterConn) {
-		return;
-	}
-	MasterConn *eptr = gMasterConn;
-	eventloop_timeunregister(eptr->sessionsDownloadInitHandle);
-	eventloop_timeunregister(eptr->changelogFlushHandle);
-	masterconn_term();
+void MasterConn::becomeMaster() {
+	eventloop_timeunregister(sessionsDownloadInitHandle);
+	eventloop_timeunregister(changelogFlushHandle);
 }
 
-void masterconn_reload(void) {
-	if (!gMasterConn) {
-		return;
-	}
-	MasterConn *eptr = gMasterConn;
-	uint32_t ReconnectionDelay;
+void MasterConn::loadConfig() {
+	MasterHost = cfg_getstring("MASTER_HOST","sfsmaster");
+	MasterPort = cfg_getstring("MASTER_PORT","9419");
+	BindHost = cfg_getstring("BIND_HOST","*");
+	masterTimeout = cfg_getuint32("MASTER_TIMEOUT",60);
+	BackMetaCopies = cfg_getuint32("BACK_META_KEEP_PREVIOUS",3);
 
+	masterTimeout = std::min(masterTimeout, kMaxMasterTimeout);
+	masterTimeout = std::max<uint32_t>(masterTimeout, kMinMasterTimeout);
+}
+
+void MasterConn::reload() {
 	std::string newMasterHost = cfg_getstring("MASTER_HOST","sfsmaster");
 	std::string newMasterPort = cfg_getstring("MASTER_PORT","9419");
 	std::string newBindHost = cfg_getstring("BIND_HOST","*");
@@ -1045,66 +1108,125 @@ void masterconn_reload(void) {
 		MasterHost = newMasterHost;
 		MasterPort = newMasterPort;
 		BindHost = newBindHost;
-		eptr->isMasterAddressValid = 0;
-		if (eptr->mode != MasterConn::Mode::Free) {
-			eptr->mode = MasterConn::Mode::Kill;
+		isMasterAddressValid = 0;
+		if (mode != Mode::Free) {
+			mode = Mode::Kill;
 		}
 	}
 
-	Timeout = cfg_getuint32("MASTER_TIMEOUT",60);
+	masterTimeout = cfg_getuint32("MASTER_TIMEOUT",60);
 	BackMetaCopies = cfg_getuint32("BACK_META_KEEP_PREVIOUS",3);
-	ReconnectionDelay = cfg_getuint32("MASTER_RECONNECTION_DELAY",1);
+	auto reconnectionDelay = cfg_getuint32("MASTER_RECONNECTION_DELAY",1);
 
-	if (Timeout>65536) {
-		Timeout=65535;
-	}
-	if (Timeout<10) {
-		Timeout=10;
-	}
-	if (BackMetaCopies>99) {
-		BackMetaCopies=99;
-	}
+	masterTimeout = std::min(masterTimeout, MasterConn::kMaxMasterTimeout);
+	masterTimeout = std::max<uint32_t>(masterTimeout, MasterConn::kMinMasterTimeout);
+	BackMetaCopies = std::min(BackMetaCopies, MasterConn::kMaxBackMetaCopies);
 
 #ifdef METALOGGER
-	uint32_t metadataDownloadFreq;
-	metadataDownloadFreq = cfg_getuint32("META_DOWNLOAD_FREQ",24);
+	auto metadataDownloadFreq = cfg_getuint32("META_DOWNLOAD_FREQ", 24);
 	if (metadataDownloadFreq > (changelog_get_back_logs_config_value() / 2)) {
 		metadataDownloadFreq = (changelog_get_back_logs_config_value() / 2);
 	}
 #endif /* #ifdef METALOGGER */
 
-	eventloop_timechange(reconnect_hook,TIMEMODE_RUN_LATE,ReconnectionDelay,0);
+	eventloop_timechange(reconnect_hook,TIMEMODE_RUN_LATE,reconnectionDelay,0);
 #ifdef METALOGGER
 	eventloop_timechange(download_hook,TIMEMODE_RUN_LATE,metadataDownloadFreq*3600,630);
 #endif /* #ifndef METALOGGER */
 
 #ifndef METALOGGER
-	masterconn_int_send_matoclport(gMasterConn);
+	sendMatoClPort();
 #endif /* #ifndef METALOGGER */
 }
 
+namespace {  // Make clang-tidy happy
+
+void masterconn_sessionsdownloadinit(void) {
+	if (gMasterConn->state == MasterConn::State::kSynchronized) {
+		gMasterConn->downloadInit(DOWNLOAD_SESSIONS_SFS);
+	}
+}
+
+void masterconn_wantexit(void) {
+	if (gMasterConn != nullptr) {
+		gMasterConn->killSession();
+	}
+}
+
+int masterconn_canexit(void) {
+	return static_cast<int>(gMasterConn != nullptr ||
+	                        gMasterConn->mode == MasterConn::Mode::Free);
+}
+
+void masterconn_desc(std::vector<pollfd> &pdesc) {
+	if (gMasterConn != nullptr) {
+		gMasterConn->pollDesc(pdesc);
+	}
+}
+
+void masterconn_serve(const std::vector<pollfd> &pdesc) {
+	if (gMasterConn != nullptr) {
+		gMasterConn->serve(pdesc);
+	}
+}
+
+void masterconn_reconnect(void) {
+	if (gMasterConn != nullptr) {
+		gMasterConn->reconnect();
+	}
+}
+
+void masterconn_term(void) {
+	if (gMasterConn != nullptr) {
+		gMasterConn->terminate();
+		delete gMasterConn;
+		gMasterConn = nullptr;
+	}
+}
+
+#ifndef METALOGGER
+
+void masterconn_become_master() {
+	if (gMasterConn != nullptr) {
+		gMasterConn->becomeMaster();
+		masterconn_term();
+	}
+}
+
+#else  // #ifndef METALOGGER
+
+void masterconn_metadownloadinit(void) {
+	if (gMasterConn != nullptr) {
+		gMasterConn->downloadInit(DOWNLOAD_METADATA_SFS);
+	}
+}
+
+#endif  // #else #ifndef METALOGGER
+
+void masterconn_reload(void) {
+	if (gMasterConn != nullptr) {
+		gMasterConn->reload();
+	}
+}
+
+}  // namespace
+
 int masterconn_init(void) {
-	uint32_t ReconnectionDelay;
 #ifndef METALOGGER
 	if (metadataserver::getPersonality() != metadataserver::Personality::kShadow) {
 		return 0;
 	}
 #endif /* #ifndef METALOGGER */
-	MasterConn *eptr;
 
-	ReconnectionDelay = cfg_getuint32("MASTER_RECONNECTION_DELAY", 1);
-	MasterHost = cfg_getstring("MASTER_HOST","sfsmaster");
-	MasterPort = cfg_getstring("MASTER_PORT","9419");
-	BindHost = cfg_getstring("BIND_HOST","*");
-	Timeout = cfg_getuint32("MASTER_TIMEOUT",60);
-	BackMetaCopies = cfg_getuint32("BACK_META_KEEP_PREVIOUS",3);
+	// Create the instance for Shadows and Metaloggers only
+	gMasterConn = new MasterConn();
+	passert(gMasterConn);
 
-	if (Timeout>65536) {
-		Timeout=65535;
-	}
-	if (Timeout<10) {
-		Timeout=10;
-	}
+	// Could be multiple connections in the future, so let's use a pointer
+	auto *eptr = gMasterConn;
+
+	auto reconnectionDelay = cfg_getuint32("MASTER_RECONNECTION_DELAY", 1);
+	eptr->loadConfig();
 
 #ifdef METALOGGER
 	changelog_init(kChangelogMlFilename, 5, 1000); // may throw
@@ -1116,29 +1238,20 @@ int masterconn_init(void) {
 	}
 #endif /* #ifdef METALOGGER */
 
-	eptr = gMasterConn = new MasterConn();
-	passert(eptr);
-
-	eptr->isMasterAddressValid = 0;
-	eptr->mode = MasterConn::Mode::Free;
-	eptr->pollDescPos = -1;
-	eptr->downloadFD = MasterConn::kInvalidFD;
-	eptr->masterVersion = MasterConn::kInvalidMasterVersion;
-	eptr->sock  = MasterConn::kInvalidFD;
-	eptr->state = MasterConn::State::kNone;
 #ifdef METALOGGER
 	gMetadataBackend->changelogsMigrateFrom_1_6_29("changelog_ml");
-	lastLogVersion = gMetadataBackend->findLastLogVersion();
+	eptr->lastLogVersion = gMetadataBackend->findLastLogVersion();
 #endif /* #ifdef METALOGGER */
-	if (masterconn_initconnect(eptr)<0) {
+	if (eptr->initConnect() < 0) {
 		return -1;
 	}
-	reconnect_hook = eventloop_timeregister(TIMEMODE_RUN_LATE,ReconnectionDelay,0,masterconn_reconnect);
+	eventloop_pollregister(masterconn_desc, masterconn_serve);
+	eptr->reconnect_hook = eventloop_timeregister(TIMEMODE_RUN_LATE,reconnectionDelay,0,masterconn_reconnect);
 #ifdef METALOGGER
-	download_hook = eventloop_timeregister(TIMEMODE_RUN_LATE,metadataDownloadFreq*3600,630,masterconn_metadownloadinit);
+	eptr->download_hook = eventloop_timeregister(TIMEMODE_RUN_LATE,metadataDownloadFreq*3600,630,masterconn_metadownloadinit);
 #endif /* #ifdef METALOGGER */
 	eventloop_destructregister(masterconn_term);
-	eventloop_pollregister(masterconn_desc,masterconn_serve);
+	//eventloop_pollregister(masterconn_desc, masterconn_serve);
 	eventloop_reloadregister(masterconn_reload);
 	eventloop_wantexitregister(masterconn_wantexit);
 	eventloop_canexitregister(masterconn_canexit);

--- a/src/master/masterconn.cc
+++ b/src/master/masterconn.cc
@@ -1251,7 +1251,6 @@ int masterconn_init(void) {
 	eptr->download_hook = eventloop_timeregister(TIMEMODE_RUN_LATE,metadataDownloadFreq*3600,630,masterconn_metadownloadinit);
 #endif /* #ifdef METALOGGER */
 	eventloop_destructregister(masterconn_term);
-	//eventloop_pollregister(masterconn_desc, masterconn_serve);
 	eventloop_reloadregister(masterconn_reload);
 	eventloop_wantexitregister(masterconn_wantexit);
 	eventloop_canexitregister(masterconn_canexit);

--- a/src/master/masterconn.cc
+++ b/src/master/masterconn.cc
@@ -250,7 +250,7 @@ struct MasterConn {
 	void terminate();
 };
 
-static MasterConn *gMasterConn = nullptr;
+static std::unique_ptr<MasterConn> gMasterConn = nullptr;
 
 uint8_t *MasterConn::createPacket(uint32_t type, uint32_t size) {
 	auto outpacket = std::make_unique<PacketStruct>();
@@ -1191,8 +1191,7 @@ void masterconn_reconnect(void) {
 void masterconn_term(void) {
 	if (gMasterConn != nullptr) {
 		gMasterConn->terminate();
-		delete gMasterConn;
-		gMasterConn = nullptr;
+		gMasterConn.reset();
 	}
 }
 
@@ -1231,11 +1230,11 @@ int masterconn_init(void) {
 #endif /* #ifndef METALOGGER */
 
 	// Create the instance for Shadows and Metaloggers only
-	gMasterConn = new MasterConn();
-	passert(gMasterConn);
+	gMasterConn = std::make_unique<MasterConn>();
+	passert(gMasterConn.get());
 
 	// Could be multiple connections in the future, so let's use a pointer
-	auto *eptr = gMasterConn;
+	auto *eptr = gMasterConn.get();
 
 	auto reconnectionDelay =
 	    cfg_getuint32("MASTER_RECONNECTION_DELAY",
@@ -1277,7 +1276,7 @@ int masterconn_init(void) {
 }
 
 bool masterconn_is_connected() {
-	MasterConn *eptr = gMasterConn;
+	MasterConn *eptr = gMasterConn.get();
 	return (eptr != nullptr
 			&& (eptr->mode == MasterConn::Mode::Header || eptr->mode == MasterConn::Mode::Data) // socket is connected
 			&& eptr->masterVersion > MasterConn::kInvalidMasterVersion // registration was successful

--- a/src/master/masterconn.cc
+++ b/src/master/masterconn.cc
@@ -179,6 +179,7 @@ struct MasterConn {
 	Timeout changelogApplyErrorTimeout{
 	    std::chrono::seconds(kChangeLogApplyErrorTimeout)};
 
+	/// Last log version received from the master.
 	uint64_t lastLogVersion = 0;
 
 	// from config
@@ -248,6 +249,9 @@ struct MasterConn {
 	void killSession();
 	void beforeClose();
 	void terminate();
+
+private:
+	static std::string getDownloadingFileName(uint8_t filenum);
 };
 
 static std::unique_ptr<MasterConn> gMasterConn = nullptr;
@@ -343,10 +347,10 @@ void MasterConn::requestMetadataDump() {
 
 void MasterConn::handleChangelogApplyError(uint8_t status) {
 	if (masterVersion <= saunafsVersion(2, 5, 0)) {
-		safs_pretty_syslog(LOG_NOTICE, "Dropping in-memory metadata and starting download from master");
+		safs::log_info("Dropping in-memory metadata and starting download from master");
 		forceMetadataDownload();
 	} else {
-		safs_pretty_syslog(LOG_NOTICE, "Waiting for master to produce up-to-date metadata image");
+		safs::log_info("Waiting for master to produce up-to-date metadata image");
 		errorStatus = status;
 		requestMetadataDump();
 	}
@@ -365,7 +369,7 @@ void MasterConn::sendMatoClPort() {
 
 	if (portStr != previousPort) {
 		if (tcpresolve(nullptr, portStr.c_str(), nullptr, &port, false) < 0) {
-			safs_pretty_syslog(LOG_WARNING, "Cannot resolve MATOCL_LISTEN_PORT: %s", portStr.c_str());
+			safs::log_warn("Cannot resolve MATOCL_LISTEN_PORT: {}", portStr);
 			return;
 		}
 		previousPort = portStr;
@@ -380,7 +384,7 @@ void MasterConn::onRegistered(const uint8_t *data, uint32_t length) {
 	if (responseVersion == matoml::registerShadow::kStatusPacketVersion) {
 		uint8_t status{};
 		matoml::registerShadow::deserialize(data, length, status);
-		safs_pretty_syslog(LOG_NOTICE, "Cannot register to master: %s", saunafs_error_string(status));
+		safs::log_info("Cannot register to master: {}", saunafs_error_string(status));
 		mode = Mode::Kill;
 	} else if (responseVersion == matoml::registerShadow::kResponsePacketVersion) {
 		uint32_t incommingMasterVersion{};
@@ -392,7 +396,7 @@ void MasterConn::onRegistered(const uint8_t *data, uint32_t length) {
 			forceMetadataDownload();
 		}
 	} else {
-		safs_pretty_syslog(LOG_NOTICE, "Unknown register response: #%u", unsigned(responseVersion));
+		spdlog::info("Unknown register response: #{}", responseVersion);
 	}
 }
 #endif
@@ -407,17 +411,17 @@ void MasterConn::metachangesLog(const uint8_t *data,uint32_t length) {
 		return;
 	}
 	if (length<10) {
-		safs_pretty_syslog(LOG_NOTICE,"MATOML_METACHANGES_LOG - wrong size (%" PRIu32 "/9+data)",length);
+		safs::log_info("MATOML_METACHANGES_LOG - wrong size ({}/9+data)", length);
 		mode = Mode::Kill;
 		return;
 	}
 	if (data[0]!=0xFF) {
-		safs_pretty_syslog(LOG_NOTICE,"MATOML_METACHANGES_LOG - wrong packet");
+		safs::log_info("MATOML_METACHANGES_LOG - wrong packet");
 		mode = Mode::Kill;
 		return;
 	}
 	if (data[length-1]!='\0') {
-		safs_pretty_syslog(LOG_NOTICE,"MATOML_METACHANGES_LOG - invalid string");
+		safs::log_info("MATOML_METACHANGES_LOG - invalid string");
 		mode = Mode::Kill;
 		return;
 	}
@@ -427,7 +431,7 @@ void MasterConn::metachangesLog(const uint8_t *data,uint32_t length) {
 	const char* changelogEntry = reinterpret_cast<const char*>(data);
 
 	if ((lastLogVersion > 0) && (version != (lastLogVersion + 1))) {
-		safs_pretty_syslog(LOG_WARNING, "some changes lost: [%" PRIu64 "-%" PRIu64 "], download metadata again",lastLogVersion,version-1);
+		safs::log_warn("some changes lost: [{}}-{}}], download metadata again", lastLogVersion, version - 1);
 		handleChangelogApplyError(SAUNAFS_ERROR_METADATAVERSIONMISMATCH);
 		return;
 	}
@@ -437,11 +441,11 @@ void MasterConn::metachangesLog(const uint8_t *data,uint32_t length) {
 		std::string buf(": ");
 		buf.append(changelogEntry);
 		static char const network[] = "network";
-		uint8_t status;
-		if ((status = restore(network, version, buf.c_str(),
-				RestoreRigor::kDontIgnoreAnyErrors)) != SAUNAFS_STATUS_OK) {
-			safs_pretty_syslog(LOG_WARNING, "malformed changelog sent by the master server, can't apply it. status: %s",
-					saunafs_error_string(status));
+		uint8_t status = restore(network, version, buf.c_str(), RestoreRigor::kDontIgnoreAnyErrors);
+
+		if (status != SAUNAFS_STATUS_OK) {
+			safs::log_warn("malformed changelog sent by the master server, can't apply it. status: {}",
+			               saunafs_error_string(status));
 			handleChangelogApplyError(status);
 			return;
 		}
@@ -453,7 +457,7 @@ void MasterConn::metachangesLog(const uint8_t *data,uint32_t length) {
 
 void MasterConn::endSession(const uint8_t* data, uint32_t length) {
 	matoml::endSession::deserialize(data, length); // verify the empty packet
-	safs_pretty_syslog(LOG_NOTICE, "Master server is terminating; closing the connection...");
+	safs::log_info("Master server is terminating; closing the connection...");
 	killSession();
 }
 
@@ -491,57 +495,77 @@ int MasterConn::metadataCheck(const std::string& name) {
 		gMetadataBackend->getVersion(name);
 		return 0;
 	} catch (MetadataCheckException& ex) {
-		safs_pretty_syslog(LOG_NOTICE, "Verification of the downloaded metadata file failed: %s", ex.what());
+		safs::log_info(
+		    "Verification of the downloaded metadata file failed: {}",
+		    ex.what());
 		return -1;
 	}
 }
 
-void MasterConn::downloadNext() {
-	uint8_t *ptr;
-	uint8_t filenum;
-	int64_t dltime;
+std::string MasterConn::getDownloadingFileName(uint8_t filenum) {
+	static std::string changelogFilename_1 = changelogFilename + ".1";
+	static std::string changelogFilename_2 = changelogFilename + ".2";
 
+	switch (filenum) {
+	case DOWNLOAD_METADATA_SFS:
+		return "metadata";
+	case DOWNLOAD_SESSIONS_SFS:
+		return "sessions";
+	case DOWNLOAD_CHANGELOG_SFS:
+		return changelogFilename_1;
+	case DOWNLOAD_CHANGELOG_SFS_1:
+		return changelogFilename_2;
+	default:
+		return "???";
+	}
+}
+
+void MasterConn::downloadNext() {
 	if (downloadOffset >= fileSize) {   // end of file
-		filenum = downloadingFileNum;
+		auto filenum = downloadingFileNum;
 		if (downloadEnd() < 0) {
 			return;
 		}
-		dltime = eventloop_utime() - downloadStartTimeInMicroSeconds;
+
+		int64_t dltime = eventloop_utime() - downloadStartTimeInMicroSeconds;
 		if (dltime<=0) {
 			dltime=1;
 		}
-		std::string changelogFilename_1 = changelogFilename + ".1";
-		std::string changelogFilename_2 = changelogFilename + ".2";
-		safs_pretty_syslog(LOG_NOTICE, "%s downloaded %" PRIu64 "B/%" PRIu64 ".%06" PRIu32 "s (%.3f MB/s)",
-				(filenum == DOWNLOAD_METADATA_SFS) ? "metadata" :
-				(filenum == DOWNLOAD_SESSIONS_SFS) ? "sessions" :
-				(filenum == DOWNLOAD_CHANGELOG_SFS) ? changelogFilename_1.c_str() :
-				(filenum == DOWNLOAD_CHANGELOG_SFS_1) ? changelogFilename_2.c_str() : "???",
-				fileSize, dltime/1000000, (uint32_t)(dltime%1000000),
-				(double)(fileSize) / (double)(dltime));
+
+		static std::string changelogFilename_1 = changelogFilename + ".1";
+		static std::string changelogFilename_2 = changelogFilename + ".2";
+		static constexpr uint32_t kMicroSecondsInSecond = 1000000;
+
+		safs::log_info(
+		    "{} downloaded {}B/{}.{:06}s ({:.3f} MB/s)",
+		    getDownloadingFileName(filenum), fileSize,
+		    dltime / kMicroSecondsInSecond,
+		    static_cast<uint32_t>(dltime % kMicroSecondsInSecond),
+		    static_cast<double>(fileSize) / static_cast<double>(dltime));
+
 		if (filenum == DOWNLOAD_METADATA_SFS) {
 			if (metadataCheck(metadataTmpFilename) == 0) {
 				if (cfgBackMetaKeepPrevious>0) {
 					rotateFiles(metadataFilename, cfgBackMetaKeepPrevious, 1);
 				}
 				if (rename(metadataTmpFilename.c_str(), metadataFilename.c_str()) < 0) {
-					safs_pretty_syslog(LOG_NOTICE,"can't rename downloaded metadata - do it manually before next download");
+					safs::log_info("can't rename downloaded metadata - do it manually before next download");
 				}
 			}
 			downloadInit(DOWNLOAD_CHANGELOG_SFS);
 		} else if (filenum == DOWNLOAD_CHANGELOG_SFS) {
 			if (::rename(changelogTmpFilename.c_str(), changelogFilename_1.c_str()) < 0) {
-				safs_pretty_syslog(LOG_NOTICE,"can't rename downloaded changelog - do it manually before next download");
+				safs::log_info("can't rename downloaded changelog - do it manually before next download");
 			}
 			downloadInit(DOWNLOAD_CHANGELOG_SFS_1);
 		} else if (filenum == DOWNLOAD_CHANGELOG_SFS_1) {
 			if (::rename(changelogTmpFilename.c_str(), changelogFilename_2.c_str()) < 0) {
-				safs_pretty_syslog(LOG_NOTICE,"can't rename downloaded changelog - do it manually before next download");
+				safs::log_info("can't rename downloaded changelog - do it manually before next download");
 			}
 			downloadInit(DOWNLOAD_SESSIONS_SFS);
 		} else if (filenum == DOWNLOAD_SESSIONS_SFS) {
 			if (::rename(sessionsTmpFilename.c_str(), sessionsFilename.c_str()) < 0) {
-				safs_pretty_syslog(LOG_NOTICE,"can't rename downloaded sessions - do it manually before next download");
+				safs::log_info("can't rename downloaded sessions - do it manually before next download");
 			} else {
 #ifndef METALOGGER
 				/*
@@ -552,10 +576,10 @@ void MasterConn::downloadNext() {
 					try {
 						fs_loadall();
 						lastLogVersion = fs_getversion() - 1;
-						safs_pretty_syslog(LOG_NOTICE, "synced at version = %" PRIu64, lastLogVersion);
+						safs::log_info("synced at version = {}", lastLogVersion);
 						state = MasterConn::State::kSynchronized;
 					} catch (Exception& ex) {
-						safs_pretty_syslog(LOG_WARNING, "can't load downloaded metadata and changelogs: %s",
+						safs::log_warn("can't load downloaded metadata and changelogs: {}",
 								ex.what());
 						uint8_t status = ex.status();
 						if (status == SAUNAFS_STATUS_OK) {
@@ -572,7 +596,7 @@ void MasterConn::downloadNext() {
 			}
 		}
 	} else {        // send request for next data packet
-		ptr = createPacket(MLTOMA_DOWNLOAD_DATA, 12);
+		auto *ptr = createPacket(MLTOMA_DOWNLOAD_DATA, 12);
 		put64bit(&ptr, downloadOffset);
 		if (fileSize - downloadOffset > kMetadataDownloadBlocksize) {
 			put32bit(&ptr, kMetadataDownloadBlocksize);
@@ -584,7 +608,7 @@ void MasterConn::downloadNext() {
 
 void MasterConn::downloadStart(const uint8_t *data, uint32_t length) {
 	if (length != 1 && length != 8) {
-		safs_pretty_syslog(LOG_NOTICE,"MATOML_DOWNLOAD_START - wrong size (%" PRIu32 "/1|8)",length);
+		safs::log_info("MATOML_DOWNLOAD_START - wrong size ({}/1|8)", length);
 		mode = Mode::Kill;
 		return;
 	}
@@ -593,7 +617,7 @@ void MasterConn::downloadStart(const uint8_t *data, uint32_t length) {
 
 	if (length == 1) {
 		downloadingFileNum = 0;
-		safs_pretty_syslog(LOG_NOTICE,"download start error");
+		safs::log_info("download start error");
 		return;
 	}
 
@@ -615,13 +639,13 @@ void MasterConn::downloadStart(const uint8_t *data, uint32_t length) {
 			|| (downloadingFileNum == DOWNLOAD_CHANGELOG_SFS_1)) {
 		downloadFD = ::open(changelogTmpFilename.c_str(), O_WRONLY | O_TRUNC | O_CREAT, 0666);
 	} else {
-		safs_pretty_syslog(LOG_NOTICE,"unexpected MATOML_DOWNLOAD_START packet");
+		safs::log_info("unexpected MATOML_DOWNLOAD_START packet");
 		mode = Mode::Kill;
 		return;
 	}
 
 	if (downloadFD < 0) {
-		safs_silent_errlog(LOG_NOTICE,"error opening metafile");
+		safs::log_info("error opening metafile");
 		downloadEnd();
 		return;
 	}
@@ -636,13 +660,13 @@ void MasterConn::downloadData(const uint8_t *data,uint32_t length) {
 	ssize_t ret;
 
 	if (downloadFD < 0) {
-		safs_pretty_syslog(LOG_NOTICE,"MATOML_DOWNLOAD_DATA - file not opened");
+		safs::log_info("MATOML_DOWNLOAD_DATA - file not opened");
 		mode = MasterConn::Mode::Kill;
 		return;
 	}
 
 	if (length<16) {
-		safs_pretty_syslog(LOG_NOTICE,"MATOML_DOWNLOAD_DATA - wrong size (%" PRIu32 "/16+data)",length);
+		safs::log_info("MATOML_DOWNLOAD_DATA - wrong size ({}/16+data)", length);
 		mode = MasterConn::Mode::Kill;
 		return;
 	}
@@ -653,19 +677,19 @@ void MasterConn::downloadData(const uint8_t *data,uint32_t length) {
 	crc = get32bit(&data);
 
 	if (leng+16!=length) {
-		safs_pretty_syslog(LOG_NOTICE,"MATOML_DOWNLOAD_DATA - wrong size (%" PRIu32 "/16+%" PRIu32 ")",length,leng);
+		safs::log_info("MATOML_DOWNLOAD_DATA - wrong size ({}/16+{})", length, leng);
 		mode = MasterConn::Mode::Kill;
 		return;
 	}
 
 	if (offset != downloadOffset) {
-		safs_pretty_syslog(LOG_NOTICE,"MATOML_DOWNLOAD_DATA - unexpected file offset (%" PRIu64 "/%" PRIu64 ")",offset,downloadOffset);
+		safs::log_info("MATOML_DOWNLOAD_DATA - unexpected file offset ({}/{})", offset, downloadOffset);
 		mode = MasterConn::Mode::Kill;
 		return;
 	}
 
 	if (offset + leng > fileSize) {
-		safs_pretty_syslog(LOG_NOTICE,"MATOML_DOWNLOAD_DATA - unexpected file size (%" PRIu64 "/%" PRIu64 ")",offset+leng,fileSize);
+		safs::log_info("MATOML_DOWNLOAD_DATA - unexpected file size ({}/{})", offset + leng, fileSize);
 		mode = MasterConn::Mode::Kill;
 		return;
 	}
@@ -689,7 +713,7 @@ void MasterConn::downloadData(const uint8_t *data,uint32_t length) {
 	}
 
 	if (crc != mycrc32(0,data,leng)) {
-		safs_pretty_syslog(LOG_NOTICE,"metafile data crc error");
+		safs::log_info("metafile data crc error");
 		if (downloadRetryCnt >= 5) {
 			downloadEnd();
 		} else {
@@ -700,7 +724,7 @@ void MasterConn::downloadData(const uint8_t *data,uint32_t length) {
 	}
 
 	if (::fsync(downloadFD) < 0) {
-		safs_silent_errlog(LOG_NOTICE,"error syncing metafile");
+		safs::log_info("error syncing metafile");
 		if (downloadRetryCnt >= 5) {
 			downloadEnd();
 		} else {
@@ -719,16 +743,16 @@ void MasterConn::downloadData(const uint8_t *data,uint32_t length) {
 void MasterConn::changelogApplyError(const uint8_t *data, uint32_t length) {
 	uint8_t status{};
 	matoml::changelogApplyError::deserialize(data, length, status);
-	safs_silent_syslog(LOG_DEBUG, "master.matoml_changelog_apply_error status: %u", status);
+	safs::log_debug("master.matoml_changelog_apply_error status: {}", status);
 
 	if (status == SAUNAFS_STATUS_OK) {
 		forceMetadataDownload();
 	} else if (status == SAUNAFS_ERROR_DELAYED) {
 		state = State::kLimbo;
-		safs_pretty_syslog(LOG_NOTICE, "Master temporarily refused to produce a new metadata image");
+		safs::log_info("Master temporarily refused to produce a new metadata image");
 	} else {
 		state = State::kLimbo;
-		safs_pretty_syslog(LOG_NOTICE, "Master failed to produce a new metadata image: %s", saunafs_error_string(status));
+		safs::log_info("Master failed to produce a new metadata image: {}", saunafs_error_string(status));
 	}
 }
 
@@ -772,12 +796,12 @@ void MasterConn::gotPacket(uint32_t type,const uint8_t *data,uint32_t length) {
 				changelogApplyError(data, length);
 				break;
 			default:
-				safs_pretty_syslog(LOG_NOTICE,"got unknown message (type:%" PRIu32 ")",type);
+				safs::log_info("got unknown message (type: {})", type);
 				mode = Mode::Kill;
 				break;
 		}
 	} catch (IncorrectDeserializationException& ex) {
-		safs_pretty_syslog(LOG_NOTICE, "Packet 0x%" PRIX32 " - can't deserialize: %s", type, ex.what());
+		safs::log_info("Packet 0x{:X} - can't deserialize: {}", type, ex.what());
 		mode = Mode::Kill;
 	}
 }
@@ -834,9 +858,8 @@ int MasterConn::initConnect() {
 			masterPort = mport;
 			isMasterAddressValid = 1;
 		} else {
-			safs_pretty_syslog(LOG_WARNING,
-					"can't resolve master host/port (%s:%s)",
-					cfgMasterHost.c_str(), cfgMasterPort.c_str());
+			safs::log_warn("can't resolve master host/port ({}:{})",
+			               cfgMasterHost.c_str(), cfgMasterPort.c_str());
 			return -1;
 		}
 	}
@@ -875,11 +898,11 @@ int MasterConn::initConnect() {
 	}
 
 	if (status == 0) {
-		safs_pretty_syslog(LOG_NOTICE,"connected to Master immediately");
+		safs::log_info("connected to Master immediately");
 		onConnected();
 	} else {
 		mode = Mode::Connecting;
-		safs_pretty_syslog_attempt(LOG_NOTICE,"connecting to Master");
+		safs::log_info("connecting to Master");
 	}
 
 	return 0;
@@ -912,13 +935,13 @@ void MasterConn::readFromSocket() {
 	while (mode != MasterConn::Mode::Kill) {
 		i = ::read(sock, inputPacket.startPtr, inputPacket.bytesLeft);
 		if (i==0) {
-			safs_pretty_syslog(LOG_NOTICE,"connection was reset by Master");
+			safs::log_info("connection was reset by Master");
 			killSession();
 			return;
 		}
 		if (i<0) {
 			if (errno!=EAGAIN) {
-				safs_silent_errlog(LOG_NOTICE,"read from Master error");
+				safs_silent_errlog(LOG_NOTICE, "read from Master error");
 				killSession();
 			}
 			return;
@@ -935,7 +958,7 @@ void MasterConn::readFromSocket() {
 
 			if (size > 0) {
 				if (size > kMaxPacketSize) {
-					safs_pretty_syslog(LOG_WARNING,"Master packet too long (%" PRIu32 "/%u)",size,kMaxPacketSize);
+					safs::log_warn("Master packet too long ({}/{})", size, kMaxPacketSize);
 					killSession();
 					return;
 				}

--- a/src/master/masterconn.cc
+++ b/src/master/masterconn.cc
@@ -65,24 +65,6 @@
 #include "master/restore.h"
 #endif /* #ifndef METALOGGER */
 
-namespace {
-#ifdef METALOGGER
-const std::string metadataFilename = kMetadataMlFilename;
-const std::string metadataTmpFilename = kMetadataMlTmpFilename;
-const std::string changelogFilename = kChangelogMlFilename;
-const std::string changelogTmpFilename = kChangelogMlTmpFilename;
-const std::string sessionsFilename = kSessionsMlFilename;
-const std::string sessionsTmpFilename = kSessionsMlTmpFilename;
-#else  /* #ifdef METALOGGER */
-const std::string metadataFilename = kMetadataFilename;
-const std::string metadataTmpFilename = kMetadataTmpFilename;
-const std::string changelogFilename = kChangelogFilename;
-const std::string changelogTmpFilename = kChangelogTmpFilename;
-const std::string sessionsFilename = kSessionsFilename;
-const std::string sessionsTmpFilename = kSessionsTmpFilename;
-#endif /* #else #ifdef METALOGGER */
-}  // namespace
-
 /// Block size for metadata download (1 MB).
 constexpr uint32_t kMetadataDownloadBlocksize = 1000000U;
 
@@ -90,8 +72,8 @@ constexpr uint32_t kMetadataDownloadBlocksize = 1000000U;
 constexpr uint32_t kMaxPacketSize = 1500000U;
 
 struct PacketStruct {
-	uint8_t *startPtr;
-	uint32_t bytesLeft;
+	uint8_t *startPtr{};
+	uint32_t bytesLeft{0};
 	std::vector<uint8_t> packet;
 };
 
@@ -250,11 +232,75 @@ struct MasterConn {
 	void beforeClose();
 	void terminate();
 
+	// Helpers to determine the correct version (metalogger or not)
+
+	static inline const std::string &getMetadataFilename();
+	static inline const std::string &getMetadataTmpFilename();
+	static inline const std::string &getChangelogFilename();
+	static inline const std::string &getChangelogTmpFilename();
+	static inline const std::string &getSessionsFilename();
+	static inline const std::string &getSessionsTmpFilename();
+
 private:
 	static std::string getDownloadingFileName(uint8_t filenum);
 };
 
 static std::unique_ptr<MasterConn> gMasterConn = nullptr;
+
+inline const std::string &MasterConn::getMetadataFilename() {
+#ifdef METALOGGER
+	static const std::string metadataFilename = kMetadataMlFilename;
+#else  /* #ifdef METALOGGER */
+	static const std::string metadataFilename = kMetadataFilename;
+#endif /* #else #ifdef METALOGGER */
+
+	return metadataFilename;
+}
+
+inline const std::string &MasterConn::getMetadataTmpFilename() {
+#ifdef METALOGGER
+	static const std::string metadataTmpFilename = kMetadataMlTmpFilename;
+#else  /* #ifdef METALOGGER */
+	static const std::string metadataTmpFilename = kMetadataTmpFilename;
+#endif /* #else #ifdef METALOGGER */
+	return metadataTmpFilename;
+}
+
+inline const std::string &MasterConn::getChangelogFilename() {
+#ifdef METALOGGER
+	static const std::string changelogFilename = kChangelogMlFilename;
+#else  /* #ifdef METALOGGER */
+	static const std::string changelogFilename = kChangelogFilename;
+#endif /* #else #ifdef METALOGGER */
+	return changelogFilename;
+}
+
+inline const std::string &MasterConn::getChangelogTmpFilename() {
+#ifdef METALOGGER
+	static const std::string changelogTmpFilename = kChangelogMlTmpFilename;
+#else  /* #ifdef METALOGGER */
+	static const std::string changelogTmpFilename = kChangelogTmpFilename;
+#endif /* #else #ifdef METALOGGER */
+	return changelogTmpFilename;
+}
+
+inline const std::string &MasterConn::getSessionsFilename() {
+#ifdef METALOGGER
+	static const std::string sessionsFilename = kSessionsMlFilename;
+#else  /* #ifdef METALOGGER */
+	static const std::string sessionsFilename = kSessionsFilename;
+#endif /* #else #ifdef METALOGGER */
+	return sessionsFilename;
+}
+
+inline const std::string &MasterConn::getSessionsTmpFilename() {
+#ifdef METALOGGER
+	static const std::string sessionsTmpFilename = kSessionsMlTmpFilename;
+#else  /* #ifdef METALOGGER */
+	static const std::string sessionsTmpFilename = kSessionsTmpFilename;
+#endif /* #else #ifdef METALOGGER */
+	return sessionsTmpFilename;
+}
 
 uint8_t *MasterConn::createPacket(uint32_t type, uint32_t size) {
 	auto outpacket = std::make_unique<PacketStruct>();
@@ -503,8 +549,8 @@ int MasterConn::metadataCheck(const std::string& name) {
 }
 
 std::string MasterConn::getDownloadingFileName(uint8_t filenum) {
-	static std::string changelogFilename_1 = changelogFilename + ".1";
-	static std::string changelogFilename_2 = changelogFilename + ".2";
+	static std::string changelogFilename_1 = getChangelogFilename() + ".1";
+	static std::string changelogFilename_2 = getChangelogFilename() + ".2";
 
 	switch (filenum) {
 	case DOWNLOAD_METADATA_SFS:
@@ -532,8 +578,8 @@ void MasterConn::downloadNext() {
 			dltime=1;
 		}
 
-		static std::string changelogFilename_1 = changelogFilename + ".1";
-		static std::string changelogFilename_2 = changelogFilename + ".2";
+		static std::string changelogFilename_1 = getChangelogFilename() + ".1";
+		static std::string changelogFilename_2 = getChangelogFilename() + ".2";
 		static constexpr uint32_t kMicroSecondsInSecond = 1000000;
 
 		safs::log_info(
@@ -544,27 +590,27 @@ void MasterConn::downloadNext() {
 		    static_cast<double>(fileSize) / static_cast<double>(dltime));
 
 		if (filenum == DOWNLOAD_METADATA_SFS) {
-			if (metadataCheck(metadataTmpFilename) == 0) {
+			if (metadataCheck(getMetadataTmpFilename()) == 0) {
 				if (cfgBackMetaKeepPrevious>0) {
-					rotateFiles(metadataFilename, cfgBackMetaKeepPrevious, 1);
+					rotateFiles(getMetadataFilename(), cfgBackMetaKeepPrevious, 1);
 				}
-				if (rename(metadataTmpFilename.c_str(), metadataFilename.c_str()) < 0) {
+				if (::rename(getMetadataTmpFilename().c_str(), getMetadataFilename().c_str()) < 0) {
 					safs::log_info("can't rename downloaded metadata - do it manually before next download");
 				}
 			}
 			downloadInit(DOWNLOAD_CHANGELOG_SFS);
 		} else if (filenum == DOWNLOAD_CHANGELOG_SFS) {
-			if (::rename(changelogTmpFilename.c_str(), changelogFilename_1.c_str()) < 0) {
+			if (::rename(getChangelogTmpFilename().c_str(), changelogFilename_1.c_str()) < 0) {
 				safs::log_info("can't rename downloaded changelog - do it manually before next download");
 			}
 			downloadInit(DOWNLOAD_CHANGELOG_SFS_1);
 		} else if (filenum == DOWNLOAD_CHANGELOG_SFS_1) {
-			if (::rename(changelogTmpFilename.c_str(), changelogFilename_2.c_str()) < 0) {
+			if (::rename(getChangelogTmpFilename().c_str(), changelogFilename_2.c_str()) < 0) {
 				safs::log_info("can't rename downloaded changelog - do it manually before next download");
 			}
 			downloadInit(DOWNLOAD_SESSIONS_SFS);
 		} else if (filenum == DOWNLOAD_SESSIONS_SFS) {
-			if (::rename(sessionsTmpFilename.c_str(), sessionsFilename.c_str()) < 0) {
+			if (::rename(getSessionsTmpFilename().c_str(), getSessionsFilename().c_str()) < 0) {
 				safs::log_info("can't rename downloaded sessions - do it manually before next download");
 			} else {
 #ifndef METALOGGER
@@ -632,12 +678,15 @@ void MasterConn::downloadStart(const uint8_t *data, uint32_t length) {
 	downloadStartTimeInMicroSeconds = eventloop_utime();
 
 	if (downloadingFileNum == DOWNLOAD_METADATA_SFS) {
-		downloadFD = ::open(metadataTmpFilename.c_str(), O_WRONLY | O_TRUNC | O_CREAT, 0666);
+		downloadFD = ::open(getMetadataTmpFilename().c_str(),
+		                    O_WRONLY | O_TRUNC | O_CREAT, 0666);
 	} else if (downloadingFileNum == DOWNLOAD_SESSIONS_SFS) {
-		downloadFD = ::open(sessionsTmpFilename.c_str(), O_WRONLY | O_TRUNC | O_CREAT, 0666);
-	} else if ((downloadingFileNum == DOWNLOAD_CHANGELOG_SFS)
-			|| (downloadingFileNum == DOWNLOAD_CHANGELOG_SFS_1)) {
-		downloadFD = ::open(changelogTmpFilename.c_str(), O_WRONLY | O_TRUNC | O_CREAT, 0666);
+		downloadFD = ::open(getSessionsTmpFilename().c_str(),
+		                    O_WRONLY | O_TRUNC | O_CREAT, 0666);
+	} else if ((downloadingFileNum == DOWNLOAD_CHANGELOG_SFS) ||
+	           (downloadingFileNum == DOWNLOAD_CHANGELOG_SFS_1)) {
+		downloadFD = ::open(getChangelogTmpFilename().c_str(),
+		                    O_WRONLY | O_TRUNC | O_CREAT, 0666);
 	} else {
 		safs::log_info("unexpected MATOML_DOWNLOAD_START packet");
 		mode = Mode::Kill;
@@ -760,9 +809,9 @@ void MasterConn::beforeClose() {
 	if (downloadFD >= 0) {
 		::close(downloadFD);
 		downloadFD = MasterConn::kInvalidFD;
-		::unlink(metadataTmpFilename.c_str());
-		::unlink(sessionsTmpFilename.c_str());
-		::unlink(changelogTmpFilename.c_str());
+		::unlink(getMetadataTmpFilename().c_str());
+		::unlink(getSessionsTmpFilename().c_str());
+		::unlink(getChangelogTmpFilename().c_str());
 	}
 }
 

--- a/src/master/masterconn.cc
+++ b/src/master/masterconn.cc
@@ -110,6 +110,14 @@ struct MasterConn {
 	static constexpr uint32_t kMinMasterTimeout = 10;
 	static constexpr uint32_t kMaxBackMetaCopies = 100;
 
+	static constexpr uint32_t kCfgDefaultBackMetaKeepPrevious = 3;
+	static constexpr const char *kCfgDefaultMasterHost = "sfsmaster";
+	static constexpr const char *kCfgDefaultMasterPort = "9419";
+	static constexpr const char *kCfgDefaultBindHost = "*";
+	static constexpr uint32_t kCfgDefaultMasterTimeout = 60;
+	static constexpr uint32_t kCfgDefaultMasterReconnectionDelay = 1;
+	static constexpr uint32_t kCfgDefaultMetaDownloadFreq = 24;
+
 	enum class Mode : uint8_t {
 		Free,        ///< Connection is not in use.
 		Connecting,  ///< Connection is being established.
@@ -174,16 +182,16 @@ struct MasterConn {
 	uint64_t lastLogVersion = 0;
 
 	// from config
-	uint32_t BackMetaCopies;
-	std::string MasterHost;
-	std::string MasterPort;
-	std::string BindHost;
-	uint32_t masterTimeout;
+	uint32_t cfgBackMetaKeepPrevious = kCfgDefaultBackMetaKeepPrevious;
+	std::string cfgMasterHost = kCfgDefaultMasterHost;
+	std::string cfgMasterPort = kCfgDefaultMasterPort;
+	std::string cfgBindHost = kCfgDefaultBindHost;
+	uint32_t cfgMasterTimeout = kCfgDefaultMasterTimeout;
 
 	// Callbacks
-	void *reconnect_hook;
+	void *reconnect_hook{};
 #ifdef METALOGGER
-	void *download_hook;
+	void *download_hook{};
 #endif /* #ifdef METALOGGER */
 
 	// Configuration
@@ -282,7 +290,7 @@ void MasterConn::sendRegister() {
 	if (state == State::kSynchronized) {
 		metadataVersion = fs_getversion();
 	}
-	auto request = mltoma::registerShadow::build(SAUNAFS_VERSHEX, masterTimeout * 1000, metadataVersion);
+	auto request = mltoma::registerShadow::build(SAUNAFS_VERSHEX, cfgMasterTimeout * 1000, metadataVersion);
 	createPacket(std::move(request));
 	return;
 #endif
@@ -293,7 +301,7 @@ void MasterConn::sendRegister() {
 		put16bit(&buff,SAUNAFS_PACKAGE_VERSION_MAJOR);
 		put8bit(&buff,SAUNAFS_PACKAGE_VERSION_MINOR);
 		put8bit(&buff,SAUNAFS_PACKAGE_VERSION_MICRO);
-		put16bit(&buff,masterTimeout);
+		put16bit(&buff,cfgMasterTimeout);
 		put64bit(&buff,lastLogVersion);
 	} else {
 		buff = createPacket(MLTOMA_REGISTER, 1 + 4 + 2);
@@ -301,7 +309,7 @@ void MasterConn::sendRegister() {
 		put16bit(&buff,SAUNAFS_PACKAGE_VERSION_MAJOR);
 		put8bit(&buff,SAUNAFS_PACKAGE_VERSION_MINOR);
 		put8bit(&buff,SAUNAFS_PACKAGE_VERSION_MICRO);
-		put16bit(&buff,masterTimeout);
+		put16bit(&buff,cfgMasterTimeout);
 	}
 }
 
@@ -513,8 +521,8 @@ void MasterConn::downloadNext() {
 				(double)(fileSize) / (double)(dltime));
 		if (filenum == DOWNLOAD_METADATA_SFS) {
 			if (metadataCheck(metadataTmpFilename) == 0) {
-				if (BackMetaCopies>0) {
-					rotateFiles(metadataFilename, BackMetaCopies, 1);
+				if (cfgBackMetaKeepPrevious>0) {
+					rotateFiles(metadataFilename, cfgBackMetaKeepPrevious, 1);
 				}
 				if (rename(metadataTmpFilename.c_str(), metadataFilename.c_str()) < 0) {
 					safs_pretty_syslog(LOG_NOTICE,"can't rename downloaded metadata - do it manually before next download");
@@ -816,19 +824,19 @@ int MasterConn::initConnect() {
 	if (isMasterAddressValid == 0) {
 		uint32_t mip,bip;
 		uint16_t mport;
-		if (tcpresolve(BindHost.c_str(), NULL, &bip, NULL, 1)>=0) {
+		if (tcpresolve(cfgBindHost.c_str(), NULL, &bip, NULL, 1)>=0) {
 			bindIP = bip;
 		} else {
 			bindIP = 0;
 		}
-		if (tcpresolve(MasterHost.c_str(), MasterPort.c_str(), &mip, &mport, 0)>=0) {
+		if (tcpresolve(cfgMasterHost.c_str(), cfgMasterPort.c_str(), &mip, &mport, 0)>=0) {
 			masterIP = mip;
 			masterPort = mport;
 			isMasterAddressValid = 1;
 		} else {
 			safs_pretty_syslog(LOG_WARNING,
 					"can't resolve master host/port (%s:%s)",
-					MasterHost.c_str(), MasterPort.c_str());
+					cfgMasterHost.c_str(), cfgMasterPort.c_str());
 			return -1;
 		}
 	}
@@ -1046,10 +1054,10 @@ void MasterConn::serve(const std::vector<pollfd> &pdesc) {
 				lastWrite = now;
 				writeToSocket();
 			}
-			if ((mode == Mode::Header || mode == Mode::Data) && lastRead + masterTimeout < now) {
+			if ((mode == Mode::Header || mode == Mode::Data) && lastRead + cfgMasterTimeout < now) {
 				mode = Mode::Kill;
 			}
-			if ((mode == Mode::Header || mode == Mode::Data) && lastWrite + (masterTimeout / 3) < now && outputQueue.empty()) {
+			if ((mode == Mode::Header || mode == Mode::Data) && lastWrite + (cfgMasterTimeout / 3) < now && outputQueue.empty()) {
 				createPacket(ANTOAN_NOP, 0);
 			}
 		}
@@ -1089,41 +1097,45 @@ void MasterConn::becomeMaster() {
 }
 
 void MasterConn::loadConfig() {
-	MasterHost = cfg_getstring("MASTER_HOST","sfsmaster");
-	MasterPort = cfg_getstring("MASTER_PORT","9419");
-	BindHost = cfg_getstring("BIND_HOST","*");
-	masterTimeout = cfg_getuint32("MASTER_TIMEOUT",60);
-	BackMetaCopies = cfg_getuint32("BACK_META_KEEP_PREVIOUS",3);
+	cfgMasterHost = cfg_getstring("MASTER_HOST", kCfgDefaultMasterHost);
+	cfgMasterPort = cfg_getstring("MASTER_PORT", kCfgDefaultMasterPort);
+	cfgBindHost = cfg_getstring("BIND_HOST", kCfgDefaultBindHost);
+	cfgMasterTimeout = cfg_getuint32("MASTER_TIMEOUT", kCfgDefaultMasterTimeout);
+	cfgBackMetaKeepPrevious = cfg_getuint32("BACK_META_KEEP_PREVIOUS",
+	                                        kCfgDefaultBackMetaKeepPrevious);
 
-	masterTimeout = std::min(masterTimeout, kMaxMasterTimeout);
-	masterTimeout = std::max<uint32_t>(masterTimeout, kMinMasterTimeout);
+	cfgMasterTimeout = std::min(cfgMasterTimeout, kMaxMasterTimeout);
+	cfgMasterTimeout = std::max<uint32_t>(cfgMasterTimeout, kMinMasterTimeout);
 }
 
 void MasterConn::reload() {
-	std::string newMasterHost = cfg_getstring("MASTER_HOST","sfsmaster");
-	std::string newMasterPort = cfg_getstring("MASTER_PORT","9419");
-	std::string newBindHost = cfg_getstring("BIND_HOST","*");
+	std::string newMasterHost = cfg_getstring("MASTER_HOST", kCfgDefaultMasterHost);
+	std::string newMasterPort = cfg_getstring("MASTER_PORT", kCfgDefaultMasterPort);
+	std::string newBindHost = cfg_getstring("BIND_HOST", kCfgDefaultBindHost);
 
-	if (newMasterHost != MasterHost || newMasterPort != MasterPort || newBindHost != BindHost) {
-		MasterHost = newMasterHost;
-		MasterPort = newMasterPort;
-		BindHost = newBindHost;
+	if (newMasterHost != cfgMasterHost || newMasterPort != cfgMasterPort || newBindHost != cfgBindHost) {
+		cfgMasterHost = newMasterHost;
+		cfgMasterPort = newMasterPort;
+		cfgBindHost = newBindHost;
 		isMasterAddressValid = 0;
 		if (mode != Mode::Free) {
 			mode = Mode::Kill;
 		}
 	}
 
-	masterTimeout = cfg_getuint32("MASTER_TIMEOUT",60);
-	BackMetaCopies = cfg_getuint32("BACK_META_KEEP_PREVIOUS",3);
-	auto reconnectionDelay = cfg_getuint32("MASTER_RECONNECTION_DELAY",1);
+	cfgMasterTimeout = cfg_getuint32("MASTER_TIMEOUT", kCfgDefaultMasterTimeout);
+	cfgBackMetaKeepPrevious = cfg_getuint32("BACK_META_KEEP_PREVIOUS",
+	                                        kCfgDefaultBackMetaKeepPrevious);
+	auto reconnectionDelay = cfg_getuint32("MASTER_RECONNECTION_DELAY",
+	                                       kCfgDefaultMasterReconnectionDelay);
 
-	masterTimeout = std::min(masterTimeout, MasterConn::kMaxMasterTimeout);
-	masterTimeout = std::max<uint32_t>(masterTimeout, MasterConn::kMinMasterTimeout);
-	BackMetaCopies = std::min(BackMetaCopies, MasterConn::kMaxBackMetaCopies);
+	cfgMasterTimeout = std::min(cfgMasterTimeout, MasterConn::kMaxMasterTimeout);
+	cfgMasterTimeout = std::max<uint32_t>(cfgMasterTimeout, MasterConn::kMinMasterTimeout);
+	cfgBackMetaKeepPrevious = std::min(cfgBackMetaKeepPrevious, MasterConn::kMaxBackMetaCopies);
 
 #ifdef METALOGGER
-	auto metadataDownloadFreq = cfg_getuint32("META_DOWNLOAD_FREQ", 24);
+	auto metadataDownloadFreq =
+	    cfg_getuint32("META_DOWNLOAD_FREQ", kCfgDefaultMetaDownloadFreq);
 	if (metadataDownloadFreq > (changelog_get_back_logs_config_value() / 2)) {
 		metadataDownloadFreq = (changelog_get_back_logs_config_value() / 2);
 	}
@@ -1225,14 +1237,16 @@ int masterconn_init(void) {
 	// Could be multiple connections in the future, so let's use a pointer
 	auto *eptr = gMasterConn;
 
-	auto reconnectionDelay = cfg_getuint32("MASTER_RECONNECTION_DELAY", 1);
+	auto reconnectionDelay =
+	    cfg_getuint32("MASTER_RECONNECTION_DELAY",
+	                  MasterConn::kCfgDefaultMasterReconnectionDelay);
 	eptr->loadConfig();
 
 #ifdef METALOGGER
 	changelog_init(kChangelogMlFilename, 5, 1000); // may throw
 	changelog_disable_flush(); // metalogger does it once a second
-	uint32_t metadataDownloadFreq;
-	metadataDownloadFreq = cfg_getuint32("META_DOWNLOAD_FREQ",24);
+	auto metadataDownloadFreq =
+	    cfg_getuint32("META_DOWNLOAD_FREQ", MasterConn::kCfgDefaultMetaDownloadFreq);
 	if (metadataDownloadFreq > (changelog_get_back_logs_config_value() / 2)) {
 		metadataDownloadFreq = (changelog_get_back_logs_config_value() / 2);
 	}

--- a/src/master/masterconn.cc
+++ b/src/master/masterconn.cc
@@ -81,7 +81,7 @@ struct MasterConn {
 	static constexpr uint32_t kMetadataDownloadBlocksize = 1000000U;
 	/// Safety measure about expected max packet size.
 	static constexpr uint32_t kMaxPacketSize = 1500000U;
-	static constexpr uint8_t kHeaderSize = 8;  ///< Packet type + size.
+	static constexpr uint8_t kHeaderSize = 8;      ///< Packet type + size.
 	static constexpr uint8_t kPacketTypeSize = 4;  ///< sizeof(uint32_t).
 	static constexpr uint8_t kChangeLogApplyErrorTimeout = 10;
 	static constexpr int kInvalidFD = -1;
@@ -99,6 +99,8 @@ struct MasterConn {
 	static constexpr uint32_t kCfgDefaultMasterTimeout = 60;
 	static constexpr uint32_t kCfgDefaultMasterReconnectionDelay = 1;
 	static constexpr uint32_t kCfgDefaultMetaDownloadFreq = 24;
+
+	static constexpr uint32_t kMillisecondsInSecond = 1000;
 
 	enum class Mode : uint8_t {
 		Free,        ///< Connection is not in use.
@@ -121,45 +123,42 @@ struct MasterConn {
 		kLimbo
 	};
 
-	Mode mode{Mode::Free};  ///< Current connection mode.
+	Mode mode{Mode::Free};      ///< Current connection mode.
 	State state{State::kNone};  ///< Current synchronization state.
 
-	int sock{kInvalidFD};  ///< Socket descriptor.
+	int sock{kInvalidFD};             ///< Socket descriptor.
 	int32_t pollDescPos{kInvalidFD};  ///< Position in the poll desc. array.
-	uint32_t lastRead{};  ///< Timestamp of the last read operation.
-	uint32_t lastWrite{};  ///< Timestamp of the last write operation.
+	uint32_t lastRead{};              ///< Timestamp of the last read operation.
+	uint32_t lastWrite{};             ///< Timestamp of the last write operation.
 
 	/// Master version in the other end. Known after registration.
 	uint32_t masterVersion{kInvalidMasterVersion};
 
-	std::array<uint8_t, kHeaderSize> headerBuffer{};  ///< Buffer for headers.
-	PacketStruct inputPacket{};  ///< Structure for the input packet.
-	/// Queue of output packets.
-	std::queue<std::unique_ptr<PacketStruct>> outputQueue;
+	std::array<uint8_t, kHeaderSize> headerBuffer{};        ///< Buffer for headers.
+	PacketStruct inputPacket{};                             ///< Structure for the input packet.
+	std::queue<std::unique_ptr<PacketStruct>> outputQueue;  ///< Queue of output packets.
 
-	uint32_t bindIP{};  ///< IP address to bind the socket.
-	uint32_t masterIP{};  ///< IP address of the master server.
-	uint16_t masterPort{};  ///< Port of the master server.
+	uint32_t bindIP{};                ///< IP address to bind the socket.
+	uint32_t masterIP{};              ///< IP address of the master server.
+	uint16_t masterPort{};            ///< Port of the master server.
 	uint8_t isMasterAddressValid{0};  /// Known after (re)connections.
 
 	uint8_t downloadRetryCnt{};  ///< Retry count for downloads.
 	/// Number of the file being downloaded (metadata, changelogs, sessions).
 	/// 0 if no download is in progress.
 	uint8_t downloadingFileNum{};
-	int downloadFD{kInvalidFD};  ///< FD for the file being downloaded.
-	uint64_t fileSize{};  ///< Size of the file being downloaded.
-	uint64_t downloadOffset{};  ///< Offset for the download.
+	int downloadFD{kInvalidFD};                  ///< FD for the file being downloaded.
+	uint64_t fileSize{};                         ///< Size of the file being downloaded.
+	uint64_t downloadOffset{};                   ///< Offset for the download.
 	uint64_t downloadStartTimeInMicroSeconds{};  ///< Download start time.
 
-	/// Callback to download sessions periodically.
-	void* sessionsDownloadInitHandle{};
-	/// Callback to flush the changelog file(s) periodically.
-	void* changelogFlushHandle{};
+	void *sessionsDownloadInitHandle{};  ///< Callback to download sessions periodically.
+
+	void *changelogFlushHandle{};  ///< Callback to flush the changelog file(s) periodically.
 
 	uint8_t errorStatus{};  ///< Error status for mltoma::changelogApplyError.
 	/// Timeout for mltoma::changelogApplyError packets.
-	Timeout changelogApplyErrorTimeout{
-	    std::chrono::seconds(kChangeLogApplyErrorTimeout)};
+	Timeout changelogApplyErrorTimeout{std::chrono::seconds(kChangeLogApplyErrorTimeout)};
 
 	/// Last log version received from the master.
 	uint64_t lastLogVersion = 0;
@@ -187,7 +186,7 @@ struct MasterConn {
 
 	uint8_t *createPacket(uint32_t type, uint32_t size);
 	void createPacket(std::vector<uint8_t> data);
-	void gotPacket(uint32_t type,const uint8_t *data,uint32_t length);
+	void gotPacket(uint32_t type, const uint8_t *data, uint32_t length);
 
 	int initConnect();
 	void onConnected();
@@ -206,7 +205,7 @@ struct MasterConn {
 	void downloadInit(uint8_t filenum);
 	void downloadStart(const uint8_t *data, uint32_t length);
 	void requestMetadataDump();
-	int metadataCheck(const std::string& name);
+	int metadataCheck(const std::string &name);
 
 	// Changelogs
 
@@ -227,7 +226,7 @@ struct MasterConn {
 
 	// Shutting down
 
-	void endSession(const uint8_t* data, uint32_t length);
+	void endSession(const uint8_t *data, uint32_t length);
 	void killSession();
 	void beforeClose();
 	void terminate();
@@ -310,8 +309,8 @@ uint8_t *MasterConn::createPacket(uint32_t type, uint32_t size) {
 	passert(outpacket->packet.data());
 	outpacket->bytesLeft = psize;
 	auto *ptr = outpacket->packet.data();
-	put32bit(&ptr,type);
-	put32bit(&ptr,size);
+	put32bit(&ptr, type);
+	put32bit(&ptr, size);
 	outpacket->startPtr = outpacket->packet.data();
 	outputQueue.push(std::move(outpacket));
 
@@ -335,29 +334,28 @@ void MasterConn::sendRegister() {
 #ifndef METALOGGER
 	// shadow master registration
 	uint64_t metadataVersion = 0;
-	if (state == State::kSynchronized) {
-		metadataVersion = fs_getversion();
-	}
-	auto request = mltoma::registerShadow::build(SAUNAFS_VERSHEX, cfgMasterTimeout * 1000, metadataVersion);
+	if (state == State::kSynchronized) { metadataVersion = fs_getversion(); }
+	auto request = mltoma::registerShadow::build(
+	    SAUNAFS_VERSHEX, cfgMasterTimeout * kMillisecondsInSecond, metadataVersion);
 	createPacket(std::move(request));
 	return;
 #endif
 
-	if (lastLogVersion>0) {
+	if (lastLogVersion > 0) {
 		auto *buff = createPacket(MLTOMA_REGISTER, 1 + 4 + 2 + 8);
-		put8bit(&buff,2);
-		put16bit(&buff,SAUNAFS_PACKAGE_VERSION_MAJOR);
-		put8bit(&buff,SAUNAFS_PACKAGE_VERSION_MINOR);
-		put8bit(&buff,SAUNAFS_PACKAGE_VERSION_MICRO);
-		put16bit(&buff,cfgMasterTimeout);
-		put64bit(&buff,lastLogVersion);
+		put8bit(&buff, 2);
+		put16bit(&buff, SAUNAFS_PACKAGE_VERSION_MAJOR);
+		put8bit(&buff, SAUNAFS_PACKAGE_VERSION_MINOR);
+		put8bit(&buff, SAUNAFS_PACKAGE_VERSION_MICRO);
+		put16bit(&buff, cfgMasterTimeout);
+		put64bit(&buff, lastLogVersion);
 	} else {
 		auto *buff = createPacket(MLTOMA_REGISTER, 1 + 4 + 2);
-		put8bit(&buff,1);
-		put16bit(&buff,SAUNAFS_PACKAGE_VERSION_MAJOR);
-		put8bit(&buff,SAUNAFS_PACKAGE_VERSION_MINOR);
-		put8bit(&buff,SAUNAFS_PACKAGE_VERSION_MICRO);
-		put16bit(&buff,cfgMasterTimeout);
+		put8bit(&buff, 1);
+		put16bit(&buff, SAUNAFS_PACKAGE_VERSION_MAJOR);
+		put8bit(&buff, SAUNAFS_PACKAGE_VERSION_MINOR);
+		put8bit(&buff, SAUNAFS_PACKAGE_VERSION_MICRO);
+		put16bit(&buff, cfgMasterTimeout);
 	}
 }
 
@@ -368,9 +366,7 @@ void MasterConn::sendMetaloggerConfig() {
 }
 
 void MasterConn::killSession() {
-	if (mode != Mode::Free) {
-		mode = Mode::Kill;
-	}
+	if (mode != Mode::Free) { mode = Mode::Kill; }
 }
 
 void MasterConn::forceMetadataDownload() {
@@ -404,9 +400,7 @@ void MasterConn::handleChangelogApplyError(uint8_t status) {
 void MasterConn::sendMatoClPort() {
 	static std::string previousPort;
 
-	if (masterVersion < SAUNAFS_VERSION(2, 5, 5)) {
-		return;
-	}
+	if (masterVersion < SAUNAFS_VERSION(2, 5, 5)) { return; }
 
 	std::string portStr = cfg_getstring("MATOCL_LISTEN_PORT", "9421");
 	static uint16_t port = 0;
@@ -433,7 +427,8 @@ void MasterConn::onRegistered(const uint8_t *data, uint32_t length) {
 	} else if (responseVersion == matoml::registerShadow::kResponsePacketVersion) {
 		uint32_t incommingMasterVersion{};
 		uint64_t masterMetadataVersion{};
-		matoml::registerShadow::deserialize(data, length, incommingMasterVersion, masterMetadataVersion);
+		matoml::registerShadow::deserialize(data, length, incommingMasterVersion,
+		                                    masterMetadataVersion);
 		masterVersion = incommingMasterVersion;
 		sendMatoClPort();
 		if ((state == State::kSynchronized) && (fs_getversion() != masterMetadataVersion)) {
@@ -445,26 +440,26 @@ void MasterConn::onRegistered(const uint8_t *data, uint32_t length) {
 }
 #endif
 
-void MasterConn::metachangesLog(const uint8_t *data,uint32_t length) {
+void MasterConn::metachangesLog(const uint8_t *data, uint32_t length) {
 	if ((length == 1) && (data[0] == FORCE_LOG_ROTATE)) {
 #ifdef METALOGGER
-		// In metalogger rotates are forced by the master server. Shadow masters rotate changelogs
-		// every hour -- when creating a new metadata file.
+		// In metalogger rotates are forced by the master server. Shadow masters
+		// rotate changelogs every hour -- when creating a new metadata file.
 		changelog_rotate();
 #endif /* #ifdef METALOGGER */
 		return;
 	}
-	if (length<10) {
+	if (length < 10) {
 		safs::log_info("MATOML_METACHANGES_LOG - wrong size ({}/9+data)", length);
 		mode = Mode::Kill;
 		return;
 	}
-	if (data[0]!=0xFF) {
+	if (data[0] != 0xFF) {
 		safs::log_info("MATOML_METACHANGES_LOG - wrong packet");
 		mode = Mode::Kill;
 		return;
 	}
-	if (data[length-1]!='\0') {
+	if (data[length - 1] != '\0') {
 		safs::log_info("MATOML_METACHANGES_LOG - invalid string");
 		mode = Mode::Kill;
 		return;
@@ -472,10 +467,11 @@ void MasterConn::metachangesLog(const uint8_t *data,uint32_t length) {
 
 	data++;
 	uint64_t version = get64bit(&data);
-	const char* changelogEntry = reinterpret_cast<const char*>(data);
+	const char *changelogEntry = reinterpret_cast<const char *>(data);
 
 	if ((lastLogVersion > 0) && (version != (lastLogVersion + 1))) {
-		safs::log_warn("some changes lost: [{}-{}], download metadata again", lastLogVersion, version - 1);
+		safs::log_warn("some changes lost: [{}-{}], download metadata again", lastLogVersion,
+		               version - 1);
 		handleChangelogApplyError(SAUNAFS_ERROR_METADATAVERSIONMISMATCH);
 		return;
 	}
@@ -488,8 +484,9 @@ void MasterConn::metachangesLog(const uint8_t *data,uint32_t length) {
 		uint8_t status = restore(network, version, buf.c_str(), RestoreRigor::kDontIgnoreAnyErrors);
 
 		if (status != SAUNAFS_STATUS_OK) {
-			safs::log_warn("malformed changelog sent by the master server, can't apply it. status: {}",
-			               saunafs_error_string(status));
+			safs::log_warn(
+			    "malformed changelog sent by the master server, can't apply it. status: {}",
+			    saunafs_error_string(status));
 			handleChangelogApplyError(status);
 			return;
 		}
@@ -499,8 +496,8 @@ void MasterConn::metachangesLog(const uint8_t *data,uint32_t length) {
 	lastLogVersion = version;
 }
 
-void MasterConn::endSession(const uint8_t* data, uint32_t length) {
-	matoml::endSession::deserialize(data, length); // verify the empty packet
+void MasterConn::endSession(const uint8_t *data, uint32_t length) {
+	matoml::endSession::deserialize(data, length);  // verify the empty packet
 	safs::log_info("Master server is terminating; closing the connection...");
 	killSession();
 }
@@ -511,7 +508,7 @@ int MasterConn::downloadEnd() {
 
 	if (downloadFD >= 0) {
 		if (::close(downloadFD) < 0) {
-			safs_silent_errlog(LOG_NOTICE,"error closing metafile");
+			safs_silent_errlog(LOG_NOTICE, "error closing metafile");
 			downloadFD = kInvalidFD;
 			return -1;
 		}
@@ -528,20 +525,16 @@ void MasterConn::downloadInit(uint8_t filenum) {
 		put8bit(&ptr, filenum);
 		downloadingFileNum = filenum;
 
-		if (filenum == DOWNLOAD_METADATA_SFS) {
-			state = State::kDownloading;
-		}
+		if (filenum == DOWNLOAD_METADATA_SFS) { state = State::kDownloading; }
 	}
 }
 
-int MasterConn::metadataCheck(const std::string& name) {
+int MasterConn::metadataCheck(const std::string &name) {
 	try {
 		gMetadataBackend->getVersion(name);
 		return 0;
-	} catch (MetadataCheckException& ex) {
-		safs::log_info(
-		    "Verification of the downloaded metadata file failed: {}",
-		    ex.what());
+	} catch (MetadataCheckException &ex) {
+		safs::log_info("Verification of the downloaded metadata file failed: {}", ex.what());
 		return -1;
 	}
 }
@@ -565,51 +558,49 @@ std::string MasterConn::getDownloadingFileName(uint8_t filenum) {
 }
 
 void MasterConn::downloadNext() {
-	if (downloadOffset >= fileSize) {   // end of file
+	if (downloadOffset >= fileSize) {  // end of file
 		auto filenum = downloadingFileNum;
-		if (downloadEnd() < 0) {
-			return;
-		}
+		if (downloadEnd() < 0) { return; }
 
 		int64_t dltime = eventloop_utime() - downloadStartTimeInMicroSeconds;
-		if (dltime<=0) {
-			dltime=1;
-		}
+		if (dltime <= 0) { dltime = 1; }
 
 		static std::string changelogFilename_1 = getChangelogFilename() + ".1";
 		static std::string changelogFilename_2 = getChangelogFilename() + ".2";
 		static constexpr uint32_t kMicroSecondsInSecond = 1000000;
 
-		safs::log_info(
-		    "{} downloaded {}B/{}.{:06}s ({:.3f} MB/s)",
-		    getDownloadingFileName(filenum), fileSize,
-		    dltime / kMicroSecondsInSecond,
-		    static_cast<uint32_t>(dltime % kMicroSecondsInSecond),
-		    static_cast<double>(fileSize) / static_cast<double>(dltime));
+		safs::log_info("{} downloaded {}B/{}.{:06}s ({:.3f} MB/s)", getDownloadingFileName(filenum),
+		               fileSize, dltime / kMicroSecondsInSecond,
+		               static_cast<uint32_t>(dltime % kMicroSecondsInSecond),
+		               static_cast<double>(fileSize) / static_cast<double>(dltime));
 
 		if (filenum == DOWNLOAD_METADATA_SFS) {
 			if (metadataCheck(getMetadataTmpFilename()) == 0) {
-				if (cfgBackMetaKeepPrevious>0) {
+				if (cfgBackMetaKeepPrevious > 0) {
 					rotateFiles(getMetadataFilename(), cfgBackMetaKeepPrevious, 1);
 				}
 				if (::rename(getMetadataTmpFilename().c_str(), getMetadataFilename().c_str()) < 0) {
-					safs::log_info("can't rename downloaded metadata - do it manually before next download");
+					safs::log_info(
+					    "can't rename downloaded metadata - do it manually before next download");
 				}
 			}
 			downloadInit(DOWNLOAD_CHANGELOG_SFS);
 		} else if (filenum == DOWNLOAD_CHANGELOG_SFS) {
 			if (::rename(getChangelogTmpFilename().c_str(), changelogFilename_1.c_str()) < 0) {
-				safs::log_info("can't rename downloaded changelog - do it manually before next download");
+				safs::log_info(
+				    "can't rename downloaded changelog - do it manually before next download");
 			}
 			downloadInit(DOWNLOAD_CHANGELOG_SFS_1);
 		} else if (filenum == DOWNLOAD_CHANGELOG_SFS_1) {
 			if (::rename(getChangelogTmpFilename().c_str(), changelogFilename_2.c_str()) < 0) {
-				safs::log_info("can't rename downloaded changelog - do it manually before next download");
+				safs::log_info(
+				    "can't rename downloaded changelog - do it manually before next download");
 			}
 			downloadInit(DOWNLOAD_SESSIONS_SFS);
 		} else if (filenum == DOWNLOAD_SESSIONS_SFS) {
 			if (::rename(getSessionsTmpFilename().c_str(), getSessionsFilename().c_str()) < 0) {
-				safs::log_info("can't rename downloaded sessions - do it manually before next download");
+				safs::log_info(
+				    "can't rename downloaded sessions - do it manually before next download");
 			} else {
 #ifndef METALOGGER
 				/*
@@ -622,9 +613,9 @@ void MasterConn::downloadNext() {
 						lastLogVersion = fs_getversion() - 1;
 						safs::log_info("synced at version = {}", lastLogVersion);
 						state = State::kSynchronized;
-					} catch (Exception& ex) {
+					} catch (Exception &ex) {
 						safs::log_warn("can't load downloaded metadata and changelogs: {}",
-								ex.what());
+						               ex.what());
 						uint8_t status = ex.status();
 						if (status == SAUNAFS_STATUS_OK) {
 							// unknown error - tell the master to apply changelogs and hope that
@@ -634,12 +625,12 @@ void MasterConn::downloadNext() {
 						handleChangelogApplyError(status);
 					}
 				}
-#else /* #ifndef METALOGGER */
+#else  /* #ifndef METALOGGER */
 				state = State::kSynchronized;
 #endif /* #else #ifndef METALOGGER */
 			}
 		}
-	} else {        // send request for next data packet
+	} else {  // send request for next data packet
 		auto *ptr = createPacket(MLTOMA_DOWNLOAD_DATA, 12);
 		put64bit(&ptr, downloadOffset);
 		if (fileSize - downloadOffset > kMetadataDownloadBlocksize) {
@@ -679,15 +670,12 @@ void MasterConn::downloadStart(const uint8_t *data, uint32_t length) {
 	static constexpr int kFileFlags = O_WRONLY | O_TRUNC | O_CREAT;
 
 	if (downloadingFileNum == DOWNLOAD_METADATA_SFS) {
-		downloadFD = ::open(getMetadataTmpFilename().c_str(), kFileFlags,
-		                    kFilePermissions);
+		downloadFD = ::open(getMetadataTmpFilename().c_str(), kFileFlags, kFilePermissions);
 	} else if (downloadingFileNum == DOWNLOAD_SESSIONS_SFS) {
-		downloadFD = ::open(getSessionsTmpFilename().c_str(), kFileFlags,
-		                    kFilePermissions);
+		downloadFD = ::open(getSessionsTmpFilename().c_str(), kFileFlags, kFilePermissions);
 	} else if ((downloadingFileNum == DOWNLOAD_CHANGELOG_SFS) ||
 	           (downloadingFileNum == DOWNLOAD_CHANGELOG_SFS_1)) {
-		downloadFD = ::open(getChangelogTmpFilename().c_str(), kFileFlags,
-		                    kFilePermissions);
+		downloadFD = ::open(getChangelogTmpFilename().c_str(), kFileFlags, kFilePermissions);
 	} else {
 		safs::log_info("unexpected MATOML_DOWNLOAD_START packet");
 		mode = Mode::Kill;
@@ -703,7 +691,7 @@ void MasterConn::downloadStart(const uint8_t *data, uint32_t length) {
 	downloadNext();
 }
 
-void MasterConn::downloadData(const uint8_t *data,uint32_t length) {
+void MasterConn::downloadData(const uint8_t *data, uint32_t length) {
 	uint64_t offset;
 	uint32_t leng;
 	uint32_t crc;
@@ -715,7 +703,7 @@ void MasterConn::downloadData(const uint8_t *data,uint32_t length) {
 		return;
 	}
 
-	if (length<16) {
+	if (length < 16) {
 		safs::log_info("MATOML_DOWNLOAD_DATA - wrong size ({}/16+data)", length);
 		mode = Mode::Kill;
 		return;
@@ -726,27 +714,29 @@ void MasterConn::downloadData(const uint8_t *data,uint32_t length) {
 	leng = get32bit(&data);
 	crc = get32bit(&data);
 
-	if (leng+16!=length) {
+	if (leng + 16 != length) {
 		safs::log_info("MATOML_DOWNLOAD_DATA - wrong size ({}/16+{})", length, leng);
 		mode = Mode::Kill;
 		return;
 	}
 
 	if (offset != downloadOffset) {
-		safs::log_info("MATOML_DOWNLOAD_DATA - unexpected file offset ({}/{})", offset, downloadOffset);
+		safs::log_info("MATOML_DOWNLOAD_DATA - unexpected file offset ({}/{})", offset,
+		               downloadOffset);
 		mode = Mode::Kill;
 		return;
 	}
 
 	if (offset + leng > fileSize) {
-		safs::log_info("MATOML_DOWNLOAD_DATA - unexpected file size ({}/{})", offset + leng, fileSize);
+		safs::log_info("MATOML_DOWNLOAD_DATA - unexpected file size ({}/{})", offset + leng,
+		               fileSize);
 		mode = Mode::Kill;
 		return;
 	}
 
 #ifdef SAUNAFS_HAVE_PWRITE
 	ret = ::pwrite(downloadFD, data, leng, offset);
-#else /* SAUNAFS_HAVE_PWRITE */
+#else  /* SAUNAFS_HAVE_PWRITE */
 	::lseek(downloadFD, offset, SEEK_SET);
 	ret = ::write(downloadFD, data, leng);
 #endif /* SAUNAFS_HAVE_PWRITE */
@@ -762,7 +752,7 @@ void MasterConn::downloadData(const uint8_t *data,uint32_t length) {
 		return;
 	}
 
-	if (crc != mycrc32(0,data,leng)) {
+	if (crc != mycrc32(0, data, leng)) {
 		safs::log_info("metafile data crc error");
 		if (downloadRetryCnt >= 5) {
 			downloadEnd();
@@ -784,8 +774,8 @@ void MasterConn::downloadData(const uint8_t *data,uint32_t length) {
 		return;
 	}
 
-	downloadOffset+=leng;
-	downloadRetryCnt=0;
+	downloadOffset += leng;
+	downloadRetryCnt = 0;
 
 	downloadNext();
 }
@@ -802,7 +792,8 @@ void MasterConn::changelogApplyError(const uint8_t *data, uint32_t length) {
 		safs::log_info("Master temporarily refused to produce a new metadata image");
 	} else {
 		state = State::kLimbo;
-		safs::log_info("Master failed to produce a new metadata image: {}", saunafs_error_string(status));
+		safs::log_info("Master failed to produce a new metadata image: {}",
+		               saunafs_error_string(status));
 	}
 }
 
@@ -816,41 +807,41 @@ void MasterConn::beforeClose() {
 	}
 }
 
-void MasterConn::gotPacket(uint32_t type,const uint8_t *data,uint32_t length) {
+void MasterConn::gotPacket(uint32_t type, const uint8_t *data, uint32_t length) {
 	try {
 		switch (type) {
-			case ANTOAN_NOP:
-				break;
-			case ANTOAN_UNKNOWN_COMMAND: // for future use
-				break;
-			case ANTOAN_BAD_COMMAND_SIZE: // for future use
-				break;
+		case ANTOAN_NOP:
+			break;
+		case ANTOAN_UNKNOWN_COMMAND:  // for future use
+			break;
+		case ANTOAN_BAD_COMMAND_SIZE:  // for future use
+			break;
 #ifndef METALOGGER
-			case SAU_MATOML_REGISTER_SHADOW:
-			    onRegistered(data, length);
-			    break;
+		case SAU_MATOML_REGISTER_SHADOW:
+			onRegistered(data, length);
+			break;
 #endif
-			case MATOML_METACHANGES_LOG:
-				metachangesLog(data,length);
-				break;
-			case SAU_MATOML_END_SESSION:
-			    endSession(data, length);
-			    break;
-			case MATOML_DOWNLOAD_START:
-			    downloadStart(data, length);
-			    break;
-			case MATOML_DOWNLOAD_DATA:
-			    downloadData(data, length);
-			    break;
-			case SAU_MATOML_CHANGELOG_APPLY_ERROR:
-				changelogApplyError(data, length);
-				break;
-			default:
-				safs::log_info("got unknown message (type: {})", type);
-				mode = Mode::Kill;
-				break;
+		case MATOML_METACHANGES_LOG:
+			metachangesLog(data, length);
+			break;
+		case SAU_MATOML_END_SESSION:
+			endSession(data, length);
+			break;
+		case MATOML_DOWNLOAD_START:
+			downloadStart(data, length);
+			break;
+		case MATOML_DOWNLOAD_DATA:
+			downloadData(data, length);
+			break;
+		case SAU_MATOML_CHANGELOG_APPLY_ERROR:
+			changelogApplyError(data, length);
+			break;
+		default:
+			safs::log_info("got unknown message (type: {})", type);
+			mode = Mode::Kill;
+			break;
 		}
-	} catch (IncorrectDeserializationException& ex) {
+	} catch (IncorrectDeserializationException &ex) {
 		safs::log_info("Packet 0x{:X} - can't deserialize: {}", type, ex.what());
 		mode = Mode::Kill;
 	}
@@ -863,9 +854,7 @@ void MasterConn::terminate() {
 		if (mode != Mode::Connecting) {
 			inputPacket.packet.clear();
 
-			while(!outputQueue.empty()) {
-				outputQueue.pop();
-			}
+			while (!outputQueue.empty()) { outputQueue.pop(); }
 		}
 	}
 }
@@ -894,22 +883,21 @@ void MasterConn::onConnected() {
 }
 
 int MasterConn::initConnect() {
-	int status;
 	if (isMasterAddressValid == 0) {
-		uint32_t mip,bip;
+		uint32_t mip, bip;
 		uint16_t mport;
-		if (tcpresolve(cfgBindHost.c_str(), NULL, &bip, NULL, 1)>=0) {
+		if (tcpresolve(cfgBindHost.c_str(), NULL, &bip, NULL, 1) >= 0) {
 			bindIP = bip;
 		} else {
 			bindIP = 0;
 		}
-		if (tcpresolve(cfgMasterHost.c_str(), cfgMasterPort.c_str(), &mip, &mport, 0)>=0) {
+		if (tcpresolve(cfgMasterHost.c_str(), cfgMasterPort.c_str(), &mip, &mport, 0) >= 0) {
 			masterIP = mip;
 			masterPort = mport;
 			isMasterAddressValid = 1;
 		} else {
-			safs::log_warn("can't resolve master host/port ({}:{})",
-			               cfgMasterHost.c_str(), cfgMasterPort.c_str());
+			safs::log_warn("can't resolve master host/port ({}:{})", cfgMasterHost.c_str(),
+			               cfgMasterPort.c_str());
 			return -1;
 		}
 	}
@@ -917,12 +905,12 @@ int MasterConn::initConnect() {
 	sock = tcpsocket();
 
 	if (sock < 0) {
-		safs_pretty_errlog(LOG_WARNING,"create socket, error");
+		safs_pretty_errlog(LOG_WARNING, "create socket, error");
 		return -1;
 	}
 
 	if (tcpnonblock(sock) < 0) {
-		safs_pretty_errlog(LOG_WARNING,"set nonblock, error");
+		safs_pretty_errlog(LOG_WARNING, "set nonblock, error");
 		tcpclose(sock);
 		sock = kInvalidFD;
 		return -1;
@@ -930,17 +918,17 @@ int MasterConn::initConnect() {
 
 	if (bindIP > 0) {
 		if (tcpnumbind(sock, bindIP, 0) < 0) {
-			safs_pretty_errlog(LOG_WARNING,"can't bind socket to given ip");
+			safs_pretty_errlog(LOG_WARNING, "can't bind socket to given ip");
 			tcpclose(sock);
 			sock = kInvalidFD;
 			return -1;
 		}
 	}
 
-	status = tcpnumconnect(sock, masterIP, masterPort);
+	auto status = tcpnumconnect(sock, masterIP, masterPort);
 
 	if (status < 0) {
-		safs_pretty_errlog(LOG_WARNING,"connect failed, error");
+		safs_pretty_errlog(LOG_WARNING, "connect failed, error");
 		tcpclose(sock);
 		sock = kInvalidFD;
 		isMasterAddressValid = 0;
@@ -1009,8 +997,7 @@ void MasterConn::readFromSocket() {
 
 			if (size > 0) {
 				if (size > kMaxPacketSize) {
-					safs::log_warn("Master packet too long ({}/{})", size,
-					               kMaxPacketSize);
+					safs::log_warn("Master packet too long ({}/{})", size, kMaxPacketSize);
 					killSession();
 					return;
 				}
@@ -1039,9 +1026,7 @@ void MasterConn::readFromSocket() {
 			inputPacket.packet.clear();
 		}
 
-		if (watchdog.expired()) {
-			break;
-		}
+		if (watchdog.expired()) { break; }
 	}
 }
 
@@ -1074,26 +1059,21 @@ void MasterConn::writeToSocket() {
 
 		outputQueue.pop();
 
-		if (watchdog.expired()) {
-			break;
-		}
+		if (watchdog.expired()) { break; }
 	}
 }
 
 void MasterConn::pollDesc(std::vector<pollfd> &pdesc) {
 	pollDescPos = kInvalidPollDescPos;
 
-	if (mode == Mode::Free || sock < 0) {
-		return;
-	}
+	if (mode == Mode::Free || sock < 0) { return; }
 
 	if (mode == Mode::Header || mode == Mode::Data) {
 		pdesc.push_back({sock, POLLIN, 0});
 		pollDescPos = static_cast<int32_t>(pdesc.size() - 1);
 	}
 
-	if (((mode == Mode::Header || mode == Mode::Data) &&
-	     !outputQueue.empty()) ||
+	if (((mode == Mode::Header || mode == Mode::Data) && !outputQueue.empty()) ||
 	    (mode == Mode::Connecting)) {
 		if (pollDescPos >= 0) {
 			pdesc[pollDescPos].events |= POLLOUT;
@@ -1107,7 +1087,7 @@ void MasterConn::pollDesc(std::vector<pollfd> &pdesc) {
 void MasterConn::serve(const std::vector<pollfd> &pdesc) {
 	uint32_t now = eventloop_time();
 
-	if (pollDescPos>=0 && (pdesc[pollDescPos].revents & (POLLHUP | POLLERR))) {
+	if (pollDescPos >= 0 && (pdesc[pollDescPos].revents & (POLLHUP | POLLERR))) {
 		if (mode == Mode::Connecting) {
 			connectTest();
 		} else {
@@ -1116,23 +1096,26 @@ void MasterConn::serve(const std::vector<pollfd> &pdesc) {
 	}
 
 	if (mode == Mode::Connecting) {
-		if (sock >= 0 && pollDescPos >= 0 && (pdesc[pollDescPos].revents & POLLOUT)) { // FD_ISSET(eptr->sock,wset)) {
+		if (sock >= 0 && pollDescPos >= 0 && (pdesc[pollDescPos].revents & POLLOUT)) {
 			connectTest();
 		}
 	} else {
 		if (pollDescPos >= 0) {
-			if ((mode == Mode::Header || mode == Mode::Data) && (pdesc[pollDescPos].revents & POLLIN)) { // FD_ISSET(eptr->sock,rset)) {
+			if ((mode == Mode::Header || mode == Mode::Data) &&
+			    (pdesc[pollDescPos].revents & POLLIN)) {
 				lastRead = now;
 				readFromSocket();
 			}
-			if ((mode == Mode::Header || mode == Mode::Data) && (pdesc[pollDescPos].revents & POLLOUT)) { // FD_ISSET(eptr->sock,wset)) {
+			if ((mode == Mode::Header || mode == Mode::Data) &&
+			    (pdesc[pollDescPos].revents & POLLOUT)) {
 				lastWrite = now;
 				writeToSocket();
 			}
 			if ((mode == Mode::Header || mode == Mode::Data) && lastRead + cfgMasterTimeout < now) {
 				mode = Mode::Kill;
 			}
-			if ((mode == Mode::Header || mode == Mode::Data) && lastWrite + (cfgMasterTimeout / 3) < now && outputQueue.empty()) {
+			if ((mode == Mode::Header || mode == Mode::Data) &&
+			    lastWrite + (cfgMasterTimeout / 3) < now && outputQueue.empty()) {
 				createPacket(ANTOAN_NOP, 0);
 			}
 		}
@@ -1145,9 +1128,7 @@ void MasterConn::serve(const std::vector<pollfd> &pdesc) {
 
 		inputPacket.packet.clear();
 
-		while (!outputQueue.empty()) {
-			outputQueue.pop();
-		}
+		while (!outputQueue.empty()) { outputQueue.pop(); }
 
 		mode = Mode::Free;
 		masterVersion = kInvalidMasterVersion;
@@ -1155,14 +1136,10 @@ void MasterConn::serve(const std::vector<pollfd> &pdesc) {
 }
 
 void MasterConn::reconnect() {
-	if (mode == Mode::Free && gExitingStatus == ExitingStatus::kRunning) {
-		initConnect();
-	}
+	if (mode == Mode::Free && gExitingStatus == ExitingStatus::kRunning) { initConnect(); }
 
 	if ((mode == Mode::Header || mode == Mode::Data) && state == State::kLimbo) {
-		if (changelogApplyErrorTimeout.expired()) {
-			requestMetadataDump();
-		}
+		if (changelogApplyErrorTimeout.expired()) { requestMetadataDump(); }
 	}
 }
 
@@ -1176,8 +1153,8 @@ void MasterConn::loadConfig() {
 	cfgMasterPort = cfg_getstring("MASTER_PORT", kCfgDefaultMasterPort);
 	cfgBindHost = cfg_getstring("BIND_HOST", kCfgDefaultBindHost);
 	cfgMasterTimeout = cfg_getuint32("MASTER_TIMEOUT", kCfgDefaultMasterTimeout);
-	cfgBackMetaKeepPrevious = cfg_getuint32("BACK_META_KEEP_PREVIOUS",
-	                                        kCfgDefaultBackMetaKeepPrevious);
+	cfgBackMetaKeepPrevious =
+	    cfg_getuint32("BACK_META_KEEP_PREVIOUS", kCfgDefaultBackMetaKeepPrevious);
 
 	cfgMasterTimeout = std::min(cfgMasterTimeout, kMaxMasterTimeout);
 	cfgMasterTimeout = std::max<uint32_t>(cfgMasterTimeout, kMinMasterTimeout);
@@ -1188,37 +1165,35 @@ void MasterConn::reload() {
 	std::string newMasterPort = cfg_getstring("MASTER_PORT", kCfgDefaultMasterPort);
 	std::string newBindHost = cfg_getstring("BIND_HOST", kCfgDefaultBindHost);
 
-	if (newMasterHost != cfgMasterHost || newMasterPort != cfgMasterPort || newBindHost != cfgBindHost) {
+	if (newMasterHost != cfgMasterHost || newMasterPort != cfgMasterPort ||
+	    newBindHost != cfgBindHost) {
 		cfgMasterHost = newMasterHost;
 		cfgMasterPort = newMasterPort;
 		cfgBindHost = newBindHost;
 		isMasterAddressValid = 0;
-		if (mode != Mode::Free) {
-			mode = Mode::Kill;
-		}
+		if (mode != Mode::Free) { mode = Mode::Kill; }
 	}
 
 	cfgMasterTimeout = cfg_getuint32("MASTER_TIMEOUT", kCfgDefaultMasterTimeout);
-	cfgBackMetaKeepPrevious = cfg_getuint32("BACK_META_KEEP_PREVIOUS",
-	                                        kCfgDefaultBackMetaKeepPrevious);
-	auto reconnectionDelay = cfg_getuint32("MASTER_RECONNECTION_DELAY",
-	                                       kCfgDefaultMasterReconnectionDelay);
+	cfgBackMetaKeepPrevious =
+	    cfg_getuint32("BACK_META_KEEP_PREVIOUS", kCfgDefaultBackMetaKeepPrevious);
+	auto reconnectionDelay =
+	    cfg_getuint32("MASTER_RECONNECTION_DELAY", kCfgDefaultMasterReconnectionDelay);
 
 	cfgMasterTimeout = std::min(cfgMasterTimeout, MasterConn::kMaxMasterTimeout);
 	cfgMasterTimeout = std::max<uint32_t>(cfgMasterTimeout, MasterConn::kMinMasterTimeout);
 	cfgBackMetaKeepPrevious = std::min(cfgBackMetaKeepPrevious, MasterConn::kMaxBackMetaCopies);
 
 #ifdef METALOGGER
-	auto metadataDownloadFreq =
-	    cfg_getuint32("META_DOWNLOAD_FREQ", kCfgDefaultMetaDownloadFreq);
+	auto metadataDownloadFreq = cfg_getuint32("META_DOWNLOAD_FREQ", kCfgDefaultMetaDownloadFreq);
 	if (metadataDownloadFreq > (changelog_get_back_logs_config_value() / 2)) {
 		metadataDownloadFreq = (changelog_get_back_logs_config_value() / 2);
 	}
 #endif /* #ifdef METALOGGER */
 
-	eventloop_timechange(reconnect_hook,TIMEMODE_RUN_LATE,reconnectionDelay,0);
+	eventloop_timechange(reconnect_hook, TIMEMODE_RUN_LATE, reconnectionDelay, 0);
 #ifdef METALOGGER
-	eventloop_timechange(download_hook,TIMEMODE_RUN_LATE,metadataDownloadFreq*3600,630);
+	eventloop_timechange(download_hook, TIMEMODE_RUN_LATE, metadataDownloadFreq * 3600, 630);
 #endif /* #ifndef METALOGGER */
 
 #ifndef METALOGGER
@@ -1235,32 +1210,23 @@ void masterconn_sessionsdownloadinit(void) {
 }
 
 void masterconn_wantexit(void) {
-	if (gMasterConn != nullptr) {
-		gMasterConn->killSession();
-	}
+	if (gMasterConn != nullptr) { gMasterConn->killSession(); }
 }
 
 int masterconn_canexit(void) {
-	return static_cast<int>(gMasterConn != nullptr ||
-	                        gMasterConn->mode == MasterConn::Mode::Free);
+	return static_cast<int>(gMasterConn != nullptr || gMasterConn->mode == MasterConn::Mode::Free);
 }
 
 void masterconn_desc(std::vector<pollfd> &pdesc) {
-	if (gMasterConn != nullptr) {
-		gMasterConn->pollDesc(pdesc);
-	}
+	if (gMasterConn != nullptr) { gMasterConn->pollDesc(pdesc); }
 }
 
 void masterconn_serve(const std::vector<pollfd> &pdesc) {
-	if (gMasterConn != nullptr) {
-		gMasterConn->serve(pdesc);
-	}
+	if (gMasterConn != nullptr) { gMasterConn->serve(pdesc); }
 }
 
 void masterconn_reconnect(void) {
-	if (gMasterConn != nullptr) {
-		gMasterConn->reconnect();
-	}
+	if (gMasterConn != nullptr) { gMasterConn->reconnect(); }
 }
 
 void masterconn_term(void) {
@@ -1282,26 +1248,20 @@ void masterconn_become_master() {
 #else  // #ifndef METALOGGER
 
 void masterconn_metadownloadinit(void) {
-	if (gMasterConn != nullptr) {
-		gMasterConn->downloadInit(DOWNLOAD_METADATA_SFS);
-	}
+	if (gMasterConn != nullptr) { gMasterConn->downloadInit(DOWNLOAD_METADATA_SFS); }
 }
 
 #endif  // #else #ifndef METALOGGER
 
 void masterconn_reload(void) {
-	if (gMasterConn != nullptr) {
-		gMasterConn->reload();
-	}
+	if (gMasterConn != nullptr) { gMasterConn->reload(); }
 }
 
 }  // namespace
 
 int masterconn_init(void) {
 #ifndef METALOGGER
-	if (metadataserver::getPersonality() != metadataserver::Personality::kShadow) {
-		return 0;
-	}
+	if (metadataserver::getPersonality() != metadataserver::Personality::kShadow) { return 0; }
 #endif /* #ifndef METALOGGER */
 
 	// Create the instance for Shadows and Metaloggers only
@@ -1312,13 +1272,12 @@ int masterconn_init(void) {
 	auto *eptr = gMasterConn.get();
 
 	auto reconnectionDelay =
-	    cfg_getuint32("MASTER_RECONNECTION_DELAY",
-	                  MasterConn::kCfgDefaultMasterReconnectionDelay);
+	    cfg_getuint32("MASTER_RECONNECTION_DELAY", MasterConn::kCfgDefaultMasterReconnectionDelay);
 	eptr->loadConfig();
 
 #ifdef METALOGGER
-	changelog_init(kChangelogMlFilename, 5, 1000); // may throw
-	changelog_disable_flush(); // metalogger does it once a second
+	changelog_init(kChangelogMlFilename, 5, 1000);  // may throw
+	changelog_disable_flush();                      // metalogger does it once a second
 	auto metadataDownloadFreq =
 	    cfg_getuint32("META_DOWNLOAD_FREQ", MasterConn::kCfgDefaultMetaDownloadFreq);
 	if (metadataDownloadFreq > (changelog_get_back_logs_config_value() / 2)) {
@@ -1330,13 +1289,13 @@ int masterconn_init(void) {
 	gMetadataBackend->changelogsMigrateFrom_1_6_29("changelog_ml");
 	eptr->lastLogVersion = gMetadataBackend->findLastLogVersion();
 #endif /* #ifdef METALOGGER */
-	if (eptr->initConnect() < 0) {
-		return -1;
-	}
+	if (eptr->initConnect() < 0) { return -1; }
 	eventloop_pollregister(masterconn_desc, masterconn_serve);
-	eptr->reconnect_hook = eventloop_timeregister(TIMEMODE_RUN_LATE,reconnectionDelay,0,masterconn_reconnect);
+	eptr->reconnect_hook =
+	    eventloop_timeregister(TIMEMODE_RUN_LATE, reconnectionDelay, 0, masterconn_reconnect);
 #ifdef METALOGGER
-	eptr->download_hook = eventloop_timeregister(TIMEMODE_RUN_LATE,metadataDownloadFreq*3600,630,masterconn_metadownloadinit);
+	eptr->download_hook = eventloop_timeregister(TIMEMODE_RUN_LATE, metadataDownloadFreq * 3600,
+	                                             630, masterconn_metadownloadinit);
 #endif /* #ifdef METALOGGER */
 	eventloop_destructregister(masterconn_term);
 	eventloop_reloadregister(masterconn_reload);
@@ -1345,15 +1304,18 @@ int masterconn_init(void) {
 #ifndef METALOGGER
 	metadataserver::registerFunctionCalledOnPromotion(masterconn_become_master);
 #endif
-	eptr->sessionsDownloadInitHandle = eventloop_timeregister(TIMEMODE_RUN_LATE,60,0,masterconn_sessionsdownloadinit);
-	eptr->changelogFlushHandle = eventloop_timeregister(TIMEMODE_RUN_LATE,1,0,changelog_flush);
+	eptr->sessionsDownloadInitHandle =
+	    eventloop_timeregister(TIMEMODE_RUN_LATE, 60, 0, masterconn_sessionsdownloadinit);
+	eptr->changelogFlushHandle = eventloop_timeregister(TIMEMODE_RUN_LATE, 1, 0, changelog_flush);
 	return 0;
 }
 
 bool masterconn_is_connected() {
 	MasterConn *eptr = gMasterConn.get();
-	return (eptr != nullptr
-			&& (eptr->mode == MasterConn::Mode::Header || eptr->mode == MasterConn::Mode::Data) // socket is connected
-			&& eptr->masterVersion > MasterConn::kInvalidMasterVersion // registration was successful
-	);
+
+	return (eptr != nullptr &&
+	        // socket is connected
+	        (eptr->mode == MasterConn::Mode::Header || eptr->mode == MasterConn::Mode::Data)
+	        // registration was successful
+	        && eptr->masterVersion > MasterConn::kInvalidMasterVersion);
 }

--- a/src/master/metadata_backend_file.h
+++ b/src/master/metadata_backend_file.h
@@ -59,6 +59,8 @@ public:
 	/// @param file -- path to the changelog file
 	/// @return 0 in case of any error.
 	uint64_t changelogGetLastLogVersion(const std::string& fname) override;
+#else   // #ifndef METALOGGER
+	uint64_t findLastLogVersion() override;
 #endif  // #ifndef METALOGGER
 
 #if !defined(METARESTORE) && !defined(METALOGGER)

--- a/src/master/metadata_backend_interface.h
+++ b/src/master/metadata_backend_interface.h
@@ -117,6 +117,8 @@ public:
 	/// @param file -- path to the changelog file
 	/// @return 0 in case of any error.
 	virtual uint64_t changelogGetLastLogVersion(const std::string& fname) = 0;
+#else   // #ifndef METALOGGER
+	virtual uint64_t findLastLogVersion() = 0;
 #endif  // #ifndef METALOGGER
 
 // Available for master and shadow only


### PR DESCRIPTION
This PR partially refactors masterconn.cc, which is used by Shadows and Metaloggers to represent a connection to the active Master server. The main changes include:

Key Improvements

- Renamed masterconn to MasterConn for better readability.
- Encapsulated responsibilities within MasterConn by making standalone functions class members, reducing the need for pointer calls.
- Replaced C-style data structures with std::queue and std::vector, eliminating redundant implementations.
- Prepared for multiple instances: While a singleton still exists, the new structure makes it easier to add more instances.
- Reduced clang-tidy warnings, with more improvements to follow.
- Moved code related to MetadataBackendFile to its appropriate file for better modularity.

Additional Enhancements

- Improved readability by:
  - Adopting semi-camel-case variable names.
  - Renaming variables for better consistency and clarity.
- Added documentation to improve maintainability.
- Reduced enum sizes for efficiency.
- Prepared for future separation of the struct into .h and .cc files, ensuring a cleaner distinction between interface and implementation.

Next Steps (Future PRs)

- Keep refactoring beyond masterconn.cc, gradually improving related files.
- Continue addressing clang-tidy warnings.
- Remove magic constants related to legacy protocol packets, replacing them with the new serialization/deserialization mechanism.
- Apply common project-wide improvements across all files.

This PR focuses solely on masterconn.cc to keep the changes manageable for review. More refinements will follow in subsequent PRs.