### PR TITLE
ci: Add merge queue branches to CI

### DIFF
--- a/.github/workflows/run-unit-and-ganesha-tests.yml
+++ b/.github/workflows/run-unit-and-ganesha-tests.yml
@@ -2,6 +2,7 @@ name: Run Unit and Ganesha Tests
 
 on:
     push:
+    merge_group:
     pull_request:
         branches:
             - "*"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -260,6 +260,7 @@ pipeline {
                             when {
                                 anyOf {
                                     branch 'dev'
+                                    branch 'gh-readonly-queue/*'
                                     branch 'stable'
                                     changeRequest()
                                 }
@@ -273,6 +274,7 @@ pipeline {
                             when {
                                 anyOf {
                                     branch 'dev'
+                                    branch 'gh-readonly-queue/*'
                                     branch 'stable'
                                     changeRequest()
                                 }


### PR DESCRIPTION
Idea is to explore using Github merge queues, to better coordinate merging multiple PR's that are approved and passed CI initially, but require updating each time one is merged to dev.

Note that this is not yet enabled. This commit just makes it possible to enable it.