### PR TITLE
fix(chunkserver): Wait for GC before terminate

### DIFF
--- a/src/chunkserver/chunkserver-common/disk_plugin.h
+++ b/src/chunkserver/chunkserver-common/disk_plugin.h
@@ -35,6 +35,9 @@ public:
 	/// debugging purposes.
 	std::string toString() override;
 
+	/// Do specific resources cleanup.
+	virtual void cleanup() = 0;
+
 private:
 	/// Needed for correct logging after upgrade to c++23
 	std::shared_ptr<spdlog::logger> logger_;

--- a/src/chunkserver/chunkserver-common/plugin_manager.cc
+++ b/src/chunkserver/chunkserver-common/plugin_manager.cc
@@ -116,3 +116,12 @@ bool PluginManager::checkVersion(IPlugin *plugin) {
 
 	return false;
 }
+
+void PluginManager::cleanupPlugins() {
+	for (auto &[name, plugin] : diskPlugins_) {
+		if (plugin) {
+			safs::log_info("Cleaning up plugin {}", plugin->toString());
+			plugin->cleanup();
+		}
+	}
+}

--- a/src/chunkserver/chunkserver-common/plugin_manager.h
+++ b/src/chunkserver/chunkserver-common/plugin_manager.h
@@ -46,6 +46,9 @@ public:
 	/// True if this plugin manager can handle the plugin based on the version.
 	bool checkVersion(IPlugin *plugin);
 
+	/// Cleanup resources for all the needed plugins.
+	void cleanupPlugins();
+
 private:
 	/// Creators should never be out of scope or the plugin will be unloaded
 	std::map<std::string, boost::function<IPlugin_t>> creators_;

--- a/src/chunkserver/hddspacemgr.cc
+++ b/src/chunkserver/hddspacemgr.cc
@@ -2446,6 +2446,9 @@ void hddTerminate(void) {
 	// started, so do not join with them
 	uint32_t terminate = gTerminate.exchange(true);
 
+	// Request plugins to cleanup before removing Chunks and Disks
+	pluginManager.cleanupPlugins();
+
 	if (terminate == 0) {
 		gTesterThread.join();
 		gDisksThread.join();


### PR DESCRIPTION
The previous hddTerminate function could remove Disks and Chunks before
the Garbage Collection thread joins, causing potential races. This
change prevents the described scenario by requesting the plugins a
clean termination (including potential GC thread).

Signed-off-by: guillex <guillex@leil.io>