### PR TITLE
feat: Disable creation of empty files for full disk

### DIFF
--- a/doc/sfsmaster.cfg.5.adoc
+++ b/doc/sfsmaster.cfg.5.adoc
@@ -262,6 +262,12 @@ Set to either 1 to enable, or 0 to disable (default is 0)
 *PROMETHEUS_HOST (EXPERIMENTAL)*:: Host address where Prometheus metric data
 can be collected, must be in the format of HOST:PORT (default 0.0.0.0:9499)
 
+*CREATE_EMPTY_FOLDERS_WHEN_SPACE_DEPLETED (EXPERIMENTAL)* When enabled,
+this option allows the system to create metadata for empty folders when
+storage space is depleted. This helps preserving the intended file and
+directory structure. When this option is disabled, no metadata for folders
+will be created if there is insufficient storage space (default: 1).
+
 *LOG_LEVEL*:: Setup logging. Uses the environment variable SAUNAFS_LOG_LEVEL or
 config value LOG_LEVEL to determine logging level. Valid log levels are
 - 'trace'

--- a/src/admin/dump_config_command.cc
+++ b/src/admin/dump_config_command.cc
@@ -129,6 +129,7 @@ const static std::unordered_map<std::string, std::string> defaultOptionsMaster =
     {"SNAPSHOT_INITIAL_BATCH_SIZE_LIMIT", "10000"},
     {"FILE_TEST_LOOP_MIN_TIME", "3600"},
     {"PRIORITIZE_DATA_PARTS", "1"},
+    {"CREATE_EMPTY_FOLDERS_WHEN_SPACE_DEPLETED", "1"},
 };
 
 const static std::unordered_map<std::string, std::string> defaultOptionsShadow = {

--- a/src/data/sfsmaster.cfg.in
+++ b/src/data/sfsmaster.cfg.in
@@ -332,3 +332,8 @@
 ## port where it will listen for scrapers. Must in the format of HOST:PORT.
 ## (Default: 0.0.0.0:9499)
 # PROMETHEUS_HOST=0.0.0.0:9499
+
+## This option allows the system to create metadata for empty folders when
+## storage space is depleted.
+## (Default: 1)
+# CREATE_EMPTY_FOLDERS_WHEN_SPACE_DEPLETED = 1

--- a/src/master/filesystem.cc
+++ b/src/master/filesystem.cc
@@ -57,6 +57,8 @@ static bool gAutoRecovery = false;
 bool gMagicAutoFileRepair = false;
 bool gAtimeDisabled = false;
 
+bool gDisableEmptyFoldersMetadataOnFullDisk = false;
+
 uint32_t gTestStartTime;
 
 static bool gSaveMetadataAtExit = true;
@@ -359,6 +361,14 @@ static void fs_read_config_file() {
 		" entries are deprecated. Use OPERATIONS_DELAY_INIT and OPERATIONS_DELAY_DISCONNECT instead.");
 	}
 	gEmptyReservedFilesPeriod = cfg_getuint32("EMPTY_RESERVED_FILES_PERIOD_MSECONDS", 0);
+
+	gDisableEmptyFoldersMetadataOnFullDisk =
+	    cfg_getint32("CREATE_EMPTY_FOLDERS_WHEN_SPACE_DEPLETED", 1) == 0;
+	if (gDisableEmptyFoldersMetadataOnFullDisk) {
+		safs::log_info(
+		    "CREATE_EMPTY_FOLDERS_WHEN_SPACE_DEPLETED option is disabled. "
+		    "Empty folders will not be created when space is depleted.");
+	}
 
 	chunk_invalidate_goal_cache();
 	fs_read_goal_config_file(); // may throw

--- a/src/master/filesystem_metadata.h
+++ b/src/master/filesystem_metadata.h
@@ -150,6 +150,7 @@ extern FilesystemMetadata *gMetadata;
 extern ChecksumBackgroundUpdater gChecksumBackgroundUpdater;
 extern bool gDisableChecksumVerification;
 extern uint32_t gTestStartTime;
+extern bool gDisableEmptyFoldersMetadataOnFullDisk;
 
 #ifndef METARESTORE
 extern std::map<int, Goal> gGoalDefinitions;

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -28,6 +28,7 @@
 
 #include "common/attributes.h"
 #include "common/event_loop.h"
+#include "errors/saunafs_error_codes.h"
 #include "filesystem_metadata.h"
 #include "master/changelog.h"
 #include "master/chunks.h"
