### PR TITLE
fix(main): Fix test starting master when it's not running.

### DIFF
--- a/src/main/main.cc
+++ b/src/main/main.cc
@@ -644,6 +644,7 @@ FileLock::LockStatus FileLock::wdlock(RunMode runmode, uint32_t timeout) {
 		return LockStatus::kFail;
 	} else if (runmode==RunMode::kTest) {
 		fprintf(stderr, STR(APPNAME) " is not running\n");
+		return LockStatus::kTest;
 	} else if (runmode==RunMode::kIsAlive) {
 		return LockStatus::kSuccess;
 	}


### PR DESCRIPTION
The LockStatus was returning the correct kTest when it was running, but returning LockStatus::kSuccess when not. This caused the master/chunkserver/metalogger to start up when running with test subcommand.
This was probably due to recent changes how test works, where it now checks for kTest when determining whether to start master or not. The commit makes sure that it correctly returns LockStatus::kTest when no lock is found.