### PR TITLE
feat(tools)!: Remove deprecated commands from saunafs

### DIFF
--- a/src/tools/get_goal.cc
+++ b/src/tools/get_goal.cc
@@ -127,10 +127,6 @@ static int gene_get_goal_run(int argc, char **argv, int rflag) {
 	return status;
 }
 
-int rget_goal_run(int argc, char **argv) {
-	return gene_get_goal_run(argc, argv, 1);
-}
-
 int get_goal_run(int argc, char **argv) {
 	return gene_get_goal_run(argc, argv, 0);
 }

--- a/src/tools/get_trashtime.cc
+++ b/src/tools/get_trashtime.cc
@@ -196,10 +196,6 @@ static int gene_get_trashtime_run(int argc, char **argv, int rflag) {
 	return status;
 }
 
-int rget_trashtime_run(int argc, char **argv) {
-	return gene_get_trashtime_run(argc, argv, 1);
-}
-
 int get_trashtime_run(int argc, char **argv) {
 	return gene_get_trashtime_run(argc, argv, 0);
 }

--- a/src/tools/main.cc
+++ b/src/tools/main.cc
@@ -79,11 +79,6 @@ int main(int argc, char **argv) {
 		} else {
 			status = func(argc - 1, &argv[1]);
 		}
-		if (func_name == "rgetgoal" || func_name == "rsetgoal" || func_name == "rgettrashtime" ||
-		    func_name == "rsettrashtime") {
-			fmt::println(stderr, "Warning: {} is deprecated (use {} -r instead)",
-			        func_name, func_name.substr(1, func_name.size() - 1));
-		}
 	} else if (argc == 1) {
 		std::string command;
 		std::vector<char*> argv_new;

--- a/src/tools/set_goal.cc
+++ b/src/tools/set_goal.cc
@@ -152,9 +152,6 @@ static int gene_set_goal_run(int argc, char **argv, int rflag) {
 	return status;
 }
 
-int rset_goal_run(int argc, char **argv) {
-	return gene_set_goal_run(argc, argv, 1);
-}
 int set_goal_run(int argc, char **argv) {
 	return gene_set_goal_run(argc, argv, 0);
 }

--- a/src/tools/set_trashtime.cc
+++ b/src/tools/set_trashtime.cc
@@ -217,10 +217,6 @@ static int gene_set_trashtime_run(int argc, char **argv, int rflag) {
 	return status;
 }
 
-int rset_trashtime_run(int argc, char **argv) {
-	return gene_set_trashtime_run(argc, argv, 1);
-}
-
 int set_trashtime_run(int argc, char **argv) {
 	return gene_set_trashtime_run(argc, argv, 0);
 }

--- a/src/tools/tools_commands.cc
+++ b/src/tools/tools_commands.cc
@@ -57,10 +57,6 @@ void printTools() {
 	fprintf(stderr, "\trremove\n");
 	fprintf(stderr, "\thelp [tool name]\n");
 	fprintf(stderr, "deprecated tools:\n");
-	fprintf(stderr, "\trgetgoal = getgoal -r\n");
-	fprintf(stderr, "\trsetgoal = setgoal -r\n");
-	fprintf(stderr, "\trgettrashtime = gettrashtime -r\n");
-	fprintf(stderr, "\trsettrashtime = settrashtime -r\n");
 }
 
 void printOptions() {
@@ -99,13 +95,9 @@ static int exit_func(int /*argc*/, char **/*argv*/) {
 
 static std::unordered_map<std::string, std::function<int(int, char **)>> sauna_commands({
 	{"getgoal", get_goal_run},
-	{"rgetgoal", rget_goal_run},
 	{"setgoal", set_goal_run},
-	{"rsetgoal", rset_goal_run},
 	{"gettrashtime", get_trashtime_run},
-	{"rgettrashtime", rget_trashtime_run},
 	{"settrashtime", set_trashtime_run},
-	{"rsettrashtime", rset_trashtime_run},
 	{"checkfile", check_file_run},
 	{"fileinfo", file_info_run},
 	{"appendchunks", append_file_run},


### PR DESCRIPTION
These commands have been deprecated for a very long time. It's safe to remove them.

BREAKING CHANGE: Some scripts might still rely on them