### PR TITLE
feat(mount): Add reconnection related options

### DIFF
--- a/doc/sfsmount.1.adoc
+++ b/doc/sfsmount.1.adoc
@@ -255,6 +255,22 @@ disabled (default: 0).
 When set to 1, use the user and group specific quota hard limit to calculate
 the volume size (default: 0).
 
+*-o maxwaitretrytime=*'SECS'::
+Set the maximum wait time in seconds for retrying a master server communication
+attempt in seconds (default: 10).
+
+*-o mastercommsleeptimedivisor=*'N'::
+Specify the number of retry attempts between each increase of the
+master-communication sleep interval. The client starts with a 1 second
+pause and adds 1 second every N retries, up to the maxwaitretrytime limit.
+When reconnecting, the client makes up to sfsioretries attempts, applying
+the computed pause at each zero-based retry.
+For example, with mastercommsleeptimedivisor=2, maxwaitretrytime=3 and
+sfsioretries=10 the sleep intervals are:
+try 0 → 1 s, try 1 → 1 s, try 2 → 2 s, try 3 → 2 s, try 4 → 3 s,
+then 3 s for all subsequent retries until reaching the last retry counter
+index, which would be try 9 (default: 3).
+
 General mount options (see *mount*(8) manual):
 
 *-o rw* | *-o ro*::

--- a/src/mount/fuse/main.cc
+++ b/src/mount/fuse/main.cc
@@ -266,6 +266,8 @@ static int mainloop(struct fuse_args *args, struct fuse_cmdline_opts *fuse_opts,
 	params.message_suppression_period = gMountOptions.messagesuppressionperiod;
 	params.statfs_cache_timeout = gMountOptions.statfscachetimeout;
 	params.use_quota_in_volume_size = gMountOptions.usequotainvolumesize;
+	params.max_wait_retry_time = gMountOptions.maxwaitretrytime;
+	params.mastercomm_sleep_time_divisor = gMountOptions.mastercommsleeptimedivisor;
 
 	if (!gMountOptions.meta) {
 		SaunaClient::fs_init(params);
@@ -279,7 +281,8 @@ static int mainloop(struct fuse_args *args, struct fuse_cmdline_opts *fuse_opts,
 				return 1;
 			}
 		}
-		fs_init_threads(params.io_retries);
+		fs_init_threads(params.io_retries, params.max_wait_retry_time,
+		                params.mastercomm_sleep_time_divisor);
 	}
 
 	struct fuse_session *se;

