### PR TITLE
Add saunafs version name on code

### DIFF
--- a/src/cgi/sfs.cgi.in
+++ b/src/cgi/sfs.cgi.in
@@ -51,6 +51,7 @@ SAU_MATOCL_MOUNT_INFO_LIST = 1610
 SAUNAFS_VERSION_WITH_QUOTAS = (2, 5, 0)
 SAUNAFS_VERSION_WITH_CUSTOM_GOALS = (2, 5, 3)
 SAUNAFS_VERSION_WITH_LIST_OF_SHADOWS = (2, 5, 5)
+SAUNAFS_VERSION_WITH_MOUNT_INFO_IN_MONITORING = (5, 0, 0)
 
 cgitb.enable()
 
@@ -217,7 +218,7 @@ def cltoma_list_goals():
 
 def cltoma_mount_info_list():
     entries = dict()
-    if masterversion >= (5, 0, 0):
+    if masterversion >= SAUNAFS_VERSION_WITH_MOUNT_INFO_IN_MONITORING:
         request = make_sau_message(SAU_CLTOMA_MOUNT_INFO_LIST, 0, b"")
         response = send_and_receive(
             masterhost, masterport, request, SAU_MATOCL_MOUNT_INFO_LIST, 0)

--- a/src/common/saunafs_version.h
+++ b/src/common/saunafs_version.h
@@ -47,3 +47,4 @@ constexpr uint32_t kFirstECVersion = saunafsVersion(3, 9, 5);
 constexpr uint32_t kACL11Version = saunafsVersion(3, 11, 0);
 constexpr uint32_t kRichACLVersion = saunafsVersion(3, 12, 0);
 constexpr uint32_t kEC2Version = saunafsVersion(3, 13, 0);
+constexpr uint32_t kFirstVersionWithPathByInodeHiddenFile = saunafsVersion(4, 8, 0);

--- a/src/common/saunafs_version.h
+++ b/src/common/saunafs_version.h
@@ -49,3 +49,4 @@ constexpr uint32_t kRichACLVersion = saunafsVersion(3, 12, 0);
 constexpr uint32_t kEC2Version = saunafsVersion(3, 13, 0);
 constexpr uint32_t kFirstVersionWithPathByInodeHiddenFile = saunafsVersion(4, 8, 0);
 constexpr uint32_t kFirstVersionWithUseQuotaInVolumeSize = saunafsVersion(4, 9, 0);
+constexpr uint32_t kFirstVersionWithMountInfoOnMonitoring = saunafsVersion(5, 0, 0);

--- a/src/common/saunafs_version.h
+++ b/src/common/saunafs_version.h
@@ -48,3 +48,4 @@ constexpr uint32_t kACL11Version = saunafsVersion(3, 11, 0);
 constexpr uint32_t kRichACLVersion = saunafsVersion(3, 12, 0);
 constexpr uint32_t kEC2Version = saunafsVersion(3, 13, 0);
 constexpr uint32_t kFirstVersionWithPathByInodeHiddenFile = saunafsVersion(4, 8, 0);
+constexpr uint32_t kFirstVersionWithUseQuotaInVolumeSize = saunafsVersion(4, 9, 0);

--- a/src/mount/mastercomm.cc
+++ b/src/mount/mastercomm.cc
@@ -3164,11 +3164,12 @@ uint8_t fs_makesnapshot(inode_t src_inode, inode_t dst_inode, const std::string 
 uint8_t fs_get_self_quota(uint32_t uid, uint32_t gid, inode_t inode,
                           std::vector<QuotaEntry> &quotaEntries) {
 	threc *rec = fs_get_my_threc();
-	if (masterversion < saunafsVersion(4, 9, 0)) {
+	if (masterversion < kFirstVersionWithUseQuotaInVolumeSize) {
 		safs::log_warn(
 		    "fs_get_self_quota: Operation not supported for current master version: {}, for this operation "
-		    "master version should be 4.9.0 or higher",
-		    saunafsVersionToString(masterversion));
+		    "master version should be {} or higher",
+		    saunafsVersionToString(masterversion),
+		    saunafsVersionToString(kFirstVersionWithUseQuotaInVolumeSize));
 		return SAUNAFS_ERROR_ENOTSUP;
 	}
 	auto message = cltoma::fuseGetSelfQuota::build(rec->packetId, uid, gid, inode);

--- a/src/mount/mastercomm.cc
+++ b/src/mount/mastercomm.cc
@@ -1092,7 +1092,7 @@ void* fs_nop_thread(void *arg) {
 				free(inodespacket);
 			}
 
-			if (masterversion >= saunafsVersion(5, 0, 0) && !disconnect && gChangedTweaksValue) {
+			if (masterversion >= kFirstVersionWithMountInfoOnMonitoring && !disconnect && gChangedTweaksValue) {
 				gChangedTweaksValue = false;
 				std::string mountInfoStr;
 				{

--- a/src/mount/mastercomm.cc
+++ b/src/mount/mastercomm.cc
@@ -2826,11 +2826,12 @@ uint8_t fs_setacl(inode_t inode, uint32_t uid, uint32_t gid, AclType type,
 
 uint8_t fs_fullpath(inode_t inode, uint32_t uid, uint32_t gid, std::string &fullPath) {
 	threc *rec = fs_get_my_threc();
-	if (masterversion < saunafsVersion(4, 8, 0)) {
+	if (masterversion < kFirstVersionWithPathByInodeHiddenFile) {
 		safs::log_warn(
 		    "fs_fullpath: Operation not supported for current master version: {}, for this operation "
-		    "master version should be 4.8.0 or higher",
-		    saunafsVersionToString(masterversion));
+		    "master version should be {} or higher",
+		    saunafsVersionToString(masterversion),
+		    saunafsVersionToString(kFirstVersionWithPathByInodeHiddenFile));
 		return SAUNAFS_ERROR_ENOTSUP;
 	}
 	auto message =


### PR DESCRIPTION
This PR is the first of a series of changes related to modifying current uses of `saunafsVersion(M, m, p)` on the codebase by the corresponding feature/change/improvement introduced a given version `vM.m.p`. The intention is to make clearer the logic on some parts of the code, depending on the specific version of SaunaFS being used.   