### PR TITLE
feat(master): Make MetadataDumper extensible

### DIFF
--- a/src/master/filesystem.cc
+++ b/src/master/filesystem.cc
@@ -44,7 +44,6 @@
 #include "master/metadata_backend_common.h"
 #include "master/metadata_backend_file.h"
 #include "master/metadata_backend_interface.h"
-#include "master/metadata_dumper.h"
 #include "master/restore.h"
 #include "slogger/slogger.h"
 
@@ -128,7 +127,7 @@ void fs_periodic_storeall() {
 		return;
 	}
 
-	gMetadataBackend->fs_storeall(MetadataDumper::kBackgroundDump);  // ignore error
+	gMetadataBackend->fs_storeall(DumpType::kBackgroundDump);  // ignore error
 }
 
 void fs_term(void) {
@@ -141,8 +140,7 @@ void fs_term(void) {
 	if (gMetadata != nullptr && gSaveMetadataAtExit) {
 		for (;;) {
 			metadataStored =
-			    (gMetadataBackend->fs_storeall(
-			         MetadataDumper::kForegroundDump) == SAUNAFS_STATUS_OK);
+			    (gMetadataBackend->fs_storeall(DumpType::kForegroundDump) == SAUNAFS_STATUS_OK);
 			if (metadataStored) {
 				break;
 			}

--- a/src/master/filesystem_metadata.h
+++ b/src/master/filesystem_metadata.h
@@ -32,7 +32,6 @@
 #include "master/filesystem_xattr.h"
 #include "master/id_pool_detainer.h"
 #include "master/locks.h"
-#include "master/metadata_dumper.h"
 #include "master/task_manager.h"
 
 /** Metadata of the filesystem.
@@ -155,7 +154,6 @@ extern bool gDisableEmptyFoldersMetadataOnFullDisk;
 
 #ifndef METARESTORE
 extern std::map<int, Goal> gGoalDefinitions;
-extern MetadataDumper metadataDumper;
 extern bool gAtimeDisabled;
 extern bool gMagicAutoFileRepair;
 #endif

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -5440,8 +5440,7 @@ void matoclserv_admin_save_metadata(matoclserventry* eptr, const uint8_t* data, 
 	if (eptr->registered == ClientState::kAdmin) {
 		safs::log_info("saving metadata image requested using saunafs-admin by {}",
 		               ipToString(eptr->peerIpAddress));
-		uint8_t status = gMetadataBackend->fs_storeall(
-		    MetadataDumper::DumpType::kBackgroundDump);
+		uint8_t status = gMetadataBackend->fs_storeall(DumpType::kBackgroundDump);
 
 		if (status != SAUNAFS_STATUS_OK || asynchronous) {
 			matoclserv_createpacket(eptr, matocl::adminSaveMetadata::build(status));

--- a/src/master/matomlserv.cc
+++ b/src/master/matomlserv.cc
@@ -608,7 +608,7 @@ void matomlserv_changelog_apply_error(matomlserventry *eptr, const uint8_t *data
 				"SAU_MLTOMA_CHANGELOG_APPLY_ERROR, status: %s - storing metadata",
 				saunafs_error_string(recvStatus));
 		gShadowQueue.addRequest(eptr);
-		gMetadataBackend->fs_storeall(MetadataDumper::kBackgroundDump);
+		gMetadataBackend->fs_storeall(DumpType::kBackgroundDump);
 		if (recvStatus == SAUNAFS_ERROR_BADMETADATACHECKSUM) {
 			fs_start_checksum_recalculation();
 		}

--- a/src/master/metadata_backend_file.cc
+++ b/src/master/metadata_backend_file.cc
@@ -45,15 +45,14 @@
 #include <master/matoclserv.h>
 #include <master/matomlserv.h>
 #include <master/metadata_backend_common.h>
-#include <master/metadata_dumper.h>
+#include <master/metadata_dumper_file.h>
 #include <master/restore.h>
 #include <slogger/slogger.h>
 #include "protocol/SFSCommunication.h"
 
 MetadataBackendFile::MetadataBackendFile()
 #if !defined(METARESTORE) && !defined(METALOGGER)
-    : dumper_(std::make_unique<MetadataDumper>(kMetadataFilename,
-                                               kMetadataTmpFilename))
+    : dumper_(std::make_unique<MetadataDumperFile>(kMetadataFilename, kMetadataTmpFilename))
 #endif  // #if !defined(METARESTORE) && !defined(METALOGGER)
 {
 	safs::log_info("Metadata backend: {}", backendType());
@@ -210,7 +209,7 @@ void MetadataBackendFile::load_changelogs() {
 	} catch (const FilesystemException &ex) {
 		throw FilesystemException("error loading changelogs: " + ex.message());
 	}
-	gMetadataBackend->fs_storeall(MetadataDumper::DumpType::kForegroundDump);
+	gMetadataBackend->fs_storeall(DumpType::kForegroundDump);
 	metadataserver::setPersonality(personality);
 }
 
@@ -258,7 +257,7 @@ void MetadataBackendFile::load_changelog(const std::string &path) {
 	}
 }
 
-uint8_t MetadataBackendFile::fs_storeall(MetadataDumper::DumpType dumpType) {
+uint8_t MetadataBackendFile::fs_storeall(DumpType dumpType) {
 	if (gMetadata == nullptr) {
 		// Periodic dump in shadow master or a request from saunafs-admin
 		safs_pretty_syslog(LOG_INFO,
@@ -282,7 +281,7 @@ uint8_t MetadataBackendFile::fs_storeall(MetadataDumper::DumpType dumpType) {
 	    dumpType, fs_checksum(ChecksumMode::kGetCurrent));
 	uint8_t status = SAUNAFS_STATUS_OK;
 
-	if (dumpType == MetadataDumper::kForegroundDump) {
+	if (dumpType == DumpType::kForegroundDump) {
 		cstream_t fd(fopen(kMetadataTmpFilename, "w"));
 		if (fd == nullptr) {
 			safs_pretty_syslog(LOG_ERR, "can't open metadata file");
@@ -409,7 +408,7 @@ uint64_t MetadataBackendFile::changelogGetLastLogVersion(const std::string& fnam
 	return lastLogVersion;
 }
 
-bool xattr_load(MetadataLoader::Options options) {
+static bool xattr_load(MetadataLoader::Options options) {
 	const uint8_t *ptr;
 	inode_t inode;
 	uint8_t anleng;
@@ -550,8 +549,8 @@ static bool fs_load_generic(const std::shared_ptr<MemoryMappedFile> &metadataFil
  * @param init A flag to indicate whether to initialize the static variable.
  * @return 0 on success, 1 if last edge mark is found, -1 if unknown node type.
  */
-int8_t fs_parseEdge(const std::shared_ptr<MemoryMappedFile> &metadataFile, size_t &sectionOffset,
-                 int ignoreFlag, bool init = false) {
+static int8_t fs_parseEdge(const std::shared_ptr<MemoryMappedFile> &metadataFile,
+                           size_t &sectionOffset, int ignoreFlag, bool init = false) {
 	static const int8_t kError = -1;
 	static const int8_t kSuccess = 0;
 	static const int8_t kLastEdge = 1;
@@ -718,7 +717,8 @@ int8_t fs_parseEdge(const std::shared_ptr<MemoryMappedFile> &metadataFile, size_
  * @param sectionOffset A reference to point to the next node attribute.
  * @return 0 on success, 1 if last node mark is found, -1 if unknown node type.
  */
-int8_t fs_parseNode(const std::shared_ptr<MemoryMappedFile> & metadataFile, size_t &sectionOffset) {
+static int8_t fs_parseNode(const std::shared_ptr<MemoryMappedFile> &metadataFile,
+                           size_t &sectionOffset) {
 	static const int8_t kError = -1;
 	static const int8_t kSuccess = 0;
 	static const int8_t kLastNode = 1;
@@ -824,7 +824,7 @@ int8_t fs_parseNode(const std::shared_ptr<MemoryMappedFile> & metadataFile, size
 	return kSuccess;
 }
 
-int fs_lostnode(FSNode *p) {
+static int fs_lostnode(FSNode *p) {
 	uint8_t artname[40];
 	uint32_t i, l;
 	i = 0;
@@ -845,7 +845,7 @@ int fs_lostnode(FSNode *p) {
 	return -1;
 }
 
-int fs_checknodes(int ignoreflag) {
+static int fs_checknodes(int ignoreflag) {
 	uint32_t i;
 	FSNode *p;
 	for (i = 0; i < NODEHASHSIZE; i++) {
@@ -869,7 +869,7 @@ int fs_checknodes(int ignoreflag) {
 	return 1;
 }
 
-bool fs_loadnodes(MetadataLoader::Options options) {
+static bool fs_loadnodes(MetadataLoader::Options options) {
 	int8_t status;
 	do {
 		status = fs_parseNode(options.metadataFile, options.offset);
@@ -880,7 +880,7 @@ bool fs_loadnodes(MetadataLoader::Options options) {
 	return true;
 }
 
-bool fs_loadedges(MetadataLoader::Options options) {
+static bool fs_loadedges(MetadataLoader::Options options) {
 	int8_t status;
 	fs_parseEdge(options.metadataFile, options.offset, options.ignoreFlag, true);
 	do {
@@ -991,7 +991,7 @@ static const std::vector<MetadataSection> kMetadataSections = {
                     [](const MetadataLoader::Options &) { return true; }, true, true),
 };
 
-bool isEndOfMetadata(const uint8_t *sectionPtr) {
+static bool isEndOfMetadata(const uint8_t *sectionPtr) {
 	static constexpr std::string_view kMetadataTrailer("[" SFSSIGNATURE " EOF MARKER]");
 	static constexpr std::string_view kMetadataLegacyTrailer("[MFS EOF MARKER]");
 	return ((memcmp(sectionPtr, kMetadataTrailer.data(),
@@ -1000,8 +1000,7 @@ bool isEndOfMetadata(const uint8_t *sectionPtr) {
 	              ::kMetadataSectionHeaderSize) == kOpSuccess));
 }
 
-int fs_load(const std::shared_ptr<MemoryMappedFile> &metadataFile,
-            int ignoreflag) {
+static int fs_load(const std::shared_ptr<MemoryMappedFile> &metadataFile, int ignoreflag) {
 	static constexpr uint8_t kMetadataHeaderOffset = 8;
 
 	/// Skip File Signature
@@ -1127,7 +1126,7 @@ bool isNewMetadataFile([[maybe_unused]]const uint8_t *headerPtr) {
 			safs_pretty_syslog(LOG_NOTICE, "empty filesystem created");
 			// after creating new filesystem always create "back" file for using
 			// in metarestore
-			gMetadataBackend->fs_storeall(MetadataDumper::kForegroundDump);
+			gMetadataBackend->fs_storeall(DumpType::kForegroundDump);
 			return true;
 		}
 	}
@@ -1135,7 +1134,7 @@ bool isNewMetadataFile([[maybe_unused]]const uint8_t *headerPtr) {
 	return false;
 }
 
-bool checkMetadataSignature(const std::shared_ptr<MemoryMappedFile> &metadataFile) {
+static bool checkMetadataSignature(const std::shared_ptr<MemoryMappedFile> &metadataFile) {
 	static constexpr std::string_view kMetadataHeaderNewV2_9(SFSSIGNATURE "M 2.9");
 	static constexpr std::string_view kMetadataHeaderOldV2_9(SAUSIGNATURE "M 2.9");
 	static constexpr std::string_view kMetadataHeaderLegacy("LIZM 2.9");

--- a/src/master/metadata_backend_file.h
+++ b/src/master/metadata_backend_file.h
@@ -84,9 +84,9 @@ public:
 	/// Performs the actual metadata dump to persistent location.
 	/// @param dumpType -- type of the dump (foreground, background, etc.).
 	/// @return false in case of error.
-	uint8_t fs_storeall(MetadataDumper::DumpType dumpType) override;
+	uint8_t fs_storeall(DumpType dumpType) override;
 
-	MetadataDumper *dumper() override { return dumper_.get(); }
+	IMetadataDumper *dumper() override { return dumper_.get(); }
 #endif  // #if !defined(METARESTORE) && !defined(METALOGGER)
 
 private:
@@ -135,6 +135,6 @@ private:
 #if !defined(METARESTORE) && !defined(METALOGGER)
 	int emergency_storeall(const std::string &fname);
 
-	std::unique_ptr<MetadataDumper> dumper_;
+	std::unique_ptr<IMetadataDumper> dumper_;
 #endif  // #ifndef METARESTORE
 };

--- a/src/master/metadata_backend_interface.h
+++ b/src/master/metadata_backend_interface.h
@@ -26,7 +26,7 @@
 
 #include <common/exceptions.h>
 #include <master/filesystem_node_types.h>
-#include <master/metadata_dumper.h>
+#include <master/metadata_dumper_interface.h>
 
 // Metadata related exceptions
 SAUNAFS_CREATE_EXCEPTION_CLASS(MetadataCheckException, Exception);
@@ -140,10 +140,10 @@ public:
 	/// Performs the actual metadata dump to persistent location.
 	/// @param dumpType -- type of the dump (foreground, background, etc.).
 	/// @return false in case of error.
-	virtual uint8_t fs_storeall(MetadataDumper::DumpType dumpType) = 0;
+	virtual uint8_t fs_storeall(DumpType dumpType) = 0;
 
 	// TODO(guillex): Use a generic MetadaDumper later
-	virtual MetadataDumper *dumper() = 0;
+	virtual IMetadataDumper *dumper() = 0;
 #endif  // #if !defined(METARESTORE) && !defined(METALOGGER)
 };
 

--- a/src/master/metadata_dumper_file.cc
+++ b/src/master/metadata_dumper_file.cc
@@ -21,7 +21,7 @@
 #include "common/platform.h"
 #include "slogger/slogger.h"
 
-#include "master/metadata_dumper.h"
+#include "master/metadata_dumper_file.h"
 
 #include <string>
 
@@ -38,36 +38,34 @@ static bool createPipe(int pipefds[2]) {
 	return true;
 }
 
-MetadataDumper::MetadataDumper(
-		const std::string& metadataFilename,
-		const std::string& metadataTmpFilename)
-		: useMetarestore_(false),
-		  dumpingSucceeded_(true),
-		  dumpingProcessFd_(-1),
-		  dumpingProcessPollFdsPos_(-1),
-		  dumpingProcessOutputEmpty_(true),
-		  metadataFilename_(metadataFilename),
-		  metadataTmpFilename_(metadataTmpFilename) {
-}
+MetadataDumperFile::MetadataDumperFile(const std::string &metadataFilename,
+                                       const std::string &metadataTmpFilename)
+    : useMetarestore_(false),
+      dumpingSucceeded_(true),
+      dumpingProcessFd_(-1),
+      dumpingProcessPollFdsPos_(-1),
+      dumpingProcessOutputEmpty_(true),
+      metadataFilename_(metadataFilename),
+      metadataTmpFilename_(metadataTmpFilename) {}
 
-bool MetadataDumper::dumpSucceeded() const {
+bool MetadataDumperFile::dumpSucceeded() const {
 	return dumpingSucceeded_;
 }
 
-bool MetadataDumper::inProgress() const {
+bool MetadataDumperFile::inProgress() const {
 	return dumpingProcessFd_ != -1;
 }
 
-bool MetadataDumper::useMetarestore() const {
+bool MetadataDumperFile::useMetarestore() const {
 	return useMetarestore_;
 }
 
 
-void MetadataDumper::setMetarestorePath(const std::string& path) {
+void MetadataDumperFile::setMetarestorePath(const std::string& path) {
 	metarestorePath_ = path;
 }
 
-void MetadataDumper::setUseMetarestore(bool useMetarestore) {
+void MetadataDumperFile::setUseMetarestore(bool useMetarestore) {
 	useMetarestore_ = useMetarestore;
 }
 
@@ -97,8 +95,8 @@ void MetadataDumper::setUseMetarestore(bool useMetarestore) {
  *    execMetarestore() modifies dumpType to kForegroundDump for the child.
  */
 
-bool MetadataDumper::start(MetadataDumper::DumpType& dumpType, uint64_t checksum) {
-	if (dumpType == kForegroundDump) {
+bool MetadataDumperFile::start(DumpType &dumpType, uint64_t checksum) {
+	if (dumpType == DumpType::kForegroundDump) {
 		return false;
 	}
 
@@ -122,7 +120,7 @@ bool MetadataDumper::start(MetadataDumper::DumpType& dumpType, uint64_t checksum
 	// can't communicate with child? foreground dump
 	if (!createPipe(pipeFd)) {
 		safs_pretty_syslog(LOG_ERR, "couldn't communicate with child, foreground dump");
-		dumpType = kForegroundDump;
+		dumpType = DumpType::kForegroundDump;
 		dumpingSucceeded_ = false;
 		return false;
 	}
@@ -133,7 +131,7 @@ bool MetadataDumper::start(MetadataDumper::DumpType& dumpType, uint64_t checksum
 		case -1:
 			// on fork error store metadata in foreground
 			safs_pretty_errlog(LOG_ERR, "fork failed");
-			dumpType = kForegroundDump;
+			dumpType = DumpType::kForegroundDump;
 			close(pipeFd[0]); // ignore close errors
 			close(pipeFd[1]);
 			return false;
@@ -172,7 +170,7 @@ bool MetadataDumper::start(MetadataDumper::DumpType& dumpType, uint64_t checksum
 			if (useMetarestore_ && !dumpingSucceeded_) {
 				safs_pretty_syslog(LOG_NOTICE, "something previously failed, dump by master");
 			}
-			dumpType = kForegroundDump; // child process stores metadata in its foreground
+			dumpType = DumpType::kForegroundDump; // child process stores metadata in its foreground
 			return true;
 		default:
 			dumpingProcessOutputEmpty_ = true;
@@ -184,7 +182,7 @@ bool MetadataDumper::start(MetadataDumper::DumpType& dumpType, uint64_t checksum
 }
 
 // for poll
-void MetadataDumper::pollDesc(std::vector<pollfd> &pdesc) {
+void MetadataDumperFile::pollDesc(std::vector<pollfd> &pdesc) {
 	if (dumpingProcessFd_ != -1) {
 		pdesc.push_back({dumpingProcessFd_,POLLIN,0});
 		dumpingProcessPollFdsPos_ = pdesc.size() - 1;
@@ -193,7 +191,7 @@ void MetadataDumper::pollDesc(std::vector<pollfd> &pdesc) {
 	}
 }
 
-void MetadataDumper::pollServe(const std::vector<pollfd> &pdesc) {
+void MetadataDumperFile::pollServe(const std::vector<pollfd> &pdesc) {
 	if (dumpingProcessPollFdsPos_ == -1) {
 		return;
 	}
@@ -223,7 +221,7 @@ void MetadataDumper::pollServe(const std::vector<pollfd> &pdesc) {
 	}
 }
 
-void MetadataDumper::dumpingFinished() {
+void MetadataDumperFile::dumpingFinished() {
 	if (close(dumpingProcessFd_) == -1) {
 		safs_pretty_errlog(LOG_ERR, "pipe close failed");
 	}
@@ -234,7 +232,7 @@ void MetadataDumper::dumpingFinished() {
 	}
 }
 
-void MetadataDumper::waitUntilFinished(SteadyDuration timeout) {
+void MetadataDumperFile::waitUntilFinished(SteadyDuration timeout) {
 	// pollDesc uses at most one pollfd
 	std::vector<pollfd> pfd;
 	Timeout stopwatch(timeout);
@@ -258,7 +256,7 @@ void MetadataDumper::waitUntilFinished(SteadyDuration timeout) {
 	}
 }
 
-void MetadataDumper::waitUntilFinished() {
+void MetadataDumperFile::waitUntilFinished() {
 	// let's say a year is enough
 	waitUntilFinished(std::chrono::hours(24 * 365));
 }

--- a/src/master/metadata_dumper_file.h
+++ b/src/master/metadata_dumper_file.h
@@ -29,39 +29,33 @@
 #include <vector>
 
 #include "common/time_utils.h"
+#include "master/metadata_dumper_interface.h"
 
-class MetadataDumper {
+class MetadataDumperFile : public IMetadataDumper {
 public:
-	enum DumpType {
-		kForegroundDump,
-		kBackgroundDump
-	};
+	MetadataDumperFile(const std::string &metadataFilename, const std::string &metadataTmpFilename);
 
-	MetadataDumper(
-			const std::string& metadataFilename,
-			const std::string& metadataTmpFilename);
+	bool dumpSucceeded() const override;
+	bool inProgress() const override;
+	bool useMetarestore() const override;
 
-	bool dumpSucceeded() const;
-	bool inProgress() const;
-	bool useMetarestore() const;
-
-	void setMetarestorePath(const std::string& path);
-	void setUseMetarestore(bool val);
+	void setMetarestorePath(const std::string& path) override;
+	void setUseMetarestore(bool val) override;
 
 	/// returns true and modifies dumpType (to FOREGROUND_DUMP) if we return as a child
-	bool start(DumpType& dumpType, uint64_t checksum);
+	bool start(DumpType& dumpType, uint64_t checksum) override;
 
 	// for poll
-	void pollDesc(std::vector<pollfd> &pdesc);
-	void pollServe(const std::vector<pollfd> &pdesc);
+	void pollDesc(std::vector<pollfd> &pdesc) override;
+	void pollServe(const std::vector<pollfd> &pdesc) override;
 
 	/// waits until the metadumper finishes
-	void waitUntilFinished();
+	void waitUntilFinished() override;
 
+private:
 	/// waits until the metadumper finishes but not longer than timeout
 	void waitUntilFinished(SteadyDuration timeout);
 
-protected:
 	void dumpingFinished();
 
 	/// how long can the decimal representation of a(n) (u)int64 be

--- a/src/master/metadata_dumper_interface.h
+++ b/src/master/metadata_dumper_interface.h
@@ -1,0 +1,70 @@
+/*
+   Copyright 2023      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "common/platform.h"
+
+#include <poll.h>
+#include <syslog.h>
+#include <unistd.h>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+/// Enum to represent the type of metadata dump
+enum class DumpType : uint8_t {
+	kForegroundDump,  ///< Foreground dump (immediate dump by the current process)
+	kBackgroundDump   ///< Background dump (periodic or scheduled, maybe through forking)
+};
+
+/// Interface for metadata dumper implementations
+/// This interface defines the methods required for any metadata dumper,
+/// allowing for different implementations (e.g., file-based, network-based).
+/// It also provides a way to check the status of the dump and manage its lifecycle.
+class IMetadataDumper {
+public:
+	/// Default constructor
+	IMetadataDumper() = default;
+
+	/// Disable unnecessary copy and move operations
+	IMetadataDumper(const IMetadataDumper &) = delete;
+	IMetadataDumper &operator=(const IMetadataDumper &) = delete;
+	IMetadataDumper(IMetadataDumper &&) = delete;
+	IMetadataDumper &operator=(IMetadataDumper &&) = delete;
+
+	/// Virtual destructor to allow proper cleanup of derived classes
+	virtual ~IMetadataDumper() = default;
+
+	virtual bool dumpSucceeded() const = 0;
+	virtual bool inProgress() const = 0;
+	virtual bool useMetarestore() const = 0;
+
+	virtual void setMetarestorePath(const std::string& path) = 0;
+	virtual void setUseMetarestore(bool val) = 0;
+
+	/// returns true and modifies dumpType (to FOREGROUND_DUMP) if we return as a child
+	virtual bool start(DumpType& dumpType, uint64_t checksum) = 0;
+
+	// for poll
+	virtual void pollDesc(std::vector<pollfd> &pdesc) = 0;
+	virtual void pollServe(const std::vector<pollfd> &pdesc) = 0;
+
+	/// waits until the metadumper finishes
+	virtual void waitUntilFinished() = 0;
+};


### PR DESCRIPTION
With new metadata backends comming soon, the former MetadataDumper needs to be easily extensible. This commit:

- Adds the new IMetadataDumper interface to allow extensibility.
- Renames MetadataDumper to be MetadataDumperFile, which is consistent with the implementation.
- Uses the new interface in IMetadataBackend and the concrete implementation where needed.
- Ensures internal linking (static) for the functions in MetadataBackendFile, to avoid collisions with other implementations (testing).