### PR TITLE
chore(chunkserver): Rename JobPool::checkjobs

### DIFF
--- a/src/chunkserver/bgjobs.cc
+++ b/src/chunkserver/bgjobs.cc
@@ -75,7 +75,7 @@ JobPool::~JobPool() {
 		if (thread.joinable()) { thread.join(); }
 	}
 
-	if (!statusQueue->isEmpty()) { checkJobs(); }
+	if (!statusQueue->isEmpty()) { processCompletedJobs(); }
 
 	jobsQueue.reset();
 	statusQueue.reset();
@@ -139,11 +139,12 @@ void JobPool::disableJobs(std::list<uint32_t> &jobIds) {
 	}
 }
 
-void JobPool::checkJobs() {
-	uint32_t jobId;
-	uint8_t status;
+void JobPool::processCompletedJobs() {
+	uint32_t jobId{};
+	uint8_t status{};
 	bool notLastJob = true;
-	do {
+
+	while (notLastJob) {
 		notLastJob = receiveStatus(jobId, status);
 		auto jobIterator = jobHash.find(jobId);
 		if (jobIterator != jobHash.end()) {
@@ -151,7 +152,7 @@ void JobPool::checkJobs() {
 			if (callback) { callback(status, jobIterator->second->extra); }
 			jobHash.erase(jobIterator);
 		}
-	} while (notLastJob);
+	}
 }
 
 void JobPool::changeCallback(uint32_t jobId, JobCallback callback, void *extra) {

--- a/src/chunkserver/bgjobs.h
+++ b/src/chunkserver/bgjobs.h
@@ -128,7 +128,7 @@ public:
 	void disableJobs(std::list<uint32_t> &jobIds);
 
 	/// @brief Checks the status of jobs in the JobPool and calls their callbacks.
-	void checkJobs();
+	void processCompletedJobs();
 
 	/// @brief Changes the callback function for a specific job.
 	///

--- a/src/chunkserver/bgjobs_unittest.cc
+++ b/src/chunkserver/bgjobs_unittest.cc
@@ -39,7 +39,7 @@ private:
 			int ret = poll(&wakeupDescPollFd, 1, kWaitTimeMs);
 			if (ret > 0) {
 				if (wakeupDescPollFd.revents & POLLIN) {
-					jobPool->checkJobs();
+					jobPool->processCompletedJobs();
 				}
 			}
 		}
@@ -143,6 +143,6 @@ TEST_F(JobPoolTest, JobStatusHandling) {
 	// Wait for the job to be processed
 	std::this_thread::sleep_for(std::chrono::milliseconds(kWaitTimeMs));
 
-	jobPool->checkJobs();
+	jobPool->processCompletedJobs();
 	EXPECT_EQ(counter.load(), 1);
 }

--- a/src/chunkserver/masterconn.cc
+++ b/src/chunkserver/masterconn.cc
@@ -730,7 +730,7 @@ void masterconn_serve(const std::vector<pollfd> &pdesc) {
 		// Check if there are any background jobs to process.
 		if ((eptr->mode == ConnectionMode::CONNECTED) && gJobFDpDescPos >= 0 &&
 		    (pdesc[gJobFDpDescPos].revents & POLLIN)) {
-			gJobPool->checkJobs();
+			gJobPool->processCompletedJobs();
 		}
 
 		if (eptr->pDescPos >= 0) {

--- a/src/chunkserver/network_worker_thread.cc
+++ b/src/chunkserver/network_worker_thread.cc
@@ -195,7 +195,7 @@ void NetworkWorkerThread::servePoll() {
 	ChunkserverEntry::State lstate;
 
 	if (pdesc[JOB_FD_PDESC_POS].revents & POLLIN) {
-		bgJobPool_->checkJobs();
+		bgJobPool_->processCompletedJobs();
 	}
 	std::unique_lock lock(csservheadLock);
 	for (auto& entry : csservEntries) {


### PR DESCRIPTION
The function was renamed to JobPool::processCompletedJobs, which is more consistent with its work.

Misc: avoid do-while warning from clang-tidy.