### PR TITLE
chore(chunkserver): Homogenize file headers

### DIFF
--- a/src/chunkserver/bgjobs.cc
+++ b/src/chunkserver/bgjobs.cc
@@ -19,8 +19,8 @@
  */
 
 #include "common/platform.h"
-#include "chunkserver/bgjobs.h"
 
+#include "chunkserver/bgjobs.h"
 #include "chunkserver/chunk_replicator.h"
 #include "chunkserver/hddspacemgr.h"
 #include "common/chunk_part_type.h"
@@ -31,7 +31,8 @@
 #include "devtools/request_log.h"
 #include "slogger/slogger.h"
 
-#include <atomic>
+#include <sys/syslog.h>
+#include <unistd.h>
 #include <cassert>
 #include <cstdint>
 #include <cstring>
@@ -39,8 +40,6 @@
 #include <memory>
 #include <mutex>
 #include <thread>
-#include <sys/syslog.h>
-#include <unistd.h>
 #include <unordered_map>
 #include <utility>
 #include <vector>

--- a/src/chunkserver/chartsdata.cc
+++ b/src/chunkserver/chartsdata.cc
@@ -18,18 +18,20 @@
    along with SaunaFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "chartsdata.h"
+#include "common/platform.h"
 
-#include <errno.h>
+#include "chunkserver/chartsdata.h"
+
 #include <fcntl.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <sys/resource.h>
 #include <sys/time.h>
 #include <syslog.h>
-#include <time.h>
 #include <unistd.h>
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
 
 #include "chunkserver-common/hdd_stats.h"
 #include "chunkserver/chunk_replicator.h"

--- a/src/chunkserver/chartsdata.h
+++ b/src/chunkserver/chartsdata.h
@@ -22,8 +22,6 @@
 
 #include "common/platform.h"
 
-#include <inttypes.h>
-
 #define SECONDS_IN_ONE_MINUTE 60
 #define SECONDS_IN_ONE_HOUR   3600
 

--- a/src/chunkserver/chunk_filename_parser.cc
+++ b/src/chunkserver/chunk_filename_parser.cc
@@ -18,10 +18,9 @@
  */
 
 #include "common/platform.h"
-#include "chunkserver/chunk_filename_parser.h"
 
+#include "chunkserver/chunk_filename_parser.h"
 #include "common/chunk_part_type.h"
-#include "common/goal.h"
 #include "common/parser.h"
 #include "common/slice_traits.h"
 

--- a/src/chunkserver/chunk_filename_parser_unittest.cc
+++ b/src/chunkserver/chunk_filename_parser_unittest.cc
@@ -18,11 +18,11 @@
  */
 
 #include "common/platform.h"
+
 #include "common/slice_traits.h"
 #include "chunkserver/chunk_filename_parser.h"
 
 #include <gtest/gtest.h>
