### PR TITLE
Fix cgi multi chunkservers table

### DIFF
--- a/src/cgi/sfs.cgi.in
+++ b/src/cgi/sfs.cgi.in
@@ -292,7 +292,7 @@ def cltoma_metadataservers_list():
     for (addr, port, v1, v2, v3) in servers:
         # for shadow masters, addr is int (4 bytes) -- convert it to string.
         # for the active master we use "masterhost" to connect with it and we don't know the real IP
-        ip = addr_to_host(addr) if isinstance(addr, int) else "-"
+        ip = addr_to_host(addr) if isinstance(addr, int) else masterhost
         version = "%u.%u.%u" % (v1, v2, v3)
         if port == 0:
             # shadow didn't register its port yet

--- a/src/cgi/sfs.cgi.in
+++ b/src/cgi/sfs.cgi.in
@@ -1382,7 +1382,11 @@ if "CS" in sectionset:
                 pos = pos + 54
             strip = "%u.%u.%u.%u" % (ip1, ip2, ip3, ip4)
             try:
-                host = (socket.gethostbyaddr(strip))[0]
+                host, aliases, _ = (socket.gethostbyaddr(strip))
+                all_hosts = [host] + aliases
+                port_suffix = f"{port % 100:02d}"
+                prefix = f"cs{port_suffix}-"
+                host = next((name for name in all_hosts if name.startswith(prefix)), host)
             except Exception:
                 host = "(unresolved)"
             if CSorder == 1:


### PR DESCRIPTION
The current implementation displays the primary hostname from reverse DNS, which can be ambiguous in environments where Chunkservers use multiple services (and thus multiple aliases).

This change enhances the hostname resolution logic to:

- Extract all aliases from reverse DNS (gethostbyaddr).
- Match aliases against the expected naming pattern
  eg `cs<portNumber>-<hostname> (e.g., cs01-cluster-01)`
- Fall back to the default hostname if no matching alias is found.

This ensures the Chunkserver table reflects the correct alias when available (e.g., cs01-cluster-01 instead of just cluster-01),
improving clarity for multi-services deployments.

Name patter for hosts file with multiple service:
`e.g., 10.0.0.60 pegasus-01 cs01-pegasus-01 cs15-pegasus-01 sfsmaster # Two services on same node IP but ports 9901 and 9915`