### PR TITLE
feat(chunkserver): Make struct masterconn a class

### DIFF
--- a/src/chunkserver/init.h
+++ b/src/chunkserver/init.h
@@ -39,11 +39,11 @@ inline const std::vector<RunTab> runTabs = {
     RunTab{loadPlugins, "plugin manager"}, RunTab{hddInit, "hdd space manager"},
     // Has to be before "masterconn"
     RunTab{mainNetworkThreadInit, "main server module"},
+    RunTab{masterconn_init_threads, "master connection module - threads"},
     RunTab{masterconn_init, "master connection module"},
     RunTab{chartsdata_init, "charts module"}};
 
 /// Functions to call delayed after the initialization is correct
 inline const std::vector<RunTab> lateRunTabs = {
-    RunTab{masterconn_init_threads, "master connection module - threads"},
     RunTab{hddLateInit, "hdd space manager - threads"},
     RunTab{mainNetworkThreadInitThreads, "main server module - threads"}};

--- a/src/chunkserver/masterconn.cc
+++ b/src/chunkserver/masterconn.cc
@@ -309,7 +309,7 @@ public:
 		}
 	}
 
-	void servePoll(const std::vector<pollfd> &pdesc) {
+	void handlePollErrors(const std::vector<pollfd> &pdesc) {
 		// Check if the socket has been closed or has an error.
 		if (pDescPos_ >= 0 && (pdesc[pDescPos_].revents & (POLLHUP | POLLERR))) {
 			if (mode_ == ConnectionMode::CONNECTING) {
@@ -318,7 +318,9 @@ public:
 				mode_ = ConnectionMode::KILL;
 			}
 		}
+	}
 
+	void servePoll(const std::vector<pollfd> &pdesc) {
 		if (mode_ == ConnectionMode::CONNECTING) {
 			// Check if the connection has been established.
 			if (socketFD_ >= 0 && pDescPos_ >= 0 && (pdesc[pDescPos_].revents & POLLOUT)) {
@@ -422,7 +424,6 @@ public:
 				return;
 			}
 
-			// stats_bytesout += bytesWritten;
 			bytesOut_ += bytesWritten;
 			pack.bytesSent += bytesWritten;
 
@@ -486,9 +487,8 @@ public:
 		auto *outputPacket = new OutputPacket;
 		cstoma::createChunk::serialize(outputPacket->packet, chunkId, chunkType, SAUNAFS_STATUS_OK);
 		if (jobPool_) {
-			job_create(
-			    *jobPool_, [this](uint8_t status, void *packet) { sauJobFinished(status, packet); },
-			    outputPacket, chunkId, chunkVersion, chunkType);
+			job_create(*jobPool_, sauJobFinished(this), outputPacket, chunkId, chunkVersion,
+			           chunkType);
 		} else {
 			safs::log_err("masterconn_create: jobPool is null.");
 			delete outputPacket;
@@ -504,9 +504,8 @@ public:
 		auto *outputPacket = new OutputPacket;
 		cstoma::deleteChunk::serialize(outputPacket->packet, chunkId, chunkType, 0);
 		if (jobPool_) {
-			job_delete(
-			    *jobPool_, [this](uint8_t status, void *packet) { sauJobFinished(status, packet); },
-			    outputPacket, chunkId, chunkVersion, chunkType);
+			job_delete(*jobPool_, sauJobFinished(this), outputPacket, chunkId, chunkVersion,
+			           chunkType);
 		} else {
 			safs::log_err("masterconn_delete: jobPool is null.");
 			delete outputPacket;
@@ -523,9 +522,8 @@ public:
 		auto *outputPacket = new OutputPacket;
 		cstoma::setVersion::serialize(outputPacket->packet, chunkId, chunkType, 0);
 		if (jobPool_) {
-			job_version(
-			    *jobPool_, [this](uint8_t status, void *packet) { sauJobFinished(status, packet); },
-			    outputPacket, chunkId, chunkVersion, chunkType, newVersion);
+			job_version(*jobPool_, sauJobFinished(this), outputPacket, chunkId, chunkVersion,
+			            chunkType, newVersion);
 		} else {
 			safs::log_err("masterconn_setversion: jobPool is null.");
 			delete outputPacket;
@@ -542,10 +540,8 @@ public:
 		auto *outputPacket = new OutputPacket;
 		cstoma::duplicateChunk::serialize(outputPacket->packet, newChunkId, chunkType, 0);
 		if (jobPool_) {
-			job_duplicate(
-			    *jobPool_, [this](uint8_t status, void *packet) { sauJobFinished(status, packet); },
-			    outputPacket, oldChunkId, oldChunkVersion, oldChunkVersion, chunkType, newChunkId,
-			    newChunkVersion);
+			job_duplicate(*jobPool_, sauJobFinished(this), outputPacket, oldChunkId,
+			              oldChunkVersion, oldChunkVersion, chunkType, newChunkId, newChunkVersion);
 		} else {
 			safs::log_err("masterconn_duplicate: jobPool is null.");
 			delete outputPacket;
@@ -564,9 +560,8 @@ public:
 		auto *outputPacket = new OutputPacket;
 		cstoma::truncate::serialize(outputPacket->packet, chunkId, chunkType, 0);
 		if (jobPool_) {
-			job_truncate(
-			    *jobPool_, [this](uint8_t status, void *packet) { sauJobFinished(status, packet); },
-			    outputPacket, chunkId, chunkType, version, newVersion, chunkLength);
+			job_truncate(*jobPool_, sauJobFinished(this), outputPacket, chunkId, chunkType, version,
+			             newVersion, chunkLength);
 		} else {
 			safs::log_err("masterconn_truncate: jobPool is null.");
 			delete outputPacket;
@@ -584,10 +579,8 @@ public:
 		auto *outputPacket = new OutputPacket;
 		cstoma::duptruncChunk::serialize(outputPacket->packet, copyChunkId, chunkType, 0);
 		if (jobPool_) {
-			job_duptrunc(
-			    *jobPool_, [this](uint8_t status, void *packet) { sauJobFinished(status, packet); },
-			    outputPacket, chunkId, chunkVersion, chunkVersion, chunkType, copyChunkId,
-			    copyChunkVersion, newLength);
+			job_duptrunc(*jobPool_, sauJobFinished(this), outputPacket, chunkId, chunkVersion,
+			             chunkVersion, chunkType, copyChunkId, copyChunkVersion, newLength);
 		} else {
 			safs::log_err("masterconn_duptrunc: jobPool is null.");
 			delete outputPacket;
@@ -615,11 +608,8 @@ public:
 			sauJobFinished(SAUNAFS_ERROR_WAITING, outputPacket);
 		} else {
 			if (jobPool_) {
-				job_replicate(
-				    *jobPool_,
-				    [this](uint8_t status, void *packet) { sauJobFinished(status, packet); },
-				    outputPacket, chunkId, chunkVersion, chunkType, sourcesBufferSize,
-				    sourcesBuffer);
+				job_replicate(*jobPool_, sauJobFinished(this), outputPacket, chunkId, chunkVersion,
+				              chunkType, sourcesBufferSize, sourcesBuffer);
 			} else {
 				safs::log_err("masterconn_replicate: jobPool is null.");
 				delete outputPacket;
@@ -628,6 +618,13 @@ public:
 	}
 
 	// Callbacks
+
+	static std::function<void(uint8_t status, void *packet)> sauJobFinished(
+	    MasterConn *masterConn) {
+		return [masterConn](uint8_t status, void *packet) {
+			masterConn->sauJobFinished(status, packet);
+		};
+	}
 
 	void sauJobFinished(uint8_t status, void *packet) {
 		auto *outputPacket = static_cast<OutputPacket *>(packet);
@@ -808,8 +805,6 @@ void masterconn_desc(std::vector<pollfd> &pdesc) {
 	// For each connection to master (currently only one), add its socket to the pollfd array.
 	MasterConn *eptr = gMasterConnSingleton.get();
 
-	eptr->providePollDescriptors(pdesc);
-
 	// Add the descriptor for listening for background jobs finishing.
 	gJobFDpDescPos = -1;
 
@@ -817,6 +812,8 @@ void masterconn_desc(std::vector<pollfd> &pdesc) {
 		pdesc.emplace_back(gJobFD, POLLIN, 0);
 		gJobFDpDescPos = static_cast<int32_t>(pdesc.size() - 1);
 	}
+
+	eptr->providePollDescriptors(pdesc);
 }
 
 void masterconn_send_status() {
@@ -836,6 +833,8 @@ void masterconn_serve(const std::vector<pollfd> &pdesc) {
 	LOG_AVG_TILL_END_OF_SCOPE0("master_serve");
 	
 	MasterConn *eptr = gMasterConnSingleton.get();
+
+	eptr->handlePollErrors(pdesc);
 	
 	// Check if there are any background jobs to process.
 	if ((eptr->mode() == ConnectionMode::CONNECTED) && gJobFDpDescPos >= 0 &&

--- a/src/chunkserver/masterconn.cc
+++ b/src/chunkserver/masterconn.cc
@@ -68,11 +68,6 @@ static bool gEnableLoadFactor;
 static std::string gLabel;
 static uint32_t gTimeout_ms;
 
-// Stats
-static uint64_t stats_bytesout = 0;
-static uint64_t stats_bytesin = 0;
-static uint32_t stats_maxjobscnt = 0;
-
 enum class ConnectionMode : std::uint8_t {
 	FREE,        /// There is no socket for the connection yet.
 	CONNECTING,  /// Connection is being established.
@@ -383,7 +378,7 @@ public:
 				return;
 			}
 
-			stats_bytesin += ret;
+			bytesIn_ += ret;
 
 			try {
 				inputPacket_.increaseBytesRead(ret);
@@ -427,7 +422,8 @@ public:
 				return;
 			}
 
-			stats_bytesout += bytesWritten;
+			// stats_bytesout += bytesWritten;
+			bytesOut_ += bytesWritten;
 			pack.bytesSent += bytesWritten;
 
 			if (pack.packet.size() != pack.bytesSent) { return; }
@@ -684,6 +680,14 @@ public:
 
 	void setMasterAddressValid(bool valid) { isMasterAddressValid_ = valid; }
 
+	uint64_t bytesIn() const { return bytesIn_; }
+	uint64_t bytesOut() const { return bytesOut_; }
+
+	void resetStats() {
+		bytesIn_ = 0;
+		bytesOut_ = 0;
+	}
+
 private:
 	std::string masterHostStr_;                  ///< Hostname of the master server.
 	std::string masterPortStr_;                  ///< Port of the master server.
@@ -701,6 +705,10 @@ private:
 	NetworkAddress address_;            ///< Address of this master server (IP and port).
 	NetworkAddress bindHostAddress_;    ///< Address to bind the socket to (IP and port).
 	bool isMasterAddressValid_{false};  ///< Tells if the master address is valid.
+
+	// Statistics
+	uint64_t bytesIn_ = 0;   ///< Number of bytes read from the master.
+	uint64_t bytesOut_ = 0;  ///< Number of bytes sent to the master.
 };
 
 //  From config
@@ -724,12 +732,21 @@ static uint32_t gNumberOfWorkers = kDefaultNumberOfWorkers;
 
 static void* gReconnectHook;
 
+//  Stats
+static uint32_t stats_maxjobscnt = 0;
+
 void masterconn_stats(uint64_t *bin,uint64_t *bout,uint32_t *maxjobscnt) {
-	*bin = stats_bytesin;
-	*bout = stats_bytesout;
+	//  For each connection, add the statistics
+	auto totalBytesIn = gMasterConnSingleton->bytesIn();
+	auto totalBytesOut = gMasterConnSingleton->bytesOut();
+
+	*bin = totalBytesIn;
+	*bout = totalBytesOut;
+
+	gMasterConnSingleton->resetStats();
+
+	// Get the stats non dependent on specific connections
 	*maxjobscnt = stats_maxjobscnt;
-	stats_bytesin = 0;
-	stats_bytesout = 0;
 	stats_maxjobscnt = 0;
 }
 

--- a/src/chunkserver/masterconn.cc
+++ b/src/chunkserver/masterconn.cc
@@ -29,14 +29,12 @@
 #include <unistd.h>
 #include <algorithm>
 #include <cerrno>
-#include <cinttypes>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
 #include <list>
-#include <stdexcept>
 
 #include "chunkserver-common/hdd_utils.h"
 #include "chunkserver/bgjobs.h"
@@ -217,12 +215,12 @@ public:
 		socketFD_ = tcpsocket();
 
 		if (socketFD_ < 0) {
-			safs_pretty_errlog(LOG_WARNING, "master connection module: create socket error");
+			safs::log_error_code(errno, "master connection module: create socket error");
 			return -1;
 		}
 
 		if (tcpnonblock(socketFD_) < 0) {
-			safs_pretty_errlog(LOG_WARNING, "master connection module: set nonblock error");
+			safs::log_error_code(errno, "master connection module: set nonblock error");
 			tcpclose(socketFD_);
 			socketFD_ = -1;
 			return -1;
@@ -230,8 +228,7 @@ public:
 
 		if (bindHostAddress_.ip > 0) {
 			if (tcpnumbind(socketFD_, bindHostAddress_.ip, 0) < 0) {
-				safs_pretty_errlog(LOG_WARNING,
-				                   "master connection module: can't bind socket to given ip");
+				safs::log_error_code(errno, "master connection module: can't bind socket to given ip");
 				tcpclose(socketFD_);
 				socketFD_ = -1;
 				return -1;
@@ -241,7 +238,7 @@ public:
 		int status = tcpnumconnect(socketFD_, address_.ip, address_.port);
 
 		if (status < 0) {
-			safs_pretty_errlog(LOG_WARNING, "master connection module: connect failed");
+			safs::log_error_code(errno, "master connection module: connect failed");
 			tcpclose(socketFD_);
 			socketFD_ = -1;
 			isMasterAddressValid_ = false;
@@ -249,11 +246,11 @@ public:
 		}
 
 		if (status == 0) {
-			safs_pretty_syslog(LOG_NOTICE, "connected to Master immediately");
+			safs::log_info("connected to Master immediately");
 			onConnected();
 		} else {
 			mode_ = ConnectionMode::CONNECTING;
-			safs_pretty_syslog_attempt(LOG_NOTICE, "connecting to Master");
+			safs::log_info("connecting to Master");
 		}
 
 		return 0;
@@ -263,7 +260,7 @@ public:
 		int status = tcpgetstatus(socketFD_);
 
 		if (status) {
-			safs_silent_errlog(LOG_WARNING, "connection failed, error");
+			safs::log_error_code(errno, "connection failed");
 			tcpclose(socketFD_);
 			socketFD_ = -1;
 			mode_ = ConnectionMode::FREE;
@@ -367,14 +364,14 @@ public:
 			ssize_t ret = ::read(socketFD_, inputPacket_.pointerToBeReadInto(), bytesToRead);
 
 			if (ret == 0) {
-				safs_silent_syslog(LOG_NOTICE, "connection reset by Master");
+				safs::log_info("connection reset by Master");
 				mode_ = ConnectionMode::KILL;
 				return;
 			}
 
 			if (ret < 0) {
 				if (errno != EAGAIN) {
-					safs_silent_errlog(LOG_NOTICE, "read from Master error");
+					safs::log_error_code(errno, "read from Master error");
 					mode_ = ConnectionMode::KILL;
 				}
 				return;
@@ -385,7 +382,7 @@ public:
 			try {
 				inputPacket_.increaseBytesRead(ret);
 			} catch (InputPacketTooLongException &ex) {
-				safs_silent_syslog(LOG_WARNING, "reading from master: %s", ex.what());
+				safs::log_warn("reading from master: {}", ex.what());
 				mode_ = ConnectionMode::KILL;
 				return;
 			}
@@ -418,7 +415,7 @@ public:
 
 			if (bytesWritten < 0) {
 				if (errno != EAGAIN) {
-					safs_silent_errlog(LOG_NOTICE, "write to Master error");
+					safs::log_error_code(errno, "write to Master error");
 					mode_ = ConnectionMode::KILL;
 				}
 				return;
@@ -490,7 +487,7 @@ public:
 			job_create(*jobPool_, sauJobFinished(this), outputPacket, chunkId, chunkVersion,
 			           chunkType);
 		} else {
-			safs::log_err("masterconn_create: jobPool is null.");
+			safs::log_err("MasterConn::createChunk: jobPool is null.");
 			delete outputPacket;
 		}
 	}
@@ -507,7 +504,7 @@ public:
 			job_delete(*jobPool_, sauJobFinished(this), outputPacket, chunkId, chunkVersion,
 			           chunkType);
 		} else {
-			safs::log_err("masterconn_delete: jobPool is null.");
+			safs::log_err("MasterConn::deleteChunk: jobPool is null.");
 			delete outputPacket;
 		}
 	}
@@ -525,7 +522,7 @@ public:
 			job_version(*jobPool_, sauJobFinished(this), outputPacket, chunkId, chunkVersion,
 			            chunkType, newVersion);
 		} else {
-			safs::log_err("masterconn_setversion: jobPool is null.");
+			safs::log_err("MasterConn::setChunkVersion: jobPool is null.");
 			delete outputPacket;
 		}
 	}
@@ -543,7 +540,7 @@ public:
 			job_duplicate(*jobPool_, sauJobFinished(this), outputPacket, oldChunkId,
 			              oldChunkVersion, oldChunkVersion, chunkType, newChunkId, newChunkVersion);
 		} else {
-			safs::log_err("masterconn_duplicate: jobPool is null.");
+			safs::log_err("MasterConn::duplicateChunk: jobPool is null.");
 			delete outputPacket;
 		}
 	}
@@ -563,7 +560,7 @@ public:
 			job_truncate(*jobPool_, sauJobFinished(this), outputPacket, chunkId, chunkType, version,
 			             newVersion, chunkLength);
 		} else {
-			safs::log_err("masterconn_truncate: jobPool is null.");
+			safs::log_err("MasterConn::truncateChunk: jobPool is null.");
 			delete outputPacket;
 		}
 	}
@@ -582,7 +579,7 @@ public:
 			job_duptrunc(*jobPool_, sauJobFinished(this), outputPacket, chunkId, chunkVersion,
 			             chunkVersion, chunkType, copyChunkId, copyChunkVersion, newLength);
 		} else {
-			safs::log_err("masterconn_duptrunc: jobPool is null.");
+			safs::log_err("MasterConn::duplicateTruncateChunk: jobPool is null.");
 			delete outputPacket;
 		}
 	}
@@ -601,7 +598,7 @@ public:
 		auto *outputPacket = new OutputPacket;
 		cstoma::replicateChunk::serialize(outputPacket->packet, chunkId, chunkType,
 		                                  SAUNAFS_STATUS_OK, chunkVersion);
-		safs_silent_syslog(LOG_DEBUG, "cs.matocs.replicate %" PRIu64, chunkId);
+		safs::log_debug("cs.matocs.replicate {}", chunkId);
 
 		if (hddScansInProgress()) {
 			// Disk scan in progress - replication is not possible
@@ -611,7 +608,7 @@ public:
 				job_replicate(*jobPool_, sauJobFinished(this), outputPacket, chunkId, chunkVersion,
 				              chunkType, sourcesBufferSize, sourcesBuffer);
 			} else {
-				safs::log_err("masterconn_replicate: jobPool is null.");
+				safs::log_err("MasterConn::replicateChunk: jobPool is null.");
 				delete outputPacket;
 			}
 		}
@@ -876,7 +873,7 @@ bool masterconn_load_label() {
 	std::string oldLabel = gLabel;
 	gLabel = cfg_getstring("LABEL", MediaLabelManager::kWildcard);
 	if (!MediaLabelManager::isLabelValid(gLabel)) {
-		safs_pretty_syslog(LOG_WARNING,"invalid label '%s'", gLabel.c_str());
+		safs::log_warn("invalid label '{}'", gLabel);
 		return false;
 	}
 	return gLabel != oldLabel;

--- a/src/chunkserver/masterconn.cc
+++ b/src/chunkserver/masterconn.cc
@@ -925,10 +925,15 @@ int masterconn_init(void) {
 	gTimeout_ms = get_cfg_timeout();
 	gEnableLoadFactor = static_cast<bool>(cfg_getuint32("ENABLE_LOAD_FACTOR", 0));
 
-	gNumberOfWorkers = cfg_get_minvalue<uint32_t>("MASTER_NR_OF_WORKERS", kDefaultNumberOfWorkers,
-	                                              kMinNumberOfWorkers);
-
 	if (!masterconn_load_label()) { return -1; }
+
+	// Create the connections (only one at this point)
+	gMasterConnSingleton = std::make_unique<MasterConn>(gMasterHost, gMasterPort, gJobPool);
+	MasterConn *eptr = gMasterConnSingleton.get();
+	passert(eptr);
+
+	// Init the connections
+	if (eptr->initConnect() < 0) { return -1; }
 
 	// Register the callbacks in the event loop
 	eventloop_eachloopregister(masterconn_check_hdd_reports);
@@ -945,12 +950,12 @@ int masterconn_init(void) {
 }
 
 int masterconn_init_threads(void) {
+	gNumberOfWorkers = cfg_get_minvalue<uint32_t>("MASTER_NR_OF_WORKERS", kDefaultNumberOfWorkers,
+	                                              kMinNumberOfWorkers);
+
 	try {
 		gJobPool =
 		    std::make_shared<JobPool>("ma", gNumberOfWorkers, kMaxBackgroundJobsCount, &gJobFD);
-	} catch (const std::runtime_error &e) {
-		safs::log_err("masterconn_init_threads: Failed to create JobPool instance: {}", e.what());
-		return -1;
 	} catch (const std::exception &e) {
 		safs::log_err("masterconn_init_threads: Failed to create JobPool instance: {}", e.what());
 		return -1;
@@ -962,14 +967,6 @@ int masterconn_init_threads(void) {
 	}
 
 	safs::log_info("master connection: {} background workers created", gNumberOfWorkers);
-
-	// Create the connections (only one at this point)
-	gMasterConnSingleton = std::make_unique<MasterConn>(gMasterHost, gMasterPort, gJobPool);
-	MasterConn *eptr = gMasterConnSingleton.get();
-	passert(eptr);
-
-	// Init the connections
-	if (eptr->initConnect() < 0) { return -1; }
 
 	return 0;
 }

--- a/src/chunkserver/masterconn.cc
+++ b/src/chunkserver/masterconn.cc
@@ -30,6 +30,7 @@
 #include <algorithm>
 #include <cerrno>
 #include <cinttypes>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -61,6 +62,24 @@
 static constexpr uint32_t kMaxPacketSize = 10000;
 static constexpr uint32_t kMaxBackgroundJobsCount = 1000;
 
+// from config
+static std::string gMasterHost;
+static std::string gMasterPort;
+static std::string gBindHostStr;
+static NetworkAddress gBindHost;
+static bool gEnableLoadFactor;
+
+static std::string gLabel;
+static uint32_t gTimeout_ms;
+
+// JobPool shared between all connections to MDSs
+static std::unique_ptr<JobPool> gJobPool;
+
+// Stats
+static uint64_t stats_bytesout = 0;
+static uint64_t stats_bytesin = 0;
+static uint32_t stats_maxjobscnt = 0;
+
 enum class ConnectionMode : std::uint8_t {
 	FREE,        /// There is no socket for the connection yet.
 	CONNECTING,  /// Connection is being established.
@@ -68,8 +87,13 @@ enum class ConnectionMode : std::uint8_t {
 	KILL         /// Connection has been dropped, a reconnection will be attempted.
 };
 
-struct MasterConn {
-	MasterConn() : inputPacket(kMaxPacketSize) {}
+
+/// @brief Class representing a connection to a Metadata Server (MDS).
+///
+/// Currently, only one active MDS (known as Master) is supported.
+class MasterConn {
+public:
+	MasterConn() : inputPacket_(kMaxPacketSize) {}
 
 	// Disable unneeded copying and moving of the connection objects.
 	MasterConn(const MasterConn &) = delete;
@@ -78,46 +102,579 @@ struct MasterConn {
 	MasterConn &operator=(const MasterConn &&) = delete;
 
 	~MasterConn() {
-		if (sock >= 0) { tcpclose(sock); }
+		if (socketFD_ >= 0) { tcpclose(socketFD_); }
 	}
 
-	ConnectionMode mode{ConnectionMode::FREE};
-	int sock{-1};
-	int32_t pDescPos{-1};  ///< Position in the pollfd array.
-	Timer lastRead;
-	Timer lastWrite;
-	InputPacket inputPacket;
-	std::list<OutputPacket> outputPackets;
-	NetworkAddress address;
-	bool isMasterAddressValid{false};
+	// Packet handling
+
+	static void deletePacket(void *packet) {
+		auto *outputPacket = static_cast<OutputPacket *>(packet);
+		delete outputPacket;
+	}
+
+	void attachPacket(void *packet) {
+		auto *outputPacket = static_cast<OutputPacket *>(packet);
+		outputPackets_.emplace_back(std::move(*outputPacket));
+		delete outputPacket;
+	}
+
+	void createAttachedPacket(MessageBuffer serializedPacket) {
+		outputPackets_.emplace_back(std::move(serializedPacket));
+	}
+
+	template <class... Data>
+	void createAttachedNoVersionPacket(PacketHeader::Type type, const Data &...data) {
+		std::vector<uint8_t> buffer;
+		serializeLegacyPacket(buffer, type, data...);
+		createAttachedPacket(std::move(buffer));
+	}
+
+	// Connection management
+
+	void sendRegisterLabel() {
+		if (mode_ == ConnectionMode::CONNECTED) {
+			createAttachedPacket(cstoma::registerLabel::build(gLabel));
+		}
+	}
+
+	void sendConfig() {
+		if (mode_ == ConnectionMode::CONNECTED) {
+			createAttachedPacket(cstoma::registerConfig::build(cfg_yaml_string()));
+		}
+	}
+
+	void sendRegister() {
+		uint32_t myip;
+		uint16_t myport;
+		uint64_t usedspace, totalspace;
+		uint64_t tdusedspace, tdtotalspace;
+		uint32_t chunkcount, tdchunkcount;
+
+		myip = mainNetworkThreadGetListenIp();
+		myport = mainNetworkThreadGetListenPort();
+		createAttachedPacket(
+		    cstoma::registerHost::build(myip, myport, gTimeout_ms, SAUNAFS_VERSHEX));
+
+		hddForeachChunkInBulks([this](const std::vector<ChunkWithVersionAndType> &chunksBulk) {
+			createAttachedPacket(cstoma::registerChunks::build(chunksBulk));
+		});
+
+		hddGetTotalSpace(&usedspace, &totalspace, &chunkcount, &tdusedspace, &tdtotalspace,
+		                 &tdchunkcount);
+		auto registerSpace = cstoma::registerSpace::build(usedspace, totalspace, chunkcount,
+		                                                  tdusedspace, tdtotalspace, tdchunkcount);
+		createAttachedPacket(std::move(registerSpace));
+		sendRegisterLabel();
+		sendConfig();
+	}
+
+	int initConnect() {
+		if (!isMasterAddressValid_) {
+			uint32_t mip;
+			uint32_t bip;
+			uint16_t mport;
+
+			if (tcpresolve(gBindHostStr.c_str(), nullptr, &bip, nullptr, 1) < 0) { bip = 0; }
+
+			gBindHost.ip = bip;
+
+			if (tcpresolve(gMasterHost.c_str(), gMasterPort.c_str(), &mip, &mport, 0) >= 0) {
+				if (isLoopbackAddress(mip)) {
+					safs::log_warn(
+					    "Chunkserver loopback IP addresses are experimental; consider assigning an IP address to chunkserver (via /etc/hosts or some other way)");
+				}
+				address_.ip = mip;
+				address_.port = mport;
+				isMasterAddressValid_ = true;
+			} else {
+				safs::log_warn("master connection module: can't resolve master host/port ({}:{})",
+				               gMasterHost, gMasterPort);
+				return -1;
+			}
+		}
+
+		socketFD_ = tcpsocket();
+
+		if (socketFD_ < 0) {
+			safs_pretty_errlog(LOG_WARNING, "master connection module: create socket error");
+			return -1;
+		}
+
+		if (tcpnonblock(socketFD_) < 0) {
+			safs_pretty_errlog(LOG_WARNING, "master connection module: set nonblock error");
+			tcpclose(socketFD_);
+			socketFD_ = -1;
+			return -1;
+		}
+
+		if (gBindHost.ip > 0) {
+			if (tcpnumbind(socketFD_, gBindHost.ip, 0) < 0) {
+				safs_pretty_errlog(LOG_WARNING,
+				                   "master connection module: can't bind socket to given ip");
+				tcpclose(socketFD_);
+				socketFD_ = -1;
+				return -1;
+			}
+		}
+
+		int status = tcpnumconnect(socketFD_, address_.ip, address_.port);
+
+		if (status < 0) {
+			safs_pretty_errlog(LOG_WARNING, "master connection module: connect failed");
+			tcpclose(socketFD_);
+			socketFD_ = -1;
+			isMasterAddressValid_ = false;
+			return -1;
+		}
+
+		if (status == 0) {
+			safs_pretty_syslog(LOG_NOTICE, "connected to Master immediately");
+			onConnected();
+		} else {
+			mode_ = ConnectionMode::CONNECTING;
+			safs_pretty_syslog_attempt(LOG_NOTICE, "connecting to Master");
+		}
+
+		return 0;
+	}
+
+	void connectTest() {
+		int status = tcpgetstatus(socketFD_);
+
+		if (status) {
+			safs_silent_errlog(LOG_WARNING, "connection failed, error");
+			tcpclose(socketFD_);
+			socketFD_ = -1;
+			mode_ = ConnectionMode::FREE;
+			isMasterAddressValid_ = 0;
+		} else {
+			safs::log_info("connected to Master");
+			onConnected();
+		}
+	}
+
+	void onConnected() {
+		tcpnodelay(socketFD_);
+		mode_ = ConnectionMode::CONNECTED;
+		inputPacket_.reset();
+
+		sendRegister();
+		lastRead_.reset();
+		lastWrite_.reset();
+	}
+
+	// Polling
+
+	void providePollDescriptors(std::vector<pollfd> &pdesc) {
+		pDescPos_ = -1;
+
+		if (mode_ == ConnectionMode::FREE || socketFD_ < 0) { return; }
+
+		if (mode_ == ConnectionMode::CONNECTED) {
+			if (gJobPool->getJobCount() < (kMaxBackgroundJobsCount * 9) / 10) {
+				pdesc.emplace_back(socketFD_, POLLIN, 0);
+				pDescPos_ = static_cast<int32_t>(pdesc.size() - 1);
+			}
+		}
+
+		if (((mode_ == ConnectionMode::CONNECTED) && !outputPackets_.empty()) ||
+		    mode_ == ConnectionMode::CONNECTING) {
+			if (pDescPos_ >= 0) {
+				pdesc[pDescPos_].events |= POLLOUT;
+			} else {
+				pdesc.emplace_back(socketFD_, POLLOUT, 0);
+				pDescPos_ = static_cast<int32_t>(pdesc.size() - 1);
+			}
+		}
+	}
+
+	void servePoll(const std::vector<pollfd> &pdesc) {
+		// Check if the socket has been closed or has an error.
+		if (pDescPos_ >= 0 && (pdesc[pDescPos_].revents & (POLLHUP | POLLERR))) {
+			if (mode_ == ConnectionMode::CONNECTING) {
+				connectTest();
+			} else {
+				mode_ = ConnectionMode::KILL;
+			}
+		}
+
+		if (mode_ == ConnectionMode::CONNECTING) {
+			// Check if the connection has been established.
+			if (socketFD_ >= 0 && pDescPos_ >= 0 && (pdesc[pDescPos_].revents & POLLOUT)) {
+				connectTest();
+			}
+		} else {
+			if (pDescPos_ >= 0) {
+				// Check if there is data to read from this connection
+				if ((mode_ == ConnectionMode::CONNECTED) && (pdesc[pDescPos_].revents & POLLIN)) {
+					lastRead_.reset();
+					readFromSocket();
+				}
+
+				// Check if there is data to write to this connection
+				if ((mode_ == ConnectionMode::CONNECTED) && (pdesc[pDescPos_].revents & POLLOUT)) {
+					lastWrite_.reset();
+					writeToSocket();
+				}
+
+				// Check if the connection has not been used for a while and should be closed
+				if ((mode_ == ConnectionMode::CONNECTED) && lastRead_.elapsed_ms() > gTimeout_ms) {
+					mode_ = ConnectionMode::KILL;
+				}
+
+				// Keep the connection alive by sending a NOP packet
+				if ((mode_ == ConnectionMode::CONNECTED) &&
+				    lastWrite_.elapsed_ms() > (gTimeout_ms / 3) && outputPackets_.empty()) {
+					createAttachedNoVersionPacket(ANTOAN_NOP, 0);
+				}
+			}
+		}
+	}
+
+	void readFromSocket() {
+		ActiveLoopWatchdog watchdog(std::chrono::milliseconds(20));
+
+		watchdog.start();
+
+		while (mode_ != ConnectionMode::KILL) {
+			// If the job pool is too busy, do not read more data.
+			if (gJobPool->getJobCount() >= (kMaxBackgroundJobsCount * 9) / 10) { return; }
+
+			uint32_t bytesToRead = inputPacket_.bytesToBeRead();
+			ssize_t ret = ::read(socketFD_, inputPacket_.pointerToBeReadInto(), bytesToRead);
+
+			if (ret == 0) {
+				safs_silent_syslog(LOG_NOTICE, "connection reset by Master");
+				mode_ = ConnectionMode::KILL;
+				return;
+			}
+
+			if (ret < 0) {
+				if (errno != EAGAIN) {
+					safs_silent_errlog(LOG_NOTICE, "read from Master error");
+					mode_ = ConnectionMode::KILL;
+				}
+				return;
+			}
+
+			stats_bytesin += ret;
+
+			try {
+				inputPacket_.increaseBytesRead(ret);
+			} catch (InputPacketTooLongException &ex) {
+				safs_silent_syslog(LOG_WARNING, "reading from master: %s", ex.what());
+				mode_ = ConnectionMode::KILL;
+				return;
+			}
+
+			if (ret == bytesToRead && !inputPacket_.hasData()) {
+				continue;  // there might be more data to read in socket's buffer
+			}
+
+			if (!inputPacket_.hasData()) { return; }
+
+			// We have a complete packet in the input buffer, let's process it.
+			gotPacket(inputPacket_.getHeader(), inputPacket_.getData());
+
+			inputPacket_.reset();
+
+			if (watchdog.expired()) { break; }
+		}
+	}
+
+	void writeToSocket() {
+		ActiveLoopWatchdog watchdog(std::chrono::milliseconds(20));
+		ssize_t bytesWritten{-1};
+
+		watchdog.start();
+
+		while (!outputPackets_.empty()) {
+			OutputPacket &pack = outputPackets_.front();
+			bytesWritten = ::write(socketFD_, pack.packet.data() + pack.bytesSent,
+			                       pack.packet.size() - pack.bytesSent);
+
+			if (bytesWritten < 0) {
+				if (errno != EAGAIN) {
+					safs_silent_errlog(LOG_NOTICE, "write to Master error");
+					mode_ = ConnectionMode::KILL;
+				}
+				return;
+			}
+
+			stats_bytesout += bytesWritten;
+			pack.bytesSent += bytesWritten;
+
+			if (pack.packet.size() != pack.bytesSent) { return; }
+
+			outputPackets_.pop_front();
+
+			if (watchdog.expired()) { break; }
+		}
+	}
+
+	void gotPacket(PacketHeader header, const MessageBuffer &message) try {
+		switch (header.type) {
+		case ANTOAN_NOP:
+			break;
+		case ANTOAN_UNKNOWN_COMMAND:  // for future use
+			break;
+		case ANTOAN_BAD_COMMAND_SIZE:  // for future use
+			break;
+		case SAU_MATOCS_CREATE_CHUNK:
+			createChunk(message);
+			break;
+		case SAU_MATOCS_DELETE_CHUNK:
+			deleteChunk(message);
+			break;
+		case SAU_MATOCS_SET_VERSION:
+			setChunkVersion(message);
+			break;
+		case SAU_MATOCS_DUPLICATE_CHUNK:
+			duplicateChunk(message);
+			break;
+		case SAU_MATOCS_REPLICATE_CHUNK:
+			replicateChunk(message);
+			break;
+		case SAU_MATOCS_TRUNCATE:
+			truncateChunk(message);
+			break;
+		case SAU_MATOCS_DUPTRUNC_CHUNK:
+			duplicateTruncateChunk(message);
+			break;
+		default:
+			safs::log_info("got unknown message (type: {})", header.type);
+			mode_ = ConnectionMode::KILL;
+		}
+	} catch (IncorrectDeserializationException &e) {
+		safs::log_info(
+		    "chunkserver <-> master module: got inconsistent message "
+		    "(type:{}, length:{}), {}",
+		    header.type, uint32_t(message.size()), e.what());
+		mode_ = ConnectionMode::KILL;
+	}
+
+	// Chunk operations
+
+	void createChunk(const std::vector<uint8_t> &data) {
+		uint64_t chunkId;
+		ChunkPartType chunkType = slice_traits::standard::ChunkPartType();
+		uint32_t chunkVersion;
+
+		matocs::createChunk::deserialize(data, chunkId, chunkType, chunkVersion);
+		auto *outputPacket = new OutputPacket;
+		cstoma::createChunk::serialize(outputPacket->packet, chunkId, chunkType, SAUNAFS_STATUS_OK);
+		if (gJobPool) {
+			job_create(
+			    *gJobPool, [this](uint8_t status, void *packet) { sauJobFinished(status, packet); },
+			    outputPacket, chunkId, chunkVersion, chunkType);
+		} else {
+			safs::log_err("masterconn_create: jobPool is null.");
+			delete outputPacket;
+		}
+	}
+
+	void deleteChunk(const std::vector<uint8_t> &data) {
+		uint64_t chunkId;
+		uint32_t chunkVersion;
+		ChunkPartType chunkType = slice_traits::standard::ChunkPartType();
+
+		matocs::deleteChunk::deserialize(data, chunkId, chunkType, chunkVersion);
+		auto *outputPacket = new OutputPacket;
+		cstoma::deleteChunk::serialize(outputPacket->packet, chunkId, chunkType, 0);
+		if (gJobPool) {
+			job_delete(
+			    *gJobPool, [this](uint8_t status, void *packet) { sauJobFinished(status, packet); },
+			    outputPacket, chunkId, chunkVersion, chunkType);
+		} else {
+			safs::log_err("masterconn_delete: jobPool is null.");
+			delete outputPacket;
+		}
+	}
+
+	void setChunkVersion(const std::vector<uint8_t> &data) {
+		uint64_t chunkId;
+		uint32_t chunkVersion;
+		uint32_t newVersion;
+		ChunkPartType chunkType = slice_traits::standard::ChunkPartType();
+
+		matocs::setVersion::deserialize(data, chunkId, chunkType, chunkVersion, newVersion);
+		auto *outputPacket = new OutputPacket;
+		cstoma::setVersion::serialize(outputPacket->packet, chunkId, chunkType, 0);
+		if (gJobPool) {
+			job_version(
+			    *gJobPool, [this](uint8_t status, void *packet) { sauJobFinished(status, packet); },
+			    outputPacket, chunkId, chunkVersion, chunkType, newVersion);
+		} else {
+			safs::log_err("masterconn_setversion: jobPool is null.");
+			delete outputPacket;
+		}
+	}
+
+	void duplicateChunk(const std::vector<uint8_t> &data) {
+		uint64_t newChunkId, oldChunkId;
+		uint32_t newChunkVersion, oldChunkVersion;
+		ChunkPartType chunkType = slice_traits::standard::ChunkPartType();
+
+		matocs::duplicateChunk::deserialize(data, newChunkId, newChunkVersion, chunkType,
+		                                    oldChunkId, oldChunkVersion);
+		auto *outputPacket = new OutputPacket;
+		cstoma::duplicateChunk::serialize(outputPacket->packet, newChunkId, chunkType, 0);
+		if (gJobPool) {
+			job_duplicate(
+			    *gJobPool, [this](uint8_t status, void *packet) { sauJobFinished(status, packet); },
+			    outputPacket, oldChunkId, oldChunkVersion, oldChunkVersion, chunkType, newChunkId,
+			    newChunkVersion);
+		} else {
+			safs::log_err("masterconn_duplicate: jobPool is null.");
+			delete outputPacket;
+		}
+	}
+
+	void truncateChunk(const std::vector<uint8_t> &data) {
+		uint64_t chunkId;
+		ChunkPartType chunkType = slice_traits::standard::ChunkPartType();
+		uint32_t version;
+		uint32_t chunkLength;
+		uint32_t newVersion;
+
+		matocs::truncateChunk::deserialize(data, chunkId, chunkType, chunkLength, newVersion,
+		                                   version);
+		auto *outputPacket = new OutputPacket;
+		cstoma::truncate::serialize(outputPacket->packet, chunkId, chunkType, 0);
+		if (gJobPool) {
+			job_truncate(
+			    *gJobPool, [this](uint8_t status, void *packet) { sauJobFinished(status, packet); },
+			    outputPacket, chunkId, chunkType, version, newVersion, chunkLength);
+		} else {
+			safs::log_err("masterconn_truncate: jobPool is null.");
+			delete outputPacket;
+		}
+	}
+
+	void duplicateTruncateChunk(const std::vector<uint8_t> &data) {
+		uint64_t chunkId, copyChunkId;
+		uint32_t chunkVersion, copyChunkVersion;
+		ChunkPartType chunkType = slice_traits::standard::ChunkPartType();
+		uint32_t newLength;
+
+		matocs::duptruncChunk::deserialize(data, copyChunkId, copyChunkVersion, chunkType, chunkId,
+		                                   chunkVersion, newLength);
+		auto *outputPacket = new OutputPacket;
+		cstoma::duptruncChunk::serialize(outputPacket->packet, copyChunkId, chunkType, 0);
+		if (gJobPool) {
+			job_duptrunc(
+			    *gJobPool, [this](uint8_t status, void *packet) { sauJobFinished(status, packet); },
+			    outputPacket, chunkId, chunkVersion, chunkVersion, chunkType, copyChunkId,
+			    copyChunkVersion, newLength);
+		} else {
+			safs::log_err("masterconn_duptrunc: jobPool is null.");
+			delete outputPacket;
+		}
+	}
+
+	void replicateChunk(const std::vector<uint8_t> &data) {
+		uint64_t chunkId;
+		ChunkPartType chunkType = slice_traits::standard::ChunkPartType();
+		uint32_t chunkVersion;
+		uint32_t sourcesBufferSize;
+		const uint8_t *sourcesBuffer;
+
+		matocs::replicateChunk::deserializePartial(data, chunkId, chunkVersion, chunkType,
+		                                           sourcesBuffer);
+		sourcesBufferSize = data.size() - (sourcesBuffer - data.data());
+
+		auto *outputPacket = new OutputPacket;
+		cstoma::replicateChunk::serialize(outputPacket->packet, chunkId, chunkType,
+		                                  SAUNAFS_STATUS_OK, chunkVersion);
+		safs_silent_syslog(LOG_DEBUG, "cs.matocs.replicate %" PRIu64, chunkId);
+
+		if (hddScansInProgress()) {
+			// Disk scan in progress - replication is not possible
+			sauJobFinished(SAUNAFS_ERROR_WAITING, outputPacket);
+		} else {
+			if (gJobPool) {
+				job_replicate(
+				    *gJobPool,
+				    [this](uint8_t status, void *packet) { sauJobFinished(status, packet); },
+				    outputPacket, chunkId, chunkVersion, chunkType, sourcesBufferSize,
+				    sourcesBuffer);
+			} else {
+				safs::log_err("masterconn_replicate: jobPool is null.");
+				delete outputPacket;
+			}
+		}
+	}
+
+	// Callbacks
+
+	void sauJobFinished(uint8_t status, void *packet) {
+		auto *outputPacket = static_cast<OutputPacket *>(packet);
+
+		if (mode_ == ConnectionMode::CONNECTED) {
+			cstoma::overwriteStatusField(outputPacket->packet, status);
+			attachPacket(packet);
+		} else {
+			deletePacket(packet);
+		}
+	}
+
+	// Termination
+
+	void releaseResources() {
+		if (mode_ != ConnectionMode::FREE && mode_ != ConnectionMode::CONNECTING) {
+			tcpclose(socketFD_);
+			inputPacket_.reset();
+		}
+	}
+
+	void resetPackets() {
+		inputPacket_.reset();
+		outputPackets_.clear();
+	}
+
+	// Getters and setters
+
+	ConnectionMode mode() const { return mode_; }
+
+	void setMode(ConnectionMode newMode) { mode_ = newMode; }
+
+	const NetworkAddress &address() const { return address_; }
+
+	void setAddress(uint32_t ip_, uint16_t port_) {
+		address_.ip = ip_;
+		address_.port = port_;
+	}
+
+	int socketFD() const { return socketFD_; }
+
+	bool isMasterAddressValid() const { return isMasterAddressValid_; }
+
+	void setMasterAddressValid(bool valid) { isMasterAddressValid_ = valid; }
+
+private:
+	ConnectionMode mode_{ConnectionMode::FREE};  ///< Current mode of the connection to this master.
+	int socketFD_{-1};                           ///< Socket file descriptor for this connection.
+	int32_t pDescPos_{-1};                       ///< Position in the pollfd array.
+	Timer lastRead_;                             ///< Time since the last read operation.
+	Timer lastWrite_;                            ///< Time since the last write operation.
+	InputPacket inputPacket_;                    ///< Input buffer for reading data from the socket.
+	std::list<OutputPacket> outputPackets_;      ///< Output packets to be sent to the master.
+	NetworkAddress address_;                     ///< Address of this master server (IP and port).
+	bool isMasterAddressValid_{false};           ///< Tells if the master address is valid.
 };
 
 static const uint64_t kSendStatusDelay = 5;
 
 static std::unique_ptr<MasterConn> gMasterConnSingleton = nullptr;
-static std::unique_ptr<JobPool> gJobPool;
 
 static int gJobFD{-1};  ///< File descriptor for the job pool notifications
 static int32_t gJobFDpDescPos{-1};  ///< Position in the pollfd array for the job pool notifications
-
-// from config
-static std::string gMasterHost;
-static std::string gMasterPort;
-static std::string gBindHostStr;
-static NetworkAddress gBindHost;
-static uint32_t gTimeout_ms;
-static std::string gLabel;
-static bool gEnableLoadFactor;
 
 constexpr uint32_t kDefaultNumberOfWorkers = 10;
 constexpr uint32_t kMinNumberOfWorkers = 2;
 static uint32_t gNumberOfWorkers = kDefaultNumberOfWorkers;
 
-static uint64_t stats_bytesout = 0;
-static uint64_t stats_bytesin = 0;
-static uint32_t stats_maxjobscnt = 0;
-
-static void* reconnect_hook;
+static void* gReconnectHook;
 
 void masterconn_stats(uint64_t *bin,uint64_t *bout,uint32_t *maxjobscnt) {
 	*bin = stats_bytesin;
@@ -128,569 +685,73 @@ void masterconn_stats(uint64_t *bin,uint64_t *bout,uint32_t *maxjobscnt) {
 	stats_maxjobscnt = 0;
 }
 
-void* masterconn_create_detached_packet(uint32_t type,uint32_t size) {
-	return new OutputPacket(PacketHeader(type, size));
-}
-
-uint8_t* masterconn_get_packet_data(void *packet) {
-	OutputPacket* outpacket = (OutputPacket*)packet;
-	return outpacket->packet.data() + PacketHeader::kSize;
-}
-
-void masterconn_delete_packet(void *packet) {
-	OutputPacket* outputPacket = (OutputPacket*)packet;
-	delete outputPacket;
-}
-
-void masterconn_attach_packet(MasterConn *eptr, void* packet) {
-	OutputPacket* outputPacket = (OutputPacket*) packet;
-	eptr->outputPackets.emplace_back(std::move(*outputPacket));
-	delete outputPacket;
-}
-
-void masterconn_create_attached_packet(MasterConn *eptr, MessageBuffer serializedPacket) {
-	eptr->outputPackets.emplace_back(std::move(serializedPacket));
-}
-
-template<class... Data>
-void masterconn_create_attached_no_version_packet(MasterConn *eptr,
-		PacketHeader::Type type, const Data&... data) {
-	std::vector<uint8_t> buffer;
-	serializeLegacyPacket(buffer, type, data...);
-	masterconn_create_attached_packet(eptr, std::move(buffer));
-}
-
-void masterconn_sendregisterlabel(MasterConn *eptr) {
-	if (eptr->mode == ConnectionMode::CONNECTED) {
-		masterconn_create_attached_packet(eptr, cstoma::registerLabel::build(gLabel));
-	}
-}
-
-void masterconn_send_metalogger_config(MasterConn *eptr) {
-	if (eptr->mode == ConnectionMode::CONNECTED) {
-		masterconn_create_attached_packet(
-		    eptr, cstoma::registerConfig::build(cfg_yaml_string()));
-	}
-}
-
-void masterconn_sendregister(MasterConn *eptr) {
-	uint32_t myip;
-	uint16_t myport;
-	uint64_t usedspace,totalspace;
-	uint64_t tdusedspace,tdtotalspace;
-	uint32_t chunkcount,tdchunkcount;
-
-	myip = mainNetworkThreadGetListenIp();
-	myport = mainNetworkThreadGetListenPort();
-	masterconn_create_attached_packet(
-	    eptr, cstoma::registerHost::build(myip, myport, gTimeout_ms,
-	                                      SAUNAFS_VERSHEX));
-
-	hddForeachChunkInBulks(
-	    [eptr](const std::vector<ChunkWithVersionAndType> &chunksBulk) {
-		    masterconn_create_attached_packet(
-		        eptr, cstoma::registerChunks::build(chunksBulk));
-	    });
-
-	hddGetTotalSpace(&usedspace, &totalspace, &chunkcount, &tdusedspace,
-	                 &tdtotalspace, &tdchunkcount);
-	auto registerSpace =
-	    cstoma::registerSpace::build(usedspace, totalspace, chunkcount,
-	                                 tdusedspace, tdtotalspace, tdchunkcount);
-	masterconn_create_attached_packet(eptr, std::move(registerSpace));
-	masterconn_sendregisterlabel(eptr);
-	masterconn_send_metalogger_config(eptr);
-}
-
 void masterconn_check_hdd_reports() {
 	MasterConn *eptr = gMasterConnSingleton.get();
 	uint32_t errorcounter;
-	if (eptr->mode == ConnectionMode::CONNECTED) {
+	if (eptr->mode() == ConnectionMode::CONNECTED) {
 		if (hddGetAndResetSpaceChanged()) {
-			uint64_t usedspace,totalspace,tdusedspace,tdtotalspace;
-			uint32_t chunkcount,tdchunkcount;
+			uint64_t usedspace, totalspace, tdusedspace, tdtotalspace;
+			uint32_t chunkcount, tdchunkcount;
 			hddGetTotalSpace(&usedspace, &totalspace, &chunkcount, &tdusedspace, &tdtotalspace,
-					&tdchunkcount);
-			masterconn_create_attached_no_version_packet(
-					eptr, CSTOMA_SPACE,
-					usedspace, totalspace, chunkcount, tdusedspace, tdtotalspace, tdchunkcount);
+			                 &tdchunkcount);
+			eptr->createAttachedNoVersionPacket(CSTOMA_SPACE, usedspace, totalspace, chunkcount,
+			                                    tdusedspace, tdtotalspace, tdchunkcount);
 		}
 		errorcounter = hddGetAndResetErrorCounter();
 		while (errorcounter) {
-			masterconn_create_attached_no_version_packet(eptr, CSTOMA_ERROR_OCCURRED);
+			eptr->createAttachedNoVersionPacket(CSTOMA_ERROR_OCCURRED);
 			errorcounter--;
 		}
 
 		std::vector<ChunkWithType> chunks_with_type;
 		hddGetDamagedChunks(chunks_with_type, 1000);
 		if (!chunks_with_type.empty()) {
-			masterconn_create_attached_packet(eptr, cstoma::chunkDamaged::build(chunks_with_type));
+			eptr->createAttachedPacket(cstoma::chunkDamaged::build(chunks_with_type));
 		}
 
 		hddGetLostChunks(chunks_with_type, 1000);
 		if (!chunks_with_type.empty()) {
-			masterconn_create_attached_packet(eptr, cstoma::chunkLost::build(chunks_with_type));
+			eptr->createAttachedPacket(cstoma::chunkLost::build(chunks_with_type));
 		}
 
 		std::vector<ChunkWithVersionAndType> chunks_with_version;
 		hddGetNewChunks(chunks_with_version, 1000);
 		if (!chunks_with_version.empty()) {
-			masterconn_create_attached_packet(eptr, cstoma::chunkNew::build(chunks_with_version));
+			eptr->createAttachedPacket(cstoma::chunkNew::build(chunks_with_version));
 		}
 	}
 }
 
-void masterconn_jobfinished(uint8_t status, void *packet) {
-	uint8_t *ptr;
-	MasterConn *eptr = gMasterConnSingleton.get();
-	if (eptr->mode == ConnectionMode::CONNECTED) {
-		ptr = masterconn_get_packet_data(packet);
-		ptr[8]=status;
-		masterconn_attach_packet(eptr,packet);
-	} else {
-		masterconn_delete_packet(packet);
-	}
-}
-
-void masterconn_saujobfinished(uint8_t status, void *packet) {
-	OutputPacket* outputPacket = static_cast<OutputPacket*>(packet);
-	MasterConn *eptr = gMasterConnSingleton.get();
-	if (eptr->mode == ConnectionMode::CONNECTED) {
-		cstoma::overwriteStatusField(outputPacket->packet, status);
-		masterconn_attach_packet(eptr, packet);
-	} else {
-		masterconn_delete_packet(packet);
-	}
-}
-
-void masterconn_chunkopfinished(uint8_t status,void *packet) {
-	uint8_t *ptr;
-	MasterConn *eptr = gMasterConnSingleton.get();
-	if (eptr->mode == ConnectionMode::CONNECTED) {
-		ptr = masterconn_get_packet_data(packet);
-		ptr[32]=status;
-		masterconn_attach_packet(eptr,packet);
-	} else {
-		masterconn_delete_packet(packet);
-	}
-}
-
-void masterconn_replicationfinished(uint8_t status,void *packet) {
-	uint8_t *ptr;
-	MasterConn *eptr = gMasterConnSingleton.get();
-//      syslog(LOG_NOTICE,"job replication status: %" PRIu8,status);
-	if (eptr->mode == ConnectionMode::CONNECTED) {
-		ptr = masterconn_get_packet_data(packet);
-		ptr[12]=status;
-		masterconn_attach_packet(eptr,packet);
-	} else {
-		masterconn_delete_packet(packet);
-	}
-}
-
-void masterconn_unwantedjobfinished(uint8_t status,void *packet) {
+void masterconn_unwantedjobfinished(uint8_t status, void *packet) {
 	(void)status;
-	masterconn_delete_packet(packet);
+	MasterConn::deletePacket(packet);
 }
-
-void masterconn_create([[maybe_unused]] MasterConn *eptr, const std::vector<uint8_t> &data) {
-	uint64_t chunkId;
-	ChunkPartType chunkType = slice_traits::standard::ChunkPartType();
-	uint32_t chunkVersion;
-
-	matocs::createChunk::deserialize(data, chunkId, chunkType, chunkVersion);
-	OutputPacket *outputPacket = new OutputPacket;
-	cstoma::createChunk::serialize(outputPacket->packet, chunkId, chunkType, SAUNAFS_STATUS_OK);
-	if (gJobPool) {
-		job_create(*gJobPool, masterconn_saujobfinished, outputPacket, chunkId, chunkVersion,
-		           chunkType);
-	}
-	else {
-		safs::log_err("masterconn_create: jobPool is null.");
-		delete outputPacket;
-	}
-}
-
-void masterconn_delete([[maybe_unused]] MasterConn *eptr, const std::vector<uint8_t> &data) {
-	uint64_t chunkId;
-	uint32_t chunkVersion;
-	ChunkPartType chunkType = slice_traits::standard::ChunkPartType();
-
-	matocs::deleteChunk::deserialize(data, chunkId, chunkType, chunkVersion);
-	OutputPacket* outputPacket = new OutputPacket;
-	cstoma::deleteChunk::serialize(outputPacket->packet, chunkId, chunkType, 0);
-	if (gJobPool) {
-		job_delete(*gJobPool, masterconn_saujobfinished, outputPacket, chunkId, chunkVersion,
-		           chunkType);
-	} else {
-		safs::log_err("masterconn_delete: jobPool is null.");
-		delete outputPacket;
-	}
-}
-
-void masterconn_setversion([[maybe_unused]] MasterConn *eptr, const std::vector<uint8_t> &data) {
-	uint64_t chunkId;
-	uint32_t chunkVersion;
-	uint32_t newVersion;
-	ChunkPartType chunkType = slice_traits::standard::ChunkPartType();
-
-	matocs::setVersion::deserialize(data, chunkId, chunkType, chunkVersion, newVersion);
-	OutputPacket* outputPacket = new OutputPacket;
-	cstoma::setVersion::serialize(outputPacket->packet, chunkId, chunkType, 0);
-	if (gJobPool) {
-		job_version(*gJobPool, masterconn_saujobfinished, outputPacket, chunkId, chunkVersion,
-		            chunkType, newVersion);
-	} else {
-		safs::log_err("masterconn_setversion: jobPool is null.");
-		delete outputPacket;
-	}
-}
-
-void masterconn_duplicate([[maybe_unused]] MasterConn *eptr, const std::vector<uint8_t> &data) {
-	uint64_t newChunkId, oldChunkId;
-	uint32_t newChunkVersion, oldChunkVersion;
-	ChunkPartType chunkType = slice_traits::standard::ChunkPartType();
-
-	matocs::duplicateChunk::deserialize(data, newChunkId, newChunkVersion, chunkType,
-			oldChunkId, oldChunkVersion);
-	OutputPacket* outputPacket = new OutputPacket;
-	cstoma::duplicateChunk::serialize(outputPacket->packet, newChunkId, chunkType, 0);
-	if (gJobPool) {
-		job_duplicate(*gJobPool, masterconn_saujobfinished, outputPacket, oldChunkId,
-		              oldChunkVersion, oldChunkVersion, chunkType, newChunkId, newChunkVersion);
-	} else {
-		safs::log_err("masterconn_duplicate: jobPool is null.");
-		delete outputPacket;
-	}
-}
-
-void masterconn_truncate([[maybe_unused]] MasterConn *eptr, const std::vector<uint8_t> &data) {
-	uint64_t chunkId;
-	ChunkPartType chunkType = slice_traits::standard::ChunkPartType();
-	uint32_t version;
-	uint32_t chunkLength;
-	uint32_t newVersion;
-
-	matocs::truncateChunk::deserialize(data, chunkId, chunkType, chunkLength, newVersion, version);
-	OutputPacket* outputPacket = new OutputPacket;
-	cstoma::truncate::serialize(outputPacket->packet, chunkId, chunkType, 0);
-	if (gJobPool) {
-		job_truncate(*gJobPool, masterconn_saujobfinished, outputPacket, chunkId, chunkType, version,
-		             newVersion, chunkLength);
-	} else {
-		safs::log_err("masterconn_truncate: jobPool is null.");
-		delete outputPacket;
-	}
-}
-
-void masterconn_duptrunc([[maybe_unused]] MasterConn *eptr, const std::vector<uint8_t> &data) {
-	uint64_t chunkId, copyChunkId;
-	uint32_t chunkVersion, copyChunkVersion;
-	ChunkPartType chunkType = slice_traits::standard::ChunkPartType();
-	uint32_t newLength;
-
-	matocs::duptruncChunk::deserialize(data, copyChunkId, copyChunkVersion,
-			chunkType, chunkId, chunkVersion, newLength);
-	OutputPacket* outputPacket = new OutputPacket;
-	cstoma::duptruncChunk::serialize(outputPacket->packet, copyChunkId, chunkType, 0);
-	if (gJobPool) {
-		job_duptrunc(*gJobPool, masterconn_saujobfinished, outputPacket, chunkId, chunkVersion,
-		             chunkVersion, chunkType, copyChunkId, copyChunkVersion, newLength);
-	} else {
-		safs::log_err("masterconn_duptrunc: jobPool is null.");
-		delete outputPacket;
-	}
-}
-
-void masterconn_replicate(const std::vector<uint8_t>& data) {
-	uint64_t chunkId;
-	ChunkPartType chunkType = slice_traits::standard::ChunkPartType();
-	uint32_t chunkVersion;
-	uint32_t sourcesBufferSize;
-	const uint8_t* sourcesBuffer;
-
-	matocs::replicateChunk::deserializePartial(data,
-			chunkId, chunkVersion, chunkType, sourcesBuffer);
-	sourcesBufferSize = data.size() - (sourcesBuffer - data.data());
-
-	OutputPacket* outputPacket = new OutputPacket;
-	cstoma::replicateChunk::serialize(outputPacket->packet,
-			chunkId, chunkType, SAUNAFS_STATUS_OK, chunkVersion);
-	safs_silent_syslog(LOG_DEBUG, "cs.matocs.replicate %" PRIu64, chunkId);
-	if (hddScansInProgress()) {
-		// Disk scan in progress - replication is not possible
-		masterconn_saujobfinished(SAUNAFS_ERROR_WAITING, outputPacket);
-	} else {
-		if (gJobPool) {
-			job_replicate(*gJobPool, masterconn_saujobfinished, outputPacket, chunkId, chunkVersion,
-			              chunkType, sourcesBufferSize, sourcesBuffer);
-		} else {
-			safs::log_err("masterconn_replicate: jobPool is null.");
-			delete outputPacket;
-		}
-	}
-
-}
-
-void masterconn_gotpacket(MasterConn *eptr, PacketHeader header, const MessageBuffer& message) try {
-	switch (header.type) {
-		case ANTOAN_NOP:
-			break;
-		case ANTOAN_UNKNOWN_COMMAND: // for future use
-			break;
-		case ANTOAN_BAD_COMMAND_SIZE: // for future use
-			break;
-		case SAU_MATOCS_CREATE_CHUNK:
-			masterconn_create(eptr, message);
-			break;
-		case SAU_MATOCS_DELETE_CHUNK:
-			masterconn_delete(eptr, message);
-			break;
-		case SAU_MATOCS_SET_VERSION:
-			masterconn_setversion(eptr, message);
-			break;
-		case SAU_MATOCS_DUPLICATE_CHUNK:
-			masterconn_duplicate(eptr, message);
-			break;
-		case SAU_MATOCS_REPLICATE_CHUNK:
-			masterconn_replicate(message);
-			break;
-		case SAU_MATOCS_TRUNCATE:
-			masterconn_truncate(eptr, message);
-			break;
-		case SAU_MATOCS_DUPTRUNC_CHUNK:
-			masterconn_duptrunc(eptr, message);
-			break;
-		default:
-			safs_pretty_syslog(LOG_NOTICE,"got unknown message (type:%" PRIu32 ")", header.type);
-			eptr->mode = ConnectionMode::KILL;
-	}
-} catch (IncorrectDeserializationException& e) {
-	safs_pretty_syslog(LOG_NOTICE,
-			"chunkserver <-> master module: got inconsistent message "
-			"(type:%" PRIu32 ", length:%" PRIu32"), %s",
-			header.type, uint32_t(message.size()), e.what());
-	eptr->mode = ConnectionMode::KILL;
-}
-
 
 void masterconn_term(void) {
-	MasterConn *eptr = gMasterConnSingleton.get();
-
 	gJobPool.reset();
 
-	if (eptr->mode != ConnectionMode::FREE && eptr->mode != ConnectionMode::CONNECTING) {
-		tcpclose(eptr->sock);
-		eptr->inputPacket.reset();
-	}
+	// For each connection (currently only one), release its resources.
+	MasterConn *eptr = gMasterConnSingleton.get();
+
+	eptr->releaseResources();
 
 	gMasterConnSingleton.reset();
 }
 
-void masterconn_connected(MasterConn *eptr) {
-	tcpnodelay(eptr->sock);
-	eptr->mode = ConnectionMode::CONNECTED;
-	eptr->inputPacket.reset();
-
-	masterconn_sendregister(eptr);
-	eptr->lastRead.reset();
-	eptr->lastWrite.reset();
-}
-
-int masterconn_initconnect(MasterConn *eptr) {
-	int status;
-
-	if (!eptr->isMasterAddressValid) {
-		uint32_t mip;
-		uint32_t bip;
-		uint16_t mport;
-
-		if (tcpresolve(gBindHostStr.c_str(), nullptr, &bip, nullptr, 1) < 0) { bip = 0; }
-
-		gBindHost.ip = bip;
-
-		if (tcpresolve(gMasterHost.c_str(), gMasterPort.c_str(), &mip, &mport, 0) >= 0) {
-			if (isLoopbackAddress(mip)) {
-				safs::log_warn(
-				    "Chunkserver loopback IP addresses are experimental; consider assigning an IP address to chunkserver (via /etc/hosts or some other way)");
-			}
-			eptr->address.ip = mip;
-			eptr->address.port = mport;
-			eptr->isMasterAddressValid = true;
-		} else {
-			safs::log_warn("master connection module: can't resolve master host/port ({}:{})",
-			               gMasterHost, gMasterPort);
-			return -1;
-		}
-	}
-
-	eptr->sock = tcpsocket();
-
-	if (eptr->sock<0) {
-		safs_pretty_errlog(LOG_WARNING,"master connection module: create socket error");
-		return -1;
-	}
-
-	if (tcpnonblock(eptr->sock)<0) {
-		safs_pretty_errlog(LOG_WARNING,"master connection module: set nonblock error");
-		tcpclose(eptr->sock);
-		eptr->sock = -1;
-		return -1;
-	}
-
-	if (gBindHost.ip > 0) {
-		if (tcpnumbind(eptr->sock, gBindHost.ip, 0) < 0) {
-			safs_pretty_errlog(LOG_WARNING,
-			                   "master connection module: can't bind socket to given ip");
-			tcpclose(eptr->sock);
-			eptr->sock = -1;
-			return -1;
-		}
-	}
-
-	status = tcpnumconnect(eptr->sock, eptr->address.ip, eptr->address.port);
-
-	if (status<0) {
-		safs_pretty_errlog(LOG_WARNING,"master connection module: connect failed");
-		tcpclose(eptr->sock);
-		eptr->sock = -1;
-		eptr->isMasterAddressValid = false;
-		return -1;
-	}
-
-	if (status==0) {
-		safs_pretty_syslog(LOG_NOTICE,"connected to Master immediately");
-		masterconn_connected(eptr);
-	} else {
-		eptr->mode = ConnectionMode::CONNECTING;
-		safs_pretty_syslog_attempt(LOG_NOTICE,"connecting to Master");
-	}
-
-	return 0;
-}
-
-void masterconn_connecttest(MasterConn *eptr) {
-	int status;
-
-	status = tcpgetstatus(eptr->sock);
-	if (status) {
-		safs_silent_errlog(LOG_WARNING,"connection failed, error");
-		tcpclose(eptr->sock);
-		eptr->sock = -1;
-		eptr->mode = ConnectionMode::FREE;
-		eptr->isMasterAddressValid = 0;
-	} else {
-		safs_pretty_syslog(LOG_NOTICE,"connected to Master");
-		masterconn_connected(eptr);
-	}
-}
-
-void masterconn_read(MasterConn *eptr) {
-	ActiveLoopWatchdog watchdog(std::chrono::milliseconds(20));
-
-	watchdog.start();
-	while (eptr->mode != ConnectionMode::KILL) {
-		// If the job pool is too busy, do not read more data.
-		if (gJobPool->getJobCount() >= (kMaxBackgroundJobsCount * 9) / 10) { return; }
-
-		uint32_t bytesToRead = eptr->inputPacket.bytesToBeRead();
-		ssize_t ret = ::read(eptr->sock, eptr->inputPacket.pointerToBeReadInto(), bytesToRead);
-
-		if (ret == 0) {
-			safs_silent_syslog(LOG_NOTICE, "connection reset by Master");
-			eptr->mode = ConnectionMode::KILL;
-			return;
-		}
-
-		if (ret < 0) {
-			if (errno != EAGAIN) {
-				safs_silent_errlog(LOG_NOTICE, "read from Master error");
-				eptr->mode = ConnectionMode::KILL;
-			}
-			return;
-		}
-
-		stats_bytesin += ret;
-
-		try {
-			eptr->inputPacket.increaseBytesRead(ret);
-		} catch (InputPacketTooLongException &ex) {
-			safs_silent_syslog(LOG_WARNING, "reading from master: %s", ex.what());
-			eptr->mode = ConnectionMode::KILL;
-			return;
-		}
-
-		if (ret == bytesToRead && !eptr->inputPacket.hasData()) {
-			continue;  // there might be more data to read in socket's buffer
-		}
-
-		if (!eptr->inputPacket.hasData()) { return; }
-
-		// We have a complete packet in the input buffer, let's process it.
-		masterconn_gotpacket(eptr, eptr->inputPacket.getHeader(), eptr->inputPacket.getData());
-
-		eptr->inputPacket.reset();
-
-		if (watchdog.expired()) { break; }
-	}
-}
-
-void masterconn_write(MasterConn *eptr) {
-	ActiveLoopWatchdog watchdog(std::chrono::milliseconds(20));
-	int32_t bytesWritten{-1};
-
-	watchdog.start();
-	while (!eptr->outputPackets.empty()) {
-		OutputPacket &pack = eptr->outputPackets.front();
-		bytesWritten = ::write(eptr->sock, pack.packet.data() + pack.bytesSent,
-		                       pack.packet.size() - pack.bytesSent);
-
-		if (bytesWritten < 0) {
-			if (errno != EAGAIN) {
-				safs_silent_errlog(LOG_NOTICE, "write to Master error");
-				eptr->mode = ConnectionMode::KILL;
-			}
-			return;
-		}
-
-		stats_bytesout += bytesWritten;
-		pack.bytesSent += bytesWritten;
-
-		if (pack.packet.size() != pack.bytesSent) { return; }
-
-		eptr->outputPackets.pop_front();
-
-		if (watchdog.expired()) { break; }
-	}
-}
-
 void masterconn_desc(std::vector<pollfd> &pdesc) {
 	LOG_AVG_TILL_END_OF_SCOPE0("master_desc");
+
+	// For each connection to master (currently only one), add its socket to the pollfd array.
 	MasterConn *eptr = gMasterConnSingleton.get();
 
-	eptr->pDescPos = -1;
+	eptr->providePollDescriptors(pdesc);
+
+	// Add the descriptor for listening for background jobs finishing.
 	gJobFDpDescPos = -1;
 
-	if (eptr->mode == ConnectionMode::FREE || eptr->sock < 0) { return; }
-
-	if (eptr->mode == ConnectionMode::CONNECTED) {
+	if (eptr->mode() == ConnectionMode::CONNECTED) {
 		pdesc.emplace_back(gJobFD, POLLIN, 0);
 		gJobFDpDescPos = static_cast<int32_t>(pdesc.size() - 1);
-
-		if (gJobPool->getJobCount() < (kMaxBackgroundJobsCount * 9) / 10) {
-			pdesc.emplace_back(eptr->sock, POLLIN, 0);
-			eptr->pDescPos = static_cast<int32_t>(pdesc.size() - 1);
-		}
-	}
-
-	if (((eptr->mode == ConnectionMode::CONNECTED) && !eptr->outputPackets.empty()) ||
-	    eptr->mode == ConnectionMode::CONNECTING) {
-		if (eptr->pDescPos >= 0) {
-			pdesc[eptr->pDescPos].events |= POLLOUT;
-		} else {
-			pdesc.emplace_back(eptr->sock, POLLOUT, 0);
-			eptr->pDescPos = static_cast<int32_t>(pdesc.size() - 1);
-		}
 	}
 }
 
@@ -700,9 +761,8 @@ void masterconn_send_status() {
 
 	if (gEnableLoadFactor) {
 		uint8_t load_factor = hddGetLoadFactor();
-		if (eptr->mode == ConnectionMode::CONNECTED && load_factor != prev_factor) {
-			masterconn_create_attached_packet(eptr,
-				cstoma::status::build(load_factor));
+		if (eptr->mode() == ConnectionMode::CONNECTED && load_factor != prev_factor) {
+			eptr->createAttachedPacket(cstoma::status::build(load_factor));
 			prev_factor = load_factor;
 		}
 	}
@@ -710,76 +770,37 @@ void masterconn_send_status() {
 
 void masterconn_serve(const std::vector<pollfd> &pdesc) {
 	LOG_AVG_TILL_END_OF_SCOPE0("master_serve");
+	
 	MasterConn *eptr = gMasterConnSingleton.get();
-
-	// Check if the socket has been closed or has an error.
-	if (eptr->pDescPos >= 0 && (pdesc[eptr->pDescPos].revents & (POLLHUP | POLLERR))) {
-		if (eptr->mode == ConnectionMode::CONNECTING) {
-			masterconn_connecttest(eptr);
-		} else {
-			eptr->mode = ConnectionMode::KILL;
-		}
+	
+	// Check if there are any background jobs to process.
+	if ((eptr->mode() == ConnectionMode::CONNECTED) && gJobFDpDescPos >= 0 &&
+	    (pdesc[gJobFDpDescPos].revents & POLLIN)) {
+		gJobPool->processCompletedJobs();
 	}
 
-	if (eptr->mode == ConnectionMode::CONNECTING) {
-		// Check if the connection has been established.
-		if (eptr->sock >= 0 && eptr->pDescPos >= 0 && (pdesc[eptr->pDescPos].revents & POLLOUT)) {
-			masterconn_connecttest(eptr);
-		}
-	} else {
-		// Check if there are any background jobs to process.
-		if ((eptr->mode == ConnectionMode::CONNECTED) && gJobFDpDescPos >= 0 &&
-		    (pdesc[gJobFDpDescPos].revents & POLLIN)) {
-			gJobPool->processCompletedJobs();
-		}
+	// For each connection to master (currently only one), process its socket.
+	eptr->servePoll(pdesc);
 
-		if (eptr->pDescPos >= 0) {
-			// Check if there is data to read from this connection
-			if ((eptr->mode == ConnectionMode::CONNECTED) &&
-			    (pdesc[eptr->pDescPos].revents & POLLIN)) {
-				eptr->lastRead.reset();
-				masterconn_read(eptr);
-			}
-
-			// Check if there is data to write to this connection
-			if ((eptr->mode == ConnectionMode::CONNECTED) &&
-			    (pdesc[eptr->pDescPos].revents & POLLOUT)) {
-				eptr->lastWrite.reset();
-				masterconn_write(eptr);
-			}
-
-			// Check if the connection has not been used for a while and should be closed
-			if ((eptr->mode == ConnectionMode::CONNECTED) &&
-			    eptr->lastRead.elapsed_ms() > gTimeout_ms) {
-				eptr->mode = ConnectionMode::KILL;
-			}
-
-			// Keep the connection alive by sending a NOP packet
-			if ((eptr->mode == ConnectionMode::CONNECTED) &&
-			    eptr->lastWrite.elapsed_ms() > (gTimeout_ms / 3) && eptr->outputPackets.empty()) {
-				masterconn_create_attached_no_version_packet(eptr, ANTOAN_NOP, 0);
-			}
-		}
-	}
-
-	if (eptr->mode == ConnectionMode::CONNECTED) {
+	// Update general statistics
+	if (eptr->mode() == ConnectionMode::CONNECTED) {
 		uint32_t jobscnt = gJobPool->getJobCount();
 		stats_maxjobscnt = std::max(jobscnt, stats_maxjobscnt);
 	}
 
-	if (eptr->mode == ConnectionMode::KILL) {
+	// If the connection is in KILL mode, disable the job pool and close the socket.
+	if (eptr->mode() == ConnectionMode::KILL) {
 		gJobPool->disableAndChangeCallbackAll(masterconn_unwantedjobfinished);
-		tcpclose(eptr->sock);
-		eptr->inputPacket.reset();
-		eptr->outputPackets.clear();
-		eptr->mode = ConnectionMode::FREE;
+		tcpclose(eptr->socketFD());
+		eptr->resetPackets();
+		eptr->setMode(ConnectionMode::FREE);
 	}
 }
 
 void masterconn_reconnect(void) {
 	MasterConn *eptr = gMasterConnSingleton.get();
-	if (eptr->mode == ConnectionMode::FREE) {
-		masterconn_initconnect(eptr);
+	if (eptr->mode() == ConnectionMode::FREE) {
+		eptr->initConnect();
 	}
 }
 
@@ -807,7 +828,7 @@ void masterconn_reload(void) {
 
 	gEnableLoadFactor = static_cast<bool>(cfg_getuint32("ENABLE_LOAD_FACTOR", 0));
 
-	if (eptr->isMasterAddressValid && eptr->mode != ConnectionMode::FREE) {
+	if (eptr->isMasterAddressValid() && eptr->mode() != ConnectionMode::FREE) {
 		uint32_t mip{};
 		uint32_t bip{};
 		uint16_t mport{};
@@ -816,7 +837,7 @@ void masterconn_reload(void) {
 
 		if (gBindHost.ip != bip) {
 			gBindHost.ip = bip;
-			eptr->mode = ConnectionMode::KILL;
+			eptr->setMode(ConnectionMode::KILL);
 		}
 
 		if (tcpresolve(gMasterHost.c_str(), gMasterPort.c_str(), &mip, &mport, 0) >= 0) {
@@ -825,35 +846,32 @@ void masterconn_reload(void) {
 				    "Chunkserver loopback IP addresses are experimental; consider a non-loopback IP address to chunkserver (via /etc/hosts or some other way)");
 			}
 
-			if (eptr->address.ip != mip || eptr->address.port != mport) {
-				eptr->address.ip = mip;
-				eptr->address.port = mport;
-				eptr->mode = ConnectionMode::KILL;
+			if (eptr->address().ip != mip || eptr->address().port != mport) {
+				eptr->setAddress(mip, mport);
+				eptr->setMode(ConnectionMode::KILL);
 			}
 		} else {
 			safs::log_warn("master connection module: can't resolve master host/port ({}:{})",
 			               gMasterHost, gMasterPort);
 		}
 	} else {
-		eptr->isMasterAddressValid = false;
+		eptr->setMasterAddressValid(false);
 	}
 
 	gTimeout_ms = get_cfg_timeout();
 
 	uint32_t reconnectionDelay = cfg_getuint32("MASTER_RECONNECTION_DELAY", 5);
 
-	if (masterconn_load_label()) { masterconn_sendregisterlabel(eptr); }
+	if (masterconn_load_label()) { eptr->sendRegisterLabel(); }
 
-	masterconn_send_metalogger_config(eptr);
+	eptr->sendConfig();
 
-	eventloop_timechange(reconnect_hook, TIMEMODE_RUN_LATE, reconnectionDelay, 0);
+	eventloop_timechange(gReconnectHook, TIMEMODE_RUN_LATE, reconnectionDelay, 0);
 }
 
 int masterconn_init(void) {
-	uint32_t ReconnectionDelay;
-	MasterConn *eptr;
-
-	ReconnectionDelay = cfg_getuint32("MASTER_RECONNECTION_DELAY", 5);
+	// Read the configuration
+	uint32_t reconnectionDelay = cfg_getuint32("MASTER_RECONNECTION_DELAY", 5);
 	gMasterHost = cfg_getstring("MASTER_HOST", "sfsmaster");
 	gMasterPort = cfg_getstring("MASTER_PORT", "9420");
 	gBindHostStr = cfg_getstring("BIND_HOST", "*");
@@ -865,22 +883,21 @@ int masterconn_init(void) {
 
 	if (!masterconn_load_label()) { return -1; }
 
+	// Create the connections (only one at this point)
 	gMasterConnSingleton = std::make_unique<MasterConn>();
-	eptr = gMasterConnSingleton.get();
+	MasterConn *eptr = gMasterConnSingleton.get();
 	passert(eptr);
 
-	eptr->isMasterAddressValid = false;
-	eptr->mode = ConnectionMode::FREE;
-	eptr->pDescPos = -1;
+	// Init the connections
+	if (eptr->initConnect() < 0) { return -1; }
 
-	if (masterconn_initconnect(eptr) < 0) { return -1; }
-
+	// Register the callbacks in the event loop
 	eventloop_eachloopregister(masterconn_check_hdd_reports);
 	eventloop_timeregister(TIMEMODE_RUN_LATE, kSendStatusDelay,
 	                       rnd_ranged<uint32_t>(kSendStatusDelay), masterconn_send_status);
-	reconnect_hook =
-	    eventloop_timeregister(TIMEMODE_RUN_LATE, ReconnectionDelay,
-	                           rnd_ranged<uint32_t>(ReconnectionDelay), masterconn_reconnect);
+	gReconnectHook =
+	    eventloop_timeregister(TIMEMODE_RUN_LATE, reconnectionDelay,
+	                           rnd_ranged<uint32_t>(reconnectionDelay), masterconn_reconnect);
 	eventloop_destructregister(masterconn_term);
 	eventloop_pollregister(masterconn_desc, masterconn_serve);
 	eventloop_reloadregister(masterconn_reload);

--- a/src/chunkserver/masterconn.cc
+++ b/src/chunkserver/masterconn.cc
@@ -62,13 +62,9 @@
 static constexpr uint32_t kMaxPacketSize = 10000;
 static constexpr uint32_t kMaxBackgroundJobsCount = 1000;
 
-// from config
-static std::string gMasterHost;
-static std::string gMasterPort;
+// Common variables from config
 static std::string gBindHostStr;
-static NetworkAddress gBindHost;
 static bool gEnableLoadFactor;
-
 static std::string gLabel;
 static uint32_t gTimeout_ms;
 
@@ -89,7 +85,9 @@ enum class ConnectionMode : std::uint8_t {
 /// Currently, only one active MDS (known as Master) is supported.
 class MasterConn {
 public:
-	explicit MasterConn(const std::shared_ptr<JobPool> &jobPool) : jobPool_(jobPool) {}
+	explicit MasterConn(const std::string &masterHostStr, const std::string &masterPortStr,
+	                    const std::shared_ptr<JobPool> &jobPool)
+	    : masterHostStr_(masterHostStr), masterPortStr_(masterPortStr), jobPool_(jobPool) {}
 
 	// Disable unneeded copying and moving of the connection objects.
 	MasterConn(const MasterConn &) = delete;
@@ -123,6 +121,38 @@ public:
 		std::vector<uint8_t> buffer;
 		serializeLegacyPacket(buffer, type, data...);
 		createAttachedPacket(std::move(buffer));
+	}
+
+	// Configuration
+
+	void reloadConfig() {
+		auto newMasterHostStr_ = cfg_getstring("MASTER_HOST", "sfsmaster");
+		auto newMasterPortStr_ = cfg_getstring("MASTER_PORT", "9420");
+
+		if (newMasterHostStr_ == masterHostStr_ && newMasterPortStr_ == masterPortStr_) {
+			return;  // no change
+		}
+
+		masterHostStr_ = newMasterHostStr_;
+		masterPortStr_ = newMasterPortStr_;
+
+		uint32_t mip{};
+		uint16_t mport{};
+
+		if (tcpresolve(masterHostStr_.c_str(), masterPortStr_.c_str(), &mip, &mport, 0) >= 0) {
+			if (isLoopbackAddress(mip)) {
+				safs::log_warn(
+				    "Chunkserver loopback IP addresses are experimental; consider a non-loopback IP address to chunkserver (via /etc/hosts or some other way)");
+			}
+
+			if (address().ip != mip || address().port != mport) {
+				setMasterAddress(mip, mport);
+				setMode(ConnectionMode::KILL);
+			}
+		} else {
+			safs::log_warn("master connection module: can't resolve master host/port ({}:{})",
+			               masterHostStr_, masterPortStr_);
+		}
 	}
 
 	// Connection management
@@ -166,15 +196,15 @@ public:
 
 	int initConnect() {
 		if (!isMasterAddressValid_) {
-			uint32_t mip;
-			uint32_t bip;
-			uint16_t mport;
+			uint32_t mip{};
+			uint32_t bip{};
+			uint16_t mport{};
 
 			if (tcpresolve(gBindHostStr.c_str(), nullptr, &bip, nullptr, 1) < 0) { bip = 0; }
 
-			gBindHost.ip = bip;
+			bindHostAddress_.ip = bip;
 
-			if (tcpresolve(gMasterHost.c_str(), gMasterPort.c_str(), &mip, &mport, 0) >= 0) {
+			if (tcpresolve(masterHostStr_.c_str(), masterPortStr_.c_str(), &mip, &mport, 0) >= 0) {
 				if (isLoopbackAddress(mip)) {
 					safs::log_warn(
 					    "Chunkserver loopback IP addresses are experimental; consider assigning an IP address to chunkserver (via /etc/hosts or some other way)");
@@ -184,7 +214,7 @@ public:
 				isMasterAddressValid_ = true;
 			} else {
 				safs::log_warn("master connection module: can't resolve master host/port ({}:{})",
-				               gMasterHost, gMasterPort);
+				               masterHostStr_, masterPortStr_);
 				return -1;
 			}
 		}
@@ -203,8 +233,8 @@ public:
 			return -1;
 		}
 
-		if (gBindHost.ip > 0) {
-			if (tcpnumbind(socketFD_, gBindHost.ip, 0) < 0) {
+		if (bindHostAddress_.ip > 0) {
+			if (tcpnumbind(socketFD_, bindHostAddress_.ip, 0) < 0) {
 				safs_pretty_errlog(LOG_WARNING,
 				                   "master connection module: can't bind socket to given ip");
 				tcpclose(socketFD_);
@@ -636,9 +666,16 @@ public:
 
 	const NetworkAddress &address() const { return address_; }
 
-	void setAddress(uint32_t ip_, uint16_t port_) {
+	void setMasterAddress(uint32_t ip_, uint16_t port_) {
 		address_.ip = ip_;
 		address_.port = port_;
+	}
+
+	const NetworkAddress &bindHostAddress() const { return bindHostAddress_; }
+
+	void setBindHostAddress(uint32_t ip_, uint16_t port_) {
+		bindHostAddress_.ip = ip_;
+		bindHostAddress_.port = port_;
 	}
 
 	int socketFD() const { return socketFD_; }
@@ -648,7 +685,10 @@ public:
 	void setMasterAddressValid(bool valid) { isMasterAddressValid_ = valid; }
 
 private:
-	std::shared_ptr<JobPool> jobPool_;           ///< Shared reference to the JobPool
+	std::string masterHostStr_;                  ///< Hostname of the master server.
+	std::string masterPortStr_;                  ///< Port of the master server.
+	std::shared_ptr<JobPool> jobPool_;           ///< Shared reference to the JobPool.
+
 	ConnectionMode mode_{ConnectionMode::FREE};  ///< Current mode of the connection to this master.
 	int socketFD_{-1};                           ///< Socket file descriptor for this connection.
 	int32_t pDescPos_{-1};                       ///< Position in the pollfd array.
@@ -656,9 +696,16 @@ private:
 	Timer lastWrite_;                            ///< Time since the last write operation.
 	InputPacket inputPacket_{kMaxPacketSize};    ///< Input buffer for reading data from the socket.
 	std::list<OutputPacket> outputPackets_;      ///< Output packets to be sent to the master.
-	NetworkAddress address_;                     ///< Address of this master server (IP and port).
-	bool isMasterAddressValid_{false};           ///< Tells if the master address is valid.
+
+
+	NetworkAddress address_;            ///< Address of this master server (IP and port).
+	NetworkAddress bindHostAddress_;    ///< Address to bind the socket to (IP and port).
+	bool isMasterAddressValid_{false};  ///< Tells if the master address is valid.
 };
+
+//  From config
+static std::string gMasterHost;
+static std::string gMasterPort;
 
 static const uint64_t kSendStatusDelay = 5;
 
@@ -820,52 +867,35 @@ bool masterconn_load_label() {
 }
 
 void masterconn_reload(void) {
-	MasterConn *eptr = gMasterConnSingleton.get();
-
-	gMasterHost = cfg_getstring("MASTER_HOST", "sfsmaster");
-	gMasterPort = cfg_getstring("MASTER_PORT", "9420");
+	//  Read the common configuration from file.
 	gBindHostStr = cfg_getstring("BIND_HOST", "*");
-
 	gEnableLoadFactor = static_cast<bool>(cfg_getuint32("ENABLE_LOAD_FACTOR", 0));
 
+	uint32_t bip = 0;
+
+	if (tcpresolve(gBindHostStr.c_str(), nullptr, &bip, nullptr, 1) < 0) { bip = 0; }
+
+	// For each connection, reload the configuration and reconnect if needed.
+	MasterConn *eptr = gMasterConnSingleton.get();
+
 	if (eptr->isMasterAddressValid() && eptr->mode() != ConnectionMode::FREE) {
-		uint32_t mip{};
-		uint32_t bip{};
-		uint16_t mport{};
-
-		if (tcpresolve(gBindHostStr.c_str(), nullptr, &bip, nullptr, 1) < 0) { bip = 0; }
-
-		if (gBindHost.ip != bip) {
-			gBindHost.ip = bip;
+		if (eptr->bindHostAddress().ip != bip) {
+			eptr->setBindHostAddress(bip, eptr->bindHostAddress().port);
 			eptr->setMode(ConnectionMode::KILL);
 		}
 
-		if (tcpresolve(gMasterHost.c_str(), gMasterPort.c_str(), &mip, &mport, 0) >= 0) {
-			if (isLoopbackAddress(mip)) {
-				safs::log_warn(
-				    "Chunkserver loopback IP addresses are experimental; consider a non-loopback IP address to chunkserver (via /etc/hosts or some other way)");
-			}
-
-			if (eptr->address().ip != mip || eptr->address().port != mport) {
-				eptr->setAddress(mip, mport);
-				eptr->setMode(ConnectionMode::KILL);
-			}
-		} else {
-			safs::log_warn("master connection module: can't resolve master host/port ({}:{})",
-			               gMasterHost, gMasterPort);
-		}
+		eptr->reloadConfig();
 	} else {
 		eptr->setMasterAddressValid(false);
 	}
 
 	gTimeout_ms = get_cfg_timeout();
 
-	uint32_t reconnectionDelay = cfg_getuint32("MASTER_RECONNECTION_DELAY", 5);
-
 	if (masterconn_load_label()) { eptr->sendRegisterLabel(); }
 
 	eptr->sendConfig();
 
+	uint32_t reconnectionDelay = cfg_getuint32("MASTER_RECONNECTION_DELAY", 5);
 	eventloop_timechange(gReconnectHook, TIMEMODE_RUN_LATE, reconnectionDelay, 0);
 }
 
@@ -917,7 +947,7 @@ int masterconn_init_threads(void) {
 	safs::log_info("master connection: {} background workers created", gNumberOfWorkers);
 
 	// Create the connections (only one at this point)
-	gMasterConnSingleton = std::make_unique<MasterConn>(gJobPool);
+	gMasterConnSingleton = std::make_unique<MasterConn>(gMasterHost, gMasterPort, gJobPool);
 	MasterConn *eptr = gMasterConnSingleton.get();
 	passert(eptr);
 

--- a/src/chunkserver/masterconn.cc
+++ b/src/chunkserver/masterconn.cc
@@ -72,9 +72,6 @@ static bool gEnableLoadFactor;
 static std::string gLabel;
 static uint32_t gTimeout_ms;
 
-// JobPool shared between all connections to MDSs
-static std::unique_ptr<JobPool> gJobPool;
-
 // Stats
 static uint64_t stats_bytesout = 0;
 static uint64_t stats_bytesin = 0;
@@ -87,13 +84,12 @@ enum class ConnectionMode : std::uint8_t {
 	KILL         /// Connection has been dropped, a reconnection will be attempted.
 };
 
-
 /// @brief Class representing a connection to a Metadata Server (MDS).
 ///
 /// Currently, only one active MDS (known as Master) is supported.
 class MasterConn {
 public:
-	MasterConn() : inputPacket_(kMaxPacketSize) {}
+	explicit MasterConn(const std::shared_ptr<JobPool> &jobPool) : jobPool_(jobPool) {}
 
 	// Disable unneeded copying and moving of the connection objects.
 	MasterConn(const MasterConn &) = delete;
@@ -271,7 +267,7 @@ public:
 		if (mode_ == ConnectionMode::FREE || socketFD_ < 0) { return; }
 
 		if (mode_ == ConnectionMode::CONNECTED) {
-			if (gJobPool->getJobCount() < (kMaxBackgroundJobsCount * 9) / 10) {
+			if (jobPool_->getJobCount() < (kMaxBackgroundJobsCount * 9) / 10) {
 				pdesc.emplace_back(socketFD_, POLLIN, 0);
 				pDescPos_ = static_cast<int32_t>(pdesc.size() - 1);
 			}
@@ -338,7 +334,7 @@ public:
 
 		while (mode_ != ConnectionMode::KILL) {
 			// If the job pool is too busy, do not read more data.
-			if (gJobPool->getJobCount() >= (kMaxBackgroundJobsCount * 9) / 10) { return; }
+			if (jobPool_->getJobCount() >= (kMaxBackgroundJobsCount * 9) / 10) { return; }
 
 			uint32_t bytesToRead = inputPacket_.bytesToBeRead();
 			ssize_t ret = ::read(socketFD_, inputPacket_.pointerToBeReadInto(), bytesToRead);
@@ -463,9 +459,9 @@ public:
 		matocs::createChunk::deserialize(data, chunkId, chunkType, chunkVersion);
 		auto *outputPacket = new OutputPacket;
 		cstoma::createChunk::serialize(outputPacket->packet, chunkId, chunkType, SAUNAFS_STATUS_OK);
-		if (gJobPool) {
+		if (jobPool_) {
 			job_create(
-			    *gJobPool, [this](uint8_t status, void *packet) { sauJobFinished(status, packet); },
+			    *jobPool_, [this](uint8_t status, void *packet) { sauJobFinished(status, packet); },
 			    outputPacket, chunkId, chunkVersion, chunkType);
 		} else {
 			safs::log_err("masterconn_create: jobPool is null.");
@@ -481,9 +477,9 @@ public:
 		matocs::deleteChunk::deserialize(data, chunkId, chunkType, chunkVersion);
 		auto *outputPacket = new OutputPacket;
 		cstoma::deleteChunk::serialize(outputPacket->packet, chunkId, chunkType, 0);
-		if (gJobPool) {
+		if (jobPool_) {
 			job_delete(
-			    *gJobPool, [this](uint8_t status, void *packet) { sauJobFinished(status, packet); },
+			    *jobPool_, [this](uint8_t status, void *packet) { sauJobFinished(status, packet); },
 			    outputPacket, chunkId, chunkVersion, chunkType);
 		} else {
 			safs::log_err("masterconn_delete: jobPool is null.");
@@ -500,9 +496,9 @@ public:
 		matocs::setVersion::deserialize(data, chunkId, chunkType, chunkVersion, newVersion);
 		auto *outputPacket = new OutputPacket;
 		cstoma::setVersion::serialize(outputPacket->packet, chunkId, chunkType, 0);
-		if (gJobPool) {
+		if (jobPool_) {
 			job_version(
-			    *gJobPool, [this](uint8_t status, void *packet) { sauJobFinished(status, packet); },
+			    *jobPool_, [this](uint8_t status, void *packet) { sauJobFinished(status, packet); },
 			    outputPacket, chunkId, chunkVersion, chunkType, newVersion);
 		} else {
 			safs::log_err("masterconn_setversion: jobPool is null.");
@@ -519,9 +515,9 @@ public:
 		                                    oldChunkId, oldChunkVersion);
 		auto *outputPacket = new OutputPacket;
 		cstoma::duplicateChunk::serialize(outputPacket->packet, newChunkId, chunkType, 0);
-		if (gJobPool) {
+		if (jobPool_) {
 			job_duplicate(
-			    *gJobPool, [this](uint8_t status, void *packet) { sauJobFinished(status, packet); },
+			    *jobPool_, [this](uint8_t status, void *packet) { sauJobFinished(status, packet); },
 			    outputPacket, oldChunkId, oldChunkVersion, oldChunkVersion, chunkType, newChunkId,
 			    newChunkVersion);
 		} else {
@@ -541,9 +537,9 @@ public:
 		                                   version);
 		auto *outputPacket = new OutputPacket;
 		cstoma::truncate::serialize(outputPacket->packet, chunkId, chunkType, 0);
-		if (gJobPool) {
+		if (jobPool_) {
 			job_truncate(
-			    *gJobPool, [this](uint8_t status, void *packet) { sauJobFinished(status, packet); },
+			    *jobPool_, [this](uint8_t status, void *packet) { sauJobFinished(status, packet); },
 			    outputPacket, chunkId, chunkType, version, newVersion, chunkLength);
 		} else {
 			safs::log_err("masterconn_truncate: jobPool is null.");
@@ -561,9 +557,9 @@ public:
 		                                   chunkVersion, newLength);
 		auto *outputPacket = new OutputPacket;
 		cstoma::duptruncChunk::serialize(outputPacket->packet, copyChunkId, chunkType, 0);
-		if (gJobPool) {
+		if (jobPool_) {
 			job_duptrunc(
-			    *gJobPool, [this](uint8_t status, void *packet) { sauJobFinished(status, packet); },
+			    *jobPool_, [this](uint8_t status, void *packet) { sauJobFinished(status, packet); },
 			    outputPacket, chunkId, chunkVersion, chunkVersion, chunkType, copyChunkId,
 			    copyChunkVersion, newLength);
 		} else {
@@ -592,9 +588,9 @@ public:
 			// Disk scan in progress - replication is not possible
 			sauJobFinished(SAUNAFS_ERROR_WAITING, outputPacket);
 		} else {
-			if (gJobPool) {
+			if (jobPool_) {
 				job_replicate(
-				    *gJobPool,
+				    *jobPool_,
 				    [this](uint8_t status, void *packet) { sauJobFinished(status, packet); },
 				    outputPacket, chunkId, chunkVersion, chunkType, sourcesBufferSize,
 				    sourcesBuffer);
@@ -652,12 +648,13 @@ public:
 	void setMasterAddressValid(bool valid) { isMasterAddressValid_ = valid; }
 
 private:
+	std::shared_ptr<JobPool> jobPool_;           ///< Shared reference to the JobPool
 	ConnectionMode mode_{ConnectionMode::FREE};  ///< Current mode of the connection to this master.
 	int socketFD_{-1};                           ///< Socket file descriptor for this connection.
 	int32_t pDescPos_{-1};                       ///< Position in the pollfd array.
 	Timer lastRead_;                             ///< Time since the last read operation.
 	Timer lastWrite_;                            ///< Time since the last write operation.
-	InputPacket inputPacket_;                    ///< Input buffer for reading data from the socket.
+	InputPacket inputPacket_{kMaxPacketSize};    ///< Input buffer for reading data from the socket.
 	std::list<OutputPacket> outputPackets_;      ///< Output packets to be sent to the master.
 	NetworkAddress address_;                     ///< Address of this master server (IP and port).
 	bool isMasterAddressValid_{false};           ///< Tells if the master address is valid.
@@ -665,6 +662,10 @@ private:
 
 static const uint64_t kSendStatusDelay = 5;
 
+//  JobPool shared between all connections to MDSs
+static std::shared_ptr<JobPool> gJobPool;
+
+//  Singleton for the MasterConn instance (will become a list of connections in the future)
 static std::unique_ptr<MasterConn> gMasterConnSingleton = nullptr;
 
 static int gJobFD{-1};  ///< File descriptor for the job pool notifications
@@ -728,14 +729,13 @@ void masterconn_unwantedjobfinished(uint8_t status, void *packet) {
 }
 
 void masterconn_term(void) {
-	gJobPool.reset();
-
-	// For each connection (currently only one), release its resources.
+	//  For each connection (currently only one), release its resources.
 	MasterConn *eptr = gMasterConnSingleton.get();
-
 	eptr->releaseResources();
-
 	gMasterConnSingleton.reset();
+
+	//  Now reset the last reference to the job pool.
+	gJobPool.reset();
 }
 
 void masterconn_desc(std::vector<pollfd> &pdesc) {
@@ -883,14 +883,6 @@ int masterconn_init(void) {
 
 	if (!masterconn_load_label()) { return -1; }
 
-	// Create the connections (only one at this point)
-	gMasterConnSingleton = std::make_unique<MasterConn>();
-	MasterConn *eptr = gMasterConnSingleton.get();
-	passert(eptr);
-
-	// Init the connections
-	if (eptr->initConnect() < 0) { return -1; }
-
 	// Register the callbacks in the event loop
 	eventloop_eachloopregister(masterconn_check_hdd_reports);
 	eventloop_timeregister(TIMEMODE_RUN_LATE, kSendStatusDelay,
@@ -908,7 +900,7 @@ int masterconn_init(void) {
 int masterconn_init_threads(void) {
 	try {
 		gJobPool =
-		    std::make_unique<JobPool>("ma", gNumberOfWorkers, kMaxBackgroundJobsCount, &gJobFD);
+		    std::make_shared<JobPool>("ma", gNumberOfWorkers, kMaxBackgroundJobsCount, &gJobFD);
 	} catch (const std::runtime_error &e) {
 		safs::log_err("masterconn_init_threads: Failed to create JobPool instance: {}", e.what());
 		return -1;
@@ -923,6 +915,14 @@ int masterconn_init_threads(void) {
 	}
 
 	safs::log_info("master connection: {} background workers created", gNumberOfWorkers);
+
+	// Create the connections (only one at this point)
+	gMasterConnSingleton = std::make_unique<MasterConn>(gJobPool);
+	MasterConn *eptr = gMasterConnSingleton.get();
+	passert(eptr);
+
+	// Init the connections
+	if (eptr->initConnect() < 0) { return -1; }
 
 	return 0;
 }


### PR DESCRIPTION
This change prepares the masterconn module of the chunkserver to support multiple MDS connections in the future. The main changes are:

- MasterConn is now a class with more responsibilities, which fosters later support for multiple connections.
- Simpler callbacks handling from the global masterconn functions.
- Simplified polling.
- Small documentation (will continue).

Next commits will move the MasterConn class to own files, to keep simple the management of multiple connections in masterconn.h and masterconn.cc.