### PR TITLE
feat(mount): Improve mount read algorithm

### DIFF
--- a/src/mount/readahead_adviser.h
+++ b/src/mount/readahead_adviser.h
@@ -91,15 +91,18 @@ public:
 	}
 
 	/*!
+	* \brief Estimate the time a readahead request will be needed.
+	*/
+	double expectedNeededTime_us(uint64_t aheadSize) {
+		return aheadSize / throughputMBps();
+	}
+
+	/*!
 	 * \brief Estimation of the size of data requested by the process
 	 * considering the last read requests made.
 	 */
 	uint64_t throughputWindow() {
-		int64_t timestamp = timer_.elapsed_us();
-		double throughput_MBps = static_cast<double>(requested_bytes_) /
-		                         (timestamp - history_.front().timestamp);
-
-		return kConservativeMultiplier * throughput_MBps * timeout_ms_
+		return kConservativeMultiplier * throughputMBps() * timeout_ms_
 		       * kBytesInOneKiB;
 	}
 
@@ -141,6 +144,25 @@ public:
 	}
 
 private:
+
+	/*!
+	* \brief Calculates an estimation of the throughput in MB/s considering the current history.
+	* The timestamp that could be provided is to save the call to ```elapsed_us``` if already done.
+	*/
+	double throughputMBps(int64_t timestamp = 0) {
+		if (timestamp == 0) {
+			timestamp = timer_.elapsed_us();
+		}
+		// Make sure non-zero division
+		double throughput_MBps = static_cast<double>(requested_bytes_) /
+		                         std::max<int64_t>(timestamp - history_.front().timestamp, 1);
+
+		if (throughput_MBps <= 0) {
+			safs::log_warn("Throughput must be greater than 0, current value: {}", throughput_MBps);
+			throughput_MBps = kNeutralThroughput;
+		}
+		return throughput_MBps;
+	}
 
 	/*!
 	 * \brief Calculates the absolute difference between two ```uint64_t``` values.
@@ -191,12 +213,10 @@ private:
 	 * \param timestamp time point used for latency estimation
 	 */
 	void adjustMaxWindowSize(int64_t timestamp) {
-		double throughput_MBps =
-		    (double)requested_bytes_ / (timestamp - history_.front().timestamp);
 		// Max window size is set on the basis of estimated throughput
 		max_window_size_ = std::min<uint64_t>(
 		    window_size_limit_,
-		    kConservativeMultiplier * throughput_MBps * timeout_ms_ * 1024);
+		    kConservativeMultiplier * throughputMBps(timestamp) * timeout_ms_ * kBytesInOneKiB);
 		max_window_size_ = std::max(max_window_size_, kInitWindowSize);
 	}
 
@@ -239,7 +259,8 @@ private:
 	// This multiplier makes the raw estimation of the throughput window a much
 	// conservative one -- it is much safer to assume the process won't ask more
 	// data than expected.
-	static const int64_t kConservativeMultiplier = 2;
+	static const int64_t kConservativeMultiplier = 1;
+	static const uint64_t kNeutralThroughput = 1;
 	static const uint16_t kBytesInOneKiB = 1024;
 	// up to add a command line options for these parameters
 	static const int64_t kErrorThreshold = SFSBLOCKSIZE;

