### PR TITLE
build: Set GIT_* definitions to N/A if no git info generated

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,6 +228,8 @@ elseif(GENERATE_GIT_INFO)
   execute_process(COMMAND "git" "rev-parse" "HEAD"
   OUTPUT_VARIABLE GIT_COMMIT OUTPUT_STRIP_TRAILING_WHITESPACE)
   add_compile_definitions(GIT_COMMIT="${GIT_COMMIT}")
+else()
+  add_compile_definitions(GIT_COMMIT="N/A")
 endif()
 
 if(GIT_BRANCH)
@@ -236,6 +238,8 @@ elseif(GENERATE_GIT_INFO)
   execute_process(COMMAND "git" "rev-parse" "--abbrev-ref" "HEAD"
   OUTPUT_VARIABLE GIT_BRANCH OUTPUT_STRIP_TRAILING_WHITESPACE)
   add_compile_definitions(GIT_BRANCH="${GIT_BRANCH}")
+else()
+  add_compile_definitions(GIT_BRANCH="N/A")
 endif()
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")

--- a/src/common/version.h
+++ b/src/common/version.h
@@ -26,16 +26,8 @@ inline std::string version() {
 	return "Version: " \
 	SAUNAFS_PACKAGE_VERSION "\n"
 	"Build time: " BUILD_TIME "\n"
-	#ifdef GIT_COMMIT
 		"Git commit: " GIT_COMMIT "\n"
-	#else
-		"Git commit: N/A\n"
-	#endif
-	#ifdef GIT_BRANCH
 		"Git branch: " GIT_BRANCH
-	#else
-		"Git branch: N/A"
-	#endif
 	;
 }
 


### PR DESCRIPTION
Previously, you were required to add ifdefs for GIT_INFO and GIT_COMMIT. This change falls back to "N/A" in the CMake file if it's not defined in any other way (e.g GENERATE_GIT_INFO is off).