### PR TITLE
feat(chunkserver): Use eventfd in JobPool

### DIFF
--- a/src/chunkserver/bgjobs.cc
+++ b/src/chunkserver/bgjobs.cc
@@ -31,6 +31,7 @@
 #include "devtools/request_log.h"
 #include "slogger/slogger.h"
 
+#include <sys/eventfd.h>
 #include <sys/syslog.h>
 #include <unistd.h>
 #include <cassert>
@@ -45,18 +46,15 @@
 #include <vector>
 
 constexpr auto kInvalidJob = nullptr;
-constexpr auto STATUS_BYTE_SIZE = 1;
 
 JobPool::JobPool(const std::string &name, uint8_t workers, uint32_t maxJobs, int *wakeupDesc)
-    : name_(name), workers(workers) {
-	int fd[2];
-	if (pipe(fd) < 0) {  // pipe is a critical resource for communication within the JobPool
-		throw std::runtime_error("JobPool: Failed to create pipe: " + std::string(strerror(errno)));
+    // EFD_NONBLOCK to prevent blocking reads/writes
+    : notifierFD_(::eventfd(0, EFD_NONBLOCK)), name_(name), workers(workers) {
+	if (notifierFD_ < 0) {
+		throw std::runtime_error("JobPool: eventfd() failed: " + std::string(strerror(errno)));
 	}
-	rpipe = fd[0];
-	wpipe = fd[1];
 
-	*wakeupDesc = fd[0];
+	*wakeupDesc = notifierFD_;
 
 	jobsQueue = std::make_unique<ProducerConsumerQueue>(maxJobs);
 	statusQueue = std::make_unique<ProducerConsumerQueue>();
@@ -82,8 +80,7 @@ JobPool::~JobPool() {
 
 	workerThreads.clear();
 
-	close(rpipe);
-	close(wpipe);
+	close(notifierFD_);
 }
 
 uint32_t JobPool::addJob(ChunkOperation operation, JobCallback callback, void *extra,
@@ -221,24 +218,31 @@ void JobPool::workerThread(const std::string &poolName, uint8_t workerId) {
 }
 
 void JobPool::sendStatus(uint32_t jobId, uint8_t status) {
-	std::lock_guard pipeLockGuard(pipeMutex);
+	std::lock_guard statusLock(statusMutex_);
+
 	if (statusQueue->isEmpty()) {
-		eassert(write(wpipe, &status, STATUS_BYTE_SIZE) == STATUS_BYTE_SIZE &&
-		        "JobPool: SendStatus: Failed to write status to pipe");
+		static constexpr eventfd_t dummyValue = 1;  // Dummy value just to wake up the eventfd
+		eassert(::eventfd_write(notifierFD_, dummyValue) == 0 &&
+		        "JobPool: SendStatus: Failed to write to eventfd");
 	}
+
 	statusQueue->put(jobId, status, nullptr, 1);
 }
 
 bool JobPool::receiveStatus(uint32_t &jobId, uint8_t &status) {
 	uint32_t qstatus = 0;
-	std::lock_guard pipeLockGuard(pipeMutex);
+	std::lock_guard statusLock(statusMutex_);
+
 	statusQueue->get(&jobId, &qstatus, nullptr, nullptr);
 	status = qstatus;
+
 	if (statusQueue->isEmpty()) {
-		eassert(read(rpipe, &qstatus, STATUS_BYTE_SIZE) == STATUS_BYTE_SIZE &&
-		        "JobPool: ReceiveStatus: Failed to read status from pipe");
+		eventfd_t dummyEvent;  // Only to clear the eventfd
+		eassert(::eventfd_read(notifierFD_, &dummyEvent) == 0 &&
+		        "JobPool: ReceiveStatus: Failed to read from eventfd");
 		return false;
 	}
+
 	return true;
 }
 

--- a/src/chunkserver/bgjobs.h
+++ b/src/chunkserver/bgjobs.h
@@ -172,12 +172,11 @@ private:
 	/// @return 1 if a status was received, 0 otherwise.
 	bool receiveStatus(uint32_t &jobId, uint8_t &status);
 
-	int rpipe;                                         /// Read pipe for job status notifications.
-	int wpipe;                                         /// Write pipe for job status notifications.
+	int notifierFD_;                                   /// File descriptor for notifications.
 	std::string name_;                                 /// Human readable id of the JobPool.
 	uint8_t workers;                                   /// Number of worker threads in the pool.
 	std::vector<std::thread> workerThreads;            /// Vector of worker threads.
-	std::mutex pipeMutex;                              /// Mutex for pipe operations.
+	std::mutex statusMutex_;                           /// Mutex for status notifications.
 	std::mutex jobsMutex;                              /// Mutex for job operations.
 	std::unique_ptr<ProducerConsumerQueue> jobsQueue;  /// Queue for jobs.
 	std::unique_ptr<ProducerConsumerQueue> statusQueue;          /// Queue for job statuses.


### PR DESCRIPTION
The previous version was using a regular pipe for notifications. This change replaces the pipe by an eventfd, in order to:

- Reduce kernel overhead.
- Use simpler and specialized API.
- Use only one file descriptor instead of two.