### PR TITLE
fix: Modify maxReadAheadRequests default value

### DIFF
--- a/doc/sfsmount.1.adoc
+++ b/doc/sfsmount.1.adoc
@@ -170,7 +170,7 @@ Set percentage of system memory used for max value of read cache size (default: 
 Define number of read workers (default: 30).
 
 *-o maxreadaheadrequests=*'N'::
-Define number of readahead requests per inode (default: 5).
+Define number of readahead requests per inode (default: 2).
 
 *-o sfsrlimitnofile=*'N'::
 Try to change limit of simultaneously opened file descriptors on startup

--- a/src/mount/sauna_client.h
+++ b/src/mount/sauna_client.h
@@ -73,7 +73,7 @@ struct FsInitParams {
 	static constexpr unsigned kDefaultReadaheadMaxWindowSize = 65536;
 	static constexpr unsigned kDefaultReadCacheMaxSizePercentage = 60;
 	static constexpr unsigned kDefaultReadWorkers = 30;
-	static constexpr unsigned kDefaultMaxReadaheadRequests = 5;
+	static constexpr unsigned kDefaultMaxReadaheadRequests = 2;
 	static constexpr bool     kDefaultPrefetchXorStripes = false;
 
 	static constexpr float    kDefaultBandwidthOveruse = 1.0;

--- a/tests/test_suites/SanityChecks/test_options_random_casing.sh
+++ b/tests/test_suites/SanityChecks/test_options_random_casing.sh
@@ -12,7 +12,7 @@ cd "${info[mount0]}"
 # Expected values are current defaults
 assert_equals $(cat .saunafs_tweaks | egrep CacheExpirationTime | awk '{print $2}') 1000
 assert_equals $(cat .saunafs_tweaks | egrep WriteMaxRetries | awk '{print $2}') 30
-assert_equals $(cat .saunafs_tweaks | egrep MaxReadaheadRequests | awk '{print $2}') 5
+assert_equals $(cat .saunafs_tweaks | egrep MaxReadaheadRequests | awk '{print $2}') 2
 assert_equals $(cat .saunafs_tweaks | egrep ReadWaveTimeout | awk '{print $2}') 500
 
 cd /


### PR DESCRIPTION
Prevents timeouts and network overloads when small files are read.
May impact performance of sequential reading on big files.