### PR TITLE
test: Use machine multiplier for rescaling timeouts

### DIFF
--- a/tests/test_suites/ShortSystemTests/test_replication_bandwidth_limiting.sh
+++ b/tests/test_suites/ShortSystemTests/test_replication_bandwidth_limiting.sh
@@ -42,7 +42,11 @@ expected_time_s=$((file_size_kb * chunks_count / replication_limit))
 accepted_inaccuracy_s=5
 if valgrind_enabled; then
 	accepted_inaccuracy_s=30
+else
+	accepted_inaccuracy_s="$(timeout_rescale_seconds $accepted_inaccuracy_s)"
 fi;
+echo "accepted_inaccuracy_s: $accepted_inaccuracy_s"
+
 assert_success wait_for \
 		'[ "$health_ok" == "$(chunks_health)" ]' \
 		"$((expected_time_s + accepted_inaccuracy_s)) seconds"

--- a/tests/tools/timeout.sh
+++ b/tests/tools/timeout.sh
@@ -2,18 +2,14 @@ timeout_killer_thread() {
 	# Python3 is used here to perform floating-point multiplication in timeout computation
 	assert_program_installed python3
 
-	local machine_environment_multiplier=1
-	if [[ ! -z "${SAUNAFS_TEST_TIMEOUT_MULTIPLIER:-}" ]]; then
-		machine_environment_multiplier="$SAUNAFS_TEST_TIMEOUT_MULTIPLIER"
-	fi
-
 	while ! test_frozen; do
 		sleep 1
 		if test_frozen; then
 			return
 		fi
 
-		local multiplier=$(cat "$test_timeout_multiplier_file")
+		local multiplier=$(timeout_get_multiplier)
+		local machine_multiplier=$(timeout_get_machine_multiplier)
 		local begin_ts=$(cat "$test_timeout_begin_ts_file") || true
 		local value_string=$(cat "$test_timeout_value_file") || true
 		local value=$(($(date +%s -d "$value_string") - $(date +%s)))
@@ -30,7 +26,7 @@ timeout_killer_thread() {
 			continue
 		fi
 
-		local total_timeout=$(($value * $multiplier * $machine_environment_multiplier))
+		local total_timeout=$(($value * $multiplier * $machine_multiplier))
 		local end_ts=$(($begin_ts + $total_timeout))
 
 		if (( now_ts >= end_ts )); then
@@ -44,7 +40,7 @@ timeout_killer_thread() {
 
 			local test_timeout_message=$( printf "$format" \
 				"$total_timeout" \
-				"$value" "$machine_environment_multiplier" "$multiplier" \
+				"$value" "$machine_multiplier" "$multiplier" \
 				"$value_string" )
 
 			test_add_failure "$test_timeout_message"
@@ -55,9 +51,17 @@ timeout_killer_thread() {
 }
 
 timeout_init() {
+	local machine_multiplier=1
+	if [[ ! -z "${SAUNAFS_TEST_TIMEOUT_MULTIPLIER:-}" ]]; then
+		machine_multiplier="$SAUNAFS_TEST_TIMEOUT_MULTIPLIER"
+	fi
+
+	test_timeout_machine_multiplier_file="$TEMP_DIR/$(unique_file)_timeout_machine.txt"
 	test_timeout_begin_ts_file="$TEMP_DIR/$(unique_file)_timeout_beginTS.txt"
 	test_timeout_multiplier_file="$TEMP_DIR/$(unique_file)_timeout_multiplier.txt"
 	test_timeout_value_file="$TEMP_DIR/$(unique_file)_timeout_value.txt"
+
+	timeout_set_machine_multiplier "$machine_multiplier"
 
 	# default timeout values
 	timeout_set "30 seconds"
@@ -77,21 +81,33 @@ timeout_set_multiplier() {
 	echo "$1" > "$test_timeout_multiplier_file"
 }
 
+timeout_set_machine_multiplier() {
+	echo "$1" > "$test_timeout_machine_multiplier_file"
+}
+
 timeout_get_multiplier() {
 	cat "$test_timeout_multiplier_file"
 }
 
+timeout_get_machine_multiplier() {
+	cat "$test_timeout_machine_multiplier_file"
+}
+
 # takes as parameter timeout (e.g. '1 minute') and rescales it by multiplier
 # prints result in seconds to standard output (e.g. '900 seconds')
+# SAUNAFS_TEST_TIMEOUT_MULTIPLIER will compound the existing multiplier
 timeout_rescale() {
-	local multiplier=$(timeout_get_multiplier)
+	local test_multiplier=$(timeout_get_multiplier)
+	local machine_multiplier=$(timeout_get_machine_multiplier)
 	local value=$(($(date +%s -d "$1") - $(date +%s)))
-	echo $((value * multiplier)) seconds
+	echo $((value * test_multiplier * machine_multiplier)) seconds
 }
 
 # takes as parameter timeout in seconds (e.g. '60') and rescales it by multiplier
 # prints result to standard output (e.g. '900')
+# SAUNAFS_TEST_TIMEOUT_MULTIPLIER will compound the existing multiplier
 timeout_rescale_seconds() {
-	local multiplier=$(timeout_get_multiplier)
-	echo $(($1 * multiplier))
+	local test_multiplier=$(timeout_get_multiplier)
+	local machine_multiplier=$(timeout_get_machine_multiplier)
+	echo $(($1 * test_multiplier * machine_multiplier))
 }


### PR DESCRIPTION
This should hopefully prevent timeouts on certain commands.

* Use timeout_rescale for test_replication_bandwidth_limiting test