### PR TITLE
test: Add tests for saunafs-admin on Windows

### DIFF
--- a/tests/test_suites/ShortSystemTests/test_admin_list_mounts.sh
+++ b/tests/test_suites/ShortSystemTests/test_admin_list_mounts.sh
@@ -2,7 +2,7 @@ MOUNTS=4 \
 	USE_RAMDISK=YES \
 	setup_local_empty_saunafs info
 
-mounts=$(saunafs-admin list-mounts --porcelain --verbose localhost "${info[matocl]}")
+mounts=$(saunafs_admin_command list-mounts --porcelain --verbose localhost "${info[matocl]}")
 expect_equals "4" $(wc -l <<< "$mounts")
 for i in {1..4}; do
 	if is_windows_system; then

--- a/tests/test_suites/ShortSystemTests/test_admin_magic_recalculate_metadata_checksum.sh
+++ b/tests/test_suites/ShortSystemTests/test_admin_magic_recalculate_metadata_checksum.sh
@@ -20,19 +20,19 @@ fi
 
 
 # Verify if wrong password doesn't work
-assert_failure saunafs-admin magic-recalculate-metadata-checksum localhost "$port" <<< "no-pass"
+assert_failure saunafs_admin_command magic-recalculate-metadata-checksum localhost "$port" <<< "no-pass"
 
 assert_equals 0 $(grep updater_end "$TEMP_DIR/log" | wc -l)
 assert_equals 0 $(grep updater_start "$TEMP_DIR/log" | wc -l)
 
 # Verify if the command without --async blocks us until checksum is recalculated
-time assert_success saunafs-admin magic-recalculate-metadata-checksum localhost "$port" <<< "pass"
+time assert_success saunafs_admin_command magic-recalculate-metadata-checksum localhost "$port" <<< "pass"
 log_data=$(tail -n 100 "$TEMP_DIR/log")
 assert_equals 1 $(echo "$log_data" | grep updater_end | wc -l)
 assert_equals 1 $(echo "$log_data" | grep updater_start | wc -l)
 
 # Verify if the command with --async starts the process, but doesn't block us
-time assert_success saunafs-admin magic-recalculate-metadata-checksum localhost "$port" --async <<< "pass"
+time assert_success saunafs_admin_command magic-recalculate-metadata-checksum localhost "$port" --async <<< "pass"
 log_data=$(tail -n 100 "$TEMP_DIR/log")
 assert_equals 2 $(echo "$log_data" | grep updater_start | wc -l)
 assert_equals 1 $(echo "$log_data" | grep updater_end | wc -l)

--- a/tests/test_suites/ShortSystemTests/test_admin_save_metadata.sh
+++ b/tests/test_suites/ShortSystemTests/test_admin_save_metadata.sh
@@ -29,28 +29,28 @@ expect_equals 2 $(count_metadata_files) # 'SFSM NEW' and it's binary form
 # Verify if wrong password doesn't work
 touch "${info[mount0]}/file1"  # To make changelog not empty for metarestore
 rm -f "$TEMP_DIR"/dump_*
-assert_failure saunafs-admin save-metadata localhost "$port" <<< "no-pass"
+assert_failure saunafs_admin_command save-metadata localhost "$port" <<< "no-pass"
 assert_equals 2 $(count_metadata_files)
 assert_file_not_exists "$TEMP_DIR/dump_started"
 
 # Verify if the command without --async blocks us until metadata is created
 touch "${info[mount0]}/file2"  # To make changelog not empty for metarestore
 rm -f "$TEMP_DIR"/dump_*
-assert_success saunafs-admin save-metadata localhost "$port" <<< "pass"
+assert_success saunafs_admin_command save-metadata localhost "$port" <<< "pass"
 assert_file_exists "$TEMP_DIR/dump_finished"
 assert_equals 3 $(count_metadata_files)
 
 # Verify if the command with --async starts the process, but doesn't block us
 rm -f $TEMP_DIR/dump_*
 touch "${info[mount0]}/file3"  # To make changelog not empty for metarestore
