### PR TITLE
build(uraft): Update boost functions to work with boost 1.87

### DIFF
--- a/src/uraft/main.cc
+++ b/src/uraft/main.cc
@@ -226,7 +226,7 @@ int main(int argc, char **argv) {
 		return EXIT_FAILURE;
 	}
 
-	boost::asio::io_service  io_service;
+	boost::asio::io_context  io_service;
 	uRaftController          server(io_service);
 #if (BOOST_VERSION >= 104700)
 	boost::asio::signal_set  signals(io_service, SIGINT, SIGTERM);
@@ -236,7 +236,7 @@ int main(int argc, char **argv) {
 		server.set_options(opt);
 		makePidFile(pidfile);
 #if (BOOST_VERSION >= 104700)
-		signals.async_wait(boost::bind(&boost::asio::io_service::stop, &io_service));
+		signals.async_wait(boost::bind(&boost::asio::io_context::stop, &io_service));
 #endif
 		server.init();
 

--- a/src/uraft/uraft.cc
+++ b/src/uraft/uraft.cc
@@ -1,4 +1,7 @@
 #include "common/platform.h"
+
+#include <boost/lexical_cast.hpp>
+
 #include "uraft.h"
 
 #if defined(SAUNAFS_HAVE_GETIFADDRS)
@@ -12,7 +15,7 @@
 
 using boost::asio::ip::udp;
 
-uRaft::uRaft(boost::asio::io_service &ios)
+uRaft::uRaft(boost::asio::io_context &ios)
 	: io_service_(ios),
 	  socket_(ios),
 	  election_timer_(ios),
@@ -385,27 +388,29 @@ void uRaft::init() {
 	for (int i = 0; i < (int)node_.size(); i++) {
 		std::string::size_type p = opt_.server[i].find(":");
 		boost::system::error_code err;
-		udp::resolver::iterator   iendpoint;
+		udp::resolver::results_type results;
+
 
 		if (p != std::string::npos) {
-			udp::resolver::query query(udp::v4(), opt_.server[i].substr(0, p),
-			                           opt_.server[i].substr(p + 1));
-
-			iendpoint = resolver.resolve(query, err);
+			results = resolver.resolve(opt_.server[i].substr(0, p), opt_.server[i].substr(p + 1), err);
 			if (err) {
 				throw std::runtime_error("Failed to resolve dns name '" + opt_.server[i] + "'");
 			}
 		} else {
-			udp::resolver::query query(udp::v4(), opt_.server[i],
-			                           boost::lexical_cast<std::string>(opt_.port));
-			iendpoint = resolver.resolve(query, err);
+			results = resolver.resolve(opt_.server[i], boost::lexical_cast<std::string>(opt_.port), err);
 			if (err) {
 				throw std::runtime_error("Failed to resolve dns name '" + opt_.server[i]
 				                         + ":" + boost::lexical_cast<std::string>(opt_.port)+"'");
 			}
 		}
 
-		node_[i].addr = *iendpoint;
+		if (results.empty()) {
+			throw std::runtime_error(
+			    "Failed to resolve dns name '" + opt_.server[i] + ":" +
+			    boost::lexical_cast<std::string>(opt_.port) +
+			    "':" + "No results found");
+		}
+		node_[i].addr = results.begin()->endpoint();
 	}
 
 	state_.id = opt_.id;

--- a/src/uraft/uraft.h
+++ b/src/uraft/uraft.h
@@ -88,7 +88,7 @@ protected:
 	};
 
 public:
-	uRaft(boost::asio::io_service &ios);
+	uRaft(boost::asio::io_context &ios);
 	virtual ~uRaft();
 
 	//! Initialization of uRaft internal data.
@@ -160,7 +160,7 @@ protected:
 	int scanLocalInterfaces();
 
 protected:
-	boost::asio::io_service                 &io_service_;
+	boost::asio::io_context                 &io_service_;
 	boost::asio::ip::udp::socket            socket_;
 	boost::asio::deadline_timer             election_timer_,heartbeat_timer_;
 	boost::asio::deadline_timer             loyalty_agreement_timer_;

--- a/src/uraft/uraftcontroller.cc
+++ b/src/uraft/uraftcontroller.cc
@@ -18,7 +18,7 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/version.hpp>
 
-uRaftController::uRaftController(boost::asio::io_service &ios)
+uRaftController::uRaftController(boost::asio::io_context &ios)
 	: uRaftStatus(ios),
 	  check_cmd_status_timer_(ios),
 	  check_node_status_timer_(ios),
@@ -269,7 +269,7 @@ bool uRaftController::runSlowCommand(const std::string &cmd) {
 	command_timer_.reset();
 
 #if (BOOST_VERSION >= 104700)
-	io_service_.notify_fork(boost::asio::io_service::fork_prepare);
+	io_service_.notify_fork(boost::asio::io_context::fork_prepare);
 #endif
 
 	command_pid_ = fork();
@@ -282,7 +282,7 @@ bool uRaftController::runSlowCommand(const std::string &cmd) {
 	}
 
 #if (BOOST_VERSION >= 104700)
-	io_service_.notify_fork(boost::asio::io_service::fork_parent);
+	io_service_.notify_fork(boost::asio::io_context::fork_parent);
 #endif
 
 	return true;
@@ -304,7 +304,7 @@ bool uRaftController::runCommand(const std::vector<std::string> &cmd, std::strin
 	}
 
 #if (BOOST_VERSION >= 104700)
-	io_service_.notify_fork(boost::asio::io_service::fork_prepare);
+	io_service_.notify_fork(boost::asio::io_context::fork_prepare);
 #endif
 
 	pid = fork();
@@ -328,7 +328,7 @@ bool uRaftController::runCommand(const std::vector<std::string> &cmd, std::strin
 	}
 
 #if (BOOST_VERSION >= 104700)
-	io_service_.notify_fork(boost::asio::io_service::fork_parent);
+	io_service_.notify_fork(boost::asio::io_context::fork_parent);
 #endif
 
 	close(pipe_fd[1]);

--- a/src/uraft/uraftcontroller.h
+++ b/src/uraft/uraftcontroller.h
@@ -38,7 +38,7 @@ public:
 	};
 
 public:
-	uRaftController(boost::asio::io_service &);
+	uRaftController(boost::asio::io_context &);
 	virtual ~uRaftController();
 
 	//! Initialize data.

--- a/src/uraft/uraftstatus.cc
+++ b/src/uraft/uraftstatus.cc
@@ -4,7 +4,7 @@
 #include <iostream>
 #include <boost/format.hpp>
 
-uRaftStatusConnection::uRaftStatusConnection(boost::asio::io_service &ios)
+uRaftStatusConnection::uRaftStatusConnection(boost::asio::io_context &ios)
 	: data_(),
 	  socket_(ios) {
 }
@@ -22,7 +22,7 @@ boost::asio::ip::tcp::socket &uRaftStatusConnection::socket() {
 	return socket_;
 }
 
-uRaftStatus::uRaftStatus(boost::asio::io_service &ios)
+uRaftStatus::uRaftStatus(boost::asio::io_context &ios)
 	: uRaft(ios),
 	  acceptor_(ios),
 	  socket_(ios) {

--- a/src/uraft/uraftstatus.h
+++ b/src/uraft/uraftstatus.h
@@ -12,7 +12,7 @@
  */
 class uRaftStatusConnection : public std::enable_shared_from_this<uRaftStatusConnection> {
 public:
-	uRaftStatusConnection(boost::asio::io_service &ios);
+	uRaftStatusConnection(boost::asio::io_context &ios);
 
 	void init();
 	boost::asio::ip::tcp::socket& socket();
@@ -37,7 +37,7 @@ public:
 	};
 
 public:
-	uRaftStatus(boost::asio::io_service &ios);
+	uRaftStatus(boost::asio::io_context &ios);
 	virtual ~uRaftStatus();
 
 	//! Initialize server.


### PR DESCRIPTION
Uraft was causing compilation errors with boost 1.87, as some backwards compatible stuff was removed in later versions. This fixes those issues by using library calls available in Boost 1.87 and earlier versions.