### PR TITLE
feat(mds,chunkserver): Add CLUSTER_ID config var

### DIFF
--- a/doc/sfschunkserver.cfg.5.adoc
+++ b/doc/sfschunkserver.cfg.5.adoc
@@ -52,6 +52,9 @@ sfsmaster)
 
 *MASTER_PORT*:: number of SaunaFS master port to connect with (default is 9420)
 
+*CLUSTER_ID*:: Only connect to metadata servers with this CLUSTER_ID.
+Prevents accidental connections to wrong metadata servers. (default is 'default')
+
 *MASTER_RECONNECTION_DELAY*:: delay in seconds before trying to reconnect to
 the master server after disconnection (default is 5)
 

--- a/doc/sfsmaster.cfg.5.adoc
+++ b/doc/sfsmaster.cfg.5.adoc
@@ -39,6 +39,9 @@ the other way around is forbidden. +
 by HA cluster, server runs in 'shadow' mode as long as its not remotely
 promoted to 'master'.
 
+*CLUSTER_ID*:: Uniquely identifies this namespace.
+Prevents accidental connections to wrong metadata or chunkservers. (default is 'default')
+
 *DATA_PATH*:: where to store metadata files and lock file
 
 *WORKING_USER*:: user to run daemon as

--- a/src/chunkserver/master_connection.cc
+++ b/src/chunkserver/master_connection.cc
@@ -77,6 +77,14 @@ void MasterConn::reloadConfig() {
 	auto newMasterHostStr_ = cfg_getstring("MASTER_HOST", "sfsmaster");
 	auto newMasterPortStr_ = cfg_getstring("MASTER_PORT", "9420");
 
+	auto newClusterId = cfg_getstring("CLUSTER_ID", "default");
+
+	if (newClusterId != clusterId_) {
+		safs::log_warn(
+		    "MasterConn: Non-reloadable CLUSTER_ID changed from {} to {} during reload. Using the original value until restart.",
+		    clusterId_, newClusterId);
+	}
+
 	if (newMasterHostStr_ == masterHostStr_ && newMasterPortStr_ == masterPortStr_) {
 		return;  // no change
 	}
@@ -98,7 +106,7 @@ void MasterConn::reloadConfig() {
 			setMode(ConnectionMode::KILL);
 		}
 	} else {
-		safs::log_warn("master connection module: can't resolve master host/port ({}:{})",
+		safs::log_warn("MasterConn: can't resolve master host/port ({}:{})",
 		               masterHostStr_, masterPortStr_);
 	}
 }
@@ -126,6 +134,8 @@ void MasterConn::sendRegister() {
 	createAttachedPacket(
 	    cstoma::registerHost::build(myip, myport, gTimeout_ms, SAUNAFS_VERSHEX, clusterId_));
 
+	safs::log_info("MasterConn: registering to MDS: {}", address_.toString());
+
 	registrationStatus_ = RegistrationStatus::kRegistrationRequested;
 }
 
