### PR TITLE
fix: Show same stats as CGI in statfs call

### DIFF
--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -347,9 +347,6 @@ void fs_statfs(const FsContext &context, uint64_t *totalspace, uint64_t *availsp
 		fsnodes_quota_adjust_space(rn, *totalspace, *availspace);
 		fsnodes_get_stats(rn, &sr);
 		*inodes = sr.inodes;
-		if (sr.realsize + *availspace < *totalspace) {
-			*totalspace = sr.realsize + *availspace;
-		}
 	}
 	++gFsStatsArray[FsStats::Statfs];
 	metrics::Counter::increment(metrics::Counter::Master::FS_STATFS);


### PR DESCRIPTION
Statfs was showing different values for available, total and used space than CGI was showing. This changes that to show the same values for statfs system call as fs_info call.