### PR TITLE
refactor(fuse): Partially refactor FUSE metadata mountpoint and add testing

### DIFF
--- a/src/common/attributes.h
+++ b/src/common/attributes.h
@@ -22,7 +22,61 @@
 
 #include "common/platform.h"
 
+#include <fcntl.h>
+#include <sys/stat.h>
+
+#include "protocol/SFSCommunication.h"
+
 #include <array>
 #include <cstdint>
 
 typedef std::array<uint8_t, 35> Attributes;
+
+constexpr int saunaFileTypeToPosix(unsigned char type) {
+	switch (type) {
+	case TYPE_BLOCKDEV:
+		return S_IFBLK;
+	case TYPE_CHARDEV:
+		return S_IFCHR;
+	case TYPE_DIRECTORY:
+		return S_IFDIR;
+	case TYPE_FIFO:
+		return S_IFIFO;
+	case TYPE_FILE:
+		return S_IFREG;
+	case TYPE_SOCKET:
+		return S_IFSOCK;
+	case TYPE_SYMLINK:
+		return S_IFLNK;
+	default:
+		return 0;
+	}
+}
+
+struct PosixFileAttributes {
+	uint8_t type;
+	uint16_t permissions;
+	uint32_t userID;
+	uint32_t groupID;
+	uint32_t accessTime;
+	uint32_t modificationTime;
+	uint32_t creationTime;
+	uint32_t hardLinkCount;
+	uint64_t size;
+
+	constexpr struct stat getStat() const {
+		struct stat fileStat{};
+		fileStat.st_mode = saunaFileTypeToPosix(type) | permissions;
+		fileStat.st_size = static_cast<off_t>(size);
+		// TODO(Urmas): Why are we returning to clients blocks of 512?
+		// Instead of S_BLKSIZE, it should SFSBLOCKSIZE
+		fileStat.st_blocks = (static_cast<off_t>(size) + S_BLKSIZE - 1) / S_BLKSIZE;
+		fileStat.st_uid = userID;
+		fileStat.st_gid = groupID;
+		fileStat.st_atime = accessTime;
+		fileStat.st_mtime = modificationTime;
+		fileStat.st_ctime = creationTime;
+		fileStat.st_nlink = hardLinkCount;
+		return fileStat;
+	}
+};

