### PR TITLE
fix: Add permission to DATA_PATH set by package

### DIFF
--- a/debian/saunafs-metalogger.postinst
+++ b/debian/saunafs-metalogger.postinst
@@ -1,0 +1,21 @@
+#! /bin/sh
+
+# Ensure proper permissions on data dir and run dir.
+
+SAUNAFS_USER="saunafs"
+SAUNAFS_GROUP="saunafs"
+SAUNAFS_DATA_PATH="/var/lib/saunafs"
+
+check_dirs() {
+	# check that the metadata dir exists
+	if [ ! -d "$SAUNAFS_DATA_PATH" ]; then
+		mkdir -p "$SAUNAFS_DATA_PATH"
+	fi
+	chmod 0755 "$SAUNAFS_DATA_PATH"
+	chown -R $SAUNAFS_USER:$SAUNAFS_GROUP "$SAUNAFS_DATA_PATH"
+}
+
+check_dirs
+#DEBHELPER#
+
+# vim: ft=sh


### PR DESCRIPTION
The metalogger package was not correctly setting user and group to default DATA_PATH. This was unnoticed because the path was shared by master package and only if metalogger is install stand-alone then the error is raised.