--- a/src/mount/readdata.cc
+++ b/src/mount/readdata.cc
@@ -272,7 +272,7 @@ bool ReadaheadOperationsManager::request(
 	// Let's check if we very recently finished the request we've been waiting
 	// for
 	if (!result.back()->done) {
-		rcvpPtr = addRequest_(rrec, result.back());
+		rcvpPtr = addRequest_(rrec, result.back(), 0);
 	}
 
 	addExtraRequests_(rrec, offset, recommendedSize,
@@ -287,24 +287,25 @@ bool ReadaheadOperationsManager::request(
 }
 
 Request ReadaheadOperationsManager::nextRequest() {
-	Request request = readaheadRequestContainer_.front();
+	massert(!readaheadRequestContainer_.empty(), "There is no request to be processed");
+	Request request = readaheadRequestContainer_.top().second;
 	readaheadRequestContainer_.pop();
 	return request;
 }
 
 void ReadaheadOperationsManager::putTerminateRequest() {
 	std::unique_lock requestsLock(gReadaheadRequestsContainerMutex);
-	readaheadRequestContainer_.push(
-	    std::make_pair(EMPTY_REQUEST, EMPTY_REQUEST));
+	putRequestWithPriority(std::numeric_limits<int64_t>::max(), EMPTY_REQUEST, EMPTY_REQUEST);
 	readOperationsAvailable.notify_one();
 }
 
 RequestConditionVariablePair *ReadaheadOperationsManager::addRequest_(
-    ReadRecord *rrec, ReadCache::Entry *entry) {
+    ReadRecord *rrec, ReadCache::Entry *entry, int64_t extraPriority) {
 	ReadaheadRequestPtr readaheadRequestPtr =
 	    ReadaheadRequestPtr(new ReadaheadRequestEntry(entry));
 	std::unique_lock requestsLock(gReadaheadRequestsContainerMutex);
-	readaheadRequestContainer_.push(std::make_pair(rrec, readaheadRequestPtr));
+	int64_t priority = requestsTimer_.elapsed_us() + extraPriority;
+	putRequestWithPriority(priority, rrec, readaheadRequestPtr);
 	rrec->requestsNotDone++;
 	entry->acquire();
 
@@ -339,13 +340,20 @@ void ReadaheadOperationsManager::addExtraRequests_(
 			continue;
 		}
 
-		ReadCache::Entry *entry = rrec->cache.forceInsert(
-		    maximumRequestedOffset, satisfyingSize);
+		// Try to align extra requests to SFSCHUNKSIZE
+		uint64_t extraRequestSize = std::min<uint64_t>(
+		    satisfyingSize, SFSCHUNKSIZE - (maximumRequestedOffset % SFSCHUNKSIZE));
+		ReadCache::Entry *entry = rrec->cache.forceInsert(maximumRequestedOffset, extraRequestSize);
+
+		massert(maximumRequestedOffset >= currentOffset,
+		        "Maximum requested offset should be greater than or equal current offset");
+		int64_t extraPriority =
+		    rrec->readahead_adviser.expectedNeededTime_us(maximumRequestedOffset - currentOffset);
 
 		// we are not going to use the return value from the addRequest_ call
-		addRequest_(rrec, entry);
+		addRequest_(rrec, entry, extraPriority);
 
-		maximumRequestedOffset += satisfyingSize;
+		maximumRequestedOffset += extraRequestSize;
 	}
 }
 

--- a/src/mount/readdata.h
+++ b/src/mount/readdata.h
@@ -311,10 +311,19 @@ public:
 	/** \brief Insert a request signaling one read worker thread to stop.
 	 *
 	 * requestsLock: UNLOCKED
-	*/
+	 */
 	void putTerminateRequest();
 
 private:
+	/** \brief Insert a request consisting of the passed parameters.
+	 *
+	 * requestsLock: LOCKED
+	 */
+	void putRequestWithPriority(int64_t priority, ReadRecord *readRecord,
+	                            ReadaheadRequestPtr request) {
+		readaheadRequestContainer_.emplace(priority, std::make_pair(readRecord, request));
+	}
+
 	/**
 	 * \brief Add a readahead request to the underlying container and to the
 	 * provided ```ReadRecord```'s ```ReadaheadRequests``` member.
@@ -324,11 +333,13 @@ private:
 	 * \param rrec The related ```ReadRecord```.
 	 * \param entry Pointer to the ```Entry``` in the read cache of the given
 	 * ```ReadRecord```.
+	 * \param extraPriority How much time after the current time the request
+	 * should be needed in microseconds.
 	 * \return ```RequestConditionVariablePair``` - A pair of pointers to the
 	 * request inserted and the ```std::conditional_variable``` to wait for.
 	 */
-	RequestConditionVariablePair *addRequest_(ReadRecord *rrec,
-	                                          ReadCache::Entry *entry);
+	RequestConditionVariablePair *addRequest_(ReadRecord *rrec, ReadCache::Entry *entry,
+	                                          int64_t extraPriority);
 
 	/**
 	 * \brief Add extra requests to increase the cached data from a given offset.
@@ -352,13 +363,16 @@ private:
 	 * scheduled request. If not, this value provides the starting offset to
 	 * add the extra requests.
 	 */
-	void addExtraRequests_(ReadRecord *rrec, uint64_t currentOffset,
-	                       uint64_t satisfyingSize,
+	void addExtraRequests_(ReadRecord *rrec, uint64_t currentOffset, uint64_t satisfyingSize,
 	                       uint64_t maximumRequestedOffset);
 
-	using ReadaheadRequestContainer = std::queue<Request>;
+	using RequestWithPriority = std::pair<int64_t, Request>;
+	using ReadaheadRequestContainer =
+	    std::priority_queue<RequestWithPriority, std::vector<RequestWithPriority>,
+	                        std::greater<RequestWithPriority>>;
 
 	ReadaheadRequestContainer readaheadRequestContainer_;
+	Timer requestsTimer_;
 };
 
 inline uint64_t round_up_to_blocksize(uint64_t bytes);


### PR DESCRIPTION
List of changes:
- reduce the kConservativeMultiplier constant from 2 to 1. Should
reduce the number of possibly wasted read requests.
- add priority to the ReadaheadRequestContainer. This way the most
needed requests should be picked first by the workers.

The priority is defined as the approximate time the readahead requests
will be needed in microseconds. This is achieved by putting an extra
(in addition to current timestamp) priority of 0 to the already needed
requests, and an approximated value to the ahead requests.
- try to align the extra readahead requests. The goal is to ask for
full chunks, instead of splitting it into several requests.

Signed-off-by: Dave <dave@leil.io>