### PR TITLE
perf: Skip metadata dump during chunk registration

### DIFF
--- a/src/master/chunks.h
+++ b/src/master/chunks.h
@@ -28,12 +28,15 @@
 #include "common/chunk_type_with_address.h"
 #include "common/chunk_with_address_and_label.h"
 #include "common/chunks_availability_state.h"
+#include "common/time_utils.h"
 #include "master/checksum.h"
 #include "master/metadata_loader.h"
 
 struct matocsserventry;
 
 extern bool gAvoidSameIpChunkservers;
+
+extern Timeout gTimeoutSinceLastChunkRegistration;
 
 int chunk_increase_version(uint64_t chunkid);
 int chunk_set_version(uint64_t chunkid,uint32_t version);

--- a/src/master/filesystem.cc
+++ b/src/master/filesystem.cc
@@ -119,11 +119,16 @@ static void metadataPollServe(const std::vector<pollfd> &pdesc) {
 }
 
 void fs_periodic_storeall() {
-	auto result = gMetadataBackend->fs_storeall(
-	    MetadataDumper::kBackgroundDump);  // ignore error
+	// Prevent metadata dump while chunks registration is in progress to prevent slowing down
+	// the chunks registration process
+	auto isChunkRegistrationInProgress = !gTimeoutSinceLastChunkRegistration.expired();
+	if (isChunkRegistrationInProgress) {
+		safs::log_info(
+		    "periodic metadata dump was skipped while chunks registration is in progress");
+		return;
+	}
 
-	safs_silent_syslog(LOG_DEBUG, "periodic metadata dump: %s",
-	                   (SAUNAFS_STATUS_OK == result) ? "success" : "failure");
+	gMetadataBackend->fs_storeall(MetadataDumper::kBackgroundDump);  // ignore error
 }
 
 void fs_term(void) {

--- a/src/master/matocsserv.cc
+++ b/src/master/matocsserv.cc
@@ -70,6 +70,15 @@ enum{KILL, CONNECTED};
 double gLoadFactorPenalty = 0.;
 bool gPrioritizeDataParts = true;
 
+// A safe threshold of 15 seconds to determine whether chunks registration is in progress and
+// prevent dumping metadata.
+constexpr auto kTimeoutForChunkRegistration = std::chrono::seconds(15);
+
+// Default value of 1 second to initialize the Timeout instance.
+// This value expires fast enough to not affect metadata dump when the cluster starts empty and
+// there is no chunks registration.
+Timeout gTimeoutSinceLastChunkRegistration(std::chrono::seconds(1));
+
 struct matocsserventry {
 	matocsserventry() : inputPacket(MaxPacketSize) {}
 
@@ -1112,6 +1121,8 @@ void matocsserv_sau_register_chunks(matocsserventry *eptr, const std::vector<uin
 			chunk_server_has_chunk(eptr, chunk.id, chunk.version, slice_traits::standard::ChunkPartType());
 		}
 	}
+	// Chunks registration is in progress, so we reset the timeout
+	gTimeoutSinceLastChunkRegistration = Timeout(kTimeoutForChunkRegistration);
 }
 
 void matocsserv_sau_register_space(matocsserventry *eptr, const std::vector<uint8_t>& data) {

--- a/src/master/metadata_backend_file.cc
+++ b/src/master/metadata_backend_file.cc
@@ -321,6 +321,7 @@ uint8_t MetadataBackendFile::fs_storeall(MetadataDumper::DumpType dumpType) {
 		}
 		if (child) {
 			printf("OK\n");  // give sfsmetarestore another chance
+			safs::log_info("Child process for metadata dumping finished (pid: {})", getpid());
 			exit(0);
 		}
 		broadcast_metadata_saved(status);

--- a/src/master/metadata_dumper.cc
+++ b/src/master/metadata_dumper.cc
@@ -19,6 +19,7 @@
  */
 
 #include "common/platform.h"
+#include "slogger/slogger.h"
 
 #include "master/metadata_dumper.h"
 
@@ -127,6 +128,7 @@ bool MetadataDumper::start(MetadataDumper::DumpType& dumpType, uint64_t checksum
 	}
 
 	// the child process tells the parent process "OK" or "ERR", until then parent assumes "ERR"
+	safs::log_info("Starting fork process for metadata dumping...");
 	switch (fork()) {
 		case -1:
 			// on fork error store metadata in foreground
@@ -136,6 +138,7 @@ bool MetadataDumper::start(MetadataDumper::DumpType& dumpType, uint64_t checksum
 			close(pipeFd[1]);
 			return false;
 		case 0:
+			safs::log_info("Child process started for metadata dumping (pid: {})", getpid());
 			close(pipeFd[0]); // ignore close error
 			if (dup2(pipeFd[1], STDOUT_FILENO)  == -1) {
 				// can't give the response
@@ -198,7 +201,7 @@ void MetadataDumper::pollServe(const std::vector<pollfd> &pdesc) {
 		char buffer[1024];
 		int ret = read(dumpingProcessFd_, buffer, sizeof(buffer) - 1);
 		if (ret == -1) {
-			safs_pretty_errlog(LOG_WARNING, "read from the process dumping metadata failed");
+			safs::log_warn("read from the process dumping metadata failed");
 			dumpingFinished();
 		} else if (ret == 0) {
 			dumpingFinished();
@@ -207,8 +210,9 @@ void MetadataDumper::pollServe(const std::vector<pollfd> &pdesc) {
 			dumpingProcessOutputEmpty_ = false;
 			dumpingSucceeded_ = std::string(buffer) == "OK\n";
 			if (!dumpingSucceeded_) {
-				safs_pretty_syslog(LOG_WARNING, "metadata dumping failed: expected 'OK', received '%s'",
-						buffer);
+				safs::log_warn("metadata dumping failed: expected 'OK', received {}", buffer);
+			} else {
+				safs::log_info("periodic metadata dump: success");
 			}
 		}
 	}

--- a/tests/test_suites/ShortSystemTests/test_metadata_prevent_dump_and_chunks_registration.sh
+++ b/tests/test_suites/ShortSystemTests/test_metadata_prevent_dump_and_chunks_registration.sh
@@ -1,0 +1,58 @@
+timeout_set '1 minutes'
+period=10
+
+CHUNKSERVERS=1 \
+	MASTERSERVERS=1 \
+	MASTER_EXTRA_CONFIG="METADATA_DUMP_PERIOD_SECONDS = 10|MAGIC_DEBUG_LOG = ${TEMP_DIR}/log" \
+	setup_local_empty_saunafs info
+
+is_time_for_metadata_dump() {
+	# The period is 10 seconds, so the modulo should be 0 every 10 seconds in UNIX time
+	[ "$(( $(date +%s) % period))" -eq 0 ]
+}
+
+echo "metadata dump will take place every ${period} seconds..."
+
+# Create a lot of small files to generate chunks
+mkdir ${info[mount0]}/1M.files
+for i in $(seq 1 2000); do
+	dd if=/dev/zero of="${info[mount0]}/1M.files/file_${i}" bs=1M count=1 status=none
+done
+
+# Stop the chunkserver daemon
+saunafs_chunkserver_daemon 0 stop
+
+# Clean the logs
+truncate -s0 "${TEMP_DIR}/log"
+
+# Start the chunkserver again to trigger chunks registration
+saunafs_chunkserver_daemon 0 start
+
+saunafs_wait_for_ready_chunkservers 1
+
+# Wait for the next metadata dump
+while ! is_time_for_metadata_dump; do
+	echo "Waiting for next metadata dump, current seconds: $(date +%S)"
+	sleep 1
+done
+
+# Confirm the metadata dump is skipped during chunks registration in the master
+assert_eventually "grep -q 'metadata dump was skipped' ${TEMP_DIR}/log"
+
+# Confirm the metadata dump is successful in the shadow
+assert_eventually "grep -q 'periodic metadata dump: success' ${TEMP_DIR}/log"
+
+# Clean the logs
+truncate -s0 "${TEMP_DIR}/log"
+
+# Wait for the next metadata dump
+while ! is_time_for_metadata_dump; do
+	echo "Waiting for next metadata dump, current seconds: $(date +%S)"
+	sleep 1
+done
+
+# Confirm metadata dump was not skipped in the master
+assert_awk_finds_no '/metadata dump was skipped:/' "${TEMP_DIR}/log"
+
+# Confirm metadata dump was successful in the master and shadow
+assert_eventually "grep 'periodic metadata dump: success' ${TEMP_DIR}/log | wc -l" "2"


### PR DESCRIPTION
This commit prevents metadata dumps from running while chunks registration is active. This avoids a potential performance degradation caused by running two resource-intensive operations in parallel. The improvement is especially noticeable in large-scale deployments, where chunks registration can take several minutes and collide with the periodic metadata dump.

Additionally, logs were added to the dumping logic to better identify different stages of the forking process.