### PR TITLE
Fix chunkserver locking

### DIFF
--- a/src/chunkserver/chunkserver-common/hdd_utils.cc
+++ b/src/chunkserver/chunkserver-common/hdd_utils.cc
@@ -71,7 +71,6 @@ void hddChunkRelease(IChunk *chunk) {
 	} else if (chunk->state() == ChunkState::ToBeDeleted) {
 		if (chunk->condVar()) {
 			chunk->setState(ChunkState::Deleted);
-			chunksMapUniqueLock.unlock();
 			chunk->condVar()->condVar.notify_one();
 		} else {
 			hddRemoveChunkFromContainers(chunk);

--- a/src/chunkserver/hddspacemgr.cc
+++ b/src/chunkserver/hddspacemgr.cc
@@ -770,6 +770,7 @@ int hddRead(uint64_t chunkId, uint32_t version, ChunkPartType chunkType,
 					               chunk->fullDataFilename().c_str(), initialBlock,
 					               initialBlock + numBlocks - 1);
 					hddReportDamagedChunk(chunk->id(), chunk->type());
+					hddChunkRelease(chunk);
 					return SAUNAFS_ERROR_IO;
 				}
 			}
@@ -795,6 +796,10 @@ int hddRead(uint64_t chunkId, uint32_t version, ChunkPartType chunkType,
 
 	// The remaining must be within a block
 	if (offsetWithinBlock + size > SFSBLOCKSIZE) {
+		safs::log_warn(
+		    "hddRead: partial block read bigger than block size: offset in block: {}, size: {}",
+		    offsetWithinBlock, size);
+		hddChunkRelease(chunk);
 		return SAUNAFS_ERROR_WRONGSIZE;
 	}
 

--- a/tests/tools/valgrind-helgrind.supp
+++ b/tests/tools/valgrind-helgrind.supp
@@ -66,7 +66,7 @@
    # False positive about gPollTimeout (not atomic to avoid not needed overhead)
    poll_timeout_loading
    Helgrind:Race
-   fun:_Z27eventloop_load_poll_timeoutv
+   fun:*eventloop_load_poll_timeout*
    fun:_Z13eventloop_runv
    fun:main
 }


### PR DESCRIPTION
This change includes the following commits:
- Removal of unneeded mutex unlock before signaling a CV.
- Improve helgrind suppressions for GCC and Clang.
- Ensure the chunk is release even if the read failed (should fix pread_EIO related tests).

Co-authored-by: guillex <guillex@leil.io>

Signed-off-by: Dave <dave@leil.io>