### PR TITLE
fix(clang): Fix error when prometheus is disabled

### DIFF
--- a/src/metrics/metrics.cc
+++ b/src/metrics/metrics.cc
@@ -47,9 +47,6 @@
 #include "metrics/master.h"
 #include "slogger/slogger.h"
 
-
-constexpr auto THREAD_SLEEP_TIME_MS = 100;
-
 namespace metrics {
 
 std::unique_ptr<std::jthread>
@@ -69,6 +66,8 @@ void init(const char* /* unused */) {
 }
 }
 #else
+
+constexpr auto THREAD_SLEEP_TIME_MS = 100;
 
 class PrometheusMetrics {
 public:


### PR DESCRIPTION
Clang was reporting an unused resource when prometheus was disabled. This change moves the involved declaration to the block where it is used.