### PR TITLE
Fix: Correct quota per directory calculation

### DIFF
--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -2054,16 +2054,37 @@ void matoclserv_sau_get_self_quota(matoclserventry *eptr, const uint8_t *data, u
 	std::vector<std::string> info;
 	uint8_t status;
 	deserializePacketVersionNoHeader(data, length, version);
-	
+
+	auto foundContextRootInodeResult = [&](uint32_t rootInode) {
+		for (const auto &result : results) {
+			if (result.entryKey.owner.ownerType == QuotaOwnerType::kInode && 
+				result.entryKey.owner.ownerId == rootInode) {
+				return true;
+			}
+		}
+		return false;
+	};
+
 	std::vector<QuotaOwner> owners;
 	cltoma::fuseGetSelfQuota::deserialize(data, length, messageId, uid, gid);
 	status = matoclserv_check_group_cache(eptr, gid);
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
+		uint32_t rootInode = context.rootinode();
 		owners.emplace_back(QuotaOwnerType::kUser, uid);
 		owners.emplace_back(QuotaOwnerType::kGroup, gid);
-		owners.emplace_back(QuotaOwnerType::kInode, context.rootinode());
+		owners.emplace_back(QuotaOwnerType::kInode, rootInode);
 		status = fs_quota_get(context, owners, results);
+
+		if (!foundContextRootInodeResult(rootInode)) {
+			auto ino = fsnodes_id_to_node(rootInode);
+			statsrecord rootInodeStatRec;
+			fsnodes_get_stats(ino, &rootInodeStatRec);
+			results.emplace_back(
+				QuotaEntry{QuotaEntryKey{QuotaOwner{QuotaOwnerType::kInode, rootInode},
+											QuotaRigor::kUsed, QuotaResource::kSize},
+											rootInodeStatRec.size});
+		}
 	}
 
 	MessageBuffer reply;

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -2049,7 +2049,7 @@ void matoclserv_sau_full_path_by_inode(matoclserventry *eptr, const uint8_t *dat
 }
 
 void matoclserv_sau_get_self_quota(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
-	uint32_t version, messageId, uid, gid;
+	uint32_t version, messageId, uid, gid, inode;
 	std::vector<QuotaEntry> results;
 	std::vector<std::string> info;
 	uint8_t status;
@@ -2066,22 +2066,24 @@ void matoclserv_sau_get_self_quota(matoclserventry *eptr, const uint8_t *data, u
 	};
 
 	std::vector<QuotaOwner> owners;
-	cltoma::fuseGetSelfQuota::deserialize(data, length, messageId, uid, gid);
+	cltoma::fuseGetSelfQuota::deserialize(data, length, messageId, uid, gid, inode);
 	status = matoclserv_check_group_cache(eptr, gid);
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		uint32_t rootInode = context.rootinode();
+		if (inode == SPECIAL_INODE_ROOT) {
+			inode = context.rootinode();
+		}
 		owners.emplace_back(QuotaOwnerType::kUser, uid);
 		owners.emplace_back(QuotaOwnerType::kGroup, gid);
-		owners.emplace_back(QuotaOwnerType::kInode, rootInode);
+		owners.emplace_back(QuotaOwnerType::kInode, inode);
 		status = fs_quota_get(context, owners, results);
 
-		if (!foundContextRootInodeResult(rootInode)) {
-			auto ino = fsnodes_id_to_node(rootInode);
+		if (inode == context.rootinode() && !foundContextRootInodeResult(inode)) {
+			auto ino = fsnodes_id_to_node(inode);
 			statsrecord rootInodeStatRec;
 			fsnodes_get_stats(ino, &rootInodeStatRec);
 			results.emplace_back(
-				QuotaEntry{QuotaEntryKey{QuotaOwner{QuotaOwnerType::kInode, rootInode},
+				QuotaEntry{QuotaEntryKey{QuotaOwner{QuotaOwnerType::kInode, inode},
 											QuotaRigor::kUsed, QuotaResource::kSize},
 											rootInodeStatRec.size});
 		}

--- a/src/mount/mastercomm.cc
+++ b/src/mount/mastercomm.cc
@@ -3126,7 +3126,7 @@ uint8_t fs_makesnapshot(uint32_t src_inode, uint32_t dst_inode, const std::strin
 	}
 }
 
-uint8_t fs_get_self_quota(uint32_t uid, uint32_t gid, std::vector<QuotaEntry> &quotaEntries) {
+uint8_t fs_get_self_quota(uint32_t uid, uint32_t gid, uint32_t inode, std::vector<QuotaEntry> &quotaEntries) {
 	threc *rec = fs_get_my_threc();
 	if (masterversion < saunafsVersion(4, 9, 0)) {
 		safs::log_warn(
@@ -3135,7 +3135,7 @@ uint8_t fs_get_self_quota(uint32_t uid, uint32_t gid, std::vector<QuotaEntry> &q
 		    saunafsVersionToString(masterversion));
 		return SAUNAFS_ERROR_ENOTSUP;
 	}
-	auto message = cltoma::fuseGetSelfQuota::build(rec->packetId, uid, gid);
+	auto message = cltoma::fuseGetSelfQuota::build(rec->packetId, uid, gid, inode);
 
 	if (!fs_saucreatepacket(rec, message)) {
 		return SAUNAFS_ERROR_IO;

--- a/src/mount/mastercomm.h
+++ b/src/mount/mastercomm.h
@@ -121,7 +121,7 @@ void fs_setlk_interrupt(const safs_locks::InterruptData &data);
 
 uint8_t fs_makesnapshot(uint32_t src_inode, uint32_t dst_parent, const std::string &dst_name,
 	                uint32_t uid, uint32_t gid, uint8_t can_overwrite, uint32_t &job_id);
-uint8_t fs_get_self_quota(uint32_t uid, uint32_t gid,
+uint8_t fs_get_self_quota(uint32_t uid, uint32_t gid, uint32_t inode,
                           std::vector<QuotaEntry> &quota_entries);
 uint8_t fs_getgoal(uint32_t inode, std::string &goal);
 uint8_t fs_setgoal(uint32_t inode, uint32_t uid, const std::string &goal_name, uint8_t smode);

--- a/src/mount/sauna_client.cc
+++ b/src/mount/sauna_client.cc
@@ -734,7 +734,7 @@ struct statvfs statfs(Context &ctx, Inode ino) {
 		std::vector<QuotaEntry> quota_entries;
 		auto gid = ctx.gids[0];
 
-		auto status = fs_get_self_quota(ctx.uid, gid, quota_entries);
+		auto status = fs_get_self_quota(ctx.uid, gid, ino, quota_entries);
 		if (status == SAUNAFS_STATUS_OK) {
 			uint64_t userUsedSpace = 0;
 			uint64_t userTotalSpace = std::numeric_limits<uint64_t>::max();

--- a/src/mount/sauna_client.cc
+++ b/src/mount/sauna_client.cc
@@ -785,7 +785,7 @@ struct statvfs statfs(Context &ctx, Inode ino) {
 			uint64_t inodeAvailSpace = inodeTotalSpace - inodeUsedSpace;
 			availspace =
 			    std::min({userAvailSpace, inodeAvailSpace, groupAvailSpace, availspace});
-			totalspace = userUsedSpace + availspace;
+			totalspace = inodeUsedSpace + availspace;
 		}
 	}
 

--- a/src/protocol/cltoma.h
+++ b/src/protocol/cltoma.h
@@ -360,7 +360,8 @@ SAUNAFS_DEFINE_PACKET_SERIALIZATION(
 		cltoma, fuseGetSelfQuota, SAU_CLTOMA_FUSE_GET_SELF_QUOTA, 0,
 		uint32_t, messageId,
 		uint32_t, uid,
-		uint32_t, gid)
+		uint32_t, gid,
+		uint32_t, inode)
 
 SAUNAFS_DEFINE_PACKET_SERIALIZATION(
 		cltoma, recursiveRemove, SAU_CLTOMA_RECURSIVE_REMOVE, 0,

--- a/tests/test_suites/ShortSystemTests/test_quota_in_volume_size_stat_update.sh
+++ b/tests/test_suites/ShortSystemTests/test_quota_in_volume_size_stat_update.sh
@@ -1,0 +1,48 @@
+timeout_set 40 seconds
+
+check_stat() {
+    dir=$1
+    total_expected=$2
+    free_expected=$3
+
+    stat_output=$(stat -f "$dir")
+    block_size=$(echo "$stat_output" | grep "Block size" | awk '{print $3}')
+    blocks_total=$(echo "$stat_output" | grep "Blocks: Total" | awk '{print $3}')
+    blocks_free=$(echo "$stat_output" | grep "Blocks: Free" | awk '{print $3}')
+
+    total_calculated=$((total_expected / block_size))
+    free_calculated=$((free_expected / block_size))
+
+    echo "Directory: $dir"
+    echo "Expected Blocks Total: $total_calculated, Actual: $blocks_total"
+    echo "Expected Blocks Free: $free_calculated, Actual: $blocks_free"
+}
+
+CHUNKSERVERS=1 \
+	USE_RAMDISK=YES \
+	SFSEXPORTS_EXTRA_OPTIONS="allcanchangequota" \
+	MOUNT_EXTRA_CONFIG="usequotainvolumesize=1,statfscachetimeout=1,sfsreportreservedperiod=1" \
+	setup_local_empty_saunafs info
+
+cd "${info[mount0]}"
+
+# Test stat command updated capacity
+mkdir -p ./app1 ./app2/nested
+saunafs setquota -d 0 1G 0 0 ./app1
+saunafs setquota -d 0 2G 0 0 ./app2
+head -c 100M /dev/random > ./app1/app1_file
+head -c 100M /dev/random > ./app2/app2_file
+head -c 100M /dev/random > ./app2/nested/app2_nested_file
+
+stat -f ./app1
+stat -f ./app2
+stat -f ./app2/nested
+
+# Check ./app1, expect 1GB total and 900MB free
+check_stat ./app1 $((1024 * 1024 * 1024)) $((900 * 1024 * 1024))
+
+# Check ./app2, expect 2GB total and 1800MB free
+check_stat ./app2 $((2 * 1024 * 1024 * 1024)) $((1800 * 1024 * 1024))
+
+# Check ./app2/nested, expect 2GB total and 1800MB free
+check_stat ./app2/nested $((2 * 1024 * 1024 * 1024)) $((1800 * 1024 * 1024))


### PR DESCRIPTION
Previous changes related to adding quotas per directory as part of the volume size calculation did not correctly display the used space when a quota was set on the root directory. This issue was specifically observed on the Windows client. This commit resolves the issue.