### PR TITLE
Improve nop thread behavior

### DIFF
--- a/src/mount/mastercomm.cc
+++ b/src/mount/mastercomm.cc
@@ -1069,6 +1069,7 @@ void* fs_nop_thread(void *arg) {
 				put32bit(&ptr,4);
 				put32bit(&ptr,0);
 				if (tcptowrite(fd,hdr,12,1000)!=12) {
+					safs::log_warn("Failed to send ANTOAN_NOP to master");
 					disconnect = true;
 				} else {
 					master_stats_add(MASTER_BYTESSENT,12);
@@ -1088,6 +1089,7 @@ void* fs_nop_thread(void *arg) {
 					put32bit(&ptr, inode);
 				}
 				if (tcptowrite(fd,inodespacket,inodesleng,1000)!=inodesleng) {
+					safs::log_warn("Failed to send CLTOMA_FUSE_RESERVED_INODES to master");
 					disconnect = true;
 				} else {
 					master_stats_add(MASTER_BYTESSENT,inodesleng);

--- a/src/mount/mastercomm.cc
+++ b/src/mount/mastercomm.cc
@@ -1047,6 +1047,10 @@ void* fs_nop_thread(void *arg) {
 		now = time(NULL);
 		std::unique_lock<std::mutex> fdLock(fdMutex);
 		if (fterm) {
+			if (disconnect) {  // setDisconnect was already called async
+				fdLock.unlock();
+				return nullptr;
+			}
 			if (fd>=0) {
 				fs_close_session();
 			}
@@ -1072,7 +1076,7 @@ void* fs_nop_thread(void *arg) {
 				}
 				lastwrite=now;
 			}
-			if (++inodeswritecnt >= gInitParams.report_reserved_period) {
+			if (++inodeswritecnt >= gInitParams.report_reserved_period && !disconnect) {
 				inodeswritecnt = 0;
 				std::unique_lock<std::mutex> asLock(acquiredFileMutex);
 				inodesleng = 8 + 4 * acquiredFiles.size();


### PR DESCRIPTION
This PR introduces two main changes:
- Addition of proper locking release of lock for client to master communication file descriptor.
- Add useful logging messages on cases when master was disconnected and `fs_nop_thread` was not able to info to it.