### PR TITLE
fix(chunkserver): Protect status in OutputBuffer

### DIFF
--- a/src/chunkserver/bgjobs.cc
+++ b/src/chunkserver/bgjobs.cc
@@ -272,7 +272,7 @@ uint32_t job_read(JobPool &jobPool, JobPool::JobCallback callback, void *extra, 
 
 		status = hddRead(chunkId, version, chunkType, offset, size, maxBlocksToBeReadBehind,
 		                 blocksToBeReadAhead, outputBuffer);
-		outputBuffer->status = status;
+		outputBuffer->setStatus(status);
 
 		if (performHddOpen && status != SAUNAFS_STATUS_OK) {
 			int ret = hddClose(chunkId, chunkType);

--- a/src/chunkserver/chunkserver_entry.cc
+++ b/src/chunkserver/chunkserver_entry.cc
@@ -281,7 +281,8 @@ void ChunkserverEntry::delayedCloseCallback(uint8_t status, void *entry) {
 	           status == SAUNAFS_STATUS_OK) {  // this could be job_open
 
 		while (!eptr->pendingReadDataPackets.empty() &&
-		       eptr->pendingReadDataPackets.front()->outputBuffer->status != kNotSaunafsStatus) {
+		       eptr->pendingReadDataPackets.front()->outputBuffer->getStatus() !=
+		           kNotSaunafsStatus) {
 			getReadOutputBufferPool().put(
 			    std::move(eptr->pendingReadDataPackets.front()->outputBuffer));
 			eptr->pendingReadDataPackets.pop_front();
@@ -309,7 +310,7 @@ void ChunkserverEntry::delayedDiscardCallback(uint8_t status, void *entry) {
 	auto *eptr = static_cast<ChunkserverEntry*>(entry);
 
 	while (!eptr->toDiscardReadDataPackets.empty() &&
-	       eptr->toDiscardReadDataPackets.front()->outputBuffer->status != kNotSaunafsStatus) {
+	       eptr->toDiscardReadDataPackets.front()->outputBuffer->getStatus() != kNotSaunafsStatus) {
 		getReadOutputBufferPool().put(
 		    std::move(eptr->toDiscardReadDataPackets.front()->outputBuffer));
 		eptr->toDiscardReadDataPackets.pop_front();
@@ -330,7 +331,7 @@ void ChunkserverEntry::readDiscardCallback(uint8_t status, void *entry) {
 	auto *eptr = static_cast<ChunkserverEntry *>(entry);
 
 	while (!eptr->toDiscardReadDataPackets.empty() &&
-	       eptr->toDiscardReadDataPackets.front()->outputBuffer->status != kNotSaunafsStatus) {
+	       eptr->toDiscardReadDataPackets.front()->outputBuffer->getStatus() != kNotSaunafsStatus) {
 		getReadOutputBufferPool().put(
 		    std::move(eptr->toDiscardReadDataPackets.front()->outputBuffer));
 		eptr->toDiscardReadDataPackets.pop_front();
@@ -426,7 +427,7 @@ void ChunkserverEntry::readContinue(uint16_t callMaxParallelHddReadJobs) {
 	TRACETHIS2(offset, size);
 
 	while (!pendingReadDataPackets.empty() &&
-	       pendingReadDataPackets.front()->outputBuffer->status == SAUNAFS_STATUS_OK) {
+	       pendingReadDataPackets.front()->outputBuffer->getStatus() == SAUNAFS_STATUS_OK) {
 		attachPacket(std::move(pendingReadDataPackets.front()));
 		pendingReadDataPackets.pop_front();
 		workerJobPool->changeCallback(pendingReadJobIds.front(), kEmptyCallback, kEmptyExtra);

--- a/src/chunkserver/output_buffer.cc
+++ b/src/chunkserver/output_buffer.cc
@@ -80,7 +80,7 @@ void OutputBuffer::clear() {
 	crcBuffer_.clear();
 	headerBuffer_.clear();
 
-	status = kNotSaunafsStatus;
+	setStatus(kNotSaunafsStatus);
 }
 
 bool OutputBuffer::checkCRC(size_t bytes, uint32_t crc, uint32_t startingOffset) const {

--- a/src/chunkserver/output_buffer.h
+++ b/src/chunkserver/output_buffer.h
@@ -24,6 +24,7 @@
 #include <sys/types.h>
 #include <cstdint>
 #include <cstring>
+#include <mutex>
 #include <vector>
 
 #include "chunkserver-common/chunk_interface.h"
@@ -252,8 +253,17 @@ public:
 	/// @brief Clears the buffer.
 	void clear();
 
-	/// Status of the buffer's related read operation.
-	std::atomic_uint8_t status{kNotSaunafsStatus};
+	/// @brief Returns the `status` in a thread-safe manner.
+	uint8_t getStatus() {
+		std::lock_guard<std::mutex> lock(mutex_);
+		return status;
+	}
+
+	/// @brief Sets the `status` in a thread-safe manner.
+	void setStatus(uint8_t newStatus) {
+		std::lock_guard<std::mutex> lock(mutex_);
+		status = newStatus;
+	}
 
 private:
 	// The current remaining bytes to be written to the file descriptor at once.
@@ -264,6 +274,12 @@ private:
 	const size_t headerSize_;
 	// The number of blocks.
 	const size_t numBlocks_;
+
+	/// Protects the `status` member variable used for custom thread synchronization.
+	std::mutex mutex_;
+
+	/// Status of the buffer's related read operation.
+	uint8_t status{kNotSaunafsStatus};
 
 	// The buffer for the block data.
 	Buffer<std::vector<uint8_t, AlignedAllocator<uint8_t, disk::kIoBlockSize>>> blockBuffer_;


### PR DESCRIPTION
Merge after PR #396

Even if it was an atomic, helgrind was complaining about possible race.
This change protects the variable with a mutex and removes the helgrind
warnings.

Co-authored-by: dave <dave@leil.io>

Signed-off-by: guillex <guillex@leil.io>