### PR TITLE
ci: Add vcpkg action and submodule

### DIFF
--- a/.github/workflows/run-unit-and-ganesha-tests.yml
+++ b/.github/workflows/run-unit-and-ganesha-tests.yml
@@ -13,9 +13,21 @@ jobs:
         env:
             SAUNAFS_TEST_TIMEOUT_MULTIPLIER: 2
 
+
         steps:
             - name: Checkout repository
               uses: actions/checkout@v4
+              with:
+                  submodules: true
+                  fetch-depth: 0
+
+            - name: ccache
+              uses: hendrikmuhs/ccache-action@v1.2
+              with:
+                  create-symlink: true
+
+            - name: Setup anew (or from cache) vcpkg
+              uses: lukka/run-vcpkg@v11
 
             - name: Install nfs-ganesha v4.3 from Ubuntu repository
               run: |
@@ -33,35 +45,34 @@ jobs:
                   cd $GITHUB_WORKSPACE/tests
                   sudo ./setup_machine.sh setup /mnt/hdb /mnt/hdc /mnt/hdd
                   cd $GITHUB_WORKSPACE
-                  $GITHUB_WORKSPACE/utils/vcpkg_setup.sh
-                  vcpkg install --triplet x64-linux
 
             - name: Build SaunaFS
               run: |
-                source /var/lib/saunafs_setup_machine_venv/bin/activate
-                mkdir -p build
-                cd build
-                nice cmake \
-                -DCMAKE_TOOLCHAIN_FILE="${HOME}/vcpkg/scripts/buildsystems/vcpkg.cmake" \
-                -DENABLE_CLIENT_LIB=ON \
-                -DENABLE_DOCS=ON \
-                -DENABLE_NFS_GANESHA=ON \
-                -DENABLE_POLONAISE=OFF \
-                -DENABLE_URAFT=ON \
-                -DGSH_CAN_HOST_LOCAL_FS=ON \
-                -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-                -DCMAKE_INSTALL_PREFIX="${GITHUB_WORKSPACE}/install/saunafs/" \
-                -DENABLE_TESTS=ON \
-                -DCODE_COVERAGE=OFF \
-                -DSAUNAFS_TEST_POINTER_OBFUSCATION=ON \
-                -DENABLE_WERROR=ON \
-                "${GITHUB_WORKSPACE}"
-                make -j"$(nproc)" install
+                  export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+                  source /var/lib/saunafs_setup_machine_venv/bin/activate
+                  mkdir -p build
+                  cd build
+                  nice cmake \
+                  -DCMAKE_TOOLCHAIN_FILE="${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" \
+                  -DENABLE_CLIENT_LIB=ON \
+                  -DENABLE_DOCS=ON \
+                  -DENABLE_NFS_GANESHA=ON \
+                  -DENABLE_POLONAISE=OFF \
+                  -DENABLE_URAFT=ON \
+                  -DGSH_CAN_HOST_LOCAL_FS=ON \
+                  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+                  -DCMAKE_INSTALL_PREFIX="${GITHUB_WORKSPACE}/install/saunafs/" \
+                  -DENABLE_TESTS=ON \
+                  -DCODE_COVERAGE=OFF \
+                  -DSAUNAFS_TEST_POINTER_OBFUSCATION=ON \
+                  -DENABLE_WERROR=ON \
+                  "${GITHUB_WORKSPACE}"
+                  make -j"$(nproc)" install
 
 
             - name: Run Unit Tests suite
               run: |
-                "${GITHUB_WORKSPACE}/build/src/unittests/unittests" --gtest_color=yes
+                  "${GITHUB_WORKSPACE}/build/src/unittests/unittests" --gtest_color=yes
 
             - name: Run Ganesha suite
               run: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vcpkg"]
+	path = vcpkg
+	url = https://github.com/microsoft/vcpkg


### PR DESCRIPTION
Goal of this commit is to improve the reliability of the CI. Using vcpkg as a submodule is also recommended by vcpkg.