### PR TITLE
fix: Fix replicate related chunkserver locking

### DIFF
--- a/src/chunkserver/chunk_replicator.cc
+++ b/src/chunkserver/chunk_replicator.cc
@@ -161,7 +161,7 @@ void ChunkReplicator::replicate(ChunkFileCreator& fileCreator,
 	}
 
 	fileCreator.create();
-	static const SteadyDuration max_wait_time = std::chrono::milliseconds(total_timeout_ms_);
+	const SteadyDuration max_wait_time = std::chrono::milliseconds(total_timeout_ms_);
 	Timeout timeout{max_wait_time};
 	for (int firstBlock = 0; firstBlock < blocks; firstBlock += batchSize) {
 		int nrOfBlocks = std::min(blocks - firstBlock, batchSize);

--- a/src/chunkserver/hddspacemgr.cc
+++ b/src/chunkserver/hddspacemgr.cc
@@ -484,6 +484,7 @@ void hddGetTotalSpace(uint64_t *usedSpace, uint64_t *totalSpace,
 					total += disk->totalSpace();
 				}
 
+				std::lock_guard testsLockGuard(gTestsMutex);
 				chunks += disk->chunks().size();
 			} else {
 				if (disk->scanState() == IDisk::ScanState::kWorking) {
@@ -491,6 +492,7 @@ void hddGetTotalSpace(uint64_t *usedSpace, uint64_t *totalSpace,
 					toDelTotal += disk->totalSpace();
 				}
 
+				std::lock_guard testsLockGuard(gTestsMutex);
 				toDelChunks += disk->chunks().size();
 			}
 		}

--- a/src/chunkserver/hddspacemgr.cc
+++ b/src/chunkserver/hddspacemgr.cc
@@ -2147,6 +2147,7 @@ void hddTesterThread() {
 	uint32_t elapsedTimeMs = 0;
 	uint64_t startMicroSecs = 0;
 	uint64_t endMicroSecs = 0;
+	std::string chunkName;
 
 	while (!gTerminate) {
 		startMicroSecs = getMicroSecsTime();
@@ -2168,6 +2169,7 @@ void hddTesterThread() {
 				chunkId = chunk->id();
 				version = chunk->version();
 				chunkType = chunk->type();
+				chunkName = chunk->fullDataFilename();
 			}
 		}
 
@@ -2179,9 +2181,8 @@ void hddTesterThread() {
 				safs_pretty_syslog(LOG_DEBUG,
 				                   "Tester: chunk: %lu, v: %u, type: %s, file: "
 				                   "%s: tested (OK)",
-				                   chunkId, version,
-				                   chunkType.toString().c_str(),
-				                   chunk->fullDataFilename().c_str());
+				                   chunkId, version, chunkType.toString().c_str(),
+				                   chunkName.c_str());
 			}
 		}
 


### PR DESCRIPTION
This PR includes several small fixes in the chunkserver locking mechanism related to replicate operations:
- Fix race condition in max_wait_time: The max_wait_time had static modifier which apparently tried to make it
shared among all the ChunkReplicator instances created. Those instances
could be created from different threads simultaneously, causing a data
race condition warning while doing an intensive replicate
(rebalance/replicate) workload. The proposal is to leave it as a
regular local const variable.
- Protect chunks structure in hddGetTotalSpace: The chunks structure from the disks class needs to be protected with
the gTestsMutex mutex. This protection was missing in this function and
is being added by this change.
- Avoid unprotected access to chunk members: This change targets removing an unprotected access (chunk isn't locked
nor the gChunksMapMutex) to the chunk's data file name that is being
tested by the tester thread in the chunkserver.

Signed-off-by: Dave <dave@leil.io>