### PR TITLE
Refactor chunkserver bgjobs

### DIFF
--- a/src/chunkserver/bgjobs.cc
+++ b/src/chunkserver/bgjobs.cc
@@ -49,7 +49,9 @@ constexpr auto kInvalidJob = nullptr;
 
 JobPool::JobPool(uint8_t workers, uint32_t maxJobs, int *wakeupDesc) : workers(workers) {
 	int fd[2];
-	if (pipe(fd) < 0) { throw std::runtime_error("Failed to create pipe"); }
+	if (pipe(fd) < 0) {  // pipe is a critical resource for communication within the JobPool
+		throw std::runtime_error("Failed to create pipe: " + std::string(strerror(errno)));
+	}
 	rpipe = fd[0];
 	wpipe = fd[1];
 

--- a/src/chunkserver/bgjobs.cc
+++ b/src/chunkserver/bgjobs.cc
@@ -44,9 +44,6 @@
 #include <utility>
 #include <vector>
 
-#define JHASHSIZE 0x400
-#define JHASHPOS(id) ((id)&0x3FF)
-
 constexpr auto kInvalidJob = nullptr;
 
 JobPool::JobPool(uint8_t workers, uint32_t maxJobs, int *wakeupDesc) : workers(workers) {

--- a/src/chunkserver/bgjobs.cc
+++ b/src/chunkserver/bgjobs.cc
@@ -177,7 +177,7 @@ void JobPool::workerThread() {
 
 		if (jobState == State::Disabled) {
 			status = SAUNAFS_ERROR_NOTDONE;
-			sendStatus(jobId, status);
+			jobsUniqueLock.unlock();
 			continue;
 		}
 

--- a/src/chunkserver/bgjobs.cc
+++ b/src/chunkserver/bgjobs.cc
@@ -47,10 +47,6 @@
 #define JHASHSIZE 0x400
 #define JHASHPOS(id) ((id)&0x3FF)
 
-/// This is a special value used to determine the chunk operation that will be executed
-/// by \ref hddChunkOperation function.
-constexpr uint32_t kWildCardLength = 0xFFFFFFFF;
-
 constexpr auto kInvalidJob = nullptr;
 
 
@@ -263,14 +259,51 @@ void JobPool::workerThread() {
 			status = SAUNAFS_ERROR_EINVAL;
 			break;
 		}
-		case ChunkOperation::ChunkOp:
+		case ChunkOperation::Delete:
 		{
 			auto args =
 			    std::unique_ptr<chunk_chunkop_args>(static_cast<chunk_chunkop_args *>(job->args));
-			// TODO(Crash): Refactor hddChunkOperation and separate operations and states
-			status =
-			    hddChunkOperation(args->chunkid, args->version, args->chunkType, args->newversion,
-			                      args->copychunkid, args->copyversion, args->length);
+			status = hddInternalDelete(args->chunkid, args->version, args->chunkType);
+			break;
+		}
+		case ChunkOperation::Create:
+		{
+			auto args =
+			    std::unique_ptr<chunk_chunkop_args>(static_cast<chunk_chunkop_args *>(job->args));
+			status = hddInternalCreate(args->chunkid, args->version, args->chunkType);
+			break;
+		}
+		case ChunkOperation::ChangeVersion:
+		{
+			auto args =
+			    std::unique_ptr<chunk_chunkop_args>(static_cast<chunk_chunkop_args *>(job->args));
+			status = hddInternalUpdateVersion(args->chunkid, args->version, args->newversion,
+			                                  args->chunkType);
+			break;
+		}
+		case ChunkOperation::Truncate:
+		{
+			auto args =
+			    std::unique_ptr<chunk_chunkop_args>(static_cast<chunk_chunkop_args *>(job->args));
+			status = hddTruncate(args->chunkid, args->version, args->chunkType, args->newversion,
+			                     args->length);
+			break;
+		}
+		case ChunkOperation::Duplicate:
+		{
+			auto args =
+			    std::unique_ptr<chunk_chunkop_args>(static_cast<chunk_chunkop_args *>(job->args));
+			status = hddDuplicate(args->chunkid, args->version, args->newversion, args->chunkType,
+			                      args->copychunkid, args->copyversion);
+			break;
+		}
+		case ChunkOperation::DuplicateTruncate:
+		{
+			auto args =
+			    std::unique_ptr<chunk_chunkop_args>(static_cast<chunk_chunkop_args *>(job->args));
+			status = hddDuplicateTruncate(args->chunkid, args->version, args->newversion,
+			                              args->chunkType, args->copychunkid, args->copyversion,
+			                              args->length);
 			break;
 		}
 		case ChunkOperation::Open:
@@ -471,43 +504,41 @@ uint32_t job_replicate(JobPool &jobPool, JobPool::JobCallback callback, void *ex
 	                      extra);
 }
 
-uint32_t job_chunkop(JobPool &jobPool, JobPool::JobCallback callback, void *extra, uint64_t chunkId,
-                     uint32_t chunkVersion, ChunkPartType chunkType, uint32_t newChunkVersion,
-                     uint64_t copyChunkId, uint32_t copyChunkVersion, uint32_t length) {
-    auto args = std::make_unique<chunk_chunkop_args>();
-    args->chunkid = chunkId;
-    args->version = chunkVersion;
-    args->newversion = newChunkVersion;
-    args->copychunkid = copyChunkId;
-    args->copyversion = copyChunkVersion;
-    args->length = length;
-    args->chunkType = chunkType;
-	return jobPool.addJob(JobPool::ChunkOperation::ChunkOp, args.release(), std::move(callback),
-	                      extra);
-}
-
 uint32_t job_invalid(JobPool &jobPool, JobPool::JobCallback callback, void *extra) {
 	return jobPool.addJob(JobPool::ChunkOperation::Invalid, nullptr, std::move(callback), extra);
 }
 
 uint32_t job_delete(JobPool &jobPool, JobPool::JobCallback callback, void *extra, uint64_t chunkId,
 	uint32_t chunkVersion, ChunkPartType chunkType) {
-	return job_chunkop(jobPool, std::move(callback), extra, chunkId, chunkVersion, chunkType, 0, 0,
-	                   0, 0);
+	auto args = std::make_unique<chunk_chunkop_args>();
+	args->chunkid = chunkId;
+	args->version = chunkVersion;
+	args->chunkType = chunkType;
+	return jobPool.addJob(JobPool::ChunkOperation::Delete, args.release(), std::move(callback),
+	                      extra);
 }
 
 uint32_t job_create(JobPool &jobPool, JobPool::JobCallback callback, void *extra, uint64_t chunkId,
 	uint32_t chunkVersion, ChunkPartType chunkType) {
-	return job_chunkop(jobPool, std::move(callback), extra, chunkId, chunkVersion, chunkType, 0, 0,
-	                   0, 1);
+	auto args = std::make_unique<chunk_chunkop_args>();
+	args->chunkid = chunkId;
+	args->version = chunkVersion;
+	args->chunkType = chunkType;
+	return jobPool.addJob(JobPool::ChunkOperation::Create, args.release(), std::move(callback),
+	                      extra);
 }
 
 uint32_t job_version(JobPool &jobPool, const JobPool::JobCallback &callback, void *extra,
                      uint64_t chunkId, uint32_t chunkVersion, ChunkPartType chunkType,
                      uint32_t newChunkVersion) {
 	if (newChunkVersion > 0) {
-		return job_chunkop(jobPool, callback, extra, chunkId, chunkVersion, chunkType,
-		                   newChunkVersion, 0, 0, kWildCardLength);
+		auto args = std::make_unique<chunk_chunkop_args>();
+		args->chunkid = chunkId;
+		args->version = chunkVersion;
+		args->newversion = newChunkVersion;
+		args->chunkType = chunkType;
+		return jobPool.addJob(JobPool::ChunkOperation::ChangeVersion, args.release(), callback,
+		                      extra);
 	}
 	return job_invalid(jobPool, callback, extra);
 }
@@ -515,9 +546,14 @@ uint32_t job_version(JobPool &jobPool, const JobPool::JobCallback &callback, voi
 uint32_t job_truncate(JobPool &jobPool, const JobPool::JobCallback &callback, void *extra,
 	uint64_t chunkId, ChunkPartType chunkType, uint32_t chunkVersion,
 	uint32_t newChunkVersion, uint32_t length) {
-	if (newChunkVersion > 0 && length != kWildCardLength) {
-		return job_chunkop(jobPool, callback, extra, chunkId, chunkVersion, chunkType,
-		                   newChunkVersion, 0, 0, length);
+	if (newChunkVersion > 0) {
+		auto args = std::make_unique<chunk_chunkop_args>();
+		args->chunkid = chunkId;
+		args->version = chunkVersion;
+		args->newversion = newChunkVersion;
+		args->length = length;
+		args->chunkType = chunkType;
+		return jobPool.addJob(JobPool::ChunkOperation::Truncate, args.release(), callback, extra);
 	}
 	return job_invalid(jobPool, callback, extra);
 }
@@ -525,9 +561,15 @@ uint32_t job_truncate(JobPool &jobPool, const JobPool::JobCallback &callback, vo
 uint32_t job_duplicate(JobPool &jobPool, const JobPool::JobCallback &callback, void *extra,
                        uint64_t chunkId, uint32_t chunkVersion, uint32_t newChunkVersion,
                        ChunkPartType chunkType, uint64_t chunkIdCopy, uint32_t chunkVersionCopy) {
-	if (newChunkVersion > 0 && chunkIdCopy > 0) {
-		return job_chunkop(jobPool, callback, extra, chunkId, chunkVersion, chunkType,
-		                   newChunkVersion, chunkIdCopy, chunkVersionCopy, kWildCardLength);
+	if (newChunkVersion > 0) {
+		auto args = std::make_unique<chunk_chunkop_args>();
+		args->chunkid = chunkId;
+		args->version = chunkVersion;
+		args->newversion = newChunkVersion;
+		args->chunkType = chunkType;
+		args->copychunkid = chunkIdCopy;
+		args->copyversion = chunkVersionCopy;
+		return jobPool.addJob(JobPool::ChunkOperation::Duplicate, args.release(), callback, extra);
 	}
 	return job_invalid(jobPool, callback, extra);
 }
@@ -536,9 +578,17 @@ uint32_t job_duptrunc(JobPool &jobPool, const JobPool::JobCallback &callback, vo
                       uint64_t chunkId, uint32_t chunkVersion, uint32_t newChunkVersion,
                       ChunkPartType chunkType, uint64_t chunkIdCopy, uint32_t chunkVersionCopy,
                       uint32_t length) {
-	if (newChunkVersion > 0 && chunkIdCopy > 0 && length != kWildCardLength) {
-		return job_chunkop(jobPool, callback, extra, chunkId, chunkVersion, chunkType,
-		                   newChunkVersion, chunkIdCopy, chunkVersionCopy, length);
+	if (newChunkVersion > 0) {
+		auto args = std::make_unique<chunk_chunkop_args>();
+		args->chunkid = chunkId;
+		args->version = chunkVersion;
+		args->newversion = newChunkVersion;
+		args->copychunkid = chunkIdCopy;
+		args->copyversion = chunkVersionCopy;
+		args->length = length;
+		args->chunkType = chunkType;
+		return jobPool.addJob(JobPool::ChunkOperation::DuplicateTruncate, args.release(), callback,
+		                      extra);
 	}
 	return job_invalid(jobPool, callback, extra);
 }

--- a/src/chunkserver/bgjobs.cc
+++ b/src/chunkserver/bgjobs.cc
@@ -49,75 +49,6 @@
 
 constexpr auto kInvalidJob = nullptr;
 
-
-// for ChunkOp
-struct chunk_chunkop_args {
-	uint64_t chunkid,copychunkid;
-	uint32_t version,newversion,copyversion;
-	uint32_t length;
-	ChunkPartType chunkType;
-};
-
-// for Open and Close
-struct chunk_open_and_close_args {
-	uint64_t chunkid;
-	ChunkPartType chunkType;
-};
-
-// for Read
-struct chunk_read_args {
-	uint64_t chunkid;
-	uint32_t version;
-	ChunkPartType chunkType;
-	uint32_t offset,size;
-	uint8_t *crcbuff;
-	uint32_t maxBlocksToBeReadBehind;
-	uint32_t blocksToBeReadAhead;
-	OutputBuffer* outputBuffer;
-	bool performHddOpen;
-};
-
-// for Prefetch
-struct chunk_prefetch_args {
-	uint64_t chunkid;
-	uint32_t version;
-	ChunkPartType chunkType;
-	uint32_t firstBlock;
-	uint32_t nrOfBlocks;
-};
-
-// for Write
- struct chunk_write_args {
-	uint64_t chunkId;
-	uint32_t chunkVersion;
-	ChunkPartType chunkType;
-	uint16_t blocknum;
-	uint32_t offset, size;
-	uint32_t crc;
-	const uint8_t *buffer;
-};
-
-struct chunk_get_blocks_args {
-	uint64_t chunkId;
-	uint32_t chunkVersion;
-	ChunkPartType chunkType;
-	uint16_t* blocks;
-};
-
-struct chunk_legacy_replication_args {
-	uint64_t chunkid;
-	uint32_t version;
-	uint8_t srccnt;
-};
-
-struct chunk_replication_args {
-	uint64_t chunkId;
-	uint32_t chunkVersion;
-	ChunkPartType chunkType;
-	uint32_t sourcesBufferSize;
-	uint8_t* sourcesBuffer;
-};
-
 JobPool::JobPool(uint8_t workers, uint32_t maxJobs, int *wakeupDesc) : workers(workers) {
 	int fd[2];
 	if (pipe(fd) < 0) { throw std::runtime_error("Failed to create pipe"); }
@@ -154,14 +85,15 @@ JobPool::~JobPool() {
 	close(wpipe);
 }
 
-uint32_t JobPool::addJob(ChunkOperation operation, void *args, JobCallback callback, void *extra) {
+uint32_t JobPool::addJob(ChunkOperation operation, JobCallback callback, void *extra,
+                         ProcessJobCallback processJob) {
 	std::unique_lock lock(jobsMutex);
 	uint32_t jobId = nextJobId++;
 	auto job = std::make_unique<Job>();
 	job->jobId = jobId;
 	job->callback = std::move(callback);
+	job->processJob = std::move(processJob);
 	job->extra = extra;
-	job->args = args;
 	job->state = JobPool::State::Enabled;
 	jobHash[jobId] = std::move(job);
 	jobsQueue->put(jobId, operation, reinterpret_cast<uint8_t *>(jobHash[jobId].get()), 1);
@@ -253,144 +185,12 @@ void JobPool::workerThread() {
 		}
 
 		jobsUniqueLock.unlock();
-		switch (operation) {
-		case ChunkOperation::Invalid:
-		{
-			status = SAUNAFS_ERROR_EINVAL;
-			break;
-		}
-		case ChunkOperation::Delete:
-		{
-			auto args =
-			    std::unique_ptr<chunk_chunkop_args>(static_cast<chunk_chunkop_args *>(job->args));
-			status = hddInternalDelete(args->chunkid, args->version, args->chunkType);
-			break;
-		}
-		case ChunkOperation::Create:
-		{
-			auto args =
-			    std::unique_ptr<chunk_chunkop_args>(static_cast<chunk_chunkop_args *>(job->args));
-			status = hddInternalCreate(args->chunkid, args->version, args->chunkType);
-			break;
-		}
-		case ChunkOperation::ChangeVersion:
-		{
-			auto args =
-			    std::unique_ptr<chunk_chunkop_args>(static_cast<chunk_chunkop_args *>(job->args));
-			status = hddInternalUpdateVersion(args->chunkid, args->version, args->newversion,
-			                                  args->chunkType);
-			break;
-		}
-		case ChunkOperation::Truncate:
-		{
-			auto args =
-			    std::unique_ptr<chunk_chunkop_args>(static_cast<chunk_chunkop_args *>(job->args));
-			status = hddTruncate(args->chunkid, args->version, args->chunkType, args->newversion,
-			                     args->length);
-			break;
-		}
-		case ChunkOperation::Duplicate:
-		{
-			auto args =
-			    std::unique_ptr<chunk_chunkop_args>(static_cast<chunk_chunkop_args *>(job->args));
-			status = hddDuplicate(args->chunkid, args->version, args->newversion, args->chunkType,
-			                      args->copychunkid, args->copyversion);
-			break;
-		}
-		case ChunkOperation::DuplicateTruncate:
-		{
-			auto args =
-			    std::unique_ptr<chunk_chunkop_args>(static_cast<chunk_chunkop_args *>(job->args));
-			status = hddDuplicateTruncate(args->chunkid, args->version, args->newversion,
-			                              args->chunkType, args->copychunkid, args->copyversion,
-			                              args->length);
-			break;
-		}
-		case ChunkOperation::Open:
-		{
-			auto args = std::unique_ptr<chunk_open_and_close_args>(
-			    static_cast<chunk_open_and_close_args *>(job->args));
-			status = hddOpen(args->chunkid, args->chunkType);
-			break;
-		}
-		case ChunkOperation::Close:
-		{
-			auto args = std::unique_ptr<chunk_open_and_close_args>(
-			    static_cast<chunk_open_and_close_args *>(job->args));
-			status = hddClose(args->chunkid, args->chunkType);
-			break;
-		}
-		case ChunkOperation::Read:
-		{
-			auto args = std::unique_ptr<chunk_read_args>(static_cast<chunk_read_args *>(job->args));
-			LOG_AVG_TILL_END_OF_SCOPE0("job_read");
-			if (args->performHddOpen) {
-				status = hddOpen(args->chunkid, args->chunkType);
-				if (status != SAUNAFS_STATUS_OK) { break; }
-			}
 
-			status = hddRead(args->chunkid, args->version, args->chunkType, args->offset,
-			                 args->size, args->maxBlocksToBeReadBehind, args->blocksToBeReadAhead,
-			                 args->outputBuffer);
-
-			if (args->performHddOpen && status != SAUNAFS_STATUS_OK) {
-				int ret = hddClose(args->chunkid, args->chunkType);
-				if (ret != SAUNAFS_STATUS_OK) {
-					safs_silent_syslog(LOG_ERR,
-					                   "read job: cannot close chunk after read error (%s): %s",
-					                   saunafs_error_string(status), saunafs_error_string(ret));
-				}
-			}
-			break;
-		}
-		case ChunkOperation::Prefetch:
-		{
-			auto args =
-			    std::unique_ptr<chunk_prefetch_args>(static_cast<chunk_prefetch_args *>(job->args));
-			status = hddPrefetchBlocks(args->chunkid, args->chunkType, args->firstBlock,
-			                           args->nrOfBlocks);
-			break;
-		}
-		case ChunkOperation::Write:
-		{
-			auto args =
-			    std::unique_ptr<chunk_write_args>(static_cast<chunk_write_args *>(job->args));
-			status = hddChunkWriteBlock(args->chunkId, args->chunkVersion, args->chunkType,
-			                            args->blocknum, args->offset, args->size, args->crc,
-			                            args->buffer);
-			if (status != SAUNAFS_STATUS_OK) {
-				safs::log_err("Failed to write chunk id {}: {}", args->chunkId,
-				              saunafs_error_string(status));
-			}
-			break;
-		}
-		case ChunkOperation::Replicate:
-		{
-			auto args = std::unique_ptr<chunk_replication_args>(
-			    static_cast<chunk_replication_args *>(job->args));
-			try {
-				std::vector<ChunkTypeWithAddress> sources;
-				deserialize(args->sourcesBuffer, args->sourcesBufferSize, sources);
-				ChunkFileCreator creator(args->chunkId, args->chunkVersion, args->chunkType);
-				gReplicator.replicate(creator, sources);
-				status = SAUNAFS_STATUS_OK;
-			} catch (Exception &ex) {
-				safs_pretty_syslog(LOG_WARNING, "replication error: %s", ex.what());
-				status = ex.status();
-			}
-			break;
-		}
-		case ChunkOperation::GetBlocks:
-		{
-			auto args = std::unique_ptr<chunk_get_blocks_args>(
-			    static_cast<chunk_get_blocks_args *>(job->args));
-			status = hddChunkGetNumberOfBlocks(args->chunkId, args->chunkType, args->chunkVersion,
-			                                   args->blocks);
-			break;
-		}
-		default:
-			status = SAUNAFS_ERROR_EINVAL;
-			break;
+		auto processJobCallback = job->processJob;
+		if (processJobCallback) {
+			status = processJobCallback();
+		} else {
+			status = SAUNAFS_ERROR_NOTDONE;
 		}
 
 		sendStatus(jobId, status);
@@ -417,128 +217,134 @@ int JobPool::receiveStatus(uint32_t &jobId, uint8_t &status) {
 
 uint32_t job_open(JobPool &jobPool, JobPool::JobCallback callback, void *extra, uint64_t chunkId,
                   ChunkPartType chunkType) {
-	auto args = std::make_unique<chunk_open_and_close_args>();
-	args->chunkid = chunkId;
-	args->chunkType = chunkType;
-	return jobPool.addJob(JobPool::ChunkOperation::Open, args.release(), std::move(callback),
-	                      extra);
+	JobPool::ProcessJobCallback processJob = [=]() -> uint8_t {
+		return hddOpen(chunkId, chunkType);
+	};
+	return jobPool.addJob(JobPool::ChunkOperation::Open, std::move(callback), extra, processJob);
 }
 
 uint32_t job_close(JobPool &jobPool, JobPool::JobCallback callback, void *extra, uint64_t chunkId,
 	ChunkPartType chunkType) {
-	auto args = std::make_unique<chunk_open_and_close_args>();
-	args->chunkid = chunkId;
-	args->chunkType = chunkType;
-	return jobPool.addJob(JobPool::ChunkOperation::Close, args.release(), std::move(callback),
-	                      extra);
+	JobPool::ProcessJobCallback processJob = [=]() -> uint8_t {
+		return hddClose(chunkId, chunkType);
+	};
+	return jobPool.addJob(JobPool::ChunkOperation::Close, std::move(callback), extra, processJob);
 }
 
 uint32_t job_read(JobPool &jobPool, JobPool::JobCallback callback, void *extra, uint64_t chunkId,
                   uint32_t version, ChunkPartType chunkType, uint32_t offset, uint32_t size,
                   uint32_t maxBlocksToBeReadBehind, uint32_t blocksToBeReadAhead,
                   OutputBuffer *outputBuffer, bool performHddOpen) {
-	auto args = std::make_unique<chunk_read_args>();
-	args->chunkid = chunkId;
-	args->version = version;
-	args->chunkType = chunkType;
-	args->offset = offset;
-	args->size = size;
-	args->maxBlocksToBeReadBehind = maxBlocksToBeReadBehind;
-	args->blocksToBeReadAhead = blocksToBeReadAhead;
-	args->outputBuffer = outputBuffer;
-	args->performHddOpen = performHddOpen;
-	return jobPool.addJob(JobPool::ChunkOperation::Read, args.release(), std::move(callback),
-	                      extra);
+	JobPool::ProcessJobCallback processJob = [=]() -> uint8_t {
+		LOG_AVG_TILL_END_OF_SCOPE0("job_read");
+		uint8_t status = SAUNAFS_STATUS_OK;
+		if (performHddOpen) {
+			status = hddOpen(chunkId, chunkType);
+			if (status != SAUNAFS_STATUS_OK) { return status; }
+		}
+
+		status = hddRead(chunkId, version, chunkType, offset, size, maxBlocksToBeReadBehind,
+		                 blocksToBeReadAhead, outputBuffer);
+
+		if (performHddOpen && status != SAUNAFS_STATUS_OK) {
+			int ret = hddClose(chunkId, chunkType);
+			if (ret != SAUNAFS_STATUS_OK) {
+				safs_silent_syslog(LOG_ERR,
+				                   "read job: cannot close chunk after read error (%s): %s",
+				                   saunafs_error_string(status), saunafs_error_string(ret));
+			}
+		}
+		return status;
+	};
+	return jobPool.addJob(JobPool::ChunkOperation::Read, std::move(callback), extra, processJob);
 }
 
-uint32_t job_prefetch(JobPool &jobPool, uint64_t chunkId, uint32_t version, ChunkPartType chunkType,
+uint32_t job_prefetch(JobPool &jobPool, uint64_t chunkId, uint32_t  /*version*/, ChunkPartType chunkType,
 	uint32_t firstBlockToBePrefetched, uint32_t blocksToBePrefetched) {
-	auto args = std::make_unique<chunk_prefetch_args>();
-	args->chunkid = chunkId;
-	args->version = version;
-	args->chunkType = chunkType;
-	args->firstBlock = firstBlockToBePrefetched;
-	args->nrOfBlocks = blocksToBePrefetched;
-	return jobPool.addJob(JobPool::ChunkOperation::Prefetch, args.release(), nullptr, nullptr);
+	JobPool::ProcessJobCallback processJob = [=]() -> uint8_t {
+		return hddPrefetchBlocks(chunkId, chunkType, firstBlockToBePrefetched,
+		                         blocksToBePrefetched);
+	};
+	return jobPool.addJob(JobPool::ChunkOperation::Prefetch, nullptr, nullptr, processJob);
 }
 
 uint32_t job_write(JobPool &jobPool, JobPool::JobCallback callback, void *extra, uint64_t chunkId,
                    uint32_t chunkVersion, ChunkPartType chunkType, uint16_t blockNum,
                    uint32_t offset, uint32_t size, uint32_t crc, const uint8_t *buffer) {
-	auto args = std::make_unique<chunk_write_args>();
-	args->chunkId = chunkId;
-	args->chunkVersion = chunkVersion;
-	args->chunkType = chunkType;
-	args->blocknum = blockNum;
-	args->offset = offset;
-	args->size = size;
-	args->crc = crc;
-	args->buffer = buffer;
-	return jobPool.addJob(JobPool::ChunkOperation::Write, args.release(), std::move(callback),
-	                      extra);
+	JobPool::ProcessJobCallback processJob = [=]() -> uint8_t {
+		auto status = hddChunkWriteBlock(chunkId, chunkVersion, chunkType, blockNum, offset, size,
+		                                 crc, buffer);
+
+		if (status != SAUNAFS_STATUS_OK) {
+			safs::log_err("Failed to write chunk id {}: {}", chunkId, saunafs_error_string(status));
+		}
+
+		return status;
+	};
+	return jobPool.addJob(JobPool::ChunkOperation::Write, std::move(callback), extra, processJob);
 }
 
 uint32_t job_get_blocks(JobPool &jobPool, JobPool::JobCallback callback, void *extra,
                         uint64_t chunkId, uint32_t version, ChunkPartType chunkType,
                         uint16_t *blocks) {
-	auto args = std::make_unique<chunk_get_blocks_args>();
-	args->chunkId = chunkId;
-	args->chunkVersion = version;
-	args->chunkType = chunkType;
-	args->blocks = blocks;
-	return jobPool.addJob(JobPool::ChunkOperation::GetBlocks, args.release(), std::move(callback),
-	                      extra);
+	JobPool::ProcessJobCallback processJob = [=]() -> uint8_t {
+		return hddChunkGetNumberOfBlocks(chunkId, chunkType, version, blocks);
+	};
+	return jobPool.addJob(JobPool::ChunkOperation::GetBlocks, std::move(callback), extra,
+	                      processJob);
 }
 
 uint32_t job_replicate(JobPool &jobPool, JobPool::JobCallback callback, void *extra,
                        uint64_t chunkId, uint32_t chunkVersion, ChunkPartType chunkType,
                        uint32_t sourcesBufferSize, const uint8_t *sourcesBuffer) {
-	auto args = std::make_unique<chunk_replication_args>();
-	args->chunkId = chunkId;
-	args->chunkVersion = chunkVersion;
-	args->chunkType = chunkType;
-	args->sourcesBufferSize = sourcesBufferSize;
-	args->sourcesBuffer = new uint8_t[sourcesBufferSize];
-	std::memcpy(args->sourcesBuffer, sourcesBuffer, sourcesBufferSize);
-	return jobPool.addJob(JobPool::ChunkOperation::Replicate, args.release(), std::move(callback),
-	                      extra);
+	JobPool::ProcessJobCallback processJob = [=]() -> uint8_t {
+		uint8_t status = SAUNAFS_STATUS_OK;
+		try {
+			std::vector<ChunkTypeWithAddress> sources;
+			deserialize(sourcesBuffer, sourcesBufferSize, sources);
+			ChunkFileCreator creator(chunkId, chunkVersion, chunkType);
+			gReplicator.replicate(creator, sources);
+		} catch (Exception &ex) {
+			safs_pretty_syslog(LOG_WARNING, "replication error: %s", ex.what());
+			status = ex.status();
+		}
+		return status;
+	};
+	return jobPool.addJob(JobPool::ChunkOperation::Replicate, std::move(callback), extra,
+	                      processJob);
 }
 
 uint32_t job_invalid(JobPool &jobPool, JobPool::JobCallback callback, void *extra) {
-	return jobPool.addJob(JobPool::ChunkOperation::Invalid, nullptr, std::move(callback), extra);
+	JobPool::ProcessJobCallback processJob = [=]() -> uint8_t {
+		return SAUNAFS_ERROR_EINVAL;
+	};
+	return jobPool.addJob(JobPool::ChunkOperation::Invalid, std::move(callback), extra, processJob);
 }
 
 uint32_t job_delete(JobPool &jobPool, JobPool::JobCallback callback, void *extra, uint64_t chunkId,
 	uint32_t chunkVersion, ChunkPartType chunkType) {
-	auto args = std::make_unique<chunk_chunkop_args>();
-	args->chunkid = chunkId;
-	args->version = chunkVersion;
-	args->chunkType = chunkType;
-	return jobPool.addJob(JobPool::ChunkOperation::Delete, args.release(), std::move(callback),
-	                      extra);
+	JobPool::ProcessJobCallback processJob = [=]() -> uint8_t {
+		return hddInternalDelete(chunkId, chunkVersion, chunkType);
+	};
+	return jobPool.addJob(JobPool::ChunkOperation::Delete, std::move(callback), extra, processJob);
 }
 
 uint32_t job_create(JobPool &jobPool, JobPool::JobCallback callback, void *extra, uint64_t chunkId,
 	uint32_t chunkVersion, ChunkPartType chunkType) {
-	auto args = std::make_unique<chunk_chunkop_args>();
-	args->chunkid = chunkId;
-	args->version = chunkVersion;
-	args->chunkType = chunkType;
-	return jobPool.addJob(JobPool::ChunkOperation::Create, args.release(), std::move(callback),
-	                      extra);
+	JobPool::ProcessJobCallback processJob = [=]() -> uint8_t {
+		return hddInternalCreate(chunkId, chunkVersion, chunkType);
+	};
+	return jobPool.addJob(JobPool::ChunkOperation::Create, std::move(callback), extra, processJob);
 }
 
 uint32_t job_version(JobPool &jobPool, const JobPool::JobCallback &callback, void *extra,
                      uint64_t chunkId, uint32_t chunkVersion, ChunkPartType chunkType,
                      uint32_t newChunkVersion) {
 	if (newChunkVersion > 0) {
-		auto args = std::make_unique<chunk_chunkop_args>();
-		args->chunkid = chunkId;
-		args->version = chunkVersion;
-		args->newversion = newChunkVersion;
-		args->chunkType = chunkType;
-		return jobPool.addJob(JobPool::ChunkOperation::ChangeVersion, args.release(), callback,
-		                      extra);
+		JobPool::ProcessJobCallback processJob = [=]() -> uint8_t {
+			return hddInternalUpdateVersion(chunkId, chunkVersion, newChunkVersion, chunkType);
+		};
+		return jobPool.addJob(JobPool::ChunkOperation::ChangeVersion, callback, extra, processJob);
 	}
 	return job_invalid(jobPool, callback, extra);
 }
@@ -547,13 +353,10 @@ uint32_t job_truncate(JobPool &jobPool, const JobPool::JobCallback &callback, vo
 	uint64_t chunkId, ChunkPartType chunkType, uint32_t chunkVersion,
 	uint32_t newChunkVersion, uint32_t length) {
 	if (newChunkVersion > 0) {
-		auto args = std::make_unique<chunk_chunkop_args>();
-		args->chunkid = chunkId;
-		args->version = chunkVersion;
-		args->newversion = newChunkVersion;
-		args->length = length;
-		args->chunkType = chunkType;
-		return jobPool.addJob(JobPool::ChunkOperation::Truncate, args.release(), callback, extra);
+		JobPool::ProcessJobCallback processJob = [=]() -> uint8_t {
+			return hddTruncate(chunkId, chunkVersion, chunkType, newChunkVersion, length);
+		};
+		return jobPool.addJob(JobPool::ChunkOperation::Truncate, callback, extra, processJob);
 	}
 	return job_invalid(jobPool, callback, extra);
 }
@@ -562,14 +365,11 @@ uint32_t job_duplicate(JobPool &jobPool, const JobPool::JobCallback &callback, v
                        uint64_t chunkId, uint32_t chunkVersion, uint32_t newChunkVersion,
                        ChunkPartType chunkType, uint64_t chunkIdCopy, uint32_t chunkVersionCopy) {
 	if (newChunkVersion > 0) {
-		auto args = std::make_unique<chunk_chunkop_args>();
-		args->chunkid = chunkId;
-		args->version = chunkVersion;
-		args->newversion = newChunkVersion;
-		args->chunkType = chunkType;
-		args->copychunkid = chunkIdCopy;
-		args->copyversion = chunkVersionCopy;
-		return jobPool.addJob(JobPool::ChunkOperation::Duplicate, args.release(), callback, extra);
+		JobPool::ProcessJobCallback processJob = [=]() -> uint8_t {
+			return hddDuplicate(chunkId, chunkVersion, newChunkVersion, chunkType, chunkIdCopy,
+			                    chunkVersionCopy);
+		};
+		return jobPool.addJob(JobPool::ChunkOperation::Duplicate, callback, extra, processJob);
 	}
 	return job_invalid(jobPool, callback, extra);
 }
@@ -579,16 +379,12 @@ uint32_t job_duptrunc(JobPool &jobPool, const JobPool::JobCallback &callback, vo
                       ChunkPartType chunkType, uint64_t chunkIdCopy, uint32_t chunkVersionCopy,
                       uint32_t length) {
 	if (newChunkVersion > 0) {
-		auto args = std::make_unique<chunk_chunkop_args>();
-		args->chunkid = chunkId;
-		args->version = chunkVersion;
-		args->newversion = newChunkVersion;
-		args->copychunkid = chunkIdCopy;
-		args->copyversion = chunkVersionCopy;
-		args->length = length;
-		args->chunkType = chunkType;
-		return jobPool.addJob(JobPool::ChunkOperation::DuplicateTruncate, args.release(), callback,
-		                      extra);
+		JobPool::ProcessJobCallback processJob = [=]() -> uint8_t {
+			return hddDuplicateTruncate(chunkId, chunkVersion, newChunkVersion, chunkType,
+			                            chunkIdCopy, chunkVersionCopy, length);
+		};
+		return jobPool.addJob(JobPool::ChunkOperation::DuplicateTruncate, callback, extra,
+		                      processJob);
 	}
 	return job_invalid(jobPool, callback, extra);
 }

--- a/src/chunkserver/bgjobs.cc
+++ b/src/chunkserver/bgjobs.cc
@@ -46,11 +46,12 @@
 #include <vector>
 
 constexpr auto kInvalidJob = nullptr;
+constexpr auto STATUS_BYTE_SIZE = 1;
 
 JobPool::JobPool(uint8_t workers, uint32_t maxJobs, int *wakeupDesc) : workers(workers) {
 	int fd[2];
 	if (pipe(fd) < 0) {  // pipe is a critical resource for communication within the JobPool
-		throw std::runtime_error("Failed to create pipe: " + std::string(strerror(errno)));
+		throw std::runtime_error("JobPool: Failed to create pipe: " + std::string(strerror(errno)));
 	}
 	rpipe = fd[0];
 	wpipe = fd[1];
@@ -128,7 +129,7 @@ void JobPool::disableJob(uint32_t jobId) {
 void JobPool::checkJobs() {
 	uint32_t jobId;
 	uint8_t status;
-	int notLastJob = 1;
+	bool notLastJob = true;
 	do {
 		notLastJob = receiveStatus(jobId, status);
 		auto jobIterator = jobHash.find(jobId);
@@ -137,7 +138,7 @@ void JobPool::checkJobs() {
 			if (callback) { callback(status, jobIterator->second->extra); }
 			jobHash.erase(jobIterator);
 		}
-	} while (notLastJob > 0);
+	} while (notLastJob);
 }
 
 void JobPool::changeCallback(uint32_t jobId, JobCallback callback, void *extra) {
@@ -198,20 +199,24 @@ void JobPool::workerThread() {
 
 void JobPool::sendStatus(uint32_t jobId, uint8_t status) {
 	std::lock_guard pipeLockGuard(pipeMutex);
-	if (statusQueue->isEmpty()) { eassert(write(wpipe, &status, 1) == 1); }
+	if (statusQueue->isEmpty()) {
+		eassert(write(wpipe, &status, STATUS_BYTE_SIZE) == STATUS_BYTE_SIZE &&
+		        "JobPool: SendStatus: Failed to write status to pipe");
+	}
 	statusQueue->put(jobId, status, nullptr, 1);
 }
 
-int JobPool::receiveStatus(uint32_t &jobId, uint8_t &status) {
+bool JobPool::receiveStatus(uint32_t &jobId, uint8_t &status) {
 	uint32_t qstatus = 0;
 	std::lock_guard pipeLockGuard(pipeMutex);
 	statusQueue->get(&jobId, &qstatus, nullptr, nullptr);
 	status = qstatus;
 	if (statusQueue->isEmpty()) {
-		eassert(read(rpipe, &qstatus, 1) == 1);
-		return 0;
+		eassert(read(rpipe, &qstatus, STATUS_BYTE_SIZE) == STATUS_BYTE_SIZE &&
+		        "JobPool: ReceiveStatus: Failed to read status from pipe");
+		return false;
 	}
-	return 1;
+	return true;
 }
 
 uint32_t job_open(JobPool &jobPool, JobPool::JobCallback callback, void *extra, uint64_t chunkId,
@@ -257,13 +262,14 @@ uint32_t job_read(JobPool &jobPool, JobPool::JobCallback callback, void *extra, 
 	return jobPool.addJob(JobPool::ChunkOperation::Read, std::move(callback), extra, processJob);
 }
 
-uint32_t job_prefetch(JobPool &jobPool, uint64_t chunkId, uint32_t  /*version*/, ChunkPartType chunkType,
-	uint32_t firstBlockToBePrefetched, uint32_t blocksToBePrefetched) {
+uint32_t job_prefetch(JobPool &jobPool, uint64_t chunkId, ChunkPartType chunkType,
+                      uint32_t firstBlockToBePrefetched, uint32_t blocksToBePrefetched) {
 	JobPool::ProcessJobCallback processJob = [=]() -> uint8_t {
 		return hddPrefetchBlocks(chunkId, chunkType, firstBlockToBePrefetched,
 		                         blocksToBePrefetched);
 	};
-	return jobPool.addJob(JobPool::ChunkOperation::Prefetch, nullptr, nullptr, processJob);
+	return jobPool.addJob(JobPool::ChunkOperation::Prefetch, kEmptyCallback, kEmptyExtra,
+	                      processJob);
 }
 
 uint32_t job_write(JobPool &jobPool, JobPool::JobCallback callback, void *extra, uint64_t chunkId,

--- a/src/chunkserver/bgjobs.cc
+++ b/src/chunkserver/bgjobs.cc
@@ -21,18 +21,6 @@
 #include "common/platform.h"
 #include "chunkserver/bgjobs.h"
 
-#include <cerrno>
-#include <cinttypes>
-#include <climits>
-#include <pthread.h>
-#include <cstdlib>
-#include <cstring>
-#include <syslog.h>
-#include <unistd.h>
-#include <cassert>
-#include <cstdint>
-#include <mutex>
-
 #include "chunkserver/chunk_replicator.h"
 #include "chunkserver/hddspacemgr.h"
 #include "common/chunk_part_type.h"
@@ -42,29 +30,31 @@
 #include "devtools/TracePrinter.h"
 #include "devtools/request_log.h"
 
+#include <atomic>
+#include <cassert>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <sys/syslog.h>
+#include <unistd.h>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
 #define JHASHSIZE 0x400
 #define JHASHPOS(id) ((id)&0x3FF)
 
-enum {
-	JSTATE_DISABLED,
-	JSTATE_ENABLED,
-	JSTATE_INPROGRESS
-};
+/// This is a special value used to determine the chunk operation that will be executed
+/// by \ref hddChunkOperation function.
+constexpr uint32_t kWildCardLength = 0xFFFFFFFF;
 
-enum {
-	OP_EXIT,
-	OP_INVAL,
-	OP_CHUNKOP,
-	OP_OPEN,
-	OP_CLOSE,
-	OP_READ,
-	OP_PREFETCH,
-	OP_WRITE,
-	OP_REPLICATE,
-	OP_GET_BLOCKS
-};
+constexpr auto kInvalidJob = nullptr;
 
-// for OP_CHUNKOP
+
+// for ChunkOp
 struct chunk_chunkop_args {
 	uint64_t chunkid,copychunkid;
 	uint32_t version,newversion,copyversion;
@@ -72,13 +62,13 @@ struct chunk_chunkop_args {
 	ChunkPartType chunkType;
 };
 
-// for OP_OPEN and OP_CLOSE
+// for Open and Close
 struct chunk_open_and_close_args {
 	uint64_t chunkid;
 	ChunkPartType chunkType;
 };
 
-// for OP_READ
+// for Read
 struct chunk_read_args {
 	uint64_t chunkid;
 	uint32_t version;
@@ -91,7 +81,7 @@ struct chunk_read_args {
 	bool performHddOpen;
 };
 
-// for OP_PREFETCH
+// for Prefetch
 struct chunk_prefetch_args {
 	uint64_t chunkid;
 	uint32_t version;
@@ -100,7 +90,7 @@ struct chunk_prefetch_args {
 	uint32_t nrOfBlocks;
 };
 
-// for OP_WRITE
+// for Write
  struct chunk_write_args {
 	uint64_t chunkId;
 	uint32_t chunkVersion;
@@ -132,440 +122,290 @@ struct chunk_replication_args {
 	uint8_t* sourcesBuffer;
 };
 
-struct job {
-	uint32_t jobid;
-	void (*callback)(uint8_t status,void *extra);
-	void *extra;
-	void *args;
-	uint8_t jstate;
-	job *next;
-};
+JobPool::JobPool(uint8_t workers, uint32_t maxJobs, int *wakeupDesc) : workers(workers) {
+	int fd[2];
+	if (pipe(fd) < 0) { throw std::runtime_error("Failed to create pipe"); }
+	rpipe = fd[0];
+	wpipe = fd[1];
 
-struct jobpool {
-	int rpipe,wpipe;
-	uint8_t workers;
-	pthread_t *workerthreads;
-	std::mutex pipeMutex;
-	std::mutex jobsMutex;
-	std::unique_ptr<ProducerConsumerQueue> jobsQueue;
-	std::unique_ptr<ProducerConsumerQueue> statusQueue;
-	job* jobhash[JHASHSIZE];
-	uint32_t nextjobid = 1;
+	*wakeupDesc = fd[0];
 
-	jobpool(int rpipe, int wpipe, uint8_t workers, uint32_t maxJobs)
-	    : rpipe(rpipe), wpipe(wpipe), workers(workers) {
-		workerthreads = (pthread_t *)malloc(sizeof(pthread_t) * workers);
-		passert(workerthreads);
+	jobsQueue = std::make_unique<ProducerConsumerQueue>(maxJobs);
+	statusQueue = std::make_unique<ProducerConsumerQueue>();
 
-		jobsQueue = std::make_unique<ProducerConsumerQueue>(maxJobs);
-		statusQueue = std::make_unique<ProducerConsumerQueue>();
-
-		for (auto &job : jobhash) { job = nullptr; }
-	};
-};
-
-static inline void job_send_status(jobpool *jp, uint32_t jobid, uint8_t status) {
-	TRACETHIS2(jobid, (int)status);
-
-	std::lock_guard pipeLockGuard(jp->pipeMutex);
-
-	if (jp->statusQueue->isEmpty()) {   // first status
-		eassert(write(jp->wpipe,&status,1)==1); // write anything to wake up select
+	for (uint8_t i = 0; i < workers; ++i) {
+		workerThreads.emplace_back(&JobPool::workerThread, this);
 	}
-	jp->statusQueue->put(jobid, status, nullptr, 1);
 }
 
-static inline int job_receive_status(jobpool *jp,uint32_t *jobid,uint8_t *status) {
-	TRACETHIS();
-	uint32_t qstatus;
-
-	std::lock_guard pipeLockGuard(jp->pipeMutex);
-
-	jp->statusQueue->get(jobid, &qstatus, nullptr, nullptr);
-	*status = qstatus;
-	PRINTTHIS(*jobid);
-	PRINTTHIS((int)*status);
-	if (jp->statusQueue->isEmpty()) {
-		eassert(read(jp->rpipe,&qstatus,1)==1); // make pipe empty
-		return 0;       // last element
+JobPool::~JobPool() {
+	for (uint8_t i = 0; i < workers; ++i) {
+		jobsQueue->put(0, JobPool::ChunkOperation::Exit, nullptr, 1);
 	}
-	return 1;       // not last
+
+	for (auto &thread : workerThreads) {
+		if (thread.joinable()) { thread.join(); }
+	}
+
+	if (!statusQueue->isEmpty()) { checkJobs(); }
+
+	jobsQueue.reset();
+	statusQueue.reset();
+
+	workerThreads.clear();
+
+	close(rpipe);
+	close(wpipe);
 }
 
-void* job_worker(void *th_arg) {
-	TRACETHIS();
+uint32_t JobPool::addJob(ChunkOperation operation, void *args, JobCallback callback, void *extra) {
+	std::unique_lock lock(jobsMutex);
+	uint32_t jobId = nextJobId++;
+	auto job = std::make_unique<Job>();
+	job->jobId = jobId;
+	job->callback = std::move(callback);
+	job->extra = extra;
+	job->args = args;
+	job->state = JobPool::State::Enabled;
+	jobHash[jobId] = std::move(job);
+	jobsQueue->put(jobId, operation, reinterpret_cast<uint8_t *>(jobHash[jobId].get()), 1);
+	return jobId;
+}
 
+uint32_t JobPool::getJobCount() const {
+	TRACETHIS();
+	return jobsQueue->elements();
+}
+
+void JobPool::disableAndChangeCallbackAll(const JobCallback& callback) {
+	std::lock_guard jobsLockGuard(jobsMutex);
+	for (auto &[jobId, job] : jobHash) {
+		if (job->state == JobPool::State::Enabled) { job->state = JobPool::State::Disabled; }
+		job->callback = callback;
+	}
+}
+
+void JobPool::disableJob(uint32_t jobId) {
+	std::unique_lock jobsUniqueLock(jobsMutex, std::defer_lock);
+	auto jobIterator = jobHash.find(jobId);
+	if (jobIterator != jobHash.end()) {
+		jobsUniqueLock.lock();
+		if (jobIterator->second->state == JobPool::State::Enabled) {
+			jobIterator->second->state = JobPool::State::Disabled;
+		}
+		jobsUniqueLock.unlock();
+	}
+}
+
+void JobPool::checkJobs() {
+	uint32_t jobId;
+	uint8_t status;
+
+	receiveStatus(jobId, status);
+
+	auto jobIterator = jobHash.find(jobId);
+	if (jobIterator != jobHash.end()) {
+		auto callback = jobIterator->second->callback;
+		if (callback) {
+			callback(status, jobIterator->second->extra);
+		}
+		jobHash.erase(jobIterator);
+	}
+}
+
+void JobPool::changeCallback(uint32_t jobId, JobCallback callback, void *extra) {
+	std::unique_lock lock(jobsMutex);
+	auto jobIterator = jobHash.find(jobId);
+	if (jobIterator != jobHash.end()) {
+		jobIterator->second->callback = std::move(callback);
+		jobIterator->second->extra = extra;
+	}
+}
+
+void JobPool::workerThread() {
 	static std::atomic_uint16_t workersCounter(0);
 	std::string threadName = "jobWorker " + std::to_string(workersCounter++);
 	pthread_setname_np(pthread_self(), threadName.c_str());
 
-	jobpool *jp = (jobpool*)th_arg;
-	job *jptr;
-	uint8_t *jptrarg;
-	uint8_t status, jstate;
-	uint32_t jobid;
-	uint32_t op;
+	uint32_t jobId;
+	uint32_t operation;
+	uint8_t *jobPtrArg;
+	State jobState;
+	uint8_t status = SAUNAFS_STATUS_OK;
 
-	std::unique_lock jobsUniqueLock(jp->jobsMutex, std::defer_lock);
+	std::unique_lock jobsUniqueLock(jobsMutex, std::defer_lock);
 
-	for (;;) {
-		jp->jobsQueue->get(&jobid, &op, &jptrarg, nullptr);
-		jptr = (job*)jptrarg;
-		PRINTTHIS(op);
+	while (true) {
+		jobsQueue->get(&jobId, &operation, &jobPtrArg, nullptr);
+		Job *job = reinterpret_cast<Job *>(jobPtrArg);
+
 		jobsUniqueLock.lock();
-		if (jptr!=NULL) {
-			jstate=jptr->jstate;
-			if (jptr->jstate==JSTATE_ENABLED) {
-				jptr->jstate=JSTATE_INPROGRESS;
-			}
-		} else {
-			jstate=JSTATE_DISABLED;
+		if (job == kInvalidJob) {
+			jobState = State::Disabled;
 		}
+		else {
+			jobState = job->state;
+			if (job->state == State::Enabled) { job->state = State::InProgress; }
+		}
+
+		if (operation == ChunkOperation::Exit) { break; }
+
+		if (jobState == State::Disabled) {
+			status = SAUNAFS_ERROR_NOTDONE;
+			sendStatus(jobId, status);
+			continue;
+		}
+
 		jobsUniqueLock.unlock();
-		switch (op) {
-			case OP_INVAL:
-				status = SAUNAFS_ERROR_EINVAL;
-				break;
-			case OP_CHUNKOP:
-			{
-				auto opargs = (chunk_chunkop_args*)(jptr->args);
-				if (jstate==JSTATE_DISABLED) {
-					status = SAUNAFS_ERROR_NOTDONE;
-				} else {
-					status = hddChunkOperation(opargs->chunkid, opargs->version, opargs->chunkType,
-							opargs->newversion, opargs->copychunkid, opargs->copyversion,
-							opargs->length);
-				}
-				break;
-			}
-			case OP_OPEN:
-			{
-				auto ocargs = (chunk_open_and_close_args*)(jptr->args);
-				if (jstate==JSTATE_DISABLED) {
-					status = SAUNAFS_ERROR_NOTDONE;
-				} else {
-					status = hddOpen(ocargs->chunkid, ocargs->chunkType);
-				}
-				break;
-			}
-			case OP_CLOSE:
-			{
-				auto ocargs = (chunk_open_and_close_args*)(jptr->args);
-				if (jstate==JSTATE_DISABLED) {
-					status = SAUNAFS_ERROR_NOTDONE;
-				} else {
-					status = hddClose(ocargs->chunkid, ocargs->chunkType);
-				}
-				break;
-			}
-			case OP_READ:
-			{
-				auto rdargs = (chunk_read_args*)(jptr->args);
-				if (jstate==JSTATE_DISABLED) {
-					status = SAUNAFS_ERROR_NOTDONE;
-					break;
-				}
-				LOG_AVG_TILL_END_OF_SCOPE0("job_read");
-				if (rdargs->performHddOpen) {
-					status = hddOpen(rdargs->chunkid, rdargs->chunkType);
-					if (status != SAUNAFS_STATUS_OK) {
-						break;
-					}
-				}
-
-				status = hddRead(rdargs->chunkid, rdargs->version, rdargs->chunkType,
-						rdargs->offset, rdargs->size, rdargs->maxBlocksToBeReadBehind,
-						rdargs->blocksToBeReadAhead, rdargs->outputBuffer);
-
-				if (rdargs->performHddOpen && status != SAUNAFS_STATUS_OK) {
-					int ret = hddClose(rdargs->chunkid, rdargs->chunkType);
-					if (ret != SAUNAFS_STATUS_OK) {
-						safs_silent_syslog(LOG_ERR,
-								"read job: cannot close chunk after read error (%s): %s",
-								saunafs_error_string(status),
-								saunafs_error_string(ret));
-					}
-				}
-				break;
-			}
-			case OP_PREFETCH:
-			{
-				auto prefetchArgs = (chunk_prefetch_args*)(jptr->args);
-				status = hddPrefetchBlocks(prefetchArgs->chunkid, prefetchArgs->chunkType,
-						prefetchArgs->firstBlock, prefetchArgs->nrOfBlocks);
-				break;
-			}
-			case OP_WRITE:
-			{
-				auto wrargs = (chunk_write_args*)(jptr->args);
-				if (jstate==JSTATE_DISABLED) {
-					status = SAUNAFS_ERROR_NOTDONE;
-				} else {
-				    status = hddChunkWriteBlock(
-				        wrargs->chunkId, wrargs->chunkVersion,
-				        wrargs->chunkType, wrargs->blocknum, wrargs->offset,
-				        wrargs->size, wrargs->crc, wrargs->buffer);
-				}
-				if (status != SAUNAFS_STATUS_OK) {
-						safs::log_err("Failed to write chunk id {}: {}", wrargs->chunkId, saunafs_error_string(status));
-				}
-				break;
-			}
-			case OP_GET_BLOCKS:
-			{
-				auto gbargs = (chunk_get_blocks_args*)(jptr->args);
-				if (jstate == JSTATE_DISABLED) {
-					status = SAUNAFS_ERROR_NOTDONE;
-				} else {
-					status = hddChunkGetNumberOfBlocks(gbargs->chunkId, gbargs->chunkType,
-							gbargs->chunkVersion, gbargs->blocks);
-				}
-				break;
-			}
-			case OP_REPLICATE:
-			{
-				auto rpargs = (chunk_replication_args*)(jptr->args);
-				if (jstate==JSTATE_DISABLED) {
-					status = SAUNAFS_ERROR_NOTDONE;
-				} else {
-					try {
-						std::vector<ChunkTypeWithAddress> sources;
-						deserialize(rpargs->sourcesBuffer, rpargs->sourcesBufferSize, sources);
-						ChunkFileCreator creator(
-								rpargs->chunkId, rpargs->chunkVersion, rpargs->chunkType);
-						gReplicator.replicate(creator, sources);
-						status = SAUNAFS_STATUS_OK;
-					} catch (Exception& ex) {
-						safs_pretty_syslog(LOG_WARNING, "replication error: %s", ex.what());
-						status = ex.status();
-					}
-				}
-				break;
-			}
-			default:
-				return nullptr;
+		switch (operation) {
+		case ChunkOperation::Invalid:
+		{
+			status = SAUNAFS_ERROR_EINVAL;
+			break;
 		}
-		job_send_status(jp,jobid,status);
-	}
-}
-
-static inline uint32_t job_new(jobpool *jp,uint32_t op,void *args,void (*callback)(uint8_t status,void *extra),void *extra) {
-	TRACETHIS();
-	uint32_t jobid = jp->nextjobid;
-	uint32_t jhpos = JHASHPOS(jobid);
-	job *jptr;
-	jptr = (job*) malloc(sizeof(job));
-	passert(jptr);
-	jptr->jobid = jobid;
-	jptr->callback = callback;
-	jptr->extra = extra;
-	jptr->args = args;
-	jptr->jstate = JSTATE_ENABLED;
-	jptr->next = jp->jobhash[jhpos];
-	jp->jobhash[jhpos] = jptr;
-	jp->jobsQueue->put(jobid, op, reinterpret_cast<uint8_t*>(jptr), 1);
-	jp->nextjobid++;
-	if (jp->nextjobid==0) {
-		jp->nextjobid=1;
-	}
-	return jobid;
-}
-
-/* interface */
-
-void* job_pool_new(uint8_t workers,uint32_t jobs,int *wakeupdesc) {
-	TRACETHIS();
-	int fd[2];
-	uint32_t i;
-	pthread_attr_t thattr;
-	jobpool* jp;
-
-	if (pipe(fd)<0) {
-		return NULL;
-	}
-	jp = new jobpool(fd[0], fd[1], workers, jobs);
-	passert(jp);
-	*wakeupdesc = fd[0];
-	zassert(pthread_attr_init(&thattr));
-	zassert(pthread_attr_setstacksize(&thattr,0x100000));
-	zassert(pthread_attr_setdetachstate(&thattr,PTHREAD_CREATE_JOINABLE));
-	for (i=0 ; i<workers ; i++) {
-		zassert(pthread_create(jp->workerthreads + i, &thattr, job_worker, jp));
-	}
-	zassert(pthread_attr_destroy(&thattr));
-	return jp;
-}
-
-uint32_t job_pool_jobs_count(void *jpool) {
-	TRACETHIS();
-	jobpool* jp = (jobpool*)jpool;
-	return jp->jobsQueue->elements();
-}
-
-void job_pool_disable_and_change_callback_all(void *jpool,void (*callback)(uint8_t status,void *extra)) {
-	TRACETHIS();
-	jobpool* jp = (jobpool*)jpool;
-	uint32_t jhpos;
-	job *jptr;
-
-	std::lock_guard jobsLockGuard(jp->jobsMutex);
-
-	for (jhpos = 0 ; jhpos<JHASHSIZE ; jhpos++) {
-		for (jptr = jp->jobhash[jhpos] ; jptr ; jptr=jptr->next) {
-			if (jptr->jstate==JSTATE_ENABLED) {
-				jptr->jstate=JSTATE_DISABLED;
+		case ChunkOperation::ChunkOp:
+		{
+			auto args =
+			    std::unique_ptr<chunk_chunkop_args>(static_cast<chunk_chunkop_args *>(job->args));
+			// TODO(Crash): Refactor hddChunkOperation and separate operations and states
+			status =
+			    hddChunkOperation(args->chunkid, args->version, args->chunkType, args->newversion,
+			                      args->copychunkid, args->copyversion, args->length);
+			break;
+		}
+		case ChunkOperation::Open:
+		{
+			auto args = std::unique_ptr<chunk_open_and_close_args>(
+			    static_cast<chunk_open_and_close_args *>(job->args));
+			status = hddOpen(args->chunkid, args->chunkType);
+			break;
+		}
+		case ChunkOperation::Close:
+		{
+			auto args = std::unique_ptr<chunk_open_and_close_args>(
+			    static_cast<chunk_open_and_close_args *>(job->args));
+			status = hddClose(args->chunkid, args->chunkType);
+			break;
+		}
+		case ChunkOperation::Read:
+		{
+			auto args = std::unique_ptr<chunk_read_args>(static_cast<chunk_read_args *>(job->args));
+			LOG_AVG_TILL_END_OF_SCOPE0("job_read");
+			if (args->performHddOpen) {
+				status = hddOpen(args->chunkid, args->chunkType);
+				if (status != SAUNAFS_STATUS_OK) { break; }
 			}
-			jptr->callback=callback;
-		}
-	}
-}
 
-void job_pool_disable_job(void *jpool,uint32_t jobid) {
-	TRACETHIS();
-	jobpool* jp = (jobpool*)jpool;
-	uint32_t jhpos = JHASHPOS(jobid);
-	job *jptr;
+			status = hddRead(args->chunkid, args->version, args->chunkType, args->offset,
+			                 args->size, args->maxBlocksToBeReadBehind, args->blocksToBeReadAhead,
+			                 args->outputBuffer);
 
-	std::unique_lock jobsUniqueLock(jp->jobsMutex, std::defer_lock);
-
-	for (jptr = jp->jobhash[jhpos] ; jptr ; jptr=jptr->next) {
-		if (jptr->jobid==jobid) {
-			jobsUniqueLock.lock();
-			if (jptr->jstate==JSTATE_ENABLED) {
-				jptr->jstate=JSTATE_DISABLED;
-			}
-			jobsUniqueLock.unlock();
-		}
-	}
-}
-
-void job_pool_change_callback(void *jpool,uint32_t jobid,void (*callback)(uint8_t status,void *extra),void *extra) {
-	TRACETHIS();
-	jobpool* jp = (jobpool*)jpool;
-	uint32_t jhpos = JHASHPOS(jobid);
-	job *jptr;
-	for (jptr = jp->jobhash[jhpos] ; jptr ; jptr=jptr->next) {
-		if (jptr->jobid==jobid) {
-			jptr->callback=callback;
-			jptr->extra=extra;
-		}
-	}
-}
-
-void job_pool_check_jobs(void *jpool) {
-	TRACETHIS();
-	jobpool* jp = (jobpool*)jpool;
-	uint32_t jobid,jhpos;
-	uint8_t status;
-	int notlast;
-	job **jhandle,*jptr;
-	do {
-		notlast = job_receive_status(jp,&jobid,&status);
-		jhpos = JHASHPOS(jobid);
-		jhandle = jp->jobhash+jhpos;
-		while ((jptr = *jhandle)) {
-			if (jptr->jobid==jobid) {
-				if (jptr->callback) {
-					jptr->callback(status,jptr->extra);
+			if (args->performHddOpen && status != SAUNAFS_STATUS_OK) {
+				int ret = hddClose(args->chunkid, args->chunkType);
+				if (ret != SAUNAFS_STATUS_OK) {
+					safs_silent_syslog(LOG_ERR,
+					                   "read job: cannot close chunk after read error (%s): %s",
+					                   saunafs_error_string(status), saunafs_error_string(ret));
 				}
-				*jhandle = jptr->next;
-				if (jptr->args) {
-					free(jptr->args);
-				}
-				free(jptr);
-				break;
-			} else {
-				jhandle = &(jptr->next);
 			}
+			break;
 		}
-	} while (notlast);
+		case ChunkOperation::Prefetch:
+		{
+			auto args =
+			    std::unique_ptr<chunk_prefetch_args>(static_cast<chunk_prefetch_args *>(job->args));
+			status = hddPrefetchBlocks(args->chunkid, args->chunkType, args->firstBlock,
+			                           args->nrOfBlocks);
+			break;
+		}
+		case ChunkOperation::Write:
+		{
+			auto args =
+			    std::unique_ptr<chunk_write_args>(static_cast<chunk_write_args *>(job->args));
+			status = hddChunkWriteBlock(args->chunkId, args->chunkVersion, args->chunkType,
+			                            args->blocknum, args->offset, args->size, args->crc,
+			                            args->buffer);
+			if (status != SAUNAFS_STATUS_OK) {
+				safs::log_err("Failed to write chunk id {}: {}", args->chunkId,
+				              saunafs_error_string(status));
+			}
+			break;
+		}
+		case ChunkOperation::Replicate:
+		{
+			auto args = std::unique_ptr<chunk_replication_args>(
+			    static_cast<chunk_replication_args *>(job->args));
+			try {
+				std::vector<ChunkTypeWithAddress> sources;
+				deserialize(args->sourcesBuffer, args->sourcesBufferSize, sources);
+				ChunkFileCreator creator(args->chunkId, args->chunkVersion, args->chunkType);
+				gReplicator.replicate(creator, sources);
+				status = SAUNAFS_STATUS_OK;
+			} catch (Exception &ex) {
+				safs_pretty_syslog(LOG_WARNING, "replication error: %s", ex.what());
+				status = ex.status();
+			}
+			break;
+		}
+		case ChunkOperation::GetBlocks:
+		{
+			auto args = std::unique_ptr<chunk_get_blocks_args>(
+			    static_cast<chunk_get_blocks_args *>(job->args));
+			status = hddChunkGetNumberOfBlocks(args->chunkId, args->chunkType, args->chunkVersion,
+			                                   args->blocks);
+			break;
+		}
+		default:
+			status = SAUNAFS_ERROR_EINVAL;
+			break;
+		}
+
+		sendStatus(jobId, status);
+	}
 }
 
-void job_pool_delete(void *jpool) {
-	TRACETHIS();
-	jobpool* jp = (jobpool*)jpool;
-	uint32_t i;
-
-	for (i = 0; i < jp->workers; i++) {
-		jp->jobsQueue->put(0, OP_EXIT, nullptr, 1);
-	}
-
-	for (i = 0; i < jp->workers; i++) {
-		zassert(pthread_join(jp->workerthreads[i], NULL));
-	}
-
-	sassert(jp->jobsQueue->isEmpty());
-
-	if (!jp->statusQueue->isEmpty()) {
-		job_pool_check_jobs(jp);
-	}
-
-	jp->jobsQueue.reset();
-	jp->statusQueue.reset();
-	free(jp->workerthreads);
-	close(jp->rpipe);
-	close(jp->wpipe);
-	delete jp;
+void JobPool::sendStatus(uint32_t jobId, uint8_t status) {
+	std::lock_guard pipeLockGuard(pipeMutex);
+	if (statusQueue->isEmpty()) { eassert(write(wpipe, &status, 1) == 1); }
+	statusQueue->put(jobId, status, nullptr, 1);
 }
 
-uint32_t job_inval(void *jpool,void (*callback)(uint8_t status,void *extra),void *extra) {
-	TRACETHIS();
-	jobpool* jp = (jobpool*)jpool;
-	return job_new(jp,OP_INVAL,NULL,callback,extra);
+int JobPool::receiveStatus(uint32_t &jobId, uint8_t &status) {
+	uint32_t qstatus = 0;
+	std::lock_guard pipeLockGuard(pipeMutex);
+	statusQueue->get(&jobId, &qstatus, nullptr, nullptr);
+	status = qstatus;
+	if (statusQueue->isEmpty()) {
+		eassert(read(rpipe, &qstatus, 1) == 1);
+		return 0;
+	}
+	return 1;
 }
 
-uint32_t job_chunkop(void *jpool, void (*callback)(uint8_t status, void *extra), void *extra,
-		uint64_t chunkid, uint32_t version, ChunkPartType chunkType, uint32_t newversion,
-		uint64_t copychunkid, uint32_t copyversion, uint32_t length) {
-	TRACETHIS();
-	jobpool* jp = (jobpool*)jpool;
-	chunk_chunkop_args *args;
-	args = (chunk_chunkop_args*) malloc(sizeof(chunk_chunkop_args));
-	passert(args);
-	args->chunkid = chunkid;
-	args->version = version;
-	args->newversion = newversion;
-	args->copychunkid = copychunkid;
-	args->copyversion = copyversion;
-	args->length = length;
+uint32_t job_open(JobPool &jobPool, JobPool::JobCallback callback, void *extra, uint64_t chunkId,
+                  ChunkPartType chunkType) {
+	auto args = std::make_unique<chunk_open_and_close_args>();
+	args->chunkid = chunkId;
 	args->chunkType = chunkType;
-	return job_new(jp,OP_CHUNKOP,args,callback,extra);
+	return jobPool.addJob(JobPool::ChunkOperation::Open, args.release(), std::move(callback),
+	                      extra);
 }
 
-uint32_t job_open(void *jpool, void (*callback)(uint8_t status,void *extra), void *extra,
-		uint64_t chunkid, ChunkPartType chunkType) {
-	TRACETHIS();
-	jobpool* jp = (jobpool*)jpool;
-	chunk_open_and_close_args *args;
-	args = (chunk_open_and_close_args*) malloc(sizeof(chunk_open_and_close_args));
-	passert(args);
-	args->chunkid = chunkid;
+uint32_t job_close(JobPool &jobPool, JobPool::JobCallback callback, void *extra, uint64_t chunkId,
+	ChunkPartType chunkType) {
+	auto args = std::make_unique<chunk_open_and_close_args>();
+	args->chunkid = chunkId;
 	args->chunkType = chunkType;
-	return job_new(jp,OP_OPEN,args,callback,extra);
+	return jobPool.addJob(JobPool::ChunkOperation::Close, args.release(), std::move(callback),
+	                      extra);
 }
 
-uint32_t job_close(void *jpool, void (*callback)(uint8_t status,void *extra), void *extra,
-		uint64_t chunkid, ChunkPartType chunkType) {
-	TRACETHIS();
-	jobpool* jp = (jobpool*)jpool;
-	chunk_open_and_close_args *args;
-	args = (chunk_open_and_close_args*) malloc(sizeof(chunk_open_and_close_args));
-	passert(args);
-	args->chunkid = chunkid;
-	args->chunkType = chunkType;
-	return job_new(jp,OP_CLOSE,args,callback,extra);
-}
-
-uint32_t job_read(void *jpool, void (*callback)(uint8_t status, void *extra), void *extra,
-		uint64_t chunkid, uint32_t version, ChunkPartType chunkType, uint32_t offset, uint32_t size,
-		uint32_t maxBlocksToBeReadBehind, uint32_t blocksToBeReadAhead,
-		OutputBuffer* outputBuffer, bool performHddOpen) {
-	TRACETHIS();
-	jobpool* jp = (jobpool*)jpool;
-	chunk_read_args *args;
-	args = (chunk_read_args*) malloc(sizeof(chunk_read_args));
-	passert(args);
-	args->chunkid = chunkid;
+uint32_t job_read(JobPool &jobPool, JobPool::JobCallback callback, void *extra, uint64_t chunkId,
+                  uint32_t version, ChunkPartType chunkType, uint32_t offset, uint32_t size,
+                  uint32_t maxBlocksToBeReadBehind, uint32_t blocksToBeReadAhead,
+                  OutputBuffer *outputBuffer, bool performHddOpen) {
+	auto args = std::make_unique<chunk_read_args>();
+	args->chunkid = chunkId;
 	args->version = version;
 	args->chunkType = chunkType;
 	args->offset = offset;
@@ -574,76 +414,131 @@ uint32_t job_read(void *jpool, void (*callback)(uint8_t status, void *extra), vo
 	args->blocksToBeReadAhead = blocksToBeReadAhead;
 	args->outputBuffer = outputBuffer;
 	args->performHddOpen = performHddOpen;
-	return job_new(jp,OP_READ,args,callback,extra);
+	return jobPool.addJob(JobPool::ChunkOperation::Read, args.release(), std::move(callback),
+	                      extra);
 }
 
-uint32_t job_prefetch(void *jpool, uint64_t chunkid, uint32_t version, ChunkPartType chunkType,
-		uint32_t firstBlockToBePrefetched, uint32_t nrOfBlocksToBePrefetched) {
-	TRACETHIS();
-	jobpool* jp = (jobpool*)jpool;
-	chunk_prefetch_args* args;
-	args = (chunk_prefetch_args*) malloc(sizeof(chunk_prefetch_args));
-	passert(args);
-	args->chunkid = chunkid;
+uint32_t job_prefetch(JobPool &jobPool, uint64_t chunkId, uint32_t version, ChunkPartType chunkType,
+	uint32_t firstBlockToBePrefetched, uint32_t blocksToBePrefetched) {
+	auto args = std::make_unique<chunk_prefetch_args>();
+	args->chunkid = chunkId;
 	args->version = version;
 	args->chunkType = chunkType;
 	args->firstBlock = firstBlockToBePrefetched;
-	args->nrOfBlocks = nrOfBlocksToBePrefetched;
-	return job_new(jp,OP_PREFETCH, args, nullptr, nullptr);
+	args->nrOfBlocks = blocksToBePrefetched;
+	return jobPool.addJob(JobPool::ChunkOperation::Prefetch, args.release(), nullptr, nullptr);
 }
 
-
-uint32_t job_write(void *jpool, void (*callback)(uint8_t status, void *extra), void *extra,
-		uint64_t chunkId, uint32_t chunkVersion, ChunkPartType chunkType,
-		uint16_t blocknum, uint32_t offset, uint32_t size, uint32_t crc, const uint8_t *buffer) {
-	TRACETHIS();
-	jobpool* jp = (jobpool*)jpool;
-	chunk_write_args *args;
-	args = (chunk_write_args*) malloc(sizeof(chunk_write_args));
-	passert(args);
+uint32_t job_write(JobPool &jobPool, JobPool::JobCallback callback, void *extra, uint64_t chunkId,
+                   uint32_t chunkVersion, ChunkPartType chunkType, uint16_t blockNum,
+                   uint32_t offset, uint32_t size, uint32_t crc, const uint8_t *buffer) {
+	auto args = std::make_unique<chunk_write_args>();
 	args->chunkId = chunkId;
 	args->chunkVersion = chunkVersion;
-	args->chunkType = chunkType,
-	args->blocknum = blocknum;
+	args->chunkType = chunkType;
+	args->blocknum = blockNum;
 	args->offset = offset;
 	args->size = size;
 	args->crc = crc;
 	args->buffer = buffer;
-	return job_new(jp, OP_WRITE, args, callback, extra);
+	return jobPool.addJob(JobPool::ChunkOperation::Write, args.release(), std::move(callback),
+	                      extra);
 }
 
-uint32_t job_get_blocks(void *jpool, void (*callback)(uint8_t status, void *extra), void *extra,
-		uint64_t chunkId, uint32_t version, ChunkPartType chunkType, uint16_t* blocks) {
-	TRACETHIS();
-	jobpool* jp = (jobpool*)jpool;
-	chunk_get_blocks_args *args;
-	args = (chunk_get_blocks_args*) malloc(sizeof(chunk_get_blocks_args));
-	passert(args);
+uint32_t job_get_blocks(JobPool &jobPool, JobPool::JobCallback callback, void *extra,
+                        uint64_t chunkId, uint32_t version, ChunkPartType chunkType,
+                        uint16_t *blocks) {
+	auto args = std::make_unique<chunk_get_blocks_args>();
 	args->chunkId = chunkId;
 	args->chunkVersion = version;
 	args->chunkType = chunkType;
 	args->blocks = blocks;
-	return job_new(jp, OP_GET_BLOCKS, args, callback, extra);
+	return jobPool.addJob(JobPool::ChunkOperation::GetBlocks, args.release(), std::move(callback),
+	                      extra);
 }
 
-uint32_t job_replicate(void *jpool, void (*callback)(uint8_t status, void *extra), void *extra,
-		uint64_t chunkId, uint32_t chunkVersion, ChunkPartType chunkType,
-		uint32_t sourcesBufferSize, const uint8_t* sourcesBuffer) {
-	TRACETHIS();
-	jobpool* jp = (jobpool*)jpool;
-	chunk_replication_args *args;
-	// It's an ugly hack to allocate the memory for the structure and for the "sources" in a single
-	// call, but as long as the whole 'args' are allocated with malloc I can't do much about it
-	args = (chunk_replication_args*) malloc(sizeof(chunk_replication_args) + sourcesBufferSize);
-	passert(args);
+uint32_t job_replicate(JobPool &jobPool, JobPool::JobCallback callback, void *extra,
+                       uint64_t chunkId, uint32_t chunkVersion, ChunkPartType chunkType,
+                       uint32_t sourcesBufferSize, const uint8_t *sourcesBuffer) {
+	auto args = std::make_unique<chunk_replication_args>();
 	args->chunkId = chunkId;
 	args->chunkVersion = chunkVersion;
 	args->chunkType = chunkType;
 	args->sourcesBufferSize = sourcesBufferSize;
+	args->sourcesBuffer = new uint8_t[sourcesBufferSize];
+	std::memcpy(args->sourcesBuffer, sourcesBuffer, sourcesBufferSize);
+	return jobPool.addJob(JobPool::ChunkOperation::Replicate, args.release(), std::move(callback),
+	                      extra);
+}
 
-	// Ugly.
-	args->sourcesBuffer = (uint8_t*)args + sizeof(chunk_replication_args);
-	memcpy((void*)args->sourcesBuffer, (void*)sourcesBuffer, sourcesBufferSize);
+uint32_t job_chunkop(JobPool &jobPool, JobPool::JobCallback callback, void *extra, uint64_t chunkId,
+                     uint32_t chunkVersion, ChunkPartType chunkType, uint32_t newChunkVersion,
+                     uint64_t copyChunkId, uint32_t copyChunkVersion, uint32_t length) {
+    auto args = std::make_unique<chunk_chunkop_args>();
+    args->chunkid = chunkId;
+    args->version = chunkVersion;
+    args->newversion = newChunkVersion;
+    args->copychunkid = copyChunkId;
+    args->copyversion = copyChunkVersion;
+    args->length = length;
+    args->chunkType = chunkType;
+	return jobPool.addJob(JobPool::ChunkOperation::ChunkOp, args.release(), std::move(callback),
+	                      extra);
+}
 
-	return job_new(jp, OP_REPLICATE, args, callback, extra);
+uint32_t job_invalid(JobPool &jobPool, JobPool::JobCallback callback, void *extra) {
+	return jobPool.addJob(JobPool::ChunkOperation::Invalid, nullptr, std::move(callback), extra);
+}
+
+uint32_t job_delete(JobPool &jobPool, JobPool::JobCallback callback, void *extra, uint64_t chunkId,
+	uint32_t chunkVersion, ChunkPartType chunkType) {
+	return job_chunkop(jobPool, std::move(callback), extra, chunkId, chunkVersion, chunkType, 0, 0,
+	                   0, 0);
+}
+
+uint32_t job_create(JobPool &jobPool, JobPool::JobCallback callback, void *extra, uint64_t chunkId,
+	uint32_t chunkVersion, ChunkPartType chunkType) {
+	return job_chunkop(jobPool, std::move(callback), extra, chunkId, chunkVersion, chunkType, 0, 0,
+	                   0, 1);
+}
+
+uint32_t job_version(JobPool &jobPool, const JobPool::JobCallback &callback, void *extra,
+                     uint64_t chunkId, uint32_t chunkVersion, ChunkPartType chunkType,
+                     uint32_t newChunkVersion) {
+	if (newChunkVersion > 0) {
+		return job_chunkop(jobPool, callback, extra, chunkId, chunkVersion, chunkType,
+		                   newChunkVersion, 0, 0, kWildCardLength);
+	}
+	return job_invalid(jobPool, callback, extra);
+}
+
+uint32_t job_truncate(JobPool &jobPool, const JobPool::JobCallback &callback, void *extra,
+	uint64_t chunkId, ChunkPartType chunkType, uint32_t chunkVersion,
+	uint32_t newChunkVersion, uint32_t length) {
+	if (newChunkVersion > 0 && length != kWildCardLength) {
+		return job_chunkop(jobPool, callback, extra, chunkId, chunkVersion, chunkType,
+		                   newChunkVersion, 0, 0, length);
+	}
+	return job_invalid(jobPool, callback, extra);
+}
+
+uint32_t job_duplicate(JobPool &jobPool, const JobPool::JobCallback &callback, void *extra,
+                       uint64_t chunkId, uint32_t chunkVersion, uint32_t newChunkVersion,
+                       ChunkPartType chunkType, uint64_t chunkIdCopy, uint32_t chunkVersionCopy) {
+	if (newChunkVersion > 0 && chunkIdCopy > 0) {
+		return job_chunkop(jobPool, callback, extra, chunkId, chunkVersion, chunkType,
+		                   newChunkVersion, chunkIdCopy, chunkVersionCopy, kWildCardLength);
+	}
+	return job_invalid(jobPool, callback, extra);
+}
+
+uint32_t job_duptrunc(JobPool &jobPool, const JobPool::JobCallback &callback, void *extra,
+                      uint64_t chunkId, uint32_t chunkVersion, uint32_t newChunkVersion,
+                      ChunkPartType chunkType, uint64_t chunkIdCopy, uint32_t chunkVersionCopy,
+                      uint32_t length) {
+	if (newChunkVersion > 0 && chunkIdCopy > 0 && length != kWildCardLength) {
+		return job_chunkop(jobPool, callback, extra, chunkId, chunkVersion, chunkType,
+		                   newChunkVersion, chunkIdCopy, chunkVersionCopy, length);
+	}
+	return job_invalid(jobPool, callback, extra);
 }

--- a/src/chunkserver/bgjobs.cc
+++ b/src/chunkserver/bgjobs.cc
@@ -29,6 +29,7 @@
 #include "common/pcqueue.h"
 #include "devtools/TracePrinter.h"
 #include "devtools/request_log.h"
+#include "slogger/slogger.h"
 
 #include <atomic>
 #include <cassert>
@@ -125,21 +126,19 @@ void JobPool::disableJob(uint32_t jobId) {
 void JobPool::checkJobs() {
 	uint32_t jobId;
 	uint8_t status;
-
-	receiveStatus(jobId, status);
-
-	auto jobIterator = jobHash.find(jobId);
-	if (jobIterator != jobHash.end()) {
-		auto callback = jobIterator->second->callback;
-		if (callback) {
-			callback(status, jobIterator->second->extra);
+	int notLastJob = 1;
+	do {
+		notLastJob = receiveStatus(jobId, status);
+		auto jobIterator = jobHash.find(jobId);
+		if (jobIterator != jobHash.end()) {
+			auto callback = jobIterator->second->callback;
+			if (callback) { callback(status, jobIterator->second->extra); }
+			jobHash.erase(jobIterator);
 		}
-		jobHash.erase(jobIterator);
-	}
+	} while (notLastJob > 0);
 }
 
 void JobPool::changeCallback(uint32_t jobId, JobCallback callback, void *extra) {
-	std::unique_lock lock(jobsMutex);
 	auto jobIterator = jobHash.find(jobId);
 	if (jobIterator != jobHash.end()) {
 		jobIterator->second->callback = std::move(callback);
@@ -178,6 +177,7 @@ void JobPool::workerThread() {
 		if (jobState == State::Disabled) {
 			status = SAUNAFS_ERROR_NOTDONE;
 			jobsUniqueLock.unlock();
+			sendStatus(jobId, status);
 			continue;
 		}
 
@@ -246,9 +246,8 @@ uint32_t job_read(JobPool &jobPool, JobPool::JobCallback callback, void *extra, 
 		if (performHddOpen && status != SAUNAFS_STATUS_OK) {
 			int ret = hddClose(chunkId, chunkType);
 			if (ret != SAUNAFS_STATUS_OK) {
-				safs_silent_syslog(LOG_ERR,
-				                   "read job: cannot close chunk after read error (%s): %s",
-				                   saunafs_error_string(status), saunafs_error_string(ret));
+				safs::log_err("read job: cannot close chunk after read error ({}): {}",
+				              saunafs_error_string(status), saunafs_error_string(ret));
 			}
 		}
 		return status;
@@ -302,7 +301,7 @@ uint32_t job_replicate(JobPool &jobPool, JobPool::JobCallback callback, void *ex
 			ChunkFileCreator creator(chunkId, chunkVersion, chunkType);
 			gReplicator.replicate(creator, sources);
 		} catch (Exception &ex) {
-			safs_pretty_syslog(LOG_WARNING, "replication error: %s", ex.what());
+			safs::log_warn("replication error: {}", ex.what());
 			status = ex.status();
 		}
 		return status;

--- a/src/chunkserver/bgjobs.h
+++ b/src/chunkserver/bgjobs.h
@@ -33,6 +33,9 @@
 #include <unordered_map>
 #include <vector>
 
+constexpr auto kEmptyCallback = nullptr;
+constexpr auto kEmptyExtra = nullptr;
+
 /**
  * @class JobPool
  * @brief Manages and processes background jobs in a thread pool.
@@ -72,7 +75,6 @@ public:
 		GetBlocks
 	};
 
-public:
 	/// @brief Callback function type for job completion.
 	///
 	/// @param status The status of the job.
@@ -152,7 +154,7 @@ private:
 	/// @param jobId The ID of the job.
 	/// @param status The status of the job.
 	/// @return 1 if a status was received, 0 otherwise.
-	int receiveStatus(uint32_t &jobId, uint8_t &status);
+	bool receiveStatus(uint32_t &jobId, uint8_t &status);
 
 	int rpipe;                                         /// Read pipe for job status notifications.
 	int wpipe;                                         /// Write pipe for job status notifications.
@@ -212,12 +214,11 @@ uint32_t job_read(JobPool &jobPool, JobPool::JobCallback callback, void *extra, 
 ///
 /// @param jobPool The JobPool instance.
 /// @param chunkId The ID of the chunk.
-/// @param version The version of the chunk.
 /// @param chunkType The type of the chunk.
 /// @param firstBlockToBePrefetched The first block to be prefetched.
 /// @param blocksToBePrefetched The number of blocks to be prefetched.
 /// @return The ID of the added job.
-uint32_t job_prefetch(JobPool &jobPool, uint64_t chunkId, uint32_t version, ChunkPartType chunkType,
+uint32_t job_prefetch(JobPool &jobPool, uint64_t chunkId, ChunkPartType chunkType,
                       uint32_t firstBlockToBePrefetched, uint32_t blocksToBePrefetched);
 
 /// @brief Adds a write job to the JobPool.

--- a/src/chunkserver/bgjobs.h
+++ b/src/chunkserver/bgjobs.h
@@ -45,6 +45,12 @@ public:
 		Exit,
 		Invalid,
 		ChunkOp,
+		ChangeVersion,
+		Duplicate,
+		Truncate,
+		DuplicateTruncate,
+		Delete,
+		Create,
 		Open,
 		Close,
 		Read,
@@ -116,10 +122,6 @@ uint32_t job_get_blocks(JobPool &jobPool, JobPool::JobCallback callback, void *e
 uint32_t job_replicate(JobPool &jobPool, JobPool::JobCallback callback, void *extra,
                        uint64_t chunkId, uint32_t chunkVersion, ChunkPartType chunkType,
                        uint32_t sourcesBufferSize, const uint8_t *sourcesBuffer);
-
-uint32_t job_chunkop(JobPool &jobPool, JobPool::JobCallback callback, void *extra, uint64_t chunkId,
-                     uint32_t chunkVersion, ChunkPartType chunkType, uint32_t newChunkVersion,
-                     uint64_t copyChunkId, uint32_t copyChunkVersion, uint32_t length);
 
 uint32_t job_invalid(JobPool &jobPool, JobPool::JobCallback callback, void *extra);
 

--- a/src/chunkserver/bgjobs.h
+++ b/src/chunkserver/bgjobs.h
@@ -57,7 +57,6 @@ public:
 	enum ChunkOperation {
 		Exit,
 		Invalid,
-		ChunkOp,
 		ChangeVersion,
 		Duplicate,
 		Truncate,
@@ -362,7 +361,3 @@ uint32_t job_duptrunc(JobPool &jobPool, const JobPool::JobCallback &callback, vo
                       uint64_t chunkId, uint32_t chunkVersion, uint32_t newChunkVersion,
                       ChunkPartType chunkType, uint64_t chunkIdCopy, uint32_t chunkVersionCopy,
                       uint32_t length);
-
-/* srcs: srccnt * (chunkid:64 chunkVersion:32 ip:32 port:16) */
-uint32_t job_legacy_replicate(void *jpool,void (*callback)(uint8_t status,void *extra),void *extra,uint64_t chunkid,uint32_t chunkVersion,uint8_t srccnt,const uint8_t *srcs);
-uint32_t job_legacy_replicate_simple(void *jpool,void (*callback)(uint8_t status,void *extra),void *extra,uint64_t chunkid,uint32_t chunkVersion,uint32_t ip,uint16_t port);

--- a/src/chunkserver/bgjobs.h
+++ b/src/chunkserver/bgjobs.h
@@ -62,11 +62,13 @@ public:
 
 public:
 	using JobCallback = std::function<void(uint8_t status, void *extra)>;
+	using ProcessJobCallback = std::function<uint8_t()>;
 
 	JobPool(uint8_t workers, uint32_t maxJobs, int *wakeupDesc);
 	~JobPool();
 
-	uint32_t addJob(ChunkOperation operation, void *args, JobCallback callback, void *extra);
+	uint32_t addJob(ChunkOperation operation, JobCallback callback, void *extra,
+	                ProcessJobCallback processJob);
 	uint32_t getJobCount() const;
 	void disableAndChangeCallbackAll(const JobCallback& callback);
 	void disableJob(uint32_t jobId);
@@ -77,8 +79,8 @@ private:
 	struct Job {
 		uint32_t jobId;
 		JobCallback callback;
+		ProcessJobCallback processJob;
 		void *extra;
-		void *args;
 		JobPool::State state;
 	};
 

--- a/src/chunkserver/bgjobs.h
+++ b/src/chunkserver/bgjobs.h
@@ -22,80 +22,129 @@
 
 #include "common/platform.h"
 
-#include <inttypes.h>
+#include "chunkserver/output_buffer.h"
+#include "common/pcqueue.h"
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <unordered_map>
 #include <vector>
 
-#include "chunkserver/output_buffer.h"
-#include "common/chunk_type_with_address.h"
+class JobPool {
+public:
+	enum class State : uint8_t {
+		Disabled,
+		Enabled,
+		InProgress
+	};
 
-void* job_pool_new(uint8_t workers,uint32_t jobs,int *wakeupdesc);
-uint32_t job_pool_jobs_count(void *jpool);
-void job_pool_disable_and_change_callback_all(void *jpool,void (*callback)(uint8_t status,void *extra));
-void job_pool_disable_job(void *jpool,uint32_t jobid);
-void job_pool_check_jobs(void *jpool);
-void job_pool_change_callback(void *jpool,uint32_t jobid,void (*callback)(uint8_t status,void *extra),void *extra);
-void job_pool_delete(void *jpool);
+	enum ChunkOperation {
+		Exit,
+		Invalid,
+		ChunkOp,
+		Open,
+		Close,
+		Read,
+		Prefetch,
+		Write,
+		Replicate,
+		GetBlocks
+	};
 
+public:
+	using JobCallback = std::function<void(uint8_t status, void *extra)>;
 
-uint32_t job_inval(void *jpool,void (*callback)(uint8_t status,void *extra),void *extra);
-uint32_t job_chunkop(void *jpool, void (*callback)(uint8_t status, void *extra), void *extra,
-		uint64_t chunkId, uint32_t chunkVersion, ChunkPartType chunkType, uint32_t newChunkVersion,
-		uint64_t copyChunkId, uint32_t copyChunkVersion, uint32_t length);
+	JobPool(uint8_t workers, uint32_t maxJobs, int *wakeupDesc);
+	~JobPool();
 
-#define job_delete(jobPool, callback, extra, chunkId, chunkVersion, chunkType) \
-	job_chunkop(jobPool, callback, extra, chunkId, chunkVersion, chunkType, 0, 0, 0, 0)
+	uint32_t addJob(ChunkOperation operation, void *args, JobCallback callback, void *extra);
+	uint32_t getJobCount() const;
+	void disableAndChangeCallbackAll(const JobCallback& callback);
+	void disableJob(uint32_t jobId);
+	void checkJobs();
+	void changeCallback(uint32_t jobId, JobCallback callback, void *extra);
 
-#define job_create(jobPool, callback, extra, chunkId, chunkType, chunkVersion) \
-	job_chunkop(jobPool, callback, extra, chunkId, chunkVersion, chunkType, 0, 0, 0, 1)
+private:
+	struct Job {
+		uint32_t jobId;
+		JobCallback callback;
+		void *extra;
+		void *args;
+		JobPool::State state;
+	};
 
-#define job_test(jobPool, callback, extra, chunkId, chunkVersion) job_chunkop(jobPool, callback, \
-		extra, chunkId, chunkVersion, ChunkType::getStandardChunkType(), 0, 0, 0, 2)
+	void workerThread();
+	void sendStatus(uint32_t jobId, uint8_t status);
+	int receiveStatus(uint32_t &jobId, uint8_t &status);
 
-#define job_version(jobPool, callback, extra, chunkId, chunkVersion, chunkType, \
-		newChunkVersion) \
-	(((newChunkVersion)>0) \
-	? job_chunkop(jobPool, callback, extra, chunkId, chunkVersion, chunkType, newChunkVersion, 0, \
-			0, 0xFFFFFFFF) \
-	: job_inval(jobPool, callback, extra))
+	int rpipe, wpipe;
+	uint8_t workers;
+	std::vector<std::thread> workerThreads;
+	std::mutex pipeMutex;
+	std::mutex jobsMutex;
+	std::unique_ptr<ProducerConsumerQueue> jobsQueue;
+	std::unique_ptr<ProducerConsumerQueue> statusQueue;
+	std::unordered_map<uint32_t, std::unique_ptr<Job>> jobHash;
+	uint32_t nextJobId = 1;
+};
 
-#define job_truncate(jobPool, callback, extra, chunkId, chunkType, chunkVersion, newChunkVersion, \
-		length) (((newChunkVersion) > 0 && (length) != 0xFFFFFFFF) \
-	? job_chunkop(jobPool, callback, extra, chunkId, chunkVersion, \
-			chunkType, newChunkVersion, 0, 0, length) \
-	: job_inval(jobPool, callback, extra))
+uint32_t job_open(JobPool &jobPool, JobPool::JobCallback callback, void *extra,
+                  uint64_t chunkId, ChunkPartType chunkType);
 
-#define job_duplicate(jobPool, callback, extra, chunkId, chunkVersion, newChunkVersion, chunkType, \
-		chunkIdCopy, chunkVersionCopy) \
-	(((newChunkVersion > 0) && (chunkIdCopy) > 0) \
-	? job_chunkop(jobPool, callback, extra, chunkId, chunkVersion, chunkType, \
-			newChunkVersion, chunkIdCopy, chunkVersionCopy, 0xFFFFFFFF) \
-	: job_inval(jobPool, callback, extra))
+uint32_t job_close(JobPool &jobPool, JobPool::JobCallback callback, void *extra, uint64_t chunkId,
+                   ChunkPartType chunkType);
 
-#define job_duptrunc(jobPool, callback, extra, chunkId, chunkVersion, newChunkVersion, chunkType, \
-		chunkIdCopy, chunkVersionCopy, length) \
-	(((newChunkVersion > 0) && (chunkIdCopy) > 0 && (length) != 0xFFFFFFFF) \
-	? job_chunkop(jobPool, callback, extra, chunkId, chunkVersion, chunkType, \
-			newChunkVersion, chunkIdCopy, chunkVersionCopy, length) \
-	: job_inval(jobPool, callback, extra))
+uint32_t job_read(JobPool &jobPool, JobPool::JobCallback callback, void *extra, uint64_t chunkId,
+                  uint32_t version, ChunkPartType chunkType, uint32_t offset, uint32_t size,
+                  uint32_t maxBlocksToBeReadBehind, uint32_t blocksToBeReadAhead,
+                  OutputBuffer *outputBuffer, bool performHddOpen);
 
-uint32_t job_open(void *jpool, void (*callback)(uint8_t status, void *extra), void *extra,
-		uint64_t chunkid, ChunkPartType chunkType);
-uint32_t job_close(void *jpool, void (*callback)(uint8_t status, void *extra), void *extra,
-		uint64_t chunkid, ChunkPartType chunkType);
-uint32_t job_read(void *jpool, void (*callback)(uint8_t status,void *extra), void *extra,
-		uint64_t chunkid, uint32_t chunkVersion, ChunkPartType chunkType,
-		uint32_t offset, uint32_t size, uint32_t maxBlocksToBeReadBehind,
-		uint32_t blocksToBeReadAhead, OutputBuffer *outputBuffer, bool performHddOpen);
-uint32_t job_prefetch(void *jpool, uint64_t chunkid, uint32_t version, ChunkPartType chunkType,
-		uint32_t firstBlockToBePrefetched, uint32_t nrOfBlocksToBePrefetched) ;
-uint32_t job_write(void *jpool, void (*callback)(uint8_t status, void *extra), void *extra,
-		uint64_t chunkId, uint32_t chunkVersion, ChunkPartType chunkType,
-		uint16_t blocknum, uint32_t offset, uint32_t size, uint32_t crc, const uint8_t *buffer);
-uint32_t job_get_blocks(void *jpool, void (*callback)(uint8_t status, void *extra), void *extra,
-		uint64_t chunkId, uint32_t version, ChunkPartType chunkType, uint16_t* blocks);
-uint32_t job_replicate(void *jpool, void (*callback)(uint8_t status, void *extra), void *extra,
-		uint64_t chunkId, uint32_t chunkVersion, ChunkPartType chunkType,
-		uint32_t sourcesBufferSize, const uint8_t* sourcesBuffer);
+uint32_t job_prefetch(JobPool &jobPool, uint64_t chunkId, uint32_t version, ChunkPartType chunkType,
+                      uint32_t firstBlockToBePrefetched, uint32_t blocksToBePrefetched);
+
+uint32_t job_write(JobPool &jobPool, JobPool::JobCallback callback, void *extra, uint64_t chunkId,
+                   uint32_t chunkVersion, ChunkPartType chunkType, uint16_t blockNum,
+                   uint32_t offset, uint32_t size, uint32_t crc, const uint8_t *buffer);
+
+uint32_t job_get_blocks(JobPool &jobPool, JobPool::JobCallback callback, void *extra,
+                        uint64_t chunkId, uint32_t version, ChunkPartType chunkType,
+                        uint16_t *blocks);
+
+uint32_t job_replicate(JobPool &jobPool, JobPool::JobCallback callback, void *extra,
+                       uint64_t chunkId, uint32_t chunkVersion, ChunkPartType chunkType,
+                       uint32_t sourcesBufferSize, const uint8_t *sourcesBuffer);
+
+uint32_t job_chunkop(JobPool &jobPool, JobPool::JobCallback callback, void *extra, uint64_t chunkId,
+                     uint32_t chunkVersion, ChunkPartType chunkType, uint32_t newChunkVersion,
+                     uint64_t copyChunkId, uint32_t copyChunkVersion, uint32_t length);
+
+uint32_t job_invalid(JobPool &jobPool, JobPool::JobCallback callback, void *extra);
+
+uint32_t job_delete(JobPool &jobPool, JobPool::JobCallback callback, void *extra, uint64_t chunkId,
+                    uint32_t chunkVersion, ChunkPartType chunkType);
+
+uint32_t job_create(JobPool &jobPool, JobPool::JobCallback callback, void *extra, uint64_t chunkId,
+                    uint32_t chunkVersion, ChunkPartType chunkType);
+
+uint32_t job_version(JobPool &jobPool, const JobPool::JobCallback &callback, void *extra,
+                     uint64_t chunkId, uint32_t chunkVersion, ChunkPartType chunkType,
+                     uint32_t newChunkVersion);
+
+uint32_t job_truncate(JobPool &jobPool, const JobPool::JobCallback &callback, void *extra,
+                      uint64_t chunkId, ChunkPartType chunkType, uint32_t chunkVersion,
+                      uint32_t newChunkVersion, uint32_t length);
+
+uint32_t job_duplicate(JobPool &jobPool, const JobPool::JobCallback &callback, void *extra,
+                       uint64_t chunkId, uint32_t chunkVersion, uint32_t newChunkVersion,
+                       ChunkPartType chunkType, uint64_t chunkIdCopy, uint32_t chunkVersionCopy);
+
+uint32_t job_duptrunc(JobPool &jobPool, const JobPool::JobCallback &callback, void *extra,
+                      uint64_t chunkId, uint32_t chunkVersion, uint32_t newChunkVersion,
+                      ChunkPartType chunkType, uint64_t chunkIdCopy, uint32_t chunkVersionCopy,
+                      uint32_t length);
 
 /* srcs: srccnt * (chunkid:64 chunkVersion:32 ip:32 port:16) */
 uint32_t job_legacy_replicate(void *jpool,void (*callback)(uint8_t status,void *extra),void *extra,uint64_t chunkid,uint32_t chunkVersion,uint8_t srccnt,const uint8_t *srcs);

--- a/src/chunkserver/bgjobs.h
+++ b/src/chunkserver/bgjobs.h
@@ -33,14 +33,27 @@
 #include <unordered_map>
 #include <vector>
 
+/**
+ * @class JobPool
+ * @brief Manages and processes background jobs in a thread pool.
+ *
+ * The JobPool class is responsible for managing and processing background jobs
+ * using a pool of worker threads. It provides functions to manage jobs and
+ * callbacks to process them. The class uses a producer-consumer pattern to handle
+ * job requests and status updates.
+ */
 class JobPool {
 public:
+	/// @enum State
+	/// @brief Represents the state of a job.
 	enum class State : uint8_t {
-		Disabled,
-		Enabled,
-		InProgress
+		Disabled,  /// Job is disabled and will not be processed.
+		Enabled,   /// Job is enabled and ready to be processed.
+		InProgress /// Job is currently being processed.
 	};
 
+	/// @enum ChunkOperation
+	/// @brief Represents the type of operation to be performed on a chunk.
 	enum ChunkOperation {
 		Exit,
 		Invalid,
@@ -61,90 +74,290 @@ public:
 	};
 
 public:
+	/// @brief Callback function type for job completion.
+	///
+	/// @param status The status of the job.
+	/// @param extra Additional data passed to the callback, like ChunkserverEntry entries.
 	using JobCallback = std::function<void(uint8_t status, void *extra)>;
+
+	/// @brief Callback function type for processing a job.
+	///
+	/// @return The status of the job processing.
 	using ProcessJobCallback = std::function<uint8_t()>;
 
+	/// @brief Constructor for JobPool.
+	///
+	/// @param workers The number of worker threads in the pool.
+	/// @param maxJobs The maximum number of jobs that can be queued.
+	/// @param wakeupDesc Pointer to the file descriptor for wakeup notifications.
+	/// @throws std::runtime_error If the pipe creation fails.
 	JobPool(uint8_t workers, uint32_t maxJobs, int *wakeupDesc);
+
+	/// @brief Destructor for JobPool.
 	~JobPool();
 
+	/// @brief Adds a job to the JobPool.
+	///
+	/// @param operation The type of operation to be performed on the chunk.
+	/// @param callback The callback function to be called upon job completion.
+	/// @param extra Additional data to be passed to the callback.
+	/// @param processJob The callback function to process the job.
+	/// @return The ID of the added job.
 	uint32_t addJob(ChunkOperation operation, JobCallback callback, void *extra,
 	                ProcessJobCallback processJob);
+
+	/// @brief Gets the number of jobs in the JobPool.
 	uint32_t getJobCount() const;
+
+	/// @brief Disables all jobs and changes their callback function.
+	///
+	/// @param callback The new callback function to be set for all jobs.
 	void disableAndChangeCallbackAll(const JobCallback& callback);
+
+	/// @brief Disables a specific job.
+	///
+	/// @param jobId The ID of the job to be disabled.
 	void disableJob(uint32_t jobId);
+
+	/// @brief Checks the status of jobs in the JobPool and calls their callbacks.
 	void checkJobs();
+
+	/// @brief Changes the callback function for a specific job.
+	///
+	/// @param jobId The ID of the job.
+	/// @param callback The new callback function.
+	/// @param extra Additional data to be passed to the new callback.
 	void changeCallback(uint32_t jobId, JobCallback callback, void *extra);
 
 private:
+	/// @brief Represents a job in the JobPool.
 	struct Job {
-		uint32_t jobId;
-		JobCallback callback;
-		ProcessJobCallback processJob;
-		void *extra;
-		JobPool::State state;
+		uint32_t jobId;                 // The ID of the job.
+		JobCallback callback;           // The callback function to be called upon job completion.
+		ProcessJobCallback processJob;  // The callback function to process the job.
+		void *extra;                    // Additional data for the callback.
+		JobPool::State state;           // The state of the job.
 	};
 
+	/// @brief Worker thread function.
 	void workerThread();
+
+	/// @brief Sends the status of a job.
+	///
+	/// @param jobId The ID of the job.
+	/// @param status The status of the job.
 	void sendStatus(uint32_t jobId, uint8_t status);
+
+	/// @brief Receives the status of a job.
+	///
+	/// @param jobId The ID of the job.
+	/// @param status The status of the job.
+	/// @return 1 if a status was received, 0 otherwise.
 	int receiveStatus(uint32_t &jobId, uint8_t &status);
 
-	int rpipe, wpipe;
-	uint8_t workers;
-	std::vector<std::thread> workerThreads;
-	std::mutex pipeMutex;
-	std::mutex jobsMutex;
-	std::unique_ptr<ProducerConsumerQueue> jobsQueue;
-	std::unique_ptr<ProducerConsumerQueue> statusQueue;
-	std::unordered_map<uint32_t, std::unique_ptr<Job>> jobHash;
-	uint32_t nextJobId = 1;
+	int rpipe;                                         /// Read pipe for job status notifications.
+	int wpipe;                                         /// Write pipe for job status notifications.
+	uint8_t workers;                                   /// Number of worker threads in the pool.
+	std::vector<std::thread> workerThreads;            /// Vector of worker threads.
+	std::mutex pipeMutex;                              /// Mutex for pipe operations.
+	std::mutex jobsMutex;                              /// Mutex for job operations.
+	std::unique_ptr<ProducerConsumerQueue> jobsQueue;  /// Queue for jobs.
+	std::unique_ptr<ProducerConsumerQueue> statusQueue;          /// Queue for job statuses.
+	std::unordered_map<uint32_t, std::unique_ptr<Job>> jobHash;  /// Hash map of job.
+	uint32_t nextJobId = 1;                                      /// Next job ID to be assigned.
 };
 
+/// @brief Adds an open job to the JobPool.
+///
+/// @param jobPool The JobPool instance.
+/// @param callback The callback function to be called upon job completion.
+/// @param extra Additional data to be passed to the callback.
+/// @param chunkId The ID of the chunk.
+/// @param chunkType The type of the chunk.
+/// @return The ID of the added job.
 uint32_t job_open(JobPool &jobPool, JobPool::JobCallback callback, void *extra,
                   uint64_t chunkId, ChunkPartType chunkType);
 
+/// @brief Adds a close job to the JobPool.
+///
+/// @param jobPool The JobPool instance.
+/// @param callback The callback function to be called upon job completion.
+/// @param extra Additional data to be passed to the callback.
+/// @param chunkId The ID of the chunk.
+/// @param chunkType The type of the chunk.
+/// @return The ID of the added job.
 uint32_t job_close(JobPool &jobPool, JobPool::JobCallback callback, void *extra, uint64_t chunkId,
                    ChunkPartType chunkType);
 
+/// @brief Adds a read job to the JobPool.
+///
+/// @param jobPool The JobPool instance.
+/// @param callback The callback function to be called upon job completion.
+/// @param extra Additional data to be passed to the callback.
+/// @param chunkId The ID of the chunk.
+/// @param version The version of the chunk.
+/// @param chunkType The type of the chunk.
+/// @param offset The offset to read from.
+/// @param size The size to read.
+/// @param maxBlocksToBeReadBehind The maximum blocks to be read behind.
+/// @param blocksToBeReadAhead The blocks to be read ahead.
+/// @param outputBuffer The output buffer for the read data.
+/// @param performHddOpen Whether to perform HDD open.
+/// @return The ID of the added job.
 uint32_t job_read(JobPool &jobPool, JobPool::JobCallback callback, void *extra, uint64_t chunkId,
                   uint32_t version, ChunkPartType chunkType, uint32_t offset, uint32_t size,
                   uint32_t maxBlocksToBeReadBehind, uint32_t blocksToBeReadAhead,
                   OutputBuffer *outputBuffer, bool performHddOpen);
 
+/// @brief Adds a prefetch job to the JobPool.
+///
+/// @param jobPool The JobPool instance.
+/// @param chunkId The ID of the chunk.
+/// @param version The version of the chunk.
+/// @param chunkType The type of the chunk.
+/// @param firstBlockToBePrefetched The first block to be prefetched.
+/// @param blocksToBePrefetched The number of blocks to be prefetched.
+/// @return The ID of the added job.
 uint32_t job_prefetch(JobPool &jobPool, uint64_t chunkId, uint32_t version, ChunkPartType chunkType,
                       uint32_t firstBlockToBePrefetched, uint32_t blocksToBePrefetched);
 
+/// @brief Adds a write job to the JobPool.
+///
+/// @param jobPool The JobPool instance.
+/// @param callback The callback function to be called upon job completion.
+/// @param extra Additional data to be passed to the callback.
+/// @param chunkId The ID of the chunk.
+/// @param chunkVersion The version of the chunk.
+/// @param chunkType The type of the chunk.
+/// @param blockNum The block number to write.
+/// @param offset The offset to write to.
+/// @param size The size to write.
+/// @param crc The CRC of the data.
+/// @param buffer The data buffer to write.
+/// @return The ID of the added job.
 uint32_t job_write(JobPool &jobPool, JobPool::JobCallback callback, void *extra, uint64_t chunkId,
                    uint32_t chunkVersion, ChunkPartType chunkType, uint16_t blockNum,
                    uint32_t offset, uint32_t size, uint32_t crc, const uint8_t *buffer);
 
+/// @brief Adds a get blocks job to the JobPool.
+///
+/// @param jobPool The JobPool instance.
+/// @param callback The callback function to be called upon job completion.
+/// @param extra Additional data to be passed to the callback.
+/// @param chunkId The ID of the chunk.
+/// @param version The version of the chunk.
+/// @param chunkType The type of the chunk.
+/// @param blocks The blocks to get.
+/// @return The ID of the added job.
 uint32_t job_get_blocks(JobPool &jobPool, JobPool::JobCallback callback, void *extra,
                         uint64_t chunkId, uint32_t version, ChunkPartType chunkType,
                         uint16_t *blocks);
 
+/// @brief Adds a replicate job to the JobPool.
+///
+/// @param jobPool The JobPool instance.
+/// @param callback The callback function to be called upon job completion.
+/// @param extra Additional data to be passed to the callback.
+/// @param chunkId The ID of the chunk.
+/// @param chunkVersion The version of the chunk.
+/// @param chunkType The type of the chunk.
+/// @param sourcesBufferSize The size of the sources buffer.
+/// @param sourcesBuffer The sources buffer.
+/// @return The ID of the added job.
 uint32_t job_replicate(JobPool &jobPool, JobPool::JobCallback callback, void *extra,
                        uint64_t chunkId, uint32_t chunkVersion, ChunkPartType chunkType,
                        uint32_t sourcesBufferSize, const uint8_t *sourcesBuffer);
 
+/// @brief Adds an invalid job to the JobPool.
+///
+/// @param jobPool The JobPool instance.
+/// @param callback The callback function to be called upon job completion.
+/// @param extra Additional data to be passed to the callback.
+/// @return The ID of the added job.
 uint32_t job_invalid(JobPool &jobPool, JobPool::JobCallback callback, void *extra);
 
+/// @brief Adds a delete job to the JobPool.
+///
+/// @param jobPool The JobPool instance.
+/// @param callback The callback function to be called upon job completion.
+/// @param extra Additional data to be passed to the callback.
+/// @param chunkId The ID of the chunk.
+/// @param chunkVersion The version of the chunk.
+/// @param chunkType The type of the chunk.
+/// @return The ID of the added job.
 uint32_t job_delete(JobPool &jobPool, JobPool::JobCallback callback, void *extra, uint64_t chunkId,
                     uint32_t chunkVersion, ChunkPartType chunkType);
 
+/// @brief Adds a create job to the JobPool.
+///
+/// @param jobPool The JobPool instance.
+/// @param callback The callback function to be called upon job completion.
+/// @param extra Additional data to be passed to the callback.
+/// @param chunkId The ID of the chunk.
+/// @param chunkVersion The version of the chunk.
+/// @param chunkType The type of the chunk.
+/// @return The ID of the added job.
 uint32_t job_create(JobPool &jobPool, JobPool::JobCallback callback, void *extra, uint64_t chunkId,
                     uint32_t chunkVersion, ChunkPartType chunkType);
 
+/// @brief Adds a change version job to the JobPool.
+///
+/// @param jobPool The JobPool instance.
+/// @param callback The callback function to be called upon job completion.
+/// @param extra Additional data to be passed to the callback.
+/// @param chunkId The ID of the chunk.
+/// @param chunkVersion The version of the chunk.
+/// @param chunkType The type of the chunk.
+/// @param newChunkVersion The new version of the chunk.
+/// @return The ID of the added job.
 uint32_t job_version(JobPool &jobPool, const JobPool::JobCallback &callback, void *extra,
                      uint64_t chunkId, uint32_t chunkVersion, ChunkPartType chunkType,
                      uint32_t newChunkVersion);
 
+/// @brief Adds a truncate job to the JobPool.
+///
+/// @param jobPool The JobPool instance.
+/// @param callback The callback function to be called upon job completion.
+/// @param extra Additional data to be passed to the callback.
+/// @param chunkId The ID of the chunk.
+/// @param chunkType The type of the chunk.
+/// @param chunkVersion The version of the chunk.
+/// @param newChunkVersion The new version of the chunk.
+/// @param length The length to truncate to.
+/// @return The ID of the added job.
 uint32_t job_truncate(JobPool &jobPool, const JobPool::JobCallback &callback, void *extra,
                       uint64_t chunkId, ChunkPartType chunkType, uint32_t chunkVersion,
                       uint32_t newChunkVersion, uint32_t length);
 
+/// @brief Adds a duplicate job to the JobPool.
+///
+/// @param jobPool The JobPool instance.
+/// @param callback The callback function to be called upon job completion.
+/// @param extra Additional data to be passed to the callback.
+/// @param chunkId The ID of the chunk.
+/// @param chunkVersion The version of the chunk.
+/// @param newChunkVersion The new version of the chunk.
+/// @param chunkType The type of the chunk.
+/// @param chunkIdCopy The ID of the chunk to copy.
+/// @param chunkVersionCopy The version of the chunk to copy.
+/// @return The ID of the added job.
 uint32_t job_duplicate(JobPool &jobPool, const JobPool::JobCallback &callback, void *extra,
                        uint64_t chunkId, uint32_t chunkVersion, uint32_t newChunkVersion,
                        ChunkPartType chunkType, uint64_t chunkIdCopy, uint32_t chunkVersionCopy);
 
+/// @brief Adds a duplicate and truncate job to the JobPool.
+///
+/// @param jobPool The JobPool instance.
+/// @param callback The callback function to be called upon job completion.
+/// @param extra Additional data to be passed to the callback.
+/// @param chunkId The ID of the chunk.
+/// @param chunkVersion The version of the chunk.
+/// @param newChunkVersion The new version of the chunk.
+/// @param chunkType The type of the chunk.
+/// @param chunkIdCopy The ID of the chunk to copy.
+/// @param chunkVersionCopy The version of the chunk to copy.
+/// @param length The length to truncate to.
+/// @return The ID of the added job.
 uint32_t job_duptrunc(JobPool &jobPool, const JobPool::JobCallback &callback, void *extra,
                       uint64_t chunkId, uint32_t chunkVersion, uint32_t newChunkVersion,
                       ChunkPartType chunkType, uint64_t chunkIdCopy, uint32_t chunkVersionCopy,

--- a/src/chunkserver/bgjobs_unittest.cc
+++ b/src/chunkserver/bgjobs_unittest.cc
@@ -1,0 +1,141 @@
+/*
+   Copyright 2025 Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "chunkserver/bgjobs.h"
+#include <sys/poll.h>
+#include <thread>
+
+#include "gtest/gtest.h"
+
+void mockJobCallback(uint8_t  /*status*/, void *extra) {
+	auto *counter = static_cast<std::atomic<int> *>(extra);
+	counter->fetch_add(1);
+}
+
+constexpr uint32_t kWaitTimeMs = 100;
+
+// Test fixture for JobPool tests
+class JobPoolTest : public ::testing::Test {
+private:
+	void servePoll() {
+		while (!terminate) {
+			int ret = poll(&wakeupDescPollFd, 1, kWaitTimeMs);
+			if (ret > 0) {
+				if (wakeupDescPollFd.revents & POLLIN) {
+					jobPool->checkJobs();
+				}
+			}
+		}
+	}
+
+protected:
+	void SetUp() override {
+		wakeupDesc = 0;
+		jobPool = std::make_unique<JobPool>(4, 10, &wakeupDesc);
+		counter.store(0);
+		counter2.store(0);
+		wakeupDescPollFd = {wakeupDesc, POLLIN, 0};
+		startServePoll();
+	}
+
+	void TearDown() override {
+		stopServePoll();
+		jobPool.reset();
+	}
+
+	void startServePoll() {
+		terminate = false;
+		servePollThread = std::thread([this]() { servePoll(); });
+	}
+
+	void stopServePoll() {
+		std::unique_lock lock(mutex_);
+		terminate = true;
+		lock.unlock();
+
+		if (servePollThread.joinable()) { servePollThread.join(); }
+	}
+
+	JobPool::ProcessJobCallback mockProcessJob = []() -> uint8_t {
+		return 0;  // Return success status
+	};
+
+	std::unique_ptr<JobPool> jobPool;
+	int wakeupDesc;
+	std::atomic<int> counter;
+	std::atomic<int> counter2;
+	struct pollfd wakeupDescPollFd;
+	std::thread servePollThread;
+	bool terminate;
+	std::mutex mutex_;
+};
+
+// Test job addition
+TEST_F(JobPoolTest, AddJob) {
+	jobPool->addJob(JobPool::ChunkOperation::Read, mockJobCallback, &counter, mockProcessJob);
+	EXPECT_EQ(jobPool->getJobCount(), 1U);
+}
+
+// Test job processing
+TEST_F(JobPoolTest, ProcessJob) {
+	jobPool->addJob(JobPool::ChunkOperation::Read, mockJobCallback, &counter, mockProcessJob);
+
+	// Wait for the job to be processed
+	std::this_thread::sleep_for(std::chrono::milliseconds(kWaitTimeMs));
+
+	EXPECT_EQ(counter.load(), 1);
+}
+
+// Test job disabling
+TEST_F(JobPoolTest, DisableJob) {
+	uint32_t jobId =
+	    jobPool->addJob(JobPool::ChunkOperation::Read, mockJobCallback, &counter, mockProcessJob);
+	jobPool->disableJob(jobId);
+
+	// Wait for the job to be processed
+	std::this_thread::sleep_for(std::chrono::milliseconds(kWaitTimeMs));
+
+	EXPECT_EQ(counter.load(), 0);
+}
+
+// Test changing callbacks
+TEST_F(JobPoolTest, ChangeCallback) {
+	uint32_t jobId =
+	    jobPool->addJob(JobPool::ChunkOperation::Read, mockJobCallback, &counter, mockProcessJob);
+	jobPool->changeCallback(jobId, mockJobCallback, &counter2);
+
+	// Wait for the job to be processed
+	std::this_thread::sleep_for(std::chrono::milliseconds(kWaitTimeMs));
+
+	EXPECT_EQ(counter.load(), 0);
+	EXPECT_EQ(counter2.load(), 1);
+}
+
+// Test job status handling
+TEST_F(JobPoolTest, JobStatusHandling) {
+	// Stop the servePoll thread to disable automatic job dispatching
+	stopServePoll();
+
+	jobPool->addJob(JobPool::ChunkOperation::Read, mockJobCallback, &counter, mockProcessJob);
+
+	// Wait for the job to be processed
+	std::this_thread::sleep_for(std::chrono::milliseconds(kWaitTimeMs));
+
+	jobPool->checkJobs();
+	EXPECT_EQ(counter.load(), 1);
+}

--- a/src/chunkserver/bgjobs_unittest.cc
+++ b/src/chunkserver/bgjobs_unittest.cc
@@ -17,6 +17,8 @@
 */
 
 #include "chunkserver/bgjobs.h"
+#include "errors/saunafs_error_codes.h"
+
 #include <sys/poll.h>
 #include <thread>
 
@@ -103,14 +105,19 @@ TEST_F(JobPoolTest, ProcessJob) {
 
 // Test job disabling
 TEST_F(JobPoolTest, DisableJob) {
+	JobPool::JobCallback mockedJobCallback = [](uint8_t status, void *extra) -> void {
+		auto *counter = static_cast<std::atomic<int> *>(extra);
+		counter->store(status);
+	};
+
 	uint32_t jobId =
-	    jobPool->addJob(JobPool::ChunkOperation::Read, mockJobCallback, &counter, mockProcessJob);
+	    jobPool->addJob(JobPool::ChunkOperation::Read, mockedJobCallback, &counter, mockProcessJob);
 	jobPool->disableJob(jobId);
 
 	// Wait for the job to be processed
 	std::this_thread::sleep_for(std::chrono::milliseconds(kWaitTimeMs));
 
-	EXPECT_EQ(counter.load(), 0);
+	EXPECT_EQ(counter.load(), SAUNAFS_ERROR_NOTDONE);
 }
 
 // Test changing callbacks

--- a/src/chunkserver/chunkserver_entry.cc
+++ b/src/chunkserver/chunkserver_entry.cc
@@ -294,8 +294,7 @@ void ChunkserverEntry::delayedCloseCallback(uint8_t status, void *entry) {
 		eptr->isChunkOpen = 1;
 	}
 	if (eptr->isChunkOpen) {
-		job_close(eptr->workerJobPool, nullptr, nullptr, eptr->chunkId,
-		          eptr->chunkType);
+		job_close(*eptr->workerJobPool, nullptr, nullptr, eptr->chunkId, eptr->chunkType);
 		eptr->isChunkOpen = 0;
 	}
 	eptr->state = State::Closed;
@@ -319,8 +318,7 @@ void ChunkserverEntry::readFinishedCallback(uint8_t status, void *entry) {
 		    buffer, eptr->chunkId, status);
 		eptr->createAttachedPacket(buffer);
 		if (eptr->isChunkOpen) {
-			job_close(eptr->workerJobPool, nullptr, nullptr, eptr->chunkId,
-			          eptr->chunkType);
+			job_close(*eptr->workerJobPool, nullptr, nullptr, eptr->chunkId, eptr->chunkType);
 			eptr->isChunkOpen = 0;
 		}
 		// after sending status even if there was an error it's possible to
@@ -353,8 +351,7 @@ void ChunkserverEntry::readContinue() {
 		createAttachedPacket(buffer);
 		sassert(isChunkOpen);
 
-		job_close(workerJobPool, nullptr, nullptr, chunkId,
-		          chunkType);
+		job_close(*workerJobPool, nullptr, nullptr, chunkId, chunkType);
 		isChunkOpen = 0;
 		// no error - do not disconnect - go direct to the IDLE state, ready for
 		// requests on the same connection
@@ -391,10 +388,8 @@ void ChunkserverEntry::readContinue() {
 			maxReadBehindBlocks = std::min(totalRequestBlocks,
 					gHDDReadAhead.maxBlocksToBeReadBehind());
 		}
-
-		readJobId = job_read(workerJobPool, readFinishedCallback, this, chunkId,
-		                     chunkVersion, chunkType, offset, thisPartSize,
-		                     maxReadBehindBlocks, readAheadBlocks,
+		readJobId = job_read(*workerJobPool, readFinishedCallback, this, chunkId, chunkVersion,
+		                     chunkType, offset, thisPartSize, maxReadBehindBlocks, readAheadBlocks,
 		                     readPacket->outputBuffer.get(), !isChunkOpen);
 		if (readJobId == 0) {
 			state = State::Close;
@@ -508,8 +503,7 @@ void ChunkserverEntry::prefetch(const uint8_t *data, PacketHeader::Type type,
 	auto lastByte = offset + size - 1;
 	auto lastBlock = lastByte / SFSBLOCKSIZE;
 	auto nrOfBlocks = lastBlock - firstBlock + 1;
-	job_prefetch(workerJobPool, chunkId, chunkVersion, chunkType, firstBlock,
-	             nrOfBlocks);
+	job_prefetch(*workerJobPool, chunkId, chunkVersion, chunkType, firstBlock, nrOfBlocks);
 }
 
 // bg writing
@@ -651,8 +645,7 @@ void ChunkserverEntry::writeInit(const uint8_t *data, PacketHeader::Type type,
 	}
 	stats_hlopw++;
 	writeJobWriteId = 0;
-	writeJobId = job_open(workerJobPool, writeFinishedCallback, this, chunkId,
-	                      chunkType);
+	writeJobId = job_open(*workerJobPool, writeFinishedCallback, this, chunkId, chunkType);
 }
 
 void ChunkserverEntry::writeData(const uint8_t *data, PacketHeader::Type type,
@@ -717,9 +710,8 @@ void ChunkserverEntry::writeData(const uint8_t *data, PacketHeader::Type type,
 
 	preserveInputPacket();
 	writeJobWriteId = writeId;
-	writeJobId = job_write(workerJobPool, writeFinishedCallback, this,
-	                       opChunkId, chunkVersion, chunkType, blocknum,
-	                       opOffset, opSize, crc, dataToWrite);
+	writeJobId = job_write(*workerJobPool, writeFinishedCallback, this, opChunkId, chunkVersion,
+	                       chunkType, blocknum, opOffset, opSize, crc, dataToWrite);
 }
 
 void ChunkserverEntry::writeStatus(const uint8_t *data, PacketHeader::Type type,
@@ -824,7 +816,7 @@ void ChunkserverEntry::writeEnd(const uint8_t *data, uint32_t length) {
 		return;
 	}
 	if (isChunkOpen) {
-		job_close(workerJobPool, nullptr, nullptr, chunkId, chunkType);
+		job_close(*workerJobPool, nullptr, nullptr, chunkId, chunkType);
 		isChunkOpen = 0;
 	}
 	if (fwdSocket > 0) {
@@ -883,19 +875,17 @@ void ChunkserverEntry::sauGetChunkBlocks(const uint8_t *data, uint32_t length) {
 		cstocs::getChunkBlocks::deserialize(data, length, chunkId, chunkVersion,
 		                                    chunkType);
 
-		getBlocksJobId = job_get_blocks(
-		    workerJobPool, sauGetChunkBlocksFinishedCallback, this, chunkId,
-		    chunkVersion, chunkType, &getBlocksJobResult);
+		getBlocksJobId = job_get_blocks(*workerJobPool, sauGetChunkBlocksFinishedCallback, this,
+		                                chunkId, chunkVersion, chunkType, &getBlocksJobResult);
 
 	} else {
 		legacy::ChunkPartType legacy_type;
 		cstocs::getChunkBlocks::deserialize(data, length, chunkId, chunkVersion,
 		                                    legacy_type);
 		chunkType = legacy_type;
-
-		getBlocksJobId = job_get_blocks(
-		    workerJobPool, sauGetChunkBlocksFinishedLegacyCallback, this,
-		    chunkId, chunkVersion, chunkType, &getBlocksJobResult);
+		getBlocksJobId =
+		    job_get_blocks(*workerJobPool, sauGetChunkBlocksFinishedLegacyCallback, this, chunkId,
+		                   chunkVersion, chunkType, &getBlocksJobResult);
 	}
 	state = State::GetBlock;
 }
@@ -904,9 +894,8 @@ void ChunkserverEntry::getChunkBlocks(const uint8_t *data, uint32_t length) {
 	deserializeAllLegacyPacketDataNoHeader(data, length, chunkId,
 	                                       chunkVersion);
 	chunkType = slice_traits::standard::ChunkPartType();
-	getBlocksJobId =
-	    job_get_blocks(workerJobPool, getChunkBlocksFinishedCallback, this,
-	                   chunkId, chunkVersion, chunkType, &(getBlocksJobResult));
+	getBlocksJobId = job_get_blocks(*workerJobPool, getChunkBlocksFinishedCallback, this, chunkId,
+	                                chunkVersion, chunkType, &(getBlocksJobResult));
 	state = State::GetBlock;
 }
 
@@ -1029,23 +1018,20 @@ void ChunkserverEntry::outputCheckReadFinished() {
 void ChunkserverEntry::closeJobs() {
 	TRACETHIS();
 	if (readJobId > 0) {
-		job_pool_disable_job(workerJobPool, readJobId);
-		job_pool_change_callback(workerJobPool, readJobId, delayedCloseCallback,
-		                         this);
+		workerJobPool->disableJob(readJobId);
+		workerJobPool->changeCallback(readJobId, delayedCloseCallback, this);
 		state = State::CloseWait;
 	} else if (writeJobId > 0) {
-		job_pool_disable_job(workerJobPool, writeJobId);
-		job_pool_change_callback(workerJobPool, writeJobId,
-		                         delayedCloseCallback, this);
+		workerJobPool->disableJob(writeJobId);
+		workerJobPool->changeCallback(writeJobId, delayedCloseCallback, this);
 		state = State::CloseWait;
 	} else if (getBlocksJobId > 0) {
-		job_pool_disable_job(workerJobPool, getBlocksJobId);
-		job_pool_change_callback(workerJobPool, getBlocksJobId,
-		                         delayedCloseCallback, this);
+		workerJobPool->disableJob(getBlocksJobId);
+		workerJobPool->changeCallback(getBlocksJobId, delayedCloseCallback, this);
 		state = State::CloseWait;
 	} else {
 		if (isChunkOpen) {
-			job_close(workerJobPool, nullptr, nullptr, chunkId, chunkType);
+			job_close(*workerJobPool, nullptr, nullptr, chunkId, chunkType);
 			isChunkOpen = 0;
 		}
 		state = State::Closed;

--- a/src/chunkserver/chunkserver_entry.cc
+++ b/src/chunkserver/chunkserver_entry.cc
@@ -294,7 +294,8 @@ void ChunkserverEntry::delayedCloseCallback(uint8_t status, void *entry) {
 		eptr->isChunkOpen = 1;
 	}
 	if (eptr->isChunkOpen) {
-		job_close(*eptr->workerJobPool, nullptr, nullptr, eptr->chunkId, eptr->chunkType);
+		job_close(*eptr->workerJobPool, kEmptyCallback, kEmptyExtra, eptr->chunkId,
+		          eptr->chunkType);
 		eptr->isChunkOpen = 0;
 	}
 	eptr->state = State::Closed;
@@ -503,7 +504,7 @@ void ChunkserverEntry::prefetch(const uint8_t *data, PacketHeader::Type type,
 	auto lastByte = offset + size - 1;
 	auto lastBlock = lastByte / SFSBLOCKSIZE;
 	auto nrOfBlocks = lastBlock - firstBlock + 1;
-	job_prefetch(*workerJobPool, chunkId, chunkVersion, chunkType, firstBlock, nrOfBlocks);
+	job_prefetch(*workerJobPool, chunkId, chunkType, firstBlock, nrOfBlocks);
 }
 
 // bg writing

--- a/src/chunkserver/chunkserver_entry.h
+++ b/src/chunkserver/chunkserver_entry.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "bgjobs.h"
 #include "common/platform.h"
 
 #include <cstdint>
@@ -119,7 +120,7 @@ struct ChunkserverEntry {
 	static constexpr uint32_t kGenerateChartExpectedPacketSize =
 	    sizeof(uint32_t);
 
-	void* workerJobPool; // Job pool assigned to a given network worker thread
+	JobPool *workerJobPool;  // Job pool assigned to a given network worker thread
 
 	ChunkserverEntry::State state = ChunkserverEntry::State::Idle;
 	ChunkserverEntry::Mode mode = ChunkserverEntry::Mode::Header;
@@ -183,7 +184,7 @@ struct ChunkserverEntry {
 
 	LOG_AVG_TYPE readOperationTimer;
 
-	ChunkserverEntry(int socket, void *workerJobPool)
+	ChunkserverEntry(int socket, JobPool *workerJobPool)
 	    : workerJobPool(workerJobPool), sock(socket) {
 		inputPacket.bytesLeft = PacketHeader::kSize;
 		inputPacket.startPtr = headerBuffer;

--- a/src/chunkserver/hddspacemgr.cc
+++ b/src/chunkserver/hddspacemgr.cc
@@ -2016,53 +2016,22 @@ int hddInternalDelete(uint64_t chunkId, uint32_t version,
 	return hddInternalDelete(chunk, version);
 }
 
-/* all chunk operations in one call */
-// newversion>0 && length==0xFFFFFFFF && copychunkid==0    -> change version
-// newversion>0 && length==0xFFFFFFFF && copycnunkid>0     -> duplicate
-// newversion>0 && length<=SFSCHUNKSIZE && copychunkid==0  -> truncate
-// newversion>0 && length<=SFSCHUNKSIZE && copychunkid>0   -> dup and truncate
-// newversion==0 && length==0                             -> delete
-// newversion==0 && length==1                             -> create
-// newversion==0 && length==2                             -> check chunk content
-int hddChunkOperation(uint64_t chunkId, uint32_t chunkVersion,
-                      ChunkPartType chunkType, uint32_t chunkNewVersion,
-                      uint64_t chunkIdCopy, uint32_t chunkVersionCopy,
-                      uint32_t length) {
-	TRACETHIS();
+int hddTruncate(uint64_t chunkId, uint32_t chunkVersion, ChunkPartType chunkType,
+	uint32_t chunkNewVersion, uint32_t length) {
+	return hddInternalTruncate(chunkId, chunkType, chunkVersion, chunkNewVersion, length);
+}
 
-	if (chunkNewVersion > 0) {
-		if (length == 0xFFFFFFFF) {
-			if (chunkIdCopy == 0) {
-				return hddInternalUpdateVersion(chunkId, chunkVersion,
-				                                chunkNewVersion, chunkType);
-			} else {
-				return hddInternalDuplicate(chunkId, chunkVersion,
-				                            chunkNewVersion, chunkType,
-				                            chunkIdCopy, chunkVersionCopy);
-			}
-		} else if (length <= SFSCHUNKSIZE) {
-			if (chunkIdCopy == 0) {
-				return hddInternalTruncate(chunkId, chunkType, chunkVersion,
-				                           chunkNewVersion, length);
-			} else {
-				return hddInternalDuplicateTruncate(
-				    chunkId, chunkVersion, chunkNewVersion, chunkType,
-				    chunkIdCopy, chunkVersionCopy, length);
-			}
-		} else {
-			return SAUNAFS_ERROR_EINVAL;
-		}
-	} else {
-		if (length == 0) {
-			return hddInternalDelete(chunkId, chunkVersion, chunkType);
-		} else if (length == 1) {
-			return hddInternalCreate(chunkId, chunkVersion, chunkType);
-		} else if (length == 2) {
-			return hddInternalTestChunk(chunkId, chunkVersion, chunkType);
-		} else {
-			return SAUNAFS_ERROR_EINVAL;
-		}
-	}
+int hddDuplicate(uint64_t chunkId, uint32_t chunkVersion, uint32_t chunkNewVersion,
+                 ChunkPartType chunkType, uint64_t copyChunkId, uint32_t copyChunkVersion) {
+	return hddInternalDuplicate(chunkId, chunkVersion, chunkNewVersion, chunkType, copyChunkId,
+	                            copyChunkVersion);
+}
+
+int hddDuplicateTruncate(uint64_t chunkId, uint32_t chunkVersion, uint32_t chunkNewVersion,
+                         ChunkPartType chunkType, uint64_t copyChunkId, uint32_t copyChunkVersion,
+                         uint32_t length) {
+	return hddInternalDuplicateTruncate(chunkId, chunkVersion, chunkNewVersion, chunkType,
+	                                    copyChunkId, copyChunkVersion, length);
 }
 
 static UniqueQueue<ChunkWithVersionAndType> gTestChunkQueue;

--- a/src/chunkserver/hddspacemgr.h
+++ b/src/chunkserver/hddspacemgr.h
@@ -77,19 +77,15 @@ int hddChunkGetNumberOfBlocks(uint64_t chunkId, ChunkPartType chunkType,
                               uint32_t version, uint16_t *blocks);
 
 /* chunk operations */
+int hddTruncate(uint64_t chunkId, uint32_t chunkVersion, ChunkPartType chunkType,
+                uint32_t chunkNewVersion, uint32_t length);
 
-/* all chunk operations in one call */
-// chunkNewVersion>0 && length==0xFFFFFFFF && chunkIdCopy==0   -> change version
-// chunkNewVersion>0 && length==0xFFFFFFFF && chunkIdCopy>0     -> duplicate
-// chunkNewVersion>0 && length<=SFSCHUNKSIZE && chunkIdCopy==0  -> truncate
-// chunkNewVersion>0 && length<=SFSCHUNKSIZE && chunkIdCopy>0   -> dup and turn
-// chunkNewVersion==0 && length==0                              -> delete
-// chunkNewVersion==0 && length==1                              -> create
-// chunkNewVersion==0 && length==2                              -> test
-int hddChunkOperation(uint64_t chunkId, uint32_t chunkVersion,
-                      ChunkPartType chunkType, uint32_t chunkNewVersion,
-                      uint64_t chunkIdCopy, uint32_t chunkVersionCopy,
-                      uint32_t length);
+int hddDuplicate(uint64_t chunkId, uint32_t chunkVersion, uint32_t chunkNewVersion,
+                 ChunkPartType chunkType, uint64_t copyChunkId, uint32_t copyChunkVersion);
+
+int hddDuplicateTruncate(uint64_t chunkId, uint32_t chunkVersion, uint32_t chunkNewVersion,
+                         ChunkPartType chunkType, uint64_t copyChunkId, uint32_t copyChunkVersion,
+                         uint32_t length);
 
 /* chunk testing */
 void hddAddChunkToTestQueue(ChunkWithVersionAndType chunk);

--- a/src/chunkserver/masterconn.cc
+++ b/src/chunkserver/masterconn.cc
@@ -874,7 +874,10 @@ int masterconn_init_threads(void) {
 		return -1;
 	}
 
-	if (jobPool == nullptr) { return -1; }
+	if (jobPool == nullptr) {
+		safs::log_err("masterconn_init_threads: jobPool is null. Unable to create worker threads.");
+		return -1;
+	}
 
 	safs_pretty_syslog(LOG_INFO,
 	                   "master connection: %u background workers created",

--- a/src/chunkserver/masterconn.cc
+++ b/src/chunkserver/masterconn.cc
@@ -21,20 +21,17 @@
 #include "common/platform.h"
 #include "chunkserver/masterconn.h"
 
-#include <errno.h>
-#include <inttypes.h>
+#include <cerrno>
+#include <cinttypes>
 #include <netinet/in.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <sys/types.h>
 #include <sys/uio.h>
 #include <syslog.h>
-#include <time.h>
+#include <ctime>
 #include <unistd.h>
-#include <algorithm>
-#include <list>
-
 #include <list>
 
 #include "chunkserver-common/hdd_utils.h"
@@ -42,13 +39,9 @@
 #include "chunkserver/hddspacemgr.h"
 #include "chunkserver/network_main_thread.h"
 #include "config/cfg.h"
-#include "common/datapack.h"
 #include "common/event_loop.h"
-#include "common/goal.h"
 #include "common/loop_watchdog.h"
-#include "common/main.h"
 #include "common/massert.h"
-#include "common/legacy_vector.h"
 #include "common/output_packet.h"
 #include "common/random.h"
 #include "slogger/slogger.h"
@@ -102,7 +95,7 @@ struct masterconn {
 static const uint64_t kSendStatusDelay = 5;
 
 static masterconn *masterconnsingleton=NULL;
-static void *jpool;
+static std::unique_ptr<JobPool> jobPool;
 static int jobfd;
 static int32_t jobfdpdescpos;
 
@@ -310,7 +303,7 @@ void masterconn_create(masterconn */*eptr*/, const std::vector<uint8_t> &data) {
 	matocs::createChunk::deserialize(data, chunkId, chunkType, chunkVersion);
 	OutputPacket *outputPacket = new OutputPacket;
 	cstoma::createChunk::serialize(outputPacket->packet, chunkId, chunkType, SAUNAFS_STATUS_OK);
-	job_create(jpool, masterconn_saujobfinished, outputPacket, chunkId, chunkType, chunkVersion);
+	job_create(*jobPool, masterconn_saujobfinished, outputPacket, chunkId, chunkVersion, chunkType);
 }
 
 void masterconn_delete(masterconn */*eptr*/, const std::vector<uint8_t>& data) {
@@ -321,7 +314,7 @@ void masterconn_delete(masterconn */*eptr*/, const std::vector<uint8_t>& data) {
 	matocs::deleteChunk::deserialize(data, chunkId, chunkType, chunkVersion);
 	OutputPacket* outputPacket = new OutputPacket;
 	cstoma::deleteChunk::serialize(outputPacket->packet, chunkId, chunkType, 0);
-	job_delete(jpool, masterconn_saujobfinished, outputPacket, chunkId, chunkVersion, chunkType);
+	job_delete(*jobPool, masterconn_saujobfinished, outputPacket, chunkId, chunkVersion, chunkType);
 }
 
 void masterconn_setversion(masterconn */*eptr*/, const std::vector<uint8_t>& data) {
@@ -333,8 +326,8 @@ void masterconn_setversion(masterconn */*eptr*/, const std::vector<uint8_t>& dat
 	matocs::setVersion::deserialize(data, chunkId, chunkType, chunkVersion, newVersion);
 	OutputPacket* outputPacket = new OutputPacket;
 	cstoma::setVersion::serialize(outputPacket->packet, chunkId, chunkType, 0);
-	job_version(jpool, masterconn_saujobfinished, outputPacket, chunkId, chunkVersion, chunkType,
-			newVersion);
+	job_version(*jobPool, masterconn_saujobfinished, outputPacket, chunkId, chunkVersion, chunkType,
+	            newVersion);
 }
 
 void masterconn_duplicate(masterconn* /*eptr*/,const std::vector<uint8_t>& data) {
@@ -346,8 +339,8 @@ void masterconn_duplicate(masterconn* /*eptr*/,const std::vector<uint8_t>& data)
 			oldChunkId, oldChunkVersion);
 	OutputPacket* outputPacket = new OutputPacket;
 	cstoma::duplicateChunk::serialize(outputPacket->packet, newChunkId, chunkType, 0);
-	job_duplicate(jpool, masterconn_saujobfinished, outputPacket, oldChunkId,
-			oldChunkVersion, oldChunkVersion, chunkType, newChunkId, newChunkVersion);
+	job_duplicate(*jobPool, masterconn_saujobfinished, outputPacket, oldChunkId, oldChunkVersion,
+	              oldChunkVersion, chunkType, newChunkId, newChunkVersion);
 }
 
 void masterconn_truncate(masterconn */*eptr*/, const std::vector<uint8_t>& data) {
@@ -360,7 +353,7 @@ void masterconn_truncate(masterconn */*eptr*/, const std::vector<uint8_t>& data)
 	matocs::truncateChunk::deserialize(data, chunkId, chunkType, chunkLength, newVersion, version);
 	OutputPacket* outputPacket = new OutputPacket;
 	cstoma::truncate::serialize(outputPacket->packet, chunkId, chunkType, 0);
-	job_truncate(jpool, masterconn_saujobfinished, outputPacket, chunkId, chunkType, version,
+	job_truncate(*jobPool, masterconn_saujobfinished, outputPacket, chunkId, chunkType, version,
 			newVersion, chunkLength);
 }
 
@@ -374,8 +367,8 @@ void masterconn_duptrunc(masterconn* /*eptr*/, const std::vector<uint8_t>& data)
 			chunkType, chunkId, chunkVersion, newLength);
 	OutputPacket* outputPacket = new OutputPacket;
 	cstoma::duptruncChunk::serialize(outputPacket->packet, copyChunkId, chunkType, 0);
-	job_duptrunc(jpool, masterconn_saujobfinished, outputPacket, chunkId,
-			chunkVersion, chunkVersion, chunkType, copyChunkId, copyChunkVersion, newLength);
+	job_duptrunc(*jobPool, masterconn_saujobfinished, outputPacket, chunkId, chunkVersion,
+	             chunkVersion, chunkType, copyChunkId, copyChunkVersion, newLength);
 }
 
 void masterconn_replicate(const std::vector<uint8_t>& data) {
@@ -397,8 +390,8 @@ void masterconn_replicate(const std::vector<uint8_t>& data) {
 		// Disk scan in progress - replication is not possible
 		masterconn_saujobfinished(SAUNAFS_ERROR_WAITING, outputPacket);
 	} else {
-		job_replicate(jpool, masterconn_saujobfinished, outputPacket,
-				chunkId, chunkVersion, chunkType, sourcesBufferSize, sourcesBuffer);
+		job_replicate(*jobPool, masterconn_saujobfinished, outputPacket, chunkId, chunkVersion,
+		              chunkType, sourcesBufferSize, sourcesBuffer);
 	}
 
 }
@@ -449,7 +442,7 @@ void masterconn_term(void) {
 //      syslog(LOG_INFO,"closing %s:%s",MasterHost,MasterPort);
 	masterconn *eptr = masterconnsingleton;
 
-	job_pool_delete(jpool);
+	jobPool.reset();
 
 	if (eptr->mode!=FREE && eptr->mode!=CONNECTING) {
 		tcpclose(eptr->sock);
@@ -553,7 +546,7 @@ void masterconn_read(masterconn *eptr) {
 
 	watchdog.start();
 	while (eptr->mode != KILL) {
-		if (job_pool_jobs_count(jpool) >= (BGJOBSCNT * 9) / 10) {
+		if (jobPool->getJobCount() >= (BGJOBSCNT * 9) / 10) {
 			return;
 		}
 		uint32_t bytesToRead = eptr->inputPacket.bytesToBeRead();
@@ -637,7 +630,7 @@ void masterconn_desc(std::vector<pollfd> &pdesc) {
 	if (eptr->mode == CONNECTED) {
 		pdesc.push_back({jobfd,POLLIN,0});
 		jobfdpdescpos = pdesc.size() - 1;
-		if (job_pool_jobs_count(jpool)<(BGJOBSCNT*9)/10) {
+		if (jobPool->getJobCount() < (BGJOBSCNT * 9) / 10) {
 			pdesc.push_back({eptr->sock,POLLIN,0});
 			eptr->pdescpos = pdesc.size() - 1;
 		}
@@ -684,7 +677,7 @@ void masterconn_serve(const std::vector<pollfd> &pdesc) {
 		}
 	} else {
 		if ((eptr->mode == CONNECTED) && jobfdpdescpos>=0 && (pdesc[jobfdpdescpos].revents & POLLIN)) { // FD_ISSET(jobfd,rset)) {
-			job_pool_check_jobs(jpool);
+			jobPool->checkJobs();
 		}
 		if (eptr->pdescpos>=0) {
 			if ((eptr->mode == CONNECTED) && (pdesc[eptr->pdescpos].revents & POLLIN)) { // FD_ISSET(eptr->sock,rset)) {
@@ -704,13 +697,13 @@ void masterconn_serve(const std::vector<pollfd> &pdesc) {
 		}
 	}
 	if (eptr->mode == CONNECTED) {
-		uint32_t jobscnt = job_pool_jobs_count(jpool);
+		uint32_t jobscnt = jobPool->getJobCount();
 		if (jobscnt>=stats_maxjobscnt) {
 			stats_maxjobscnt=jobscnt;
 		}
 	}
 	if (eptr->mode == KILL) {
-		job_pool_disable_and_change_callback_all(jpool,masterconn_unwantedjobfinished);
+		jobPool->disableAndChangeCallbackAll(masterconn_unwantedjobfinished);
 		tcpclose(eptr->sock);
 		eptr->inputPacket.reset();
 		eptr->outputPackets.clear();
@@ -832,9 +825,9 @@ int masterconn_init(void) {
 }
 
 int masterconn_init_threads(void) {
-	jpool = job_pool_new(gNumberOfWorkers, BGJOBSCNT, &jobfd);
+	jobPool = std::make_unique<JobPool>(gNumberOfWorkers, BGJOBSCNT, &jobfd);
 
-	if (jpool == nullptr) { return -1; }
+	if (jobPool == nullptr) { return -1; }
 
 	safs_pretty_syslog(LOG_INFO,
 	                   "master connection: %u background workers created",

--- a/src/chunkserver/masterconn.cc
+++ b/src/chunkserver/masterconn.cc
@@ -33,6 +33,7 @@
 #include <ctime>
 #include <unistd.h>
 #include <list>
+#include <stdexcept>
 
 #include "chunkserver-common/hdd_utils.h"
 #include "chunkserver/bgjobs.h"
@@ -303,7 +304,14 @@ void masterconn_create(masterconn */*eptr*/, const std::vector<uint8_t> &data) {
 	matocs::createChunk::deserialize(data, chunkId, chunkType, chunkVersion);
 	OutputPacket *outputPacket = new OutputPacket;
 	cstoma::createChunk::serialize(outputPacket->packet, chunkId, chunkType, SAUNAFS_STATUS_OK);
-	job_create(*jobPool, masterconn_saujobfinished, outputPacket, chunkId, chunkVersion, chunkType);
+	if (jobPool) {
+		job_create(*jobPool, masterconn_saujobfinished, outputPacket, chunkId, chunkVersion,
+		           chunkType);
+	}
+	else {
+		safs::log_err("masterconn_create: jobPool is null.");
+		delete outputPacket;
+	}
 }
 
 void masterconn_delete(masterconn */*eptr*/, const std::vector<uint8_t>& data) {
@@ -314,7 +322,13 @@ void masterconn_delete(masterconn */*eptr*/, const std::vector<uint8_t>& data) {
 	matocs::deleteChunk::deserialize(data, chunkId, chunkType, chunkVersion);
 	OutputPacket* outputPacket = new OutputPacket;
 	cstoma::deleteChunk::serialize(outputPacket->packet, chunkId, chunkType, 0);
-	job_delete(*jobPool, masterconn_saujobfinished, outputPacket, chunkId, chunkVersion, chunkType);
+	if (jobPool) {
+		job_delete(*jobPool, masterconn_saujobfinished, outputPacket, chunkId, chunkVersion,
+		           chunkType);
+	} else {
+		safs::log_err("masterconn_delete: jobPool is null.");
+		delete outputPacket;
+	}
 }
 
 void masterconn_setversion(masterconn */*eptr*/, const std::vector<uint8_t>& data) {
@@ -326,8 +340,13 @@ void masterconn_setversion(masterconn */*eptr*/, const std::vector<uint8_t>& dat
 	matocs::setVersion::deserialize(data, chunkId, chunkType, chunkVersion, newVersion);
 	OutputPacket* outputPacket = new OutputPacket;
 	cstoma::setVersion::serialize(outputPacket->packet, chunkId, chunkType, 0);
-	job_version(*jobPool, masterconn_saujobfinished, outputPacket, chunkId, chunkVersion, chunkType,
-	            newVersion);
+	if (jobPool) {
+		job_version(*jobPool, masterconn_saujobfinished, outputPacket, chunkId, chunkVersion,
+		            chunkType, newVersion);
+	} else {
+		safs::log_err("masterconn_setversion: jobPool is null.");
+		delete outputPacket;
+	}
 }
 
 void masterconn_duplicate(masterconn* /*eptr*/,const std::vector<uint8_t>& data) {
@@ -339,8 +358,13 @@ void masterconn_duplicate(masterconn* /*eptr*/,const std::vector<uint8_t>& data)
 			oldChunkId, oldChunkVersion);
 	OutputPacket* outputPacket = new OutputPacket;
 	cstoma::duplicateChunk::serialize(outputPacket->packet, newChunkId, chunkType, 0);
-	job_duplicate(*jobPool, masterconn_saujobfinished, outputPacket, oldChunkId, oldChunkVersion,
-	              oldChunkVersion, chunkType, newChunkId, newChunkVersion);
+	if (jobPool) {
+		job_duplicate(*jobPool, masterconn_saujobfinished, outputPacket, oldChunkId,
+		              oldChunkVersion, oldChunkVersion, chunkType, newChunkId, newChunkVersion);
+	} else {
+		safs::log_err("masterconn_duplicate: jobPool is null.");
+		delete outputPacket;
+	}
 }
 
 void masterconn_truncate(masterconn */*eptr*/, const std::vector<uint8_t>& data) {
@@ -353,8 +377,13 @@ void masterconn_truncate(masterconn */*eptr*/, const std::vector<uint8_t>& data)
 	matocs::truncateChunk::deserialize(data, chunkId, chunkType, chunkLength, newVersion, version);
 	OutputPacket* outputPacket = new OutputPacket;
 	cstoma::truncate::serialize(outputPacket->packet, chunkId, chunkType, 0);
-	job_truncate(*jobPool, masterconn_saujobfinished, outputPacket, chunkId, chunkType, version,
-			newVersion, chunkLength);
+	if (jobPool) {
+		job_truncate(*jobPool, masterconn_saujobfinished, outputPacket, chunkId, chunkType, version,
+		             newVersion, chunkLength);
+	} else {
+		safs::log_err("masterconn_truncate: jobPool is null.");
+		delete outputPacket;
+	}
 }
 
 void masterconn_duptrunc(masterconn* /*eptr*/, const std::vector<uint8_t>& data) {
@@ -367,8 +396,13 @@ void masterconn_duptrunc(masterconn* /*eptr*/, const std::vector<uint8_t>& data)
 			chunkType, chunkId, chunkVersion, newLength);
 	OutputPacket* outputPacket = new OutputPacket;
 	cstoma::duptruncChunk::serialize(outputPacket->packet, copyChunkId, chunkType, 0);
-	job_duptrunc(*jobPool, masterconn_saujobfinished, outputPacket, chunkId, chunkVersion,
-	             chunkVersion, chunkType, copyChunkId, copyChunkVersion, newLength);
+	if (jobPool) {
+		job_duptrunc(*jobPool, masterconn_saujobfinished, outputPacket, chunkId, chunkVersion,
+		             chunkVersion, chunkType, copyChunkId, copyChunkVersion, newLength);
+	} else {
+		safs::log_err("masterconn_duptrunc: jobPool is null.");
+		delete outputPacket;
+	}
 }
 
 void masterconn_replicate(const std::vector<uint8_t>& data) {
@@ -390,8 +424,13 @@ void masterconn_replicate(const std::vector<uint8_t>& data) {
 		// Disk scan in progress - replication is not possible
 		masterconn_saujobfinished(SAUNAFS_ERROR_WAITING, outputPacket);
 	} else {
-		job_replicate(*jobPool, masterconn_saujobfinished, outputPacket, chunkId, chunkVersion,
-		              chunkType, sourcesBufferSize, sourcesBuffer);
+		if (jobPool) {
+			job_replicate(*jobPool, masterconn_saujobfinished, outputPacket, chunkId, chunkVersion,
+			              chunkType, sourcesBufferSize, sourcesBuffer);
+		} else {
+			safs::log_err("masterconn_replicate: jobPool is null.");
+			delete outputPacket;
+		}
 	}
 
 }
@@ -825,7 +864,15 @@ int masterconn_init(void) {
 }
 
 int masterconn_init_threads(void) {
-	jobPool = std::make_unique<JobPool>(gNumberOfWorkers, BGJOBSCNT, &jobfd);
+	try {
+		jobPool = std::make_unique<JobPool>(gNumberOfWorkers, BGJOBSCNT, &jobfd);
+	} catch (const std::runtime_error &e) {
+		safs::log_err("masterconn_init_threads: Failed to create JobPool instance: {}", e.what());
+		return -1;
+	} catch (const std::exception &e) {
+		safs::log_err("masterconn_init_threads: Failed to create JobPool instance: {}", e.what());
+		return -1;
+	}
 
 	if (jobPool == nullptr) { return -1; }
 

--- a/src/chunkserver/network_main_thread.cc
+++ b/src/chunkserver/network_main_thread.cc
@@ -210,7 +210,7 @@ void mainNetworkThreadServe(const std::vector<pollfd> &pdesc) {
 			if (nextNetworkThread == networkThreadObjects.end()) {
 				nextNetworkThread = networkThreadObjects.begin();
 			}
-			if (job_pool_jobs_count(nextNetworkThread->bgJobPool())
+			if (nextNetworkThread->backgroundJobPool()->getJobCount()
 					>= (gBgjobsCountPerNetworkWorker * 9) / 10) {
 				safs_pretty_syslog(LOG_WARNING, "jobs queue is full !!!");
 				tcpclose(newSocketFD);

--- a/src/chunkserver/network_worker_thread.cc
+++ b/src/chunkserver/network_worker_thread.cc
@@ -66,9 +66,6 @@ NetworkWorkerThread::NetworkWorkerThread(uint32_t nrOfBgjobsWorkers,
 #endif
 	try {
 		bgJobPool_ = std::make_unique<JobPool>(nrOfBgjobsWorkers, bgjobsCount, &bgJobPoolWakeUpFd_);
-	} catch (const std::runtime_error &e) {
-		safs::log_err("NetworkWorkerThread: Failed to create JobPool instance: {}", e.what());
-		throw;
 	} catch (const std::exception &e) {
 		safs::log_err("NetworkWorkerThread: Failed to create JobPool instance: {}", e.what());
 		throw;

--- a/src/chunkserver/network_worker_thread.cc
+++ b/src/chunkserver/network_worker_thread.cc
@@ -322,10 +322,10 @@ void NetworkWorkerThread::addConnection(int newSocketFD) {
 		csservEntries.emplace_front(newSocketFD, bgJobPool_.get());
 		csservEntries.front().lastActivity = eventloop_time();
 	} catch (const std::runtime_error &e) {
-		safs_pretty_syslog(LOG_ERR, "Failed to add connection: %s", e.what());
+		safs::log_err("Failed to add connection: {}", e.what());
 		tcpclose(newSocketFD);
 	} catch (const std::exception &e) {
-		safs_pretty_syslog(LOG_ERR, "Unexpected error: %s", e.what());
+		safs::log_err("Unexpected error: {}", e.what());
 		tcpclose(newSocketFD);
 	}
 

--- a/src/chunkserver/network_worker_thread.cc
+++ b/src/chunkserver/network_worker_thread.cc
@@ -64,7 +64,15 @@ NetworkWorkerThread::NetworkWorkerThread(uint32_t nrOfBgjobsWorkers,
 	static constexpr int kPageAlignedPipeSize = 4096 * 32;
 	eassert(fcntl(notify_pipe[1], F_SETPIPE_SZ, kPageAlignedPipeSize));
 #endif
-	bgJobPool_ = std::make_unique<JobPool>(nrOfBgjobsWorkers, bgjobsCount, &bgJobPoolWakeUpFd_);
+	try {
+		bgJobPool_ = std::make_unique<JobPool>(nrOfBgjobsWorkers, bgjobsCount, &bgJobPoolWakeUpFd_);
+	} catch (const std::runtime_error &e) {
+		safs::log_err("NetworkWorkerThread: Failed to create JobPool instance: {}", e.what());
+		throw;
+	} catch (const std::exception &e) {
+		safs::log_err("NetworkWorkerThread: Failed to create JobPool instance: {}", e.what());
+		throw;
+	}
 }
 
 void NetworkWorkerThread::operator()() {

--- a/src/chunkserver/network_worker_thread.cc
+++ b/src/chunkserver/network_worker_thread.cc
@@ -64,8 +64,7 @@ NetworkWorkerThread::NetworkWorkerThread(uint32_t nrOfBgjobsWorkers,
 	static constexpr int kPageAlignedPipeSize = 4096 * 32;
 	eassert(fcntl(notify_pipe[1], F_SETPIPE_SZ, kPageAlignedPipeSize));
 #endif
-	bgJobPool_ =
-	    job_pool_new(nrOfBgjobsWorkers, bgjobsCount, &bgJobPoolWakeUpFd_);
+	bgJobPool_ = std::make_unique<JobPool>(nrOfBgjobsWorkers, bgjobsCount, &bgJobPoolWakeUpFd_);
 }
 
 void NetworkWorkerThread::operator()() {
@@ -102,7 +101,7 @@ void NetworkWorkerThread::operator()() {
 
 void NetworkWorkerThread::terminate() {
 	TRACETHIS();
-	job_pool_delete(bgJobPool_);
+	bgJobPool_.reset();
 
 	std::unique_lock lock(csservheadLock);
 
@@ -190,7 +189,7 @@ void NetworkWorkerThread::servePoll() {
 	ChunkserverEntry::State lstate;
 
 	if (pdesc[JOB_FD_PDESC_POS].revents & POLLIN) {
-		job_pool_check_jobs(bgJobPool_);
+		bgJobPool_->checkJobs();
 	}
 	std::unique_lock lock(csservheadLock);
 	for (auto& entry : csservEntries) {
@@ -283,7 +282,7 @@ void NetworkWorkerThread::servePoll() {
 		}
 	}
 
-	jobscnt = job_pool_jobs_count(bgJobPool_);
+	jobscnt = bgJobPool_->getJobCount();
 //      // Lock free stats_maxjobscnt = max(stats_maxjobscnt, jobscnt), but I don't trust myself :(...
 //      uint32_t expected_value = stats_maxjobscnt;
 //      while (jobscnt > expected_value
@@ -318,8 +317,17 @@ void NetworkWorkerThread::addConnection(int newSocketFD) {
 	tcpnodelay(newSocketFD);
 
 	std::unique_lock lock(csservheadLock);
-	csservEntries.emplace_front(newSocketFD, bgJobPool_);
-	csservEntries.front().lastActivity = eventloop_time();
+	try {
+		if (!bgJobPool_) { throw std::runtime_error("JobPool instance is null"); }
+		csservEntries.emplace_front(newSocketFD, bgJobPool_.get());
+		csservEntries.front().lastActivity = eventloop_time();
+	} catch (const std::runtime_error &e) {
+		safs_pretty_syslog(LOG_ERR, "Failed to add connection: %s", e.what());
+		tcpclose(newSocketFD);
+	} catch (const std::exception &e) {
+		safs_pretty_syslog(LOG_ERR, "Unexpected error: %s", e.what());
+		tcpclose(newSocketFD);
+	}
 
 	eassert(write(notify_pipe[1], "9", 1) == 1);
 }

--- a/src/chunkserver/network_worker_thread.h
+++ b/src/chunkserver/network_worker_thread.h
@@ -28,6 +28,7 @@
 #include <vector>
 
 #include "chunkserver/chunkserver_entry.h"
+#include "chunkserver/bgjobs.h"
 
 class NetworkWorkerThread {
 public:
@@ -42,8 +43,9 @@ public:
 	void operator()();
 	void askForTermination();
 	void addConnection(int newSocketFD);
-	void* bgJobPool() {
-		return bgJobPool_;
+
+	JobPool *backgroundJobPool() {
+		return bgJobPool_.get();
 	}
 
 private:
@@ -55,7 +57,7 @@ private:
 	std::mutex csservheadLock;
 	std::list<ChunkserverEntry> csservEntries;
 
-	void *bgJobPool_;
+	std::unique_ptr<JobPool> bgJobPool_;
 	int bgJobPoolWakeUpFd_;
 	static const uint32_t JOB_FD_PDESC_POS = 1;
 	std::vector<struct pollfd> pdesc;


### PR DESCRIPTION
This PR refactors the background jobs (bgjobs.{h,cc}) used by the chunkserver.

**Key changes:**
- Add the `JobPool` to manage bgjobs: previously background jobs were
  managed using raw pointers and macros, leading to complex and hard to
  maintain code. The `JobPool` class introduces modern C++ features to
  make the code more efficient, readable and easier to maintain.
  
- Refactor `hddChunkOperation`: this function handled all chunk
  operations using different argument combinations, making the code
  complex and hard to maintain. The new version separates this function
  into multiple functions, each with a single responsibility.
  
- Introduce a `ProcessJobCallback` in the `Job` structure to manage
  job execution. This simplifies the `workerThread` function of every
  job and remove redundant job arguments used in the previous version.
  
- Add documentation and unit tests for the `JobPool` class.