### PR TITLE
feat!(master): Avoid overlapping scheduled deletions

### DIFF
--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -606,7 +606,7 @@ FSNode *fsnodes_create_node(uint32_t ts, FSNodeDirectory *parent, const HString 
 		node->trashtime = parent->trashtime;
 	} else {
 		node->goal = DEFAULT_GOAL;
-		node->trashtime = DEFAULT_TRASHTIME;
+		node->trashtime = kDefaultTrashTime;
 	}
 	if (type == FSNode::kDirectory) {
 		node->mode = (mode & 07777) | (parent->mode & 0xF000);

--- a/src/master/filesystem_operations.h
+++ b/src/master/filesystem_operations.h
@@ -31,7 +31,13 @@
 #include "protocol/lock_info.h"
 
 #define DEFAULT_GOAL 1
-#define DEFAULT_TRASHTIME 86400
+
+/// Default trashtime of 26 hours and 17 minutes.
+/// This time is selected for two main reasons:
+/// 1. Avoid overlapping daily scheduled file deletions with actual chunk deletions from the
+///    previous day.
+/// 2. Reduce collisions of chunk deletions and metadata dump operations.
+constexpr uint32_t kDefaultTrashTime = 94620;
 
 namespace FsStats {
 enum {

--- a/src/master/metadata_backend_file.cc
+++ b/src/master/metadata_backend_file.cc
@@ -1095,7 +1095,7 @@ void fs_new(void) {
 	gMetadata->root->ctime = gMetadata->root->mtime = gMetadata->root->atime =
 	    eventloop_time();
 	gMetadata->root->goal = DEFAULT_GOAL;
-	gMetadata->root->trashtime = DEFAULT_TRASHTIME;
+	gMetadata->root->trashtime = kDefaultTrashTime;
 	gMetadata->root->mode = 0777;
 	gMetadata->root->uid = 0;
 	gMetadata->root->gid = 0;

--- a/tests/test_suites/SanityChecks/test_sfstools.sh
+++ b/tests/test_suites/SanityChecks/test_sfstools.sh
@@ -19,7 +19,7 @@ assert_equals "$goal" "dir: 2"
 
 
 time=$(saunafs gettrashtime test)
-assert_equals "$time" "test: 86400"
+assert_equals "$time" "test: 94620"
 saunafs settrashtime 0 test
 time=$(saunafs gettrashtime test)
 assert_equals "$time" "test: 0"


### PR DESCRIPTION
This change increases the default trash time from 24 hours to 26 hours and 17 minutes, to prevent overlapping of scheduled file deletions with the actual deletion of chunks from the previous day.