### PR TITLE
fix: chunkserver-common linking errors in GCC-13

### DIFF
--- a/src/chunkserver/chunkserver-common/CMakeLists.txt
+++ b/src/chunkserver/chunkserver-common/CMakeLists.txt
@@ -5,6 +5,8 @@ shared_add_library(chunkserver-common ${CHUNKSERVER_PLUGINS_SOURCES})
 target_link_libraries(chunkserver-common safsprotocol sfscommon
         ${Boost_LIBRARIES} ${ADDITIONAL_LIBS})
 
+shared_target_link_libraries(chunkserver-common STATIC sfserr SHARED sfserr_pic)
+
 create_unittest(chunkserver-common ${CHUNKSERVER_PLUGINS_TESTS})
 link_unittest(chunkserver-common
         GTest::gtest


### PR DESCRIPTION
PR #339 introduced a dependency on the `saunafs_error_string()` function in the `chunkserver-common` library, specifically in files like `cmr_disk.cc` and `chunk_trash_manager.cc.` This led to undefined reference errors during linking with some compilers such as GCC 13, while newer compilers like GCC 14 did not report this issue.

This commit updates the `CMakeLists.txt` of the `chunkserver-common` library to explicitly link against the `sfserror` library, resolving the linking errors with GCC 13.