### PR TITLE
ci: Fix Ubuntu 24.04 images not being deleted

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -355,7 +355,7 @@ pipeline {
                                 docker rm $(docker stop $(docker ps -a -q --filter ancestor=saunafs-test --format="{{.ID}}")) || true
                                 '''
                             sh """
-                                docker image rm ${env.REGISTRY_IMAGE_NAME}:${GIT_COMMIT} || true
+                                docker image rm ${env.REGISTRY_IMAGE_NAME} || true
                                 docker image rm saunafs-test:latest || true
                                 """
                         }


### PR DESCRIPTION
Due to a mistake, the tag for the image was being added twice, first in the Registry image name, and then again later when cleaning up, causing it to fail silently.

This should hopefully fix the no space problems for now.