### PR TITLE
chore: Fix warning on chunkserver config file

### DIFF
--- a/src/data/sfschunkserver.cfg.in
+++ b/src/data/sfschunkserver.cfg.in
@@ -53,7 +53,7 @@
 
 ## Number of threads that the connection to master may use to process operations
 ## on chunks, like create, duplicate, replicate and truncate.
-(Default: 10, Minimum: 2)
+## (Default: 10, Minimum: 2)
 # MASTER_NR_OF_WORKERS = 10
 
 ## IP address to listen on for client (sfsmount) connections:


### PR DESCRIPTION
Removed warning from chunkserver default configuration file due to uncommented line interpreted as configuration data.