### PR TITLE
chore: Add ignore for deliver-win-release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,7 @@ tests/test_suites/ICETests
 ###########
 src/mount/windows
 create-win-release.bat
+deliver-win-release.bat
 
 # Test setup #
 ##############


### PR DESCRIPTION
This commit prevents the deliver-win-release.bat script from being included in the repository when creating the corresponding hardlinks from the Windows client repository.