### PR TITLE
ci: Add clang-tidy comments for PR's

### DIFF
--- a/.github/workflows/post-static-analysis.yml
+++ b/.github/workflows/post-static-analysis.yml
@@ -1,0 +1,93 @@
+# Secure workflow with access to repository secrets and GitHub token for posting analysis results
+name: Post the static analysis results
+
+on:
+  workflow_run:
+    workflows: [ "Static analysis" ]
+    types: [ completed ]
+
+jobs:
+  clang-tidy-results:
+    # Trigger the job only if the previous (insecure) workflow completed successfully
+    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: write
+      # OPTIONAL: auto-closing conversations requires the `contents` permission
+      contents: write
+    steps:
+    - name: Download analysis results
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{ github.event.workflow_run.id }},
+          });
+          const matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "clang-tidy-result"
+          })[0];
+          const download = await github.rest.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: matchArtifact.id,
+              archive_format: "zip",
+          });
+          const fs = require("fs");
+          fs.writeFileSync("${{ github.workspace }}/clang-tidy-result.zip", Buffer.from(download.data));
+    - name: Extract analysis results
+      run: |
+        mkdir clang-tidy-result
+        unzip -j clang-tidy-result.zip -d clang-tidy-result
+    - name: Set environment variables
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const assert = require("node:assert").strict;
+          const fs = require("fs");
+          function exportVar(varName, fileName, regEx) {
+              const val = fs.readFileSync("${{ github.workspace }}/clang-tidy-result/" + fileName, {
+                  encoding: "ascii"
+              }).trimEnd();
+              assert.ok(regEx.test(val), "Invalid value format for " + varName);
+              core.exportVariable(varName, val);
+          }
+          exportVar("PR_ID", "pr-id.txt", /^[0-9]+$/);
+          exportVar("PR_HEAD_REPO", "pr-head-repo.txt", /^[-./0-9A-Z_a-z]+$/);
+          exportVar("PR_HEAD_SHA", "pr-head-sha.txt", /^[0-9A-Fa-f]+$/);
+    - uses: actions/checkout@v4
+      with:
+        repository: ${{ env.PR_HEAD_REPO }}
+        ref: ${{ env.PR_HEAD_SHA }}
+        persist-credentials: false
+    - name: Redownload analysis results
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{ github.event.workflow_run.id }},
+          });
+          const matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "clang-tidy-result"
+          })[0];
+          const download = await github.rest.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: matchArtifact.id,
+              archive_format: "zip",
+          });
+          const fs = require("fs");
+          fs.writeFileSync("${{ github.workspace }}/clang-tidy-result.zip", Buffer.from(download.data));
+    - name: Extract analysis results
+      run: |
+        mkdir clang-tidy-result
+        unzip -j clang-tidy-result.zip -d clang-tidy-result
+    - name: Run clang-tidy-pr-comments action
+      uses: platisd/clang-tidy-pr-comments@v1
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        clang_tidy_fixes: clang-tidy-result/fixes.yml
+        pull_request_id: ${{ env.PR_ID }}

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -14,12 +14,21 @@ jobs:
         submodules: true
         fetch-depth: 0
 
-    - name: Setup anew (or from cache) vcpkg
-      uses: lukka/run-vcpkg@v11
-
-    - name: Install packages
+    - name: Install nfs-ganesha v4.3 from Ubuntu repository
       run: |
-        sudo ./tests/install-packages.sh
+          sudo apt update
+          sudo apt install -y nfs-common nfs-ganesha nfs-ganesha-vfs
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+          python-version: "3.x"
+
+    - name: Install SaunaFS dependencies, setup environment and build
+      run: |
+        sudo mkdir /mnt/hd{b,c,d}
+        cd $GITHUB_WORKSPACE/tests
+        sudo ./setup_machine.sh setup /mnt/hdb /mnt/hdc /mnt/hdd
 
     - name: Fetch base branch
       run: |
@@ -29,14 +38,33 @@ jobs:
     - name: Install clang-tidy
       run: |
         sudo apt-get update
