### PR TITLE
feat(tools)!: Remove default timeout from some saunafs operations

### DIFF
--- a/src/tools/file_info.cc
+++ b/src/tools/file_info.cc
@@ -29,14 +29,12 @@
 #include "tools/tools_commands.h"
 #include "tools/tools_common_functions.h"
 
-static int kDefaultTimeout = 10 * 1000;              // default timeout (10 seconds)
 static int kInfiniteTimeout = 10 * 24 * 3600 * 1000; // simulate infinite timeout (10 days)
 
 static void file_info_usage() {
 	fprintf(stderr,
 	        "show files info (shows detailed info of each file chunk)\n\nusage:\n"
 	        " saunafs fileinfo name [name ...]\n");
-	fprintf(stderr, " -l - wait until fileinfo will finish (otherwise there is a 10s timeout) (will be default in 5.0.0)\n");
 }
 
 static std::string chunkTypeToString(ChunkPartType type) {
@@ -49,12 +47,11 @@ static std::string chunkTypeToString(ChunkPartType type) {
 	return "";
 }
 
-static int chunks_info(const char *file_name, int fd, inode_t inode, bool long_wait) {
+static int chunks_info(const char *file_name, int fd, inode_t inode) {
 	static constexpr uint32_t kRequestSize = 100;
 	std::vector<ChunkWithAddressAndLabel> chunks;
 	std::vector<uint8_t> buffer;
 	uint32_t message_id, chunk_index;
-	int timeout_ms = long_wait ? kInfiniteTimeout : kDefaultTimeout;
 
 	chunk_index = 0;
 
@@ -67,7 +64,7 @@ static int chunks_info(const char *file_name, int fd, inode_t inode, bool long_w
 		}
 
 		buffer.resize(PacketHeader::kSize);
-		if (tcptoread(fd, buffer.data(), PacketHeader::kSize, timeout_ms) != (int)PacketHeader::kSize) {
+		if (tcptoread(fd, buffer.data(), PacketHeader::kSize, kInfiniteTimeout) != (int)PacketHeader::kSize) {
 			printf("%s [%" PRIu32 "]: master query: receive error\n", file_name, chunk_index);
 			return -1;
 		}
@@ -83,7 +80,7 @@ static int chunks_info(const char *file_name, int fd, inode_t inode, bool long_w
 
 		buffer.resize(header.length);
 
-		if (tcptoread(fd, buffer.data(), header.length, timeout_ms) != (int)header.length) {
+		if (tcptoread(fd, buffer.data(), header.length, kInfiniteTimeout) != (int)header.length) {
 			printf("%s [%" PRIu32 "]: master query: receive error\n", file_name, chunk_index);
 			return -1;
 		}
@@ -149,15 +146,10 @@ static int chunks_info(const char *file_name, int fd, inode_t inode, bool long_w
 	return 0;
 }
 
-static int file_info(const char *fileName, bool long_wait) {
+static int file_info(const char *fileName) {
 	std::vector<uint8_t> buffer;
 	inode_t inode;
 	int fd;
-
-	fmt::println(
-	    stderr,
-	    "Warning: -l option will be the default behavior in 5.0.0 and the option removed. If you wish for timeouts, use the `timeout` command");
-
 
 	fd = open_master_conn(fileName, &inode, nullptr, false);
 	if (fd < 0) {
@@ -166,7 +158,7 @@ static int file_info(const char *fileName, bool long_wait) {
 	try {
 		printf("%s:\n", fileName);
 
-		if (chunks_info(fileName, fd, inode, long_wait) < 0) {
+		if (chunks_info(fileName, fd, inode) < 0) {
 			close_master_conn(1);
 			return -1;
 		}
@@ -182,15 +174,6 @@ static int file_info(const char *fileName, bool long_wait) {
 int file_info_run(int argc, char **argv) {
 	int status;
 
-	int ch;
-	bool long_wait = false;
-	while ((ch = getopt(argc, argv, "l")) != -1) {
-		switch (ch) {
-		case 'l':
-			long_wait = true;
-			break;
-		}
-	}
 	argc -= optind;
 	argv += optind;
 
@@ -201,7 +184,7 @@ int file_info_run(int argc, char **argv) {
 
 	status = 0;
 	while (argc > 0) {
-		if (file_info(*argv, long_wait) < 0) {
+		if (file_info(*argv) < 0) {
 			status = 1;
 		}
 		argc--;

--- a/src/tools/master_functions.cc
+++ b/src/tools/master_functions.cc
@@ -35,7 +35,7 @@
 
 #include "common/datapack.h"
 #include "common/serialization.h"
-#include "common/server_connection.h"	
+#include "common/server_connection.h"
 #include "common/special_inode_defs.h"
 #include "common/sockets.h"
 #include "common/stat_defs.h"
@@ -217,7 +217,7 @@ size_t find_nth_occurrence(const std::string &str, char ch, int n) {
 	return pos;
 }
 
-// Converts a WSL path (e.g., \\wsl.localhost\Ubuntu-24.04\mnt\c\path) 
+// Converts a WSL path (e.g., \\wsl.localhost\Ubuntu-24.04\mnt\c\path)
 // to a Windows path (e.g., C:\path).
 void wsl_to_windows_path(char *rpath, size_t rpath_size) {
 	std::string wsl_path(rpath);

--- a/src/tools/recursive_remove.cc
+++ b/src/tools/recursive_remove.cc
@@ -34,17 +34,14 @@
 #include "tools/tools_commands.h"
 #include "tools/tools_common_functions.h"
 
-static int kDefaultTimeout = 60 * 1000;              // default timeout (60 seconds)
 static int kInfiniteTimeout = 10 * 24 * 3600 * 1000; // simulate infinite timeout (10 days)
 
 static void recursive_remove_usage() {
 	fprintf(stderr,
-	        "recursive remove\n\nusage:\n saunafs rremove [-l] name [name ...]\n");
-	fprintf(stderr, " -l - wait until removing will finish (otherwise there is %ds timeout) (will be default in 5.0.0)\n",
-		kDefaultTimeout/1000);
+	        "recursive remove\n\nusage:\n saunafs rremove name [name ...]\n");
 }
 
-static int recursive_remove(const char *file_name, int long_wait) {
+static int recursive_remove(const char *file_name) {
 	char path_buf[PATH_MAX];
 	inode_t parent;
 	uint32_t uid, gid;
@@ -59,10 +56,6 @@ static int recursive_remove(const char *file_name, int long_wait) {
 	sigaddset(&set, SIGHUP);
 	sigaddset(&set, SIGUSR1);
 	sigprocmask(SIG_BLOCK, &set, NULL);
-
-	fmt::println(
-	    stderr,
-	    "Warning: -l option will be the default behavior in 5.0.0 and the option removed. If you wish for timeouts, use the `timeout` command");
 
 	auto find_last_delimiter_pos = [](const std::string &parent_path) {
 		std::size_t last_pos_delimiter_unix = parent_path.find_last_of("/");
@@ -115,7 +108,7 @@ static int recursive_remove(const char *file_name, int long_wait) {
 		auto response = ServerConnection::sendAndReceive(fd,
 				request, SAU_MATOCL_REQUEST_TASK_ID,
 				ServerConnection::ReceiveMode::kReceiveFirstNonNopMessage,
-				long_wait ? kInfiniteTimeout : kDefaultTimeout);
+				kInfiniteTimeout);
 		matocl::requestTaskId::deserialize(response, msgid, job_id);
 
 		std::thread signal_thread(std::bind(signalHandler, job_id));
@@ -129,7 +122,7 @@ static int recursive_remove(const char *file_name, int long_wait) {
 		request = cltoma::recursiveRemove::build(msgid, job_id, parent, fname, uid, gid);
 		response = ServerConnection::sendAndReceive(fd, request, SAU_MATOCL_RECURSIVE_REMOVE,
 					ServerConnection::ReceiveMode::kReceiveFirstNonNopMessage,
-					long_wait ? kInfiniteTimeout : kDefaultTimeout);
+					kInfiniteTimeout);
 
 		matocl::recursiveRemove::deserialize(response, msgid, status);
 
@@ -152,28 +145,18 @@ static int recursive_remove(const char *file_name, int long_wait) {
 }
 
 int recursive_remove_run(int argc, char **argv) {
-	int ch;
-	int status;
-	int long_wait = 0;
-
-	while ((ch = getopt(argc, argv, "l")) != -1) {
-		switch(ch) {
-			case 'l':
-				long_wait = 1;
-				break;
-		}
-	}
-	argc -= optind;
-	argv += optind;
+	int status = 0;
 
 	if (argc < 1) {
 		recursive_remove_usage();
 		return 1;
 	}
+	// Go past initial command
+	argc--;
+	argv++;
 
-	status = 0;
 	while (argc > 0) {
-		if (recursive_remove(*argv, long_wait) < 0) {
+		if (recursive_remove(*argv) < 0) {
 			status = 1;
 		}
 		argc--;

--- a/src/tools/set_goal.cc
+++ b/src/tools/set_goal.cc
@@ -30,7 +30,6 @@
 #include "tools/tools_commands.h"
 #include "tools/tools_common_functions.h"
 
-static int kDefaultTimeout = 30 * 1000;
 static int kInfiniteTimeout = 10 * 24 * 3600 * 1000; // simulate infinite timeout (10 days)
 
 static void set_goal_usage() {
@@ -43,7 +42,7 @@ static void set_goal_usage() {
 	fprintf(stderr, " GOAL - set goal to given goal name\n");
 }
 
-static int set_goal(const char *fname, const std::string &goal, uint8_t mode, int long_wait) {
+static int set_goal(const char *fname, const std::string &goal, uint8_t mode) {
 	inode_t inode;
 	int fd;
 	uint32_t messageId = 0;
@@ -61,7 +60,7 @@ static int set_goal(const char *fname, const std::string &goal, uint8_t mode, in
 		auto request = cltoma::fuseSetGoal::build(messageId, inode, uid, goal, mode);
 		auto response = ServerConnection::sendAndReceive(fd, request, SAU_MATOCL_FUSE_SETGOAL,
 		                    ServerConnection::ReceiveMode::kReceiveFirstNonNopMessage,
-		                    long_wait ? kInfiniteTimeout : kDefaultTimeout);
+		                    kInfiniteTimeout);
 		inode_t changed;
 		inode_t notChanged;
 		inode_t notPermitted;
@@ -99,7 +98,6 @@ static int set_goal(const char *fname, const std::string &goal, uint8_t mode, in
 static int gene_set_goal_run(int argc, char **argv, int rflag) {
 	int ch, status;
 	std::string goal;
-	int long_wait = 0;
 
 	while ((ch = getopt(argc, argv, "rnhHl")) != -1) {
 		switch (ch) {
@@ -114,9 +112,6 @@ static int gene_set_goal_run(int argc, char **argv, int rflag) {
 			break;
 		case 'r':
 			rflag = 1;
-			break;
-		case 'l':
-			long_wait = 1;
 			break;
 		}
 	}
@@ -143,7 +138,7 @@ static int gene_set_goal_run(int argc, char **argv, int rflag) {
 	}
 	status = 0;
 	while (argc > 0) {
-		if (set_goal(*argv, goal, (rflag) ? (SMODE_SET | SMODE_RMASK) : SMODE_SET, long_wait) < 0) {
+		if (set_goal(*argv, goal, (rflag) ? (SMODE_SET | SMODE_RMASK) : SMODE_SET) < 0) {
 			status = 1;
 		}
 		argc--;

--- a/src/tools/set_trashtime.cc
+++ b/src/tools/set_trashtime.cc
@@ -32,22 +32,20 @@
 #include "tools/tools_commands.h"
 #include "tools/tools_common_functions.h"
 
-static int kDefaultTimeout = 30 * 1000;
 static int kInfiniteTimeout = -1;
 
 static void set_trashtime_usage() {
 	fprintf(stderr,
 	        "set objects trashtime (how many seconds file should be left in trash)\n\nusage: "
-	        "\n saunafs settrashtime [-nhHrl] SECONDS[-|+] name [name ...]\n");
+	        "\n saunafs settrashtime [-nhHr] SECONDS[-|+] name [name ...]\n");
 	print_numberformat_options();
 	print_recursive_option();
-	fprintf(stderr, " -l - wait until settrashtime will finish (otherwise there is 30s timeout) (will be default in 5.0.0)\n");
 	fprintf(stderr, " SECONDS+ - if trashtime smaller then given value, increase trashtime to given value\n");
 	fprintf(stderr, " SECONDS- - if trashtime bigger then given value, decrease trashtime to given value\n");
 	fprintf(stderr, " SECONDS - just set trashtime to given value\n");
 }
 
-static int set_trashtime(const char *fname, uint32_t trashtime, uint8_t mode, int long_wait) {
+static int set_trashtime(const char *fname, uint32_t trashtime, uint8_t mode) {
 	uint32_t cmd, leng, uid;
 	inode_t inode, changed, notchanged, notpermitted;
 
@@ -66,10 +64,6 @@ static int set_trashtime(const char *fname, uint32_t trashtime, uint8_t mode, in
 		return -1;
 	}
 
-	fmt::println(
-	    stderr,
-	    "Warning: -l option will be the default behavior in 5.0.0 and the option removed. If you wish for timeouts, use the `timeout` command");
-
 	uid = getUId();
 	wptr = reqbuff;
 	put32bit(&wptr, CLTOMA_FUSE_SETTRASHTIME);
@@ -85,11 +79,9 @@ static int set_trashtime(const char *fname, uint32_t trashtime, uint8_t mode, in
 		close_master_conn(1);
 		return -1;
 	}
-
 	constexpr uint32_t kAnswerHeaderSize = sizeof(cmd) + sizeof(leng);
-	int effectiveTimeout = long_wait ? kInfiniteTimeout : kDefaultTimeout;
 
-	if (tcptoread(fd, reqbuff, kAnswerHeaderSize, effectiveTimeout) != kAnswerHeaderSize) {
+	if (tcptoread(fd, reqbuff, kAnswerHeaderSize, kInfiniteTimeout) != kAnswerHeaderSize) {
 		printf("%s: master query: receive error\n", fname);
 		close_master_conn(1);
 		return -1;
@@ -103,7 +95,7 @@ static int set_trashtime(const char *fname, uint32_t trashtime, uint8_t mode, in
 		return -1;
 	}
 	buff = (uint8_t *)malloc(leng);
-	if (tcptoread(fd, buff, leng, long_wait ? kInfiniteTimeout : kDefaultTimeout) != (int32_t)leng) {
+	if (tcptoread(fd, buff, leng,  kInfiniteTimeout) != (int32_t)leng) {
 		printf("%s: master query: receive error\n", fname);
 		free(buff);
 		close_master_conn(1);
@@ -150,7 +142,6 @@ static int gene_set_trashtime_run(int argc, char **argv, int rflag) {
 	int ch, status;
 	uint32_t trashtime = 86400;
 	uint8_t smode = SMODE_SET;
-	int long_wait = 0;
 
 	while ((ch = getopt(argc, argv, "rnhHl")) != -1) {
 		switch (ch) {
@@ -165,9 +156,6 @@ static int gene_set_trashtime_run(int argc, char **argv, int rflag) {
 			break;
 		case 'r':
 			rflag = 1;
-			break;
-		case 'l':
-			long_wait = 1;
 			break;
 		}
 	}
@@ -208,7 +196,7 @@ static int gene_set_trashtime_run(int argc, char **argv, int rflag) {
 	}
 	status = 0;
 	while (argc > 0) {
-		if (set_trashtime(*argv, trashtime, (rflag) ? (smode | SMODE_RMASK) : smode, long_wait) < 0) {
+		if (set_trashtime(*argv, trashtime, (rflag) ? (smode | SMODE_RMASK) : smode) < 0) {
 			status = 1;
 		}
 		argc--;

--- a/src/tools/snapshot.cc
+++ b/src/tools/snapshot.cc
@@ -21,6 +21,7 @@
 #include "common/platform.h"
 
 #include <errno.h>
+#include <fmt/base.h>
 #include <limits.h>
 #include <signal.h>
 #include <stdlib.h>
@@ -37,7 +38,6 @@
 #include "tools/tools_commands.h"
 #include "tools/tools_common_functions.h"
 
-static int kDefaultTimeout = 60 * 1000;              // default timeout (60 seconds)
 static int kInfiniteTimeout = 10 * 24 * 3600 * 1000; // simulate infinite timeout (10 days)
 #ifdef _WIN32
 static struct stat kDefaultEmptyStat = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
@@ -47,21 +47,16 @@ static void snapshot_usage() {
 	fprintf(stderr,
 	        "make snapshot (lazy copy)\n\nusage:\n saunafs makesnapshot [-ofl] src [src ...] dst\n");
 	fprintf(stderr, " -o,-f - allow to overwrite existing objects\n");
-	fprintf(stderr, " -l - wait until snapshot will finish (otherwise there is 60s timeout) (will be default in 5.0.0)\n");
 }
 
 static int make_snapshot(const char *dstdir, const char *dstbase, const char *srcname,
-                         inode_t srcinode, uint8_t canoverwrite, int long_wait,
-                         uint8_t ignore_missing_src, int initial_batch_size) {
+                         inode_t srcinode, uint8_t canoverwrite, uint8_t ignore_missing_src,
+                         int initial_batch_size) {
 	inode_t dstinode;
 	uint32_t nleng, uid, gid;
 	uint8_t status;
 	uint32_t msgid = 0, job_id;
 	int fd;
-
-	fmt::println(
-	    stderr,
-	    "Warning: -l option will be the default behavior in 5.0.0 and the option removed. If you wish for timeouts, use the `timeout` command");
 
 	sigset_t set;
 	sigemptyset(&set);
@@ -91,7 +86,7 @@ static int make_snapshot(const char *dstdir, const char *dstbase, const char *sr
 		auto response = ServerConnection::sendAndReceive(fd, request,
 				SAU_MATOCL_REQUEST_TASK_ID,
 				ServerConnection::ReceiveMode::kReceiveFirstNonNopMessage,
-				long_wait ? kInfiniteTimeout : kDefaultTimeout);
+				kInfiniteTimeout);
 		matocl::requestTaskId::deserialize(response, msgid, job_id);
 
 		std::thread signal_thread(std::bind(signalHandler, job_id));
@@ -99,6 +94,7 @@ static int make_snapshot(const char *dstdir, const char *dstbase, const char *sr
 		/* destructor of LambdaGuard will send SIGUSR1 signal in order to
 		 * return from signalHandler function and join thread */
 		auto join_guard = makeLambdaGuard([&signal_thread]() {
+			fmt::println("sending SIGUSR1 to signal_thread");
 			kill(getpid(), SIGUSR1);
 			signal_thread.join();
 		});
@@ -106,7 +102,7 @@ static int make_snapshot(const char *dstdir, const char *dstbase, const char *sr
 		                                  uid, gid, canoverwrite, ignore_missing_src, initial_batch_size);
 		response = ServerConnection::sendAndReceive(fd, request, SAU_MATOCL_FUSE_SNAPSHOT,
 				ServerConnection::ReceiveMode::kReceiveFirstNonNopMessage,
-				long_wait ? kInfiniteTimeout : kDefaultTimeout);
+				kInfiniteTimeout);
 		matocl::snapshot::deserialize(response, msgid, status);
 
 		close_master_conn(0);
@@ -129,7 +125,7 @@ static int make_snapshot(const char *dstdir, const char *dstbase, const char *sr
 }
 
 static int snapshot(const char *dstname, char *const *srcnames, uint32_t srcelements,
-					uint8_t canowerwrite, int long_wait, uint8_t ignore_missing_src, int initial_batch_size) {
+					uint8_t canowerwrite, uint8_t ignore_missing_src, int initial_batch_size) {
 	char to[PATH_MAX + 1], base[PATH_MAX + 1], dir[PATH_MAX + 1];
 	char src[PATH_MAX + 1];
 	std::string lookup_dstname = std::string(dstname);
@@ -208,9 +204,9 @@ static int snapshot(const char *dstname, char *const *srcnames, uint32_t srcelem
 		inode_t srcinode;
 		int fd = open_master_conn(srcnames[0], &srcinode, NULL, true);
 		if (fd < 0) { return -1; }
-		return make_snapshot(to, base, srcnames[0], srcinode, canowerwrite, long_wait, ignore_missing_src, initial_batch_size);
+		return make_snapshot(to, base, srcnames[0], srcinode, canowerwrite, ignore_missing_src, initial_batch_size);
 #else
-		return make_snapshot(to, base, srcnames[0], sst.st_ino, canowerwrite, long_wait, ignore_missing_src, initial_batch_size);
+		return make_snapshot(to, base, srcnames[0], sst.st_ino, canowerwrite, ignore_missing_src, initial_batch_size);
 #endif
 	} else {  // dst exists
 		if (!get_full_path(dstname, to)) {
@@ -247,9 +243,9 @@ static int snapshot(const char *dstname, char *const *srcnames, uint32_t srcelem
 			inode_t srcinode;
 			int fd = open_master_conn(srcnames[0], &srcinode, NULL, true);
 			if (fd < 0) { return -1; }
-			return make_snapshot(dir, base, srcnames[0], srcinode, canowerwrite, long_wait, ignore_missing_src, initial_batch_size);
+			return make_snapshot(dir, base, srcnames[0], srcinode, canowerwrite, ignore_missing_src, initial_batch_size);
 #else
-			return make_snapshot(dir, base, srcnames[0], sst.st_ino, canowerwrite, long_wait, ignore_missing_src, initial_batch_size);
+			return make_snapshot(dir, base, srcnames[0], sst.st_ino, canowerwrite, ignore_missing_src, initial_batch_size);
 #endif
 		} else {  // dst is a directory
 			status = 0;
@@ -298,10 +294,10 @@ static int snapshot(const char *dstname, char *const *srcnames, uint32_t srcelem
 					int fd =
 					    open_master_conn(srcnames[i], &srcinode, NULL, true);
 					if (fd < 0) { return -1; }
-					if (make_snapshot(to, base, srcnames[i], srcinode, canowerwrite, long_wait,
+					if (make_snapshot(to, base, srcnames[i], srcinode, canowerwrite,
 					                  ignore_missing_src, initial_batch_size) < 0) {
 #else
-					if (make_snapshot(to, base, srcnames[i], sst.st_ino, canowerwrite, long_wait,
+					if (make_snapshot(to, base, srcnames[i], sst.st_ino, canowerwrite,
 					                  ignore_missing_src, initial_batch_size) < 0) {
 #endif
 						status = -1;
@@ -327,10 +323,10 @@ static int snapshot(const char *dstname, char *const *srcnames, uint32_t srcelem
 						                          true);
 						if (fd < 0) { return -1; }
 						if (make_snapshot(to, base, srcnames[i], srcinode, canowerwrite,
-						                  long_wait, ignore_missing_src, initial_batch_size) < 0) {
+						                  ignore_missing_src, initial_batch_size) < 0) {
 #else
 						if (make_snapshot(to, base, srcnames[i], sst.st_ino, canowerwrite,
-						                  long_wait, ignore_missing_src, initial_batch_size) < 0) {
+						                  ignore_missing_src, initial_batch_size) < 0) {
 #endif
 							status = -1;
 						}
@@ -348,10 +344,10 @@ static int snapshot(const char *dstname, char *const *srcnames, uint32_t srcelem
 						                          true);
 						if (fd < 0) { return -1; }
 						if (make_snapshot(dir, base, srcnames[i], srcinode, canowerwrite,
-						                  long_wait, ignore_missing_src, initial_batch_size) < 0) {
+						                  ignore_missing_src, initial_batch_size) < 0) {
 #else
 						if (make_snapshot(dir, base, srcnames[i], sst.st_ino, canowerwrite,
-						                  long_wait, ignore_missing_src, initial_batch_size) < 0) {
+						                  ignore_missing_src, initial_batch_size) < 0) {
 #endif
 							status = -1;
 						}
@@ -366,18 +362,14 @@ static int snapshot(const char *dstname, char *const *srcnames, uint32_t srcelem
 int snapshot_run(int argc, char **argv) {
 	int ch;
 	int oflag = 0;
-	int lflag = 0;
 	uint8_t ignore_missing_src = 0;
 	int initial_batch_size = 0;
 
-	while ((ch = getopt(argc, argv, "folis:")) != -1) {
+	while ((ch = getopt(argc, argv, "fois:")) != -1) {
 		switch (ch) {
 		case 'f':
 		case 'o':
 			oflag = 1;
-			break;
-		case 'l':
-			lflag = 1;
 			break;
 		case 'i':
 			ignore_missing_src = 1;
@@ -393,5 +385,5 @@ int snapshot_run(int argc, char **argv) {
 		snapshot_usage();
 		return 1;
 	}
-	return snapshot(argv[argc - 1], argv, argc - 1, oflag, lflag, ignore_missing_src, initial_batch_size);
+	return snapshot(argv[argc - 1], argv, argc - 1, oflag, ignore_missing_src, initial_batch_size);
 }

--- a/src/tools/tools_common_functions.cc
+++ b/src/tools/tools_common_functions.cc
@@ -53,10 +53,13 @@ void signalHandler(uint32_t job_id) {
 	sigaddset(&set, SIGHUP);
 	sigaddset(&set, SIGUSR1);
 	int sig = 0;
+	// In case you need it if the program crashed and want to cancel the task
+	fmt::println("Setup signal handler for task id {}", job_id);
 #ifndef _WIN32
 	sigwait(&set, &sig);
 #endif
 	if (sig == SIGINT || sig == SIGTERM || sig == SIGHUP) {
+		fmt::println("Stopping task id {}", job_id);
 		inode_t inode;
 		int fd = open_master_conn(".", &inode, nullptr, false);
 		if (fd < 0) {


### PR DESCRIPTION
The timeout was always default 30 seconds. But this didn't make any
sense, because the master would continue performing the operation
regardless. Worse, some functions were cleanly stopping the operations
on master if SIGINT or SIGTERM was send, but this timeout would not and
simply close the connection once timeout reached. Old behaviour could be
mostly restored with `timeout`.

* Add some logging for the task ID

BREAKING CHANGE: Existing scripts that rely on this -l behaviour will
break.

Signed-off-by: Urmas Rist <urmas@leil.io>