### PR TITLE
fix(master): Correct default listen host and port

### DIFF
--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -6419,10 +6419,8 @@ void matoclserv_reload(void) {
 }
 
 int matoclserv_networkinit(void) {
-	if (cfg_isdefined("MATOCL_LISTEN_HOST") || cfg_isdefined("MATOCL_LISTEN_PORT")) {
-		ListenHost = cfg_getstr("MATOCL_LISTEN_HOST","*");
-		ListenPort = cfg_getstr("MATOCL_LISTEN_PORT","9421");
-	}
+	ListenHost = cfg_getstr("MATOCL_LISTEN_HOST","*");
+	ListenPort = cfg_getstr("MATOCL_LISTEN_PORT","9421");
 	RejectOld = cfg_getuint32("REJECT_OLD_CLIENTS",0);
 
 	if (matoclserv_iolimits_reload() != 0) {


### PR DESCRIPTION
Due to changes introduced in deprecation commit a5ed228, it became necessary to handle the scenario where the configuration for the master host and port to listen for connections is not defined in its default configuration file. This commit addresses that scenario, ensuring the master server correctly handles cases where those values are not explicitly defined in the configuration file.