### PR TITLE
feat: Add initial scripts for FoundationDB

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,6 +38,19 @@ def runSanity() {
         """
     publishJunit(resultsFile)
 }
+def runFoundationDB() {
+    def resultsFile = "test_results_fdb.xml"
+    sh """
+        ./sfstests/sfstests \
+        --auth /etc/apt/auth.conf.d/ \
+        --suite FDBTests \
+        --workers 1 \
+        --multiplier ${MACHINE_MULTIPLIER} \
+        --cpus 2 \
+        --xml-path ${resultsFile}
+        """
+    publishJunit(resultsFile)
+}
 def runShort() {
     def resultsFile = "test_results_short.xml"
     sh """
@@ -283,6 +296,12 @@ pipeline {
                         stage('Run Sanity') {
                             steps {
                                 runSanity()
+                            }
+                        }
+
+                        stage('Run FoundationDB tests') {
+                            steps {
+                                runFoundationDB()
                             }
                         }
 

--- a/tests/ci_build/install-foundationdb.sh
+++ b/tests/ci_build/install-foundationdb.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+# This script installs FoundationDB on a Debian-based system.
+# It downloads the client and server packages from the official GitHub repository,
+# installs them, and verifies the installation.
+
+set -eu -o pipefail
+
+readonly workspace="/tmp/saunafs-foundationdb-tmp"
+
+function die() {
+	echo "Error: ${*}" >&2
+
+	# Check if the workspace exists and remove it
+	if [ -d "${workspace}" ]; then
+		echo "Removing temporary workspace..."
+		rm -rf "${workspace:?}"
+	fi
+
+	exit 1
+}
+
+# Ensure the script is run as root
+if [ "$(id -u)" -ne 0 ]; then
+	die "This script must be run as root. Please use sudo."
+fi
+
+fdb_version="7.3.63"
+
+# Check if FoundationDB is already installed by using fdbcli
+if command -v fdbcli &> /dev/null; then
+	echo "FoundationDB is already installed. Version:"
+	fdbcli --version
+	exit 0
+fi
+
+# Check if wget is installed
+if ! command -v wget &> /dev/null; then
+	die "wget is not installed. Please install wget first."
+fi
+
+# Create the temporary workspace
+mkdir -p "${workspace}"
+
+# Define some useful variables
+client_pkg="foundationdb-clients_${fdb_version}-1_amd64.deb"
+server_pkg="foundationdb-server_${fdb_version}-1_amd64.deb"
+hash_suffix=".sha256"
+base_url="https://github.com/apple/foundationdb/releases/download/${fdb_version}"
+
+# Download the client and server packages
+echo "Downloading FoundationDB packages..."
+wget "${base_url}/${client_pkg}" -O "${workspace}/${client_pkg}" || die "Failed to download client package"
+wget "${base_url}/${server_pkg}" -O "${workspace}/${server_pkg}" || die "Failed to download server package"
+
+# Download the SHA256 hash file
+wget "${base_url}/${client_pkg}${hash_suffix}" -O "${workspace}/${client_pkg}${hash_suffix}" || die "Failed to download client hash file"
+wget "${base_url}/${server_pkg}${hash_suffix}" -O "${workspace}/${server_pkg}${hash_suffix}" || die "Failed to download server hash file"
+
+# Verify the downloaded packages
+echo "Verifying downloaded packages..."
+cd "${workspace}" || die "Failed to change directory to ${workspace}"
+sha256sum -c "${client_pkg}${hash_suffix}" || die "Client package verification failed"
+sha256sum -c "${server_pkg}${hash_suffix}" || die "Server package verification failed"
+cd - || die "Failed to change back to previous directory"
+
+# Install the packages
+echo "Installing FoundationDB packages..."
+dpkg -i "${workspace}/${client_pkg}" "${workspace}/${server_pkg}" || die "Failed to install FoundationDB packages"
+
+# Fix any missing dependencies
+echo "Fixing missing dependencies..."
+apt-get install -f -y || die "Failed to fix missing dependencies"
+
+# Verify the installation
+echo "Verifying FoundationDB installation..."
+if command -v fdbcli &> /dev/null; then
+	echo "FoundationDB CLI installed successfully."
+	fdbcli --version
+else
+	echo "FoundationDB CLI installation failed."
+	exit 1
+fi
+
+# Stop FoundationDB service if running after the installation
+systemctl stop foundationdb || true
+
+# Clean up temporary workspace
+echo "Removing temporary workspace..."
+rm -r "${workspace:?}"
+
+echo "FoundationDB installation completed successfully."

--- a/tests/docker/Dockerfile.test
+++ b/tests/docker/Dockerfile.test
@@ -17,6 +17,7 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
 	apt-get update && apt-get install tini && \
     ./tests/install-packages.sh;
 
+COPY ./tests/ci_build/install-foundationdb.sh ./tests/ci_build/
 COPY ./tests/setup_machine.sh ./tests/
 
 # Run the setup-test-machine.sh script

--- a/tests/setup_machine.sh
+++ b/tests/setup_machine.sh
@@ -194,6 +194,9 @@ if [ ! -f /etc/sudoers.d/saunafstest ] || ! grep -q '# FoundationDB' /etc/sudoer
 	END
 fi
 
+echo ; echo 'Install FoundationDB'
+"$script_dir/ci_build/install-foundationdb.sh"
+
 echo ; echo 'Fixing GIDs of users'
 for name in saunafstest saunafstest_{0..9}; do
 	uid=$(getent passwd "${name}" | cut -d: -f3)

--- a/tests/setup_machine.sh
+++ b/tests/setup_machine.sh
@@ -186,6 +186,14 @@ if [ ! -f /etc/sudoers.d/saunafstest ] || ! grep -q '# Client' /etc/sudoers.d/sa
 	END
 fi
 
+if [ ! -f /etc/sudoers.d/saunafstest ] || ! grep -q '# FoundationDB' /etc/sudoers.d/saunafstest > /dev/null; then
+	cat <<-'END' >>/etc/sudoers.d/saunafstest
+		# FoundationDB
+		saunafstest ALL = NOPASSWD: /usr/lib/foundationdb/fdbmonitor --conffile*
+		saunafstest ALL = NOPASSWD: /usr/bin/pkill -f fdbmonitor*
+	END
+fi
+
 echo ; echo 'Fixing GIDs of users'
 for name in saunafstest saunafstest_{0..9}; do
 	uid=$(getent passwd "${name}" | cut -d: -f3)

--- a/tests/test_suites/FDBTests/test_fdb_basics.sh
+++ b/tests/test_suites/FDBTests/test_fdb_basics.sh
@@ -1,0 +1,11 @@
+CHUNKSERVERS=1 \
+	METADATA_BACKEND=FDB \
+	USE_RAMDISK=YES \
+	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER" \
+	CHUNKSERVER_EXTRA_CONFIG="GARBAGE_COLLECTION_FREQ_MS = 0|HDD_TEST_FREQ = 100000" \
+	AUTO_SHADOW_MASTER="NO" \
+	setup_local_empty_saunafs info
+
+cd "${info[mount0]}"
+
+echo saunafs > file

--- a/tests/test_suites/FDBTests/test_fdb_basics.sh
+++ b/tests/test_suites/FDBTests/test_fdb_basics.sh
@@ -8,4 +8,4 @@ CHUNKSERVERS=1 \
 
 cd "${info[mount0]}"
 
-echo saunafs > file
+assert_success sfs-test-fdb "/tmp/saunafs-fdb-test/conf/fdb.cluster"

--- a/tests/tools/foundationdb.sh
+++ b/tests/tools/foundationdb.sh
@@ -1,15 +1,6 @@
 #!/usr/bin/env bash
 
-# Starts a temporary FoundationDB Cluster in /tmp/saunafs-fdb-test.
-# The cluster uses two servers on ports 4500 and 4501.
-# This script is intended for testing purposes only.
-
-set -eu -o pipefail
-
-readonly script_name=$(basename "$0")
 readonly workspace="/tmp/saunafs-fdb-test"
-
-readonly action="${1:-}"
 
 function create_workspace() {
 	mkdir -p "${workspace}"/{conf,data,logs}
@@ -84,20 +75,3 @@ function start_fdb_cluster() {
 function stop_fdb_cluster() {
 	cleanup_fdb_cluster
 }
-
-function main() {
-  case "${action}" in
-    start)
-      start_fdb_cluster
-      ;;
-    stop)
-      stop_fdb_cluster
-      ;;
-    *)
-      echo "Usage: ${script_name} {start|stop}"
-      exit 1
-      ;;
-  esac
-}
-
-main "$@"

--- a/tests/tools/foundationdb.sh
+++ b/tests/tools/foundationdb.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+
+# Starts a temporary FoundationDB Cluster in /tmp/saunafs-fdb-test.
+# The cluster uses two servers on ports 4500 and 4501.
+# This script is intended for testing purposes only.
+
+set -eu -o pipefail
+
+readonly script_name=$(basename "$0")
+readonly workspace="/tmp/saunafs-fdb-test"
+
+readonly action="${1:-}"
+
+function create_workspace() {
+	mkdir -p "${workspace}"/{conf,data,logs}
+	chown -R "$(id -un):$(id -gn)" "${workspace}"
+}
+
+function create_config_file() {
+	cat > "${workspace}/conf/foundationdb.conf" <<EOF
+[fdbmonitor]
+user = $(id -un)
+group = $(id -gn)
+lockfile = ${workspace}/fdbmonitor.pid
+
+[general]
+restart-delay = 60
+cluster-file = ${workspace}/conf/fdb.cluster
+
+[fdbserver]
+command = /usr/sbin/fdbserver
+public_address = 127.0.0.1:\$ID
+listen_address = public
+datadir = ${workspace}/data/\$ID
+logdir = ${workspace}/logs
+
+[fdbserver.4500]
+[fdbserver.4501]
+
+[backup_agent]
+command = /usr/lib/foundationdb/backup_agent/backup_agent
+logdir = ${workspace}/logs
+
+[backup_agent.1]
+EOF
+}
+
+function check_cluster_status() {
+	fdbcli --exec "status" --cluster-file "${workspace}/conf/fdb.cluster"
+}
+
+function cleanup_fdb_cluster() {
+	sudo pkill -f fdbmonitor || true
+	rm -r "${workspace:?}" || true
+}
+
+function start_fdb_cluster() {
+	cleanup_fdb_cluster
+	create_workspace
+
+	# Create cluster file manually
+	if [ ! -f "${workspace}/conf/fdb.cluster" ]; then
+		echo "Creating new cluster configuration..."
+		readonly description="saunafstest"
+		readonly cluster_id="$(mktemp -u XXXXXXXX)"
+		echo "${description}:${cluster_id}@127.0.0.1:4500" > "${workspace}/conf/fdb.cluster"
+		chmod 644 "${workspace}/conf/fdb.cluster"
+	fi
+
+	create_config_file
+
+	# Start FoundationDB with required sudo privileges
+	sudo /usr/lib/foundationdb/fdbmonitor --conffile "${workspace}/conf/foundationdb.conf" &
+
+	# Wait for fdbmonitor to initialize
+	sleep 3
+
+	# Ensure cluster is configured
+	fdbcli --exec "configure new single memory" --cluster-file "${workspace}/conf/fdb.cluster"
+
+	check_cluster_status
+}
+
+function stop_fdb_cluster() {
+	cleanup_fdb_cluster
+}
+
+function main() {
+  case "${action}" in
+    start)
+      start_fdb_cluster
+      ;;
+    stop)
+      stop_fdb_cluster
+      ;;
+    *)
+      echo "Usage: ${script_name} {start|stop}"
+      exit 1
+      ;;
+  esac
+}
+
+main "$@"

