### PR TITLE
ci: Prevent duplicate GitHub action workflow runs

### DIFF
--- a/.github/workflows/run-unit-and-ganesha-tests.yml
+++ b/.github/workflows/run-unit-and-ganesha-tests.yml
@@ -1,11 +1,8 @@
 name: Run Unit and Ganesha Tests
 
 on:
-    push:
     merge_group:
     pull_request:
-        branches:
-            - "*"
 
 jobs:
     Run-Unit-Tests-and-Ganesha:


### PR DESCRIPTION
This PR prevents running twice the Github Actions pipeline used for Ganesha and unit tests.
Now, the pipeline runs only for Pull Requests.