-assert_success saunafs-admin save-metadata localhost "$port" --async <<< "pass"
+assert_success saunafs_admin_command save-metadata localhost "$port" --async <<< "pass"
 assert_file_not_exists "$TEMP_DIR/dump_finished"
 assert_equals 3 $(count_metadata_files)
 
 # Verify if the command fails if a dump is in progress
 touch "${info[mount0]}/file4"  # To make changelog not empty for metarestore
-assert_failure saunafs-admin save-metadata localhost "$port" --async <<< "pass"
-assert_failure saunafs-admin save-metadata localhost "$port" <<< "pass"
+assert_failure saunafs_admin_command save-metadata localhost "$port" --async <<< "pass"
+assert_failure saunafs_admin_command save-metadata localhost "$port" <<< "pass"
 assert_equals 3 $(count_metadata_files)
 
 # Verify if the async dump eventually finishes
@@ -58,13 +58,13 @@ assert_eventually_prints 4 'count_metadata_files'
 
 # Verify if save-metadata properly reports status of the operation (using metarestore)
 chmod -w "${info[master_data_path]}"  # Make it impossible to save metadata
-assert_failure saunafs-admin save-metadata localhost "$port" <<< "pass"
+assert_failure saunafs_admin_command save-metadata localhost "$port" <<< "pass"
 chmod +w "${info[master_data_path]}"  # Fix data dir
 
 # Verify if save-metadata properly reports status of the operation (using fork)
 sed -i -re "s/(MAGIC_PREFER_BACKGROUND_DUMP).*/\1 = 0/" "${info[master_cfg]}"
 saunafs_admin_master reload-config
-assert_success saunafs-admin save-metadata localhost "$port" <<< "pass"
+assert_success saunafs_admin_command save-metadata localhost "$port" <<< "pass"
 chmod -w "${info[master_data_path]}"  # Make it impossible to save metadata
-assert_failure saunafs-admin save-metadata localhost "$port" <<< "pass"
+assert_failure saunafs_admin_command save-metadata localhost "$port" <<< "pass"
 chmod +w "${info[master_data_path]}"  # Fix data dir

--- a/tests/test_suites/ShortSystemTests/test_replication_bandwidth_limiting.sh
+++ b/tests/test_suites/ShortSystemTests/test_replication_bandwidth_limiting.sh
@@ -14,7 +14,7 @@ CHUNKSERVERS=2 \
 	setup_local_empty_saunafs info
 
 chunks_health() {
-	saunafs-admin chunks-health --porcelain localhost "${info[matocl]}"
+	saunafs_admin_command chunks-health --porcelain localhost "${info[matocl]}"
 }
 
 cd "${info[mount0]}"

--- a/tests/tools/config.sh
+++ b/tests/tools/config.sh
@@ -50,6 +50,7 @@ export PATH="$SAUNAFS_ROOT/sbin:$SAUNAFS_ROOT/bin:$PATH"
 if is_windows_system; then
 	export PATH="$(get_windows_homepath)/SaunaFS:/mnt/c/Windows/System32:$PATH"
 	export SAFS_MOUNT_COMMAND="sfsmount.exe"
+	export SAFS_ADMIN_COMMAND="saunafs-admin.exe"
 fi
 
 # Quick checks needed to call test_begin and test_fail

--- a/tests/tools/saunafs.sh
+++ b/tests/tools/saunafs.sh
@@ -131,6 +131,15 @@ setup_local_empty_saunafs() {
 	done
 }
 
+saunafs_admin_command() {
+	if is_windows_system; then
+		${SAFS_ADMIN_COMMAND} "$@" | tr -d '\r'
+	else
+		saunafs-admin "$@"
+	fi
+	return ${PIPESTATUS[0]}
+}
+
 saunafs_fusermount() {
 	fuse_version=$(${SAFS_MOUNT_COMMAND} --version 2>&1 | grep "FUSE library" | grep -Eo "[0-9]+\..+")
 	if [[ "$fuse_version" =~ ^3\..+$ ]]; then


### PR DESCRIPTION
This commit fixes tests for saunafs-admin to be run on the Windows testing framework.