### PR TITLE
test: Fix flaky metadata dumping test

### DIFF
--- a/tests/test_suites/ShortSystemTests/test_metadata_prevent_dump_and_chunks_registration.sh
+++ b/tests/test_suites/ShortSystemTests/test_metadata_prevent_dump_and_chunks_registration.sh
@@ -30,10 +30,12 @@ saunafs_chunkserver_daemon 0 start
 
 saunafs_wait_for_ready_chunkservers 1
 
-# Wait for the next metadata dump
-while ! is_time_for_metadata_dump; do
-	echo "Waiting for next metadata dump, current seconds: $(date +%S)"
-	sleep 1
+# Wait for the next two metadata dump executions to prevent the test being flaky
+for i in $(seq 1 2); do
+	while ! is_time_for_metadata_dump; do
+		echo "Waiting for next metadata dump, current seconds: $(date +%S)"
+		sleep 1
+	done
 done
 
 # Confirm the metadata dump is skipped during chunks registration in the master


### PR DESCRIPTION
Previously, test_metadata_prevent_dump_and_chunks_registration failed randomly because one step was sensitive to the wait for the next metadata dump cycle, which for some runs was too small, causing the test to fail.

This commit introduces an extra wait for the next metadata dump cycle to make sure there is enough time to produce the expected log during the metadata dump.

Signed-by-off: Crash <crash@leil.io>