### PR TITLE
fix(ci): Fix broken lukka/run-vcpkg action

### DIFF
--- a/.github/workflows/run-unit-and-ganesha-tests.yml
+++ b/.github/workflows/run-unit-and-ganesha-tests.yml
@@ -27,8 +27,9 @@ jobs:
               with:
                   create-symlink: true
 
-            - name: Setup anew (or from cache) vcpkg
-              uses: lukka/run-vcpkg@v11
+            # Reference for previous vcpkg setup: maybe we can fix it in the future
+            #- name: Setup a new (or from cache) vcpkg
+            #  uses: lukka/run-vcpkg@v11
 
             - name: Install nfs-ganesha v4.3 from Ubuntu repository
               run: |
@@ -45,7 +46,20 @@ jobs:
                   sudo mkdir /mnt/hd{b,c,d}
                   cd $GITHUB_WORKSPACE/tests
                   sudo ./setup_machine.sh setup /mnt/hdb /mnt/hdc /mnt/hdd
-                  cd $GITHUB_WORKSPACE
+
+            - name: Cache vcpkg downloads
+              uses: actions/cache@v4
+              with:
+                path: |
+                  ~/.cache/vcpkg
+                key: ${{ runner.os }}-vcpkg-${{ hashFiles('vcpkg.json') }}
+                restore-keys: |
+                  ${{ runner.os }}-vcpkg-
+
+            - name: Setup vcpkg and install dependencies
+              run: |
+                $GITHUB_WORKSPACE/utils/vcpkg_setup.sh
+                vcpkg install --triplet x64-linux
 
             - name: Build SaunaFS
               run: |
@@ -54,7 +68,7 @@ jobs:
                   mkdir -p build
                   cd build
                   nice cmake \
-                  -DCMAKE_TOOLCHAIN_FILE="${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" \
+                  -DCMAKE_TOOLCHAIN_FILE="${HOME}/vcpkg/scripts/buildsystems/vcpkg.cmake" \
                   -DENABLE_CLIENT_LIB=ON \
                   -DENABLE_DOCS=ON \
                   -DENABLE_NFS_GANESHA=ON \


### PR DESCRIPTION
The lukka/run-vcpkg action started failing during builds with repeated:
  curl: warning: failed with exit code 28
This caused the CI pipeline to hang indefinitely until timeout.

This commit replaces the action with a manual vcpkg setup using the existing SaunaFS script (utils/vcpkg_setup.sh). It also adds caching of the vcpkg download directory to avoid redundant downloads and improve CI performance.

The relevant changes are:
- Removed lukka/run-vcpkg GitHub Action.
- Added vcpkg_setup.sh invocation.
- Cached ~/.cache/vcpkg using actions/cache.