### PR TITLE
fix: Fix master reload crash

### DIFF
--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -6376,10 +6376,9 @@ void matoclserv_reload(void) {
 
 	char *oldListenHost = ListenHost;
 	char *oldListenPort = ListenPort;
-	if (cfg_isdefined("MATOCL_LISTEN_HOST") || cfg_isdefined("MATOCL_LISTEN_PORT")) {
-		ListenHost = cfg_getstr("MATOCL_LISTEN_HOST","*");
-		ListenPort = cfg_getstr("MATOCL_LISTEN_PORT","9421");
-	}
+	ListenHost = cfg_getstr("MATOCL_LISTEN_HOST","*");
+	ListenPort = cfg_getstr("MATOCL_LISTEN_PORT","9421");
+
 	if (strcmp(oldListenHost,ListenHost)==0 && strcmp(oldListenPort,ListenPort)==0) {
 		free(oldListenHost);
 		free(oldListenPort);


### PR DESCRIPTION
Due to changes introduced in deprecation commit a5ed228, it became
necessary to handle the scenario where the configuration for the
master host and port to listen for connections are not defined in
its default configuration file when reloading the configuration. This
commit addresses that scenario, which could cause a master crash when
releasing the ListenPort or ListenHost variables a few lines below.

Signed-off-by: Dave <dave@leil.io>