--- a/src/common/attributes_unittest.cc
+++ b/src/common/attributes_unittest.cc
@@ -1,0 +1,77 @@
+/*
+   Copyright 2025      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// NOLINTBEGIN
+
+#include <gtest/gtest.h>
+
+#include "common/attributes.h"
+
+TEST(Attributes, TypeToPosix) {
+
+	EXPECT_EQ(saunaFileTypeToPosix('q'), 0010000);
+	EXPECT_EQ(saunaFileTypeToPosix('c'), 0020000);
+	EXPECT_EQ(saunaFileTypeToPosix('d'), 0040000);
+	EXPECT_EQ(saunaFileTypeToPosix('b'), 0060000);
+	EXPECT_EQ(saunaFileTypeToPosix('f'), 0100000);
+	EXPECT_EQ(saunaFileTypeToPosix('l'), 0120000);
+	EXPECT_EQ(saunaFileTypeToPosix('s'), 0140000);
+	EXPECT_EQ(saunaFileTypeToPosix('\t'), 0);
+
+}
+
+TEST(Attributes, PosixFileAttrsToStat) {
+	PosixFileAttributes attrs = {
+		.type = 'f',
+		.permissions = 0456,
+		.userID = 567,
+		.groupID = 234,
+		.accessTime = 10,
+		.modificationTime = 412,
+		.creationTime = 794,
+		.hardLinkCount = 50,
+		.size = 1024,
+	};
+	struct stat converted = attrs.getStat();
+
+	EXPECT_EQ(converted.st_mode, 0100456U);
+	EXPECT_EQ(converted.st_size, 1024);
+	EXPECT_EQ(converted.st_uid, attrs.userID);
+	EXPECT_EQ(converted.st_gid, attrs.groupID);
+	EXPECT_EQ(converted.st_atime, attrs.accessTime);
+	EXPECT_EQ(converted.st_mtime, attrs.modificationTime);
+	EXPECT_EQ(converted.st_ctime, attrs.creationTime);
+	EXPECT_EQ(converted.st_nlink, attrs.hardLinkCount);
+	EXPECT_EQ(converted.st_blocks, 2U);
+
+	attrs.size = 1025;
+	converted = attrs.getStat();
+	EXPECT_EQ(converted.st_blocks, 3U);
+	attrs.size = 0;
+	converted = attrs.getStat();
+	EXPECT_EQ(converted.st_blocks, 0U);
+	attrs.size = 1;
+	converted = attrs.getStat();
+	EXPECT_EQ(converted.st_blocks, 1U);
+	attrs.size = 512;
+	converted = attrs.getStat();
+	EXPECT_EQ(converted.st_blocks, 1U);
+
+}
+
+// NOLINTEND

--- a/src/mount/fuse/CMakeLists.txt
+++ b/src/mount/fuse/CMakeLists.txt
@@ -1,9 +1,10 @@
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+add_subdirectory(sfs_fuselib)
 
 collect_sources(MOUNT_FUSE)
 
 add_executable(sfsmount ${MOUNT_FUSE_MAIN} ${MOUNT_FUSE_SOURCES})
-target_link_libraries(sfsmount mount sfscommon ${FUSE3_LIBRARY})
+target_link_libraries(sfsmount mount sfscommon sfs_fuselib ${FUSE3_LIBRARY})
 target_include_directories(sfsmount PRIVATE ${FUSE3_INCLUDE_DIR})
 target_compile_definitions(sfsmount PRIVATE "-DAPPNAME=sfsmount" "-DCFGNAME=sfsmount" -DAPP_EXAMPLES_DIRECTORY="${CLIENT_EXAMPLES_SUBDIR}" ${FUSE3_CFLAGS_OTHER} "-DFUSE_USE_VERSION=30")
 install(TARGETS sfsmount RUNTIME DESTINATION ${BIN_SUBDIR})

--- a/src/mount/fuse/main.cc
+++ b/src/mount/fuse/main.cc
@@ -41,6 +41,7 @@
 #include "mount/g_io_limiters.h"
 #include "mount/mastercomm.h"
 #include "mount/masterproxy.h"
+#include "mount/mount_info.h"
 #include "mount/option_casing_normalization.h"
 #include "mount/readdata.h"
 #include "mount/stats.h"
@@ -291,7 +292,7 @@ static int mainloop(struct fuse_args *args, struct fuse_cmdline_opts *fuse_opts,
 
 	struct fuse_session *se;
 	if (gMountOptions.meta) {
-		sfs_meta_init(gMountOptions.debug, gMountOptions.entrycacheto, gMountOptions.attrcacheto);
+		sfs_meta_init(gMountOptions.entrycacheto, gMountOptions.attrcacheto);
 		se = fuse_session_new(args, &sfs_meta_oper, sizeof(sfs_meta_oper), (void *)conn_opts);
 	} else {
 		se = fuse_session_new(args, &sfs_oper, sizeof(sfs_oper), (void *)conn_opts);

--- a/src/mount/fuse/mount_config.cc
+++ b/src/mount/fuse/mount_config.cc
@@ -19,6 +19,7 @@
 
 #include "common/platform.h"
 #include "mount/fuse/mount_config.h"
+#include "mount/mount_info.h"
 #include "mount/sugid_clear_mode_string.h"
 
 #include <stdio.h>

--- a/src/mount/fuse/sfs_fuse.cc
+++ b/src/mount/fuse/sfs_fuse.cc
@@ -19,6 +19,7 @@
  */
 
 #include "common/platform.h"
+
 #include "mount/fuse/sfs_fuse.h"
 
 #include <atomic>
@@ -33,11 +34,12 @@
 #include "common/special_inode_defs.h"
 #include "common/time_utils.h"
 #include "mount/fuse/lock_conversion.h"
+#include "mount/group_cache.h"
 #include "mount/sauna_client.h"
 #include "mount/sauna_client_context.h"
 #include "mount/thread_safe_map.h"
-#include "protocol/cltoma.h"
 #include "protocol/SFSCommunication.h"
+#include "protocol/cltoma.h"
 
 #include "grp.h"
 #include "pwd.h"

--- a/src/mount/fuse/sfs_fuselib/CMakeLists.txt
+++ b/src/mount/fuse/sfs_fuselib/CMakeLists.txt
@@ -1,0 +1,7 @@
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+
+collect_sources(SFS_FUSELIB)
+
+shared_add_library(sfs_fuselib ${SFS_FUSELIB_SOURCES})
+create_unittest(sfs_fuselib ${SAUNAFS_FUSE_LIB_TESTS})
+link_unittest(sfs_fuselib sfs_fuselib sfscommon)

