### PR TITLE
Improve chunkserver logging

### DIFF
--- a/src/chunkserver/hddspacemgr.cc
+++ b/src/chunkserver/hddspacemgr.cc
@@ -703,7 +703,10 @@ int hddRead(uint64_t chunkId, uint32_t version, ChunkPartType chunkType,
 	LOG_AVG_TILL_END_OF_SCOPE0("hddRead");
 	TRACETHIS3(chunkId, offset, size);
 
-	safs_silent_syslog(LOG_DEBUG, "chunkserver.hddRead");
+	uint16_t block = offset / SFSBLOCKSIZE;
+
+	safs::log_debug("hddRead: chunkId: {}, block: {}, offset: {}, size: {}",
+	                chunkId, block, offset, size);
 
 	uint32_t offsetWithinBlock = offset % SFSBLOCKSIZE;
 
@@ -722,8 +725,6 @@ int hddRead(uint64_t chunkId, uint32_t version, ChunkPartType chunkType,
 		hddChunkRelease(chunk);
 		return SAUNAFS_ERROR_WRONGVERSION;
 	}
-
-	uint16_t block = offset / SFSBLOCKSIZE;
 
 	// Zoned devices use direct_io, so prefetched data is not cached
 	if (!chunk->owner()->isZonedDevice()) {

--- a/src/slogger/slogger.cc
+++ b/src/slogger/slogger.cc
@@ -187,7 +187,10 @@ void safs::drop_all_logs() {
 bool safs::add_log_syslog([[maybe_unused]] log_level::LogLevel level) {
 #ifndef _WIN32
 	try {
-		LoggerPtr logger = spdlog::syslog_logger_mt("syslog");
+		static constexpr bool kEnableFormatting = true;
+		// Except for first and last arguments, the rest are defaults
+		LoggerPtr logger = spdlog::syslog_logger_mt("syslog", "", 0, LOG_USER, kEnableFormatting);
+		logger->set_pattern("[%t] %l: %v");
 		logger->set_level((spdlog::level::level_enum)level);
 		return true;
 	} catch (const spdlog::spdlog_ex &e) {

--- a/tests/test_suites/ShortSystemTests/test_no_reads_during_small_ec_files_write.sh
+++ b/tests/test_suites/ShortSystemTests/test_no_reads_during_small_ec_files_write.sh
@@ -15,6 +15,6 @@ for i in {1..100}; do
 	dd if=/dev/zero of=file${i} bs=33 count=1 oflag=direct status=progress
 done
 
-number_of_extra_reads=$(grep chunkserver.hddRead $TEMP_DIR/log | wc -l);
+number_of_extra_reads=$(grep "hddRead" $TEMP_DIR/log | wc -l);
 
 assert_equals "0" "${number_of_extra_reads}"

--- a/tests/test_suites/ShortSystemTests/test_reads_during_small_ec_files_write_parallel.sh
+++ b/tests/test_suites/ShortSystemTests/test_reads_during_small_ec_files_write_parallel.sh
@@ -42,7 +42,7 @@ for index in ${!positions[@]}; do
 	echo -n "1" | dd of="${info[mount0]}/file0" seek=$position bs=1 count=1 oflag=direct status=progress
 
 	# Check the number of extra reads
-	number_of_extra_reads=$(grep chunkserver.hddRead $TEMP_DIR/log | wc -l);
+	number_of_extra_reads=$(grep "hddRead" $TEMP_DIR/log | wc -l);
 
 	# Assert that the number of extra reads is as expected
 	assert_equals ${expected_reads_one_mountpoint[$index]} "${number_of_extra_reads}"
@@ -63,7 +63,7 @@ for index in ${!positions[@]}; do
 done
 
 # Check the number of extra reads
-number_of_extra_reads=$(grep chunkserver.hddRead $TEMP_DIR/log | wc -l);
+number_of_extra_reads=$(grep "hddRead" $TEMP_DIR/log | wc -l);
 
 # Assert that the number of extra reads is as expected
 assert_less_or_equal "${number_of_extra_reads}" "${total_expected_reads}"


### PR DESCRIPTION
This PR contain changes to facilitate the debugging, mainly but not limited to the Chunkserver.
The main changes are:
- The slogger is now able to add the log level and the thread id (TID) to the syslog.
- The hddRead function now prints more useful information in debug mode.
- Misc: the tests relying in the log message were updated.