### PR TITLE
build: Fix master not building on gcc12 when prometheus missing

### DIFF
--- a/src/metrics/metrics.cc
+++ b/src/metrics/metrics.cc
@@ -49,6 +49,18 @@
 
 namespace metrics {
 
+#ifndef HAVE_PROMETHEUS
+
+void destroy() {}
+
+void init(const char* /* unused */) {
+	safs::log_err(
+	    "could not setup prometheus server: Prometheus isn't compiled with "
+	    "this program");
+}
+}
+#else
+
 std::unique_ptr<std::jthread>
     gMetricsMainThread;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
@@ -58,14 +70,6 @@ void destroy() {
 	}
 }
 
-#ifndef HAVE_PROMETHEUS
-void init(const char* /* unused */) {
-	safs::log_err(
-	    "could not setup prometheus server: Prometheus isn't compiled with "
-	    "this program");
-}
-}
-#else
 
 constexpr auto THREAD_SLEEP_TIME_MS = 100;
 


### PR DESCRIPTION
On GCC12 debian, the master would not build because it's expecting jthread to be defined. However, in the ifdefs it's not included. Fix is to just include an empty destroy function that does nothing if prometheus is not compiled with.