### PR TITLE
fix: Inconsistent total capacity in CGI and statfs

### DIFF
--- a/src/chunkserver/chunkserver-common/cmr_disk.cc
+++ b/src/chunkserver/chunkserver-common/cmr_disk.cc
@@ -84,6 +84,11 @@ void CmrDisk::refreshDataDiskUsage() {
 	} else {
 		setAvailableSpace(availableSpace() - leaveFreeSpace());
 	}
+	if (totalSpace() < leaveFreeSpace()) {
+		setTotalSpace(0ULL);
+	} else {
+		setTotalSpace(totalSpace() - leaveFreeSpace());
+	}
 }
 
 int CmrDisk::updateChunkAttributes(IChunk *chunk, bool isFromScan) {

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -346,9 +346,6 @@ void fs_statfs(const FsContext &context, uint64_t *totalspace, uint64_t *availsp
 		fsnodes_quota_adjust_space(rn, *totalspace, *availspace);
 		fsnodes_get_stats(rn, &sr);
 		*inodes = sr.inodes;
-		if (sr.realsize + *availspace < *totalspace) {
-			*totalspace = sr.realsize + *availspace;
-		}
 	}
 	++gFsStatsArray[FsStats::Statfs];
 }


### PR DESCRIPTION
The CGI and statfs system call where reporting different total capacities of the filesystem.

The CGI monitoring was showing the total capacity of all hard drives, regardless of limits in HDD_LEAVE_SPACE_DEFAULT option. Meanwhile, statfs was showing total capacity as space available on all hard drives + actual used bytes for chunks (or the reported total capacity on all hard drives, whichever was lower).

This commit tries to get rid of these discrepancies by discounting the HDD_LEAVE_SPACE_DEFAULT value towards the final capacity of a drive in the chunkserver. Both statfs and CGI will now show this capacity in the same way.