### PR TITLE
test(tools): Fix saunafs command tests for Windows

### DIFF
--- a/tests/test_suites/SanityChecks/test_dirinfo.sh
+++ b/tests/test_suites/SanityChecks/test_dirinfo.sh
@@ -23,7 +23,7 @@ mkdir dir
 
 # 100 KB, goal 2
 touch dir/file1
-saunafs setgoal 2 dir/file1
+saunafs_command setgoal 2 dir/file1
 dd if=/dev/zero of=dir/file1 bs=100KiB count=1
 	  length[dir/file1]=$(parse_si_suffix 100K)
 	    size[dir/file1]=$((1 * header_size + 2 * block))
@@ -31,7 +31,7 @@ dd if=/dev/zero of=dir/file1 bs=100KiB count=1
 
 # 1 B, goal 3
 touch dir/file2
-saunafs setgoal 3 dir/file2
+saunafs_command setgoal 3 dir/file2
 dd if=/dev/zero of=dir/file2 bs=1 count=1
 	  length[dir/file2]=1
 	    size[dir/file2]=$((1 * header_size + 1 * block))
@@ -39,7 +39,7 @@ dd if=/dev/zero of=dir/file2 bs=1 count=1
 
 # 64 KB, goal 2
 touch dir/file3
-saunafs setgoal 2 dir/file3
+saunafs_command setgoal 2 dir/file3
 dd if=/dev/zero of=dir/file3 bs=64KiB count=1
 	length[dir/file3]=65536
 	    size[dir/file3]=$((1 * header_size + 1 * block))
@@ -47,7 +47,7 @@ dd if=/dev/zero of=dir/file3 bs=64KiB count=1
 
 # 1 KB, goal xor2
 touch dir/filex1
-saunafs setgoal xor2 dir/filex1
+saunafs_command setgoal xor2 dir/filex1
 dd if=/dev/zero of=dir/filex1 bs=1KiB count=1
 	  length[dir/filex1]=$(parse_si_suffix 1K)
 	    size[dir/filex1]=$((1 * header_size + 1 * block))
@@ -55,7 +55,7 @@ dd if=/dev/zero of=dir/filex1 bs=1KiB count=1
 
 # 100 KB, goal xor2
 touch dir/filex2
-saunafs setgoal xor2 dir/filex2
+saunafs_command setgoal xor2 dir/filex2
 dd if=/dev/zero of=dir/filex2 bs=100KiB count=1
 	  length[dir/filex2]=$(parse_si_suffix 100K)
 	    size[dir/filex2]=$((1 * header_size + 2 * block))
@@ -63,7 +63,7 @@ dd if=/dev/zero of=dir/filex2 bs=100KiB count=1
 
 # 70 MB, goal xor3
 touch dir/filex3
-saunafs setgoal xor3 dir/filex3
+saunafs_command setgoal xor3 dir/filex3
 dd if=/dev/zero of=dir/filex3 bs=1MiB count=70
 	  length[dir/filex3]=$(parse_si_suffix 70M)
 	    size[dir/filex3]=$((2 * header_size + 1120 * block))
@@ -71,7 +71,7 @@ dd if=/dev/zero of=dir/filex3 bs=1MiB count=70
 
 # 70 MB + 1 B, goal xor2
 touch dir/filex4
-saunafs setgoal xor2 dir/filex4
+saunafs_command setgoal xor2 dir/filex4
 dd if=/dev/zero of=dir/filex4 bs=1MiB count=70
 echo >> dir/filex4
 	  length[dir/filex4]=$(($(parse_si_suffix 70M) + 1))
@@ -80,7 +80,7 @@ echo >> dir/filex4
 
 # 64 KB, goal xor2
 touch dir/filex5
-saunafs setgoal xor2 dir/filex5
+saunafs_command setgoal xor2 dir/filex5
 dd if=/dev/zero of=dir/filex5 bs=64KiB count=1
 	  length[dir/filex5]=65536
 	    size[dir/filex5]=$((1 * header_size + 1 * block))

--- a/tests/test_suites/SanityChecks/test_fileinfo.sh
+++ b/tests/test_suites/SanityChecks/test_fileinfo.sh
@@ -45,13 +45,13 @@ files=()
 for goal in 1 2 3 xor2 xor3 ec32; do
 	file="file_goal_$goal"
 	touch "$file"
