### PR TITLE
refactor(mount): Refactor get self quota

### DIFF
--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -2066,7 +2066,12 @@ void matoclserv_sau_get_self_quota(matoclserventry *eptr, const uint8_t *data, u
 	};
 
 	std::vector<QuotaOwner> owners;
-	cltoma::fuseGetSelfQuota::deserialize(data, length, messageId, uid, gid, inode);
+	if (version == cltoma::fuseGetSelfQuota::kGetSelfQuotaWithInode) {
+		cltoma::fuseGetSelfQuota::deserialize(data, length, messageId, uid, gid, inode);
+	} else {
+		cltoma::fuseGetSelfQuota::deserialize(data, length, messageId, uid, gid);
+		inode = SPECIAL_INODE_ROOT;
+	}
 	status = matoclserv_check_group_cache(eptr, gid);
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);

--- a/src/protocol/cltoma.h
+++ b/src/protocol/cltoma.h
@@ -356,8 +356,15 @@ SAUNAFS_DEFINE_PACKET_SERIALIZATION(cltoma, fullPathByInode, SAU_CLTOMA_FULL_PAT
 		uint32_t, uid,
 		uint32_t, gid)
 
+SAUNAFS_DEFINE_PACKET_VERSION(cltoma, fuseGetSelfQuota, kGetSelfQuota, 0)
+SAUNAFS_DEFINE_PACKET_VERSION(cltoma, fuseGetSelfQuota, kGetSelfQuotaWithInode, 1)
 SAUNAFS_DEFINE_PACKET_SERIALIZATION(
-		cltoma, fuseGetSelfQuota, SAU_CLTOMA_FUSE_GET_SELF_QUOTA, 0,
+		cltoma, fuseGetSelfQuota, SAU_CLTOMA_FUSE_GET_SELF_QUOTA, kGetSelfQuota,
+		uint32_t, messageId,
+		uint32_t, uid,
+		uint32_t, gid)
+SAUNAFS_DEFINE_PACKET_SERIALIZATION(
+		cltoma, fuseGetSelfQuota, SAU_CLTOMA_FUSE_GET_SELF_QUOTA, kGetSelfQuotaWithInode,
 		uint32_t, messageId,
 		uint32_t, uid,
 		uint32_t, gid,


### PR DESCRIPTION
Previous changes introduced in commit `a1db23de` caused the master server to malfunction with clients at or below the `v4.9.0` release. This commit refactors the code for the self quota retrieval functions so that no changes break the client–master communication protocol, while maintaining the previously introduced functionality and ensuring compatibility with older client versions.