### PR TITLE
feat!: Remove deprecated sfscachefiles option

### DIFF
--- a/doc/sfsmount.1.adoc
+++ b/doc/sfsmount.1.adoc
@@ -111,10 +111,6 @@ Print some SaunaFS-specific debugging information.
 *-o sfscachemode=*'CACHEMODE'::
 Set cache mode (see *DATA CACHE MODES*; default is AUTO).
 
-*-o sfscachefiles*::
-(deprecated) Preserve file data in cache (equivalent to *-o
-sfscachemode=*'YES'). Will be removed in 5.0.0.
-
 *-o sfsattrcacheto=*'SEC'::
 Set attributes cache timeout in seconds (default: 1.0).
 

--- a/src/mount/fuse/main.cc
+++ b/src/mount/fuse/main.cc
@@ -586,16 +586,8 @@ int main(int argc, char *argv[]) try {
 
 	init_fuse_lowlevel_ops();
 
-	if (gMountOptions.cachemode && gMountOptions.cachefiles) {
-		fprintf(stderr,
-			"sfscachemode and sfscachefiles options are exclusive "
-			"- use only " "sfscachemode\nsee: %s -h for help\n",
-		        argv[0]);
-		return 1;
-	}
-
 	if (!gMountOptions.cachemode) {
-		gMountOptions.keepcache = (gMountOptions.cachefiles) ? 1 : 0;
+		gMountOptions.keepcache = 0;
 	} else if (!strcasecmp(gMountOptions.cachemode, "AUTO")) {
 		gMountOptions.keepcache = 0;
 	} else if (!strcasecmp(gMountOptions.cachemode, "YES") ||

--- a/src/mount/fuse/mount_config.cc
+++ b/src/mount/fuse/mount_config.cc
@@ -68,7 +68,6 @@ struct fuse_opt gSfsOptsStage2[] = {
 	SFS_OPT("sfsacl", acl, 1),
 	SFS_OPT("sfsrwlock=%d", rwlock, 0),
 	SFS_OPT("sfsdonotrememberpassword", donotrememberpassword, 1),
-	SFS_OPT("sfscachefiles", cachefiles, 1),
 	SFS_OPT("sfscachemode=%s", cachemode, 0),
 	SFS_OPT("sfsmkdircopysgid=%u", mkdircopysgid, 0),
 	SFS_OPT("sfssugidclearmode=%s", sugidclearmodestr, 0),
@@ -155,10 +154,6 @@ void initialize_opts_name_values() {
 	gOptsNameValues["sfsrwlock"] = std::to_string(gMountOptions.rwlock);
 	gOptsNameValues["sfsdonotrememberpassword"] =
 	    std::to_string(gMountOptions.donotrememberpassword);
-	if (gMountOptions.cachefiles) {
-		fprintf(stderr, "Warning: sfscachefiles is deprecated, use -o sfscachemode=YES");
-	}
-	gOptsNameValues["sfscachefiles"] = std::to_string(gMountOptions.cachefiles);
 	gOptsNameValues["sfscachemode"] =
 	    gMountOptions.cachemode ? std::string(gMountOptions.cachemode) : "AUTO";
 	gOptsNameValues["sfsmkdircopysgid"] = std::to_string(gMountOptions.mkdircopysgid);
@@ -303,7 +298,6 @@ void usage(const char *progname) {
 				"operation (default: %d)\n"
 "    -o sfssugidclearmode=SMODE  set sugid clear mode (see below ; default: %s)\n"
 "    -o sfscachemode=CMODE       set cache mode (see below ; default: AUTO)\n"
-"    -o sfscachefiles            (deprecated) equivalent to '-o sfscachemode=YES'\n"
 "    -o sfsattrcacheto=SEC       set attributes cache timeout in seconds "
 				"(default: %.2f)\n"
 "    -o sfsentrycacheto=SEC      set file entry cache timeout in seconds "

--- a/src/mount/fuse/mount_config.h
+++ b/src/mount/fuse/mount_config.h
@@ -84,7 +84,6 @@ struct sfsopts_ {
 	char *sugidclearmodestr;
 	SugidClearMode sugidclearmode;
 	char *cachemode;
-	int cachefiles;
 	int keepcache;
 	int passwordask;
 	int donotrememberpassword;
@@ -151,7 +150,6 @@ struct sfsopts_ {
 		sugidclearmodestr(NULL),
 		sugidclearmode(SaunaClient::FsInitParams::kDefaultSugidClearMode),
 		cachemode(NULL),
-		cachefiles(0),
 		keepcache(SaunaClient::FsInitParams::kDefaultKeepCache),
 		passwordask(0),
 		donotrememberpassword(SaunaClient::FsInitParams::kDefaultDoNotRememberPassword),


### PR DESCRIPTION
The `-o sfscachefiles` mount option, previously marked as deprecated and equivalent to `-o sfscachemode=YES`, has now been fully removed.

Changes include:
- Removal of the option from documentation and help text.
- Elimination of related parsing, validation, and warning logic.
- Removal of the `cachefiles` field from the `sfsopts_` structure.

This simplifies the mount option handling and completes the transition to `sfscachemode` ahead of the SaunaFS v5.0.0 release.

BREAKING CHANGE:
Users relying on -o sfscachefiles must switch to -o sfscachemode=YES. The old option is no longer recognized and will cause an error if used.