### PR TITLE
chore: Add icon resource to Windows binaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -371,6 +371,7 @@ endif()
 include_directories(src) # Allow paths relative to src, eg. #include common/crc.h
 link_directories(${LINK_DIRECTORIES} ${FUSE_LIBRARY_DIR})
 
+set(ICON_RESOURCE_FILE "")
 if(MINGW)
   option(ENABLE_WINFSP_WINCLIENT  "Enable winfsp library based windows client build"    ON)
 
@@ -379,6 +380,8 @@ if(MINGW)
     set(WINFSP_FUSE_DLL  "C:/Program Files (x86)/WinFsp/bin/winfsp-x64.dll"    CACHE STRING "winfsp-fuse dll for specific arch")
     set(WINFSP_FUSE_LIBRARY  "C:/Program Files (x86)/WinFsp/lib/winfsp-x64.lib"    CACHE STRING "winfsp-fuse lib for specific arch")
   endif()
+
+  set(ICON_RESOURCE_FILE "${CMAKE_SOURCE_DIR}/src/mount/windows/resources/icons/icon.rc")
 endif()
 
 add_subdirectory(external)

--- a/src/admin/CMakeLists.txt
+++ b/src/admin/CMakeLists.txt
@@ -5,7 +5,11 @@ target_link_libraries(saunafs-admin-lib sfscommon)
 create_unittest(saunafs-admin-lib ${SAUNAFS_ADMIN_TESTS})
 link_unittest(saunafs-admin-lib sfscommon)
 
-add_executable(saunafs-admin ${SAUNAFS_ADMIN_MAIN})
+if(ICON_RESOURCE_FILE STREQUAL "")
+  add_executable(saunafs-admin ${SAUNAFS_ADMIN_MAIN})
+else()
+  add_executable(saunafs-admin ${SAUNAFS_ADMIN_MAIN} ${ICON_RESOURCE_FILE})
+endif()
 target_link_libraries(saunafs-admin saunafs-admin-lib)
 install(TARGETS saunafs-admin RUNTIME DESTINATION ${BIN_SUBDIR})
 


### PR DESCRIPTION
This commit adds an icon resource to the binaries compiled for Windows in order to better distinguish them from other executables.