### PR TITLE
fix(mount, master): Fix path by inode permissions

### DIFF
--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -493,7 +493,9 @@ uint8_t fs_full_path_by_inode(const FsContext &context, uint32_t initial_inode,
 	std::string current_name = "";
 
 	while (current_inode != context.rootinode()) {
-		if (!current_node) { return SAUNAFS_ERROR_ENOENT; }
+		if (!current_node || current_node->parent.empty()) { 
+			return SAUNAFS_ERROR_ENOENT; 
+		}
 		auto [parentId, nameHandle] = current_node->parent[0];
 		auto parent_node = fsnodes_id_to_node<FSNodeDirectory>(parentId);
 		current_name = nameHandle->get();

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -489,15 +489,25 @@ uint8_t fs_whole_path_lookup(const FsContext &context, uint32_t parent, const st
 uint8_t fs_full_path_by_inode(const FsContext &context, uint32_t initial_inode,
                               std::string &fullPath) {
 	uint32_t current_inode = initial_inode;
-	FSNode *current_node = fsnodes_id_to_node(current_inode);
+	FSNode *parent_node;
+	FSNode *current_node;
 	std::string current_name = "";
+
+	uint8_t status = verify_session(context, OperationMode::kReadOnly, SessionType::kNotMeta);
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+
+	status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny, MODE_MASK_R,
+	                                        initial_inode, &current_node);
+	if (status != SAUNAFS_STATUS_OK) { return status; }
 
 	while (current_inode != context.rootinode()) {
 		if (!current_node || current_node->parent.empty()) { 
 			return SAUNAFS_ERROR_ENOENT; 
 		}
 		auto [parentId, nameHandle] = current_node->parent[0];
-		auto parent_node = fsnodes_id_to_node<FSNodeDirectory>(parentId);
+		status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny, MODE_MASK_R,
+		                                        parentId, &parent_node);
+		if (status != SAUNAFS_STATUS_OK) { return status; }
 		current_name = nameHandle->get();
 		fullPath = current_inode == initial_inode
 		               ? current_name

--- a/src/mount/mastercomm.cc
+++ b/src/mount/mastercomm.cc
@@ -2796,7 +2796,9 @@ uint8_t fs_fullpath(uint32_t inode, uint32_t uid,
 	threc *rec = fs_get_my_threc();
 	auto message =
 	    cltoma::fullPathByInode::build(rec->packetId, inode, uid, gid);
-	if (!fs_saucreatepacket(rec, message)) { return SAUNAFS_ERROR_IO; }
+	if (!fs_saucreatepacket(rec, message)) { 
+		return SAUNAFS_ERROR_IO; 
+	}
 	if (!fs_sausendandreceive(rec, SAU_MATOCL_FULL_PATH_BY_INODE, message)) {
 		return SAUNAFS_ERROR_IO;
 	}

--- a/src/mount/sauna_client.cc
+++ b/src/mount/sauna_client.cc
@@ -908,15 +908,24 @@ EntryParam lookup(Context &ctx, Inode parent, const char *name) {
 		InodePathByInode::inodePathInfo.locked = true;
 		InodePathByInode::inodePathInfo.inode = inode;
 		std::string fullPath = "";
-		RETRY_ON_ERROR_WITH_UPDATED_CREDENTIALS(status, ctx,
+		int lookupStatus = SAUNAFS_STATUS_OK;
+		int getattrStatus = SAUNAFS_STATUS_OK;
+		RETRY_ON_ERROR_WITH_UPDATED_CREDENTIALS(lookupStatus, ctx,
 		fs_fullpath(inode, ctx.uid, ctx.gid, fullPath));
-		RETRY_ON_ERROR_WITH_UPDATED_CREDENTIALS(status, ctx,
+		RETRY_ON_ERROR_WITH_UPDATED_CREDENTIALS(getattrStatus, ctx,
 			fs_getattr(inode, ctx.uid, ctx.gid, attr));
+		if (lookupStatus != SAUNAFS_STATUS_OK || getattrStatus != SAUNAFS_STATUS_OK) {
+			status = lookupStatus != SAUNAFS_STATUS_OK ? lookupStatus : getattrStatus;
+			InodePathByInode::inodePathInfo.locked = false;
+			InodePathByInode::inodePathInfo.cv.notify_one();
+			lock.unlock();
+			throw RequestException(status);
+		}
+		status = SAUNAFS_STATUS_OK;
 		InodePathByInode::inodePathInfo.pathByInode = new char[fullPath.length() + 1];
 		std::strcpy(InodePathByInode::inodePathInfo.pathByInode, fullPath.c_str());
 		attr[0] = TYPE_FILE;
 		inode = parent;
-		status = 0;
 		icacheflag = 0;
 	} else if (usedircache && gDirEntryCache.lookup(ctx,parent,std::string(name,nleng),inode,attr)) {
 		if (debug_mode) {

--- a/tests/test_suites/ShortSystemTests/test_path_by_inode.sh
+++ b/tests/test_suites/ShortSystemTests/test_path_by_inode.sh
@@ -1,4 +1,5 @@
 USE_RAMDISK=YES \
+	MOUNT_0_EXTRA_CONFIG="sfscachemode=NEVER,sfsdirentrycacheto=0" \
 	setup_local_empty_saunafs info
 
 cd "${info[mount0]}"
@@ -38,3 +39,16 @@ echo "data6" > $(cat .saunafs_path_by_inode/6)
 assert_equals "data4" "$(cat file1)"
 assert_equals "data5" "$(cat folder/file2)"
 assert_equals "data6" "$(cat folder/folder2/file3)"
+
+# check removing files by their path
+rm $(cat .saunafs_path_by_inode/2)
+assert_failure cat file1
+
+# requesting path of removed file or unexisting inode should 
+# return not such file or directory
+assert_failure cat .saunafs_path_by_inode/2
+assert_failure cat .saunafs_path_by_inode/1500
+
+# the .saunafs_path_by_inode directory is not writable or removable
+assert_failure rm .saunafs_path_by_inode
+assert_failure touch .saunafs_path_by_inode/file

--- a/tests/test_suites/ShortSystemTests/test_path_by_inode.sh
+++ b/tests/test_suites/ShortSystemTests/test_path_by_inode.sh
@@ -1,54 +1,18 @@
-USE_RAMDISK=YES \
-	MOUNT_0_EXTRA_CONFIG="sfscachemode=NEVER,sfsdirentrycacheto=0" \
-	setup_local_empty_saunafs info
+source test_suites/TestTemplates/test_path_by_inode.inc
 
-cd "${info[mount0]}"
-touch file1
-mkdir folder
-touch folder/file2
-mkdir folder/folder2
-touch folder/folder2/file3
+assert_success cat .saunafs_path_by_inode/4
+chmod 200 folder/file2
+assert_failure cat .saunafs_path_by_inode/4
 
-cat .saunafs_path_by_inode/2
-cat .saunafs_path_by_inode/3
-cat .saunafs_path_by_inode/4
-cat .saunafs_path_by_inode/5
-cat .saunafs_path_by_inode/6
+# if a user has no reading permissions to a parent folder, 
+# then all path from all possible children inodes cannot 
+# be accessed
+assert_success cat .saunafs_path_by_inode/3
+assert_success cat .saunafs_path_by_inode/5
+assert_success cat .saunafs_path_by_inode/6
 
-# check file paths by inode
-assert_equals "file1" "$(cat .saunafs_path_by_inode/2)"
-assert_equals "folder" "$(cat .saunafs_path_by_inode/3)"
-assert_equals "folder/file2" "$(cat .saunafs_path_by_inode/4)"
-assert_equals "folder/folder2" "$(cat .saunafs_path_by_inode/5)"
-assert_equals "folder/folder2/file3" "$(cat .saunafs_path_by_inode/6)"
+chmod 200 folder
 
-# check reading from files by their path
-echo "data1" > file1
-echo "data2" > folder/file2
-echo "data3" > folder/folder2/file3
-
-assert_equals "data1" "$(cat $(cat .saunafs_path_by_inode/2))"
-assert_equals "data2" "$(cat $(cat .saunafs_path_by_inode/4))"
-assert_equals "data3" "$(cat $(cat .saunafs_path_by_inode/6))"
-
-# check writing to files by their path
-echo "data4" > $(cat .saunafs_path_by_inode/2)
-echo "data5" > $(cat .saunafs_path_by_inode/4)
-echo "data6" > $(cat .saunafs_path_by_inode/6)
-
-assert_equals "data4" "$(cat file1)"
-assert_equals "data5" "$(cat folder/file2)"
-assert_equals "data6" "$(cat folder/folder2/file3)"
-
-# check removing files by their path
-rm $(cat .saunafs_path_by_inode/2)
-assert_failure cat file1
-
-# requesting path of removed file or unexisting inode should 
-# return not such file or directory
-assert_failure cat .saunafs_path_by_inode/2
-assert_failure cat .saunafs_path_by_inode/1500
-
-# the .saunafs_path_by_inode directory is not writable or removable
-assert_failure rm .saunafs_path_by_inode
-assert_failure touch .saunafs_path_by_inode/file
+assert_failure cat .saunafs_path_by_inode/3
+assert_failure cat .saunafs_path_by_inode/5
+assert_failure cat .saunafs_path_by_inode/6

--- a/tests/test_suites/TestTemplates/test_path_by_inode.inc
+++ b/tests/test_suites/TestTemplates/test_path_by_inode.inc
@@ -1,0 +1,54 @@
+USE_RAMDISK=YES \
+	MOUNT_0_EXTRA_CONFIG="sfscachemode=NEVER,sfsdirentrycacheto=0" \
+	setup_local_empty_saunafs info
+
+cd "${info[mount0]}"
+touch file1
+mkdir folder
+touch folder/file2
+mkdir folder/folder2
+touch folder/folder2/file3
+
+cat .saunafs_path_by_inode/2
+cat .saunafs_path_by_inode/3
+cat .saunafs_path_by_inode/4
+cat .saunafs_path_by_inode/5
+cat .saunafs_path_by_inode/6
+
+# check file paths by inode
+assert_equals "file1" "$(cat .saunafs_path_by_inode/2)"
+assert_equals "folder" "$(cat .saunafs_path_by_inode/3)"
+assert_equals "folder/file2" "$(cat .saunafs_path_by_inode/4)"
+assert_equals "folder/folder2" "$(cat .saunafs_path_by_inode/5)"
+assert_equals "folder/folder2/file3" "$(cat .saunafs_path_by_inode/6)"
+
+# check reading from files by their path
+echo "data1" > file1
+echo "data2" > folder/file2
+echo "data3" > folder/folder2/file3
+
+assert_equals "data1" "$(cat $(cat .saunafs_path_by_inode/2))"
+assert_equals "data2" "$(cat $(cat .saunafs_path_by_inode/4))"
+assert_equals "data3" "$(cat $(cat .saunafs_path_by_inode/6))"
+
+# check writing to files by their path
+echo "data4" > $(cat .saunafs_path_by_inode/2)
+echo "data5" > $(cat .saunafs_path_by_inode/4)
+echo "data6" > $(cat .saunafs_path_by_inode/6)
+
+assert_equals "data4" "$(cat file1)"
+assert_equals "data5" "$(cat folder/file2)"
+assert_equals "data6" "$(cat folder/folder2/file3)"
+
+# check removing files by their path
+rm $(cat .saunafs_path_by_inode/2)
+assert_failure cat file1
+
+# requesting path of removed file or unexisting inode should 
+# return not such file or directory
+assert_failure cat .saunafs_path_by_inode/2
+assert_failure cat .saunafs_path_by_inode/1500
+
+# the .saunafs_path_by_inode directory is not writable or removable
+assert_failure rm .saunafs_path_by_inode
+assert_failure touch .saunafs_path_by_inode/file


### PR DESCRIPTION
## Fix path by inode improvements
1) Fix behavior when the given inode was not existing.
2) Ensure that the user has permissions to all nodes in the path that contains the given inode.