### PR TITLE
Refactor matoclserv files

### DIFF
--- a/src/master/init.h
+++ b/src/master/init.h
@@ -67,7 +67,7 @@ inline const std::vector<RunTab> runTabs = {
     // has to be before 'fs_init' and 'matoclserv_networkinit'
     RunTab{dcm_init, "data cache manager"},
     // has to be before 'fs_init'
-    RunTab{matoclserv_sessionsinit, "load stored sessions"},
+    RunTab{matoclserv_sessions_init, "load stored sessions"},
     RunTab{exports_init, "exports manager"},
     RunTab{topology_init, "net topology module"},
     // the lambda is used to select the correct fs_init overload
@@ -76,7 +76,7 @@ inline const std::vector<RunTab> runTabs = {
     RunTab{masterconn_init, "communication with master server"},
     RunTab{matomlserv_init, "communication with metalogger"},
     RunTab{matocsserv_init, "communication with chunkserver"},
-    RunTab{matoclserv_networkinit, "communication with clients"}};
+    RunTab{matoclserv_network_init, "communication with clients"}};
 
 /// Functions to call delayed after the initialization is correct
 inline const std::vector<RunTab> lateRunTabs = {};

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -604,22 +604,19 @@ void matoclserv_store_sessions() {
 	    sizeof(session::rootuid) + sizeof(session::rootgid) + sizeof(session::mapalluid) +
 	    sizeof(session::mapallgid);
 	constexpr uint32_t kBufferSize = kSessionSerializedSize + (SESSION_STATS * 8);
-	uint8_t fsesrecord[kBufferSize]; // 4+4+4+4+1+1+1+4+4+4+4+4+4+SESSION_STATS*4+SESSION_STATS*4
-	uint8_t *ptr;
-	int i;
-	FILE *fd;
+	std::vector<uint8_t> fsesrecord(kBufferSize); // 4+4+4+4+1+1+1+4+4+4+4+4+4+SESSION_STATS*4+SESSION_STATS*4
 
-	fd = fopen(kSessionsTmpFilename, "w");
+	FILE *fd = fopen(kSessionsTmpFilename, "w");
 	if (fd == NULL) {
 		safs_silent_errlog(LOG_WARNING,"can't store sessions, open error");
 		return;
 	}
 
-	memcpy(fsesrecord, SFSSIGNATURE "S \001\006\004", 8);
-	ptr = fsesrecord + 8;
+	memcpy(fsesrecord.data(), SFSSIGNATURE "S \001\006\004", 8);
+	uint8_t *ptr = fsesrecord.data() + 8;
 	put16bit(&ptr,SESSION_STATS);
 
-	if (fwrite(fsesrecord, 10, 1, fd) != 1) {
+	if (fwrite(fsesrecord.data(), 10, 1, fd) != 1) {
 		safs_pretty_syslog(LOG_WARNING,"can't store sessions, fwrite error");
 		fclose(fd);
 		return;
@@ -627,7 +624,7 @@ void matoclserv_store_sessions() {
 
 	for (const auto& sessionPtr : sessionVector) {
 		if (sessionPtr->newsession == 1) {
-			ptr = fsesrecord;
+			ptr = fsesrecord.data();
 			ileng = sessionPtr->info.size();
 
 			put32bit(&ptr, sessionPtr->sessionid);
@@ -644,14 +641,14 @@ void matoclserv_store_sessions() {
 			put32bit(&ptr, sessionPtr->mapalluid);
 			put32bit(&ptr, sessionPtr->mapallgid);
 
-			for (i = 0; i < SESSION_STATS; i++) {
+			for (auto i = 0; i < SESSION_STATS; i++) {
 				put32bit(&ptr, sessionPtr->currentopstats[i]);
 			}
 
-			for (i = 0; i < SESSION_STATS; i++) {
+			for (auto i = 0; i < SESSION_STATS; i++) {
 				put32bit(&ptr, sessionPtr->lasthouropstats[i]);
 			}
-			if (fwrite(fsesrecord, kBufferSize, 1, fd) != 1) {
+			if (fwrite(fsesrecord.data(), kBufferSize, 1, fd) != 1) {
 				safs_pretty_syslog(LOG_WARNING,"can't store sessions, fwrite error");
 				fclose(fd);
 				return;
@@ -783,7 +780,7 @@ int matoclserv_load_sessions() {
 	while (!feof(fd)) {
 		r = fread(fsesrecord.data(), fsesrecord.size(), 1, fd);
 
-		if (r==1) {
+		if (r == 1) {
 			ptr = fsesrecord.data();
 			auto sessionPtr = std::make_unique<session>();
 			passert(sessionPtr);

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -100,7 +100,7 @@ enum class ClientConnectionMode : std::uint8_t {
 };
 
 // chunkDelayedOperation types
-enum ChunkDelayedOperationType : std::uint32_t {
+enum DelayedChunkOperationType : std::uint32_t {
 	FUSE_WRITE,          /// Reply to FUSE_WRITE_CHUNK is delayed
 	FUSE_TRUNCATE,       /// Reply to FUSE_TRUNCATE which does not require writing is delayed
 	FUSE_TRUNCATE_BEGIN, /// Reply to FUSE_TRUNCATE which does require writing is delayed
@@ -116,95 +116,95 @@ struct matoclserventry;
 // locked chunks
 class PacketSerializer;
 
-struct chunkDelayedOperation {
-	uint64_t chunkid;
-	uint64_t fleng;     // file length
-	uint32_t lockid;    // lock ID
-	uint32_t qid;       // queryid for answer
-	inode_t inode;      // inode
-	uint32_t uid;
-	uint32_t gid;
-	uint32_t auid;
-	uint32_t agid;
-	uint8_t type;
-	const PacketSerializer* serializer;
+struct DelayedChunkOperation {
+	uint64_t chunkId;       ///< Chunk ID
+	uint64_t fileLength;    ///< File length
+	uint32_t lockId;        ///< Lock ID
+	uint32_t messageId;     ///< Message ID for reply
+	inode_t inode;          ///< Inode
+	uint32_t uid;           ///< Remapped uid of the user which will run the operation
+	uint32_t gid;           ///< Remapped gid of the user which will run the operation
+	uint32_t auid;          ///< Real uid (not remapped) of the user who will run the operation
+	uint32_t agid;          ///< Real gid (not remapped) of the user who will run the operation
+	uint8_t type;           ///< Delayed operation type: FUSE_WRITE, FUSE_TRUNCATE,
+	                        ///< FUSE_TRUNCATE_BEGIN or FUSE_TRUNCATE_END
+	const PacketSerializer* serializer;  ///< Packet serializer for the operation
 };
 
-struct session {
+struct Session {
 	using GroupCache = GenericLruCache<uint32_t, FsContext::GroupsContainer, 1024>;
+	using OpenFilesSet = std::set<inode_t>;
 
-	using OpenedFilesSet = std::set<inode_t>;
+	uint32_t sessionId;      ///< Session ID
+	std::string info;        ///< Mount point path
+	std::string mountInfo;   ///< Mount information shown in the CGI, e.g., arguments, mount options
+	std::string config;      ///< Session configuration
+	uint32_t peerIpAddress;  ///< Peer IP address
+	uint16_t peerPort{};     ///< Peer port
+	uint8_t newSession;      ///< Indicates if this is a new session (1) or a reconnect (0)
+	uint8_t flags;           ///< Session flags. See more details in SFSCommunication.h
+	uint8_t minGoal;         ///< Minimum goal allowed for this session
+	uint8_t maxGoal;         ///< Maximum goal allowed for this session
+	uint32_t minTrashTime;   ///< Minimum time in seconds to keep files in trash
+	uint32_t maxTrashTime;   ///< Maximum time in seconds to keep files in trash
+	uint32_t rootUid;        ///< Remapped UID of the user who created the session
+	uint32_t rootGid;        ///< Remapped GID of the user who created the session
+	uint32_t mapAllUid;    ///< UID to map all non-root users to when the session has SESFLAG_MAPALL
+	                       ///< flag set)
+	uint32_t mapAllGid;    ///< GID to map all non-root users to when the session has SESFLAG_MAPALL
+	                       ///< flag set)
+	inode_t rootInode;     ///< Special Root Inode with value = 1
+	uint32_t disconnectedTimestamp;  ///< Last connected timestamp for this session
+	                                 ///< A value = 0 means a client is connected
+	                                 ///< A value > 0 means the last disconnection timestamp
+	uint32_t connections;  ///< Number of active connections. A value of 0 means no connections
+	std::array<uint32_t, SESSION_STATS> currHourOperationsStats; ///< Current hour operations stats
+	std::array<uint32_t, SESSION_STATS> prevHourOperationsStats; ///< Previous hour operations stats
+	GroupCache groupsCache;     ///< Cache for groups ID for this session
+	OpenFilesSet openFilesSet;  ///< Set of open files for this session
 
-	uint32_t sessionid;
-	std::string info;
-	std::string mountinfo;
-	std::string config;
-	uint32_t peerip;
-	uint16_t peerport{};
-	uint8_t newsession;
-	uint8_t sesflags;
-	uint8_t mingoal;
-	uint8_t maxgoal;
-	uint32_t mintrashtime;
-	uint32_t maxtrashtime;
-	uint32_t rootuid;
-	uint32_t rootgid;
-	uint32_t mapalluid;
-	uint32_t mapallgid;
-	inode_t rootinode;
-	uint32_t disconnected;  // 0 = connected ; other = disconnection timestamp
-	uint32_t nsocks;        // >0 - connected (number of active connections) ; 0 - not connected
-	std::array<uint32_t,SESSION_STATS> currentopstats;
-	std::array<uint32_t,SESSION_STATS> lasthouropstats;
-	GroupCache group_cache;
-	OpenedFilesSet openedfiles;
-
-	session()
-	    : sessionid(),
+	Session()
+	    : sessionId(),
 	      info(),
-	      peerip(),
-	      newsession(),
-	      sesflags(),
-	      mingoal(GoalId::kMin),
-	      maxgoal(GoalId::kMax),
-	      mintrashtime(),
-	      maxtrashtime(std::numeric_limits<uint32_t>::max()),
-	      rootuid(),
-	      rootgid(),
-	      mapalluid(),
-	      mapallgid(),
-	      rootinode(SPECIAL_INODE_ROOT),
-	      disconnected(),
-	      nsocks(),
-	      currentopstats(),
-	      lasthouropstats(),
-	      group_cache(),
-	      openedfiles() {
+	      peerIpAddress(),
+	      newSession(),
+	      flags(),
+	      minGoal(GoalId::kMin),
+	      maxGoal(GoalId::kMax),
+	      minTrashTime(),
+	      maxTrashTime(std::numeric_limits<uint32_t>::max()),
+	      rootUid(),
+	      rootGid(),
+	      mapAllUid(),
+	      mapAllGid(),
+	      rootInode(SPECIAL_INODE_ROOT),
+	      disconnectedTimestamp(),
+	      connections(),
+	      currHourOperationsStats(),
+	      prevHourOperationsStats(),
+	      groupsCache(),
+	      openFilesSet() {
 	}
 };
 
 struct packetstruct {
 	struct packetstruct *next;
-	uint8_t *startptr;
-	uint32_t bytesleft;
+	uint8_t *startPtr;
+	uint32_t bytesLeft;
 	uint8_t *packet;
 };
 
-/** This looks to be the client type. This is set in matoclserv_serve and matoclserv_fuse_register, and there are 3 possible values:
- *
- *    0: new client (default, just after TCP accept)
- *       This is referred to as "unregistered clients".
- *    1: FUSE_REGISTER_BLOB_NOACL       or (FUSE_REGISTER_BLOB_ACL and (REGISTER_NEWSESSION or REGISTER_NEWMETASESSION or REGISTER_RECONNECT))
- *       This is referred to as "mounts and new tools" or "standard, registered clients".
- *  100: FUSE_REGISTER_BLOB_TOOLS_NOACL or (FUSE_REGISTER_BLOB_ACL and REGISTER_TOOLS)
- *       This is referred to as "old sfstools".
- *  665: saunafs-admin after successful authentication
- */
+///< This looks to be the client type.
+///< This is set in matoclserv_serve and matoclserv_fuse_register, and there are 4 possible values:
 enum class ClientState {
-	kUnregistered = 0,
-	kRegistered = 1,
-	kOldTools = 100,
-	kAdmin = 665
+	kUnregistered = 0,  ///< New client (default, just after TCP accept).
+	                    ///  This is referred to as "unregistered clients".
+	kRegistered = 1,    ///< FUSE_REGISTER_BLOB_NOACL or (FUSE_REGISTER_BLOB_ACL and
+	                  ///<  (REGISTER_NEWSESSION or REGISTER_NEWMETASESSION or REGISTER_RECONNECT))
+	           ///< This is referred to as "mounts and new tools" or "standard, registered clients".
+	kOldTools = 100, ///< FUSE_REGISTER_BLOB_TOOLS_NOACL or (FUSE_REGISTER_BLOB_ACL and REGISTER_TOOLS)
+	           ///< This is referred to as "old sfstools" or "old tools clients".
+	kAdmin = 665 ///< saunafs-admin after successful authentication
 };
 
 /// Values for matoclserventry.adminTask
@@ -217,35 +217,40 @@ enum class AdminTask {
 	kRecalculateChecksums   ///< Admin successfully requested recalculation of metadata checksum
 };
 
-/** Client entry in the server. */
+///< Client entry in the server.
 struct matoclserventry {
-	ClientState registered;
-	ClientConnectionMode mode;
-	bool iolimits;
-	int sock;                               //socket number
-	int32_t pdescpos;
-	uint32_t lastread,lastwrite;            //time of last activity
-	uint32_t version;
-	uint32_t peerip;
-	uint16_t peerport;
-	uint8_t hdrbuff[8];
-	packetstruct inputpacket;
-	packetstruct *outputhead,**outputtail;
+	ClientState registered;           ///< Client state, see ClientState enum
+	ClientConnectionMode mode;        ///< Connection mode, see ClientConnectionMode enum
+	bool ioLimitsEnabled;             ///< Whether I/O limits are enabled for this client
+	int socket;                       ///< Socket number
+	int32_t pDescPos;                 ///< Position in the poll descriptors array
+	uint32_t lastReadTimestamp;       ///< Timestamp of last read operation
+	uint32_t lastWriteTimestamp;      ///< Timestamp of last write operation
+	uint32_t version;                 ///< SaunaFS version of the client, see saunafsVersion()
+	uint32_t peerIpAddress;           ///< Peer IP address of the client
+	uint16_t peerPort;                ///< Peer port of the client
+	uint8_t headerBuffer[8];          ///< Buffer for packet header
+	packetstruct inputPacket;         ///< Input packet structure for reading data from the client
+	packetstruct *outputPacketHead;   ///< Pointer to the head of the output packet list
+	packetstruct **outputPacketTail;  ///< Pointer to the tail of the output packet list
 
 	static constexpr uint8_t kPasswordSize = 32;
-	uint8_t passwordrnd[kPasswordSize];
-	session *sesdata;
+	uint8_t randomPassword[kPasswordSize];  ///< Random password for authentication
+	Session *sessionData;                   ///< Pointer to the session data for this client
+	///< Challenge data for admin authentication
 	std::unique_ptr<SauMatoclAdminRegisterChallengeData> adminChallenge;
-	AdminTask adminTask;                   // admin task requested by this client
-	std::vector<std::unique_ptr<chunkDelayedOperation>> chunkdelayedops;
+	AdminTask adminTask;  ///< admin task requested by this client
+	///< Delayed chunk operations for this client
+	std::vector<std::unique_ptr<DelayedChunkOperation>> delayedChunkOperations;
 };
 
-static std::vector<std::unique_ptr<session>> sessionVector;
+static std::vector<std::unique_ptr<Session>> sessionVector;
 static std::list<std::unique_ptr<matoclserventry>> matoclservList;
 
-static int lsock;
-static int32_t lsockpdescpos;
-static int exiting,starting;
+static int masterSocket;             ///< Master socket for accepting new connections
+static int32_t masterSocketDescPos;  ///< Position in the poll descriptors array for masterSocket
+static int exiting;   ///< Flag indicating whether the server is exiting (1) or running (0)
+static int starting;  ///< Flag indicating whether the server is starting (1) or not (0)
 
 // from config
 static std::string ListenHost;
@@ -259,10 +264,10 @@ static uint32_t gIoLimitsConfigId;
 static std::string gIoLimitsSubsystem;
 static IoLimitsDatabase gIoLimitsDatabase;
 
-static uint32_t stats_prcvd = 0;
-static uint32_t stats_psent = 0;
-static uint64_t stats_brcvd = 0;
-static uint64_t stats_bsent = 0;
+static uint32_t statsPacketsReceived = 0;
+static uint32_t statsPacketsSent = 0;
+static uint64_t statsBytesReceived = 0;
+static uint64_t statsBytesSent = 0;
 
 static void getStandardChunkCopies(const std::vector<ChunkTypeWithAddress>& allCopies,
 		std::vector<NetworkAddress>& standardCopies);
@@ -535,15 +540,15 @@ const PacketSerializer* PacketSerializer::getSerializer(PacketHeader::Type type,
 }
 
 void matoclserv_stats(uint64_t stats[5]) {
-	stats[0] = stats_prcvd;
-	stats[1] = stats_psent;
-	stats[2] = stats_brcvd;
-	stats[3] = stats_bsent;
+	stats[0] = statsPacketsReceived;
+	stats[1] = statsPacketsSent;
+	stats[2] = statsBytesReceived;
+	stats[3] = statsBytesSent;
 
-	stats_prcvd = 0;
-	stats_psent = 0;
-	stats_brcvd = 0;
-	stats_bsent = 0;
+	statsPacketsReceived = 0;
+	statsPacketsSent = 0;
+	statsBytesReceived = 0;
+	statsBytesSent = 0;
 }
 
 /// Returns the connection for a given session.
@@ -551,7 +556,7 @@ void matoclserv_stats(uint64_t stats[5]) {
 /// @return Pointer to the matoclserventry if found, nullptr otherwise
 matoclserventry *matoclserv_find_connection(uint32_t sessionId) {
 	for (const auto& eptr : matoclservList) {
-		if (eptr->sesdata && eptr->sesdata->sessionid == sessionId) {
+		if (eptr->sessionData && eptr->sessionData->sessionId == sessionId) {
 			return eptr.get();
 		}
 	}
@@ -562,14 +567,14 @@ matoclserventry *matoclserv_find_connection(uint32_t sessionId) {
 /// @param newSession Indicates if this is a new session
 /// @param noNewId Indicates if a new session ID should be generated
 /// @return Pointer to the newly created session
-session *matoclserv_new_session(uint8_t newSession, uint8_t noNewId) {
-	auto sessionPtr = std::make_unique<session>();
+Session *matoclserv_new_session(uint8_t newSession, uint8_t noNewId) {
+	auto sessionPtr = std::make_unique<Session>();
 	passert(sessionPtr.get());
 
 	auto newSessionIdNotNeeded = (newSession == 0 && noNewId);
-	sessionPtr->sessionid = (newSessionIdNotNeeded) ? 0 : fs_newsessionid();
-	sessionPtr->newsession = newSession;
-	sessionPtr->nsocks = 1;
+	sessionPtr->sessionId = (newSessionIdNotNeeded) ? 0 : fs_newsessionid();
+	sessionPtr->newSession = newSession;
+	sessionPtr->connections = 1;
 	sessionVector.push_back(std::move(sessionPtr));
 	return sessionVector.back().get();
 }
@@ -577,16 +582,16 @@ session *matoclserv_new_session(uint8_t newSession, uint8_t noNewId) {
 /// Returns the session for a given ID.
 /// @param sessionId The session ID to search for
 /// @return Pointer to the session if found, nullptr otherwise
-session* matoclserv_find_session(uint32_t sessionId) {
+Session* matoclserv_find_session(uint32_t sessionId) {
 	if (sessionId == 0) { return nullptr; }
 
 	for (const auto& sessionPtr : sessionVector) {
-		if (sessionPtr->sessionid == sessionId) {
-			if (sessionPtr->newsession >= 2) {
-				sessionPtr->newsession -= 2;
+		if (sessionPtr->sessionId == sessionId) {
+			if (sessionPtr->newSession >= 2) {
+				sessionPtr->newSession -= 2;
 			}
-			sessionPtr->nsocks++;
-			sessionPtr->disconnected = 0;
+			sessionPtr->connections++;
+			sessionPtr->disconnectedTimestamp = 0;
 			return sessionPtr.get();
 		}
 	}
@@ -599,9 +604,9 @@ void matoclserv_close_session(uint32_t sessionId) {
 	if (sessionId == 0) { return; }
 
 	for (const auto& sessionPtr : sessionVector) {
-		if (sessionPtr->sessionid == sessionId) {
-			if (sessionPtr->nsocks == 1 && sessionPtr->newsession < 2) {
-				sessionPtr->newsession += 2;
+		if (sessionPtr->sessionId == sessionId) {
+			if (sessionPtr->connections == 1 && sessionPtr->newSession < 2) {
+				sessionPtr->newSession += 2;
 			}
 		}
 	}
@@ -611,11 +616,11 @@ void matoclserv_close_session(uint32_t sessionId) {
 void matoclserv_store_sessions() {
 	uint32_t sessionInfoLength;
 	constexpr uint32_t kSessionSerializedSize =
-	    sizeof(session::sessionid) + sizeof(sessionInfoLength) + sizeof(session::peerip) +
-	    sizeof(session::rootinode) + sizeof(session::sesflags) + sizeof(session::mingoal) +
-	    sizeof(session::maxgoal) + sizeof(session::mintrashtime) + sizeof(session::maxtrashtime) +
-	    sizeof(session::rootuid) + sizeof(session::rootgid) + sizeof(session::mapalluid) +
-	    sizeof(session::mapallgid);
+	    sizeof(Session::sessionId) + sizeof(sessionInfoLength) + sizeof(Session::peerIpAddress) +
+	    sizeof(Session::rootInode) + sizeof(Session::flags) + sizeof(Session::minGoal) +
+	    sizeof(Session::maxGoal) + sizeof(Session::minTrashTime) + sizeof(Session::maxTrashTime) +
+	    sizeof(Session::rootUid) + sizeof(Session::rootGid) + sizeof(Session::mapAllUid) +
+	    sizeof(Session::mapAllGid);
 	constexpr uint32_t kBufferSize = kSessionSerializedSize + (SESSION_STATS * 8);
 	std::vector<uint8_t> fsesrecord(kBufferSize); // 4+4+4+4+1+1+1+4+4+4+4+4+4+SESSION_STATS*4+SESSION_STATS*4
 
@@ -636,30 +641,30 @@ void matoclserv_store_sessions() {
 	}
 
 	for (const auto& sessionPtr : sessionVector) {
-		if (sessionPtr->newsession == 1) {
+		if (sessionPtr->newSession == 1) {
 			ptr = fsesrecord.data();
 			sessionInfoLength = sessionPtr->info.size();
 
-			put32bit(&ptr, sessionPtr->sessionid);
+			put32bit(&ptr, sessionPtr->sessionId);
 			put32bit(&ptr, sessionInfoLength);
-			put32bit(&ptr, sessionPtr->peerip);
-			put32bit(&ptr, sessionPtr->rootinode);
-			put8bit(&ptr, sessionPtr->sesflags);
-			put8bit(&ptr, sessionPtr->mingoal);
-			put8bit(&ptr, sessionPtr->maxgoal);
-			put32bit(&ptr, sessionPtr->mintrashtime);
-			put32bit(&ptr, sessionPtr->maxtrashtime);
-			put32bit(&ptr, sessionPtr->rootuid);
-			put32bit(&ptr, sessionPtr->rootgid);
-			put32bit(&ptr, sessionPtr->mapalluid);
-			put32bit(&ptr, sessionPtr->mapallgid);
+			put32bit(&ptr, sessionPtr->peerIpAddress);
+			put32bit(&ptr, sessionPtr->rootInode);
+			put8bit(&ptr, sessionPtr->flags);
+			put8bit(&ptr, sessionPtr->minGoal);
+			put8bit(&ptr, sessionPtr->maxGoal);
+			put32bit(&ptr, sessionPtr->minTrashTime);
+			put32bit(&ptr, sessionPtr->maxTrashTime);
+			put32bit(&ptr, sessionPtr->rootUid);
+			put32bit(&ptr, sessionPtr->rootGid);
+			put32bit(&ptr, sessionPtr->mapAllUid);
+			put32bit(&ptr, sessionPtr->mapAllGid);
 
 			for (auto i = 0; i < SESSION_STATS; i++) {
-				put32bit(&ptr, sessionPtr->currentopstats[i]);
+				put32bit(&ptr, sessionPtr->currHourOperationsStats[i]);
 			}
 
 			for (auto i = 0; i < SESSION_STATS; i++) {
-				put32bit(&ptr, sessionPtr->lasthouropstats[i]);
+				put32bit(&ptr, sessionPtr->prevHourOperationsStats[i]);
 			}
 
 			if (fwrite(fsesrecord.data(), kBufferSize, 1, fd) != 1) {
@@ -767,18 +772,18 @@ int matoclserv_load_sessions() {
 
 	// Compile time constants
 	constexpr uint8_t kStatEntrySize =
-	    sizeof(std::remove_extent<decltype(session::currentopstats)>::type::value_type) +
-	    sizeof(std::remove_extent<decltype(session::lasthouropstats)>::type::value_type);
+	    sizeof(std::remove_extent<decltype(Session::currHourOperationsStats)>::type::value_type) +
+	    sizeof(std::remove_extent<decltype(Session::prevHourOperationsStats)>::type::value_type);
 
-	constexpr uint32_t kCommonSize = sizeof(session::sessionid) + sizeof(sessionInfoLength) +
-	                                 sizeof(session::peerip) + sizeof(session::rootinode) +
-	                                 sizeof(session::sesflags) + sizeof(session::rootuid) +
-	                                 sizeof(session::rootgid);
+	constexpr uint32_t kCommonSize = sizeof(Session::sessionId) + sizeof(sessionInfoLength) +
+	                                 sizeof(Session::peerIpAddress) + sizeof(Session::rootInode) +
+	                                 sizeof(Session::flags) + sizeof(Session::rootUid) +
+	                                 sizeof(Session::rootGid);
 	constexpr uint32_t kExtraSizeWithMapAll =
-	    sizeof(session::mapalluid) + sizeof(session::mapallgid);
+	    sizeof(Session::mapAllUid) + sizeof(Session::mapAllGid);
 	constexpr uint32_t kExtraSizeWithGoalTrash =
-	    sizeof(session::mingoal) + sizeof(session::maxgoal) + sizeof(session::mintrashtime) +
-	    sizeof(session::maxtrashtime);
+	    sizeof(Session::minGoal) + sizeof(Session::maxGoal) + sizeof(Session::minTrashTime) +
+	    sizeof(Session::maxTrashTime);
 
 	// statsInFile is unknown at compile time, we need to use a runtime constant
 	const uint32_t kStatsSize = statsInFile * kStatEntrySize;
@@ -797,32 +802,32 @@ int matoclserv_load_sessions() {
 
 		if (bytesRead == 1) {
 			ptr = sessionBuffer.data();
-			auto sessionPtr = std::make_unique<session>();
+			auto sessionPtr = std::make_unique<Session>();
 			passert(sessionPtr);
-			get32bit(&ptr, sessionPtr->sessionid);
+			get32bit(&ptr, sessionPtr->sessionId);
 			get32bit(&ptr, sessionInfoLength);
-			get32bit(&ptr, sessionPtr->peerip);
-			getINode(&ptr, sessionPtr->rootinode);
-			sessionPtr->sesflags = get8bit(&ptr);
+			get32bit(&ptr, sessionPtr->peerIpAddress);
+			getINode(&ptr, sessionPtr->rootInode);
+			sessionPtr->flags = get8bit(&ptr);
 			if (goalTrashData) {
-				sessionPtr->mingoal = get8bit(&ptr);
-				sessionPtr->maxgoal = get8bit(&ptr);
-				get32bit(&ptr, sessionPtr->mintrashtime);
-				get32bit(&ptr, sessionPtr->maxtrashtime);
+				sessionPtr->minGoal = get8bit(&ptr);
+				sessionPtr->maxGoal = get8bit(&ptr);
+				get32bit(&ptr, sessionPtr->minTrashTime);
+				get32bit(&ptr, sessionPtr->maxTrashTime);
 			}
-			get32bit(&ptr, sessionPtr->rootuid);
-			get32bit(&ptr, sessionPtr->rootgid);
+			get32bit(&ptr, sessionPtr->rootUid);
+			get32bit(&ptr, sessionPtr->rootGid);
 			if (mapAllData) {
-				get32bit(&ptr, sessionPtr->mapalluid);
-				get32bit(&ptr, sessionPtr->mapallgid);
+				get32bit(&ptr, sessionPtr->mapAllUid);
+				get32bit(&ptr, sessionPtr->mapAllGid);
 			}
-			sessionPtr->newsession = 1;
-			sessionPtr->disconnected = eventloop_time();
+			sessionPtr->newSession = 1;
+			sessionPtr->disconnectedTimestamp = eventloop_time();
 			for (uint32_t i = 0; i < SESSION_STATS; i++) {
 				if (i < statsInFile) {
-					get32bit(&ptr, sessionPtr->currentopstats[i]);
+					get32bit(&ptr, sessionPtr->currHourOperationsStats[i]);
 				} else {
-					sessionPtr->currentopstats[i] = 0;
+					sessionPtr->currHourOperationsStats[i] = 0;
 				}
 			}
 
@@ -832,9 +837,9 @@ int matoclserv_load_sessions() {
 
 			for (uint32_t i = 0; i < SESSION_STATS; i++) {
 				if (i < statsInFile) {
-					get32bit(&ptr, sessionPtr->lasthouropstats[i]);
+					get32bit(&ptr, sessionPtr->prevHourOperationsStats[i]);
 				} else {
-					sessionPtr->lasthouropstats[i] = 0;
+					sessionPtr->prevHourOperationsStats[i] = 0;
 				}
 			}
 
@@ -868,15 +873,15 @@ int matoclserv_load_sessions() {
 /// @param currentSession Pointer to the session
 /// @param inode The inode of the open file
 /// @return SAUNAFS_STATUS_OK if the file was successfully acquired, or an error code otherwise
-int matoclserv_insert_open_file(session *currentSession, inode_t inode) {
-	if (currentSession->openedfiles.contains(inode)) {
+int matoclserv_insert_open_file(Session *currentSession, inode_t inode) {
+	if (currentSession->openFilesSet.contains(inode)) {
 		return SAUNAFS_STATUS_OK;  // file already acquired - nothing to do
 	}
 
 	int status = fs_acquire(FsContext::getForMaster(eventloop_time()), inode,
-	                        currentSession->sessionid);
+	                        currentSession->sessionId);
 
-	if (status == SAUNAFS_STATUS_OK) { currentSession->openedfiles.insert(inode); }
+	if (status == SAUNAFS_STATUS_OK) { currentSession->openFilesSet.insert(inode); }
 
 	return status;
 }
@@ -888,21 +893,21 @@ int matoclserv_insert_open_file(session *currentSession, inode_t inode) {
 /// Otherwise, a new session will be created and the open file will be added to the new session.
 void matoclserv_add_open_file(uint32_t sessionId, uint32_t inode) {
 	for (const auto& sessionPtr : sessionVector) {
-		if (sessionPtr->sessionid == sessionId) {
-			if (!sessionPtr->openedfiles.contains(inode)) {
-				sessionPtr->openedfiles.insert(inode);
+		if (sessionPtr->sessionId == sessionId) {
+			if (!sessionPtr->openFilesSet.contains(inode)) {
+				sessionPtr->openFilesSet.insert(inode);
 			}
 			return;
 		}
 	}
 
 	// If session does not exist, create a new one
-	auto sessionPtr = std::make_unique<session>();
+	auto sessionPtr = std::make_unique<Session>();
 	passert(sessionPtr.get());
-	sessionPtr->sessionid = sessionId;
+	sessionPtr->sessionId = sessionId;
 	/* session created by filesystem - only for old clients (pre 1.5.13) */
-	sessionPtr->disconnected = eventloop_time();
-	sessionPtr->openedfiles.insert(inode);
+	sessionPtr->disconnectedTimestamp = eventloop_time();
+	sessionPtr->openFilesSet.insert(inode);
 	sessionVector.push_back(std::move(sessionPtr));
 }
 
@@ -911,9 +916,9 @@ void matoclserv_add_open_file(uint32_t sessionId, uint32_t inode) {
 /// @param inode The inode of the open file
 void matoclserv_remove_open_file(uint32_t sessionId, uint32_t inode) {
 	for (const auto& sessionPtr : sessionVector) {
-		if (sessionPtr->sessionid == sessionId) {
-			if (sessionPtr->openedfiles.contains(inode)) {
-				sessionPtr->openedfiles.erase(inode);
+		if (sessionPtr->sessionId == sessionId) {
+			if (sessionPtr->openFilesSet.contains(inode)) {
+				sessionPtr->openFilesSet.erase(inode);
 			}
 			return;
 		}
@@ -927,7 +932,7 @@ void matoclserv_reset_session_timeouts() {
 	uint32_t now = eventloop_time();
 
 	for (auto& sessionPtr : sessionVector) {
-		sessionPtr->disconnected = now;
+		sessionPtr->disconnectedTimestamp = now;
 	}
 }
 
@@ -945,15 +950,15 @@ uint8_t *matoclserv_createpacket(matoclserventry *eptr, uint32_t type, uint32_t 
 	uint32_t packetSize = sizeof(type) + sizeof(size) + size;
 	outpacket->packet = (uint8_t *)malloc(packetSize);
 	passert(outpacket->packet);
-	outpacket->bytesleft = packetSize;
+	outpacket->bytesLeft = packetSize;
 
 	uint8_t *ptr = outpacket->packet;
 	put32bit(&ptr, type);
 	put32bit(&ptr, size);
-	outpacket->startptr = (uint8_t *)(outpacket->packet);
+	outpacket->startPtr = (uint8_t *)(outpacket->packet);
 	outpacket->next = NULL;
-	*(eptr->outputtail) = outpacket;
-	eptr->outputtail = &(outpacket->next);
+	*(eptr->outputPacketTail) = outpacket;
+	eptr->outputPacketTail = &(outpacket->next);
 	return ptr;
 }
 
@@ -966,13 +971,13 @@ void matoclserv_createpacket(matoclserventry *eptr, const MessageBuffer &buffer)
 	outpacket->packet = (uint8_t *)malloc(buffer.size());
 	passert(outpacket->packet);
 
-	outpacket->bytesleft = buffer.size();
+	outpacket->bytesLeft = buffer.size();
 	// TODO unificate output packets and remove suboptimal memory copying
 	memcpy(outpacket->packet, buffer.data(), buffer.size());
-	outpacket->startptr = outpacket->packet;
+	outpacket->startPtr = outpacket->packet;
 	outpacket->next = NULL;
-	*(eptr->outputtail) = outpacket;
-	eptr->outputtail = &(outpacket->next);
+	*(eptr->outputPacketTail) = outpacket;
+	eptr->outputPacketTail = &(outpacket->next);
 }
 
 /// Checks if user/group ID remapping is required for a given client connection.
@@ -980,7 +985,7 @@ void matoclserv_createpacket(matoclserventry *eptr, const MessageBuffer &buffer)
 /// @param uid The user ID to check
 /// @return true if remapping is required, false otherwise
 static inline bool matoclserv_ugid_remap_required(matoclserventry *eptr, uint32_t uid) {
-	return uid == 0 || eptr->sesdata->sesflags & SESFLAG_MAPALL;
+	return uid == 0 || eptr->sessionData->flags & SESFLAG_MAPALL;
 }
 
 /// Remaps user and group IDs for a given client connection.
@@ -989,14 +994,14 @@ static inline bool matoclserv_ugid_remap_required(matoclserventry *eptr, uint32_
 /// @param agid Pointer to the group ID to remap
 static inline void matoclserv_ugid_remap(matoclserventry *eptr, uint32_t *auid, uint32_t *agid) {
 	if (*auid == 0) {
-		*auid = eptr->sesdata->rootuid;
+		*auid = eptr->sessionData->rootUid;
 		if (agid) {
-			*agid = eptr->sesdata->rootgid;
+			*agid = eptr->sessionData->rootGid;
 		}
-	} else if (eptr->sesdata->sesflags & SESFLAG_MAPALL) {
-		*auid = eptr->sesdata->mapalluid;
+	} else if (eptr->sessionData->flags & SESFLAG_MAPALL) {
+		*auid = eptr->sessionData->mapAllUid;
 		if (agid) {
-			*agid = eptr->sesdata->mapallgid;
+			*agid = eptr->sessionData->mapAllGid;
 		}
 	}
 }
@@ -1010,19 +1015,19 @@ static inline uint8_t matoclserv_check_group_cache(matoclserventry *eptr, uint32
 		return SAUNAFS_STATUS_OK;
 	}
 
-	assert(eptr && eptr->sesdata);
-	auto it = eptr->sesdata->group_cache.find(user_groups::decodeGroupCacheId(gid));
-	return (it == eptr->sesdata->group_cache.end()) ? SAUNAFS_ERROR_GROUPNOTREGISTERED
-	                                                : SAUNAFS_STATUS_OK;
+	assert(eptr && eptr->sessionData);
+	auto it = eptr->sessionData->groupsCache.find(user_groups::decodeGroupCacheId(gid));
+	return (it == eptr->sessionData->groupsCache.end()) ? SAUNAFS_ERROR_GROUPNOTREGISTERED
+	                                                    : SAUNAFS_STATUS_OK;
 }
 
 /// Returns FsContext without information about sessions like user ID or group ID
 /// @param eptr Pointer to the client connection in the master
 /// @return FsContext with session data
 static inline FsContext matoclserv_get_context(matoclserventry *eptr) {
-	assert(eptr && eptr->sesdata);
-	return FsContext::getForMaster(eventloop_time(), eptr->sesdata->rootinode,
-	                               eptr->sesdata->sesflags);
+	assert(eptr && eptr->sessionData);
+	return FsContext::getForMaster(eventloop_time(), eptr->sessionData->rootInode,
+	                               eptr->sessionData->flags);
 }
 
 /// Returns FsContext with information about sessions like user ID and group ID
@@ -1030,20 +1035,20 @@ static inline FsContext matoclserv_get_context(matoclserventry *eptr) {
 /// @param uid The user ID to use in the context
 /// @param gid The group ID to use in the context
 static inline FsContext matoclserv_get_context(matoclserventry *eptr, uint32_t uid, uint32_t gid) {
-	assert(eptr && eptr->sesdata);
+	assert(eptr && eptr->sessionData);
 
 	if (user_groups::isGroupCacheId(gid)) {
-		auto it = eptr->sesdata->group_cache.find(user_groups::decodeGroupCacheId(gid));
-		if (it == eptr->sesdata->group_cache.end()) {
+		auto it = eptr->sessionData->groupsCache.find(user_groups::decodeGroupCacheId(gid));
+		if (it == eptr->sessionData->groupsCache.end()) {
 			throw std::runtime_error("Missing group data in session cache");
 		}
 
 		assert(!it->second.empty());
 
 		if (!matoclserv_ugid_remap_required(eptr, uid)) {
-			return FsContext::getForMasterWithSession(eventloop_time(), eptr->sesdata->rootinode,
-			                                          eptr->sesdata->sesflags, uid, it->second,
-			                                          uid, it->second[0]);
+			return FsContext::getForMasterWithSession(
+			    eventloop_time(), eptr->sessionData->rootInode, eptr->sessionData->flags, uid,
+			    it->second, uid, it->second[0]);
 		}
 
 		FsContext::GroupsContainer gids;
@@ -1059,16 +1064,16 @@ static inline FsContext matoclserv_get_context(matoclserventry *eptr, uint32_t u
 		uint32_t auid = uid;
 		matoclserv_ugid_remap(eptr, &uid, nullptr);
 
-		return FsContext::getForMasterWithSession(eventloop_time(), eptr->sesdata->rootinode,
-		                                          eptr->sesdata->sesflags, uid, std::move(gids),
+		return FsContext::getForMasterWithSession(eventloop_time(), eptr->sessionData->rootInode,
+		                                          eptr->sessionData->flags, uid, std::move(gids),
 		                                          auid, it->second[0]);
 	}
 
 	uint32_t auid = uid;
 	uint32_t agid = gid;
 	matoclserv_ugid_remap(eptr, &uid, &gid);
-	return FsContext::getForMasterWithSession(eventloop_time(), eptr->sesdata->rootinode,
-	                                          eptr->sesdata->sesflags, uid, gid, auid, agid);
+	return FsContext::getForMasterWithSession(eventloop_time(), eptr->sessionData->rootInode,
+	                                          eptr->sessionData->flags, uid, gid, auid, agid);
 }
 
 /// Extracts network addresses of standard chunk copies from a list of all chunk copies.
@@ -1112,7 +1117,7 @@ uint8_t matoclserv_fuse_write_chunk_respond(matoclserventry *eptr,
                                             uint32_t lockId) {
 	uint32_t chunkVersion;
 	std::vector<ChunkTypeWithAddress> allChunkCopies;
-	uint8_t status = chunk_getversionandlocations(chunkId, eptr->peerip, chunkVersion,
+	uint8_t status = chunk_getversionandlocations(chunkId, eptr->peerIpAddress, chunkVersion,
 			kMaxNumberOfChunkCopies, allChunkCopies);
 
 	remove_unsupported_ec_parts(eptr->version, allChunkCopies);
@@ -1144,7 +1149,7 @@ uint8_t matoclserv_fuse_write_chunk_respond(matoclserventry *eptr,
 }
 
 void matoclserv_chunk_status(uint64_t chunkId, uint8_t status) {
-	chunkDelayedOperation *operation;
+	DelayedChunkOperation *operation;
 	const PacketSerializer *serializer;
 
 	matoclserventry *eptr = NULL;
@@ -1163,14 +1168,14 @@ void matoclserv_chunk_status(uint64_t chunkId, uint8_t status) {
 	for (; eptrIterator != matoclservList.end() && eptr == NULL; eptrIterator++) {
 		matoclserventry* eaptr = eptrIterator->get();
 		if (eaptr->mode != ClientConnectionMode::KILL) {
-			auto chunkOpsIterator = eaptr->chunkdelayedops.begin();
-			while (chunkOpsIterator != eaptr->chunkdelayedops.end() && eptr == NULL) {
+			auto chunkOpsIterator = eaptr->delayedChunkOperations.begin();
+			while (chunkOpsIterator != eaptr->delayedChunkOperations.end() && eptr == NULL) {
 				operation = chunkOpsIterator->get();
-				if (operation->chunkid == chunkId) {
+				if (operation->chunkId == chunkId) {
 					eptr = eaptr;
-					messageId = operation->qid;
-					fileLength = operation->fleng;
-					lockId = operation->lockid;
+					messageId = operation->messageId;
+					fileLength = operation->fileLength;
+					lockId = operation->lockId;
 					operationType = operation->type;
 					inode = operation->inode;
 					uid = operation->uid;
@@ -1179,7 +1184,7 @@ void matoclserv_chunk_status(uint64_t chunkId, uint8_t status) {
 					agid = operation->agid;
 					serializer = operation->serializer;
 
-					chunkOpsIterator = eaptr->chunkdelayedops.erase(chunkOpsIterator);
+					chunkOpsIterator = eaptr->delayedChunkOperations.erase(chunkOpsIterator);
 				} else {
 					++chunkOpsIterator;
 				}
@@ -1191,11 +1196,12 @@ void matoclserv_chunk_status(uint64_t chunkId, uint8_t status) {
 		safs_pretty_syslog(LOG_WARNING,"got chunk status, but don't want it");
 		return;
 	}
-	if (status == SAUNAFS_STATUS_OK) { dcm_modify(inode, eptr->sesdata->sessionid); }
+	if (status == SAUNAFS_STATUS_OK) { dcm_modify(inode, eptr->sessionData->sessionId); }
 
 	std::vector<uint8_t> reply;
-	FsContext context = FsContext::getForMasterWithSession(
-	    eventloop_time(), eptr->sesdata->rootinode, eptr->sesdata->sesflags, uid, gid, auid, agid);
+	FsContext context =
+	    FsContext::getForMasterWithSession(eventloop_time(), eptr->sessionData->rootInode,
+	                                       eptr->sessionData->flags, uid, gid, auid, agid);
 
 	switch (operationType) {
 	case FUSE_WRITE:
@@ -1431,34 +1437,34 @@ void matoclserv_session_list(matoclserventry *eptr, const uint8_t *data, uint32_
 
 	uint32_t size = sizeof(uint16_t);  // 2 bytes for SESSION_STATS
 
-	constexpr uint32_t kExtraVModeSize = sizeof(session::mingoal) + sizeof(session::maxgoal) +
-	                                     sizeof(session::mintrashtime) +
-	                                     sizeof(session::maxtrashtime);
+	constexpr uint32_t kExtraVModeSize = sizeof(Session::minGoal) + sizeof(Session::maxGoal) +
+	                                     sizeof(Session::minTrashTime) +
+	                                     sizeof(Session::maxTrashTime);
 
 	constexpr uint32_t kCommonSessionSize =
-	    sizeof(session::sessionid) + sizeof(matoclserventry::peerip) +
-	    sizeof(matoclserventry::version) + sizeof(sessionInfoLength) + sizeof(session::sesflags) +
-	    sizeof(session::rootuid) + sizeof(session::rootgid) + sizeof(session::mapalluid) +
-	    sizeof(session::mapallgid);
+	    sizeof(Session::sessionId) + sizeof(matoclserventry::peerIpAddress) +
+	    sizeof(matoclserventry::version) + sizeof(sessionInfoLength) + sizeof(Session::flags) +
+	    sizeof(Session::rootUid) + sizeof(Session::rootGid) + sizeof(Session::mapAllUid) +
+	    sizeof(Session::mapAllGid);
 
 	constexpr uint32_t kCurrentPlusLastHourEntrySize = sizeof(uint32_t) + sizeof(uint32_t);
 
 	for (const auto &eaptr : matoclservList) {
-		if (eaptr->mode != ClientConnectionMode::KILL && eaptr->sesdata &&
+		if (eaptr->mode != ClientConnectionMode::KILL && eaptr->sessionData &&
 		    eaptr->registered == ClientState::kRegistered) {
 			size += kCommonSessionSize + (SESSION_STATS * kCurrentPlusLastHourEntrySize) +
 			        (vmode ? kExtraVModeSize : 0);
 
-			if (!eaptr->sesdata->info.empty()) {
-				size += eaptr->sesdata->info.size();
+			if (!eaptr->sessionData->info.empty()) {
+				size += eaptr->sessionData->info.size();
 			}
 
-			if (eaptr->sesdata->rootinode == 0) {
-				size += sizeof(session::rootinode);
+			if (eaptr->sessionData->rootInode == 0) {
+				size += sizeof(Session::rootInode);
 				size += 1;  // for '.'
 			} else {
 				size += sizeof(pathLength);
-				size += fs_getdirpath_size(eaptr->sesdata->rootinode);
+				size += fs_getdirpath_size(eaptr->sessionData->rootInode);
 			}
 		}
 	}
@@ -1468,52 +1474,52 @@ void matoclserv_session_list(matoclserventry *eptr, const uint8_t *data, uint32_
 	put16bit(&ptr, SESSION_STATS);
 
 	for (const auto &eaptr : matoclservList) {
-		if (eaptr->mode != ClientConnectionMode::KILL && eaptr->sesdata &&
+		if (eaptr->mode != ClientConnectionMode::KILL && eaptr->sessionData &&
 		    eaptr->registered == ClientState::kRegistered) {
-			put32bit(&ptr, eaptr->sesdata->sessionid);
-			put32bit(&ptr, eaptr->peerip);
+			put32bit(&ptr, eaptr->sessionData->sessionId);
+			put32bit(&ptr, eaptr->peerIpAddress);
 			put32bit(&ptr, eaptr->version);
 
-			if (!eaptr->sesdata->info.empty()) {
-				sessionInfoLength = eaptr->sesdata->info.size();
+			if (!eaptr->sessionData->info.empty()) {
+				sessionInfoLength = eaptr->sessionData->info.size();
 				put32bit(&ptr, sessionInfoLength);
-				memcpy(ptr, eaptr->sesdata->info.data(), sessionInfoLength);
+				memcpy(ptr, eaptr->sessionData->info.data(), sessionInfoLength);
 				ptr += sessionInfoLength;
 			} else {
 				put32bit(&ptr, 0);
 			}
 
-			if (eaptr->sesdata->rootinode == 0) {
+			if (eaptr->sessionData->rootInode == 0) {
 				putINode(&ptr, static_cast<inode_t>(1));
 				put8bit(&ptr, '.');
 			} else {
-				pathLength = fs_getdirpath_size(eaptr->sesdata->rootinode);
+				pathLength = fs_getdirpath_size(eaptr->sessionData->rootInode);
 				put32bit(&ptr, pathLength);
 				if (pathLength > 0) {
-					fs_getdirpath_data(eaptr->sesdata->rootinode, ptr, pathLength);
+					fs_getdirpath_data(eaptr->sessionData->rootInode, ptr, pathLength);
 					ptr += pathLength;
 				}
 			}
 
-			put8bit(&ptr, eaptr->sesdata->sesflags);
-			put32bit(&ptr, eaptr->sesdata->rootuid);
-			put32bit(&ptr, eaptr->sesdata->rootgid);
-			put32bit(&ptr, eaptr->sesdata->mapalluid);
-			put32bit(&ptr, eaptr->sesdata->mapallgid);
+			put8bit(&ptr, eaptr->sessionData->flags);
+			put32bit(&ptr, eaptr->sessionData->rootUid);
+			put32bit(&ptr, eaptr->sessionData->rootGid);
+			put32bit(&ptr, eaptr->sessionData->mapAllUid);
+			put32bit(&ptr, eaptr->sessionData->mapAllGid);
 
 			if (vmode) {
-				put8bit(&ptr, eaptr->sesdata->mingoal);
-				put8bit(&ptr, eaptr->sesdata->maxgoal);
-				put32bit(&ptr, eaptr->sesdata->mintrashtime);
-				put32bit(&ptr, eaptr->sesdata->maxtrashtime);
+				put8bit(&ptr, eaptr->sessionData->minGoal);
+				put8bit(&ptr, eaptr->sessionData->maxGoal);
+				put32bit(&ptr, eaptr->sessionData->minTrashTime);
+				put32bit(&ptr, eaptr->sessionData->maxTrashTime);
 			}
 
-			if (eaptr->sesdata) {
+			if (eaptr->sessionData) {
 				for (auto i = 0; i < SESSION_STATS; i++) {
-					put32bit(&ptr, eaptr->sesdata->currentopstats[i]);
+					put32bit(&ptr, eaptr->sessionData->currHourOperationsStats[i]);
 				}
 				for (auto i = 0; i < SESSION_STATS; i++) {
-					put32bit(&ptr, eaptr->sesdata->lasthouropstats[i]);
+					put32bit(&ptr, eaptr->sessionData->prevHourOperationsStats[i]);
 				}
 			} else {
 				memset(ptr, 0xFF,
@@ -1538,11 +1544,11 @@ void matoclserv_mount_info_list(matoclserventry *eptr, const uint8_t *data, uint
 	cltoma::mountInfoList::deserialize(data, length);
 
 	for (const auto &eaptr : matoclservList) {
-		if (eaptr->mode != ClientConnectionMode::KILL && eaptr->sesdata != nullptr &&
+		if (eaptr->mode != ClientConnectionMode::KILL && eaptr->sessionData != nullptr &&
 		    eaptr->registered == ClientState::kRegistered) {
 			MountInfoEntry entry;
-			entry.sessionId = eaptr->sesdata->sessionid;
-			entry.mountInfo = eaptr->sesdata->mountinfo;
+			entry.sessionId = eaptr->sessionData->sessionId;
+			entry.mountInfo = eaptr->sessionData->mountInfo;
 			mountInfoList.push_back(entry);
 		}
 	}
@@ -1784,7 +1790,7 @@ static void matoclserv_send_iolimits_cfg(matoclserventry *eptr) {
 
 static void matoclserv_broadcast_iolimits_cfg() {
 	for (const auto &eptr : matoclservList) {
-		if (eptr->iolimits) {
+		if (eptr->ioLimitsEnabled) {
 			matoclserv_send_iolimits_cfg(eptr.get());
 		}
 	}
@@ -1804,7 +1810,8 @@ void matoclserv_fuse_register(matoclserventry *eptr, const uint8_t *data, uint32
 
 	constexpr uint32_t kBlobSize = REGISTER_BLOB_SIZE;
 	constexpr uint32_t kBlobSizeWithVersion = kBlobSize + sizeof(matoclserventry::version);
-	constexpr uint32_t kBlobSizeWithSessionIdAndVersion = kBlobSizeWithVersion + sizeof(session::sessionid);
+	constexpr uint32_t kBlobSizeWithSessionIdAndVersion =
+	    kBlobSizeWithVersion + sizeof(Session::sessionId);
 
 	if (starting) {
 		eptr->mode = ClientConnectionMode::KILL;
@@ -1862,39 +1869,39 @@ void matoclserv_fuse_register(matoclserventry *eptr, const uint8_t *data, uint32
 
 		if (sessionId == 0) {           // new session
 			status = SAUNAFS_STATUS_OK; // exports_check(eptr->peerip,(const uint8_t*)"",NULL,NULL,&sesflags);      // check privileges for '/' w/o password
-			eptr->sesdata = matoclserv_new_session(0, toolsNoACL);
+			eptr->sessionData = matoclserv_new_session(0, toolsNoACL);
 
-			if (eptr->sesdata == nullptr) {
+			if (eptr->sessionData == nullptr) {
 				safs::log_info("can't allocate session record");
 				eptr->mode = ClientConnectionMode::KILL;
 				return;
 			}
 
-			eptr->sesdata->rootinode = SPECIAL_INODE_ROOT;
-			eptr->sesdata->sesflags = 0;
-			eptr->sesdata->peerip = eptr->peerip;
-			eptr->sesdata->peerport = eptr->peerport;
+			eptr->sessionData->rootInode = SPECIAL_INODE_ROOT;
+			eptr->sessionData->flags = 0;
+			eptr->sessionData->peerIpAddress = eptr->peerIpAddress;
+			eptr->sessionData->peerPort = eptr->peerPort;
 		} else {  // reconnect or tools
-			eptr->sesdata = matoclserv_find_session(sessionId);
-			if (eptr->sesdata == nullptr) {      // in old model if session doesn't exist then create it
-				eptr->sesdata = matoclserv_new_session(0, 0);
+			eptr->sessionData = matoclserv_find_session(sessionId);
+			if (eptr->sessionData == nullptr) {      // in old model if session doesn't exist then create it
+				eptr->sessionData = matoclserv_new_session(0, 0);
 
-				if (eptr->sesdata == nullptr) {
+				if (eptr->sessionData == nullptr) {
 					safs::log_info("can't allocate session record");
 					eptr->mode = ClientConnectionMode::KILL;
 					return;
 				}
 
-				eptr->sesdata->rootinode = SPECIAL_INODE_ROOT;
-				eptr->sesdata->sesflags = 0;
-				eptr->sesdata->peerip = eptr->peerip;
-				eptr->sesdata->peerport = eptr->peerport;
+				eptr->sessionData->rootInode = SPECIAL_INODE_ROOT;
+				eptr->sessionData->flags = 0;
+				eptr->sessionData->peerIpAddress = eptr->peerIpAddress;
+				eptr->sessionData->peerPort = eptr->peerPort;
 				status = SAUNAFS_STATUS_OK;
-			} else if (eptr->sesdata->peerip == 0) {  // created by "filesystem"
-				eptr->sesdata->peerip = eptr->peerip;
-				eptr->sesdata->peerport = eptr->peerport;
+			} else if (eptr->sessionData->peerIpAddress == 0) {  // created by "filesystem"
+				eptr->sessionData->peerIpAddress = eptr->peerIpAddress;
+				eptr->sessionData->peerPort = eptr->peerPort;
 				status = SAUNAFS_STATUS_OK;
-			} else if (eptr->sesdata->peerip == eptr->peerip) {
+			} else if (eptr->sessionData->peerIpAddress == eptr->peerIpAddress) {
 				status = SAUNAFS_STATUS_OK;
 			} else {
 				status = SAUNAFS_ERROR_EACCES;
@@ -1919,7 +1926,7 @@ void matoclserv_fuse_register(matoclserventry *eptr, const uint8_t *data, uint32
 		if (toolsNoACL) {
 			put8bit(&wptr, status);
 		} else {
-			sessionId = eptr->sesdata->sessionid;
+			sessionId = eptr->sessionData->sessionId;
 			put32bit(&wptr, sessionId);
 		}
 
@@ -1976,9 +1983,9 @@ void matoclserv_fuse_register(matoclserventry *eptr, const uint8_t *data, uint32
 			}
 			wptr = matoclserv_createpacket(eptr,MATOCL_FUSE_REGISTER, matoclserventry::kPasswordSize);
 			for (i = 0; i < matoclserventry::kPasswordSize; i++) {
-				eptr->passwordrnd[i] = rnd<uint8_t>();
+				eptr->randomPassword[i] = rnd<uint8_t>();
 			}
-			memcpy(wptr, eptr->passwordrnd, matoclserventry::kPasswordSize);
+			memcpy(wptr, eptr->randomPassword, matoclserventry::kPasswordSize);
 
 			return;
 		case REGISTER_NEWSESSION:
@@ -2018,13 +2025,14 @@ void matoclserv_fuse_register(matoclserventry *eptr, const uint8_t *data, uint32
 				path = (const uint8_t*)"";
 			}
 			if (length == kRegisterNewSessionMinSize + 16 + ileng + pleng) {
-				status = exports_check(eptr->peerip, eptr->version, 0, path, eptr->passwordrnd,
-				                       rptr, &sesflags, &rootuid, &rootgid, &mapalluid, &mapallgid,
-				                       &mingoal, &maxgoal, &mintrashtime, &maxtrashtime);
+				status =
+				    exports_check(eptr->peerIpAddress, eptr->version, 0, path, eptr->randomPassword,
+				                  rptr, &sesflags, &rootuid, &rootgid, &mapalluid, &mapallgid,
+				                  &mingoal, &maxgoal, &mintrashtime, &maxtrashtime);
 			} else {
-				status = exports_check(eptr->peerip, eptr->version, 0, path, NULL, NULL, &sesflags,
-				                       &rootuid, &rootgid, &mapalluid, &mapallgid, &mingoal,
-				                       &maxgoal, &mintrashtime, &maxtrashtime);
+				status = exports_check(eptr->peerIpAddress, eptr->version, 0, path, NULL, NULL,
+				                       &sesflags, &rootuid, &rootgid, &mapalluid, &mapallgid,
+				                       &mingoal, &maxgoal, &mintrashtime, &maxtrashtime);
 			}
 
 			if (status == SAUNAFS_STATUS_OK) {
@@ -2032,39 +2040,39 @@ void matoclserv_fuse_register(matoclserventry *eptr, const uint8_t *data, uint32
 			}
 
 			if (status == SAUNAFS_STATUS_OK) {
-				eptr->sesdata = matoclserv_new_session(1, 0);
-				if (eptr->sesdata == nullptr) {
+				eptr->sessionData = matoclserv_new_session(1, 0);
+				if (eptr->sessionData == nullptr) {
 					safs::log_info("can't allocate session record");
 					eptr->mode = ClientConnectionMode::KILL;
 					return;
 				}
 
-				eptr->sesdata->rootinode = rootinode;
-				eptr->sesdata->sesflags = sesflags;
-				eptr->sesdata->rootuid = rootuid;
-				eptr->sesdata->rootgid = rootgid;
-				eptr->sesdata->mapalluid = mapalluid;
-				eptr->sesdata->mapallgid = mapallgid;
-				eptr->sesdata->mingoal = mingoal;
-				eptr->sesdata->maxgoal = maxgoal;
-				eptr->sesdata->mintrashtime = mintrashtime;
-				eptr->sesdata->maxtrashtime = maxtrashtime;
-				eptr->sesdata->peerip = eptr->peerip;
-				eptr->sesdata->peerport = eptr->peerport;
+				eptr->sessionData->rootInode = rootinode;
+				eptr->sessionData->flags = sesflags;
+				eptr->sessionData->rootUid = rootuid;
+				eptr->sessionData->rootGid = rootgid;
+				eptr->sessionData->mapAllUid = mapalluid;
+				eptr->sessionData->mapAllGid = mapallgid;
+				eptr->sessionData->minGoal = mingoal;
+				eptr->sessionData->maxGoal = maxgoal;
+				eptr->sessionData->minTrashTime = mintrashtime;
+				eptr->sessionData->maxTrashTime = maxtrashtime;
+				eptr->sessionData->peerIpAddress = eptr->peerIpAddress;
+				eptr->sessionData->peerPort = eptr->peerPort;
 				if (ileng>0) {
 					if (info[ileng-1]==0) {
-						eptr->sesdata->info = std::string(info);
+						eptr->sessionData->info = std::string(info);
 					} else {
-						eptr->sesdata->info = std::string(info, ileng);
+						eptr->sessionData->info = std::string(info, ileng);
 					}
 				}
 
 				safs::log_info(
 				    "Session {} created for mount: {} exported path: {} with ip: {} and port: {}",
-				    eptr->sesdata->sessionid,
-				    !eptr->sesdata->info.empty() ? eptr->sesdata->info : "unknown info",
-				    path ? (const char *)path : "unknown path", ipToString(eptr->peerip),
-				    eptr->peerport);
+				    eptr->sessionData->sessionId,
+				    !eptr->sessionData->info.empty() ? eptr->sessionData->info : "unknown info",
+				    (path != nullptr) ? reinterpret_cast<const char *>(path) : "unknown path",
+				    ipToString(eptr->peerIpAddress), eptr->peerPort);
 
 				matoclserv_store_sessions();
 			}
@@ -2083,7 +2091,7 @@ void matoclserv_fuse_register(matoclserventry *eptr, const uint8_t *data, uint32
 				put8bit(&wptr, status);
 				return;
 			}
-			sessionId = eptr->sesdata->sessionid;
+			sessionId = eptr->sessionData->sessionId;
 			if (eptr->version == saunafsVersion(1, 6, 21)) {
 				put32bit(&wptr, 0);
 			} else if (eptr->version >= saunafsVersion(1, 6, 22)) {
@@ -2106,7 +2114,7 @@ void matoclserv_fuse_register(matoclserventry *eptr, const uint8_t *data, uint32
 				put32bit(&wptr, maxtrashtime);
 			}
 			if (eptr->version >= saunafsVersion(1, 6, 30)) {
-				eptr->iolimits = true;
+				eptr->ioLimitsEnabled = true;
 				matoclserv_send_iolimits_cfg(eptr);
 			}
 			eptr->registered = ClientState::kRegistered;
@@ -2134,47 +2142,49 @@ void matoclserv_fuse_register(matoclserventry *eptr, const uint8_t *data, uint32
 			rptr += ileng;
 
 			if (length == kRegisterNewMetaSessionMinSize + 16 + ileng) {
-				status = exports_check(eptr->peerip, eptr->version, 1, NULL, eptr->passwordrnd,
-				                       rptr, &sesflags, &rootuid, &rootgid, &mapalluid, &mapallgid,
-				                       &mingoal, &maxgoal, &mintrashtime, &maxtrashtime);
+				status =
+				    exports_check(eptr->peerIpAddress, eptr->version, 1, NULL, eptr->randomPassword,
+				                  rptr, &sesflags, &rootuid, &rootgid, &mapalluid, &mapallgid,
+				                  &mingoal, &maxgoal, &mintrashtime, &maxtrashtime);
 			} else {
-				status = exports_check(eptr->peerip, eptr->version, 1, NULL, NULL, NULL, &sesflags,
-				                       &rootuid, &rootgid, &mapalluid, &mapallgid, &mingoal,
-				                       &maxgoal, &mintrashtime, &maxtrashtime);
+				status = exports_check(eptr->peerIpAddress, eptr->version, 1, NULL, NULL, NULL,
+				                       &sesflags, &rootuid, &rootgid, &mapalluid, &mapallgid,
+				                       &mingoal, &maxgoal, &mintrashtime, &maxtrashtime);
 			}
 
 			if (status == SAUNAFS_STATUS_OK) {
-				eptr->sesdata = matoclserv_new_session(1, 0);
-				if (eptr->sesdata == nullptr) {
+				eptr->sessionData = matoclserv_new_session(1, 0);
+				if (eptr->sessionData == nullptr) {
 					safs::log_info("can't allocate session record");
 					eptr->mode = ClientConnectionMode::KILL;
 					return;
 				}
 
-				eptr->sesdata->rootinode = 0;
-				eptr->sesdata->sesflags = sesflags;
-				eptr->sesdata->rootuid = 0;
-				eptr->sesdata->rootgid = 0;
-				eptr->sesdata->mapalluid = 0;
-				eptr->sesdata->mapallgid = 0;
-				eptr->sesdata->mingoal = mingoal;
-				eptr->sesdata->maxgoal = maxgoal;
-				eptr->sesdata->mintrashtime = mintrashtime;
-				eptr->sesdata->maxtrashtime = maxtrashtime;
-				eptr->sesdata->peerip = eptr->peerip;
-				eptr->sesdata->peerport = eptr->peerport;
+				eptr->sessionData->rootInode = 0;
+				eptr->sessionData->flags = sesflags;
+				eptr->sessionData->rootUid = 0;
+				eptr->sessionData->rootGid = 0;
+				eptr->sessionData->mapAllUid = 0;
+				eptr->sessionData->mapAllGid = 0;
+				eptr->sessionData->minGoal = mingoal;
+				eptr->sessionData->maxGoal = maxgoal;
+				eptr->sessionData->minTrashTime = mintrashtime;
+				eptr->sessionData->maxTrashTime = maxtrashtime;
+				eptr->sessionData->peerIpAddress = eptr->peerIpAddress;
+				eptr->sessionData->peerPort = eptr->peerPort;
 				if (ileng > 0) {
 					if (info[ileng - 1] == 0) {
-						eptr->sesdata->info = std::string(info);
+						eptr->sessionData->info = std::string(info);
 					} else {
-						eptr->sesdata->info = std::string(info, ileng);
+						eptr->sessionData->info = std::string(info, ileng);
 					}
 				}
 
-				safs::log_info("Meta session {} created for mount: {} with ip: {} and port: {}",
-				               eptr->sesdata->sessionid,
-				               !eptr->sesdata->info.empty() ? eptr->sesdata->info : "unknown info",
-				               ipToString(eptr->peerip), eptr->peerport);
+				safs::log_info(
+				    "Meta session {} created for mount: {} with ip: {} and port: {}",
+				    eptr->sessionData->sessionId,
+				    !eptr->sessionData->info.empty() ? eptr->sessionData->info : "unknown info",
+				    ipToString(eptr->peerIpAddress), eptr->peerPort);
 
 				matoclserv_store_sessions();
 			}
@@ -2191,7 +2201,7 @@ void matoclserv_fuse_register(matoclserventry *eptr, const uint8_t *data, uint32
 				put8bit(&wptr,status);
 				return;
 			}
-			sessionId = eptr->sesdata->sessionid;
+			sessionId = eptr->sessionData->sessionId;
 			if (eptr->version >= saunafsVersion(1, 6, 21)) {
 				put16bit(&wptr,SAUNAFS_PACKAGE_VERSION_MAJOR);
 				put8bit(&wptr,SAUNAFS_PACKAGE_VERSION_MINOR);
@@ -2217,20 +2227,20 @@ void matoclserv_fuse_register(matoclserventry *eptr, const uint8_t *data, uint32
 			}
 			get32bit(&rptr, sessionId);
 			get32bit(&rptr, eptr->version);
-			eptr->sesdata = matoclserv_find_session(sessionId);
-			if (eptr->sesdata == nullptr || eptr->sesdata->peerip == 0) {
+			eptr->sessionData = matoclserv_find_session(sessionId);
+			if (eptr->sessionData == nullptr || eptr->sessionData->peerIpAddress == 0) {
 				status = SAUNAFS_ERROR_BADSESSIONID;
 			} else {
-				if ((eptr->sesdata->sesflags & SESFLAG_DYNAMICIP) == 0 &&
-				    eptr->peerip != eptr->sesdata->peerip) {
+				if ((eptr->sessionData->flags & SESFLAG_DYNAMICIP) == 0 &&
+				    eptr->peerIpAddress != eptr->sessionData->peerIpAddress) {
 					status = SAUNAFS_ERROR_EACCES;
 				} else {
 					status = SAUNAFS_STATUS_OK;
 					safs::log_info(
 					    "Session {} reconnected for mount: {} with ip: {} and port: {}",
-					    eptr->sesdata->sessionid,
-					    !eptr->sesdata->info.empty() ? eptr->sesdata->info : "unknown info",
-					    ipToString(eptr->peerip), eptr->peerport);
+					    eptr->sessionData->sessionId,
+					    !eptr->sessionData->info.empty() ? eptr->sessionData->info : "unknown info",
+					    ipToString(eptr->peerIpAddress), eptr->peerPort);
 				}
 			}
 			wptr = matoclserv_createpacket(eptr,MATOCL_FUSE_REGISTER, sizeof(status));
@@ -2238,8 +2248,9 @@ void matoclserv_fuse_register(matoclserventry *eptr, const uint8_t *data, uint32
 			if (status != SAUNAFS_STATUS_OK) { return; }
 
 			if (rcode == REGISTER_RECONNECT) {
-				if (eptr->version >= saunafsVersion(1, 6, 30) && eptr->sesdata->rootinode != 0) {
-					eptr->iolimits = true;
+				if (eptr->version >= saunafsVersion(1, 6, 30) &&
+				    eptr->sessionData->rootInode != 0) {
+					eptr->ioLimitsEnabled = true;
 					matoclserv_send_iolimits_cfg(eptr);
 				}
 				eptr->registered = ClientState::kRegistered;
@@ -2256,8 +2267,9 @@ void matoclserv_fuse_register(matoclserventry *eptr, const uint8_t *data, uint32
 			}
 			get32bit(&rptr, sessionId);
 			matoclserv_close_session(sessionId);
-			safs::log_info("Session {} for mount {} was closed", sessionId,
-			               !eptr->sesdata->info.empty() ? eptr->sesdata->info : "unknown info");
+			safs::log_info(
+			    "Session {} for mount {} was closed", sessionId,
+			    !eptr->sessionData->info.empty() ? eptr->sessionData->info : "unknown info");
 			eptr->mode = ClientConnectionMode::KILL;
 			return;
 		}
@@ -2271,14 +2283,14 @@ void matoclserv_fuse_register(matoclserventry *eptr, const uint8_t *data, uint32
 }
 
 void matoclserv_register_config(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
-	cltoma::registerConfig::deserialize(data, length, eptr->sesdata->config);
+	cltoma::registerConfig::deserialize(data, length, eptr->sessionData->config);
 }
 
 void matoclserv_update_mount_info(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	std::string mount_info;
 	cltoma::updateMountInfo::deserialize(data, length, mount_info);
-	if (eptr->sesdata && eptr->sesdata->mountinfo != mount_info) {
-		eptr->sesdata->mountinfo = mount_info;
+	if (eptr->sessionData && eptr->sessionData->mountInfo != mount_info) {
+		eptr->sessionData->mountInfo = mount_info;
 	}
 }
 
@@ -2306,13 +2318,13 @@ void matoclserv_fuse_reserved_inodes(matoclserventry *eptr, const uint8_t *data,
 
 	FsContext context = FsContext::getForMaster(eventloop_time());
 	changelog_disable_flush();
-	auto it = eptr->sesdata->openedfiles.begin();
-	while (it != eptr->sesdata->openedfiles.end()) {
+	auto it = eptr->sessionData->openFilesSet.begin();
+	while (it != eptr->sessionData->openFilesSet.end()) {
 		inode_t openFileIno = *it;
 		if (!inodes_to_reserve.contains(openFileIno)) {
 			// erase files not belonging to the reserve inodes list provided
-			fs_release(context, openFileIno, eptr->sesdata->sessionid);
-			it = eptr->sesdata->openedfiles.erase(it);
+			fs_release(context, openFileIno, eptr->sessionData->sessionId);
+			it = eptr->sessionData->openFilesSet.erase(it);
 		} else {
 			// skip files already in session
 			it++;
@@ -2322,17 +2334,17 @@ void matoclserv_fuse_reserved_inodes(matoclserventry *eptr, const uint8_t *data,
 	}
 
 	for (const auto &inode_to_reserve : inodes_to_reserve) {
-		if (fs_acquire(context, inode_to_reserve, eptr->sesdata->sessionid) ==
+		if (fs_acquire(context, inode_to_reserve, eptr->sessionData->sessionId) ==
 		    SAUNAFS_STATUS_OK) {
 			// Insert reserved inodes into the opened files set
-			eptr->sesdata->openedfiles.insert(inode_to_reserve);
+			eptr->sessionData->openFilesSet.insert(inode_to_reserve);
 		}
 	}
 	changelog_enable_flush();
 }
 
 void matoclserv_fuse_statfs(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
-	uint64_t totalspace,availspace,trashspace,reservedspace;
+	uint64_t totalspace, availspace, trashspace, reservedspace;
 	uint32_t msgid;
 	inode_t inodes;
 	uint8_t *ptr;
@@ -2361,8 +2373,8 @@ void matoclserv_fuse_statfs(matoclserventry *eptr, const uint8_t *data, uint32_t
 	put64bit(&ptr, reservedspace);
 	putINode(&ptr, inodes);
 
-	if (eptr->sesdata) {
-		eptr->sesdata->currentopstats[0]++;
+	if (eptr->sessionData) {
+		eptr->sessionData->currHourOperationsStats[0]++;
 	}
 }
 
@@ -2421,7 +2433,7 @@ void matoclserv_sau_whole_path_lookup(matoclserventry *eptr, const uint8_t *data
 	} else {
 		matoclserv_createpacket(eptr, matocl::wholePathLookup::build(msgid, found_inode, attr));
 	}
-	eptr->sesdata->currentopstats[3]++;
+	eptr->sessionData->currHourOperationsStats[3]++;
 }
 
 void matoclserv_sau_full_path_by_inode(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
@@ -2444,7 +2456,7 @@ void matoclserv_sau_full_path_by_inode(matoclserventry *eptr, const uint8_t *dat
 	} else {
 		matoclserv_createpacket(eptr, matocl::fullPathByInode::build(msgid, fullPath));
 	}
-	eptr->sesdata->currentopstats[3]++;
+	eptr->sessionData->currHourOperationsStats[3]++;
 }
 
 void matoclserv_sau_get_self_quota(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
@@ -2518,7 +2530,7 @@ void matoclserv_fuse_lookup(matoclserventry *eptr, const uint8_t *data, uint32_t
 	constexpr uint32_t kExpectedPacketSize =
 	    sizeof(msgid) + sizeof(inode) + sizeof(uid) + sizeof(gid) + sizeof(nleng);
 	if (length < kExpectedPacketSize) {
-		safs_pretty_syslog(LOG_NOTICE,"CLTOMA_FUSE_LOOKUP - wrong size (%" PRIu32 ")",length);
+		safs::log_info("CLTOMA_FUSE_LOOKUP - wrong size ({})", length);
 		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
@@ -2526,7 +2538,7 @@ void matoclserv_fuse_lookup(matoclserventry *eptr, const uint8_t *data, uint32_t
 	getINode(&data, inode);
 	nleng = get8bit(&data);
 	if (length != kExpectedPacketSize + nleng) {
-		safs_pretty_syslog(LOG_NOTICE,"CLTOMA_FUSE_LOOKUP - wrong size (%" PRIu32 ":nleng=%" PRIu8 ")",length,nleng);
+		safs::log_info("CLTOMA_FUSE_LOOKUP - wrong size ({}:nleng={})", length, nleng);
 		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
@@ -2552,7 +2564,7 @@ void matoclserv_fuse_lookup(matoclserventry *eptr, const uint8_t *data, uint32_t
 		putINode(&ptr,newinode);
 		memcpy(ptr, attr.data(), attr.size());
 	}
-	eptr->sesdata->currentopstats[3]++;
+	eptr->sessionData->currHourOperationsStats[3]++;
 }
 
 void matoclserv_fuse_getattr(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
@@ -2591,8 +2603,8 @@ void matoclserv_fuse_getattr(matoclserventry *eptr, const uint8_t *data, uint32_
 	} else {
 		memcpy(ptr, attr.data(), attr.size());
 	}
-	if (eptr->sesdata) {
-		eptr->sesdata->currentopstats[1]++;
+	if (eptr->sessionData) {
+		eptr->sessionData->currHourOperationsStats[1]++;
 	}
 }
 
@@ -2661,8 +2673,8 @@ void matoclserv_fuse_setattr(matoclserventry *eptr, const uint8_t *data, uint32_
 		memcpy(ptr, attr.data(), attr.size());
 	}
 
-	if (eptr->sesdata) {
-		eptr->sesdata->currentopstats[2]++;
+	if (eptr->sessionData) {
+		eptr->sessionData->currHourOperationsStats[2]++;
 	}
 }
 
@@ -2738,8 +2750,8 @@ void matoclserv_fuse_truncate(matoclserventry *eptr, PacketHeader header, const 
 			std::vector<uint8_t> reply;
 			matocl::fuseTruncate::serialize(reply, messageId, fileLength, lockId);
 			matoclserv_createpacket(eptr, std::move(reply));
-			if (eptr->sesdata) {
-				eptr->sesdata->currentopstats[2]++;
+			if (eptr->sessionData) {
+				eptr->sessionData->currHourOperationsStats[2]++;
 			}
 			return;
 		}
@@ -2747,22 +2759,22 @@ void matoclserv_fuse_truncate(matoclserventry *eptr, PacketHeader header, const 
 
 	if (status == SAUNAFS_ERROR_DELAYED) {
 		// Duplicate or truncate request has been sent to chunkservers, delay the reply
-		auto chunkOperationPtr = std::make_unique<chunkDelayedOperation>();
+		auto chunkOperationPtr = std::make_unique<DelayedChunkOperation>();
 		passert(chunkOperationPtr.get());
-		chunkOperationPtr->chunkid = chunkId;
-		chunkOperationPtr->qid = messageId;
+		chunkOperationPtr->chunkId = chunkId;
+		chunkOperationPtr->messageId = messageId;
 		chunkOperationPtr->inode = inode;
 		chunkOperationPtr->uid = context.uid();
 		chunkOperationPtr->gid = context.gid();
 		chunkOperationPtr->auid = context.auid();
 		chunkOperationPtr->agid = context.agid();
-		chunkOperationPtr->fleng = length;
-		chunkOperationPtr->lockid = lockId;
+		chunkOperationPtr->fileLength = length;
+		chunkOperationPtr->lockId = lockId;
 		chunkOperationPtr->type = type;
 		chunkOperationPtr->serializer = serializer;
-		eptr->chunkdelayedops.push_back(std::move(chunkOperationPtr));
-		if (eptr->sesdata) {
-			eptr->sesdata->currentopstats[2]++;
+		eptr->delayedChunkOperations.push_back(std::move(chunkOperationPtr));
+		if (eptr->sessionData) {
+			eptr->sessionData->currHourOperationsStats[2]++;
 		}
 		return;
 	}
@@ -2770,7 +2782,7 @@ void matoclserv_fuse_truncate(matoclserventry *eptr, PacketHeader header, const 
 		status = fs_do_setlength(context, inode, length, attr);
 	}
 	if (status == SAUNAFS_STATUS_OK) {
-		dcm_modify(inode, eptr->sesdata->sessionid);
+		dcm_modify(inode, eptr->sessionData->sessionId);
 	}
 
 	std::vector<uint8_t> reply;
@@ -2781,8 +2793,8 @@ void matoclserv_fuse_truncate(matoclserventry *eptr, PacketHeader header, const 
 		serializer->serializeFuseTruncate(reply, type, messageId, status);
 	}
 	matoclserv_createpacket(eptr, std::move(reply));
-	if (eptr->sesdata) {
-		eptr->sesdata->currentopstats[2]++;
+	if (eptr->sessionData) {
+		eptr->sessionData->currHourOperationsStats[2]++;
 	}
 }
 
@@ -2829,8 +2841,8 @@ void matoclserv_fuse_readlink(matoclserventry *eptr, const uint8_t *data, uint32
 		ptr[path.length()] = 0;
 	}
 
-	if (eptr->sesdata) {
-		eptr->sesdata->currentopstats[7]++;
+	if (eptr->sessionData) {
+		eptr->sessionData->currHourOperationsStats[7]++;
 	}
 }
 
@@ -2909,8 +2921,8 @@ void matoclserv_fuse_symlink(matoclserventry *eptr, const uint8_t *data, uint32_
 		memcpy(ptr, attr.data(), attr.size());
 	}
 
-	if (eptr->sesdata) {
-		eptr->sesdata->currentopstats[6]++;
+	if (eptr->sessionData) {
+		eptr->sessionData->currHourOperationsStats[6]++;
 	}
 }
 
@@ -2954,8 +2966,8 @@ void matoclserv_fuse_mknod(matoclserventry *eptr, PacketHeader header, const uin
 		serializeLegacyPacket(reply, MATOCL_FUSE_MKNOD, messageId, status);
 	}
 	matoclserv_createpacket(eptr, std::move(reply));
-	if (eptr->sesdata) {
-		eptr->sesdata->currentopstats[8]++;
+	if (eptr->sessionData) {
+		eptr->sessionData->currHourOperationsStats[8]++;
 	}
 }
 
@@ -3005,8 +3017,8 @@ void matoclserv_fuse_mkdir(matoclserventry *eptr, PacketHeader header, const uin
 		serializeLegacyPacket(reply, MATOCL_FUSE_MKDIR, messageId, status);
 	}
 	matoclserv_createpacket(eptr, std::move(reply));
-	if (eptr->sesdata) {
-		eptr->sesdata->currentopstats[4]++;
+	if (eptr->sessionData) {
+		eptr->sessionData->currHourOperationsStats[4]++;
 	}
 }
 
@@ -3057,8 +3069,8 @@ void matoclserv_fuse_unlink(matoclserventry *eptr, const uint8_t *data, uint32_t
 	put32bit(&ptr, msgid);
 	put8bit(&ptr, status);
 
-	if (eptr->sesdata) {
-		eptr->sesdata->currentopstats[9]++;
+	if (eptr->sessionData) {
+		eptr->sessionData->currHourOperationsStats[9]++;
 	}
 }
 
@@ -3084,7 +3096,7 @@ void matoclserv_fuse_recursive_remove(matoclserventry *eptr, const uint8_t *data
 
 		status = fs_recursive_remove(context, parent_inode, HString(name),
 					    std::bind(matoclserv_fuse_recursive_remove_wake_up,
-				      eptr->sesdata->sessionid, msgid, std::placeholders::_1), job_id);
+				      eptr->sessionData->sessionId, msgid, std::placeholders::_1), job_id);
 	}
 	if (status != SAUNAFS_ERROR_WAITING) {
 		matoclserv_createpacket(eptr, matocl::recursiveRemove::build(msgid, status));
@@ -3138,8 +3150,8 @@ void matoclserv_fuse_rmdir(matoclserventry *eptr, const uint8_t *data, uint32_t 
 	put32bit(&ptr, msgid);
 	put8bit(&ptr, status);
 
-	if (eptr->sesdata) {
-		eptr->sesdata->currentopstats[5]++;
+	if (eptr->sessionData) {
+		eptr->sessionData->currHourOperationsStats[5]++;
 	}
 }
 
@@ -3220,8 +3232,8 @@ void matoclserv_fuse_rename(matoclserventry *eptr, const uint8_t *data, uint32_t
 		put8bit(&ptr,status);
 	}
 
-	if (eptr->sesdata) {
-		eptr->sesdata->currentopstats[10]++;
+	if (eptr->sessionData) {
+		eptr->sessionData->currHourOperationsStats[10]++;
 	}
 }
 
@@ -3287,8 +3299,8 @@ void matoclserv_fuse_link(matoclserventry *eptr, const uint8_t *data, uint32_t l
 		memcpy(ptr, attr.data(), attr.size());
 	}
 
-	if (eptr->sesdata) {
-		eptr->sesdata->currentopstats[11]++;
+	if (eptr->sessionData) {
+		eptr->sessionData->currHourOperationsStats[11]++;
 	}
 }
 
@@ -3342,7 +3354,7 @@ void matoclserv_fuse_getdir(matoclserventry *eptr,const PacketHeader &header, co
 		matocl::fuseGetDir::serialize(buffer, message_id, status);
 	}
 
-	eptr->sesdata->currentopstats[12]++;
+	eptr->sessionData->currHourOperationsStats[12]++;
 	matoclserv_createpacket(eptr, std::move(buffer));
 }
 
@@ -3383,7 +3395,7 @@ void matoclserv_fuse_getdir(matoclserventry *eptr, const uint8_t *data, uint32_t
 		ptr = matoclserv_createpacket(eptr, MATOCL_FUSE_GETDIR, sizeof(msgid) + sizeof(status));
 		put32bit(&ptr, msgid);
 		put8bit(&ptr, status);
-		eptr->sesdata->currentopstats[12]++;
+		eptr->sessionData->currHourOperationsStats[12]++;
 		return;
 	}
 
@@ -3404,7 +3416,7 @@ void matoclserv_fuse_getdir(matoclserventry *eptr, const uint8_t *data, uint32_t
 		fs_readdir_data(context, flags, custom, ptr);
 	}
 
-	eptr->sesdata->currentopstats[12]++;
+	eptr->sessionData->currHourOperationsStats[12]++;
 }
 
 void matoclserv_fuse_open(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
@@ -3437,12 +3449,12 @@ void matoclserv_fuse_open(matoclserventry *eptr, const uint8_t *data, uint32_t l
 
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = matoclserv_insert_open_file(eptr->sesdata, inode);
+		status = matoclserv_insert_open_file(eptr->sessionData, inode);
 		if (status == SAUNAFS_STATUS_OK) { status = fs_opencheck(context, inode, flags, attr); }
 	}
 
 	if (eptr->version >= 0x010609 && status == SAUNAFS_STATUS_OK) {
-		allowcache = dcm_open(inode, eptr->sesdata->sessionid);
+		allowcache = dcm_open(inode, eptr->sessionData->sessionId);
 		if (allowcache == 0) {
 			attr[1] &= (0xFF ^ (MATTR_ALLOWDATACACHE << 4));
 		}
@@ -3459,8 +3471,8 @@ void matoclserv_fuse_open(matoclserventry *eptr, const uint8_t *data, uint32_t l
 		put8bit(&ptr, status);
 	}
 
-	if (eptr->sesdata) {
-		eptr->sesdata->currentopstats[13]++;
+	if (eptr->sessionData) {
+		eptr->sessionData->currHourOperationsStats[13]++;
 	}
 }
 
@@ -3483,7 +3495,7 @@ void matoclserv_fuse_read_chunk(matoclserventry *eptr, PacketHeader header, cons
 	std::vector<ChunkTypeWithAddress> allChunkCopies;
 	if (status == SAUNAFS_STATUS_OK) {
 		if (chunkid > 0) {
-			status = chunk_getversionandlocations(chunkid, eptr->peerip, version,
+			status = chunk_getversionandlocations(chunkid, eptr->peerIpAddress, version,
 					kMaxNumberOfChunkCopies, allChunkCopies);
 			remove_unsupported_ec_parts(eptr->version, allChunkCopies);
 		} else {
@@ -3497,13 +3509,13 @@ void matoclserv_fuse_read_chunk(matoclserventry *eptr, PacketHeader header, cons
 		return;
 	}
 
-	dcm_access(inode, eptr->sesdata->sessionid);
+	dcm_access(inode, eptr->sessionData->sessionId);
 	serializer->serializeFuseReadChunk(outMessage, messageId, fleng, chunkid, version,
 			allChunkCopies);
 	matoclserv_createpacket(eptr, outMessage);
 
-	if (eptr->sesdata) {
-		eptr->sesdata->currentopstats[14]++;
+	if (eptr->sessionData) {
+		eptr->sessionData->currHourOperationsStats[14]++;
 	}
 }
 
@@ -3528,7 +3540,8 @@ void matoclserv_chunks_info(matoclserventry *eptr, const uint8_t *data, uint32_t
 	status = matoclserv_check_group_cache(eptr, gid);
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = fs_getchunksinfo(context, eptr->peerip, inode, chunk_index, chunk_count, chunks);
+		status =
+		    fs_getchunksinfo(context, eptr->peerIpAddress, inode, chunk_index, chunk_count, chunks);
 	}
 
 	if (status != SAUNAFS_STATUS_OK) {
@@ -3570,19 +3583,19 @@ void matoclserv_fuse_write_chunk(matoclserventry *eptr, PacketHeader header, con
 	}
 
 	if (opflag) {   // wait for operation end
-		auto operation = std::make_unique<chunkDelayedOperation>();
+		auto operation = std::make_unique<DelayedChunkOperation>();
 		passert(operation.get());
-		memset(operation.get(), 0, sizeof(chunkDelayedOperation));
+		memset(operation.get(), 0, sizeof(DelayedChunkOperation));
 		operation->inode = inode;
-		operation->chunkid = chunkId;
-		operation->qid = messageId;
-		operation->fleng = fileLength;
-		operation->lockid = lockId;
+		operation->chunkId = chunkId;
+		operation->messageId = messageId;
+		operation->fileLength = fileLength;
+		operation->lockId = lockId;
 		operation->type = FUSE_WRITE;
 		operation->serializer = serializer;
-		eptr->chunkdelayedops.push_back(std::move(operation));
+		eptr->delayedChunkOperations.push_back(std::move(operation));
 	} else {        // return status immediately
-		dcm_modify(inode,eptr->sesdata->sessionid);
+		dcm_modify(inode,eptr->sessionData->sessionId);
 		status = matoclserv_fuse_write_chunk_respond(eptr, serializer,
 				chunkId, messageId, fileLength, lockId);
 		if (status != SAUNAFS_STATUS_OK) {
@@ -3590,8 +3603,8 @@ void matoclserv_fuse_write_chunk(matoclserventry *eptr, PacketHeader header, con
 		}
 	}
 
-	if (eptr->sesdata) {
-		eptr->sesdata->currentopstats[15]++;
+	if (eptr->sessionData) {
+		eptr->sessionData->currHourOperationsStats[15]++;
 	}
 }
 
@@ -3614,13 +3627,13 @@ void matoclserv_fuse_write_chunk_end(matoclserventry *eptr, PacketHeader header,
 	if (lockId == 0) {
 		// this lock id passed to chunk_unlock would force chunk unlock
 		status = SAUNAFS_ERROR_WRONGLOCKID;
-	} else if (eptr->sesdata->sesflags & SESFLAG_READONLY) {
+	} else if (eptr->sessionData->flags & SESFLAG_READONLY) {
 		status = SAUNAFS_ERROR_EROFS;
 	} else {
 		status = fs_writeend(inode, fileLength, chunkId, lockId);
 	}
 
-	dcm_modify(inode,eptr->sesdata->sessionid);
+	dcm_modify(inode,eptr->sessionData->sessionId);
 	serializer->serializeFuseWriteChunkEnd(outMessage, messageId, status);
 	matoclserv_createpacket(eptr, outMessage);
 }
@@ -3826,17 +3839,18 @@ void matoclserv_fuse_settrashtime(matoclserventry *eptr, PacketHeader header, co
 	status = SAUNAFS_STATUS_OK;
 	switch (smode & SMODE_TMASK) {
 	case SMODE_SET:
-		if (trashtime < eptr->sesdata->mintrashtime || trashtime > eptr->sesdata->maxtrashtime) {
+		if (trashtime < eptr->sessionData->minTrashTime ||
+		    trashtime > eptr->sessionData->maxTrashTime) {
 			status = SAUNAFS_ERROR_EPERM;
 		}
 		break;
 	case SMODE_INCREASE:
-		if (trashtime > eptr->sesdata->maxtrashtime) {
+		if (trashtime > eptr->sessionData->maxTrashTime) {
 			status = SAUNAFS_ERROR_EPERM;
 		}
 		break;
 	case SMODE_DECREASE:
-		if (trashtime < eptr->sesdata->mintrashtime) {
+		if (trashtime < eptr->sessionData->minTrashTime) {
 			status = SAUNAFS_ERROR_EPERM;
 		}
 		break;
@@ -3848,13 +3862,13 @@ void matoclserv_fuse_settrashtime(matoclserventry *eptr, PacketHeader header, co
 	if (status == SAUNAFS_STATUS_OK) {
 		status = fs_settrashtime(matoclserv_get_context(eptr, uid, 0), inode, trashtime,
 					 smode, settrashtime_stats,
-			   std::bind(matoclserv_fuse_settrashtime_wake_up, eptr->sesdata->sessionid,
+			   std::bind(matoclserv_fuse_settrashtime_wake_up, eptr->sessionData->sessionId,
 				     msgid, settrashtime_stats, std::placeholders::_1));
 	}
 
 	if (status != SAUNAFS_ERROR_WAITING) {
-		matoclserv_fuse_settrashtime_wake_up(eptr->sesdata->sessionid, msgid, settrashtime_stats,
-		                                     status);
+		matoclserv_fuse_settrashtime_wake_up(eptr->sessionData->sessionId, msgid,
+		                                     settrashtime_stats, status);
 	}
 }
 
@@ -3979,10 +3993,10 @@ void matoclserv_fuse_setgoal(matoclserventry *eptr, PacketHeader header, const u
 		status = SAUNAFS_ERROR_EINVAL;
 	}
 	if (status == SAUNAFS_STATUS_OK) {
-		if (status == SAUNAFS_STATUS_OK && goalId < eptr->sesdata->mingoal) {
+		if (status == SAUNAFS_STATUS_OK && goalId < eptr->sessionData->minGoal) {
 			status = SAUNAFS_ERROR_EPERM;
 		}
-		if (status == SAUNAFS_STATUS_OK && goalId > eptr->sesdata->maxgoal) {
+		if (status == SAUNAFS_STATUS_OK && goalId > eptr->sessionData->maxGoal) {
 			status = SAUNAFS_ERROR_EPERM;
 		}
 	}
@@ -3993,12 +4007,12 @@ void matoclserv_fuse_setgoal(matoclserventry *eptr, PacketHeader header, const u
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, 0);
 		status = fs_setgoal(context, inode, goalId, smode, setgoal_stats,
-			   std::bind(matoclserv_fuse_setgoal_wake_up, eptr->sesdata->sessionid,
+			   std::bind(matoclserv_fuse_setgoal_wake_up, eptr->sessionData->sessionId,
 				     msgid, header.type, setgoal_stats, std::placeholders::_1));
 	}
 
 	if (status != SAUNAFS_ERROR_WAITING) {
-		matoclserv_fuse_setgoal_wake_up(eptr->sesdata->sessionid, msgid, header.type,
+		matoclserv_fuse_setgoal_wake_up(eptr->sessionData->sessionId, msgid, header.type,
 						setgoal_stats, status);
 	}
 }
@@ -4360,10 +4374,10 @@ void matoclserv_fuse_snapshot(matoclserventry *eptr, PacketHeader header, const 
 		status = fs_snapshot(context, inode, inode_dst, HString(std::move(name_dst)),
 		                     canoverwrite, ignore_missing_src, initial_batch_size,
 		                     std::bind(matoclserv_fuse_snapshot_wake_up, header.type,
-		                     eptr->sesdata->sessionid, msgid, std::placeholders::_1), job_id);
+		                     eptr->sessionData->sessionId, msgid, std::placeholders::_1), job_id);
 	}
 	if (status != SAUNAFS_ERROR_WAITING) {
-		matoclserv_fuse_snapshot_wake_up(header.type, eptr->sesdata->sessionid, msgid, status);
+		matoclserv_fuse_snapshot_wake_up(header.type, eptr->sessionData->sessionId, msgid, status);
 	}
 }
 
@@ -4483,7 +4497,7 @@ void matoclserv_fuse_gettrash(matoclserventry *eptr, const uint8_t *data, uint32
 
 	get32bit(&data, msgid);
 
-	status = fs_readtrash_size(eptr->sesdata->rootinode,eptr->sesdata->sesflags,&dleng);
+	status = fs_readtrash_size(eptr->sessionData->rootInode,eptr->sessionData->flags,&dleng);
 
 	ptr = matoclserv_createpacket(
 	    eptr, MATOCL_FUSE_GETTRASH,
@@ -4494,7 +4508,7 @@ void matoclserv_fuse_gettrash(matoclserventry *eptr, const uint8_t *data, uint32
 	if (status != SAUNAFS_STATUS_OK) {
 		put8bit(&ptr, status);
 	} else {
-		fs_readtrash_data(eptr->sesdata->rootinode, eptr->sesdata->sesflags, ptr);
+		fs_readtrash_data(eptr->sessionData->rootInode, eptr->sessionData->flags, ptr);
 	}
 }
 
@@ -4535,7 +4549,8 @@ void matoclserv_fuse_getdetachedattr(matoclserventry *eptr, const uint8_t *data,
 		dtype = DTYPE_UNKNOWN;
 	}
 
-	status = fs_getdetachedattr(eptr->sesdata->rootinode,eptr->sesdata->sesflags,inode,attr,dtype);
+	status = fs_getdetachedattr(eptr->sessionData->rootInode, eptr->sessionData->flags, inode, attr,
+	                            dtype);
 
 	constexpr uint32_t kFailedSize = sizeof(msgid) + sizeof(status);
 	constexpr uint32_t kSuccessSize = sizeof(msgid) + attr.size();
@@ -4572,7 +4587,7 @@ void matoclserv_fuse_gettrashpath(matoclserventry *eptr, const uint8_t *data, ui
 	get32bit(&data, msgid);
 	getINode(&data, inode);
 
-	status = fs_gettrashpath(eptr->sesdata->rootinode, eptr->sesdata->sesflags, inode, path);
+	status = fs_gettrashpath(eptr->sessionData->rootInode, eptr->sessionData->flags, inode, path);
 
 	constexpr uint32_t kFailedSize = sizeof(msgid) + sizeof(status);
 	const uint32_t kSuccessSize = sizeof(msgid) + sizeof(uint32_t) + path.length() + 1;
@@ -4705,7 +4720,7 @@ void matoclserv_fuse_getreserved(matoclserventry *eptr, const uint8_t *data, uin
 
 	get32bit(&data, msgid);
 
-	status = fs_readreserved_size(eptr->sesdata->rootinode, eptr->sesdata->sesflags, &dleng);
+	status = fs_readreserved_size(eptr->sessionData->rootInode, eptr->sessionData->flags, &dleng);
 
 	constexpr uint32_t kFailedSize = sizeof(msgid) + sizeof(status);
 	const uint32_t kSuccessSize = sizeof(msgid) + dleng;
@@ -4718,7 +4733,7 @@ void matoclserv_fuse_getreserved(matoclserventry *eptr, const uint8_t *data, uin
 	if (status!=SAUNAFS_STATUS_OK) {
 		put8bit(&ptr,status);
 	} else {
-		fs_readreserved_data(eptr->sesdata->rootinode, eptr->sesdata->sesflags, ptr);
+		fs_readreserved_data(eptr->sessionData->rootInode, eptr->sessionData->flags, ptr);
 	}
 }
 
@@ -4857,7 +4872,7 @@ void matoclserv_fuse_flock(matoclserventry *eptr, const uint8_t *data, uint32_t 
 	}
 
 	std::vector<FileLocks::Owner> applied;
-	status = fs_flock_op(context, inode, owner, eptr->sesdata->sessionid, requestId, messageId,
+	status = fs_flock_op(context, inode, owner, eptr->sessionData->sessionId, requestId, messageId,
 			op, nonblocking, applied);
 
 	matoclserv_lock_wake_up(applied, safs_locks::Type::kFlock);
@@ -4899,7 +4914,7 @@ void matoclserv_fuse_getlk(matoclserventry *eptr, const uint8_t *data, uint32_t 
 	}
 
 	status = fs_posixlock_probe(context, inode, lock_info.l_start, lock_end, owner,
-			eptr->sesdata->sessionid, 0, message_id, lock_info.l_type, lock_info);
+			eptr->sessionData->sessionId, 0, message_id, lock_info.l_type, lock_info);
 
 	// Standard states that lock of length 0 is a lock till EOF
 	if (lock_info.l_len == std::numeric_limits<int64_t>::max()) {
@@ -4952,7 +4967,7 @@ void matoclserv_fuse_setlk(matoclserventry *eptr, const uint8_t *data, uint32_t 
 
 	std::vector<FileLocks::Owner> applied;
 	status = fs_posixlock_op(context, inode, lock_info.l_start, lock_end,
-			owner, eptr->sesdata->sessionid, request_id, message_id, op, nonblocking, applied);
+			owner, eptr->sessionData->sessionId, request_id, message_id, op, nonblocking, applied);
 
 	matoclserv_lock_wake_up(applied, safs_locks::Type::kPosix);
 
@@ -5118,7 +5133,7 @@ void matoclserv_fuse_locks_interrupt(matoclserventry *eptr, const uint8_t *data,
 
 	// we do not reply, so there is not need for checking status of this fs_operation
 	fs_locks_remove_pending(context, type, interruptData.owner,
-			   eptr->sesdata->sessionid, interruptData.ino, interruptData.reqid);
+			   eptr->sessionData->sessionId, interruptData.ino, interruptData.reqid);
 }
 
 void matoclserv_update_credentials(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
@@ -5127,15 +5142,15 @@ void matoclserv_update_credentials(matoclserventry *eptr, const uint8_t *data, u
 
 	cltoma::updateCredentials::deserialize(data, length, messageId, index, gids);
 
-	assert(eptr->sesdata);
+	assert(eptr->sessionData);
 
-	auto it = eptr->sesdata->group_cache.find(index);
-	if (it != eptr->sesdata->group_cache.end()) {
+	auto it = eptr->sessionData->groupsCache.find(index);
+	if (it != eptr->sessionData->groupsCache.end()) {
 		it->second.clear();
 		it->second.insert(it->second.end(), gids.begin(), gids.end());
 	} else {
 		FsContext::GroupsContainer tmp(gids.begin(), gids.end());
-		eptr->sesdata->group_cache.insert(std::move(index), std::move(tmp));
+		eptr->sessionData->groupsCache.insert(std::move(index), std::move(tmp));
 	}
 
 	matoclserv_createpacket(eptr, matocl::updateCredentials::build(messageId, SAUNAFS_STATUS_OK));
@@ -5371,7 +5386,7 @@ void matoclserv_admin_reload(matoclserventry* eptr, const uint8_t* data, uint32_
 		eptr->adminTask = AdminTask::kReload; // mark, that this admin waits for response
 		eventloop_want_to_reload();
 		safs::log_info("reload of the config file requested using saunafs-admin by {}",
-		               ipToString(eptr->peerip));
+		               ipToString(eptr->peerIpAddress));
 	} else {
 		safs::log_info("SAU_CLTOMA_ADMIN_RELOAD: available only for registered admins");
 		eptr->mode = ClientConnectionMode::KILL;
@@ -5383,7 +5398,7 @@ std::string get_client_configs() {
 
 	for (const auto& sessionPtr : sessionVector) {
 		if (sessionPtr->config.empty()) { continue; }
-		NetworkAddress addr(sessionPtr->peerip, sessionPtr->peerport);
+		NetworkAddress addr(sessionPtr->peerIpAddress, sessionPtr->peerPort);
 		client_configs[addr.toString()] = sessionPtr->config;
 	}
 
@@ -5417,7 +5432,7 @@ void matoclserv_admin_save_metadata(matoclserventry* eptr, const uint8_t* data, 
 
 	if (eptr->registered == ClientState::kAdmin) {
 		safs::log_info("saving metadata image requested using saunafs-admin by {}",
-		               ipToString(eptr->peerip));
+		               ipToString(eptr->peerIpAddress));
 		uint8_t status = gMetadataBackend->fs_storeall(
 		    MetadataDumper::DumpType::kBackgroundDump);
 
@@ -5453,7 +5468,7 @@ void matoclserv_admin_recalculate_metadata_checksum(matoclserventry *eptr, const
 
 	if (eptr->registered == ClientState::kAdmin) {
 		safs::log_info("metadata checksum recalculation requested using saunafs-admin by {}",
-		               ipToString(eptr->peerip));
+		               ipToString(eptr->peerIpAddress));
 		uint8_t status = fs_start_checksum_recalculation();
 
 		if (status != SAUNAFS_STATUS_OK || asynchronous) {
@@ -5500,19 +5515,19 @@ void matocl_locks_release(const FsContext &context, inode_t inode, uint32_t sess
 	}
 }
 
-void matocl_close_files(session *currentSession) {
+void matocl_close_files(Session *currentSession) {
 	FsContext context = FsContext::getForMaster(eventloop_time());
 
-	for (const auto &openFileInode : currentSession->openedfiles) {
-		fs_release(context, openFileInode, currentSession->sessionid);
-		matocl_locks_release(context, openFileInode, currentSession->sessionid);
+	for (const auto &openFileInode : currentSession->openFilesSet) {
+		fs_release(context, openFileInode, currentSession->sessionId);
+		matocl_locks_release(context, openFileInode, currentSession->sessionId);
 	}
 
-	currentSession->openedfiles.clear();
+	currentSession->openFilesSet.clear();
 }
 
-uint32_t session_number_of_files(session *currentSession) {
-	return currentSession->openedfiles.size();
+uint32_t session_number_of_files(Session *currentSession) {
+	return currentSession->openFilesSet.size();
 }
 
 void matoclserv_session_files(matoclserventry *eptr,
@@ -5522,15 +5537,15 @@ void matoclserv_session_files(matoclserventry *eptr,
 	MessageBuffer reply;
 
 	for (const auto &eaptr : matoclservList) {
-		if (eaptr->mode == ClientConnectionMode::KILL || !eaptr->sesdata ||
+		if (eaptr->mode == ClientConnectionMode::KILL || !eaptr->sessionData ||
 		    eaptr->registered != ClientState::kRegistered) {
 			continue;
 		}
 
 		SessionFiles session;
-		session.sessionId = eaptr->sesdata->sessionid;
-		session.peerIp = eaptr->sesdata->peerip;
-		session.filesNumber = session_number_of_files(eaptr->sesdata);
+		session.sessionId = eaptr->sessionData->sessionId;
+		session.peerIp = eaptr->sessionData->peerIpAddress;
+		session.filesNumber = session_number_of_files(eaptr->sessionData);
 		sessions.push_back(session);
 	}
 
@@ -5538,7 +5553,7 @@ void matoclserv_session_files(matoclserventry *eptr,
 	matoclserv_createpacket(eptr, std::move(reply));
 }
 
-void matocl_session_timedout(session *currentSession) {
+void matocl_session_timedout(Session *currentSession) {
 	matocl_close_files(currentSession);
 }
 
@@ -5552,7 +5567,7 @@ void matoclserv_session_delete(matoclserventry *eptr, const uint8_t *data, uint3
 	matoclserventry *target = nullptr;
 
 	for (const auto &eaptr : matoclservList) {
-		if (eaptr->sesdata && eaptr->sesdata->sessionid == sessionId) {
+		if (eaptr->sessionData && eaptr->sessionData->sessionId == sessionId) {
 			target = eaptr.get();
 			break;
 		}
@@ -5568,7 +5583,7 @@ void matoclserv_session_delete(matoclserventry *eptr, const uint8_t *data, uint3
 		// Otherwise, it will take a few moments before the session
 		// times out and the files are removed automatically, unless the
 		// peer reconnects during that time
-		matocl_close_files(target->sesdata);
+		matocl_close_files(target->sessionData);
 	}
 
 	MessageBuffer reply;
@@ -5581,10 +5596,11 @@ void matocl_session_check() {
 
 	for (auto sessionIt = sessionVector.begin(); sessionIt != sessionVector.end();) {
 		auto& sessionPtr = *sessionIt;
-		if (sessionPtr->nsocks == 0 &&
-		    ((sessionPtr->newsession > 1 && sessionPtr->disconnected < now) ||
-		     (sessionPtr->newsession == 1 && sessionPtr->disconnected + SessionSustainTime < now) ||
-		     (sessionPtr->newsession == 0 && sessionPtr->disconnected + 7200 < now))) {
+		if (sessionPtr->connections == 0 &&
+		    ((sessionPtr->newSession > 1 && sessionPtr->disconnectedTimestamp < now) ||
+		     (sessionPtr->newSession == 1 &&
+		      sessionPtr->disconnectedTimestamp + SessionSustainTime < now) ||
+		     (sessionPtr->newSession == 0 && sessionPtr->disconnectedTimestamp + 7200 < now))) {
 			matocl_session_timedout(sessionPtr.get());
 			sessionIt = sessionVector.erase(sessionIt);
 		} else {
@@ -5593,31 +5609,31 @@ void matocl_session_check() {
 	}
 }
 
-void matocl_session_statsmove() {
+void matocl_session_stats_rotate() {
 	for (auto& sessionPtr : sessionVector) {
-		sessionPtr->lasthouropstats = sessionPtr->currentopstats;
-		sessionPtr->currentopstats.fill(0);
+		sessionPtr->prevHourOperationsStats = sessionPtr->currHourOperationsStats;
+		sessionPtr->currHourOperationsStats.fill(0);
 	}
 	matoclserv_store_sessions();
 }
 
-void matocl_beforedisconnect(matoclserventry *eptr) {
+void matocl_before_disconnect(matoclserventry *eptr) {
 	// unlock locked chunks
-	for (const auto &operation : eptr->chunkdelayedops) {
+	for (const auto &operation : eptr->delayedChunkOperations) {
 		if (operation->type == FUSE_TRUNCATE) {
-			fs_end_setlength(operation->chunkid);
+			fs_end_setlength(operation->chunkId);
 		}
 	}
 
-	eptr->chunkdelayedops.clear();
+	eptr->delayedChunkOperations.clear();
 
-	if (eptr->sesdata) {
-		if (eptr->sesdata->nsocks > 0) {
-			eptr->sesdata->nsocks--;
+	if (eptr->sessionData) {
+		if (eptr->sessionData->connections > 0) {
+			eptr->sessionData->connections--;
 		}
 
-		if (eptr->sesdata->nsocks == 0) {
-			eptr->sesdata->disconnected = eventloop_time();
+		if (eptr->sessionData->connections == 0) {
+			eptr->sessionData->disconnectedTimestamp = eventloop_time();
 		}
 	}
 }
@@ -5789,7 +5805,7 @@ void matoclserv_gotpacket(matoclserventry *eptr, uint32_t type, const uint8_t *d
 				    eptr->mode = ClientConnectionMode::KILL;
 			}
 		} else if (eptr->registered == ClientState::kRegistered) {      // mounts and new tools
-			if (eptr->sesdata == NULL) {
+			if (eptr->sessionData == NULL) {
 				safs::log_err("registered connection without sesdata !!!");
 				eptr->mode = ClientConnectionMode::KILL;
 				return;
@@ -6048,7 +6064,7 @@ void matoclserv_gotpacket(matoclserventry *eptr, uint32_t type, const uint8_t *d
 				    eptr->mode=ClientConnectionMode::KILL;
 			}
 		} else if (eptr->registered == ClientState::kOldTools) {        // old sfstools
-			if (eptr->sesdata==NULL) {
+			if (eptr->sessionData == NULL) {
 				safs::log_err("registered connection (tools) without sesdata !!!");
 				eptr->mode=ClientConnectionMode::KILL;
 				return;
@@ -6116,14 +6132,14 @@ void matoclserv_term() {
 	packetstruct *pptr,*pptrn;
 
 	safs::log_info("main master server module: closing {}:{}", ListenHost, ListenPort);
-	tcpclose(lsock);
+	tcpclose(masterSocket);
 
 	for (const auto &eptr : matoclservList) {
-		if (eptr->inputpacket.packet) {
-			free(eptr->inputpacket.packet);
+		if (eptr->inputPacket.packet) {
+			free(eptr->inputPacket.packet);
 		}
 
-		for (pptr = eptr->outputhead ; pptr ; pptr = pptrn) {
+		for (pptr = eptr->outputPacketHead ; pptr ; pptr = pptrn) {
 			pptrn = pptr->next;
 			if (pptr->packet) {
 				free(pptr->packet);
@@ -6131,7 +6147,7 @@ void matoclserv_term() {
 			free(pptr);
 		}
 
-		eptr->chunkdelayedops.clear();
+		eptr->delayedChunkOperations.clear();
 	}
 
 	matoclservList.clear();
@@ -6146,11 +6162,11 @@ void matoclserv_read(matoclserventry *eptr) {
 
 	watchdog.start();
 	while (eptr->mode != ClientConnectionMode::KILL) {
-		i = read(eptr->sock, eptr->inputpacket.startptr, eptr->inputpacket.bytesleft);
+		i = read(eptr->socket, eptr->inputPacket.startPtr, eptr->inputPacket.bytesLeft);
 		if (i == 0) {
 			if (eptr->registered == ClientState::kRegistered) {       // show this message only for standard, registered clients
 				safs::log_info("connection with client (ip:{}) has been closed by peer",
-				               ipToString(eptr->peerip));
+				               ipToString(eptr->peerIpAddress));
 			}
 			eptr->mode = ClientConnectionMode::KILL;
 			return;
@@ -6162,7 +6178,7 @@ void matoclserv_read(matoclserventry *eptr) {
 				if (errno != ECONNRESET) {
 #endif
 					safs_silent_errlog(LOG_NOTICE, "main master server module: (ip:%s) read error",
-					                   ipToString(eptr->peerip).c_str());
+					                   ipToString(eptr->peerIpAddress).c_str());
 #ifdef ECONNRESET
 				}
 #endif
@@ -6170,17 +6186,17 @@ void matoclserv_read(matoclserventry *eptr) {
 			}
 			return;
 		}
-		eptr->inputpacket.startptr += i;
-		eptr->inputpacket.bytesleft -= i;
+		eptr->inputPacket.startPtr += i;
+		eptr->inputPacket.bytesLeft -= i;
 		metrics::Counter::increment(metrics::Counter::Master::CLIENT_RX_BYTES, i);
-		stats_brcvd += i;
+		statsBytesReceived += i;
 
-		if (eptr->inputpacket.bytesleft > 0) {
+		if (eptr->inputPacket.bytesLeft > 0) {
 			return;
 		}
 
 		if (eptr->mode == ClientConnectionMode::HEADER) {
-			ptr = eptr->hdrbuff + 4;
+			ptr = eptr->headerBuffer + 4;
 			get32bit(&ptr, size);
 			if (size > 0) {
 				if (size > MaxPacketSize) {
@@ -6189,10 +6205,10 @@ void matoclserv_read(matoclserventry *eptr) {
 					eptr->mode = ClientConnectionMode::KILL;
 					return;
 				}
-				eptr->inputpacket.packet = (uint8_t*) malloc(size);
-				passert(eptr->inputpacket.packet);
-				eptr->inputpacket.bytesleft = size;
-				eptr->inputpacket.startptr = eptr->inputpacket.packet;
+				eptr->inputPacket.packet = (uint8_t*) malloc(size);
+				passert(eptr->inputPacket.packet);
+				eptr->inputPacket.bytesLeft = size;
+				eptr->inputPacket.startPtr = eptr->inputPacket.packet;
 				eptr->mode = ClientConnectionMode::DATA;
 				continue;
 			}
@@ -6200,21 +6216,21 @@ void matoclserv_read(matoclserventry *eptr) {
 		}
 
 		if (eptr->mode==ClientConnectionMode::DATA) {
-			ptr = eptr->hdrbuff;
+			ptr = eptr->headerBuffer;
 			get32bit(&ptr, type);
 			get32bit(&ptr, size);
 
 			eptr->mode = ClientConnectionMode::HEADER;
-			eptr->inputpacket.bytesleft = 8;
-			eptr->inputpacket.startptr = eptr->hdrbuff;
-			matoclserv_gotpacket(eptr,type,eptr->inputpacket.packet,size);
-			stats_prcvd++;
+			eptr->inputPacket.bytesLeft = 8;
+			eptr->inputPacket.startPtr = eptr->headerBuffer;
+			matoclserv_gotpacket(eptr,type,eptr->inputPacket.packet,size);
+			statsPacketsReceived++;
 			metrics::Counter::increment(metrics::Counter::Master::CLIENT_RX_PACKETS);
 
-			if (eptr->inputpacket.packet) {
-				free(eptr->inputpacket.packet);
+			if (eptr->inputPacket.packet) {
+				free(eptr->inputPacket.packet);
 			}
-			eptr->inputpacket.packet=NULL;
+			eptr->inputPacket.packet=NULL;
 			break;
 		}
 
@@ -6231,30 +6247,30 @@ void matoclserv_write(matoclserventry *eptr) {
 
 	watchdog.start();
 	for (;;) {
-		pack = eptr->outputhead;
+		pack = eptr->outputPacketHead;
 		if (pack == NULL) { return; }
-		i = write(eptr->sock, pack->startptr, pack->bytesleft);
+		i = write(eptr->socket, pack->startPtr, pack->bytesLeft);
 		if (i < 0) {
 			if (errno != EAGAIN) {
 				safs_silent_errlog(LOG_NOTICE, "main master server module: (ip:%s) write error",
-				                   ipToString(eptr->peerip).c_str());
+				                   ipToString(eptr->peerIpAddress).c_str());
 				eptr->mode = ClientConnectionMode::KILL;
 			}
 			return;
 		}
-		pack->startptr += i;
-		pack->bytesleft -= i;
+		pack->startPtr += i;
+		pack->bytesLeft -= i;
 		metrics::Counter::increment(metrics::Counter::Master::CLIENT_TX_BYTES, i);
-		stats_bsent += i;
-		if (pack->bytesleft > 0) {
+		statsBytesSent += i;
+		if (pack->bytesLeft > 0) {
 			return;
 		}
 		free(pack->packet);
-		stats_psent++;
+		statsPacketsSent++;
 		metrics::Counter::increment(metrics::Counter::Master::CLIENT_TX_PACKETS);
-		eptr->outputhead = pack->next;
-		if (eptr->outputhead == NULL) {
-			eptr->outputtail = &(eptr->outputhead);
+		eptr->outputPacketHead = pack->next;
+		if (eptr->outputPacketHead == NULL) {
+			eptr->outputPacketTail = &(eptr->outputPacketHead);
 		}
 		free(pack);
 
@@ -6273,11 +6289,11 @@ int matoclserv_canexit(void) {
 	static bool terminatorPacketSent = false;
 
 	for (const auto &eptr : matoclservList) {
-		if (eptr->outputhead != NULL) {
+		if (eptr->outputPacketHead != NULL) {
 			return 0;
 		}
 
-		if (!eptr->chunkdelayedops.empty()) {
+		if (!eptr->delayedChunkOperations.empty()) {
 			return 0;
 		}
 
@@ -6311,21 +6327,21 @@ int matoclserv_canexit(void) {
 
 void matoclserv_desc(std::vector<pollfd> &pdesc) {
 	if (exiting == 0) {
-		pdesc.push_back({lsock, POLLIN, 0});
-		lsockpdescpos = pdesc.size() - 1;
+		pdesc.push_back({masterSocket, POLLIN, 0});
+		masterSocketDescPos = pdesc.size() - 1;
 	} else {
-		lsockpdescpos = -1;
+		masterSocketDescPos = -1;
 	}
 
 	for (const auto &eptr : matoclservList) {
-		pdesc.push_back({eptr->sock, 0, 0});
-		eptr->pdescpos = pdesc.size() - 1;
+		pdesc.push_back({eptr->socket, 0, 0});
+		eptr->pDescPos = pdesc.size() - 1;
 
 		if (exiting == 0) {
 			pdesc.back().events |= POLLIN;
 		}
 
-		if (eptr->outputhead != NULL) {
+		if (eptr->outputPacketHead != NULL) {
 			pdesc.back().events |= POLLOUT;
 		}
 	}
@@ -6333,38 +6349,38 @@ void matoclserv_desc(std::vector<pollfd> &pdesc) {
 
 
 void matoclserv_serve(const std::vector<pollfd> &pdesc) {
-	uint32_t now=eventloop_time();
+	uint32_t now = eventloop_time();
 	packetstruct *pptr;
 	packetstruct *paptr;
 
-	if (lsockpdescpos >= 0 && (pdesc[lsockpdescpos].revents & POLLIN)) {
-		int ns = tcpaccept(lsock);
+	if (masterSocketDescPos >= 0 && (pdesc[masterSocketDescPos].revents & POLLIN)) {
+		int ns = tcpaccept(masterSocket);
 		if (ns < 0) {
 			safs_silent_errlog(LOG_NOTICE,"main master server module: accept error");
 		} else {
 			tcpnonblock(ns);
 			tcpnodelay(ns);
 			auto eptr = std::make_unique<matoclserventry>();
-			eptr->sock = ns;
-			eptr->pdescpos = -1;
-			tcpgetpeer(ns,&(eptr->peerip),&(eptr->peerport));
+			eptr->socket = ns;
+			eptr->pDescPos = -1;
+			tcpgetpeer(ns, &(eptr->peerIpAddress), &(eptr->peerPort));
 			eptr->registered = ClientState::kUnregistered;
-			eptr->iolimits = false;
+			eptr->ioLimitsEnabled = false;
 			eptr->version = 0;
 			eptr->mode = ClientConnectionMode::HEADER;
-			eptr->lastread = now;
-			eptr->lastwrite = now;
-			eptr->inputpacket.next = NULL;
-			eptr->inputpacket.bytesleft = 8;
-			eptr->inputpacket.startptr = eptr->hdrbuff;
-			eptr->inputpacket.packet = NULL;
+			eptr->lastReadTimestamp = now;
+			eptr->lastWriteTimestamp = now;
+			eptr->inputPacket.next = NULL;
+			eptr->inputPacket.bytesLeft = 8;
+			eptr->inputPacket.startPtr = eptr->headerBuffer;
+			eptr->inputPacket.packet = NULL;
 			eptr->adminTask = AdminTask::kNone;
-			eptr->outputhead = NULL;
-			eptr->outputtail = &(eptr->outputhead);
+			eptr->outputPacketHead = NULL;
+			eptr->outputPacketTail = &(eptr->outputPacketHead);
 
-			eptr->chunkdelayedops.clear();
-			eptr->sesdata = NULL;
-			memset(eptr->passwordrnd, 0, 32);
+			eptr->delayedChunkOperations.clear();
+			eptr->sessionData = NULL;
+			memset(eptr->randomPassword, 0, 32);
 
 			matoclservList.push_front(std::move(eptr));
 		}
@@ -6372,14 +6388,14 @@ void matoclserv_serve(const std::vector<pollfd> &pdesc) {
 
 // read
 	for (const auto &eptr : matoclservList) {
-		if (eptr->pdescpos >= 0) {
-			if (pdesc[eptr->pdescpos].revents & (POLLERR|POLLHUP)) {
+		if (eptr->pDescPos >= 0) {
+			if (pdesc[eptr->pDescPos].revents & (POLLERR | POLLHUP)) {
 				eptr->mode = ClientConnectionMode::KILL;
 			}
 
-			if ((pdesc[eptr->pdescpos].revents & POLLIN) &&
+			if ((pdesc[eptr->pDescPos].revents & POLLIN) &&
 			    eptr->mode != ClientConnectionMode::KILL) {
-				eptr->lastread = now;
+				eptr->lastReadTimestamp = now;
 				matoclserv_read(eptr.get());
 			}
 		}
@@ -6387,37 +6403,39 @@ void matoclserv_serve(const std::vector<pollfd> &pdesc) {
 
 // write
 	for (const auto &eptr : matoclservList) {
-		if (eptr->lastwrite + 2 < now && eptr->registered != ClientState::kOldTools &&
-		    eptr->outputhead == NULL) {
+		if (eptr->lastWriteTimestamp + 2 < now && eptr->registered != ClientState::kOldTools &&
+		    eptr->outputPacketHead == NULL) {
 			// 4 byte length because of 'msgid'
 			uint8_t *ptr = matoclserv_createpacket(eptr.get(), ANTOAN_NOP, 4);
 			*((uint32_t *)ptr) = 0;
 		}
 
-		if (eptr->pdescpos >= 0) {
-			if ((((pdesc[eptr->pdescpos].events & POLLOUT) == 0 && (eptr->outputhead)) ||
-			     (pdesc[eptr->pdescpos].revents & POLLOUT)) &&
+		if (eptr->pDescPos >= 0) {
+			if ((((pdesc[eptr->pDescPos].events & POLLOUT) == 0 && (eptr->outputPacketHead)) ||
+			     (pdesc[eptr->pDescPos].revents & POLLOUT)) &&
 			    eptr->mode != ClientConnectionMode::KILL) {
-				eptr->lastwrite = now;
+				eptr->lastWriteTimestamp = now;
 				matoclserv_write(eptr.get());
 			}
 		}
 
-		if (eptr->lastread + 10 < now && exiting == 0) { eptr->mode = ClientConnectionMode::KILL; }
+		if (eptr->lastReadTimestamp + 10 < now && exiting == 0) {
+			eptr->mode = ClientConnectionMode::KILL;
+		}
 	}
 
 // close
 	for (auto eptrIt = matoclservList.begin(); eptrIt != matoclservList.end();) {
 		auto *eptr = eptrIt->get();
 		if (eptr->mode == ClientConnectionMode::KILL) {
-			matocl_beforedisconnect(eptr);
-			tcpclose(eptr->sock);
+			matocl_before_disconnect(eptr);
+			tcpclose(eptr->socket);
 
-			if (eptr->inputpacket.packet) {
-				free(eptr->inputpacket.packet);
+			if (eptr->inputPacket.packet) {
+				free(eptr->inputPacket.packet);
 			}
 
-			pptr = eptr->outputhead;
+			pptr = eptr->outputPacketHead;
 			while (pptr) {
 				if (pptr->packet) {
 					free(pptr->packet);
@@ -6527,7 +6545,7 @@ void matoclserv_become_master() {
 	}
 
 	eventloop_timeregister(TIMEMODE_RUN_LATE, 10, 0, matocl_session_check);
-	eventloop_timeregister(TIMEMODE_RUN_LATE, 3600, 0, matocl_session_statsmove);
+	eventloop_timeregister(TIMEMODE_RUN_LATE, 3600, 0, matocl_session_stats_rotate);
 	return;
 }
 
@@ -6604,8 +6622,8 @@ void matoclserv_reload() {
 
 	safs::log_info("main master server module: socket address has changed, now listen on {}:{}",
 	               ListenHost, ListenPort);
-	tcpclose(lsock);
-	lsock = newlsock;
+	tcpclose(masterSocket);
+	masterSocket = newlsock;
 }
 
 int matoclserv_network_init() {
@@ -6625,21 +6643,21 @@ int matoclserv_network_init() {
 	}
 
 	exiting = 0;
-	lsock = tcpsocket();
-	if (lsock < 0) {
+	masterSocket = tcpsocket();
+	if (masterSocket < 0) {
 		safs::log_err("main master server module: can't create socket");
 		return -1;
 	}
 
-	tcpnonblock(lsock);
-	tcpnodelay(lsock);
-	tcpreuseaddr(lsock);
+	tcpnonblock(masterSocket);
+	tcpnodelay(masterSocket);
+	tcpreuseaddr(masterSocket);
 
-	if (tcpsetacceptfilter(lsock) < 0 && errno != ENOTSUP) {
+	if (tcpsetacceptfilter(masterSocket) < 0 && errno != ENOTSUP) {
 		safs::log_info("main master server module: can't set accept filter");
 	}
 
-	if (tcpstrlisten(lsock, ListenHost.c_str(), ListenPort.c_str(), 100) < 0) {
+	if (tcpstrlisten(masterSocket, ListenHost.c_str(), ListenPort.c_str(), 100) < 0) {
 		safs::log_err("main master server module: can't listen on {}:{}", ListenHost, ListenPort);
 		return -1;
 	}
@@ -6663,7 +6681,7 @@ int matoclserv_network_init() {
 
 void matoclserv_session_unload() {
 	for (const auto& sessionPtr : sessionVector) {
-		sessionPtr->openedfiles.clear();
+		sessionPtr->openFilesSet.clear();
 	}
 
 	sessionVector.clear();

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -110,6 +110,7 @@ enum DelayedChunkOperationType : std::uint32_t {
 #define SESSION_STATS 16
 
 const uint32_t kMaxNumberOfChunkCopies = 100U;
+constexpr uint8_t kClientInactivityTimeout = 10;
 
 struct matoclserventry;
 
@@ -625,7 +626,7 @@ void matoclserv_store_sessions() {
 	std::vector<uint8_t> fsesrecord(kBufferSize); // 4+4+4+4+1+1+1+4+4+4+4+4+4+SESSION_STATS*4+SESSION_STATS*4
 
 	FILE *fd = fopen(kSessionsTmpFilename, "w");
-	if (fd == NULL) {
+	if (fd == nullptr) {
 		safs_silent_errlog(LOG_WARNING,"can't store sessions, open error");
 		return;
 	}
@@ -956,7 +957,7 @@ uint8_t *matoclserv_createpacket(matoclserventry *eptr, uint32_t type, uint32_t 
 	put32bit(&ptr, type);
 	put32bit(&ptr, size);
 	outpacket->startPtr = (uint8_t *)(outpacket->packet);
-	outpacket->next = NULL;
+	outpacket->next = nullptr;
 	*(eptr->outputPacketTail) = outpacket;
 	eptr->outputPacketTail = &(outpacket->next);
 	return ptr;
@@ -975,7 +976,7 @@ void matoclserv_createpacket(matoclserventry *eptr, const MessageBuffer &buffer)
 	// TODO unificate output packets and remove suboptimal memory copying
 	memcpy(outpacket->packet, buffer.data(), buffer.size());
 	outpacket->startPtr = outpacket->packet;
-	outpacket->next = NULL;
+	outpacket->next = nullptr;
 	*(eptr->outputPacketTail) = outpacket;
 	eptr->outputPacketTail = &(outpacket->next);
 }
@@ -1152,7 +1153,7 @@ void matoclserv_chunk_status(uint64_t chunkId, uint8_t status) {
 	DelayedChunkOperation *operation;
 	const PacketSerializer *serializer;
 
-	matoclserventry *eptr = NULL;
+	matoclserventry *eptr = nullptr;
 	uint32_t lockId = 0;
 	uint32_t messageId = 0;
 	uint64_t fileLength = 0;
@@ -1165,11 +1166,11 @@ void matoclserv_chunk_status(uint64_t chunkId, uint8_t status) {
 	serializer = nullptr;
 
 	auto eptrIterator = matoclservList.begin();
-	for (; eptrIterator != matoclservList.end() && eptr == NULL; eptrIterator++) {
+	for (; eptrIterator != matoclservList.end() && eptr == nullptr; eptrIterator++) {
 		matoclserventry* eaptr = eptrIterator->get();
 		if (eaptr->mode != ClientConnectionMode::KILL) {
 			auto chunkOpsIterator = eaptr->delayedChunkOperations.begin();
-			while (chunkOpsIterator != eaptr->delayedChunkOperations.end() && eptr == NULL) {
+			while (chunkOpsIterator != eaptr->delayedChunkOperations.end() && eptr == nullptr) {
 				operation = chunkOpsIterator->get();
 				if (operation->chunkId == chunkId) {
 					eptr = eaptr;
@@ -1661,11 +1662,11 @@ void matoclserv_fstest_info(matoclserventry *eptr, const uint8_t *data, uint32_t
 	uint32_t loopStart;
 	uint32_t loopEnd;
 	uint32_t chunks;
-	uint32_t ugchunks;
-	uint32_t mchunks;
+	uint32_t underGoalChunks;
+	uint32_t missingChunks;
 	inode_t files;
-	inode_t ugfiles;
-	inode_t mfiles;
+	inode_t underGoalFiles;
+	inode_t missingFiles;
 	uint8_t *ptr;
 	(void)data;
 
@@ -1676,21 +1677,23 @@ void matoclserv_fstest_info(matoclserventry *eptr, const uint8_t *data, uint32_t
 	}
 
 	std::string report;
-	fs_test_getdata(loopStart, loopEnd, files, ugfiles, mfiles, chunks, ugchunks, mchunks, report);
+	fs_test_getdata(loopStart, loopEnd, files, underGoalFiles, missingFiles, chunks,
+	                underGoalChunks, missingChunks, report);
 
 	constexpr uint32_t kPacketExtraSize = sizeof(loopStart) + sizeof(loopEnd) + sizeof(files) +
-	                                      sizeof(ugfiles) + sizeof(mfiles) + sizeof(chunks) +
-	                                      sizeof(ugchunks) + sizeof(mchunks) + sizeof(uint32_t);
+	                                      sizeof(underGoalFiles) + sizeof(missingFiles) +
+	                                      sizeof(chunks) + sizeof(underGoalChunks) +
+	                                      sizeof(missingChunks) + sizeof(uint32_t);
 	ptr = matoclserv_createpacket(eptr, MATOCL_FSTEST_INFO, report.size() + kPacketExtraSize);
 
 	put32bit(&ptr, loopStart);
 	put32bit(&ptr, loopEnd);
 	putINode(&ptr, files);
-	putINode(&ptr, ugfiles);
-	putINode(&ptr, mfiles);
+	putINode(&ptr, underGoalFiles);
+	putINode(&ptr, missingFiles);
 	put32bit(&ptr, chunks);
-	put32bit(&ptr, ugchunks);
-	put32bit(&ptr, mchunks);
+	put32bit(&ptr, underGoalChunks);
+	put32bit(&ptr, missingChunks);
 	put32bit(&ptr, (uint32_t)report.size());
 
 	if (!report.empty()) { memcpy(ptr, report.c_str(), report.size()); }
@@ -1936,22 +1939,22 @@ void matoclserv_fuse_register(matoclserventry *eptr, const uint8_t *data, uint32
 
 	// clients with ACL support and new tools
 	if (clientsWithACL) {
-		inode_t rootinode;
-		uint8_t sesflags;
-		uint8_t mingoal, maxgoal;
-		uint32_t mintrashtime, maxtrashtime;
-		uint32_t rootuid, rootgid;
-		uint32_t mapalluid, mapallgid;
-		uint32_t ileng, pleng;
-		uint8_t i, rcode;
+		inode_t rootInode;
+		uint8_t sessionFlags;
+		uint8_t minGoal, maxGoal;
+		uint32_t minTrashTime, maxTrashTime;
+		uint32_t rootUid, rootGid;
+		uint32_t mapAllUid, mapAllGid;
+		uint32_t infoLength, pathLength;
+		uint8_t rcode;
 		const uint8_t *path;
 		const char *info;
 
 		constexpr uint32_t kBlobSizeWithRCode = kBlobSize + sizeof(rcode);
 		constexpr uint32_t kRegisterNewMetaSessionMinSize =
-		    kBlobSizeWithRCode + sizeof(eptr->version) + sizeof(ileng);
+		    kBlobSizeWithRCode + sizeof(eptr->version) + sizeof(infoLength);
 		constexpr uint32_t kRegisterNewSessionMinSize =
-		    kRegisterNewMetaSessionMinSize + sizeof(pleng);
+		    kRegisterNewMetaSessionMinSize + sizeof(pathLength);
 		constexpr uint32_t kRegisterWithSessionIdAndVersion =
 		    kBlobSizeWithRCode + sizeof(sessionId) + sizeof(eptr->version);
 
@@ -1982,8 +1985,8 @@ void matoclserv_fuse_register(matoclserventry *eptr, const uint8_t *data, uint32
 				return;
 			}
 			wptr = matoclserv_createpacket(eptr,MATOCL_FUSE_REGISTER, matoclserventry::kPasswordSize);
-			for (i = 0; i < matoclserventry::kPasswordSize; i++) {
-				eptr->randomPassword[i] = rnd<uint8_t>();
+			for (auto index = 0; index < matoclserventry::kPasswordSize; index++) {
+				eptr->randomPassword[index] = rnd<uint8_t>();
 			}
 			memcpy(wptr, eptr->randomPassword, matoclserventry::kPasswordSize);
 
@@ -1996,47 +1999,49 @@ void matoclserv_fuse_register(matoclserventry *eptr, const uint8_t *data, uint32
 				return;
 			}
 			get32bit(&rptr, eptr->version);
-			get32bit(&rptr, ileng);
-			if (length < kRegisterNewSessionMinSize + ileng) {
-				safs::log_info("CLTOMA_FUSE_REGISTER/ACL.2 - wrong size ({}/>={}+ileng({}))",
-				               length, kRegisterNewSessionMinSize, ileng);
+			get32bit(&rptr, infoLength);
+			if (length < kRegisterNewSessionMinSize + infoLength) {
+				safs::log_info("CLTOMA_FUSE_REGISTER/ACL.2 - wrong size ({}/>={} + infoLength({}))",
+				               length, kRegisterNewSessionMinSize, infoLength);
 				eptr->mode = ClientConnectionMode::KILL;
 				return;
 			}
 			info = (const char*)rptr;
-			rptr += ileng;
-			get32bit(&rptr, pleng);
-			if (length != kRegisterNewSessionMinSize + ileng + pleng &&
-			    length != kRegisterNewSessionMinSize + 16 + ileng + pleng) {
+			rptr += infoLength;
+			get32bit(&rptr, pathLength);
+			if (length != kRegisterNewSessionMinSize + infoLength + pathLength &&
+			    length != kRegisterNewSessionMinSize + 16 + infoLength + pathLength) {
 				safs::log_info(
-				    "CLTOMA_FUSE_REGISTER/ACL.2 - wrong size ({}/{} + ileng({}) + pleng({}) + 16)",
-				    length, kRegisterNewSessionMinSize, ileng, pleng);
+				    "CLTOMA_FUSE_REGISTER/ACL.2 - wrong size "
+				    "({}/{} + infoLength({}) + pathLength({}) + 16)",
+				    length, kRegisterNewSessionMinSize, infoLength, pathLength);
 				eptr->mode = ClientConnectionMode::KILL;
 				return;
 			}
 			path = rptr;
-			rptr += pleng;
-			if (pleng > 0 && rptr[-1] != 0) {
+			rptr += pathLength;
+			if (pathLength > 0 && rptr[-1] != 0) {
 				safs::log_info("CLTOMA_FUSE_REGISTER/ACL.2 - received path without ending zero");
 				eptr->mode = ClientConnectionMode::KILL;
 				return;
 			}
-			if (pleng == 0) {
+			if (pathLength == 0) {
 				path = (const uint8_t*)"";
 			}
-			if (length == kRegisterNewSessionMinSize + 16 + ileng + pleng) {
+			if (length == kRegisterNewSessionMinSize + 16 + infoLength + pathLength) {
 				status =
 				    exports_check(eptr->peerIpAddress, eptr->version, 0, path, eptr->randomPassword,
-				                  rptr, &sesflags, &rootuid, &rootgid, &mapalluid, &mapallgid,
-				                  &mingoal, &maxgoal, &mintrashtime, &maxtrashtime);
+				                  rptr, &sessionFlags, &rootUid, &rootGid, &mapAllUid, &mapAllGid,
+				                  &minGoal, &maxGoal, &minTrashTime, &maxTrashTime);
 			} else {
-				status = exports_check(eptr->peerIpAddress, eptr->version, 0, path, NULL, NULL,
-				                       &sesflags, &rootuid, &rootgid, &mapalluid, &mapallgid,
-				                       &mingoal, &maxgoal, &mintrashtime, &maxtrashtime);
+				status =
+				    exports_check(eptr->peerIpAddress, eptr->version, 0, path, nullptr, nullptr,
+				                  &sessionFlags, &rootUid, &rootGid, &mapAllUid, &mapAllGid,
+				                  &minGoal, &maxGoal, &minTrashTime, &maxTrashTime);
 			}
 
 			if (status == SAUNAFS_STATUS_OK) {
-				status = fs_getrootinode(&rootinode, path);
+				status = fs_getrootinode(&rootInode, path);
 			}
 
 			if (status == SAUNAFS_STATUS_OK) {
@@ -2047,23 +2052,24 @@ void matoclserv_fuse_register(matoclserventry *eptr, const uint8_t *data, uint32
 					return;
 				}
 
-				eptr->sessionData->rootInode = rootinode;
-				eptr->sessionData->flags = sesflags;
-				eptr->sessionData->rootUid = rootuid;
-				eptr->sessionData->rootGid = rootgid;
-				eptr->sessionData->mapAllUid = mapalluid;
-				eptr->sessionData->mapAllGid = mapallgid;
-				eptr->sessionData->minGoal = mingoal;
-				eptr->sessionData->maxGoal = maxgoal;
-				eptr->sessionData->minTrashTime = mintrashtime;
-				eptr->sessionData->maxTrashTime = maxtrashtime;
+				eptr->sessionData->rootInode = rootInode;
+				eptr->sessionData->flags = sessionFlags;
+				eptr->sessionData->rootUid = rootUid;
+				eptr->sessionData->rootGid = rootGid;
+				eptr->sessionData->mapAllUid = mapAllUid;
+				eptr->sessionData->mapAllGid = mapAllGid;
+				eptr->sessionData->minGoal = minGoal;
+				eptr->sessionData->maxGoal = maxGoal;
+				eptr->sessionData->minTrashTime = minTrashTime;
+				eptr->sessionData->maxTrashTime = maxTrashTime;
 				eptr->sessionData->peerIpAddress = eptr->peerIpAddress;
 				eptr->sessionData->peerPort = eptr->peerPort;
-				if (ileng>0) {
-					if (info[ileng-1]==0) {
+
+				if (infoLength > 0) {
+					if (info[infoLength - 1] == 0) {
 						eptr->sessionData->info = std::string(info);
 					} else {
-						eptr->sessionData->info = std::string(info, ileng);
+						eptr->sessionData->info = std::string(info, infoLength);
 					}
 				}
 
@@ -2100,18 +2106,18 @@ void matoclserv_fuse_register(matoclserventry *eptr, const uint8_t *data, uint32
 				put8bit(&wptr, SAUNAFS_PACKAGE_VERSION_MICRO);
 			}
 			put32bit(&wptr, sessionId);
-			put8bit(&wptr, sesflags);
-			put32bit(&wptr, rootuid);
-			put32bit(&wptr, rootgid);
+			put8bit(&wptr, sessionFlags);
+			put32bit(&wptr, rootUid);
+			put32bit(&wptr, rootGid);
 			if (eptr->version>=saunafsVersion(1, 6, 1)) {
-				put32bit(&wptr,mapalluid);
-				put32bit(&wptr,mapallgid);
+				put32bit(&wptr, mapAllUid);
+				put32bit(&wptr, mapAllGid);
 			}
 			if (eptr->version >= saunafsVersion(1, 6, 26)) {
-				put8bit(&wptr, mingoal);
-				put8bit(&wptr, maxgoal);
-				put32bit(&wptr, mintrashtime);
-				put32bit(&wptr, maxtrashtime);
+				put8bit(&wptr, minGoal);
+				put8bit(&wptr, maxGoal);
+				put32bit(&wptr, minTrashTime);
+				put32bit(&wptr, maxTrashTime);
 			}
 			if (eptr->version >= saunafsVersion(1, 6, 30)) {
 				eptr->ioLimitsEnabled = true;
@@ -2128,28 +2134,29 @@ void matoclserv_fuse_register(matoclserventry *eptr, const uint8_t *data, uint32
 			}
 
 			get32bit(&rptr, eptr->version);
-			get32bit(&rptr, ileng);
+			get32bit(&rptr, infoLength);
 
-			if (length != kRegisterNewMetaSessionMinSize + ileng &&
-			    length != kRegisterNewMetaSessionMinSize + 16 + ileng) {
+			if (length != kRegisterNewMetaSessionMinSize + infoLength &&
+			    length != kRegisterNewMetaSessionMinSize + 16 + infoLength) {
 				safs::log_info("CLTOMA_FUSE_REGISTER/ACL.5 - wrong size ({}/{} + ileng({}) + 16)",
-				               length, kRegisterNewMetaSessionMinSize, ileng);
+				               length, kRegisterNewMetaSessionMinSize, infoLength);
 				eptr->mode = ClientConnectionMode::KILL;
 				return;
 			}
 
 			info = (const char*)rptr;
-			rptr += ileng;
+			rptr += infoLength;
 
-			if (length == kRegisterNewMetaSessionMinSize + 16 + ileng) {
-				status =
-				    exports_check(eptr->peerIpAddress, eptr->version, 1, NULL, eptr->randomPassword,
-				                  rptr, &sesflags, &rootuid, &rootgid, &mapalluid, &mapallgid,
-				                  &mingoal, &maxgoal, &mintrashtime, &maxtrashtime);
+			if (length == kRegisterNewMetaSessionMinSize + 16 + infoLength) {
+				status = exports_check(eptr->peerIpAddress, eptr->version, 1, nullptr,
+				                       eptr->randomPassword, rptr, &sessionFlags, &rootUid,
+				                       &rootGid, &mapAllUid, &mapAllGid, &minGoal, &maxGoal,
+				                       &minTrashTime, &maxTrashTime);
 			} else {
-				status = exports_check(eptr->peerIpAddress, eptr->version, 1, NULL, NULL, NULL,
-				                       &sesflags, &rootuid, &rootgid, &mapalluid, &mapallgid,
-				                       &mingoal, &maxgoal, &mintrashtime, &maxtrashtime);
+				status =
+				    exports_check(eptr->peerIpAddress, eptr->version, 1, nullptr, nullptr, nullptr,
+				                  &sessionFlags, &rootUid, &rootGid, &mapAllUid, &mapAllGid,
+				                  &minGoal, &maxGoal, &minTrashTime, &maxTrashTime);
 			}
 
 			if (status == SAUNAFS_STATUS_OK) {
@@ -2161,22 +2168,22 @@ void matoclserv_fuse_register(matoclserventry *eptr, const uint8_t *data, uint32
 				}
 
 				eptr->sessionData->rootInode = 0;
-				eptr->sessionData->flags = sesflags;
+				eptr->sessionData->flags = sessionFlags;
 				eptr->sessionData->rootUid = 0;
 				eptr->sessionData->rootGid = 0;
 				eptr->sessionData->mapAllUid = 0;
 				eptr->sessionData->mapAllGid = 0;
-				eptr->sessionData->minGoal = mingoal;
-				eptr->sessionData->maxGoal = maxgoal;
-				eptr->sessionData->minTrashTime = mintrashtime;
-				eptr->sessionData->maxTrashTime = maxtrashtime;
+				eptr->sessionData->minGoal = minGoal;
+				eptr->sessionData->maxGoal = maxGoal;
+				eptr->sessionData->minTrashTime = minTrashTime;
+				eptr->sessionData->maxTrashTime = maxTrashTime;
 				eptr->sessionData->peerIpAddress = eptr->peerIpAddress;
 				eptr->sessionData->peerPort = eptr->peerPort;
-				if (ileng > 0) {
-					if (info[ileng - 1] == 0) {
+				if (infoLength > 0) {
+					if (info[infoLength - 1] == 0) {
 						eptr->sessionData->info = std::string(info);
 					} else {
-						eptr->sessionData->info = std::string(info, ileng);
+						eptr->sessionData->info = std::string(info, infoLength);
 					}
 				}
 
@@ -2207,13 +2214,13 @@ void matoclserv_fuse_register(matoclserventry *eptr, const uint8_t *data, uint32
 				put8bit(&wptr,SAUNAFS_PACKAGE_VERSION_MINOR);
 				put8bit(&wptr,SAUNAFS_PACKAGE_VERSION_MICRO);
 			}
-			put32bit(&wptr,sessionId);
-			put8bit(&wptr,sesflags);
+			put32bit(&wptr, sessionId);
+			put8bit(&wptr, sessionFlags);
 			if (eptr->version >= saunafsVersion(1, 6, 26)) {
-				put8bit(&wptr,mingoal);
-				put8bit(&wptr,maxgoal);
-				put32bit(&wptr,mintrashtime);
-				put32bit(&wptr,maxtrashtime);
+				put8bit(&wptr, minGoal);
+				put8bit(&wptr, maxGoal);
+				put32bit(&wptr, minTrashTime);
+				put32bit(&wptr, maxTrashTime);
 			}
 			eptr->registered = ClientState::kRegistered;
 			return;
@@ -5805,7 +5812,7 @@ void matoclserv_gotpacket(matoclserventry *eptr, uint32_t type, const uint8_t *d
 				    eptr->mode = ClientConnectionMode::KILL;
 			}
 		} else if (eptr->registered == ClientState::kRegistered) {      // mounts and new tools
-			if (eptr->sessionData == NULL) {
+			if (eptr->sessionData == nullptr) {
 				safs::log_err("registered connection without sesdata !!!");
 				eptr->mode = ClientConnectionMode::KILL;
 				return;
@@ -6064,7 +6071,7 @@ void matoclserv_gotpacket(matoclserventry *eptr, uint32_t type, const uint8_t *d
 				    eptr->mode=ClientConnectionMode::KILL;
 			}
 		} else if (eptr->registered == ClientState::kOldTools) {        // old sfstools
-			if (eptr->sessionData == NULL) {
+			if (eptr->sessionData == nullptr) {
 				safs::log_err("registered connection (tools) without sesdata !!!");
 				eptr->mode=ClientConnectionMode::KILL;
 				return;
@@ -6156,14 +6163,14 @@ void matoclserv_term() {
 
 void matoclserv_read(matoclserventry *eptr) {
 	SignalLoopWatchdog watchdog;
-	int32_t i;
+	int32_t bytesRead;
 	uint32_t type,size;
 	const uint8_t *ptr;
 
 	watchdog.start();
 	while (eptr->mode != ClientConnectionMode::KILL) {
-		i = read(eptr->socket, eptr->inputPacket.startPtr, eptr->inputPacket.bytesLeft);
-		if (i == 0) {
+		bytesRead = read(eptr->socket, eptr->inputPacket.startPtr, eptr->inputPacket.bytesLeft);
+		if (bytesRead == 0) {
 			if (eptr->registered == ClientState::kRegistered) {       // show this message only for standard, registered clients
 				safs::log_info("connection with client (ip:{}) has been closed by peer",
 				               ipToString(eptr->peerIpAddress));
@@ -6172,7 +6179,7 @@ void matoclserv_read(matoclserventry *eptr) {
 			return;
 		}
 
-		if (i < 0) {
+		if (bytesRead < 0) {
 			if (errno != EAGAIN) {
 #ifdef ECONNRESET
 				if (errno != ECONNRESET) {
@@ -6186,10 +6193,10 @@ void matoclserv_read(matoclserventry *eptr) {
 			}
 			return;
 		}
-		eptr->inputPacket.startPtr += i;
-		eptr->inputPacket.bytesLeft -= i;
-		metrics::Counter::increment(metrics::Counter::Master::CLIENT_RX_BYTES, i);
-		statsBytesReceived += i;
+		eptr->inputPacket.startPtr += bytesRead;
+		eptr->inputPacket.bytesLeft -= bytesRead;
+		metrics::Counter::increment(metrics::Counter::Master::CLIENT_RX_BYTES, bytesRead);
+		statsBytesReceived += bytesRead;
 
 		if (eptr->inputPacket.bytesLeft > 0) {
 			return;
@@ -6230,7 +6237,7 @@ void matoclserv_read(matoclserventry *eptr) {
 			if (eptr->inputPacket.packet) {
 				free(eptr->inputPacket.packet);
 			}
-			eptr->inputPacket.packet=NULL;
+			eptr->inputPacket.packet = nullptr;
 			break;
 		}
 
@@ -6248,7 +6255,7 @@ void matoclserv_write(matoclserventry *eptr) {
 	watchdog.start();
 	for (;;) {
 		pack = eptr->outputPacketHead;
-		if (pack == NULL) { return; }
+		if (pack == nullptr) { return; }
 		i = write(eptr->socket, pack->startPtr, pack->bytesLeft);
 		if (i < 0) {
 			if (errno != EAGAIN) {
@@ -6269,7 +6276,7 @@ void matoclserv_write(matoclserventry *eptr) {
 		statsPacketsSent++;
 		metrics::Counter::increment(metrics::Counter::Master::CLIENT_TX_PACKETS);
 		eptr->outputPacketHead = pack->next;
-		if (eptr->outputPacketHead == NULL) {
+		if (eptr->outputPacketHead == nullptr) {
 			eptr->outputPacketTail = &(eptr->outputPacketHead);
 		}
 		free(pack);
@@ -6280,16 +6287,16 @@ void matoclserv_write(matoclserventry *eptr) {
 	}
 }
 
-void matoclserv_wantexit(void) {
+void matoclserv_wantexit() {
 	exiting = 1;
 }
 
-int matoclserv_canexit(void) {
-	matoclserventry *adminTerminator = NULL;
+int matoclserv_canexit() {
+	matoclserventry *adminTerminator = nullptr;
 	static bool terminatorPacketSent = false;
 
 	for (const auto &eptr : matoclservList) {
-		if (eptr->outputPacketHead != NULL) {
+		if (eptr->outputPacketHead != nullptr) {
 			return 0;
 		}
 
@@ -6302,7 +6309,7 @@ int matoclserv_canexit(void) {
 		}
 	}
 
-	if (adminTerminator != NULL && !terminatorPacketSent) {
+	if (adminTerminator != nullptr && !terminatorPacketSent) {
 		// Are we replying to termination request?
 		if (!matomlserv_canexit()){  // make sure there are no ml connected
 			safs_pretty_syslog(LOG_INFO, "Waiting for ml connections to close...");
@@ -6341,7 +6348,7 @@ void matoclserv_desc(std::vector<pollfd> &pdesc) {
 			pdesc.back().events |= POLLIN;
 		}
 
-		if (eptr->outputPacketHead != NULL) {
+		if (eptr->outputPacketHead != nullptr) {
 			pdesc.back().events |= POLLOUT;
 		}
 	}
@@ -6370,16 +6377,16 @@ void matoclserv_serve(const std::vector<pollfd> &pdesc) {
 			eptr->mode = ClientConnectionMode::HEADER;
 			eptr->lastReadTimestamp = now;
 			eptr->lastWriteTimestamp = now;
-			eptr->inputPacket.next = NULL;
+			eptr->inputPacket.next = nullptr;
 			eptr->inputPacket.bytesLeft = 8;
 			eptr->inputPacket.startPtr = eptr->headerBuffer;
-			eptr->inputPacket.packet = NULL;
+			eptr->inputPacket.packet = nullptr;
 			eptr->adminTask = AdminTask::kNone;
-			eptr->outputPacketHead = NULL;
+			eptr->outputPacketHead = nullptr;
 			eptr->outputPacketTail = &(eptr->outputPacketHead);
 
 			eptr->delayedChunkOperations.clear();
-			eptr->sessionData = NULL;
+			eptr->sessionData = nullptr;
 			memset(eptr->randomPassword, 0, 32);
 
 			matoclservList.push_front(std::move(eptr));
@@ -6404,7 +6411,7 @@ void matoclserv_serve(const std::vector<pollfd> &pdesc) {
 // write
 	for (const auto &eptr : matoclservList) {
 		if (eptr->lastWriteTimestamp + 2 < now && eptr->registered != ClientState::kOldTools &&
-		    eptr->outputPacketHead == NULL) {
+		    eptr->outputPacketHead == nullptr) {
 			// 4 byte length because of 'msgid'
 			uint8_t *ptr = matoclserv_createpacket(eptr.get(), ANTOAN_NOP, 4);
 			*((uint32_t *)ptr) = 0;
@@ -6419,7 +6426,8 @@ void matoclserv_serve(const std::vector<pollfd> &pdesc) {
 			}
 		}
 
-		if (eptr->lastReadTimestamp + 10 < now && exiting == 0) {
+		// Disconnect clients that have not requested any data for a while
+		if (eptr->lastReadTimestamp + kClientInactivityTimeout < now && exiting == 0) {
 			eptr->mode = ClientConnectionMode::KILL;
 		}
 	}
@@ -6452,7 +6460,7 @@ void matoclserv_serve(const std::vector<pollfd> &pdesc) {
 	}
 }
 
-void matoclserv_start_cond_check(void) {
+void matoclserv_start_cond_check() {
 	if (starting) {
 		// very simple condition checking if all chunkservers have been connected
 		// in the future master will know his chunkservers list and then this condition will be

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -523,14 +523,15 @@ const PacketSerializer* PacketSerializer::getSerializer(PacketHeader::Type type,
 	if (type <= PacketHeader::kMaxOldPacketType) {
 		static LegacyPacketSerializer singleton;
 		return &singleton;
-	} else {
-		static SaunaFsPacketSerializer singleton;
-		if (version < kFirstECVersion) {
-			static SaunaFsStdXorPacketSerializer singleton_stdxor;
-			return &singleton_stdxor;
-		}
-		return &singleton;
 	}
+
+	static SaunaFsPacketSerializer singleton;
+	if (version < kFirstECVersion) {
+		static SaunaFsStdXorPacketSerializer singletonStdXor;
+		return &singletonStdXor;
+	}
+
+	return &singleton;
 }
 
 void matoclserv_stats(uint64_t stats[5]) {
@@ -538,42 +539,49 @@ void matoclserv_stats(uint64_t stats[5]) {
 	stats[1] = stats_psent;
 	stats[2] = stats_brcvd;
 	stats[3] = stats_bsent;
+
 	stats_prcvd = 0;
 	stats_psent = 0;
 	stats_brcvd = 0;
 	stats_bsent = 0;
 }
 
-matoclserventry *matoclserv_find_connection(uint32_t id) {
+/// Returns the connection for a given session.
+/// @param sessionId The session ID to search for
+/// @return Pointer to the matoclserventry if found, nullptr otherwise
+matoclserventry *matoclserv_find_connection(uint32_t sessionId) {
 	for (const auto& eptr : matoclservList) {
-		if (eptr->sesdata && eptr->sesdata->sessionid == id) {
+		if (eptr->sesdata && eptr->sesdata->sessionid == sessionId) {
 			return eptr.get();
 		}
 	}
 	return nullptr;
 }
 
-/* new registration procedure */
-session *matoclserv_new_session(uint8_t newsession, uint8_t nonewid) {
+/// Creates a new session.
+/// @param newSession Indicates if this is a new session
+/// @param noNewId Indicates if a new session ID should be generated
+/// @return Pointer to the newly created session
+session *matoclserv_new_session(uint8_t newSession, uint8_t noNewId) {
 	auto sessionPtr = std::make_unique<session>();
 	passert(sessionPtr.get());
-	if (newsession==0 && nonewid) {
-		sessionPtr->sessionid = 0;
-	} else {
-		sessionPtr->sessionid = fs_newsessionid();
-	}
 
-	sessionPtr->newsession = newsession;
+	auto newSessionIdNotNeeded = (newSession == 0 && noNewId);
+	sessionPtr->sessionid = (newSessionIdNotNeeded) ? 0 : fs_newsessionid();
+	sessionPtr->newsession = newSession;
 	sessionPtr->nsocks = 1;
 	sessionVector.push_back(std::move(sessionPtr));
 	return sessionVector.back().get();
 }
 
-session* matoclserv_find_session(uint32_t sessionid) {
-	if (sessionid == 0) { return nullptr; }
+/// Returns the session for a given ID.
+/// @param sessionId The session ID to search for
+/// @return Pointer to the session if found, nullptr otherwise
+session* matoclserv_find_session(uint32_t sessionId) {
+	if (sessionId == 0) { return nullptr; }
 
 	for (const auto& sessionPtr : sessionVector) {
-		if (sessionPtr->sessionid == sessionid) {
+		if (sessionPtr->sessionid == sessionId) {
 			if (sessionPtr->newsession >= 2) {
 				sessionPtr->newsession -= 2;
 			}
@@ -585,11 +593,13 @@ session* matoclserv_find_session(uint32_t sessionid) {
 	return nullptr;
 }
 
-void matoclserv_close_session(uint32_t sessionid) {
-	if (sessionid == 0) { return; }
+/// Closes a session by its ID.
+/// @param sessionId The session ID to close
+void matoclserv_close_session(uint32_t sessionId) {
+	if (sessionId == 0) { return; }
 
 	for (const auto& sessionPtr : sessionVector) {
-		if (sessionPtr->sessionid == sessionid) {
+		if (sessionPtr->sessionid == sessionId) {
 			if (sessionPtr->nsocks == 1 && sessionPtr->newsession < 2) {
 				sessionPtr->newsession += 2;
 			}
@@ -597,10 +607,11 @@ void matoclserv_close_session(uint32_t sessionid) {
 	}
 }
 
+/// Stores all sessions to a file.
 void matoclserv_store_sessions() {
-	uint32_t ileng;
+	uint32_t sessionInfoLength;
 	constexpr uint32_t kSessionSerializedSize =
-	    sizeof(session::sessionid) + sizeof(ileng) + sizeof(session::peerip) +
+	    sizeof(session::sessionid) + sizeof(sessionInfoLength) + sizeof(session::peerip) +
 	    sizeof(session::rootinode) + sizeof(session::sesflags) + sizeof(session::mingoal) +
 	    sizeof(session::maxgoal) + sizeof(session::mintrashtime) + sizeof(session::maxtrashtime) +
 	    sizeof(session::rootuid) + sizeof(session::rootgid) + sizeof(session::mapalluid) +
@@ -627,10 +638,10 @@ void matoclserv_store_sessions() {
 	for (const auto& sessionPtr : sessionVector) {
 		if (sessionPtr->newsession == 1) {
 			ptr = fsesrecord.data();
-			ileng = sessionPtr->info.size();
+			sessionInfoLength = sessionPtr->info.size();
 
 			put32bit(&ptr, sessionPtr->sessionid);
-			put32bit(&ptr, ileng);
+			put32bit(&ptr, sessionInfoLength);
 			put32bit(&ptr, sessionPtr->peerip);
 			put32bit(&ptr, sessionPtr->rootinode);
 			put8bit(&ptr, sessionPtr->sesflags);
@@ -650,15 +661,16 @@ void matoclserv_store_sessions() {
 			for (auto i = 0; i < SESSION_STATS; i++) {
 				put32bit(&ptr, sessionPtr->lasthouropstats[i]);
 			}
+
 			if (fwrite(fsesrecord.data(), kBufferSize, 1, fd) != 1) {
-				safs_pretty_syslog(LOG_WARNING,"can't store sessions, fwrite error");
+				safs::log_warn("can't store sessions, fwrite error");
 				fclose(fd);
 				return;
 			}
 
-			if (ileng > 0) {
-				if (fwrite(sessionPtr->info.data(), ileng, 1, fd) != 1) {
-					safs_pretty_syslog(LOG_WARNING, "can't store sessions, fwrite error");
+			if (sessionInfoLength > 0) {
+				if (fwrite(sessionPtr->info.data(), sessionInfoLength, 1, fd) != 1) {
+					safs::log_warn("can't store sessions, fwrite error");
 					fclose(fd);
 					return;
 				}
@@ -678,18 +690,19 @@ void matoclserv_store_sessions() {
 
 #define MFSSIGNATURE "MFS"
 
+/// Loads all sessions from a file.
+/// @return 0 on success, -1 on error
 int matoclserv_load_sessions() {
-	uint32_t ileng;
-	uint8_t hdr[8];  // for signature and version. e.g. "SFS" " S 1.5"
-	std::vector<uint8_t> fsesrecord;
+	uint32_t sessionInfoLength;
+	uint8_t headerBuffer[8];  // for signature and version. e.g. "SFS" " S 1.5"
+	std::vector<uint8_t> sessionBuffer;
 	const uint8_t *ptr;
-	uint8_t mapalldata;
-	uint8_t goaltrashdata;
-	uint32_t i,statsinfile;
-	int r;
-	FILE *fd;
+	uint8_t mapAllData;
+	uint8_t goalTrashData;
+	uint32_t statsInFile;
+	int bytesRead;
 
-	fd = fopen(kSessionsFilename, "r");
+	FILE *fd = fopen(kSessionsFilename, "r");
 
 	if (fd == nullptr) {
 		safs_silent_errlog(LOG_WARNING, "can't load sessions, fopen error");
@@ -702,52 +715,52 @@ int matoclserv_load_sessions() {
 
 	const size_t kSessionsHeaderSize = strlen(SFSSIGNATURE) + 5;
 
-	if (fread(hdr, kSessionsHeaderSize, 1, fd) != 1) {
-		safs_pretty_syslog(LOG_WARNING, "can't load sessions, fread error");
+	if (fread(headerBuffer, kSessionsHeaderSize, 1, fd) != 1) {
+		safs::log_warn("can't load sessions, fread error");
 		fclose(fd);
 		return -1;
 	}
 
 	// Guillex: Only "S \001\006\004" (last option) is expected
-	if (memcmp(hdr, SFSSIGNATURE "S 1.5", kSessionsHeaderSize) == 0 ||
-	    memcmp(hdr, MFSSIGNATURE "S 1.5", kSessionsHeaderSize) == 0) {
-		mapalldata = 0;
-		goaltrashdata = 0;
-		statsinfile = 16;
-	} else if (memcmp(hdr, SFSSIGNATURE "S \001\006\001", kSessionsHeaderSize) == 0 ||
-	           memcmp(hdr, MFSSIGNATURE "S \001\006\001", kSessionsHeaderSize) == 0) {
-		mapalldata = 1;
-		goaltrashdata = 0;
-		statsinfile = 16;
-	} else if (memcmp(hdr, SFSSIGNATURE "S \001\006\002", kSessionsHeaderSize) == 0 ||
-	           memcmp(hdr, MFSSIGNATURE "S \001\006\002", kSessionsHeaderSize) == 0) {
-		mapalldata = 1;
-		goaltrashdata = 0;
-		statsinfile = 21;
-	} else if (memcmp(hdr, SFSSIGNATURE "S \001\006\003", kSessionsHeaderSize) == 0 ||
-	           memcmp(hdr, MFSSIGNATURE "S \001\006\003", kSessionsHeaderSize) == 0) {
-		mapalldata = 1;
-		goaltrashdata = 0;
-		if (fread(hdr, 2, 1, fd) != 1) {
-			safs_pretty_syslog(LOG_WARNING,"can't load sessions, fread error");
+	if (memcmp(headerBuffer, SFSSIGNATURE "S 1.5", kSessionsHeaderSize) == 0 ||
+	    memcmp(headerBuffer, MFSSIGNATURE "S 1.5", kSessionsHeaderSize) == 0) {
+		mapAllData = 0;
+		goalTrashData = 0;
+		statsInFile = 16;
+	} else if (memcmp(headerBuffer, SFSSIGNATURE "S \001\006\001", kSessionsHeaderSize) == 0 ||
+	           memcmp(headerBuffer, MFSSIGNATURE "S \001\006\001", kSessionsHeaderSize) == 0) {
+		mapAllData = 1;
+		goalTrashData = 0;
+		statsInFile = 16;
+	} else if (memcmp(headerBuffer, SFSSIGNATURE "S \001\006\002", kSessionsHeaderSize) == 0 ||
+	           memcmp(headerBuffer, MFSSIGNATURE "S \001\006\002", kSessionsHeaderSize) == 0) {
+		mapAllData = 1;
+		goalTrashData = 0;
+		statsInFile = 21;
+	} else if (memcmp(headerBuffer, SFSSIGNATURE "S \001\006\003", kSessionsHeaderSize) == 0 ||
+	           memcmp(headerBuffer, MFSSIGNATURE "S \001\006\003", kSessionsHeaderSize) == 0) {
+		mapAllData = 1;
+		goalTrashData = 0;
+		if (fread(headerBuffer, 2, 1, fd) != 1) {
+			safs::log_warn("can't load sessions, fread error");
 			fclose(fd);
 			return -1;
 		}
-		ptr = hdr;
-		statsinfile = get16bit(&ptr);
-	} else if (memcmp(hdr, SFSSIGNATURE "S \001\006\004", kSessionsHeaderSize) == 0 ||
-	           memcmp(hdr, MFSSIGNATURE "S \001\006\004", kSessionsHeaderSize) == 0) {
-		mapalldata = 1;
-		goaltrashdata = 1;
-		if (fread(hdr, sizeof(uint16_t), 1, fd) != 1) {
-			safs_pretty_syslog(LOG_WARNING, "can't load sessions, fread error");
+		ptr = headerBuffer;
+		statsInFile = get16bit(&ptr);
+	} else if (memcmp(headerBuffer, SFSSIGNATURE "S \001\006\004", kSessionsHeaderSize) == 0 ||
+	           memcmp(headerBuffer, MFSSIGNATURE "S \001\006\004", kSessionsHeaderSize) == 0) {
+		mapAllData = 1;
+		goalTrashData = 1;
+		if (fread(headerBuffer, sizeof(uint16_t), 1, fd) != 1) {
+			safs::log_warn("can't load sessions, fread error");
 			fclose(fd);
 			return -1;
 		}
-		ptr = hdr;
-		statsinfile = get16bit(&ptr);
+		ptr = headerBuffer;
+		statsInFile = get16bit(&ptr);
 	} else {
-		safs_pretty_syslog(LOG_WARNING,"can't load sessions, bad header");
+		safs::log_warn("can't load sessions, bad header");
 		fclose(fd);
 		return -1;
 	}
@@ -757,7 +770,7 @@ int matoclserv_load_sessions() {
 	    sizeof(std::remove_extent<decltype(session::currentopstats)>::type::value_type) +
 	    sizeof(std::remove_extent<decltype(session::lasthouropstats)>::type::value_type);
 
-	constexpr uint32_t kCommonSize = sizeof(session::sessionid) + sizeof(ileng) +
+	constexpr uint32_t kCommonSize = sizeof(session::sessionid) + sizeof(sessionInfoLength) +
 	                                 sizeof(session::peerip) + sizeof(session::rootinode) +
 	                                 sizeof(session::sesflags) + sizeof(session::rootuid) +
 	                                 sizeof(session::rootgid);
@@ -767,31 +780,31 @@ int matoclserv_load_sessions() {
 	    sizeof(session::mingoal) + sizeof(session::maxgoal) + sizeof(session::mintrashtime) +
 	    sizeof(session::maxtrashtime);
 
-	// statsinfile is unknown at compile time, we need to use a runtime constant
-	const uint32_t kStatsSize = statsinfile * kStatEntrySize;
+	// statsInFile is unknown at compile time, we need to use a runtime constant
+	const uint32_t kStatsSize = statsInFile * kStatEntrySize;
 
-	if (mapalldata == 0) {
-		fsesrecord.resize(kCommonSize + kStatsSize);
-	} else if (goaltrashdata == 0) {
-		fsesrecord.resize(kCommonSize + kExtraSizeWithMapAll + kStatsSize);
+	if (mapAllData == 0) {
+		sessionBuffer.resize(kCommonSize + kStatsSize);
+	} else if (goalTrashData == 0) {
+		sessionBuffer.resize(kCommonSize + kExtraSizeWithMapAll + kStatsSize);
 	} else {
-		fsesrecord.resize(kCommonSize + kExtraSizeWithMapAll + kExtraSizeWithGoalTrash +
+		sessionBuffer.resize(kCommonSize + kExtraSizeWithMapAll + kExtraSizeWithGoalTrash +
 		                  kStatsSize);
 	}
 
 	while (!feof(fd)) {
-		r = fread(fsesrecord.data(), fsesrecord.size(), 1, fd);
+		bytesRead = fread(sessionBuffer.data(), sessionBuffer.size(), 1, fd);
 
-		if (r == 1) {
-			ptr = fsesrecord.data();
+		if (bytesRead == 1) {
+			ptr = sessionBuffer.data();
 			auto sessionPtr = std::make_unique<session>();
 			passert(sessionPtr);
 			get32bit(&ptr, sessionPtr->sessionid);
-			get32bit(&ptr, ileng);
+			get32bit(&ptr, sessionInfoLength);
 			get32bit(&ptr, sessionPtr->peerip);
 			getINode(&ptr, sessionPtr->rootinode);
 			sessionPtr->sesflags = get8bit(&ptr);
-			if (goaltrashdata) {
+			if (goalTrashData) {
 				sessionPtr->mingoal = get8bit(&ptr);
 				sessionPtr->maxgoal = get8bit(&ptr);
 				get32bit(&ptr, sessionPtr->mintrashtime);
@@ -799,71 +812,83 @@ int matoclserv_load_sessions() {
 			}
 			get32bit(&ptr, sessionPtr->rootuid);
 			get32bit(&ptr, sessionPtr->rootgid);
-			if (mapalldata) {
+			if (mapAllData) {
 				get32bit(&ptr, sessionPtr->mapalluid);
 				get32bit(&ptr, sessionPtr->mapallgid);
 			}
 			sessionPtr->newsession = 1;
 			sessionPtr->disconnected = eventloop_time();
-			for (i = 0; i < SESSION_STATS; i++) {
-				if (i < statsinfile) {
+			for (uint32_t i = 0; i < SESSION_STATS; i++) {
+				if (i < statsInFile) {
 					get32bit(&ptr, sessionPtr->currentopstats[i]);
 				} else {
 					sessionPtr->currentopstats[i] = 0;
 				}
 			}
 
-			if (statsinfile > SESSION_STATS) {
-				ptr += 4 * (statsinfile - SESSION_STATS);
+			if (statsInFile > SESSION_STATS) {
+				ptr += 4 * (statsInFile - SESSION_STATS);
 			}
-			for (i = 0; i < SESSION_STATS; i++) {
-				if (i < statsinfile) {
+
+			for (uint32_t i = 0; i < SESSION_STATS; i++) {
+				if (i < statsInFile) {
 					get32bit(&ptr, sessionPtr->lasthouropstats[i]);
 				} else {
 					sessionPtr->lasthouropstats[i] = 0;
 				}
 			}
-			if (ileng > 0) {
-				sessionPtr->info.resize(ileng);
-				if (fread(sessionPtr->info.data(), ileng, 1, fd) != 1) {
+
+			if (sessionInfoLength > 0) {
+				sessionPtr->info.resize(sessionInfoLength);
+				if (fread(sessionPtr->info.data(), sessionInfoLength, 1, fd) != 1) {
 					sessionPtr.reset();
-					safs_pretty_syslog(LOG_WARNING,"can't load sessions, fread error");
+					safs::log_warn("can't load sessions, fread error");
 					fclose(fd);
 					return -1;
 				}
 			}
+
 			sessionVector.push_back(std::move(sessionPtr));
 		}
 
 		if (ferror(fd)) {
-			safs_pretty_syslog(LOG_WARNING,"can't load sessions, fread error");
+			safs::log_warn("can't load sessions, fread error");
 			fclose(fd);
 			return -1;
 		}
 	}
 
-	safs_pretty_syslog(LOG_NOTICE, "sessions have been loaded");
+	safs::log_info("sessions have been loaded");
 	fclose(fd);
 	return 1;
 }
 #undef MFSSIGNATURE
 
-int matoclserv_insert_openfile(session *cr, inode_t inode) {
-	if (cr->openedfiles.contains(inode)) {
+/// Inserts an open file to the list of open files for a given session.
+/// @param currentSession Pointer to the session
+/// @param inode The inode of the open file
+/// @return SAUNAFS_STATUS_OK if the file was successfully acquired, or an error code otherwise
+int matoclserv_insert_open_file(session *currentSession, inode_t inode) {
+	if (currentSession->openedfiles.contains(inode)) {
 		return SAUNAFS_STATUS_OK;  // file already acquired - nothing to do
 	}
 
 	int status = fs_acquire(FsContext::getForMaster(eventloop_time()), inode,
-	                        cr->sessionid);
-	if (status == SAUNAFS_STATUS_OK) {
-		cr->openedfiles.insert(inode);
-	}
+	                        currentSession->sessionid);
+
+	if (status == SAUNAFS_STATUS_OK) { currentSession->openedfiles.insert(inode); }
+
 	return status;
 }
 
-void matoclserv_add_open_file(uint32_t sessionid, uint32_t inode) {
+/// Adds an open file to the list of open files for a given session.
+/// @param sessionId The ID of the session
+/// @param inode The inode of the open file
+/// If the session exists, the open file will be added to the list of open files of the session.
+/// Otherwise, a new session will be created and the open file will be added to the new session.
+void matoclserv_add_open_file(uint32_t sessionId, uint32_t inode) {
 	for (const auto& sessionPtr : sessionVector) {
-		if (sessionPtr->sessionid == sessionid) {
+		if (sessionPtr->sessionid == sessionId) {
 			if (!sessionPtr->openedfiles.contains(inode)) {
 				sessionPtr->openedfiles.insert(inode);
 			}
@@ -874,16 +899,19 @@ void matoclserv_add_open_file(uint32_t sessionid, uint32_t inode) {
 	// If session does not exist, create a new one
 	auto sessionPtr = std::make_unique<session>();
 	passert(sessionPtr.get());
-	sessionPtr->sessionid = sessionid;
-/* session created by filesystem - only for old clients (pre 1.5.13) */
+	sessionPtr->sessionid = sessionId;
+	/* session created by filesystem - only for old clients (pre 1.5.13) */
 	sessionPtr->disconnected = eventloop_time();
 	sessionPtr->openedfiles.insert(inode);
 	sessionVector.push_back(std::move(sessionPtr));
 }
 
-void matoclserv_remove_open_file(uint32_t sessionid, uint32_t inode) {
+/// Removes an open file from a given session.
+/// @param sessionId The IF of the session
+/// @param inode The inode of the open file
+void matoclserv_remove_open_file(uint32_t sessionId, uint32_t inode) {
 	for (const auto& sessionPtr : sessionVector) {
-		if (sessionPtr->sessionid == sessionid) {
+		if (sessionPtr->sessionid == sessionId) {
 			if (sessionPtr->openedfiles.contains(inode)) {
 				sessionPtr->openedfiles.erase(inode);
 			}
@@ -891,9 +919,10 @@ void matoclserv_remove_open_file(uint32_t sessionid, uint32_t inode) {
 		}
 	}
 
-	safs_pretty_syslog(LOG_ERR, "sessions file is corrupted");
+	safs::log_err("sessions file is corrupted");
 }
 
+/// Resets the session timeouts for all sessions.
 void matoclserv_reset_session_timeouts() {
 	uint32_t now = eventloop_time();
 
@@ -902,32 +931,41 @@ void matoclserv_reset_session_timeouts() {
 	}
 }
 
-uint8_t* matoclserv_createpacket(matoclserventry *eptr,uint32_t type,uint32_t size) {
+/// Creates a new output packet for a given session entry.
+/// @param eptr Pointer to the client connection in the master
+/// @param type The type of the packet
+/// @param size The size of the packet data
+/// @return Pointer to the start of the packet data
+uint8_t *matoclserv_createpacket(matoclserventry *eptr, uint32_t type, uint32_t size) {
 	packetstruct *outpacket;
-	uint8_t *ptr;
-	uint32_t psize;
 
-	outpacket=(packetstruct*)malloc(sizeof(packetstruct));
+	outpacket = (packetstruct *)malloc(sizeof(packetstruct));
 	passert(outpacket);
-	psize = sizeof(type) + sizeof(size) + size;
-	outpacket->packet= (uint8_t*) malloc(psize);
+
+	uint32_t packetSize = sizeof(type) + sizeof(size) + size;
+	outpacket->packet = (uint8_t *)malloc(packetSize);
 	passert(outpacket->packet);
-	outpacket->bytesleft = psize;
-	ptr = outpacket->packet;
-	put32bit(&ptr,type);
-	put32bit(&ptr,size);
-	outpacket->startptr = (uint8_t*)(outpacket->packet);
+	outpacket->bytesleft = packetSize;
+
+	uint8_t *ptr = outpacket->packet;
+	put32bit(&ptr, type);
+	put32bit(&ptr, size);
+	outpacket->startptr = (uint8_t *)(outpacket->packet);
 	outpacket->next = NULL;
 	*(eptr->outputtail) = outpacket;
 	eptr->outputtail = &(outpacket->next);
 	return ptr;
 }
 
-void matoclserv_createpacket(matoclserventry *eptr, const MessageBuffer& buffer) {
-	packetstruct *outpacket = (packetstruct*)malloc(sizeof(packetstruct));
+/// Creates a new output packet for a given session entry.
+/// @param eptr Pointer to the client connection in the master
+/// @param buffer The message buffer containing the packet data
+void matoclserv_createpacket(matoclserventry *eptr, const MessageBuffer &buffer) {
+	packetstruct *outpacket = (packetstruct *)malloc(sizeof(packetstruct));
 	passert(outpacket);
-	outpacket->packet = (uint8_t*) malloc(buffer.size());
+	outpacket->packet = (uint8_t *)malloc(buffer.size());
 	passert(outpacket->packet);
+
 	outpacket->bytesleft = buffer.size();
 	// TODO unificate output packets and remove suboptimal memory copying
 	memcpy(outpacket->packet, buffer.data(), buffer.size());
@@ -937,17 +975,25 @@ void matoclserv_createpacket(matoclserventry *eptr, const MessageBuffer& buffer)
 	eptr->outputtail = &(outpacket->next);
 }
 
+/// Checks if user/group ID remapping is required for a given client connection.
+/// @param eptr Pointer to the client connection in the master
+/// @param uid The user ID to check
+/// @return true if remapping is required, false otherwise
 static inline bool matoclserv_ugid_remap_required(matoclserventry *eptr, uint32_t uid) {
 	return uid == 0 || eptr->sesdata->sesflags & SESFLAG_MAPALL;
 }
 
-static inline void matoclserv_ugid_remap(matoclserventry *eptr,uint32_t *auid,uint32_t *agid) {
-	if (*auid==0) {
+/// Remaps user and group IDs for a given client connection.
+/// @param eptr Pointer to the client connection in the master
+/// @param auid Pointer to the user ID to remap
+/// @param agid Pointer to the group ID to remap
+static inline void matoclserv_ugid_remap(matoclserventry *eptr, uint32_t *auid, uint32_t *agid) {
+	if (*auid == 0) {
 		*auid = eptr->sesdata->rootuid;
 		if (agid) {
 			*agid = eptr->sesdata->rootgid;
 		}
-	} else if (eptr->sesdata->sesflags&SESFLAG_MAPALL) {
+	} else if (eptr->sesdata->sesflags & SESFLAG_MAPALL) {
 		*auid = eptr->sesdata->mapalluid;
 		if (agid) {
 			*agid = eptr->sesdata->mapallgid;
@@ -955,6 +1001,10 @@ static inline void matoclserv_ugid_remap(matoclserventry *eptr,uint32_t *auid,ui
 	}
 }
 
+/// Checks whether a given group ID is registered in the session cache.
+/// @param eptr Pointer to the client connection in the master
+/// @param gid The group ID to check
+/// @return SAUNAFS_STATUS_OK if the group is registered, SAUNAFS_ERROR_GROUPNOTREGISTERED otherwise
 static inline uint8_t matoclserv_check_group_cache(matoclserventry *eptr, uint32_t gid) {
 	if (!user_groups::isGroupCacheId(gid)) {
 		return SAUNAFS_STATUS_OK;
@@ -962,20 +1012,23 @@ static inline uint8_t matoclserv_check_group_cache(matoclserventry *eptr, uint32
 
 	assert(eptr && eptr->sesdata);
 	auto it = eptr->sesdata->group_cache.find(user_groups::decodeGroupCacheId(gid));
-	return it == eptr->sesdata->group_cache.end() ? SAUNAFS_ERROR_GROUPNOTREGISTERED : SAUNAFS_STATUS_OK;
+	return (it == eptr->sesdata->group_cache.end()) ? SAUNAFS_ERROR_GROUPNOTREGISTERED
+	                                                : SAUNAFS_STATUS_OK;
 }
 
-/**
- * Returns FsContext with session data but without uid/gid data
- */
+/// Returns FsContext without information about sessions like user ID or group ID
+/// @param eptr Pointer to the client connection in the master
+/// @return FsContext with session data
 static inline FsContext matoclserv_get_context(matoclserventry *eptr) {
 	assert(eptr && eptr->sesdata);
-	return FsContext::getForMaster(eventloop_time(), eptr->sesdata->rootinode, eptr->sesdata->sesflags);
+	return FsContext::getForMaster(eventloop_time(), eptr->sesdata->rootinode,
+	                               eptr->sesdata->sesflags);
 }
 
-/**
- * Returns FsContext with session data and uid/gid data
- */
+/// Returns FsContext with information about sessions like user ID and group ID
+/// @param eptr Pointer to the client connection in the master
+/// @param uid The user ID to use in the context
+/// @param gid The group ID to use in the context
 static inline FsContext matoclserv_get_context(matoclserventry *eptr, uint32_t uid, uint32_t gid) {
 	assert(eptr && eptr->sesdata);
 
@@ -1006,17 +1059,21 @@ static inline FsContext matoclserv_get_context(matoclserventry *eptr, uint32_t u
 		uint32_t auid = uid;
 		matoclserv_ugid_remap(eptr, &uid, nullptr);
 
-		return FsContext::getForMasterWithSession(eventloop_time(),
-			eptr->sesdata->rootinode, eptr->sesdata->sesflags, uid, std::move(gids), auid, it->second[0]);
+		return FsContext::getForMasterWithSession(eventloop_time(), eptr->sesdata->rootinode,
+		                                          eptr->sesdata->sesflags, uid, std::move(gids),
+		                                          auid, it->second[0]);
 	}
 
 	uint32_t auid = uid;
 	uint32_t agid = gid;
 	matoclserv_ugid_remap(eptr, &uid, &gid);
-	return FsContext::getForMasterWithSession(eventloop_time(),
-			eptr->sesdata->rootinode, eptr->sesdata->sesflags, uid, gid, auid, agid);
+	return FsContext::getForMasterWithSession(eventloop_time(), eptr->sesdata->rootinode,
+	                                          eptr->sesdata->sesflags, uid, gid, auid, agid);
 }
 
+/// Extracts network addresses of standard chunk copies from a list of all chunk copies.
+/// @param allCopies List of all chunk copies with their addresses
+/// @param standardCopies Output vector to store the addresses of standard chunk copies
 static void getStandardChunkCopies(const std::vector<ChunkTypeWithAddress>& allCopies,
 		std::vector<NetworkAddress>& standardCopies) {
 	sassert(standardCopies.empty());
@@ -1027,19 +1084,32 @@ static void getStandardChunkCopies(const std::vector<ChunkTypeWithAddress>& allC
 	}
 }
 
-static void remove_unsupported_ec_parts(uint32_t client_version, std::vector<ChunkTypeWithAddress> &chunk_list) {
-	auto it = std::remove_if(chunk_list.begin(), chunk_list.end(),
-	     [client_version](const ChunkTypeWithAddress &entry) {
+/// Removes unsupported EC parts from a given list of chunk parts.
+/// @param version The client version
+/// @param chunksList The list of chunk parts to filter
+static void remove_unsupported_ec_parts(uint32_t version,
+                                        std::vector<ChunkTypeWithAddress> &chunksList) {
+	auto it = std::remove_if(chunksList.begin(), chunksList.end(),
+	     [version](const ChunkTypeWithAddress &entry) {
 		return slice_traits::isEC(entry.chunk_type) &&
 		       slice_traits::ec::isEC2Part(entry.chunk_type) &&
-		       (client_version < kEC2Version || entry.chunkserver_version < kEC2Version);
+		       (version < kEC2Version || entry.chunkserver_version < kEC2Version);
 	});
-	chunk_list.erase(it, chunk_list.end());
+	chunksList.erase(it, chunksList.end());
 }
 
+/// Responds to a FUSE write chunk request.
+/// @param eptr Pointer to the client connection in the master
+/// @param serializer The packet serializer to use
+/// @param chunkId The ID of the chunk being written
+/// @param messageId The ID of the message
+/// @param fileLength The length of the file being written
+/// @param lockId The lock ID for the chunk
+/// @return SAUNAFS_STATUS_OK on success, or an error code otherwise
 uint8_t matoclserv_fuse_write_chunk_respond(matoclserventry *eptr,
-		const PacketSerializer* serializer, uint64_t chunkId, uint32_t messageId,
-		uint64_t fileLength, uint32_t lockId) {
+                                            const PacketSerializer *serializer, uint64_t chunkId,
+                                            uint32_t messageId, uint64_t fileLength,
+                                            uint32_t lockId) {
 	uint32_t chunkVersion;
 	std::vector<ChunkTypeWithAddress> allChunkCopies;
 	uint8_t status = chunk_getversionandlocations(chunkId, eptr->peerip, chunkVersion,
@@ -1051,7 +1121,10 @@ uint8_t matoclserv_fuse_write_chunk_respond(matoclserventry *eptr,
 	if (status == SAUNAFS_STATUS_OK && !serializer->isSaunaFsPacketSerializer()) {
 		for (const ChunkTypeWithAddress& chunkCopy : allChunkCopies) {
 			if (!slice_traits::isStandard(chunkCopy.chunk_type)) {
-				safs::log_err("matoclserv_fuse_write_chunk_respond: client tried to modify standard copy of a xor chunk, chunkID {}", chunkId);
+				safs::log_err(
+				    "matoclserv_fuse_write_chunk_respond: client tried to modify "
+				    "standard copy of a xor chunk, chunkID {}",
+				    chunkId);
 				status = SAUNAFS_ERROR_NOCHUNK;
 				break;
 			}
@@ -1065,19 +1138,20 @@ uint8_t matoclserv_fuse_write_chunk_respond(matoclserventry *eptr,
 	} else {
 		serializer->serializeFuseWriteChunk(outMessage, messageId, status);
 	}
+
 	matoclserv_createpacket(eptr, outMessage);
 	return status;
 }
 
-void matoclserv_chunk_status(uint64_t chunkid,uint8_t status) {
+void matoclserv_chunk_status(uint64_t chunkId, uint8_t status) {
 	chunkDelayedOperation *operation;
 	const PacketSerializer *serializer;
 
 	matoclserventry *eptr = NULL;
-	uint32_t lockid = 0;
-	uint32_t qid = 0;
-	uint64_t fleng = 0;
-	uint8_t type = 0;
+	uint32_t lockId = 0;
+	uint32_t messageId = 0;
+	uint64_t fileLength = 0;
+	uint8_t operationType = 0;
 	uint32_t inode = 0;
 	uint32_t uid = 0;
 	uint32_t gid = 0;
@@ -1092,12 +1166,12 @@ void matoclserv_chunk_status(uint64_t chunkid,uint8_t status) {
 			auto chunkOpsIterator = eaptr->chunkdelayedops.begin();
 			while (chunkOpsIterator != eaptr->chunkdelayedops.end() && eptr == NULL) {
 				operation = chunkOpsIterator->get();
-				if (operation->chunkid == chunkid) {
+				if (operation->chunkid == chunkId) {
 					eptr = eaptr;
-					qid = operation->qid;
-					fleng = operation->fleng;
-					lockid = operation->lockid;
-					type = operation->type;
+					messageId = operation->qid;
+					fileLength = operation->fleng;
+					lockId = operation->lockid;
+					operationType = operation->type;
 					inode = operation->inode;
 					uid = operation->uid;
 					gid = operation->gid;
@@ -1117,44 +1191,42 @@ void matoclserv_chunk_status(uint64_t chunkid,uint8_t status) {
 		safs_pretty_syslog(LOG_WARNING,"got chunk status, but don't want it");
 		return;
 	}
-	if (status==SAUNAFS_STATUS_OK) {
-		dcm_modify(inode,eptr->sesdata->sessionid);
-	}
+	if (status == SAUNAFS_STATUS_OK) { dcm_modify(inode, eptr->sesdata->sessionid); }
 
 	std::vector<uint8_t> reply;
-	FsContext context = FsContext::getForMasterWithSession(eventloop_time(), eptr->sesdata->rootinode,
-	                                             eptr->sesdata->sesflags, uid, gid, auid, agid);
+	FsContext context = FsContext::getForMasterWithSession(
+	    eventloop_time(), eptr->sesdata->rootinode, eptr->sesdata->sesflags, uid, gid, auid, agid);
 
-	switch (type) {
+	switch (operationType) {
 	case FUSE_WRITE:
 		if (status != SAUNAFS_STATUS_OK) {
-			serializer->serializeFuseWriteChunk(reply, qid, status);
+			serializer->serializeFuseWriteChunk(reply, messageId, status);
 			matoclserv_createpacket(eptr, std::move(reply));
 		} else {
 			status = matoclserv_fuse_write_chunk_respond(eptr, serializer,
-					chunkid, qid, fleng, lockid);
+					chunkId, messageId, fileLength, lockId);
 		}
 		if (status != SAUNAFS_STATUS_OK) {
-			fs_writeend(0, 0, chunkid, 0); // ignore status - just do it.
+			fs_writeend(0, 0, chunkId, 0); // ignore status - just do it.
 		}
 		return;
 	case FUSE_TRUNCATE_BEGIN:
 		if (status != SAUNAFS_STATUS_OK) {
-			matocl::fuseTruncate::serialize(reply, qid, status);
+			matocl::fuseTruncate::serialize(reply, messageId, status);
 		} else {
-			matocl::fuseTruncate::serialize(reply, qid, fleng, lockid);
+			matocl::fuseTruncate::serialize(reply, messageId, fileLength, lockId);
 		}
 		matoclserv_createpacket(eptr, std::move(reply));
 		return;
 	case FUSE_TRUNCATE:
 	case FUSE_TRUNCATE_END:
-		fs_end_setlength(chunkid);
+		fs_end_setlength(chunkId);
 		if (status != SAUNAFS_STATUS_OK) {
-			serializer->serializeFuseTruncate(reply, type, qid, status);
+			serializer->serializeFuseTruncate(reply, operationType, messageId, status);
 		} else {
 			Attributes attr;
-			fs_do_setlength(context, inode, fleng, attr);
-			serializer->serializeFuseTruncate(reply, type, qid, attr);
+			fs_do_setlength(context, inode, fileLength, attr);
+			serializer->serializeFuseTruncate(reply, operationType, messageId, attr);
 		}
 		matoclserv_createpacket(eptr, std::move(reply));
 		return;
@@ -1163,9 +1235,13 @@ void matoclserv_chunk_status(uint64_t chunkid,uint8_t status) {
 	}
 }
 
+/// Handles the CLTOMA_CSERV_LIST command, which lists all chunkservers.
+/// @param eptr Pointer to the client connection in the master
+/// @param data Pointer to the data received from the client
+/// @param length The length of the data received
 void matoclserv_cserv_list(matoclserventry *eptr, const uint8_t */*data*/, uint32_t length) {
-	if (length!=0) {
-		safs_pretty_syslog(LOG_NOTICE,"CLTOMA_CSERV_LIST - wrong size (%" PRIu32 "/0)",length);
+	if (length != 0) {
+		safs::log_info("CLTOMA_CSERV_LIST - wrong size ({}/0)",length);
 		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
@@ -1196,6 +1272,11 @@ void matoclserv_cserv_list(matoclserventry *eptr, const uint8_t */*data*/, uint3
 	}
 }
 
+/// Handles the SAU_CLTOMA_CSERV_LIST command.
+/// @param eptr Pointer to the client connection in the master
+/// @param data Pointer to the data received from the client
+/// @param length The length of the data received
+/// This function serializes the list of chunkservers and sends it back to the client.
 void matoclserv_sau_cserv_list(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	MessageBuffer buffer;
 	PacketVersion version;
@@ -1205,27 +1286,32 @@ void matoclserv_sau_cserv_list(matoclserventry *eptr, const uint8_t *data, uint3
 	if (version == cltoma::cservList::kStandard) {
 		matocl::cservList::serialize(buffer, csdb_chunkserver_list());
 	} else if (version == cltoma::cservList::kWithMessageId) {
-		uint32_t message_id;
-		cltoma::cservList::deserialize(data, length, message_id, dummy);
-		matocl::cservList::serialize(buffer, message_id, csdb_chunkserver_list());
+		uint32_t messageId = 0;
+		cltoma::cservList::deserialize(data, length, messageId, dummy);
+		matocl::cservList::serialize(buffer, messageId, csdb_chunkserver_list());
 	} else {
-		safs_pretty_syslog(LOG_NOTICE,"SAU_CSERV_LIST - wrong packet version %u", version);
+		safs::log_info("SAU_CSERV_LIST - wrong packet version {}", version);
 		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
+
 	matoclserv_createpacket(eptr, std::move(buffer));
 }
 
-void matoclserv_cserv_removeserv(matoclserventry *eptr,const uint8_t *data,uint32_t length) {
+/// Handles the CLTOMA_CSSERV_REMOVESERV command, which removes a chunkserver.
+/// @param eptr Pointer to the client connection in the master
+/// @param data Pointer to the data received from the client
+/// @param length The length of the data received
+/// This function extracts the IP address and port of the chunkserver that will be removed
+/// from the database.
+void matoclserv_cserv_removeserv(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	uint32_t ip;
 	uint16_t port;
 
 	constexpr uint32_t kExpectedSize = sizeof(ip) + sizeof(port);
 
 	if (length != kExpectedSize) {
-		safs_pretty_syslog(LOG_NOTICE,
-		                   "CLTOMA_CSSERV_REMOVESERV - wrong size (%" PRIu32 "/%" PRIu32 ")",
-		                   length, kExpectedSize);
+		safs::log_info("CLTOMA_CSSERV_REMOVESERV - wrong size ({}/{})", length, kExpectedSize);
 		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
@@ -1233,11 +1319,16 @@ void matoclserv_cserv_removeserv(matoclserventry *eptr,const uint8_t *data,uint3
 	get32bit(&data, ip);
 	port = get16bit(&data);
 
-	csdb_remove_server(ip,port);
+	csdb_remove_server(ip, port);
 
 	matoclserv_createpacket(eptr, MATOCL_CSSERV_REMOVESERV, 0);
 }
 
+/// Handles the SAU_CLTOMA_IOLIMITS_STATUS command, which retrieves the I/O limits status.
+/// @param eptr Pointer to the client connection in the master
+/// @param data Pointer to the data received from the client
+/// @param length The length of the data received
+/// This function retrieves the I/O limits configuration and serializes it into a response packet.
 void matoclserv_iolimits_status(matoclserventry* eptr, const uint8_t* data, uint32_t length) {
 	uint32_t messageId;
 	cltoma::iolimitsStatus::deserialize(data, length, messageId);
@@ -1250,57 +1341,83 @@ void matoclserv_iolimits_status(matoclserventry* eptr, const uint8_t* data, uint
 			gIoLimitsAccumulate_ms,
 			gIoLimitsSubsystem,
 			gIoLimitsDatabase.getGroupsAndLimits());
+
 	matoclserv_createpacket(eptr, std::move(buffer));
 }
 
+/// Handles the SAU_CLTOMA_METADATASERVER_STATUS command, which retrieves the metadata server status.
+/// @param eptr Pointer to the client connection in the master
+/// @param data Pointer to the data received from the client
+/// @param length The length of the data received
 void matoclserv_metadataserver_status(matoclserventry* eptr, const uint8_t* data, uint32_t length) {
-	uint32_t messageId;
+	uint32_t messageId = 0;
 	cltoma::metadataserverStatus::deserialize(data, length, messageId);
 
 	uint64_t metadataVersion = 0;
 	try {
 		metadataVersion = fs_getversion();
-	} catch (NoMetadataException&) {}
-	uint8_t status = metadataserver::isMaster()
-		? SAU_METADATASERVER_STATUS_MASTER
-		: (masterconn_is_connected()
-			 ? SAU_METADATASERVER_STATUS_SHADOW_CONNECTED
-			 : SAU_METADATASERVER_STATUS_SHADOW_DISCONNECTED);
+	} catch (NoMetadataException &) {}
+
+	uint8_t status =
+	    metadataserver::isMaster()
+	        ? SAU_METADATASERVER_STATUS_MASTER
+	        : (masterconn_is_connected() ? SAU_METADATASERVER_STATUS_SHADOW_CONNECTED
+	                                     : SAU_METADATASERVER_STATUS_SHADOW_DISCONNECTED);
 
 	MessageBuffer buffer;
-	matocl::metadataserverStatus::serialize(buffer,
-			messageId,
-			status,
-			metadataVersion);
+	matocl::metadataserverStatus::serialize(buffer, messageId, status, metadataVersion);
 	matoclserv_createpacket(eptr, std::move(buffer));
 }
 
+/// Handles the SAU_CLTOMA_LIST_GOALS command, which lists all goals defined in the system.
+/// @param eptr Pointer to the client connection in the master
+///
+/// This function retrieves the goal definitions from the filesystem and serializes them into a
+/// response packet.
 void matoclserv_list_goals(matoclserventry* eptr) {
-	std::vector<SerializedGoal> serialized_goals;
-	const std::map<int, Goal>& goal_map = fs_get_goal_definitions();
-	for (const auto& goal : goal_map) {
-		serialized_goals.emplace_back(goal.first, goal.second.getName(), to_string(goal.second));
+	std::vector<SerializedGoal> serializedGoals;
+	const std::map<int, Goal>& goalsMap = fs_get_goal_definitions();
+
+	for (const auto& goal : goalsMap) {
+		serializedGoals.emplace_back(goal.first, goal.second.getName(), to_string(goal.second));
 	}
-	matoclserv_createpacket(eptr, matocl::listGoals::build(serialized_goals));
+
+	matoclserv_createpacket(eptr, matocl::listGoals::build(serializedGoals));
 }
 
+/// Handles the SAU_CLTOMA_CHUNKS_HEALTH command, which retrieves the health status of chunks.
+/// @param eptr Pointer to the client connection in the master
+/// @param data Pointer to the data received from the client
+/// @param length The length of the data received
+///
+/// This function deserializes the request data to determine if only regular chunks should be
+/// considered for health checks, and then builds a response message containing the health status
+/// of the chunks, including their availability and replication states.
 void matoclserv_chunks_health(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	bool regularChunksOnly;
 	cltoma::chunksHealth::deserialize(data, length, regularChunksOnly);
 	auto message = matocl::chunksHealth::build(regularChunksOnly,
 			chunk_get_availability_state(),
 			chunk_get_replication_state());
+
 	matoclserv_createpacket(eptr, std::move(message));
 }
 
-void matoclserv_session_list(matoclserventry *eptr,const uint8_t *data,uint32_t length) {
-	uint32_t ileng;
-	uint32_t pleng;
+/// Handles the CLTOMA_SESSION_LIST command, which lists all active sessions.
+/// @param eptr Pointer to the client connection in the master
+/// @param data Pointer to the data received from the client
+/// @param length The length of the data received
+///
+/// This function retrieves the session information for all active sessions and serializes it into
+/// a response packet. The response includes session statistics, user and group IDs, and other
+/// session-related data.
+void matoclserv_session_list(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
+	uint32_t sessionInfoLength;
+	uint32_t pathLength;
 	uint8_t vmode;
 
 	if (length != 0 && length != sizeof(vmode)) {
-		safs_pretty_syslog(LOG_NOTICE, "CLTOMA_SESSION_LIST - wrong size (%" PRIu32 "/(0|%lu))",
-		                   length, sizeof(vmode));
+		safs::log_info("CLTOMA_SESSION_LIST - wrong size ({}/(0|{}))", length, sizeof(vmode));
 		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
@@ -1320,7 +1437,7 @@ void matoclserv_session_list(matoclserventry *eptr,const uint8_t *data,uint32_t 
 
 	constexpr uint32_t kCommonSessionSize =
 	    sizeof(session::sessionid) + sizeof(matoclserventry::peerip) +
-	    sizeof(matoclserventry::version) + sizeof(ileng) + sizeof(session::sesflags) +
+	    sizeof(matoclserventry::version) + sizeof(sessionInfoLength) + sizeof(session::sesflags) +
 	    sizeof(session::rootuid) + sizeof(session::rootgid) + sizeof(session::mapalluid) +
 	    sizeof(session::mapallgid);
 
@@ -1340,7 +1457,7 @@ void matoclserv_session_list(matoclserventry *eptr,const uint8_t *data,uint32_t 
 				size += sizeof(session::rootinode);
 				size += 1;  // for '.'
 			} else {
-				size += sizeof(pleng);
+				size += sizeof(pathLength);
 				size += fs_getdirpath_size(eaptr->sesdata->rootinode);
 			}
 		}
@@ -1358,10 +1475,10 @@ void matoclserv_session_list(matoclserventry *eptr,const uint8_t *data,uint32_t 
 			put32bit(&ptr, eaptr->version);
 
 			if (!eaptr->sesdata->info.empty()) {
-				ileng = eaptr->sesdata->info.size();
-				put32bit(&ptr, ileng);
-				memcpy(ptr, eaptr->sesdata->info.data(), ileng);
-				ptr += ileng;
+				sessionInfoLength = eaptr->sesdata->info.size();
+				put32bit(&ptr, sessionInfoLength);
+				memcpy(ptr, eaptr->sesdata->info.data(), sessionInfoLength);
+				ptr += sessionInfoLength;
 			} else {
 				put32bit(&ptr, 0);
 			}
@@ -1370,11 +1487,11 @@ void matoclserv_session_list(matoclserventry *eptr,const uint8_t *data,uint32_t 
 				putINode(&ptr, static_cast<inode_t>(1));
 				put8bit(&ptr, '.');
 			} else {
-				pleng = fs_getdirpath_size(eaptr->sesdata->rootinode);
-				put32bit(&ptr, pleng);
-				if (pleng > 0) {
-					fs_getdirpath_data(eaptr->sesdata->rootinode, ptr, pleng);
-					ptr += pleng;
+				pathLength = fs_getdirpath_size(eaptr->sesdata->rootinode);
+				put32bit(&ptr, pathLength);
+				if (pathLength > 0) {
+					fs_getdirpath_data(eaptr->sesdata->rootinode, ptr, pathLength);
+					ptr += pathLength;
 				}
 			}
 
@@ -1407,6 +1524,14 @@ void matoclserv_session_list(matoclserventry *eptr,const uint8_t *data,uint32_t 
 	}
 }
 
+/// Handles the SAU_CLTOMA_MOUNT_INFO_LIST command, which retrieves the list of mount information
+/// for all active sessions.
+/// @param eptr Pointer to the client connection in the master
+/// @param data Pointer to the data received from the client
+/// @param length The length of the data received
+///
+/// This function serializes the mount information for each active session and sends it back to the
+/// client. Each entry in the list contains the session ID and the mount information.
 void matoclserv_mount_info_list(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	std::vector<MountInfoEntry> mountInfoList;
 
@@ -1425,62 +1550,77 @@ void matoclserv_mount_info_list(matoclserventry *eptr, const uint8_t *data, uint
 	matoclserv_createpacket(eptr, matocl::mountInfoList::build(mountInfoList));
 }
 
-void matoclserv_chart(matoclserventry *eptr,const uint8_t *data,uint32_t length) {
-	uint32_t chartid;
+/// Handles the CLTOAN_CHART command, which generates a chart based on the provided chart ID.
+/// @param eptr Pointer to the client connection in the master
+/// @param data Pointer to the data received from the client
+/// @param length The length of the data received
+///
+/// This function retrieves the chart data based on the chart ID and sends it back to the client
+/// as a PNG or CSV file, depending on the chart ID.
+void matoclserv_chart(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
+	uint32_t chartId = 0;
 	uint8_t *ptr;
-	uint32_t l;
+	uint32_t chartLength;
 
-	if (length != sizeof(chartid)) {
-		safs_pretty_syslog(LOG_NOTICE, "CLTOAN_CHART - wrong size (%" PRIu32 "/%lu)", length,
-		                   sizeof(chartid));
+	if (length != sizeof(chartId)) {
+		safs::log_info("CLTOAN_CHART - wrong size ({}/{})", length, sizeof(chartId));
 		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
-	get32bit(&data, chartid);
+	get32bit(&data, chartId);
 
-	if(chartid <= CHARTS_CSV_CHARTID_BASE){
-		l = charts_make_png(chartid);
-		ptr = matoclserv_createpacket(eptr, ANTOCL_CHART, l);
-		if (l>0) {
-			charts_get_png(ptr);
-		}
+	if (chartId <= CHARTS_CSV_CHARTID_BASE) {
+		chartLength = charts_make_png(chartId);
+		ptr = matoclserv_createpacket(eptr, ANTOCL_CHART, chartLength);
+		if (chartLength > 0) { charts_get_png(ptr); }
 	} else {
-		l = charts_make_csv(chartid % CHARTS_CSV_CHARTID_BASE);
-		ptr = matoclserv_createpacket(eptr, ANTOCL_CHART, l);
-		if (l>0) {
-			charts_get_csv(ptr);
-		}
+		chartLength = charts_make_csv(chartId % CHARTS_CSV_CHARTID_BASE);
+		ptr = matoclserv_createpacket(eptr, ANTOCL_CHART, chartLength);
+		if (chartLength > 0) { charts_get_csv(ptr); }
 	}
 }
 
-void matoclserv_chart_data(matoclserventry *eptr,const uint8_t *data,uint32_t length) {
-	uint32_t chartid;
+/// Handles the CLTOAN_CHART_DATA command, which retrieves data for a specific chart.
+/// @param eptr Pointer to the client connection in the master
+/// @param data Pointer to the data received from the client
+/// @param length The length of the data received
+///
+/// This function retrieves the data for the specified chart ID and sends it back to the client.
+void matoclserv_chart_data(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
+	uint32_t chartId = 0;
 	uint8_t *ptr;
-	uint32_t l;
+	uint32_t chartsDataLength;
 
-	if (length != sizeof(chartid)) {
-		safs_pretty_syslog(LOG_NOTICE, "CLTOAN_CHART_DATA - wrong size (%" PRIu32 "/%lu)", length,
-		                   sizeof(chartid));
+	if (length != sizeof(chartId)) {
+		safs::log_info("CLTOAN_CHART_DATA - wrong size ({}/{})", length, sizeof(chartId));
 		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
-	get32bit(&data, chartid);
+	get32bit(&data, chartId);
 
-	l = charts_datasize(chartid);
+	chartsDataLength = charts_datasize(chartId);
 
-	ptr = matoclserv_createpacket(eptr, ANTOCL_CHART_DATA, l);
+	ptr = matoclserv_createpacket(eptr, ANTOCL_CHART_DATA, chartsDataLength);
 
-	if (l > 0) { charts_makedata(ptr, chartid); }
+	if (chartsDataLength > 0) { charts_makedata(ptr, chartId); }
 }
 
-void matoclserv_info(matoclserventry *eptr,const uint8_t *data,uint32_t length) {
+/// Handles the CLTOMA_INFO command, which retrieves information about the SaunaFS system.
+/// @param eptr Pointer to the client connection in the master
+/// @param data Pointer to the data received from the client
+/// @param length The length of the data received
+///
+/// This function gathers various statistics about the SaunaFS system, including total space,
+/// available space, trash space, reserved space, and memory usage. It then serializes this
+/// information into a response packet and sends it back to the client.
+void matoclserv_info(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	SaunaFsStatistics statistics;
 	(void)data;
 
 	if (length != 0) {
-		safs_pretty_syslog(LOG_NOTICE,"CLTOMA_INFO - wrong size (%" PRIu32 "/0)",length);
+		safs::log_info("CLTOMA_INFO - wrong size ({}/0)", length);
 		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
@@ -1503,28 +1643,42 @@ void matoclserv_info(matoclserventry *eptr,const uint8_t *data,uint32_t length) 
 	matoclserv_createpacket(eptr, response);
 }
 
-void matoclserv_fstest_info(matoclserventry *eptr,const uint8_t *data,uint32_t length) {
-	uint32_t loopstart,loopend,chunks,ugchunks,mchunks;
-	inode_t files,ugfiles,mfiles;
+/// Handles the CLTOMA_FSTEST_INFO command, which retrieves filesystem test information.
+/// @param eptr Pointer to the client connection in the master
+/// @param data Pointer to the data received from the client
+/// @param length The length of the data received
+///
+/// This function gathers various statistics about the filesystem, including loop start and end,
+/// number of files, chunks, and user/group files. It then serializes this information into a
+/// response packet and sends it back to the client.
+void matoclserv_fstest_info(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
+	uint32_t loopStart;
+	uint32_t loopEnd;
+	uint32_t chunks;
+	uint32_t ugchunks;
+	uint32_t mchunks;
+	inode_t files;
+	inode_t ugfiles;
+	inode_t mfiles;
 	uint8_t *ptr;
 	(void)data;
 
 	if (length != 0) {
-		safs_pretty_syslog(LOG_NOTICE, "CLTOMA_FSTEST_INFO - wrong size (%" PRIu32 "/0)", length);
+		safs::log_info("CLTOMA_FSTEST_INFO - wrong size ({}/0)", length);
 		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
 	std::string report;
-	fs_test_getdata(loopstart, loopend, files, ugfiles, mfiles, chunks, ugchunks, mchunks, report);
+	fs_test_getdata(loopStart, loopEnd, files, ugfiles, mfiles, chunks, ugchunks, mchunks, report);
 
-	constexpr uint32_t kPacketExtraSize = sizeof(loopstart) + sizeof(loopend) + sizeof(files) +
+	constexpr uint32_t kPacketExtraSize = sizeof(loopStart) + sizeof(loopEnd) + sizeof(files) +
 	                                      sizeof(ugfiles) + sizeof(mfiles) + sizeof(chunks) +
 	                                      sizeof(ugchunks) + sizeof(mchunks) + sizeof(uint32_t);
 	ptr = matoclserv_createpacket(eptr, MATOCL_FSTEST_INFO, report.size() + kPacketExtraSize);
 
-	put32bit(&ptr, loopstart);
-	put32bit(&ptr, loopend);
+	put32bit(&ptr, loopStart);
+	put32bit(&ptr, loopEnd);
 	putINode(&ptr, files);
 	putINode(&ptr, ugfiles);
 	putINode(&ptr, mfiles);
@@ -1536,13 +1690,17 @@ void matoclserv_fstest_info(matoclserventry *eptr,const uint8_t *data,uint32_t l
 	if (!report.empty()) { memcpy(ptr, report.c_str(), report.size()); }
 }
 
+/// Handles the CLTOMA_CHUNKSTEST_INFO command, which retrieves the serialized size of the
+/// information related to the process of testing chunks.
+/// @param eptr Pointer to the client connection in the master
+/// @param data Pointer to the data received from the client
+/// @param length The length of the data received
 void matoclserv_chunkstest_info(matoclserventry *eptr,const uint8_t *data,uint32_t length) {
 	uint8_t *ptr;
 	(void)data;
 
 	if (length != 0) {
-		safs_pretty_syslog(LOG_NOTICE, "CLTOMA_CHUNKSTEST_INFO - wrong size (%" PRIu32 "/0)",
-		                   length);
+		safs::log_info("CLTOMA_CHUNKSTEST_INFO - wrong size ({}/0)", length);
 		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
@@ -1553,27 +1711,27 @@ void matoclserv_chunkstest_info(matoclserventry *eptr,const uint8_t *data,uint32
 	chunk_store_info(ptr);
 }
 
-void matoclserv_chunks_matrix(matoclserventry *eptr,const uint8_t *data,uint32_t length) {
+void matoclserv_chunks_matrix(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	uint8_t *ptr;
-	uint8_t matrixid;
+	uint8_t matrixId;
 	(void)data;
 
-	if (length > sizeof(matrixid)) {
-		safs_pretty_syslog(LOG_NOTICE, "CLTOMA_CHUNKS_MATRIX - wrong size (%" PRIu32 "/0|%zu)",
-		                   length, sizeof(matrixid));
+	if (length > sizeof(matrixId)) {
+		safs::log_info("CLTOMA_CHUNKS_MATRIX - wrong size ({}/0|{})", length, sizeof(matrixId));
 		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
 	if (length == 1) {
-		matrixid = get8bit(&data);
+		matrixId = get8bit(&data);
 	} else {
-		matrixid = 0;
+		matrixId = 0;
 	}
 
 	ptr = matoclserv_createpacket(eptr, MATOCL_CHUNKS_MATRIX,
 	                              CHUNK_MATRIX_SIZE * CHUNK_MATRIX_SIZE * sizeof(uint32_t));
-	chunk_store_chunkcounters(ptr, matrixid);
+
+	chunk_store_chunkcounters(ptr, matrixId);
 }
 
 void matoclserv_exports_info(matoclserventry *eptr,const uint8_t *data,uint32_t length) {
@@ -1581,8 +1739,7 @@ void matoclserv_exports_info(matoclserventry *eptr,const uint8_t *data,uint32_t 
 	uint8_t vmode;
 
 	if (length != 0 && length != sizeof(vmode)) {
-		safs_pretty_syslog(LOG_NOTICE, "CLTOMA_EXPORTS_INFO - wrong size (%" PRIu32 "/0|%zu)",
-		                   length, sizeof(vmode));
+		safs::log_info("CLTOMA_EXPORTS_INFO - wrong size ({}/0|{})", length, sizeof(vmode));
 		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
@@ -1597,12 +1754,12 @@ void matoclserv_exports_info(matoclserventry *eptr,const uint8_t *data,uint32_t 
 	exports_info_data(vmode, ptr);
 }
 
-void matoclserv_mlog_list(matoclserventry *eptr,const uint8_t *data,uint32_t length) {
+void matoclserv_mlog_list(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	uint8_t *ptr;
 	(void)data;
 
 	if (length != 0) {
-		safs_pretty_syslog(LOG_NOTICE, "CLTOMA_MLOG_LIST - wrong size (%" PRIu32 "/0)", length);
+		safs::log_info("CLTOMA_MLOG_LIST - wrong size ({}/0)", length);
 		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
@@ -1633,16 +1790,16 @@ static void matoclserv_broadcast_iolimits_cfg() {
 	}
 }
 
-void matoclserv_ping(matoclserventry *eptr,const uint8_t *data,uint32_t length) {
+void matoclserv_ping(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	uint32_t size;
 	deserializeAllLegacyPacketDataNoHeader(data, length, size);
 	matoclserv_createpacket(eptr, ANTOAN_PING_REPLY, size);
 }
 
-void matoclserv_fuse_register(matoclserventry *eptr,const uint8_t *data,uint32_t length) {
+void matoclserv_fuse_register(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	const uint8_t *rptr;
 	uint8_t *wptr;
-	uint32_t sessionid;
+	uint32_t sessionId;
 	uint8_t status;
 
 	constexpr uint32_t kBlobSize = REGISTER_BLOB_SIZE;
@@ -1655,9 +1812,7 @@ void matoclserv_fuse_register(matoclserventry *eptr,const uint8_t *data,uint32_t
 	}
 
 	if (length < kBlobSize) {
-		safs_pretty_syslog(LOG_NOTICE,
-		                   "CLTOMA_FUSE_REGISTER - wrong size (%" PRIu32 "/<%" PRIu32 ")", length,
-		                   kBlobSize);
+		safs::log_info("CLTOMA_FUSE_REGISTER - wrong size ({}/<{})", length, kBlobSize);
 		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
@@ -1669,25 +1824,21 @@ void matoclserv_fuse_register(matoclserventry *eptr,const uint8_t *data,uint32_t
 	// Unregistered no ACL clients and tools
 	if (eptr->registered == ClientState::kUnregistered && (clientsNoACL || toolsNoACL)) {
 		if (RejectOld) {
-			safs_pretty_syslog(LOG_NOTICE,"CLTOMA_FUSE_REGISTER/NOACL - rejected (option REJECT_OLD_CLIENTS is set)");
+			safs::log_info("CLTOMA_FUSE_REGISTER/NOACL - rejected (option REJECT_OLD_CLIENTS is set)");
 			eptr->mode = ClientConnectionMode::KILL;
 			return;
 		}
 		if (toolsNoACL) {
 			if (length != kBlobSize && length != kBlobSizeWithVersion) {
-				safs_pretty_syslog(LOG_NOTICE,
-				                   "CLTOMA_FUSE_REGISTER/NOACL-TOOLS - wrong size (%" PRIu32
-				                   "/%" PRIu32 "|%" PRIu32 ")",
-				                   length, kBlobSize, kBlobSizeWithVersion);
+				safs::log_info("CLTOMA_FUSE_REGISTER/NOACL-TOOLS - wrong size ({}/{}|{})", length,
+				               kBlobSize, kBlobSizeWithVersion);
 				eptr->mode = ClientConnectionMode::KILL;
 				return;
 			}
 		} else {  // clientsNoACL
 			if (length != kBlobSizeWithVersion && length != kBlobSizeWithSessionIdAndVersion) {
-				safs_pretty_syslog(LOG_NOTICE,
-				                   "CLTOMA_FUSE_REGISTER/NOACL-MOUNT - wrong size (%" PRIu32
-				                   "/%" PRIu32 "|%" PRIu32 ")",
-				                   length, kBlobSizeWithVersion, kBlobSizeWithSessionIdAndVersion);
+				safs::log_info("CLTOMA_FUSE_REGISTER/NOACL-MOUNT - wrong size ({}/{}|{})", length,
+				               kBlobSizeWithVersion, kBlobSizeWithSessionIdAndVersion);
 				eptr->mode = ClientConnectionMode::KILL;
 				return;
 			}
@@ -1696,40 +1847,44 @@ void matoclserv_fuse_register(matoclserventry *eptr,const uint8_t *data,uint32_t
 		rptr = data + kBlobSize;
 
 		if (toolsNoACL) {
-			sessionid = 0;
+			sessionId = 0;
 			if (length == kBlobSizeWithVersion) { get32bit(&rptr, eptr->version); }
 		} else {
-			get32bit(&rptr, sessionid);
+			get32bit(&rptr, sessionId);
 			if (length == kBlobSizeWithSessionIdAndVersion) { get32bit(&rptr, eptr->version); }
 		}
 
-		if (eptr->version<0x010500 && !toolsNoACL) {
-			safs_pretty_syslog(LOG_NOTICE,"got register packet from mount older than 1.5 - rejecting");
+		if (eptr->version < 0x010500 && !toolsNoACL) {
+			safs::log_info("got register packet from mount older than 1.5 - rejecting");
 			eptr->mode = ClientConnectionMode::KILL;
 			return;
 		}
 
-		if (sessionid == 0) {           // new session
+		if (sessionId == 0) {           // new session
 			status = SAUNAFS_STATUS_OK; // exports_check(eptr->peerip,(const uint8_t*)"",NULL,NULL,&sesflags);      // check privileges for '/' w/o password
 			eptr->sesdata = matoclserv_new_session(0, toolsNoACL);
+
 			if (eptr->sesdata == nullptr) {
-				safs_pretty_syslog(LOG_NOTICE, "can't allocate session record");
+				safs::log_info("can't allocate session record");
 				eptr->mode = ClientConnectionMode::KILL;
 				return;
 			}
+
 			eptr->sesdata->rootinode = SPECIAL_INODE_ROOT;
 			eptr->sesdata->sesflags = 0;
 			eptr->sesdata->peerip = eptr->peerip;
 			eptr->sesdata->peerport = eptr->peerport;
 		} else {  // reconnect or tools
-			eptr->sesdata = matoclserv_find_session(sessionid);
+			eptr->sesdata = matoclserv_find_session(sessionId);
 			if (eptr->sesdata == nullptr) {      // in old model if session doesn't exist then create it
 				eptr->sesdata = matoclserv_new_session(0, 0);
+
 				if (eptr->sesdata == nullptr) {
-					safs_pretty_syslog(LOG_NOTICE, "can't allocate session record");
+					safs::log_info("can't allocate session record");
 					eptr->mode = ClientConnectionMode::KILL;
 					return;
 				}
+
 				eptr->sesdata->rootinode = SPECIAL_INODE_ROOT;
 				eptr->sesdata->sesflags = 0;
 				eptr->sesdata->peerip = eptr->peerip;
@@ -1753,7 +1908,7 @@ void matoclserv_fuse_register(matoclserventry *eptr,const uint8_t *data,uint32_t
 		} else {
 			wptr = matoclserv_createpacket(
 			    eptr, MATOCL_FUSE_REGISTER,
-			    (status != SAUNAFS_STATUS_OK) ? sizeof(status) : sizeof(sessionid));
+			    (status != SAUNAFS_STATUS_OK) ? sizeof(status) : sizeof(sessionId));
 		}
 
 		if (status != SAUNAFS_STATUS_OK) {
@@ -1764,8 +1919,8 @@ void matoclserv_fuse_register(matoclserventry *eptr,const uint8_t *data,uint32_t
 		if (toolsNoACL) {
 			put8bit(&wptr, status);
 		} else {
-			sessionid = eptr->sesdata->sessionid;
-			put32bit(&wptr, sessionid);
+			sessionId = eptr->sesdata->sessionid;
+			put32bit(&wptr, sessionId);
 		}
 
 		eptr->registered = (toolsNoACL) ? ClientState::kOldTools : ClientState::kRegistered;
@@ -1776,12 +1931,12 @@ void matoclserv_fuse_register(matoclserventry *eptr,const uint8_t *data,uint32_t
 	if (clientsWithACL) {
 		inode_t rootinode;
 		uint8_t sesflags;
-		uint8_t mingoal,maxgoal;
-		uint32_t mintrashtime,maxtrashtime;
-		uint32_t rootuid,rootgid;
-		uint32_t mapalluid,mapallgid;
-		uint32_t ileng,pleng;
-		uint8_t i,rcode;
+		uint8_t mingoal, maxgoal;
+		uint32_t mintrashtime, maxtrashtime;
+		uint32_t rootuid, rootgid;
+		uint32_t mapalluid, mapallgid;
+		uint32_t ileng, pleng;
+		uint8_t i, rcode;
 		const uint8_t *path;
 		const char *info;
 
@@ -1791,12 +1946,11 @@ void matoclserv_fuse_register(matoclserventry *eptr,const uint8_t *data,uint32_t
 		constexpr uint32_t kRegisterNewSessionMinSize =
 		    kRegisterNewMetaSessionMinSize + sizeof(pleng);
 		constexpr uint32_t kRegisterWithSessionIdAndVersion =
-		    kBlobSizeWithRCode + sizeof(sessionid) + sizeof(eptr->version);
+		    kBlobSizeWithRCode + sizeof(sessionId) + sizeof(eptr->version);
 
 		if (length < kBlobSizeWithRCode) {
-			safs_pretty_syslog(LOG_NOTICE,
-			                   "CLTOMA_FUSE_REGISTER/ACL - wrong size (%" PRIu32 "/<%u)", length,
-			                   kBlobSizeWithRCode);
+			safs::log_info("CLTOMA_FUSE_REGISTER/ACL - wrong size ({}/<{})", length,
+			               kBlobSizeWithRCode);
 			eptr->mode = ClientConnectionMode::KILL;
 			return;
 		}
@@ -1806,10 +1960,8 @@ void matoclserv_fuse_register(matoclserventry *eptr,const uint8_t *data,uint32_t
 
 		if ((eptr->registered == ClientState::kUnregistered && rcode == REGISTER_CLOSESESSION) ||
 		    (eptr->registered != ClientState::kUnregistered && rcode != REGISTER_CLOSESESSION)) {
-			safs_pretty_syslog(
-			    LOG_NOTICE,
-			    "CLTOMA_FUSE_REGISTER/ACL - wrong rcode (%d) for registered status (%d)", rcode,
-			    (int)eptr->registered);
+			safs::log_info("CLTOMA_FUSE_REGISTER/ACL - wrong rcode ({}) for registered status ({})",
+			               rcode, (int)eptr->registered);
 			eptr->mode = ClientConnectionMode::KILL;
 			return;
 		}
@@ -1817,9 +1969,8 @@ void matoclserv_fuse_register(matoclserventry *eptr,const uint8_t *data,uint32_t
 		switch (rcode) {
 		case REGISTER_GETRANDOM:
 			if (length != kBlobSizeWithRCode) {
-				safs_pretty_syslog(LOG_NOTICE,
-				                   "CLTOMA_FUSE_REGISTER/ACL.1 - wrong size (%" PRIu32 "/%u)",
-				                   length, kBlobSizeWithRCode);
+				safs::log_info("CLTOMA_FUSE_REGISTER/ACL.1 - wrong size ({}/{})", length,
+				               kBlobSizeWithRCode);
 				eptr->mode = ClientConnectionMode::KILL;
 				return;
 			}
@@ -1832,40 +1983,34 @@ void matoclserv_fuse_register(matoclserventry *eptr,const uint8_t *data,uint32_t
 			return;
 		case REGISTER_NEWSESSION:
 			if (length < kRegisterNewSessionMinSize) {
-				safs_pretty_syslog(LOG_NOTICE,
-				                   "CLTOMA_FUSE_REGISTER/ACL.2 - wrong size (%" PRIu32 "/>=%" PRIu32
-				                   ")",
-				                   length, kRegisterNewSessionMinSize);
+				safs::log_info("CLTOMA_FUSE_REGISTER/ACL.2 - wrong size ({}/>={})", length,
+				               kRegisterNewSessionMinSize);
 				eptr->mode = ClientConnectionMode::KILL;
 				return;
 			}
 			get32bit(&rptr, eptr->version);
 			get32bit(&rptr, ileng);
 			if (length < kRegisterNewSessionMinSize + ileng) {
-				safs_pretty_syslog(LOG_NOTICE,
-				                   "CLTOMA_FUSE_REGISTER/ACL.2 - wrong size (%" PRIu32 "/>=%" PRIu32
-				                   "+ileng(%" PRIu32 "))",
-				                   length, kRegisterNewSessionMinSize, ileng);
+				safs::log_info("CLTOMA_FUSE_REGISTER/ACL.2 - wrong size ({}/>={}+ileng({}))",
+				               length, kRegisterNewSessionMinSize, ileng);
 				eptr->mode = ClientConnectionMode::KILL;
 				return;
 			}
 			info = (const char*)rptr;
-			rptr+=ileng;
+			rptr += ileng;
 			get32bit(&rptr, pleng);
 			if (length != kRegisterNewSessionMinSize + ileng + pleng &&
 			    length != kRegisterNewSessionMinSize + 16 + ileng + pleng) {
-				safs_pretty_syslog(LOG_NOTICE,
-				                   "CLTOMA_FUSE_REGISTER/ACL.2 - wrong size (%" PRIu32 "/%" PRIu32
-				                   "+ileng(%" PRIu32 ")+pleng(%" PRIu32 ")[+16])",
-				                   length, kRegisterNewSessionMinSize, ileng, pleng);
+				safs::log_info(
+				    "CLTOMA_FUSE_REGISTER/ACL.2 - wrong size ({}/{} + ileng({}) + pleng({}) + 16)",
+				    length, kRegisterNewSessionMinSize, ileng, pleng);
 				eptr->mode = ClientConnectionMode::KILL;
 				return;
 			}
 			path = rptr;
-			rptr+=pleng;
+			rptr += pleng;
 			if (pleng > 0 && rptr[-1] != 0) {
-				safs_pretty_syslog(
-				    LOG_NOTICE, "CLTOMA_FUSE_REGISTER/ACL.2 - received path without ending zero");
+				safs::log_info("CLTOMA_FUSE_REGISTER/ACL.2 - received path without ending zero");
 				eptr->mode = ClientConnectionMode::KILL;
 				return;
 			}
@@ -1889,7 +2034,7 @@ void matoclserv_fuse_register(matoclserventry *eptr,const uint8_t *data,uint32_t
 			if (status == SAUNAFS_STATUS_OK) {
 				eptr->sesdata = matoclserv_new_session(1, 0);
 				if (eptr->sesdata == nullptr) {
-					safs_pretty_syslog(LOG_NOTICE, "can't allocate session record");
+					safs::log_info("can't allocate session record");
 					eptr->mode = ClientConnectionMode::KILL;
 					return;
 				}
@@ -1938,7 +2083,7 @@ void matoclserv_fuse_register(matoclserventry *eptr,const uint8_t *data,uint32_t
 				put8bit(&wptr, status);
 				return;
 			}
-			sessionid = eptr->sesdata->sessionid;
+			sessionId = eptr->sesdata->sessionid;
 			if (eptr->version == saunafsVersion(1, 6, 21)) {
 				put32bit(&wptr, 0);
 			} else if (eptr->version >= saunafsVersion(1, 6, 22)) {
@@ -1946,7 +2091,7 @@ void matoclserv_fuse_register(matoclserventry *eptr,const uint8_t *data,uint32_t
 				put8bit(&wptr, SAUNAFS_PACKAGE_VERSION_MINOR);
 				put8bit(&wptr, SAUNAFS_PACKAGE_VERSION_MICRO);
 			}
-			put32bit(&wptr, sessionid);
+			put32bit(&wptr, sessionId);
 			put8bit(&wptr, sesflags);
 			put32bit(&wptr, rootuid);
 			put32bit(&wptr, rootgid);
@@ -1968,10 +2113,8 @@ void matoclserv_fuse_register(matoclserventry *eptr,const uint8_t *data,uint32_t
 			return;
 		case REGISTER_NEWMETASESSION:
 			if (length < kRegisterNewMetaSessionMinSize) {
-				safs_pretty_syslog(LOG_NOTICE,
-				                   "CLTOMA_FUSE_REGISTER/ACL.5 - wrong size (%" PRIu32 "/>=%" PRIu32
-				                   ")",
-				                   length, kRegisterNewMetaSessionMinSize);
+				safs::log_info("CLTOMA_FUSE_REGISTER/ACL.5 - wrong size ({}/>={})", length,
+				               kRegisterNewMetaSessionMinSize);
 				eptr->mode = ClientConnectionMode::KILL;
 				return;
 			}
@@ -1981,16 +2124,14 @@ void matoclserv_fuse_register(matoclserventry *eptr,const uint8_t *data,uint32_t
 
 			if (length != kRegisterNewMetaSessionMinSize + ileng &&
 			    length != kRegisterNewMetaSessionMinSize + 16 + ileng) {
-				safs_pretty_syslog(LOG_NOTICE,
-				                   "CLTOMA_FUSE_REGISTER/ACL.5 - wrong size (%" PRIu32 "/%" PRIu32
-				                   "+ileng(%" PRIu32 ")[+16])",
-				                   length, kRegisterNewMetaSessionMinSize, ileng);
+				safs::log_info("CLTOMA_FUSE_REGISTER/ACL.5 - wrong size ({}/{} + ileng({}) + 16)",
+				               length, kRegisterNewMetaSessionMinSize, ileng);
 				eptr->mode = ClientConnectionMode::KILL;
 				return;
 			}
 
 			info = (const char*)rptr;
-			rptr+=ileng;
+			rptr += ileng;
 
 			if (length == kRegisterNewMetaSessionMinSize + 16 + ileng) {
 				status = exports_check(eptr->peerip, eptr->version, 1, NULL, eptr->passwordrnd,
@@ -2005,7 +2146,7 @@ void matoclserv_fuse_register(matoclserventry *eptr,const uint8_t *data,uint32_t
 			if (status == SAUNAFS_STATUS_OK) {
 				eptr->sesdata = matoclserv_new_session(1, 0);
 				if (eptr->sesdata == nullptr) {
-					safs_pretty_syslog(LOG_NOTICE, "can't allocate session record");
+					safs::log_info("can't allocate session record");
 					eptr->mode = ClientConnectionMode::KILL;
 					return;
 				}
@@ -2050,13 +2191,13 @@ void matoclserv_fuse_register(matoclserventry *eptr,const uint8_t *data,uint32_t
 				put8bit(&wptr,status);
 				return;
 			}
-			sessionid = eptr->sesdata->sessionid;
+			sessionId = eptr->sesdata->sessionid;
 			if (eptr->version >= saunafsVersion(1, 6, 21)) {
 				put16bit(&wptr,SAUNAFS_PACKAGE_VERSION_MAJOR);
 				put8bit(&wptr,SAUNAFS_PACKAGE_VERSION_MINOR);
 				put8bit(&wptr,SAUNAFS_PACKAGE_VERSION_MICRO);
 			}
-			put32bit(&wptr,sessionid);
+			put32bit(&wptr,sessionId);
 			put8bit(&wptr,sesflags);
 			if (eptr->version >= saunafsVersion(1, 6, 26)) {
 				put8bit(&wptr,mingoal);
@@ -2068,17 +2209,15 @@ void matoclserv_fuse_register(matoclserventry *eptr,const uint8_t *data,uint32_t
 			return;
 		case REGISTER_RECONNECT:
 		case REGISTER_TOOLS:
-			if (length<kRegisterWithSessionIdAndVersion) {
-				safs_pretty_syslog(LOG_NOTICE,
-				                   "CLTOMA_FUSE_REGISTER/ACL.%" PRIu8 " - wrong size (%" PRIu32
-				                   "/>=%" PRIu32 ")",
-				                   rcode, length, kRegisterWithSessionIdAndVersion);
+			if (length < kRegisterWithSessionIdAndVersion) {
+				safs::log_info("CLTOMA_FUSE_REGISTER/ACL.{} - wrong size ({}/>={})", rcode, length,
+				               kRegisterWithSessionIdAndVersion);
 				eptr->mode = ClientConnectionMode::KILL;
 				return;
 			}
-			get32bit(&rptr, sessionid);
+			get32bit(&rptr, sessionId);
 			get32bit(&rptr, eptr->version);
-			eptr->sesdata = matoclserv_find_session(sessionid);
+			eptr->sesdata = matoclserv_find_session(sessionId);
 			if (eptr->sesdata == nullptr || eptr->sesdata->peerip == 0) {
 				status = SAUNAFS_ERROR_BADSESSIONID;
 			} else {
@@ -2109,32 +2248,29 @@ void matoclserv_fuse_register(matoclserventry *eptr,const uint8_t *data,uint32_t
 			}
 			return;
 		case REGISTER_CLOSESESSION:
-			if (length < kBlobSizeWithRCode + sizeof(sessionid)) {
-				safs_pretty_syslog(LOG_NOTICE,
-				                   "CLTOMA_FUSE_REGISTER/ACL.6 - wrong size (%" PRIu32 "/>=%lu)",
-				                   length, kBlobSizeWithRCode + sizeof(sessionid));
+			if (length < kBlobSizeWithRCode + sizeof(sessionId)) {
+				safs::log_info("CLTOMA_FUSE_REGISTER/ACL.6 - wrong size ({}/>={})", length,
+				               kBlobSizeWithRCode + sizeof(sessionId));
 				eptr->mode = ClientConnectionMode::KILL;
 				return;
 			}
-			get32bit(&rptr, sessionid);
-			matoclserv_close_session(sessionid);
-			safs::log_info("Session {} for mount {} was closed", sessionid,
+			get32bit(&rptr, sessionId);
+			matoclserv_close_session(sessionId);
+			safs::log_info("Session {} for mount {} was closed", sessionId,
 			               !eptr->sesdata->info.empty() ? eptr->sesdata->info : "unknown info");
 			eptr->mode = ClientConnectionMode::KILL;
 			return;
 		}
-		safs_pretty_syslog(LOG_NOTICE, "CLTOMA_FUSE_REGISTER/ACL - wrong rcode (%" PRIu8 ")",
-		                   rcode);
+		safs::log_info("CLTOMA_FUSE_REGISTER/ACL - wrong rcode ({})", rcode);
 		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
-	safs_pretty_syslog(LOG_NOTICE, "CLTOMA_FUSE_REGISTER - wrong register blob");
+	safs::log_info("CLTOMA_FUSE_REGISTER - wrong register blob");
 	eptr->mode = ClientConnectionMode::KILL;
 }
 
-void matoclserv_register_config(matoclserventry *eptr, const uint8_t *data,
-                                uint32_t length) {
+void matoclserv_register_config(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	cltoma::registerConfig::deserialize(data, length, eptr->sesdata->config);
 }
 
@@ -2146,7 +2282,7 @@ void matoclserv_update_mount_info(matoclserventry *eptr, const uint8_t *data, ui
 	}
 }
 
-void matoclserv_fuse_reserved_inodes(matoclserventry *eptr,const uint8_t *data,uint32_t length) {
+void matoclserv_fuse_reserved_inodes(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	const uint8_t *ptr;
 
 	if (length % kinode_t_size != 0) {
@@ -2195,7 +2331,7 @@ void matoclserv_fuse_reserved_inodes(matoclserventry *eptr,const uint8_t *data,u
 	changelog_enable_flush();
 }
 
-void matoclserv_fuse_statfs(matoclserventry *eptr,const uint8_t *data,uint32_t length) {
+void matoclserv_fuse_statfs(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	uint64_t totalspace,availspace,trashspace,reservedspace;
 	uint32_t msgid;
 	inode_t inodes;
@@ -2230,7 +2366,7 @@ void matoclserv_fuse_statfs(matoclserventry *eptr,const uint8_t *data,uint32_t l
 	}
 }
 
-void matoclserv_fuse_access(matoclserventry *eptr,const uint8_t *data,uint32_t length) {
+void matoclserv_fuse_access(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	inode_t inode;
 	uint32_t uid,gid;
 	uint8_t modemask;
@@ -2369,7 +2505,7 @@ void matoclserv_sau_get_self_quota(matoclserventry *eptr, const uint8_t *data, u
 	matoclserv_createpacket(eptr, std::move(reply));
 }
 
-void matoclserv_fuse_lookup(matoclserventry *eptr,const uint8_t *data,uint32_t length) {
+void matoclserv_fuse_lookup(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	inode_t inode;
 	uint32_t uid,gid;
 	uint8_t nleng;
@@ -2419,7 +2555,7 @@ void matoclserv_fuse_lookup(matoclserventry *eptr,const uint8_t *data,uint32_t l
 	eptr->sesdata->currentopstats[3]++;
 }
 
-void matoclserv_fuse_getattr(matoclserventry *eptr,const uint8_t *data,uint32_t length) {
+void matoclserv_fuse_getattr(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	inode_t inode;
 	uint32_t uid,gid;
 	Attributes attr;
@@ -2460,7 +2596,7 @@ void matoclserv_fuse_getattr(matoclserventry *eptr,const uint8_t *data,uint32_t 
 	}
 }
 
-void matoclserv_fuse_setattr(matoclserventry *eptr,const uint8_t *data,uint32_t length) {
+void matoclserv_fuse_setattr(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	inode_t inode;
 	uint32_t uid,gid;
 	uint8_t setmask;
@@ -2650,7 +2786,7 @@ void matoclserv_fuse_truncate(matoclserventry *eptr, PacketHeader header, const 
 	}
 }
 
-void matoclserv_fuse_readlink(matoclserventry *eptr,const uint8_t *data,uint32_t length) {
+void matoclserv_fuse_readlink(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	inode_t inode;
 	uint32_t msgid;
 	uint8_t *ptr;
@@ -2698,7 +2834,7 @@ void matoclserv_fuse_readlink(matoclserventry *eptr,const uint8_t *data,uint32_t
 	}
 }
 
-void matoclserv_fuse_symlink(matoclserventry *eptr,const uint8_t *data,uint32_t length) {
+void matoclserv_fuse_symlink(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	inode_t inode;
 	uint8_t nleng;
 	const uint8_t *name, *path;
@@ -2803,9 +2939,8 @@ void matoclserv_fuse_mknod(matoclserventry *eptr, PacketHeader header, const uin
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
 
-		status = fs_mknod(context,
-				inode, HString(std::move(name)),
-				type, mode, umask, rdev, &newinode, attr);
+		status = fs_mknod(context, inode, HString(std::move(name)), type, mode, umask, rdev,
+		                  &newinode, attr);
 	}
 
 	MessageBuffer reply;
@@ -2875,7 +3010,7 @@ void matoclserv_fuse_mkdir(matoclserventry *eptr, PacketHeader header, const uin
 	}
 }
 
-void matoclserv_fuse_unlink(matoclserventry *eptr,const uint8_t *data,uint32_t length) {
+void matoclserv_fuse_unlink(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	inode_t inode;
 	uint32_t uid,gid;
 	uint8_t nleng;
@@ -2929,9 +3064,7 @@ void matoclserv_fuse_unlink(matoclserventry *eptr,const uint8_t *data,uint32_t l
 
 void matoclserv_fuse_recursive_remove_wake_up(uint32_t session_id, uint32_t msgid, int status) {
 	matoclserventry *eptr = matoclserv_find_connection(session_id);
-	if (!eptr) {
-		return;
-	}
+	if (!eptr) { return; }
 	matoclserv_createpacket(eptr, matocl::recursiveRemove::build(msgid, status));
 }
 
@@ -2958,7 +3091,7 @@ void matoclserv_fuse_recursive_remove(matoclserventry *eptr, const uint8_t *data
 	}
 }
 
-void matoclserv_fuse_rmdir(matoclserventry *eptr,const uint8_t *data,uint32_t length) {
+void matoclserv_fuse_rmdir(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	inode_t inode;
 	uint32_t uid,gid;
 	uint8_t nleng;
@@ -3010,7 +3143,7 @@ void matoclserv_fuse_rmdir(matoclserventry *eptr,const uint8_t *data,uint32_t le
 	}
 }
 
-void matoclserv_fuse_rename(matoclserventry *eptr,const uint8_t *data,uint32_t length) {
+void matoclserv_fuse_rename(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	inode_t inode;
 	inode_t inode_src;
 	inode_t inode_dst;
@@ -3078,7 +3211,7 @@ void matoclserv_fuse_rename(matoclserventry *eptr,const uint8_t *data,uint32_t l
 		ptr = matoclserv_createpacket(eptr, MATOCL_FUSE_RENAME, sizeof(msgid) + sizeof(status));
 	}
 
-	put32bit(&ptr,msgid);
+	put32bit(&ptr, msgid);
 
 	if (eptr->version >= 0x010615 && status == SAUNAFS_STATUS_OK) {
 		putINode(&ptr, inode);
@@ -3092,7 +3225,7 @@ void matoclserv_fuse_rename(matoclserventry *eptr,const uint8_t *data,uint32_t l
 	}
 }
 
-void matoclserv_fuse_link(matoclserventry *eptr,const uint8_t *data,uint32_t length) {
+void matoclserv_fuse_link(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	inode_t inode;
 	inode_t inode_dst;
 	uint8_t nleng_dst;
@@ -3213,7 +3346,7 @@ void matoclserv_fuse_getdir(matoclserventry *eptr,const PacketHeader &header, co
 	matoclserv_createpacket(eptr, std::move(buffer));
 }
 
-void matoclserv_fuse_getdir(matoclserventry *eptr,const uint8_t *data,uint32_t length) {
+void matoclserv_fuse_getdir(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	inode_t inode;
 	uint32_t uid,gid;
 	uint8_t flags;
@@ -3274,7 +3407,7 @@ void matoclserv_fuse_getdir(matoclserventry *eptr,const uint8_t *data,uint32_t l
 	eptr->sesdata->currentopstats[12]++;
 }
 
-void matoclserv_fuse_open(matoclserventry *eptr,const uint8_t *data,uint32_t length) {
+void matoclserv_fuse_open(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	inode_t inode;
 	uint32_t uid,gid;
 	uint8_t flags;
@@ -3304,16 +3437,14 @@ void matoclserv_fuse_open(matoclserventry *eptr,const uint8_t *data,uint32_t len
 
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = matoclserv_insert_openfile(eptr->sesdata,inode);
-		if (status==SAUNAFS_STATUS_OK) {
-			status = fs_opencheck(context,inode,flags,attr);
-		}
+		status = matoclserv_insert_open_file(eptr->sesdata, inode);
+		if (status == SAUNAFS_STATUS_OK) { status = fs_opencheck(context, inode, flags, attr); }
 	}
 
-	if (eptr->version>=0x010609 && status==SAUNAFS_STATUS_OK) {
-		allowcache = dcm_open(inode,eptr->sesdata->sessionid);
-		if (allowcache==0) {
-			attr[1]&=(0xFF^(MATTR_ALLOWDATACACHE<<4));
+	if (eptr->version >= 0x010609 && status == SAUNAFS_STATUS_OK) {
+		allowcache = dcm_open(inode, eptr->sesdata->sessionid);
+		if (allowcache == 0) {
+			attr[1] &= (0xFF ^ (MATTR_ALLOWDATACACHE << 4));
 		}
 		ptr = matoclserv_createpacket(eptr,MATOCL_FUSE_OPEN, sizeof(msgid) + attr.size());
 	} else {
@@ -3425,8 +3556,7 @@ void matoclserv_fuse_write_chunk(matoclserventry *eptr, PacketHeader header, con
 	std::vector<uint8_t> receivedData(data, data + header.length);
 	serializer->deserializeFuseWriteChunk(receivedData, messageId, inode, chunkIndex, lockId);
 
-	uint32_t min_server_version
-		= header.type == SAU_CLTOMA_FUSE_WRITE_CHUNK ? kFirstXorVersion : 0;
+	uint32_t min_server_version = header.type == SAU_CLTOMA_FUSE_WRITE_CHUNK ? kFirstXorVersion : 0;
 
 	// Original Legacy (1.6.27) does not use lock ID's
 	bool useDummyLockId = (header.type == CLTOMA_FUSE_WRITE_CHUNK);
@@ -3465,8 +3595,8 @@ void matoclserv_fuse_write_chunk(matoclserventry *eptr, PacketHeader header, con
 	}
 }
 
-void matoclserv_fuse_write_chunk_end(matoclserventry *eptr,
-		PacketHeader header, const uint8_t *data) {
+void matoclserv_fuse_write_chunk_end(matoclserventry *eptr, PacketHeader header,
+                                     const uint8_t *data) {
 	sassert(header.type == CLTOMA_FUSE_WRITE_CHUNK_END
 			|| header.type == SAU_CLTOMA_FUSE_WRITE_CHUNK_END);
 	uint32_t messageId;
@@ -3480,6 +3610,7 @@ void matoclserv_fuse_write_chunk_end(matoclserventry *eptr,
 	std::vector<uint8_t> request(data, data + header.length);
 	const PacketSerializer* serializer = PacketSerializer::getSerializer(header.type, eptr->version);
 	serializer->deserializeFuseWriteChunkEnd(request, messageId, chunkId, lockId, inode, fileLength);
+
 	if (lockId == 0) {
 		// this lock id passed to chunk_unlock would force chunk unlock
 		status = SAUNAFS_ERROR_WRONGLOCKID;
@@ -3488,6 +3619,7 @@ void matoclserv_fuse_write_chunk_end(matoclserventry *eptr,
 	} else {
 		status = fs_writeend(inode, fileLength, chunkId, lockId);
 	}
+
 	dcm_modify(inode,eptr->sesdata->sessionid);
 	serializer->serializeFuseWriteChunkEnd(outMessage, messageId, status);
 	matoclserv_createpacket(eptr, outMessage);
@@ -3546,7 +3678,7 @@ void matoclserv_fuse_repair(matoclserventry *eptr, const uint8_t *data, uint32_t
 	}
 }
 
-void matoclserv_fuse_check(matoclserventry *eptr,const uint8_t *data,uint32_t length) {
+void matoclserv_fuse_check(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	inode_t inode;
 	uint32_t chunkcount[CHUNK_MATRIX_SIZE];
 	uint32_t msgid;
@@ -3721,8 +3853,8 @@ void matoclserv_fuse_settrashtime(matoclserventry *eptr, PacketHeader header, co
 	}
 
 	if (status != SAUNAFS_ERROR_WAITING) {
-		matoclserv_fuse_settrashtime_wake_up(eptr->sesdata->sessionid, msgid,
-						     settrashtime_stats, status);
+		matoclserv_fuse_settrashtime_wake_up(eptr->sesdata->sessionid, msgid, settrashtime_stats,
+		                                     status);
 	}
 }
 
@@ -3871,13 +4003,13 @@ void matoclserv_fuse_setgoal(matoclserventry *eptr, PacketHeader header, const u
 	}
 }
 
-void matoclserv_fuse_geteattr(matoclserventry *eptr,const uint8_t *data,uint32_t length) {
+void matoclserv_fuse_geteattr(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	inode_t inode;
 	uint32_t msgid;
 	constexpr uint8_t kMaxEattr = 16;
 	uint32_t feattrtab[kMaxEattr];
 	uint32_t deattrtab[kMaxEattr];
-	uint8_t i,fn,dn,gmode;
+	uint8_t i, fn, dn, gmode;
 	uint8_t *ptr;
 	uint8_t status;
 
@@ -3896,8 +4028,8 @@ void matoclserv_fuse_geteattr(matoclserventry *eptr,const uint8_t *data,uint32_t
 	gmode = get8bit(&data);
 
 	status = fs_geteattr(matoclserv_get_context(eptr), inode, gmode, feattrtab, deattrtab);
-	fn=0;
-	dn=0;
+	fn = 0;
+	dn = 0;
 
 	if (status == SAUNAFS_STATUS_OK) {
 		for (i = 0; i < kMaxEattr; i++) {
@@ -3935,7 +4067,7 @@ void matoclserv_fuse_geteattr(matoclserventry *eptr,const uint8_t *data,uint32_t
 	}
 }
 
-void matoclserv_fuse_seteattr(matoclserventry *eptr,const uint8_t *data,uint32_t length) {
+void matoclserv_fuse_seteattr(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	inode_t inode;
 	uint32_t uid;
 	uint32_t msgid;
@@ -3982,7 +4114,7 @@ void matoclserv_fuse_seteattr(matoclserventry *eptr,const uint8_t *data,uint32_t
 	}
 }
 
-void matoclserv_fuse_getxattr(matoclserventry *eptr,const uint8_t *data,uint32_t length) {
+void matoclserv_fuse_getxattr(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	inode_t inode;
 	uint32_t uid, gid;
 	uint32_t msgid;
@@ -4077,7 +4209,7 @@ void matoclserv_fuse_getxattr(matoclserventry *eptr,const uint8_t *data,uint32_t
 	}
 }
 
-void matoclserv_fuse_setxattr(matoclserventry *eptr,const uint8_t *data,uint32_t length) {
+void matoclserv_fuse_setxattr(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	inode_t inode;
 	uint32_t uid, gid;
 	uint32_t msgid;
@@ -4235,7 +4367,7 @@ void matoclserv_fuse_snapshot(matoclserventry *eptr, PacketHeader header, const 
 	}
 }
 
-void matoclserv_fuse_getdirstats_old(matoclserventry *eptr,const uint8_t *data,uint32_t length) {
+void matoclserv_fuse_getdirstats_old(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	inode_t inode = 0, inodes = 0, files = 0, dirs = 0, links = 0;
 	uint32_t chunks = 0;
 	uint64_t leng = 0, size = 0, rsize = 0;
@@ -4288,7 +4420,7 @@ void matoclserv_fuse_getdirstats_old(matoclserventry *eptr,const uint8_t *data,u
 	}
 }
 
-void matoclserv_fuse_getdirstats(matoclserventry *eptr,const uint8_t *data,uint32_t length) {
+void matoclserv_fuse_getdirstats(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	inode_t inode = 0, inodes = 0, files = 0, dirs = 0, links = 0;
 	uint32_t chunks = 0;
 	uint64_t leng = 0, size = 0, rsize = 0;
@@ -4336,7 +4468,7 @@ void matoclserv_fuse_getdirstats(matoclserventry *eptr,const uint8_t *data,uint3
 	}
 }
 
-void matoclserv_fuse_gettrash(matoclserventry *eptr,const uint8_t *data,uint32_t length) {
+void matoclserv_fuse_gettrash(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	uint32_t msgid;
 	uint8_t *ptr;
 	uint8_t status;
@@ -4366,15 +4498,18 @@ void matoclserv_fuse_gettrash(matoclserventry *eptr,const uint8_t *data,uint32_t
 	}
 }
 
-void matoclserv_fuse_gettrash(matoclserventry *eptr, const PacketHeader &header, const uint8_t *data) {
+void matoclserv_fuse_gettrash(matoclserventry *eptr, const PacketHeader &header,
+                              const uint8_t *data) {
 	uint32_t off, max_entries, msg_id;
 	cltoma::fuseGetTrash::deserialize(data, header.length, msg_id, off, max_entries);
 	std::vector<NamedInodeEntry> entries;
-	fs_readtrash(off, std::min<uint32_t>(max_entries, matocl::fuseGetDir::kMaxNumberOfDirectoryEntries), entries);
+	fs_readtrash(off,
+	             std::min<uint32_t>(max_entries, matocl::fuseGetDir::kMaxNumberOfDirectoryEntries),
+	             entries);
 	matoclserv_createpacket(eptr, matocl::fuseGetTrash::build(msg_id, entries));
 }
 
-void matoclserv_fuse_getdetachedattr(matoclserventry *eptr,const uint8_t *data,uint32_t length) {
+void matoclserv_fuse_getdetachedattr(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	inode_t inode;
 	Attributes attr;
 	uint32_t msgid;
@@ -4417,7 +4552,7 @@ void matoclserv_fuse_getdetachedattr(matoclserventry *eptr,const uint8_t *data,u
 	}
 }
 
-void matoclserv_fuse_gettrashpath(matoclserventry *eptr,const uint8_t *data,uint32_t length) {
+void matoclserv_fuse_gettrashpath(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	inode_t inode;
 	uint32_t msgid;
 	uint8_t *ptr;
@@ -4459,7 +4594,7 @@ void matoclserv_fuse_gettrashpath(matoclserventry *eptr,const uint8_t *data,uint
 	}
 }
 
-void matoclserv_fuse_settrashpath(matoclserventry *eptr,const uint8_t *data,uint32_t length) {
+void matoclserv_fuse_settrashpath(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	inode_t inode;
 	const uint8_t *path;
 	uint32_t pleng;
@@ -4501,7 +4636,7 @@ void matoclserv_fuse_settrashpath(matoclserventry *eptr,const uint8_t *data,uint
 	put8bit(&ptr, status);
 }
 
-void matoclserv_fuse_undel(matoclserventry *eptr,const uint8_t *data,uint32_t length) {
+void matoclserv_fuse_undel(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	inode_t inode;
 	uint32_t msgid;
 	uint8_t status;
@@ -4527,7 +4662,7 @@ void matoclserv_fuse_undel(matoclserventry *eptr,const uint8_t *data,uint32_t le
 	put8bit(&ptr, status);
 }
 
-void matoclserv_fuse_purge(matoclserventry *eptr,const uint8_t *data,uint32_t length) {
+void matoclserv_fuse_purge(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	inode_t inode;
 	uint32_t msgid;
 	uint8_t *ptr;
@@ -4552,8 +4687,7 @@ void matoclserv_fuse_purge(matoclserventry *eptr,const uint8_t *data,uint32_t le
 	put8bit(&ptr, status);
 }
 
-
-void matoclserv_fuse_getreserved(matoclserventry *eptr,const uint8_t *data,uint32_t length) {
+void matoclserv_fuse_getreserved(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	uint32_t msgid;
 	uint8_t *ptr;
 	uint8_t status;
@@ -4588,11 +4722,14 @@ void matoclserv_fuse_getreserved(matoclserventry *eptr,const uint8_t *data,uint3
 	}
 }
 
-void matoclserv_fuse_getreserved(matoclserventry *eptr, const PacketHeader &header, const uint8_t *data) {
+void matoclserv_fuse_getreserved(matoclserventry *eptr, const PacketHeader &header,
+                                 const uint8_t *data) {
 	uint32_t off, max_entries, msg_id;
 	cltoma::fuseGetReserved::deserialize(data, header.length, msg_id, off, max_entries);
 	std::vector<NamedInodeEntry> entries;
-	fs_readreserved(off, std::min<uint32_t>(max_entries, matocl::fuseGetDir::kMaxNumberOfDirectoryEntries), entries);
+	fs_readreserved(
+	    off, std::min<uint32_t>(max_entries, matocl::fuseGetDir::kMaxNumberOfDirectoryEntries),
+	    entries);
 	matoclserv_createpacket(eptr, matocl::fuseGetReserved::build(msg_id, entries));
 }
 
@@ -4621,10 +4758,12 @@ void matoclserv_fuse_getacl(matoclserventry *eptr, const uint8_t *data, uint32_t
 	RichACL acl;
 
 	uint8_t status = matoclserv_check_group_cache(eptr, gid);
+
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
 		status = fs_getacl(context, inode, acl);
 	}
+
 	if (status == SAUNAFS_STATUS_OK) {
 		if (eptr->version >= kRichACLVersion) {
 			FSNode *node = fsnodes_id_to_node(inode);
@@ -4638,6 +4777,7 @@ void matoclserv_fuse_getacl(matoclserventry *eptr, const uint8_t *data, uint32_t
 				// default behavior for unknown acl type.
 				posix_acl = acl.convertToPosixACL();
 			}
+
 			if (posix_acl.first) {
 				if (eptr->version >= kACL11Version) {
 					matocl::fuseGetAcl::serialize(reply, messageId, posix_acl.second);
@@ -4650,14 +4790,15 @@ void matoclserv_fuse_getacl(matoclserventry *eptr, const uint8_t *data, uint32_t
 			}
 		}
 	}
+
 	if (status != SAUNAFS_STATUS_OK) {
 		matocl::fuseGetAcl::serialize(reply, messageId, status);
 	}
+
 	matoclserv_createpacket(eptr, std::move(reply));
 }
 
-static void matoclserv_lock_wake_up(uint32_t sessionid, uint32_t messageId,
-		safs_locks::Type type) {
+static void matoclserv_lock_wake_up(uint32_t sessionid, uint32_t messageId, safs_locks::Type type) {
 	matoclserventry *eptr;
 	MessageBuffer reply;
 
@@ -4675,7 +4816,7 @@ static void matoclserv_lock_wake_up(uint32_t sessionid, uint32_t messageId,
 		matocl::fuseSetlk::serialize(reply, messageId, SAUNAFS_STATUS_OK);
 		break;
 	default:
-		safs_pretty_syslog(LOG_ERR, "Incorrect lock type passed for lock wakeup: %u", (unsigned)type);
+		safs::log_err("Incorrect lock type passed for lock wakeup: {}", (unsigned)type);
 		return;
 	}
 
@@ -4705,7 +4846,7 @@ void matoclserv_fuse_flock(matoclserventry *eptr, const uint8_t *data, uint32_t 
 	deserializePacketVersionNoHeader(data, length, version);
 
 	if (version != 0) {
-		safs_pretty_syslog(LOG_ERR, "flock wrong message version\n");
+		safs::log_err("flock wrong message version\n");
 		return;
 	}
 	cltoma::fuseFlock::deserialize(data, length, messageId, inode, owner, requestId, op);
@@ -4832,7 +4973,8 @@ void matoclserv_list_defective_files(matoclserventry *eptr, const uint8_t *data,
 	uint64_t entry_index, number_of_entries;
 	cltoma::listDefectiveFiles::deserialize(data, length, flags, entry_index, number_of_entries);
 	number_of_entries = std::min(number_of_entries, kMaxNumberOfDefectiveEntries);
-	std::vector<DefectiveFileInfo> files_info = fs_get_defective_nodes_info(flags, number_of_entries, entry_index);
+	std::vector<DefectiveFileInfo> files_info =
+	    fs_get_defective_nodes_info(flags, number_of_entries, entry_index);
 	matoclserv_createpacket(eptr, matocl::listDefectiveFiles::build(entry_index, files_info));
 }
 
@@ -4848,7 +4990,7 @@ void matoclserv_manage_locks_list(matoclserventry *eptr, const uint8_t *data, ui
 	int status;
 
 	if (eptr->registered != ClientState::kAdmin) {
-		safs_pretty_syslog(LOG_NOTICE, "Listing file locks is available only for registered admins");
+		safs::log_info("Listing file locks is available only for registered admins");
 		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
@@ -4869,9 +5011,9 @@ void matoclserv_manage_locks_list(matoclserventry *eptr, const uint8_t *data, ui
 	}
 
 	if (status != SAUNAFS_STATUS_OK) {
-		safs_pretty_syslog(LOG_WARNING, "Master received invalid lock type %" PRIu8
-		                                " from in SAU_CLTOMA_MANAGE_LOCKS_LIST packet",
-		                   (uint8_t)type);
+		safs::log_warn(
+		    "Master received invalid lock type {} from in SAU_CLTOMA_MANAGE_LOCKS_LIST packet",
+		    (uint8_t)type);
 	}
 
 	MessageBuffer reply;
@@ -4892,7 +5034,7 @@ void matoclserv_manage_locks_unlock(matoclserventry *eptr, const uint8_t *data, 
 	std::vector<FileLocks::Owner> flocks_applied, posix_applied;
 
 	if (eptr->registered != ClientState::kAdmin) {
-		safs_pretty_syslog(LOG_NOTICE, "Removing file locks is available only for registered admins");
+		safs::log_info("Removing file locks is available only for registered admins");
 		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
@@ -4968,7 +5110,7 @@ void matoclserv_fuse_locks_interrupt(matoclserventry *eptr, const uint8_t *data,
 	deserializePacketVersionNoHeader(data, length, version);
 
 	if (version != 0) {
-		safs_pretty_syslog(LOG_ERR, "fuse_flock_interrupt wrong message version\n");
+		safs::log_err("fuse_flock_interrupt wrong message version\n");
 		return;
 	}
 
@@ -5021,7 +5163,7 @@ void matoclserv_fuse_setacl(matoclserventry *eptr, const uint8_t *data, uint32_t
 	} else if (version == cltoma::fuseSetAcl::kRichACL) {
 		cltoma::fuseSetAcl::deserialize(data, length, messageId, inode, uid, gid, rich_acl);
 	} else {
-		safs_pretty_syslog(LOG_WARNING, "SAU_CLTOMA_FUSE_SET_ACL: unknown packet version");
+		safs::log_warn("SAU_CLTOMA_FUSE_SET_ACL: unknown packet version");
 		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
@@ -5048,6 +5190,7 @@ void matoclserv_fuse_setquota(matoclserventry *eptr, const uint8_t *data, uint32
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
 		status = fs_quota_set(context, entries);
 	}
+
 	MessageBuffer reply;
 	matocl::fuseSetQuota::serialize(reply, messageId, status);
 	matoclserv_createpacket(eptr, std::move(reply));
@@ -5058,7 +5201,9 @@ void matoclserv_fuse_getquota(matoclserventry *eptr, const uint8_t *data, uint32
 	std::vector<QuotaEntry> results;
 	std::vector<std::string> info;
 	uint8_t status;
+
 	deserializePacketVersionNoHeader(data, length, version);
+
 	if (version == cltoma::fuseGetQuota::kAllLimits) {
 		cltoma::fuseGetQuota::deserialize(data, length, messageId, uid, gid);
 		status = matoclserv_check_group_cache(eptr, gid);
@@ -5078,15 +5223,18 @@ void matoclserv_fuse_getquota(matoclserventry *eptr, const uint8_t *data, uint32
 		throw IncorrectDeserializationException(
 				"Unknown SAU_CLTOMA_FUSE_GET_QUOTA version: " + std::to_string(version));
 	}
+
 	MessageBuffer reply;
 	if (status == SAUNAFS_STATUS_OK) {
 		status = fs_quota_get_info(matoclserv_get_context(eptr), results, info);
 	}
+
 	if (status == SAUNAFS_STATUS_OK) {
 		matocl::fuseGetQuota::serialize(reply, messageId, results, info);
 	} else {
 		matocl::fuseGetQuota::serialize(reply, messageId, status);
 	}
+
 	matoclserv_createpacket(eptr, std::move(reply));
 }
 
@@ -5095,19 +5243,21 @@ void matoclserv_iolimit(matoclserventry *eptr, const uint8_t *data, uint32_t len
 	uint32_t configVersion;
 	std::string groupId;
 	uint64_t requestedBytes;
+
 	cltoma::iolimit::deserialize(data, length, msgid, configVersion, groupId, requestedBytes);
 	uint64_t grantedBytes;
+
 	if (configVersion != gIoLimitsConfigId) {
 		grantedBytes = 0;
 	} else {
 		try {
-			grantedBytes = gIoLimitsDatabase.request(
-					SteadyClock::now(), groupId, requestedBytes);
+			grantedBytes = gIoLimitsDatabase.request(SteadyClock::now(), groupId, requestedBytes);
 		} catch (IoLimitsDatabase::InvalidGroupIdException&) {
-			safs_pretty_syslog(LOG_NOTICE, "SAU_CLTOMA_IOLIMIT: Invalid group: %s", groupId.c_str());
+			safs::log_info("SAU_CLTOMA_IOLIMIT: Invalid group: {}", groupId);
 			grantedBytes = 0;
 		}
 	}
+
 	MessageBuffer reply;
 	matocl::iolimit::serialize(reply, msgid, configVersion, groupId, grantedBytes);
 	matoclserv_createpacket(eptr, std::move(reply));
@@ -5132,7 +5282,7 @@ void matoclserv_admin_register(matoclserventry* eptr, const uint8_t* data, uint3
 		}
 		matoclserv_createpacket(eptr, matocl::adminRegisterChallenge::build(array));
 	} else {
-		safs_pretty_syslog(LOG_NOTICE, "SAU_CLTOMA_ADMIN_REGISTER_CHALLENGE: retry not allowed");
+		safs::log_info("SAU_CLTOMA_ADMIN_REGISTER_CHALLENGE: retry not allowed");
 		eptr->mode = ClientConnectionMode::KILL;
 	}
 }
@@ -5141,6 +5291,7 @@ void matoclserv_admin_register_response(matoclserventry* eptr, const uint8_t* da
 		uint32_t length) {
 	SauCltomaAdminRegisterResponseData receivedDigest;
 	cltoma::adminRegisterResponse::deserialize(data, length, receivedDigest);
+
 	if (eptr->adminChallenge) {
 		std::string password = cfg_getstring("ADMIN_PASSWORD", "");
 		if (password == "") {
@@ -5148,6 +5299,7 @@ void matoclserv_admin_register_response(matoclserventry* eptr, const uint8_t* da
 			safs_pretty_syslog(LOG_WARNING, "admin access disabled");
 			return;
 		}
+
 		auto digest = md5_challenge_response(*eptr->adminChallenge, password);
 		if (receivedDigest == digest) {
 			matoclserv_createpacket(eptr, matocl::adminRegisterResponse::build(SAUNAFS_STATUS_OK));
@@ -5156,36 +5308,38 @@ void matoclserv_admin_register_response(matoclserventry* eptr, const uint8_t* da
 			matoclserv_createpacket(eptr, matocl::adminRegisterResponse::build(SAUNAFS_ERROR_BADPASSWORD));
 			safs_pretty_syslog(LOG_WARNING, "admin authentication error");
 		}
+
 		eptr->adminChallenge.reset();
 	} else {
-		safs_pretty_syslog(LOG_NOTICE,
-				"SAU_CLTOMA_ADMIN_REGISTER_RESPONSE: response without previous challenge");
+		safs::log_info("SAU_CLTOMA_ADMIN_REGISTER_RESPONSE: response without previous challenge");
 		eptr->mode = ClientConnectionMode::KILL;
 	}
 }
 
 void matoclserv_admin_become_master(matoclserventry* eptr, const uint8_t* data, uint32_t length) {
 	cltoma::adminBecomeMaster::deserialize(data, length);
+
 	if (eptr->registered == ClientState::kAdmin) {
 		bool succ = metadataserver::promoteAutoToMaster();
 		uint8_t status = succ ? SAUNAFS_STATUS_OK : SAUNAFS_ERROR_NOTPOSSIBLE;
 		matoclserv_createpacket(eptr, matocl::adminBecomeMaster::build(status));
 	} else {
-		safs_pretty_syslog(LOG_NOTICE,
-				"SAU_CLTOMA_ADMIN_BECOME_MASTER: available only for registered admins");
+		safs::log_info("SAU_CLTOMA_ADMIN_BECOME_MASTER: available only for registered admins");
 		eptr->mode = ClientConnectionMode::KILL;
 	}
 }
 
-void matoclserv_admin_stop_without_metadata_dump(
-			matoclserventry* eptr, const uint8_t* data, uint32_t length) {
+void matoclserv_admin_stop_without_metadata_dump(matoclserventry *eptr, const uint8_t *data,
+                                                 uint32_t length) {
 	cltoma::adminStopWithoutMetadataDump::deserialize(data, length);
+
 	if (eptr->registered == ClientState::kAdmin) {
 		if (metadataserver::isMaster()) {
-			if (matomlserv_shadows_count() == 0){
-				safs_pretty_syslog(LOG_WARNING, "SAU_CLTOMA_ADMIN_STOP_WITHOUT_METADATA_DUMP: Trying to stop"
-						" master server with disabled metadata dump when no shadow servers are "
-						"connected.");
+			if (matomlserv_shadows_count() == 0) {
+				safs::log_warn(
+				    "SAU_CLTOMA_ADMIN_STOP_WITHOUT_METADATA_DUMP: Trying to stop"
+				    " master server with disabled metadata dump when no shadow servers are "
+				    "connected.");
 				matoclserv_createpacket(eptr, matocl::adminStopWithoutMetadataDump::build(EPERM));
 			} else {
 				fs_disable_metadata_dump_on_exit();
@@ -5203,65 +5357,70 @@ void matoclserv_admin_stop_without_metadata_dump(
 			matoclserv_createpacket(eptr, matocl::adminStopWithoutMetadataDump::build(status));
 		}
 	} else {
-		safs_pretty_syslog(LOG_NOTICE,
-				"SAU_CLTOMA_ADMIN_STOP_WITHOUT_METADATA_DUMP:"
-				" available only for registered admins");
+		safs::log_info(
+		    "SAU_CLTOMA_ADMIN_STOP_WITHOUT_METADATA_DUMP:"
+		    " available only for registered admins");
 		eptr->mode = ClientConnectionMode::KILL;
 	}
 }
 
 void matoclserv_admin_reload(matoclserventry* eptr, const uint8_t* data, uint32_t length) {
 	cltoma::adminReload::deserialize(data, length);
+
 	if (eptr->registered == ClientState::kAdmin) {
 		eptr->adminTask = AdminTask::kReload; // mark, that this admin waits for response
 		eventloop_want_to_reload();
-		safs_pretty_syslog(LOG_NOTICE, "reload of the config file requested using saunafs-admin by %s",
-				ipToString(eptr->peerip).c_str());
+		safs::log_info("reload of the config file requested using saunafs-admin by {}",
+		               ipToString(eptr->peerip));
 	} else {
-		safs_pretty_syslog(LOG_NOTICE, "SAU_CLTOMA_ADMIN_RELOAD: available only for registered admins");
+		safs::log_info("SAU_CLTOMA_ADMIN_RELOAD: available only for registered admins");
 		eptr->mode = ClientConnectionMode::KILL;
 	}
 }
 
 std::string get_client_configs() {
 	std::map<std::string, std::string> client_configs;
+
 	for (const auto& sessionPtr : sessionVector) {
 		if (sessionPtr->config.empty()) { continue; }
 		NetworkAddress addr(sessionPtr->peerip, sessionPtr->peerport);
 		client_configs[addr.toString()] = sessionPtr->config;
 	}
+
 	return cfg_yaml_list("clients", client_configs);
 }
 
 void matoclserv_admin_dump_config(matoclserventry *eptr) {
 	if (eptr->registered != ClientState::kAdmin) {
-		safs_pretty_syslog(LOG_NOTICE,
-		                   "SAU_CLTOMA_ADMING_DUMP_CONFIG: available only for "
-		                   "registered admins");
+		safs::log_info("SAU_CLTOMA_ADMING_DUMP_CONFIG: available only for registered admins");
 		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
+
 	MessageBuffer reply;
 
-	auto master_config =
-	    cfg_yaml_string((metadataserver::isMaster() ? "master" : "shadow"));
+	auto master_config = cfg_yaml_string((metadataserver::isMaster() ? "master" : "shadow"));
 	auto chunkserver_configs = csdb_chunkserver_configs();
 	auto metalogger_configs = get_metaloggers_config();
 	auto client_configs = get_client_configs();
+
 	matocl::adminDumpConfiguration::serialize(
 	    reply, master_config + "\n" + chunkserver_configs + "\n" +
 	               metalogger_configs + "\n" + client_configs);
+
 	matoclserv_createpacket(eptr, reply);
 }
 
 void matoclserv_admin_save_metadata(matoclserventry* eptr, const uint8_t* data, uint32_t length) {
 	bool asynchronous;
 	cltoma::adminSaveMetadata::deserialize(data, length, asynchronous);
+
 	if (eptr->registered == ClientState::kAdmin) {
-		safs_pretty_syslog(LOG_NOTICE, "saving metadata image requested using saunafs-admin by %s",
-				ipToString(eptr->peerip).c_str());
+		safs::log_info("saving metadata image requested using saunafs-admin by {}",
+		               ipToString(eptr->peerip));
 		uint8_t status = gMetadataBackend->fs_storeall(
 		    MetadataDumper::DumpType::kBackgroundDump);
+
 		if (status != SAUNAFS_STATUS_OK || asynchronous) {
 			matoclserv_createpacket(eptr, matocl::adminSaveMetadata::build(status));
 		} else {
@@ -5269,7 +5428,7 @@ void matoclserv_admin_save_metadata(matoclserventry* eptr, const uint8_t* data, 
 			eptr->adminTask = AdminTask::kSaveMetadata;
 		}
 	} else {
-		safs_pretty_syslog(LOG_NOTICE, "SAU_CLTOMA_ADMIN_SAVE_METADATA: available only for registered admins");
+		safs::log_info("SAU_CLTOMA_ADMIN_SAVE_METADATA: available only for registered admins");
 		eptr->mode = ClientConnectionMode::KILL;
 	}
 }
@@ -5278,6 +5437,7 @@ void matoclserv_broadcast_metadata_saved(uint8_t status) {
 	if (exiting) {
 		return;
 	}
+
 	for (const auto &eptr : matoclservList) {
 		if (eptr->adminTask == AdminTask::kSaveMetadata) {
 			matoclserv_createpacket(eptr.get(), matocl::adminSaveMetadata::build(status));
@@ -5286,14 +5446,16 @@ void matoclserv_broadcast_metadata_saved(uint8_t status) {
 	}
 }
 
-void matoclserv_admin_recalculate_metadata_checksum(matoclserventry* eptr,
-		const uint8_t* data, uint32_t length) {
+void matoclserv_admin_recalculate_metadata_checksum(matoclserventry *eptr, const uint8_t *data,
+                                                    uint32_t length) {
 	bool asynchronous;
 	cltoma::adminRecalculateMetadataChecksum::deserialize(data, length, asynchronous);
+
 	if (eptr->registered == ClientState::kAdmin) {
-		safs_pretty_syslog(LOG_NOTICE, "metadata checksum recalculation requested using saunafs-admin by %s",
-					ipToString(eptr->peerip).c_str());
+		safs::log_info("metadata checksum recalculation requested using saunafs-admin by {}",
+		               ipToString(eptr->peerip));
 		uint8_t status = fs_start_checksum_recalculation();
+
 		if (status != SAUNAFS_STATUS_OK || asynchronous) {
 			matoclserv_createpacket(eptr, matocl::adminRecalculateMetadataChecksum::build(status));
 		} else {
@@ -5301,8 +5463,8 @@ void matoclserv_admin_recalculate_metadata_checksum(matoclserventry* eptr,
 			eptr->adminTask = AdminTask::kRecalculateChecksums;
 		}
 	} else {
-		safs_pretty_syslog(LOG_NOTICE, "SAU_CLTOMA_ADMIN_RECALCULATE_METADATA_CHECKSUM: "
-				"available only for registered admins");
+		safs::log_info(
+		    "SAU_CLTOMA_ADMIN_RECALCULATE_METADATA_CHECKSUM: available only for registered admins");
 		eptr->mode = ClientConnectionMode::KILL;
 	}
 }
@@ -5311,40 +5473,46 @@ void matoclserv_broadcast_metadata_checksum_recalculated(uint8_t status) {
 	if (exiting) {
 		return;
 	}
+
 	for (const auto &eptr : matoclservList) {
 		if (eptr->adminTask == AdminTask::kRecalculateChecksums) {
-			matoclserv_createpacket(eptr.get(), matocl::adminRecalculateMetadataChecksum::build(status));
+			matoclserv_createpacket(eptr.get(),
+			                        matocl::adminRecalculateMetadataChecksum::build(status));
 			eptr->adminTask = AdminTask::kNone;
 		}
 	}
 }
 
-void matocl_locks_release(const FsContext &context, inode_t inode, uint32_t sessionid) {
+void matocl_locks_release(const FsContext &context, inode_t inode, uint32_t sessionId) {
 	std::vector<FileLocks::Owner> applied;
 
-	fs_locks_clear_session(context, (uint8_t)safs_locks::Type::kFlock, inode, sessionid, applied);
+	fs_locks_clear_session(context, (uint8_t)safs_locks::Type::kFlock, inode, sessionId, applied);
+
 	for (auto candidate : applied) {
 		matoclserv_lock_wake_up(candidate.sessionid, candidate.msgid, safs_locks::Type::kFlock);
 	}
 
 	applied.clear();
-	fs_locks_clear_session(context, (uint8_t)safs_locks::Type::kPosix, inode, sessionid, applied);
+	fs_locks_clear_session(context, (uint8_t)safs_locks::Type::kPosix, inode, sessionId, applied);
+
 	for (auto candidate : applied) {
 		matoclserv_lock_wake_up(candidate.sessionid, candidate.msgid, safs_locks::Type::kPosix);
 	}
 }
 
-void matocl_close_files(session *sesdata) {
+void matocl_close_files(session *currentSession) {
 	FsContext context = FsContext::getForMaster(eventloop_time());
-	for (const auto &openFileInode : sesdata->openedfiles) {
-		fs_release(context, openFileInode, sesdata->sessionid);
-		matocl_locks_release(context, openFileInode, sesdata->sessionid);
+
+	for (const auto &openFileInode : currentSession->openedfiles) {
+		fs_release(context, openFileInode, currentSession->sessionid);
+		matocl_locks_release(context, openFileInode, currentSession->sessionid);
 	}
-	sesdata->openedfiles.clear();
+
+	currentSession->openedfiles.clear();
 }
 
-uint32_t session_number_of_files(session *sess) {
-	return sess->openedfiles.size();
+uint32_t session_number_of_files(session *currentSession) {
+	return currentSession->openedfiles.size();
 }
 
 void matoclserv_session_files(matoclserventry *eptr,
@@ -5370,12 +5538,11 @@ void matoclserv_session_files(matoclserventry *eptr,
 	matoclserv_createpacket(eptr, std::move(reply));
 }
 
-void matocl_session_timedout(session *sesdata) {
-	matocl_close_files(sesdata);
+void matocl_session_timedout(session *currentSession) {
+	matocl_close_files(currentSession);
 }
 
-void matoclserv_session_delete(matoclserventry *eptr, const uint8_t *data,
-                               uint32_t length) {
+void matoclserv_session_delete(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	uint8_t status = SAUNAFS_STATUS_OK;
 	uint64_t sessionId = 0;
 
@@ -5392,11 +5559,7 @@ void matoclserv_session_delete(matoclserventry *eptr, const uint8_t *data,
 	}
 
 	if (!target) {
-		safs_pretty_syslog(LOG_ERR,
-		                   "SAU_CLTOMA_DELETE_SESSION - "
-		                   "session not found "
-		                   "(session id: %" PRIu64 ")",
-		                   sessionId);
+		safs::log_err("SAU_CLTOMA_DELETE_SESSION - session not found (session id: {})", sessionId);
 		status = SAUNAFS_ERROR_BADSESSIONID;
 	} else {
 		matoclserv_close_session(sessionId);
@@ -5413,7 +5576,7 @@ void matoclserv_session_delete(matoclserventry *eptr, const uint8_t *data,
 	matoclserv_createpacket(eptr, reply);
 }
 
-void matocl_session_check(void) {
+void matocl_session_check() {
 	uint32_t now = eventloop_time();
 
 	for (auto sessionIt = sessionVector.begin(); sessionIt != sessionVector.end();) {
@@ -5430,7 +5593,7 @@ void matocl_session_check(void) {
 	}
 }
 
-void matocl_session_statsmove(void) {
+void matocl_session_statsmove() {
 	for (auto& sessionPtr : sessionVector) {
 		sessionPtr->lasthouropstats = sessionPtr->currentopstats;
 		sessionPtr->currentopstats.fill(0);
@@ -5439,7 +5602,7 @@ void matocl_session_statsmove(void) {
 }
 
 void matocl_beforedisconnect(matoclserventry *eptr) {
-// unlock locked chunks
+	// unlock locked chunks
 	for (const auto &operation : eptr->chunkdelayedops) {
 		if (operation->type == FUSE_TRUNCATE) {
 			fs_end_setlength(operation->chunkid);
@@ -5449,29 +5612,35 @@ void matocl_beforedisconnect(matoclserventry *eptr) {
 	eptr->chunkdelayedops.clear();
 
 	if (eptr->sesdata) {
-		if (eptr->sesdata->nsocks>0) {
+		if (eptr->sesdata->nsocks > 0) {
 			eptr->sesdata->nsocks--;
 		}
-		if (eptr->sesdata->nsocks==0) {
+
+		if (eptr->sesdata->nsocks == 0) {
 			eptr->sesdata->disconnected = eventloop_time();
 		}
 	}
 }
 
-void matoclserv_gotpacket(matoclserventry *eptr,uint32_t type,const uint8_t *data,uint32_t length) {
-	if (type==ANTOAN_NOP) {
+void matoclserv_gotpacket(matoclserventry *eptr, uint32_t type, const uint8_t *data,
+                          uint32_t length) {
+	if (type == ANTOAN_NOP) {
 		return;
 	}
-	if (type==ANTOAN_UNKNOWN_COMMAND) { // for future use
+
+	if (type == ANTOAN_UNKNOWN_COMMAND) { // for future use
 		return;
 	}
-	if (type==ANTOAN_BAD_COMMAND_SIZE) { // for future use
+
+	if (type == ANTOAN_BAD_COMMAND_SIZE) { // for future use
 		return;
 	}
-	if (type==ANTOAN_PING) {
-		matoclserv_ping(eptr,data,length);
+
+	if (type == ANTOAN_PING) {
+		matoclserv_ping(eptr, data, length);
 		return;
 	}
+
 	try {
 		if (!metadataserver::isMaster()) {     // shadow
 			switch (type) {
@@ -5503,60 +5672,62 @@ void matoclserv_gotpacket(matoclserventry *eptr,uint32_t type,const uint8_t *dat
 					matoclserv_admin_dump_config(eptr);
 					break;
 				default:
-					safs_pretty_syslog(LOG_NOTICE,"main master server module: got invalid message in shadow state (type:%" PRIu32 ")",type);
-					eptr->mode = ClientConnectionMode::KILL;
+				    safs::log_info(
+				        "main master server module: got invalid message in shadow state (type:{})",
+				        type);
+				    eptr->mode = ClientConnectionMode::KILL;
 			}
 		} else if (eptr->registered == ClientState::kUnregistered
 				|| eptr->registered == ClientState::kAdmin) { // beware that in this context sesdata is NULL
 			switch (type) {
 				case CLTOMA_FUSE_REGISTER:
-					matoclserv_fuse_register(eptr,data,length);
-					break;
+				    matoclserv_fuse_register(eptr, data, length);
+				    break;
 				case CLTOMA_CSERV_LIST:
-					matoclserv_cserv_list(eptr,data,length);
-					break;
+				    matoclserv_cserv_list(eptr, data, length);
+				    break;
 				case SAU_CLTOMA_CSERV_LIST:
 					matoclserv_sau_cserv_list(eptr, data, length);
 					break;
 				case CLTOMA_SESSION_LIST:
-					matoclserv_session_list(eptr,data,length);
-					break;
+				    matoclserv_session_list(eptr, data, length);
+				    break;
 				case SAU_CLTOMA_MOUNT_INFO_LIST:
-					matoclserv_mount_info_list(eptr,data,length);
-					break;
+				    matoclserv_mount_info_list(eptr, data, length);
+				    break;
 				case SAU_CLTOMA_SESSION_FILES:
 					matoclserv_session_files(eptr, data, length);
 					break;
 				case SAU_CLTOMA_DELETE_SESSION:
-					matoclserv_session_delete(eptr,data,length);
-					break;
+				    matoclserv_session_delete(eptr, data, length);
+				    break;
 				case CLTOAN_CHART:
-					matoclserv_chart(eptr,data,length);
-					break;
+				    matoclserv_chart(eptr, data, length);
+				    break;
 				case CLTOAN_CHART_DATA:
-					matoclserv_chart_data(eptr,data,length);
-					break;
+				    matoclserv_chart_data(eptr, data, length);
+				    break;
 				case CLTOMA_INFO:
-					matoclserv_info(eptr,data,length);
-					break;
+				    matoclserv_info(eptr, data, length);
+				    break;
 				case CLTOMA_FSTEST_INFO:
-					matoclserv_fstest_info(eptr,data,length);
-					break;
+				    matoclserv_fstest_info(eptr, data, length);
+				    break;
 				case CLTOMA_CHUNKSTEST_INFO:
-					matoclserv_chunkstest_info(eptr,data,length);
-					break;
+				    matoclserv_chunkstest_info(eptr, data, length);
+				    break;
 				case CLTOMA_CHUNKS_MATRIX:
-					matoclserv_chunks_matrix(eptr,data,length);
-					break;
+				    matoclserv_chunks_matrix(eptr, data, length);
+				    break;
 				case CLTOMA_EXPORTS_INFO:
-					matoclserv_exports_info(eptr,data,length);
-					break;
+				    matoclserv_exports_info(eptr, data, length);
+				    break;
 				case CLTOMA_MLOG_LIST:
-					matoclserv_mlog_list(eptr,data,length);
-					break;
+				    matoclserv_mlog_list(eptr, data, length);
+				    break;
 				case CLTOMA_CSSERV_REMOVESERV:
-					matoclserv_cserv_removeserv(eptr,data,length);
-					break;
+				    matoclserv_cserv_removeserv(eptr, data, length);
+				    break;
 				case SAU_CLTOMA_IOLIMITS_STATUS:
 					matoclserv_iolimits_status(eptr, data, length);
 					break;
@@ -5600,11 +5771,11 @@ void matoclserv_gotpacket(matoclserventry *eptr,uint32_t type,const uint8_t *dat
 					matoclserv_list_defective_files(eptr, data, length);
 					break;
 				case SAU_CLTOMA_MANAGE_LOCKS_LIST:
-					matoclserv_manage_locks_list(eptr,data,length);
-					break;
+				    matoclserv_manage_locks_list(eptr, data, length);
+				    break;
 				case SAU_CLTOMA_MANAGE_LOCKS_UNLOCK:
-					matoclserv_manage_locks_unlock(eptr,data,length);
-					break;
+				    matoclserv_manage_locks_unlock(eptr, data, length);
+				    break;
 				case SAU_CLTOMA_LIST_TASKS:
 					matoclserv_list_tasks(eptr);
 					break;
@@ -5612,49 +5783,51 @@ void matoclserv_gotpacket(matoclserventry *eptr,uint32_t type,const uint8_t *dat
 					matoclserv_stop_task(eptr, data, length);
 					break;
 				default:
-					safs_pretty_syslog(LOG_NOTICE,"main master server module: got unknown message from unregistered (type:%" PRIu32 ")",type);
-					eptr->mode=ClientConnectionMode::KILL;
+				    safs::log_info(
+				        "main master server module: got unknown message from unregistered (type:{})",
+				        type);
+				    eptr->mode = ClientConnectionMode::KILL;
 			}
 		} else if (eptr->registered == ClientState::kRegistered) {      // mounts and new tools
-			if (eptr->sesdata==NULL) {
-				safs_pretty_syslog(LOG_ERR,"registered connection without sesdata !!!");
-				eptr->mode=ClientConnectionMode::KILL;
+			if (eptr->sesdata == NULL) {
+				safs::log_err("registered connection without sesdata !!!");
+				eptr->mode = ClientConnectionMode::KILL;
 				return;
 			}
 			switch (type) {
 				case CLTOMA_FUSE_REGISTER:
-					matoclserv_fuse_register(eptr,data,length);
-					break;
+				    matoclserv_fuse_register(eptr, data, length);
+				    break;
 				case SAU_CLTOMA_REGISTER_CONFIG:
-					matoclserv_register_config(eptr,data,length);
-					break;
+				    matoclserv_register_config(eptr, data, length);
+				    break;
 				case SAU_CLTOMA_UPDATE_MOUNT_INFO:
-					matoclserv_update_mount_info(eptr,data,length);
-					break;
+				    matoclserv_update_mount_info(eptr, data, length);
+				    break;
 				case CLTOMA_FUSE_RESERVED_INODES:
-					matoclserv_fuse_reserved_inodes(eptr,data,length);
-					break;
+				    matoclserv_fuse_reserved_inodes(eptr, data, length);
+				    break;
 				case CLTOMA_FUSE_STATFS:
-					matoclserv_fuse_statfs(eptr,data,length);
-					break;
+				    matoclserv_fuse_statfs(eptr, data, length);
+				    break;
 				case CLTOMA_FUSE_ACCESS:
-					matoclserv_fuse_access(eptr,data,length);
-					break;
+				    matoclserv_fuse_access(eptr, data, length);
+				    break;
 				case CLTOMA_FUSE_LOOKUP:
-					matoclserv_fuse_lookup(eptr,data,length);
-					break;
+				    matoclserv_fuse_lookup(eptr, data, length);
+				    break;
 				case CLTOMA_FUSE_GETATTR:
-					matoclserv_fuse_getattr(eptr,data,length);
-					break;
+				    matoclserv_fuse_getattr(eptr, data, length);
+				    break;
 				case CLTOMA_FUSE_SETATTR:
-					matoclserv_fuse_setattr(eptr,data,length);
-					break;
+				    matoclserv_fuse_setattr(eptr, data, length);
+				    break;
 				case CLTOMA_FUSE_READLINK:
-					matoclserv_fuse_readlink(eptr,data,length);
-					break;
+				    matoclserv_fuse_readlink(eptr, data, length);
+				    break;
 				case CLTOMA_FUSE_SYMLINK:
-					matoclserv_fuse_symlink(eptr,data,length);
-					break;
+				    matoclserv_fuse_symlink(eptr, data, length);
+				    break;
 				case CLTOMA_FUSE_MKNOD:
 				case SAU_CLTOMA_FUSE_MKNOD:
 					matoclserv_fuse_mknod(eptr, PacketHeader(type, length), data);
@@ -5664,26 +5837,26 @@ void matoclserv_gotpacket(matoclserventry *eptr,uint32_t type,const uint8_t *dat
 					matoclserv_fuse_mkdir(eptr, PacketHeader(type, length), data);
 					break;
 				case CLTOMA_FUSE_UNLINK:
-					matoclserv_fuse_unlink(eptr,data,length);
-					break;
+				    matoclserv_fuse_unlink(eptr, data, length);
+				    break;
 				case CLTOMA_FUSE_RMDIR:
-					matoclserv_fuse_rmdir(eptr,data,length);
-					break;
+				    matoclserv_fuse_rmdir(eptr, data, length);
+				    break;
 				case CLTOMA_FUSE_RENAME:
 					matoclserv_fuse_rename(eptr,data,length);
 					break;
 				case CLTOMA_FUSE_LINK:
-					matoclserv_fuse_link(eptr,data,length);
-					break;
+				    matoclserv_fuse_link(eptr, data, length);
+				    break;
 				case CLTOMA_FUSE_GETDIR:
-					matoclserv_fuse_getdir(eptr,data,length);
-					break;
+				    matoclserv_fuse_getdir(eptr, data, length);
+				    break;
 				case SAU_CLTOMA_FUSE_GETDIR:
 					matoclserv_fuse_getdir(eptr, PacketHeader(type, length), data);
 					break;
 				case CLTOMA_FUSE_OPEN:
-					matoclserv_fuse_open(eptr,data,length);
-					break;
+				    matoclserv_fuse_open(eptr, data, length);
+				    break;
 				case SAU_CLTOMA_FUSE_READ_CHUNK:
 				case CLTOMA_FUSE_READ_CHUNK:
 					matoclserv_fuse_read_chunk(eptr, PacketHeader(type, length), data);
@@ -5701,38 +5874,38 @@ void matoclserv_gotpacket(matoclserventry *eptr,uint32_t type,const uint8_t *dat
 					break;
 					// fuse - meta
 				case CLTOMA_FUSE_GETTRASH:
-					matoclserv_fuse_gettrash(eptr,data,length);
-					break;
+				    matoclserv_fuse_gettrash(eptr, data, length);
+				    break;
 				case SAU_CLTOMA_FUSE_GETTRASH:
 					matoclserv_fuse_gettrash(eptr, PacketHeader(type, length), data);
 					break;
 				case CLTOMA_FUSE_GETDETACHEDATTR:
-					matoclserv_fuse_getdetachedattr(eptr,data,length);
-					break;
+				    matoclserv_fuse_getdetachedattr(eptr, data, length);
+				    break;
 				case CLTOMA_FUSE_GETTRASHPATH:
-					matoclserv_fuse_gettrashpath(eptr,data,length);
-					break;
+				    matoclserv_fuse_gettrashpath(eptr, data, length);
+				    break;
 				case CLTOMA_FUSE_SETTRASHPATH:
-					matoclserv_fuse_settrashpath(eptr,data,length);
-					break;
+				    matoclserv_fuse_settrashpath(eptr, data, length);
+				    break;
 				case CLTOMA_FUSE_UNDEL:
-					matoclserv_fuse_undel(eptr,data,length);
-					break;
+				    matoclserv_fuse_undel(eptr, data, length);
+				    break;
 				case CLTOMA_FUSE_PURGE:
-					matoclserv_fuse_purge(eptr,data,length);
-					break;
+				    matoclserv_fuse_purge(eptr, data, length);
+				    break;
 				case CLTOMA_FUSE_GETRESERVED:
-					matoclserv_fuse_getreserved(eptr,data,length);
-					break;
+				    matoclserv_fuse_getreserved(eptr, data, length);
+				    break;
 				case SAU_CLTOMA_FUSE_GETRESERVED:
 					matoclserv_fuse_getreserved(eptr, PacketHeader(type, length), data);
 					break;
 				case CLTOMA_FUSE_CHECK:
-					matoclserv_fuse_check(eptr,data,length);
-					break;
+				    matoclserv_fuse_check(eptr, data, length);
+				    break;
 				case CLTOMA_FUSE_GETTRASHTIME:
-					matoclserv_fuse_gettrashtime(eptr,data,length);
-					break;
+				    matoclserv_fuse_gettrashtime(eptr, data, length);
+				    break;
 				case CLTOMA_FUSE_SETTRASHTIME:
 					matoclserv_fuse_settrashtime(eptr, PacketHeader(type, length), data);
 					break;
@@ -5745,29 +5918,29 @@ void matoclserv_gotpacket(matoclserventry *eptr,uint32_t type,const uint8_t *dat
 					matoclserv_fuse_setgoal(eptr, PacketHeader(type, length), data);
 					break;
 				case CLTOMA_FUSE_APPEND:
-					matoclserv_fuse_append(eptr,data,length);
-					break;
+				    matoclserv_fuse_append(eptr, data, length);
+				    break;
 				case CLTOMA_FUSE_GETDIRSTATS:
-					matoclserv_fuse_getdirstats_old(eptr,data,length);
-					break;
+				    matoclserv_fuse_getdirstats_old(eptr, data, length);
+				    break;
 				case SAU_CLTOMA_FUSE_TRUNCATE_END:
 				case SAU_CLTOMA_FUSE_TRUNCATE:
 				case CLTOMA_FUSE_TRUNCATE:
 					matoclserv_fuse_truncate(eptr, PacketHeader(type, length), data);
 					break;
 				case CLTOMA_FUSE_REPAIR:
-					matoclserv_fuse_repair(eptr,data,length);
-					break;
+				    matoclserv_fuse_repair(eptr, data, length);
+				    break;
 				case CLTOMA_FUSE_SNAPSHOT:
 				case SAU_CLTOMA_FUSE_SNAPSHOT:
 					matoclserv_fuse_snapshot(eptr, PacketHeader(type, length), data);
 					break;
 				case CLTOMA_FUSE_GETEATTR:
-					matoclserv_fuse_geteattr(eptr,data,length);
-					break;
+				    matoclserv_fuse_geteattr(eptr, data, length);
+				    break;
 				case CLTOMA_FUSE_SETEATTR:
-					matoclserv_fuse_seteattr(eptr,data,length);
-					break;
+				    matoclserv_fuse_seteattr(eptr, data, length);
+				    break;
 				case SAU_CLTOMA_FUSE_DELETE_ACL:
 					matoclserv_fuse_deleteacl(eptr, data, length);
 					break;
@@ -5785,67 +5958,65 @@ void matoclserv_gotpacket(matoclserventry *eptr,uint32_t type,const uint8_t *dat
 					break;
 					/* do not use in version before 1.7.x */
 				case CLTOMA_FUSE_GETXATTR:
-					matoclserv_fuse_getxattr(eptr,data,length);
-					break;
+				    matoclserv_fuse_getxattr(eptr, data, length);
+				    break;
 				case CLTOMA_FUSE_SETXATTR:
-					matoclserv_fuse_setxattr(eptr,data,length);
-					break;
+				    matoclserv_fuse_setxattr(eptr, data, length);
+				    break;
 					/* for tools - also should be available for registered clients */
 				case CLTOMA_CSERV_LIST:
-					matoclserv_cserv_list(eptr,data,length);
-					break;
+				    matoclserv_cserv_list(eptr, data, length);
+				    break;
 				case CLTOMA_SESSION_LIST:
-					matoclserv_session_list(eptr,data,length);
-					break;
+				    matoclserv_session_list(eptr, data, length);
+				    break;
 				case CLTOAN_CHART:
-					matoclserv_chart(eptr,data,length);
-					break;
+				    matoclserv_chart(eptr, data, length);
+				    break;
 				case CLTOAN_CHART_DATA:
-					matoclserv_chart_data(eptr,data,length);
-					break;
+				    matoclserv_chart_data(eptr, data, length);
+				    break;
 				case CLTOMA_INFO:
-					matoclserv_info(eptr,data,length);
-					break;
+				    matoclserv_info(eptr, data, length);
+				    break;
 				case CLTOMA_FSTEST_INFO:
-					matoclserv_fstest_info(eptr,data,length);
-					break;
+				    matoclserv_fstest_info(eptr, data, length);
+				    break;
 				case CLTOMA_CHUNKSTEST_INFO:
-					matoclserv_chunkstest_info(eptr,data,length);
-					break;
+				    matoclserv_chunkstest_info(eptr, data, length);
+				    break;
 				case CLTOMA_CHUNKS_MATRIX:
-					matoclserv_chunks_matrix(eptr,data,length);
-					break;
+				    matoclserv_chunks_matrix(eptr, data, length);
+				    break;
 				case CLTOMA_EXPORTS_INFO:
-					matoclserv_exports_info(eptr,data,length);
-					break;
+				    matoclserv_exports_info(eptr, data, length);
+				    break;
 				case CLTOMA_MLOG_LIST:
-					matoclserv_mlog_list(eptr,data,length);
-					break;
+				    matoclserv_mlog_list(eptr, data, length);
+				    break;
 				case CLTOMA_CSSERV_REMOVESERV:
-					matoclserv_cserv_removeserv(eptr,data,length);
-					break;
+				    matoclserv_cserv_removeserv(eptr, data, length);
+				    break;
 				case SAU_CLTOMA_IOLIMIT:
-					matoclserv_iolimit(eptr,data,length);
-					break;
+				    matoclserv_iolimit(eptr, data, length);
+				    break;
 				case SAU_CLTOMA_FUSE_SETLK:
-					matoclserv_fuse_setlk(eptr,data,length);
-					break;
+				    matoclserv_fuse_setlk(eptr, data, length);
+				    break;
 				case SAU_CLTOMA_FUSE_GETLK:
-					matoclserv_fuse_getlk(eptr,data,length);
-					break;
+				    matoclserv_fuse_getlk(eptr, data, length);
+				    break;
 				case SAU_CLTOMA_FUSE_FLOCK:
-					matoclserv_fuse_flock(eptr,data,length);
-					break;
+				    matoclserv_fuse_flock(eptr, data, length);
+				    break;
 				case SAU_CLTOMA_FUSE_FLOCK_INTERRUPT:
-					matoclserv_fuse_locks_interrupt(
-						eptr, data, length,
-						(uint8_t)safs_locks::Type::kFlock);
-					break;
+				    matoclserv_fuse_locks_interrupt(eptr, data, length,
+				                                    (uint8_t)safs_locks::Type::kFlock);
+				    break;
 				case SAU_CLTOMA_FUSE_SETLK_INTERRUPT:
-					matoclserv_fuse_locks_interrupt(
-						eptr, data, length,
-						(uint8_t)safs_locks::Type::kPosix);
-					break;
+				    matoclserv_fuse_locks_interrupt(eptr, data, length,
+				                                    (uint8_t)safs_locks::Type::kPosix);
+				    break;
 				case SAU_CLTOMA_RECURSIVE_REMOVE:
 					matoclserv_fuse_recursive_remove(eptr, data, length);
 					break;
@@ -5871,28 +6042,30 @@ void matoclserv_gotpacket(matoclserventry *eptr,uint32_t type,const uint8_t *dat
 					matoclserv_sau_cserv_list(eptr, data, length);
 					break;
 				default:
-					safs_pretty_syslog(LOG_NOTICE,"main master server module: got unknown message from sfsmount (type:%" PRIu32 ")",type);
-					eptr->mode=ClientConnectionMode::KILL;
+				    safs::log_info(
+				        "main master server module: got unknown message from sfsmount (type:{})",
+				        type);
+				    eptr->mode=ClientConnectionMode::KILL;
 			}
 		} else if (eptr->registered == ClientState::kOldTools) {        // old sfstools
 			if (eptr->sesdata==NULL) {
-				safs_pretty_syslog(LOG_ERR,"registered connection (tools) without sesdata !!!");
+				safs::log_err("registered connection (tools) without sesdata !!!");
 				eptr->mode=ClientConnectionMode::KILL;
 				return;
 			}
 			switch (type) {
 				// extra (external tools)
 				case CLTOMA_FUSE_REGISTER:
-					matoclserv_fuse_register(eptr,data,length);
-					break;
+				    matoclserv_fuse_register(eptr, data, length);
+				    break;
 				case CLTOMA_FUSE_READ_CHUNK: // used in saunafs fileinfo
 					matoclserv_fuse_read_chunk(eptr, PacketHeader(type, length), data);
 					break;
 				case CLTOMA_FUSE_CHECK:
-					matoclserv_fuse_check(eptr,data,length);
+					matoclserv_fuse_check(eptr, data, length);
 					break;
 				case CLTOMA_FUSE_GETTRASHTIME:
-					matoclserv_fuse_gettrashtime(eptr,data,length);
+					matoclserv_fuse_gettrashtime(eptr, data, length);
 					break;
 				case CLTOMA_FUSE_SETTRASHTIME:
 					matoclserv_fuse_settrashtime(eptr, PacketHeader(type, length), data);
@@ -5904,40 +6077,42 @@ void matoclserv_gotpacket(matoclserventry *eptr,uint32_t type,const uint8_t *dat
 					matoclserv_fuse_setgoal(eptr, PacketHeader(type, length), data);
 					break;
 				case CLTOMA_FUSE_APPEND:
-					matoclserv_fuse_append(eptr,data,length);
-					break;
+				    matoclserv_fuse_append(eptr, data, length);
+				    break;
 				case CLTOMA_FUSE_GETDIRSTATS:
-					matoclserv_fuse_getdirstats(eptr,data,length);
-					break;
+				    matoclserv_fuse_getdirstats(eptr, data, length);
+				    break;
 				case CLTOMA_FUSE_TRUNCATE:
 					matoclserv_fuse_truncate(eptr, PacketHeader(type, length), data);
 					break;
 				case CLTOMA_FUSE_REPAIR:
-					matoclserv_fuse_repair(eptr,data,length);
-					break;
+				    matoclserv_fuse_repair(eptr, data, length);
+				    break;
 				case CLTOMA_FUSE_SNAPSHOT:
 					matoclserv_fuse_snapshot(eptr, PacketHeader(type, length), data);
 					break;
 				case CLTOMA_FUSE_GETEATTR:
-					matoclserv_fuse_geteattr(eptr,data,length);
-					break;
+				    matoclserv_fuse_geteattr(eptr, data, length);
+				    break;
 				case CLTOMA_FUSE_SETEATTR:
-					matoclserv_fuse_seteattr(eptr,data,length);
-					break;
+				    matoclserv_fuse_seteattr(eptr, data, length);
+				    break;
 				default:
-					safs_pretty_syslog(LOG_NOTICE,"main master server module: got unknown message from saunafs <COMMAND> tools (type:%" PRIu32 ")",type);
+				    safs::log_info(
+				        "main master server module: got unknown message from saunafs "
+				        "<COMMAND> tools (type:{})", type);
 				    eptr->mode = ClientConnectionMode::KILL;
 			}
 		}
 	} catch (IncorrectDeserializationException& e) {
-		safs_pretty_syslog(LOG_NOTICE,
+		safs::log_info(
 				"main master server module: got inconsistent message from mount "
-				"(type:%" PRIu32 ", length:%" PRIu32"), %s", type, length, e.what());
+				"(type:{}, length:{}), {}", type, length, e.what());
 		eptr->mode = ClientConnectionMode::KILL;
 	}
 }
 
-void matoclserv_term(void) {
+void matoclserv_term() {
 	packetstruct *pptr,*pptrn;
 
 	safs::log_info("main master server module: closing {}:{}", ListenHost, ListenPort);
@@ -5971,20 +6146,23 @@ void matoclserv_read(matoclserventry *eptr) {
 
 	watchdog.start();
 	while (eptr->mode != ClientConnectionMode::KILL) {
-		i=read(eptr->sock,eptr->inputpacket.startptr,eptr->inputpacket.bytesleft);
-		if (i==0) {
+		i = read(eptr->sock, eptr->inputpacket.startptr, eptr->inputpacket.bytesleft);
+		if (i == 0) {
 			if (eptr->registered == ClientState::kRegistered) {       // show this message only for standard, registered clients
-				safs_pretty_syslog(LOG_NOTICE,"connection with client(ip:%u.%u.%u.%u) has been closed by peer",(eptr->peerip>>24)&0xFF,(eptr->peerip>>16)&0xFF,(eptr->peerip>>8)&0xFF,eptr->peerip&0xFF);
+				safs::log_info("connection with client (ip:{}) has been closed by peer",
+				               ipToString(eptr->peerip));
 			}
 			eptr->mode = ClientConnectionMode::KILL;
 			return;
 		}
-		if (i<0) {
-			if (errno!=EAGAIN) {
+
+		if (i < 0) {
+			if (errno != EAGAIN) {
 #ifdef ECONNRESET
-				if (errno!=ECONNRESET) {
+				if (errno != ECONNRESET) {
 #endif
-					safs_silent_errlog(LOG_NOTICE,"main master server module: (ip:%u.%u.%u.%u) read error",(eptr->peerip>>24)&0xFF,(eptr->peerip>>16)&0xFF,(eptr->peerip>>8)&0xFF,eptr->peerip&0xFF);
+					safs_silent_errlog(LOG_NOTICE, "main master server module: (ip:%s) read error",
+					                   ipToString(eptr->peerip).c_str());
 #ifdef ECONNRESET
 				}
 #endif
@@ -5992,21 +6170,22 @@ void matoclserv_read(matoclserventry *eptr) {
 			}
 			return;
 		}
-		eptr->inputpacket.startptr+=i;
-		eptr->inputpacket.bytesleft-=i;
+		eptr->inputpacket.startptr += i;
+		eptr->inputpacket.bytesleft -= i;
 		metrics::Counter::increment(metrics::Counter::Master::CLIENT_RX_BYTES, i);
-		stats_brcvd+=i;
+		stats_brcvd += i;
 
-		if (eptr->inputpacket.bytesleft>0) {
+		if (eptr->inputpacket.bytesleft > 0) {
 			return;
 		}
 
 		if (eptr->mode == ClientConnectionMode::HEADER) {
-			ptr = eptr->hdrbuff+4;
+			ptr = eptr->hdrbuff + 4;
 			get32bit(&ptr, size);
-			if (size>0) {
-				if (size>MaxPacketSize) {
-					safs_pretty_syslog(LOG_WARNING,"main master server module: packet too long (%" PRIu32 "/%u)",size,MaxPacketSize);
+			if (size > 0) {
+				if (size > MaxPacketSize) {
+					safs::log_warn("main master server module: packet too long ({}/{})", size,
+					               MaxPacketSize);
 					eptr->mode = ClientConnectionMode::KILL;
 					return;
 				}
@@ -6053,29 +6232,28 @@ void matoclserv_write(matoclserventry *eptr) {
 	watchdog.start();
 	for (;;) {
 		pack = eptr->outputhead;
-		if (pack==NULL) {
-			return;
-		}
-		i=write(eptr->sock,pack->startptr,pack->bytesleft);
-		if (i<0) {
-			if (errno!=EAGAIN) {
-				safs_silent_errlog(LOG_NOTICE,"main master server module: (ip:%u.%u.%u.%u) write error",(eptr->peerip>>24)&0xFF,(eptr->peerip>>16)&0xFF,(eptr->peerip>>8)&0xFF,eptr->peerip&0xFF);
+		if (pack == NULL) { return; }
+		i = write(eptr->sock, pack->startptr, pack->bytesleft);
+		if (i < 0) {
+			if (errno != EAGAIN) {
+				safs_silent_errlog(LOG_NOTICE, "main master server module: (ip:%s) write error",
+				                   ipToString(eptr->peerip).c_str());
 				eptr->mode = ClientConnectionMode::KILL;
 			}
 			return;
 		}
-		pack->startptr+=i;
-		pack->bytesleft-=i;
+		pack->startptr += i;
+		pack->bytesleft -= i;
 		metrics::Counter::increment(metrics::Counter::Master::CLIENT_TX_BYTES, i);
-		stats_bsent+=i;
-		if (pack->bytesleft>0) {
+		stats_bsent += i;
+		if (pack->bytesleft > 0) {
 			return;
 		}
 		free(pack->packet);
 		stats_psent++;
 		metrics::Counter::increment(metrics::Counter::Master::CLIENT_TX_PACKETS);
 		eptr->outputhead = pack->next;
-		if (eptr->outputhead==NULL) {
+		if (eptr->outputhead == NULL) {
 			eptr->outputtail = &(eptr->outputhead);
 		}
 		free(pack);
@@ -6087,7 +6265,7 @@ void matoclserv_write(matoclserventry *eptr) {
 }
 
 void matoclserv_wantexit(void) {
-	exiting=1;
+	exiting = 1;
 }
 
 int matoclserv_canexit(void) {
@@ -6258,45 +6436,52 @@ void matoclserv_serve(const std::vector<pollfd> &pdesc) {
 
 void matoclserv_start_cond_check(void) {
 	if (starting) {
-// very simple condition checking if all chunkservers have been connected
-// in the future master will know his chunkservers list and then this condition will be changed
-		if (chunk_get_missing_count()<100) {
-			starting=0;
+		// very simple condition checking if all chunkservers have been connected
+		// in the future master will know his chunkservers list and then this condition will be
+		// changed
+		if (chunk_get_missing_count() < 100) {
+			starting = 0;
 		} else {
 			starting--;
 		}
 	}
 }
 
-int matoclserv_sessionsinit(void) {
+int matoclserv_sessions_init() {
 	sessionVector.clear();
 
 	switch (matoclserv_load_sessions()) {
 		case 0: // no file
-			safs_pretty_syslog(LOG_WARNING,"sessions file %s/%s not found;"
-					" if it is not a fresh installation you have to restart all active mounts",
-					fs::getCurrentWorkingDirectoryNoThrow().c_str(), kSessionsFilename);
-			matoclserv_store_sessions();
+		    safs::log_warn(
+		        "sessions file {}/{} not found; if it is not a fresh installation "
+		        "you have to restart all active mounts",
+		        fs::getCurrentWorkingDirectoryNoThrow().c_str(), kSessionsFilename);
+		    matoclserv_store_sessions();
 			break;
 		case 1: // file loaded
-			safs_pretty_syslog(LOG_INFO,"initialized sessions from file %s/%s",
-					fs::getCurrentWorkingDirectoryNoThrow().c_str(), kSessionsFilename);
-			break;
+		    safs::log_info("initialized sessions from file {}/{}",
+		                   fs::getCurrentWorkingDirectoryNoThrow().c_str(), kSessionsFilename);
+		    break;
 		default:
-			safs_pretty_syslog(LOG_ERR,"due to missing sessions (%s/%s)"
-					" you have to restart all active mounts",
-					fs::getCurrentWorkingDirectoryNoThrow().c_str(), kSessionsFilename);
-			break;
+		    safs::log_err("due to missing sessions ({}/{}) you have to restart all active mounts",
+		                  fs::getCurrentWorkingDirectoryNoThrow().c_str(), kSessionsFilename);
+		    break;
 	}
-	SessionSustainTime = cfg_getuint32("SESSION_SUSTAIN_TIME",86400);
-	if (SessionSustainTime>7*86400) {
-		SessionSustainTime=7*86400;
-		safs_pretty_syslog(LOG_WARNING,"SESSION_SUSTAIN_TIME too big (more than week) - setting this value to one week");
+
+	SessionSustainTime = cfg_getuint32("SESSION_SUSTAIN_TIME", 86400);
+
+	if (SessionSustainTime > 7 * 86400) {
+		SessionSustainTime = 7 * 86400;
+		safs::log_warn(
+		    "SESSION_SUSTAIN_TIME too big (more than week) - setting this value to one week");
 	}
-	if (SessionSustainTime<60) {
-		SessionSustainTime=60;
-		safs_pretty_syslog(LOG_WARNING,"SESSION_SUSTAIN_TIME too low (less than minute) - setting this value to one minute");
+
+	if (SessionSustainTime < 60) {
+		SessionSustainTime = 60;
+		safs::log_warn(
+		    "SESSION_SUSTAIN_TIME too low (less than minute) - setting this value to one minute");
 	}
+
 	return 0;
 }
 
@@ -6312,8 +6497,8 @@ int matoclserv_iolimits_reload() {
 			gIoLimitsDatabase.setLimits(
 					SteadyClock::now(), configLoader.limits(), gIoLimitsAccumulate_ms);
 		} catch (Exception& ex) {
-			safs_pretty_syslog(LOG_ERR, "failed to process global I/O limits configuration "
-					"file (%s): %s", configFile.c_str(), ex.message().c_str());
+			safs::log_err("failed to process global I/O limits configuration file ({}): {}",
+			              configFile, ex.message());
 			return -1;
 		}
 	} else {
@@ -6332,19 +6517,21 @@ int matoclserv_iolimits_reload() {
 	return 0;
 }
 
-void  matoclserv_become_master() {
+void matoclserv_become_master() {
 	starting = 120;
 	matoclserv_reset_session_timeouts();
 	matoclserv_start_cond_check();
+
 	if (starting) {
-		eventloop_timeregister(TIMEMODE_RUN_LATE,1,0,matoclserv_start_cond_check);
+		eventloop_timeregister(TIMEMODE_RUN_LATE, 1, 0, matoclserv_start_cond_check);
 	}
-	eventloop_timeregister(TIMEMODE_RUN_LATE,10,0,matocl_session_check);
-	eventloop_timeregister(TIMEMODE_RUN_LATE,3600,0,matocl_session_statsmove);
+
+	eventloop_timeregister(TIMEMODE_RUN_LATE, 10, 0, matocl_session_check);
+	eventloop_timeregister(TIMEMODE_RUN_LATE, 3600, 0, matocl_session_statsmove);
 	return;
 }
 
-void matoclserv_reload(void) {
+void matoclserv_reload() {
 	// Notify admins that reload was performed - put responses in their packet queues
 	for (const auto &eptr : matoclservList) {
 		if (eptr->adminTask == AdminTask::kReload) {
@@ -6353,8 +6540,9 @@ void matoclserv_reload(void) {
 		}
 	}
 
-	RejectOld = cfg_getuint32("REJECT_OLD_CLIENTS",0);
-	SessionSustainTime = cfg_getuint32("SESSION_SUSTAIN_TIME",86400);
+	RejectOld = cfg_getuint32("REJECT_OLD_CLIENTS", 0);
+	SessionSustainTime = cfg_getuint32("SESSION_SUSTAIN_TIME", 86400);
+
 	if (SessionSustainTime > 7 * 86400) {
 		SessionSustainTime = 7 * 86400;
 		safs::log_warn(
@@ -6401,7 +6589,7 @@ void matoclserv_reload(void) {
 	tcpreuseaddr(newlsock);
 
 	if (tcpsetacceptfilter(newlsock) < 0 && errno != ENOTSUP) {
-		safs_silent_errlog(LOG_NOTICE,"main master server module: can't set accept filter");
+		safs_silent_errlog(LOG_NOTICE, "main master server module: can't set accept filter");
 	}
 
 	if (tcpstrlisten(newlsock, ListenHost.c_str(), ListenPort.c_str(), 100) < 0) {
@@ -6420,7 +6608,7 @@ void matoclserv_reload(void) {
 	lsock = newlsock;
 }
 
-int matoclserv_networkinit(void) {
+int matoclserv_network_init() {
 	auto host = cfg_getstr("MATOCL_LISTEN_HOST", "*");
 	auto port = cfg_getstr("MATOCL_LISTEN_PORT", "9421");
 
@@ -6430,7 +6618,7 @@ int matoclserv_networkinit(void) {
 	free(host);  // to avoid memory leak allocated by strdup in cfg_getstr() function
 	free(port);  // to avoid memory leak allocated by strdup in cfg_getstr() function
 
-	RejectOld = cfg_getuint32("REJECT_OLD_CLIENTS",0);
+	RejectOld = cfg_getuint32("REJECT_OLD_CLIENTS", 0);
 
 	if (matoclserv_iolimits_reload() != 0) {
 		return -1;
@@ -6473,7 +6661,7 @@ int matoclserv_networkinit(void) {
 	return 0;
 }
 
-void matoclserv_session_unload(void) {
+void matoclserv_session_unload() {
 	for (const auto& sessionPtr : sessionVector) {
 		sessionPtr->openedfiles.clear();
 	}

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -93,13 +93,18 @@
 #define MaxPacketSize 1000000
 
 // matoclserventry.mode
-enum {KILL,HEADER,DATA};
-// chunklis.type
-enum {
-	FUSE_WRITE,          // reply to FUSE_WRITE_CHUNK is delayed
-	FUSE_TRUNCATE,       // reply to FUSE_TRUNCATE which does not require writing is delayed
-	FUSE_TRUNCATE_BEGIN, // reply to FUSE_TRUNCATE which does require writing is delayed
-	FUSE_TRUNCATE_END    // reply to FUSE_TRUNCATE_END is delayed
+enum class ClientConnectionMode : std::uint8_t {
+	KILL,			/// Connection is terminated,
+	HEADER,			/// Read header
+	DATA			/// Read data packet
+};
+
+// chunkDelayedOperation types
+enum ChunkDelayedOperationType : std::uint32_t {
+	FUSE_WRITE,          /// Reply to FUSE_WRITE_CHUNK is delayed
+	FUSE_TRUNCATE,       /// Reply to FUSE_TRUNCATE which does not require writing is delayed
+	FUSE_TRUNCATE_BEGIN, /// Reply to FUSE_TRUNCATE which does require writing is delayed
+	FUSE_TRUNCATE_END    /// Reply to FUSE_TRUNCATE_END is delayed
 };
 
 #define SESSION_STATS 16
@@ -111,7 +116,7 @@ struct matoclserventry;
 // locked chunks
 class PacketSerializer;
 
-struct chunklist {
+struct chunkDelayedOperation {
 	uint64_t chunkid;
 	uint64_t fleng;     // file length
 	uint32_t lockid;    // lock ID
@@ -215,7 +220,7 @@ enum class AdminTask {
 /** Client entry in the server. */
 struct matoclserventry {
 	ClientState registered;
-	uint8_t mode;                           //0 - not active, 1 - read header, 2 - read packet
+	ClientConnectionMode mode;
 	bool iolimits;
 	int sock;                               //socket number
 	int32_t pdescpos;
@@ -232,7 +237,7 @@ struct matoclserventry {
 	session *sesdata;
 	std::unique_ptr<SauMatoclAdminRegisterChallengeData> adminChallenge;
 	AdminTask adminTask;                   // admin task requested by this client
-	std::vector<std::unique_ptr<chunklist>> chunkdelayedops;
+	std::vector<std::unique_ptr<chunkDelayedOperation>> chunkdelayedops;
 };
 
 static std::vector<std::unique_ptr<session>> sessionVector;
@@ -1065,7 +1070,7 @@ uint8_t matoclserv_fuse_write_chunk_respond(matoclserventry *eptr,
 }
 
 void matoclserv_chunk_status(uint64_t chunkid,uint8_t status) {
-	chunklist *currentChunk;
+	chunkDelayedOperation *operation;
 	const PacketSerializer *serializer;
 
 	matoclserventry *eptr = NULL;
@@ -1083,26 +1088,26 @@ void matoclserv_chunk_status(uint64_t chunkid,uint8_t status) {
 	auto eptrIterator = matoclservList.begin();
 	for (; eptrIterator != matoclservList.end() && eptr == NULL; eptrIterator++) {
 		matoclserventry* eaptr = eptrIterator->get();
-		if (eaptr->mode != KILL) {
-			auto chunkListIterator = eaptr->chunkdelayedops.begin();
-			while (chunkListIterator != eaptr->chunkdelayedops.end() && eptr == NULL) {
-				currentChunk = chunkListIterator->get();
-				if (currentChunk->chunkid == chunkid) {
+		if (eaptr->mode != ClientConnectionMode::KILL) {
+			auto chunkOpsIterator = eaptr->chunkdelayedops.begin();
+			while (chunkOpsIterator != eaptr->chunkdelayedops.end() && eptr == NULL) {
+				operation = chunkOpsIterator->get();
+				if (operation->chunkid == chunkid) {
 					eptr = eaptr;
-					qid = currentChunk->qid;
-					fleng = currentChunk->fleng;
-					lockid = currentChunk->lockid;
-					type = currentChunk->type;
-					inode = currentChunk->inode;
-					uid = currentChunk->uid;
-					gid = currentChunk->gid;
-					auid = currentChunk->auid;
-					agid = currentChunk->agid;
-					serializer = currentChunk->serializer;
+					qid = operation->qid;
+					fleng = operation->fleng;
+					lockid = operation->lockid;
+					type = operation->type;
+					inode = operation->inode;
+					uid = operation->uid;
+					gid = operation->gid;
+					auid = operation->auid;
+					agid = operation->agid;
+					serializer = operation->serializer;
 
-					chunkListIterator = eaptr->chunkdelayedops.erase(chunkListIterator);
+					chunkOpsIterator = eaptr->chunkdelayedops.erase(chunkOpsIterator);
 				} else {
-					++chunkListIterator;
+					++chunkOpsIterator;
 				}
 			}
 		}
@@ -1161,7 +1166,7 @@ void matoclserv_chunk_status(uint64_t chunkid,uint8_t status) {
 void matoclserv_cserv_list(matoclserventry *eptr, const uint8_t */*data*/, uint32_t length) {
 	if (length!=0) {
 		safs_pretty_syslog(LOG_NOTICE,"CLTOMA_CSERV_LIST - wrong size (%" PRIu32 "/0)",length);
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -1205,7 +1210,7 @@ void matoclserv_sau_cserv_list(matoclserventry *eptr, const uint8_t *data, uint3
 		matocl::cservList::serialize(buffer, message_id, csdb_chunkserver_list());
 	} else {
 		safs_pretty_syslog(LOG_NOTICE,"SAU_CSERV_LIST - wrong packet version %u", version);
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 	matoclserv_createpacket(eptr, std::move(buffer));
@@ -1217,11 +1222,11 @@ void matoclserv_cserv_removeserv(matoclserventry *eptr,const uint8_t *data,uint3
 
 	constexpr uint32_t kExpectedSize = sizeof(ip) + sizeof(port);
 
-	if (length!=kExpectedSize) {
+	if (length != kExpectedSize) {
 		safs_pretty_syslog(LOG_NOTICE,
 		                   "CLTOMA_CSSERV_REMOVESERV - wrong size (%" PRIu32 "/%" PRIu32 ")",
 		                   length, kExpectedSize);
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -1296,7 +1301,7 @@ void matoclserv_session_list(matoclserventry *eptr,const uint8_t *data,uint32_t 
 	if (length != 0 && length != sizeof(vmode)) {
 		safs_pretty_syslog(LOG_NOTICE, "CLTOMA_SESSION_LIST - wrong size (%" PRIu32 "/(0|%lu))",
 		                   length, sizeof(vmode));
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -1322,7 +1327,7 @@ void matoclserv_session_list(matoclserventry *eptr,const uint8_t *data,uint32_t 
 	constexpr uint32_t kCurrentPlusLastHourEntrySize = sizeof(uint32_t) + sizeof(uint32_t);
 
 	for (const auto &eaptr : matoclservList) {
-		if (eaptr->mode != KILL && eaptr->sesdata &&
+		if (eaptr->mode != ClientConnectionMode::KILL && eaptr->sesdata &&
 		    eaptr->registered == ClientState::kRegistered) {
 			size += kCommonSessionSize + (SESSION_STATS * kCurrentPlusLastHourEntrySize) +
 			        (vmode ? kExtraVModeSize : 0);
@@ -1346,7 +1351,7 @@ void matoclserv_session_list(matoclserventry *eptr,const uint8_t *data,uint32_t 
 	put16bit(&ptr, SESSION_STATS);
 
 	for (const auto &eaptr : matoclservList) {
-		if (eaptr->mode != KILL && eaptr->sesdata &&
+		if (eaptr->mode != ClientConnectionMode::KILL && eaptr->sesdata &&
 		    eaptr->registered == ClientState::kRegistered) {
 			put32bit(&ptr, eaptr->sesdata->sessionid);
 			put32bit(&ptr, eaptr->peerip);
@@ -1408,7 +1413,7 @@ void matoclserv_mount_info_list(matoclserventry *eptr, const uint8_t *data, uint
 	cltoma::mountInfoList::deserialize(data, length);
 
 	for (const auto &eaptr : matoclservList) {
-		if (eaptr->mode != KILL && eaptr->sesdata != nullptr &&
+		if (eaptr->mode != ClientConnectionMode::KILL && eaptr->sesdata != nullptr &&
 		    eaptr->registered == ClientState::kRegistered) {
 			MountInfoEntry entry;
 			entry.sessionId = eaptr->sesdata->sessionid;
@@ -1428,7 +1433,7 @@ void matoclserv_chart(matoclserventry *eptr,const uint8_t *data,uint32_t length)
 	if (length != sizeof(chartid)) {
 		safs_pretty_syslog(LOG_NOTICE, "CLTOAN_CHART - wrong size (%" PRIu32 "/%lu)", length,
 		                   sizeof(chartid));
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -1457,7 +1462,7 @@ void matoclserv_chart_data(matoclserventry *eptr,const uint8_t *data,uint32_t le
 	if (length != sizeof(chartid)) {
 		safs_pretty_syslog(LOG_NOTICE, "CLTOAN_CHART_DATA - wrong size (%" PRIu32 "/%lu)", length,
 		                   sizeof(chartid));
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -1476,7 +1481,7 @@ void matoclserv_info(matoclserventry *eptr,const uint8_t *data,uint32_t length) 
 
 	if (length != 0) {
 		safs_pretty_syslog(LOG_NOTICE,"CLTOMA_INFO - wrong size (%" PRIu32 "/0)",length);
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -1506,7 +1511,7 @@ void matoclserv_fstest_info(matoclserventry *eptr,const uint8_t *data,uint32_t l
 
 	if (length != 0) {
 		safs_pretty_syslog(LOG_NOTICE, "CLTOMA_FSTEST_INFO - wrong size (%" PRIu32 "/0)", length);
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -1538,7 +1543,7 @@ void matoclserv_chunkstest_info(matoclserventry *eptr,const uint8_t *data,uint32
 	if (length != 0) {
 		safs_pretty_syslog(LOG_NOTICE, "CLTOMA_CHUNKSTEST_INFO - wrong size (%" PRIu32 "/0)",
 		                   length);
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -1556,7 +1561,7 @@ void matoclserv_chunks_matrix(matoclserventry *eptr,const uint8_t *data,uint32_t
 	if (length > sizeof(matrixid)) {
 		safs_pretty_syslog(LOG_NOTICE, "CLTOMA_CHUNKS_MATRIX - wrong size (%" PRIu32 "/0|%zu)",
 		                   length, sizeof(matrixid));
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -1578,7 +1583,7 @@ void matoclserv_exports_info(matoclserventry *eptr,const uint8_t *data,uint32_t 
 	if (length != 0 && length != sizeof(vmode)) {
 		safs_pretty_syslog(LOG_NOTICE, "CLTOMA_EXPORTS_INFO - wrong size (%" PRIu32 "/0|%zu)",
 		                   length, sizeof(vmode));
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -1598,7 +1603,7 @@ void matoclserv_mlog_list(matoclserventry *eptr,const uint8_t *data,uint32_t len
 
 	if (length != 0) {
 		safs_pretty_syslog(LOG_NOTICE, "CLTOMA_MLOG_LIST - wrong size (%" PRIu32 "/0)", length);
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -1645,7 +1650,7 @@ void matoclserv_fuse_register(matoclserventry *eptr,const uint8_t *data,uint32_t
 	constexpr uint32_t kBlobSizeWithSessionIdAndVersion = kBlobSizeWithVersion + sizeof(session::sessionid);
 
 	if (starting) {
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -1653,7 +1658,7 @@ void matoclserv_fuse_register(matoclserventry *eptr,const uint8_t *data,uint32_t
 		safs_pretty_syslog(LOG_NOTICE,
 		                   "CLTOMA_FUSE_REGISTER - wrong size (%" PRIu32 "/<%" PRIu32 ")", length,
 		                   kBlobSize);
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -1665,7 +1670,7 @@ void matoclserv_fuse_register(matoclserventry *eptr,const uint8_t *data,uint32_t
 	if (eptr->registered == ClientState::kUnregistered && (clientsNoACL || toolsNoACL)) {
 		if (RejectOld) {
 			safs_pretty_syslog(LOG_NOTICE,"CLTOMA_FUSE_REGISTER/NOACL - rejected (option REJECT_OLD_CLIENTS is set)");
-			eptr->mode = KILL;
+			eptr->mode = ClientConnectionMode::KILL;
 			return;
 		}
 		if (toolsNoACL) {
@@ -1674,7 +1679,7 @@ void matoclserv_fuse_register(matoclserventry *eptr,const uint8_t *data,uint32_t
 				                   "CLTOMA_FUSE_REGISTER/NOACL-TOOLS - wrong size (%" PRIu32
 				                   "/%" PRIu32 "|%" PRIu32 ")",
 				                   length, kBlobSize, kBlobSizeWithVersion);
-				eptr->mode = KILL;
+				eptr->mode = ClientConnectionMode::KILL;
 				return;
 			}
 		} else {  // clientsNoACL
@@ -1683,7 +1688,7 @@ void matoclserv_fuse_register(matoclserventry *eptr,const uint8_t *data,uint32_t
 				                   "CLTOMA_FUSE_REGISTER/NOACL-MOUNT - wrong size (%" PRIu32
 				                   "/%" PRIu32 "|%" PRIu32 ")",
 				                   length, kBlobSizeWithVersion, kBlobSizeWithSessionIdAndVersion);
-				eptr->mode = KILL;
+				eptr->mode = ClientConnectionMode::KILL;
 				return;
 			}
 		}
@@ -1700,7 +1705,7 @@ void matoclserv_fuse_register(matoclserventry *eptr,const uint8_t *data,uint32_t
 
 		if (eptr->version<0x010500 && !toolsNoACL) {
 			safs_pretty_syslog(LOG_NOTICE,"got register packet from mount older than 1.5 - rejecting");
-			eptr->mode = KILL;
+			eptr->mode = ClientConnectionMode::KILL;
 			return;
 		}
 
@@ -1709,7 +1714,7 @@ void matoclserv_fuse_register(matoclserventry *eptr,const uint8_t *data,uint32_t
 			eptr->sesdata = matoclserv_new_session(0, toolsNoACL);
 			if (eptr->sesdata == nullptr) {
 				safs_pretty_syslog(LOG_NOTICE, "can't allocate session record");
-				eptr->mode = KILL;
+				eptr->mode = ClientConnectionMode::KILL;
 				return;
 			}
 			eptr->sesdata->rootinode = SPECIAL_INODE_ROOT;
@@ -1722,7 +1727,7 @@ void matoclserv_fuse_register(matoclserventry *eptr,const uint8_t *data,uint32_t
 				eptr->sesdata = matoclserv_new_session(0, 0);
 				if (eptr->sesdata == nullptr) {
 					safs_pretty_syslog(LOG_NOTICE, "can't allocate session record");
-					eptr->mode = KILL;
+					eptr->mode = ClientConnectionMode::KILL;
 					return;
 				}
 				eptr->sesdata->rootinode = SPECIAL_INODE_ROOT;
@@ -1792,7 +1797,7 @@ void matoclserv_fuse_register(matoclserventry *eptr,const uint8_t *data,uint32_t
 			safs_pretty_syslog(LOG_NOTICE,
 			                   "CLTOMA_FUSE_REGISTER/ACL - wrong size (%" PRIu32 "/<%u)", length,
 			                   kBlobSizeWithRCode);
-			eptr->mode = KILL;
+			eptr->mode = ClientConnectionMode::KILL;
 			return;
 		}
 
@@ -1805,7 +1810,7 @@ void matoclserv_fuse_register(matoclserventry *eptr,const uint8_t *data,uint32_t
 			    LOG_NOTICE,
 			    "CLTOMA_FUSE_REGISTER/ACL - wrong rcode (%d) for registered status (%d)", rcode,
 			    (int)eptr->registered);
-			eptr->mode = KILL;
+			eptr->mode = ClientConnectionMode::KILL;
 			return;
 		}
 
@@ -1815,7 +1820,7 @@ void matoclserv_fuse_register(matoclserventry *eptr,const uint8_t *data,uint32_t
 				safs_pretty_syslog(LOG_NOTICE,
 				                   "CLTOMA_FUSE_REGISTER/ACL.1 - wrong size (%" PRIu32 "/%u)",
 				                   length, kBlobSizeWithRCode);
-				eptr->mode = KILL;
+				eptr->mode = ClientConnectionMode::KILL;
 				return;
 			}
 			wptr = matoclserv_createpacket(eptr,MATOCL_FUSE_REGISTER, matoclserventry::kPasswordSize);
@@ -1831,7 +1836,7 @@ void matoclserv_fuse_register(matoclserventry *eptr,const uint8_t *data,uint32_t
 				                   "CLTOMA_FUSE_REGISTER/ACL.2 - wrong size (%" PRIu32 "/>=%" PRIu32
 				                   ")",
 				                   length, kRegisterNewSessionMinSize);
-				eptr->mode = KILL;
+				eptr->mode = ClientConnectionMode::KILL;
 				return;
 			}
 			get32bit(&rptr, eptr->version);
@@ -1841,7 +1846,7 @@ void matoclserv_fuse_register(matoclserventry *eptr,const uint8_t *data,uint32_t
 				                   "CLTOMA_FUSE_REGISTER/ACL.2 - wrong size (%" PRIu32 "/>=%" PRIu32
 				                   "+ileng(%" PRIu32 "))",
 				                   length, kRegisterNewSessionMinSize, ileng);
-				eptr->mode = KILL;
+				eptr->mode = ClientConnectionMode::KILL;
 				return;
 			}
 			info = (const char*)rptr;
@@ -1853,7 +1858,7 @@ void matoclserv_fuse_register(matoclserventry *eptr,const uint8_t *data,uint32_t
 				                   "CLTOMA_FUSE_REGISTER/ACL.2 - wrong size (%" PRIu32 "/%" PRIu32
 				                   "+ileng(%" PRIu32 ")+pleng(%" PRIu32 ")[+16])",
 				                   length, kRegisterNewSessionMinSize, ileng, pleng);
-				eptr->mode = KILL;
+				eptr->mode = ClientConnectionMode::KILL;
 				return;
 			}
 			path = rptr;
@@ -1861,7 +1866,7 @@ void matoclserv_fuse_register(matoclserventry *eptr,const uint8_t *data,uint32_t
 			if (pleng > 0 && rptr[-1] != 0) {
 				safs_pretty_syslog(
 				    LOG_NOTICE, "CLTOMA_FUSE_REGISTER/ACL.2 - received path without ending zero");
-				eptr->mode = KILL;
+				eptr->mode = ClientConnectionMode::KILL;
 				return;
 			}
 			if (pleng == 0) {
@@ -1885,7 +1890,7 @@ void matoclserv_fuse_register(matoclserventry *eptr,const uint8_t *data,uint32_t
 				eptr->sesdata = matoclserv_new_session(1, 0);
 				if (eptr->sesdata == nullptr) {
 					safs_pretty_syslog(LOG_NOTICE, "can't allocate session record");
-					eptr->mode = KILL;
+					eptr->mode = ClientConnectionMode::KILL;
 					return;
 				}
 
@@ -1912,7 +1917,7 @@ void matoclserv_fuse_register(matoclserventry *eptr,const uint8_t *data,uint32_t
 				safs::log_info(
 				    "Session {} created for mount: {} exported path: {} with ip: {} and port: {}",
 				    eptr->sesdata->sessionid,
-				    eptr->sesdata->info ? eptr->sesdata->info : "unknown info",
+				    !eptr->sesdata->info.empty() ? eptr->sesdata->info : "unknown info",
 				    path ? (const char *)path : "unknown path", ipToString(eptr->peerip),
 				    eptr->peerport);
 
@@ -1967,7 +1972,7 @@ void matoclserv_fuse_register(matoclserventry *eptr,const uint8_t *data,uint32_t
 				                   "CLTOMA_FUSE_REGISTER/ACL.5 - wrong size (%" PRIu32 "/>=%" PRIu32
 				                   ")",
 				                   length, kRegisterNewMetaSessionMinSize);
-				eptr->mode = KILL;
+				eptr->mode = ClientConnectionMode::KILL;
 				return;
 			}
 
@@ -1980,7 +1985,7 @@ void matoclserv_fuse_register(matoclserventry *eptr,const uint8_t *data,uint32_t
 				                   "CLTOMA_FUSE_REGISTER/ACL.5 - wrong size (%" PRIu32 "/%" PRIu32
 				                   "+ileng(%" PRIu32 ")[+16])",
 				                   length, kRegisterNewMetaSessionMinSize, ileng);
-				eptr->mode = KILL;
+				eptr->mode = ClientConnectionMode::KILL;
 				return;
 			}
 
@@ -2001,7 +2006,7 @@ void matoclserv_fuse_register(matoclserventry *eptr,const uint8_t *data,uint32_t
 				eptr->sesdata = matoclserv_new_session(1, 0);
 				if (eptr->sesdata == nullptr) {
 					safs_pretty_syslog(LOG_NOTICE, "can't allocate session record");
-					eptr->mode = KILL;
+					eptr->mode = ClientConnectionMode::KILL;
 					return;
 				}
 
@@ -2027,7 +2032,7 @@ void matoclserv_fuse_register(matoclserventry *eptr,const uint8_t *data,uint32_t
 
 				safs::log_info("Meta session {} created for mount: {} with ip: {} and port: {}",
 				               eptr->sesdata->sessionid,
-				               eptr->sesdata->info ? eptr->sesdata->info : "unknown info",
+				               !eptr->sesdata->info.empty() ? eptr->sesdata->info : "unknown info",
 				               ipToString(eptr->peerip), eptr->peerport);
 
 				matoclserv_store_sessions();
@@ -2068,7 +2073,7 @@ void matoclserv_fuse_register(matoclserventry *eptr,const uint8_t *data,uint32_t
 				                   "CLTOMA_FUSE_REGISTER/ACL.%" PRIu8 " - wrong size (%" PRIu32
 				                   "/>=%" PRIu32 ")",
 				                   rcode, length, kRegisterWithSessionIdAndVersion);
-				eptr->mode = KILL;
+				eptr->mode = ClientConnectionMode::KILL;
 				return;
 			}
 			get32bit(&rptr, sessionid);
@@ -2082,10 +2087,11 @@ void matoclserv_fuse_register(matoclserventry *eptr,const uint8_t *data,uint32_t
 					status = SAUNAFS_ERROR_EACCES;
 				} else {
 					status = SAUNAFS_STATUS_OK;
-					safs::log_info("Session {} reconnected for mount: {} with ip: {} and port: {}",
-					               eptr->sesdata->sessionid,
-					               eptr->sesdata->info ? eptr->sesdata->info : "unknown info",
-					               ipToString(eptr->peerip), eptr->peerport);
+					safs::log_info(
+					    "Session {} reconnected for mount: {} with ip: {} and port: {}",
+					    eptr->sesdata->sessionid,
+					    !eptr->sesdata->info.empty() ? eptr->sesdata->info : "unknown info",
+					    ipToString(eptr->peerip), eptr->peerport);
 				}
 			}
 			wptr = matoclserv_createpacket(eptr,MATOCL_FUSE_REGISTER, sizeof(status));
@@ -2107,24 +2113,24 @@ void matoclserv_fuse_register(matoclserventry *eptr,const uint8_t *data,uint32_t
 				safs_pretty_syslog(LOG_NOTICE,
 				                   "CLTOMA_FUSE_REGISTER/ACL.6 - wrong size (%" PRIu32 "/>=%lu)",
 				                   length, kBlobSizeWithRCode + sizeof(sessionid));
-				eptr->mode = KILL;
+				eptr->mode = ClientConnectionMode::KILL;
 				return;
 			}
 			get32bit(&rptr, sessionid);
 			matoclserv_close_session(sessionid);
 			safs::log_info("Session {} for mount {} was closed", sessionid,
-			               eptr->sesdata->info ? eptr->sesdata->info : "unknown info");
-			eptr->mode = KILL;
+			               !eptr->sesdata->info.empty() ? eptr->sesdata->info : "unknown info");
+			eptr->mode = ClientConnectionMode::KILL;
 			return;
 		}
 		safs_pretty_syslog(LOG_NOTICE, "CLTOMA_FUSE_REGISTER/ACL - wrong rcode (%" PRIu8 ")",
 		                   rcode);
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
 	safs_pretty_syslog(LOG_NOTICE, "CLTOMA_FUSE_REGISTER - wrong register blob");
-	eptr->mode = KILL;
+	eptr->mode = ClientConnectionMode::KILL;
 }
 
 void matoclserv_register_config(matoclserventry *eptr, const uint8_t *data,
@@ -2147,7 +2153,7 @@ void matoclserv_fuse_reserved_inodes(matoclserventry *eptr,const uint8_t *data,u
 		safs_pretty_syslog(LOG_NOTICE,
 		                   "CLTOMA_FUSE_RESERVED_INODES - wrong size (%" PRIu32 "/N*%zu)", length,
 		                   kinode_t_size);
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -2200,7 +2206,7 @@ void matoclserv_fuse_statfs(matoclserventry *eptr,const uint8_t *data,uint32_t l
 	if (length != kExpectedSize) {
 		safs_pretty_syslog(LOG_NOTICE, "CLTOMA_FUSE_STATFS - wrong size (%" PRIu32 "/%" PRIu32 ")",
 		                   length, kExpectedSize);
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -2236,7 +2242,7 @@ void matoclserv_fuse_access(matoclserventry *eptr,const uint8_t *data,uint32_t l
 	if (length != kPacketSize) {
 		safs_pretty_syslog(LOG_NOTICE, "CLTOMA_FUSE_ACCESS - wrong size (%" PRIu32 "/%" PRIu32 ")",
 		                   length, kPacketSize);
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 	get32bit(&data, msgid);
@@ -2377,7 +2383,7 @@ void matoclserv_fuse_lookup(matoclserventry *eptr,const uint8_t *data,uint32_t l
 	    sizeof(msgid) + sizeof(inode) + sizeof(uid) + sizeof(gid) + sizeof(nleng);
 	if (length < kExpectedPacketSize) {
 		safs_pretty_syslog(LOG_NOTICE,"CLTOMA_FUSE_LOOKUP - wrong size (%" PRIu32 ")",length);
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 	get32bit(&data, msgid);
@@ -2385,7 +2391,7 @@ void matoclserv_fuse_lookup(matoclserventry *eptr,const uint8_t *data,uint32_t l
 	nleng = get8bit(&data);
 	if (length != kExpectedPacketSize + nleng) {
 		safs_pretty_syslog(LOG_NOTICE,"CLTOMA_FUSE_LOOKUP - wrong size (%" PRIu32 ":nleng=%" PRIu8 ")",length,nleng);
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 	name = data;
@@ -2425,7 +2431,7 @@ void matoclserv_fuse_getattr(matoclserventry *eptr,const uint8_t *data,uint32_t 
 	if (length != kExpectedPacketSize) {
 		safs_pretty_syslog(LOG_NOTICE, "CLTOMA_FUSE_GETATTR - wrong size (%" PRIu32 "/%" PRIu32 ")",
 		                   length, kExpectedPacketSize);
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 	get32bit(&data, msgid);
@@ -2476,7 +2482,7 @@ void matoclserv_fuse_setattr(matoclserventry *eptr,const uint8_t *data,uint32_t 
 		safs_pretty_syslog(
 		    LOG_NOTICE, "CLTOMA_FUSE_SETATTR - wrong size (%" PRIu32 "/%" PRIu32 " | %" PRIu32 ")",
 		    length, kExpectedPacketSize, kExpectedPacketSizeWithSugid);
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -2605,20 +2611,20 @@ void matoclserv_fuse_truncate(matoclserventry *eptr, PacketHeader header, const 
 
 	if (status == SAUNAFS_ERROR_DELAYED) {
 		// Duplicate or truncate request has been sent to chunkservers, delay the reply
-		auto chunkList = std::make_unique<chunklist>();
-		passert(chunkList.get());
-		chunkList->chunkid = chunkId;
-		chunkList->qid = messageId;
-		chunkList->inode = inode;
-		chunkList->uid = context.uid();
-		chunkList->gid = context.gid();
-		chunkList->auid = context.auid();
-		chunkList->agid = context.agid();
-		chunkList->fleng = length;
-		chunkList->lockid = lockId;
-		chunkList->type = type;
-		chunkList->serializer = serializer;
-		eptr->chunkdelayedops.push_back(std::move(chunkList));
+		auto chunkOperationPtr = std::make_unique<chunkDelayedOperation>();
+		passert(chunkOperationPtr.get());
+		chunkOperationPtr->chunkid = chunkId;
+		chunkOperationPtr->qid = messageId;
+		chunkOperationPtr->inode = inode;
+		chunkOperationPtr->uid = context.uid();
+		chunkOperationPtr->gid = context.gid();
+		chunkOperationPtr->auid = context.auid();
+		chunkOperationPtr->agid = context.agid();
+		chunkOperationPtr->fleng = length;
+		chunkOperationPtr->lockid = lockId;
+		chunkOperationPtr->type = type;
+		chunkOperationPtr->serializer = serializer;
+		eptr->chunkdelayedops.push_back(std::move(chunkOperationPtr));
 		if (eptr->sesdata) {
 			eptr->sesdata->currentopstats[2]++;
 		}
@@ -2657,7 +2663,7 @@ void matoclserv_fuse_readlink(matoclserventry *eptr,const uint8_t *data,uint32_t
 		safs_pretty_syslog(LOG_NOTICE,
 		                   "CLTOMA_FUSE_READLINK - wrong size (%" PRIu32 "/%" PRIu32 ")", length,
 		                   kExpectedPacketSize);
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -2710,7 +2716,7 @@ void matoclserv_fuse_symlink(matoclserventry *eptr,const uint8_t *data,uint32_t 
 	if (length < kMinExpectedPacketSize) {
 		safs_pretty_syslog(LOG_NOTICE, "CLTOMA_FUSE_SYMLINK - wrong size (%" PRIu32 "/%" PRIu32 ")",
 		                   length, kMinExpectedPacketSize);
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -2722,7 +2728,7 @@ void matoclserv_fuse_symlink(matoclserventry *eptr,const uint8_t *data,uint32_t 
 		safs_pretty_syslog(LOG_NOTICE,
 		                   "CLTOMA_FUSE_SYMLINK - wrong size (%" PRIu32 ":nleng=%" PRIu8 ")",
 		                   length, nleng);
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -2733,7 +2739,7 @@ void matoclserv_fuse_symlink(matoclserventry *eptr,const uint8_t *data,uint32_t 
 		safs_pretty_syslog(LOG_NOTICE,
 		       "CLTOMA_FUSE_SYMLINK - wrong size (%" PRIu32 ":nleng=%" PRIu8 ":pleng=%" PRIu32 ")",
 		       length, nleng, pleng);
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -2883,7 +2889,7 @@ void matoclserv_fuse_unlink(matoclserventry *eptr,const uint8_t *data,uint32_t l
 
 	if (length < kMinExpectedPacketSize) {
 		safs_pretty_syslog(LOG_NOTICE,"CLTOMA_FUSE_UNLINK - wrong size (%" PRIu32 ")",length);
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -2895,7 +2901,7 @@ void matoclserv_fuse_unlink(matoclserventry *eptr,const uint8_t *data,uint32_t l
 		safs_pretty_syslog(LOG_NOTICE,
 		                   "CLTOMA_FUSE_UNLINK - wrong size (%" PRIu32 ":nleng=%" PRIu8 ")", length,
 		                   nleng);
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -2966,7 +2972,7 @@ void matoclserv_fuse_rmdir(matoclserventry *eptr,const uint8_t *data,uint32_t le
 
 	if (length < kMinExpectedPacketSize) {
 		safs_pretty_syslog(LOG_NOTICE, "CLTOMA_FUSE_RMDIR - wrong size (%" PRIu32 ")", length);
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -2978,7 +2984,7 @@ void matoclserv_fuse_rmdir(matoclserventry *eptr,const uint8_t *data,uint32_t le
 		safs_pretty_syslog(LOG_NOTICE,
 		                   "CLTOMA_FUSE_RMDIR - wrong size (%" PRIu32 ":nleng=%" PRIu8 ")", length,
 		                   nleng);
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -3022,7 +3028,7 @@ void matoclserv_fuse_rename(matoclserventry *eptr,const uint8_t *data,uint32_t l
 
 	if (length < kMinExpectedPacketSize) {
 		safs_pretty_syslog(LOG_NOTICE, "CLTOMA_FUSE_RENAME - wrong size (%" PRIu32 ")", length);
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -3034,7 +3040,7 @@ void matoclserv_fuse_rename(matoclserventry *eptr,const uint8_t *data,uint32_t l
 		safs_pretty_syslog(LOG_NOTICE,
 		                   "CLTOMA_FUSE_RENAME - wrong size (%" PRIu32 ":nleng_src=%" PRIu8 ")",
 		                   length, nleng_src);
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -3048,7 +3054,7 @@ void matoclserv_fuse_rename(matoclserventry *eptr,const uint8_t *data,uint32_t l
 		                   "CLTOMA_FUSE_RENAME - wrong size (%" PRIu32 ":nleng_src=%" PRIu8
 		                   ":nleng_dst=%" PRIu8 ")",
 		                   length, nleng_src, nleng_dst);
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -3104,7 +3110,7 @@ void matoclserv_fuse_link(matoclserventry *eptr,const uint8_t *data,uint32_t len
 
 	if (length < kMinExpectedPacketSize) {
 		safs_pretty_syslog(LOG_NOTICE, "CLTOMA_FUSE_LINK - wrong size (%" PRIu32 ")", length);
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -3117,7 +3123,7 @@ void matoclserv_fuse_link(matoclserventry *eptr,const uint8_t *data,uint32_t len
 		safs_pretty_syslog(LOG_NOTICE,
 		                   "CLTOMA_FUSE_LINK - wrong size (%" PRIu32 ":nleng_dst=%" PRIu8 ")",
 		                   length, nleng_dst);
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -3224,7 +3230,7 @@ void matoclserv_fuse_getdir(matoclserventry *eptr,const uint8_t *data,uint32_t l
 		safs_pretty_syslog(LOG_NOTICE,
 		                   "CLTOMA_FUSE_GETDIR - wrong size (%" PRIu32 "/%" PRIu32 "|%" PRIu32 ")",
 		                   length, kExpectedSize, kExpectedSizeWithFlags);
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -3284,7 +3290,7 @@ void matoclserv_fuse_open(matoclserventry *eptr,const uint8_t *data,uint32_t len
 	if (length != kExpectedSize) {
 		safs_pretty_syslog(LOG_NOTICE, "CLTOMA_FUSE_OPEN - wrong size (%" PRIu32 "/%" PRIu32 ")",
 		                   length, kExpectedSize);
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -3434,17 +3440,17 @@ void matoclserv_fuse_write_chunk(matoclserventry *eptr, PacketHeader header, con
 	}
 
 	if (opflag) {   // wait for operation end
-		auto currentChunk = std::make_unique<chunklist>();
-		passert(currentChunk.get());
-		memset(currentChunk.get(), 0, sizeof(chunklist));
-		currentChunk->inode = inode;
-		currentChunk->chunkid = chunkId;
-		currentChunk->qid = messageId;
-		currentChunk->fleng = fileLength;
-		currentChunk->lockid = lockId;
-		currentChunk->type = FUSE_WRITE;
-		currentChunk->serializer = serializer;
-		eptr->chunkdelayedops.push_back(std::move(currentChunk));
+		auto operation = std::make_unique<chunkDelayedOperation>();
+		passert(operation.get());
+		memset(operation.get(), 0, sizeof(chunkDelayedOperation));
+		operation->inode = inode;
+		operation->chunkid = chunkId;
+		operation->qid = messageId;
+		operation->fleng = fileLength;
+		operation->lockid = lockId;
+		operation->type = FUSE_WRITE;
+		operation->serializer = serializer;
+		eptr->chunkdelayedops.push_back(std::move(operation));
 	} else {        // return status immediately
 		dcm_modify(inode,eptr->sesdata->sessionid);
 		status = matoclserv_fuse_write_chunk_respond(eptr, serializer,
@@ -3510,7 +3516,7 @@ void matoclserv_fuse_repair(matoclserventry *eptr, const uint8_t *data, uint32_t
 		safs_pretty_syslog(
 		    LOG_NOTICE, "CLTOMA_FUSE_REPAIR - wrong size (%" PRIu32 "/(%" PRIu32 "|%" PRIu32 "))",
 		    length, kMinExpectedPacketSize, kMaxExpectedPacketSize);
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -3552,7 +3558,7 @@ void matoclserv_fuse_check(matoclserventry *eptr,const uint8_t *data,uint32_t le
 	if (length != kExpectedSize) {
 		safs_pretty_syslog(LOG_NOTICE, "CLTOMA_FUSE_CHECK - wrong size (%" PRIu32 "/%" PRIu32 ")",
 		                   length, kExpectedSize);
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -3621,7 +3627,7 @@ void matoclserv_fuse_gettrashtime(matoclserventry *eptr,const uint8_t *data,uint
 		safs_pretty_syslog(LOG_NOTICE,
 		                   "CLTOMA_FUSE_GETTRASHTIME - wrong size (%" PRIu32 "/%" PRIu32 ")",
 		                   length, kExpectedSize);
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -3881,7 +3887,7 @@ void matoclserv_fuse_geteattr(matoclserventry *eptr,const uint8_t *data,uint32_t
 		safs_pretty_syslog(LOG_NOTICE,
 		                   "CLTOMA_FUSE_GETEATTR - wrong size (%" PRIu32 "/%" PRIu32 ")", length,
 		                   kExpectedSize);
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -3945,7 +3951,7 @@ void matoclserv_fuse_seteattr(matoclserventry *eptr,const uint8_t *data,uint32_t
 		safs_pretty_syslog(LOG_NOTICE,
 		                   "CLTOMA_FUSE_SETEATTR - wrong size (%" PRIu32 "/%" PRIu32 ")", length,
 		                   kExpectedSize);
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -3994,7 +4000,7 @@ void matoclserv_fuse_getxattr(matoclserventry *eptr,const uint8_t *data,uint32_t
 		safs_pretty_syslog(LOG_NOTICE,
 		                   "CLTOMA_FUSE_GETXATTR - wrong min size (%" PRIu32 "/%" PRIu32 ")",
 		                   length, kExpectedMinSize);
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -4011,7 +4017,7 @@ void matoclserv_fuse_getxattr(matoclserventry *eptr,const uint8_t *data,uint32_t
 		safs_pretty_syslog(LOG_NOTICE,
 		                   "CLTOMA_FUSE_GETXATTR - wrong size (%" PRIu32 ":anleng=%" PRIu8 ")",
 		                   length, anleng);
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -4091,7 +4097,7 @@ void matoclserv_fuse_setxattr(matoclserventry *eptr,const uint8_t *data,uint32_t
 		safs_pretty_syslog(LOG_NOTICE,
 		                   "CLTOMA_FUSE_SETXATTR - wrong min size (%" PRIu32 "/%" PRIu32 ")",
 		                   length, kExpectedMinSize);
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -4106,7 +4112,7 @@ void matoclserv_fuse_setxattr(matoclserventry *eptr,const uint8_t *data,uint32_t
 		safs_pretty_syslog(LOG_NOTICE,
 		                   "CLTOMA_FUSE_SETXATTR - wrong size (%" PRIu32 ":anleng=%" PRIu8 ")",
 		                   length, anleng);
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -4119,7 +4125,7 @@ void matoclserv_fuse_setxattr(matoclserventry *eptr,const uint8_t *data,uint32_t
 		                   "CLTOMA_FUSE_SETXATTR - wrong size (%" PRIu32 ":anleng=%" PRIu8
 		                   ":avleng=%" PRIu32 ")",
 		                   length, anleng, avleng);
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -4154,7 +4160,7 @@ void matoclserv_fuse_append(matoclserventry *eptr, const uint8_t *data, uint32_t
 	if (length != kExpectedSize) {
 		safs_pretty_syslog(LOG_NOTICE, "CLTOMA_FUSE_APPEND - wrong size (%" PRIu32 "/%" PRIu32 ")",
 		                   length, kExpectedSize);
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -4243,7 +4249,7 @@ void matoclserv_fuse_getdirstats_old(matoclserventry *eptr,const uint8_t *data,u
 		safs_pretty_syslog(LOG_NOTICE,
 			"CLTOMA_FUSE_GETDIRSTATS - wrong size (%" PRIu32 "/%" PRIu32 ")", length,
 			kExpectedLength);
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -4296,7 +4302,7 @@ void matoclserv_fuse_getdirstats(matoclserventry *eptr,const uint8_t *data,uint3
 		safs_pretty_syslog(LOG_NOTICE,
 		                   "CLTOMA_FUSE_GETDIRSTATS - wrong size (%" PRIu32 "/%" PRIu32 ")", length,
 		                   kExpectedLength);
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -4339,7 +4345,7 @@ void matoclserv_fuse_gettrash(matoclserventry *eptr,const uint8_t *data,uint32_t
 	if (length != sizeof(msgid)) {
 		safs_pretty_syslog(LOG_NOTICE, "CLTOMA_FUSE_GETTRASH - wrong size (%" PRIu32 "/%zu)",
 		                   length, sizeof(msgid));
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -4383,7 +4389,7 @@ void matoclserv_fuse_getdetachedattr(matoclserventry *eptr,const uint8_t *data,u
 		safs_pretty_syslog(LOG_NOTICE,
 		                   "CLTOMA_FUSE_GETDETACHEDATTR - wrong size (%" PRIu32 "/%u-%u)", length,
 		                   kExpectedMinLength, kExpectedMaxLength);
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 	get32bit(&data, msgid);
@@ -4424,7 +4430,7 @@ void matoclserv_fuse_gettrashpath(matoclserventry *eptr,const uint8_t *data,uint
 		safs_pretty_syslog(LOG_NOTICE,
 		                   "CLTOMA_FUSE_GETTRASHPATH - wrong size (%" PRIu32 "/%" PRIu32 ")",
 		                   length, kExpectedLength);
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -4467,7 +4473,7 @@ void matoclserv_fuse_settrashpath(matoclserventry *eptr,const uint8_t *data,uint
 		safs_pretty_syslog(LOG_NOTICE,
 		                   "CLTOMA_FUSE_SETTRASHPATH - wrong size (%" PRIu32 "/<%" PRIu32 ")",
 		                   length, kExpectedMinLength);
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -4479,7 +4485,7 @@ void matoclserv_fuse_settrashpath(matoclserventry *eptr,const uint8_t *data,uint
 		safs_pretty_syslog(LOG_NOTICE,
 		                   "CLTOMA_FUSE_SETTRASHPATH - wrong size (%" PRIu32 "/%" PRIu32 ")",
 		                   length, kExpectedMinLength + pleng);
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -4506,7 +4512,7 @@ void matoclserv_fuse_undel(matoclserventry *eptr,const uint8_t *data,uint32_t le
 	if (length != kExpectedLength) {
 		safs_pretty_syslog(LOG_NOTICE, "CLTOMA_FUSE_UNDEL - wrong size (%" PRIu32 "/%" PRIu32 ")",
 		                   length, kExpectedLength);
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -4532,7 +4538,7 @@ void matoclserv_fuse_purge(matoclserventry *eptr,const uint8_t *data,uint32_t le
 	if (length != kExpectedLength) {
 		safs_pretty_syslog(LOG_NOTICE, "CLTOMA_FUSE_PURGE - wrong size (%" PRIu32 "/%" PRIu32 ")",
 		                   length, kExpectedLength);
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -4559,7 +4565,7 @@ void matoclserv_fuse_getreserved(matoclserventry *eptr,const uint8_t *data,uint3
 		safs_pretty_syslog(LOG_NOTICE,
 		                   "CLTOMA_FUSE_GETRESERVED - wrong size (%" PRIu32 "/%" PRIu32 ")", length,
 		                   kExpectedSize);
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -4843,7 +4849,7 @@ void matoclserv_manage_locks_list(matoclserventry *eptr, const uint8_t *data, ui
 
 	if (eptr->registered != ClientState::kAdmin) {
 		safs_pretty_syslog(LOG_NOTICE, "Listing file locks is available only for registered admins");
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -4887,7 +4893,7 @@ void matoclserv_manage_locks_unlock(matoclserventry *eptr, const uint8_t *data, 
 
 	if (eptr->registered != ClientState::kAdmin) {
 		safs_pretty_syslog(LOG_NOTICE, "Removing file locks is available only for registered admins");
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -5016,7 +5022,7 @@ void matoclserv_fuse_setacl(matoclserventry *eptr, const uint8_t *data, uint32_t
 		cltoma::fuseSetAcl::deserialize(data, length, messageId, inode, uid, gid, rich_acl);
 	} else {
 		safs_pretty_syslog(LOG_WARNING, "SAU_CLTOMA_FUSE_SET_ACL: unknown packet version");
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 
@@ -5127,7 +5133,7 @@ void matoclserv_admin_register(matoclserventry* eptr, const uint8_t* data, uint3
 		matoclserv_createpacket(eptr, matocl::adminRegisterChallenge::build(array));
 	} else {
 		safs_pretty_syslog(LOG_NOTICE, "SAU_CLTOMA_ADMIN_REGISTER_CHALLENGE: retry not allowed");
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 	}
 }
 
@@ -5154,7 +5160,7 @@ void matoclserv_admin_register_response(matoclserventry* eptr, const uint8_t* da
 	} else {
 		safs_pretty_syslog(LOG_NOTICE,
 				"SAU_CLTOMA_ADMIN_REGISTER_RESPONSE: response without previous challenge");
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 	}
 }
 
@@ -5167,7 +5173,7 @@ void matoclserv_admin_become_master(matoclserventry* eptr, const uint8_t* data, 
 	} else {
 		safs_pretty_syslog(LOG_NOTICE,
 				"SAU_CLTOMA_ADMIN_BECOME_MASTER: available only for registered admins");
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 	}
 }
 
@@ -5200,7 +5206,7 @@ void matoclserv_admin_stop_without_metadata_dump(
 		safs_pretty_syslog(LOG_NOTICE,
 				"SAU_CLTOMA_ADMIN_STOP_WITHOUT_METADATA_DUMP:"
 				" available only for registered admins");
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 	}
 }
 
@@ -5213,7 +5219,7 @@ void matoclserv_admin_reload(matoclserventry* eptr, const uint8_t* data, uint32_
 				ipToString(eptr->peerip).c_str());
 	} else {
 		safs_pretty_syslog(LOG_NOTICE, "SAU_CLTOMA_ADMIN_RELOAD: available only for registered admins");
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 	}
 }
 
@@ -5232,7 +5238,7 @@ void matoclserv_admin_dump_config(matoclserventry *eptr) {
 		safs_pretty_syslog(LOG_NOTICE,
 		                   "SAU_CLTOMA_ADMING_DUMP_CONFIG: available only for "
 		                   "registered admins");
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
 	MessageBuffer reply;
@@ -5264,7 +5270,7 @@ void matoclserv_admin_save_metadata(matoclserventry* eptr, const uint8_t* data, 
 		}
 	} else {
 		safs_pretty_syslog(LOG_NOTICE, "SAU_CLTOMA_ADMIN_SAVE_METADATA: available only for registered admins");
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 	}
 }
 
@@ -5297,7 +5303,7 @@ void matoclserv_admin_recalculate_metadata_checksum(matoclserventry* eptr,
 	} else {
 		safs_pretty_syslog(LOG_NOTICE, "SAU_CLTOMA_ADMIN_RECALCULATE_METADATA_CHECKSUM: "
 				"available only for registered admins");
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 	}
 }
 
@@ -5348,7 +5354,7 @@ void matoclserv_session_files(matoclserventry *eptr,
 	MessageBuffer reply;
 
 	for (const auto &eaptr : matoclservList) {
-		if (eaptr->mode == KILL || !eaptr->sesdata ||
+		if (eaptr->mode == ClientConnectionMode::KILL || !eaptr->sesdata ||
 		    eaptr->registered != ClientState::kRegistered) {
 			continue;
 		}
@@ -5394,7 +5400,7 @@ void matoclserv_session_delete(matoclserventry *eptr, const uint8_t *data,
 		status = SAUNAFS_ERROR_BADSESSIONID;
 	} else {
 		matoclserv_close_session(sessionId);
-		target->mode = KILL;
+		target->mode = ClientConnectionMode::KILL;
 		// Force closure of files immediately.
 		// Otherwise, it will take a few moments before the session
 		// times out and the files are removed automatically, unless the
@@ -5498,7 +5504,7 @@ void matoclserv_gotpacket(matoclserventry *eptr,uint32_t type,const uint8_t *dat
 					break;
 				default:
 					safs_pretty_syslog(LOG_NOTICE,"main master server module: got invalid message in shadow state (type:%" PRIu32 ")",type);
-					eptr->mode = KILL;
+					eptr->mode = ClientConnectionMode::KILL;
 			}
 		} else if (eptr->registered == ClientState::kUnregistered
 				|| eptr->registered == ClientState::kAdmin) { // beware that in this context sesdata is NULL
@@ -5607,12 +5613,12 @@ void matoclserv_gotpacket(matoclserventry *eptr,uint32_t type,const uint8_t *dat
 					break;
 				default:
 					safs_pretty_syslog(LOG_NOTICE,"main master server module: got unknown message from unregistered (type:%" PRIu32 ")",type);
-					eptr->mode=KILL;
+					eptr->mode=ClientConnectionMode::KILL;
 			}
 		} else if (eptr->registered == ClientState::kRegistered) {      // mounts and new tools
 			if (eptr->sesdata==NULL) {
 				safs_pretty_syslog(LOG_ERR,"registered connection without sesdata !!!");
-				eptr->mode=KILL;
+				eptr->mode=ClientConnectionMode::KILL;
 				return;
 			}
 			switch (type) {
@@ -5866,12 +5872,12 @@ void matoclserv_gotpacket(matoclserventry *eptr,uint32_t type,const uint8_t *dat
 					break;
 				default:
 					safs_pretty_syslog(LOG_NOTICE,"main master server module: got unknown message from sfsmount (type:%" PRIu32 ")",type);
-					eptr->mode=KILL;
+					eptr->mode=ClientConnectionMode::KILL;
 			}
 		} else if (eptr->registered == ClientState::kOldTools) {        // old sfstools
 			if (eptr->sesdata==NULL) {
 				safs_pretty_syslog(LOG_ERR,"registered connection (tools) without sesdata !!!");
-				eptr->mode=KILL;
+				eptr->mode=ClientConnectionMode::KILL;
 				return;
 			}
 			switch (type) {
@@ -5920,14 +5926,14 @@ void matoclserv_gotpacket(matoclserventry *eptr,uint32_t type,const uint8_t *dat
 					break;
 				default:
 					safs_pretty_syslog(LOG_NOTICE,"main master server module: got unknown message from saunafs <COMMAND> tools (type:%" PRIu32 ")",type);
-					eptr->mode=KILL;
+				    eptr->mode = ClientConnectionMode::KILL;
 			}
 		}
 	} catch (IncorrectDeserializationException& e) {
 		safs_pretty_syslog(LOG_NOTICE,
 				"main master server module: got inconsistent message from mount "
 				"(type:%" PRIu32 ", length:%" PRIu32"), %s", type, length, e.what());
-		eptr->mode = KILL;
+		eptr->mode = ClientConnectionMode::KILL;
 	}
 }
 
@@ -5967,13 +5973,13 @@ void matoclserv_read(matoclserventry *eptr) {
 	const uint8_t *ptr;
 
 	watchdog.start();
-	while (eptr->mode != KILL) {
+	while (eptr->mode != ClientConnectionMode::KILL) {
 		i=read(eptr->sock,eptr->inputpacket.startptr,eptr->inputpacket.bytesleft);
 		if (i==0) {
 			if (eptr->registered == ClientState::kRegistered) {       // show this message only for standard, registered clients
 				safs_pretty_syslog(LOG_NOTICE,"connection with client(ip:%u.%u.%u.%u) has been closed by peer",(eptr->peerip>>24)&0xFF,(eptr->peerip>>16)&0xFF,(eptr->peerip>>8)&0xFF,eptr->peerip&0xFF);
 			}
-			eptr->mode = KILL;
+			eptr->mode = ClientConnectionMode::KILL;
 			return;
 		}
 		if (i<0) {
@@ -5985,7 +5991,7 @@ void matoclserv_read(matoclserventry *eptr) {
 #ifdef ECONNRESET
 				}
 #endif
-				eptr->mode = KILL;
+				eptr->mode = ClientConnectionMode::KILL;
 			}
 			return;
 		}
@@ -5998,31 +6004,31 @@ void matoclserv_read(matoclserventry *eptr) {
 			return;
 		}
 
-		if (eptr->mode==HEADER) {
+		if (eptr->mode == ClientConnectionMode::HEADER) {
 			ptr = eptr->hdrbuff+4;
 			get32bit(&ptr, size);
 			if (size>0) {
 				if (size>MaxPacketSize) {
 					safs_pretty_syslog(LOG_WARNING,"main master server module: packet too long (%" PRIu32 "/%u)",size,MaxPacketSize);
-					eptr->mode = KILL;
+					eptr->mode = ClientConnectionMode::KILL;
 					return;
 				}
 				eptr->inputpacket.packet = (uint8_t*) malloc(size);
 				passert(eptr->inputpacket.packet);
 				eptr->inputpacket.bytesleft = size;
 				eptr->inputpacket.startptr = eptr->inputpacket.packet;
-				eptr->mode = DATA;
+				eptr->mode = ClientConnectionMode::DATA;
 				continue;
 			}
-			eptr->mode = DATA;
+			eptr->mode = ClientConnectionMode::DATA;
 		}
 
-		if (eptr->mode==DATA) {
+		if (eptr->mode==ClientConnectionMode::DATA) {
 			ptr = eptr->hdrbuff;
 			get32bit(&ptr, type);
 			get32bit(&ptr, size);
 
-			eptr->mode=HEADER;
+			eptr->mode = ClientConnectionMode::HEADER;
 			eptr->inputpacket.bytesleft = 8;
 			eptr->inputpacket.startptr = eptr->hdrbuff;
 			matoclserv_gotpacket(eptr,type,eptr->inputpacket.packet,size);
@@ -6057,7 +6063,7 @@ void matoclserv_write(matoclserventry *eptr) {
 		if (i<0) {
 			if (errno!=EAGAIN) {
 				safs_silent_errlog(LOG_NOTICE,"main master server module: (ip:%u.%u.%u.%u) write error",(eptr->peerip>>24)&0xFF,(eptr->peerip>>16)&0xFF,(eptr->peerip>>8)&0xFF,eptr->peerip&0xFF);
-				eptr->mode = KILL;
+				eptr->mode = ClientConnectionMode::KILL;
 			}
 			return;
 		}
@@ -6170,7 +6176,7 @@ void matoclserv_serve(const std::vector<pollfd> &pdesc) {
 			eptr->registered = ClientState::kUnregistered;
 			eptr->iolimits = false;
 			eptr->version = 0;
-			eptr->mode = HEADER;
+			eptr->mode = ClientConnectionMode::HEADER;
 			eptr->lastread = now;
 			eptr->lastwrite = now;
 			eptr->inputpacket.next = NULL;
@@ -6193,10 +6199,11 @@ void matoclserv_serve(const std::vector<pollfd> &pdesc) {
 	for (const auto &eptr : matoclservList) {
 		if (eptr->pdescpos >= 0) {
 			if (pdesc[eptr->pdescpos].revents & (POLLERR|POLLHUP)) {
-				eptr->mode = KILL;
+				eptr->mode = ClientConnectionMode::KILL;
 			}
 
-			if ((pdesc[eptr->pdescpos].revents & POLLIN) && eptr->mode != KILL) {
+			if ((pdesc[eptr->pdescpos].revents & POLLIN) &&
+			    eptr->mode != ClientConnectionMode::KILL) {
 				eptr->lastread = now;
 				matoclserv_read(eptr.get());
 			}
@@ -6215,19 +6222,19 @@ void matoclserv_serve(const std::vector<pollfd> &pdesc) {
 		if (eptr->pdescpos >= 0) {
 			if ((((pdesc[eptr->pdescpos].events & POLLOUT) == 0 && (eptr->outputhead)) ||
 			     (pdesc[eptr->pdescpos].revents & POLLOUT)) &&
-			    eptr->mode != KILL) {
+			    eptr->mode != ClientConnectionMode::KILL) {
 				eptr->lastwrite = now;
 				matoclserv_write(eptr.get());
 			}
 		}
 
-		if (eptr->lastread + 10 < now && exiting == 0) { eptr->mode = KILL; }
+		if (eptr->lastread + 10 < now && exiting == 0) { eptr->mode = ClientConnectionMode::KILL; }
 	}
 
 // close
 	for (auto eptrIt = matoclservList.begin(); eptrIt != matoclservList.end();) {
 		auto *eptr = eptrIt->get();
-		if (eptr->mode == KILL) {
+		if (eptr->mode == ClientConnectionMode::KILL) {
 			matocl_beforedisconnect(eptr);
 			tcpclose(eptr->sock);
 

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -123,7 +123,6 @@ struct chunklist {
 	uint32_t agid;
 	uint8_t type;
 	const PacketSerializer* serializer;
-	struct chunklist *next;
 };
 
 struct session {
@@ -233,7 +232,7 @@ struct matoclserventry {
 	session *sesdata;
 	std::unique_ptr<SauMatoclAdminRegisterChallengeData> adminChallenge;
 	AdminTask adminTask;                   // admin task requested by this client
-	chunklist *chunkdelayedops;
+	std::vector<std::unique_ptr<chunklist>> chunkdelayedops;
 };
 
 static std::vector<std::unique_ptr<session>> sessionVector;
@@ -1066,48 +1065,44 @@ uint8_t matoclserv_fuse_write_chunk_respond(matoclserventry *eptr,
 }
 
 void matoclserv_chunk_status(uint64_t chunkid,uint8_t status) {
-	uint32_t lockid,qid,inode,uid,gid,auid,agid;
-	uint64_t fleng;
-	uint8_t type;
-	chunklist *cl,**acl;
-	matoclserventry *eptr;
+	chunklist *currentChunk;
 	const PacketSerializer *serializer;
 
-	eptr=NULL;
-	lockid=0;
-	qid=0;
-	fleng=0;
-	type=0;
-	inode=0;
-	uid=0;
-	gid=0;
-	auid=0;
-	agid=0;
+	matoclserventry *eptr = NULL;
+	uint32_t lockid = 0;
+	uint32_t qid = 0;
+	uint64_t fleng = 0;
+	uint8_t type = 0;
+	uint32_t inode = 0;
+	uint32_t uid = 0;
+	uint32_t gid = 0;
+	uint32_t auid = 0;
+	uint32_t agid = 0;
 	serializer = nullptr;
+
 	auto eptrIterator = matoclservList.begin();
 	for (; eptrIterator != matoclservList.end() && eptr == NULL; eptrIterator++) {
 		matoclserventry* eaptr = eptrIterator->get();
 		if (eaptr->mode != KILL) {
-			acl = &(eaptr->chunkdelayedops);
-			while (*acl && eptr == NULL) {
-				cl = *acl;
-				if (cl->chunkid == chunkid) {
+			auto chunkListIterator = eaptr->chunkdelayedops.begin();
+			while (chunkListIterator != eaptr->chunkdelayedops.end() && eptr == NULL) {
+				currentChunk = chunkListIterator->get();
+				if (currentChunk->chunkid == chunkid) {
 					eptr = eaptr;
-					qid = cl->qid;
-					fleng = cl->fleng;
-					lockid = cl->lockid;
-					type = cl->type;
-					inode = cl->inode;
-					uid = cl->uid;
-					gid = cl->gid;
-					auid = cl->auid;
-					agid = cl->agid;
-					serializer = cl->serializer;
+					qid = currentChunk->qid;
+					fleng = currentChunk->fleng;
+					lockid = currentChunk->lockid;
+					type = currentChunk->type;
+					inode = currentChunk->inode;
+					uid = currentChunk->uid;
+					gid = currentChunk->gid;
+					auid = currentChunk->auid;
+					agid = currentChunk->agid;
+					serializer = currentChunk->serializer;
 
-					*acl = cl->next;
-					free(cl);
+					chunkListIterator = eaptr->chunkdelayedops.erase(chunkListIterator);
 				} else {
-					acl = &(cl->next);
+					++chunkListIterator;
 				}
 			}
 		}
@@ -2610,21 +2605,20 @@ void matoclserv_fuse_truncate(matoclserventry *eptr, PacketHeader header, const 
 
 	if (status == SAUNAFS_ERROR_DELAYED) {
 		// Duplicate or truncate request has been sent to chunkservers, delay the reply
-		chunklist *cl = (chunklist*)malloc(sizeof(chunklist));
-		passert(cl);
-		cl->chunkid = chunkId;
-		cl->qid = messageId;
-		cl->inode = inode;
-		cl->uid = context.uid();
-		cl->gid = context.gid();
-		cl->auid = context.auid();
-		cl->agid = context.agid();
-		cl->fleng = length;
-		cl->lockid = lockId;
-		cl->type = type;
-		cl->serializer = serializer;
-		cl->next = eptr->chunkdelayedops;
-		eptr->chunkdelayedops = cl;
+		auto chunkList = std::make_unique<chunklist>();
+		passert(chunkList.get());
+		chunkList->chunkid = chunkId;
+		chunkList->qid = messageId;
+		chunkList->inode = inode;
+		chunkList->uid = context.uid();
+		chunkList->gid = context.gid();
+		chunkList->auid = context.auid();
+		chunkList->agid = context.agid();
+		chunkList->fleng = length;
+		chunkList->lockid = lockId;
+		chunkList->type = type;
+		chunkList->serializer = serializer;
+		eptr->chunkdelayedops.push_back(std::move(chunkList));
 		if (eptr->sesdata) {
 			eptr->sesdata->currentopstats[2]++;
 		}
@@ -3418,7 +3412,7 @@ void matoclserv_fuse_write_chunk(matoclserventry *eptr, PacketHeader header, con
 	uint32_t lockId;
 	uint32_t messageId;
 	uint8_t opflag;
-	chunklist *cl;
+
 	std::vector<uint8_t> outMessage;
 	const PacketSerializer* serializer = PacketSerializer::getSerializer(header.type, eptr->version);
 
@@ -3440,18 +3434,17 @@ void matoclserv_fuse_write_chunk(matoclserventry *eptr, PacketHeader header, con
 	}
 
 	if (opflag) {   // wait for operation end
-		cl = (chunklist*)malloc(sizeof(chunklist));
-		passert(cl);
-		memset(cl, 0, sizeof(chunklist));
-		cl->inode = inode;
-		cl->chunkid = chunkId;
-		cl->qid = messageId;
-		cl->fleng = fileLength;
-		cl->lockid = lockId;
-		cl->type = FUSE_WRITE;
-		cl->next = eptr->chunkdelayedops;
-		cl->serializer = serializer;
-		eptr->chunkdelayedops = cl;
+		auto currentChunk = std::make_unique<chunklist>();
+		passert(currentChunk.get());
+		memset(currentChunk.get(), 0, sizeof(chunklist));
+		currentChunk->inode = inode;
+		currentChunk->chunkid = chunkId;
+		currentChunk->qid = messageId;
+		currentChunk->fleng = fileLength;
+		currentChunk->lockid = lockId;
+		currentChunk->type = FUSE_WRITE;
+		currentChunk->serializer = serializer;
+		eptr->chunkdelayedops.push_back(std::move(currentChunk));
 	} else {        // return status immediately
 		dcm_modify(inode,eptr->sesdata->sessionid);
 		status = matoclserv_fuse_write_chunk_respond(eptr, serializer,
@@ -5440,18 +5433,15 @@ void matocl_session_statsmove(void) {
 }
 
 void matocl_beforedisconnect(matoclserventry *eptr) {
-	chunklist *cl,*acl;
 // unlock locked chunks
-	cl=eptr->chunkdelayedops;
-	while (cl) {
-		acl = cl;
-		cl=cl->next;
-		if (acl->type == FUSE_TRUNCATE) {
-			fs_end_setlength(acl->chunkid);
+	for (const auto &operation : eptr->chunkdelayedops) {
+		if (operation->type == FUSE_TRUNCATE) {
+			fs_end_setlength(operation->chunkid);
 		}
-		free(acl);
 	}
-	eptr->chunkdelayedops=NULL;
+
+	eptr->chunkdelayedops.clear();
+
 	if (eptr->sesdata) {
 		if (eptr->sesdata->nsocks>0) {
 			eptr->sesdata->nsocks--;
@@ -5943,7 +5933,6 @@ void matoclserv_gotpacket(matoclserventry *eptr,uint32_t type,const uint8_t *dat
 
 void matoclserv_term(void) {
 	packetstruct *pptr,*pptrn;
-	chunklist *cl,*cln;
 
 	safs::log_info("main master server module: closing {}:{}", ListenHost, ListenPort);
 	tcpclose(lsock);
@@ -5961,10 +5950,7 @@ void matoclserv_term(void) {
 			free(pptr);
 		}
 
-		for (cl = eptr->chunkdelayedops ; cl ; cl = cln) {
-			cln = cl->next;
-			free(cl);
-		}
+		eptr->chunkdelayedops.clear();
 	}
 
 	matoclservList.clear();
@@ -6110,7 +6096,7 @@ int matoclserv_canexit(void) {
 			return 0;
 		}
 
-		if (eptr->chunkdelayedops != NULL) {
+		if (!eptr->chunkdelayedops.empty()) {
 			return 0;
 		}
 
@@ -6195,7 +6181,7 @@ void matoclserv_serve(const std::vector<pollfd> &pdesc) {
 			eptr->outputhead = NULL;
 			eptr->outputtail = &(eptr->outputhead);
 
-			eptr->chunkdelayedops = NULL;
+			eptr->chunkdelayedops.clear();
 			eptr->sesdata = NULL;
 			memset(eptr->passwordrnd, 0, 32);
 

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -234,12 +234,11 @@ struct matoclserventry {
 	std::unique_ptr<SauMatoclAdminRegisterChallengeData> adminChallenge;
 	AdminTask adminTask;                   // admin task requested by this client
 	chunklist *chunkdelayedops;
-
-	struct matoclserventry *next;
 };
 
 static std::vector<std::unique_ptr<session>> sessionVector;
-static matoclserventry *matoclservhead=NULL;
+static std::list<std::unique_ptr<matoclserventry>> matoclservList;
+
 static int lsock;
 static int32_t lsockpdescpos;
 static int exiting,starting;
@@ -542,10 +541,9 @@ void matoclserv_stats(uint64_t stats[5]) {
 }
 
 matoclserventry *matoclserv_find_connection(uint32_t id) {
-	matoclserventry *eptr;
-	for (eptr = matoclservhead; eptr; eptr = eptr->next) {
+	for (const auto& eptr : matoclservList) {
 		if (eptr->sesdata && eptr->sesdata->sessionid == id) {
-			return eptr;
+			return eptr.get();
 		}
 	}
 	return nullptr;
@@ -1072,7 +1070,7 @@ void matoclserv_chunk_status(uint64_t chunkid,uint8_t status) {
 	uint64_t fleng;
 	uint8_t type;
 	chunklist *cl,**acl;
-	matoclserventry *eptr,*eaptr;
+	matoclserventry *eptr;
 	const PacketSerializer *serializer;
 
 	eptr=NULL;
@@ -1086,12 +1084,14 @@ void matoclserv_chunk_status(uint64_t chunkid,uint8_t status) {
 	auid=0;
 	agid=0;
 	serializer = nullptr;
-	for (eaptr = matoclservhead ; eaptr && eptr==NULL ; eaptr=eaptr->next) {
-		if (eaptr->mode!=KILL) {
+	auto eptrIterator = matoclservList.begin();
+	for (; eptrIterator != matoclservList.end() && eptr == NULL; eptrIterator++) {
+		matoclserventry* eaptr = eptrIterator->get();
+		if (eaptr->mode != KILL) {
 			acl = &(eaptr->chunkdelayedops);
-			while (*acl && eptr==NULL) {
+			while (*acl && eptr == NULL) {
 				cl = *acl;
-				if (cl->chunkid==chunkid) {
+				if (cl->chunkid == chunkid) {
 					eptr = eaptr;
 					qid = cl->qid;
 					fleng = cl->fleng;
@@ -1294,9 +1294,8 @@ void matoclserv_chunks_health(matoclserventry *eptr, const uint8_t *data, uint32
 }
 
 void matoclserv_session_list(matoclserventry *eptr,const uint8_t *data,uint32_t length) {
-	uint8_t *ptr;
-	matoclserventry *eaptr;
-	uint32_t size,ileng,pleng,i;
+	uint32_t ileng;
+	uint32_t pleng;
 	uint8_t vmode;
 
 	if (length != 0 && length != sizeof(vmode)) {
@@ -1313,7 +1312,7 @@ void matoclserv_session_list(matoclserventry *eptr,const uint8_t *data,uint32_t 
 		vmode = get8bit(&data);
 	}
 
-	size = sizeof(uint16_t);  // 2 bytes for SESSION_STATS
+	uint32_t size = sizeof(uint16_t);  // 2 bytes for SESSION_STATS
 
 	constexpr uint32_t kExtraVModeSize = sizeof(session::mingoal) + sizeof(session::maxgoal) +
 	                                     sizeof(session::mintrashtime) +
@@ -1327,7 +1326,7 @@ void matoclserv_session_list(matoclserventry *eptr,const uint8_t *data,uint32_t 
 
 	constexpr uint32_t kCurrentPlusLastHourEntrySize = sizeof(uint32_t) + sizeof(uint32_t);
 
-	for (eaptr = matoclservhead; eaptr; eaptr = eaptr->next) {
+	for (const auto &eaptr : matoclservList) {
 		if (eaptr->mode != KILL && eaptr->sesdata &&
 		    eaptr->registered == ClientState::kRegistered) {
 			size += kCommonSessionSize + (SESSION_STATS * kCurrentPlusLastHourEntrySize) +
@@ -1347,11 +1346,11 @@ void matoclserv_session_list(matoclserventry *eptr,const uint8_t *data,uint32_t 
 		}
 	}
 
-	ptr = matoclserv_createpacket(eptr, MATOCL_SESSION_LIST, size);
+	uint8_t *ptr = matoclserv_createpacket(eptr, MATOCL_SESSION_LIST, size);
 
 	put16bit(&ptr, SESSION_STATS);
 
-	for (eaptr = matoclservhead; eaptr; eaptr = eaptr->next) {
+	for (const auto &eaptr : matoclservList) {
 		if (eaptr->mode != KILL && eaptr->sesdata &&
 		    eaptr->registered == ClientState::kRegistered) {
 			put32bit(&ptr, eaptr->sesdata->sessionid);
@@ -1393,10 +1392,10 @@ void matoclserv_session_list(matoclserventry *eptr,const uint8_t *data,uint32_t 
 			}
 
 			if (eaptr->sesdata) {
-				for (i = 0; i < SESSION_STATS; i++) {
+				for (auto i = 0; i < SESSION_STATS; i++) {
 					put32bit(&ptr, eaptr->sesdata->currentopstats[i]);
 				}
-				for (i = 0; i < SESSION_STATS; i++) {
+				for (auto i = 0; i < SESSION_STATS; i++) {
 					put32bit(&ptr, eaptr->sesdata->lasthouropstats[i]);
 				}
 			} else {
@@ -1410,11 +1409,12 @@ void matoclserv_session_list(matoclserventry *eptr,const uint8_t *data,uint32_t 
 
 void matoclserv_mount_info_list(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	std::vector<MountInfoEntry> mountInfoList;
-	matoclserventry *eaptr;
+
 	cltoma::mountInfoList::deserialize(data, length);
 
-	for (eaptr = matoclservhead ; eaptr ; eaptr=eaptr->next) {
-		if (eaptr->mode != KILL && eaptr->sesdata && eaptr->registered == ClientState::kRegistered) {
+	for (const auto &eaptr : matoclservList) {
+		if (eaptr->mode != KILL && eaptr->sesdata != nullptr &&
+		    eaptr->registered == ClientState::kRegistered) {
 			MountInfoEntry entry;
 			entry.sessionId = eaptr->sesdata->sessionid;
 			entry.mountInfo = eaptr->sesdata->mountinfo;
@@ -1626,9 +1626,9 @@ static void matoclserv_send_iolimits_cfg(matoclserventry *eptr) {
 }
 
 static void matoclserv_broadcast_iolimits_cfg() {
-	for (matoclserventry *eptr = matoclservhead; eptr; eptr = eptr->next) {
+	for (const auto &eptr : matoclservList) {
 		if (eptr->iolimits) {
-			matoclserv_send_iolimits_cfg(eptr);
+			matoclserv_send_iolimits_cfg(eptr.get());
 		}
 	}
 }
@@ -5279,9 +5279,9 @@ void matoclserv_broadcast_metadata_saved(uint8_t status) {
 	if (exiting) {
 		return;
 	}
-	for (matoclserventry* eptr = matoclservhead; eptr != nullptr; eptr = eptr->next) {
+	for (const auto &eptr : matoclservList) {
 		if (eptr->adminTask == AdminTask::kSaveMetadata) {
-			matoclserv_createpacket(eptr, matocl::adminSaveMetadata::build(status));
+			matoclserv_createpacket(eptr.get(), matocl::adminSaveMetadata::build(status));
 			eptr->adminTask = AdminTask::kNone;
 		}
 	}
@@ -5312,9 +5312,9 @@ void matoclserv_broadcast_metadata_checksum_recalculated(uint8_t status) {
 	if (exiting) {
 		return;
 	}
-	for (matoclserventry* eptr = matoclservhead; eptr != nullptr; eptr = eptr->next) {
+	for (const auto &eptr : matoclservList) {
 		if (eptr->adminTask == AdminTask::kRecalculateChecksums) {
-			matoclserv_createpacket(eptr, matocl::adminRecalculateMetadataChecksum::build(status));
+			matoclserv_createpacket(eptr.get(), matocl::adminRecalculateMetadataChecksum::build(status));
 			eptr->adminTask = AdminTask::kNone;
 		}
 	}
@@ -5351,11 +5351,10 @@ uint32_t session_number_of_files(session *sess) {
 void matoclserv_session_files(matoclserventry *eptr,
                               [[maybe_unused]] const uint8_t *data,
                               [[maybe_unused]] uint32_t length) {
-	matoclserventry *eaptr;
 	std::vector<SessionFiles> sessions;
 	MessageBuffer reply;
 
-	for (eaptr = matoclservhead; eaptr; eaptr = eaptr->next) {
+	for (const auto &eaptr : matoclservList) {
 		if (eaptr->mode == KILL || !eaptr->sesdata ||
 		    eaptr->registered != ClientState::kRegistered) {
 			continue;
@@ -5386,8 +5385,9 @@ void matoclserv_session_delete(matoclserventry *eptr, const uint8_t *data,
 	// Find the session with the given sessionId
 	matoclserventry *target = nullptr;
 
-	for (target = matoclservhead; target; target = target->next) {
-		if (target->sesdata && target->sesdata->sessionid == sessionId) {
+	for (const auto &eaptr : matoclservList) {
+		if (eaptr->sesdata && eaptr->sesdata->sessionid == sessionId) {
+			target = eaptr.get();
 			break;
 		}
 	}
@@ -5942,18 +5942,17 @@ void matoclserv_gotpacket(matoclserventry *eptr,uint32_t type,const uint8_t *dat
 }
 
 void matoclserv_term(void) {
-	matoclserventry *eptr,*eptrn;
 	packetstruct *pptr,*pptrn;
 	chunklist *cl,*cln;
 
-	safs_pretty_syslog(LOG_NOTICE,"main master server module: closing %s:%s",ListenHost,ListenPort);
+	safs::log_info("main master server module: closing {}:{}", ListenHost, ListenPort);
 	tcpclose(lsock);
 
-	for (eptr = matoclservhead ; eptr ; eptr = eptrn) {
-		eptrn = eptr->next;
+	for (const auto &eptr : matoclservList) {
 		if (eptr->inputpacket.packet) {
 			free(eptr->inputpacket.packet);
 		}
+
 		for (pptr = eptr->outputhead ; pptr ; pptr = pptrn) {
 			pptrn = pptr->next;
 			if (pptr->packet) {
@@ -5961,12 +5960,14 @@ void matoclserv_term(void) {
 			}
 			free(pptr);
 		}
+
 		for (cl = eptr->chunkdelayedops ; cl ; cl = cln) {
 			cln = cl->next;
 			free(cl);
 		}
-		delete eptr;
 	}
+
+	matoclservList.clear();
 	matoclserv_session_unload();
 
 	free(ListenHost);
@@ -6103,17 +6104,21 @@ void matoclserv_wantexit(void) {
 int matoclserv_canexit(void) {
 	matoclserventry *adminTerminator = NULL;
 	static bool terminatorPacketSent = false;
-	for (matoclserventry* eptr = matoclservhead; eptr != nullptr; eptr = eptr->next) {
-		if (eptr->outputhead!=NULL) {
+
+	for (const auto &eptr : matoclservList) {
+		if (eptr->outputhead != NULL) {
 			return 0;
 		}
-		if (eptr->chunkdelayedops!=NULL) {
+
+		if (eptr->chunkdelayedops != NULL) {
 			return 0;
 		}
+
 		if (eptr->adminTask == AdminTask::kTerminate) {
-			adminTerminator = eptr;
+			adminTerminator = eptr.get();
 		}
 	}
+
 	if (adminTerminator != NULL && !terminatorPacketSent) {
 		// Are we replying to termination request?
 		if (!matomlserv_canexit()){  // make sure there are no ml connected
@@ -6125,32 +6130,35 @@ int matoclserv_canexit(void) {
 			terminatorPacketSent = true;
 		}
 	}
+
 	// Wait for the admin which requested termination (if exists) to disconnect.
 	// This ensures that he received the response (or died and is no longer interested).
-	for (matoclserventry* eptr = matoclservhead; eptr != nullptr; eptr = eptr->next) {
+	for (const auto &eptr : matoclservList) {
 		if (eptr->adminTask == AdminTask::kTerminate) {
 			return 0;
 		}
 	}
+
 	return 1;
 }
 
 void matoclserv_desc(std::vector<pollfd> &pdesc) {
-	matoclserventry *eptr;
-
-	if (exiting==0) {
-		pdesc.push_back({lsock,POLLIN,0});
+	if (exiting == 0) {
+		pdesc.push_back({lsock, POLLIN, 0});
 		lsockpdescpos = pdesc.size() - 1;
 	} else {
 		lsockpdescpos = -1;
 	}
-	for (eptr=matoclservhead ; eptr ; eptr=eptr->next) {
-		pdesc.push_back({eptr->sock,0,0});
+
+	for (const auto &eptr : matoclservList) {
+		pdesc.push_back({eptr->sock, 0, 0});
 		eptr->pdescpos = pdesc.size() - 1;
-		if (exiting==0) {
+
+		if (exiting == 0) {
 			pdesc.back().events |= POLLIN;
 		}
-		if (eptr->outputhead!=NULL) {
+
+		if (eptr->outputhead != NULL) {
 			pdesc.back().events |= POLLOUT;
 		}
 	}
@@ -6159,20 +6167,17 @@ void matoclserv_desc(std::vector<pollfd> &pdesc) {
 
 void matoclserv_serve(const std::vector<pollfd> &pdesc) {
 	uint32_t now=eventloop_time();
-	matoclserventry *eptr,**kptr;
-	packetstruct *pptr,*paptr;
-	int ns;
+	packetstruct *pptr;
+	packetstruct *paptr;
 
-	if (lsockpdescpos>=0 && (pdesc[lsockpdescpos].revents & POLLIN)) {
-		ns=tcpaccept(lsock);
-		if (ns<0) {
+	if (lsockpdescpos >= 0 && (pdesc[lsockpdescpos].revents & POLLIN)) {
+		int ns = tcpaccept(lsock);
+		if (ns < 0) {
 			safs_silent_errlog(LOG_NOTICE,"main master server module: accept error");
 		} else {
 			tcpnonblock(ns);
 			tcpnodelay(ns);
-			eptr = new matoclserventry;
-			eptr->next = matoclservhead;
-			matoclservhead = eptr;
+			auto eptr = std::make_unique<matoclserventry>();
 			eptr->sock = ns;
 			eptr->pdescpos = -1;
 			tcpgetpeer(ns,&(eptr->peerip),&(eptr->peerport));
@@ -6192,50 +6197,58 @@ void matoclserv_serve(const std::vector<pollfd> &pdesc) {
 
 			eptr->chunkdelayedops = NULL;
 			eptr->sesdata = NULL;
-			memset(eptr->passwordrnd,0,32);
+			memset(eptr->passwordrnd, 0, 32);
+
+			matoclservList.push_front(std::move(eptr));
 		}
 	}
 
 // read
-	for (eptr=matoclservhead ; eptr ; eptr=eptr->next) {
-		if (eptr->pdescpos>=0) {
+	for (const auto &eptr : matoclservList) {
+		if (eptr->pdescpos >= 0) {
 			if (pdesc[eptr->pdescpos].revents & (POLLERR|POLLHUP)) {
 				eptr->mode = KILL;
 			}
-			if ((pdesc[eptr->pdescpos].revents & POLLIN) && eptr->mode!=KILL) {
+
+			if ((pdesc[eptr->pdescpos].revents & POLLIN) && eptr->mode != KILL) {
 				eptr->lastread = now;
-				matoclserv_read(eptr);
+				matoclserv_read(eptr.get());
 			}
 		}
 	}
 
 // write
-	for (eptr=matoclservhead ; eptr ; eptr=eptr->next) {
-		if (eptr->lastwrite+2<now && eptr->registered != ClientState::kOldTools
-				&& eptr->outputhead==NULL) {
-			uint8_t *ptr = matoclserv_createpacket(eptr,ANTOAN_NOP,4);      // 4 byte length because of 'msgid'
-			*((uint32_t*)ptr) = 0;
+	for (const auto &eptr : matoclservList) {
+		if (eptr->lastwrite + 2 < now && eptr->registered != ClientState::kOldTools &&
+		    eptr->outputhead == NULL) {
+			// 4 byte length because of 'msgid'
+			uint8_t *ptr = matoclserv_createpacket(eptr.get(), ANTOAN_NOP, 4);
+			*((uint32_t *)ptr) = 0;
 		}
-		if (eptr->pdescpos>=0) {
-			if ((((pdesc[eptr->pdescpos].events & POLLOUT)==0 && (eptr->outputhead)) || (pdesc[eptr->pdescpos].revents & POLLOUT)) && eptr->mode!=KILL) {
+
+		if (eptr->pdescpos >= 0) {
+			if ((((pdesc[eptr->pdescpos].events & POLLOUT) == 0 && (eptr->outputhead)) ||
+			     (pdesc[eptr->pdescpos].revents & POLLOUT)) &&
+			    eptr->mode != KILL) {
 				eptr->lastwrite = now;
-				matoclserv_write(eptr);
+				matoclserv_write(eptr.get());
 			}
 		}
-		if (eptr->lastread+10<now && exiting==0) {
-			eptr->mode = KILL;
-		}
+
+		if (eptr->lastread + 10 < now && exiting == 0) { eptr->mode = KILL; }
 	}
 
 // close
-	kptr = &matoclservhead;
-	while ((eptr=*kptr)) {
+	for (auto eptrIt = matoclservList.begin(); eptrIt != matoclservList.end();) {
+		auto *eptr = eptrIt->get();
 		if (eptr->mode == KILL) {
 			matocl_beforedisconnect(eptr);
 			tcpclose(eptr->sock);
+
 			if (eptr->inputpacket.packet) {
 				free(eptr->inputpacket.packet);
 			}
+
 			pptr = eptr->outputhead;
 			while (pptr) {
 				if (pptr->packet) {
@@ -6245,10 +6258,10 @@ void matoclserv_serve(const std::vector<pollfd> &pdesc) {
 				pptr = pptr->next;
 				free(paptr);
 			}
-			*kptr = eptr->next;
-			delete eptr;
+
+			eptrIt = matoclservList.erase(eptrIt);
 		} else {
-			kptr = &(eptr->next);
+			++eptrIt;
 		}
 	}
 }
@@ -6343,9 +6356,9 @@ void  matoclserv_become_master() {
 
 void matoclserv_reload(void) {
 	// Notify admins that reload was performed - put responses in their packet queues
-	for (matoclserventry* eptr = matoclservhead; eptr != nullptr; eptr = eptr->next) {
+	for (const auto &eptr : matoclservList) {
 		if (eptr->adminTask == AdminTask::kReload) {
-			matoclserv_createpacket(eptr, matocl::adminReload::build(SAUNAFS_STATUS_OK));
+			matoclserv_createpacket(eptr.get(), matocl::adminReload::build(SAUNAFS_STATUS_OK));
 			eptr->adminTask = AdminTask::kNone;
 		}
 	}
@@ -6433,7 +6446,7 @@ int matoclserv_networkinit(void) {
 	}
 	safs_pretty_syslog(LOG_NOTICE,"main master server module: listen on %s:%s",ListenHost,ListenPort);
 
-	matoclservhead = NULL;
+	matoclservList.clear();
 
 	if (metadataserver::isMaster()) {
 		matoclserv_become_master();

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -154,7 +154,6 @@ struct session {
 	std::array<uint32_t,SESSION_STATS> lasthouropstats;
 	GroupCache group_cache;
 	OpenedFilesSet openedfiles;
-	struct session *next;
 
 	session()
 	    : sessionid(),
@@ -176,8 +175,7 @@ struct session {
 	      currentopstats(),
 	      lasthouropstats(),
 	      group_cache(),
-	      openedfiles(),
-	      next() {
+	      openedfiles() {
 	}
 };
 
@@ -240,7 +238,7 @@ struct matoclserventry {
 	struct matoclserventry *next;
 };
 
-static session *sessionshead=NULL;
+static std::vector<std::unique_ptr<session>> sessionVector;
 static matoclserventry *matoclservhead=NULL;
 static int lsock;
 static int32_t lsockpdescpos;
@@ -554,61 +552,50 @@ matoclserventry *matoclserv_find_connection(uint32_t id) {
 }
 
 /* new registration procedure */
-session* matoclserv_new_session(uint8_t newsession,uint8_t nonewid) {
-	session *asesdata = new session();
-	passert(asesdata);
+session *matoclserv_new_session(uint8_t newsession, uint8_t nonewid) {
+	auto sessionPtr = std::make_unique<session>();
+	passert(sessionPtr.get());
 	if (newsession==0 && nonewid) {
-		asesdata->sessionid = 0;
+		sessionPtr->sessionid = 0;
 	} else {
-		asesdata->sessionid = fs_newsessionid();
+		sessionPtr->sessionid = fs_newsessionid();
 	}
 
-	asesdata->newsession = newsession;
-	asesdata->nsocks = 1;
-	asesdata->next = sessionshead;
-	sessionshead = asesdata;
-	return asesdata;
+	sessionPtr->newsession = newsession;
+	sessionPtr->nsocks = 1;
+	sessionVector.push_back(std::move(sessionPtr));
+	return sessionVector.back().get();
 }
 
 session* matoclserv_find_session(uint32_t sessionid) {
-	session *asesdata;
-	if (sessionid==0) {
-		return NULL;
-	}
-	for (asesdata = sessionshead ; asesdata ; asesdata=asesdata->next) {
-		if (asesdata->sessionid==sessionid) {
-//                      syslog(LOG_NOTICE,"found: %u ; before ; nsocks: %u ; state: %u",sessionid,asesdata->nsocks,asesdata->newsession);
-			if (asesdata->newsession>=2) {
-				asesdata->newsession-=2;
+	if (sessionid == 0) { return nullptr; }
+
+	for (const auto& sessionPtr : sessionVector) {
+		if (sessionPtr->sessionid == sessionid) {
+			if (sessionPtr->newsession >= 2) {
+				sessionPtr->newsession -= 2;
 			}
-			asesdata->nsocks++;
-//                      syslog(LOG_NOTICE,"found: %u ; after ; nsocks: %u ; state: %u",sessionid,asesdata->nsocks,asesdata->newsession);
-			asesdata->disconnected = 0;
-			return asesdata;
+			sessionPtr->nsocks++;
+			sessionPtr->disconnected = 0;
+			return sessionPtr.get();
 		}
 	}
-	return NULL;
+	return nullptr;
 }
 
 void matoclserv_close_session(uint32_t sessionid) {
-	session *asesdata;
-	if (sessionid==0) {
-		return;
-	}
-	for (asesdata = sessionshead ; asesdata ; asesdata=asesdata->next) {
-		if (asesdata->sessionid==sessionid) {
-//                      syslog(LOG_NOTICE,"close: %u ; before ; nsocks: %u ; state: %u",sessionid,asesdata->nsocks,asesdata->newsession);
-			if (asesdata->nsocks==1 && asesdata->newsession<2) {
-				asesdata->newsession+=2;
+	if (sessionid == 0) { return; }
+
+	for (const auto& sessionPtr : sessionVector) {
+		if (sessionPtr->sessionid == sessionid) {
+			if (sessionPtr->nsocks == 1 && sessionPtr->newsession < 2) {
+				sessionPtr->newsession += 2;
 			}
-//                      syslog(LOG_NOTICE,"close: %u ; after ; nsocks: %u ; state: %u",sessionid,asesdata->nsocks,asesdata->newsession);
 		}
 	}
-	return;
 }
 
 void matoclserv_store_sessions() {
-	session *asesdata;
 	uint32_t ileng;
 	constexpr uint32_t kSessionSerializedSize =
 	    sizeof(session::sessionid) + sizeof(ileng) + sizeof(session::peerip) +
@@ -623,72 +610,80 @@ void matoclserv_store_sessions() {
 	FILE *fd;
 
 	fd = fopen(kSessionsTmpFilename, "w");
-	if (fd==NULL) {
+	if (fd == NULL) {
 		safs_silent_errlog(LOG_WARNING,"can't store sessions, open error");
 		return;
 	}
-	memcpy(fsesrecord,SFSSIGNATURE "S \001\006\004",8);
-	ptr = fsesrecord+8;
+
+	memcpy(fsesrecord, SFSSIGNATURE "S \001\006\004", 8);
+	ptr = fsesrecord + 8;
 	put16bit(&ptr,SESSION_STATS);
-	if (fwrite(fsesrecord,10,1,fd)!=1) {
+
+	if (fwrite(fsesrecord, 10, 1, fd) != 1) {
 		safs_pretty_syslog(LOG_WARNING,"can't store sessions, fwrite error");
 		fclose(fd);
 		return;
 	}
-	for (asesdata = sessionshead ; asesdata ; asesdata=asesdata->next) {
-		if (asesdata->newsession==1) {
+
+	for (const auto& sessionPtr : sessionVector) {
+		if (sessionPtr->newsession == 1) {
 			ptr = fsesrecord;
-			if (asesdata->info) {
-				ileng = strlen(asesdata->info);
+			if (sessionPtr->info) {
+				ileng = strlen(sessionPtr->info);
 			} else {
 				ileng = 0;
 			}
-			put32bit(&ptr,asesdata->sessionid);
-			put32bit(&ptr,ileng);
-			put32bit(&ptr,asesdata->peerip);
-			putINode(&ptr,asesdata->rootinode);
-			put8bit(&ptr,asesdata->sesflags);
-			put8bit(&ptr,asesdata->mingoal);
-			put8bit(&ptr,asesdata->maxgoal);
-			put32bit(&ptr,asesdata->mintrashtime);
-			put32bit(&ptr,asesdata->maxtrashtime);
-			put32bit(&ptr,asesdata->rootuid);
-			put32bit(&ptr,asesdata->rootgid);
-			put32bit(&ptr,asesdata->mapalluid);
-			put32bit(&ptr,asesdata->mapallgid);
-			for (i=0 ; i<SESSION_STATS ; i++) {
-				put32bit(&ptr,asesdata->currentopstats[i]);
+
+			put32bit(&ptr, sessionPtr->sessionid);
+			put32bit(&ptr, ileng);
+			put32bit(&ptr, sessionPtr->peerip);
+			put32bit(&ptr, sessionPtr->rootinode);
+			put8bit(&ptr, sessionPtr->sesflags);
+			put8bit(&ptr, sessionPtr->mingoal);
+			put8bit(&ptr, sessionPtr->maxgoal);
+			put32bit(&ptr, sessionPtr->mintrashtime);
+			put32bit(&ptr, sessionPtr->maxtrashtime);
+			put32bit(&ptr, sessionPtr->rootuid);
+			put32bit(&ptr, sessionPtr->rootgid);
+			put32bit(&ptr, sessionPtr->mapalluid);
+			put32bit(&ptr, sessionPtr->mapallgid);
+
+			for (i = 0; i < SESSION_STATS; i++) {
+				put32bit(&ptr, sessionPtr->currentopstats[i]);
 			}
-			for (i=0 ; i<SESSION_STATS ; i++) {
-				put32bit(&ptr,asesdata->lasthouropstats[i]);
+
+			for (i = 0; i < SESSION_STATS; i++) {
+				put32bit(&ptr, sessionPtr->lasthouropstats[i]);
 			}
 			if (fwrite(fsesrecord, kBufferSize, 1, fd) != 1) {
 				safs_pretty_syslog(LOG_WARNING,"can't store sessions, fwrite error");
 				fclose(fd);
 				return;
 			}
-			if (ileng>0) {
-				if (fwrite(asesdata->info,ileng,1,fd)!=1) {
-					safs_pretty_syslog(LOG_WARNING,"can't store sessions, fwrite error");
+
+			if (ileng > 0) {
+				if (fwrite(sessionPtr->info, ileng, 1, fd) != 1) {
+					safs_pretty_syslog(LOG_WARNING, "can't store sessions, fwrite error");
 					fclose(fd);
 					return;
 				}
 			}
 		}
 	}
-	if (fclose(fd)!=0) {
+
+	if (fclose(fd) != 0) {
 		safs_silent_errlog(LOG_WARNING,"can't store sessions, fclose error");
 		return;
 	}
+
 	if (rename(kSessionsTmpFilename, kSessionsFilename) < 0) {
-		safs_silent_errlog(LOG_WARNING,"can't store sessions, rename error");
+		safs_silent_errlog(LOG_WARNING, "can't store sessions, rename error");
 	}
 }
 
 #define MFSSIGNATURE "MFS"
 
 int matoclserv_load_sessions() {
-	session *asesdata;
 	uint32_t ileng;
 	uint8_t hdr[8];  // for signature and version. e.g. "SFS" " S 1.5"
 	std::vector<uint8_t> fsesrecord;
@@ -738,7 +733,7 @@ int matoclserv_load_sessions() {
 	           memcmp(hdr, MFSSIGNATURE "S \001\006\003", kSessionsHeaderSize) == 0) {
 		mapalldata = 1;
 		goaltrashdata = 0;
-		if (fread(hdr,2,1,fd)!=1) {
+		if (fread(hdr, 2, 1, fd) != 1) {
 			safs_pretty_syslog(LOG_WARNING,"can't load sessions, fread error");
 			fclose(fd);
 			return -1;
@@ -794,59 +789,60 @@ int matoclserv_load_sessions() {
 
 		if (r==1) {
 			ptr = fsesrecord.data();
-			asesdata = new session();
-			passert(asesdata);
-			get32bit(&ptr, asesdata->sessionid);
+			auto sessionPtr = std::make_unique<session>();
+			passert(sessionPtr);
+			get32bit(&ptr, sessionPtr->sessionid);
 			get32bit(&ptr, ileng);
-			get32bit(&ptr, asesdata->peerip);
-			getINode(&ptr, asesdata->rootinode);
-			asesdata->sesflags = get8bit(&ptr);
+			get32bit(&ptr, sessionPtr->peerip);
+			getINode(&ptr, sessionPtr->rootinode);
+			sessionPtr->sesflags = get8bit(&ptr);
 			if (goaltrashdata) {
-				asesdata->mingoal = get8bit(&ptr);
-				asesdata->maxgoal = get8bit(&ptr);
-				get32bit(&ptr, asesdata->mintrashtime);
-				get32bit(&ptr, asesdata->maxtrashtime);
+				sessionPtr->mingoal = get8bit(&ptr);
+				sessionPtr->maxgoal = get8bit(&ptr);
+				get32bit(&ptr, sessionPtr->mintrashtime);
+				get32bit(&ptr, sessionPtr->maxtrashtime);
 			}
-			get32bit(&ptr, asesdata->rootuid);
-			get32bit(&ptr, asesdata->rootgid);
+			get32bit(&ptr, sessionPtr->rootuid);
+			get32bit(&ptr, sessionPtr->rootgid);
 			if (mapalldata) {
-				get32bit(&ptr, asesdata->mapalluid);
-				get32bit(&ptr, asesdata->mapallgid);
+				get32bit(&ptr, sessionPtr->mapalluid);
+				get32bit(&ptr, sessionPtr->mapallgid);
 			}
-			asesdata->newsession = 1;
-			asesdata->disconnected = eventloop_time();
-			for (i=0 ; i<SESSION_STATS ; i++) {
-				if (i<statsinfile) {
-					get32bit(&ptr, asesdata->currentopstats[i]);
+			sessionPtr->newsession = 1;
+			sessionPtr->disconnected = eventloop_time();
+			for (i = 0; i < SESSION_STATS; i++) {
+				if (i < statsinfile) {
+					get32bit(&ptr, sessionPtr->currentopstats[i]);
 				} else {
-					asesdata->currentopstats[i] = 0;
+					sessionPtr->currentopstats[i] = 0;
 				}
 			}
-			if (statsinfile>SESSION_STATS) {
-				ptr+=4*(statsinfile-SESSION_STATS);
+
+			if (statsinfile > SESSION_STATS) {
+				ptr += 4 * (statsinfile - SESSION_STATS);
 			}
-			for (i=0 ; i<SESSION_STATS ; i++) {
-				if (i<statsinfile) {
-					get32bit(&ptr, asesdata->lasthouropstats[i]);
+			for (i = 0; i < SESSION_STATS; i++) {
+				if (i < statsinfile) {
+					get32bit(&ptr, sessionPtr->lasthouropstats[i]);
 				} else {
-					asesdata->lasthouropstats[i] = 0;
+					sessionPtr->lasthouropstats[i] = 0;
 				}
 			}
-			if (ileng>0) {
-				asesdata->info = (char*) malloc(ileng+1);
-				passert(asesdata->info);
-				if (fread(asesdata->info,ileng,1,fd)!=1) {
-					free(asesdata->info);
-					delete asesdata;
+			if (ileng > 0) {
+				sessionPtr->info = (char *)malloc(ileng + 1);
+				passert(sessionPtr->info);
+				if (fread(sessionPtr->info, ileng, 1, fd) != 1) {
+					free(sessionPtr->info);
+					sessionPtr.reset();
 					safs_pretty_syslog(LOG_WARNING,"can't load sessions, fread error");
 					fclose(fd);
 					return -1;
 				}
-				asesdata->info[ileng]=0;
+				sessionPtr->info[ileng] = 0;
 			}
-			asesdata->next = sessionshead;
-			sessionshead = asesdata;
+			sessionVector.push_back(std::move(sessionPtr));
 		}
+
 		if (ferror(fd)) {
 			safs_pretty_syslog(LOG_WARNING,"can't load sessions, fread error");
 			fclose(fd);
@@ -873,46 +869,44 @@ int matoclserv_insert_openfile(session *cr, inode_t inode) {
 	return status;
 }
 
-void matoclserv_add_open_file(uint32_t sessionid, inode_t inode) {
-	session *asesdata;
+void matoclserv_add_open_file(uint32_t sessionid, uint32_t inode) {
+	for (const auto& sessionPtr : sessionVector) {
+		if (sessionPtr->sessionid == sessionid) {
+			if (!sessionPtr->openedfiles.contains(inode)) {
+				sessionPtr->openedfiles.insert(inode);
+			}
+			return;
+		}
+	}
 
-	for (asesdata = sessionshead ; asesdata && asesdata->sessionid!=sessionid; asesdata=asesdata->next) ;
-	if (asesdata==NULL) {
-		asesdata = new session();
-		passert(asesdata);
-		asesdata->sessionid = sessionid;
+	// If session does not exist, create a new one
+	auto sessionPtr = std::make_unique<session>();
+	passert(sessionPtr.get());
+	sessionPtr->sessionid = sessionid;
 /* session created by filesystem - only for old clients (pre 1.5.13) */
-		asesdata->disconnected = eventloop_time();
-		asesdata->next = sessionshead;
-		sessionshead = asesdata;
-	}
-
-	if (asesdata->openedfiles.contains(inode)) {
-		return;  // file already open - nothing to do
-	}
-	asesdata->openedfiles.insert(inode);
+	sessionPtr->disconnected = eventloop_time();
+	sessionPtr->openedfiles.insert(inode);
+	sessionVector.push_back(std::move(sessionPtr));
 }
 
-void matoclserv_remove_open_file(uint32_t sessionid, inode_t inode) {
-	session *asesdata;
+void matoclserv_remove_open_file(uint32_t sessionid, uint32_t inode) {
+	for (const auto& sessionPtr : sessionVector) {
+		if (sessionPtr->sessionid == sessionid) {
+			if (sessionPtr->openedfiles.contains(inode)) {
+				sessionPtr->openedfiles.erase(inode);
+			}
+			return;
+		}
+	}
 
-	for (asesdata = sessionshead; asesdata && asesdata->sessionid != sessionid; asesdata = asesdata->next) {
-	}
-	if (asesdata == NULL) {
-		safs_pretty_syslog(LOG_ERR, "sessions file is corrupted");
-		return;
-	}
-
-	if (asesdata->openedfiles.contains(inode)) {
-		asesdata->openedfiles.erase(inode);
-	}
+	safs_pretty_syslog(LOG_ERR, "sessions file is corrupted");
 }
 
 void matoclserv_reset_session_timeouts() {
-	session *asesdata;
 	uint32_t now = eventloop_time();
-	for (asesdata = sessionshead ; asesdata ; asesdata=asesdata->next) {
-		asesdata->disconnected = now;
+
+	for (auto& sessionPtr : sessionVector) {
+		sessionPtr->disconnected = now;
 	}
 }
 
@@ -5250,10 +5244,10 @@ void matoclserv_admin_reload(matoclserventry* eptr, const uint8_t* data, uint32_
 
 std::string get_client_configs() {
 	std::map<std::string, std::string> client_configs;
-	for (session *sess = sessionshead; sess != nullptr; sess = sess->next) {
-		if (sess->config.empty()) { continue; }
-		NetworkAddress addr(sess->peerip, sess->peerport);
-		client_configs[addr.toString()] = sess->config;
+	for (const auto& sessionPtr : sessionVector) {
+		if (sessionPtr->config.empty()) { continue; }
+		NetworkAddress addr(sessionPtr->peerip, sessionPtr->peerport);
+		client_configs[addr.toString()] = sessionPtr->config;
 	}
 	return cfg_yaml_list("clients", client_configs);
 }
@@ -5442,29 +5436,26 @@ void matoclserv_session_delete(matoclserventry *eptr, const uint8_t *data,
 }
 
 void matocl_session_check(void) {
-	session **sesdata,*asesdata;
-	uint32_t now;
+	uint32_t now = eventloop_time();
 
-	now = eventloop_time();
-	sesdata = &(sessionshead);
-	while ((asesdata=*sesdata)) {
-//              syslog(LOG_NOTICE,"session: %u ; nsocks: %u ; state: %u ; disconnected: %u",asesdata->sessionid,asesdata->nsocks,asesdata->newsession,asesdata->disconnected);
-		if (asesdata->nsocks==0 && ((asesdata->newsession>1 && asesdata->disconnected<now) || (asesdata->newsession==1 && asesdata->disconnected+SessionSustainTime<now) || (asesdata->newsession==0 && asesdata->disconnected+7200<now))) {
-//                      syslog(LOG_NOTICE,"remove session: %u",asesdata->sessionid);
-			matocl_session_timedout(asesdata);
-			*sesdata = asesdata->next;
-			delete asesdata;
+	for (auto sessionIt = sessionVector.begin(); sessionIt != sessionVector.end();) {
+		auto& sessionPtr = *sessionIt;
+		if (sessionPtr->nsocks == 0 &&
+		    ((sessionPtr->newsession > 1 && sessionPtr->disconnected < now) ||
+		     (sessionPtr->newsession == 1 && sessionPtr->disconnected + SessionSustainTime < now) ||
+		     (sessionPtr->newsession == 0 && sessionPtr->disconnected + 7200 < now))) {
+			matocl_session_timedout(sessionPtr.get());
+			sessionIt = sessionVector.erase(sessionIt);
 		} else {
-			sesdata = &(asesdata->next);
+			++sessionIt;
 		}
 	}
 }
 
 void matocl_session_statsmove(void) {
-	session *sesdata;
-	for (sesdata = sessionshead ; sesdata ; sesdata=sesdata->next) {
-		sesdata->lasthouropstats = sesdata->currentopstats;
-		sesdata->currentopstats.fill(0);
+	for (auto& sessionPtr : sessionVector) {
+		sessionPtr->lasthouropstats = sessionPtr->currentopstats;
+		sessionPtr->currentopstats.fill(0);
 	}
 	matoclserv_store_sessions();
 }
@@ -6296,7 +6287,7 @@ void matoclserv_start_cond_check(void) {
 }
 
 int matoclserv_sessionsinit(void) {
-	sessionshead = NULL;
+	sessionVector.clear();
 
 	switch (matoclserv_load_sessions()) {
 		case 0: // no file
@@ -6478,13 +6469,12 @@ int matoclserv_networkinit(void) {
 }
 
 void matoclserv_session_unload(void) {
-	for (session* ss = sessionshead, *ssn = NULL; ss ; ss = ssn) {
-		ssn = ss->next;
-		ss->openedfiles.clear();
-		if (ss->info) {
-			free(ss->info);
+	for (const auto& sessionPtr : sessionVector) {
+		sessionPtr->openedfiles.clear();
+		if (sessionPtr->info) {
+			free(sessionPtr->info);
 		}
-		delete ss;
 	}
-	sessionshead = nullptr;
+
+	sessionVector.clear();
 }

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -248,8 +248,8 @@ static int32_t lsockpdescpos;
 static int exiting,starting;
 
 // from config
-static char *ListenHost;
-static char *ListenPort;
+static std::string ListenHost;
+static std::string ListenPort;
 static uint32_t RejectOld;
 static uint32_t SessionSustainTime;
 
@@ -5961,9 +5961,6 @@ void matoclserv_term(void) {
 
 	matoclservList.clear();
 	matoclserv_session_unload();
-
-	free(ListenHost);
-	free(ListenPort);
 }
 
 void matoclserv_read(matoclserventry *eptr) {
@@ -6358,63 +6355,81 @@ void matoclserv_reload(void) {
 
 	RejectOld = cfg_getuint32("REJECT_OLD_CLIENTS",0);
 	SessionSustainTime = cfg_getuint32("SESSION_SUSTAIN_TIME",86400);
-	if (SessionSustainTime>7*86400) {
-		SessionSustainTime=7*86400;
-		safs_pretty_syslog(LOG_WARNING,"SESSION_SUSTAIN_TIME too big (more than week) - setting this value to one week");
+	if (SessionSustainTime > 7 * 86400) {
+		SessionSustainTime = 7 * 86400;
+		safs::log_warn(
+		    "SESSION_SUSTAIN_TIME too big (more than week) - setting this value to one week");
 	}
-	if (SessionSustainTime<60) {
-		SessionSustainTime=60;
-		safs_pretty_syslog(LOG_WARNING,"SESSION_SUSTAIN_TIME too low (less than minute) - setting this value to one minute");
+
+	if (SessionSustainTime < 60) {
+		SessionSustainTime = 60;
+		safs::log_warn(
+		    "SESSION_SUSTAIN_TIME too low (less than minute) - setting this value to one minute");
 	}
 
 	matoclserv_iolimits_reload();
 
-	char *oldListenHost = ListenHost;
-	char *oldListenPort = ListenPort;
-	ListenHost = cfg_getstr("MATOCL_LISTEN_HOST","*");
-	ListenPort = cfg_getstr("MATOCL_LISTEN_PORT","9421");
+	std::string oldListenHost = ListenHost;
+	std::string oldListenPort = ListenPort;
 
-	if (strcmp(oldListenHost,ListenHost)==0 && strcmp(oldListenPort,ListenPort)==0) {
-		free(oldListenHost);
-		free(oldListenPort);
-		safs_pretty_syslog(LOG_NOTICE,"main master server module: socket address hasn't changed (%s:%s)",ListenHost,ListenPort);
+	auto host = cfg_getstr("MATOCL_LISTEN_HOST","*");
+	auto port = cfg_getstr("MATOCL_LISTEN_PORT","9421");
+
+	ListenHost = host;
+	ListenPort = port;
+
+	free(host); // to avoid memory leak allocated by strdup in cfg_getstr() function
+	free(port); // to avoid memory leak allocated by strdup in cfg_getstr() function
+
+	if (oldListenHost == ListenHost && oldListenPort == ListenPort) {
+		safs::log_info("main master server module: socket address hasn't changed ({}:{})",
+		               ListenHost, ListenPort);
 		return;
 	}
 
 	int newlsock = tcpsocket();
-	if (newlsock<0) {
-		safs_pretty_errlog(LOG_WARNING,"main master server module: socket address has changed, but can't create new socket");
-		free(ListenHost);
-		free(ListenPort);
+	if (newlsock < 0) {
+		safs::log_warn(
+		    "main master server module: socket address has changed, but can't create new socket");
 		ListenHost = oldListenHost;
 		ListenPort = oldListenPort;
 		return;
 	}
+
 	tcpnonblock(newlsock);
 	tcpnodelay(newlsock);
 	tcpreuseaddr(newlsock);
-	if (tcpsetacceptfilter(newlsock)<0 && errno!=ENOTSUP) {
+
+	if (tcpsetacceptfilter(newlsock) < 0 && errno != ENOTSUP) {
 		safs_silent_errlog(LOG_NOTICE,"main master server module: can't set accept filter");
 	}
-	if (tcpstrlisten(newlsock,ListenHost,ListenPort,100)<0) {
-		safs_pretty_errlog(LOG_ERR,"main master server module: socket address has changed, but can't listen on socket (%s:%s)",ListenHost,ListenPort);
-		free(ListenHost);
-		free(ListenPort);
+
+	if (tcpstrlisten(newlsock, ListenHost.c_str(), ListenPort.c_str(), 100) < 0) {
+		safs::log_err(
+		    "main master server module: socket address has changed, but can't listen on socket ({}:{})",
+		    ListenHost, ListenPort);
 		ListenHost = oldListenHost;
 		ListenPort = oldListenPort;
 		tcpclose(newlsock);
 		return;
 	}
-	safs_pretty_syslog(LOG_NOTICE,"main master server module: socket address has changed, now listen on %s:%s",ListenHost,ListenPort);
-	free(oldListenHost);
-	free(oldListenPort);
+
+	safs::log_info("main master server module: socket address has changed, now listen on {}:{}",
+	               ListenHost, ListenPort);
 	tcpclose(lsock);
 	lsock = newlsock;
 }
 
 int matoclserv_networkinit(void) {
-	ListenHost = cfg_getstr("MATOCL_LISTEN_HOST","*");
-	ListenPort = cfg_getstr("MATOCL_LISTEN_PORT","9421");
+	auto host = cfg_getstr("MATOCL_LISTEN_HOST", "*");
+	auto port = cfg_getstr("MATOCL_LISTEN_PORT", "9421");
+
+	ListenHost = host;
+	ListenPort = port;
+
+	free(host);  // to avoid memory leak allocated by strdup in cfg_getstr() function
+	free(port);  // to avoid memory leak allocated by strdup in cfg_getstr() function
+
 	RejectOld = cfg_getuint32("REJECT_OLD_CLIENTS",0);
 
 	if (matoclserv_iolimits_reload() != 0) {
@@ -6423,27 +6438,32 @@ int matoclserv_networkinit(void) {
 
 	exiting = 0;
 	lsock = tcpsocket();
-	if (lsock<0) {
-		safs_pretty_errlog(LOG_ERR,"main master server module: can't create socket");
+	if (lsock < 0) {
+		safs::log_err("main master server module: can't create socket");
 		return -1;
 	}
+
 	tcpnonblock(lsock);
 	tcpnodelay(lsock);
 	tcpreuseaddr(lsock);
-	if (tcpsetacceptfilter(lsock)<0 && errno!=ENOTSUP) {
-		safs_silent_errlog(LOG_NOTICE,"main master server module: can't set accept filter");
+
+	if (tcpsetacceptfilter(lsock) < 0 && errno != ENOTSUP) {
+		safs::log_info("main master server module: can't set accept filter");
 	}
-	if (tcpstrlisten(lsock,ListenHost,ListenPort,100)<0) {
-		safs_pretty_errlog(LOG_ERR,"main master server module: can't listen on %s:%s",ListenHost,ListenPort);
+
+	if (tcpstrlisten(lsock, ListenHost.c_str(), ListenPort.c_str(), 100) < 0) {
+		safs::log_err("main master server module: can't listen on {}:{}", ListenHost, ListenPort);
 		return -1;
 	}
-	safs_pretty_syslog(LOG_NOTICE,"main master server module: listen on %s:%s",ListenHost,ListenPort);
+
+	safs::log_info("main master server module: listen on {}:{}", ListenHost, ListenPort);
 
 	matoclservList.clear();
 
 	if (metadataserver::isMaster()) {
 		matoclserv_become_master();
 	}
+
 	eventloop_reloadregister(matoclserv_reload);
 	metadataserver::registerFunctionCalledOnPromotion(matoclserv_become_master);
 	eventloop_destructregister(matoclserv_term);

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -132,7 +132,7 @@ struct session {
 	using OpenedFilesSet = std::set<inode_t>;
 
 	uint32_t sessionid;
-	char *info;
+	std::string info;
 	std::string mountinfo;
 	std::string config;
 	uint32_t peerip;
@@ -628,11 +628,7 @@ void matoclserv_store_sessions() {
 	for (const auto& sessionPtr : sessionVector) {
 		if (sessionPtr->newsession == 1) {
 			ptr = fsesrecord;
-			if (sessionPtr->info) {
-				ileng = strlen(sessionPtr->info);
-			} else {
-				ileng = 0;
-			}
+			ileng = sessionPtr->info.size();
 
 			put32bit(&ptr, sessionPtr->sessionid);
 			put32bit(&ptr, ileng);
@@ -662,7 +658,7 @@ void matoclserv_store_sessions() {
 			}
 
 			if (ileng > 0) {
-				if (fwrite(sessionPtr->info, ileng, 1, fd) != 1) {
+				if (fwrite(sessionPtr->info.data(), ileng, 1, fd) != 1) {
 					safs_pretty_syslog(LOG_WARNING, "can't store sessions, fwrite error");
 					fclose(fd);
 					return;
@@ -829,16 +825,13 @@ int matoclserv_load_sessions() {
 				}
 			}
 			if (ileng > 0) {
-				sessionPtr->info = (char *)malloc(ileng + 1);
-				passert(sessionPtr->info);
-				if (fread(sessionPtr->info, ileng, 1, fd) != 1) {
-					free(sessionPtr->info);
+				sessionPtr->info.resize(ileng);
+				if (fread(sessionPtr->info.data(), ileng, 1, fd) != 1) {
 					sessionPtr.reset();
 					safs_pretty_syslog(LOG_WARNING,"can't load sessions, fread error");
 					fclose(fd);
 					return -1;
 				}
-				sessionPtr->info[ileng] = 0;
 			}
 			sessionVector.push_back(std::move(sessionPtr));
 		}
@@ -1343,8 +1336,8 @@ void matoclserv_session_list(matoclserventry *eptr,const uint8_t *data,uint32_t 
 			size += kCommonSessionSize + (SESSION_STATS * kCurrentPlusLastHourEntrySize) +
 			        (vmode ? kExtraVModeSize : 0);
 
-			if (eaptr->sesdata->info) {
-				size += strlen(eaptr->sesdata->info);
+			if (!eaptr->sesdata->info.empty()) {
+				size += eaptr->sesdata->info.size();
 			}
 
 			if (eaptr->sesdata->rootinode == 0) {
@@ -1368,10 +1361,10 @@ void matoclserv_session_list(matoclserventry *eptr,const uint8_t *data,uint32_t 
 			put32bit(&ptr, eaptr->peerip);
 			put32bit(&ptr, eaptr->version);
 
-			if (eaptr->sesdata->info) {
-				ileng = strlen(eaptr->sesdata->info);
+			if (!eaptr->sesdata->info.empty()) {
+				ileng = eaptr->sesdata->info.size();
 				put32bit(&ptr, ileng);
-				memcpy(ptr, eaptr->sesdata->info, ileng);
+				memcpy(ptr, eaptr->sesdata->info.data(), ileng);
 				ptr += ileng;
 			} else {
 				put32bit(&ptr, 0);
@@ -1916,15 +1909,11 @@ void matoclserv_fuse_register(matoclserventry *eptr,const uint8_t *data,uint32_t
 				eptr->sesdata->maxtrashtime = maxtrashtime;
 				eptr->sesdata->peerip = eptr->peerip;
 				eptr->sesdata->peerport = eptr->peerport;
-				if (ileng > 0) {
-					if (info[ileng - 1] == 0) {
-						eptr->sesdata->info = strdup(info);
-						passert(eptr->sesdata->info);
+				if (ileng>0) {
+					if (info[ileng-1]==0) {
+						eptr->sesdata->info = std::string(info);
 					} else {
-						eptr->sesdata->info = (char *)malloc(ileng + 1);
-						passert(eptr->sesdata->info);
-						memcpy(eptr->sesdata->info, info, ileng);
-						eptr->sesdata->info[ileng] = 0;
+						eptr->sesdata->info = std::string(info, ileng);
 					}
 				}
 
@@ -2038,13 +2027,9 @@ void matoclserv_fuse_register(matoclserventry *eptr,const uint8_t *data,uint32_t
 				eptr->sesdata->peerport = eptr->peerport;
 				if (ileng > 0) {
 					if (info[ileng - 1] == 0) {
-						eptr->sesdata->info = strdup(info);
-						passert(eptr->sesdata->info);
+						eptr->sesdata->info = std::string(info);
 					} else {
-						eptr->sesdata->info = (char *)malloc(ileng + 1);
-						passert(eptr->sesdata->info);
-						memcpy(eptr->sesdata->info, info, ileng);
-						eptr->sesdata->info[ileng] = 0;
+						eptr->sesdata->info = std::string(info, ileng);
 					}
 				}
 
@@ -5392,9 +5377,6 @@ void matoclserv_session_files(matoclserventry *eptr,
 
 void matocl_session_timedout(session *sesdata) {
 	matocl_close_files(sesdata);
-	if (sesdata->info) {
-		free(sesdata->info);
-	}
 }
 
 void matoclserv_session_delete(matoclserventry *eptr, const uint8_t *data,
@@ -6471,9 +6453,6 @@ int matoclserv_networkinit(void) {
 void matoclserv_session_unload(void) {
 	for (const auto& sessionPtr : sessionVector) {
 		sessionPtr->openedfiles.clear();
-		if (sessionPtr->info) {
-			free(sessionPtr->info);
-		}
 	}
 
 	sessionVector.clear();

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -649,7 +649,7 @@ void matoclserv_store_sessions() {
 			put32bit(&ptr, sessionPtr->sessionId);
 			put32bit(&ptr, sessionInfoLength);
 			put32bit(&ptr, sessionPtr->peerIpAddress);
-			put32bit(&ptr, sessionPtr->rootInode);
+			putINode(&ptr, sessionPtr->rootInode);
 			put8bit(&ptr, sessionPtr->flags);
 			put8bit(&ptr, sessionPtr->minGoal);
 			put8bit(&ptr, sessionPtr->maxGoal);
@@ -892,7 +892,7 @@ int matoclserv_insert_open_file(Session *currentSession, inode_t inode) {
 /// @param inode The inode of the open file
 /// If the session exists, the open file will be added to the list of open files of the session.
 /// Otherwise, a new session will be created and the open file will be added to the new session.
-void matoclserv_add_open_file(uint32_t sessionId, uint32_t inode) {
+void matoclserv_add_open_file(uint32_t sessionId, inode_t inode) {
 	for (const auto& sessionPtr : sessionVector) {
 		if (sessionPtr->sessionId == sessionId) {
 			if (!sessionPtr->openFilesSet.contains(inode)) {
@@ -915,7 +915,7 @@ void matoclserv_add_open_file(uint32_t sessionId, uint32_t inode) {
 /// Removes an open file from a given session.
 /// @param sessionId The IF of the session
 /// @param inode The inode of the open file
-void matoclserv_remove_open_file(uint32_t sessionId, uint32_t inode) {
+void matoclserv_remove_open_file(uint32_t sessionId, inode_t inode) {
 	for (const auto& sessionPtr : sessionVector) {
 		if (sessionPtr->sessionId == sessionId) {
 			if (sessionPtr->openFilesSet.contains(inode)) {
@@ -1158,7 +1158,7 @@ void matoclserv_chunk_status(uint64_t chunkId, uint8_t status) {
 	uint32_t messageId = 0;
 	uint64_t fileLength = 0;
 	uint8_t operationType = 0;
-	uint32_t inode = 0;
+	inode_t inode = 0;
 	uint32_t uid = 0;
 	uint32_t gid = 0;
 	uint32_t auid = 0;

--- a/src/master/matoclserv.h
+++ b/src/master/matoclserv.h
@@ -26,16 +26,43 @@
 
 #include "common/type_defs.h"
 
+/// Get stats from client and reset them in the server.
+/// @param stats Array of 5 elements to store stats in the following order:
+/// 0 - packets received
+/// 1 - packets sent
+/// 2 - bytes received
+/// 3 - bytes sent
 void matoclserv_stats(uint64_t stats[5]);
-void matoclserv_chunk_status(uint64_t chunkid, uint8_t status);
-void matoclserv_add_open_file(uint32_t sessionid, inode_t inode);
-void matoclserv_remove_open_file(uint32_t sessionid, inode_t inode);
-int matoclserv_sessionsinit(void);
-int matoclserv_networkinit(void);
-void matoclserv_session_unload(void);
+
+/// Sends the status of a delayed operation associated with a chunk over the network.
+/// @param chunkId The ID of the chunk associated with the delayed operation
+/// @param status  The status of the operation, (e.g., SAUNAFS_STATUS_OK, SAUNAFS_ERROR_NOTDONE)
+void matoclserv_chunk_status(uint64_t chunkId, uint8_t status);
+
+/// Adds an open file to the list of open files for a given session.
+/// @param sessionId The ID of the session to which the open file will be added
+/// @param inode The inode of the open file to add
+void matoclserv_add_open_file(uint32_t sessionId, inode_t inode);
+
+/// Removes an open file from the list of open files for a given session.
+/// @param sessionId The ID of the session from which the open file will be removed
+/// @param inode The inode of the open file to remove
+void matoclserv_remove_open_file(uint32_t sessionId, inode_t inode);
+
+/// Loads and initializes the sessions.
+int matoclserv_sessions_init();
+
+/// Initializes the network configuration and register the eventloop callbacks.
+/// @return 0 on success, negative value on error
+int matoclserv_network_init();
+
+/// Clears the sessions.
+void matoclserv_session_unload();
 
 /// Notify interested clients about the status of metadata saving process.
+/// @param status Status of the metadata saving process
 void matoclserv_broadcast_metadata_saved(uint8_t status);
 
 /// Notify interested clients about the status of metadata checksum recalculation process.
+/// @param status Status of the metadata checksum recalculation process
 void matoclserv_broadcast_metadata_checksum_recalculated(uint8_t status);


### PR DESCRIPTION
This PR refactors matoclserv files to:

- Replace custom C-linked lists of raw `session`* pointers with a `std::vector` of smart pointers.
- Replace session `info` attribute (raw char pointer) with a `std::string` to avoid low level memory management.
- Replace auxiliary raw pointers (`fsesrecord`) used to load and save sessions with `std::vector<uint8_t>`.
- Replace custom C-linked list to store `matoclserventry` with a `std::list` of smart pointers.
- Replace custom C-linked list to store chunk delayed operations with a `std::vector` of smart pointers.
- Rename `chunklist` to `DelayedChunkOperation`, which matches better the function of this attribute in `matoclserventry`.
- Modernize raw char pointers used by `ListenHost` and `ListenPort` with `std::string`.
- Rename attributes and variables to use more meaningful names.
- Replace some log messages with the new log format.
- Apply code style formatting in selected areas.
- Add documentation for `Session`, `matoclserventry`, `DelayedChunkOperation` and others.

Signed-off-by: Crash <crash@leil.io>