### PR TITLE
fix(master): Large trash causing crash

### DIFF
--- a/doc/sfsmount.1.adoc
+++ b/doc/sfsmount.1.adoc
@@ -46,7 +46,8 @@ SaunaFS options:
 Loads file with additional mount options.
 
 *-m*, *--meta*, *-o sfsmeta*::
-Mount SFSMETA companion filesystem instead of primary SaunaFS.
+Mount SFSMETA companion filesystem instead of primary SaunaFS. This allows you
+to interact with trashed and reserved files. (See NOTES)
 
 *-n*, *--nostdopts*::
 Omit default mount options (*-o allow_other,default_permissions*). Equivalent
@@ -322,6 +323,24 @@ You can define your `/etc/fstab` SaunaFS share like this:
 
 Report bugs to the Github repository <https://github.com/leil/saunafs> as an
 issue.
+
+== NOTES
+
+The metadata mount point has two directories available: 'trash' and 'reserved'.
+
+In 'trash' you can see files that have been deleted but are still being kept in
+master trash. You can undelete them by moving the files into 'trash/undel', and
+delete permanently by deleting them again.
+
+There is a bug with this though. See BUGS for more details.
+
+== BUGS
+
+Due to a limit in the protocol, the metadata mount point can at most return the
+first 1 million trash/reserved files. To see more, you will need to either
+delete or undelete the existing files. Older versions of master (4.9.0 or
+earlier) will crash when reading a lot of files in trash/reserved. After around
+1 million files in trash/reserved, it becomes unsafe to read trash.
 
 == COPYRIGHT
 

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -39,6 +39,7 @@
 #include "master/filesystem_periodic.h"
 #include "master/filesystem_quota.h"
 #include "master/fs_context.h"
+#include "slogger/slogger.h"
 
 #ifndef NDEBUG
   #include "master/personality.h"
@@ -725,6 +726,7 @@ void fsnodes_getpath(FSNodeDirectory *parent, FSNode *child, std::string &path) 
 
 
 #ifndef METARESTORE
+constexpr uint32_t kOldPathContainerLimit = 1000000;
 
 template<class T>
 static inline uint32_t getdetachedsize(const T &data) {
@@ -732,13 +734,19 @@ static inline uint32_t getdetachedsize(const T &data) {
 	              || std::is_same<T, ReservedPathContainer>::value, "unsupported container");
 	uint32_t result = 0;
 	std::string name;
+	uint32_t count = 0;
 	for (const auto &entry : data) {
+		if (count > kOldPathContainerLimit) {
+			// See explanation in getdetacheddata
+			break;
+		}
 		name = (std::string)entry.second;
 		if (name.length() > 240) {
 			result += 245;
 		} else {
 			result += 5 + name.length();
 		}
+		count++;
 	}
 	return result;
 }
@@ -759,7 +767,19 @@ static inline void getdetacheddata(const T &data, uint8_t *dbuff) {
 	uint8_t *sptr;
 	uint8_t c;
 	std::string name;
+	// Limit to 1 million, see explanation below
+	uint32_t count = 0;
 	for (const auto &entry : data) {
+		if (count > kOldPathContainerLimit) {
+			// Due to the size limit of packets (at time of writing,
+			// UINT32_MAX), if we write any more we risk overflowing buffer.
+			// While this could be done better rather than an arbitrary limit,
+			// there's already an alternative in client library that allows
+			// buffered reads from trash/reserved.
+			safs::log_warn("getdetachedsize: path container size longer than {}, truncating",
+				  kOldPathContainerLimit);
+			break;
+		}
 		name = (std::string)entry.second;
 
 		if (name.length() > 240) {
@@ -791,6 +811,7 @@ static inline void getdetacheddata(const T &data, uint8_t *dbuff) {
 				dbuff++;
 			}
 		}
+		count++;
 		put32bit(&dbuff, getdetacheddata_getNodeId(entry.first));
 	}
 }


### PR DESCRIPTION
The current FUSE metadata mount is reading the entire trash from master, however the protocol is limited to UINT32_MAX - 8 bytes. When the trash data exceeds this, it's causing wrapping to the uint32 variable, which is then used to determine the malloc size of the memory to write the data, causing a buffer overflow. Besides, it will allocate a lot of memory for large trash sizes and hang master as it tries to respond with the *ENTIRE* trash to client.

The fix to this is limiting the amount of files that master will return. Currently, this is 1 million. There are some drawbacks with this approach: To see newer trash entries, you will need to delete or undelete files first.

A more general solution is actually implemented, which allows buffering the trash from client (SAU_CLTOMA_FUSE_GETTRASH) using max_entries. Unfortunately, this was never implemented for the FUSE meta mount. Another commit should be made to make the clients use this. But the focus of this commit is fixing CLTOMA_FUSE_GETTRASH packet, so metadata clients using this will not crash master.