### PR TITLE
fix(chunkserver): Improve chunkserver locking

### DIFF
--- a/src/chunkserver/chunkserver-common/hdd_utils.cc
+++ b/src/chunkserver/chunkserver-common/hdd_utils.cc
@@ -360,8 +360,7 @@ IChunk *hddChunkFindOrCreatePlusLock(IDisk *disk, uint64_t chunkid,
 				    hddRecreateChunk(effectiveDisk, chunk, chunkid, chunkType);
 				return chunk;
 			}
-			if (chunk->condVar() !=
-			    nullptr) {  // waiting threads - wake them up
+			if (chunk->condVar() != nullptr) {  // waiting threads - wake them up
 				chunk->condVar()->condVar.notify_one();
 			} else {  // no more waiting threads - remove
 				hddRemoveChunkFromContainers(chunk);
@@ -383,13 +382,14 @@ IChunk *hddChunkFindOrCreatePlusLock(IDisk *disk, uint64_t chunkid,
 			    chunksMapLock,
 			    std::chrono::seconds(kSecondsToWaitForLockedChunk_));
 			chunk->condVar()->numberOfWaitingThreads--;
+			uint32_t waitingThreads = chunk->condVar()->numberOfWaitingThreads;
 			if (chunk->condVar()->numberOfWaitingThreads == 0) {
 				// No more waiting threads, store it to be reused
 				gFreeCondVars.emplace_back(std::move(chunk->condVar()));
 			}
 			if (status == std::cv_status::timeout) {
-				safs_pretty_syslog(LOG_WARNING, "Chunk locked for long time");
-				return nullptr;
+				safs::log_warn("Chunk {} locked for {} seconds, waiting threads {}", chunkid,
+				               kSecondsToWaitForLockedChunk_, waitingThreads);
 			}
 		}
 	}

--- a/src/chunkserver/chunkserver-common/hdd_utils.cc
+++ b/src/chunkserver/chunkserver-common/hdd_utils.cc
@@ -404,7 +404,7 @@ IChunk *hddRecreateChunk(IDisk *disk, IChunk *chunk, uint64_t chunkId,
 
 		if (chunk->state() != ChunkState::Deleted &&
 		    chunk->owner() != nullptr) {
-			const std::scoped_lock lock(gTestsMutex);
+			const std::lock_guard lock(gTestsMutex);
 			disk->chunks().remove(chunk);
 			disk->setNeedRefresh(true);
 		}

--- a/src/chunkserver/chunkserver-common/hdd_utils.h
+++ b/src/chunkserver/chunkserver-common/hdd_utils.h
@@ -31,7 +31,7 @@ inline std::mutex gMasterReportsLock;
 /// release the condition variable waiting on a Chunk. The number is small
 /// enough not to stop the operation (mount retries) and big enough to detect
 /// unusual/unexpected behavior.
-static constexpr uint8_t kSecondsToWaitForLockedChunk_ = 20;
+static constexpr uint8_t kSecondsToWaitForLockedChunk_ = 30;
 
 /// Adds the error to the Disk owner of chunk in a thread sage way and preserves
 /// the errno to be used in later checks.

--- a/src/chunkserver/hddspacemgr.cc
+++ b/src/chunkserver/hddspacemgr.cc
@@ -2154,7 +2154,10 @@ void hddTesterThread() {
 		chunk = ChunkNotFound;
 
 		{
-			std::scoped_lock lock(gDisksMutex, gChunksMapMutex, gTestsMutex);
+			// We could use a scoped_lock here, but helgrind complains about it
+			std::lock_guard gDisksLock(gDisksMutex);
+			std::lock_guard gChunksMapLock(gChunksMapMutex);
+			std::lock_guard gTestsLock(gTestsMutex);
 
 			bool testerResetExpected = true;
 			if (gResetTester.compare_exchange_strong(testerResetExpected,


### PR DESCRIPTION
fix(chunkserver): Fix locking and helgrind warns

This PR addresses two aspects related to locking in the chunkservers:
- Remove not correct `return nullptr` after waiting for long time.
- More strict locking order, to help helgrind with possible false positives.