### PR TITLE
fix: Fix CS restart while replicating

### DIFF
--- a/src/chunkserver/chunkserver-common/chunk_with_fd.cc
+++ b/src/chunkserver/chunkserver-common/chunk_with_fd.cc
@@ -36,7 +36,9 @@ std::string FDChunk::fullMetaFilename() const {
 }
 
 const std::string FDChunk::metaFilename() const {
-	if (version_ == 0) {
+	// If version is not set, return an empty string.
+	// This is remain consistent with some checks.
+	if (!isVersionSet_) {
 		return "";
 	}
 	return generateFilenameForVersion(version_, true);
@@ -48,7 +50,9 @@ std::string FDChunk::fullDataFilename() const {
 }
 
 const std::string FDChunk::dataFilename() const {
-	if (version_ == 0) {
+	// If version is not set, return an empty string.
+	// This is remain consistent with some checks.
+	if (!isVersionSet_) {
 		return "";
 	}
 	return generateFilenameForVersion(version_, false);
@@ -137,7 +141,10 @@ void FDChunk::setBlockCountFromDataFileSize(off_t fileSize) {
 	blocks_ = fileSize / SFSBLOCKSIZE;
 }
 
-void FDChunk::setVersion(uint32_t _version) { version_ = _version; }
+void FDChunk::setVersion(uint32_t _version) {
+	version_ = _version;
+	isVersionSet_ = true;
+}
 
 int32_t FDChunk::metaFD() const { return metaFD_; }
 

--- a/src/chunkserver/chunkserver-common/chunk_with_fd.h
+++ b/src/chunkserver/chunkserver-common/chunk_with_fd.h
@@ -180,14 +180,15 @@ private:
 	/// Guarded by `gChunksMapMutex`.
 	std::unique_ptr<CondVarWithWaitCount> condVar_ = nullptr;
 
-	IDisk *owner_ = nullptr;    ///< The Disk which owns this Chunk.
-	uint64_t id_;               ///< The ID of the chunk.
-	uint32_t version_ = 0;      ///< The version of the chunk.
-	ChunkPartType type_;        ///< The type of the chunk (ec:5, xor:2, etc.).
-	int32_t metaFD_ = -1;       ///< Metadata file descriptor
-	int32_t dataFD_ = -1;       ///< Data file descriptor
-	uint16_t blocks_ = 0;       ///< Number of blocks in the chunk
-	uint16_t refCount_ = 0;     ///< Used to properly release the chunk
+	IDisk *owner_ = nullptr;     ///< The Disk which owns this Chunk.
+	uint64_t id_;                ///< The ID of the chunk.
+	uint32_t version_ = 0;       ///< The version of the chunk.
+	bool isVersionSet_ = false;  ///< Tells if the version was set at least once
+	ChunkPartType type_;         ///< The type of the chunk (ec:5, xor:2, etc.).
+	int32_t metaFD_ = -1;        ///< Metadata file descriptor
+	int32_t dataFD_ = -1;        ///< Data file descriptor
+	uint16_t blocks_ = 0;        ///< Number of blocks in the chunk
+	uint16_t refCount_ = 0;      ///< Used to properly release the chunk
 	uint16_t blockExpectedToBeReadNext_ = 0;  ///< Read ahead helper
 	uint8_t validAttr_ = 0;   ///< Tells if the attributes were recently updated
 	uint8_t wasChanged_ = 0;  ///< Tells if it was changed from last flush


### PR DESCRIPTION
The version of a chunk being replicated is set to 0 from the begining.
The changes introduced in 11e46f1 set the metadata filename to empty if
that was the case. In some scenarios it may lead to unsuccessful
chunkserver restart while replicating.

Signed-off-by: Dave <dave@leil.io>