### PR TITLE
refactor(mount): Modernize pthread_mutex_t to std::mutex

### DIFF
--- a/src/mount/client_common.h
+++ b/src/mount/client_common.h
@@ -77,37 +77,6 @@ struct MagicFile {
 	bool wasWritten;
 };
 
-/**
- * A wrapper around pthread_mutex, acquiring a lock during construction and releasing it during
- * destruction in case if the lock wasn't released beforehand.
- */
-struct PthreadMutexWrapper {
-	PthreadMutexWrapper(pthread_mutex_t& mutex) : mutex_(mutex), locked_(true) {
-		pthread_mutex_lock(&mutex_);
-	}
-
-	~PthreadMutexWrapper() {
-		if (locked_) {
-			unlock();
-		}
-	}
-
-	void lock() {
-		sassert(!locked_);
-		locked_ = true;
-		pthread_mutex_lock(&mutex_);
-	}
-	void unlock() {
-		sassert(locked_);
-		locked_ = false;
-		pthread_mutex_unlock(&mutex_);
-	}
-
-private:
-	pthread_mutex_t& mutex_;
-	bool locked_;
-};
-
 namespace SaunaClient {
 void stats_inc(uint8_t id);
 

--- a/src/mount/fuse/sfs_meta_fuse.cc
+++ b/src/mount/fuse/sfs_meta_fuse.cc
@@ -50,14 +50,14 @@ struct dirbuf {
 	bool wasread;
 	uint8_t *p;
 	size_t size;
-	pthread_mutex_t lock;
+	std::mutex lock;
 };
 
 typedef struct _pathbuf {
 	int changed;
 	char *p;
 	size_t size;
-	pthread_mutex_t lock;
+	std::mutex lock;
 } pathbuf;
 
 #define READDIR_BUFFSIZE 50000
@@ -593,15 +593,7 @@ void sfs_meta_opendir(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
 	if (ino == SPECIAL_INODE_ROOT || ino == SPECIAL_INODE_META_TRASH ||
 	    ino == SPECIAL_INODE_META_UNDEL || ino == SPECIAL_INODE_META_RESERVED) {
 
-		if (!(dirinfo = (dirbuf*)malloc(sizeof(dirbuf)))) {
-			safs_pretty_syslog(LOG_EMERG, "out of memory");
-			return;
-		}
-
-		if (pthread_mutex_init(&(dirinfo->lock), NULL)) {
-			free(dirinfo);
-			return;
-		}
+		dirinfo = new dirbuf();
 
 		dirinfo->p = NULL;
 		dirinfo->size = 0;
@@ -611,10 +603,7 @@ void sfs_meta_opendir(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
 		if (fuse_reply_open(req,fi) == -ENOENT) {
 			fi->fh = 0;
 			free(dirinfo->p);
-			bool lock_destroy_failed = pthread_mutex_destroy(&(dirinfo->lock));
-			free(dirinfo);
-			if (lock_destroy_failed)
-				return;
+			delete dirinfo;
 		}
 	} else {
 		fuse_reply_err(req, ENOTDIR);
@@ -667,14 +656,13 @@ void sfs_meta_readdir(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off, st
 		fuse_reply_err(req,EINVAL);
 		return;
 	}
-	pthread_mutex_lock(&(dirinfo->lock));
+	std::lock_guard lock(dirinfo->lock);
 	if (!dirinfo->wasread || (dirinfo->wasread && off==0)) {
 		if (dirinfo->p!=NULL) {
 			free(dirinfo->p);
 		}
 		if (ino == SPECIAL_INODE_ROOT) {
 			replyDirReadRoot(req, off, size);
-			pthread_mutex_unlock(&(dirinfo->lock));
 			return;
 		}
 		dirbuf_meta_fill(dirinfo, ino);
@@ -714,17 +702,15 @@ void sfs_meta_readdir(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off, st
 		}
 		fuse_reply_buf(req,buffer,opos);
 	}
-	pthread_mutex_unlock(&(dirinfo->lock));
 }
 
 void sfs_meta_releasedir(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi) {
 	(void)ino;
 	dirbuf *dirinfo = (dirbuf *)((unsigned long)(fi->fh));
-	pthread_mutex_lock(&(dirinfo->lock));
-	pthread_mutex_unlock(&(dirinfo->lock));
-	pthread_mutex_destroy(&(dirinfo->lock));
+	dirinfo->lock.lock();
+	dirinfo->lock.unlock();
 	free(dirinfo->p);
-	free(dirinfo);
+	delete dirinfo;
 	fi->fh = 0;
 	fuse_reply_err(req,0);
 }
@@ -753,22 +739,13 @@ void sfs_meta_open(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi) {
 	if (status) {
 		fuse_reply_err(req, status);
 	} else {
-		if (!(pathinfo = (pathbuf*)malloc(sizeof(pathbuf)))) {
-			safs_pretty_syslog(LOG_EMERG, "out of memory");
-			return;
-		}
-
-		if (pthread_mutex_init(&(pathinfo->lock), NULL)) {
-			free(pathinfo);
-			return;
-		}
+		pathinfo = new pathbuf();
 
 		pathinfo->changed = 0;
 		pathinfo->size = strlen((char*)path) + 1;
 		if (!(pathinfo->p = (char*)malloc(pathinfo->size))) {
 			safs_pretty_syslog(LOG_EMERG, "out of memory");
-			pthread_mutex_destroy(&(pathinfo->lock));
-			free(pathinfo);
+			delete pathinfo;
 			return;
 		}
 		memcpy(pathinfo->p, path, pathinfo->size - 1);
@@ -778,9 +755,8 @@ void sfs_meta_open(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi) {
 
 		if (fuse_reply_open(req, fi) == -ENOENT) {
 			fi->fh = 0;
-			pthread_mutex_destroy(&(pathinfo->lock));
 			free(pathinfo->p);
-			free(pathinfo);
+			delete pathinfo;
 		}
 	}
 }
@@ -791,7 +767,7 @@ void sfs_meta_release(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
 		return;
 	}
 	pathbuf *pathinfo = (pathbuf *)((unsigned long)(fi->fh));
-	pthread_mutex_lock(&(pathinfo->lock));
+	std::unique_lock lock(pathinfo->lock);
 	if (pathinfo->changed) {
 		if (pathinfo->p[pathinfo->size-1]=='\n') {
 			pathinfo->p[pathinfo->size-1]=0;
@@ -801,10 +777,9 @@ void sfs_meta_release(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
 		}
 		fs_settrashpath(ino,(uint8_t*)pathinfo->p);
 	}
-	pthread_mutex_unlock(&(pathinfo->lock));
-	pthread_mutex_destroy(&(pathinfo->lock));
+	lock.unlock();
 	free(pathinfo->p);
-	free(pathinfo);
+	delete pathinfo;
 	fi->fh = 0;
 	fuse_reply_err(req,0);
 }
@@ -835,9 +810,9 @@ void sfs_meta_read(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off, struc
 		fuse_reply_err(req,EBADF);
 		return;
 	}
-	pthread_mutex_lock(&(pathinfo->lock));
+	std::unique_lock lock(pathinfo->lock);
 	if (off<0) {
-		pthread_mutex_unlock(&(pathinfo->lock));
+		lock.unlock();
 		fuse_reply_err(req,EINVAL);
 		return;
 	}
@@ -848,7 +823,6 @@ void sfs_meta_read(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off, struc
 	} else {
 		fuse_reply_buf(req, (pathinfo->p)+off,size);
 	}
-	pthread_mutex_unlock(&(pathinfo->lock));
 }
 
 void sfs_meta_write(fuse_req_t req, fuse_ino_t ino, const char *buf, size_t size, off_t off, struct fuse_file_info *fi) {
@@ -865,7 +839,7 @@ void sfs_meta_write(fuse_req_t req, fuse_ino_t ino, const char *buf, size_t size
 		fuse_reply_err(req,EINVAL);
 		return;
 	}
-	pthread_mutex_lock(&(pathinfo->lock));
+	std::unique_lock lock(pathinfo->lock);
 	if (pathinfo->changed==0) {
 		pathinfo->size = 0;
 	}
@@ -877,7 +851,7 @@ void sfs_meta_write(fuse_req_t req, fuse_ino_t ino, const char *buf, size_t size
 	}
 	memcpy((pathinfo->p)+off,buf,size);
 	pathinfo->changed = 1;
-	pthread_mutex_unlock(&(pathinfo->lock));
+	lock.unlock();
 	fuse_reply_write(req,size);
 }
 

--- a/src/mount/mastercomm.cc
+++ b/src/mount/mastercomm.cc
@@ -153,7 +153,7 @@ enum {
 	STATNODES
 };
 
-static uint64_t *statsptr[STATNODES];
+static std::vector<uint64_t *> statsptr(STATNODES);
 
 struct InitParams {
 	std::string bind_host;
@@ -198,22 +198,6 @@ void master_statsptr_init(void) {
 	statsptr[MASTER_BYTESRCVD] = stats_get_counterptr(stats_get_subnode(s,"bytes_received",0));
 	statsptr[MASTER_BYTESSENT] = stats_get_counterptr(stats_get_subnode(s,"bytes_sent",0));
 	statsptr[MASTER_CONNECTS] = stats_get_counterptr(stats_get_subnode(s,"reconnects",0));
-}
-
-void master_stats_inc(uint8_t id) {
-	if (id<STATNODES) {
-		stats_lock();
-		(*statsptr[id])++;
-		stats_unlock();
-	}
-}
-
-void master_stats_add(uint8_t id,uint64_t s) {
-	if (id<STATNODES) {
-		stats_lock();
-		(*statsptr[id])+=s;
-		stats_unlock();
-	}
 }
 
 static inline void setDisconnect(bool value) {
@@ -332,8 +316,8 @@ static bool fs_threc_flush(threc *rec) {
 	rec->received = false;
 	rec->sent = true;
 	lock.unlock();
-	master_stats_add(MASTER_BYTESSENT, size);
-	master_stats_inc(MASTER_PACKETSSENT);
+	stats_inc(MASTER_BYTESSENT, statsptr, size);
+	stats_inc(MASTER_PACKETSSENT, statsptr);
 	lastwrite = time(NULL);
 	return true;
 }
@@ -947,7 +931,7 @@ void fs_reconnect() {
 		fd=-1;
 		return;
 	}
-	master_stats_inc(MASTER_CONNECTS);
+	stats_inc(MASTER_CONNECTS, statsptr);
 	wptr = regbuff;
 	put32bit(&wptr,CLTOMA_FUSE_REGISTER);
 	put32bit(&wptr,73);
@@ -964,15 +948,15 @@ void fs_reconnect() {
 		fd=-1;
 		return;
 	}
-	master_stats_add(MASTER_BYTESSENT,16+64);
-	master_stats_inc(MASTER_PACKETSSENT);
+	stats_inc(MASTER_BYTESSENT, statsptr, 16 + 64);
+	stats_inc(MASTER_PACKETSSENT, statsptr);
 	if (tcptoread(fd,regbuff,8,1000)!=8) {
 		safs_pretty_syslog(LOG_WARNING,"master: register error (read header: %s)",strerr(tcpgetlasterror()));
 		tcpclose(fd);
 		fd=-1;
 		return;
 	}
-	master_stats_add(MASTER_BYTESRCVD,8);
+	stats_inc(MASTER_BYTESRCVD, statsptr, 8);
 	rptr = regbuff;
 	get32bit(&rptr, i);
 	if (i!=MATOCL_FUSE_REGISTER) {
@@ -994,8 +978,8 @@ void fs_reconnect() {
 		fd=-1;
 		return;
 	}
-	master_stats_add(MASTER_BYTESRCVD,i);
-	master_stats_inc(MASTER_PACKETSRCVD);
+	stats_inc(MASTER_BYTESRCVD, statsptr, i);
+	stats_inc(MASTER_PACKETSRCVD, statsptr);
 	rptr = regbuff;
 	if (rptr[0]!=0) {
 		sessionlost=1;
@@ -1077,8 +1061,8 @@ void* fs_nop_thread(void *arg) {
 					safs::log_warn("Failed to send ANTOAN_NOP to master");
 					disconnect = true;
 				} else {
-					master_stats_add(MASTER_BYTESSENT, kHeaderSize);
-					master_stats_inc(MASTER_PACKETSSENT);
+					stats_inc(MASTER_BYTESSENT, statsptr, kHeaderSize);
+					stats_inc(MASTER_PACKETSSENT, statsptr);
 				}
 				lastwrite = now;
 			}
@@ -1101,8 +1085,8 @@ void* fs_nop_thread(void *arg) {
 					safs::log_warn("Failed to send CLTOMA_FUSE_RESERVED_INODES to master");
 					disconnect = true;
 				} else {
-					master_stats_add(MASTER_BYTESSENT, inodesleng);
-					master_stats_inc(MASTER_PACKETSSENT);
+					stats_inc(MASTER_BYTESSENT, statsptr, inodesleng);
+					stats_inc(MASTER_PACKETSSENT, statsptr);
 				}
 
 				free(inodespacket);
@@ -1127,8 +1111,8 @@ void* fs_nop_thread(void *arg) {
 					safs::log_warn("Failed to send mount info to master");
 					disconnect = true;
 				} else {
-					master_stats_add(MASTER_BYTESSENT, messageLength);
-					master_stats_inc(MASTER_PACKETSSENT);
+					stats_inc(MASTER_BYTESSENT, statsptr, messageLength);
+					stats_inc(MASTER_PACKETSSENT, statsptr);
 				}
 			}
 		}
@@ -1157,7 +1141,7 @@ bool fs_append_from_master(MessageBuffer& buffer, uint32_t size) {
 		setDisconnect(true);
 		return false;
 	}
-	master_stats_add(MASTER_BYTESRCVD, size);
+	stats_inc(MASTER_BYTESRCVD, statsptr, size);
 	return true;
 }
 
@@ -1257,7 +1241,7 @@ void* fs_receive_thread(void *) {
 		if (!fs_deserialize_from_master(remainingBytes, packetHeader)) {
 			continue;
 		}
-		master_stats_inc(MASTER_PACKETSRCVD);
+		stats_inc(MASTER_PACKETSRCVD, statsptr);
 		remainingBytes = packetHeader.length;
 
 		{

--- a/src/mount/oplog.cc
+++ b/src/mount/oplog.cc
@@ -53,12 +53,12 @@ static fhentry *fhhead=NULL;
 static uint8_t opbuff[OPBUFFSIZE];
 static uint64_t writepos=0;
 static uint8_t waiting=0;
-static pthread_mutex_t opbufflock = PTHREAD_MUTEX_INITIALIZER;
-static pthread_cond_t nodata = PTHREAD_COND_INITIALIZER;
+static std::mutex opbufflock;
+static std::condition_variable noData;
 
 static time_t gConvTmHour = std::numeric_limits<time_t>::max(); // enforce update on first read
 static struct tm gConvTm;
-static pthread_mutex_t timelock = PTHREAD_MUTEX_INITIALIZER;
+static std::mutex timelock;
 #ifdef _WIN32
 static int debug_mode_;
 
@@ -81,7 +81,7 @@ static inline void oplog_put(uint8_t *buff,uint32_t leng) {
 		buff+=leng-OPBUFFSIZE;
 		leng=OPBUFFSIZE;
 	}
-	pthread_mutex_lock(&opbufflock);
+	std::lock_guard lock(opbufflock);
 	bpos = writepos%OPBUFFSIZE;
 	writepos+=leng;
 	if (bpos+leng>OPBUFFSIZE) {
@@ -92,10 +92,9 @@ static inline void oplog_put(uint8_t *buff,uint32_t leng) {
 	}
 	memcpy(opbuff+bpos,buff,leng);
 	if (waiting) {
-		pthread_cond_broadcast(&nodata);
+		noData.notify_all();
 		waiting=0;
 	}
-	pthread_mutex_unlock(&opbufflock);
 }
 
 static void get_time(timeval &tv, tm &ltime) {
@@ -104,14 +103,14 @@ static void get_time(timeval &tv, tm &ltime) {
 	time_t hour = tv.tv_sec / secs_per_hour;
 	unsigned secs_this_hour = tv.tv_sec % secs_per_hour;
 
-	pthread_mutex_lock(&timelock);
+	std::unique_lock lock(timelock);
 	if (hour != gConvTmHour) {
 		gConvTmHour = hour;
 		time_t convts = hour * secs_per_hour;
 		localtime_r(&convts, &gConvTm);
 	}
 	ltime = gConvTm;
-	pthread_mutex_unlock(&timelock);
+	lock.unlock();
 
 	assert(ltime.tm_sec == 0);
 	assert(ltime.tm_min == 0);
@@ -189,7 +188,7 @@ unsigned long oplog_newhandle(int hflag) {
 	fhentry *fhptr;
 	uint32_t bpos;
 
-	pthread_mutex_lock(&opbufflock);
+	std::lock_guard lock(opbufflock);
 	fhptr = (fhentry*) malloc(sizeof(fhentry));
 	fhptr->fh = nextfh++;
 	fhptr->refcount = 1;
@@ -216,18 +215,16 @@ unsigned long oplog_newhandle(int hflag) {
 	}
 	fhptr->next = fhhead;
 	fhhead = fhptr;
-	pthread_mutex_unlock(&opbufflock);
 	return fhptr->fh;
 }
 
-void oplog_releasehandle(unsigned long fh) {
-	fhentry **fhpptr,*fhptr;
-	pthread_mutex_lock(&opbufflock);
+void oplog_releasedata(unsigned long fh) {
+	fhentry **fhpptr, *fhptr;
 	fhpptr = &fhhead;
 	while ((fhptr = *fhpptr)) {
-		if (fhptr->fh==fh) {
+		if (fhptr->fh == fh) {
 			fhptr->refcount--;
-			if (fhptr->refcount==0) {
+			if (!fhptr->refcount) {
 				*fhpptr = fhptr->next;
 				free(fhptr);
 			} else {
@@ -237,16 +234,18 @@ void oplog_releasehandle(unsigned long fh) {
 			fhpptr = &(fhptr->next);
 		}
 	}
-	pthread_mutex_unlock(&opbufflock);
+}
+
+void oplog_releasehandle(unsigned long fh) {
+	std::lock_guard lock(opbufflock);
+	oplog_releasedata(fh);
 }
 
 void oplog_getdata(unsigned long fh,uint8_t **buff,uint32_t *leng,uint32_t maxleng) {
 	fhentry *fhptr;
 	uint32_t bpos;
-	struct timeval tv;
-	struct timespec ts;
 
-	pthread_mutex_lock(&opbufflock);
+	std::unique_lock lock(opbufflock);
 	for (fhptr=fhhead ; fhptr && fhptr->fh != fh ; fhptr=fhptr->next) {
 	}
 	if (fhptr==NULL) {
@@ -256,11 +255,8 @@ void oplog_getdata(unsigned long fh,uint8_t **buff,uint32_t *leng,uint32_t maxle
 	}
 	fhptr->refcount++;
 	while (fhptr->readpos>=writepos) {
-		gettimeofday(&tv,NULL);
-		ts.tv_sec = tv.tv_sec+1;
-		ts.tv_nsec = tv.tv_usec*1000;
 		waiting=1;
-		if (pthread_cond_timedwait(&nodata,&opbufflock,&ts)==ETIMEDOUT) {
+		if (noData.wait_for(lock, std::chrono::seconds(1)) == std::cv_status::timeout) {
 			*buff = (uint8_t*)"#\n";
 			*leng = 2;
 			return;
@@ -276,23 +272,6 @@ void oplog_getdata(unsigned long fh,uint8_t **buff,uint32_t *leng,uint32_t maxle
 		(*leng) = maxleng;
 	}
 	fhptr->readpos+=(*leng);
-}
 
-void oplog_releasedata(unsigned long fh) {
-	fhentry **fhpptr,*fhptr;
-	fhpptr = &fhhead;
-	while ((fhptr = *fhpptr)) {
-		if (fhptr->fh==fh) {
-			fhptr->refcount--;
-			if (fhptr->refcount==0) {
-				*fhpptr = fhptr->next;
-				free(fhptr);
-			} else {
-				fhpptr = &(fhptr->next);
-			}
-		} else {
-			fhpptr = &(fhptr->next);
-		}
-	}
-	pthread_mutex_unlock(&opbufflock);
+	oplog_releasedata(fh);
 }

--- a/src/mount/oplog.h
+++ b/src/mount/oplog.h
@@ -42,4 +42,3 @@ void oplog_printf(const char *format,...) __printflike(1, 2);
 unsigned long oplog_newhandle(int hflag);
 void oplog_releasehandle(unsigned long fh);
 void oplog_getdata(unsigned long fh,uint8_t **buff,uint32_t *leng,uint32_t maxleng);
-void oplog_releasedata(unsigned long fh);

--- a/src/mount/sauna_client.cc
+++ b/src/mount/sauna_client.cc
@@ -235,8 +235,8 @@ struct finfo {
 	void *data;
 	uint8_t use_flocks;
 	uint8_t use_posixlocks;
-	pthread_mutex_t lock;
-	pthread_mutex_t flushlock;
+	std::mutex lock;
+	std::mutex flushlock;
 };
 
 static DirEntryCache gDirEntryCache;
@@ -436,7 +436,7 @@ private:
 	bool locked_;
 };
 
-static uint64_t *statsptr[STATNODES];
+static std::vector<uint64_t *> statsptr(STATNODES);
 
 void statsptr_init(void) {
 	statsnode *s;
@@ -488,11 +488,7 @@ void statsptr_init(void) {
 }
 
 void stats_inc(uint8_t id) {
-	if (id < STATNODES) {
-		stats_lock();
-		(*statsptr[id])++;
-		stats_unlock();
-	}
+	::stats_inc(id, statsptr);
 }
 
 void type_to_stat(inode_t inode,uint8_t type, struct stat *stbuf) {
@@ -2086,19 +2082,8 @@ void releasedir(inode_t ino) {
 
 
 static finfo* fs_newfileinfo(uint8_t accmode, inode_t inode) {
-	finfo *fileinfo;
-	if (!(fileinfo = (finfo*)malloc(sizeof(finfo))))
-		throw RequestException(SAUNAFS_ERROR_OUTOFMEMORY);
-	if (pthread_mutex_init(&(fileinfo->flushlock), NULL)) {
-		free(fileinfo);
-		throw RequestException(SAUNAFS_ERROR_EPERM);
-	}
-	if (pthread_mutex_init(&(fileinfo->lock), NULL)) {
-		pthread_mutex_destroy(&(fileinfo->flushlock));
-		free(fileinfo);
-		throw RequestException(SAUNAFS_ERROR_EPERM);
-	}
-	PthreadMutexWrapper lock((fileinfo->lock)); // make helgrind happy
+	finfo *fileinfo = new finfo();
+	std::lock_guard lock((fileinfo->lock)); // make helgrind happy
 #ifdef __FreeBSD__
 	/* old FreeBSD fuse reads whole file when opening with O_WRONLY|O_APPEND,
 	 * so can't open it write-only */
@@ -2126,7 +2111,7 @@ static finfo* fs_newfileinfo(uint8_t accmode, inode_t inode) {
 
 void remove_file_info(FileInfo *f) {
 	finfo* fileinfo = (finfo*)(f->fh);
-	PthreadMutexWrapper lock(fileinfo->lock);
+	std::unique_lock lock(fileinfo->lock);
 	fileinfo->use_flocks = false;
 	fileinfo->use_posixlocks = false;
 	if (fileinfo->mode == IO_READONLY || fileinfo->mode == IO_READ) {
@@ -2135,9 +2120,8 @@ void remove_file_info(FileInfo *f) {
 		write_data_end(fileinfo->data);
 	}
 	lock.unlock(); // This unlock is needed, since we want to destroy the mutex
-	pthread_mutex_destroy(&(fileinfo->lock));
-	pthread_mutex_destroy(&(fileinfo->flushlock));
-	free(fileinfo);
+	pthread_mutex_destroy(fileinfo->lock.native_handle()); // Make helgrind happy
+	delete fileinfo;
 }
 
 EntryParam create(Context &ctx, inode_t parent, const char *name, mode_t mode,
@@ -2409,8 +2393,8 @@ ReadCache::Result read(Context &ctx,
 		safs_pretty_syslog(LOG_WARNING, "I/O limiting error: %s", ex.what());
 		throw RequestException(SAUNAFS_ERROR_IO);
 	}
-	PthreadMutexWrapper lock(fileinfo->lock);
-	PthreadMutexWrapper flushlock(fileinfo->flushlock);
+	std::lock_guard lock(fileinfo->lock);
+	std::unique_lock flushlock(fileinfo->flushlock);
 	if (fileinfo->mode==IO_WRITEONLY) {
 		oplog_printf(ctx, "read (%" PRIiNode ",%" PRIu64 ",%" PRIu64 "): %s",
 				ino,
@@ -2527,7 +2511,7 @@ BytesWritten write(Context &ctx, inode_t ino, const char *buf, size_t size, off_
 		safs_pretty_syslog(LOG_WARNING, "I/O limiting error: %s", ex.what());
 		throw RequestException(SAUNAFS_ERROR_IO);
 	}
-	PthreadMutexWrapper lock(fileinfo->lock);
+	std::lock_guard lock(fileinfo->lock);
 	if (fileinfo->mode==IO_READONLY) {
 		oplog_printf(ctx, "write (%" PRIiNode ",%" PRIu64 ",%" PRIu64 "): %s",
 				ino,
@@ -2602,7 +2586,7 @@ void flush(Context &ctx, inode_t ino, FileInfo* fi) {
 	}
 
 	err = SAUNAFS_STATUS_OK;
-	PthreadMutexWrapper lock(fileinfo->lock);
+	std::unique_lock lock(fileinfo->lock);
 	if (fileinfo->mode==IO_WRITE || fileinfo->mode==IO_WRITEONLY) {
 		err = write_data_flush(fileinfo->data);
 	}
@@ -2647,7 +2631,7 @@ void fsync(Context &ctx, inode_t ino, int datasync, FileInfo* fi) {
 		throw RequestException(SAUNAFS_ERROR_EBADF);
 	}
 	err = SAUNAFS_STATUS_OK;
-	PthreadMutexWrapper lock(fileinfo->lock);
+	std::lock_guard lock(fileinfo->lock);
 	if (fileinfo->mode==IO_WRITE || fileinfo->mode==IO_WRITEONLY) {
 		err = write_data_flush(fileinfo->data);
 	}
@@ -3417,7 +3401,7 @@ uint32_t setlk_send(Context &ctx, inode_t ino, FileInfo* fi, struct safs_locks::
 	lock_request_mutex.unlock();
 
 	if (fileinfo != NULL) {
-		PthreadMutexWrapper lock(fileinfo->lock);
+		std::lock_guard lock(fileinfo->lock);
 		fileinfo->use_posixlocks = true;
 	}
 
@@ -3466,7 +3450,7 @@ uint32_t flock_send(Context &ctx, inode_t ino, FileInfo* fi, int op) {
 	lock_request_mutex.unlock();
 
 	if (fileinfo != NULL) {
-		PthreadMutexWrapper lock(fileinfo->lock);
+		std::lock_guard lock(fileinfo->lock);
 		fileinfo->use_flocks = true;
 	}
 

--- a/src/mount/special_inode.h
+++ b/src/mount/special_inode.h
@@ -41,7 +41,7 @@ namespace InodeStats {
 		char *buff;
 		uint32_t leng;
 		uint8_t reset;
-		pthread_mutex_t lock;
+		std::mutex lock;
 	} sinfo;
 
 	extern const Attributes attr;

--- a/src/mount/special_open.cc
+++ b/src/mount/special_open.cc
@@ -45,19 +45,15 @@ static void open(const Context &ctx, FileInfo *fi) {
 
 namespace InodeStats {
 static void open(const Context &ctx, FileInfo *fi) {
-	sinfo *statsinfo;
-	statsinfo = (sinfo*) malloc(sizeof(sinfo));
+	auto *statsinfo = new sinfo();
 	if (!statsinfo) {
 		oplog_printf(ctx, "open (%" PRIiNode ") (internal node: STATS): %s",
 		            inode_,
 		            saunafs_error_string(SAUNAFS_ERROR_OUTOFMEMORY));
 		throw RequestException(SAUNAFS_ERROR_OUTOFMEMORY);
 	}
-	if (pthread_mutex_init(&(statsinfo->lock), NULL))  {
-		free(statsinfo);
-		throw RequestException(SAUNAFS_ERROR_EPERM);
-	}
-	PthreadMutexWrapper lock((statsinfo->lock));         // make helgrind happy
+
+	std::lock_guard lock(statsinfo->lock);         // make helgrind happy
 	stats_show_all(&(statsinfo->buff),&(statsinfo->leng));
 	statsinfo->reset = 0;
 	fi->fh = reinterpret_cast<uintptr_t>(statsinfo);

--- a/src/mount/special_read.cc
+++ b/src/mount/special_read.cc
@@ -83,7 +83,7 @@ static std::vector<uint8_t> read(const Context &ctx,
 	std::vector<uint8_t> ret;
 	sinfo *statsinfo = reinterpret_cast<sinfo*>(fi->fh);
 	if (statsinfo != NULL) {
-		PthreadMutexWrapper lock((statsinfo->lock));         // make helgrind happy
+		std::lock_guard lock(statsinfo->lock);         // make helgrind happy
 
 		if (off >= statsinfo->leng) {
 			printReadOplogNoData(ctx,
@@ -132,7 +132,6 @@ static std::vector<uint8_t> read(const Context &ctx,
 	uint32_t ssize;
 	uint8_t *buff;
 	oplog_getdata(fi->fh, &buff, &ssize, size);
-	oplog_releasedata(fi->fh);
 	return std::vector<uint8_t>(buff, buff + ssize);
 }
 } // InodeOplog
@@ -146,7 +145,6 @@ static std::vector<uint8_t> read(const Context &ctx,
 	uint32_t ssize;
 	uint8_t *buff;
 	oplog_getdata(fi->fh, &buff, &ssize, size);
-	oplog_releasedata(fi->fh);
 	return std::vector<uint8_t>(buff, buff + ssize);
 }
 } // InodeOphistory

--- a/src/mount/special_release.cc
+++ b/src/mount/special_release.cc
@@ -36,7 +36,7 @@ namespace InodeStats {
 static void release(FileInfo *fi) {
 	sinfo *statsinfo = reinterpret_cast<sinfo*>(fi->fh);
 	if (statsinfo!=NULL) {
-		PthreadMutexWrapper lock((statsinfo->lock));         // make helgrind happy
+		std::unique_lock lock(statsinfo->lock);         // make helgrind happy
 		if (statsinfo->buff!=NULL) {
 			free(statsinfo->buff);
 		}
@@ -44,8 +44,7 @@ static void release(FileInfo *fi) {
 			stats_reset_all();
 		}
 		lock.unlock(); // This unlock is needed, since we want to destroy the mutex
-		pthread_mutex_destroy(&(statsinfo->lock));      // make helgrind happy
-		free(statsinfo);
+		delete statsinfo;
 	}
 	oplog_printf("release (%" PRIiNode ") (internal node: STATS): OK", inode_);
 }

--- a/src/mount/special_write.cc
+++ b/src/mount/special_write.cc
@@ -42,7 +42,7 @@ static BytesWritten write(const Context &ctx, const char */*buf*/, size_t size,
 	                       off_t off, FileInfo *fi) {
 	sinfo *statsinfo = reinterpret_cast<sinfo*>(fi->fh);
 	if (statsinfo != NULL) {
-		PthreadMutexWrapper lock((statsinfo->lock));         // make helgrind happy
+		std::lock_guard lock(statsinfo->lock);         // make helgrind happy
 		statsinfo->reset = 1;
 	}
 	oplog_printf(ctx, "write (%" PRIiNode ",%" PRIu64 ",%" PRIu64 "): OK (%lu)",

--- a/src/mount/stats.cc
+++ b/src/mount/stats.cc
@@ -26,31 +26,26 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <mutex>
 
 static statsnode *firstnode = NULL;
 static uint32_t allactiveplengs = 0;
 static uint32_t activenodes = 0;
-static pthread_mutex_t glock = PTHREAD_MUTEX_INITIALIZER;
-
-void stats_lock(void) {
-	pthread_mutex_lock(&glock);
-}
-
-void stats_unlock(void) {
-	pthread_mutex_unlock(&glock);
-}
+static std::mutex glock;
 
 statsnode* stats_get_subnode(statsnode *node, const char *name, uint8_t absolute) {
-	stats_lock();
+	std::lock_guard lock(glock);
 
 	statsnode *a = node ? node->firstchild : firstnode;
 
 	for (; a; a = a->nextsibling)
-		if (!strcmp(a->name, name))
-			goto unlock_stats_and_exit;
+		if (!strcmp(a->name, name)) {
+			return a;
+		}
 
-	if (!(a = (statsnode*)malloc(sizeof(statsnode))))
-		goto unlock_stats_and_exit;
+	if (!(a = (statsnode*)malloc(sizeof(statsnode)))) {
+		return a;
+	}
 
 	a->nextsibling = node ? node->firstchild : firstnode;
 	a->firstchild = NULL;
@@ -67,7 +62,7 @@ statsnode* stats_get_subnode(statsnode *node, const char *name, uint8_t absolute
 		if (!(bstr = (char*)malloc(a->fnleng + 1))) {
 			free(a);
 			a = NULL;
-			goto unlock_stats_and_exit;
+			return a;
 		}
 
 		memcpy(bstr, node->fullname, node->fnleng);
@@ -80,18 +75,17 @@ statsnode* stats_get_subnode(statsnode *node, const char *name, uint8_t absolute
 		a->fnleng = a->nleng;
 	}
 
-	if (node)
+	if (node) {
 		node->firstchild = a;
-	else
+	} else {
 		firstnode = a;
+	}
 
-unlock_stats_and_exit:
-	stats_unlock();
 	return a;
 }
 
 uint64_t* stats_get_counterptr(statsnode *node) {
-	stats_lock();
+	std::lock_guard lock(glock);
 
 	if (!node->active) {
 		node->active = 1;
@@ -99,37 +93,37 @@ uint64_t* stats_get_counterptr(statsnode *node) {
 		activenodes++;
 	}
 
-	stats_unlock();
-
 	return &(node->counter);
 }
 
 static inline void stats_reset(statsnode *node) {
 	statsnode *a;
 
-	if (!node->absolute)
+	if (!node->absolute) {
 		node->counter = 0;
+	}
 
-	for (a = node->firstchild; a; a = a->nextsibling)
+	for (a = node->firstchild; a; a = a->nextsibling) {
 		stats_reset(a);
+	}
 }
 
 void stats_reset_all(void) {
 	statsnode *a;
-	stats_lock();
+	std::lock_guard lock(glock);
 
-	for (a = firstnode; a; a = a->nextsibling)
+	for (a = firstnode; a; a = a->nextsibling) {
 		stats_reset(a);
-
-	stats_unlock();
+	}
 }
 
 static inline uint32_t stats_print_values(char *buff, uint32_t maxleng, statsnode *n) {
-	uint32_t l = n->active ? snprintf(buff, maxleng, "%s: %" PRIu64 "\n", n->fullname, n->counter) : 0;
+	uint32_t l =
+	    n->active ? snprintf(buff, maxleng, "%s: %" PRIu64 "\n", n->fullname, n->counter) : 0;
 
-	for (statsnode *a = n->firstchild; a; a = a->nextsibling)
-		if (maxleng > l)
-			l += stats_print_values(buff + l, maxleng - l, a);
+	for (statsnode *a = n->firstchild; a; a = a->nextsibling) {
+		if (maxleng > l) { l += stats_print_values(buff + l, maxleng - l, a); }
+	}
 
 	return l;
 }
@@ -137,29 +131,30 @@ static inline uint32_t stats_print_values(char *buff, uint32_t maxleng, statsnod
 static inline uint32_t stats_print_total(char *buff, uint32_t maxleng) {
 	uint32_t l = 0;
 
-	for (statsnode *a = firstnode; a; a = a->nextsibling)
-		if (maxleng > l)
+	for (statsnode *a = firstnode; a; a = a->nextsibling) {
+		if (maxleng > l) {
 			l += stats_print_values(buff + l, maxleng - l, a);
+		}
+	}
 
 	return l;
 }
 
 void stats_show_all(char **buff, uint32_t *leng) {
-	stats_lock();
+	std::lock_guard lock(glock);
 
 	uint32_t rl = allactiveplengs + 23 * activenodes + 1;
 	*buff = (char*) malloc(rl);
 	*leng = *buff ? stats_print_total(*buff,rl) : 0;
-
-	stats_unlock();
 }
 
 void stats_free(statsnode *n) {
 	statsnode *a, *an;
 	free(n->name);
 
-	if (n->fullname != n->name)
+	if (n->fullname != n->name) {
 		free(n->fullname);
+	}
 
 	for (a = n->firstchild; a; a = an) {
 		an = a->nextsibling;
@@ -175,5 +170,19 @@ void stats_term(void) {
 		an = a->nextsibling;
 		stats_free(a);
 		free(a);
+	}
+}
+
+void stats_inc(uint8_t id, std::vector<uint64_t *> &statsptr, uint64_t inc) {
+	if (id < statsptr.size()) {
+		std::lock_guard lock(glock);
+		(*statsptr[id]) += inc;
+	}
+}
+
+void stats_dec(uint8_t id, std::vector<uint64_t *> &statsptr) {
+	if (id < statsptr.size()) {
+		std::lock_guard lock(glock);
+		(*statsptr[id])--;
 	}
 }

--- a/src/mount/stats.h
+++ b/src/mount/stats.h
@@ -23,6 +23,7 @@
 #include "common/platform.h"
 
 #include <inttypes.h>
+#include <vector>
 
 struct statsnode {
 	uint64_t counter;
@@ -40,6 +41,6 @@ statsnode* stats_get_subnode(statsnode *node, const char *name, uint8_t absolute
 uint64_t* stats_get_counterptr(statsnode *node);
 void stats_reset_all(void);
 void stats_show_all(char **buff, uint32_t *leng);
-void stats_lock(void);
-void stats_unlock(void);
 void stats_term(void);
+void stats_inc(uint8_t id, std::vector<uint64_t *> &statsptr, uint64_t inc = 1);
+void stats_dec(uint8_t id, std::vector<uint64_t *> &statsptr);

--- a/src/mount/symlinkcache.cc
+++ b/src/mount/symlinkcache.cc
@@ -21,12 +21,14 @@
 #include "common/platform.h"
 #include "mount/symlinkcache.h"
 
-#include <ctime>
 #include <inttypes.h>
 #include <pthread.h>
 #include <stdlib.h>
 #include <string.h>
+#include <ctime>
 #include <limits>
+#include <mutex>
+#include <vector>
 
 #include "common/type_defs.h"
 #include "protocol/SFSCommunication.h"
@@ -50,7 +52,7 @@ typedef struct _hashbucket {
 } hashbucket;
 
 static hashbucket *symlinkhash = NULL;
-static pthread_mutex_t slcachelock = PTHREAD_MUTEX_INITIALIZER;
+static std::mutex slcachelock;
 
 enum {
 	INSERTS = 0,
@@ -60,7 +62,7 @@ enum {
 	STATNODES
 };
 
-static uint64_t *statsptr[STATNODES];
+static std::vector<uint64_t *> statsptr(STATNODES);
 
 static inline void symlink_cache_statsptr_init(void) {
 	statsnode *s;
@@ -69,22 +71,6 @@ static inline void symlink_cache_statsptr_init(void) {
 	statsptr[SEARCH_HITS] = stats_get_counterptr(stats_get_subnode(s,"search_hits",0));
 	statsptr[SEARCH_MISSES] = stats_get_counterptr(stats_get_subnode(s,"search_misses",0));
 	statsptr[LINKS] = stats_get_counterptr(stats_get_subnode(s,"#links",1));
-}
-
-static inline void symlink_cache_stats_inc(uint8_t id) {
-	if (id<STATNODES) {
-		stats_lock();
-		(*statsptr[id])++;
-		stats_unlock();
-	}
-}
-
-static inline void symlink_cache_stats_dec(uint8_t id) {
-	if (id<STATNODES) {
-		stats_lock();
-		(*statsptr[id])--;
-		stats_unlock();
-	}
 }
 
 void symlink_cache_insert(inode_t inode,const uint8_t *path) {
@@ -99,8 +85,8 @@ void symlink_cache_insert(inode_t inode,const uint8_t *path) {
 	fi = 0;
 	fhb = NULL;
 
-	symlink_cache_stats_inc(INSERTS);
-	pthread_mutex_lock(&slcachelock);
+	stats_inc(INSERTS, statsptr);
+	std::lock_guard lock(slcachelock);
 	for (h=0 ; h<HASH_FUNCTIONS ; h++) {
 		hb = symlinkhash + ((inode*primes[h])%HASH_BUCKETS);
 		for (i=0 ; i<HASH_BUCKET_SIZE ; i++) {
@@ -110,7 +96,6 @@ void symlink_cache_insert(inode_t inode,const uint8_t *path) {
 				}
 				hb->path[i]=(uint8_t*)strdup((const char *)path);
 				hb->time[i]=now;
-				pthread_mutex_unlock(&slcachelock);
 				return;
 			}
 			if (hb->time[i]<mints) {
@@ -122,7 +107,7 @@ void symlink_cache_insert(inode_t inode,const uint8_t *path) {
 	}
 	if (fhb) {      // just sanity check
 		if (fhb->time[fi]==0) {
-			symlink_cache_stats_inc(LINKS);
+			stats_inc(LINKS, statsptr);
 		}
 		if (fhb->path[fi]) {
 			free(fhb->path[fi]);
@@ -131,7 +116,6 @@ void symlink_cache_insert(inode_t inode,const uint8_t *path) {
 		fhb->path[fi]=(uint8_t*)strdup((const char *)path);
 		fhb->time[fi]=now;
 	}
-	pthread_mutex_unlock(&slcachelock);
 }
 
 int symlink_cache_search(inode_t inode,const uint8_t **path) {
@@ -142,7 +126,7 @@ int symlink_cache_search(inode_t inode,const uint8_t **path) {
 
 	now = time(NULL);
 
-	pthread_mutex_lock(&slcachelock);
+	std::unique_lock lock(slcachelock);
 	for (h=0 ; h<HASH_FUNCTIONS ; h++) {
 		hb = symlinkhash + ((inode*primes[h])%HASH_BUCKETS);
 		for (i=0 ; i<HASH_BUCKET_SIZE ; i++) {
@@ -154,20 +138,20 @@ int symlink_cache_search(inode_t inode,const uint8_t **path) {
 					}
 					hb->time[i]=0;
 					hb->inode[i]=0;
-					pthread_mutex_unlock(&slcachelock);
-					symlink_cache_stats_dec(LINKS);
-					symlink_cache_stats_inc(SEARCH_MISSES);
+					lock.unlock();
+					stats_dec(LINKS, statsptr);
+					stats_inc(SEARCH_MISSES, statsptr);
 					return 0;
 				}
 				*path = hb->path[i];
-				pthread_mutex_unlock(&slcachelock);
-				symlink_cache_stats_inc(SEARCH_HITS);
+				lock.unlock();
+				stats_inc(SEARCH_HITS, statsptr);
 				return 1;
 			}
 		}
 	}
-	pthread_mutex_unlock(&slcachelock);
-	symlink_cache_stats_inc(SEARCH_MISSES);
+	lock.unlock();
+	stats_inc(SEARCH_MISSES, statsptr);
 	return 0;
 }
 
@@ -183,7 +167,7 @@ void symlink_cache_term(void) {
 	uint8_t i;
 	uint32_t hi;
 
-	pthread_mutex_lock(&slcachelock);
+	std::lock_guard lock(slcachelock);
 	for (hi=0 ; hi<HASH_BUCKETS ; hi++) {
 		hb = symlinkhash + hi;
 		for (i=0 ; i<HASH_BUCKET_SIZE ; i++) {
@@ -193,5 +177,4 @@ void symlink_cache_term(void) {
 		}
 	}
 	free(symlinkhash);
-	pthread_mutex_unlock(&slcachelock);
 }


### PR DESCRIPTION
List of changes:
- changed the pthread_mutex_t in several places for the modern
equivalent of std::mutex. This change also involved changing the
initialization and destruction scheme of several structures. As a
result the PthreadMutexWrapper was removed from our code.
- move the specific functions that were directly locking stats mutex
into the stats.cc file and substitute its occurrences for its
equivalent. Also, curly brackets were added and a goto: statement was
removed.
- a bit of extra refactor in the oplog.cc file: the pthread_cond_t was
modernized to std::condition_variable.

Co-authored-by: guillex <guillex@leil.io>

Signed-off-by: Dave <dave@leil.io>