### PR TITLE
refactor(chunkserver): Split OutputBuffer inner buffer

### DIFF
--- a/src/chunkserver/buffers_pool.h
+++ b/src/chunkserver/buffers_pool.h
@@ -51,6 +51,14 @@ public:
 	std::shared_ptr<T> get(size_t headerSize, size_t numBlocks) {
 		std::unique_lock lock(mutex_);
 
+		if (operationsSinceLastLog_ == kLogAfterEveryXTimes) {
+			safs::log_trace(
+			    "BuffersPool::get {} blocks, currentNumberOfBlocks_ = {}, kMaxNumberOfBlocks = {}",
+			    numBlocks, currentNumberOfBlocks_, kMaxNumberOfBlocks);
+			operationsSinceLastLog_ = 0;
+		}
+		operationsSinceLastLog_++;
+
 		auto it = buffersMap_.find({headerSize, numBlocks});
 		if (it == buffersMap_.end() || it->second.empty()) {
 			// To make sure the allocation is not done under the lock.
@@ -63,7 +71,7 @@ public:
 
 		buffers.pop();
 		buffer->clear();
-		currentSize_--;
+		currentNumberOfBlocks_ -= numBlocks;
 
 		return buffer;
 	}
@@ -74,21 +82,36 @@ public:
 	 */
 	void put(std::shared_ptr<T> &&buffer) {
 		std::unique_lock lock(mutex_);
-		auto &buffers = buffersMap_[buffer->type()];
-		if (currentSize_ < kMaxSize) {
+
+		auto [headerSize, numBlocks] = buffer->type();
+		auto &buffers = buffersMap_[{headerSize, numBlocks}];
+
+		if (operationsSinceLastLog_ == kLogAfterEveryXTimes) {
+			safs::log_trace(
+			    "BuffersPool::put {} blocks, currentNumberOfBlocks_ = {}, kMaxNumberOfBlocks = {}",
+			    numBlocks, currentNumberOfBlocks_, kMaxNumberOfBlocks);
+			operationsSinceLastLog_ = 0;
+		}
+		operationsSinceLastLog_++;
+
+		if (currentNumberOfBlocks_ + numBlocks <= kMaxNumberOfBlocks) {
 			buffer->clear();
 			buffers.push(std::move(buffer));
-			currentSize_++;
+			currentNumberOfBlocks_ += numBlocks;
 		}
 		// To make sure the deallocation is not done under the lock.
 		lock.unlock();
 	}
 
 private:
+	/// How many operations should pass between two log messages.
+	static constexpr size_t kLogAfterEveryXTimes = 1000;
+	/// Number of operations since last log message.
+	size_t operationsSinceLastLog_ = 0;
 	/// Maximum number of buffers in the pool.
-	static constexpr size_t kMaxSize = 8192;
+	static constexpr size_t kMaxNumberOfBlocks = 8192;
 	/// Current number of buffers in the pool.
-	size_t currentSize_ = 0;
+	size_t currentNumberOfBlocks_ = 0;
 	/// Buffers pool map: a queue of buffers for each type of buffer.
 	std::map<std::pair<size_t, size_t>, std::queue<std::shared_ptr<T>>> buffersMap_;
 	/// Mutex to protect the pool.

--- a/src/chunkserver/buffers_pool.h
+++ b/src/chunkserver/buffers_pool.h
@@ -44,26 +44,28 @@ public:
 
 	/**
 	 * Gets a buffer from the pool or creates a new one.
-	 * @param capacity Requested buffer capacity.
+	 * @param headerSize The size of the header.
+	 * @param numBlocks The number of blocks.
 	 * @return The existent buffer or a newly created one.
 	 */
-	std::shared_ptr<T> get(size_t capacity) {
-		std::lock_guard lock(mutex_);
+	std::shared_ptr<T> get(size_t headerSize, size_t numBlocks) {
+		std::unique_lock lock(mutex_);
 
-		if (buffers_.empty()) {
-			return std::make_shared<T>(capacity);
+		auto it = buffersMap_.find({headerSize, numBlocks});
+		if (it == buffersMap_.end() || it->second.empty()) {
+			// To make sure the allocation is not done under the lock.
+			lock.unlock();
+			return std::make_shared<T>(headerSize, numBlocks);
 		}
 
-		auto buffer = buffers_.front();
+		auto &buffers = it->second;
+		auto buffer = buffers.front();
 
-		if (buffer->capacity() == capacity) {
-			buffers_.pop();
-			buffer->clear();
+		buffers.pop();
+		buffer->clear();
+		currentSize_--;
 
-			return buffer;
-		}
-
-		return std::make_shared<T>(capacity);
+		return buffer;
 	}
 
 	/**
@@ -71,19 +73,24 @@ public:
 	 * @param buffer The buffer to put back.
 	 */
 	void put(std::shared_ptr<T> &&buffer) {
-		std::lock_guard lock(mutex_);
-
-		if (buffers_.size() < kMaxSize) {
+		std::unique_lock lock(mutex_);
+		auto &buffers = buffersMap_[buffer->type()];
+		if (currentSize_ < kMaxSize) {
 			buffer->clear();
-			buffers_.push(std::move(buffer));
+			buffers.push(std::move(buffer));
+			currentSize_++;
 		}
+		// To make sure the deallocation is not done under the lock.
+		lock.unlock();
 	}
 
 private:
 	/// Maximum number of buffers in the pool.
 	static constexpr size_t kMaxSize = 8192;
-	/// Buffers pool (container).
-	std::queue<std::shared_ptr<T>> buffers_;
+	/// Current number of buffers in the pool.
+	size_t currentSize_ = 0;
+	/// Buffers pool map: a queue of buffers for each type of buffer.
+	std::map<std::pair<size_t, size_t>, std::queue<std::shared_ptr<T>>> buffersMap_;
 	/// Mutex to protect the pool.
 	std::mutex mutex_;
 };

--- a/src/chunkserver/chunkserver_entry.cc
+++ b/src/chunkserver/chunkserver_entry.cc
@@ -41,22 +41,22 @@
 #include "chunkserver/hdd_readahead.h"
 #include "chunkserver/hddspacemgr.h"
 #include "chunkserver/network_stats.h"
+#include "chunkserver/output_buffer.h"
 #include "common/charts.h"
-#include "output_buffer.h"
+#include "common/datapack.h"
+#include "common/event_loop.h"
+#include "common/legacy_vector.h"
+#include "common/massert.h"
+#include "common/saunafs_version.h"
+#include "common/sockets.h"
+#include "devtools/TracePrinter.h"
+#include "devtools/request_log.h"
+#include "protocol/SFSCommunication.h"
 #include "protocol/cltocs.h"
 #include "protocol/cstocl.h"
 #include "protocol/cstocs.h"
-#include "common/datapack.h"
-#include "common/event_loop.h"
-#include "common/saunafs_version.h"
-#include "common/massert.h"
-#include "protocol/SFSCommunication.h"
-#include "common/legacy_vector.h"
 #include "protocol/packet.h"
 #include "slogger/slogger.h"
-#include "common/sockets.h"
-#include "devtools/request_log.h"
-#include "devtools/TracePrinter.h"
 
 constexpr uint32_t kMaxPacketSize = 100000 + SFSBLOCKSIZE;
 constexpr uint8_t kConnectRetries = 10;
@@ -138,20 +138,18 @@ MessageSerializer *MessageSerializer::getSerializer(PacketHeader::Type type) {
 
 std::unique_ptr<PacketStruct>
 ChunkserverEntry::createDetachedPacketWithOutputBuffer(
-    const std::vector<uint8_t> &packetPrefix) {
+    const std::vector<uint8_t> &packetPrefix, uint32_t numBlocks) {
 	TRACETHIS();
 
 	PacketHeader header;
 	deserializePacketHeader(packetPrefix, header);
 
-	uint32_t sizeOfWholePacket = PacketHeader::kSize + header.length;
 	std::unique_ptr<PacketStruct> outPacket = std::make_unique<PacketStruct>();
 	passert(outPacket);
 
-	outPacket->outputBuffer = getReadOutputBufferPool().get(sizeOfWholePacket);
-	outPacket->outputBuffer->status = kNotSaunafsStatus;
+	outPacket->outputBuffer = getReadOutputBufferPool().get(packetPrefix.size(), numBlocks);
 
-	if (outPacket->outputBuffer->copyIntoBuffer(packetPrefix) !=
+	if (outPacket->outputBuffer->copyIntoHeaderBuffer(packetPrefix) !=
 	    static_cast<ssize_t>(packetPrefix.size())) {
 		if (outPacket->outputBuffer) {
 			getReadOutputBufferPool().put(std::move(outPacket->outputBuffer));
@@ -436,13 +434,14 @@ void ChunkserverEntry::readContinue(uint16_t callMaxParallelHddReadJobs) {
 			const uint32_t thisPartOffset = offset % SFSBLOCKSIZE;
 			const uint32_t thisPartSize =
 			    std::min<uint32_t>(totalRequestSize, SFSBLOCKSIZE - thisPartOffset);
+			const uint32_t numBlocks = (thisPartSize + SFSBLOCKSIZE - 1) >> SFSBLOCKBITS;
 			const uint16_t totalRequestBlocks =
 			    (totalRequestSize + thisPartOffset + SFSBLOCKSIZE - 1) / SFSBLOCKSIZE;
 
 			std::vector<uint8_t> readDataPrefix;
 			messageSerializer->serializePrefixOfCstoclReadData(readDataPrefix, chunkId, offset,
 			                                                   thisPartSize);
-			auto packet = createDetachedPacketWithOutputBuffer(readDataPrefix);
+			auto packet = createDetachedPacketWithOutputBuffer(readDataPrefix, numBlocks);
 			if (packet == kInvalidPacket) {
 				state = State::Close;
 				return;

--- a/src/chunkserver/chunkserver_entry.cc
+++ b/src/chunkserver/chunkserver_entry.cc
@@ -149,7 +149,7 @@ ChunkserverEntry::createDetachedPacketWithOutputBuffer(
 
 	outPacket->outputBuffer = getReadOutputBufferPool().get(packetPrefix.size(), numBlocks);
 
-	if (outPacket->outputBuffer->copyIntoHeaderBuffer(packetPrefix) !=
+	if (outPacket->outputBuffer->copyIntoBuffer(OutputBuffer::BufferType::Header, packetPrefix) !=
 	    static_cast<ssize_t>(packetPrefix.size())) {
 		if (outPacket->outputBuffer) {
 			getReadOutputBufferPool().put(std::move(outPacket->outputBuffer));
@@ -1654,11 +1654,11 @@ void ChunkserverEntry::writeToSocket() {
 			massert(bytesInBufferAfter <= bytesInBufferBefore,
 					"New bytes in pack->outputBuffer after sending some data");
 			stats_bytesout += (bytesInBufferBefore - bytesInBufferAfter);
-			if (ret == OutputBuffer::WRITE_ERROR) {
+			if (ret == OutputBuffer::WriteStatus::Error) {
 				safs_silent_errlog(LOG_NOTICE, "(write) write error");
 				state = State::Close;
 				return;
-			} else if (ret == OutputBuffer::WRITE_AGAIN) {
+			} else if (ret == OutputBuffer::WriteStatus::Again) {
 				return;
 			}
 		} else {

--- a/src/chunkserver/chunkserver_entry.h
+++ b/src/chunkserver/chunkserver_entry.h
@@ -227,7 +227,7 @@ struct ChunkserverEntry {
 	/// Creates a detached packet with an output buffer.
 	/// @see OutputBufferPool
 	static std::unique_ptr<PacketStruct> createDetachedPacketWithOutputBuffer(
-	    const std::vector<uint8_t> &packetPrefix);
+	    const std::vector<uint8_t> &packetPrefix, uint32_t numBlocks);
 
 	/// Handles forwarding errors by setting the appropriate error status and
 	/// transitioning the connection state to `WriteFinish`.

--- a/src/chunkserver/hddspacemgr.cc
+++ b/src/chunkserver/hddspacemgr.cc
@@ -99,6 +99,7 @@
 
 constexpr int kErrorLimit = 2;
 constexpr int kLastErrorTime = 60;
+constexpr size_t kIgnoreHeaderSize = 1;
 
 inline std::atomic_bool gCheckCrcWhenReading{true};
 
@@ -658,8 +659,7 @@ static void hddReadAheadAndBehind(IChunk *chunk, uint16_t block,
 		chunk->owner()->prefetchChunkBlocks(
 		    *chunk, firstBlockToRead,
 		    blocksToBeReadAhead + block - firstBlockToRead);
-		OutputBuffer buffer =
-		    OutputBuffer(1, block - firstBlockToRead);
+		OutputBuffer buffer = OutputBuffer(kIgnoreHeaderSize, block - firstBlockToRead);
 		for (uint16_t b = firstBlockToRead; b < block; ++b) {
 			hddReadCrcAndBlock(chunk, b, &buffer);
 		}
@@ -751,7 +751,8 @@ int hddRead(uint64_t chunkId, uint32_t version, ChunkPartType chunkType,
 			status = hddCheckCrcForFullBlock(chunk, block, outputBuffer, 0, false);
 		}
 	} else {  // Partial block
-		OutputBuffer tmp(1, 1);
+		// Temporary buffer to read the full block
+		OutputBuffer tmp(kIgnoreHeaderSize, 1);
 		status = hddReadCrcAndBlock(chunk, block, &tmp);
 
 		if (status == SAUNAFS_STATUS_OK) {  // Successful read of the full block

--- a/src/chunkserver/hddspacemgr.cc
+++ b/src/chunkserver/hddspacemgr.cc
@@ -571,8 +571,11 @@ int hddReadCrcAndBlock(IChunk *chunk, uint16_t blockNumber,
 	}
 
 	if (blockNumber >= chunk->blocks()) {
-		bytesRead = outputBuffer->copyIntoCRCBuffer(&gEmptyBlockCrc, kCrcSize);
-		bytesRead += outputBuffer->copyValueIntoBlockBuffer(0, SFSBLOCKSIZE);
+		bytesRead =
+		    outputBuffer->copyIntoBuffer(OutputBuffer::BufferType::CRC, &gEmptyBlockCrc, kCrcSize);
+		// Put a block of zeros into the buffer
+		bytesRead +=
+		    outputBuffer->copyValueIntoBuffer(OutputBuffer::BufferType::Block, 0, SFSBLOCKSIZE);
 		if (static_cast<uint32_t>(bytesRead) != kHddBlockSize) {
 			return SAUNAFS_ERROR_IO;
 		}
@@ -583,8 +586,9 @@ int hddReadCrcAndBlock(IChunk *chunk, uint16_t blockNumber,
 		const uint8_t *crcData =
 		    gOpenChunks.getResource(chunk->metaFD()).crcData() +
 		    blockNumber * kCrcSize;
-		outputBuffer->copyIntoCRCBuffer(crcData, kCrcSize);
-		bytesRead = outputBuffer->copyIntoBlockBuffer(chunk, SFSBLOCKSIZE, off);
+		outputBuffer->copyIntoBuffer(OutputBuffer::BufferType::CRC, crcData, kCrcSize);
+		bytesRead =
+		    outputBuffer->copyIntoBuffer(OutputBuffer::BufferType::Block, chunk, SFSBLOCKSIZE, off);
 
 		if (bytesRead != toBeRead) {
 			hddAddErrorAndPreserveErrno(chunk);
@@ -756,9 +760,14 @@ int hddRead(uint64_t chunkId, uint32_t version, ChunkPartType chunkType,
 			if (status == SAUNAFS_STATUS_OK) {  // CRC is OK or check disabled
 				uint8_t crcBuff[kCrcSize];
 				uint8_t *crcBuffPointer = crcBuff;
-				put32bit(&crcBuffPointer, mycrc32(0, tmp.blockData() + offsetWithinBlock, size));
-				outputBuffer->copyIntoCRCBuffer(crcBuff, kCrcSize);
-				outputBuffer->copyIntoBlockBuffer(tmp.blockData() + offsetWithinBlock, size);
+				put32bit(
+				    &crcBuffPointer,
+				    mycrc32(0, tmp.rawData(OutputBuffer::BufferType::Block) + offsetWithinBlock,
+				            size));
+				outputBuffer->copyIntoBuffer(OutputBuffer::BufferType::CRC, crcBuff, kCrcSize);
+				outputBuffer->copyIntoBuffer(
+				    OutputBuffer::BufferType::Block,
+				    tmp.rawData(OutputBuffer::BufferType::Block) + offsetWithinBlock, size);
 			}
 		}
 	}

--- a/src/chunkserver/hddspacemgr.cc
+++ b/src/chunkserver/hddspacemgr.cc
@@ -571,9 +571,9 @@ int hddReadCrcAndBlock(IChunk *chunk, uint16_t blockNumber,
 	}
 
 	if (blockNumber >= chunk->blocks()) {
-		bytesRead = outputBuffer->copyIntoBuffer(&gEmptyBlockCrc, kCrcSize);
+		bytesRead = outputBuffer->copyIntoCRCBuffer(&gEmptyBlockCrc, kCrcSize);
 		static const std::vector<uint8_t> zeros_block(SFSBLOCKSIZE, 0);
-		bytesRead += outputBuffer->copyIntoBuffer(zeros_block);
+		bytesRead += outputBuffer->copyIntoBlockBuffer(zeros_block);
 		if (static_cast<uint32_t>(bytesRead) != kHddBlockSize) {
 			return SAUNAFS_ERROR_IO;
 		}
@@ -584,8 +584,8 @@ int hddReadCrcAndBlock(IChunk *chunk, uint16_t blockNumber,
 		const uint8_t *crcData =
 		    gOpenChunks.getResource(chunk->metaFD()).crcData() +
 		    blockNumber * kCrcSize;
-		outputBuffer->copyIntoBuffer(crcData, kCrcSize);
-		bytesRead = outputBuffer->copyIntoBuffer(chunk, SFSBLOCKSIZE, off);
+		outputBuffer->copyIntoCRCBuffer(crcData, kCrcSize);
+		bytesRead = outputBuffer->copyIntoBlockBuffer(chunk, SFSBLOCKSIZE, off);
 
 		if (bytesRead != toBeRead) {
 			hddAddErrorAndPreserveErrno(chunk);
@@ -656,7 +656,7 @@ static void hddReadAheadAndBehind(IChunk *chunk, uint16_t block,
 		    *chunk, firstBlockToRead,
 		    blocksToBeReadAhead + block - firstBlockToRead);
 		OutputBuffer buffer =
-		    OutputBuffer(kHddBlockSize * (block - firstBlockToRead));
+		    OutputBuffer(1, block - firstBlockToRead);
 		for (uint16_t b = firstBlockToRead; b < block; ++b) {
 			hddReadCrcAndBlock(chunk, b, &buffer);
 		}
@@ -675,19 +675,20 @@ static void hddReadAheadAndBehind(IChunk *chunk, uint16_t block,
 * @param chunk Chunk to read from.
 * @param block Block to check.
 * @param outputBuffer Assumes the outputBuffer is already filled with data.
+* @param offsetInBlockBuffer Starting index of the block in the outputBuffer.
 * @param forceCheck If true, the CRC is checked even if the option is disabled
                     from the configuration. This is needed to keep integrity of
                     partial reads.
 */
-int hddCheckCrcForFullBlock(IChunk *chunk, uint16_t block,
-                            OutputBuffer *outputBuffer, bool forceCheck) {
+int hddCheckCrcForFullBlock(IChunk *chunk, uint16_t block, OutputBuffer *outputBuffer,
+                            uint32_t offsetInBlockBuffer, bool forceCheck) {
 	if (!forceCheck && (!gCheckCrcWhenReading || block >= chunk->blocks())) {
 		return SAUNAFS_STATUS_OK;
 	}
 
 	const uint8_t *crcData =
 	    gOpenChunks.getResource(chunk->metaFD()).crcData() + block * kCrcSize;
-	if (!outputBuffer->checkCRC(SFSBLOCKSIZE, get32bit(&crcData))) {
+	if (!outputBuffer->checkCRC(SFSBLOCKSIZE, get32bit(&crcData), offsetInBlockBuffer)) {
 		hddAddChunkToTestQueue(ChunkWithVersionAndType{
 		    chunk->id(), chunk->version(), chunk->type()});
 		return SAUNAFS_ERROR_CRC;
@@ -744,24 +745,21 @@ int hddRead(uint64_t chunkId, uint32_t version, ChunkPartType chunkType,
 		status = hddReadCrcAndBlock(chunk, block, outputBuffer);
 
 		if (status == SAUNAFS_STATUS_OK) {
-			status = hddCheckCrcForFullBlock(chunk, block, outputBuffer, false);
+			status = hddCheckCrcForFullBlock(chunk, block, outputBuffer, 0, false);
 		}
 	} else {  // Partial block
-		OutputBuffer tmp(kHddBlockSize);
+		OutputBuffer tmp(1, 1);
 		status = hddReadCrcAndBlock(chunk, block, &tmp);
 
 		if (status == SAUNAFS_STATUS_OK) {  // Successful read of the full block
-			status = hddCheckCrcForFullBlock(chunk, block, &tmp, true);
+			status = hddCheckCrcForFullBlock(chunk, block, &tmp, 0, true);
 
 			if (status == SAUNAFS_STATUS_OK) {  // CRC is OK or check disabled
 				uint8_t crcBuff[kCrcSize];
 				uint8_t *crcBuffPointer = crcBuff;
-				put32bit(&crcBuffPointer,
-				         mycrc32(0, tmp.data() + kCrcSize + offsetWithinBlock,
-				                 size));
-				outputBuffer->copyIntoBuffer(crcBuff, kCrcSize);
-				outputBuffer->copyIntoBuffer(
-				    tmp.data() + kCrcSize + offsetWithinBlock, size);
+				put32bit(&crcBuffPointer, mycrc32(0, tmp.blockData() + offsetWithinBlock, size));
+				outputBuffer->copyIntoCRCBuffer(crcBuff, kCrcSize);
+				outputBuffer->copyIntoBlockBuffer(tmp.blockData() + offsetWithinBlock, size);
 			}
 		}
 	}

--- a/src/chunkserver/hddspacemgr.cc
+++ b/src/chunkserver/hddspacemgr.cc
@@ -572,8 +572,7 @@ int hddReadCrcAndBlock(IChunk *chunk, uint16_t blockNumber,
 
 	if (blockNumber >= chunk->blocks()) {
 		bytesRead = outputBuffer->copyIntoCRCBuffer(&gEmptyBlockCrc, kCrcSize);
-		static const std::vector<uint8_t> zeros_block(SFSBLOCKSIZE, 0);
-		bytesRead += outputBuffer->copyIntoBlockBuffer(zeros_block);
+		bytesRead += outputBuffer->copyValueIntoBlockBuffer(0, SFSBLOCKSIZE);
 		if (static_cast<uint32_t>(bytesRead) != kHddBlockSize) {
 			return SAUNAFS_ERROR_IO;
 		}

--- a/src/chunkserver/output_buffer.cc
+++ b/src/chunkserver/output_buffer.cc
@@ -30,71 +30,132 @@
 #include "common/crc.h"
 #include "common/massert.h"
 
-OutputBuffer::OutputBuffer(size_t internalBufferCapacity)
-    : internalBufferCapacity_(internalBufferCapacity),
-      internalBufferCapacityAligned_(getAlignedSize(internalBufferCapacity_)),
-      padding_(internalBufferCapacityAligned_ - internalBufferCapacity_),
-      buffer_(internalBufferCapacityAligned_, 0),
-      bufferUnflushedDataFirstIndex_(padding_),
-      bufferUnflushedDataOneAfterLastIndex_(padding_) {
-	eassert(internalBufferCapacity > 0);
-	buffer_.reserve(internalBufferCapacityAligned_);
+OutputBuffer::OutputBuffer(size_t headerSize, size_t numBlocks)
+    : currentRemainingBytesForFD_(0),
+      headerSize_(headerSize),
+      numBlocks_(numBlocks),
+      blockBufferCapacity_(numBlocks * SFSBLOCKSIZE),
+      blockBufferCapacityAligned_(numBlocks * SFSBLOCKSIZE + disk::kIoBlockSize),
+      blockBufferPadding_(blockBufferCapacityAligned_ - blockBufferCapacity_),
+      blockBufferUnflushedDataFirstIndex_(blockBufferPadding_),
+      blockBufferUnflushedDataOneAfterLastIndex_(blockBufferPadding_),
+      blockBuffer_(blockBufferCapacityAligned_, 0),
+      crcBufferCapacity_(kCrcSize * numBlocks),
+      crcBufferUnflushedDataFirstIndex_(0),
+      crcBufferUnflushedDataOneAfterLastIndex_(0),
+      crcBuffer_(crcBufferCapacity_, 0),
+      headerBufferCapacity_(headerSize * numBlocks),
+      headerBufferUnflushedDataFirstIndex_(0),
+      headerBufferUnflushedDataOneAfterLastIndex_(0),
+      headerBuffer_(headerBufferCapacity_, 0) {
+	eassert(blockBufferCapacity_ > 0);
+	eassert(crcBufferCapacity_ > 0);
+	eassert(headerBufferCapacity_ > 0);
+	blockBuffer_.reserve(blockBufferCapacityAligned_);
+	crcBuffer_.reserve(crcBufferCapacity_);
+	headerBuffer_.reserve(headerBufferCapacity_);
 }
 
 OutputBuffer::WriteStatus OutputBuffer::writeOutToAFileDescriptor(int outputFileDescriptor) {
+	// Let's write block by block
 	while (bytesInABuffer() > 0) {
-		ssize_t ret = ::write(outputFileDescriptor, &buffer_[bufferUnflushedDataFirstIndex_],
-				bytesInABuffer());
+		if (currentRemainingBytesForFD_ == 0) {
+			// Prepare the blockBuffer to write the current block:
+			// - move back the unflushed data in block buffer
+			// - copy the header
+			// - copy the crc
+			// - set the currentRemainingBytesForFD_
+			blockBufferUnflushedDataFirstIndex_ -= kCrcSize + headerSize_;
+			memcpy((void *)&blockBuffer_[blockBufferUnflushedDataFirstIndex_],
+			       (void *)&headerBuffer_[headerBufferUnflushedDataFirstIndex_], headerSize_);
+			headerBufferUnflushedDataFirstIndex_ += headerSize_;
+			assert(headerBufferUnflushedDataFirstIndex_ <= headerBufferUnflushedDataOneAfterLastIndex_);
+			memcpy((void *)&blockBuffer_[blockBufferUnflushedDataFirstIndex_ + headerSize_],
+			       (void *)&crcBuffer_[crcBufferUnflushedDataFirstIndex_], kCrcSize);
+			crcBufferUnflushedDataFirstIndex_ += kCrcSize;
+			assert(crcBufferUnflushedDataFirstIndex_ <= crcBufferUnflushedDataOneAfterLastIndex_);
+			currentRemainingBytesForFD_ =
+			    std::min(SFSBLOCKSIZE + kCrcSize + headerSize_, bytesInABuffer());
+		}
+		ssize_t ret =
+		    ::write(outputFileDescriptor, &blockBuffer_[blockBufferUnflushedDataFirstIndex_],
+				currentRemainingBytesForFD_);
+
 		if (ret <= 0) {
-			if (ret == 0 || errno == EAGAIN) {
-				return WRITE_AGAIN;
-			}
+			if (ret == 0 || errno == EAGAIN) { return WRITE_AGAIN; }
 			return WRITE_ERROR;
 		}
-		bufferUnflushedDataFirstIndex_ += ret;
+		currentRemainingBytesForFD_ -= ret;
+		blockBufferUnflushedDataFirstIndex_ += ret;
 	}
 	return WRITE_DONE;
 }
 
 size_t OutputBuffer::bytesInABuffer() const {
-	return bufferUnflushedDataOneAfterLastIndex_ - bufferUnflushedDataFirstIndex_;
+	return (blockBufferUnflushedDataOneAfterLastIndex_ - blockBufferUnflushedDataFirstIndex_) +
+	       (crcBufferUnflushedDataOneAfterLastIndex_ - crcBufferUnflushedDataFirstIndex_) +
+	       (headerBufferUnflushedDataOneAfterLastIndex_ - headerBufferUnflushedDataFirstIndex_);
 }
 
 void OutputBuffer::clear() {
-	bufferUnflushedDataFirstIndex_ = padding_;
-	bufferUnflushedDataOneAfterLastIndex_ = padding_;
+	currentRemainingBytesForFD_ = 0;
+
+	blockBufferUnflushedDataFirstIndex_ = blockBufferPadding_;
+	blockBufferUnflushedDataOneAfterLastIndex_ = blockBufferPadding_;
+	crcBufferUnflushedDataFirstIndex_ = 0;
+	crcBufferUnflushedDataOneAfterLastIndex_ = 0;
+	headerBufferUnflushedDataFirstIndex_ = 0;
+	headerBufferUnflushedDataOneAfterLastIndex_ = 0;
+
+	status = kNotSaunafsStatus;
 }
 
-ssize_t OutputBuffer::copyIntoBuffer(IChunk *chunk, size_t len, off_t offset) {
-	eassert(len + bufferUnflushedDataOneAfterLastIndex_ <=
-	        internalBufferCapacityAligned_);
+ssize_t OutputBuffer::copyIntoBlockBuffer(IChunk *chunk, size_t len, off_t offset) {
+	eassert(len + blockBufferUnflushedDataOneAfterLastIndex_ <= blockBufferCapacityAligned_);
 	off_t bytes_written = 0;
 
 	while (len > 0) {
 		ssize_t ret = chunk->owner()->preadData(
-		    chunk, &buffer_[bufferUnflushedDataOneAfterLastIndex_], len, offset);
+		    chunk, &blockBuffer_[blockBufferUnflushedDataOneAfterLastIndex_], len, offset);
 		if (ret <= 0) {
 			return bytes_written;
 		}
 		len -= ret;
-		bufferUnflushedDataOneAfterLastIndex_ += ret;
+		blockBufferUnflushedDataOneAfterLastIndex_ += ret;
 		bytes_written += ret;
 	}
 
 	return bytes_written;
 }
 
-bool OutputBuffer::checkCRC(size_t bytes, uint32_t crc) const {
-	assert(bufferUnflushedDataOneAfterLastIndex_ - bytes > 0
-			&& bufferUnflushedDataOneAfterLastIndex_ - bytes < buffer_.size());
-	return mycrc32(0, &buffer_[bufferUnflushedDataOneAfterLastIndex_ - bytes], bytes) == crc;
+bool OutputBuffer::checkCRC(size_t bytes, uint32_t crc, uint32_t startingOffset) const {
+	startingOffset += blockBufferPadding_;
+	assert(startingOffset > 0 && startingOffset < blockBuffer_.size());
+	return mycrc32(0, &blockBuffer_[startingOffset], bytes) == crc;
 }
 
-ssize_t OutputBuffer::copyIntoBuffer(const void *mem, size_t len) {
-	eassert(bufferUnflushedDataOneAfterLastIndex_ + len <=
-	        internalBufferCapacityAligned_);
-	memcpy((void*)&buffer_[bufferUnflushedDataOneAfterLastIndex_], mem, len);
-	bufferUnflushedDataOneAfterLastIndex_ += len;
-
+ssize_t OutputBuffer::copyIntoCRCBuffer(const void *mem, size_t len) {
+	eassert(crcBufferUnflushedDataOneAfterLastIndex_ + len <= crcBufferCapacity_);
+	memcpy((void *)&crcBuffer_[crcBufferUnflushedDataOneAfterLastIndex_], mem, len);
+	crcBufferUnflushedDataOneAfterLastIndex_ += len;
 	return len;
+}
+
+ssize_t OutputBuffer::copyIntoBlockBuffer(const void *mem, size_t len) {
+	eassert(blockBufferUnflushedDataOneAfterLastIndex_ + len <= blockBufferCapacityAligned_);
+	memcpy((void *)&blockBuffer_[blockBufferUnflushedDataOneAfterLastIndex_], mem, len);
+	blockBufferUnflushedDataOneAfterLastIndex_ += len;
+	return len;
+}
+
+ssize_t OutputBuffer::copyIntoBlockBuffer(const std::vector<uint8_t> &mem) {
+	return copyIntoBlockBuffer(mem.data(), mem.size());
+}
+
+ssize_t OutputBuffer::copyIntoHeaderBuffer(const std::vector<uint8_t> &mem) {
+	eassert(headerBufferUnflushedDataOneAfterLastIndex_ + mem.size() <= headerBufferCapacity_);
+	memcpy((void *)&headerBuffer_[headerBufferUnflushedDataOneAfterLastIndex_], mem.data(),
+	       mem.size());
+	headerBufferUnflushedDataOneAfterLastIndex_ += mem.size();
+	return mem.size();
 }

--- a/src/chunkserver/output_buffer.cc
+++ b/src/chunkserver/output_buffer.cc
@@ -148,8 +148,11 @@ ssize_t OutputBuffer::copyIntoBlockBuffer(const void *mem, size_t len) {
 	return len;
 }
 
-ssize_t OutputBuffer::copyIntoBlockBuffer(const std::vector<uint8_t> &mem) {
-	return copyIntoBlockBuffer(mem.data(), mem.size());
+ssize_t OutputBuffer::copyValueIntoBlockBuffer(uint8_t value, size_t len) {
+	eassert(blockBufferUnflushedDataOneAfterLastIndex_ + len <= blockBufferCapacityAligned_);
+	memset((void *)&blockBuffer_[blockBufferUnflushedDataOneAfterLastIndex_], value, len);
+	blockBufferUnflushedDataOneAfterLastIndex_ += len;
+	return len;
 }
 
 ssize_t OutputBuffer::copyIntoHeaderBuffer(const std::vector<uint8_t> &mem) {

--- a/src/chunkserver/output_buffer.cc
+++ b/src/chunkserver/output_buffer.cc
@@ -34,27 +34,9 @@ OutputBuffer::OutputBuffer(size_t headerSize, size_t numBlocks)
     : currentRemainingBytesForFD_(0),
       headerSize_(headerSize),
       numBlocks_(numBlocks),
-      blockBufferCapacity_(numBlocks * SFSBLOCKSIZE),
-      blockBufferCapacityAligned_(numBlocks * SFSBLOCKSIZE + disk::kIoBlockSize),
-      blockBufferPadding_(blockBufferCapacityAligned_ - blockBufferCapacity_),
-      blockBufferUnflushedDataFirstIndex_(blockBufferPadding_),
-      blockBufferUnflushedDataOneAfterLastIndex_(blockBufferPadding_),
-      blockBuffer_(blockBufferCapacityAligned_, 0),
-      crcBufferCapacity_(kCrcSize * numBlocks),
-      crcBufferUnflushedDataFirstIndex_(0),
-      crcBufferUnflushedDataOneAfterLastIndex_(0),
-      crcBuffer_(crcBufferCapacity_, 0),
-      headerBufferCapacity_(headerSize * numBlocks),
-      headerBufferUnflushedDataFirstIndex_(0),
-      headerBufferUnflushedDataOneAfterLastIndex_(0),
-      headerBuffer_(headerBufferCapacity_, 0) {
-	eassert(blockBufferCapacity_ > 0);
-	eassert(crcBufferCapacity_ > 0);
-	eassert(headerBufferCapacity_ > 0);
-	blockBuffer_.reserve(blockBufferCapacityAligned_);
-	crcBuffer_.reserve(crcBufferCapacity_);
-	headerBuffer_.reserve(headerBufferCapacity_);
-}
+      blockBuffer_(numBlocks * SFSBLOCKSIZE, disk::kIoBlockSize),
+      crcBuffer_(numBlocks * kCrcSize),
+      headerBuffer_(numBlocks * headerSize) {}
 
 OutputBuffer::WriteStatus OutputBuffer::writeOutToAFileDescriptor(int outputFileDescriptor) {
 	// Let's write block by block
@@ -65,100 +47,102 @@ OutputBuffer::WriteStatus OutputBuffer::writeOutToAFileDescriptor(int outputFile
 			// - copy the header
 			// - copy the crc
 			// - set the currentRemainingBytesForFD_
-			blockBufferUnflushedDataFirstIndex_ -= kCrcSize + headerSize_;
-			memcpy((void *)&blockBuffer_[blockBufferUnflushedDataFirstIndex_],
-			       (void *)&headerBuffer_[headerBufferUnflushedDataFirstIndex_], headerSize_);
-			headerBufferUnflushedDataFirstIndex_ += headerSize_;
-			assert(headerBufferUnflushedDataFirstIndex_ <= headerBufferUnflushedDataOneAfterLastIndex_);
-			memcpy((void *)&blockBuffer_[blockBufferUnflushedDataFirstIndex_ + headerSize_],
-			       (void *)&crcBuffer_[crcBufferUnflushedDataFirstIndex_], kCrcSize);
-			crcBufferUnflushedDataFirstIndex_ += kCrcSize;
-			assert(crcBufferUnflushedDataFirstIndex_ <= crcBufferUnflushedDataOneAfterLastIndex_);
+			blockBuffer_.moveUnflushedDataFirstIndex(-(int32_t)(kCrcSize));
+			crcBuffer_.copyFromBuffer(blockBuffer_.getUnflushedDataFirstIndex(), kCrcSize);
+			blockBuffer_.moveUnflushedDataFirstIndex(-(int32_t)(headerSize_));
+			headerBuffer_.copyFromBuffer(blockBuffer_.getUnflushedDataFirstIndex(), headerSize_);
 			currentRemainingBytesForFD_ =
 			    std::min(SFSBLOCKSIZE + kCrcSize + headerSize_, bytesInABuffer());
 		}
-		ssize_t ret =
-		    ::write(outputFileDescriptor, &blockBuffer_[blockBufferUnflushedDataFirstIndex_],
-				currentRemainingBytesForFD_);
+		ssize_t ret = ::write(outputFileDescriptor, blockBuffer_.getUnflushedDataFirstIndex(),
+		                      currentRemainingBytesForFD_);
 
 		if (ret <= 0) {
-			if (ret == 0 || errno == EAGAIN) { return WRITE_AGAIN; }
-			return WRITE_ERROR;
+			if (ret == 0 || errno == EAGAIN) { return WriteStatus::Again; }
+			return WriteStatus::Error;
 		}
 		currentRemainingBytesForFD_ -= ret;
-		blockBufferUnflushedDataFirstIndex_ += ret;
+		blockBuffer_.moveUnflushedDataFirstIndex(ret);
 	}
-	return WRITE_DONE;
+	return WriteStatus::Done;
 }
 
 size_t OutputBuffer::bytesInABuffer() const {
-	return (blockBufferUnflushedDataOneAfterLastIndex_ - blockBufferUnflushedDataFirstIndex_) +
-	       (crcBufferUnflushedDataOneAfterLastIndex_ - crcBufferUnflushedDataFirstIndex_) +
-	       (headerBufferUnflushedDataOneAfterLastIndex_ - headerBufferUnflushedDataFirstIndex_);
+	return blockBuffer_.bytesInABuffer() + crcBuffer_.bytesInABuffer() +
+	       headerBuffer_.bytesInABuffer();
 }
 
 void OutputBuffer::clear() {
 	currentRemainingBytesForFD_ = 0;
 
-	blockBufferUnflushedDataFirstIndex_ = blockBufferPadding_;
-	blockBufferUnflushedDataOneAfterLastIndex_ = blockBufferPadding_;
-	crcBufferUnflushedDataFirstIndex_ = 0;
-	crcBufferUnflushedDataOneAfterLastIndex_ = 0;
-	headerBufferUnflushedDataFirstIndex_ = 0;
-	headerBufferUnflushedDataOneAfterLastIndex_ = 0;
+	blockBuffer_.clear();
+	crcBuffer_.clear();
+	headerBuffer_.clear();
 
 	status = kNotSaunafsStatus;
 }
 
-ssize_t OutputBuffer::copyIntoBlockBuffer(IChunk *chunk, size_t len, off_t offset) {
-	eassert(len + blockBufferUnflushedDataOneAfterLastIndex_ <= blockBufferCapacityAligned_);
-	off_t bytes_written = 0;
-
-	while (len > 0) {
-		ssize_t ret = chunk->owner()->preadData(
-		    chunk, &blockBuffer_[blockBufferUnflushedDataOneAfterLastIndex_], len, offset);
-		if (ret <= 0) {
-			return bytes_written;
-		}
-		len -= ret;
-		blockBufferUnflushedDataOneAfterLastIndex_ += ret;
-		bytes_written += ret;
-	}
-
-	return bytes_written;
-}
-
 bool OutputBuffer::checkCRC(size_t bytes, uint32_t crc, uint32_t startingOffset) const {
-	startingOffset += blockBufferPadding_;
-	assert(startingOffset > 0 && startingOffset < blockBuffer_.size());
-	return mycrc32(0, &blockBuffer_[startingOffset], bytes) == crc;
+	return mycrc32(0, blockBuffer_.paddedIndex(startingOffset), bytes) == crc;
 }
 
-ssize_t OutputBuffer::copyIntoCRCBuffer(const void *mem, size_t len) {
-	eassert(crcBufferUnflushedDataOneAfterLastIndex_ + len <= crcBufferCapacity_);
-	memcpy((void *)&crcBuffer_[crcBufferUnflushedDataOneAfterLastIndex_], mem, len);
-	crcBufferUnflushedDataOneAfterLastIndex_ += len;
-	return len;
+ssize_t OutputBuffer::copyIntoBuffer(BufferType type, IChunk *chunk, size_t len, off_t offset) {
+	massert(type == BufferType::Block, "Invalid buffer type");
+	return blockBuffer_.copyIntoBuffer(chunk, len, offset);
 }
 
-ssize_t OutputBuffer::copyIntoBlockBuffer(const void *mem, size_t len) {
-	eassert(blockBufferUnflushedDataOneAfterLastIndex_ + len <= blockBufferCapacityAligned_);
-	memcpy((void *)&blockBuffer_[blockBufferUnflushedDataOneAfterLastIndex_], mem, len);
-	blockBufferUnflushedDataOneAfterLastIndex_ += len;
-	return len;
+ssize_t OutputBuffer::copyIntoBuffer(BufferType type, const void *mem, size_t len) {
+	switch (type) {
+	case BufferType::Block:
+		return blockBuffer_.copyIntoBuffer(mem, len);
+	case BufferType::CRC:
+		return crcBuffer_.copyIntoBuffer(mem, len);
+	case BufferType::Header:
+		return headerBuffer_.copyIntoBuffer(mem, len);
+	default:
+		safs::log_err("Invalid buffer type");
+		return 0;
+	}
 }
 
-ssize_t OutputBuffer::copyValueIntoBlockBuffer(uint8_t value, size_t len) {
-	eassert(blockBufferUnflushedDataOneAfterLastIndex_ + len <= blockBufferCapacityAligned_);
-	memset((void *)&blockBuffer_[blockBufferUnflushedDataOneAfterLastIndex_], value, len);
-	blockBufferUnflushedDataOneAfterLastIndex_ += len;
-	return len;
+ssize_t OutputBuffer::copyIntoBuffer(BufferType type, const std::vector<uint8_t> &mem) {
+	switch (type) {
+	case BufferType::Block:
+		return blockBuffer_.copyIntoBuffer(mem.data(), mem.size());
+	case BufferType::CRC:
+		return crcBuffer_.copyIntoBuffer(mem.data(), mem.size());
+	case BufferType::Header:
+		return headerBuffer_.copyIntoBuffer(mem.data(), mem.size());
+	default:
+		safs::log_err("Invalid buffer type");
+		return 0;
+	}
 }
 
-ssize_t OutputBuffer::copyIntoHeaderBuffer(const std::vector<uint8_t> &mem) {
-	eassert(headerBufferUnflushedDataOneAfterLastIndex_ + mem.size() <= headerBufferCapacity_);
-	memcpy((void *)&headerBuffer_[headerBufferUnflushedDataOneAfterLastIndex_], mem.data(),
-	       mem.size());
-	headerBufferUnflushedDataOneAfterLastIndex_ += mem.size();
-	return mem.size();
+ssize_t OutputBuffer::copyValueIntoBuffer(BufferType type, uint8_t value, size_t len) {
+	switch (type) {
+	case BufferType::Block:
+		return blockBuffer_.copyValueIntoBuffer(value, len);
+	case BufferType::CRC:
+		return crcBuffer_.copyValueIntoBuffer(value, len);
+	case BufferType::Header:
+		return headerBuffer_.copyValueIntoBuffer(value, len);
+	default:
+		safs::log_err("Invalid buffer type");
+		return 0;
+	}
+}
+
+const uint8_t *OutputBuffer::rawData(BufferType type) const {
+	switch (type) {
+	case BufferType::Block:
+		return blockBuffer_.paddedIndex(0);
+	case BufferType::CRC:
+		return crcBuffer_.paddedIndex(0);
+	case BufferType::Header:
+		return headerBuffer_.paddedIndex(0);
+	default:
+		safs::log_err("Invalid buffer type");
+		return 0;
+	}
 }

--- a/src/chunkserver/output_buffer.cc
+++ b/src/chunkserver/output_buffer.cc
@@ -43,13 +43,14 @@ OutputBuffer::WriteStatus OutputBuffer::writeOutToAFileDescriptor(int outputFile
 	while (bytesInABuffer() > 0) {
 		if (currentRemainingBytesForFD_ == 0) {
 			// Prepare the blockBuffer to write the current block:
-			// - move back the unflushed data in block buffer
-			// - copy the header
+			// - move back the unflushed data in block buffer kCrcSize bytes back
 			// - copy the crc
+			// - move back the unflushed data in block buffer headerSize_ bytes back
+			// - copy the header
 			// - set the currentRemainingBytesForFD_
-			blockBuffer_.moveUnflushedDataFirstIndex(-(int32_t)(kCrcSize));
+			blockBuffer_.moveUnflushedDataFirstIndex(-(static_cast<int32_t>(kCrcSize)));
 			crcBuffer_.copyFromBuffer(blockBuffer_.getUnflushedDataFirstIndex(), kCrcSize);
-			blockBuffer_.moveUnflushedDataFirstIndex(-(int32_t)(headerSize_));
+			blockBuffer_.moveUnflushedDataFirstIndex(-(static_cast<int32_t>(headerSize_)));
 			headerBuffer_.copyFromBuffer(blockBuffer_.getUnflushedDataFirstIndex(), headerSize_);
 			currentRemainingBytesForFD_ =
 			    std::min(SFSBLOCKSIZE + kCrcSize + headerSize_, bytesInABuffer());
@@ -87,7 +88,11 @@ bool OutputBuffer::checkCRC(size_t bytes, uint32_t crc, uint32_t startingOffset)
 }
 
 ssize_t OutputBuffer::copyIntoBuffer(BufferType type, IChunk *chunk, size_t len, off_t offset) {
-	massert(type == BufferType::Block, "Invalid buffer type");
+	if (type != BufferType::Block) {
+		safs::log_warn("(OutputBuffer) Invalid buffer type, using block buffer");
+		type = BufferType::Block;
+	}
+
 	return blockBuffer_.copyIntoBuffer(chunk, len, offset);
 }
 
@@ -100,7 +105,7 @@ ssize_t OutputBuffer::copyIntoBuffer(BufferType type, const void *mem, size_t le
 	case BufferType::Header:
 		return headerBuffer_.copyIntoBuffer(mem, len);
 	default:
-		safs::log_err("Invalid buffer type");
+		safs::log_warn("(OutputBuffer) Invalid buffer type");
 		return 0;
 	}
 }
@@ -114,7 +119,7 @@ ssize_t OutputBuffer::copyIntoBuffer(BufferType type, const std::vector<uint8_t>
 	case BufferType::Header:
 		return headerBuffer_.copyIntoBuffer(mem.data(), mem.size());
 	default:
-		safs::log_err("Invalid buffer type");
+		safs::log_warn("(OutputBuffer) Invalid buffer type");
 		return 0;
 	}
 }
@@ -128,7 +133,7 @@ ssize_t OutputBuffer::copyValueIntoBuffer(BufferType type, uint8_t value, size_t
 	case BufferType::Header:
 		return headerBuffer_.copyValueIntoBuffer(value, len);
 	default:
-		safs::log_err("Invalid buffer type");
+		safs::log_warn("(OutputBuffer) Invalid buffer type");
 		return 0;
 	}
 }
@@ -142,7 +147,7 @@ const uint8_t *OutputBuffer::rawData(BufferType type) const {
 	case BufferType::Header:
 		return headerBuffer_.paddedIndex(0);
 	default:
-		safs::log_err("Invalid buffer type");
+		safs::log_warn("(OutputBuffer) Invalid buffer type");
 		return 0;
 	}
 }

--- a/src/chunkserver/output_buffer.h
+++ b/src/chunkserver/output_buffer.h
@@ -40,42 +40,50 @@ public:
 		WRITE_ERROR
 	};
 
-	explicit OutputBuffer(size_t internalBufferCapacity);
+	explicit OutputBuffer(size_t headerSize, size_t numBlocks);
 	~OutputBuffer() = default;
 
-	ssize_t copyIntoBuffer(IChunk *chunk, size_t len, off_t offset);
-	ssize_t copyIntoBuffer(const void *mem, size_t len);
+	ssize_t copyIntoBlockBuffer(IChunk *chunk, size_t len, off_t offset);
 
-	bool checkCRC(size_t bytes, uint32_t crc) const;
+	bool checkCRC(size_t bytes, uint32_t crc, uint32_t startingOffset) const;
 
-	ssize_t copyIntoBuffer(const std::vector<uint8_t>& mem) {
-		return copyIntoBuffer(mem.data(), mem.size());
-	}
+	ssize_t copyIntoCRCBuffer(const void *mem, size_t len);
+	ssize_t copyIntoBlockBuffer(const void *mem, size_t len);
+	ssize_t copyIntoBlockBuffer(const std::vector<uint8_t> &mem);
+	ssize_t copyIntoHeaderBuffer(const std::vector<uint8_t> &mem);
 
 	WriteStatus writeOutToAFileDescriptor(int outputFileDescriptor);
 
 	size_t bytesInABuffer() const;
-	inline size_t capacity() const { return internalBufferCapacity_; }
-	inline const uint8_t *data() const { return buffer_.data(); }
+	inline std::pair<size_t, size_t> type() const { return {headerSize_, numBlocks_}; }
+	inline const uint8_t *blockData() const { return blockBuffer_.data(); }
 	void clear();
-
-	static inline size_t getAlignedSize(size_t capacity) {
-		size_t remainder = capacity % disk::kIoBlockSize;
-
-		if (remainder == 0) { return capacity; }
-
-		return capacity + disk::kIoBlockSize - remainder;
-	}
 
 	std::atomic_uint8_t status{kNotSaunafsStatus};
 
 private:
-	const size_t internalBufferCapacity_;
-	const size_t internalBufferCapacityAligned_;
-	const size_t padding_;
-	std::vector<uint8_t, AlignedAllocator<uint8_t, disk::kIoBlockSize>> buffer_;
-	size_t bufferUnflushedDataFirstIndex_;
-	size_t bufferUnflushedDataOneAfterLastIndex_;
+	// The current remaining bytes to be written to the file descriptor at once.
+	// When the buffer is prepared, should be equal to: SFSBLOCKSIZE + kCrcSize + headerSize_.
+	// 0 means that the buffer is not prepared.
+	size_t currentRemainingBytesForFD_;
+	const size_t headerSize_;
+	const size_t numBlocks_;
+
+	const size_t blockBufferCapacity_;
+	const size_t blockBufferCapacityAligned_;
+	const size_t blockBufferPadding_;
+	size_t blockBufferUnflushedDataFirstIndex_;
+	size_t blockBufferUnflushedDataOneAfterLastIndex_;
+	std::vector<uint8_t, AlignedAllocator<uint8_t, disk::kIoBlockSize>> blockBuffer_;
+
+	const size_t crcBufferCapacity_;
+	size_t crcBufferUnflushedDataFirstIndex_;
+	size_t crcBufferUnflushedDataOneAfterLastIndex_;
+	std::vector<uint8_t> crcBuffer_;
+	const size_t headerBufferCapacity_;
+	size_t headerBufferUnflushedDataFirstIndex_;
+	size_t headerBufferUnflushedDataOneAfterLastIndex_;
+	std::vector<uint8_t> headerBuffer_;
 };
 
 using OutputBufferPool = BuffersPool<OutputBuffer>;

--- a/src/chunkserver/output_buffer.h
+++ b/src/chunkserver/output_buffer.h
@@ -34,29 +34,107 @@ constexpr uint8_t kNotSaunafsStatus = 255;
 
 class OutputBuffer {
 public:
-	enum WriteStatus {
-		WRITE_DONE,
-		WRITE_AGAIN,
-		WRITE_ERROR
+	enum class WriteStatus : uint8_t {
+		Done,
+		Again,
+		Error
+	};
+
+	enum class BufferType : uint8_t {
+		Block,
+		CRC,
+		Header
+	};
+
+	template <typename C = std::vector<uint8_t>>
+	class Buffer {
+	public:
+		Buffer(size_t capacity, size_t padding = 0)
+		    : capacity_(capacity),
+		      trueCapacity_(capacity + padding),
+		      padding_(padding),
+		      unflushedDataFirstIndex_(padding),
+		      unflushedDataOneAfterLastIndex_(padding),
+		      data_(trueCapacity_) {
+			eassert(trueCapacity_ > 0);
+			data_.reserve(trueCapacity_);
+		}
+		~Buffer() = default;
+
+		ssize_t copyFromBuffer(const void *mem, size_t len) {
+			eassert(unflushedDataFirstIndex_ + len <= unflushedDataOneAfterLastIndex_);
+			memcpy((void *)mem, &data_[unflushedDataFirstIndex_], len);
+			unflushedDataFirstIndex_ += len;
+			return len;
+		}
+		ssize_t copyIntoBuffer(const void *mem, size_t len) {
+			eassert(unflushedDataOneAfterLastIndex_ + len <= trueCapacity_);
+			memcpy((void *)&data_[unflushedDataOneAfterLastIndex_], mem, len);
+			unflushedDataOneAfterLastIndex_ += len;
+			return len;
+		}
+		ssize_t copyValueIntoBuffer(uint8_t value, size_t len) {
+			eassert(unflushedDataOneAfterLastIndex_ + len <= trueCapacity_);
+			memset((void *)&data_[unflushedDataOneAfterLastIndex_], value, len);
+			unflushedDataOneAfterLastIndex_ += len;
+			return len;
+		}
+		ssize_t copyIntoBuffer(IChunk *chunk, size_t len, off_t offset) {
+			eassert(unflushedDataOneAfterLastIndex_ + len <= trueCapacity_);
+			off_t bytes_written = 0;
+			while (len > 0) {
+				ssize_t ret = chunk->owner()->preadData(
+				    chunk, &data_[unflushedDataOneAfterLastIndex_], len, offset);
+				if (ret <= 0) { return bytes_written; }
+				len -= ret;
+				unflushedDataOneAfterLastIndex_ += ret;
+				bytes_written += ret;
+			}
+			return bytes_written;
+		}
+		void clear() {
+			unflushedDataFirstIndex_ = padding_;
+			unflushedDataOneAfterLastIndex_ = padding_;
+		}
+		inline size_t capacity() const { return capacity_; }
+		inline size_t bytesInABuffer() const {
+			return unflushedDataOneAfterLastIndex_ - unflushedDataFirstIndex_;
+		}
+		inline const uint8_t *paddedIndex(size_t index) const {
+			assert(index < capacity_);
+			return data_.data() + index + padding_;
+		}
+		inline const uint8_t *getUnflushedDataFirstIndex() const {
+			return &data_[unflushedDataFirstIndex_];
+		}
+		inline void moveUnflushedDataFirstIndex(int64_t offset) {
+			unflushedDataFirstIndex_ += offset;
+		}
+
+	private:
+		const size_t capacity_;
+		const size_t trueCapacity_;
+		const size_t padding_;
+		size_t unflushedDataFirstIndex_;
+		size_t unflushedDataOneAfterLastIndex_;
+		C data_;
 	};
 
 	explicit OutputBuffer(size_t headerSize, size_t numBlocks);
 	~OutputBuffer() = default;
 
-	ssize_t copyIntoBlockBuffer(IChunk *chunk, size_t len, off_t offset);
-
 	bool checkCRC(size_t bytes, uint32_t crc, uint32_t startingOffset) const;
 
-	ssize_t copyIntoCRCBuffer(const void *mem, size_t len);
-	ssize_t copyIntoBlockBuffer(const void *mem, size_t len);
-	ssize_t copyValueIntoBlockBuffer(uint8_t value, size_t len);
-	ssize_t copyIntoHeaderBuffer(const std::vector<uint8_t> &mem);
+	ssize_t copyIntoBuffer(BufferType type, IChunk *chunk, size_t len, off_t offset);
+	ssize_t copyIntoBuffer(BufferType type, const void *mem, size_t len);
+	ssize_t copyIntoBuffer(BufferType type, const std::vector<uint8_t> &mem);
+	ssize_t copyValueIntoBuffer(BufferType type, uint8_t value, size_t len);
 
 	WriteStatus writeOutToAFileDescriptor(int outputFileDescriptor);
 
 	size_t bytesInABuffer() const;
 	inline std::pair<size_t, size_t> type() const { return {headerSize_, numBlocks_}; }
-	inline const uint8_t *blockData() const { return blockBuffer_.data(); }
+	const uint8_t *rawData(BufferType type) const;
 	void clear();
 
 	std::atomic_uint8_t status{kNotSaunafsStatus};
@@ -69,21 +147,9 @@ private:
 	const size_t headerSize_;
 	const size_t numBlocks_;
 
-	const size_t blockBufferCapacity_;
-	const size_t blockBufferCapacityAligned_;
-	const size_t blockBufferPadding_;
-	size_t blockBufferUnflushedDataFirstIndex_;
-	size_t blockBufferUnflushedDataOneAfterLastIndex_;
-	std::vector<uint8_t, AlignedAllocator<uint8_t, disk::kIoBlockSize>> blockBuffer_;
-
-	const size_t crcBufferCapacity_;
-	size_t crcBufferUnflushedDataFirstIndex_;
-	size_t crcBufferUnflushedDataOneAfterLastIndex_;
-	std::vector<uint8_t> crcBuffer_;
-	const size_t headerBufferCapacity_;
-	size_t headerBufferUnflushedDataFirstIndex_;
-	size_t headerBufferUnflushedDataOneAfterLastIndex_;
-	std::vector<uint8_t> headerBuffer_;
+	Buffer<std::vector<uint8_t, AlignedAllocator<uint8_t, disk::kIoBlockSize>>> blockBuffer_;
+	Buffer<std::vector<uint8_t>> crcBuffer_;
+	Buffer<std::vector<uint8_t>> headerBuffer_;
 };
 
 using OutputBufferPool = BuffersPool<OutputBuffer>;

--- a/src/chunkserver/output_buffer.h
+++ b/src/chunkserver/output_buffer.h
@@ -32,23 +32,56 @@
 
 constexpr uint8_t kNotSaunafsStatus = 255;
 
+/**
+ * @class OutputBuffer
+ * @brief Manages the output buffer for writing data to a file descriptor.
+ *
+ * The OutputBuffer class is responsible for managing the data to be written to
+ * a file descriptor. It provides functions to copy data into the buffer and write
+ * it to the file descriptor.
+ *
+ * The buffer is divided into three parts:
+ *
+ * - Header: The header of the packet.
+ *
+ * - CRC: The CRC of the block of data.
+ *
+ * - Block: The data block to be sent.
+ *
+ * The buffer is prepared to write the data to the file descriptor at once. The order of
+ * the final write interleaves the header, the CRC, and the block. All the headers are
+ * supposed to have the same length, which must be provided during the buffer creation.
+ * The sizes of CRC (kCrcSize) and the block (SFSBLOCKSIZE) buffers per block are fixed.
+ *
+ * The block buffer is aligned to the disk I/O block size. To get the expected behavior the only
+ * block which may not be complete is the last one.
+ */
 class OutputBuffer {
 public:
+	/// @enum WriteStatus
+	/// @brief Represents the status of the write operation.
 	enum class WriteStatus : uint8_t {
-		Done,
-		Again,
-		Error
+		Done,   // The write operation was successful.
+		Again,  // The write operation should be retried.
+		Error   // An error occurred during the write operation.
 	};
 
+	/// @enum BufferType
+	/// @brief Represents the type of buffer.
 	enum class BufferType : uint8_t {
-		Block,
-		CRC,
-		Header
+		Block,  // The block buffer.
+		CRC,    // The CRC buffer.
+		Header  // The header buffer.
 	};
 
-	template <typename C = std::vector<uint8_t>>
+	/// @class Buffer
+	/// @brief Manages a data buffer.
+	template <typename ContainerType = std::vector<uint8_t>>
 	class Buffer {
 	public:
+		/// @brief Constructs a buffer with the given capacity and padding.
+		/// @param capacity The capacity of the buffer.
+		/// @param padding The padding of the buffer.
 		Buffer(size_t capacity, size_t padding = 0)
 		    : capacity_(capacity),
 		      trueCapacity_(capacity + padding),
@@ -59,26 +92,49 @@ public:
 			eassert(trueCapacity_ > 0);
 			data_.reserve(trueCapacity_);
 		}
+
+		/// @brief Default destructor.
 		~Buffer() = default;
 
+		/// @brief Copies data from the buffer to the given memory.
+		/// This operation counts as flushing the data.
+		/// @param mem The memory to copy the data to.
+		/// @param len The length of the data to copy.
+		/// @return The number of bytes copied.
 		ssize_t copyFromBuffer(const void *mem, size_t len) {
 			eassert(unflushedDataFirstIndex_ + len <= unflushedDataOneAfterLastIndex_);
 			memcpy((void *)mem, &data_[unflushedDataFirstIndex_], len);
 			unflushedDataFirstIndex_ += len;
 			return len;
 		}
+
+		/// @brief Appends data to the buffer from the given memory.
+		/// @param mem The memory to copy the data from.
+		/// @param len The length of the data to copy.
+		/// @return The number of bytes copied.
 		ssize_t copyIntoBuffer(const void *mem, size_t len) {
 			eassert(unflushedDataOneAfterLastIndex_ + len <= trueCapacity_);
 			memcpy((void *)&data_[unflushedDataOneAfterLastIndex_], mem, len);
 			unflushedDataOneAfterLastIndex_ += len;
 			return len;
 		}
+
+		/// @brief Appends a value to the buffer a given number of times.
+		/// @param value The value to copy.
+		/// @param len The number of times to copy the value.
+		/// @return The number of bytes copied.
 		ssize_t copyValueIntoBuffer(uint8_t value, size_t len) {
 			eassert(unflushedDataOneAfterLastIndex_ + len <= trueCapacity_);
 			memset((void *)&data_[unflushedDataOneAfterLastIndex_], value, len);
 			unflushedDataOneAfterLastIndex_ += len;
 			return len;
 		}
+
+		/// @brief Appends data from the given chunk to the buffer.
+		/// @param chunk The chunk to copy the data from.
+		/// @param len The length of the data to copy.
+		/// @param offset The offset to copy the data from.
+		/// @return The number of bytes copied.
 		ssize_t copyIntoBuffer(IChunk *chunk, size_t len, off_t offset) {
 			eassert(unflushedDataOneAfterLastIndex_ + len <= trueCapacity_);
 			off_t bytes_written = 0;
@@ -92,68 +148,135 @@ public:
 			}
 			return bytes_written;
 		}
+
+		/// @brief Clears the buffer.
 		void clear() {
 			unflushedDataFirstIndex_ = padding_;
 			unflushedDataOneAfterLastIndex_ = padding_;
 		}
+
+		/// @brief Returns the capacity of the buffer.
 		inline size_t capacity() const { return capacity_; }
+
+		/// @brief Returns the number of unflushed bytes in the buffer.
 		inline size_t bytesInABuffer() const {
 			return unflushedDataOneAfterLastIndex_ - unflushedDataFirstIndex_;
 		}
+
+		/// @brief Returns the pointer to the given index considering the padding.
+		/// @param index The index to get the pointer to.
 		inline const uint8_t *paddedIndex(size_t index) const {
 			assert(index < capacity_);
 			return data_.data() + index + padding_;
 		}
+
+		/// @brief Returns the pointer to the first unflushed data.
 		inline const uint8_t *getUnflushedDataFirstIndex() const {
 			return &data_[unflushedDataFirstIndex_];
 		}
+
+		/// @brief Moves the first unflushed data index by the given offset.
+		/// @param offset The offset to move the index by.
 		inline void moveUnflushedDataFirstIndex(int64_t offset) {
 			unflushedDataFirstIndex_ += offset;
 		}
 
 	private:
-		const size_t capacity_;
-		const size_t trueCapacity_;
-		const size_t padding_;
-		size_t unflushedDataFirstIndex_;
-		size_t unflushedDataOneAfterLastIndex_;
-		C data_;
+		const size_t capacity_;      // The capacity of the buffer.
+		const size_t trueCapacity_;  // The real size of the underlying container.
+		const size_t padding_;       // The amount of unused space at the start of the container.
+		size_t unflushedDataFirstIndex_;         // The index of the first unflushed data.
+		size_t unflushedDataOneAfterLastIndex_;  // The index of the first byte after the last
+		                                         // unflushed data.
+		ContainerType data_;                     // The underlying data container.
 	};
 
+	/// @brief Constructs an OutputBuffer with the given header size and number of blocks.
+	/// @param headerSize The size of the header.
+	/// @param numBlocks The number of blocks.
 	explicit OutputBuffer(size_t headerSize, size_t numBlocks);
+
+	/// @brief Default destructor.
 	~OutputBuffer() = default;
 
+	/// @brief Checks the CRC of the data inside the block buffer.
+	/// @param bytes The number of bytes to check.
+	/// @param crc The CRC to check.
+	/// @param startingOffset The starting offset of the data in the block buffer (without padding).
+	/// @return True if the CRC is correct, false otherwise.
 	bool checkCRC(size_t bytes, uint32_t crc, uint32_t startingOffset) const;
 
+	/// @brief Copies data from the given chunk into the buffer.
+	/// Note: The type must be BufferType::Block.
+	/// @param type The type of buffer to copy the data into.
+	/// @param chunk The chunk to copy the data from.
+	/// @param len The length of the data to copy.
+	/// @param offset The offset to copy the data from.
+	/// @return The number of bytes copied.
 	ssize_t copyIntoBuffer(BufferType type, IChunk *chunk, size_t len, off_t offset);
+
+	/// @brief Copies data from the given memory into the buffer.
+	/// @param type The type of buffer to copy the data into.
+	/// @param mem The memory to copy the data from.
+	/// @param len The length of the data to copy.
+	/// @return The number of bytes copied.
 	ssize_t copyIntoBuffer(BufferType type, const void *mem, size_t len);
+
+	/// @brief Copies entire data from the given vector into the buffer.
+	/// @param type The type of buffer to copy the data into.
+	/// @param mem The vector to copy the data from.
+	/// @return The number of bytes copied.
 	ssize_t copyIntoBuffer(BufferType type, const std::vector<uint8_t> &mem);
+
+	/// @brief Copies a value into the buffer a given number of times.
+	/// @param type The type of buffer to copy the value into.
+	/// @param value The value to copy.
+	/// @param len The number of times to copy the value.
+	/// @return The number of bytes copied.
 	ssize_t copyValueIntoBuffer(BufferType type, uint8_t value, size_t len);
 
+	/// @brief Writes the data to the given file descriptor.
+	/// @param outputFileDescriptor The file descriptor to write the data to.
+	/// @return The status of the write operation.
 	WriteStatus writeOutToAFileDescriptor(int outputFileDescriptor);
 
+	/// @brief Returns the number of unflushed bytes in the buffer.
 	size_t bytesInABuffer() const;
+
+	/// @brief Returns the type of the buffer.
 	inline std::pair<size_t, size_t> type() const { return {headerSize_, numBlocks_}; }
+
+	/// @brief Returns the pointer to the beginning (after padding) of the data of the given type.
 	const uint8_t *rawData(BufferType type) const;
+
+	/// @brief Clears the buffer.
 	void clear();
 
+	/// Status of the buffer's related read operation.
 	std::atomic_uint8_t status{kNotSaunafsStatus};
 
 private:
 	// The current remaining bytes to be written to the file descriptor at once.
 	// When the buffer is prepared, should be equal to: SFSBLOCKSIZE + kCrcSize + headerSize_.
-	// 0 means that the buffer is not prepared.
+	// 0 means that the buffer is not prepared or is finished.
 	size_t currentRemainingBytesForFD_;
+	// The size of the header.
 	const size_t headerSize_;
+	// The number of blocks.
 	const size_t numBlocks_;
 
+	// The buffer for the block data.
 	Buffer<std::vector<uint8_t, AlignedAllocator<uint8_t, disk::kIoBlockSize>>> blockBuffer_;
+	// The buffer for the CRC data.
 	Buffer<std::vector<uint8_t>> crcBuffer_;
+	// The buffer for the header data.
 	Buffer<std::vector<uint8_t>> headerBuffer_;
 };
 
 using OutputBufferPool = BuffersPool<OutputBuffer>;
 
+/// @brief Returns the read output buffer pool.
+/// It is a singleton.
 inline OutputBufferPool &getReadOutputBufferPool() {
 	static OutputBufferPool readOutputBuffersPool;
 	return readOutputBuffersPool;

--- a/src/chunkserver/output_buffer.h
+++ b/src/chunkserver/output_buffer.h
@@ -49,7 +49,7 @@ public:
 
 	ssize_t copyIntoCRCBuffer(const void *mem, size_t len);
 	ssize_t copyIntoBlockBuffer(const void *mem, size_t len);
-	ssize_t copyIntoBlockBuffer(const std::vector<uint8_t> &mem);
+	ssize_t copyValueIntoBlockBuffer(uint8_t value, size_t len);
 	ssize_t copyIntoHeaderBuffer(const std::vector<uint8_t> &mem);
 
 	WriteStatus writeOutToAFileDescriptor(int outputFileDescriptor);

--- a/src/chunkserver/output_buffer_unittest.cc
+++ b/src/chunkserver/output_buffer_unittest.cc
@@ -49,14 +49,17 @@ TEST(OutputBufferTests, outputBuffersTest) {
 
 	uint8_t buf[WRITE_SIZE];
 	memset(buf, VALUE, WRITE_SIZE);
-	ASSERT_EQ(outputBuffer.copyIntoHeaderBuffer(std::vector<uint8_t>(testHeaderSize, VALUE)), testHeaderSize);
-	ASSERT_EQ(outputBuffer.copyIntoCRCBuffer(buf, kCrcSize), kCrcSize);
-	ASSERT_EQ(outputBuffer.copyIntoBlockBuffer(buf, WRITE_SIZE_DATA), WRITE_SIZE_DATA);
+	ASSERT_EQ(outputBuffer.copyIntoBuffer(OutputBuffer::BufferType::Header,
+	                                      std::vector<uint8_t>(testHeaderSize, VALUE)),
+	          testHeaderSize);
+	ASSERT_EQ(outputBuffer.copyIntoBuffer(OutputBuffer::BufferType::CRC, buf, kCrcSize), kCrcSize);
+	ASSERT_EQ(outputBuffer.copyIntoBuffer(OutputBuffer::BufferType::Block, buf, WRITE_SIZE_DATA),
+	          WRITE_SIZE_DATA);
 
 	while (true) {
 		OutputBuffer::WriteStatus status = outputBuffer.writeOutToAFileDescriptor(auxPipeFileDescriptors[1]);
-		ASSERT_NE(status, OutputBuffer::WRITE_ERROR);
-		if (status == OutputBuffer::WRITE_DONE) {
+		ASSERT_NE(status, OutputBuffer::WriteStatus::Error);
+		if (status == OutputBuffer::WriteStatus::Done) {
 			break;
 		}
 		sleep(1);

--- a/src/chunkserver/output_buffer_unittest.cc
+++ b/src/chunkserver/output_buffer_unittest.cc
@@ -27,7 +27,8 @@
 #include "unittests/TemporaryDirectory.h"
 
 TEST(OutputBufferTests, outputBuffersTest) {
-	OutputBuffer outputBuffer(1, 8);
+	const ssize_t  testHeaderSize = 1;
+	OutputBuffer outputBuffer(testHeaderSize, 8);
 
 	int auxPipeFileDescriptors[2];
 
@@ -42,12 +43,15 @@ TEST(OutputBufferTests, outputBuffersTest) {
 #endif
 
 
-	const unsigned WRITE_SIZE = 10;
+	const unsigned WRITE_SIZE_DATA = 10;
+	const unsigned WRITE_SIZE = WRITE_SIZE_DATA + kCrcSize + testHeaderSize;
 	unsigned VALUE = 17u;
 
 	uint8_t buf[WRITE_SIZE];
 	memset(buf, VALUE, WRITE_SIZE);
-	ASSERT_EQ(outputBuffer.copyIntoBlockBuffer(buf, WRITE_SIZE), WRITE_SIZE);
+	ASSERT_EQ(outputBuffer.copyIntoHeaderBuffer(std::vector<uint8_t>(testHeaderSize, VALUE)), testHeaderSize);
+	ASSERT_EQ(outputBuffer.copyIntoCRCBuffer(buf, kCrcSize), kCrcSize);
+	ASSERT_EQ(outputBuffer.copyIntoBlockBuffer(buf, WRITE_SIZE_DATA), WRITE_SIZE_DATA);
 
 	while (true) {
 		OutputBuffer::WriteStatus status = outputBuffer.writeOutToAFileDescriptor(auxPipeFileDescriptors[1]);

--- a/src/chunkserver/output_buffer_unittest.cc
+++ b/src/chunkserver/output_buffer_unittest.cc
@@ -27,7 +27,7 @@
 #include "unittests/TemporaryDirectory.h"
 
 TEST(OutputBufferTests, outputBuffersTest) {
-	OutputBuffer outputBuffer(512*1024);
+	OutputBuffer outputBuffer(1, 8);
 
 	int auxPipeFileDescriptors[2];
 
@@ -47,7 +47,7 @@ TEST(OutputBufferTests, outputBuffersTest) {
 
 	uint8_t buf[WRITE_SIZE];
 	memset(buf, VALUE, WRITE_SIZE);
-	ASSERT_EQ(outputBuffer.copyIntoBuffer(buf, WRITE_SIZE), WRITE_SIZE);
+	ASSERT_EQ(outputBuffer.copyIntoBlockBuffer(buf, WRITE_SIZE), WRITE_SIZE);
 
 	while (true) {
 		OutputBuffer::WriteStatus status = outputBuffer.writeOutToAFileDescriptor(auxPipeFileDescriptors[1]);

--- a/src/chunkserver/output_buffer_unittest.cc
+++ b/src/chunkserver/output_buffer_unittest.cc
@@ -18,17 +18,23 @@
  */
 
 #include "common/platform.h"
+
 #include <fcntl.h>
-#include <cstdlib>
-#include <string>
 #include <gtest/gtest.h>
+#include <cstdlib>
+#include <random>
+#include <string>
 
 #include "chunkserver/output_buffer.h"
+#include "common/crc.h"
 #include "unittests/TemporaryDirectory.h"
 
-TEST(OutputBufferTests, outputBuffersTest) {
-	const ssize_t  testHeaderSize = 1;
-	OutputBuffer outputBuffer(testHeaderSize, 8);
+const ssize_t testHeaderSize = 1;
+const ssize_t testNumBlocks = 4;
+const ssize_t testPipePageSize = 512 * 1024;
+
+TEST(OutputBufferTests, outputBufferBasicTest) {
+	OutputBuffer outputBuffer(testHeaderSize, testNumBlocks);
 
 	int auxPipeFileDescriptors[2];
 
@@ -39,36 +45,178 @@ TEST(OutputBufferTests, outputBuffersTest) {
 #endif
 
 #ifdef F_SETPIPE_SZ
-	ASSERT_NE(fcntl(auxPipeFileDescriptors[1], F_SETPIPE_SZ, 512*1024), -1);
+	ASSERT_NE(fcntl(auxPipeFileDescriptors[1], F_SETPIPE_SZ, testPipePageSize), -1);
 #endif
 
+	const unsigned writeSizeData = 10;
+	const unsigned writeSize = writeSizeData + kCrcSize + testHeaderSize;
+	const unsigned value = 17u;
 
-	const unsigned WRITE_SIZE_DATA = 10;
-	const unsigned WRITE_SIZE = WRITE_SIZE_DATA + kCrcSize + testHeaderSize;
-	unsigned VALUE = 17u;
-
-	uint8_t buf[WRITE_SIZE];
-	memset(buf, VALUE, WRITE_SIZE);
+	std::vector<uint8_t> buf(writeSize, value);
 	ASSERT_EQ(outputBuffer.copyIntoBuffer(OutputBuffer::BufferType::Header,
-	                                      std::vector<uint8_t>(testHeaderSize, VALUE)),
+	                                      std::vector<uint8_t>(testHeaderSize, value)),
 	          testHeaderSize);
-	ASSERT_EQ(outputBuffer.copyIntoBuffer(OutputBuffer::BufferType::CRC, buf, kCrcSize), kCrcSize);
-	ASSERT_EQ(outputBuffer.copyIntoBuffer(OutputBuffer::BufferType::Block, buf, WRITE_SIZE_DATA),
-	          WRITE_SIZE_DATA);
+	ASSERT_EQ(outputBuffer.copyIntoBuffer(OutputBuffer::BufferType::CRC, buf.data(), kCrcSize),
+	          kCrcSize);
+	ASSERT_EQ(
+	    outputBuffer.copyIntoBuffer(OutputBuffer::BufferType::Block, buf.data(), writeSizeData),
+	    writeSizeData);
 
 	while (true) {
-		OutputBuffer::WriteStatus status = outputBuffer.writeOutToAFileDescriptor(auxPipeFileDescriptors[1]);
+		OutputBuffer::WriteStatus status =
+		    outputBuffer.writeOutToAFileDescriptor(auxPipeFileDescriptors[1]);
 		ASSERT_NE(status, OutputBuffer::WriteStatus::Error);
-		if (status == OutputBuffer::WriteStatus::Done) {
-			break;
-		}
+		if (status == OutputBuffer::WriteStatus::Done) { break; }
 		sleep(1);
 	}
 
-	ASSERT_EQ(read(auxPipeFileDescriptors[0], buf, WRITE_SIZE), WRITE_SIZE) << "errno: " << errno;
+	ASSERT_EQ(read(auxPipeFileDescriptors[0], buf.data(), writeSize), writeSize)
+	    << "errno: " << errno;
 
-	for (unsigned j = 0; j < WRITE_SIZE; ++j) {
-		ASSERT_EQ(VALUE, buf[j]) << "Byte " << j << " in block doesn't match";
+	for (uint32_t j = 0; j < writeSize; ++j) {
+		ASSERT_EQ(value, buf[j]) << "Byte " << j << " in block doesn't match";
+	}
+	close(auxPipeFileDescriptors[0]);
+	close(auxPipeFileDescriptors[1]);
+}
+
+TEST(OutputBufferTests, outputBufferCheckCrcTest) {
+	OutputBuffer outputBuffer(testHeaderSize, testNumBlocks);
+
+	std::mt19937_64 rng(time(0));
+	std::vector<uint32_t> blocksCrc(testNumBlocks);
+	std::vector<uint8_t> buf(SFSBLOCKSIZE);
+	// Put testNumBlocks blocks of random data into the buffer
+	for (uint32_t blockNumber = 0; blockNumber < testNumBlocks; blockNumber++) {
+		for (uint32_t i = 0; i < SFSBLOCKSIZE;) {
+			uint64_t randomValue = rng();
+			memcpy(buf.data() + i, &randomValue, sizeof(randomValue));
+			i += sizeof(randomValue);
+		}
+		blocksCrc[blockNumber] = mycrc32(0, buf.data(), SFSBLOCKSIZE);
+		ASSERT_EQ(
+		    outputBuffer.copyIntoBuffer(OutputBuffer::BufferType::Block, buf.data(), SFSBLOCKSIZE),
+		    SFSBLOCKSIZE)
+		    << "Failed to copy block " << blockNumber << " into the buffer";
+	}
+
+	// Randomize the order of blocks to check the CRC
+	std::vector<uint32_t> orderToCheckCrc;
+	for (uint32_t i = 0; i < testNumBlocks; i++) { orderToCheckCrc.push_back(i); }
+	std::shuffle(orderToCheckCrc.begin(), orderToCheckCrc.end(), rng);
+
+	// Check CRC for the blocks in the randomized order
+	for (auto blockNumber : orderToCheckCrc) {
+		ASSERT_TRUE(
+		    outputBuffer.checkCRC(SFSBLOCKSIZE, blocksCrc[blockNumber], blockNumber * SFSBLOCKSIZE))
+		    << "CRC check failed for block " << blockNumber;
+	}
+}
+
+TEST(OutputBufferTests, outputBufferCopyValueTest) {
+	OutputBuffer outputBuffer(testHeaderSize, testNumBlocks);
+
+	std::vector<uint8_t> buf(SFSBLOCKSIZE, 0);
+	const auto emptyBlockCrc = mycrc32(0, buf.data(), SFSBLOCKSIZE);
+
+	// Put testNumBlocks blocks of zeroes into the buffer
+	for (uint32_t blockNumber = 0; blockNumber < testNumBlocks; blockNumber++) {
+		ASSERT_EQ(
+		    outputBuffer.copyValueIntoBuffer(OutputBuffer::BufferType::Block, 0, SFSBLOCKSIZE),
+		    SFSBLOCKSIZE)
+		    << "Failed to copy zeroes block " << blockNumber << " into the buffer";
+	}
+
+	// Randomize the order of blocks to check the CRC
+	std::vector<uint32_t> orderToCheckCrc;
+	for (uint32_t i = 0; i < testNumBlocks; i++) { orderToCheckCrc.push_back(i); }
+	std::shuffle(orderToCheckCrc.begin(), orderToCheckCrc.end(), std::mt19937_64(time(0)));
+
+	// Check CRC for the blocks in the randomized order
+	for (auto blockNumber : orderToCheckCrc) {
+		ASSERT_TRUE(outputBuffer.checkCRC(SFSBLOCKSIZE, emptyBlockCrc, blockNumber * SFSBLOCKSIZE))
+		    << "CRC check failed for block " << blockNumber;
+	}
+}
+
+TEST(OutputBufferTests, outputBufferSeveralBlocksInBufferTest) {
+	OutputBuffer outputBuffer(testHeaderSize, testNumBlocks);
+
+	int auxPipeFileDescriptors[2];
+
+#if defined(__APPLE__)
+	ASSERT_NE(pipe(auxPipeFileDescriptors), -1);
+#else
+	ASSERT_NE(pipe2(auxPipeFileDescriptors, O_NONBLOCK), -1);
+#endif
+
+#ifdef F_SETPIPE_SZ
+	ASSERT_NE(fcntl(auxPipeFileDescriptors[1], F_SETPIPE_SZ, testPipePageSize), -1);
+#endif
+
+	std::mt19937_64 rng(time(0));
+	std::vector<uint8_t> buf(SFSBLOCKSIZE);
+
+	// Put testNumBlocks - 1 blocks of random data into the buffer
+	std::vector<uint32_t> blockDataSizesLog2;
+	for (uint32_t i = 0; i < testNumBlocks - 1; i++) { blockDataSizesLog2.push_back(16); }
+	// The last block is smaller
+	uint32_t lastBlockSizeLog2 = 10;
+	blockDataSizesLog2.push_back(lastBlockSizeLog2);
+
+	for (uint32_t blockNumber = 0; blockNumber < testNumBlocks; blockNumber++) {
+		uint8_t headerValue = blockDataSizesLog2[blockNumber];
+		uint32_t blockSize = 1 << headerValue;
+		for (uint32_t i = 0; i < blockSize;) {
+			uint64_t randomValue = rng();
+			memcpy(buf.data() + i, &randomValue, sizeof(randomValue));
+			i += sizeof(randomValue);
+		}
+		ASSERT_EQ(outputBuffer.copyIntoBuffer(OutputBuffer::BufferType::Header,
+		                                      std::vector<uint8_t>(testHeaderSize, headerValue)),
+		          testHeaderSize);
+		auto crc = mycrc32(0, buf.data(), blockSize);
+		ASSERT_EQ(outputBuffer.copyIntoBuffer(OutputBuffer::BufferType::CRC, &crc, kCrcSize),
+		          kCrcSize);
+		ASSERT_EQ(
+		    outputBuffer.copyIntoBuffer(OutputBuffer::BufferType::Block, buf.data(), blockSize),
+		    blockSize);
+	}
+
+	while (true) {
+		OutputBuffer::WriteStatus status =
+		    outputBuffer.writeOutToAFileDescriptor(auxPipeFileDescriptors[1]);
+		ASSERT_NE(status, OutputBuffer::WriteStatus::Error);
+		if (status == OutputBuffer::WriteStatus::Done) { break; }
+		sleep(1);
+	}
+
+	uint32_t expectedSize = testNumBlocks * kCrcSize + testNumBlocks * testHeaderSize;
+	for (uint32_t blockSizeLog2 : blockDataSizesLog2) { expectedSize += 1u << blockSizeLog2; }
+	buf.resize(expectedSize);
+	buf.reserve(expectedSize);
+
+	ASSERT_EQ(read(auxPipeFileDescriptors[0], buf.data(), expectedSize), expectedSize)
+	    << "errno: " << errno;
+
+	// Check the actually written data
+	uint32_t offset = 0;
+	for (uint32_t j = 0; j < testNumBlocks; ++j) {
+		// Get the header value
+		auto headerValue = buf[offset];
+		offset += testHeaderSize;
+
+		// Get the CRC
+		auto crc = *reinterpret_cast<const uint32_t *>(buf.data() + offset);
+		offset += kCrcSize;
+
+		// Remember the block size was 2^headerValue
+		auto blockSize = 1u << headerValue;
+
+		// Check the block data matches the CRC
+		ASSERT_EQ(mycrc32(0, buf.data() + offset, blockSize), crc)
+		    << "CRC check failed for block " << j;
+		offset += blockSize;
 	}
 	close(auxPipeFileDescriptors[0]);
 	close(auxPipeFileDescriptors[1]);


### PR DESCRIPTION
The main goal of this change is to prepare the `OutputBuffer` to emplace
bigger pieces of data at once during pread calls. This could not be
achieved previously because the buffer should have a sequence of
header, CRC, data block, header, CRC and so on.

The class `OutputBuffer::Buffer` is created for this purpose. This is a
generic class to implement the three types of buffers an `OutputBuffer`
has. Taking this into consideration, the implementation of the
`OutputBuffer` could be made simpler and more readable.

Side changes:
- increase readability of putting data into the `OutputBuffer`.
- save the allocation of a block of zeros when asking for block beyond current number of blocks in chunk.
- modernize the `WriteStatus` enum.
- change `BuffersPool` to adapt to the new format of the `OutputBuffer`. Keep track of the number of block in the buffers instead of the number of buffers, and log it from time to time.
- add documentation for the `OutputBuffer` class.
- improve the unit tests suite of the `OutputBuffer` class.

The idea is to squash all these commits.

Signed-off-by: Dave <dave@leil.io>