### PR TITLE
fix(tools): Fix saunafs command folder resolution

### DIFF
--- a/src/tools/master_functions.cc
+++ b/src/tools/master_functions.cc
@@ -275,7 +275,7 @@ int open_master_conn(const char *name, uint32_t *inode, mode_t *mode,
 	std::string name_to_use = std::string(name);
 #ifdef _WIN32
 	int master_conn_retries = 0;
-	if (name_to_use.back() == '\\' || name_to_use.back() == '/') {
+	if (name_to_use.back() == '\\' || name_to_use.back() == '/' || name_to_use.back() == '"') {
 		name_to_use.pop_back();
 	}
 #endif


### PR DESCRIPTION
Previous changes to the path resolution for `saunafs` commands did not correctly handle folders with spaces in their names when executed. This issue was specifically present in the Windows version of the `saunafs` commands, particularly for paths formatted like `folder name\`. This commit solves that issue.