### PR TITLE
fix: Fix masterconn_canexit()

### DIFF
--- a/src/master/masterconn.cc
+++ b/src/master/masterconn.cc
@@ -1214,7 +1214,8 @@ void masterconn_wantexit(void) {
 }
 
 int masterconn_canexit(void) {
-	return static_cast<int>(gMasterConn != nullptr || gMasterConn->mode == MasterConn::Mode::Free);
+	return static_cast<int>(gMasterConn == nullptr || gMasterConn->mode == MasterConn::Mode::Free ||
+		gMasterConn->mode == MasterConn::Mode::Kill);
 }
 
 void masterconn_desc(std::vector<pollfd> &pdesc) {


### PR DESCRIPTION
The masterconn_canexit function was crashing the master(shadow) process
when the first part of the condition checked was failing: the
gMasterConn was a nullptr and the second part of the OR was
SEGFAULTing.

Signed-off-by: Dave <dave@leil.io>