@@ -45,10 +46,18 @@
 #include "master/task_manager.h"
 #include "metrics/metrics.h"
 #include "protocol/matocl.h"
+#include "slogger/slogger.h"
 
 std::array<uint32_t, FsStats::Size> gFsStatsArray = {{}};
 
 [[maybe_unused]] static const char kAclXattrs[] = "system.richacl";
+
+inline bool isDepletedSpace() {
+	uint64_t totalSpace = 0;
+	uint64_t availableSpace = 0;
+	matocsserv_getspace(&totalSpace, &availableSpace);
+	return (totalSpace < SFSCHUNKSIZE || availableSpace < SFSCHUNKSIZE);
+}
 
 void fs_retrieve_stats(std::array<uint32_t, FsStats::Size> &output_stats) {
 	output_stats = gFsStatsArray;
@@ -1007,6 +1016,7 @@ uint8_t fs_mknod(const FsContext &context, uint32_t parent, const HString &name,
 	    fsnodes_quota_exceeded_dir(wd, {{QuotaResource::kInodes, 1}})) {
 		return SAUNAFS_ERROR_QUOTA;
 	}
+
 	static_cast<FSNodeDirectory *>(wd)->case_insensitive =
 	    context.sesflags() & SESFLAG_CASEINSENSITIVE;
 	p = fsnodes_create_node(ts, static_cast<FSNodeDirectory*>(wd), name, type, mode, umask, context.uid(), context.gid(), 0,
@@ -1055,6 +1065,14 @@ uint8_t fs_mkdir(const FsContext &context, uint32_t parent, const HString &name,
 	    fsnodes_quota_exceeded_dir(wd, {{QuotaResource::kInodes, 1}})) {
 		return SAUNAFS_ERROR_QUOTA;
 	}
+
+	if (gDisableEmptyFoldersMetadataOnFullDisk) {
+		if (isDepletedSpace()) {
+			safs::log_err("fs_mkdir: not enough space to create a folder");
+			return SAUNAFS_ERROR_NOSPACE;
+		}
+	}
+
 	static_cast<FSNodeDirectory *>(wd)->case_insensitive =
 	    context.sesflags() & SESFLAG_CASEINSENSITIVE;
 	p = fsnodes_create_node(ts, static_cast<FSNodeDirectory *>(wd), name, FSNode::kDirectory, mode,

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_allow_empty_folders_metadata_after_full_disk.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_allow_empty_folders_metadata_after_full_disk.sh
@@ -1,0 +1,68 @@
+timeout_set 3 minutes
+
+CHUNKSERVERS=1 \
+	USE_RAMDISK=YES \
+	CHUNKSERVER_EXTRA_CONFIG="READ_AHEAD_KB = 1024|MAX_READ_BEHIND_KB = 2048" \
+	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER,sfsioretries=10" \
+	setup_local_empty_saunafs info
+
+test_error_cleanup() {
+	sudo umount -l "${TEMP_DIR}/mnt/ganesha"
+	sudo pkill -9 ganesha.nfsd
+}
+
+mkdir -p "${TEMP_DIR}/mnt/ganesha"
+
+create_ganesha_pid_file
+
+cd ${info[mount0]}
+
+cat <<EOF > ${info[mount0]}/ganesha.conf
+NFSV4 {
+	Grace_Period = 10;
+	Lease_Lifetime = 10;
+}
+EXPORT {
+	Attr_Expiration_Time = 10;
+	Export_Id = 2;
+	Path = /;
+	Pseudo = /;
+	Access_Type = RW;
+	FSAL {
+		Name = SaunaFS;
+		hostname = localhost;
+		port = ${saunafs_info_[matocl]};
+		# How often to retry to connect
+		io_retries = 15;
+		cache_expiration_time_ms = 2500;
+	}
+	Protocols = 4;
+	CLIENT {
+		Clients = localhost;
+	}
+}
+EOF
+
+sudo /usr/bin/ganesha.nfsd -f ${info[mount0]}/ganesha.conf -L /tmp/ganesha.log
+
+check_rpc_service
+sudo mount -vvvv localhost:/ "${TEMP_DIR}/mnt/ganesha"
+
+# Write a big file to deplete the space of 2 GiB
+assert_failure dd if=/dev/zero of="${TEMP_DIR}/mnt/ganesha/largefile" bs=1M count=2048 \
+	oflag=direct conv=notrunc status=none
+
+# Create two 1MiB files, which should fail
+assert_failure dd if=/dev/zero of="${TEMP_DIR}/mnt/ganesha/1MiBfile.1" bs=1M count=1
+assert_failure dd if=/dev/zero of="${TEMP_DIR}/mnt/ganesha/1MiBfile.2" bs=1M count=1
+
+# Create a folder, which should be successful
+assert_success mkdir "${TEMP_DIR}/mnt/ganesha/empty.folder"
+
+# Validate empty files were created
+assert_success ls -lh "${TEMP_DIR}/mnt/ganesha/1MiBfile.1"
+assert_success ls -lh "${TEMP_DIR}/mnt/ganesha/1MiBfile.2"
+
+ls -lh "${TEMP_DIR}/mnt/ganesha/"
+
+test_error_cleanup || true

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_disable_empty_folders_metadata_after_full_disk.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_disable_empty_folders_metadata_after_full_disk.sh
@@ -1,0 +1,76 @@
+timeout_set 2 minutes
+
+CHUNKSERVERS=1 \
+	USE_RAMDISK=YES \
+	MASTER_EXTRA_CONFIG="CREATE_EMPTY_FOLDERS_WHEN_SPACE_DEPLETED = 0" \
+	CHUNKSERVER_EXTRA_CONFIG="READ_AHEAD_KB = 1024|MAX_READ_BEHIND_KB = 2048`
+			`|HDD_LEAVE_SPACE_DEFAULT = 0MiB" \
+	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER,sfsioretries=10" \
+	setup_local_empty_saunafs info
+
+test_error_cleanup() {
+	sudo umount -l "${TEMP_DIR}/mnt/ganesha"
+	sudo pkill -9 ganesha.nfsd
+}
+
+mkdir -p "${TEMP_DIR}/mnt/ganesha"
+
+create_ganesha_pid_file
+
+cd ${info[mount0]}
+
+cat <<EOF > ${info[mount0]}/ganesha.conf
+NFSV4 {
+	Grace_Period = 10;
+	Lease_Lifetime = 10;
+}
+EXPORT {
+	Attr_Expiration_Time = 10;
+	Export_Id = 2;
+	Path = /;
+	Pseudo = /;
+	Access_Type = RW;
+	FSAL {
+		Name = SaunaFS;
+		hostname = localhost;
+		port = ${saunafs_info_[matocl]};
+		# How often to retry to connect
+		io_retries = 15;
+		cache_expiration_time_ms = 2500;
+	}
+	Protocols = 4;
+	CLIENT {
+		Clients = localhost;
+	}
+}
+EOF
+
+sudo /usr/bin/ganesha.nfsd -f ${info[mount0]}/ganesha.conf
+
+check_rpc_service
+sudo mount -vvvv localhost:/ "${TEMP_DIR}/mnt/ganesha"
+
+# Write a 2G file, remaining 48 MiB of available space
+assert_success dd if=/dev/zero of="${TEMP_DIR}/mnt/ganesha/largefile" bs=1M count=2000 \
+	oflag=direct conv=notrunc status=none
+
+# Create a 48 MiB file to deplete the available space
+assert_failure dd if=/dev/zero of="${TEMP_DIR}/mnt/ganesha/48MiBfile" bs=1M count=48 \
+	oflag=direct status=none
+
+# Try to create a folder, which should fail
+assert_failure mkdir "${TEMP_DIR}/mnt/ganesha/empty.folder"
+
+# Try to create a 1 MiB file, which should fail
+assert_failure dd if=/dev/zero of="${TEMP_DIR}/mnt/ganesha/1MiBfile" bs=1M count=1 \
+	oflag=direct status=none
+
+# Validate empty file was created
+assert_success ls -lh "${TEMP_DIR}/mnt/ganesha/1MiBfile"
+
+# Validate empty folder was not created
+assert_failure ls -lh "${TEMP_DIR}/mnt/ganesha/empty.folder"
+
+assert_success ls -lh "${TEMP_DIR}/mnt/ganesha"
+
+test_error_cleanup || true

--- a/tests/test_suites/ShortSystemTests/test_allow_empty_folders_metadata_after_full_disk.sh
+++ b/tests/test_suites/ShortSystemTests/test_allow_empty_folders_metadata_after_full_disk.sh
@@ -1,0 +1,26 @@
+timeout_set 2 minutes
+
+CHUNKSERVERS=1 \
+	USE_RAMDISK=YES \
+	CHUNKSERVER_EXTRA_CONFIG="READ_AHEAD_KB = 1024|MAX_READ_BEHIND_KB = 2048" \
+	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER,sfsioretries=10" \
+	setup_local_empty_saunafs info
+
+cd ${info[mount0]}
+
+# Write a big file to deplete the space of 2 GiB
+assert_failure dd if=/dev/zero of="${info[mount0]}/largefile" bs=1M count=2048 \
+	oflag=direct conv=notrunc status=none
+
+# Try to create a file, which should fail
+assert_failure dd if=/dev/zero of="${info[mount0]}/1MiBfile.1" bs=1M count=1
+assert_failure dd if=/dev/zero of="${info[mount0]}/1MiBfile.2" bs=1M count=1
+
+# Try to create a folder, which should be successful
+assert_success mkdir "${info[mount0]}/empty.folder"
+
+# Validate empty files were created
+assert_success ls -lh "${info[mount0]}/1MiBfile.1"
+assert_success ls -lh "${info[mount0]}/1MiBfile.2"
+
+ls -lh "${info[mount0]}"

--- a/tests/test_suites/ShortSystemTests/test_disable_empty_folders_metadata_after_full_disk.sh
+++ b/tests/test_suites/ShortSystemTests/test_disable_empty_folders_metadata_after_full_disk.sh
@@ -1,0 +1,32 @@
+timeout_set 1 minutes
+
+CHUNKSERVERS=1 \
+	USE_RAMDISK=YES \
+	MASTER_EXTRA_CONFIG="CREATE_EMPTY_FOLDERS_WHEN_SPACE_DEPLETED = 0" \
+	CHUNKSERVER_EXTRA_CONFIG="READ_AHEAD_KB = 1024|MAX_READ_BEHIND_KB = 2048`
+			`|HDD_LEAVE_SPACE_DEFAULT = 0MiB" \
+	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER,sfsioretries=10" \
+	setup_local_empty_saunafs info
+
+cd ${info[mount0]}
+
+# Write a 2G file, remaining 48 MiB of available space
+assert_success dd if=/dev/zero of="${info[mount0]}/largefile" bs=1M count=2000 \
+	oflag=direct conv=notrunc status=none
+
+# Create a 48 MiB file to deplete the available space
+assert_failure dd if=/dev/zero of="${info[mount0]}/48MiBfile" bs=1M count=48 oflag=direct status=none
+
+# Try to create a folder, which should fail
+assert_failure mkdir "${info[mount0]}/empty.folder"
+
+# Try to create a 1 MiB file, which should fail
+assert_failure dd if=/dev/zero of="${info[mount0]}/1MiBfile" bs=1M count=1 oflag=direct status=none
+
+# Validate empty file was successfully created
+assert_success ls -lh "${info[mount0]}/1MiBfile"
+
+# Validate empty folder was not created
+assert_failure ls -lh "${info[mount0]}/empty.folder"
+
+assert_success ls -lh "${info[mount0]}"


### PR DESCRIPTION
**Summary**
This PR introduces a new configuration option for the master server to control metadata creation behavior when disk space is depleted.

Previously, even when disk space was exhausted, metadata for files and directories could still be created—leading to the presence of empty files or folders. This update prevents such metadata from being created for folders when the system is out of space.

**Key Changes**

- A new option was added: `CREATE_EMPTY_FOLDERS_WHEN_SPACE_DEPLETED` (default: 1).
   - When set to `0`, metadata for empty folders will not be created if there is no available space.
   - This helps prevent inconsistent or misleading filesystem state when disk space is full.

- The new option modify the behavior of `fs_mkdir` function:
   - If the option is disabled and the disk is full, `fs_mkdir` operation returns `SAUNAFS_ERROR_NOSPACE` and skip metadata creation.

**Test coverage**

Considering the new option affects Linux and NFS clients, both clients were tested (with option enabled and disabled) under full-disk conditions:

- `test_nfs_ganesha_allow_empty_folders_metadata_after_full_disk.sh:` validates that enabling the option (default value) allows NFS clients to create empty folders when the space is depleted (expected behavior).

- `test_nfs_ganesha_disable_empty_folders_metadata_after_full_disk.sh:` validates that disabling the option (set value = 0)  prevent NFS clients to create empty folders when the space is depleted.

- `test_allow_empty_folders_metadata_after_full_disk.sh:` validates that enabling the option (default value) allows Linux clients to create empty folders when the space is depleted (expected behavior).

- `test_disable_empty_folders_metadata_after_full_disk.sh:` validates that disabling the option (set value = 0)  prevent Linux clients to create empty folders when the space is depleted.

**Related Issue**
Fixes: #317