-        sudo apt-get install -y clang-tidy python3-yaml
+        sudo apt-get install -y clang-tidy libc++-18-dev
+        pip3 install PyYAML
+
+    - name: Install LLVM and Clang
+      run: |
+          sudo $GITHUB_WORKSPACE/tests/llvm.sh
+
+    - name: Cache vcpkg downloads
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cache/vcpkg
+        key: ${{ runner.os }}-vcpkg-${{ hashFiles('vcpkg.json') }}
+        restore-keys: |
+          ${{ runner.os }}-vcpkg-
+
+    - name: Setup vcpkg and install dependencies
+      run: |
+        $GITHUB_WORKSPACE/utils/vcpkg_setup.sh
+        vcpkg install --triplet x64-linux
 
     - name: Prepare compile_commands.json
       run: |
         mkdir -p build
         cmake -B build \
+            -DCMAKE_TOOLCHAIN_FILE="${HOME}/vcpkg/scripts/buildsystems/vcpkg.cmake" \
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-            -DCMAKE_TOOLCHAIN_FILE="${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" \
             -DENABLE_CLIENT_LIB=ON \
             -DENABLE_DOCS=ON \
             -DENABLE_NFS_GANESHA=ON \

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,70 @@
+# Insecure workflow with limited permissions that should provide analysis results through an artifact
+name: Static analysis
+
+on: pull_request
+
+jobs:
+  clang-tidy:
+    runs-on: ubuntu-24.04
+    steps:
+
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        submodules: true
+        fetch-depth: 0
+
+    - name: Setup anew (or from cache) vcpkg
+      uses: lukka/run-vcpkg@v11
+
+    - name: Install packages
+      run: |
+        sudo ./tests/install-packages.sh
+
+    - name: Fetch base branch
+      run: |
+        git remote add upstream "https://github.com/${{ github.event.pull_request.base.repo.full_name }}"
+        git fetch --no-tags --no-recurse-submodules upstream "${{ github.event.pull_request.base.ref }}"
+
+    - name: Install clang-tidy
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y clang-tidy python3-yaml
+
+    - name: Prepare compile_commands.json
+      run: |
+        mkdir -p build
+        cmake -B build \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+            -DCMAKE_TOOLCHAIN_FILE="${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" \
+            -DENABLE_CLIENT_LIB=ON \
+            -DENABLE_DOCS=ON \
+            -DENABLE_NFS_GANESHA=ON \
+            -DENABLE_POLONAISE=OFF \
+            -DENABLE_URAFT=ON \
+            -DGSH_CAN_HOST_LOCAL_FS=ON \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCMAKE_INSTALL_PREFIX="${GITHUB_WORKSPACE}/install/saunafs/" \
+            -DENABLE_TESTS=ON \
+            -DCODE_COVERAGE=OFF \
+            -DSAUNAFS_TEST_POINTER_OBFUSCATION=ON \
+            -DENABLE_WERROR=ON \
+
+    - name: Create results directory
+      run: |
+        mkdir clang-tidy-result
+
+    - name: Analyze
+      run: |
+        git diff -U0 "$(git merge-base HEAD "upstream/${{ github.event.pull_request.base.ref }}")" | clang-tidy-diff -p1 -path build -export-fixes clang-tidy-result/fixes.yml
+
+    - name: Save PR metadata
+      run: |
+        echo "${{ github.event.number }}" > clang-tidy-result/pr-id.txt
+        echo "${{ github.event.pull_request.head.repo.full_name }}" > clang-tidy-result/pr-head-repo.txt
+        echo "${{ github.event.pull_request.head.sha }}" > clang-tidy-result/pr-head-sha.txt
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: clang-tidy-result
+        path: clang-tidy-result/

--- a/src/main/main.cc
+++ b/src/main/main.cc
@@ -826,6 +826,8 @@ int main(int argc,char **argv) {
 	std::string cfgfile = default_cfgfile;
 	std::string pidfile;
 
+	printf("Hello world!");
+
 	prepareEnvironment();
 	mycrc32_init();
 


### PR DESCRIPTION
There are two seperate actions: One for running clang-tidy with no secrets, and another with secrets. This ensures that if the former is compromised, the latter secrets should be safe.