### PR TITLE
fix(chunkserver): Fix NetworkWorkerThread names

### DIFF
--- a/src/chunkserver/network_worker_thread.cc
+++ b/src/chunkserver/network_worker_thread.cc
@@ -77,7 +77,7 @@ void NetworkWorkerThread::operator()() {
 	TRACETHIS();
 
 	static std::atomic_uint16_t threadCounter(0);
-	std::string threadName = "networkWorker " + std::to_string(threadCounter++);
+	std::string threadName = "netWorker_" + std::to_string(threadCounter++);
 	pthread_setname_np(pthread_self(), threadName.c_str());
 
 	while (!doTerminate) {


### PR DESCRIPTION
The previous version could generate long thread names (more than 16 characters) when the number of NetworkWorkerThread is increased, for instance: `networkWorker 16` already contains 16 characters which is the maximum allowed.

This change makes the prefix shorter to avoid thread names being ignored.