### PR TITLE
fix: Fix client recover when master disconnects

### DIFF
--- a/src/mount/mastercomm.cc
+++ b/src/mount/mastercomm.cc
@@ -356,11 +356,6 @@ static bool fs_threc_send_receive(threc *rec, bool filter, PacketHeader::Type ex
 					}
 				}
 			}
-#ifdef _WIN32
-			else if (gIsDisconnectedFromMaster.load()) {
-				return false;
-			}
-#endif
 			sleep(sleep_time(cnt));
 			continue;
 		}


### PR DESCRIPTION
From commit 88f6a0e, changes were introduced to modify the behavior of the client when the master disconnects. These changes ensured that the client would remain unusable but would not crash in such scenarios.

However, the changes caused an issue in the Windows client, preventing it from recovering from a read/write operation when the master disconnects. As a result, the client was unable to correctly complete the operation once the master reconnected.

To address this, the best course of action is to undo those changes, ensuring that the Windows client maintains a more consistent and reliable behavior.