--- a/src/mount/fuse/sfs_fuselib/metadata.cc
+++ b/src/mount/fuse/sfs_fuselib/metadata.cc
@@ -1,0 +1,89 @@
+/*
+   Copyright 2025      Leil Storage OÜ
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "common/platform.h"
+
+#include <sys/stat.h>
+#include <cstdint>
+#include <cstdlib>
+#include <string>
+#include "mount/fuse/sfs_fuselib/metadata.h"
+
+#include "common/attributes.h"
+#include "common/special_inode_defs.h"
+#include "mount/exports.h"
+
+void sfsMetaStat(inode_t inode, struct stat *stbuf) {
+	time_t now = time(nullptr);
+	constexpr int allowAll = 0777;
+	constexpr int allowReadExecAll = 0555;
+	constexpr int allowReadExecRoot = 0500;
+	constexpr int allowRootAll = 0700;
+	constexpr int allowRootWriteOnly = 0200;
+
+	stbuf->st_ino = inode;
+	stbuf->st_size = 0;
+	stbuf->st_blocks = 0;
+	stbuf->st_uid = 0;
+	stbuf->st_gid = 0;
+	stbuf->st_atime = now;
+	stbuf->st_mtime = now;
+	stbuf->st_ctime = now;
+
+	switch (inode) {
+	case SPECIAL_INODE_ROOT:
+		stbuf->st_nlink = 4;
+		stbuf->st_mode = S_IFDIR | META_ROOT_MODE;
+		break;
+	case SPECIAL_INODE_META_TRASH:
+		stbuf->st_nlink = 3;
+		stbuf->st_mode = S_IFDIR | (nonRootAllowedToUseMeta() ? allowAll : allowRootAll);
+		break;
+	case SPECIAL_INODE_META_UNDEL:
+		stbuf->st_nlink = 2;
+		stbuf->st_mode = S_IFDIR | (nonRootAllowedToUseMeta() ? allowAll : allowRootWriteOnly);
+		break;
+	case SPECIAL_INODE_META_RESERVED:
+		stbuf->st_nlink = 2;
+		stbuf->st_mode = S_IFDIR | (nonRootAllowedToUseMeta() ? allowReadExecAll : allowReadExecRoot);
+		break;
+	default:
+		break;
+	}
+}
+
+inode_t metadataNameToInode(const std::string &name) {
+	inode_t inode = 0;
+	size_t end = 0;
+	const int base16 = 16;
+
+	try {
+		inode = std::stoul(name, &end, base16);
+		if (name.at(end) == '|' && name.at(end + 1) != 0) {
+			return inode;
+		}
+	} catch (std::exception &e) {
+		safs::log_err("Could not convert metadata name to inode: {}", e.what());
+	}
+
+	return 0;
+}
+
+void resetStat(inode_t inode, unsigned char type, struct stat &fileStat) {
+	memset(&fileStat, 0 ,sizeof(struct stat));
+	fileStat.st_ino = inode;
+	fileStat.st_mode = saunaFileTypeToPosix(type);
+}

--- a/src/mount/fuse/sfs_fuselib/metadata.h
+++ b/src/mount/fuse/sfs_fuselib/metadata.h
@@ -1,0 +1,85 @@
+/*
+   Copyright 2025      Leil Storage OÜ
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "common/platform.h"
+
+#include <ctime>
+#include <cstring>
+#include <string>
+#include "common/attributes.h"
+#include "common/special_inode_defs.h"
+#include "protocol/SFSCommunication.h"
+#include "slogger/slogger.h"
+
+enum : uint16_t {
+	READDIR_BUFFSIZE = 50000,
+	PATH_SIZE_LIMIT = 1024,
+	META_ROOT_MODE = 0555,
+};
+
+struct MetaStat {
+	std::string name;
+	inode_t inode{};
+	char type{};
+};
+
+static constexpr std::array<MetaStat, 4> rootDirEntries() {
+		auto rootDir = MetaStat(".", SPECIAL_INODE_ROOT, TYPE_DIRECTORY);
+		auto upDir = MetaStat("..", SPECIAL_INODE_ROOT, TYPE_DIRECTORY);
+		auto trash = MetaStat(SPECIAL_FILE_NAME_META_TRASH, SPECIAL_INODE_META_TRASH, TYPE_DIRECTORY);
+		auto reserved = MetaStat(SPECIAL_FILE_NAME_META_RESERVED, SPECIAL_INODE_META_RESERVED, TYPE_DIRECTORY);
+		std::array<MetaStat, 4> entries = {rootDir, upDir, trash, reserved};
+		return entries;
+}
+
+void sfsMetaStat(inode_t inode, struct stat *stbuf);
+
+uint32_t metadataNameToInode(const std::string &name);
+
+/**
+ * Memsets the stat struct to 0, and then sets the inode and SaunaFS file type.
+ *
+ * @param inode New inode type to set
+ * @param type SaunaFS type to convert to system type
+ * @param fileStat Reference to the stat structure that will be reset.
+ */
+void resetStat(inode_t inode, unsigned char type, struct stat &fileStat);
+
+/**
+ * Returns the stat structure with attributes for the master info file
+ *
+ * @returns .masterinfo stat
+ */
+constexpr struct stat getMasterInfoStat() {
+	struct stat fileStat{};
+	constexpr PosixFileAttributes attrs = {
+		.type = 'f',
+		.permissions = 0444,
+		.userID = 0,
+		.groupID = 0,
+		.accessTime = 0,
+		.modificationTime = 0,
+		.creationTime = 0,
+		.hardLinkCount = 1,
+		.size = 14,
+	};
+	fileStat = attrs.getStat();
+	fileStat.st_ino = SPECIAL_INODE_MASTERINFO;
+
+	return fileStat;
+}

