### PR TITLE
fix(chunkserver): Fix long rebalancing/replicate

### DIFF
--- a/src/chunkserver/bgjobs.cc
+++ b/src/chunkserver/bgjobs.cc
@@ -324,12 +324,15 @@ uint32_t job_get_blocks(JobPool &jobPool, JobPool::JobCallback callback, void *e
 
 uint32_t job_replicate(JobPool &jobPool, JobPool::JobCallback callback, void *extra,
                        uint64_t chunkId, uint32_t chunkVersion, ChunkPartType chunkType,
-                       uint32_t sourcesBufferSize, const uint8_t *sourcesBuffer) {
+                       uint32_t sourcesBufferSize, const uint8_t *sourcesBufferPtr) {
+	// Copy the sources buffer to a vector to ensure it is valid for the lifetime of the job
+	std::vector<uint8_t> sourcesBuffer(sourcesBufferSize);
+	std::memcpy(sourcesBuffer.data(), sourcesBufferPtr, sourcesBufferSize);
 	JobPool::ProcessJobCallback processJob = [=]() -> uint8_t {
 		uint8_t status = SAUNAFS_STATUS_OK;
 		try {
 			std::vector<ChunkTypeWithAddress> sources;
-			deserialize(sourcesBuffer, sourcesBufferSize, sources);
+			deserialize(sourcesBuffer.data(), sourcesBufferSize, sources);
 			ChunkFileCreator creator(chunkId, chunkVersion, chunkType);
 			gReplicator.replicate(creator, sources);
 		} catch (Exception &ex) {

--- a/tests/test_suites/ShortSystemTests/test_rebalancing_no_errors.sh
+++ b/tests/test_suites/ShortSystemTests/test_rebalancing_no_errors.sh
@@ -1,0 +1,50 @@
+timeout_set 10 minutes
+
+CHUNKSERVERS=5 \
+	DISK_PER_CHUNKSERVER=1 \
+	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER" \
+	USE_RAMDISK=YES \
+	MASTER_EXTRA_CONFIG="CHUNKS_LOOP_MIN_TIME = 10`
+		`|CHUNKS_LOOP_MAX_CPU = 90`
+		`|CHUNKS_WRITE_REP_LIMIT = 20`
+		`|CHUNKS_READ_REP_LIMIT = 20`
+		`|CHUNKS_SOFT_DEL_LIMIT = 5`
+		`|CHUNKS_HARD_DEL_LIMIT = 5`
+		`|OPERATIONS_DELAY_INIT = 5`
+		`|OPERATIONS_DELAY_DISCONNECT = 5`
+		`|ACCEPTABLE_DIFFERENCE = 0.01" \
+	CHUNKSERVER_EXTRA_CONFIG="MAGIC_DEBUG_LOG = $TEMP_DIR/log|MASTER_NR_OF_WORKERS = 2" \
+	setup_local_empty_saunafs info
+
+cd "${info[mount0]}"
+mkdir dir
+saunafs setgoal ec21 dir
+cd dir
+
+for i in {1..1000}; do
+    # create a file of 1MB with zeroes
+    dd if=/dev/zero of="file.$i" bs=1MiB count=1 status=none
+done
+
+# Shutdown 5th server
+saunafs_chunkserver_daemon 4 stop
+# Make the last chunkserver have less available space and restart it
+sed -i s/"HDD_LEAVE_SPACE_DEFAULT = 128MiB"/"HDD_LEAVE_SPACE_DEFAULT = 1024MiB"/g \
+       "${info[chunkserver4_cfg]}"
+saunafs_chunkserver_daemon 4 start
+
+saunafs_wait_for_all_ready_chunkservers
+
+sleep 120
+
+# Check the chunkserver logs for errors
+# On unsuccessful runs the errors should be created when replicating parts from the 5th chunkserver
+# to the other chunkservers
+cat "$TEMP_DIR/log"
+assert_failure grep -q "hddChunkGetNumberOfBlocks: Couldn't find chunkID" "$TEMP_DIR/log"
+assert_failure grep -q "hddOpen: could not find chunkid" "$TEMP_DIR/log"
+
+list_cs_info=$(saunafs-admin list-chunkservers localhost "${info[matocl]}")
+# Check that all chunkservers didn't have errors, and one of them has 0 chunks
+assert_equals "$(echo "${list_cs_info}" | grep -c 'errors: 0')" "${info[chunkserver_count]}"
+assert_equals "$(echo "${list_cs_info}" | grep -c 'chunks: 0')" 1

--- a/tests/test_suites/ShortSystemTests/test_replication_no_errors.sh
+++ b/tests/test_suites/ShortSystemTests/test_replication_no_errors.sh
@@ -1,0 +1,44 @@
+timeout_set 10 minutes
+
+CHUNKSERVERS=5 \
+	DISK_PER_CHUNKSERVER=1 \
+	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER" \
+	USE_RAMDISK=YES \
+	MASTER_EXTRA_CONFIG="CHUNKS_LOOP_MIN_TIME = 10`
+		`|CHUNKS_LOOP_MAX_CPU = 90`
+		`|CHUNKS_WRITE_REP_LIMIT = 20`
+		`|CHUNKS_READ_REP_LIMIT = 20`
+		`|CHUNKS_SOFT_DEL_LIMIT = 5`
+		`|CHUNKS_HARD_DEL_LIMIT = 5`
+		`|OPERATIONS_DELAY_INIT = 5`
+		`|OPERATIONS_DELAY_DISCONNECT = 5`
+		`|ACCEPTABLE_DIFFERENCE = 0.01" \
+	MASTER_CUSTOM_GOALS="10 ec31: \$ec(3,1)" \
+	CHUNKSERVER_EXTRA_CONFIG="MAGIC_DEBUG_LOG = $TEMP_DIR/log|MASTER_NR_OF_WORKERS = 2" \
+	setup_local_empty_saunafs info
+
+cd "${info[mount0]}"
+mkdir dir
+saunafs setgoal ec21 dir
+cd dir
+
+for i in {1..1000}; do
+    # create a file of 1MB with zeroes
+    dd if=/dev/zero of="file.$i" bs=1MiB count=1 status=none
+done
+
+# Change the goal of the directory to ec31
+saunafs setgoal ec31 -r .
+
+sleep 120
+
+# Check the chunkserver logs for errors
+# On unsuccessful runs the errors should be created when replicating parts from one goal
+# to the other
+cat "$TEMP_DIR/log"
+assert_failure grep -q "hddChunkGetNumberOfBlocks: Couldn't find chunkID" "$TEMP_DIR/log"
+assert_failure grep -q "hddOpen: could not find chunkid" "$TEMP_DIR/log"
+
+list_cs_info=$(saunafs-admin list-chunkservers localhost "${info[matocl]}")
+# Check that all chunkservers didn't have errors
+assert_equals "$(echo "${list_cs_info}" | grep -c 'errors: 0')" "${info[chunkserver_count]}"


### PR DESCRIPTION
The current rebalancing and replicate algorithm is based on the master
message to the chunkserver to replicate a specific part of the chunk.

That job is posted by the network workers of the chunkserver listening
to master, but processed by the job workers. At the moment of posting
the job to the JobPool, the buffer to be deserialized contains the
expected list of sources to get the chunks from, but this buffer is
relative to the master connection which may change after several other
incoming packets. So, when a job worker gets the actual job, the data
inside the buffers could have changed.

The proposed fix is to deserialize before posting the job in the JobPool.

A couple of tests were added to check there are no errors during
rebalancing and replication.

Signed-off-by: Dave <dave@leil.io>

Co-authored-by: Crash <crash@leil.io>