### PR TITLE
fix: Fix truncate tests

### DIFF
--- a/src/mount/chunk_locator.h
+++ b/src/mount/chunk_locator.h
@@ -113,6 +113,10 @@ public:
 		return locationInfo_;
 	}
 
+	virtual bool shouldReset() const {
+		return true;
+	}
+
 protected:
 	WriteChunkLocator(uint32_t inode, uint32_t index, uint32_t lockId)
 			: inode_(inode),
@@ -130,8 +134,10 @@ protected:
 class TruncateWriteChunkLocator : public WriteChunkLocator {
 public:
 	// Locator is created for single operation
-	explicit TruncateWriteChunkLocator(uint32_t inode, uint32_t index, uint32_t lockId)
-		: WriteChunkLocator(inode, index, lockId) {
+	explicit TruncateWriteChunkLocator(uint32_t inode, uint32_t index, uint32_t lockId,
+	                                   uint64_t targetSize)
+	    : WriteChunkLocator(inode, index, lockId) {
+		targetSize_ = targetSize;
 	}
 
 	~TruncateWriteChunkLocator() {
@@ -141,4 +147,12 @@ public:
 
 	// In this case a chunk is unlocked by master so this locator will be simply destroyed
 	void unlockChunk() {}
+
+	bool shouldReset() const {
+		return locationInfo_.fileLength == targetSize_;
+	}
+
+private:
+	// Target offset to fill with zeros up to
+	uint64_t targetSize_;
 };

--- a/src/mount/writedata.cc
+++ b/src/mount/writedata.cc
@@ -343,7 +343,9 @@ void write_enqueue(inodedata* id, Glock&) {
 void write_job_delayed_end(inodedata* id, int status, int seconds, Glock &lock) {
 	LOG_AVG_TILL_END_OF_SCOPE0("write_job_delayed_end");
 	LOG_AVG_TILL_END_OF_SCOPE1("write_job_delayed_end#sec", seconds);
-	id->locator.reset();
+	if (id->locator != nullptr && id->locator->shouldReset()) {
+		id->locator.reset();
+	}
 	if (status != SAUNAFS_STATUS_OK) {
 		safs_pretty_syslog(LOG_WARNING, "error writing file number %" PRIu32 ": %s", id->inode, saunafs_error_string(status));
 		id->status = status;
@@ -470,6 +472,13 @@ void InodeChunkWriter::processJob(inodedata* inodeData) {
 				// has to be flushed, because no more data will be added to it
 				canWait = false;
 			}
+
+			if (!locator->shouldReset()) {
+				// In the case of a truncate operation that is not finished yet, we don't want to
+				// reset the locator, because it will be used later to lock the chunk again
+				inodeData_->locator = std::move(locator);
+			}
+
 			write_job_delayed_end(inodeData_, SAUNAFS_STATUS_OK, (canWait ? 1 : 0), lock);
 		} catch (Exception& e) {
 			std::string errorString = e.what();
@@ -1004,7 +1013,8 @@ int write_data_truncate(uint32_t inode, bool opened, uint32_t uid, uint32_t gid,
 
 		// Something has to be written, so pass our lock to writing threads
 		sassert(id->dataChain.empty());
-		id->locator.reset(new TruncateWriteChunkLocator(inode, length / SFSCHUNKSIZE, lockId));
+		id->locator.reset(
+		    new TruncateWriteChunkLocator(inode, length / SFSCHUNKSIZE, lockId, endOffset));
 
 		// And now pass block of zeros to writing threads
 		std::vector<uint8_t> zeros(endOffset - length, 0);


### PR DESCRIPTION
The truncate tests in our testing framework have been unstable since
some time ago, failing from time to time. This commit targets to fix
those failures.

The detected failing pattern is the following:
- some truncate operation needs to be done in such a way that needs to
recalculate the last block of the parity parts blocks by writing some zeroes.
- the caching (write_blocks function) of those zeroes happens in such a
way that some of those blocks are processed first and some later on.
- the first blocks are got by the write workers, and synced to the
chunkservers with its load of zeroes.
- during the work of that write worker, the WriteChunkLocator (in this
case a TruncateWriteChunkLocator) is moved from the inodedata where it
was taken and never moved back.
- the second batch of blocks of zeroes is got by another write worker
but the inodedata which needs to have the correct locator (the one that
maintains the lockId) does not have it, so the locate and locking of
the chunk fails with SAUNAFS_ERROR_LOCKED.
- the write algorithm keeps retrying until time expires.

The proposed solution is the following:
- implement a shouldReset() member for the WriteChunkLocator with a
specific implementation for TruncateWriteChunkLocator.
- check for it right before going to destroy the locator in processJob
and right before going to reset the inodedata's locator in
write_job_delayed_end.
- the shouldReset function always returns true for the
WriteChunkLocator as it was doing. In the case of a
TruncateWriteChunkLocator, it compares the target size of the truncate
and the current committed size to the chunkservers.

Signed-off-by: Dave <dave@leil.io>