### PR TITLE
feat: Add log to 4.11

### DIFF
--- a/.github/workflows/run-unit-and-ganesha-tests.yml
+++ b/.github/workflows/run-unit-and-ganesha-tests.yml
@@ -26,8 +26,9 @@ jobs:
               with:
                   create-symlink: true
 
-            - name: Setup anew (or from cache) vcpkg
-              uses: lukka/run-vcpkg@v11
+            # Reference for previous vcpkg setup: maybe we can fix it in the future
+            #- name: Setup a new (or from cache) vcpkg
+            #  uses: lukka/run-vcpkg@v11
 
             - name: Install nfs-ganesha v4.3 from Ubuntu repository
               run: |
@@ -44,7 +45,20 @@ jobs:
                   sudo mkdir /mnt/hd{b,c,d}
                   cd $GITHUB_WORKSPACE/tests
                   sudo ./setup_machine.sh setup /mnt/hdb /mnt/hdc /mnt/hdd
-                  cd $GITHUB_WORKSPACE
+
+            - name: Cache vcpkg downloads
+              uses: actions/cache@v4
+              with:
+                path: |
+                  ~/.cache/vcpkg
+                key: ${{ runner.os }}-vcpkg-${{ hashFiles('vcpkg.json') }}
+                restore-keys: |
+                  ${{ runner.os }}-vcpkg-
+
+            - name: Setup vcpkg and install dependencies
+              run: |
+                $GITHUB_WORKSPACE/utils/vcpkg_setup.sh
+                vcpkg install --triplet x64-linux
 
             - name: Build SaunaFS
               run: |
@@ -53,7 +67,7 @@ jobs:
                   mkdir -p build
                   cd build
                   nice cmake \
-                  -DCMAKE_TOOLCHAIN_FILE="${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" \
+                  -DCMAKE_TOOLCHAIN_FILE="${HOME}/vcpkg/scripts/buildsystems/vcpkg.cmake" \
                   -DENABLE_CLIENT_LIB=ON \
                   -DENABLE_DOCS=ON \
                   -DENABLE_NFS_GANESHA=ON \

--- a/src/master/restore.cc
+++ b/src/master/restore.cc
@@ -346,6 +346,12 @@ int do_length(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
 	GETU32(inode,ptr);
 	EAT(ptr,filename,lv,',');
 	GETU64(length,ptr);
+	if (*ptr == ',') {
+		safs::log_err(
+		    "5.0.0 or later changelog found in file {}:{}. Run with later version of sfsmetarestore or downgrade the changelogs, see man 7 saunafs-migrations",
+		    filename, lv);
+		return -1;
+	}
 	EAT(ptr,filename,lv,')');
 	return fs_apply_length(ts,inode,length);
 }


### PR DESCRIPTION
**NOTE: THIS PR SHOULD NOT BE MERGED. IT'S ONLY FOR REVIEW.** I will merge the commits manually and make a 4.11 release.

First commit adds a simple log to warn about the changelog breakage. Otherwise it would have error-ed out failing to parse the file with no clue why.

Second commit is simply fixing the Github actions that was already fixed in dev. Should not affect anything, but fixes Github actions.