### PR TITLE
tests: Support VALGRIND_TOOL from environment

### DIFF
--- a/tests/tools/run_test_concurrently.sh
+++ b/tests/tools/run_test_concurrently.sh
@@ -66,6 +66,7 @@ RESET=$(tput sgr0)
 
 if [ $VALGRIND == "Yes" ]; then
 	export USE_VALGRIND=YES
+	export VALGRIND_TOOL="memcheck"
 fi
 
 # TODO: maybe somehow implement the following lines, to not run compilation,

--- a/tests/tools/test.sh
+++ b/tests/tools/test.sh
@@ -128,7 +128,8 @@ test_begin() {
 	timeout_init
 	system_init
 	if [[ ${USE_VALGRIND} ]]; then
-		valgrind_enable
+		valgrind_tool=${VALGRIND_TOOL:-}
+		valgrind_enable ${valgrind_tool}
 	fi
 	if [[ ${DEBUG} ]]; then
 		export PS4='+$(basename "${BASH_SOURCE:-}"):${LINENO:-}:${FUNCNAME[0]:+${FUNCNAME[0]}():} '


### PR DESCRIPTION
The test framework allows to execute multiple tests under valgrind by setting the environment variable USE_VALGRIND. Previously only `memcheck` was used by this approach.

This change adds support for using the environment variable VALGRIND_TOOL to determine the tool to use. The possible options so far are `helgrind` or the default `memcheck`.

Usage example:

export USE_VALGRIND=YES
export VALGRIND_TOOL=helgrind
saunafs-tests --gtest_filter="SanityChecks.test_*"