### PR TITLE
feat(chunkserver): Reduce strings RAM usage

### DIFF
--- a/src/chunkserver/chunk_unittest.cc
+++ b/src/chunkserver/chunk_unittest.cc
@@ -70,7 +70,6 @@ TEST_F(ChunkTests, GetFileName) {
 	standardChunk.setId(0x123456);
 	standardChunk.setOwner(&disk);
 	standardChunk.setVersion(0xabcd);
-	standardChunk.updateFilenamesFromVersion(0xabcd);
 	EXPECT_EQ("/mnt/chunks12/"
 	          "chunk_0000000000123456_0000ABCD" CHUNK_METADATA_FILE_EXTENSION,
 	          standardChunk.fullMetaFilename());
@@ -78,7 +77,6 @@ TEST_F(ChunkTests, GetFileName) {
 	chunk_1_of_3.setId(0x8765430d);
 	chunk_1_of_3.setOwner(&disk);
 	chunk_1_of_3.setVersion(0x654321);
-	chunk_1_of_3.updateFilenamesFromVersion(0x654321);
 	EXPECT_EQ("/mnt/chunks65/chunk_xor_1_of_3_000000008765430D_00654321"
 	          CHUNK_METADATA_FILE_EXTENSION,
 	          chunk_1_of_3.fullMetaFilename());
@@ -86,7 +84,6 @@ TEST_F(ChunkTests, GetFileName) {
 	chunk_p_of_3.setId(0x1234567890abcdef);
 	chunk_p_of_3.setOwner(&disk);
 	chunk_p_of_3.setVersion(0x12345678);
-	chunk_p_of_3.updateFilenamesFromVersion(0x12345678);
 	EXPECT_EQ("/mnt/chunksAB/chunk_xor_parity_of_3_1234567890ABCDEF_12345678"
 	          CHUNK_METADATA_FILE_EXTENSION,
 	          chunk_p_of_3.fullMetaFilename());

--- a/src/chunkserver/chunkserver-common/chunk_interface.h
+++ b/src/chunkserver/chunkserver-common/chunk_interface.h
@@ -88,24 +88,13 @@ public:
 	virtual std::string fullMetaFilename() const = 0;
 
 	/// Getter for the name of the metadata file.
-	virtual const std::string &metaFilename() const = 0;
-	/// Setter for the name of the metadata file.
-	virtual void setMetaFilename(const std::string& _metaFilename) = 0;
+	virtual const std::string metaFilename() const = 0;
 
 	/// Returns the full path to the data file.
 	virtual std::string fullDataFilename() const = 0;
 
 	/// Getter for the name of the data file.
-	virtual const std::string &dataFilename() const = 0;
-	/// Setter for the name of the data file.
-	virtual void setDataFilename(const std::string &_dataFilename) = 0;
-
-	/// Updates the metadata and data filenames according to the given version.
-	/// The version of the Chunk is included in the filenames. Therefore, when
-	/// the version changes, the filenames must be updated.
-	/// Some scenarios where the version changes are when a Chunk is created and
-	/// during operations like duplicate or truncate.
-	virtual void updateFilenamesFromVersion(uint32_t _version) = 0;
+	virtual const std::string dataFilename() const = 0;
 
 	/// Generates the name of the metadata file for the given version.
 	virtual std::string generateMetadataFilenameForVersion(

--- a/src/chunkserver/chunkserver-common/chunk_with_fd.cc
+++ b/src/chunkserver/chunkserver-common/chunk_with_fd.cc
@@ -32,29 +32,26 @@ FDChunk::FDChunk(uint64_t chunkId, ChunkPartType type, ChunkState state)
 
 std::string FDChunk::fullMetaFilename() const {
 	return owner_->metaPath() + Subfolder::getSubfolderNameGivenChunkId(id_) +
-	       "/" + metaFilename_;
+	       "/" + generateFilenameForVersion(version_, true);
 }
 
-const std::string &FDChunk::metaFilename() const { return metaFilename_; }
-
-void FDChunk::setMetaFilename(const std::string &_metaFilename) {
-	metaFilename_ = _metaFilename;
+const std::string FDChunk::metaFilename() const {
+	if (version_ == 0) {
+		return "";
+	}
+	return generateFilenameForVersion(version_, true);
 }
 
 std::string FDChunk::fullDataFilename() const {
 	return owner_->dataPath() + Subfolder::getSubfolderNameGivenChunkId(id_) +
-	       "/" + dataFilename_;
+	       "/" + generateFilenameForVersion(version_, false);
 }
 
-const std::string &FDChunk::dataFilename() const { return dataFilename_; }
-
-void FDChunk::setDataFilename(const std::string &_dataFilename) {
-	dataFilename_ = _dataFilename;
-}
-
-void FDChunk::updateFilenamesFromVersion(uint32_t _version) {
-	metaFilename_ = generateMetadataFilenameForVersion(_version);
-	dataFilename_ = generateDataFilenameForVersion(_version);
+const std::string FDChunk::dataFilename() const {
+	if (version_ == 0) {
+		return "";
+	}
+	return generateFilenameForVersion(version_, false);
 }
 
 std::string FDChunk::generateMetadataFilenameForVersion(

--- a/src/chunkserver/chunkserver-common/chunk_with_fd.h
+++ b/src/chunkserver/chunkserver-common/chunk_with_fd.h
@@ -63,20 +63,13 @@ public:
 	std::string fullMetaFilename() const override;
 
 	/// Getter for the name of the metadata filename.
-	const std::string &metaFilename() const override;
-	/// Setter for the name of the metadata filename.
-	void setMetaFilename(const std::string &_metaFilename) override;
+	const std::string metaFilename() const override;
 
 	/// Returns the full path to the data file.
 	std::string fullDataFilename() const override;
 
 	/// Getter for the name of the data filename.
-	const std::string &dataFilename() const override;
-	/// Setter for the name of the data filename.
-	void setDataFilename(const std::string &_dataFilename) override;
-
-	/// Updates the metadata and data filenames according to the given version.
-	void updateFilenamesFromVersion(uint32_t _version) override;
+	const std::string dataFilename() const override;
 
 	/// Generates the metadata filename for the given version.
 	std::string generateMetadataFilenameForVersion(
@@ -191,8 +184,6 @@ private:
 	uint64_t id_;               ///< The ID of the chunk.
 	uint32_t version_ = 0;      ///< The version of the chunk.
 	ChunkPartType type_;        ///< The type of the chunk (ec:5, xor:2, etc.).
-	std::string metaFilename_;  ///< Metadata filename (header + CRC).
-	std::string dataFilename_;  ///< Data filename (blocks of data).
 	int32_t metaFD_ = -1;       ///< Metadata file descriptor
 	int32_t dataFD_ = -1;       ///< Data file descriptor
 	uint16_t blocks_ = 0;       ///< Number of blocks in the chunk

--- a/src/chunkserver/chunkserver-common/cmr_chunk.cc
+++ b/src/chunkserver/chunkserver-common/cmr_chunk.cc
@@ -59,8 +59,6 @@ int CmrChunk::renameChunkFile(uint32_t new_version) {
 	}
 
 	setVersion(new_version);
-	setMetaFilename(newMetaBasename);
-	setDataFilename(newDataBasename);
 
 	return 0;
 }

--- a/src/chunkserver/chunkserver-common/cmr_disk.cc
+++ b/src/chunkserver/chunkserver-common/cmr_disk.cc
@@ -338,7 +338,6 @@ int CmrDisk::overwriteChunkVersion(IChunk *chunk, uint32_t newVersion) {
 	HddStats::overheadWrite(size);
 
 	chunk->setVersion(newVersion);
-	chunk->updateFilenamesFromVersion(newVersion);
 
 	return SAUNAFS_STATUS_OK;
 }

--- a/src/chunkserver/hddspacemgr.cc
+++ b/src/chunkserver/hddspacemgr.cc
@@ -216,7 +216,6 @@ static IChunk *hddChunkCreate(IDisk *disk, uint64_t chunkId,
 
 	chunk->setVersion(version);
 	disk->setNeedRefresh(true);
-	chunk->updateFilenamesFromVersion(version);
 
 	std::lock_guard testsLockGuard(gTestsMutex);
 	disk->chunks().insert(chunk);
@@ -2251,7 +2250,6 @@ static inline void hddAddChunkFromDiskScan(IDisk *disk,
 	}
 
 	chunk->setVersion(version);
-	chunk->updateFilenamesFromVersion(version);
 	sassert(chunk->fullMetaFilename() == fullname);
 
 	{


### PR DESCRIPTION
This PR targets reducing the memory used by the chunkservers by not
storing the metadata and data file names in the chunk structure. These
file names would be then calculated on fly every time some of them is
requested.

Signed-off-by: Dave <dave@leil.io>