--- a/tests/tools/saunafs.sh
+++ b/tests/tools/saunafs.sh
@@ -5,6 +5,7 @@
 setup_local_empty_saunafs() {
 	local use_legacy=${USE_LEGACY:-}
 	local use_saunafsXX=${START_WITH_LEGACY_SAUNAFS:-}
+	local metadata_backend=${METADATA_BACKEND:-FILE}
 	local use_ramdisk=${USE_RAMDISK:-}
 	local use_zoned_disks=${USE_ZONED_DISKS:-}
 	local zone_size_mb=${ZONE_SIZE_MB:-256}
@@ -28,6 +29,8 @@ setup_local_empty_saunafs() {
 	declare -gA saunafs_info_
 	saunafs_info_[chunkserver_count]=$number_of_chunkservers
 	saunafs_info_[admin_password]=${ADMIN_PASSWORD:-password}
+
+	init_metadata_backend
 
 	# Enable always ramdisk for zoned devices
 	if parse_true "${use_zoned_disks}"; then
@@ -129,6 +132,16 @@ setup_local_empty_saunafs() {
 	for key in "${!saunafs_info_[@]}"; do
 		eval "$out_var['$key']='${saunafs_info_[$key]}'"
 	done
+}
+
+init_metadata_backend() {
+	case ${metadata_backend} in
+		"FDB")
+			declare -g USE_FDB="${metadata_backend}"
+			export USE_FDB
+			start_fdb_cluster
+			;;
+	esac
 }
 
 saunafs_admin_command() {
@@ -349,6 +362,7 @@ create_sfsmaster_master_cfg_() {
 	echo "${MASTER_EXTRA_CONFIG-}" | tr '|' '\n'
 	echo "${!this_module_cfg_variable-}" | tr '|' '\n'
 	create_bdb_name_storage_entry_
+	echo "METADATA_BACKEND = ${metadata_backend}"
 }
 
 create_sfsmaster_shadow_cfg_() {
@@ -373,6 +387,7 @@ create_sfsmaster_shadow_cfg_() {
 	echo "${MASTER_EXTRA_CONFIG-}" | tr '|' '\n'
 	echo "${!this_module_cfg_variable-}" | tr '|' '\n'
 	create_bdb_name_storage_entry_
+	echo "METADATA_BACKEND = ${metadata_backend}"
 }
 
 saunafs_make_conf_for_shadow() {

--- a/tests/tools/test.sh
+++ b/tests/tools/test.sh
@@ -69,6 +69,11 @@ test_end() {
 		remove_all_emulated_zoned_disks
 	fi
 
+	if [[ ${USE_FDB:-} ]]; then
+		stop_fdb_cluster
+		echo "FoundationDB cluster has been stopped."
+	fi
+
 	local errors=$(cat "$test_result_file")
 	if [[ $errors ]]; then
 		exit 1

--- a/tests/tools/test_main.sh
+++ b/tests/tools/test_main.sh
@@ -15,6 +15,7 @@ done
 . tools/legacy.sh
 . tools/string.sh
 . tools/nullblk_zoned.sh
+. tools/foundationdb.sh
 . tools/saunafs.sh
 . tools/saunafsXX.sh
 . tools/network.sh

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -72,6 +72,11 @@ install(TARGETS readdir-unlink-test RUNTIME DESTINATION ${BIN_SUBDIR})
 add_executable(big-session-metadata-benchmark big_session_metadata_benchmark.cc)
 install(TARGETS big-session-metadata-benchmark RUNTIME DESTINATION ${BIN_SUBDIR})
 
+# sfs-test-fdb Checks if the expected FDB database is operable
+add_executable(sfs-test-fdb sfs_test_fdb.cc)
+target_link_libraries(sfs-test-fdb fdb_c)
+install(TARGETS sfs-test-fdb RUNTIME DESTINATION ${BIN_SUBDIR})
+
 add_library(slow_chunk_scan SHARED slow_chunk_scan.c)
 if(NOT CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
   target_link_libraries(slow_chunk_scan dl)

--- a/utils/sfs_test_fdb.cc
+++ b/utils/sfs_test_fdb.cc
@@ -1,0 +1,140 @@
+/*
+   Copyright 2023 Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// This app connects to the specified FoundationDB cluster file, inserts
+// a key-value pair, retrieves it and checks if the value is present.
+// It is a simple test to check if the FoundationDB client library is
+// communicating correctly with the cluster.
+
+#include <unistd.h>
+#include <cassert>
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <thread>
+#include <vector>
+
+#define FDB_API_VERSION 730
+#include <foundationdb/fdb_c.h>
+#include <foundationdb/fdb_c_types.h>
+
+constexpr fdb_error_t kNoError = 0;
+
+namespace {
+void usage(char *progName) {
+	std::cerr << "Usage: " << progName << " <cluster_file>\n";
+	std::cerr << "Default path: /etc/foundationdb/fdb.cluster\n";
+	exit(1);
+}
+
+void checkError(fdb_error_t errorNumber) {
+	if (errorNumber != kNoError) {
+		std::cerr << "FDB error: " << fdb_get_error(errorNumber) << "\n";
+		exit(errorNumber);
+	}
+}
+
+void runNetworkThread() { checkError(fdb_run_network()); }
+
+void setValue(FDBDatabase *database, size_t keySize, const uint8_t *key, size_t valueSize,
+              const uint8_t *value) {
+	FDBTransaction *transaction{};
+	checkError(fdb_database_create_transaction(database, &transaction));
+	fdb_transaction_set(transaction, key, static_cast<int>(keySize), value,
+	                    static_cast<int>(valueSize));
+	FDBFuture *commitFuture = fdb_transaction_commit(transaction);
+	checkError(fdb_future_block_until_ready(commitFuture));
+	fdb_future_destroy(commitFuture);
+	fdb_transaction_destroy(transaction);
+}
+
+std::vector<uint8_t> getValue(FDBDatabase *database, size_t keySize, const uint8_t *key) {
+	FDBTransaction *transaction = nullptr;
+	checkError(fdb_database_create_transaction(database, &transaction));
+	static constexpr fdb_bool_t kUseSnapshot{0};
+	FDBFuture *getValueFuture =
+	    fdb_transaction_get(transaction, key, static_cast<int>(keySize), kUseSnapshot);
+	checkError(fdb_future_block_until_ready(getValueFuture));
+
+	fdb_bool_t valuePresent{};
+	const uint8_t *valueRead{};
+	int valueLength{};
+	checkError(fdb_future_get_value(getValueFuture, &valuePresent, &valueRead, &valueLength));
+
+	std::vector<uint8_t> result;
+
+	if (valuePresent != 0) { result.assign(valueRead, valueRead + valueLength); }
+
+	fdb_future_destroy(getValueFuture);
+	fdb_transaction_destroy(transaction);
+
+	return result;
+}
+
+void cleanupFDB(FDBDatabase *database, std::jthread &networkThread) {
+	if (database != nullptr) {
+		fdb_database_destroy(database);
+	}
+
+	if (networkThread.joinable()) {
+		checkError(fdb_stop_network());
+	}
+}
+}  // namespace
+
+int main(int argc, char **argv) {
+	if (argc > 2) { usage(argv[0]); }
+
+	// Default path
+	std::string clusterFile = "/etc/foundationdb/fdb.cluster";
+
+	if (argc == 2) { clusterFile = std::string(argv[1]); }
+
+	// Set up network
+	checkError(fdb_select_api_version(FDB_API_VERSION));
+	checkError(fdb_setup_network());
+
+	// Run network thread
+	std::jthread networkThread([] { runNetworkThread(); });
+
+	FDBDatabase *database = nullptr;
+	checkError(fdb_create_database(clusterFile.c_str(), &database));
+
+	std::cout << "Connected to FoundationDB cluster: " << clusterFile << "\n";
+
+	std::vector<uint8_t> key{'f', 'o', 'o'};
+	std::vector<uint8_t> value{'b', 'a', 'r'};
+
+	// Create a transaction to insert a key-value pair (foo, bar)
+	setValue(database, key.size(), key.data(), value.size(), value.data());
+	// Create a transaction to retrieve the value for key "foo"
+	auto retrievedValue = getValue(database, key.size(), key.data());
+
+	if (retrievedValue != value) {
+		std::cerr << "Error: Retrieved value does not match expected value.\n";
+		cleanupFDB(database, networkThread);
+		return 1;
+	}
+
+	std::cout << "Value retrieved successfully: foo = "
+	          << std::string(retrievedValue.begin(), retrievedValue.end()) << "\n";
+
+	cleanupFDB(database, networkThread);
+
+	return 0;
+}


### PR DESCRIPTION
This pull request introduces scripts to automate the installation and
management of FoundationDB for testing purposes. The changes are
mostly:

- Add a script to install FoundationDB.
- Add script to provide functions to start and stop on-demand
  FoundationDB clusters for testing.
- Integrate into the testing framework.
- Create an app in C++ to test the connectivity to the on-demand FDB
  cluster.
- Create the FDBTests suite with one basic test.

Signed-off-by: guillex <guillex@leil.io>