-
 
 TEST(ChunkFilenameParser, ParseStandardChunkFilename) {
 	ChunkFilenameParser filenameParser("chunk_0000000000550A00_00000001"

--- a/src/chunkserver/chunk_replicator.cc
+++ b/src/chunkserver/chunk_replicator.cc
@@ -18,21 +18,20 @@
  */
 
 #include "common/platform.h"
+
 #include "chunkserver/chunk_replicator.h"
 
 #include <unistd.h>
-#include <cassert>
 #include <algorithm>
-#include <initializer_list>
-#include <memory>
+#include <cassert>
 #include <string>
 
 #include "chunkserver/g_limiters.h"
 #include "common/aligned_allocator.h"
 #include "common/crc.h"
 #include "common/exception.h"
-#include "common/saunafs_version.h"
 #include "common/read_plan_executor.h"
+#include "common/saunafs_version.h"
 #include "common/sockets.h"
 #include "protocol/cstocs.h"
 

--- a/src/chunkserver/chunk_replicator.h
+++ b/src/chunkserver/chunk_replicator.h
@@ -22,7 +22,6 @@
 #include "common/platform.h"
 
 #include <cstdint>
-#include <memory>
 #include <mutex>
 
 #include "chunkserver/chunk_file_creator.h"

--- a/src/chunkserver/chunkserver-common/chunk_signature.h
+++ b/src/chunkserver/chunkserver-common/chunk_signature.h
@@ -25,7 +25,6 @@
 #include <cstdlib>
 
 #include "common/chunk_part_type.h"
-#include "common/serialization_macros.h"
 
 class IDisk;
 

--- a/src/chunkserver/chunkserver-common/chunk_trash_index.cc
+++ b/src/chunkserver/chunkserver-common/chunk_trash_index.cc
@@ -16,7 +16,9 @@
    along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "chunk_trash_index.h"
+#include "common/platform.h"
+
+#include "chunkserver-common/chunk_trash_index.h"
 
 ChunkTrashIndex &ChunkTrashIndex::instance() {
 	static ChunkTrashIndex instance;

--- a/src/chunkserver/chunkserver-common/chunk_trash_manager.cc
+++ b/src/chunkserver/chunkserver-common/chunk_trash_manager.cc
@@ -16,11 +16,13 @@
    along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "common/platform.h"
+
 #include <syslog.h>
 #include <memory>
 
-#include "chunk_trash_manager.h"
-#include "chunk_trash_manager_impl.h"
+#include "chunkserver-common/chunk_trash_manager.h"
+#include "chunkserver-common/chunk_trash_manager_impl.h"
 #include "config/cfg.h"
 #include "errors/saunafs_error_codes.h"
 #include "slogger/slogger.h"

--- a/src/chunkserver/chunkserver-common/chunk_trash_manager_impl.cc
+++ b/src/chunkserver/chunkserver-common/chunk_trash_manager_impl.cc
@@ -16,16 +16,16 @@
    along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "common/platform.h"
+
 #include <sys/statvfs.h>
 #include <algorithm>
-
 #include <ctime>
-#include "errors/saunafs_error_codes.h"
-#include "fmt/format.h"
-#include "slogger/slogger.h"
 
-#include "chunk_trash_manager_impl.h"
+#include "chunkserver-common/chunk_trash_manager_impl.h"
 #include "config/cfg.h"
+#include "errors/saunafs_error_codes.h"
+#include "slogger/slogger.h"
 
 namespace fs = std::filesystem;
 

--- a/src/chunkserver/chunkserver-common/chunk_trash_manager_impl.h
+++ b/src/chunkserver/chunkserver-common/chunk_trash_manager_impl.h
@@ -22,8 +22,8 @@
 
 #include <string>
 
-#include "chunk_trash_index.h"
-#include "chunk_trash_manager.h"
+#include "chunkserver-common/chunk_trash_index.h"
+#include "chunkserver-common/chunk_trash_manager.h"
 #include "errors/saunafs_error_codes.h"
 
 class ChunkTrashManagerImpl : public IChunkTrashManagerImpl {

--- a/src/chunkserver/chunkserver-common/chunk_trash_manager_impl_unittest.cc
+++ b/src/chunkserver/chunkserver-common/chunk_trash_manager_impl_unittest.cc
@@ -16,6 +16,8 @@
    along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "common/platform.h"
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <sys/statvfs.h>
@@ -23,8 +25,7 @@
 #include <fstream>
 #include <thread>
 
-#include "chunk_trash_index.h"
-#include "chunk_trash_manager_impl.h"
+#include "chunkserver-common/chunk_trash_manager_impl.h"
 #include "errors/saunafs_error_codes.h"  // Include the error codes header
 
 int fake_statvfs(const char *path, struct statvfs *buf) {

--- a/src/chunkserver/chunkserver-common/chunk_trash_manager_unittest.cc
+++ b/src/chunkserver/chunkserver-common/chunk_trash_manager_unittest.cc
@@ -16,7 +16,10 @@
    along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "chunk_trash_manager.h"
+#include "common/platform.h"
+
+#include "chunkserver-common/chunk_trash_manager.h"
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 

--- a/src/chunkserver/chunkserver-common/chunk_with_fd.cc
+++ b/src/chunkserver/chunkserver-common/chunk_with_fd.cc
@@ -1,6 +1,27 @@
-#include "chunk_with_fd.h"
-#include <fcntl.h>
+/*
+   Copyright 2013-2015 Skytechnology sp. z o.o.
+   Copyright 2023      Leil Storage OÜ
 
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "common/platform.h"
+
+#include "chunkserver-common/chunk_with_fd.h"
+
+#include <fcntl.h>
 #include <iomanip>
 
 #include "chunkserver-common/subfolder.h"

--- a/src/chunkserver/chunkserver-common/cmr_chunk.cc
+++ b/src/chunkserver/chunkserver-common/cmr_chunk.cc
@@ -1,6 +1,25 @@
-#include <common/platform.h>
+/*
+   Copyright 2013-2015 Skytechnology sp. z o.o.
+   Copyright 2023      Leil Storage OÜ
 
-#include "cmr_chunk.h"
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "common/platform.h"
+
+#include "chunkserver-common/cmr_chunk.h"
 
 #include "chunkserver-common/subfolder.h"
 #include "common/slice_traits.h"

--- a/src/chunkserver/chunkserver-common/cmr_disk.cc
+++ b/src/chunkserver/chunkserver-common/cmr_disk.cc
@@ -1,13 +1,34 @@
-#include "cmr_disk.h"
+/*
+   Copyright 2013-2015 Skytechnology sp. z o.o.
+   Copyright 2023      Leil Storage OÜ
 
-#include <filesystem>
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "common/platform.h"
+
+#include "chunkserver-common/cmr_disk.h"
+
 #include <fcntl.h>
-#include <iostream>
 #include <linux/falloc.h>
 #include <sys/stat.h>
 #include <sys/statvfs.h>
+#include <filesystem>
 
 #include "chunkserver-common/chunk_interface.h"
+#include "chunkserver-common/chunk_trash_manager.h"
 #include "chunkserver-common/cmr_chunk.h"
 #include "chunkserver-common/global_shared_resources.h"
 #include "chunkserver-common/hdd_stats.h"
@@ -16,8 +37,6 @@
 #include "devtools/TracePrinter.h"
 #include "devtools/request_log.h"
 #include "errors/saunafs_error_codes.h"
-
-#include "chunk_trash_manager.h"
 
 CmrDisk::CmrDisk(const std::string &_metaPath, const std::string &_dataPath,
                  bool _isMarkedForRemoval, bool _isZonedDevice)

--- a/src/chunkserver/chunkserver-common/cmr_disk.h
+++ b/src/chunkserver/chunkserver-common/cmr_disk.h
@@ -1,3 +1,22 @@
+/*
+   Copyright 2013-2015 Skytechnology sp. z o.o.
+   Copyright 2023      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include "common/platform.h"

--- a/src/chunkserver/chunkserver-common/default_disk_manager.cc
+++ b/src/chunkserver/chunkserver-common/default_disk_manager.cc
@@ -18,15 +18,15 @@
 
 #include "common/platform.h"
 
-#include <fstream>
-
 #include "chunkserver-common/default_disk_manager.h"
+
+#include <fstream>
 
 #include "chunkserver-common/cmr_disk.h"
 #include "chunkserver-common/global_shared_resources.h"
 #include "chunkserver-common/plugin_manager.h"
-#include "config/cfg.h"
 #include "common/exceptions.h"
+#include "config/cfg.h"
 #include "devtools/TracePrinter.h"
 
 int DefaultDiskManager::parseCfgLine(std::string hddCfgLine) {

--- a/src/chunkserver/chunkserver-common/disk_chunks.cc
+++ b/src/chunkserver/chunkserver-common/disk_chunks.cc
@@ -1,4 +1,24 @@
-#include "disk_chunks.h"
+/*
+   Copyright 2023 Leil Storage
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "common/platform.h"
+
+#include "chunkserver-common/disk_chunks.h"
 
 #include "chunkserver-common/chunk_interface.h"
 #include "common/random.h"

--- a/src/chunkserver/chunkserver-common/disk_chunks.h
+++ b/src/chunkserver/chunkserver-common/disk_chunks.h
@@ -1,4 +1,24 @@
+/*
+   Copyright 2023 Leil Storage
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
+
+#include "common/platform.h"
 
 #include <cstddef>
 #include <limits>

--- a/src/chunkserver/chunkserver-common/disk_interface.h
+++ b/src/chunkserver/chunkserver-common/disk_interface.h
@@ -1,3 +1,21 @@
+/*
+   Copyright 2023 Leil Storage
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include "common/platform.h"

--- a/src/chunkserver/chunkserver-common/disk_plugin.cc
+++ b/src/chunkserver/chunkserver-common/disk_plugin.cc
@@ -1,4 +1,24 @@
-#include "disk_plugin.h"
+/*
+   Copyright 2023 Leil Storage
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "common/platform.h"
+
+#include "chunkserver-common/disk_plugin.h"
 
 #include "chunkserver-common/disk_with_fd.h"
 

--- a/src/chunkserver/chunkserver-common/disk_plugin.h
+++ b/src/chunkserver/chunkserver-common/disk_plugin.h
@@ -1,4 +1,24 @@
+/*
+   Copyright 2023 Leil Storage
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
+
+#include "common/platform.h"
 
 #include "chunkserver-common/disk_interface.h"
 #include "chunkserver-common/iplugin.h"

--- a/src/chunkserver/chunkserver-common/disk_utils.cc
+++ b/src/chunkserver/chunkserver-common/disk_utils.cc
@@ -1,4 +1,24 @@
-#include "disk_utils.h"
+/*
+   Copyright 2023 Leil Storage
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "common/platform.h"
+
+#include "chunkserver-common/disk_utils.h"
 
 namespace disk {
 

--- a/src/chunkserver/chunkserver-common/disk_utils.h
+++ b/src/chunkserver/chunkserver-common/disk_utils.h
@@ -1,3 +1,21 @@
+/*
+   Copyright 2023 Leil Storage
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include "common/platform.h"

--- a/src/chunkserver/chunkserver-common/disk_with_fd.cc
+++ b/src/chunkserver/chunkserver-common/disk_with_fd.cc
@@ -1,8 +1,28 @@
-#include "disk_with_fd.h"
+/*
+   Copyright 2023 Leil Storage
 
-#include <bitset>
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "common/platform.h"
+
+#include "chunkserver-common/disk_with_fd.h"
+
 #include <fcntl.h>
 #include <sys/stat.h>
+#include <bitset>
 #include <cstdio>
 
 #include "chunkserver-common/chunk_interface.h"

--- a/src/chunkserver/chunkserver-common/disk_with_fd.h
+++ b/src/chunkserver/chunkserver-common/disk_with_fd.h
@@ -1,3 +1,21 @@
+/*
+   Copyright 2023 Leil Storage
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include "common/platform.h"

--- a/src/chunkserver/chunkserver-common/global_shared_resources.h
+++ b/src/chunkserver/chunkserver-common/global_shared_resources.h
@@ -1,4 +1,24 @@
+/*
+   Copyright 2023 Leil Storage
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
+
+#include "common/platform.h"
 
 #include "chunkserver-common/chunk_map.h"
 #include "chunkserver-common/disk_interface.h"

--- a/src/chunkserver/chunkserver-common/hdd_stats.cc
+++ b/src/chunkserver/chunkserver-common/hdd_stats.cc
@@ -1,4 +1,24 @@
-#include "hdd_stats.h"
+/*
+   Copyright 2023 Leil Storage
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "common/platform.h"
+
+#include "chunkserver-common/hdd_stats.h"
 
 #include "chunkserver-common/disk_interface.h"
 #include "devtools/TracePrinter.h"

--- a/src/chunkserver/chunkserver-common/hdd_stats.h
+++ b/src/chunkserver/chunkserver-common/hdd_stats.h
@@ -1,10 +1,28 @@
+/*
+   Copyright 2023 Leil Storage
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include "common/platform.h"
 
+#include <sys/time.h>
 #include <atomic>
 #include <functional>
-#include <sys/time.h>
 
 class IDisk;
 using MicroSeconds = uint64_t;

--- a/src/chunkserver/chunkserver-common/hdd_utils.cc
+++ b/src/chunkserver/chunkserver-common/hdd_utils.cc
@@ -1,6 +1,24 @@
+/*
+   Copyright 2023 Leil Storage
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "common/platform.h"
 
-#include "hdd_utils.h"
+#include "chunkserver-common/hdd_utils.h"
 
 #include <fcntl.h>
 #include <sys/time.h>

--- a/src/chunkserver/chunkserver-common/hdd_utils.h
+++ b/src/chunkserver/chunkserver-common/hdd_utils.h
@@ -1,3 +1,21 @@
+/*
+   Copyright 2023 Leil Storage
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include "common/platform.h"

--- a/src/chunkserver/chunkserver-common/iostat.h
+++ b/src/chunkserver/chunkserver-common/iostat.h
@@ -27,17 +27,15 @@
 
 #include "common/platform.h"
 
-#include <cassert>
-#include <cstdio>
-#include <cstring>
-#include <algorithm>
-#include <unordered_map>
-#include <vector>
-
 #include <sys/stat.h>
 #include <sys/sysmacros.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <algorithm>
+#include <cassert>
+#include <cstdio>
+#include <cstring>
+#include <unordered_map>
 
 #ifndef __linux__
 

--- a/src/chunkserver/chunkserver-common/iplugin.h
+++ b/src/chunkserver/chunkserver-common/iplugin.h
@@ -1,4 +1,24 @@
+/*
+   Copyright 2023 Leil Storage
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
+
+#include "common/platform.h"
 
 #include <boost/config.hpp>
 #include <boost/dll/alias.hpp>

--- a/src/chunkserver/chunkserver-common/plugin_manager.cc
+++ b/src/chunkserver/chunkserver-common/plugin_manager.cc
@@ -19,6 +19,7 @@
 #include "common/platform.h"
 
 #include "chunkserver-common/plugin_manager.h"
+
 #include <boost/filesystem/exception.hpp>
 
 #include "chunkserver-common/disk_plugin.h"

--- a/src/chunkserver/chunkserver-common/plugin_manager.h
+++ b/src/chunkserver/chunkserver-common/plugin_manager.h
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include "common/platform.h"
+
 #include <map>
 
 #include <boost/dll/import.hpp>

--- a/src/chunkserver/chunkserver-common/subfolder.h
+++ b/src/chunkserver/chunkserver-common/subfolder.h
@@ -1,4 +1,24 @@
+/*
+   Copyright 2023 Leil Storage
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
+
+#include "common/platform.h"
 
 #include <array>
 #include <string>

--- a/src/chunkserver/g_limiters.cc
+++ b/src/chunkserver/g_limiters.cc
@@ -18,6 +18,7 @@
  */
 
 #include "common/platform.h"
+
 #include "chunkserver/g_limiters.h"
 
 ReplicationBandwidthLimiter& replicationBandwidthLimiter() {

--- a/src/chunkserver/hdd_readahead.cc
+++ b/src/chunkserver/hdd_readahead.cc
@@ -18,6 +18,7 @@
  */
 
 #include "common/platform.h"
+
 #include "chunkserver/hdd_readahead.h"
 
 HDDReadAhead gHDDReadAhead;

--- a/src/chunkserver/hdd_readahead.h
+++ b/src/chunkserver/hdd_readahead.h
@@ -24,8 +24,6 @@
 #include <atomic>
 #include <cstdint>
 
-#include "protocol/SFSCommunication.h"
-
 class HDDReadAhead {
 public:
 	uint16_t maxBlocksToBeReadBehind() {

--- a/src/chunkserver/hdd_readahead_unittest.cc
+++ b/src/chunkserver/hdd_readahead_unittest.cc
@@ -18,6 +18,7 @@
  */
 
 #include "common/platform.h"
+
 #include "chunkserver/hdd_readahead.h"
 
 #include <gtest/gtest.h>

--- a/src/chunkserver/hddspacemgr.cc
+++ b/src/chunkserver/hddspacemgr.cc
@@ -59,7 +59,6 @@
 #endif // SAUNAFS_HAVE_THREAD_LOCAL
 #include <atomic>
 #include <deque>
-#include <fstream>
 #include <mutex>
 #include <string>
 #include <thread>
@@ -78,19 +77,18 @@
 #include "chunkserver-common/subfolder.h"
 #include "chunkserver/chartsdata.h"
 #include "chunkserver/chunk_filename_parser.h"
-#include "config/cfg.h"
 #include "common/chunk_version_with_todel_flag.h"
 #include "common/crc.h"
 #include "common/datapack.h"
 #include "common/disk_info.h"
 #include "common/event_loop.h"
-#include "common/exceptions.h"
 #include "common/legacy_vector.h"
 #include "common/massert.h"
 #include "common/serialization.h"
 #include "common/slice_traits.h"
 #include "common/time_utils.h"
 #include "common/unique_queue.h"
+#include "config/cfg.h"
 #include "devtools/TracePrinter.h"
 #include "devtools/request_log.h"
 #include "errors/saunafs_error_codes.h"

--- a/src/chunkserver/masterconn.h
+++ b/src/chunkserver/masterconn.h
@@ -22,7 +22,7 @@
 
 #include "common/platform.h"
 
-#include <inttypes.h>
+#include <cstdint>
 
 void masterconn_stats(uint64_t *bin,uint64_t *bout,uint32_t *maxjobscnt);
 int masterconn_init(void);

--- a/src/chunkserver/network_main_thread.cc
+++ b/src/chunkserver/network_main_thread.cc
@@ -19,47 +19,33 @@
 
 #include "common/platform.h"
 
-#include <errno.h>
 #include <fcntl.h>
-#include <inttypes.h>
 #include <netinet/in.h>
-#include <stdlib.h>
-#include <string.h>
 #include <sys/types.h>
 #include <sys/uio.h>
 #include <syslog.h>
-#include <time.h>
 #include <unistd.h>
-#include <atomic>
-#include <memory>
-#include <mutex>
-#include <set>
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
 #include <thread>
-#include <tuple>
 
 #include "chunkserver/bgjobs.h"
+#include "chunkserver/chunk_replicator.h"
 #include "chunkserver/g_limiters.h"
 #include "chunkserver/hdd_readahead.h"
 #include "chunkserver/network_main_thread.h"
-#include "chunkserver/network_stats.h"
 #include "chunkserver/network_worker_thread.h"
-#include "chunkserver/chunk_replicator.h"
-#include "config/cfg.h"
-#include "common/charts.h"
-#include "common/event_loop.h"
-#include "protocol/cltocs.h"
-#include "protocol/cstocl.h"
-#include "protocol/cstocs.h"
 #include "common/cwrap.h"
-#include "common/datapack.h"
+#include "common/event_loop.h"
 #include "common/exceptions.h"
-#include "common/main.h"
 #include "common/massert.h"
-#include "protocol/SFSCommunication.h"
-#include "protocol/packet.h"
-#include "slogger/slogger.h"
 #include "common/sockets.h"
+#include "config/cfg.h"
 #include "devtools/TracePrinter.h"
+#include "protocol/SFSCommunication.h"
+#include "slogger/slogger.h"
 
 static int lsock;
 static int32_t lsockpdescpos;

--- a/src/chunkserver/network_main_thread.h
+++ b/src/chunkserver/network_main_thread.h
@@ -21,7 +21,7 @@
 
 #include "common/platform.h"
 
-#include <inttypes.h>
+#include <cstdint>
 
 int mainNetworkThreadInit(void);
 int mainNetworkThreadInitThreads(void);

--- a/src/chunkserver/network_stats.cc
+++ b/src/chunkserver/network_stats.cc
@@ -18,6 +18,7 @@
  */
 
 #include "common/platform.h"
+
 #include "chunkserver/network_stats.h"
 
 std::atomic<uint64_t> stats_bytesin(0);

--- a/src/chunkserver/network_stats.h
+++ b/src/chunkserver/network_stats.h
@@ -21,7 +21,6 @@
 
 #include "common/platform.h"
 
-#include <inttypes.h>
 #include <atomic>
 
 extern std::atomic<uint64_t> stats_bytesin;
@@ -30,5 +29,5 @@ extern std::atomic<uint32_t> stats_hlopr;
 extern std::atomic<uint32_t> stats_hlopw;
 extern std::atomic<uint32_t> stats_maxjobscnt;
 
-void networkStats(uint64_t *bin, uint64_t *bout, uint32_t *hlopr,
-		uint32_t *hlopw, uint32_t *maxjobscnt);
+void networkStats(uint64_t *bin, uint64_t *bout, uint32_t *hlopr, uint32_t *hlopw,
+                  uint32_t *maxjobscnt);

--- a/src/chunkserver/output_buffer.cc
+++ b/src/chunkserver/output_buffer.cc
@@ -17,8 +17,9 @@
    along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "output_buffer.h"
 #include "common/platform.h"
+
+#include "chunkserver/output_buffer.h"
 
 #include <fcntl.h>
 #include <unistd.h>
@@ -28,7 +29,6 @@
 #include <cstdint>
 
 #include "common/crc.h"
-#include "common/massert.h"
 
 OutputBuffer::OutputBuffer(size_t headerSize, size_t numBlocks)
     : currentRemainingBytesForFD_(0),

--- a/src/chunkserver/output_buffer_unittest.cc
+++ b/src/chunkserver/output_buffer_unittest.cc
@@ -23,11 +23,9 @@
 #include <gtest/gtest.h>
 #include <cstdlib>
 #include <random>
-#include <string>
 
 #include "chunkserver/output_buffer.h"
 #include "common/crc.h"
-#include "unittests/TemporaryDirectory.h"
 
 const ssize_t testHeaderSize = 1;
 const ssize_t testNumBlocks = 4;

--- a/src/chunkserver/replication_bandwidth_limiter.cc
+++ b/src/chunkserver/replication_bandwidth_limiter.cc
@@ -18,6 +18,7 @@
  */
 
 #include "common/platform.h"
+
 #include "chunkserver/replication_bandwidth_limiter.h"
 
 using namespace ioLimiting;


### PR DESCRIPTION
The change includes:

- Add missing license information to some files.
- Remove unneeded includes.
- Switch to qualified include paths for robustness against file moves.
- Apply the code style for includes, which consists in:

1. A block with only common/platform.h in each file.
2. If the .cc files is related to a .h file, then the .h file in a separate block (e.g.: a class declaration and implementation).
3. A block with standard and system files (sorted by clang-format).
4. A block with our internal files, sorted alphabetically (and logically grouped by the qualified paths).