### PR TITLE
fix(chunkserver): Amend memory management in ChunkTrashManager

### DIFF
--- a/src/chunkserver/chunkserver-common/chunk_trash_index.cc
+++ b/src/chunkserver/chunkserver-common/chunk_trash_index.cc
@@ -34,15 +34,13 @@ void ChunkTrashIndex::reset(const std::filesystem::path &diskPath) {
 	trashIndex[diskPath] = {};
 }
 
-void ChunkTrashIndex::add(const time_t &deletionTime,
-                          const std::string &filePath,
+void ChunkTrashIndex::add(const time_t &deletionTime, const std::string &filePath,
                           const std::string &diskPath) {
 	std::scoped_lock<std::mutex> const lock(trashIndexMutex);
 	trashIndex[diskPath].emplace(deletionTime, filePath);
 }
 
-bool ChunkTrashIndex::removeInternal(const time_t &deletionTime,
-                                     const std::string &filePath,
+bool ChunkTrashIndex::removeInternal(const time_t &deletionTime, const std::string &filePath,
                                      const std::string &diskPath) {
 	auto range = trashIndex[diskPath].equal_range(deletionTime);
 	// Keep iterator based loop for direct erasure (erase(it)).
@@ -55,15 +53,13 @@ bool ChunkTrashIndex::removeInternal(const time_t &deletionTime,
 	return false;
 }
 
-void ChunkTrashIndex::remove(const time_t &deletionTime,
-                             const std::string &filePath,
+void ChunkTrashIndex::remove(const time_t &deletionTime, const std::string &filePath,
                              const std::string &diskPath) {
 	std::scoped_lock<std::mutex> const lock(trashIndexMutex);
 	removeInternal(deletionTime, filePath, diskPath);
 }
 
-void ChunkTrashIndex::remove(const time_t &deletionTime,
-                             const std::string &filePath) {
+void ChunkTrashIndex::remove(const time_t &deletionTime, const std::string &filePath) {
 	std::scoped_lock<std::mutex> const lock(trashIndexMutex);
 	bool removed = false;
 	for (const auto &diskEntry : trashIndex) {
@@ -72,8 +68,8 @@ void ChunkTrashIndex::remove(const time_t &deletionTime,
 	}
 }
 
-ChunkTrashIndex::TrashIndexDiskEntries ChunkTrashIndex::getExpiredFiles(
-    const time_t &timeLimit, size_t bulkSize) {
+ChunkTrashIndex::TrashIndexDiskEntries ChunkTrashIndex::getExpiredFiles(const time_t &timeLimit,
+                                                                        size_t bulkSize) {
 	std::scoped_lock<std::mutex> const lock(trashIndexMutex);
 	return getExpiredFilesInternal(timeLimit, bulkSize);
 }
@@ -85,16 +81,16 @@ ChunkTrashIndex::TrashIndexDiskEntries ChunkTrashIndex::getExpiredFilesInternal(
 	size_t count = 0;
 	for (const auto &diskEntry : trashIndex) {
 		if (bulkSize != 0 && count >= bulkSize) { break; }
-		count += getExpiredFilesInternal(diskEntry.first, timeLimit,
-		                                 expiredFiles, bulkSize);
+		count += getExpiredFilesInternal(diskEntry.first, timeLimit, expiredFiles, bulkSize);
 	}
 
 	return expiredFiles;
 }
 
-size_t ChunkTrashIndex::getExpiredFilesInternal(
-    const std::filesystem::path &diskPath, const std::time_t &timeLimit,
-    TrashIndexDiskEntries &expiredFiles, size_t bulkSize) {
+size_t ChunkTrashIndex::getExpiredFilesInternal(const std::filesystem::path &diskPath,
+                                                const std::time_t &timeLimit,
+                                                TrashIndexDiskEntries &expiredFiles,
+                                                size_t bulkSize) {
 	auto &diskTrashIndex = trashIndex[diskPath];
 	// auto limit = diskTrashIndex.upper_bound(timeLimit);
 
@@ -126,9 +122,7 @@ ChunkTrashIndex::TrashIndexFileEntries ChunkTrashIndex::getOlderFiles(
 std::vector<std::string> ChunkTrashIndex::getDiskPaths() {
 	std::scoped_lock<std::mutex> const lock(trashIndexMutex);
 	std::vector<std::string> diskPaths;
-	for (const auto &diskEntry : trashIndex) {
-		diskPaths.push_back(diskEntry.first);
-	}
+	for (const auto &diskEntry : trashIndex) { diskPaths.push_back(diskEntry.first); }
 
 	return diskPaths;
 }

--- a/src/chunkserver/chunkserver-common/chunk_trash_index.h
+++ b/src/chunkserver/chunkserver-common/chunk_trash_index.h
@@ -44,8 +44,7 @@ public:
 	 * @brief Type for storing disk path entries and their associated file
 	 * entries.
 	 */
-	using TrashIndexDiskEntries =
-	    std::unordered_map<std::string, TrashIndexFileEntries>;
+	using TrashIndexDiskEntries = std::unordered_map<std::string, TrashIndexFileEntries>;
 
 	/**
 	 * @brief Alias for the trash index type.
@@ -86,8 +85,7 @@ public:
 	 * which means no limit).
 	 * @return A map containing expired files.
 	 */
-	TrashIndexDiskEntries getExpiredFiles(const std::time_t &timeLimit,
-	                                      size_t bulkSize = 0);
+	TrashIndexDiskEntries getExpiredFiles(const std::time_t &timeLimit, size_t bulkSize = 0);
 
 	/**
 	 * @brief Adds a file entry to the trash index with its deletion time.
@@ -120,20 +118,17 @@ public:
 	            const std::string &diskPath);
 
 	// Deleted to enforce singleton behavior
-	ChunkTrashIndex(const ChunkTrashIndex &) =
-	    delete;  ///< Copy constructor is deleted.
+	ChunkTrashIndex(const ChunkTrashIndex &) = delete;  ///< Copy constructor is deleted.
 
 	ChunkTrashIndex &operator=(const ChunkTrashIndex &) =
 	    delete;  ///< Copy assignment operator is deleted.
 
-	ChunkTrashIndex(ChunkTrashIndex &&) =
-	    delete;  ///< Move constructor is deleted.
+	ChunkTrashIndex(ChunkTrashIndex &&) = delete;  ///< Move constructor is deleted.
 
 	ChunkTrashIndex &operator=(ChunkTrashIndex &&) =
 	    delete;  ///< Move assignment operator is deleted.
 
-	TrashIndexFileEntries getOlderFiles(const std::string &diskPath,
-	                                    const size_t removalStepSize);
+	TrashIndexFileEntries getOlderFiles(const std::string &diskPath, const size_t removalStepSize);
 
 	std::vector<std::string> getDiskPaths();
 
@@ -170,8 +165,7 @@ private:
 	 */
 	size_t getExpiredFilesInternal(const std::filesystem::path &diskPath,
 	                               const std::time_t &timeLimit,
-	                               TrashIndexDiskEntries &expiredFiles,
-	                               size_t bulkSize = 0);
+	                               TrashIndexDiskEntries &expiredFiles, size_t bulkSize = 0);
 
 	/**
 	 * @brief Retrieves expired files from the trash index.

--- a/src/chunkserver/chunkserver-common/chunk_trash_index_unittest.cc
+++ b/src/chunkserver/chunkserver-common/chunk_trash_index_unittest.cc
@@ -47,8 +47,7 @@ TEST_F(ChunkTrashIndexTest, AddFileEntry) {
 
 	auto expiredFiles = index.getExpiredFiles(1234567891);
 	ASSERT_EQ(expiredFiles.size(), static_cast<size_t>(1));
-	EXPECT_EQ(expiredFiles["/testDisk"].begin()->second,
-	          "/.trash.bin/path/to/file");
+	EXPECT_EQ(expiredFiles["/testDisk"].begin()->second, "/.trash.bin/path/to/file");
 }
 
 TEST_F(ChunkTrashIndexTest, RemoveFileEntry) {
@@ -74,7 +73,7 @@ TEST_F(ChunkTrashIndexTest, RemoveFileEntryFromLastDisk) {
 	index.add(1234567890, "/path/to/file", "/testDisk");
 	index.add(123456, "/path/to/file", "/testDisk2");
 
-        // Expect removing from /testDisk
+	// Expect removing from /testDisk
 	index.remove(1234567890, "/path/to/file");
 
 	auto expiredFiles = index.getExpiredFiles(1234567891);
@@ -86,10 +85,8 @@ TEST_F(ChunkTrashIndexTest, RemoveFileEntryFromLastDisk) {
 
 TEST_F(ChunkTrashIndexTest, ThreadSafety) {
 	auto &index = ChunkTrashIndex::instance();
-	std::thread t1(
-	    [&index]() { index.add(1234567890, "/path/to/file1", "/testDisk"); });
-	std::thread t2(
-	    [&index]() { index.add(1234567891, "/path/to/file2", "/testDisk"); });
+	std::thread t1([&index]() { index.add(1234567890, "/path/to/file1", "/testDisk"); });
+	std::thread t2([&index]() { index.add(1234567891, "/path/to/file2", "/testDisk"); });
 
 	t1.join();
 	t2.join();

--- a/src/chunkserver/chunkserver-common/chunk_trash_manager.cc
+++ b/src/chunkserver/chunkserver-common/chunk_trash_manager.cc
@@ -17,41 +17,92 @@
  */
 
 #include <syslog.h>
-#include <cassert>
 #include <memory>
 
 #include "chunk_trash_manager.h"
 #include "chunk_trash_manager_impl.h"
 #include "config/cfg.h"
+#include "errors/saunafs_error_codes.h"
+#include "slogger/slogger.h"
 
 u_short ChunkTrashManager::isEnabled = 0;
+std::mutex ChunkTrashManager::implMutex;
 
-ChunkTrashManager::ImplementationPtr ChunkTrashManager::pImpl =
-    std::make_shared<ChunkTrashManagerImpl>();
+// Using the Meyer's singleton pattern to ensure proper initialization and
+// cleanup
+ChunkTrashManager::ImplementationPtr &ChunkTrashManager::getImpl() {
+	static ImplementationPtr instance =
+	    std::make_shared<ChunkTrashManagerImpl>();
+	return instance;
+}
+
+void ChunkTrashManager::setImpl(ImplementationPtr newImpl) {
+	// Protect against concurrent access
+	std::lock_guard<std::mutex> lock(implMutex);
+	if (!newImpl) {
+		safs::log_err(
+		    "Attempt to set null implementation for ChunkTrashManager");
+		return;  // Don't set null implementation
+	}
+	getImpl() = newImpl;
+}
 
 int ChunkTrashManager::moveToTrash(const std::filesystem::path &filePath,
                                    const std::filesystem::path &diskPath,
                                    const std::time_t &deletionTime) {
 	if (!isEnabled) { return 0; }
-	assert(pImpl && "Implementation should be set");
-	return pImpl->moveToTrash(filePath, diskPath, deletionTime);
+
+	// Protect against concurrent access
+	std::lock_guard<std::mutex> lock(implMutex);
+
+	auto &impl = getImpl();
+	if (!impl) {
+		safs::log_err("ChunkTrashManager implementation not initialized");
+		return SAUNAFS_ERROR_NOTDONE;
+	}
+	return impl->moveToTrash(filePath, diskPath, deletionTime);
 }
 
 int ChunkTrashManager::init(const std::string &diskPath) {
 	reloadConfig();
-	assert(pImpl && "Implementation should be set");
-	return pImpl->init(diskPath);
+
+	// Protect against concurrent access
+	std::lock_guard<std::mutex> lock(implMutex);
+
+	auto &impl = getImpl();
+	if (!impl) {
+		safs::log_err("ChunkTrashManager implementation not initialized");
+		return SAUNAFS_ERROR_NOTDONE;
+	}
+	return impl->init(diskPath);
 }
 
 void ChunkTrashManager::collectGarbage() {
 	if (!isEnabled) { return; }
-	assert(pImpl && "Implementation should be set");
-	pImpl->collectGarbage();
+
+	// Protect against concurrent access
+	std::lock_guard<std::mutex> lock(implMutex);
+
+	auto &impl = getImpl();
+	if (!impl) {
+		safs::log_err("ChunkTrashManager implementation not initialized");
+		return;
+	}
+	impl->collectGarbage();
 }
 
 void ChunkTrashManager::reloadConfig() {
-	assert(pImpl && "Implementation should be set");
+	// Protect against concurrent access
+	std::lock_guard<std::mutex> lock(implMutex);
+
+	auto &impl = getImpl();
+	if (!impl) {
+		safs::log_err("ChunkTrashManager implementation not initialized");
+		return;
+	}
+
 	isEnabled = cfg_get("CHUNK_TRASH_ENABLED", static_cast<u_short>(0));
-	safs::log_info("Chunk trash manager is {}", isEnabled ? "enabled" : "disabled");
-	pImpl->reloadConfig();
+	safs::log_info("Chunk trash manager is {}",
+	               isEnabled ? "enabled" : "disabled");
+	impl->reloadConfig();
 }

--- a/src/chunkserver/chunkserver-common/chunk_trash_manager.cc
+++ b/src/chunkserver/chunkserver-common/chunk_trash_manager.cc
@@ -31,8 +31,7 @@ std::mutex ChunkTrashManager::implMutex;
 // Using the Meyer's singleton pattern to ensure proper initialization and
 // cleanup
 ChunkTrashManager::ImplementationPtr &ChunkTrashManager::getImpl() {
-	static ImplementationPtr instance =
-	    std::make_shared<ChunkTrashManagerImpl>();
+	static ImplementationPtr instance = std::make_shared<ChunkTrashManagerImpl>();
 	return instance;
 }
 
@@ -40,8 +39,7 @@ void ChunkTrashManager::setImpl(ImplementationPtr newImpl) {
 	// Protect against concurrent access
 	std::lock_guard<std::mutex> lock(implMutex);
 	if (!newImpl) {
-		safs::log_err(
-		    "Attempt to set null implementation for ChunkTrashManager");
+		safs::log_err("Attempt to set null implementation for ChunkTrashManager");
 		return;  // Don't set null implementation
 	}
 	getImpl() = newImpl;
@@ -102,7 +100,6 @@ void ChunkTrashManager::reloadConfig() {
 	}
 
 	isEnabled = cfg_get("CHUNK_TRASH_ENABLED", static_cast<u_short>(0));
-	safs::log_info("Chunk trash manager is {}",
-	               isEnabled ? "enabled" : "disabled");
+	safs::log_info("Chunk trash manager is {}", isEnabled ? "enabled" : "disabled");
 	impl->reloadConfig();
 }

--- a/src/chunkserver/chunkserver-common/chunk_trash_manager.h
+++ b/src/chunkserver/chunkserver-common/chunk_trash_manager.h
@@ -29,8 +29,7 @@ class IChunkTrashManagerImpl {
 public:
 	virtual ~IChunkTrashManagerImpl() = default;
 
-	virtual int moveToTrash(const std::filesystem::path &,
-	                        const std::filesystem::path &,
+	virtual int moveToTrash(const std::filesystem::path &, const std::filesystem::path &,
 	                        const std::time_t &) = 0;
 
 	virtual int init(const std::string &) = 0;
@@ -83,8 +82,7 @@ public:
 	 * @return 0 on success, error code otherwise.
 	 */
 	static int moveToTrash(const std::filesystem::path &filePath,
-	                       const std::filesystem::path &diskPath,
-	                       const std::time_t &deletionTime);
+	                       const std::filesystem::path &diskPath, const std::time_t &deletionTime);
 
 	/**
 	 * @brief Runs the garbage collection process, which includes

--- a/src/chunkserver/chunkserver-common/chunk_trash_manager.h
+++ b/src/chunkserver/chunkserver-common/chunk_trash_manager.h
@@ -22,6 +22,7 @@
 
 #include <ctime>
 #include <filesystem>
+#include <mutex>
 #include <string>
 
 class IChunkTrashManagerImpl {
@@ -55,7 +56,7 @@ public:
 	 *
 	 * @param newImpl The new implementation to be set.
 	 */
-	static inline void setImpl(ImplementationPtr newImpl) { pImpl = newImpl; }
+	static void setImpl(ImplementationPtr newImpl);
 
 	/**
 	 * @brief The name of the trash directory.
@@ -69,6 +70,7 @@ public:
 	 *
 	 * @param diskPath The path of the disk where the trash directory will be
 	 * initialized.
+	 * @return Status code indicating success or failure.
 	 */
 	static int init(const std::string &diskPath);
 
@@ -96,11 +98,11 @@ public:
 
 	// Deleted to enforce singleton behavior.
 	// It follows the Static Class with Encapsulated State pattern, ensuring
-	// a single, globally accessible instance of the pImpl implementation without
-	// requiring instance management. All methods and members are static, and
-	// instantiation is prevented by deleting the constructor. This approach avoids
-	// unnecessary singleton complexity while maintaining encapsulation and
-	// controlled access to internal state.
+	// a single, globally accessible instance of the pImpl implementation
+	// without requiring instance management. All methods and members are
+	// static, and instantiation is prevented by deleting the constructor. This
+	// approach avoids unnecessary singleton complexity while maintaining
+	// encapsulation and controlled access to internal state.
 	ChunkTrashManager() = delete;
 	ChunkTrashManager(const ChunkTrashManager &) = delete;
 	ChunkTrashManager &operator=(const ChunkTrashManager &) = delete;
@@ -110,6 +112,10 @@ public:
 	~ChunkTrashManager() = default;  ///< Destructor
 
 private:
-	/// Pointer to the singleton instance of the trash manager implementation.
-	static ImplementationPtr pImpl;
+	/// Get the implementation singleton instance using Meyer's singleton
+	/// pattern for thread-safety
+	static ImplementationPtr &getImpl();
+
+	/// Mutex to protect concurrent access to the implementation singleton
+	static std::mutex implMutex;
 };

--- a/src/chunkserver/chunkserver-common/chunk_trash_manager_impl.cc
+++ b/src/chunkserver/chunkserver-common/chunk_trash_manager_impl.cc
@@ -33,29 +33,26 @@ namespace safs {
 // These functions include the error code and message in the log message.
 
 template <typename FormatType, typename... Args>
-void log_err(std::error_code error_code, const FormatType &format,
-             Args &&...args) {
-	auto extended_format =
-	    fmt::format("{} (error_code: {}, message: {})", format,
-	                error_code.value(), error_code.message());
+void log_err(std::error_code error_code, const FormatType &format, Args &&...args) {
+	auto extended_format = fmt::format("{} (error_code: {}, message: {})", format,
+	                                   error_code.value(), error_code.message());
 
 	log_err(extended_format, std::forward<Args>(args)...);
 }
 
 template <typename FormatType, typename... Args>
-void log_err(saunafs_error_code error_code, const FormatType &format,
-             Args &&...args) {
-	auto extended_format = fmt::format(
-	    "{} (saunafs_error_code: {}, message: {})", format,
-	    static_cast<int>(error_code), saunafs_error_string(error_code));
+void log_err(saunafs_error_code error_code, const FormatType &format, Args &&...args) {
+	auto extended_format =
+	    fmt::format("{} (saunafs_error_code: {}, message: {})", format,
+	                static_cast<int>(error_code), saunafs_error_string(error_code));
 
 	log_err(extended_format, std::forward<Args>(args)...);
 }
 
 template <typename FormatType, typename... Args>
 void log_err(int error_code, const FormatType &format, Args &&...args) {
-	auto extended_format = fmt::format("{} (errno: {}, message: {})", format,
-	                                   error_code, std::strerror(error_code));
+	auto extended_format =
+	    fmt::format("{} (errno: {}, message: {})", format, error_code, std::strerror(error_code));
 
 	log_err(extended_format, std::forward<Args>(args)...);
 }
@@ -64,12 +61,9 @@ void log_err(int error_code, const FormatType &format, Args &&...args) {
 
 namespace fs = std::filesystem;
 
-size_t ChunkTrashManagerImpl::availableThresholdGB =
-    kDefaultAvailableThresholdGB;
-size_t ChunkTrashManagerImpl::trashTimeLimitSeconds =
-    kDefaultTrashTimeLimitSeconds;
-size_t ChunkTrashManagerImpl::trashGarbageCollectorBulkSize =
-    kDefaultTrashGarbageCollectorBulkSize;
+size_t ChunkTrashManagerImpl::availableThresholdGB = kDefaultAvailableThresholdGB;
+size_t ChunkTrashManagerImpl::trashTimeLimitSeconds = kDefaultTrashTimeLimitSeconds;
+size_t ChunkTrashManagerImpl::trashGarbageCollectorBulkSize = kDefaultTrashGarbageCollectorBulkSize;
 size_t ChunkTrashManagerImpl::garbageCollectorSpaceRecoveryStep =
     kDefaultGarbageCollectorSpaceRecoveryStep;
 
@@ -77,23 +71,22 @@ const std::string ChunkTrashManagerImpl::kTrashGuardString =
     std::string("/") + ChunkTrashManager::kTrashDirname + "/";
 
 void ChunkTrashManagerImpl::reloadConfig() {
-	availableThresholdGB = cfg_get("CHUNK_TRASH_FREE_SPACE_THRESHOLD_GB",
-	                               kDefaultAvailableThresholdGB);
-	trashTimeLimitSeconds = cfg_get("CHUNK_TRASH_EXPIRATION_SECONDS",
-	                                kDefaultTrashTimeLimitSeconds);
-	trashGarbageCollectorBulkSize = cfg_get(
-	    "CHUNK_TRASH_GC_BATCH_SIZE", kDefaultTrashGarbageCollectorBulkSize);
-	garbageCollectorSpaceRecoveryStep =
-	    cfg_get("CHUNK_TRASH_GC_SPACE_RECOVERY_BATCH_SIZE",
-	            kDefaultGarbageCollectorSpaceRecoveryStep);
+	availableThresholdGB =
+	    cfg_get("CHUNK_TRASH_FREE_SPACE_THRESHOLD_GB", kDefaultAvailableThresholdGB);
+	trashTimeLimitSeconds =
+	    cfg_get("CHUNK_TRASH_EXPIRATION_SECONDS", kDefaultTrashTimeLimitSeconds);
+	trashGarbageCollectorBulkSize =
+	    cfg_get("CHUNK_TRASH_GC_BATCH_SIZE", kDefaultTrashGarbageCollectorBulkSize);
+	garbageCollectorSpaceRecoveryStep = cfg_get("CHUNK_TRASH_GC_SPACE_RECOVERY_BATCH_SIZE",
+	                                            kDefaultGarbageCollectorSpaceRecoveryStep);
 	safs::log_info(
 	    "Reloaded chunk trash manager configuration: "
 	    "CHUNK_TRASH_FREE_SPACE_THRESHOLD_GB={}, "
 	    "CHUNK_TRASH_EXPIRATION_SECONDS={}, "
 	    "CHUNK_TRASH_GC_BATCH_SIZE={}, "
 	    "CHUNK_TRASH_GC_SPACE_RECOVERY_BATCH_SIZE={}",
-	    availableThresholdGB, trashTimeLimitSeconds,
-	    trashGarbageCollectorBulkSize, garbageCollectorSpaceRecoveryStep);
+	    availableThresholdGB, trashTimeLimitSeconds, trashGarbageCollectorBulkSize,
+	    garbageCollectorSpaceRecoveryStep);
 }
 
 std::string ChunkTrashManagerImpl::getTimeString(std::time_t time1) {
@@ -118,43 +111,39 @@ std::string ChunkTrashManagerImpl::getTimeString(std::time_t time1) {
 	return oss.str();
 }
 
-std::time_t ChunkTrashManagerImpl::getTimeFromString(
-    const std::string &timeString, int &errorCode) {
+std::time_t ChunkTrashManagerImpl::getTimeFromString(const std::string &timeString,
+                                                     int &errorCode) {
 	errorCode = SAUNAFS_STATUS_OK;
 	std::tm time = {};
 	std::istringstream stringReader(timeString);
 	stringReader >> std::get_time(&time, kTimeStampFormat.c_str());
 	if (stringReader.fail()) {
 		errorCode = SAUNAFS_ERROR_EINVAL;
-		safs::log_err(static_cast<error_type>(errorCode),
-		              "Failed to parse time string: {}", timeString.c_str());
+		safs::log_err(static_cast<error_type>(errorCode), "Failed to parse time string: {}",
+		              timeString.c_str());
 	}
 	return std::mktime(&time);
 }
 
 ChunkTrashManagerImpl::error_type ChunkTrashManagerImpl::getMoveDestinationPath(
-    const std::string &filePath, const std::string &sourceRoot,
-    const std::string &destinationRoot, std::string &destinationPath) {
+    const std::string &filePath, const std::string &sourceRoot, const std::string &destinationRoot,
+    std::string &destinationPath) {
 	auto error_code = SAUNAFS_STATUS_OK;
 	if (filePath.find(sourceRoot) != 0) {
 		error_code = SAUNAFS_ERROR_EINVAL;
-		safs::log_err(error_code, "File path is outside the source root: {}",
-		              filePath.c_str());
+		safs::log_err(error_code, "File path is outside the source root: {}", filePath.c_str());
 		return error_code;
 	}
 
-	destinationPath =
-	    destinationRoot + "/" + filePath.substr(sourceRoot.size());
+	destinationPath = destinationRoot + "/" + filePath.substr(sourceRoot.size());
 	return error_code;
 }
 
-int ChunkTrashManagerImpl::moveToTrash(const fs::path &filePath,
-                                       const fs::path &diskPath,
+int ChunkTrashManagerImpl::moveToTrash(const fs::path &filePath, const fs::path &diskPath,
                                        const std::time_t &deletionTime) {
 	std::error_code errorCode_;
 	if (!fs::exists(filePath, errorCode_)) {
-		safs::log_err(errorCode_, "File does not exist: {}",
-		              filePath.string().c_str());
+		safs::log_err(errorCode_, "File does not exist: {}", filePath.string().c_str());
 		return SAUNAFS_ERROR_ENOENT;
 	}
 
@@ -169,8 +158,8 @@ int ChunkTrashManagerImpl::moveToTrash(const fs::path &filePath,
 	const std::string deletionTimestamp = getTimeString(deletionTime);
 	std::string trashFilename;
 
-	auto errorCode = getMoveDestinationPath(
-	    filePath.string(), diskPath.string(), trashDir.string(), trashFilename);
+	auto errorCode = getMoveDestinationPath(filePath.string(), diskPath.string(), trashDir.string(),
+	                                        trashFilename);
 	if (errorCode != SAUNAFS_STATUS_OK) {
 		safs::log_err(errorCode, "Failed to get destination path for file: {}",
 		              filePath.string().c_str());
@@ -181,15 +170,13 @@ int ChunkTrashManagerImpl::moveToTrash(const fs::path &filePath,
 
 	fs::create_directories(fs::path(trashFilename).parent_path(), errorCode_);
 	if (errorCode_) {
-		safs::log_err(errorCode_, "Failed to create trash directory: {}",
-		              trashFilename.c_str());
+		safs::log_err(errorCode_, "Failed to create trash directory: {}", trashFilename.c_str());
 		return SAUNAFS_ERROR_NOTDONE;
 	}
 
 	fs::rename(filePath, trashFilename, errorCode_);
 	if (errorCode_) {
-		safs::log_err(errorCode_, "Failed to move file to trash: {}",
-		              filePath.string().c_str());
+		safs::log_err(errorCode_, "Failed to move file to trash: {}", filePath.string().c_str());
 		return SAUNAFS_ERROR_NOTDONE;
 	}
 
@@ -202,9 +189,7 @@ void ChunkTrashManagerImpl::removeTrashFiles(
     const ChunkTrashIndex::TrashIndexDiskEntries &filesToRemove) const {
 	for (const auto &[diskPath, fileEntries] : filesToRemove) {
 		for (const auto &fileEntry : fileEntries) {
-			if (removeFileFromTrash(fileEntry.second) != SAUNAFS_STATUS_OK) {
-				continue;
-			}
+			if (removeFileFromTrash(fileEntry.second) != SAUNAFS_STATUS_OK) { continue; }
 			getTrashIndex().remove(fileEntry.first, fileEntry.second, diskPath);
 		}
 	}
@@ -233,8 +218,7 @@ int ChunkTrashManagerImpl::init(const std::string &diskPath) {
 	for (const auto &file : fs::recursive_directory_iterator(trashDir)) {
 		if (fs::is_regular_file(file) && isTrashPath(file.path().string())) {
 			const std::string filename = file.path().filename().string();
-			const std::string deletionTimeStr =
-			    filename.substr(filename.find_last_of('.') + 1);
+			const std::string deletionTimeStr = filename.substr(filename.find_last_of('.') + 1);
 			if (!isValidTimestampFormat(deletionTimeStr)) {
 				safs::log_err(SAUNAFS_ERROR_EINVAL,
 				              "Invalid timestamp format in file: {}, skipping.",
@@ -242,13 +226,11 @@ int ChunkTrashManagerImpl::init(const std::string &diskPath) {
 				continue;
 			}
 			int errorCode;
-			const std::time_t deletionTime =
-			    getTimeFromString(deletionTimeStr, errorCode);
+			const std::time_t deletionTime = getTimeFromString(deletionTimeStr, errorCode);
 			if (errorCode != SAUNAFS_STATUS_OK) {
-				safs::log_err(
-				    static_cast<error_type>(errorCode),
-				    "Failed to parse deletion time from file: {}, skipping.",
-				    file.path().string().c_str());
+				safs::log_err(static_cast<error_type>(errorCode),
+				              "Failed to parse deletion time from file: {}, skipping.",
+				              file.path().string().c_str());
 				continue;
 			}
 			getTrashIndex().add(deletionTime, file.path().string(), diskPath);
@@ -258,16 +240,12 @@ int ChunkTrashManagerImpl::init(const std::string &diskPath) {
 	return SAUNAFS_STATUS_OK;
 }
 
-bool ChunkTrashManagerImpl::isValidTimestampFormat(
-    const std::string &timestamp) {
-	return timestamp.size() == kTimeStampLength &&
-	       std::ranges::all_of(timestamp, ::isdigit);
+bool ChunkTrashManagerImpl::isValidTimestampFormat(const std::string &timestamp) {
+	return timestamp.size() == kTimeStampLength && std::ranges::all_of(timestamp, ::isdigit);
 }
 
-void ChunkTrashManagerImpl::removeExpiredFiles(const time_t &timeLimit,
-                                               size_t bulkSize) const {
-	const auto expiredFilesCollection =
-	    getTrashIndex().getExpiredFiles(timeLimit, bulkSize);
+void ChunkTrashManagerImpl::removeExpiredFiles(const time_t &timeLimit, size_t bulkSize) const {
+	const auto expiredFilesCollection = getTrashIndex().getExpiredFiles(timeLimit, bulkSize);
 	removeTrashFiles(expiredFilesCollection);
 }
 
@@ -287,8 +265,7 @@ void ChunkTrashManagerImpl::makeSpace(const std::string &diskPath,
                                       const size_t recoveryStep) const {
 	size_t availableSpace = checkAvailableSpace(diskPath);
 	while (availableSpace < spaceAvailabilityThreshold) {
-		const auto olderFilesCollection =
-		    getTrashIndex().getOlderFiles(diskPath, recoveryStep);
+		const auto olderFilesCollection = getTrashIndex().getOlderFiles(diskPath, recoveryStep);
 		if (olderFilesCollection.empty()) { break; }
 		removeTrashFiles({{diskPath, olderFilesCollection}});
 		availableSpace = checkAvailableSpace(diskPath);
@@ -311,22 +288,19 @@ void ChunkTrashManagerImpl::collectGarbage() {
 }
 
 bool ChunkTrashManagerImpl::isTrashPath(const std::string &filePath) {
-	return filePath.find("/" + ChunkTrashManager::kTrashDirname + "/") !=
-	       std::string::npos;
+	return filePath.find("/" + ChunkTrashManager::kTrashDirname + "/") != std::string::npos;
 }
 
 ChunkTrashManagerImpl::error_type ChunkTrashManagerImpl::removeFileFromTrash(
     const std::string &filePath) {
 	if (!isTrashPath(filePath)) {
-		safs::log_err(SAUNAFS_ERROR_EINVAL, "Invalid trash path: {}",
-		              filePath.c_str());
+		safs::log_err(SAUNAFS_ERROR_EINVAL, "Invalid trash path: {}", filePath.c_str());
 		return SAUNAFS_ERROR_EINVAL;
 	}
 	std::error_code errorCode;
 	fs::remove(filePath, errorCode);  // Remove the file or directory
 	if (errorCode) {
-		safs::log_err(errorCode, "Failed to remove file or directory: {}",
-		              filePath.c_str());
+		safs::log_err(errorCode, "Failed to remove file or directory: {}", filePath.c_str());
 		return SAUNAFS_ERROR_NOTDONE;
 	}
 

--- a/src/chunkserver/chunkserver-common/chunk_trash_manager_impl.cc
+++ b/src/chunkserver/chunkserver-common/chunk_trash_manager_impl.cc
@@ -101,15 +101,13 @@ std::string ChunkTrashManagerImpl::getTimeString(std::time_t time1) {
 
 #ifdef _WIN32
 	if (gmtime_s(&utcTime, &time1) != 0) {
-		safs::log_err(SAUNAFS_ERROR_EINVAL,
-		              "Failed to convert time to UTC: {}",
+		safs::log_err(SAUNAFS_ERROR_EINVAL, "Failed to convert time to UTC: {}",
 		              std::strerror(errno));
 		return "";
 	}
 #else
 	if (gmtime_r(&time1, &utcTime) == nullptr) {
-		safs::log_err(SAUNAFS_ERROR_EINVAL,
-		              "Failed to convert time to UTC: {}",
+		safs::log_err(SAUNAFS_ERROR_EINVAL, "Failed to convert time to UTC: {}",
 		              std::strerror(errno));
 		return "";
 	}
@@ -183,8 +181,7 @@ int ChunkTrashManagerImpl::moveToTrash(const fs::path &filePath,
 
 	fs::create_directories(fs::path(trashFilename).parent_path(), errorCode_);
 	if (errorCode_) {
-		safs::log_err(errorCode_,
-		              "Failed to create trash directory: {}",
+		safs::log_err(errorCode_, "Failed to create trash directory: {}",
 		              trashFilename.c_str());
 		return SAUNAFS_ERROR_NOTDONE;
 	}
@@ -196,7 +193,7 @@ int ChunkTrashManagerImpl::moveToTrash(const fs::path &filePath,
 		return SAUNAFS_ERROR_NOTDONE;
 	}
 
-	trashIndex->add(deletionTime, trashFilename, diskPath.string());
+	getTrashIndex().add(deletionTime, trashFilename, diskPath.string());
 
 	return SAUNAFS_STATUS_OK;
 }
@@ -208,7 +205,7 @@ void ChunkTrashManagerImpl::removeTrashFiles(
 			if (removeFileFromTrash(fileEntry.second) != SAUNAFS_STATUS_OK) {
 				continue;
 			}
-			trashIndex->remove(fileEntry.first, fileEntry.second, diskPath);
+			getTrashIndex().remove(fileEntry.first, fileEntry.second, diskPath);
 		}
 	}
 }
@@ -231,7 +228,7 @@ int ChunkTrashManagerImpl::init(const std::string &diskPath) {
 		}
 	}
 
-	trashIndex->reset(diskPath);
+	getTrashIndex().reset(diskPath);
 
 	for (const auto &file : fs::recursive_directory_iterator(trashDir)) {
 		if (fs::is_regular_file(file) && isTrashPath(file.path().string())) {
@@ -254,7 +251,7 @@ int ChunkTrashManagerImpl::init(const std::string &diskPath) {
 				    file.path().string().c_str());
 				continue;
 			}
-			trashIndex->add(deletionTime, file.path().string(), diskPath);
+			getTrashIndex().add(deletionTime, file.path().string(), diskPath);
 		}
 	}
 
@@ -270,7 +267,7 @@ bool ChunkTrashManagerImpl::isValidTimestampFormat(
 void ChunkTrashManagerImpl::removeExpiredFiles(const time_t &timeLimit,
                                                size_t bulkSize) const {
 	const auto expiredFilesCollection =
-	    trashIndex->getExpiredFiles(timeLimit, bulkSize);
+	    getTrashIndex().getExpiredFiles(timeLimit, bulkSize);
 	removeTrashFiles(expiredFilesCollection);
 }
 
@@ -291,7 +288,7 @@ void ChunkTrashManagerImpl::makeSpace(const std::string &diskPath,
 	size_t availableSpace = checkAvailableSpace(diskPath);
 	while (availableSpace < spaceAvailabilityThreshold) {
 		const auto olderFilesCollection =
-		    trashIndex->getOlderFiles(diskPath, recoveryStep);
+		    getTrashIndex().getOlderFiles(diskPath, recoveryStep);
 		if (olderFilesCollection.empty()) { break; }
 		removeTrashFiles({{diskPath, olderFilesCollection}});
 		availableSpace = checkAvailableSpace(diskPath);
@@ -300,7 +297,7 @@ void ChunkTrashManagerImpl::makeSpace(const std::string &diskPath,
 
 void ChunkTrashManagerImpl::makeSpace(const size_t spaceAvailabilityThreshold,
                                       const size_t recoveryStep) const {
-	for (const auto &diskPath : trashIndex->getDiskPaths()) {
+	for (const auto &diskPath : getTrashIndex().getDiskPaths()) {
 		makeSpace(diskPath, spaceAvailabilityThreshold, recoveryStep);
 	}
 }

--- a/src/chunkserver/chunkserver-common/chunk_trash_manager_impl.h
+++ b/src/chunkserver/chunkserver-common/chunk_trash_manager_impl.h
@@ -56,8 +56,7 @@ public:
 	 * @param deletionTime The time at which the file was marked for deletion.
 	 * @return Status code indicating success or failure.
 	 */
-	int moveToTrash(const std::filesystem::path &filePath,
-	                const std::filesystem::path &diskPath,
+	int moveToTrash(const std::filesystem::path &filePath, const std::filesystem::path &diskPath,
 	                const std::time_t &deletionTime) override;
 
 	/**
@@ -73,15 +72,13 @@ public:
 	 * @param timeLimit The cutoff time; files older than this will be removed.
 	 * @param bulkSize The number of files to process in a batch operation.
 	 */
-	void removeExpiredFiles(const std::time_t &timeLimit,
-	                        size_t bulkSize = 0) const;
+	void removeExpiredFiles(const std::time_t &timeLimit, size_t bulkSize = 0) const;
 
 	/**
 	 * @brief Removes a set of specified files from the trash.
 	 * @param filesToRemove The list of files to be permanently deleted.
 	 */
-	void removeTrashFiles(
-	    const ChunkTrashIndex::TrashIndexDiskEntries &filesToRemove) const;
+	void removeTrashFiles(const ChunkTrashIndex::TrashIndexDiskEntries &filesToRemove) const;
 
 	/**
 	 * @brief Checks if a given timestamp string matches the expected format.
@@ -98,8 +95,7 @@ public:
 	 * @param recoveryStep The number of files to delete in each step until
 	 * sufficient space is recovered.
 	 */
-	void makeSpace(size_t spaceAvailabilityThreshold,
-	               size_t recoveryStep) const;
+	void makeSpace(size_t spaceAvailabilityThreshold, size_t recoveryStep) const;
 
 	/**
 	 * @brief Runs the garbage collection process, which includes
@@ -114,8 +110,7 @@ public:
 	 * @param errorCode (output) The value to return in case of an error.
 	 * @return The corresponding time value.
 	 */
-	static time_t getTimeFromString(const std::string &timeString,
-	                                int &errorCode);
+	static time_t getTimeFromString(const std::string &timeString, int &errorCode);
 
 	/**
 	 * @brief Checks the available disk space on the specified disk path.
@@ -132,8 +127,7 @@ public:
 	 * @param recoveryStep The number of files to delete in each step until
 	 * sufficient space is recovered.
 	 */
-	void makeSpace(const std::string &diskPath,
-	               size_t spaceAvailabilityThreshold,
+	void makeSpace(const std::string &diskPath, size_t spaceAvailabilityThreshold,
 	               size_t recoveryStep) const;
 
 	/**
@@ -175,8 +169,7 @@ private:
 	 * @param diskPath The path of the disk to get the trash directory for.
 	 * @return The path to the trash directory.
 	 */
-	static std::filesystem::path getTrashDir(
-	    const std::filesystem::path &diskPath);
+	static std::filesystem::path getTrashDir(const std::filesystem::path &diskPath);
 
 	/**
 	 * @brief Gets the destination path for a file to be moved to the trash.

--- a/src/chunkserver/chunkserver-common/chunk_trash_manager_impl.h
+++ b/src/chunkserver/chunkserver-common/chunk_trash_manager_impl.h
@@ -143,10 +143,6 @@ public:
 	void reloadConfig() override;
 
 private:
-	/// Pointer to the singleton instance of the trash index used for managing
-	/// trash files.
-	TrashIndex *trashIndex = &ChunkTrashIndex::instance();
-
 	/// Minimum available space threshold (in GB) before triggering garbage
 	/// collection.
 	static size_t availableThresholdGB;
@@ -165,6 +161,14 @@ private:
 	/// Number of files to remove in each step to free up space when required.
 	static size_t garbageCollectorSpaceRecoveryStep;
 	static constexpr size_t kDefaultGarbageCollectorSpaceRecoveryStep = 100;
+
+	// Use a function to safely get the ChunkTrashIndex instance
+	// This prevents issues during program shutdown
+	/**
+	 * @brief Gets the singleton instance of the ChunkTrashIndex.
+	 * @return Reference to the singleton instance of ChunkTrashIndex.
+	 */
+	static TrashIndex &getTrashIndex() { return TrashIndex::instance(); }
 
 	/**
 	 * @brief Gets the trash directory for the specified disk path.

--- a/src/chunkserver/chunkserver-common/chunk_trash_manager_impl_unittest.cc
+++ b/src/chunkserver/chunkserver-common/chunk_trash_manager_impl_unittest.cc
@@ -39,9 +39,7 @@ int fake_statvfs(const char *path, struct statvfs *buf) {
 
 // Fake statvfs() definition to override the real one
 // Used by the checkAvailableSpace() method
-extern "C" int statvfs(const char *path, struct statvfs *buf) {
-	return fake_statvfs(path, buf);
-}
+extern "C" int statvfs(const char *path, struct statvfs *buf) { return fake_statvfs(path, buf); }
 
 namespace fs = std::filesystem;
 
@@ -63,24 +61,21 @@ TEST_F(ChunkTrashManagerImplTest, MoveToTrashValidFile) {
 	fs::path filePath = testDir / "valid_file.txt";
 	std::ofstream(filePath.string());  // Create a valid file
 	std::time_t deletionTime = 1729259531;
-	std::string const deletionTimeString = ChunkTrashManagerImpl::getTimeString(
-	    deletionTime);  // Convert time to string format
+	std::string const deletionTimeString =
+	    ChunkTrashManagerImpl::getTimeString(deletionTime);  // Convert time to string format
 
 	ASSERT_TRUE(fs::exists(filePath));
-	int const result =
-	    chunkTrashManagerImpl.moveToTrash(filePath, testDir, deletionTime);
+	int const result = chunkTrashManagerImpl.moveToTrash(filePath, testDir, deletionTime);
 	ASSERT_EQ(result, SAUNAFS_STATUS_OK);
 	ASSERT_FALSE(fs::exists(filePath));
-	ASSERT_TRUE(fs::exists((testDir / ".trash.bin/valid_file.txt.").string() +
-	                       deletionTimeString));
+	ASSERT_TRUE(fs::exists((testDir / ".trash.bin/valid_file.txt.").string() + deletionTimeString));
 }
 
 TEST_F(ChunkTrashManagerImplTest, MoveToTrashNonExistentFile) {
 	fs::path filePath = testDir / "non_existent_file.txt";
 	std::time_t deletionTime = std::time(nullptr);
 
-	int const result =
-	    chunkTrashManagerImpl.moveToTrash(filePath, testDir, deletionTime);
+	int const result = chunkTrashManagerImpl.moveToTrash(filePath, testDir, deletionTime);
 	ASSERT_EQ(result, SAUNAFS_ERROR_ENOENT);
 }
 
@@ -91,16 +86,13 @@ TEST_F(ChunkTrashManagerImplTest, MoveToTrashFileInNestedDirectory) {
 	std::ofstream(filePath.string());
 
 	std::time_t deletionTime = 1729259531;
-	std::string const deletionTimeString =
-	    ChunkTrashManagerImpl::getTimeString(deletionTime);
+	std::string const deletionTimeString = ChunkTrashManagerImpl::getTimeString(deletionTime);
 
-	int const result =
-	    chunkTrashManagerImpl.moveToTrash(filePath, testDir, deletionTime);
+	int const result = chunkTrashManagerImpl.moveToTrash(filePath, testDir, deletionTime);
 	ASSERT_EQ(result, SAUNAFS_STATUS_OK);
 	ASSERT_FALSE(fs::exists(filePath));
 	ASSERT_TRUE(
-	    fs::exists((testDir / ".trash.bin/nested/nested_file.txt.").string() +
-	               deletionTimeString));
+	    fs::exists((testDir / ".trash.bin/nested/nested_file.txt.").string() + deletionTimeString));
 }
 
 TEST_F(ChunkTrashManagerImplTest, MoveToTrashReadOnlyTrashDirectory) {
@@ -112,8 +104,7 @@ TEST_F(ChunkTrashManagerImplTest, MoveToTrashReadOnlyTrashDirectory) {
 	std::ofstream(filePath.string());
 	std::time_t deletionTime = 1729259531;
 
-	int const result =
-	    chunkTrashManagerImpl.moveToTrash(filePath, testDir, deletionTime);
+	int const result = chunkTrashManagerImpl.moveToTrash(filePath, testDir, deletionTime);
 	ASSERT_EQ(result, SAUNAFS_ERROR_NOTDONE);  // Expect failure
 }
 
@@ -123,21 +114,18 @@ TEST_F(ChunkTrashManagerImplTest, MoveToTrashAlreadyTrashedFile) {
 	std::time_t deletionTime = 1729259531;
 	chunkTrashManagerImpl.moveToTrash(filePath, testDir, deletionTime);
 
-	int const result =
-	    chunkTrashManagerImpl.moveToTrash(filePath, testDir, deletionTime);
+	int const result = chunkTrashManagerImpl.moveToTrash(filePath, testDir, deletionTime);
 	ASSERT_EQ(result, SAUNAFS_ERROR_ENOENT);  // Expect failure
 }
 
 TEST_F(ChunkTrashManagerImplTest, ConcurrentMoveToTrash) {
 	const int numFiles = 10;
 	std::time_t deletionTime = 1729259531;
-	const std::string deletionTimeString =
-	    ChunkTrashManagerImpl::getTimeString(deletionTime);
+	const std::string deletionTimeString = ChunkTrashManagerImpl::getTimeString(deletionTime);
 	std::vector<std::thread> threads;
 	for (int i = 0; i < numFiles; ++i) {
 		threads.emplace_back([this, i, deletionTime]() {
-			fs::path filePath =
-			    testDir / ("concurrent_file_" + std::to_string(i) + ".txt");
+			fs::path filePath = testDir / ("concurrent_file_" + std::to_string(i) + ".txt");
 			std::ofstream(filePath.string());
 			chunkTrashManagerImpl.moveToTrash(filePath, testDir, deletionTime);
 		});
@@ -147,11 +135,9 @@ TEST_F(ChunkTrashManagerImplTest, ConcurrentMoveToTrash) {
 
 	// Check if all files are moved to trash
 	for (int i = 0; i < numFiles; ++i) {
-		ASSERT_FALSE(fs::exists(
-		    testDir / ("concurrent_file_" + std::to_string(i) + ".txt")));
-		ASSERT_TRUE(
-		    fs::exists((testDir / ".trash.bin/concurrent_file_").string() +
-		               std::to_string(i) + ".txt." + deletionTimeString));
+		ASSERT_FALSE(fs::exists(testDir / ("concurrent_file_" + std::to_string(i) + ".txt")));
+		ASSERT_TRUE(fs::exists((testDir / ".trash.bin/concurrent_file_").string() +
+		                       std::to_string(i) + ".txt." + deletionTimeString));
 	}
 }
 
@@ -160,11 +146,9 @@ TEST_F(ChunkTrashManagerImplTest, PerformanceTest) {
 	auto start = std::chrono::high_resolution_clock::now();
 
 	for (int i = 0; i < numFiles; ++i) {
-		fs::path filePath =
-		    testDir / ("performance_file_" + std::to_string(i) + ".txt");
+		fs::path filePath = testDir / ("performance_file_" + std::to_string(i) + ".txt");
 		std::ofstream(filePath.string());
-		chunkTrashManagerImpl.moveToTrash(filePath, testDir,
-		                                  std::time(nullptr));
+		chunkTrashManagerImpl.moveToTrash(filePath, testDir, std::time(nullptr));
 	}
 
 	auto end = std::chrono::high_resolution_clock::now();
@@ -184,9 +168,8 @@ TEST_F(ChunkTrashManagerImplTest, MoveToTrash) {
 	std::ofstream(filePath.string());
 	std::time_t deletionTime = std::time(nullptr);
 
-	ASSERT_EQ(
-	    chunkTrashManagerImpl.moveToTrash(filePath, testDir, deletionTime),
-	    SAUNAFS_STATUS_OK);
+	ASSERT_EQ(chunkTrashManagerImpl.moveToTrash(filePath, testDir, deletionTime),
+	          SAUNAFS_STATUS_OK);
 	ASSERT_FALSE(fs::exists(filePath));  // Ensure file is moved to trash
 }
 
@@ -194,8 +177,7 @@ TEST_F(ChunkTrashManagerImplTest, MoveToTrash) {
 TEST_F(ChunkTrashManagerImplTest, GetTimeString) {
 	std::time_t testDeletionTime = 1729259531;
 	std::string testTimeString = "20241018135211";
-	std::string timeString =
-	    chunkTrashManagerImpl.getTimeString(testDeletionTime);
+	std::string timeString = chunkTrashManagerImpl.getTimeString(testDeletionTime);
 	ASSERT_EQ(timeString, testTimeString);  // Compare formatted strings
 }
 
@@ -204,31 +186,25 @@ TEST_F(ChunkTrashManagerImplTest, RemoveExpiredFiles) {
 	fs::path expiredFilePath = testDir / "expired_file.txt";
 	std::ofstream(expiredFilePath.string());
 	std::time_t oldDeletionTime = std::time(nullptr) - 86400;  // 1 day ago
-	const std::string oldDeletionTimeString =
-	    chunkTrashManagerImpl.getTimeString(oldDeletionTime);
+	const std::string oldDeletionTimeString = chunkTrashManagerImpl.getTimeString(oldDeletionTime);
 	const std::string trashPath =
-	    (testDir / ".trash.bin/expired_file.txt.").string() +
-	    oldDeletionTimeString;
+	    (testDir / ".trash.bin/expired_file.txt.").string() + oldDeletionTimeString;
 
-	chunkTrashManagerImpl.moveToTrash(expiredFilePath, testDir,
-	                                  oldDeletionTime);
+	chunkTrashManagerImpl.moveToTrash(expiredFilePath, testDir, oldDeletionTime);
 	ASSERT_FALSE(fs::exists(expiredFilePath));  // Ensure file is moved to trash
 	ASSERT_TRUE(fs::exists(trashPath));         // Ensure file is in trash
 
-	chunkTrashManagerImpl.removeExpiredFiles(std::time(nullptr) -
-	                                         3600);  // 1 hour ago
+	chunkTrashManagerImpl.removeExpiredFiles(std::time(nullptr) - 3600);  // 1 hour ago
 
-	ASSERT_FALSE(fs::exists(trashPath));  // Ensure expired file is removed
-	ASSERT_FALSE(
-	    fs::exists(expiredFilePath));  // Ensure original file is removed
+	ASSERT_FALSE(fs::exists(trashPath));        // Ensure expired file is removed
+	ASSERT_FALSE(fs::exists(expiredFilePath));  // Ensure original file is removed
 }
 
 // Testing checking valid timestamp format
 TEST_F(ChunkTrashManagerImplTest, ValidTimestampFormat) {
-	ASSERT_TRUE(chunkTrashManagerImpl.isValidTimestampFormat(
-	    "20231018120350"));  // Valid format
-	ASSERT_FALSE(chunkTrashManagerImpl.isValidTimestampFormat(
-	    "invalid_timestamp"));  // Invalid format
+	ASSERT_TRUE(chunkTrashManagerImpl.isValidTimestampFormat("20231018120350"));  // Valid format
+	ASSERT_FALSE(
+	    chunkTrashManagerImpl.isValidTimestampFormat("invalid_timestamp"));  // Invalid format
 }
 
 // Testing makeSpace functionality
@@ -236,8 +212,7 @@ TEST_F(ChunkTrashManagerImplTest, MakeSpaceRemovesOldFiles) {
 	fs::path lowSpaceFilePath = testDir / "file1.txt";
 	std::ofstream(lowSpaceFilePath.string());
 
-	chunkTrashManagerImpl.moveToTrash(lowSpaceFilePath, testDir,
-	                                  std::time(nullptr));
+	chunkTrashManagerImpl.moveToTrash(lowSpaceFilePath, testDir, std::time(nullptr));
 
 	// Simulate low space condition and check removal
 	chunkTrashManagerImpl.makeSpace(1, 1);       // 1 GB threshold
@@ -246,8 +221,7 @@ TEST_F(ChunkTrashManagerImplTest, MakeSpaceRemovesOldFiles) {
 
 // Testing check available space functionality
 TEST_F(ChunkTrashManagerImplTest, CheckAvailableSpace) {
-	size_t availableSpace =
-	    ChunkTrashManagerImpl::checkAvailableSpace(testDir.string());
+	size_t availableSpace = ChunkTrashManagerImpl::checkAvailableSpace(testDir.string());
 
 	constexpr size_t kGiBMultiplier = 1 << 30;
 	size_t expectedGb = 1024 * 4096 / kGiBMultiplier;  // Fake available space
@@ -265,16 +239,15 @@ TEST_F(ChunkTrashManagerImplTest, MakeSpaceOnSpecificDisk) {
 	chunkTrashManagerImpl.moveToTrash(filePath2, testDir, std::time(nullptr));
 
 	chunkTrashManagerImpl.makeSpace(testDir.string(), 1, 1);  // 1 GB threshold
-	ASSERT_FALSE(fs::exists(filePath1));  // Ensure the first file is removed
-	ASSERT_FALSE(fs::exists(filePath2));  // Ensure the second file is removed
+	ASSERT_FALSE(fs::exists(filePath1));                      // Ensure the first file is removed
+	ASSERT_FALSE(fs::exists(filePath2));                      // Ensure the second file is removed
 }
 
 // Testing converting time string to time value
 TEST_F(ChunkTrashManagerImplTest, GetTimeFromString) {
 	std::string timeString = "20231018120350";
 	int errorCode = 0;
-	time_t timeValue =
-	    ChunkTrashManagerImpl::getTimeFromString(timeString, errorCode);
+	time_t timeValue = ChunkTrashManagerImpl::getTimeFromString(timeString, errorCode);
 
 	std::tm tm = {};
 	strptime(timeString.c_str(), "%Y%m%d%H%M%S", &tm);

--- a/src/chunkserver/chunkserver-common/chunk_trash_manager_unittest.cc
+++ b/src/chunkserver/chunkserver-common/chunk_trash_manager_unittest.cc
@@ -55,8 +55,8 @@ TEST_F(ChunkTrashManagerTest, MoveToTrashForwardsCall) {
 	    .WillOnce(testing::Return(0));  // Assuming 0 is a success return
 	// value.
 
-	int result = ChunkTrashManager::moveToTrash(filePath, diskPath,
-	                                                       deletionTime);
+	int result =
+	    ChunkTrashManager::moveToTrash(filePath, diskPath, deletionTime);
 	EXPECT_EQ(result, 0);  // Validate that the return value is as expected.
 }
 
@@ -89,8 +89,8 @@ TEST_F(ChunkTrashManagerTest, DisabledMoveToTrashDoesNotForwardsCall) {
 	EXPECT_CALL(*mockImpl, moveToTrash(filePath, diskPath, deletionTime))
 	    .Times(0);
 
-	int result = ChunkTrashManager::moveToTrash(filePath, diskPath,
-	                                                       deletionTime);
+	int result =
+	    ChunkTrashManager::moveToTrash(filePath, diskPath, deletionTime);
 	EXPECT_EQ(result, 0);  // Validate that the return value is as expected.
 }
 

--- a/src/chunkserver/chunkserver-common/chunk_trash_manager_unittest.cc
+++ b/src/chunkserver/chunkserver-common/chunk_trash_manager_unittest.cc
@@ -23,8 +23,7 @@
 class MockChunkTrashManagerImpl : public IChunkTrashManagerImpl {
 public:
 	MOCK_METHOD(int, moveToTrash,
-	            (const std::filesystem::path &, const std::filesystem::path &,
-	             const std::time_t &),
+	            (const std::filesystem::path &, const std::filesystem::path &, const std::time_t &),
 	            ());
 	MOCK_METHOD(int, init, (const std::string &), ());
 	MOCK_METHOD(void, collectGarbage, (), ());
@@ -55,8 +54,7 @@ TEST_F(ChunkTrashManagerTest, MoveToTrashForwardsCall) {
 	    .WillOnce(testing::Return(0));  // Assuming 0 is a success return
 	// value.
 
-	int result =
-	    ChunkTrashManager::moveToTrash(filePath, diskPath, deletionTime);
+	int result = ChunkTrashManager::moveToTrash(filePath, diskPath, deletionTime);
 	EXPECT_EQ(result, 0);  // Validate that the return value is as expected.
 }
 
@@ -86,11 +84,9 @@ TEST_F(ChunkTrashManagerTest, DisabledMoveToTrashDoesNotForwardsCall) {
 	std::time_t deletionTime = 1234567890;
 	ChunkTrashManager::isEnabled = 0;
 
-	EXPECT_CALL(*mockImpl, moveToTrash(filePath, diskPath, deletionTime))
-	    .Times(0);
+	EXPECT_CALL(*mockImpl, moveToTrash(filePath, diskPath, deletionTime)).Times(0);
 
-	int result =
-	    ChunkTrashManager::moveToTrash(filePath, diskPath, deletionTime);
+	int result = ChunkTrashManager::moveToTrash(filePath, diskPath, deletionTime);
 	EXPECT_EQ(result, 0);  // Validate that the return value is as expected.
 }
 


### PR DESCRIPTION
Fixed Valgrind errors related to use-after-free issues with the shared_ptr in ChunkTrashManager during program termination. The issue occurred because static objects are destroyed in reverse order of initialization, which could cause access to already freed memory.

Changes:
- Replaced static shared_ptr instance with Meyer's singleton pattern implementation.
- Added getImpl() method that safely returns a reference to a static shared_ptr.
- Created getTrashIndex() method in ChunkTrashManagerImpl to safely access the ChunkTrashIndex.
- Updated all code to use these safer access patterns.
- Maintained backward compatibility with existing unit tests.