### PR TITLE
ci: Enable Ganesha pipeline on push to dev branch

### DIFF
--- a/.github/workflows/run-unit-and-ganesha-tests.yml
+++ b/.github/workflows/run-unit-and-ganesha-tests.yml
@@ -3,6 +3,9 @@ name: Run Unit and Ganesha Tests
 on:
     merge_group:
     pull_request:
+    push:
+        branches:
+            - dev
 
 jobs:
     Run-Unit-Tests-and-Ganesha:


### PR DESCRIPTION
Previously, the Ganesha and unit test GitHub Actions pipeline ran only for pull requests and was disabled for all push events.

This commit enables Ganesha pipeline to also run on push events to the `dev` branch, ensuring that the default branch runs these tests after any merge.