### PR TITLE
fix(chunkserver): Avoid direct mutex lock/unlock

### DIFF
--- a/src/chunkserver/chunkserver_entry.cc
+++ b/src/chunkserver/chunkserver_entry.cc
@@ -35,8 +35,10 @@
 #include <cstring>
 #include <ctime>
 #include <memory>
+#include <mutex>
 #include <set>
 
+#include "chunkserver-common/global_shared_resources.h"
 #include "chunkserver/bgjobs.h"
 #include "chunkserver/hdd_readahead.h"
 #include "chunkserver/hddspacemgr.h"
@@ -994,22 +996,20 @@ void ChunkserverEntry::getChunkBlocks(const uint8_t *data, uint32_t length) {
 
 /* IDLE operations */
 
-void ChunkserverEntry::hddListV2([[maybe_unused]] const uint8_t *data,
-                                 uint32_t length) {
+void ChunkserverEntry::hddListV2([[maybe_unused]] const uint8_t *data, uint32_t length) {
 	TRACETHIS();
-	uint32_t opSize;
-	uint8_t *ptr;
 
 	if (length != 0) {  // This packet should not have any data
-		safs_pretty_syslog(LOG_NOTICE,
-		                   "CLTOCS_HDD_LIST_V2 - wrong size (%" PRIu32 "/0)",
-		                   length);
+		safs::log_info("CLTOCS_HDD_LIST_V2 - wrong size ({}/0)", length);
 		state = State::Close;
 		return;
 	}
-	opSize = hddGetSerializedSizeOfAllDiskInfosV2(); // lock
-	ptr = createAttachedPacket(CSTOCL_HDD_LIST_V2, opSize);
-	hddSerializeAllDiskInfosV2(ptr); // unlock
+
+	std::lock_guard disksLock(gDisksMutex);
+
+	uint32_t opSize = hddGetSerializedSizeOfAllDiskInfosV2();
+	uint8_t *ptr = createAttachedPacket(CSTOCL_HDD_LIST_V2, opSize);
+	hddSerializeAllDiskInfosV2(ptr);
 }
 
 void ChunkserverEntry::listDiskGroups([[maybe_unused]] const uint8_t *data,

--- a/src/chunkserver/hddspacemgr.cc
+++ b/src/chunkserver/hddspacemgr.cc
@@ -158,12 +158,11 @@ uint32_t hddGetSerializedSizeOfAllDiskInfosV2() {
 	TRACETHIS();
 	uint32_t serializedSizeOfAllDisks = 0;
 	static constexpr uint32_t kMaxDiskInfoSerializedSizeWithoutPath = (2 + 226);
+	static constexpr size_t kMaxDiskPathSize = 255;
 
-	gDisksMutex.lock();  // Will be unlocked by hddSerializeAllDiskInfosV2
-
-	for (const auto& disk : gDisks) {
-		serializedSizeOfAllDisks += kMaxDiskInfoSerializedSizeWithoutPath
-		                            + std::min(disk->dataPath().size(), 255UL);
+	for (const auto &disk : gDisks) {
+		serializedSizeOfAllDisks += kMaxDiskInfoSerializedSizeWithoutPath +
+		                            std::min(disk->dataPath().size(), kMaxDiskPathSize);
 	}
 
 	return serializedSizeOfAllDisks;
@@ -172,17 +171,13 @@ uint32_t hddGetSerializedSizeOfAllDiskInfosV2() {
 void hddSerializeAllDiskInfosV2(uint8_t *buff) {
 	TRACETHIS();
 
-	if (buff) {
+	if (buff != nullptr) {
 		LegacyVector<DiskInfo> diskInfoVector;
 
-		for (const auto& disk : gDisks) {
-			diskInfoVector.emplace_back(disk->toDiskInfo());
-		}
+		for (const auto &disk : gDisks) { diskInfoVector.emplace_back(disk->toDiskInfo()); }
 
 		serialize(&buff, diskInfoVector);
 	}
-
-	gDisksMutex.unlock();  //Locked by hddGetSerializedSizeOfAllDiskInfosV2
 }
 
 std::string hddGetDiskGroups() {

--- a/src/chunkserver/hddspacemgr.h
+++ b/src/chunkserver/hddspacemgr.h
@@ -37,7 +37,7 @@ void hddGetLostChunks(std::vector<ChunkWithType>& chunks, std::size_t limit);
 void hddGetNewChunks(std::vector<ChunkWithVersionAndType>& chunks,
                      std::size_t limit);
 
-/* lock/unlock pair */
+/* Both must be called with the disks mutex locked */
 uint32_t hddGetSerializedSizeOfAllDiskInfosV2();
 void hddSerializeAllDiskInfosV2(uint8_t *buff);
 


### PR DESCRIPTION
hddGetSerializedSizeOfAllDiskInfosV2 and hddSerializeAllDiskInfosV2 were used as a lock/unlock pair directly on the gDisksMutex, without RAII locking. This change uses a std::lock_guard for safer behavior.

+ Misc format and logging improvements.