### PR TITLE
fix(restore.cc): Correctly convert int to uint8_t in changelog restore

### DIFF
--- a/src/master/restore.cc
+++ b/src/master/restore.cc
@@ -928,12 +928,22 @@ int restore_line(const char* filename, uint64_t lv, const char* line) {
 #endif
 		safs_pretty_syslog(LOG_ERR, "%s:%" PRIu64 ": unknown entry '%s'", filename, lv, ptr);
 	} else if (status != SAUNAFS_STATUS_OK) {
+		uint8_t errorStatus = 0;
+		if (status == -1) {
+			errorStatus = SAUNAFS_ERROR_PARSE;
+		} else if (status > SAUNAFS_ERROR_MAX || status < 0) {
+			safs::log_err("restore_line returned error code other than -1 or SAUNAFS_ERROR_CODE, in file {}:{}, status number {}", filename, lv, status);
+			assert(false);
+			errorStatus = SAUNAFS_ERROR_UNKNOWN;
+		} else {
+			errorStatus = static_cast<uint8_t>(status);
+		}
 #ifndef METARESTORE
 		safs_silent_syslog(LOG_DEBUG, "master.mismatch File %s, %" PRIu64 ", %s -- %s",
-			   filename, lv, line, saunafs_error_string(status));
+			   filename, lv, line, saunafs_error_string(errorStatus));
 #endif
 		safs_pretty_syslog(LOG_ERR, "%s:%" PRIu64 ": error: %d (%s)", filename, lv, status,
-			saunafs_error_string(status));
+			saunafs_error_string(errorStatus));
 	}
 	return status;
 }


### PR DESCRIPTION
When parsing changelogs, the do_<operation> returns int's. Sometimes these are within range of SAUNAFS_ERROR_CODES (which is max 54). But sometimes these return -1 when they have trouble parsing the lines (or potentially other unknown values). saunafs_error_string however only accepts uint8_t, which means there's an implicit conversion and could cause unknown/faulty error messages.

This fixes that by explicitly checking the -1 to mean failure in parsing lines. For other values, an assert is used when NDEBUG is set (so the programmer is aware that they are returning a wrong value) or the reasonable default of UNKNOWN error with a log explaining why.