### PR TITLE
fix(mount): Make readdir safe on session close

### DIFF
--- a/src/mount/sauna_client.cc
+++ b/src/mount/sauna_client.cc
@@ -1942,12 +1942,25 @@ std::vector<DirEntry> readdir(Context &ctx, uint64_t fh, inode_t ino, off_t off,
 		sassert(sessionIt != gReaddirSessions.end() || gReaddirSessions.empty());
 		readdirSession = &sessionIt->second;
 	}
+
+	auto clearDirEntries = [&](const uint32_t line) {
+		if (dir_entries.size() > 0) {
+			safs::log_info(
+			    "Clearing dir_entries ({} entries) at (line {}) from a previous uncompleted readdir",
+			    dir_entries.size(), line);
+			dir_entries.clear();
+		}
+	};
+
 	do {
 		updateNextReaddirEntryIndexIfMasterRestarted(*readdirSession, entry_index, ctx, ino, request_size);
+		clearDirEntries(__LINE__);
 		status = fs_getdir(ino, ctx.uid, ctx.gid, entry_index, request_size, dir_entries);
+
 		if (status == SAUNAFS_ERROR_GROUPNOTREGISTERED) {
 			registerGroupsInMaster(ctx);
 			updateNextReaddirEntryIndexIfMasterRestarted(*readdirSession, entry_index, ctx, ino, request_size);
+			clearDirEntries(__LINE__);
 			status = fs_getdir(ino, ctx.uid, ctx.gid, entry_index, request_size, dir_entries);
 		}
 	} while (readdirSession->restarted);

--- a/tests/test_suites/ShortSystemTests/test_delete_session_during_readdir.sh
+++ b/tests/test_suites/ShortSystemTests/test_delete_session_during_readdir.sh
@@ -1,0 +1,33 @@
+timeout_set '30 seconds'
+
+MOUNTS=1
+setup_local_empty_saunafs info
+
+cd "${info[mount0]}"
+mkdir "${info[mount0]}/test_dir"
+
+maxNumberOfFiles=1000
+
+# Create 1K files
+echo "Creation of 1K files started..."
+seq 1 $maxNumberOfFiles | xargs -P "$(nproc)" -I{} touch "${info[mount0]}/test_dir/file_{}"
+echo "Creation of 1K files finished!!!"
+
+saunafs-admin list-sessions localhost "${info[matocl]}"
+
+# Read the directory in background to trigger readdir
+(
+  while true; do
+    ls "${info[mount0]}/test_dir" > /dev/null
+    sleep 0.3
+  done
+) &
+
+deletions=5
+
+# Delete sessions while readdir is running
+for i in $(seq 1 "$deletions"); do
+    echo "Deleting session: iteration $i:"
+    saunafs-admin delete-session localhost "${info[matocl]}" 1
+    sleep 0.5
+done


### PR DESCRIPTION
Previously, sfsmount could crash if a client session was closed during a readdir operation. On subsequent attempts to continue reading the directory, some entries remained in the dir_entries container, causing an assertion failure that expected it to be empty.

This commit resolves the crash by ensuring the dir_entries container is cleared if a readdir operation is interrupted and leaves partial entries behind.