### PR TITLE
feat: Avoid calculate CRC twice for replications

### DIFF
--- a/src/chunkserver/chunk_file_creator.cc
+++ b/src/chunkserver/chunk_file_creator.cc
@@ -76,8 +76,8 @@ void ChunkFileCreator::write(uint32_t offset, uint32_t size, uint32_t crc,
 	int blocknum = offset / SFSBLOCKSIZE;
 	offset = offset % SFSBLOCKSIZE;
 	auto *crcData = gOpenChunks.getResource(chunk_->metaFD()).crcData();
-	int status = chunk_->owner()->writeChunkBlock(chunk_, 0, blocknum, offset,
-	                                              size, crc, crcData, buffer);
+	int status = chunk_->owner()->writeChunkBlock(chunk_, 0, blocknum, offset, size, crc, crcData,
+	                                              buffer, true);
 	if (status != SAUNAFS_STATUS_OK) {
 		throw Exception("failed to write chunk", status);
 	}

--- a/src/chunkserver/chunkserver-common/cmr_disk.cc
+++ b/src/chunkserver/chunkserver-common/cmr_disk.cc
@@ -430,7 +430,7 @@ void CmrDisk::punchHoles(IChunk *chunk, const uint8_t *buffer, uint32_t offset,
 int CmrDisk::writeChunkBlock(IChunk *chunk, uint32_t version, uint16_t blocknum,
                              uint32_t offsetInBlock, uint32_t size,
                              uint32_t crc, uint8_t *crcData,
-                             const uint8_t *buffer) {
+                             const uint8_t *buffer, bool isFromReplication) {
 	assert(chunk);
 	LOG_AVG_TILL_END_OF_SCOPE0("writeChunkBlock");
 	TRACETHIS3(chunk->id(), offsetInBlock, size);
@@ -450,7 +450,7 @@ int CmrDisk::writeChunkBlock(IChunk *chunk, uint32_t version, uint16_t blocknum,
 		return SAUNAFS_ERROR_WRONGOFFSET;
 	}
 
-	if (gCheckCrcWhenWriting) {
+	if (gCheckCrcWhenWriting && !isFromReplication) {
 		if (crc != mycrc32(0, buffer, size)) { return SAUNAFS_ERROR_CRC; }
 	}
 

--- a/src/chunkserver/chunkserver-common/cmr_disk.h
+++ b/src/chunkserver/chunkserver-common/cmr_disk.h
@@ -141,9 +141,9 @@ public:
 	                uint32_t size);
 
 	/// Writes a Chunk block
-	int writeChunkBlock(IChunk *chunk, uint32_t version, uint16_t blocknum,
-	                    uint32_t offsetInBlock, uint32_t size, uint32_t crc,
-	                    uint8_t *crcData, const uint8_t *buffer) override;
+	int writeChunkBlock(IChunk *chunk, uint32_t version, uint16_t blocknum, uint32_t offsetInBlock,
+	                    uint32_t size, uint32_t crc, uint8_t *crcData, const uint8_t *buffer,
+	                    bool isFromReplication = false) override;
 
 	/// Writes to device custom blockSize from blockBuffer
 	int writeChunkData(IChunk *chunk, uint8_t *blockBuffer, int32_t blockSize,

--- a/src/chunkserver/chunkserver-common/disk_interface.h
+++ b/src/chunkserver/chunkserver-common/disk_interface.h
@@ -222,7 +222,7 @@ public:
 	virtual int writeChunkBlock(IChunk *chunk, uint32_t version,
 	                            uint16_t blocknum, uint32_t offsetInBlock,
 	                            uint32_t size, uint32_t crc, uint8_t *crcData,
-	                            const uint8_t *buffer) = 0;
+	                            const uint8_t *buffer, bool isFromReplication = false) = 0;
 
 	/// Writes the Chunk header into the device
 	///


### PR DESCRIPTION
While doing a replication, the current behavior calculates the CRC of
the blocks to be written and then, if the chunkserver checks also CRC
while writing (HDD_CHECK_CRC_WHEN_WRITING=1 option, which is default)
it would have calculated twice the CRC for the same blocks. From one
calculation to the other the 4 byte value was being copied as a
function parameter, therefore should be safe to not check it again.

Signed-off-by: Dave <dave@leil.io>