### PR TITLE
Improve path by inode feature

### DIFF
--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -516,6 +516,7 @@ uint8_t fs_full_path_by_inode(const FsContext &context, inode_t initial_inode,
 			return SAUNAFS_ERROR_ENOENT; 
 		}
 		auto [parentId, nameHandle] = current_node->parent[0];
+		if (!nameHandle) { return SAUNAFS_ERROR_ENOENT; }
 		status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny, MODE_MASK_R,
 		                                        parentId, &parent_node);
 		if (status != SAUNAFS_STATUS_OK) { return status; }

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -512,8 +512,17 @@ uint8_t fs_full_path_by_inode(const FsContext &context, inode_t initial_inode,
 	if (status != SAUNAFS_STATUS_OK) { return status; }
 
 	while (current_inode != context.rootinode()) {
-		if (!current_node || current_node->parent.empty()) { 
-			return SAUNAFS_ERROR_ENOENT; 
+		if (!current_node || current_node->parent.empty()) {
+			if (current_node->parent.empty() &&
+			    (current_node->type == FSNode::kReserved || current_node->type == FSNode::kTrash)) {
+				current_name =
+				    current_node->type == FSNode::kTrash
+				        ? gMetadata->trash.at(TrashPathKey(current_node)).get() + " (trash)"
+				        : gMetadata->reserved.at(current_inode).get() + " (reserved)";
+				fullPath = current_name;
+				return SAUNAFS_STATUS_OK;
+			}
+			return SAUNAFS_ERROR_ENOENT;
 		}
 		auto [parentId, nameHandle] = current_node->parent[0];
 		if (!nameHandle) { return SAUNAFS_ERROR_ENOENT; }

--- a/src/mount/path_by_inode.h
+++ b/src/mount/path_by_inode.h
@@ -1,0 +1,34 @@
+/*
+
+ Copyright 2023 Leil Storage OÜ
+
+ This file is part of SaunaFS.
+
+ SaunaFS is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, version 3.
+
+ SaunaFS is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "common/platform.h"
+
+#include <condition_variable>
+#include <mutex>
+#include <string>
+
+struct InodePathInfo {
+    std::string pathByInode;
+    inode_t inode = 0; 
+    std::mutex mtx;
+    std::condition_variable cv;
+    bool locked = false;
+};
+
+inline InodePathInfo gInodePathInfo;

--- a/src/mount/sauna_client.cc
+++ b/src/mount/sauna_client.cc
@@ -941,13 +941,13 @@ EntryParam lookup(Context &ctx, inode_t parent, const char *name) {
 		if (endptr == nullptr || *endptr != '\0') {
 			throw RequestException(SAUNAFS_ERROR_EINVAL);
 		}
-		std::unique_lock<std::mutex> lock(InodePathByInode::inodePathInfo.mtx);
-		InodePathByInode::inodePathInfo.cv.wait(lock, [inode] {
-			return !InodePathByInode::inodePathInfo.locked ||
-			       InodePathByInode::inodePathInfo.inode == inode;
+		std::unique_lock<std::mutex> lock(gInodePathInfo.mtx);
+		gInodePathInfo.cv.wait(lock, [inode] {
+			return !gInodePathInfo.locked ||
+			       gInodePathInfo.inode == inode;
 		});
-		InodePathByInode::inodePathInfo.locked = true;
-		InodePathByInode::inodePathInfo.inode = inode;
+		gInodePathInfo.locked = true;
+		gInodePathInfo.inode = inode;
 		std::string fullPath = "";
 		int lookupStatus = SAUNAFS_STATUS_OK;
 		int getattrStatus = SAUNAFS_STATUS_OK;
@@ -957,14 +957,13 @@ EntryParam lookup(Context &ctx, inode_t parent, const char *name) {
 			fs_getattr(inode, ctx.uid, ctx.gid, attr));
 		if (lookupStatus != SAUNAFS_STATUS_OK || getattrStatus != SAUNAFS_STATUS_OK) {
 			status = lookupStatus != SAUNAFS_STATUS_OK ? lookupStatus : getattrStatus;
-			InodePathByInode::inodePathInfo.locked = false;
-			InodePathByInode::inodePathInfo.cv.notify_one();
+			gInodePathInfo.locked = false;
+			gInodePathInfo.cv.notify_one();
 			lock.unlock();
 			throw RequestException(status);
 		}
 		status = SAUNAFS_STATUS_OK;
-		InodePathByInode::inodePathInfo.pathByInode = new char[fullPath.length() + 1];
-		std::strcpy(InodePathByInode::inodePathInfo.pathByInode, fullPath.c_str());
+		gInodePathInfo.pathByInode = fullPath;
 		attr[0] = TYPE_FILE;
 		inode = parent;
 		icacheflag = 0;

--- a/src/mount/special_getattr.cc
+++ b/src/mount/special_getattr.cc
@@ -111,7 +111,7 @@ static AttrReply getattr(const Context &ctx, char (&attrstr)[256]) {
 
 namespace InodePathByInode {
 static AttrReply getattr(const Context &ctx, char (&attrstr)[256]) {
-	std::unique_lock<std::mutex> lock(inodePathInfo.mtx);
+	std::unique_lock<std::mutex> lock(gInodePathInfo.mtx);
 	struct stat o_stbuf;
 	memset(&o_stbuf, 0, sizeof(struct stat));
 	attr_to_stat(inode_, attr, &o_stbuf);

--- a/src/mount/special_inode.cc
+++ b/src/mount/special_inode.cc
@@ -70,9 +70,6 @@ const inode_t InodeFileByInode::inode_ = SPECIAL_INODE_FILE_BY_INODE;
 const Attributes InodePathByInode::attr =
 	  {{'d', 0x01,0xED, 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,1, 0,0,0,0,0,0,0,0}};
 const inode_t InodePathByInode::inode_ = SPECIAL_INODE_PATH_BY_INODE;
-namespace InodePathByInode {
-    InodePathInfo inodePathInfo = {nullptr, 0, std::mutex(), std::condition_variable(), false};
-}
 
 // 0x01A4 == 0b110100100 == 0644
 const Attributes InodeMountInfo::attr =

--- a/src/mount/special_inode.h
+++ b/src/mount/special_inode.h
@@ -30,6 +30,7 @@
 #include "mount/oplog.h"
 #include "mount/tweaks.h"
 #include "mount/mount_info.h"
+#include "mount/path_by_inode.h"
 
 namespace InodeMasterInfo {
 	extern const Attributes attr;
@@ -89,15 +90,6 @@ namespace InodeFileByInode {
 }
 
 namespace InodePathByInode {
-	typedef struct _inodePathInfo {
-		char *pathByInode;
-		inode_t inode;
-		std::mutex mtx;
-		std::condition_variable cv;
-		bool locked = false;
-	} InodePathInfo;
-    extern InodePathInfo inodePathInfo;
-
     extern const Attributes attr;
 	extern const inode_t inode_;
 }

--- a/src/mount/special_lookup.cc
+++ b/src/mount/special_lookup.cc
@@ -162,7 +162,7 @@ static EntryParam lookup(const Context &ctx, inode_t parent, const char *name,
 namespace InodePathByInode {
 static EntryParam lookup(const Context &ctx, inode_t parent, const char *name,
 	                            char attrstr[256]) {
-	std::unique_lock<std::mutex> lock(inodePathInfo.mtx);
+	std::unique_lock<std::mutex> lock(gInodePathInfo.mtx);
 	EntryParam e;
 	e.ino = inode_;
 	e.attr_timeout = 3600.0;

--- a/src/mount/special_open.cc
+++ b/src/mount/special_open.cc
@@ -109,14 +109,14 @@ static void open(const Context &ctx, FileInfo *fi) {
 
 namespace InodePathByInode {
 static void open(const Context &ctx, FileInfo *fi) {
-	std::unique_lock<std::mutex> lock(inodePathInfo.mtx);
+	std::unique_lock<std::mutex> lock(gInodePathInfo.mtx);
 	if ((fi->flags & O_ACCMODE) != O_RDONLY) {
 		oplog_printf(ctx, "open (%" PRIiNode ") (internal node: PATH_BY_INODE_FILE): %s",
 		            inode_,
 		            saunafs_error_string(SAUNAFS_ERROR_EACCES));
 		throw RequestException(SAUNAFS_ERROR_EACCES);
 	}
-	fi->fh = reinterpret_cast<uintptr_t>(inodePathInfo.pathByInode);
+	fi->fh = reinterpret_cast<uintptr_t>(gInodePathInfo.pathByInode.c_str());
 	fi->direct_io = 1;
 	fi->keep_cache = 0;
 	oplog_printf(ctx, "open (%" PRIiNode ") (internal node: PATH_BY_INODE_FILE): OK (1,0)",

--- a/src/mount/special_read.cc
+++ b/src/mount/special_read.cc
@@ -210,11 +210,11 @@ static std::vector<uint8_t> read(const Context &ctx,
 namespace InodePathByInode {
 static std::vector<uint8_t> read(const Context &ctx,
 		size_t size, off_t off, FileInfo *fi, int debug_mode) {
-	std::unique_lock<std::mutex> lock(inodePathInfo.mtx);
+	std::unique_lock<std::mutex> lock(gInodePathInfo.mtx);
 	if (debug_mode) {
 		printDebugReadInfo(ctx, SPECIAL_INODE_PATH_BY_INODE, size, off);
 	}
-	uint32_t ssize = strlen(inodePathInfo.pathByInode);
+	uint32_t ssize = gInodePathInfo.pathByInode.size();
 	uint8_t *buff = reinterpret_cast<uint8_t*>(fi->fh);
 	if (off >= static_cast<off_t>(ssize)) {
 		printReadOplogNoData(ctx,

--- a/src/mount/special_release.cc
+++ b/src/mount/special_release.cc
@@ -96,12 +96,11 @@ static void release(FileInfo *fi) {
 
 namespace InodePathByInode {
 static void release(FileInfo *fi) {
-	std::unique_lock<std::mutex> lock(inodePathInfo.mtx);
+	std::unique_lock<std::mutex> lock(gInodePathInfo.mtx);
 	fi->fh = 0;
-	if (inodePathInfo.locked) {
-		free(inodePathInfo.pathByInode);
-		inodePathInfo.locked = false;
-		inodePathInfo.cv.notify_one();
+	if (gInodePathInfo.locked) {
+		gInodePathInfo.locked = false;
+		gInodePathInfo.cv.notify_one();
 	}
 	oplog_printf("release (%" PRIiNode ") (internal node: PATH_BY_INODE_FILE): OK", inode_);
 }

--- a/src/mount/special_setattr.cc
+++ b/src/mount/special_setattr.cc
@@ -123,7 +123,7 @@ static AttrReply setattr(const Context &ctx, struct stat *stbuf, int to_set,
 namespace InodePathByInode {
 static AttrReply setattr(const Context &ctx, struct stat *stbuf, int to_set,
 	                 char modestr[11], char attrstr[256]) {
-	std::unique_lock<std::mutex> lock(inodePathInfo.mtx);
+	std::unique_lock<std::mutex> lock(gInodePathInfo.mtx);
 	struct stat o_stbuf;
 	memset(&o_stbuf, 0, sizeof(struct stat));
 	attr_to_stat(inode_, attr, &o_stbuf);

--- a/src/mount/special_write.cc
+++ b/src/mount/special_write.cc
@@ -100,7 +100,7 @@ static BytesWritten write(const Context &ctx, const char *buf, size_t size,
 namespace InodePathByInode {
 static BytesWritten write(const Context &ctx, const char * /*buf*/, size_t size,
 	                           off_t off, FileInfo * /*fi*/) {
-	std::unique_lock<std::mutex> lock(inodePathInfo.mtx);
+	std::unique_lock<std::mutex> lock(gInodePathInfo.mtx);
 	oplog_printf(ctx, "write (%" PRIiNode ",%" PRIu64 ",%" PRIu64 "): %s",
 	            inode_,
 	            (uint64_t)size,

--- a/tests/test_suites/TestTemplates/test_path_by_inode.inc
+++ b/tests/test_suites/TestTemplates/test_path_by_inode.inc
@@ -1,5 +1,6 @@
 USE_RAMDISK=YES \
-	MOUNT_0_EXTRA_CONFIG="sfscachemode=NEVER,sfsdirentrycacheto=0" \
+	MOUNT_0_EXTRA_CONFIG="sfscachemode=NEVER,sfsreportreservedperiod=1,sfsdirentrycacheto=0" \
+	MASTER_EXTRA_CONFIG="EMPTY_RESERVED_FILES_PERIOD_MSECONDS = 3000" \
 	setup_local_empty_saunafs info
 
 cd "${info[mount0]}"
@@ -8,12 +9,14 @@ mkdir folder
 touch folder/file2
 mkdir folder/folder2
 touch folder/folder2/file3
+touch file4
 
 cat .saunafs_path_by_inode/2
 cat .saunafs_path_by_inode/3
 cat .saunafs_path_by_inode/4
 cat .saunafs_path_by_inode/5
 cat .saunafs_path_by_inode/6
+cat .saunafs_path_by_inode/7
 
 # check file paths by inode
 assert_equals "file1" "$(cat .saunafs_path_by_inode/2)"
@@ -21,34 +24,54 @@ assert_equals "folder" "$(cat .saunafs_path_by_inode/3)"
 assert_equals "folder/file2" "$(cat .saunafs_path_by_inode/4)"
 assert_equals "folder/folder2" "$(cat .saunafs_path_by_inode/5)"
 assert_equals "folder/folder2/file3" "$(cat .saunafs_path_by_inode/6)"
+assert_equals "file4" "$(cat .saunafs_path_by_inode/7)"
 
 # check reading from files by their path
 echo "data1" > file1
 echo "data2" > folder/file2
 echo "data3" > folder/folder2/file3
+echo "data4" > file4
 
 assert_equals "data1" "$(cat $(cat .saunafs_path_by_inode/2))"
 assert_equals "data2" "$(cat $(cat .saunafs_path_by_inode/4))"
 assert_equals "data3" "$(cat $(cat .saunafs_path_by_inode/6))"
+assert_equals "data4" "$(cat $(cat .saunafs_path_by_inode/7))"
 
 # check writing to files by their path
 echo "data4" > $(cat .saunafs_path_by_inode/2)
 echo "data5" > $(cat .saunafs_path_by_inode/4)
 echo "data6" > $(cat .saunafs_path_by_inode/6)
+echo "data7" > $(cat .saunafs_path_by_inode/7)
 
 assert_equals "data4" "$(cat file1)"
 assert_equals "data5" "$(cat folder/file2)"
 assert_equals "data6" "$(cat folder/folder2/file3)"
+assert_equals "data7" "$(cat file4)"
 
 # check removing files by their path
-rm $(cat .saunafs_path_by_inode/2)
+# first check the case when the file was deleted but
+# is still on the filesystem trash
+saunafs settrashtime 2 file1
+rm file1
 assert_failure cat file1
+assert_success cat .saunafs_path_by_inode/2
+assert_equals "file1 (trash)" "$(cat .saunafs_path_by_inode/2)"
+sleep 5
 
-# requesting path of removed file or unexisting inode should 
-# return not such file or directory
+# requesting path of removed file (after trashtime expired) or 
+# unexisting inode should return not such file or directory
 assert_failure cat .saunafs_path_by_inode/2
 assert_failure cat .saunafs_path_by_inode/1500
 
 # the .saunafs_path_by_inode directory is not writable or removable
 assert_failure rm .saunafs_path_by_inode
 assert_failure touch .saunafs_path_by_inode/file
+
+# check removing a file while still in use and with no
+# trashtime is sending it to the reserved files
+saunafs settrashtime 0 file4
+while true; do echo "Data" >> file4; sleep 1; done &
+rm file4
+assert_failure cat file4
+assert_success cat .saunafs_path_by_inode/7
+assert_equals "file4 (reserved)" "$(cat .saunafs_path_by_inode/7)"


### PR DESCRIPTION
This PR contains the following changes:
- Refactor path by inode special inode related code.
- Add check for preventing coredump on master side when requesting the name of deleted inode in a path for the path by inode special hidden file.