### PR TITLE
chore(chunkserver): Improve thread names

### DIFF
--- a/src/chunkserver/bgjobs.cc
+++ b/src/chunkserver/bgjobs.cc
@@ -48,7 +48,8 @@
 constexpr auto kInvalidJob = nullptr;
 constexpr auto STATUS_BYTE_SIZE = 1;
 
-JobPool::JobPool(uint8_t workers, uint32_t maxJobs, int *wakeupDesc) : workers(workers) {
+JobPool::JobPool(const std::string &name, uint8_t workers, uint32_t maxJobs, int *wakeupDesc)
+    : name_(name), workers(workers) {
 	int fd[2];
 	if (pipe(fd) < 0) {  // pipe is a critical resource for communication within the JobPool
 		throw std::runtime_error("JobPool: Failed to create pipe: " + std::string(strerror(errno)));
@@ -62,7 +63,7 @@ JobPool::JobPool(uint8_t workers, uint32_t maxJobs, int *wakeupDesc) : workers(w
 	statusQueue = std::make_unique<ProducerConsumerQueue>();
 
 	for (uint8_t i = 0; i < workers; ++i) {
-		workerThreads.emplace_back(&JobPool::workerThread, this);
+		workerThreads.emplace_back(&JobPool::workerThread, this, name_, i);
 	}
 }
 
@@ -172,9 +173,8 @@ void JobPool::changeCallback(std::list<uint32_t> &jobIds, JobCallback callback, 
 	}
 }
 
-void JobPool::workerThread() {
-	static std::atomic_uint16_t workersCounter(0);
-	std::string threadName = "jobWorker " + std::to_string(workersCounter++);
+void JobPool::workerThread(const std::string &poolName, uint8_t workerId) {
+	std::string threadName = poolName + "_worker_" + std::to_string(workerId);
 	pthread_setname_np(pthread_self(), threadName.c_str());
 
 	uint32_t jobId;

--- a/src/chunkserver/bgjobs.h
+++ b/src/chunkserver/bgjobs.h
@@ -89,11 +89,12 @@ public:
 
 	/// @brief Constructor for JobPool.
 	///
+	/// @param name Human readable name for this pool, useful for debugging.
 	/// @param workers The number of worker threads in the pool.
 	/// @param maxJobs The maximum number of jobs that can be queued.
 	/// @param wakeupDesc Pointer to the file descriptor for wakeup notifications.
 	/// @throws std::runtime_error If the pipe creation fails.
-	JobPool(uint8_t workers, uint32_t maxJobs, int *wakeupDesc);
+	JobPool(const std::string &name, uint8_t workers, uint32_t maxJobs, int *wakeupDesc);
 
 	/// @brief Destructor for JobPool.
 	~JobPool();
@@ -154,7 +155,9 @@ private:
 	};
 
 	/// @brief Worker thread function.
-	void workerThread();
+	/// @param poolName Parent pool name, used to name the specific thread.
+	/// @param workerId Worker index in this pool, used to name the thread.
+	void workerThread(const std::string &poolName, uint8_t workerId);
 
 	/// @brief Sends the status of a job.
 	///
@@ -171,6 +174,7 @@ private:
 
 	int rpipe;                                         /// Read pipe for job status notifications.
 	int wpipe;                                         /// Write pipe for job status notifications.
+	std::string name_;                                 /// Human readable id of the JobPool.
 	uint8_t workers;                                   /// Number of worker threads in the pool.
 	std::vector<std::thread> workerThreads;            /// Vector of worker threads.
 	std::mutex pipeMutex;                              /// Mutex for pipe operations.

--- a/src/chunkserver/bgjobs_unittest.cc
+++ b/src/chunkserver/bgjobs_unittest.cc
@@ -48,7 +48,7 @@ private:
 protected:
 	void SetUp() override {
 		wakeupDesc = 0;
-		jobPool = std::make_unique<JobPool>(4, 10, &wakeupDesc);
+		jobPool = std::make_unique<JobPool>("TestPool", 4, 10, &wakeupDesc);
 		counter.store(0);
 		counter2.store(0);
 		wakeupDescPollFd = {wakeupDesc, POLLIN, 0};

--- a/src/chunkserver/masterconn.cc
+++ b/src/chunkserver/masterconn.cc
@@ -865,7 +865,7 @@ int masterconn_init(void) {
 
 int masterconn_init_threads(void) {
 	try {
-		jobPool = std::make_unique<JobPool>(gNumberOfWorkers, BGJOBSCNT, &jobfd);
+		jobPool = std::make_unique<JobPool>("ma", gNumberOfWorkers, BGJOBSCNT, &jobfd);
 	} catch (const std::runtime_error &e) {
 		safs::log_err("masterconn_init_threads: Failed to create JobPool instance: {}", e.what());
 		return -1;

--- a/src/chunkserver/network_main_thread.cc
+++ b/src/chunkserver/network_main_thread.cc
@@ -287,8 +287,8 @@ int mainNetworkThreadInit(void) {
 }
 
 int mainNetworkThreadInitThreads(void) {
-	for (unsigned i = 0; i < gNrOfNetworkWorkers; ++i) {
-		networkThreadObjects.emplace_back(gNrOfHddWorkersPerNetworkWorker,
+	for (uint32_t i = 0; i < gNrOfNetworkWorkers; ++i) {
+		networkThreadObjects.emplace_back(i, gNrOfHddWorkersPerNetworkWorker,
 				gBgjobsCountPerNetworkWorker);
 	}
 	for (auto obj = networkThreadObjects.begin(); obj != networkThreadObjects.end(); ++obj) {

--- a/src/chunkserver/network_worker_thread.cc
+++ b/src/chunkserver/network_worker_thread.cc
@@ -53,9 +53,9 @@ constexpr int getConnectTimeout(int cnt) {
 	               : kTimeoutEven * (1 << (cnt >> 1));
 }
 
-NetworkWorkerThread::NetworkWorkerThread(uint32_t nrOfBgjobsWorkers,
+NetworkWorkerThread::NetworkWorkerThread(uint32_t id, uint32_t nrOfBgjobsWorkers,
                                          uint32_t bgjobsCount)
-    : doTerminate(false) {
+    : name_("nw_" + std::to_string(id)), doTerminate(false) {
 	TRACETHIS();
 	eassert(pipe(notify_pipe) != -1);
 #ifdef F_SETPIPE_SZ
@@ -65,7 +65,8 @@ NetworkWorkerThread::NetworkWorkerThread(uint32_t nrOfBgjobsWorkers,
 	eassert(fcntl(notify_pipe[1], F_SETPIPE_SZ, kPageAlignedPipeSize));
 #endif
 	try {
-		bgJobPool_ = std::make_unique<JobPool>(nrOfBgjobsWorkers, bgjobsCount, &bgJobPoolWakeUpFd_);
+		bgJobPool_ =
+		    std::make_unique<JobPool>(name_, nrOfBgjobsWorkers, bgjobsCount, &bgJobPoolWakeUpFd_);
 	} catch (const std::exception &e) {
 		safs::log_err("NetworkWorkerThread: Failed to create JobPool instance: {}", e.what());
 		throw;

--- a/src/chunkserver/network_worker_thread.h
+++ b/src/chunkserver/network_worker_thread.h
@@ -42,7 +42,7 @@ public:
 	static constexpr uint16_t kDefaultMaxParallelHddReadJobsPerCsEntry = 16;
 	static constexpr uint16_t kDefaultMaxBlocksPerHddReadJob = 8;
 
-	NetworkWorkerThread(uint32_t nrOfBgjobsWorkers, uint32_t bgjobsCount);
+	NetworkWorkerThread(uint32_t id, uint32_t nrOfBgjobsWorkers, uint32_t bgjobsCount);
 	NetworkWorkerThread(const NetworkWorkerThread&) = delete;
 
 	// main loop
@@ -58,6 +58,9 @@ private:
 	void preparePollFds();
 	void servePoll() ;
 	void terminate();
+
+	/// Human readable name for the thread
+	std::string name_;
 
 	std::atomic<bool> doTerminate;
 	std::mutex csservheadLock;


### PR DESCRIPTION
Chunkservers use two different JobPools: for masterconn and for the NetworkWorkers. Previously the threads had generic names and were enumerated using static variables, making complex to identify them correctly at debug time.

This change assign better names for each JobPool and their worker threads. For instance:
- ma_worker_1: worker 1 assigned to the masterconn.
- nw_0_worker_5: worker 5 assigned to the NetworkWorker 0.