### PR TITLE
feat(chunkserver): Implement listeners for JobPool

### DIFF
--- a/src/chunkserver/bgjobs.cc
+++ b/src/chunkserver/bgjobs.cc
@@ -47,17 +47,24 @@
 
 constexpr auto kInvalidJob = nullptr;
 
-JobPool::JobPool(const std::string &name, uint8_t workers, uint32_t maxJobs, int nrListeners,
-                 std::vector<int> &wakeupDesc)
+JobPool::JobPool(const std::string &name, uint8_t workers, uint32_t maxJobs, uint32_t nrListeners,
+                 std::vector<int> &wakeupFDs)
     // EFD_NONBLOCK to prevent blocking reads/writes
     : listenerInfos_(nrListeners), name_(name), workers(workers) {
-	for (int i = 0; i < nrListeners; ++i) {
+	if (wakeupFDs.size() != nrListeners) {
+		safs::log_warn(
+		    "JobPool: wakeupFDs size {} does not match nrListeners {}, resizing to match.",
+		    wakeupFDs.size(), nrListeners);
+		wakeupFDs.resize(nrListeners);
+	}
+
+	for (uint32_t i = 0; i < nrListeners; ++i) {
 		listenerInfos_[i].notifierFD = ::eventfd(0, EFD_NONBLOCK);
 		if (listenerInfos_[i].notifierFD < 0) {
 			throw std::runtime_error("JobPool: eventfd() failed for listener" +
 			                         std::to_string(i) + ": " + std::string(strerror(errno)));
 		}
-		wakeupDesc[i] = listenerInfos_[i].notifierFD;
+		wakeupFDs[i] = listenerInfos_[i].notifierFD;
 
 		listenerInfos_[i].statusQueue = std::make_unique<ProducerConsumerQueue>();
 		listenerInfos_[i].nextJobId = 1;

--- a/src/chunkserver/bgjobs.cc
+++ b/src/chunkserver/bgjobs.cc
@@ -51,6 +51,8 @@ JobPool::JobPool(const std::string &name, uint8_t workers, uint32_t maxJobs, uin
                  std::vector<int> &wakeupFDs)
     // EFD_NONBLOCK to prevent blocking reads/writes
     : listenerInfos_(nrListeners), name_(name), workers(workers) {
+	nrListeners = std::max(nrListeners, 1u);  // Ensure at least one listener
+
 	if (wakeupFDs.size() != nrListeners) {
 		safs::log_warn(
 		    "JobPool: wakeupFDs size {} does not match nrListeners {}, resizing to match.",
@@ -91,17 +93,22 @@ JobPool::~JobPool() {
 	}
 
 	jobsQueue.reset();
-	for (size_t i = 0; i < listenerInfos_.size(); ++i) { listenerInfos_[i].statusQueue.reset(); }
+	for (auto &listenerInfo : listenerInfos_) { listenerInfo.statusQueue.reset(); }
 
 	workerThreads.clear();
 
-	for (auto &listenerInfo : listenerInfos_) {
-		close(listenerInfo.notifierFD);
-	}
+	for (auto &listenerInfo : listenerInfos_) { close(listenerInfo.notifierFD); }
 }
 
 uint32_t JobPool::addJob(ChunkOperation operation, JobCallback callback, void *extra,
                          ProcessJobCallback processJob, uint32_t listenerId) {
+	// Check if the listenerId is valid
+	if (listenerId >= listenerInfos_.size()) {
+		safs::log_warn("JobPool: addJob: Invalid listenerId {} for operation {}, resetting to 0",
+		               listenerId, static_cast<int>(operation));
+		listenerId = 0;  // Reset to the first listener
+	}
+
 	auto &listenerInfo = listenerInfos_[listenerId];
 	std::unique_lock lock(listenerInfo.jobsMutex);
 	uint32_t jobId = listenerInfo.nextJobId++;
@@ -124,6 +131,13 @@ uint32_t JobPool::getJobCount() const {
 }
 
 void JobPool::disableAndChangeCallbackAll(const JobCallback &callback, uint32_t listenerId) {
+	// Check if the listenerId is valid
+	if (listenerId >= listenerInfos_.size()) {
+		safs::log_warn("JobPool: disableAndChangeCallbackAll: Invalid listenerId {}, returning",
+		               listenerId);
+		return;
+	}
+
 	auto &listenerInfo = listenerInfos_[listenerId];
 	std::lock_guard jobsLockGuard(listenerInfo.jobsMutex);
 	for (auto &[jobId, job] : listenerInfo.jobHash) {
@@ -133,6 +147,13 @@ void JobPool::disableAndChangeCallbackAll(const JobCallback &callback, uint32_t 
 }
 
 void JobPool::disableJob(uint32_t jobId, uint32_t listenerId) {
+	// Check if the listenerId is valid
+	if (listenerId >= listenerInfos_.size()) {
+		safs::log_warn("JobPool: disableJob: Invalid listenerId {} for jobId {}, returning",
+		               listenerId, jobId);
+		return;
+	}
+
 	auto &listenerInfo = listenerInfos_[listenerId];
 	std::unique_lock jobsUniqueLock(listenerInfo.jobsMutex, std::defer_lock);
 	auto jobIterator = listenerInfo.jobHash.find(jobId);
@@ -146,6 +167,13 @@ void JobPool::disableJob(uint32_t jobId, uint32_t listenerId) {
 }
 
 void JobPool::disableJobs(std::list<uint32_t> &jobIds, uint32_t listenerId) {
+	// Check if the listenerId is valid
+	if (listenerId >= listenerInfos_.size()) {
+		safs::log_warn("JobPool: disableJobs: Invalid listenerId {}, returning",
+		               listenerId);
+		return;
+	}
+
 	if (jobIds.empty()) { return; }  // to save the locking
 	auto &listenerInfo = listenerInfos_[listenerId];
 	std::unique_lock jobsUniqueLock(listenerInfo.jobsMutex);
@@ -160,6 +188,13 @@ void JobPool::disableJobs(std::list<uint32_t> &jobIds, uint32_t listenerId) {
 }
 
 void JobPool::processCompletedJobs(uint32_t listenerId) {
+	// Check if the listenerId is valid
+	if (listenerId >= listenerInfos_.size()) {
+		safs::log_warn("JobPool: processCompletedJobs: Invalid listenerId {}, returning",
+		               listenerId);
+		return;
+	}
+
 	uint32_t jobId{};
 	uint8_t status{};
 	bool notLastJob = true;
@@ -177,6 +212,13 @@ void JobPool::processCompletedJobs(uint32_t listenerId) {
 
 void JobPool::changeCallback(uint32_t jobId, JobCallback callback, void *extra,
                              uint32_t listenerId) {
+	// Check if the listenerId is valid
+	if (listenerId >= listenerInfos_.size()) {
+		safs::log_warn("JobPool: changeCallback: Invalid listenerId {} for jobId {}, returning",
+		               listenerId, jobId);
+		return;
+	}
+
 	auto &listenerInfo = listenerInfos_[listenerId];
 	auto jobIterator = listenerInfo.jobHash.find(jobId);
 	if (jobIterator != listenerInfo.jobHash.end()) {
@@ -187,6 +229,13 @@ void JobPool::changeCallback(uint32_t jobId, JobCallback callback, void *extra,
 
 void JobPool::changeCallback(std::list<uint32_t> &jobIds, JobCallback callback, void *extra,
                              uint32_t listenerId) {
+	// Check if the listenerId is valid
+	if (listenerId >= listenerInfos_.size()) {
+		safs::log_warn("JobPool: changeCallback: Invalid listenerId {}, returning",
+		               listenerId);
+		return;
+	}
+
 	auto &listenerInfo = listenerInfos_[listenerId];
 	for (auto jobId : jobIds) {
 		auto jobIterator = listenerInfo.jobHash.find(jobId);
@@ -246,18 +295,32 @@ void JobPool::workerThread(const std::string &poolName, uint8_t workerId) {
 }
 
 void JobPool::sendStatus(uint32_t jobId, uint8_t status, uint32_t listenerId) {
+	// Check if the listenerId is valid
+	if (listenerId >= listenerInfos_.size()) {
+		safs::log_warn("JobPool: SendStatus: Invalid listenerId {} for jobId {}, returning",
+		               listenerId, jobId);
+		return;
+	}
+
 	auto &listenerInfo = listenerInfos_[listenerId];
 	std::lock_guard statusLock(listenerInfo.notifierMutex);
 
 	if (listenerInfo.statusQueue->isEmpty()) {
 		static constexpr eventfd_t dummyValue = 1;  // Dummy value to wake up the eventfd
 		eassert(::eventfd_write(listenerInfo.notifierFD, dummyValue) == 0 &&
-		        "JobPool: SendStatus: Failed to write status to pipe");
+		        "JobPool: SendStatus: Failed to write to eventfd");
 	}
 	listenerInfo.statusQueue->put(jobId, status, nullptr, 1);
 }
 
 bool JobPool::receiveStatus(uint32_t &jobId, uint8_t &status, uint32_t listenerId) {
+	// Check if the listenerId is valid
+	if (listenerId >= listenerInfos_.size()) {
+		safs::log_warn("JobPool: receiveStatus: Invalid listenerId {} for jobId {}, returning",
+		               listenerId, jobId);
+		return false; // Return false to indicate that we should stop processing
+	}
+
 	auto &listenerInfo = listenerInfos_[listenerId];
 	uint32_t qstatus = 0;
 	std::lock_guard statusLock(listenerInfo.notifierMutex);

--- a/src/chunkserver/bgjobs.cc
+++ b/src/chunkserver/bgjobs.cc
@@ -47,17 +47,23 @@
 
 constexpr auto kInvalidJob = nullptr;
 
-JobPool::JobPool(const std::string &name, uint8_t workers, uint32_t maxJobs, int *wakeupDesc)
+JobPool::JobPool(const std::string &name, uint8_t workers, uint32_t maxJobs, int nrListeners,
+                 std::vector<int> &wakeupDesc)
     // EFD_NONBLOCK to prevent blocking reads/writes
-    : notifierFD_(::eventfd(0, EFD_NONBLOCK)), name_(name), workers(workers) {
-	if (notifierFD_ < 0) {
-		throw std::runtime_error("JobPool: eventfd() failed: " + std::string(strerror(errno)));
+    : listenerInfos_(nrListeners), name_(name), workers(workers) {
+	for (int i = 0; i < nrListeners; ++i) {
+		listenerInfos_[i].notifierFD = ::eventfd(0, EFD_NONBLOCK);
+		if (listenerInfos_[i].notifierFD < 0) {
+			throw std::runtime_error("JobPool: eventfd() failed for listener" +
+			                         std::to_string(i) + ": " + std::string(strerror(errno)));
+		}
+		wakeupDesc[i] = listenerInfos_[i].notifierFD;
+
+		listenerInfos_[i].statusQueue = std::make_unique<ProducerConsumerQueue>();
+		listenerInfos_[i].nextJobId = 1;
 	}
 
-	*wakeupDesc = notifierFD_;
-
 	jobsQueue = std::make_unique<ProducerConsumerQueue>(maxJobs);
-	statusQueue = std::make_unique<ProducerConsumerQueue>();
 
 	for (uint8_t i = 0; i < workers; ++i) {
 		workerThreads.emplace_back(&JobPool::workerThread, this, name_, i);
@@ -73,28 +79,35 @@ JobPool::~JobPool() {
 		if (thread.joinable()) { thread.join(); }
 	}
 
-	if (!statusQueue->isEmpty()) { processCompletedJobs(); }
+	for (size_t i = 0; i < listenerInfos_.size(); ++i) {
+		if (!listenerInfos_[i].statusQueue->isEmpty()) { processCompletedJobs(i); }
+	}
 
 	jobsQueue.reset();
-	statusQueue.reset();
+	for (size_t i = 0; i < listenerInfos_.size(); ++i) { listenerInfos_[i].statusQueue.reset(); }
 
 	workerThreads.clear();
 
-	close(notifierFD_);
+	for (auto &listenerInfo : listenerInfos_) {
+		close(listenerInfo.notifierFD);
+	}
 }
 
 uint32_t JobPool::addJob(ChunkOperation operation, JobCallback callback, void *extra,
-                         ProcessJobCallback processJob) {
-	std::unique_lock lock(jobsMutex);
-	uint32_t jobId = nextJobId++;
+                         ProcessJobCallback processJob, uint32_t listenerId) {
+	auto &listenerInfo = listenerInfos_[listenerId];
+	std::unique_lock lock(listenerInfo.jobsMutex);
+	uint32_t jobId = listenerInfo.nextJobId++;
 	auto job = std::make_unique<Job>();
 	job->jobId = jobId;
 	job->callback = std::move(callback);
 	job->processJob = std::move(processJob);
 	job->extra = extra;
 	job->state = JobPool::State::Enabled;
-	jobHash[jobId] = std::move(job);
-	jobsQueue->put(jobId, operation, reinterpret_cast<uint8_t *>(jobHash[jobId].get()), 1);
+	job->listenerId = listenerId;
+	listenerInfo.jobHash[jobId] = std::move(job);
+	jobsQueue->put(jobId, operation, reinterpret_cast<uint8_t *>(listenerInfo.jobHash[jobId].get()),
+	               1);
 	return jobId;
 }
 
@@ -103,18 +116,20 @@ uint32_t JobPool::getJobCount() const {
 	return jobsQueue->elements();
 }
 
-void JobPool::disableAndChangeCallbackAll(const JobCallback& callback) {
-	std::lock_guard jobsLockGuard(jobsMutex);
-	for (auto &[jobId, job] : jobHash) {
+void JobPool::disableAndChangeCallbackAll(const JobCallback &callback, uint32_t listenerId) {
+	auto &listenerInfo = listenerInfos_[listenerId];
+	std::lock_guard jobsLockGuard(listenerInfo.jobsMutex);
+	for (auto &[jobId, job] : listenerInfo.jobHash) {
 		if (job->state == JobPool::State::Enabled) { job->state = JobPool::State::Disabled; }
 		job->callback = callback;
 	}
 }
 
-void JobPool::disableJob(uint32_t jobId) {
-	std::unique_lock jobsUniqueLock(jobsMutex, std::defer_lock);
-	auto jobIterator = jobHash.find(jobId);
-	if (jobIterator != jobHash.end()) {
+void JobPool::disableJob(uint32_t jobId, uint32_t listenerId) {
+	auto &listenerInfo = listenerInfos_[listenerId];
+	std::unique_lock jobsUniqueLock(listenerInfo.jobsMutex, std::defer_lock);
+	auto jobIterator = listenerInfo.jobHash.find(jobId);
+	if (jobIterator != listenerInfo.jobHash.end()) {
 		jobsUniqueLock.lock();
 		if (jobIterator->second->state == JobPool::State::Enabled) {
 			jobIterator->second->state = JobPool::State::Disabled;
@@ -123,12 +138,13 @@ void JobPool::disableJob(uint32_t jobId) {
 	}
 }
 
-void JobPool::disableJobs(std::list<uint32_t> &jobIds) {
-	if (jobIds.empty()) { return; } // to save the locking
-	std::unique_lock jobsUniqueLock(jobsMutex);
+void JobPool::disableJobs(std::list<uint32_t> &jobIds, uint32_t listenerId) {
+	if (jobIds.empty()) { return; }  // to save the locking
+	auto &listenerInfo = listenerInfos_[listenerId];
+	std::unique_lock jobsUniqueLock(listenerInfo.jobsMutex);
 	for (auto jobId : jobIds) {
-		auto jobIterator = jobHash.find(jobId);
-		if (jobIterator != jobHash.end()) {
+		auto jobIterator = listenerInfo.jobHash.find(jobId);
+		if (jobIterator != listenerInfo.jobHash.end()) {
 			if (jobIterator->second->state == JobPool::State::Enabled) {
 				jobIterator->second->state = JobPool::State::Disabled;
 			}
@@ -136,34 +152,38 @@ void JobPool::disableJobs(std::list<uint32_t> &jobIds) {
 	}
 }
 
-void JobPool::processCompletedJobs() {
+void JobPool::processCompletedJobs(uint32_t listenerId) {
 	uint32_t jobId{};
 	uint8_t status{};
 	bool notLastJob = true;
-
+	auto &listenerInfo = listenerInfos_[listenerId];
 	while (notLastJob) {
-		notLastJob = receiveStatus(jobId, status);
-		auto jobIterator = jobHash.find(jobId);
-		if (jobIterator != jobHash.end()) {
+		notLastJob = receiveStatus(jobId, status, listenerId);
+		auto jobIterator = listenerInfo.jobHash.find(jobId);
+		if (jobIterator != listenerInfo.jobHash.end()) {
 			auto callback = jobIterator->second->callback;
 			if (callback) { callback(status, jobIterator->second->extra); }
-			jobHash.erase(jobIterator);
+			listenerInfo.jobHash.erase(jobIterator);
 		}
 	}
 }
 
-void JobPool::changeCallback(uint32_t jobId, JobCallback callback, void *extra) {
-	auto jobIterator = jobHash.find(jobId);
-	if (jobIterator != jobHash.end()) {
+void JobPool::changeCallback(uint32_t jobId, JobCallback callback, void *extra,
+                             uint32_t listenerId) {
+	auto &listenerInfo = listenerInfos_[listenerId];
+	auto jobIterator = listenerInfo.jobHash.find(jobId);
+	if (jobIterator != listenerInfo.jobHash.end()) {
 		jobIterator->second->callback = std::move(callback);
 		jobIterator->second->extra = extra;
 	}
 }
 
-void JobPool::changeCallback(std::list<uint32_t> &jobIds, JobCallback callback, void *extra) {
+void JobPool::changeCallback(std::list<uint32_t> &jobIds, JobCallback callback, void *extra,
+                             uint32_t listenerId) {
+	auto &listenerInfo = listenerInfos_[listenerId];
 	for (auto jobId : jobIds) {
-		auto jobIterator = jobHash.find(jobId);
-		if (jobIterator != jobHash.end()) {
+		auto jobIterator = listenerInfo.jobHash.find(jobId);
+		if (jobIterator != listenerInfo.jobHash.end()) {
 			jobIterator->second->callback = std::move(callback);
 			jobIterator->second->extra = extra;
 		}
@@ -180,27 +200,28 @@ void JobPool::workerThread(const std::string &poolName, uint8_t workerId) {
 	State jobState;
 	uint8_t status = SAUNAFS_STATUS_OK;
 
-	std::unique_lock jobsUniqueLock(jobsMutex, std::defer_lock);
-
 	while (true) {
 		jobsQueue->get(&jobId, &operation, &jobPtrArg, nullptr);
-		Job *job = reinterpret_cast<Job *>(jobPtrArg);
-
-		jobsUniqueLock.lock();
-		if (job == kInvalidJob) {
-			jobState = State::Disabled;
-		}
-		else {
-			jobState = job->state;
-			if (job->state == State::Enabled) { job->state = State::InProgress; }
-		}
 
 		if (operation == ChunkOperation::Exit) { break; }
+
+		Job *job = reinterpret_cast<Job *>(jobPtrArg);
+
+		if (job == kInvalidJob) {
+			jobState = State::Disabled;
+			continue;
+		}
+
+		// job exists
+		uint32_t listenerId = job->listenerId;
+		std::unique_lock jobsUniqueLock(listenerInfos_[listenerId].jobsMutex);
+		jobState = job->state;
+		if (job->state == State::Enabled) { job->state = State::InProgress; }
 
 		if (jobState == State::Disabled) {
 			status = SAUNAFS_ERROR_NOTDONE;
 			jobsUniqueLock.unlock();
-			sendStatus(jobId, status);
+			sendStatus(jobId, status, listenerId);
 			continue;
 		}
 
@@ -213,32 +234,32 @@ void JobPool::workerThread(const std::string &poolName, uint8_t workerId) {
 			status = SAUNAFS_ERROR_NOTDONE;
 		}
 
-		sendStatus(jobId, status);
+		sendStatus(jobId, status, listenerId);
 	}
 }
 
-void JobPool::sendStatus(uint32_t jobId, uint8_t status) {
-	std::lock_guard statusLock(statusMutex_);
+void JobPool::sendStatus(uint32_t jobId, uint8_t status, uint32_t listenerId) {
+	auto &listenerInfo = listenerInfos_[listenerId];
+	std::lock_guard statusLock(listenerInfo.notifierMutex);
 
-	if (statusQueue->isEmpty()) {
-		static constexpr eventfd_t dummyValue = 1;  // Dummy value just to wake up the eventfd
-		eassert(::eventfd_write(notifierFD_, dummyValue) == 0 &&
-		        "JobPool: SendStatus: Failed to write to eventfd");
+	if (listenerInfo.statusQueue->isEmpty()) {
+		static constexpr eventfd_t dummyValue = 1;  // Dummy value to wake up the eventfd
+		eassert(::eventfd_write(listenerInfo.notifierFD, dummyValue) == 0 &&
+		        "JobPool: SendStatus: Failed to write status to pipe");
 	}
-
-	statusQueue->put(jobId, status, nullptr, 1);
+	listenerInfo.statusQueue->put(jobId, status, nullptr, 1);
 }
 
-bool JobPool::receiveStatus(uint32_t &jobId, uint8_t &status) {
+bool JobPool::receiveStatus(uint32_t &jobId, uint8_t &status, uint32_t listenerId) {
+	auto &listenerInfo = listenerInfos_[listenerId];
 	uint32_t qstatus = 0;
-	std::lock_guard statusLock(statusMutex_);
+	std::lock_guard statusLock(listenerInfo.notifierMutex);
 
-	statusQueue->get(&jobId, &qstatus, nullptr, nullptr);
+	listenerInfo.statusQueue->get(&jobId, &qstatus, nullptr, nullptr);
 	status = qstatus;
-
-	if (statusQueue->isEmpty()) {
+	if (listenerInfo.statusQueue->isEmpty()) {
 		eventfd_t dummyEvent;  // Only to clear the eventfd
-		eassert(::eventfd_read(notifierFD_, &dummyEvent) == 0 &&
+		eassert(::eventfd_read(listenerInfo.notifierFD, &dummyEvent) == 0 &&
 		        "JobPool: ReceiveStatus: Failed to read from eventfd");
 		return false;
 	}
@@ -247,25 +268,27 @@ bool JobPool::receiveStatus(uint32_t &jobId, uint8_t &status) {
 }
 
 uint32_t job_open(JobPool &jobPool, JobPool::JobCallback callback, void *extra, uint64_t chunkId,
-                  ChunkPartType chunkType) {
+                  ChunkPartType chunkType, uint32_t listenerId) {
 	JobPool::ProcessJobCallback processJob = [=]() -> uint8_t {
 		return hddOpen(chunkId, chunkType);
 	};
-	return jobPool.addJob(JobPool::ChunkOperation::Open, std::move(callback), extra, processJob);
+	return jobPool.addJob(JobPool::ChunkOperation::Open, std::move(callback), extra, processJob,
+	                      listenerId);
 }
 
 uint32_t job_close(JobPool &jobPool, JobPool::JobCallback callback, void *extra, uint64_t chunkId,
-	ChunkPartType chunkType) {
+                   ChunkPartType chunkType, uint32_t listenerId) {
 	JobPool::ProcessJobCallback processJob = [=]() -> uint8_t {
 		return hddClose(chunkId, chunkType);
 	};
-	return jobPool.addJob(JobPool::ChunkOperation::Close, std::move(callback), extra, processJob);
+	return jobPool.addJob(JobPool::ChunkOperation::Close, std::move(callback), extra, processJob,
+	                      listenerId);
 }
 
 uint32_t job_read(JobPool &jobPool, JobPool::JobCallback callback, void *extra, uint64_t chunkId,
                   uint32_t version, ChunkPartType chunkType, uint32_t offset, uint32_t size,
                   uint32_t maxBlocksToBeReadBehind, uint32_t blocksToBeReadAhead,
-                  OutputBuffer *outputBuffer, bool performHddOpen) {
+                  OutputBuffer *outputBuffer, bool performHddOpen, uint32_t listenerId) {
 	JobPool::ProcessJobCallback processJob = [=]() -> uint8_t {
 		LOG_AVG_TILL_END_OF_SCOPE0("job_read");
 		uint8_t status = SAUNAFS_STATUS_OK;
@@ -287,22 +310,25 @@ uint32_t job_read(JobPool &jobPool, JobPool::JobCallback callback, void *extra, 
 		}
 		return status;
 	};
-	return jobPool.addJob(JobPool::ChunkOperation::Read, std::move(callback), extra, processJob);
+	return jobPool.addJob(JobPool::ChunkOperation::Read, std::move(callback), extra, processJob,
+	                      listenerId);
 }
 
 uint32_t job_prefetch(JobPool &jobPool, uint64_t chunkId, ChunkPartType chunkType,
-                      uint32_t firstBlockToBePrefetched, uint32_t blocksToBePrefetched) {
+                      uint32_t firstBlockToBePrefetched, uint32_t blocksToBePrefetched,
+                      uint32_t listenerId) {
 	JobPool::ProcessJobCallback processJob = [=]() -> uint8_t {
 		return hddPrefetchBlocks(chunkId, chunkType, firstBlockToBePrefetched,
 		                         blocksToBePrefetched);
 	};
 	return jobPool.addJob(JobPool::ChunkOperation::Prefetch, kEmptyCallback, kEmptyExtra,
-	                      processJob);
+	                      processJob, listenerId);
 }
 
 uint32_t job_write(JobPool &jobPool, JobPool::JobCallback callback, void *extra, uint64_t chunkId,
                    uint32_t chunkVersion, ChunkPartType chunkType, uint16_t blockNum,
-                   uint32_t offset, uint32_t size, uint32_t crc, const uint8_t *buffer) {
+                   uint32_t offset, uint32_t size, uint32_t crc, const uint8_t *buffer,
+                   uint32_t listenerId) {
 	JobPool::ProcessJobCallback processJob = [=]() -> uint8_t {
 		auto status = hddChunkWriteBlock(chunkId, chunkVersion, chunkType, blockNum, offset, size,
 		                                 crc, buffer);
@@ -313,22 +339,24 @@ uint32_t job_write(JobPool &jobPool, JobPool::JobCallback callback, void *extra,
 
 		return status;
 	};
-	return jobPool.addJob(JobPool::ChunkOperation::Write, std::move(callback), extra, processJob);
+	return jobPool.addJob(JobPool::ChunkOperation::Write, std::move(callback), extra, processJob,
+	                      listenerId);
 }
 
 uint32_t job_get_blocks(JobPool &jobPool, JobPool::JobCallback callback, void *extra,
                         uint64_t chunkId, uint32_t version, ChunkPartType chunkType,
-                        uint16_t *blocks) {
+                        uint16_t *blocks, uint32_t listenerId) {
 	JobPool::ProcessJobCallback processJob = [=]() -> uint8_t {
 		return hddChunkGetNumberOfBlocks(chunkId, chunkType, version, blocks);
 	};
 	return jobPool.addJob(JobPool::ChunkOperation::GetBlocks, std::move(callback), extra,
-	                      processJob);
+	                      processJob, listenerId);
 }
 
 uint32_t job_replicate(JobPool &jobPool, JobPool::JobCallback callback, void *extra,
                        uint64_t chunkId, uint32_t chunkVersion, ChunkPartType chunkType,
-                       uint32_t sourcesBufferSize, const uint8_t *sourcesBufferPtr) {
+                       uint32_t sourcesBufferSize, const uint8_t *sourcesBufferPtr,
+                       uint32_t listenerId) {
 	// Copy the sources buffer to a vector to ensure it is valid for the lifetime of the job
 	std::vector<uint8_t> sourcesBuffer(sourcesBufferSize);
 	std::memcpy(sourcesBuffer.data(), sourcesBufferPtr, sourcesBufferSize);
@@ -346,80 +374,86 @@ uint32_t job_replicate(JobPool &jobPool, JobPool::JobCallback callback, void *ex
 		return status;
 	};
 	return jobPool.addJob(JobPool::ChunkOperation::Replicate, std::move(callback), extra,
-	                      processJob);
+	                      processJob, listenerId);
 }
 
-uint32_t job_invalid(JobPool &jobPool, JobPool::JobCallback callback, void *extra) {
-	JobPool::ProcessJobCallback processJob = [=]() -> uint8_t {
-		return SAUNAFS_ERROR_EINVAL;
-	};
-	return jobPool.addJob(JobPool::ChunkOperation::Invalid, std::move(callback), extra, processJob);
+uint32_t job_invalid(JobPool &jobPool, JobPool::JobCallback callback, void *extra,
+                     uint32_t listenerId) {
+	JobPool::ProcessJobCallback processJob = [=]() -> uint8_t { return SAUNAFS_ERROR_EINVAL; };
+	return jobPool.addJob(JobPool::ChunkOperation::Invalid, std::move(callback), extra, processJob,
+	                      listenerId);
 }
 
 uint32_t job_delete(JobPool &jobPool, JobPool::JobCallback callback, void *extra, uint64_t chunkId,
-	uint32_t chunkVersion, ChunkPartType chunkType) {
+                    uint32_t chunkVersion, ChunkPartType chunkType, uint32_t listenerId) {
 	JobPool::ProcessJobCallback processJob = [=]() -> uint8_t {
 		return hddInternalDelete(chunkId, chunkVersion, chunkType);
 	};
-	return jobPool.addJob(JobPool::ChunkOperation::Delete, std::move(callback), extra, processJob);
+	return jobPool.addJob(JobPool::ChunkOperation::Delete, std::move(callback), extra, processJob,
+	                      listenerId);
 }
 
 uint32_t job_create(JobPool &jobPool, JobPool::JobCallback callback, void *extra, uint64_t chunkId,
-	uint32_t chunkVersion, ChunkPartType chunkType) {
+                    uint32_t chunkVersion, ChunkPartType chunkType, uint32_t listenerId) {
 	JobPool::ProcessJobCallback processJob = [=]() -> uint8_t {
 		return hddInternalCreate(chunkId, chunkVersion, chunkType);
 	};
-	return jobPool.addJob(JobPool::ChunkOperation::Create, std::move(callback), extra, processJob);
+	return jobPool.addJob(JobPool::ChunkOperation::Create, std::move(callback), extra, processJob,
+	                      listenerId);
 }
 
 uint32_t job_version(JobPool &jobPool, const JobPool::JobCallback &callback, void *extra,
                      uint64_t chunkId, uint32_t chunkVersion, ChunkPartType chunkType,
-                     uint32_t newChunkVersion) {
+                     uint32_t newChunkVersion, uint32_t listenerId) {
 	if (newChunkVersion > 0) {
 		JobPool::ProcessJobCallback processJob = [=]() -> uint8_t {
 			return hddInternalUpdateVersion(chunkId, chunkVersion, newChunkVersion, chunkType);
 		};
-		return jobPool.addJob(JobPool::ChunkOperation::ChangeVersion, callback, extra, processJob);
+		return jobPool.addJob(JobPool::ChunkOperation::ChangeVersion, callback, extra, processJob,
+		                      listenerId);
 	}
-	return job_invalid(jobPool, callback, extra);
+	return job_invalid(jobPool, callback, extra, listenerId);
 }
 
 uint32_t job_truncate(JobPool &jobPool, const JobPool::JobCallback &callback, void *extra,
-	uint64_t chunkId, ChunkPartType chunkType, uint32_t chunkVersion,
-	uint32_t newChunkVersion, uint32_t length) {
+                      uint64_t chunkId, ChunkPartType chunkType, uint32_t chunkVersion,
+                      uint32_t newChunkVersion, uint32_t length, uint32_t listenerId) {
 	if (newChunkVersion > 0) {
 		JobPool::ProcessJobCallback processJob = [=]() -> uint8_t {
 			return hddTruncate(chunkId, chunkVersion, chunkType, newChunkVersion, length);
 		};
-		return jobPool.addJob(JobPool::ChunkOperation::Truncate, callback, extra, processJob);
+		return jobPool.addJob(JobPool::ChunkOperation::Truncate, callback, extra, processJob,
+		                      listenerId);
 	}
-	return job_invalid(jobPool, callback, extra);
+	return job_invalid(jobPool, callback, extra, listenerId);
 }
 
 uint32_t job_duplicate(JobPool &jobPool, const JobPool::JobCallback &callback, void *extra,
                        uint64_t chunkId, uint32_t chunkVersion, uint32_t newChunkVersion,
-                       ChunkPartType chunkType, uint64_t chunkIdCopy, uint32_t chunkVersionCopy) {
+                       ChunkPartType chunkType, uint64_t chunkIdCopy, uint32_t chunkVersionCopy,
+                       uint32_t listenerId) {
 	if (newChunkVersion > 0) {
 		JobPool::ProcessJobCallback processJob = [=]() -> uint8_t {
 			return hddDuplicate(chunkId, chunkVersion, newChunkVersion, chunkType, chunkIdCopy,
 			                    chunkVersionCopy);
 		};
-		return jobPool.addJob(JobPool::ChunkOperation::Duplicate, callback, extra, processJob);
+		return jobPool.addJob(JobPool::ChunkOperation::Duplicate, callback, extra, processJob,
+		                      listenerId);
 	}
-	return job_invalid(jobPool, callback, extra);
+	return job_invalid(jobPool, callback, extra, listenerId);
 }
 
 uint32_t job_duptrunc(JobPool &jobPool, const JobPool::JobCallback &callback, void *extra,
                       uint64_t chunkId, uint32_t chunkVersion, uint32_t newChunkVersion,
                       ChunkPartType chunkType, uint64_t chunkIdCopy, uint32_t chunkVersionCopy,
-                      uint32_t length) {
+                      uint32_t length, uint32_t listenerId) {
 	if (newChunkVersion > 0) {
 		JobPool::ProcessJobCallback processJob = [=]() -> uint8_t {
 			return hddDuplicateTruncate(chunkId, chunkVersion, newChunkVersion, chunkType,
 			                            chunkIdCopy, chunkVersionCopy, length);
 		};
 		return jobPool.addJob(JobPool::ChunkOperation::DuplicateTruncate, callback, extra,
-		                      processJob);
+		                      processJob, listenerId);
 	}
-	return job_invalid(jobPool, callback, extra);
+	return job_invalid(jobPool, callback, extra, listenerId);
 }

--- a/src/chunkserver/bgjobs.h
+++ b/src/chunkserver/bgjobs.h
@@ -92,10 +92,11 @@ public:
 	/// @param name Human readable name for this pool, useful for debugging.
 	/// @param workers The number of worker threads in the pool.
 	/// @param maxJobs The maximum number of jobs that can be queued.
-	/// @param wakeupDesc Pointer to the file descriptor for wakeup notifications.
+	/// @param nrListeners The number of listeners that will use this JobPool.
+	/// @param wakeupFDs A vector of file descriptors for wakeup notifications.
 	/// @throws std::runtime_error If the pipe creation fails.
-	JobPool(const std::string &name, uint8_t workers, uint32_t maxJobs, int nrListeners,
-	        std::vector<int> &wakeupDesc);
+	JobPool(const std::string &name, uint8_t workers, uint32_t maxJobs, uint32_t nrListeners,
+	        std::vector<int> &wakeupFDs);
 
 	/// @brief Destructor for JobPool.
 	~JobPool();
@@ -106,6 +107,7 @@ public:
 	/// @param callback The callback function to be called upon job completion.
 	/// @param extra Additional data to be passed to the callback.
 	/// @param processJob The callback function to process the job.
+	/// @param listenerId The ID of the listener associated with the job.
 	/// @return The ID of the added job.
 	uint32_t addJob(ChunkOperation operation, JobCallback callback, void *extra,
 	                ProcessJobCallback processJob, uint32_t listenerId = 0);
@@ -116,19 +118,24 @@ public:
 	/// @brief Disables all jobs and changes their callback function.
 	///
 	/// @param callback The new callback function to be set for all jobs.
+	/// @param listenerId The ID of the listener associated with the jobs.
 	void disableAndChangeCallbackAll(const JobCallback &callback, uint32_t listenerId = 0);
 
 	/// @brief Disables a specific job.
 	///
 	/// @param jobId The ID of the job to be disabled.
+	/// @param listenerId The ID of the listener associated with the job.
 	void disableJob(uint32_t jobId, uint32_t listenerId = 0);
 
 	/// @brief Disables a list of jobs.
 	///
 	/// @param jobIds The list of jobs by IDs to be disabled.
+	/// @param listenerId The ID of the listener associated with the jobs.
 	void disableJobs(std::list<uint32_t> &jobIds, uint32_t listenerId = 0);
 
 	/// @brief Checks the status of jobs in the JobPool and calls their callbacks.
+	///
+	/// @param listenerId The ID of the listener associated with the jobs.
 	void processCompletedJobs(uint32_t listenerId = 0);
 
 	/// @brief Changes the callback function for a specific job.
@@ -136,6 +143,7 @@ public:
 	/// @param jobId The ID of the job.
 	/// @param callback The new callback function.
 	/// @param extra Additional data to be passed to the new callback.
+	/// @param listenerId The ID of the listener associated with the jobs.
 	void changeCallback(uint32_t jobId, JobCallback callback, void *extra, uint32_t listenerId = 0);
 
 	/// @brief Changes the callback function for a list of jobs.
@@ -143,6 +151,7 @@ public:
 	/// @param jobIds The list of jobs by IDs.
 	/// @param callback The new callback function.
 	/// @param extra Additional data to be passed to the new callback.
+	/// @param listenerId The ID of the listener associated with the jobs.
 	void changeCallback(std::list<uint32_t> &jobIds, JobCallback callback, void *extra,
 	                    uint32_t listenerId = 0);
 
@@ -166,6 +175,7 @@ private:
 	///
 	/// @param jobId The ID of the job.
 	/// @param status The status of the job.
+	/// @param listenerId The ID of the listener associated with the job.
 	void sendStatus(uint32_t jobId, uint8_t status, uint32_t listenerId = 0);
 
 	/// @brief Receives the status of a job.
@@ -173,13 +183,15 @@ private:
 	/// @param jobId The ID of the job.
 	/// @param status The status of the job.
 	/// @return 1 if a status was received, 0 otherwise.
+	/// @param listenerId The ID of the listener associated with the job.
 	bool receiveStatus(uint32_t &jobId, uint8_t &status, uint32_t listenerId = 0);
 
+	/// @brief Structure to hold information about a listener.
 	struct ListenerInfo {
-		int notifierFD;           /// File descriptor for notifications.
-		std::mutex notifierMutex;  /// Mutex for pipe operations.
-		std::mutex jobsMutex;      /// Mutex for job operations.
-		std::unique_ptr<ProducerConsumerQueue> statusQueue;          /// Queue for job statuses.
+		int notifierFD;                                      /// File descriptor for notifications.
+		std::mutex notifierMutex;                            /// Mutex for pipe operations.
+		std::mutex jobsMutex;                                /// Mutex for job operations.
+		std::unique_ptr<ProducerConsumerQueue> statusQueue;  /// Queue for job statuses.
 		std::unordered_map<uint32_t, std::unique_ptr<Job>> jobHash;  /// Hash map of job.
 		uint32_t nextJobId;                                          /// Next job ID to be assigned.
 	};
@@ -198,6 +210,7 @@ private:
 /// @param extra Additional data to be passed to the callback.
 /// @param chunkId The ID of the chunk.
 /// @param chunkType The type of the chunk.
+/// @param listenerId The ID of the listener associated with the job.
 /// @return The ID of the added job.
 uint32_t job_open(JobPool &jobPool, JobPool::JobCallback callback, void *extra, uint64_t chunkId,
                   ChunkPartType chunkType, uint32_t listenerId = 0);
@@ -209,6 +222,7 @@ uint32_t job_open(JobPool &jobPool, JobPool::JobCallback callback, void *extra, 
 /// @param extra Additional data to be passed to the callback.
 /// @param chunkId The ID of the chunk.
 /// @param chunkType The type of the chunk.
+/// @param listenerId The ID of the listener associated with the job.
 /// @return The ID of the added job.
 uint32_t job_close(JobPool &jobPool, JobPool::JobCallback callback, void *extra, uint64_t chunkId,
                    ChunkPartType chunkType, uint32_t listenerId = 0);
@@ -227,6 +241,7 @@ uint32_t job_close(JobPool &jobPool, JobPool::JobCallback callback, void *extra,
 /// @param blocksToBeReadAhead The blocks to be read ahead.
 /// @param outputBuffer The output buffer for the read data.
 /// @param performHddOpen Whether to perform HDD open.
+/// @param listenerId The ID of the listener associated with the job.
 /// @return The ID of the added job.
 uint32_t job_read(JobPool &jobPool, JobPool::JobCallback callback, void *extra, uint64_t chunkId,
                   uint32_t version, ChunkPartType chunkType, uint32_t offset, uint32_t size,
@@ -240,6 +255,7 @@ uint32_t job_read(JobPool &jobPool, JobPool::JobCallback callback, void *extra, 
 /// @param chunkType The type of the chunk.
 /// @param firstBlockToBePrefetched The first block to be prefetched.
 /// @param blocksToBePrefetched The number of blocks to be prefetched.
+/// @param listenerId The ID of the listener associated with the job.
 /// @return The ID of the added job.
 uint32_t job_prefetch(JobPool &jobPool, uint64_t chunkId, ChunkPartType chunkType,
                       uint32_t firstBlockToBePrefetched, uint32_t blocksToBePrefetched,
@@ -258,6 +274,7 @@ uint32_t job_prefetch(JobPool &jobPool, uint64_t chunkId, ChunkPartType chunkTyp
 /// @param size The size to write.
 /// @param crc The CRC of the data.
 /// @param buffer The data buffer to write.
+/// @param listenerId The ID of the listener associated with the job.
 /// @return The ID of the added job.
 uint32_t job_write(JobPool &jobPool, JobPool::JobCallback callback, void *extra, uint64_t chunkId,
                    uint32_t chunkVersion, ChunkPartType chunkType, uint16_t blockNum,
@@ -273,6 +290,7 @@ uint32_t job_write(JobPool &jobPool, JobPool::JobCallback callback, void *extra,
 /// @param version The version of the chunk.
 /// @param chunkType The type of the chunk.
 /// @param blocks The blocks to get.
+/// @param listenerId The ID of the listener associated with the job.
 /// @return The ID of the added job.
 uint32_t job_get_blocks(JobPool &jobPool, JobPool::JobCallback callback, void *extra,
                         uint64_t chunkId, uint32_t version, ChunkPartType chunkType,
@@ -288,6 +306,7 @@ uint32_t job_get_blocks(JobPool &jobPool, JobPool::JobCallback callback, void *e
 /// @param chunkType The type of the chunk.
 /// @param sourcesBufferSize The size of the sources buffer.
 /// @param sourcesBuffer The sources buffer.
+/// @param listenerId The ID of the listener associated with the job.
 /// @return The ID of the added job.
 uint32_t job_replicate(JobPool &jobPool, JobPool::JobCallback callback, void *extra,
                        uint64_t chunkId, uint32_t chunkVersion, ChunkPartType chunkType,
@@ -299,6 +318,7 @@ uint32_t job_replicate(JobPool &jobPool, JobPool::JobCallback callback, void *ex
 /// @param jobPool The JobPool instance.
 /// @param callback The callback function to be called upon job completion.
 /// @param extra Additional data to be passed to the callback.
+/// @param listenerId The ID of the listener associated with the job.
 /// @return The ID of the added job.
 uint32_t job_invalid(JobPool &jobPool, JobPool::JobCallback callback, void *extra,
                      uint32_t listenerId = 0);
@@ -311,6 +331,7 @@ uint32_t job_invalid(JobPool &jobPool, JobPool::JobCallback callback, void *extr
 /// @param chunkId The ID of the chunk.
 /// @param chunkVersion The version of the chunk.
 /// @param chunkType The type of the chunk.
+/// @param listenerId The ID of the listener associated with the job.
 /// @return The ID of the added job.
 uint32_t job_delete(JobPool &jobPool, JobPool::JobCallback callback, void *extra, uint64_t chunkId,
                     uint32_t chunkVersion, ChunkPartType chunkType, uint32_t listenerId = 0);
@@ -323,6 +344,7 @@ uint32_t job_delete(JobPool &jobPool, JobPool::JobCallback callback, void *extra
 /// @param chunkId The ID of the chunk.
 /// @param chunkVersion The version of the chunk.
 /// @param chunkType The type of the chunk.
+/// @param listenerId The ID of the listener associated with the job.
 /// @return The ID of the added job.
 uint32_t job_create(JobPool &jobPool, JobPool::JobCallback callback, void *extra, uint64_t chunkId,
                     uint32_t chunkVersion, ChunkPartType chunkType, uint32_t listenerId = 0);
@@ -336,6 +358,7 @@ uint32_t job_create(JobPool &jobPool, JobPool::JobCallback callback, void *extra
 /// @param chunkVersion The version of the chunk.
 /// @param chunkType The type of the chunk.
 /// @param newChunkVersion The new version of the chunk.
+/// @param listenerId The ID of the listener associated with the job.
 /// @return The ID of the added job.
 uint32_t job_version(JobPool &jobPool, const JobPool::JobCallback &callback, void *extra,
                      uint64_t chunkId, uint32_t chunkVersion, ChunkPartType chunkType,
@@ -351,6 +374,7 @@ uint32_t job_version(JobPool &jobPool, const JobPool::JobCallback &callback, voi
 /// @param chunkVersion The version of the chunk.
 /// @param newChunkVersion The new version of the chunk.
 /// @param length The length to truncate to.
+/// @param listenerId The ID of the listener associated with the job.
 /// @return The ID of the added job.
 uint32_t job_truncate(JobPool &jobPool, const JobPool::JobCallback &callback, void *extra,
                       uint64_t chunkId, ChunkPartType chunkType, uint32_t chunkVersion,
@@ -367,6 +391,7 @@ uint32_t job_truncate(JobPool &jobPool, const JobPool::JobCallback &callback, vo
 /// @param chunkType The type of the chunk.
 /// @param chunkIdCopy The ID of the chunk to copy.
 /// @param chunkVersionCopy The version of the chunk to copy.
+/// @param listenerId The ID of the listener associated with the job.
 /// @return The ID of the added job.
 uint32_t job_duplicate(JobPool &jobPool, const JobPool::JobCallback &callback, void *extra,
                        uint64_t chunkId, uint32_t chunkVersion, uint32_t newChunkVersion,
@@ -385,6 +410,7 @@ uint32_t job_duplicate(JobPool &jobPool, const JobPool::JobCallback &callback, v
 /// @param chunkIdCopy The ID of the chunk to copy.
 /// @param chunkVersionCopy The version of the chunk to copy.
 /// @param length The length to truncate to.
+/// @param listenerId The ID of the listener associated with the job.
 /// @return The ID of the added job.
 uint32_t job_duptrunc(JobPool &jobPool, const JobPool::JobCallback &callback, void *extra,
                       uint64_t chunkId, uint32_t chunkVersion, uint32_t newChunkVersion,

--- a/src/chunkserver/bgjobs.h
+++ b/src/chunkserver/bgjobs.h
@@ -182,14 +182,14 @@ private:
 	///
 	/// @param jobId The ID of the job.
 	/// @param status The status of the job.
-	/// @return 1 if a status was received, 0 otherwise.
 	/// @param listenerId The ID of the listener associated with the job.
+	/// @return 1 if a status is not the last one, 0 if it is the last status.
 	bool receiveStatus(uint32_t &jobId, uint8_t &status, uint32_t listenerId = 0);
 
 	/// @brief Structure to hold information about a listener.
 	struct ListenerInfo {
 		int notifierFD;                                      /// File descriptor for notifications.
-		std::mutex notifierMutex;                            /// Mutex for pipe operations.
+		std::mutex notifierMutex;                            /// Mutex for event notifications.
 		std::mutex jobsMutex;                                /// Mutex for job operations.
 		std::unique_ptr<ProducerConsumerQueue> statusQueue;  /// Queue for job statuses.
 		std::unordered_map<uint32_t, std::unique_ptr<Job>> jobHash;  /// Hash map of job.

--- a/src/chunkserver/bgjobs.h
+++ b/src/chunkserver/bgjobs.h
@@ -94,7 +94,8 @@ public:
 	/// @param maxJobs The maximum number of jobs that can be queued.
 	/// @param wakeupDesc Pointer to the file descriptor for wakeup notifications.
 	/// @throws std::runtime_error If the pipe creation fails.
-	JobPool(const std::string &name, uint8_t workers, uint32_t maxJobs, int *wakeupDesc);
+	JobPool(const std::string &name, uint8_t workers, uint32_t maxJobs, int nrListeners,
+	        std::vector<int> &wakeupDesc);
 
 	/// @brief Destructor for JobPool.
 	~JobPool();
@@ -107,7 +108,7 @@ public:
 	/// @param processJob The callback function to process the job.
 	/// @return The ID of the added job.
 	uint32_t addJob(ChunkOperation operation, JobCallback callback, void *extra,
-	                ProcessJobCallback processJob);
+	                ProcessJobCallback processJob, uint32_t listenerId = 0);
 
 	/// @brief Gets the number of jobs in the JobPool.
 	uint32_t getJobCount() const;
@@ -115,34 +116,35 @@ public:
 	/// @brief Disables all jobs and changes their callback function.
 	///
 	/// @param callback The new callback function to be set for all jobs.
-	void disableAndChangeCallbackAll(const JobCallback& callback);
+	void disableAndChangeCallbackAll(const JobCallback &callback, uint32_t listenerId = 0);
 
 	/// @brief Disables a specific job.
 	///
 	/// @param jobId The ID of the job to be disabled.
-	void disableJob(uint32_t jobId);
+	void disableJob(uint32_t jobId, uint32_t listenerId = 0);
 
 	/// @brief Disables a list of jobs.
 	///
 	/// @param jobIds The list of jobs by IDs to be disabled.
-	void disableJobs(std::list<uint32_t> &jobIds);
+	void disableJobs(std::list<uint32_t> &jobIds, uint32_t listenerId = 0);
 
 	/// @brief Checks the status of jobs in the JobPool and calls their callbacks.
-	void processCompletedJobs();
+	void processCompletedJobs(uint32_t listenerId = 0);
 
 	/// @brief Changes the callback function for a specific job.
 	///
 	/// @param jobId The ID of the job.
 	/// @param callback The new callback function.
 	/// @param extra Additional data to be passed to the new callback.
-	void changeCallback(uint32_t jobId, JobCallback callback, void *extra);
+	void changeCallback(uint32_t jobId, JobCallback callback, void *extra, uint32_t listenerId = 0);
 
 	/// @brief Changes the callback function for a list of jobs.
 	///
 	/// @param jobIds The list of jobs by IDs.
 	/// @param callback The new callback function.
 	/// @param extra Additional data to be passed to the new callback.
-	void changeCallback(std::list<uint32_t> &jobIds, JobCallback callback, void *extra);
+	void changeCallback(std::list<uint32_t> &jobIds, JobCallback callback, void *extra,
+	                    uint32_t listenerId = 0);
 
 private:
 	/// @brief Represents a job in the JobPool.
@@ -152,6 +154,7 @@ private:
 		ProcessJobCallback processJob;  // The callback function to process the job.
 		void *extra;                    // Additional data for the callback.
 		JobPool::State state;           // The state of the job.
+		uint32_t listenerId;            // The ID of the listener associated with the job.
 	};
 
 	/// @brief Worker thread function.
@@ -163,25 +166,29 @@ private:
 	///
 	/// @param jobId The ID of the job.
 	/// @param status The status of the job.
-	void sendStatus(uint32_t jobId, uint8_t status);
+	void sendStatus(uint32_t jobId, uint8_t status, uint32_t listenerId = 0);
 
 	/// @brief Receives the status of a job.
 	///
 	/// @param jobId The ID of the job.
 	/// @param status The status of the job.
 	/// @return 1 if a status was received, 0 otherwise.
-	bool receiveStatus(uint32_t &jobId, uint8_t &status);
+	bool receiveStatus(uint32_t &jobId, uint8_t &status, uint32_t listenerId = 0);
 
-	int notifierFD_;                                   /// File descriptor for notifications.
+	struct ListenerInfo {
+		int notifierFD;           /// File descriptor for notifications.
+		std::mutex notifierMutex;  /// Mutex for pipe operations.
+		std::mutex jobsMutex;      /// Mutex for job operations.
+		std::unique_ptr<ProducerConsumerQueue> statusQueue;          /// Queue for job statuses.
+		std::unordered_map<uint32_t, std::unique_ptr<Job>> jobHash;  /// Hash map of job.
+		uint32_t nextJobId;                                          /// Next job ID to be assigned.
+	};
+
+	std::vector<ListenerInfo> listenerInfos_;          /// Vector of listener information.
 	std::string name_;                                 /// Human readable id of the JobPool.
 	uint8_t workers;                                   /// Number of worker threads in the pool.
 	std::vector<std::thread> workerThreads;            /// Vector of worker threads.
-	std::mutex statusMutex_;                           /// Mutex for status notifications.
-	std::mutex jobsMutex;                              /// Mutex for job operations.
 	std::unique_ptr<ProducerConsumerQueue> jobsQueue;  /// Queue for jobs.
-	std::unique_ptr<ProducerConsumerQueue> statusQueue;          /// Queue for job statuses.
-	std::unordered_map<uint32_t, std::unique_ptr<Job>> jobHash;  /// Hash map of job.
-	uint32_t nextJobId = 1;                                      /// Next job ID to be assigned.
 };
 
 /// @brief Adds an open job to the JobPool.
@@ -192,8 +199,8 @@ private:
 /// @param chunkId The ID of the chunk.
 /// @param chunkType The type of the chunk.
 /// @return The ID of the added job.
-uint32_t job_open(JobPool &jobPool, JobPool::JobCallback callback, void *extra,
-                  uint64_t chunkId, ChunkPartType chunkType);
+uint32_t job_open(JobPool &jobPool, JobPool::JobCallback callback, void *extra, uint64_t chunkId,
+                  ChunkPartType chunkType, uint32_t listenerId = 0);
 
 /// @brief Adds a close job to the JobPool.
 ///
@@ -204,7 +211,7 @@ uint32_t job_open(JobPool &jobPool, JobPool::JobCallback callback, void *extra,
 /// @param chunkType The type of the chunk.
 /// @return The ID of the added job.
 uint32_t job_close(JobPool &jobPool, JobPool::JobCallback callback, void *extra, uint64_t chunkId,
-                   ChunkPartType chunkType);
+                   ChunkPartType chunkType, uint32_t listenerId = 0);
 
 /// @brief Adds a read job to the JobPool.
 ///
@@ -224,7 +231,7 @@ uint32_t job_close(JobPool &jobPool, JobPool::JobCallback callback, void *extra,
 uint32_t job_read(JobPool &jobPool, JobPool::JobCallback callback, void *extra, uint64_t chunkId,
                   uint32_t version, ChunkPartType chunkType, uint32_t offset, uint32_t size,
                   uint32_t maxBlocksToBeReadBehind, uint32_t blocksToBeReadAhead,
-                  OutputBuffer *outputBuffer, bool performHddOpen);
+                  OutputBuffer *outputBuffer, bool performHddOpen, uint32_t listenerId = 0);
 
 /// @brief Adds a prefetch job to the JobPool.
 ///
@@ -235,7 +242,8 @@ uint32_t job_read(JobPool &jobPool, JobPool::JobCallback callback, void *extra, 
 /// @param blocksToBePrefetched The number of blocks to be prefetched.
 /// @return The ID of the added job.
 uint32_t job_prefetch(JobPool &jobPool, uint64_t chunkId, ChunkPartType chunkType,
-                      uint32_t firstBlockToBePrefetched, uint32_t blocksToBePrefetched);
+                      uint32_t firstBlockToBePrefetched, uint32_t blocksToBePrefetched,
+                      uint32_t listenerId = 0);
 
 /// @brief Adds a write job to the JobPool.
 ///
@@ -253,7 +261,8 @@ uint32_t job_prefetch(JobPool &jobPool, uint64_t chunkId, ChunkPartType chunkTyp
 /// @return The ID of the added job.
 uint32_t job_write(JobPool &jobPool, JobPool::JobCallback callback, void *extra, uint64_t chunkId,
                    uint32_t chunkVersion, ChunkPartType chunkType, uint16_t blockNum,
-                   uint32_t offset, uint32_t size, uint32_t crc, const uint8_t *buffer);
+                   uint32_t offset, uint32_t size, uint32_t crc, const uint8_t *buffer,
+                   uint32_t listenerId = 0);
 
 /// @brief Adds a get blocks job to the JobPool.
 ///
@@ -267,7 +276,7 @@ uint32_t job_write(JobPool &jobPool, JobPool::JobCallback callback, void *extra,
 /// @return The ID of the added job.
 uint32_t job_get_blocks(JobPool &jobPool, JobPool::JobCallback callback, void *extra,
                         uint64_t chunkId, uint32_t version, ChunkPartType chunkType,
-                        uint16_t *blocks);
+                        uint16_t *blocks, uint32_t listenerId = 0);
 
 /// @brief Adds a replicate job to the JobPool.
 ///
@@ -282,7 +291,8 @@ uint32_t job_get_blocks(JobPool &jobPool, JobPool::JobCallback callback, void *e
 /// @return The ID of the added job.
 uint32_t job_replicate(JobPool &jobPool, JobPool::JobCallback callback, void *extra,
                        uint64_t chunkId, uint32_t chunkVersion, ChunkPartType chunkType,
-                       uint32_t sourcesBufferSize, const uint8_t *sourcesBuffer);
+                       uint32_t sourcesBufferSize, const uint8_t *sourcesBuffer,
+                       uint32_t listenerId = 0);
 
 /// @brief Adds an invalid job to the JobPool.
 ///
@@ -290,7 +300,8 @@ uint32_t job_replicate(JobPool &jobPool, JobPool::JobCallback callback, void *ex
 /// @param callback The callback function to be called upon job completion.
 /// @param extra Additional data to be passed to the callback.
 /// @return The ID of the added job.
-uint32_t job_invalid(JobPool &jobPool, JobPool::JobCallback callback, void *extra);
+uint32_t job_invalid(JobPool &jobPool, JobPool::JobCallback callback, void *extra,
+                     uint32_t listenerId = 0);
 
 /// @brief Adds a delete job to the JobPool.
 ///
@@ -302,7 +313,7 @@ uint32_t job_invalid(JobPool &jobPool, JobPool::JobCallback callback, void *extr
 /// @param chunkType The type of the chunk.
 /// @return The ID of the added job.
 uint32_t job_delete(JobPool &jobPool, JobPool::JobCallback callback, void *extra, uint64_t chunkId,
-                    uint32_t chunkVersion, ChunkPartType chunkType);
+                    uint32_t chunkVersion, ChunkPartType chunkType, uint32_t listenerId = 0);
 
 /// @brief Adds a create job to the JobPool.
 ///
@@ -314,7 +325,7 @@ uint32_t job_delete(JobPool &jobPool, JobPool::JobCallback callback, void *extra
 /// @param chunkType The type of the chunk.
 /// @return The ID of the added job.
 uint32_t job_create(JobPool &jobPool, JobPool::JobCallback callback, void *extra, uint64_t chunkId,
-                    uint32_t chunkVersion, ChunkPartType chunkType);
+                    uint32_t chunkVersion, ChunkPartType chunkType, uint32_t listenerId = 0);
 
 /// @brief Adds a change version job to the JobPool.
 ///
@@ -328,7 +339,7 @@ uint32_t job_create(JobPool &jobPool, JobPool::JobCallback callback, void *extra
 /// @return The ID of the added job.
 uint32_t job_version(JobPool &jobPool, const JobPool::JobCallback &callback, void *extra,
                      uint64_t chunkId, uint32_t chunkVersion, ChunkPartType chunkType,
-                     uint32_t newChunkVersion);
+                     uint32_t newChunkVersion, uint32_t listenerId = 0);
 
 /// @brief Adds a truncate job to the JobPool.
 ///
@@ -343,7 +354,7 @@ uint32_t job_version(JobPool &jobPool, const JobPool::JobCallback &callback, voi
 /// @return The ID of the added job.
 uint32_t job_truncate(JobPool &jobPool, const JobPool::JobCallback &callback, void *extra,
                       uint64_t chunkId, ChunkPartType chunkType, uint32_t chunkVersion,
-                      uint32_t newChunkVersion, uint32_t length);
+                      uint32_t newChunkVersion, uint32_t length, uint32_t listenerId = 0);
 
 /// @brief Adds a duplicate job to the JobPool.
 ///
@@ -359,7 +370,8 @@ uint32_t job_truncate(JobPool &jobPool, const JobPool::JobCallback &callback, vo
 /// @return The ID of the added job.
 uint32_t job_duplicate(JobPool &jobPool, const JobPool::JobCallback &callback, void *extra,
                        uint64_t chunkId, uint32_t chunkVersion, uint32_t newChunkVersion,
-                       ChunkPartType chunkType, uint64_t chunkIdCopy, uint32_t chunkVersionCopy);
+                       ChunkPartType chunkType, uint64_t chunkIdCopy, uint32_t chunkVersionCopy,
+                       uint32_t listenerId = 0);
 
 /// @brief Adds a duplicate and truncate job to the JobPool.
 ///
@@ -377,4 +389,4 @@ uint32_t job_duplicate(JobPool &jobPool, const JobPool::JobCallback &callback, v
 uint32_t job_duptrunc(JobPool &jobPool, const JobPool::JobCallback &callback, void *extra,
                       uint64_t chunkId, uint32_t chunkVersion, uint32_t newChunkVersion,
                       ChunkPartType chunkType, uint64_t chunkIdCopy, uint32_t chunkVersionCopy,
-                      uint32_t length);
+                      uint32_t length, uint32_t listenerId = 0);

--- a/src/chunkserver/bgjobs_unittest.cc
+++ b/src/chunkserver/bgjobs_unittest.cc
@@ -34,12 +34,14 @@ constexpr uint32_t kWaitTimeMs = 100;
 // Test fixture for JobPool tests
 class JobPoolTest : public ::testing::Test {
 private:
-	void servePoll() {
+	void servePoll(uint32_t listenerId) {
+		struct pollfd wakeupDescPollFd = {wakeupDescVec[listenerId], POLLIN, 0};
 		while (!terminate) {
 			int ret = poll(&wakeupDescPollFd, 1, kWaitTimeMs);
 			if (ret > 0) {
 				if (wakeupDescPollFd.revents & POLLIN) {
-					jobPool->processCompletedJobs();
+					processingCount[listenerId].fetch_add(1);
+					jobPool->processCompletedJobs(listenerId);
 				}
 			}
 		}
@@ -47,13 +49,15 @@ private:
 
 protected:
 	void SetUp() override {
-		wakeupDesc = 0;
-		std::vector<int> wakeupDescVec(1);
-		jobPool = std::make_unique<JobPool>("TestPool", 4, 10, 1, wakeupDescVec);
-		wakeupDesc = wakeupDescVec[0];
-		counter.store(0);
-		counter2.store(0);
-		wakeupDescPollFd = {wakeupDesc, POLLIN, 0};
+		// Let's create some listeners for the JobPool
+		wakeupDescVec.resize(kNrListeners);
+		jobPool = std::make_unique<JobPool>("TestPool", 4, 10, kNrListeners, wakeupDescVec);
+		for (uint32_t i = 0; i < kNrListeners; ++i) {
+			processingCount[i] = 0;
+		}
+		for (uint32_t i = 0; i < kNrOperationTypes; ++i) {
+			counters[i] = 0;
+		}
 		startServePoll();
 	}
 
@@ -64,7 +68,9 @@ protected:
 
 	void startServePoll() {
 		terminate = false;
-		servePollThread = std::thread([this]() { servePoll(); });
+		for (uint32_t i = 0; i < kNrListeners; ++i) {
+			servePollThreads.emplace_back(&JobPoolTest::servePoll, this, i);
+		}
 	}
 
 	void stopServePoll() {
@@ -72,7 +78,12 @@ protected:
 		terminate = true;
 		lock.unlock();
 
-		if (servePollThread.joinable()) { servePollThread.join(); }
+		for (auto &thread : servePollThreads) {
+			if (thread.joinable()) {
+				thread.join();
+			}
+		}
+		servePollThreads.clear();
 	}
 
 	JobPool::ProcessJobCallback mockProcessJob = []() -> uint8_t {
@@ -80,29 +91,48 @@ protected:
 	};
 
 	std::unique_ptr<JobPool> jobPool;
-	int wakeupDesc;
-	std::atomic<int> counter;
-	std::atomic<int> counter2;
-	struct pollfd wakeupDescPollFd;
-	std::thread servePollThread;
+	std::vector<int> wakeupDescVec;
+	std::vector<std::thread> servePollThreads;
 	bool terminate;
 	std::mutex mutex_;
+	static constexpr uint32_t kNrListeners = 4;
+	static constexpr uint32_t kNrOperationTypes = 10;
+	std::atomic<int> processingCount[kNrListeners];
+	std::atomic<int> counters[kNrOperationTypes];
 };
 
 // Test job addition
 TEST_F(JobPoolTest, AddJob) {
-	jobPool->addJob(JobPool::ChunkOperation::Read, mockJobCallback, &counter, mockProcessJob);
+	jobPool->addJob(JobPool::ChunkOperation::Read, mockJobCallback, &counters[0], mockProcessJob);
 	EXPECT_EQ(jobPool->getJobCount(), 1U);
 }
 
 // Test job processing
 TEST_F(JobPoolTest, ProcessJob) {
-	jobPool->addJob(JobPool::ChunkOperation::Read, mockJobCallback, &counter, mockProcessJob);
+	const int nrJobsToProcess = 10;
+	std::vector<int> expectedCounters(kNrOperationTypes, 0);
+	std::vector<int> expectedProcessingCount(kNrListeners, 0);
 
-	// Wait for the job to be processed
-	std::this_thread::sleep_for(std::chrono::milliseconds(kWaitTimeMs));
+	for (int i = 0; i < nrJobsToProcess; ++i) {
+		auto opType = std::rand() % kNrOperationTypes;
+		auto targetListener = std::rand() % kNrListeners;
+		jobPool->addJob(JobPool::ChunkOperation::Read, mockJobCallback, &counters[opType],
+		                mockProcessJob, targetListener);
 
-	EXPECT_EQ(counter.load(), 1);
+		// Update expected counters
+		expectedCounters[opType]++;
+		expectedProcessingCount[targetListener]++;
+
+		// Wait for the job to be processed
+		std::this_thread::sleep_for(std::chrono::milliseconds(kWaitTimeMs));
+
+		for (uint32_t j = 0; j < kNrOperationTypes; ++j) {
+			EXPECT_EQ(counters[j].load(), expectedCounters[j]);
+		}
+		for (uint32_t j = 0; j < kNrListeners; ++j) {
+			EXPECT_EQ(processingCount[j].load(), expectedProcessingCount[j]);
+		}
+	}
 }
 
 // Test job disabling
@@ -112,27 +142,58 @@ TEST_F(JobPoolTest, DisableJob) {
 		counter->store(status);
 	};
 
-	uint32_t jobId =
-	    jobPool->addJob(JobPool::ChunkOperation::Read, mockedJobCallback, &counter, mockProcessJob);
-	jobPool->disableJob(jobId);
+	const uint32_t kOpToDisable = 0;           // Index of the operation to disable
+	const uint32_t kOpToNotDisable = 1;        // Index of the operation to not disable
+	const uint32_t kListenerToDisable = 0;     // Listener ID to disable the job for
+	const uint32_t kListenerToNotDisable = 1;  // Listener ID to not disable the job for
+
+	uint32_t jobIdToNotDisable =
+	    jobPool->addJob(JobPool::ChunkOperation::Read, mockedJobCallback,
+	                    &counters[kOpToNotDisable], mockProcessJob, kListenerToNotDisable);
+	uint32_t jobIdToDisable =
+	    jobPool->addJob(JobPool::ChunkOperation::Read, mockedJobCallback, &counters[kOpToDisable],
+	                    mockProcessJob, kListenerToDisable);
+
+	// Note the jobIds are equal, but we would only disable the job with the specified listener ID
+	EXPECT_EQ(jobIdToDisable, jobIdToNotDisable);
+
+	jobPool->disableJob(jobIdToDisable, kListenerToDisable);
 
 	// Wait for the job to be processed
 	std::this_thread::sleep_for(std::chrono::milliseconds(kWaitTimeMs));
 
-	EXPECT_EQ(counter.load(), SAUNAFS_ERROR_NOTDONE);
+	EXPECT_EQ(counters[kOpToDisable].load(), SAUNAFS_ERROR_NOTDONE);
+	EXPECT_EQ(counters[kOpToNotDisable].load(), SAUNAFS_STATUS_OK);
 }
 
 // Test changing callbacks
 TEST_F(JobPoolTest, ChangeCallback) {
-	uint32_t jobId =
-	    jobPool->addJob(JobPool::ChunkOperation::Read, mockJobCallback, &counter, mockProcessJob);
-	jobPool->changeCallback(jobId, mockJobCallback, &counter2);
+	const uint32_t kOriginalOpType = 0;     // Index of the operation to change the callback for
+	const uint32_t kNewOpType = 1;          // Index of the operation to change the callback to
+	const uint32_t kNotChangingOpType = 2;  // Index of the operation to not change the callback for
+	const uint32_t kChangingListenerId = 0;     // Listener ID to change the callback for
+	const uint32_t kNotChangingListenerId = 1;  // Listener ID to not change the callback for
+
+	uint32_t jobIdToNotChange =
+	    jobPool->addJob(JobPool::ChunkOperation::Read, mockJobCallback,
+	                    &counters[kNotChangingOpType], mockProcessJob, kNotChangingListenerId);
+	uint32_t jobIdToChange =
+	    jobPool->addJob(JobPool::ChunkOperation::Read, mockJobCallback, &counters[kOriginalOpType],
+	                    mockProcessJob, kChangingListenerId);
+
+	// Note the jobIds are equal, but we would only change the callback for the specified listener
+	// ID
+	EXPECT_EQ(jobIdToChange, jobIdToNotChange);
+
+	jobPool->changeCallback(jobIdToChange, mockJobCallback, &counters[kNewOpType],
+	                        kChangingListenerId);
 
 	// Wait for the job to be processed
 	std::this_thread::sleep_for(std::chrono::milliseconds(kWaitTimeMs));
 
-	EXPECT_EQ(counter.load(), 0);
-	EXPECT_EQ(counter2.load(), 1);
+	EXPECT_EQ(counters[kOriginalOpType].load(), 0);
+	EXPECT_EQ(counters[kNewOpType].load(), 1);
+	EXPECT_EQ(counters[kNotChangingOpType].load(), 1);
 }
 
 // Test job status handling
@@ -140,11 +201,16 @@ TEST_F(JobPoolTest, JobStatusHandling) {
 	// Stop the servePoll thread to disable automatic job dispatching
 	stopServePoll();
 
-	jobPool->addJob(JobPool::ChunkOperation::Read, mockJobCallback, &counter, mockProcessJob);
+	for (uint32_t i = 0; i < kNrOperationTypes; ++i) {
+		jobPool->addJob(JobPool::ChunkOperation::Read, mockJobCallback, &counters[i],
+		                mockProcessJob);
+	}
 
 	// Wait for the job to be processed
 	std::this_thread::sleep_for(std::chrono::milliseconds(kWaitTimeMs));
 
 	jobPool->processCompletedJobs();
-	EXPECT_EQ(counter.load(), 1);
+	for (uint32_t i = 0; i < kNrOperationTypes; ++i) {
+		EXPECT_EQ(counters[i].load(), 1);  // Each job should have been processed once
+	}
 }

--- a/src/chunkserver/bgjobs_unittest.cc
+++ b/src/chunkserver/bgjobs_unittest.cc
@@ -48,7 +48,9 @@ private:
 protected:
 	void SetUp() override {
 		wakeupDesc = 0;
-		jobPool = std::make_unique<JobPool>("TestPool", 4, 10, &wakeupDesc);
+		std::vector<int> wakeupDescVec(1);
+		jobPool = std::make_unique<JobPool>("TestPool", 4, 10, 1, wakeupDescVec);
+		wakeupDesc = wakeupDescVec[0];
 		counter.store(0);
 		counter2.store(0);
 		wakeupDescPollFd = {wakeupDesc, POLLIN, 0};

--- a/src/chunkserver/bgjobs_unittest.cc
+++ b/src/chunkserver/bgjobs_unittest.cc
@@ -113,6 +113,7 @@ TEST_F(JobPoolTest, ProcessJob) {
 	std::vector<int> expectedCounters(kNrOperationTypes, 0);
 	std::vector<int> expectedProcessingCount(kNrListeners, 0);
 
+	std::srand(42);  // Seed for random number generation
 	for (int i = 0; i < nrJobsToProcess; ++i) {
 		auto opType = std::rand() % kNrOperationTypes;
 		auto targetListener = std::rand() % kNrListeners;

--- a/src/chunkserver/masterconn.cc
+++ b/src/chunkserver/masterconn.cc
@@ -950,6 +950,8 @@ int masterconn_init_threads(void) {
 	                                              kMinNumberOfWorkers);
 
 	try {
+		// Create the JobPool instance with the specified number of workers, it would be serving
+		// only this master network thread, thus the number of listeners is 1.
 		std::vector<int> bgJobPoolFDs(1);
 		gJobPool = std::make_shared<JobPool>("ma", gNumberOfWorkers, kMaxBackgroundJobsCount, 1,
 		                                     bgJobPoolFDs);

--- a/src/chunkserver/masterconn.cc
+++ b/src/chunkserver/masterconn.cc
@@ -950,8 +950,10 @@ int masterconn_init_threads(void) {
 	                                              kMinNumberOfWorkers);
 
 	try {
-		gJobPool =
-		    std::make_shared<JobPool>("ma", gNumberOfWorkers, kMaxBackgroundJobsCount, &gJobFD);
+		std::vector<int> bgJobPoolFDs(1);
+		gJobPool = std::make_shared<JobPool>("ma", gNumberOfWorkers, kMaxBackgroundJobsCount, 1,
+		                                     bgJobPoolFDs);
+		gJobFD = bgJobPoolFDs[0];
 	} catch (const std::exception &e) {
 		safs::log_err("masterconn_init_threads: Failed to create JobPool instance: {}", e.what());
 		return -1;

--- a/src/chunkserver/network_worker_thread.cc
+++ b/src/chunkserver/network_worker_thread.cc
@@ -65,6 +65,8 @@ NetworkWorkerThread::NetworkWorkerThread(uint32_t id, uint32_t nrOfBgjobsWorkers
 	eassert(fcntl(notify_pipe[1], F_SETPIPE_SZ, kPageAlignedPipeSize));
 #endif
 	try {
+		// Create the JobPool instance with the specified number of workers. It would be serving
+		// only this network worker thread, thus the number of listeners is 1.
 		std::vector<int> bgJobPoolWakeUpFds(1);
 		bgJobPool_ =
 		    std::make_unique<JobPool>(name_, nrOfBgjobsWorkers, bgjobsCount, 1, bgJobPoolWakeUpFds);

--- a/src/chunkserver/network_worker_thread.cc
+++ b/src/chunkserver/network_worker_thread.cc
@@ -65,8 +65,10 @@ NetworkWorkerThread::NetworkWorkerThread(uint32_t id, uint32_t nrOfBgjobsWorkers
 	eassert(fcntl(notify_pipe[1], F_SETPIPE_SZ, kPageAlignedPipeSize));
 #endif
 	try {
+		std::vector<int> bgJobPoolWakeUpFds(1);
 		bgJobPool_ =
-		    std::make_unique<JobPool>(name_, nrOfBgjobsWorkers, bgjobsCount, &bgJobPoolWakeUpFd_);
+		    std::make_unique<JobPool>(name_, nrOfBgjobsWorkers, bgjobsCount, 1, bgJobPoolWakeUpFds);
+		bgJobPoolWakeUpFd_ = bgJobPoolWakeUpFds[0];
 	} catch (const std::exception &e) {
 		safs::log_err("NetworkWorkerThread: Failed to create JobPool instance: {}", e.what());
 		throw;


### PR DESCRIPTION
This PR targets changing the current behavior of the JobPool class,
in the way that it can serve different threads at the same time.
Current implementation does not allow a single JobPool instance to
serve different threads because it would mix up the wake up calls and
it would cause dangerous inconsistencies.

The proposed implementation partitions the JobPool inner structures for
each of the sources of jobs (which could be master or client network
workers) and creates specific channels of comunication to ensure that
only the source of a job is awaken.

This PR also includes changes in the JobPool's unittests to check the new
behavior.

The idea is to squash these commits.

Signed-off-by: Dave <dave@leil.io>