--- a/src/mount/fuse/sfs_fuselib/metadata_unittest.cc
+++ b/src/mount/fuse/sfs_fuselib/metadata_unittest.cc
@@ -1,0 +1,186 @@
+/*
+   Copyright 2025      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "common/platform.h"
+
+#include <fcntl.h>
+#include <gtest/gtest.h>
+#include "mount/exports.h"
+#include "mount/fuse/sfs_fuselib/metadata.h"
+
+namespace {
+
+void checkGenericStat(struct stat fileStat) {
+	EXPECT_EQ(fileStat.st_size, 0U);
+	EXPECT_EQ(fileStat.st_blocks, 0U);
+	EXPECT_TRUE(fileStat.st_uid == 0U);
+	EXPECT_TRUE(fileStat.st_gid == 0U);
+}
+
+}  // namespace
+
+TEST(MetadataMount, RootDirFiles) {
+	auto rootEntries = rootDirEntries();
+
+	EXPECT_EQ(rootEntries.at(0).inode, 0x01U);
+	EXPECT_EQ(rootEntries.at(1).inode, 0x01U);
+	EXPECT_EQ(rootEntries.at(2).inode, 0xFFFFFFF5U);
+	EXPECT_EQ(rootEntries.at(3).inode, 0xFFFFFFF7U);
+
+	EXPECT_EQ(rootEntries.at(2).name, "trash");
+	EXPECT_EQ(rootEntries.at(3).name, "reserved");
+
+	for (const auto &entry: rootEntries) {
+		EXPECT_EQ(entry.type, 'd');
+	}
+}
+
+TEST(MetadataMount, FileStatRootDir) {
+	struct stat fileStat{};
+	nonRootAllowedToUseMeta() = false;
+
+	sfsMetaStat(SPECIAL_INODE_ROOT, &fileStat);
+
+	EXPECT_EQ(fileStat.st_ino, SPECIAL_INODE_ROOT);
+	EXPECT_EQ(fileStat.st_nlink, 4U);
+	// S_IFDIR (040000) | META_ROOT_MODE (0555)
+	EXPECT_EQ(fileStat.st_mode, 040555U);
+
+	checkGenericStat(fileStat);
+}
+
+TEST(MetadataMount, FileStatTrashDir) {
+	struct stat fileStat{};
+	nonRootAllowedToUseMeta() = false;
+
+	sfsMetaStat(SPECIAL_INODE_META_TRASH, &fileStat);
+
+	EXPECT_EQ(fileStat.st_ino, SPECIAL_INODE_META_TRASH);
+	EXPECT_EQ(fileStat.st_nlink, 3U);
+	// S_IFDIR (040000) | 0700
+	EXPECT_EQ(fileStat.st_mode, 040700U);
+
+	nonRootAllowedToUseMeta() = true;
+	sfsMetaStat(SPECIAL_INODE_META_TRASH, &fileStat);
+	// S_IFDIR (040000) | 0777
+	EXPECT_EQ(fileStat.st_mode, 040777U);
+
+	checkGenericStat(fileStat);
+}
+
+TEST(MetadataMount, FileStatUndelDir) {
+	struct stat fileStat{};
+	nonRootAllowedToUseMeta() = false;
+
+	sfsMetaStat(SPECIAL_INODE_META_UNDEL, &fileStat);
+
+	EXPECT_EQ(fileStat.st_ino, SPECIAL_INODE_META_UNDEL);
+	EXPECT_EQ(fileStat.st_nlink, 2U);
+	// S_IFDIR (040000) | 0200
+	EXPECT_EQ(fileStat.st_mode, 040200U);
+
+	nonRootAllowedToUseMeta() = true;
+	sfsMetaStat(SPECIAL_INODE_META_TRASH, &fileStat);
+	// S_IFDIR (040000) | 0777
+	EXPECT_EQ(fileStat.st_mode, 040777U);
+
+	checkGenericStat(fileStat);
+}
+
+TEST(MetadataMount, FileStatReservedDir) {
+	struct stat fileStat{};
+	nonRootAllowedToUseMeta() = false;
+
+	sfsMetaStat(SPECIAL_INODE_META_RESERVED, &fileStat);
+
+	EXPECT_EQ(fileStat.st_ino, SPECIAL_INODE_META_RESERVED);
+	EXPECT_EQ(fileStat.st_nlink, 2U);
+	// S_IFDIR (040000) | 0500
+	EXPECT_EQ(fileStat.st_mode, 040500U);
+
+	nonRootAllowedToUseMeta() = true;
+	sfsMetaStat(SPECIAL_INODE_META_RESERVED, &fileStat);
+	// S_IFDIR (040000) | 0555
+	EXPECT_EQ(fileStat.st_mode, 040555U);
+
+	checkGenericStat(fileStat);
+}
+
+TEST(MetadataMount, MetaNameToInode) {
+	inode_t inode = 0;
+	inode = metadataNameToInode("0000000000005431| test");
+	EXPECT_EQ(inode, 0x5431U);
+	inode = metadataNameToInode("abc test");
+	EXPECT_EQ(inode, 0x0U);
+	inode = metadataNameToInode("454est");
+	EXPECT_EQ(inode, 0x0U);
+	inode = metadataNameToInode("000454|");
+	EXPECT_EQ(inode, 0x0U);
+	inode = metadataNameToInode("000454");
+	EXPECT_EQ(inode, 0x0U);
+}
+
+TEST(MetadataMount, ResetStat) {
+	struct stat fileStat{};
+	unsigned long expectInode = 5;
+	fileStat.st_ino = 1234;
+	fileStat.st_mode = S_IFDIR;
+	fileStat.st_gid = 1000;
+	resetStat(expectInode, 'f', fileStat);
+	EXPECT_EQ(fileStat.st_gid, 0U);
+	EXPECT_EQ(fileStat.st_mode, 0100000U);
+	EXPECT_EQ(fileStat.st_ino, 5U);
+
+	resetStat(1, 'd', fileStat);
+	EXPECT_EQ(fileStat.st_mode, 0040000U);
+
+	resetStat(1, 'l', fileStat);
+	EXPECT_EQ(fileStat.st_mode, 0120000U);
+
+	resetStat(1, 'f', fileStat);
+	EXPECT_EQ(fileStat.st_mode, 0100000U);
+
+	resetStat(1, 'q', fileStat);
+	EXPECT_EQ(fileStat.st_mode, 0010000U);
+
+	resetStat(1, 's', fileStat);
+	EXPECT_EQ(fileStat.st_mode, 0140000U);
+
+	resetStat(1, 'b', fileStat);
+	EXPECT_EQ(fileStat.st_mode, 0060000U);
+
+	resetStat(1, 'c', fileStat);
+	EXPECT_EQ(fileStat.st_mode, 0020000U);
+
+	resetStat(1, '\t', fileStat);
+	EXPECT_EQ(fileStat.st_mode, 0U);
+}
+
+TEST(MetadataMount, MasterInfoStat) {
+	struct stat fileStat = getMasterInfoStat();
+	EXPECT_EQ(fileStat.st_ino, 0xFFFFFFFF);
+	EXPECT_EQ(fileStat.st_mode, 0100444U);
+	EXPECT_EQ(fileStat.st_uid, 0U);
+	EXPECT_EQ(fileStat.st_gid, 0U);
+	EXPECT_EQ(fileStat.st_atime, 0U);
+	EXPECT_EQ(fileStat.st_mtime, 0U);
+	EXPECT_EQ(fileStat.st_ctime, 0U);
+	EXPECT_EQ(fileStat.st_nlink, 1U);
+	EXPECT_EQ(fileStat.st_size, 14);
+	EXPECT_EQ(fileStat.st_blocks, 1);
+}

--- a/src/mount/fuse/sfs_meta_fuse.cc
+++ b/src/mount/fuse/sfs_meta_fuse.cc
@@ -18,17 +18,15 @@
    along with SaunaFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "common/massert.h"
 #include "common/platform.h"
-#include "mount/fuse/sfs_meta_fuse.h"
 
 #include <errno.h>
+#include <fuse_lowlevel.h>
 #include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
-#include <fuse_lowlevel.h>
 #include <algorithm>
 #include <array>
 #include <cstdint>
@@ -36,13 +34,16 @@
 #include <span>
 
 #include "common/datapack.h"
-#include "common/type_defs.h"
-#include "protocol/SFSCommunication.h"
-#include "slogger/slogger.h"
+#include "common/massert.h"
 #include "common/special_inode_defs.h"
+#include "common/type_defs.h"
 #include "mount/exports.h"
+#include "mount/fuse/sfs_fuselib/metadata.h"
+#include "mount/fuse/sfs_meta_fuse.h"
 #include "mount/mastercomm.h"
 #include "mount/masterproxy.h"
+#include "protocol/SFSCommunication.h"
+#include "slogger/slogger.h"
 
 static_assert(FUSE_ROOT_ID == SPECIAL_INODE_ROOT, "invalid value of FUSE_ROOT_ID");
 
@@ -53,12 +54,12 @@ struct dirbuf {
 	std::mutex lock;
 };
 
-typedef struct _pathbuf {
+struct pathbuf {
 	int changed;
 	char *p;
 	size_t size;
 	std::mutex lock;
-} pathbuf;
+};
 
 #define READDIR_BUFFSIZE 50000
 
@@ -67,13 +68,6 @@ typedef struct _pathbuf {
 
 #define META_ROOT_MODE 0555
 
-// 0x0124 = 0444
-#ifdef MASTERINFO_WITH_VERSION
-static Attributes masterinfoattr={{'f', 0x01,0x24, 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,1, 0,0,0,0,0,0,0,14}};
-#else
-static Attributes masterinfoattr={{'f', 0x01,0x24, 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,1, 0,0,0,0,0,0,0,10}};
-#endif
-
 #define PKGVERSION \
 		((SAUNAFS_PACKAGE_VERSION_MAJOR)*1000000 + \
 		(SAUNAFS_PACKAGE_VERSION_MINOR)*1000 + \
@@ -81,81 +75,8 @@ static Attributes masterinfoattr={{'f', 0x01,0x24, 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,
 
 #define IS_SPECIAL_INODE(inode) ((inode)>=SPECIAL_INODE_BASE || (inode)==SPECIAL_INODE_ROOT)
 
-static int debug_mode = 0;
 static double entry_cache_timeout = 0.0;
 static double attr_cache_timeout = 1.0;
-
-inode_t sfs_meta_name_to_inode(const char *name) {
-	inode_t inode=0;
-	char *end;
-	inode = strtoul(name,&end,16);
-	if (*end=='|' && end[1]!=0) {
-		return inode;
-	} else {
-		return 0;
-	}
-}
-
-static void sfs_meta_type_to_stat(inode_t inode,uint8_t type, struct stat *stbuf) {
-	memset(stbuf,0,sizeof(struct stat));
-	stbuf->st_ino = inode;
-	switch (type) {
-	case TYPE_DIRECTORY:
-		stbuf->st_mode = S_IFDIR;
-		break;
-	case TYPE_SYMLINK:
-		stbuf->st_mode = S_IFLNK;
-		break;
-	case TYPE_FILE:
-		stbuf->st_mode = S_IFREG;
-		break;
-	case TYPE_FIFO:
-		stbuf->st_mode = S_IFIFO;
-		break;
-	case TYPE_SOCKET:
-		stbuf->st_mode = S_IFSOCK;
-		break;
-	case TYPE_BLOCKDEV:
-		stbuf->st_mode = S_IFBLK;
-		break;
-	case TYPE_CHARDEV:
-		stbuf->st_mode = S_IFCHR;
-		break;
-	default:
-		stbuf->st_mode = 0;
-	}
-}
-
-static void sfs_meta_stat(inode_t inode, struct stat *stbuf) {
-	int now;
-	stbuf->st_ino = inode;
-	stbuf->st_size = 0;
-	stbuf->st_blocks = 0;
-	switch (inode) {
-	case SPECIAL_INODE_ROOT:
-		stbuf->st_nlink = 4;
-		stbuf->st_mode = S_IFDIR | META_ROOT_MODE ;
-		break;
-	case SPECIAL_INODE_META_TRASH:
-		stbuf->st_nlink = 3;
-		stbuf->st_mode = S_IFDIR | (nonRootAllowedToUseMeta() ? 0777 : 0700) ;
-		break;
-	case SPECIAL_INODE_META_UNDEL:
-		stbuf->st_nlink = 2;
-		stbuf->st_mode = S_IFDIR | (nonRootAllowedToUseMeta() ? 0777 : 0200) ;
-		break;
-	case SPECIAL_INODE_META_RESERVED:
-		stbuf->st_nlink = 2;
-		stbuf->st_mode = S_IFDIR | (nonRootAllowedToUseMeta() ? 0555 : 0500) ;
-		break;
-	}
-	stbuf->st_uid = 0;
-	stbuf->st_gid = 0;
-	now = time(NULL);
-	stbuf->st_atime = now;
-	stbuf->st_mtime = now;
-	stbuf->st_ctime = now;
-}
 
 static void sfs_attr_to_stat(inode_t inode, const Attributes &attr, struct stat *stbuf) {
 	uint16_t attrmode;
@@ -229,7 +150,7 @@ void sfs_meta_lookup(fuse_req_t req, fuse_ino_t parent, const char *name) {
 			e.ino = SPECIAL_INODE_MASTERINFO;
 			e.attr_timeout = 3600.0;
 			e.entry_timeout = 3600.0;
-			sfs_attr_to_stat(SPECIAL_INODE_MASTERINFO,masterinfoattr,&e.attr);
+			e.attr = getMasterInfoStat();
 			fuse_reply_entry(req, &e);
 			return ;
 		}
@@ -242,7 +163,7 @@ void sfs_meta_lookup(fuse_req_t req, fuse_ino_t parent, const char *name) {
 		} else if (strcmp(name,SPECIAL_FILE_NAME_META_UNDEL)==0) {
 			inode = SPECIAL_INODE_META_UNDEL;
 		} else {
-			inode = sfs_meta_name_to_inode(name);
+			inode = metadataNameToInode(name);
 			if (inode>0) {
 				int status;
 				Attributes attr;
@@ -274,7 +195,7 @@ void sfs_meta_lookup(fuse_req_t req, fuse_ino_t parent, const char *name) {
 		} else if (strcmp(name,"..")==0) {
 			inode = SPECIAL_INODE_ROOT;
 		} else {
-			inode = sfs_meta_name_to_inode(name);
+			inode = metadataNameToInode(name);
 			if (inode>0) {
 				int status;
 				Attributes attr;
@@ -300,7 +221,7 @@ void sfs_meta_lookup(fuse_req_t req, fuse_ino_t parent, const char *name) {
 		e.ino = inode;
 		e.attr_timeout = attr_cache_timeout;
 		e.entry_timeout = entry_cache_timeout;
-		sfs_meta_stat(inode,&e.attr);
+		sfsMetaStat(inode,&e.attr);
 		fuse_reply_entry(req,&e);
 	}
 }
@@ -310,11 +231,11 @@ void sfs_meta_getattr(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
 	(void)fi;
 	if (ino==SPECIAL_INODE_MASTERINFO) {
 		memset(&o_stbuf, 0, sizeof(struct stat));
-		sfs_attr_to_stat(ino,masterinfoattr,&o_stbuf);
+		o_stbuf = getMasterInfoStat();
 		fuse_reply_attr(req, &o_stbuf, 3600.0);
 	} else if (IS_SPECIAL_INODE(ino)) {
 		memset(&o_stbuf, 0, sizeof(struct stat));
-		sfs_meta_stat(ino,&o_stbuf);
+		sfsMetaStat(ino,&o_stbuf);
 		fuse_reply_attr(req, &o_stbuf, attr_cache_timeout);
 	} else {
 		int status;
@@ -325,7 +246,7 @@ void sfs_meta_getattr(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
 			fuse_reply_err(req, status);
 		} else {
 			memset(&o_stbuf, 0, sizeof(struct stat));
-			sfs_attr_to_stat(ino,attr,&o_stbuf);
+			sfs_attr_to_stat(ino, attr, &o_stbuf);
 			fuse_reply_attr(req, &o_stbuf, attr_cache_timeout);
 		}
 	}
@@ -344,7 +265,7 @@ void sfs_meta_unlink(fuse_req_t req, fuse_ino_t parent, const char *name) {
 		fuse_reply_err(req,EACCES);
 		return;
 	}
-	inode = sfs_meta_name_to_inode(name);
+	inode = metadataNameToInode(name);
 	if (inode==0) {
 		fuse_reply_err(req,ENOENT);
 		return;
@@ -363,7 +284,7 @@ void sfs_meta_rename(fuse_req_t req, fuse_ino_t parent, const char *name, fuse_i
 		fuse_reply_err(req,EACCES);
 		return;
 	}
-	inode = sfs_meta_name_to_inode(name);
+	inode = metadataNameToInode(name);
 	if (inode==0) {
 		fuse_reply_err(req,ENOENT);
 		return;
@@ -392,21 +313,6 @@ static uint32_t dir_metaentries_size(inode_t ino) {
 	}
 
 	return 0;
-}
-
-struct MetaStat {
-	std::string name;
-	inode_t inode;
-	char type;
-};
-
-static constexpr std::array<MetaStat, 4> rootDirEntries() {
-		auto rootDir = MetaStat(".", SPECIAL_INODE_ROOT, TYPE_DIRECTORY);
-		auto upDir = MetaStat("..", SPECIAL_INODE_ROOT, TYPE_DIRECTORY);
-		auto trash = MetaStat(SPECIAL_FILE_NAME_META_TRASH, SPECIAL_INODE_META_TRASH, TYPE_DIRECTORY);
-		auto reserved = MetaStat(SPECIAL_FILE_NAME_META_RESERVED, SPECIAL_INODE_META_RESERVED, TYPE_DIRECTORY);
-		std::array<MetaStat, 4> entries = {rootDir, upDir, trash, reserved};
-		return entries;
 }
 
 static void dir_metaentries_fill(uint8_t *buff, inode_t ino) {
@@ -625,7 +531,7 @@ void replyDirReadRoot(fuse_req_t request, off_t offset, size_t maxsize) {
 
 	for (const auto &file : std::span(files).subspan(offset)) {
 		offset += 1;
-		sfs_meta_type_to_stat(file.inode, file.type, &statBuffer);
+		resetStat(file.inode, file.type, statBuffer);
 		size_t needed = fuse_add_direntry(request, nullptr, 0, file.name.c_str(), &statBuffer, 0);
 		if (size + needed > buffer.size() || size + needed > maxsize) {
 			// No more buffer space or we would be over maxsize
@@ -688,7 +594,7 @@ void sfs_meta_readdir(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off, st
 			if (ptr+5<=eptr) {
 				getINode(&ptr, inode);
 				type = get8bit(&ptr);
-				sfs_meta_type_to_stat(inode,type,&stbuf);
+				resetStat(inode, type, stbuf);
 				c = name[nleng];
 				name[nleng]=0;
 				oleng = fuse_add_direntry(req, buffer + opos, size - opos, name, &stbuf, off);
@@ -855,12 +761,11 @@ void sfs_meta_write(fuse_req_t req, fuse_ino_t ino, const char *buf, size_t size
 	fuse_reply_write(req,size);
 }
 
-void sfs_meta_init(int debug_mode_in,double entry_cache_timeout_in,double attr_cache_timeout_in) {
-	debug_mode = debug_mode_in;
+void sfs_meta_init(double entry_cache_timeout_in, double attr_cache_timeout_in) {
 	entry_cache_timeout = entry_cache_timeout_in;
 	attr_cache_timeout = attr_cache_timeout_in;
-	if (debug_mode) {
-		fprintf(stdout, "cache parameters: entry_cache_timeout=%.2f attr_cache_timeout=%.2f\n",
-		        entry_cache_timeout, attr_cache_timeout);
-	}
+	fmt::print(stderr,
+	           "cache parameters: entry_cache_timeout={:.2f} "
+	           "attr_cache_timeout={:.2f}\n",
+	           entry_cache_timeout, attr_cache_timeout);
 }

--- a/src/mount/fuse/sfs_meta_fuse.h
+++ b/src/mount/fuse/sfs_meta_fuse.h
@@ -37,4 +37,4 @@ void sfs_meta_open(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi);
 void sfs_meta_release(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi);
 void sfs_meta_read(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off, struct fuse_file_info *fi);
 void sfs_meta_write(fuse_req_t req, fuse_ino_t ino, const char *buf, size_t size, off_t off, struct fuse_file_info *fi);
-void sfs_meta_init(int debug_mode_in,double entry_cache_timeout_in,double attr_cache_timeout_in);
+void sfs_meta_init(double entry_cache_timeout_in, double attr_cache_timeout_in);

--- a/src/mount/sauna_client.h
+++ b/src/mount/sauna_client.h
@@ -22,23 +22,20 @@
 #include "common/platform.h"
 
 #include <string.h>
-#include "common/stat32.h"
 #include <sys/types.h>
 #include <unistd.h>
 
 #include <string>
-#include <unordered_set>
-#include <utility>
 #include <vector>
 
 #include "common/chunk_with_address_and_label.h"
 #include "common/exception.h"
+#include "common/stat_defs.h"
 #include "common/type_defs.h"
 #include "mount/group_cache.h"
 #include "mount/mount_info.h"
-#include "mount/sauna_client_context.h"
 #include "mount/readdata_cache.h"
-#include "common/stat_defs.h"
+#include "mount/sauna_client_context.h"
 #include "protocol/chunkserver_list_entry.h"
 #include "protocol/lock_info.h"
 #include "protocol/named_inode_entry.h"


### PR DESCRIPTION
This commit refactors out the metadata specific operations (that isn't touching the FUSE layer quite yet) to it's own library (saunafs_fuse_lib). The idea is to make it more easily testable the functions used while refactoring.

* Add saunafs_fuse_lib
* Refactor a bunch of metadata functions
* Write tests for those functions
* Add a more human-readable Attributes structure in common
* Cleanup headers in sauna_client (Some of them caused linkage problems to the new library)
