### PR TITLE
chore(chunkserver): Refactor masterconn

### DIFF
--- a/src/chunkserver/masterconn.cc
+++ b/src/chunkserver/masterconn.cc
@@ -591,16 +591,19 @@ void masterconn_read(MasterConn *eptr) {
 
 	watchdog.start();
 	while (eptr->mode != ConnectionMode::KILL) {
-		if (gJobPool->getJobCount() >= (kMaxBackgroundJobsCount * 9) / 10) {
-			return;
-		}
+		// If the job pool is too busy, do not read more data.
+		if (gJobPool->getJobCount() >= (kMaxBackgroundJobsCount * 9) / 10) { return; }
+
 		uint32_t bytesToRead = eptr->inputPacket.bytesToBeRead();
-		ssize_t ret = read(eptr->sock, eptr->inputPacket.pointerToBeReadInto(), bytesToRead);
+		ssize_t ret = ::read(eptr->sock, eptr->inputPacket.pointerToBeReadInto(), bytesToRead);
+
 		if (ret == 0) {
 			safs_silent_syslog(LOG_NOTICE, "connection reset by Master");
 			eptr->mode = ConnectionMode::KILL;
 			return;
-		} else if (ret < 0) {
+		}
+
+		if (ret < 0) {
 			if (errno != EAGAIN) {
 				safs_silent_errlog(LOG_NOTICE, "read from Master error");
 				eptr->mode = ConnectionMode::KILL;
@@ -609,55 +612,56 @@ void masterconn_read(MasterConn *eptr) {
 		}
 
 		stats_bytesin += ret;
+
 		try {
 			eptr->inputPacket.increaseBytesRead(ret);
-		} catch (InputPacketTooLongException& ex) {
+		} catch (InputPacketTooLongException &ex) {
 			safs_silent_syslog(LOG_WARNING, "reading from master: %s", ex.what());
 			eptr->mode = ConnectionMode::KILL;
 			return;
 		}
+
 		if (ret == bytesToRead && !eptr->inputPacket.hasData()) {
-			// there might be more data to read in socket's buffer
-			continue;
-		} else if (!eptr->inputPacket.hasData()) {
-			return;
+			continue;  // there might be more data to read in socket's buffer
 		}
 
+		if (!eptr->inputPacket.hasData()) { return; }
+
+		// We have a complete packet in the input buffer, let's process it.
 		masterconn_gotpacket(eptr, eptr->inputPacket.getHeader(), eptr->inputPacket.getData());
+
 		eptr->inputPacket.reset();
 
-		if (watchdog.expired()) {
-			break;
-		}
+		if (watchdog.expired()) { break; }
 	}
 }
 
 void masterconn_write(MasterConn *eptr) {
 	ActiveLoopWatchdog watchdog(std::chrono::milliseconds(20));
-	int32_t i;
+	int32_t bytesWritten{-1};
 
 	watchdog.start();
 	while (!eptr->outputPackets.empty()) {
-		OutputPacket& pack = eptr->outputPackets.front();
-		i=write(eptr->sock, pack.packet.data() + pack.bytesSent,
-				pack.packet.size() - pack.bytesSent);
-		if (i<0) {
-			if (errno!=EAGAIN) {
-				safs_silent_errlog(LOG_NOTICE,"write to Master error");
+		OutputPacket &pack = eptr->outputPackets.front();
+		bytesWritten = ::write(eptr->sock, pack.packet.data() + pack.bytesSent,
+		                       pack.packet.size() - pack.bytesSent);
+
+		if (bytesWritten < 0) {
+			if (errno != EAGAIN) {
+				safs_silent_errlog(LOG_NOTICE, "write to Master error");
 				eptr->mode = ConnectionMode::KILL;
 			}
 			return;
 		}
-		stats_bytesout+=i;
-		pack.bytesSent += i;
-		if (pack.packet.size() != pack.bytesSent) {
-			return;
-		}
+
+		stats_bytesout += bytesWritten;
+		pack.bytesSent += bytesWritten;
+
+		if (pack.packet.size() != pack.bytesSent) { return; }
+
 		eptr->outputPackets.pop_front();
 
-		if (watchdog.expired()) {
-			break;
-		}
+		if (watchdog.expired()) { break; }
 	}
 }
 

--- a/src/chunkserver/masterconn.cc
+++ b/src/chunkserver/masterconn.cc
@@ -96,8 +96,9 @@ static const uint64_t kSendStatusDelay = 5;
 
 static std::unique_ptr<MasterConn> gMasterConnSingleton = nullptr;
 static std::unique_ptr<JobPool> gJobPool;
-static int jobfd;
-static int32_t jobfdpdescpos;
+
+static int gJobFD{-1};  ///< File descriptor for the job pool notifications
+static int32_t gJobFDpDescPos{-1};  ///< Position in the pollfd array for the job pool notifications
 
 // from config
 static std::string gMasterHost;
@@ -665,16 +666,17 @@ void masterconn_desc(std::vector<pollfd> &pdesc) {
 	MasterConn *eptr = gMasterConnSingleton.get();
 
 	eptr->pDescPos = -1;
-	jobfdpdescpos = -1;
+	gJobFDpDescPos = -1;
 
 	if (eptr->mode == ConnectionMode::FREE || eptr->sock < 0) { return; }
 
 	if (eptr->mode == ConnectionMode::CONNECTED) {
-		pdesc.push_back({jobfd, POLLIN, 0});
-		jobfdpdescpos = pdesc.size() - 1;
+		pdesc.emplace_back(gJobFD, POLLIN, 0);
+		gJobFDpDescPos = static_cast<int32_t>(pdesc.size() - 1);
+
 		if (gJobPool->getJobCount() < (kMaxBackgroundJobsCount * 9) / 10) {
-			pdesc.push_back({eptr->sock, POLLIN, 0});
-			eptr->pDescPos = pdesc.size() - 1;
+			pdesc.emplace_back(eptr->sock, POLLIN, 0);
+			eptr->pDescPos = static_cast<int32_t>(pdesc.size() - 1);
 		}
 	}
 
@@ -683,8 +685,8 @@ void masterconn_desc(std::vector<pollfd> &pdesc) {
 		if (eptr->pDescPos >= 0) {
 			pdesc[eptr->pDescPos].events |= POLLOUT;
 		} else {
-			pdesc.push_back({eptr->sock, POLLOUT, 0});
-			eptr->pDescPos = pdesc.size() - 1;
+			pdesc.emplace_back(eptr->sock, POLLOUT, 0);
+			eptr->pDescPos = static_cast<int32_t>(pdesc.size() - 1);
 		}
 	}
 }
@@ -707,6 +709,7 @@ void masterconn_serve(const std::vector<pollfd> &pdesc) {
 	LOG_AVG_TILL_END_OF_SCOPE0("master_serve");
 	MasterConn *eptr = gMasterConnSingleton.get();
 
+	// Check if the socket has been closed or has an error.
 	if (eptr->pDescPos >= 0 && (pdesc[eptr->pDescPos].revents & (POLLHUP | POLLERR))) {
 		if (eptr->mode == ConnectionMode::CONNECTING) {
 			masterconn_connecttest(eptr);
@@ -714,31 +717,43 @@ void masterconn_serve(const std::vector<pollfd> &pdesc) {
 			eptr->mode = ConnectionMode::KILL;
 		}
 	}
+
 	if (eptr->mode == ConnectionMode::CONNECTING) {
-		if (eptr->sock >= 0 && eptr->pDescPos >= 0 &&
-		    (pdesc[eptr->pDescPos].revents & POLLOUT)) {  // FD_ISSET(eptr->sock,wset)) {
+		// Check if the connection has been established.
+		if (eptr->sock >= 0 && eptr->pDescPos >= 0 && (pdesc[eptr->pDescPos].revents & POLLOUT)) {
 			masterconn_connecttest(eptr);
 		}
 	} else {
-		if ((eptr->mode == ConnectionMode::CONNECTED) && jobfdpdescpos >= 0 &&
-		    (pdesc[jobfdpdescpos].revents & POLLIN)) {  // FD_ISSET(jobfd,rset)) {
+		// Check if there are any background jobs to process.
+		if ((eptr->mode == ConnectionMode::CONNECTED) && gJobFDpDescPos >= 0 &&
+		    (pdesc[gJobFDpDescPos].revents & POLLIN)) {
 			gJobPool->checkJobs();
 		}
 
 		if (eptr->pDescPos >= 0) {
+			// Check if there is data to read from this connection
 			if ((eptr->mode == ConnectionMode::CONNECTED) &&
-			    (pdesc[eptr->pDescPos].revents & POLLIN)) {  // FD_ISSET(eptr->sock,rset)) {
+			    (pdesc[eptr->pDescPos].revents & POLLIN)) {
 				eptr->lastRead.reset();
 				masterconn_read(eptr);
 			}
-			if ((eptr->mode == ConnectionMode::CONNECTED) && (pdesc[eptr->pDescPos].revents & POLLOUT)) { // FD_ISSET(eptr->sock,wset)) {
+
+			// Check if there is data to write to this connection
+			if ((eptr->mode == ConnectionMode::CONNECTED) &&
+			    (pdesc[eptr->pDescPos].revents & POLLOUT)) {
 				eptr->lastWrite.reset();
 				masterconn_write(eptr);
 			}
-			if ((eptr->mode == ConnectionMode::CONNECTED) && eptr->lastRead.elapsed_ms() > gTimeout_ms) {
+
+			// Check if the connection has not been used for a while and should be closed
+			if ((eptr->mode == ConnectionMode::CONNECTED) &&
+			    eptr->lastRead.elapsed_ms() > gTimeout_ms) {
 				eptr->mode = ConnectionMode::KILL;
 			}
-			if ((eptr->mode == ConnectionMode::CONNECTED) && eptr->lastWrite.elapsed_ms() > (gTimeout_ms/3) && eptr->outputPackets.empty()) {
+
+			// Keep the connection alive by sending a NOP packet
+			if ((eptr->mode == ConnectionMode::CONNECTED) &&
+			    eptr->lastWrite.elapsed_ms() > (gTimeout_ms / 3) && eptr->outputPackets.empty()) {
 				masterconn_create_attached_no_version_packet(eptr, ANTOAN_NOP, 0);
 			}
 		}
@@ -873,7 +888,7 @@ int masterconn_init(void) {
 int masterconn_init_threads(void) {
 	try {
 		gJobPool =
-		    std::make_unique<JobPool>("ma", gNumberOfWorkers, kMaxBackgroundJobsCount, &jobfd);
+		    std::make_unique<JobPool>("ma", gNumberOfWorkers, kMaxBackgroundJobsCount, &gJobFD);
 	} catch (const std::runtime_error &e) {
 		safs::log_err("masterconn_init_threads: Failed to create JobPool instance: {}", e.what());
 		return -1;

--- a/src/chunkserver/masterconn.cc
+++ b/src/chunkserver/masterconn.cc
@@ -94,7 +94,7 @@ struct MasterConn {
 
 static const uint64_t kSendStatusDelay = 5;
 
-static MasterConn *gMasterConnSingleton = nullptr;
+static std::unique_ptr<MasterConn> gMasterConnSingleton = nullptr;
 static std::unique_ptr<JobPool> gJobPool;
 static int jobfd;
 static int32_t jobfdpdescpos;
@@ -202,7 +202,7 @@ void masterconn_sendregister(MasterConn *eptr) {
 }
 
 void masterconn_check_hdd_reports() {
-	MasterConn *eptr = gMasterConnSingleton;
+	MasterConn *eptr = gMasterConnSingleton.get();
 	uint32_t errorcounter;
 	if (eptr->mode == ConnectionMode::CONNECTED) {
 		if (hddGetAndResetSpaceChanged()) {
@@ -241,7 +241,7 @@ void masterconn_check_hdd_reports() {
 
 void masterconn_jobfinished(uint8_t status, void *packet) {
 	uint8_t *ptr;
-	MasterConn *eptr = gMasterConnSingleton;
+	MasterConn *eptr = gMasterConnSingleton.get();
 	if (eptr->mode == ConnectionMode::CONNECTED) {
 		ptr = masterconn_get_packet_data(packet);
 		ptr[8]=status;
@@ -253,7 +253,7 @@ void masterconn_jobfinished(uint8_t status, void *packet) {
 
 void masterconn_saujobfinished(uint8_t status, void *packet) {
 	OutputPacket* outputPacket = static_cast<OutputPacket*>(packet);
-	MasterConn *eptr = gMasterConnSingleton;
+	MasterConn *eptr = gMasterConnSingleton.get();
 	if (eptr->mode == ConnectionMode::CONNECTED) {
 		cstoma::overwriteStatusField(outputPacket->packet, status);
 		masterconn_attach_packet(eptr, packet);
@@ -264,7 +264,7 @@ void masterconn_saujobfinished(uint8_t status, void *packet) {
 
 void masterconn_chunkopfinished(uint8_t status,void *packet) {
 	uint8_t *ptr;
-	MasterConn *eptr = gMasterConnSingleton;
+	MasterConn *eptr = gMasterConnSingleton.get();
 	if (eptr->mode == ConnectionMode::CONNECTED) {
 		ptr = masterconn_get_packet_data(packet);
 		ptr[32]=status;
@@ -276,7 +276,7 @@ void masterconn_chunkopfinished(uint8_t status,void *packet) {
 
 void masterconn_replicationfinished(uint8_t status,void *packet) {
 	uint8_t *ptr;
-	MasterConn *eptr = gMasterConnSingleton;
+	MasterConn *eptr = gMasterConnSingleton.get();
 //      syslog(LOG_NOTICE,"job replication status: %" PRIu8,status);
 	if (eptr->mode == ConnectionMode::CONNECTED) {
 		ptr = masterconn_get_packet_data(packet);
@@ -475,7 +475,7 @@ void masterconn_gotpacket(MasterConn *eptr, PacketHeader header, const MessageBu
 
 
 void masterconn_term(void) {
-	MasterConn *eptr = gMasterConnSingleton;
+	MasterConn *eptr = gMasterConnSingleton.get();
 
 	gJobPool.reset();
 
@@ -484,8 +484,7 @@ void masterconn_term(void) {
 		eptr->inputPacket.reset();
 	}
 
-	delete eptr;
-	gMasterConnSingleton = nullptr;
+	gMasterConnSingleton.reset();
 }
 
 void masterconn_connected(MasterConn *eptr) {
@@ -663,7 +662,7 @@ void masterconn_write(MasterConn *eptr) {
 
 void masterconn_desc(std::vector<pollfd> &pdesc) {
 	LOG_AVG_TILL_END_OF_SCOPE0("master_desc");
-	MasterConn *eptr = gMasterConnSingleton;
+	MasterConn *eptr = gMasterConnSingleton.get();
 
 	eptr->pDescPos = -1;
 	jobfdpdescpos = -1;
@@ -692,7 +691,7 @@ void masterconn_desc(std::vector<pollfd> &pdesc) {
 
 void masterconn_send_status() {
 	static uint8_t prev_factor = 0;
-	MasterConn *eptr = gMasterConnSingleton;
+	MasterConn *eptr = gMasterConnSingleton.get();
 
 	if (gEnableLoadFactor) {
 		uint8_t load_factor = hddGetLoadFactor();
@@ -706,7 +705,7 @@ void masterconn_send_status() {
 
 void masterconn_serve(const std::vector<pollfd> &pdesc) {
 	LOG_AVG_TILL_END_OF_SCOPE0("master_serve");
-	MasterConn *eptr = gMasterConnSingleton;
+	MasterConn *eptr = gMasterConnSingleton.get();
 
 	if (eptr->pDescPos >= 0 && (pdesc[eptr->pDescPos].revents & (POLLHUP | POLLERR))) {
 		if (eptr->mode == ConnectionMode::CONNECTING) {
@@ -760,7 +759,7 @@ void masterconn_serve(const std::vector<pollfd> &pdesc) {
 }
 
 void masterconn_reconnect(void) {
-	MasterConn *eptr = gMasterConnSingleton;
+	MasterConn *eptr = gMasterConnSingleton.get();
 	if (eptr->mode == ConnectionMode::FREE) {
 		masterconn_initconnect(eptr);
 	}
@@ -782,7 +781,7 @@ bool masterconn_load_label() {
 }
 
 void masterconn_reload(void) {
-	MasterConn *eptr = gMasterConnSingleton;
+	MasterConn *eptr = gMasterConnSingleton.get();
 
 	gMasterHost = cfg_getstring("MASTER_HOST", "sfsmaster");
 	gMasterPort = cfg_getstring("MASTER_PORT", "9420");
@@ -848,7 +847,8 @@ int masterconn_init(void) {
 
 	if (!masterconn_load_label()) { return -1; }
 
-	eptr = gMasterConnSingleton = new MasterConn;
+	gMasterConnSingleton = std::make_unique<MasterConn>();
+	eptr = gMasterConnSingleton.get();
 	passert(eptr);
 
 	eptr->isMasterAddressValid = false;

--- a/src/chunkserver/masterconn.cc
+++ b/src/chunkserver/masterconn.cc
@@ -19,19 +19,21 @@
  */
 
 #include "common/platform.h"
+
 #include "chunkserver/masterconn.h"
 
-#include <cerrno>
-#include <cinttypes>
 #include <netinet/in.h>
-#include <cstdio>
-#include <cstdlib>
-#include <cstring>
 #include <sys/types.h>
 #include <sys/uio.h>
 #include <syslog.h>
-#include <ctime>
 #include <unistd.h>
+#include <algorithm>
+#include <cerrno>
+#include <cinttypes>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
 #include <list>
 #include <stdexcept>
 
@@ -39,87 +41,82 @@
 #include "chunkserver/bgjobs.h"
 #include "chunkserver/hddspacemgr.h"
 #include "chunkserver/network_main_thread.h"
-#include "config/cfg.h"
 #include "common/event_loop.h"
 #include "common/loop_watchdog.h"
 #include "common/massert.h"
+#include "common/network_address.h"
 #include "common/output_packet.h"
 #include "common/random.h"
-#include "slogger/slogger.h"
 #include "common/sockets.h"
 #include "common/time_utils.h"
+#include "config/cfg.h"
 #include "devtools/request_log.h"
+#include "protocol/SFSCommunication.h"
 #include "protocol/cstoma.h"
 #include "protocol/input_packet.h"
 #include "protocol/matocs.h"
-#include "protocol/SFSCommunication.h"
 #include "protocol/packet.h"
+#include "slogger/slogger.h"
 
-#define MaxPacketSize 10000
+static constexpr uint32_t kMaxPacketSize = 10000;
+static constexpr uint32_t kMaxBackgroundJobsCount = 1000;
 
-// has to be less than MaxPacketSize on master side divided by 8
-#define LOSTCHUNKLIMIT 25000
-// has to be less than MaxPacketSize on master side divided by 12
-#define NEWCHUNKLIMIT 25000
+enum class ConnectionMode : std::uint8_t {
+	FREE,        /// There is no socket for the connection yet.
+	CONNECTING,  /// Connection is being established.
+	CONNECTED,   /// Connection is active.
+	KILL         /// Connection has been dropped, a reconnection will be attempted.
+};
 
-#define BGJOBSCNT 1000
+struct MasterConn {
+	MasterConn() : inputPacket(kMaxPacketSize) {}
 
-// mode
-enum {FREE,CONNECTING,CONNECTED,KILL};
+	// Disable unneeded copying and moving of the connection objects.
+	MasterConn(const MasterConn &) = delete;
+	MasterConn(MasterConn &&) = delete;
+	MasterConn &operator=(const MasterConn &) = delete;
+	MasterConn &operator=(const MasterConn &&) = delete;
 
-struct masterconn {
-	masterconn()
-	: mode(),
-	  sock(),
-	  pdescpos(),
-	  lastread(),
-	  lastwrite(),
-	  inputPacket(MaxPacketSize),
-	  outputPackets(),
-	  bindip(),
-	  masterip(),
-	  masterport(),
-	  masteraddrvalid() {}
+	~MasterConn() {
+		if (sock >= 0) { tcpclose(sock); }
+	}
 
-	int mode;
-	int sock;
-	int32_t pdescpos;
-	Timer lastread,lastwrite;
+	ConnectionMode mode{ConnectionMode::FREE};
+	int sock{-1};
+	int32_t pDescPos{-1};  ///< Position in the pollfd array.
+	Timer lastRead;
+	Timer lastWrite;
 	InputPacket inputPacket;
 	std::list<OutputPacket> outputPackets;
-	uint32_t bindip;
-	uint32_t masterip;
-	uint16_t masterport;
-	uint8_t masteraddrvalid;
+	NetworkAddress address;
+	bool isMasterAddressValid{false};
 };
 
 static const uint64_t kSendStatusDelay = 5;
 
-static masterconn *masterconnsingleton=NULL;
-static std::unique_ptr<JobPool> jobPool;
+static MasterConn *gMasterConnSingleton = nullptr;
+static std::unique_ptr<JobPool> gJobPool;
 static int jobfd;
 static int32_t jobfdpdescpos;
 
 // from config
-// static uint32_t BackLogsNumber;
-static char *MasterHost;
-static char *MasterPort;
-static char *BindHost;
-static uint32_t Timeout_ms;
-static void* reconnect_hook;
+static std::string gMasterHost;
+static std::string gMasterPort;
+static std::string gBindHostStr;
+static NetworkAddress gBindHost;
+static uint32_t gTimeout_ms;
 static std::string gLabel;
+static bool gEnableLoadFactor;
 
 constexpr uint32_t kDefaultNumberOfWorkers = 10;
 constexpr uint32_t kMinNumberOfWorkers = 2;
 static uint32_t gNumberOfWorkers = kDefaultNumberOfWorkers;
 
-static uint64_t stats_bytesout=0;
-static uint64_t stats_bytesin=0;
-static uint32_t stats_maxjobscnt=0;
+static uint64_t stats_bytesout = 0;
+static uint64_t stats_bytesin = 0;
+static uint32_t stats_maxjobscnt = 0;
 
-static bool gEnableLoadFactor;
-
-// static FILE *logfd;
+static void* reconnect_hook;
 
 void masterconn_stats(uint64_t *bin,uint64_t *bout,uint32_t *maxjobscnt) {
 	*bin = stats_bytesin;
@@ -144,38 +141,38 @@ void masterconn_delete_packet(void *packet) {
 	delete outputPacket;
 }
 
-void masterconn_attach_packet(masterconn *eptr, void* packet) {
+void masterconn_attach_packet(MasterConn *eptr, void* packet) {
 	OutputPacket* outputPacket = (OutputPacket*) packet;
 	eptr->outputPackets.emplace_back(std::move(*outputPacket));
 	delete outputPacket;
 }
 
-void masterconn_create_attached_packet(masterconn *eptr, MessageBuffer serializedPacket) {
+void masterconn_create_attached_packet(MasterConn *eptr, MessageBuffer serializedPacket) {
 	eptr->outputPackets.emplace_back(std::move(serializedPacket));
 }
 
 template<class... Data>
-void masterconn_create_attached_no_version_packet(masterconn *eptr,
+void masterconn_create_attached_no_version_packet(MasterConn *eptr,
 		PacketHeader::Type type, const Data&... data) {
 	std::vector<uint8_t> buffer;
 	serializeLegacyPacket(buffer, type, data...);
 	masterconn_create_attached_packet(eptr, std::move(buffer));
 }
 
-void masterconn_sendregisterlabel(masterconn *eptr) {
-	if (eptr->mode == CONNECTED) {
+void masterconn_sendregisterlabel(MasterConn *eptr) {
+	if (eptr->mode == ConnectionMode::CONNECTED) {
 		masterconn_create_attached_packet(eptr, cstoma::registerLabel::build(gLabel));
 	}
 }
 
-void masterconn_send_metalogger_config(masterconn *eptr) {
-	if (eptr->mode == CONNECTED) {
+void masterconn_send_metalogger_config(MasterConn *eptr) {
+	if (eptr->mode == ConnectionMode::CONNECTED) {
 		masterconn_create_attached_packet(
 		    eptr, cstoma::registerConfig::build(cfg_yaml_string()));
 	}
 }
 
-void masterconn_sendregister(masterconn *eptr) {
+void masterconn_sendregister(MasterConn *eptr) {
 	uint32_t myip;
 	uint16_t myport;
 	uint64_t usedspace,totalspace;
@@ -185,7 +182,7 @@ void masterconn_sendregister(masterconn *eptr) {
 	myip = mainNetworkThreadGetListenIp();
 	myport = mainNetworkThreadGetListenPort();
 	masterconn_create_attached_packet(
-	    eptr, cstoma::registerHost::build(myip, myport, Timeout_ms,
+	    eptr, cstoma::registerHost::build(myip, myport, gTimeout_ms,
 	                                      SAUNAFS_VERSHEX));
 
 	hddForeachChunkInBulks(
@@ -205,9 +202,9 @@ void masterconn_sendregister(masterconn *eptr) {
 }
 
 void masterconn_check_hdd_reports() {
-	masterconn *eptr = masterconnsingleton;
+	MasterConn *eptr = gMasterConnSingleton;
 	uint32_t errorcounter;
-	if (eptr->mode == CONNECTED) {
+	if (eptr->mode == ConnectionMode::CONNECTED) {
 		if (hddGetAndResetSpaceChanged()) {
 			uint64_t usedspace,totalspace,tdusedspace,tdtotalspace;
 			uint32_t chunkcount,tdchunkcount;
@@ -244,8 +241,8 @@ void masterconn_check_hdd_reports() {
 
 void masterconn_jobfinished(uint8_t status, void *packet) {
 	uint8_t *ptr;
-	masterconn *eptr = masterconnsingleton;
-	if (eptr->mode == CONNECTED) {
+	MasterConn *eptr = gMasterConnSingleton;
+	if (eptr->mode == ConnectionMode::CONNECTED) {
 		ptr = masterconn_get_packet_data(packet);
 		ptr[8]=status;
 		masterconn_attach_packet(eptr,packet);
@@ -256,8 +253,8 @@ void masterconn_jobfinished(uint8_t status, void *packet) {
 
 void masterconn_saujobfinished(uint8_t status, void *packet) {
 	OutputPacket* outputPacket = static_cast<OutputPacket*>(packet);
-	masterconn *eptr = masterconnsingleton;
-	if (eptr->mode == CONNECTED) {
+	MasterConn *eptr = gMasterConnSingleton;
+	if (eptr->mode == ConnectionMode::CONNECTED) {
 		cstoma::overwriteStatusField(outputPacket->packet, status);
 		masterconn_attach_packet(eptr, packet);
 	} else {
@@ -267,8 +264,8 @@ void masterconn_saujobfinished(uint8_t status, void *packet) {
 
 void masterconn_chunkopfinished(uint8_t status,void *packet) {
 	uint8_t *ptr;
-	masterconn *eptr = masterconnsingleton;
-	if (eptr->mode == CONNECTED) {
+	MasterConn *eptr = gMasterConnSingleton;
+	if (eptr->mode == ConnectionMode::CONNECTED) {
 		ptr = masterconn_get_packet_data(packet);
 		ptr[32]=status;
 		masterconn_attach_packet(eptr,packet);
@@ -279,9 +276,9 @@ void masterconn_chunkopfinished(uint8_t status,void *packet) {
 
 void masterconn_replicationfinished(uint8_t status,void *packet) {
 	uint8_t *ptr;
-	masterconn *eptr = masterconnsingleton;
+	MasterConn *eptr = gMasterConnSingleton;
 //      syslog(LOG_NOTICE,"job replication status: %" PRIu8,status);
-	if (eptr->mode == CONNECTED) {
+	if (eptr->mode == ConnectionMode::CONNECTED) {
 		ptr = masterconn_get_packet_data(packet);
 		ptr[12]=status;
 		masterconn_attach_packet(eptr,packet);
@@ -296,7 +293,7 @@ void masterconn_unwantedjobfinished(uint8_t status,void *packet) {
 }
 
 
-void masterconn_create(masterconn */*eptr*/, const std::vector<uint8_t> &data) {
+void masterconn_create(MasterConn */*eptr*/, const std::vector<uint8_t> &data) {
 	uint64_t chunkId;
 	ChunkPartType chunkType = slice_traits::standard::ChunkPartType();
 	uint32_t chunkVersion;
@@ -304,8 +301,8 @@ void masterconn_create(masterconn */*eptr*/, const std::vector<uint8_t> &data) {
 	matocs::createChunk::deserialize(data, chunkId, chunkType, chunkVersion);
 	OutputPacket *outputPacket = new OutputPacket;
 	cstoma::createChunk::serialize(outputPacket->packet, chunkId, chunkType, SAUNAFS_STATUS_OK);
-	if (jobPool) {
-		job_create(*jobPool, masterconn_saujobfinished, outputPacket, chunkId, chunkVersion,
+	if (gJobPool) {
+		job_create(*gJobPool, masterconn_saujobfinished, outputPacket, chunkId, chunkVersion,
 		           chunkType);
 	}
 	else {
@@ -314,7 +311,7 @@ void masterconn_create(masterconn */*eptr*/, const std::vector<uint8_t> &data) {
 	}
 }
 
-void masterconn_delete(masterconn */*eptr*/, const std::vector<uint8_t>& data) {
+void masterconn_delete(MasterConn */*eptr*/, const std::vector<uint8_t>& data) {
 	uint64_t chunkId;
 	uint32_t chunkVersion;
 	ChunkPartType chunkType = slice_traits::standard::ChunkPartType();
@@ -322,8 +319,8 @@ void masterconn_delete(masterconn */*eptr*/, const std::vector<uint8_t>& data) {
 	matocs::deleteChunk::deserialize(data, chunkId, chunkType, chunkVersion);
 	OutputPacket* outputPacket = new OutputPacket;
 	cstoma::deleteChunk::serialize(outputPacket->packet, chunkId, chunkType, 0);
-	if (jobPool) {
-		job_delete(*jobPool, masterconn_saujobfinished, outputPacket, chunkId, chunkVersion,
+	if (gJobPool) {
+		job_delete(*gJobPool, masterconn_saujobfinished, outputPacket, chunkId, chunkVersion,
 		           chunkType);
 	} else {
 		safs::log_err("masterconn_delete: jobPool is null.");
@@ -331,7 +328,7 @@ void masterconn_delete(masterconn */*eptr*/, const std::vector<uint8_t>& data) {
 	}
 }
 
-void masterconn_setversion(masterconn */*eptr*/, const std::vector<uint8_t>& data) {
+void masterconn_setversion(MasterConn */*eptr*/, const std::vector<uint8_t>& data) {
 	uint64_t chunkId;
 	uint32_t chunkVersion;
 	uint32_t newVersion;
@@ -340,8 +337,8 @@ void masterconn_setversion(masterconn */*eptr*/, const std::vector<uint8_t>& dat
 	matocs::setVersion::deserialize(data, chunkId, chunkType, chunkVersion, newVersion);
 	OutputPacket* outputPacket = new OutputPacket;
 	cstoma::setVersion::serialize(outputPacket->packet, chunkId, chunkType, 0);
-	if (jobPool) {
-		job_version(*jobPool, masterconn_saujobfinished, outputPacket, chunkId, chunkVersion,
+	if (gJobPool) {
+		job_version(*gJobPool, masterconn_saujobfinished, outputPacket, chunkId, chunkVersion,
 		            chunkType, newVersion);
 	} else {
 		safs::log_err("masterconn_setversion: jobPool is null.");
@@ -349,7 +346,7 @@ void masterconn_setversion(masterconn */*eptr*/, const std::vector<uint8_t>& dat
 	}
 }
 
-void masterconn_duplicate(masterconn* /*eptr*/,const std::vector<uint8_t>& data) {
+void masterconn_duplicate(MasterConn* /*eptr*/,const std::vector<uint8_t>& data) {
 	uint64_t newChunkId, oldChunkId;
 	uint32_t newChunkVersion, oldChunkVersion;
 	ChunkPartType chunkType = slice_traits::standard::ChunkPartType();
@@ -358,8 +355,8 @@ void masterconn_duplicate(masterconn* /*eptr*/,const std::vector<uint8_t>& data)
 			oldChunkId, oldChunkVersion);
 	OutputPacket* outputPacket = new OutputPacket;
 	cstoma::duplicateChunk::serialize(outputPacket->packet, newChunkId, chunkType, 0);
-	if (jobPool) {
-		job_duplicate(*jobPool, masterconn_saujobfinished, outputPacket, oldChunkId,
+	if (gJobPool) {
+		job_duplicate(*gJobPool, masterconn_saujobfinished, outputPacket, oldChunkId,
 		              oldChunkVersion, oldChunkVersion, chunkType, newChunkId, newChunkVersion);
 	} else {
 		safs::log_err("masterconn_duplicate: jobPool is null.");
@@ -367,7 +364,7 @@ void masterconn_duplicate(masterconn* /*eptr*/,const std::vector<uint8_t>& data)
 	}
 }
 
-void masterconn_truncate(masterconn */*eptr*/, const std::vector<uint8_t>& data) {
+void masterconn_truncate(MasterConn */*eptr*/, const std::vector<uint8_t>& data) {
 	uint64_t chunkId;
 	ChunkPartType chunkType = slice_traits::standard::ChunkPartType();
 	uint32_t version;
@@ -377,8 +374,8 @@ void masterconn_truncate(masterconn */*eptr*/, const std::vector<uint8_t>& data)
 	matocs::truncateChunk::deserialize(data, chunkId, chunkType, chunkLength, newVersion, version);
 	OutputPacket* outputPacket = new OutputPacket;
 	cstoma::truncate::serialize(outputPacket->packet, chunkId, chunkType, 0);
-	if (jobPool) {
-		job_truncate(*jobPool, masterconn_saujobfinished, outputPacket, chunkId, chunkType, version,
+	if (gJobPool) {
+		job_truncate(*gJobPool, masterconn_saujobfinished, outputPacket, chunkId, chunkType, version,
 		             newVersion, chunkLength);
 	} else {
 		safs::log_err("masterconn_truncate: jobPool is null.");
@@ -386,7 +383,7 @@ void masterconn_truncate(masterconn */*eptr*/, const std::vector<uint8_t>& data)
 	}
 }
 
-void masterconn_duptrunc(masterconn* /*eptr*/, const std::vector<uint8_t>& data) {
+void masterconn_duptrunc(MasterConn* /*eptr*/, const std::vector<uint8_t>& data) {
 	uint64_t chunkId, copyChunkId;
 	uint32_t chunkVersion, copyChunkVersion;
 	ChunkPartType chunkType = slice_traits::standard::ChunkPartType();
@@ -396,8 +393,8 @@ void masterconn_duptrunc(masterconn* /*eptr*/, const std::vector<uint8_t>& data)
 			chunkType, chunkId, chunkVersion, newLength);
 	OutputPacket* outputPacket = new OutputPacket;
 	cstoma::duptruncChunk::serialize(outputPacket->packet, copyChunkId, chunkType, 0);
-	if (jobPool) {
-		job_duptrunc(*jobPool, masterconn_saujobfinished, outputPacket, chunkId, chunkVersion,
+	if (gJobPool) {
+		job_duptrunc(*gJobPool, masterconn_saujobfinished, outputPacket, chunkId, chunkVersion,
 		             chunkVersion, chunkType, copyChunkId, copyChunkVersion, newLength);
 	} else {
 		safs::log_err("masterconn_duptrunc: jobPool is null.");
@@ -424,8 +421,8 @@ void masterconn_replicate(const std::vector<uint8_t>& data) {
 		// Disk scan in progress - replication is not possible
 		masterconn_saujobfinished(SAUNAFS_ERROR_WAITING, outputPacket);
 	} else {
-		if (jobPool) {
-			job_replicate(*jobPool, masterconn_saujobfinished, outputPacket, chunkId, chunkVersion,
+		if (gJobPool) {
+			job_replicate(*gJobPool, masterconn_saujobfinished, outputPacket, chunkId, chunkVersion,
 			              chunkType, sourcesBufferSize, sourcesBuffer);
 		} else {
 			safs::log_err("masterconn_replicate: jobPool is null.");
@@ -435,7 +432,7 @@ void masterconn_replicate(const std::vector<uint8_t>& data) {
 
 }
 
-void masterconn_gotpacket(masterconn *eptr, PacketHeader header, const MessageBuffer& message) try {
+void masterconn_gotpacket(MasterConn *eptr, PacketHeader header, const MessageBuffer& message) try {
 	switch (header.type) {
 		case ANTOAN_NOP:
 			break;
@@ -466,105 +463,114 @@ void masterconn_gotpacket(masterconn *eptr, PacketHeader header, const MessageBu
 			break;
 		default:
 			safs_pretty_syslog(LOG_NOTICE,"got unknown message (type:%" PRIu32 ")", header.type);
-			eptr->mode = KILL;
+			eptr->mode = ConnectionMode::KILL;
 	}
 } catch (IncorrectDeserializationException& e) {
 	safs_pretty_syslog(LOG_NOTICE,
 			"chunkserver <-> master module: got inconsistent message "
 			"(type:%" PRIu32 ", length:%" PRIu32"), %s",
 			header.type, uint32_t(message.size()), e.what());
-	eptr->mode = KILL;
+	eptr->mode = ConnectionMode::KILL;
 }
 
 
 void masterconn_term(void) {
-//      syslog(LOG_INFO,"closing %s:%s",MasterHost,MasterPort);
-	masterconn *eptr = masterconnsingleton;
+	MasterConn *eptr = gMasterConnSingleton;
 
-	jobPool.reset();
+	gJobPool.reset();
 
-	if (eptr->mode!=FREE && eptr->mode!=CONNECTING) {
+	if (eptr->mode != ConnectionMode::FREE && eptr->mode != ConnectionMode::CONNECTING) {
 		tcpclose(eptr->sock);
 		eptr->inputPacket.reset();
 	}
 
 	delete eptr;
-	masterconnsingleton = NULL;
-
-	free(MasterHost);
-	free(MasterPort);
-	free(BindHost);
+	gMasterConnSingleton = nullptr;
 }
 
-void masterconn_connected(masterconn *eptr) {
+void masterconn_connected(MasterConn *eptr) {
 	tcpnodelay(eptr->sock);
-	eptr->mode = CONNECTED;
+	eptr->mode = ConnectionMode::CONNECTED;
 	eptr->inputPacket.reset();
 
 	masterconn_sendregister(eptr);
-	eptr->lastread.reset();
-	eptr->lastwrite.reset();
+	eptr->lastRead.reset();
+	eptr->lastWrite.reset();
 }
 
-int masterconn_initconnect(masterconn *eptr) {
+int masterconn_initconnect(MasterConn *eptr) {
 	int status;
-	if (eptr->masteraddrvalid==0) {
-		uint32_t mip,bip;
+
+	if (!eptr->isMasterAddressValid) {
+		uint32_t mip;
+		uint32_t bip;
 		uint16_t mport;
-		if (tcpresolve(BindHost,NULL,&bip,NULL,1)<0) {
-			bip = 0;
-		}
-		eptr->bindip = bip;
-		if (tcpresolve(MasterHost,MasterPort,&mip,&mport,0)>=0) {
+
+		if (tcpresolve(gBindHostStr.c_str(), nullptr, &bip, nullptr, 1) < 0) { bip = 0; }
+
+		gBindHost.ip = bip;
+
+		if (tcpresolve(gMasterHost.c_str(), gMasterPort.c_str(), &mip, &mport, 0) >= 0) {
 			if (isLoopbackAddress(mip)) {
-				safs::log_warn("Chunkserver loopback IP addresses are experimental; consider assigning an IP address to chunkserver (via /etc/hosts or some other way)");
+				safs::log_warn(
+				    "Chunkserver loopback IP addresses are experimental; consider assigning an IP address to chunkserver (via /etc/hosts or some other way)");
 			}
-				eptr->masterip = mip;
-				eptr->masterport = mport;
-				eptr->masteraddrvalid = 1;
+			eptr->address.ip = mip;
+			eptr->address.port = mport;
+			eptr->isMasterAddressValid = true;
 		} else {
-			safs_pretty_syslog(LOG_WARNING,"master connection module: can't resolve master host/port (%s:%s)",MasterHost,MasterPort);
+			safs::log_warn("master connection module: can't resolve master host/port ({}:{})",
+			               gMasterHost, gMasterPort);
 			return -1;
 		}
 	}
-	eptr->sock=tcpsocket();
+
+	eptr->sock = tcpsocket();
+
 	if (eptr->sock<0) {
 		safs_pretty_errlog(LOG_WARNING,"master connection module: create socket error");
 		return -1;
 	}
+
 	if (tcpnonblock(eptr->sock)<0) {
 		safs_pretty_errlog(LOG_WARNING,"master connection module: set nonblock error");
 		tcpclose(eptr->sock);
 		eptr->sock = -1;
 		return -1;
 	}
-	if (eptr->bindip>0) {
-		if (tcpnumbind(eptr->sock,eptr->bindip,0)<0) {
-			safs_pretty_errlog(LOG_WARNING,"master connection module: can't bind socket to given ip");
+
+	if (gBindHost.ip > 0) {
+		if (tcpnumbind(eptr->sock, gBindHost.ip, 0) < 0) {
+			safs_pretty_errlog(LOG_WARNING,
+			                   "master connection module: can't bind socket to given ip");
 			tcpclose(eptr->sock);
 			eptr->sock = -1;
 			return -1;
 		}
 	}
-	status = tcpnumconnect(eptr->sock,eptr->masterip,eptr->masterport);
+
+	status = tcpnumconnect(eptr->sock, eptr->address.ip, eptr->address.port);
+
 	if (status<0) {
 		safs_pretty_errlog(LOG_WARNING,"master connection module: connect failed");
 		tcpclose(eptr->sock);
 		eptr->sock = -1;
-		eptr->masteraddrvalid = 0;
+		eptr->isMasterAddressValid = false;
 		return -1;
 	}
+
 	if (status==0) {
 		safs_pretty_syslog(LOG_NOTICE,"connected to Master immediately");
 		masterconn_connected(eptr);
 	} else {
-		eptr->mode = CONNECTING;
+		eptr->mode = ConnectionMode::CONNECTING;
 		safs_pretty_syslog_attempt(LOG_NOTICE,"connecting to Master");
 	}
+
 	return 0;
 }
 
-void masterconn_connecttest(masterconn *eptr) {
+void masterconn_connecttest(MasterConn *eptr) {
 	int status;
 
 	status = tcpgetstatus(eptr->sock);
@@ -572,32 +578,32 @@ void masterconn_connecttest(masterconn *eptr) {
 		safs_silent_errlog(LOG_WARNING,"connection failed, error");
 		tcpclose(eptr->sock);
 		eptr->sock = -1;
-		eptr->mode = FREE;
-		eptr->masteraddrvalid = 0;
+		eptr->mode = ConnectionMode::FREE;
+		eptr->isMasterAddressValid = 0;
 	} else {
 		safs_pretty_syslog(LOG_NOTICE,"connected to Master");
 		masterconn_connected(eptr);
 	}
 }
 
-void masterconn_read(masterconn *eptr) {
+void masterconn_read(MasterConn *eptr) {
 	ActiveLoopWatchdog watchdog(std::chrono::milliseconds(20));
 
 	watchdog.start();
-	while (eptr->mode != KILL) {
-		if (jobPool->getJobCount() >= (BGJOBSCNT * 9) / 10) {
+	while (eptr->mode != ConnectionMode::KILL) {
+		if (gJobPool->getJobCount() >= (kMaxBackgroundJobsCount * 9) / 10) {
 			return;
 		}
 		uint32_t bytesToRead = eptr->inputPacket.bytesToBeRead();
 		ssize_t ret = read(eptr->sock, eptr->inputPacket.pointerToBeReadInto(), bytesToRead);
 		if (ret == 0) {
 			safs_silent_syslog(LOG_NOTICE, "connection reset by Master");
-			eptr->mode = KILL;
+			eptr->mode = ConnectionMode::KILL;
 			return;
 		} else if (ret < 0) {
 			if (errno != EAGAIN) {
 				safs_silent_errlog(LOG_NOTICE, "read from Master error");
-				eptr->mode = KILL;
+				eptr->mode = ConnectionMode::KILL;
 			}
 			return;
 		}
@@ -607,7 +613,7 @@ void masterconn_read(masterconn *eptr) {
 			eptr->inputPacket.increaseBytesRead(ret);
 		} catch (InputPacketTooLongException& ex) {
 			safs_silent_syslog(LOG_WARNING, "reading from master: %s", ex.what());
-			eptr->mode = KILL;
+			eptr->mode = ConnectionMode::KILL;
 			return;
 		}
 		if (ret == bytesToRead && !eptr->inputPacket.hasData()) {
@@ -626,7 +632,7 @@ void masterconn_read(masterconn *eptr) {
 	}
 }
 
-void masterconn_write(masterconn *eptr) {
+void masterconn_write(MasterConn *eptr) {
 	ActiveLoopWatchdog watchdog(std::chrono::milliseconds(20));
 	int32_t i;
 
@@ -638,7 +644,7 @@ void masterconn_write(masterconn *eptr) {
 		if (i<0) {
 			if (errno!=EAGAIN) {
 				safs_silent_errlog(LOG_NOTICE,"write to Master error");
-				eptr->mode = KILL;
+				eptr->mode = ConnectionMode::KILL;
 			}
 			return;
 		}
@@ -655,43 +661,42 @@ void masterconn_write(masterconn *eptr) {
 	}
 }
 
-
 void masterconn_desc(std::vector<pollfd> &pdesc) {
 	LOG_AVG_TILL_END_OF_SCOPE0("master_desc");
-	masterconn *eptr = masterconnsingleton;
+	MasterConn *eptr = gMasterConnSingleton;
 
-	eptr->pdescpos = -1;
+	eptr->pDescPos = -1;
 	jobfdpdescpos = -1;
 
-	if (eptr->mode==FREE || eptr->sock<0) {
-		return;
-	}
-	if (eptr->mode == CONNECTED) {
-		pdesc.push_back({jobfd,POLLIN,0});
+	if (eptr->mode == ConnectionMode::FREE || eptr->sock < 0) { return; }
+
+	if (eptr->mode == ConnectionMode::CONNECTED) {
+		pdesc.push_back({jobfd, POLLIN, 0});
 		jobfdpdescpos = pdesc.size() - 1;
-		if (jobPool->getJobCount() < (BGJOBSCNT * 9) / 10) {
-			pdesc.push_back({eptr->sock,POLLIN,0});
-			eptr->pdescpos = pdesc.size() - 1;
+		if (gJobPool->getJobCount() < (kMaxBackgroundJobsCount * 9) / 10) {
+			pdesc.push_back({eptr->sock, POLLIN, 0});
+			eptr->pDescPos = pdesc.size() - 1;
 		}
 	}
-	if (((eptr->mode == CONNECTED) && !eptr->outputPackets.empty())
-			|| eptr->mode==CONNECTING) {
-		if (eptr->pdescpos>=0) {
-			pdesc[eptr->pdescpos].events |= POLLOUT;
+
+	if (((eptr->mode == ConnectionMode::CONNECTED) && !eptr->outputPackets.empty()) ||
+	    eptr->mode == ConnectionMode::CONNECTING) {
+		if (eptr->pDescPos >= 0) {
+			pdesc[eptr->pDescPos].events |= POLLOUT;
 		} else {
-			pdesc.push_back({eptr->sock,POLLOUT,0});
-			eptr->pdescpos = pdesc.size() - 1;
+			pdesc.push_back({eptr->sock, POLLOUT, 0});
+			eptr->pDescPos = pdesc.size() - 1;
 		}
 	}
 }
 
 void masterconn_send_status() {
 	static uint8_t prev_factor = 0;
-	masterconn *eptr = masterconnsingleton;
+	MasterConn *eptr = gMasterConnSingleton;
 
 	if (gEnableLoadFactor) {
 		uint8_t load_factor = hddGetLoadFactor();
-		if (eptr->mode == CONNECTED && load_factor != prev_factor) {
+		if (eptr->mode == ConnectionMode::CONNECTED && load_factor != prev_factor) {
 			masterconn_create_attached_packet(eptr,
 				cstoma::status::build(load_factor));
 			prev_factor = load_factor;
@@ -701,58 +706,62 @@ void masterconn_send_status() {
 
 void masterconn_serve(const std::vector<pollfd> &pdesc) {
 	LOG_AVG_TILL_END_OF_SCOPE0("master_serve");
-	masterconn *eptr = masterconnsingleton;
+	MasterConn *eptr = gMasterConnSingleton;
 
-	if (eptr->pdescpos>=0 && (pdesc[eptr->pdescpos].revents & (POLLHUP | POLLERR))) {
-		if (eptr->mode==CONNECTING) {
+	if (eptr->pDescPos >= 0 && (pdesc[eptr->pDescPos].revents & (POLLHUP | POLLERR))) {
+		if (eptr->mode == ConnectionMode::CONNECTING) {
 			masterconn_connecttest(eptr);
 		} else {
-			eptr->mode = KILL;
+			eptr->mode = ConnectionMode::KILL;
 		}
 	}
-	if (eptr->mode==CONNECTING) {
-		if (eptr->sock>=0 && eptr->pdescpos>=0 && (pdesc[eptr->pdescpos].revents & POLLOUT)) { // FD_ISSET(eptr->sock,wset)) {
+	if (eptr->mode == ConnectionMode::CONNECTING) {
+		if (eptr->sock >= 0 && eptr->pDescPos >= 0 &&
+		    (pdesc[eptr->pDescPos].revents & POLLOUT)) {  // FD_ISSET(eptr->sock,wset)) {
 			masterconn_connecttest(eptr);
 		}
 	} else {
-		if ((eptr->mode == CONNECTED) && jobfdpdescpos>=0 && (pdesc[jobfdpdescpos].revents & POLLIN)) { // FD_ISSET(jobfd,rset)) {
-			jobPool->checkJobs();
+		if ((eptr->mode == ConnectionMode::CONNECTED) && jobfdpdescpos >= 0 &&
+		    (pdesc[jobfdpdescpos].revents & POLLIN)) {  // FD_ISSET(jobfd,rset)) {
+			gJobPool->checkJobs();
 		}
-		if (eptr->pdescpos>=0) {
-			if ((eptr->mode == CONNECTED) && (pdesc[eptr->pdescpos].revents & POLLIN)) { // FD_ISSET(eptr->sock,rset)) {
-				eptr->lastread.reset();
+
+		if (eptr->pDescPos >= 0) {
+			if ((eptr->mode == ConnectionMode::CONNECTED) &&
+			    (pdesc[eptr->pDescPos].revents & POLLIN)) {  // FD_ISSET(eptr->sock,rset)) {
+				eptr->lastRead.reset();
 				masterconn_read(eptr);
 			}
-			if ((eptr->mode == CONNECTED) && (pdesc[eptr->pdescpos].revents & POLLOUT)) { // FD_ISSET(eptr->sock,wset)) {
-				eptr->lastwrite.reset();
+			if ((eptr->mode == ConnectionMode::CONNECTED) && (pdesc[eptr->pDescPos].revents & POLLOUT)) { // FD_ISSET(eptr->sock,wset)) {
+				eptr->lastWrite.reset();
 				masterconn_write(eptr);
 			}
-			if ((eptr->mode == CONNECTED) && eptr->lastread.elapsed_ms() > Timeout_ms) {
-				eptr->mode = KILL;
+			if ((eptr->mode == ConnectionMode::CONNECTED) && eptr->lastRead.elapsed_ms() > gTimeout_ms) {
+				eptr->mode = ConnectionMode::KILL;
 			}
-			if ((eptr->mode == CONNECTED) && eptr->lastwrite.elapsed_ms() > (Timeout_ms/3) && eptr->outputPackets.empty()) {
+			if ((eptr->mode == ConnectionMode::CONNECTED) && eptr->lastWrite.elapsed_ms() > (gTimeout_ms/3) && eptr->outputPackets.empty()) {
 				masterconn_create_attached_no_version_packet(eptr, ANTOAN_NOP, 0);
 			}
 		}
 	}
-	if (eptr->mode == CONNECTED) {
-		uint32_t jobscnt = jobPool->getJobCount();
-		if (jobscnt>=stats_maxjobscnt) {
-			stats_maxjobscnt=jobscnt;
-		}
+
+	if (eptr->mode == ConnectionMode::CONNECTED) {
+		uint32_t jobscnt = gJobPool->getJobCount();
+		stats_maxjobscnt = std::max(jobscnt, stats_maxjobscnt);
 	}
-	if (eptr->mode == KILL) {
-		jobPool->disableAndChangeCallbackAll(masterconn_unwantedjobfinished);
+
+	if (eptr->mode == ConnectionMode::KILL) {
+		gJobPool->disableAndChangeCallbackAll(masterconn_unwantedjobfinished);
 		tcpclose(eptr->sock);
 		eptr->inputPacket.reset();
 		eptr->outputPackets.clear();
-		eptr->mode = FREE;
+		eptr->mode = ConnectionMode::FREE;
 	}
 }
 
 void masterconn_reconnect(void) {
-	masterconn *eptr = masterconnsingleton;
-	if (eptr->mode==FREE) {
+	MasterConn *eptr = gMasterConnSingleton;
+	if (eptr->mode == ConnectionMode::FREE) {
 		masterconn_initconnect(eptr);
 	}
 }
@@ -773,99 +782,98 @@ bool masterconn_load_label() {
 }
 
 void masterconn_reload(void) {
-	masterconn *eptr = masterconnsingleton;
-	uint32_t ReconnectionDelay;
+	MasterConn *eptr = gMasterConnSingleton;
 
-	free(MasterHost);
-	free(MasterPort);
-	free(BindHost);
+	gMasterHost = cfg_getstring("MASTER_HOST", "sfsmaster");
+	gMasterPort = cfg_getstring("MASTER_PORT", "9420");
+	gBindHostStr = cfg_getstring("BIND_HOST", "*");
 
-	MasterHost = cfg_getstr("MASTER_HOST","sfsmaster");
-	MasterPort = cfg_getstr("MASTER_PORT","9420");
-	BindHost = cfg_getstr("BIND_HOST","*");
+	gEnableLoadFactor = static_cast<bool>(cfg_getuint32("ENABLE_LOAD_FACTOR", 0));
 
-	gEnableLoadFactor = cfg_getuint32("ENABLE_LOAD_FACTOR", 0);
+	if (eptr->isMasterAddressValid && eptr->mode != ConnectionMode::FREE) {
+		uint32_t mip{};
+		uint32_t bip{};
+		uint16_t mport{};
 
-	if (eptr->masteraddrvalid && eptr->mode!=FREE) {
-		uint32_t mip,bip;
-		uint16_t mport;
-		if (tcpresolve(BindHost,NULL,&bip,NULL,1)<0) {
-			bip = 0;
+		if (tcpresolve(gBindHostStr.c_str(), nullptr, &bip, nullptr, 1) < 0) { bip = 0; }
+
+		if (gBindHost.ip != bip) {
+			gBindHost.ip = bip;
+			eptr->mode = ConnectionMode::KILL;
 		}
-		if (eptr->bindip!=bip) {
-			eptr->bindip = bip;
-			eptr->mode = KILL;
-		}
-		if (tcpresolve(MasterHost,MasterPort,&mip,&mport,0)>=0) {
+
+		if (tcpresolve(gMasterHost.c_str(), gMasterPort.c_str(), &mip, &mport, 0) >= 0) {
 			if (isLoopbackAddress(mip)) {
-				safs::log_warn("Chunkserver loopback IP addresses are experimental; consider a non-loopback IP address to chunkserver (via /etc/hosts or some other way)");
+				safs::log_warn(
+				    "Chunkserver loopback IP addresses are experimental; consider a non-loopback IP address to chunkserver (via /etc/hosts or some other way)");
 			}
-			if (eptr->masterip != mip || eptr->masterport != mport) {
-				eptr->masterip = mip;
-				eptr->masterport = mport;
-				eptr->mode = KILL;
+
+			if (eptr->address.ip != mip || eptr->address.port != mport) {
+				eptr->address.ip = mip;
+				eptr->address.port = mport;
+				eptr->mode = ConnectionMode::KILL;
 			}
 		} else {
-			safs_pretty_syslog(LOG_WARNING,"master connection module: can't resolve master host/port (%s:%s)",MasterHost,MasterPort);
+			safs::log_warn("master connection module: can't resolve master host/port ({}:{})",
+			               gMasterHost, gMasterPort);
 		}
 	} else {
-		eptr->masteraddrvalid=0;
+		eptr->isMasterAddressValid = false;
 	}
 
-	Timeout_ms = get_cfg_timeout();
+	gTimeout_ms = get_cfg_timeout();
 
-	ReconnectionDelay = cfg_getuint32("MASTER_RECONNECTION_DELAY",5);
+	uint32_t reconnectionDelay = cfg_getuint32("MASTER_RECONNECTION_DELAY", 5);
 
-	if (masterconn_load_label()) {
-		masterconn_sendregisterlabel(eptr);
-	}
+	if (masterconn_load_label()) { masterconn_sendregisterlabel(eptr); }
+
 	masterconn_send_metalogger_config(eptr);
 
-	eventloop_timechange(reconnect_hook,TIMEMODE_RUN_LATE,ReconnectionDelay,0);
+	eventloop_timechange(reconnect_hook, TIMEMODE_RUN_LATE, reconnectionDelay, 0);
 }
 
 int masterconn_init(void) {
 	uint32_t ReconnectionDelay;
-	masterconn *eptr;
+	MasterConn *eptr;
 
-	ReconnectionDelay = cfg_getuint32("MASTER_RECONNECTION_DELAY",5);
-	MasterHost = cfg_getstr("MASTER_HOST","sfsmaster");
-	MasterPort = cfg_getstr("MASTER_PORT","9420");
-	BindHost = cfg_getstr("BIND_HOST","*");
-	Timeout_ms = get_cfg_timeout();
-//      BackLogsNumber = cfg_getuint32("BACK_LOGS",50);
-	gEnableLoadFactor = cfg_getuint32("ENABLE_LOAD_FACTOR", 0);
+	ReconnectionDelay = cfg_getuint32("MASTER_RECONNECTION_DELAY", 5);
+	gMasterHost = cfg_getstring("MASTER_HOST", "sfsmaster");
+	gMasterPort = cfg_getstring("MASTER_PORT", "9420");
+	gBindHostStr = cfg_getstring("BIND_HOST", "*");
+	gTimeout_ms = get_cfg_timeout();
+	gEnableLoadFactor = static_cast<bool>(cfg_getuint32("ENABLE_LOAD_FACTOR", 0));
 
-	gNumberOfWorkers = cfg_get_minvalue<uint32_t>(
-	    "MASTER_NR_OF_WORKERS", kDefaultNumberOfWorkers, kMinNumberOfWorkers);
+	gNumberOfWorkers = cfg_get_minvalue<uint32_t>("MASTER_NR_OF_WORKERS", kDefaultNumberOfWorkers,
+	                                              kMinNumberOfWorkers);
 
-	if (!masterconn_load_label()) {
-		return -1;
-	}
-	eptr = masterconnsingleton = new masterconn;
+	if (!masterconn_load_label()) { return -1; }
+
+	eptr = gMasterConnSingleton = new MasterConn;
 	passert(eptr);
 
-	eptr->masteraddrvalid = 0;
-	eptr->mode = FREE;
-	eptr->pdescpos = -1;
-//      logfd = NULL;
+	eptr->isMasterAddressValid = false;
+	eptr->mode = ConnectionMode::FREE;
+	eptr->pDescPos = -1;
 
-	if (masterconn_initconnect(eptr)<0) {
-		return -1;
-	}
+	if (masterconn_initconnect(eptr) < 0) { return -1; }
 
 	eventloop_eachloopregister(masterconn_check_hdd_reports);
-	eventloop_timeregister(TIMEMODE_RUN_LATE, kSendStatusDelay, rnd_ranged<uint32_t>(kSendStatusDelay), masterconn_send_status);
-	reconnect_hook = eventloop_timeregister(TIMEMODE_RUN_LATE,ReconnectionDelay,rnd_ranged<uint32_t>(ReconnectionDelay),masterconn_reconnect);
+	eventloop_timeregister(TIMEMODE_RUN_LATE, kSendStatusDelay,
+	                       rnd_ranged<uint32_t>(kSendStatusDelay), masterconn_send_status);
+	reconnect_hook =
+	    eventloop_timeregister(TIMEMODE_RUN_LATE, ReconnectionDelay,
+	                           rnd_ranged<uint32_t>(ReconnectionDelay), masterconn_reconnect);
 	eventloop_destructregister(masterconn_term);
-	eventloop_pollregister(masterconn_desc,masterconn_serve);
+	eventloop_pollregister(masterconn_desc, masterconn_serve);
 	eventloop_reloadregister(masterconn_reload);
+
 	return 0;
 }
 
 int masterconn_init_threads(void) {
 	try {
-		jobPool = std::make_unique<JobPool>("ma", gNumberOfWorkers, BGJOBSCNT, &jobfd);
+		gJobPool =
+		    std::make_unique<JobPool>("ma", gNumberOfWorkers, kMaxBackgroundJobsCount, &jobfd);
 	} catch (const std::runtime_error &e) {
 		safs::log_err("masterconn_init_threads: Failed to create JobPool instance: {}", e.what());
 		return -1;
@@ -874,14 +882,12 @@ int masterconn_init_threads(void) {
 		return -1;
 	}
 
-	if (jobPool == nullptr) {
+	if (gJobPool == nullptr) {
 		safs::log_err("masterconn_init_threads: jobPool is null. Unable to create worker threads.");
 		return -1;
 	}
 
-	safs_pretty_syslog(LOG_INFO,
-	                   "master connection: %u background workers created",
-	                   gNumberOfWorkers);
+	safs::log_info("master connection: {} background workers created", gNumberOfWorkers);
 
 	return 0;
 }

--- a/src/chunkserver/masterconn.cc
+++ b/src/chunkserver/masterconn.cc
@@ -293,8 +293,7 @@ void masterconn_unwantedjobfinished(uint8_t status,void *packet) {
 	masterconn_delete_packet(packet);
 }
 
-
-void masterconn_create(MasterConn */*eptr*/, const std::vector<uint8_t> &data) {
+void masterconn_create([[maybe_unused]] MasterConn *eptr, const std::vector<uint8_t> &data) {
 	uint64_t chunkId;
 	ChunkPartType chunkType = slice_traits::standard::ChunkPartType();
 	uint32_t chunkVersion;
@@ -312,7 +311,7 @@ void masterconn_create(MasterConn */*eptr*/, const std::vector<uint8_t> &data) {
 	}
 }
 
-void masterconn_delete(MasterConn */*eptr*/, const std::vector<uint8_t>& data) {
+void masterconn_delete([[maybe_unused]] MasterConn *eptr, const std::vector<uint8_t> &data) {
 	uint64_t chunkId;
 	uint32_t chunkVersion;
 	ChunkPartType chunkType = slice_traits::standard::ChunkPartType();
@@ -329,7 +328,7 @@ void masterconn_delete(MasterConn */*eptr*/, const std::vector<uint8_t>& data) {
 	}
 }
 
-void masterconn_setversion(MasterConn */*eptr*/, const std::vector<uint8_t>& data) {
+void masterconn_setversion([[maybe_unused]] MasterConn *eptr, const std::vector<uint8_t> &data) {
 	uint64_t chunkId;
 	uint32_t chunkVersion;
 	uint32_t newVersion;
@@ -347,7 +346,7 @@ void masterconn_setversion(MasterConn */*eptr*/, const std::vector<uint8_t>& dat
 	}
 }
 
-void masterconn_duplicate(MasterConn* /*eptr*/,const std::vector<uint8_t>& data) {
+void masterconn_duplicate([[maybe_unused]] MasterConn *eptr, const std::vector<uint8_t> &data) {
 	uint64_t newChunkId, oldChunkId;
 	uint32_t newChunkVersion, oldChunkVersion;
 	ChunkPartType chunkType = slice_traits::standard::ChunkPartType();
@@ -365,7 +364,7 @@ void masterconn_duplicate(MasterConn* /*eptr*/,const std::vector<uint8_t>& data)
 	}
 }
 
-void masterconn_truncate(MasterConn */*eptr*/, const std::vector<uint8_t>& data) {
+void masterconn_truncate([[maybe_unused]] MasterConn *eptr, const std::vector<uint8_t> &data) {
 	uint64_t chunkId;
 	ChunkPartType chunkType = slice_traits::standard::ChunkPartType();
 	uint32_t version;
@@ -384,7 +383,7 @@ void masterconn_truncate(MasterConn */*eptr*/, const std::vector<uint8_t>& data)
 	}
 }
 
-void masterconn_duptrunc(MasterConn* /*eptr*/, const std::vector<uint8_t>& data) {
+void masterconn_duptrunc([[maybe_unused]] MasterConn *eptr, const std::vector<uint8_t> &data) {
 	uint64_t chunkId, copyChunkId;
 	uint32_t chunkVersion, copyChunkVersion;
 	ChunkPartType chunkType = slice_traits::standard::ChunkPartType();

--- a/src/chunkserver/masterconn.h
+++ b/src/chunkserver/masterconn.h
@@ -24,6 +24,6 @@
 
 #include <cstdint>
 
-void masterconn_stats(uint64_t *bin,uint64_t *bout,uint32_t *maxjobscnt);
+void masterconn_stats(uint64_t *bin, uint64_t *bout, uint32_t *maxjobscnt);
 int masterconn_init(void);
 int masterconn_init_threads(void);


### PR DESCRIPTION
This change applies some improvements in the Chunkserver's masterconn, including:

- enum class ConnectionMode instead of plain enum.
- Renaming variables and struct names for readability.
- Better global variable naming.
- Shy automatic formatting (full format will be another PR).
- Use std::string to avoid free with char *.
- Minor modernizations.
- Reduction of clang-tidy warnings (will continue).
- Smart pointer for the singleton.

Note for reviewers: Stopping here to not make the PR too long.