@@ -134,13 +144,13 @@ void MasterConn::onRegistered(const std::vector<uint8_t> &data) {
 	matocs::registerHost::deserialize(data, status);
 
 	if (status != SAUNAFS_STATUS_OK) {
-		safs::log_err("Master connection registration failed with status: {}",
+		safs::log_err("MasterConn: registration to {} failed with status: {}", address_.toString(),
 		              saunafs_error_string(status));
 		setMode(ConnectionMode::KILL);
 		return;
 	}
 
-	safs::log_info("Registered to MDS at {}", address_.toString());
+	safs::log_info("MasterConn: registered to MDS: {}", address_.toString());
 
 	registrationStatus_ = RegistrationStatus::kHostRegistered;
 
@@ -187,7 +197,7 @@ int MasterConn::initConnect() {
 			address_.port = mport;
 			isMasterAddressValid_ = true;
 		} else {
-			safs::log_warn("master connection module: can't resolve master host/port ({}:{})",
+			safs::log_warn("MasterConn: can't resolve master host/port ({}:{})",
 			               masterHostStr_, masterPortStr_);
 			return -1;
 		}
@@ -196,12 +206,12 @@ int MasterConn::initConnect() {
 	socketFD_ = tcpsocket();
 
 	if (socketFD_ < 0) {
-		safs::log_error_code(errno, "master connection module: create socket error");
+		safs::log_error_code(errno, "MasterConn: create socket error");
 		return -1;
 	}
 
 	if (tcpnonblock(socketFD_) < 0) {
-		safs::log_error_code(errno, "master connection module: set nonblock error");
+		safs::log_error_code(errno, "MasterConn: set nonblock error");
 		tcpclose(socketFD_);
 		socketFD_ = -1;
 		return -1;
@@ -209,7 +219,7 @@ int MasterConn::initConnect() {
 
 	if (bindHostAddress_.ip > 0) {
 		if (tcpnumbind(socketFD_, bindHostAddress_.ip, 0) < 0) {
-			safs::log_error_code(errno, "master connection module: can't bind socket to given ip");
+			safs::log_error_code(errno, "MasterConn: can't bind socket to given ip");
 			tcpclose(socketFD_);
 			socketFD_ = -1;
 			return -1;
@@ -219,7 +229,7 @@ int MasterConn::initConnect() {
 	int status = tcpnumconnect(socketFD_, address_.ip, address_.port);
 
 	if (status < 0) {
-		safs::log_error_code(errno, "master connection module: connect failed");
+		safs::log_error_code(errno, "MasterConn: connect failed");
 		tcpclose(socketFD_);
 		socketFD_ = -1;
 		isMasterAddressValid_ = false;
@@ -227,11 +237,11 @@ int MasterConn::initConnect() {
 	}
 
 	if (status == 0) {
-		safs::log_info("connected to Master immediately");
+		safs::log_info("MasterConn: connected to Master immediately: {}", address_.toString());
 		onConnected();
 	} else {
 		mode_ = ConnectionMode::CONNECTING;
-		safs::log_info("connecting to Master");
+		safs::log_info("MasterConn: connecting to Master: {}", address_.toString());
 	}
 
 	return 0;
@@ -241,13 +251,13 @@ void MasterConn::connectTest() {
 	int status = tcpgetstatus(socketFD_);
 
 	if (status) {
-		safs::log_error_code(errno, "connection failed");
+		safs::log_error_code(errno, "MasterConn: connection failed");
 		tcpclose(socketFD_);
 		socketFD_ = -1;
 		mode_ = ConnectionMode::FREE;
 		isMasterAddressValid_ = false;
 	} else {
-		safs::log_info("connected to Master");
+		safs::log_info("MasterConn: connected to Master: {}", address_.toString());
 		onConnected();
 	}
 }
@@ -345,14 +355,14 @@ void MasterConn::readFromSocket() {
 		ssize_t ret = ::read(socketFD_, inputPacket_.pointerToBeReadInto(), bytesToRead);
 
 		if (ret == 0) {
-			safs::log_info("connection reset by Master");
+			safs::log_info("MasterConn: connection reset by Master: {}", address_.toString());
 			setMode(ConnectionMode::KILL);
 			return;
 		}
 
 		if (ret < 0) {
 			if (errno != EAGAIN) {
-				safs::log_error_code(errno, "read from Master error");
+				safs::log_error_code(errno, "MasterConn: read error from {}", address_.toString());
 				setMode(ConnectionMode::KILL);
 			}
 			return;
@@ -363,7 +373,7 @@ void MasterConn::readFromSocket() {
 		try {
 			inputPacket_.increaseBytesRead(ret);
 		} catch (InputPacketTooLongException &ex) {
-			safs::log_warn("reading from master: {}", ex.what());
+			safs::log_warn("MasterConn: reading from master: {}", ex.what());
 			setMode(ConnectionMode::KILL);
 			return;
 		}
@@ -396,7 +406,8 @@ void MasterConn::writeToSocket() {
 
 		if (bytesWritten < 0) {
 			if (errno != EAGAIN) {
-				safs::log_error_code(errno, "write to Master error");
+				safs::log_error_code(errno, "MasterConn: write to Master error: {}",
+				                     address_.toString());
 				setMode(ConnectionMode::KILL);
 			}
 			return;
@@ -446,14 +457,13 @@ void MasterConn::gotPacket(PacketHeader header, const MessageBuffer &message) tr
 		onRegistered(message);
 		break;
 	default:
-		safs::log_info("got unknown message (type: {})", header.type);
+		safs::log_info("MasterConn: got unknown message (type: {}): {}", header.type,
+		               address_.toString());
 		setMode(ConnectionMode::KILL);
 	}
 } catch (IncorrectDeserializationException &e) {
-	safs::log_info(
-	    "chunkserver <-> master module: got inconsistent message "
-	    "(type:{}, length:{}), {}",
-	    header.type, uint32_t(message.size()), e.what());
+	safs::log_info("MasterConn: got inconsistent message (type:{}, length:{}), {}, {}", header.type,
+	               uint32_t(message.size()), e.what(), address_.toString());
 	setMode(ConnectionMode::KILL);
 }
 

--- a/src/chunkserver/master_connection.cc
+++ b/src/chunkserver/master_connection.cc
@@ -118,26 +118,53 @@ void MasterConn::sendConfig() {
 }
 
 void MasterConn::sendRegister() {
-	uint32_t myip;
-	uint16_t myport;
-	uint64_t usedspace, totalspace;
-	uint64_t tdusedspace, tdtotalspace;
-	uint32_t chunkcount, tdchunkcount;
+	assert(registrationStatus_ == RegistrationStatus::kUnregistered);
 
-	myip = mainNetworkThreadGetListenIp();
-	myport = mainNetworkThreadGetListenPort();
-	createAttachedPacket(cstoma::registerHost::build(myip, myport, gTimeout_ms, SAUNAFS_VERSHEX));
+	uint32_t myip = mainNetworkThreadGetListenIp();
+	uint16_t myport = mainNetworkThreadGetListenPort();
+
+	createAttachedPacket(
+	    cstoma::registerHost::build(myip, myport, gTimeout_ms, SAUNAFS_VERSHEX, clusterId_));
+
+	registrationStatus_ = RegistrationStatus::kRegistrationRequested;
+}
+
+void MasterConn::onRegistered(const std::vector<uint8_t> &data) {
+	uint8_t status{};
+	matocs::registerHost::deserialize(data, status);
+
+	if (status != SAUNAFS_STATUS_OK) {
+		safs::log_err("Master connection registration failed with status: {}",
+		              saunafs_error_string(status));
+		setMode(ConnectionMode::KILL);
+		return;
+	}
+
+	safs::log_info("Registered to MDS at {}", address_.toString());
+
+	registrationStatus_ = RegistrationStatus::kHostRegistered;
 
 	hddForeachChunkInBulks([this](const std::vector<ChunkWithVersionAndType> &chunksBulk) {
 		createAttachedPacket(cstoma::registerChunks::build(chunksBulk));
 	});
 
-	hddGetTotalSpace(&usedspace, &totalspace, &chunkcount, &tdusedspace, &tdtotalspace,
-	                 &tdchunkcount);
-	auto registerSpace = cstoma::registerSpace::build(usedspace, totalspace, chunkcount,
-	                                                  tdusedspace, tdtotalspace, tdchunkcount);
+	uint64_t usedSpace;
+	uint64_t totalSpace;
+	uint64_t toDelUsedSpace;
+	uint64_t toDelTotalSpace;
+	uint32_t chunkCount;
+	uint32_t toDelChunkCount;
+
+	hddGetTotalSpace(&usedSpace, &totalSpace, &chunkCount, &toDelUsedSpace, &toDelTotalSpace,
+	                 &toDelChunkCount);
+	auto registerSpace = cstoma::registerSpace::build(
+	    usedSpace, totalSpace, chunkCount, toDelUsedSpace, toDelTotalSpace, toDelChunkCount);
 	createAttachedPacket(std::move(registerSpace));
+
+	registrationStatus_ = RegistrationStatus::kChunksRegistered;
+
 	sendRegisterLabel();
+
 	sendConfig();
 }
 
@@ -266,7 +293,7 @@ void MasterConn::handlePollErrors(const std::vector<pollfd> &pdesc) {
 		if (mode_ == ConnectionMode::CONNECTING) {
 			connectTest();
 		} else {
-			mode_ = ConnectionMode::KILL;
+			setMode(ConnectionMode::KILL);
 		}
 	}
 }
@@ -293,7 +320,7 @@ void MasterConn::servePoll(const std::vector<pollfd> &pdesc) {
 
 			// Check if the connection has not been used for a while and should be closed
 			if ((mode_ == ConnectionMode::CONNECTED) && lastRead_.elapsed_ms() > gTimeout_ms) {
-				mode_ = ConnectionMode::KILL;
+				setMode(ConnectionMode::KILL);
 			}
 
 			// Keep the connection alive by sending a NOP packet
@@ -319,14 +346,14 @@ void MasterConn::readFromSocket() {
 
 		if (ret == 0) {
 			safs::log_info("connection reset by Master");
-			mode_ = ConnectionMode::KILL;
+			setMode(ConnectionMode::KILL);
 			return;
 		}
 
 		if (ret < 0) {
 			if (errno != EAGAIN) {
 				safs::log_error_code(errno, "read from Master error");
-				mode_ = ConnectionMode::KILL;
+				setMode(ConnectionMode::KILL);
 			}
 			return;
 		}
@@ -337,7 +364,7 @@ void MasterConn::readFromSocket() {
 			inputPacket_.increaseBytesRead(ret);
 		} catch (InputPacketTooLongException &ex) {
 			safs::log_warn("reading from master: {}", ex.what());
-			mode_ = ConnectionMode::KILL;
+			setMode(ConnectionMode::KILL);
 			return;
 		}
 
@@ -370,7 +397,7 @@ void MasterConn::writeToSocket() {
 		if (bytesWritten < 0) {
 			if (errno != EAGAIN) {
 				safs::log_error_code(errno, "write to Master error");
-				mode_ = ConnectionMode::KILL;
+				setMode(ConnectionMode::KILL);
 			}
 			return;
 		}
@@ -415,16 +442,19 @@ void MasterConn::gotPacket(PacketHeader header, const MessageBuffer &message) tr
 	case SAU_MATOCS_DUPTRUNC_CHUNK:
 		duplicateTruncateChunk(message);
 		break;
+	case SAU_MATOCS_REGISTER_HOST:
+		onRegistered(message);
+		break;
 	default:
 		safs::log_info("got unknown message (type: {})", header.type);
-		mode_ = ConnectionMode::KILL;
+		setMode(ConnectionMode::KILL);
 	}
 } catch (IncorrectDeserializationException &e) {
 	safs::log_info(
 	    "chunkserver <-> master module: got inconsistent message "
 	    "(type:{}, length:{}), {}",
 	    header.type, uint32_t(message.size()), e.what());
-	mode_ = ConnectionMode::KILL;
+	setMode(ConnectionMode::KILL);
 }
 
 // Chunk operations

--- a/src/chunkserver/master_connection.cc
+++ b/src/chunkserver/master_connection.cc
@@ -41,6 +41,7 @@
 #include "common/loop_watchdog.h"
 #include "common/network_address.h"
 #include "common/output_packet.h"
+#include "common/saunafs_version.h"
 #include "common/sockets.h"
 #include "config/cfg.h"
 #include "protocol/SFSCommunication.h"
@@ -141,16 +142,23 @@ void MasterConn::sendRegister() {
 
 void MasterConn::onRegistered(const std::vector<uint8_t> &data) {
 	uint8_t status{};
-	matocs::registerHost::deserialize(data, status);
+	uint32_t version{};
+	std::string clusterId;
+	matocs::registerHost::deserialize(data, status, version, clusterId);
 
 	if (status != SAUNAFS_STATUS_OK) {
-		safs::log_err("MasterConn: registration to {} failed with status: {}", address_.toString(),
-		              saunafs_error_string(status));
+		safs::log_err(
+		    "MasterConn: registration to {} failed with status: {}, version: {}, clusterId: {}",
+		    address_.toString(), saunafs_error_string(status), saunafsVersionToString(version),
+		    clusterId);
 		setMode(ConnectionMode::KILL);
 		return;
 	}
 
-	safs::log_info("MasterConn: registered to MDS: {}", address_.toString());
+	version_ = version;
+
+	safs::log_info("MasterConn: registered to MDS: {}, version: {}, clusterId: {}",
+	               address_.toString(), saunafsVersionToString(version), clusterId);
 
 	registrationStatus_ = RegistrationStatus::kHostRegistered;
 

--- a/src/chunkserver/master_connection.h
+++ b/src/chunkserver/master_connection.h
@@ -30,6 +30,7 @@
 
 #include "common/network_address.h"
 #include "common/output_packet.h"
+#include "common/saunafs_version.h"
 #include "common/time_utils.h"
 #include "protocol/input_packet.h"
 
@@ -202,10 +203,11 @@ public:
 	const std::string &clusterId() const { return clusterId_; }
 
 private:
-	std::string masterHostStr_;         ///< Hostname of the master server.
-	std::string masterPortStr_;         ///< Port of the master server.
-	std::string clusterId_;             ///< Cluster ID for this connection.
-	std::shared_ptr<JobPool> jobPool_;  ///< Shared reference to the JobPool.
+	std::string masterHostStr_;                  ///< Hostname of the master server.
+	std::string masterPortStr_;                  ///< Port of the master server.
+	uint32_t version_{saunafsVersion(0, 0, 0)};  ///< Version of the master server.
+	std::string clusterId_;                      ///< Cluster ID for this connection.
+	std::shared_ptr<JobPool> jobPool_;           ///< Shared reference to the JobPool.
 
 	ConnectionMode mode_{ConnectionMode::FREE};  ///< Current mode of the connection to this master.
 	/// Registration status to this MDS.

--- a/src/chunkserver/master_connection.h
+++ b/src/chunkserver/master_connection.h
@@ -52,14 +52,25 @@ enum class ConnectionMode : std::uint8_t {
 	KILL         /// Connection has been dropped, a reconnection will be attempted.
 };
 
+/// @brief Enum representing the registration status of a connection to the Metadata Server (MDS).
+enum class RegistrationStatus : std::uint8_t {
+	kUnregistered,           ///< Initial state, not registered yet.
+	kRegistrationRequested,  ///< Registration has been requested but not yet confirmed.
+	kHostRegistered,         ///< Registration has been confirmed.
+	kChunksRegistered,       ///< Chunks have been registered with the MDS.
+};
+
 /// @brief Class representing a connection to a Metadata Server (MDS).
 ///
 /// Currently, only one active MDS (known as Master) is supported.
 class MasterConn {
 public:
 	explicit MasterConn(const std::string &masterHostStr, const std::string &masterPortStr,
-	                    const std::shared_ptr<JobPool> &jobPool)
-	    : masterHostStr_(masterHostStr), masterPortStr_(masterPortStr), jobPool_(jobPool) {}
+	                    const std::string &clusterId, const std::shared_ptr<JobPool> &jobPool)
+	    : masterHostStr_(masterHostStr),
+	      masterPortStr_(masterPortStr),
+	      clusterId_(clusterId),
+	      jobPool_(jobPool) {}
 
 	// Disable unneeded copying and moving of the connection objects.
 	MasterConn(const MasterConn &) = delete;
@@ -95,6 +106,8 @@ public:
 	void sendConfig();
 
 	void sendRegister();
+
+	void onRegistered(const std::vector<uint8_t> &data);
 
 	int initConnect();
 
@@ -148,7 +161,15 @@ public:
 
 	ConnectionMode mode() const { return mode_; }
 
-	void setMode(ConnectionMode newMode) { mode_ = newMode; }
+	RegistrationStatus registrationStatus() const { return registrationStatus_; }
+
+	void setMode(ConnectionMode newMode) {
+		mode_ = newMode;
+
+		if (mode_ == ConnectionMode::KILL) {  // The socket will be closed soon.
+			registrationStatus_ = RegistrationStatus::kUnregistered;
+		}
+	}
 
 	const NetworkAddress &address() const { return address_; }
 
@@ -178,12 +199,17 @@ public:
 		bytesOut_ = 0;
 	}
 
+	const std::string &clusterId() const { return clusterId_; }
+
 private:
 	std::string masterHostStr_;         ///< Hostname of the master server.
 	std::string masterPortStr_;         ///< Port of the master server.
+	std::string clusterId_;             ///< Cluster ID for this connection.
 	std::shared_ptr<JobPool> jobPool_;  ///< Shared reference to the JobPool.
 
 	ConnectionMode mode_{ConnectionMode::FREE};  ///< Current mode of the connection to this master.
+	/// Registration status to this MDS.
+	RegistrationStatus registrationStatus_{RegistrationStatus::kUnregistered};
 	int socketFD_{-1};                           ///< Socket file descriptor for this connection.
 	int32_t pDescPos_{-1};                       ///< Position in the pollfd array.
 	Timer lastRead_;                             ///< Time since the last read operation.

--- a/src/chunkserver/masterconn.cc
+++ b/src/chunkserver/masterconn.cc
@@ -262,6 +262,7 @@ int masterconn_init(void) {
 	uint32_t reconnectionDelay = cfg_getuint32("MASTER_RECONNECTION_DELAY", 5);
 	gMasterHost = cfg_getstring("MASTER_HOST", "sfsmaster");
 	gMasterPort = cfg_getstring("MASTER_PORT", "9420");
+	std::string clusterId = cfg_getstring("CLUSTER_ID", "default");
 	gBindHostStr = cfg_getstring("BIND_HOST", "*");
 	gTimeout_ms = get_cfg_timeout();
 	gEnableLoadFactor = static_cast<bool>(cfg_getuint32("ENABLE_LOAD_FACTOR", 0));
@@ -269,7 +270,8 @@ int masterconn_init(void) {
 	if (!masterconn_load_label()) { return -1; }
 
 	// Create the connections (only one at this point)
-	gMasterConnSingleton = std::make_unique<MasterConn>(gMasterHost, gMasterPort, gJobPool);
+	gMasterConnSingleton =
+	    std::make_unique<MasterConn>(gMasterHost, gMasterPort, clusterId, gJobPool);
 	MasterConn *eptr = gMasterConnSingleton.get();
 	passert(eptr);
 

--- a/src/common/saunafs_version.h
+++ b/src/common/saunafs_version.h
@@ -50,3 +50,4 @@ constexpr uint32_t kEC2Version = saunafsVersion(3, 13, 0);
 constexpr uint32_t kFirstVersionWithPathByInodeHiddenFile = saunafsVersion(4, 8, 0);
 constexpr uint32_t kFirstVersionWithUseQuotaInVolumeSize = saunafsVersion(4, 9, 0);
 constexpr uint32_t kFirstVersionWithMountInfoOnMonitoring = saunafsVersion(5, 0, 0);
+constexpr uint32_t kFirstVersionWithClusterId = saunafsVersion(5, 0, 0);

--- a/src/data/sfschunkserver.cfg.in
+++ b/src/data/sfschunkserver.cfg.in
@@ -47,6 +47,10 @@
 ## Master port to connect to (Default: 9420):
 # MASTER_PORT = 9420
 
+## Only connect to metadata servers with this CLUSTER_ID.
+## Prevents accidental connections to wrong metadata servers.
+# CLUSTER_ID = default
+
 ## Timeout (in seconds) for the master server connection (minimum is 0.01).
 ## (Default: 60)
 # MASTER_TIMEOUT = 60

--- a/src/data/sfsmaster.cfg.in
+++ b/src/data/sfsmaster.cfg.in
@@ -9,6 +9,10 @@
 ## Only one metadata server in SaunaFS shall have 'master' personality.
 # PERSONALITY = master
 
+## Uniquely identifies this namespace.
+## Prevents accidental connections to wrong metadata or chunkservers.
+# CLUSTER_ID = default
+
 ## Password for administrative connections and commands.
 # ADMIN_PASSWORD =
 

--- a/src/master/filesystem.cc
+++ b/src/master/filesystem.cc
@@ -336,6 +336,7 @@ static void fs_read_goal_config_file() {
 }
 
 static void fs_read_config_file() {
+	gClusterId = cfg_getstring("CLUSTER_ID", "default");
 	gAutoRecovery = cfg_getint32("AUTO_RECOVERY", 0) == 1;
 	gDisableChecksumVerification = cfg_getint32("DISABLE_METADATA_CHECKSUM_VERIFICATION", 0) != 0;
 	gMagicAutoFileRepair = cfg_getint32("MAGIC_AUTO_FILE_REPAIR", 0) == 1;
@@ -397,7 +398,13 @@ void fs_unload() {
 }
 
 int fs_init(bool doLoad) {
-	fs_read_config_file();
+	try {
+		fs_read_config_file();
+	} catch (Exception &ex) {
+		safs::log_err("Error in configuration: {}", ex.what());
+		throw;
+	}
+
 	if (!gMetadataLockfile) {
 		gMetadataLockfile.reset(new Lockfile(kMetadataFilename + std::string(".lock")));
 	}

--- a/src/master/filesystem.h
+++ b/src/master/filesystem.h
@@ -44,6 +44,8 @@
 
 SAUNAFS_CREATE_EXCEPTION_CLASS_MSG(NoMetadataException, Exception, "no metadata");
 
+inline std::string gClusterId;  ///< Unique cluster identifier
+
 uint8_t fs_cancel_job(uint32_t job_id);
 uint32_t fs_reserve_job_id();
 

--- a/src/master/matocsserv.cc
+++ b/src/master/matocsserv.cc
@@ -50,6 +50,7 @@
 #include "common/sockets.h"
 #include "common/time_utils.h"
 #include "config/cfg.h"
+#include "errors/saunafs_error_codes.h"
 #include "master/chunks.h"
 #include "master/chunkserver_db.h"
 #include "master/filesystem.h"
@@ -964,35 +965,66 @@ void matocsserv_got_duptruncchunk_status(matocsserventry* eptr, const std::vecto
 }
 
 void matocsserv_register_host(matocsserventry *eptr, uint32_t version, uint32_t servip,
-		uint16_t servport, uint32_t timeout) {
+                              uint16_t servport, uint32_t timeout, const std::string &clusterId) {
 	eptr->version  = version;
 	eptr->servip   = servip;
 	eptr->servport = servport;
 	eptr->timeout  = timeout;
+
+	if (eptr->version >= kFirstVersionWithClusterId) {
+		if (clusterId.empty()) {
+			safs::log_err("SAU_CSTOMA_REGISTER_HOST received empty cluster ID");
+			eptr->mode = KILL;
+			return;
+		}
+
+		if (clusterId != gClusterId) {
+			safs::log_err(
+			    "SAU_CSTOMA_REGISTER_HOST received mismatched cluster ID: expected {}, got {}",
+			    gClusterId, clusterId);
+			eptr->mode = KILL;
+			return;
+		}
+	}
+
 	if (eptr->timeout<10) {
 		safs_pretty_syslog(LOG_NOTICE, "SAU_CSTOMA_REGISTER communication timeout too small (%"
 				PRIu32 " milliseconds - should be at least 10 milliseconds)", eptr->timeout);
 		eptr->mode=KILL;
 		return;
 	}
+
 	if (eptr->servip==0) {
 		tcpgetpeer(eptr->sock,&(eptr->servip),NULL);
 	}
+
 	if (eptr->servstrip) {
 		free(eptr->servstrip);
 	}
+
 	eptr->servstrip = matocsserv_makestrip(eptr->servip);
+
 	if (isLoopbackAddress(eptr->servip)) {
 		safs::log_warn("Chunkserver loopback IP addresses are experimental; consider assigning a non-loopback IP address to chunkserver (via /etc/hosts or some other way)");
 	}
+
 	if (csdb_new_connection(eptr->servip,eptr->servport,eptr)<0) {
 		safs_pretty_syslog(LOG_WARNING,"chunk-server already connected !!!");
 		eptr->mode=KILL;
 		return;
 	}
+
 	eptr->csdb = csdb_find(eptr->servip, eptr->servport);
+
 	safs_pretty_syslog(LOG_NOTICE, "chunkserver register begin (packet version: 5) - ip: %s, port: %"
 			PRIu16, eptr->servstrip, eptr->servport);
+
+	// Send the answer with the status
+	if (eptr->version >= kFirstVersionWithClusterId) {
+		OutputPacket outPacket;
+		matocs::registerHost::serialize(outPacket.packet, SAUNAFS_STATUS_OK);
+		eptr->outputPackets.push_back(std::move(outPacket));
+	}
 }
 
 void register_space(matocsserventry* eptr) {
@@ -1024,13 +1056,23 @@ void matocsserv_space(matocsserventry *eptr,const uint8_t *data,uint32_t length)
 	}
 }
 
-void matocsserv_sau_register_host(matocsserventry *eptr, const std::vector<uint8_t>& data) {
+void matocsserv_sau_register_host(matocsserventry *eptr, const std::vector<uint8_t> &data) {
 	uint32_t version;
 	uint32_t servip;
 	uint16_t servport;
 	uint32_t timeout;
-	cstoma::registerHost::deserialize(data, servip, servport, timeout, version);
-	matocsserv_register_host(eptr, version, servip, servport, timeout);
+	std::string clusterId;
+
+	PacketVersion packetVersion;
+	deserializePacketVersionNoHeader(data, packetVersion);
+
+	if (packetVersion == cstoma::registerHost::kWithClusterId) {
+		cstoma::registerHost::deserialize(data, servip, servport, timeout, version, clusterId);
+	} else {
+		cstoma::registerHost::deserialize(data, servip, servport, timeout, version);
+	}
+
+	matocsserv_register_host(eptr, version, servip, servport, timeout, clusterId);
 }
 
 void matocsserv_sau_register_chunks(matocsserventry *eptr, const std::vector<uint8_t>& data) {

--- a/src/master/matocsserv.cc
+++ b/src/master/matocsserv.cc
@@ -1022,7 +1022,8 @@ void matocsserv_register_host(matocsserventry *eptr, uint32_t version, uint32_t 
 	// Send the answer with the status
 	if (eptr->version >= kFirstVersionWithClusterId) {
 		OutputPacket outPacket;
-		matocs::registerHost::serialize(outPacket.packet, SAUNAFS_STATUS_OK);
+		matocs::registerHost::serialize(outPacket.packet, SAUNAFS_STATUS_OK, SAUNAFS_VERSHEX,
+		                                gClusterId);
 		eptr->outputPackets.push_back(std::move(outPacket));
 	}
 }

--- a/src/protocol/SFSCommunication.h
+++ b/src/protocol/SFSCommunication.h
@@ -361,6 +361,10 @@ enum class SugidClearMode : uint8_t {
 #define SAU_CSTOMA_REGISTER_HOST (1000U + 100U)
 /// ip:32 port:16 timeout:32 vershex:32
 
+// 0x0497
+#define SAU_MATOCS_REGISTER_HOST (1000U + 175U)
+/// status:8
+
 // 0x044D
 #define SAU_CSTOMA_REGISTER_CHUNKS (1000U + 101U)
 /// version==0 chunks:(N * [chunkid:64 chunkversion:32 chunktype:8])

--- a/src/protocol/cstoma.h
+++ b/src/protocol/cstoma.h
@@ -50,12 +50,23 @@ SAUNAFS_DEFINE_PACKET_SERIALIZATION(
 		cstoma, chunkNew, SAU_CSTOMA_CHUNK_NEW, kECChunks,
 		std::vector<ChunkWithVersionAndType>, chunks)
 
+SAUNAFS_DEFINE_PACKET_VERSION(cstoma, registerHost, kWithoutClusterId, 0)
+SAUNAFS_DEFINE_PACKET_VERSION(cstoma, registerHost, kWithClusterId, 1)
+
 SAUNAFS_DEFINE_PACKET_SERIALIZATION(
-		cstoma, registerHost, SAU_CSTOMA_REGISTER_HOST, 0,
+		cstoma, registerHost, SAU_CSTOMA_REGISTER_HOST, kWithoutClusterId,
 		uint32_t, ip,
 		uint16_t, port,
 		uint32_t, timeout,
 		uint32_t, csVersion)
+
+SAUNAFS_DEFINE_PACKET_SERIALIZATION(
+		cstoma, registerHost, SAU_CSTOMA_REGISTER_HOST, kWithClusterId,
+		uint32_t, ip,
+		uint16_t, port,
+		uint32_t, timeout,
+		uint32_t, csVersion,
+		std::string, clusterId)
 
 SAUNAFS_DEFINE_PACKET_VERSION(cstoma, registerChunks, kStandardAndXorChunks, 0)
 SAUNAFS_DEFINE_PACKET_VERSION(cstoma, registerChunks, kStandardChunksOnly, 1)

--- a/src/protocol/matocs.h
+++ b/src/protocol/matocs.h
@@ -22,8 +22,13 @@
 #include "common/platform.h"
 
 #include "common/chunk_type_with_address.h"
+#include "protocol/SFSCommunication.h"
 #include "protocol/packet.h"
 #include "common/serialization_macros.h"
+
+SAUNAFS_DEFINE_PACKET_SERIALIZATION(
+		matocs, registerHost, SAU_MATOCS_REGISTER_HOST, 0,
+		uint8_t, status)
 
 SAUNAFS_DEFINE_PACKET_VERSION(matocs, setVersion, kStandardAndXorChunks, 0)
 SAUNAFS_DEFINE_PACKET_VERSION(matocs, setVersion, kECChunks, 1)

--- a/src/protocol/matocs.h
+++ b/src/protocol/matocs.h
@@ -28,7 +28,9 @@
 
 SAUNAFS_DEFINE_PACKET_SERIALIZATION(
 		matocs, registerHost, SAU_MATOCS_REGISTER_HOST, 0,
-		uint8_t, status)
+		uint8_t, status,
+		uint32_t, version,
+		std::string, clusterId)
 
 SAUNAFS_DEFINE_PACKET_VERSION(matocs, setVersion, kStandardAndXorChunks, 0)
 SAUNAFS_DEFINE_PACKET_VERSION(matocs, setVersion, kECChunks, 1)

--- a/tests/test_suites/SanityChecks/test_reject_chunkserver_with_wrong_cluster_id.sh
+++ b/tests/test_suites/SanityChecks/test_reject_chunkserver_with_wrong_cluster_id.sh
@@ -1,0 +1,29 @@
+CHUNKSERVERS=2 \
+	USE_RAMDISK=YES \
+	setup_local_empty_saunafs info
+
+cd "${info[mount0]}"
+
+echo "Creating files on the mount point"
+
+for fileNum in $(seq 1 5); do
+	dd if=/dev/zero of=file${fileNum} bs=1M count=1 oflag=direct &> /dev/null
+done
+
+# Both chunkservers should be ready
+assert_equals 2 $(saunafs_ready_chunkservers_count)
+
+echo "Stopping chunkserver 1"
+saunafs_chunkserver_daemon 1 stop
+
+echo "Changing CLUSTER_ID to wrong one"
+echo "CLUSTER_ID = cluster_02" >> "${info[chunkserver1_cfg]}"
+
+echo "Starting chunkserver 1 with wrong CLUSTER_ID"
+saunafs_chunkserver_daemon 1 start
+
+for i in $(seq 1 5); do
+	sleep 2
+	echo "Number of chunkservers: $(saunafs_ready_chunkservers_count)"
+	assert_equals 1 $(saunafs_ready_chunkservers_count)
+done


### PR DESCRIPTION
This change adds the CLUSTER_ID configuration variable for metadata (master, shadow) and chunkservers. The new variable should be set at the beginning and it is not intended to be changed frequently.

Metadata servers only accept connections from chunkservers with the same CLUSTER_ID (sent during registration), this prevents connections from undesired chunkservers.

To avoid breaking existent installations, the new variable defaults to 'default'. It is advisable for new installations to provide a meaningfull CLUSTER_ID.