### PR TITLE
fix: Relax constraints in malloc tests

### DIFF
--- a/tests/test_suites/ShortSystemTests/test_limit_glibc_malloc_arenas.sh
+++ b/tests/test_suites/ShortSystemTests/test_limit_glibc_malloc_arenas.sh
@@ -62,7 +62,7 @@ echo "Arena limit set to ${effectiveArenaLimit} for chunkserver 0"
 cs0PidAfter=$(saunafs_chunkserver_daemon 0 test | tr -d '\0' | awk '{print $NF}')
 virtualMemoryCS0After=$(getVirtualMemoryForPid ${cs0PidAfter})
 echo "CS0 PID: ${cs0PidAfter} - Virtual memory: ${virtualMemoryCS0After}"
-assert_less_than ${virtualMemoryCS0After} ${virtualMemoryCS0}
+assert_less_or_equal ${virtualMemoryCS0After} ${virtualMemoryCS0}
 
 ### Test the limit in the master ###
 
@@ -85,4 +85,4 @@ echo "Arena limit set to ${effectiveArenaLimit} for master 0"
 master0PidAfter=$(saunafs_master_n 0 test | tr -d '\0' | awk '{print $NF}')
 virtualMemoryMaster0After=$(getVirtualMemoryForPid ${master0PidAfter})
 echo "Master0 PID: ${master0PidAfter} - Virtual memory: ${virtualMemoryMaster0After}"
-assert_less_than ${virtualMemoryMaster0After} ${virtualMemoryMaster0}
+assert_less_or_equal ${virtualMemoryMaster0After} ${virtualMemoryMaster0}

--- a/tests/test_suites/SingleMachineTests/test_limit_glibc_malloc_arenas_client.sh
+++ b/tests/test_suites/SingleMachineTests/test_limit_glibc_malloc_arenas_client.sh
@@ -71,7 +71,7 @@ vsz_mount1=$(run_fio_and_measure_vsz "${info[mount1]}" $pid2)
 echo "VSZ for ${info[mount0]}: ${vsz_mount0}"
 echo "VSZ for ${info[mount1]}: ${vsz_mount1}"
 
-assert_less_than "${vsz_mount1}" "${vsz_mount0}"
+assert_less_or_equal "${vsz_mount1}" "${vsz_mount0}"
 
 cd $TEMP_DIR
 


### PR DESCRIPTION
This change relaxes the check on the expected memory used in the malloc
arenas tests as it does not always imply a reduce in memory.

Signed-off-by: Dave <dave@leil.io>