### PR TITLE
fix(main)!: Change test output from stderr to stdout

### DIFF
--- a/src/main/main.cc
+++ b/src/main/main.cc
@@ -534,10 +534,7 @@ FileLock::LockStatus FileLock::wdlock(RunMode runmode, uint32_t timeout) {
 			return LockStatus::kAlive;
 		}
 		if (runmode==RunMode::kTest) {
-			// TODO(5.0.0): Fix this stupidity in a breaking change by changing it
-			// to stdout. It's not that hard, stderr for logs/errors, stdout
-			// for output
-			fprintf(stderr,STR(APPNAME) " pid: %ld\n",(long)ownerpid);
+			fprintf(stdout,STR(APPNAME) " pid: %ld\n",(long)ownerpid);
 			return LockStatus::kTest;
 		}
 		if (runmode==RunMode::kStart) {

--- a/tests/test_suites/ShortSystemTests/test_cache_per_inode.sh
+++ b/tests/test_suites/ShortSystemTests/test_cache_per_inode.sh
@@ -7,7 +7,7 @@ CHUNKSERVERS=1 \
 	USE_RAMDISK=YES \
 	setup_local_empty_saunafs info
 
-cs0_pid="$(saunafs_chunkserver_daemon 0 test 2>&1 | sed 's/.*pid: //')"
+cs0_pid="$(saunafs_chunkserver_daemon 0 test | sed 's/.*pid: //')"
 test -n $cs0_pid
 kill -s SIGSTOP $cs0_pid
 

--- a/tests/test_suites/ShortSystemTests/test_cs_failure_recovery_speed.sh
+++ b/tests/test_suites/ShortSystemTests/test_cs_failure_recovery_speed.sh
@@ -17,7 +17,7 @@ wait_if_windows
 if is_windows_system; then
 	saunafs_chunkserver_daemon 0 stop
 else
-	kill -s SIGSTOP "$(saunafs_chunkserver_daemon 0 test 2>&1 | sed 's/.*pid: //')"
+	kill -s SIGSTOP "$(saunafs_chunkserver_daemon 0 test | sed 's/.*pid: //')"
 fi
 for i in {0..4}; do
 	( assert_success file-overwrite "${info[mount$i]}/dir/file$i" && touch "$TEMP_DIR/finish$i" & )

--- a/tests/test_suites/ShortSystemTests/test_cstoma_timeout.sh
+++ b/tests/test_suites/ShortSystemTests/test_cstoma_timeout.sh
@@ -8,7 +8,7 @@ assert_equals 1 $(saunafs_ready_chunkservers_count)
 
 # Make the chunkserver hang and check if master disconnects if not earlier than
 # 2/3 * MASTER_TIMEOUT and not later than after the MASTER_TIMEOUT is expired
-pid=$(saunafs_chunkserver_daemon 0 test 2>&1 | sed 's/.*pid: //')
+pid=$(saunafs_chunkserver_daemon 0 test | sed 's/.*pid: //')
 kill -STOP $pid
 assert_equals 1 $(saunafs_ready_chunkservers_count)
 sleep 6

--- a/tests/test_suites/ShortSystemTests/test_descriptors_leak_check.sh
+++ b/tests/test_suites/ShortSystemTests/test_descriptors_leak_check.sh
@@ -19,7 +19,7 @@ firstDisk=$(head -1 "${info[chunkserver0_hdd]}")
 isZoned=$(is_zoned_device "${firstDisk}")
 
 # wait for saunafs to close files
-cs_pid=$(saunafs_chunkserver_daemon 0 test 2>&1 | sed 's/.*: //')
+cs_pid=$(saunafs_chunkserver_daemon 0 test | sed 's/.*: //')
 for ((time_elapsed=0; time_elapsed < time_limit; ++time_elapsed)); do
 	leaked_descriptors_number=$(lsof +D $RAMDISK_DIR -p$cs_pid 2>/dev/null | \
 		grep -v 'lock' | grep chunk_ | wc -l)

--- a/tests/test_suites/ShortSystemTests/test_limit_glibc_malloc_arenas.sh
+++ b/tests/test_suites/ShortSystemTests/test_limit_glibc_malloc_arenas.sh
@@ -44,7 +44,7 @@ arenas=2
 ### Test the limit in the first chunkserver ###
 
 # Get initial values
-cs0Pid=$(saunafs_chunkserver_daemon 0 test 2>&1 | tr -d '\0' | awk '{print $NF}')
+cs0Pid=$(saunafs_chunkserver_daemon 0 test | tr -d '\0' | awk '{print $NF}')
 virtualMemoryCS0=$(getVirtualMemoryForPid ${cs0Pid})
 echo "CS0 PID: ${cs0Pid} - Virtual memory: ${virtualMemoryCS0}"
 
@@ -59,7 +59,7 @@ assert_equals ${arenas} ${effectiveArenaLimit}
 echo "Arena limit set to ${effectiveArenaLimit} for chunkserver 0"
 
 # Check if the memory usage decreased
-cs0PidAfter=$(saunafs_chunkserver_daemon 0 test 2>&1 | tr -d '\0' | awk '{print $NF}')
+cs0PidAfter=$(saunafs_chunkserver_daemon 0 test | tr -d '\0' | awk '{print $NF}')
 virtualMemoryCS0After=$(getVirtualMemoryForPid ${cs0PidAfter})
 echo "CS0 PID: ${cs0PidAfter} - Virtual memory: ${virtualMemoryCS0After}"
 assert_less_than ${virtualMemoryCS0After} ${virtualMemoryCS0}
@@ -67,7 +67,7 @@ assert_less_than ${virtualMemoryCS0After} ${virtualMemoryCS0}
 ### Test the limit in the master ###
 
 # Get initial values
-master0Pid=$(saunafs_master_n 0 test 2>&1 | tr -d '\0' | awk '{print $NF}')
+master0Pid=$(saunafs_master_n 0 test | tr -d '\0' | awk '{print $NF}')
 virtualMemoryMaster0=$(getVirtualMemoryForPid ${master0Pid})
 echo "Master0 PID: ${master0Pid} - Virtual memory: ${virtualMemoryMaster0}"
 
@@ -82,7 +82,7 @@ assert_equals ${arenas} ${effectiveArenaLimit}
 echo "Arena limit set to ${effectiveArenaLimit} for master 0"
 
 # Check if the memory usage decreased
-master0PidAfter=$(saunafs_master_n 0 test 2>&1 | tr -d '\0' | awk '{print $NF}')
+master0PidAfter=$(saunafs_master_n 0 test | tr -d '\0' | awk '{print $NF}')
 virtualMemoryMaster0After=$(getVirtualMemoryForPid ${master0PidAfter})
 echo "Master0 PID: ${master0PidAfter} - Virtual memory: ${virtualMemoryMaster0After}"
 assert_less_than ${virtualMemoryMaster0After} ${virtualMemoryMaster0}

--- a/tests/test_suites/ShortSystemTests/test_shadow_reconnect.sh
+++ b/tests/test_suites/ShortSystemTests/test_shadow_reconnect.sh
@@ -16,7 +16,7 @@ assert_eventually "saunafs_shadow_synchronized 1"
 files_before=$(ls "${info[master1_data_path]}" | grep -v "stats.sfs" | sort)
 
 # Make shadow master lose connection with the master by making it sleep more than timeout
-shadow_pid=$(saunafs_master_n 1 test 2>&1 | sed 's/.*: //')
+shadow_pid=$(saunafs_master_n 1 test | sed 's/.*: //')
 assert_matches "^[0-9]+$" "$shadow_pid"
 kill -STOP "$shadow_pid"
 sleep 13

--- a/tests/test_suites/ShortSystemTests/test_shadow_reloading_metadata.sh
+++ b/tests/test_suites/ShortSystemTests/test_shadow_reloading_metadata.sh
@@ -18,7 +18,7 @@ touch "${info[mount0]}"/file{1..10}
 assert_eventually "saunafs_shadow_synchronized 1"
 
 # Make shadow master lose connection with the master by making it sleep and restarting master server
-shadow_pid=$(saunafs_master_n 1 test 2>&1 | sed 's/.*: //')
+shadow_pid=$(saunafs_master_n 1 test | sed 's/.*: //')
 assert_matches "^[0-9]+$" "$shadow_pid"
 kill -STOP "$shadow_pid"
 saunafs_master_daemon restart

--- a/tests/tools/saunafs.sh
+++ b/tests/tools/saunafs.sh
@@ -141,12 +141,7 @@ saunafs_admin_command() {
 }
 
 saunafs_fusermount() {
-	fuse_version=$(${SAFS_MOUNT_COMMAND} --version 2>&1 | grep "FUSE library" | grep -Eo "[0-9]+\..+")
-	if [[ "$fuse_version" =~ ^3\..+$ ]]; then
-		fusermount3 "$@"
-	else
-		fusermount "$@"
-	fi
+	fusermount3 "$@"
 }
 
 windows_server_aux(){


### PR DESCRIPTION
The test subcommand of the daemon binaries should output the PID of the daemon to stdout, to keep stderr clean for logs and errors.

* Remove old FUSE compatibility from tests

BREAKING CHANGE: This might break scripts that rely on PID being printed to stderr.