-	saunafs setgoal "$goal" "$file"
+	saunafs_command setgoal "$goal" "$file"
 	dd if=/dev/zero of="$file" bs=1MiB count=5 seek=62 conv=notrunc
 	truncate -s 100M "$file" # Increases version of the second chunk
 	files+=("$file")
 done
 
-chunks_info=$(saunafs fileinfo "${files[@]}" \
+chunks_info=$(saunafs_command fileinfo "${files[@]}" \
 		| awk -v meta_extension="${chunk_metadata_extension}" "$awkscript" \
 		| sed -e "s|CS${info[chunkserver0_port]}|$(get_metadata_path ${info[chunkserver0_hdd]})|" \
 		| sed -e "s|CS${info[chunkserver1_port]}|$(get_metadata_path ${info[chunkserver1_hdd]})|" \

--- a/tests/test_suites/SanityChecks/test_goals.sh
+++ b/tests/test_suites/SanityChecks/test_goals.sh
@@ -6,10 +6,10 @@ CHUNKSERVERS=3 \
 cd "${info[mount0]}"
 for goal in 1 2 3; do
 	mkdir goal_$goal
-	saunafs setgoal $goal goal_$goal
+	saunafs_command setgoal $goal goal_$goal
 	file=goal_$goal/file
 	FILE_SIZE=12345678 BLOCK_SIZE=12345 file-generate $file
-	if ! saunafs checkfile $file | egrep "chunks with $goal cop(y|ies): *1$"; then
+	if ! saunafs_command checkfile $file | egrep "chunks with $goal cop(y|ies): *1$"; then
 		test_add_failure "File with goal $goal created with undergoal chunks"
 	fi
 	if ! file-validate $file; then

--- a/tests/test_suites/SanityChecks/test_quota_size.sh
+++ b/tests/test_suites/SanityChecks/test_quota_size.sh
@@ -18,8 +18,8 @@ one_chunk_file_size=$(sfs_dir_info size file_chunk)
 soft=$((2*one_kb_file_size))
 hard=$((3*one_kb_file_size))
 
-saunafs setquota -g $gid1 $soft $hard 0 0 .
-saunafs setquota -g $gid $soft $hard 0 0 .
+saunafs_command setquota -g $gid1 $soft $hard 0 0 .
+saunafs_command setquota -g $gid $soft $hard 0 0 .
 
 verify_quota "Group $gid1 -- 0 $soft $hard 0 0 0" saunafstest_1
 verify_quota "Group $gid -- 0 $soft $hard 0 0 0" saunafstest
@@ -55,18 +55,18 @@ verify_quota "Group $gid1 +- $((one_kb_file_size + one_chunk_file_size)) $soft $
 verify_quota "Group $gid -- $one_kb_file_size $soft $hard 1 0 0" saunafstest
 
 # check if snapshots are properly handled:
-saunafs makesnapshot file_2 snapshot_1
+saunafs_command makesnapshot file_2 snapshot_1
 verify_quota "Group $gid -- $soft $soft $hard 2 0 0" saunafstest
 
 # BTW, check if '+' for soft limit is properly printed..
-saunafs setquota -g $gid $((soft-1)) $hard 0 0 .
+saunafs_command setquota -g $gid $((soft-1)) $hard 0 0 .
 verify_quota "Group $gid +- $soft $((soft-1)) $hard 2 0 0" saunafstest
-saunafs setquota -g $gid $soft $hard 0 0 .  # .. OK, come back to the previous limit
+saunafs_command setquota -g $gid $soft $hard 0 0 .  # .. OK, come back to the previous limit
 
 # snapshots continued..
-saunafs makesnapshot file_2 snapshot_2
+saunafs_command makesnapshot file_2 snapshot_2
 verify_quota "Group $gid +- $hard $soft $hard 3 0 0" saunafstest
-expect_failure saunafs makesnapshot file_2 snapshot_3
+expect_failure saunafs_command makesnapshot file_2 snapshot_3
 
 # verify that we can't create new chunks by 'splitting' a chunk shared by multiple files
 expect_failure sudo -nu saunafstest_1 dd if=/dev/zero of=snapshot_2 bs=1k count=1 conv=notrunc

--- a/tests/test_suites/SanityChecks/test_snapshot.sh
+++ b/tests/test_suites/SanityChecks/test_snapshot.sh
@@ -6,17 +6,17 @@ CHUNKSERVERS=4 \
 # Create small files of goals 2 and xor3
 cd "${info[mount0]}"
 touch file{1..2}
-saunafs setgoal 2 file1
-saunafs setgoal xor3 file2
+saunafs_command setgoal 2 file1
+saunafs_command setgoal xor3 file2
 FILE_SIZE=1M file-generate file1
 FILE_SIZE=1M file-generate file2
 assert_success file-validate file*
 assert_equals 6 $(find_all_metadata_chunks | wc -l)
 
 # Create some snapshots of this file
-saunafs makesnapshot file1 file1_snapshot1
-saunafs makesnapshot file2 file2_snapshot1
-saunafs makesnapshot file2 file2_snapshot2
+saunafs_command makesnapshot file1 file1_snapshot1
+saunafs_command makesnapshot file2 file2_snapshot1
+saunafs_command makesnapshot file2 file2_snapshot2
 assert_success file-validate file*
 assert_equals 6 $(find_all_metadata_chunks | wc -l)
 

--- a/tests/test_suites/ShortSystemTests/test_recursive_remove.sh
+++ b/tests/test_suites/ShortSystemTests/test_recursive_remove.sh
@@ -24,13 +24,13 @@ function dirgenerate() {
 
 cd "${info[mount0]}"
 mkdir test
-saunafs setgoal ec test
-saunafs settrashtime 0 test
+saunafs_command setgoal ec test
+saunafs_command settrashtime 0 test
 
 cd test
 dirgenerate 8 a
 cd ..
-saunafs rremove test
+saunafs_command rremove test
 
 testfile="${info[mount0]}/test"
 
@@ -38,8 +38,8 @@ assert_eventually " [ ! -e "$testfile" ] " "3 seconds"
 
 # Testing removing files by multiple users
 mkdir test2
-saunafs setgoal ec test2
-saunafs settrashtime 0 test2
+saunafs_command setgoal ec test2
+saunafs_command settrashtime 0 test2
 
 cd test2
 dirgenerate 10 a
@@ -47,9 +47,9 @@ cd ..
 
 test0="${info[mount0]}/test2"
 
-(saunafs rremove "${test0}/root10_a/root9_left") &
-(saunafs rremove "${test0}/root10_a/root9_right/root8_left") &
+(saunafs_command rremove "${test0}/root10_a/root9_left") &
+(saunafs_command rremove "${test0}/root10_a/root9_right/root8_left") &
 wait
-saunafs rremove "${test0}"
+saunafs_command rremove "${test0}"
 
 assert_eventually " [ ! -e "$test0" ] " "3 seconds"

--- a/tests/test_suites/ShortSystemTests/test_sfsmakesnapshot.sh
+++ b/tests/test_suites/ShortSystemTests/test_sfsmakesnapshot.sh
@@ -14,13 +14,13 @@ cd "${info[mount0]}"
 mkdir dir1
 for i in 2 3; do
 	touch dir1/file$i
-	saunafs setgoal $i dir1/file$i
+	saunafs_command setgoal $i dir1/file$i
 	echo "$i$i$i" > dir1/file$i
 done
 assert_equals 5 $(find_all_metadata_chunks | wc -l) # First file has 2 chunks, the second one -- 3
 
 # Test saunafs makesnapshot of the whole directory
-assert_success saunafs makesnapshot dir1 dir2
+assert_success saunafs_command makesnapshot dir1 dir2
 expect_equals "$(ls dir1 | sort)" "$(ls dir2 | sort)"
 expect_files_equal dir1/file2 dir2/file2
 expect_files_equal dir1/file3 dir2/file3
@@ -28,14 +28,14 @@ expect_equals 5 $(find_all_metadata_chunks | wc -l)
 
 # Test saunafs makesnapshot of directory content
 mkdir dir3
-assert_success saunafs makesnapshot dir1/ dir3
+assert_success saunafs_command makesnapshot dir1/ dir3
 expect_equals "$(ls dir1 | sort)" "$(ls dir3 | sort)"
 expect_files_equal dir1/file2 dir3/file2
 expect_files_equal dir1/file3 dir3/file3
 expect_equals 5 $(find_all_metadata_chunks | wc -l)
 
 # Test saunafs makesnapshot of the whole directory into other directory
-assert_success saunafs makesnapshot dir1 dir3
+assert_success saunafs_command makesnapshot dir1 dir3
 expect_equals "$({ ls dir1; echo dir1; } | sort)" "$(ls dir3 | sort)"
 expect_equals "$(ls dir1 | sort)" "$(ls dir3/dir1 | sort)"
 expect_files_equal dir1/file2 dir3/dir1/file2
@@ -43,49 +43,49 @@ expect_files_equal dir1/file3 dir3/dir1/file3
 expect_equals 5 $(find_all_metadata_chunks | wc -l)
 
 # Test saunafs makesnapshot -o on a file which should overwrite some other file
-assert_success saunafs makesnapshot -o dir1/file3 dir2/file2
+assert_success saunafs_command makesnapshot -o dir1/file3 dir2/file2
 expect_files_equal dir1/file3 dir2/file2
-expect_equals 3 "$(saunafs getgoal dir2/file2 | awk '{print $2}')"
+expect_equals 3 "$(saunafs_command getgoal dir2/file2 | awk '{print $2}')"
 expect_equals 5 $(find_all_metadata_chunks | wc -l)
 
 # Test some wrong invocations
-expect_failure saunafs makesnapshot dir1/file3 dir3/file2     # No -o
-expect_failure saunafs makesnapshot dir1/file3 dir3/file2/    # No -o and a trailing slash
-expect_failure saunafs makesnapshot -o dir1/file3 dir3/file2/ # Trailing slash prevents from this
+expect_failure saunafs_command makesnapshot dir1/file3 dir3/file2     # No -o
+expect_failure saunafs_command makesnapshot dir1/file3 dir3/file2/    # No -o and a trailing slash
+expect_failure saunafs_command makesnapshot -o dir1/file3 dir3/file2/ # Trailing slash prevents from this
 expect_files_equal dir1/file2 dir3/file2                 # Nothing should be changed in dir3/file2!
 expect_equals 5 $(find_all_metadata_chunks | wc -l)
 
 # Snapshot of a dir, destination is a file
-expect_failure saunafs makesnapshot dir1  dir3/file2
-expect_failure saunafs makesnapshot dir1/ dir3/file2
-expect_failure saunafs makesnapshot dir1  -o dir3/file2
-expect_failure saunafs makesnapshot dir1/ -o dir3/file2
+expect_failure saunafs_command makesnapshot dir1  dir3/file2
+expect_failure saunafs_command makesnapshot dir1/ dir3/file2
+expect_failure saunafs_command makesnapshot dir1  -o dir3/file2
+expect_failure saunafs_command makesnapshot dir1/ -o dir3/file2
 expect_files_equal dir1/file2 dir3/file2                 # Nothing should be changed in dir3/file2!
 expect_equals 5 $(find_all_metadata_chunks | wc -l)
 
 # Test multiple goals for chunks shared by snapshots
-assert_success saunafs setgoal -r l0l1 dir3
-assert_eventually_prints '2' 'saunafs fileinfo dir3/file2 | grep copy | wc -l'
+assert_success saunafs_command setgoal -r l0l1 dir3
+assert_eventually_prints '2' 'saunafs_command fileinfo dir3/file2 | grep copy | wc -l'
 
-assert_success saunafs makesnapshot dir3 dir4
-assert_eventually_prints '2' 'saunafs fileinfo dir4/file2 | grep copy | wc -l'
+assert_success saunafs_command makesnapshot dir3 dir4
+assert_eventually_prints '2' 'saunafs_command fileinfo dir4/file2 | grep copy | wc -l'
 
-assert_success saunafs setgoal -r l1l2 dir4
-assert_eventually_prints '3' 'saunafs fileinfo dir3/file2 | grep copy | wc -l'
-assert_eventually_prints '3' 'saunafs fileinfo dir4/file2 | grep copy | wc -l'
+assert_success saunafs_command setgoal -r l1l2 dir4
+assert_eventually_prints '3' 'saunafs_command fileinfo dir3/file2 | grep copy | wc -l'
+assert_eventually_prints '3' 'saunafs_command fileinfo dir4/file2 | grep copy | wc -l'
 
-assert_success saunafs makesnapshot dir4 dir5
-assert_eventually_prints '3' 'saunafs fileinfo dir3/file2 | grep copy | wc -l'
-assert_eventually_prints '3' 'saunafs fileinfo dir4/file2 | grep copy | wc -l'
-assert_eventually_prints '3' 'saunafs fileinfo dir5/file2 | grep copy | wc -l'
+assert_success saunafs_command makesnapshot dir4 dir5
+assert_eventually_prints '3' 'saunafs_command fileinfo dir3/file2 | grep copy | wc -l'
+assert_eventually_prints '3' 'saunafs_command fileinfo dir4/file2 | grep copy | wc -l'
+assert_eventually_prints '3' 'saunafs_command fileinfo dir5/file2 | grep copy | wc -l'
 
-assert_success saunafs setgoal -r 3 dir5
-assert_eventually_prints '3' 'saunafs fileinfo dir3/file2 | grep copy | wc -l'
-assert_eventually_prints '3' 'saunafs fileinfo dir4/file2 | grep copy | wc -l'
-assert_eventually_prints '3' 'saunafs fileinfo dir5/file2 | grep copy | wc -l'
+assert_success saunafs_command setgoal -r 3 dir5
+assert_eventually_prints '3' 'saunafs_command fileinfo dir3/file2 | grep copy | wc -l'
+assert_eventually_prints '3' 'saunafs_command fileinfo dir4/file2 | grep copy | wc -l'
+assert_eventually_prints '3' 'saunafs_command fileinfo dir5/file2 | grep copy | wc -l'
 
-assert_success saunafs setgoal -r 4 dir4
-assert_eventually_prints '4' 'saunafs fileinfo dir3/file2 | grep copy | wc -l'
-assert_eventually_prints '4' 'saunafs fileinfo dir4/file2 | grep copy | wc -l'
-assert_eventually_prints '4' 'saunafs fileinfo dir5/file2 | grep copy | wc -l'
+assert_success saunafs_command setgoal -r 4 dir4
+assert_eventually_prints '4' 'saunafs_command fileinfo dir3/file2 | grep copy | wc -l'
+assert_eventually_prints '4' 'saunafs_command fileinfo dir4/file2 | grep copy | wc -l'
+assert_eventually_prints '4' 'saunafs_command fileinfo dir5/file2 | grep copy | wc -l'
 

--- a/tests/tools/config.sh
+++ b/tests/tools/config.sh
@@ -51,6 +51,7 @@ if is_windows_system; then
 	export PATH="$(get_windows_homepath)/SaunaFS:/mnt/c/Windows/System32:$PATH"
 	export SAFS_MOUNT_COMMAND="sfsmount.exe"
 	export SAFS_ADMIN_COMMAND="saunafs-admin.exe"
+	export SAFS_SAUNAFS_COMMAND="saunafs.exe"
 fi
 
 # Quick checks needed to call test_begin and test_fail

--- a/tests/tools/saunafs.sh
+++ b/tests/tools/saunafs.sh
@@ -140,6 +140,15 @@ saunafs_admin_command() {
 	return ${PIPESTATUS[0]}
 }
 
+saunafs_command() {
+	if is_windows_system; then
+		${SAFS_SAUNAFS_COMMAND} "$@" | tr -d '\r'
+	else
+		saunafs "$@"
+	fi
+	return ${PIPESTATUS[0]}
+}
+
 saunafs_fusermount() {
 	fusermount3 "$@"
 }
@@ -779,7 +788,7 @@ sfs_dir_info() {
 	fi
 	field=$1
 	file=$2
-	saunafs dirinfo "$file" | grep -w "$field" | grep -o '[0-9]*'
+	saunafs_command dirinfo "$file" | grep -w "$field" | grep -o '[0-9]*'
 }
 
 find_first_chunkserver_with_chunks_matching() {


### PR DESCRIPTION
Previous changes for tests for the saunafs command on for Windows were having a flaky behavior for changes from commit bd88d8b. Due to that, the changes from that commit were reverted in commit 8f2b674. This commit reintroduces the corresponding changes so that this needed fixes for the saunafs command tests on Windows are applied again.