### PR TITLE
chore: Update .clang-format file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -24,4 +24,10 @@ IncludeBlocks: Preserve
 # loop. Instead, we must use braces until it does.
 AllowShortLoopsOnASingleLine: true
 AllowShortBlocksOnASingleLine: Always
+
+# Avoid breaking string literals
+BreakStringLiterals: false
+
+# Use maximum 100 characters per line
+ColumnLimit: 100
 ...


### PR DESCRIPTION
This change updates the .clang-format to:
- Avoid breaking string literals.
- Use a maximum of 100 characters per line.
- Facilitate applying automatic format to complete files.