--- a/src/mount/fuse/mount_config.cc
+++ b/src/mount/fuse/mount_config.cc
@@ -100,6 +100,8 @@ struct fuse_opt gSfsOptsStage2[] = {
 	SFS_OPT("sfsmessagesuppressionperiod=%u", messagesuppressionperiod, 0),
 	SFS_OPT("statfscachetimeout=%d", statfscachetimeout, 0),
 	SFS_OPT("usequotainvolumesize=%d", usequotainvolumesize, 0),
+	SFS_OPT("maxwaitretrytime=%u", maxwaitretrytime, 0),
+	SFS_OPT("mastercommsleeptimedivisor=%u", mastercommsleeptimedivisor, 0),
 
 	SFS_OPT("enablefilelocks=%u", filelocks, 0),
 	SFS_OPT("nonempty", nonemptymount, 1),
@@ -196,6 +198,9 @@ void initialize_opts_name_values() {
 	    std::to_string(gMountOptions.messagesuppressionperiod);
 	gOptsNameValues["statfscachetimeout"] = std::to_string(gMountOptions.statfscachetimeout);
 	gOptsNameValues["usequotainvolumesize"] = std::to_string(gMountOptions.usequotainvolumesize);
+	gOptsNameValues["maxwaitretrytime"] = std::to_string(gMountOptions.maxwaitretrytime);
+	gOptsNameValues["mastercommsleeptimedivisor"] =
+	    std::to_string(gMountOptions.mastercommsleeptimedivisor);
 	gOptsNameValues["enablefilelocks"] = std::to_string(gMountOptions.filelocks);
 	gOptsNameValues["nonempty"] = std::to_string(gMountOptions.nonemptymount);
 
@@ -339,6 +344,11 @@ void usage(const char *progname) {
 				"the cache is disabled (default: %u)\n"
 "    -o usequotainvolumesize=0|1  when set to 1, use the user and group specific quota hard "
 				"limit to calculate the volume size (default: %u)\n"
+"    -o maxwaitretrytime=SECS    set the maximum wait time in seconds for retrying a master "
+				"server communication attempt in seconds (default: %u)\n"
+"    -o mastercommsleeptimedivisor=N  number of retries between each time increase of the "
+				"master-communication sleep interval, up to maxwaitretrytime; smaller N "
+				"converges faster—ideal for critical fast-reconnect scenarios (default: %u)\n"
 "\n",
 		SaunaClient::FsInitParams::kDefaultCacheExpirationTime,
 		SaunaClient::FsInitParams::kDefaultReadaheadMaxWindowSize,
@@ -374,7 +384,9 @@ void usage(const char *progname) {
 		SaunaClient::FsInitParams::kDefaultLogNotificationArea,
 		SaunaClient::FsInitParams::kDefaultMessageSuppressionPeriod,
 		SaunaClient::FsInitParams::kDefaultStatfsCacheTo,
-		SaunaClient::FsInitParams::kDefaultUseQuotaInVolumeSize
+		SaunaClient::FsInitParams::kDefaultUseQuotaInVolumeSize,
+		SaunaClient::FsInitParams::kDefaultMaxWaitRetryTime,
+		SaunaClient::FsInitParams::kDefaultMasterCommSleepTimeDivisor
 	);
 	printf(
 "CMODE can be set to:\n"

--- a/src/mount/fuse/mount_config.h
+++ b/src/mount/fuse/mount_config.h
@@ -121,6 +121,8 @@ struct sfsopts_ {
 	unsigned messagesuppressionperiod;
 	int statfscachetimeout;
 	int usequotainvolumesize;
+	unsigned maxwaitretrytime;
+	unsigned mastercommsleeptimedivisor;
 
 	sfsopts_()
 		: masterhost(NULL),
@@ -181,7 +183,9 @@ struct sfsopts_ {
 		limitglibcmallocarenas(SaunaClient::FsInitParams::kDefaultLimitGlibcMallocArenas),
 		malloctrimperiod(SaunaClient::FsInitParams::kDefaultMallocTrimPeriod),
 		statfscachetimeout(SaunaClient::FsInitParams::kDefaultStatfsCacheTo),
-		usequotainvolumesize(SaunaClient::FsInitParams::kDefaultUseQuotaInVolumeSize)
+		usequotainvolumesize(SaunaClient::FsInitParams::kDefaultUseQuotaInVolumeSize),
+		maxwaitretrytime(SaunaClient::FsInitParams::kDefaultMaxWaitRetryTime),
+		mastercommsleeptimedivisor(SaunaClient::FsInitParams::kDefaultMasterCommSleepTimeDivisor)
 	{ }
 };
 

--- a/src/mount/mastercomm.cc
+++ b/src/mount/mastercomm.cc
@@ -105,7 +105,9 @@ int *mountingUid  = nullptr;
 int *mountingGid = nullptr;
 #endif
 
-static uint32_t maxretries;
+static std::atomic<uint32_t> maxretries;
+static std::atomic<uint32_t> maxWaitRetryTime;
+static std::atomic<uint32_t> mastercommSleepTimeDivisor;
 
 static pthread_t rpthid,npthid;
 static std::mutex fdMutex, recMutex;
@@ -176,6 +178,14 @@ struct InitParams {
 };
 
 static InitParams gInitParams;
+
+uint32_t getSafeSleepTimeDivisor() {
+	uint32_t safeSleepTimeDivisor = mastercommSleepTimeDivisor.load();
+	if (safeSleepTimeDivisor == 0) {
+		safeSleepTimeDivisor = 1;
+	}
+	return safeSleepTimeDivisor;
+}
 
 void master_statsptr_init(void) {
 	statsnode *s;
@@ -334,11 +344,11 @@ static bool fs_threc_wait(threc *rec, std::unique_lock<std::mutex>& lock) {
 }
 
 static inline uint32_t sleep_time(uint32_t tryNo) {
-	if (tryNo < 30) {
-		return 1 + (tryNo) / 3;
-	} else {
-		return 10;
+	uint32_t safeSleepTimeDivisor = getSafeSleepTimeDivisor();
+	if (tryNo / safeSleepTimeDivisor < maxWaitRetryTime.load()) {
+		return 1 + (tryNo / safeSleepTimeDivisor);
 	}
+	return maxWaitRetryTime.load();
 }
 
 // TODO(jotek): not every request should be retransmitted if recv failed (e.g. snapshot)
@@ -1310,9 +1320,14 @@ int fs_init_master_connection(SaunaClient::FsInitParams &params
 }
 
 // called after fork
-void fs_init_threads(uint32_t retries) {
+void fs_init_threads(uint32_t retries, uint32_t maxWaitTimeForRetry, uint32_t sleepTimeDivisor) {
 	pthread_attr_t thattr;
 	maxretries = retries;
+	maxWaitRetryTime = maxWaitTimeForRetry;
+	mastercommSleepTimeDivisor = sleepTimeDivisor;
+	gTweaks.registerVariable("MaxRetriesMasterComm", maxretries, "maxretriesmastercomm");
+	gTweaks.registerVariable("MaxWaitRetryTimeMasterComm", maxWaitRetryTime, "maxwaitretrytime");
+	gTweaks.registerVariable("MasterCommSleepTimeDivisor", mastercommSleepTimeDivisor, "mastercommsleeptimedivisor");
 	fterm = 0;
 
 	pthread_attr_init(&thattr);

--- a/src/mount/mastercomm.h
+++ b/src/mount/mastercomm.h
@@ -139,7 +139,7 @@ int fs_init_master_connection(SaunaClient::FsInitParams &params
 , uint8_t &session_flags, int &mounting_uid, int &mounting_gid
 #endif
 );
-void fs_init_threads(uint32_t retries);
+void fs_init_threads(uint32_t retries, uint32_t maxWaitTimeForRetry, uint32_t sleepTimeDivisor);
 void fs_term(void);
 
 class PacketHandler {

--- a/src/mount/sauna_client.cc
+++ b/src/mount/sauna_client.cc
@@ -3633,7 +3633,8 @@ void fs_init(FsInitParams &params) {
 	}
 	symlink_cache_init(params.symlink_cache_timeout_s);
 	gGlobalIoLimiter();
-	fs_init_threads(params.io_retries);
+	fs_init_threads(params.io_retries, params.max_wait_retry_time,
+	                params.mastercomm_sleep_time_divisor);
 	masterproxy_init();
 
 	gLocalIoLimiter();

--- a/src/mount/sauna_client.h
+++ b/src/mount/sauna_client.h
@@ -83,6 +83,8 @@ struct FsInitParams {
 	static constexpr unsigned kDefaultMessageSuppressionPeriod = 10;
 	static constexpr unsigned kDefaultStatfsCacheTo = 0;
 	static constexpr bool     kDefaultUseQuotaInVolumeSize = false;
+	static constexpr unsigned kDefaultMaxWaitRetryTime = 10;
+	static constexpr unsigned kDefaultMasterCommSleepTimeDivisor = 3;
 #ifdef _WIN32
 	static constexpr unsigned kDefaultReportReservedPeriod = 60;
 	static constexpr const char *kDefaultUmaskDir = "002"; // means rwxrwxr-x permissions mask, 775 default permissions
@@ -166,7 +168,9 @@ struct FsInitParams {
 	             malloc_trim_period(kDefaultMallocTrimPeriod),
 #endif
 	             ignore_flush(kDefaultIgnoreFlush), statfs_cache_timeout(kDefaultStatfsCacheTo),
-				 use_quota_in_volume_size(kDefaultUseQuotaInVolumeSize),
+	             use_quota_in_volume_size(kDefaultUseQuotaInVolumeSize),
+	             max_wait_retry_time(kDefaultMaxWaitRetryTime),
+	             mastercomm_sleep_time_divisor(kDefaultMasterCommSleepTimeDivisor),
 	             verbose(kDefaultVerbose), direct_io(kDirectIO),
 	             log_notifications_area(kDefaultLogNotificationArea),
 	             message_suppression_period(kDefaultMessageSuppressionPeriod) {
@@ -209,7 +213,9 @@ struct FsInitParams {
 	             malloc_trim_period(kDefaultMallocTrimPeriod),
 #endif
 	             ignore_flush(kDefaultIgnoreFlush), statfs_cache_timeout(kDefaultStatfsCacheTo),
-				 use_quota_in_volume_size(kDefaultUseQuotaInVolumeSize),
+	             use_quota_in_volume_size(kDefaultUseQuotaInVolumeSize),
+	             max_wait_retry_time(kDefaultMaxWaitRetryTime),
+	             mastercomm_sleep_time_divisor(kDefaultMasterCommSleepTimeDivisor),
 	             verbose(kDefaultVerbose), direct_io(kDirectIO),
 	             log_notifications_area(kDefaultLogNotificationArea),
 	             message_suppression_period(kDefaultMessageSuppressionPeriod) {
@@ -273,6 +279,8 @@ struct FsInitParams {
 	bool ignore_flush;
 	unsigned statfs_cache_timeout;
 	bool use_quota_in_volume_size;
+	unsigned max_wait_retry_time;
+	unsigned mastercomm_sleep_time_divisor;
 	bool verbose;
 	bool direct_io;
 	int log_notifications_area;

--- a/tests/test_suites/ShortSystemTests/test_wait_retry_time_and_sleep_time_divisor.sh
+++ b/tests/test_suites/ShortSystemTests/test_wait_retry_time_and_sleep_time_divisor.sh
@@ -1,0 +1,124 @@
+timeout_set "5 minutes"
+
+run_ls_background() {
+    local suffix="$1"
+
+    # start the ls command in the background and redirect
+    # its output to a file named ls_output_<suffix>.txt
+    (
+      ls -l "${info[mount0]}" > "/tmp/ls_output_${suffix}.txt" 2>&1
+    ) &
+}
+
+USE_RAMDISK=YES \
+	CHUNKSERVERS=1 \
+	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER,sfsioretries=10,maxwaitretrytime=3,mastercommsleeptimedivisor=2" \
+	setup_local_empty_saunafs info
+
+# stop master server daemon
+saunafs_master_daemon stop
+
+# start the ls command in the background with suffix "1"
+run_ls_background "1"
+
+# wait for a duration longer than the maximum time the 
+# client will wait for the master server to return.
+# The calculation is as follows:
+# The client performs up to 10 retries, waiting a period
+# that increases by 1 second every "mastercommsleeptimedivisor"
+# iterations (in this case, every 2 iterations), up to a 
+# maximum wait time of 3 seconds per retry. 
+# This results in a total wait time of 1 + 1 + 2 + 2 + 3 + 3 + 3*4 = 24 seconds
+# per operation. Now, given that the client will perform a
+# SAU_MATOCL_UPDATE_CREDENTIALS and a MATOCL_FUSE_GETATTR operation for completing
+# the ls command, we need to wait for more than 48 seconds
+# Then we will wait for 50 seconds to reconnect the master server
+# and check that client could not successfully finish the ls command
+# before the master server is back online.
+sleep 50
+saunafs_master_daemon start
+saunafs_wait_for_ready_chunkservers 1
+
+# at this time, the ls command should have failed
+assert_success grep -q "Input/output error" "/tmp/ls_output_1.txt"
+
+# now check the case when the master server is back online
+# on a time less than the maximum time the client will wait
+# for the master server to return
+
+# stop master server daemon
+saunafs_master_daemon stop
+
+# start the ls command in the background with suffix "2"
+run_ls_background "2"
+
+# wait for a duration shorter than the maximum time the
+# client will wait for the master server to return a response
+# for the first operation during the ls command, which is
+# SAU_MATOCL_UPDATE_CREDENTIALS. Then if we reconnect the
+# master server before first 24 seconds, the ls command should
+# be able to finish successfully.
+sleep 12
+saunafs_master_daemon start
+saunafs_wait_for_ready_chunkservers 1
+
+# at this time, the ls command should have succeeded
+# and created the file ls_output_2.txt as expected
+assert_failure grep -q "Input/output error" "/tmp/ls_output_2.txt"
+
+# Add a delay of 5 seconds to ensure that cluster is stable
+sleep 5
+
+# now check changing the values of sfsioretries, maxwaitretrytime
+# and mastercommsleeptimedivisor using the tweaks file
+echo "MaxRetriesMasterComm=5" | sudo tee "${info[mount0]}/.saunafs_tweaks"
+echo "MaxWaitRetryTimeMasterComm=5" | sudo tee "${info[mount0]}/.saunafs_tweaks"
+echo "MasterCommSleepTimeDivisor=1" | sudo tee "${info[mount0]}/.saunafs_tweaks"
+
+# Check if tweaks are correctly updated
+assert_equals "5" $(cat "${info[mount0]}/.saunafs_tweaks" | egrep MaxRetriesMasterComm | awk '{print $2}')
+assert_equals "5" $(cat "${info[mount0]}/.saunafs_tweaks" | egrep MaxWaitRetryTimeMasterComm | awk '{print $2}')
+assert_equals "1" $(cat "${info[mount0]}/.saunafs_tweaks" | egrep MasterCommSleepTimeDivisor | awk '{print $2}')
+
+# stop master server daemon
+saunafs_master_daemon stop
+
+# start the ls command in the background with suffix "3"
+run_ls_background "3"
+
+# wait for a duration longer than the maximum time the
+# client will wait for the master server to return.
+# The calculation is as follows:
+# The client performs up to 1 + 2 + 3 + 4 + 5 = 15 seconds for
+# each failing operation. Then, for this case, we need to wait
+# for more than 30 seconds to check that the ls command
+# could not finish before the master server is back online.
+sleep 32
+saunafs_master_daemon start
+saunafs_wait_for_ready_chunkservers 1
+
+# at this time, the ls command should have failed
+assert_success grep -q "Input/output error" "/tmp/ls_output_3.txt"
+
+# now check the case when the master server is back online
+# on a time less than the maximum time the client will wait
+# for the master server to return
+saunafs_master_daemon stop
+
+# start the ls command in the background with suffix "4"
+run_ls_background "4"
+
+# wait for a duration shorter than the maximum time the
+# client will wait for the master server to return a response
+# for the first operation during the ls command, which is
+# SAU_MATOCL_UPDATE_CREDENTIALS.
+sleep 15
+saunafs_master_daemon start
+saunafs_wait_for_ready_chunkservers 1
+
+# if options maxwaitretrytime and mastercommsleeptimedivisor would
+# have default values (10 and 3 respectively), the ls command would have
+# failed.
+# but since we set them to 5 and 1 respectively, the ls command
+# should have succeeded as expected.
+assert_failure grep -q "Input/output error" "/tmp/ls_output_4.txt"


### PR DESCRIPTION
This commit adds the options `maxwaitretrytime` and `mastercommsleeptimedivisor` to the client in order to improve flexibility on master communication retry process in critical scenarios when fast client reconnection is required.