### PR TITLE
chore(git,cmake): Ignore CMakeUserPresets.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,7 @@ tests/hdd*
 # vcpkg #
 ##############
 vcpkg_installed
+
+# CMake #
+##############
+CMakeUserPresets.json


### PR DESCRIPTION
The user presets are meant to be used locally, no need to version it.