### PR TITLE
feat: Write more blocks at once when replicating

### DIFF
--- a/src/chunkserver/chunk_file_creator.cc
+++ b/src/chunkserver/chunk_file_creator.cc
@@ -70,18 +70,19 @@ void ChunkFileCreator::create() {
 	}
 }
 
-void ChunkFileCreator::write(const uint8_t *buffer, uint32_t numBlocks,
+void ChunkFileCreator::write(const uint8_t *buffer, uint16_t startBlock, uint16_t numBlocks,
                              std::vector<uint32_t> &crc) {
 	assert(is_open_ && !is_commited_ && chunk_);
 	auto *crcData = gOpenChunks.getResource(chunk_->metaFD()).crcData();
-	int status =
-	    chunk_->owner()->writeChunkBlocks(chunk_, 0, 0, numBlocks, crc, crcData, buffer, true);
-	if (status != static_cast<int>(numBlocks * SFSBLOCKSIZE)) {
-		if (status < 0) {
-			throw Exception("failed to write chunk", -status);
-		} else {
-			throw Exception("failed to write chunk", SAUNAFS_ERROR_IO);
+	int writtenBytes = chunk_->owner()->writeChunkBlocks(chunk_, 0, startBlock, numBlocks, crc,
+	                                                     crcData, buffer, true);
+	if (writtenBytes != static_cast<int>(numBlocks * SFSBLOCKSIZE)) {
+		if (writtenBytes < 0) {
+			int status = -writtenBytes;
+			throw Exception("failed to write chunk", status);
 		}
+
+		throw Exception("failed to write chunk", SAUNAFS_ERROR_IO);
 	}
 }
 

--- a/src/chunkserver/chunk_file_creator.cc
+++ b/src/chunkserver/chunk_file_creator.cc
@@ -70,16 +70,18 @@ void ChunkFileCreator::create() {
 	}
 }
 
-void ChunkFileCreator::write(uint32_t offset, uint32_t size, uint32_t crc,
-                             const uint8_t *buffer) {
+void ChunkFileCreator::write(const uint8_t *buffer, uint32_t numBlocks,
+                             std::vector<uint32_t> &crc) {
 	assert(is_open_ && !is_commited_ && chunk_);
-	int blocknum = offset / SFSBLOCKSIZE;
-	offset = offset % SFSBLOCKSIZE;
 	auto *crcData = gOpenChunks.getResource(chunk_->metaFD()).crcData();
-	int status = chunk_->owner()->writeChunkBlock(chunk_, 0, blocknum, offset, size, crc, crcData,
-	                                              buffer, true);
-	if (status != SAUNAFS_STATUS_OK) {
-		throw Exception("failed to write chunk", status);
+	int status =
+	    chunk_->owner()->writeChunkBlocks(chunk_, 0, 0, numBlocks, crc, crcData, buffer, true);
+	if (status != static_cast<int>(numBlocks * SFSBLOCKSIZE)) {
+		if (status < 0) {
+			throw Exception("failed to write chunk", -status);
+		} else {
+			throw Exception("failed to write chunk", SAUNAFS_ERROR_IO);
+		}
 	}
 }
 

--- a/src/chunkserver/chunk_file_creator.h
+++ b/src/chunkserver/chunk_file_creator.h
@@ -37,7 +37,7 @@ public:
 	~ChunkFileCreator();
 
 	void create();
-	void write(uint32_t offset, uint32_t size, uint32_t crc, const uint8_t* buffer);
+	void write(const uint8_t* buffer, uint32_t numBlocks, std::vector<uint32_t> &crc);
 	void commit();
 
 	uint64_t chunkId() const { return chunk_id_; }

--- a/src/chunkserver/chunk_file_creator.h
+++ b/src/chunkserver/chunk_file_creator.h
@@ -37,7 +37,8 @@ public:
 	~ChunkFileCreator();
 
 	void create();
-	void write(const uint8_t* buffer, uint32_t numBlocks, std::vector<uint32_t> &crc);
+	void write(const uint8_t *buffer, uint16_t startBlock, uint16_t numBlocks,
+	           std::vector<uint32_t> &crc);
 	void commit();
 
 	uint64_t chunkId() const { return chunk_id_; }

--- a/src/chunkserver/chunk_replicator.cc
+++ b/src/chunkserver/chunk_replicator.cc
@@ -195,7 +195,9 @@ void ChunkReplicator::replicate(ChunkFileCreator& fileCreator,
 			uint32_t crc = mycrc32(0, dataBlock, SFSBLOCKSIZE);
 			crcData.push_back(crc);
 		}
-		fileCreator.write(static_cast<const uint8_t*>(buffer.data()), nrOfBlocks, crcData);
+		fileCreator.write(static_cast<const uint8_t *>(buffer.data()),
+		                  static_cast<uint16_t>(firstBlock), static_cast<uint16_t>(nrOfBlocks),
+		                  crcData);
 	}
 
 	fileCreator.commit();

--- a/src/chunkserver/chunk_replicator.cc
+++ b/src/chunkserver/chunk_replicator.cc
@@ -188,13 +188,14 @@ void ChunkReplicator::replicate(ChunkFileCreator& fileCreator,
 				planner.buildPlan());
 		executor.executePlan(buffer, locations, connector_, timeout.remaining_ms(), wave_timeout_ms_, timeout);
 
+		std::vector<uint32_t> crcData;
 		for (int i = 0; i < nrOfBlocks; ++i) {
 			uint32_t offset = i * SFSBLOCKSIZE;
 			const uint8_t* dataBlock = buffer.data() + offset;
 			uint32_t crc = mycrc32(0, dataBlock, SFSBLOCKSIZE);
-			uint32_t offsetInChunk = offset + firstBlock * SFSBLOCKSIZE;
-			fileCreator.write(offsetInChunk, SFSBLOCKSIZE, crc, dataBlock);
+			crcData.push_back(crc);
 		}
+		fileCreator.write(static_cast<const uint8_t*>(buffer.data()), nrOfBlocks, crcData);
 	}
 
 	fileCreator.commit();

--- a/src/chunkserver/chunkserver-common/cmr_disk.cc
+++ b/src/chunkserver/chunkserver-common/cmr_disk.cc
@@ -25,6 +25,7 @@
 #include <linux/falloc.h>
 #include <sys/stat.h>
 #include <sys/statvfs.h>
+#include <sys/types.h>
 #include <filesystem>
 
 #include "chunkserver-common/chunk_interface.h"
@@ -37,6 +38,7 @@
 #include "devtools/TracePrinter.h"
 #include "devtools/request_log.h"
 #include "errors/saunafs_error_codes.h"
+#include "protocol/SFSCommunication.h"
 
 CmrDisk::CmrDisk(const std::string &_metaPath, const std::string &_dataPath,
                  bool _isMarkedForRemoval, bool _isZonedDevice)
@@ -373,6 +375,34 @@ int CmrDisk::writePartialBlockAndCrc(IChunk *chunk, const uint8_t *buffer,
 	return size;
 }
 
+int CmrDisk::writeBlocksAndCrcs(IChunk *chunk, const uint8_t *buffer, uint16_t startBlock,
+	                       uint16_t numBlocks, const uint8_t *crcBuff, uint8_t *crcData,
+	                       bool isNewBlock, const char *errorMsg) {
+	(void)isNewBlock;
+
+	uint32_t size = numBlocks * SFSBLOCKSIZE;
+	{
+		DiskWriteStatsUpdater updater(chunk->owner(), size);
+
+		auto ret = pwrite(chunk->dataFD(), buffer, size, chunk->getBlockOffset(startBlock));
+
+		if (ret != size) {
+			hddAddErrorAndPreserveErrno(chunk);
+			safs_silent_errlog(LOG_WARNING, "%s: file:%s - write error",
+			                   errorMsg, chunk->fullMetaFilename().c_str());
+			hddReportDamagedChunk(chunk->id(), chunk->type());
+			updater.markWriteAsFailed();
+			return -1;
+		}
+	}
+
+	punchHoles(chunk, buffer, chunk->getBlockOffset(startBlock), size);
+
+	memcpy(crcData + startBlock * kCrcSize, crcBuff, kCrcSize * numBlocks);
+
+	return size;
+}
+
 void CmrDisk::punchHoles(IChunk *chunk, const uint8_t *buffer, uint32_t offset,
                          uint32_t size) {
 #if defined(SAUNAFS_HAVE_FALLOCATE) && \
@@ -572,6 +602,61 @@ int CmrDisk::writeChunkBlock(IChunk *chunk, uint32_t version, uint16_t blocknum,
 	}
 
 	return SAUNAFS_STATUS_OK;
+}
+
+int CmrDisk::writeChunkBlocks(IChunk *chunk, uint32_t version, uint16_t startBlock,
+                              uint16_t numBlocks, std::vector<uint32_t> &crc, uint8_t *crcData,
+                              const uint8_t *buffer, bool isFromReplication) {
+	assert(chunk);
+	LOG_AVG_TILL_END_OF_SCOPE0("writeChunkBlock");
+	TRACETHIS3(chunk->id(), startBlock, numBlocks);
+
+	if (chunk->version() != version && version > 0) {
+		return -SAUNAFS_ERROR_WRONGVERSION;
+	}
+	if (startBlock + numBlocks > chunk->maxBlocksInFile()) {
+		return -SAUNAFS_ERROR_BNUMTOOBIG;
+	}
+	if (numBlocks > SFSBLOCKSINCHUNK || crc.size() != numBlocks) {
+		return -SAUNAFS_ERROR_WRONGSIZE;
+	}
+
+	if (gCheckCrcWhenWriting && !isFromReplication) {
+		for (uint16_t i = 0; i < numBlocks; ++i) {
+			if (crc[i] != mycrc32(0, buffer + i * SFSBLOCKSIZE, SFSBLOCKSIZE)) {
+				return -SAUNAFS_ERROR_CRC;
+			}
+		}
+	}
+
+	chunk->setWasChanged(1U);
+	bool areNewBlocks = false;
+
+	std::vector<uint8_t> crcBuff(kCrcSize * numBlocks);
+
+	uint8_t *crcBuffPointer = crcBuff.data();
+	for (auto &crcValue : crc) {
+		put32bit(&crcBuffPointer, crcValue);
+	}
+
+	const uint16_t prevBlocks = chunk->blocks();
+	if (startBlock >= chunk->blocks()) {
+		// Fill new blocks' CRCs with empty data
+		for (uint16_t i = prevBlocks; i < startBlock; i++) {
+			memcpy(crcData + i * kCrcSize, &gEmptyBlockCrc, kCrcSize);
+		}
+	}
+	if (startBlock + numBlocks > chunk->blocks()) {
+		// New blocks are added
+		chunk->setBlocks(startBlock + numBlocks);
+		areNewBlocks = true;
+	}
+
+	int written = writeBlocksAndCrcs(chunk, buffer, startBlock, numBlocks, crcBuff.data(), crcData,
+	                                 areNewBlocks, "writeChunkBlocks");
+	if (written < 0) { return -SAUNAFS_ERROR_IO; }
+
+	return numBlocks * SFSBLOCKSIZE;
 }
 
 int CmrDisk::writeChunkData(IChunk *chunk, uint8_t *blockBuffer,

--- a/src/chunkserver/chunkserver-common/cmr_disk.cc
+++ b/src/chunkserver/chunkserver-common/cmr_disk.cc
@@ -25,7 +25,6 @@
 #include <linux/falloc.h>
 #include <sys/stat.h>
 #include <sys/statvfs.h>
-#include <sys/types.h>
 #include <filesystem>
 
 #include "chunkserver-common/chunk_interface.h"
@@ -38,7 +37,6 @@
 #include "devtools/TracePrinter.h"
 #include "devtools/request_log.h"
 #include "errors/saunafs_error_codes.h"
-#include "protocol/SFSCommunication.h"
 
 CmrDisk::CmrDisk(const std::string &_metaPath, const std::string &_dataPath,
                  bool _isMarkedForRemoval, bool _isZonedDevice)
@@ -375,10 +373,10 @@ int CmrDisk::writePartialBlockAndCrc(IChunk *chunk, const uint8_t *buffer,
 	return size;
 }
 
-int CmrDisk::writeBlocksAndCrcs(IChunk *chunk, const uint8_t *buffer, uint16_t startBlock,
-	                       uint16_t numBlocks, const uint8_t *crcBuff, uint8_t *crcData,
-	                       bool isNewBlock, const char *errorMsg) {
-	(void)isNewBlock;
+int CmrDisk::writeFullBlocksAndCrcs(IChunk *chunk, const uint8_t *buffer, uint16_t startBlock,
+                                    uint16_t numBlocks, const uint8_t *crcBuff, uint8_t *crcData,
+                                    bool areNewBlocks, const char *errorMsg) {
+	(void)areNewBlocks;
 
 	uint32_t size = numBlocks * SFSBLOCKSIZE;
 	{
@@ -388,8 +386,8 @@ int CmrDisk::writeBlocksAndCrcs(IChunk *chunk, const uint8_t *buffer, uint16_t s
 
 		if (ret != size) {
 			hddAddErrorAndPreserveErrno(chunk);
-			safs_silent_errlog(LOG_WARNING, "%s: file:%s - write error",
-			                   errorMsg, chunk->fullMetaFilename().c_str());
+			safs::log_warn("{}: file:{} - write error", errorMsg,
+			               chunk->fullMetaFilename().c_str());
 			hddReportDamagedChunk(chunk->id(), chunk->type());
 			updater.markWriteAsFailed();
 			return -1;
@@ -608,7 +606,7 @@ int CmrDisk::writeChunkBlocks(IChunk *chunk, uint32_t version, uint16_t startBlo
                               uint16_t numBlocks, std::vector<uint32_t> &crc, uint8_t *crcData,
                               const uint8_t *buffer, bool isFromReplication) {
 	assert(chunk);
-	LOG_AVG_TILL_END_OF_SCOPE0("writeChunkBlock");
+	LOG_AVG_TILL_END_OF_SCOPE0("writeChunkBlocks");
 	TRACETHIS3(chunk->id(), startBlock, numBlocks);
 
 	if (chunk->version() != version && version > 0) {
@@ -617,7 +615,7 @@ int CmrDisk::writeChunkBlocks(IChunk *chunk, uint32_t version, uint16_t startBlo
 	if (startBlock + numBlocks > chunk->maxBlocksInFile()) {
 		return -SAUNAFS_ERROR_BNUMTOOBIG;
 	}
-	if (numBlocks > SFSBLOCKSINCHUNK || crc.size() != numBlocks) {
+	if (numBlocks > SFSBLOCKSINCHUNK || crc.size() != static_cast<size_t>(numBlocks)) {
 		return -SAUNAFS_ERROR_WRONGSIZE;
 	}
 
@@ -652,8 +650,8 @@ int CmrDisk::writeChunkBlocks(IChunk *chunk, uint32_t version, uint16_t startBlo
 		areNewBlocks = true;
 	}
 
-	int written = writeBlocksAndCrcs(chunk, buffer, startBlock, numBlocks, crcBuff.data(), crcData,
-	                                 areNewBlocks, "writeChunkBlocks");
+	int written = writeFullBlocksAndCrcs(chunk, buffer, startBlock, numBlocks, crcBuff.data(),
+	                                     crcData, areNewBlocks, "writeChunkBlocks");
 	if (written < 0) { return -SAUNAFS_ERROR_IO; }
 
 	return numBlocks * SFSBLOCKSIZE;

--- a/src/chunkserver/chunkserver-common/cmr_disk.h
+++ b/src/chunkserver/chunkserver-common/cmr_disk.h
@@ -132,9 +132,9 @@ public:
 	                            uint16_t blockNum, bool isNewBlock,
 	                            const char *errorMsg) override;
 	/// Writes the data and the CRC for a number of full blocks
-	int writeBlocksAndCrcs(IChunk *chunk, const uint8_t *buffer, uint16_t startBlock,
-	                       uint16_t numBlocks, const uint8_t *crcBuff, uint8_t *crcData,
-	                       bool isNewBlock, const char *errorMsg) override;
+	int writeFullBlocksAndCrcs(IChunk *chunk, const uint8_t *buffer, uint16_t startBlock,
+	                           uint16_t numBlocks, const uint8_t *crcBuff, uint8_t *crcData,
+	                           bool areNewBlocks, const char *errorMsg) override;
 
 	/// If supported, deallocates space (creates a hole) in the byte range
 	/// starting at offset and continuing for size bytes.

--- a/src/chunkserver/chunkserver-common/cmr_disk.h
+++ b/src/chunkserver/chunkserver-common/cmr_disk.h
@@ -131,6 +131,10 @@ public:
 	                            const uint8_t *crcBuff, uint8_t *crcData,
 	                            uint16_t blockNum, bool isNewBlock,
 	                            const char *errorMsg) override;
+	/// Writes the data and the CRC for a number of full blocks
+	int writeBlocksAndCrcs(IChunk *chunk, const uint8_t *buffer, uint16_t startBlock,
+	                       uint16_t numBlocks, const uint8_t *crcBuff, uint8_t *crcData,
+	                       bool isNewBlock, const char *errorMsg) override;
 
 	/// If supported, deallocates space (creates a hole) in the byte range
 	/// starting at offset and continuing for size bytes.
@@ -143,6 +147,10 @@ public:
 	/// Writes a Chunk block
 	int writeChunkBlock(IChunk *chunk, uint32_t version, uint16_t blocknum, uint32_t offsetInBlock,
 	                    uint32_t size, uint32_t crc, uint8_t *crcData, const uint8_t *buffer,
+	                    bool isFromReplication = false) override;
+	/// Writes `numBlocks` full Chunk blocks
+	int writeChunkBlocks(IChunk *chunk, uint32_t version, uint16_t startBlock, uint16_t numBlocks,
+	                     std::vector<uint32_t> &crc, uint8_t *crcData, const uint8_t *buffer,
 	                    bool isFromReplication = false) override;
 
 	/// Writes to device custom blockSize from blockBuffer

--- a/src/chunkserver/chunkserver-common/disk_interface.h
+++ b/src/chunkserver/chunkserver-common/disk_interface.h
@@ -209,19 +209,29 @@ public:
 	virtual int overwriteChunkVersion(IChunk *chunk, uint32_t newVersion) = 0;
 
 	/// Writes the data and the CRC for exactly one block
-	/// \returns number of written bytes on success or -1 on failure.
+	/// \returns number of written bytes on success or the negative of the error code on failure.
 	virtual int writePartialBlockAndCrc(IChunk *chunk, const uint8_t *buffer,
 	                                    uint32_t offsetInBlock, uint32_t size,
-	                                    const uint8_t *crcBuff,
-	                                    uint8_t *crcData, uint16_t blockNum,
-	                                    bool isNewBlock,
-	                                    const char *errorMsg) = 0;
+	                                    const uint8_t *crcBuff, uint8_t *crcData, uint16_t blockNum,
+	                                    bool isNewBlock, const char *errorMsg) = 0;
+	/// Writes the data and the CRC for a number of full blocks
+	/// \returns number of written bytes on success or the negative of the error code on failure.
+	/// If the written bytes are less than expected, it is IO error.
+	virtual int writeBlocksAndCrcs(IChunk *chunk, const uint8_t *buffer, uint16_t startBlock,
+	                               uint16_t numBlocks, const uint8_t *crcBuff, uint8_t *crcData,
+	                               bool isNewBlock, const char *errorMsg) = 0;
 
 	/// Writes a Chunk block
 	/// \return SAUNAFS_STATUS_OK on success or specific SAUNAFS_ error code
 	virtual int writeChunkBlock(IChunk *chunk, uint32_t version,
 	                            uint16_t blocknum, uint32_t offsetInBlock,
 	                            uint32_t size, uint32_t crc, uint8_t *crcData,
+	                            const uint8_t *buffer, bool isFromReplication = false) = 0;
+	/// Writes `numBlocks` full Chunk blocks
+	/// \returns number of written bytes on success or the negative of the error code on failure.
+	/// If the written bytes are less than expected, it is IO error.
+	virtual int writeChunkBlocks(IChunk *chunk, uint32_t version, uint16_t startBlock,
+	                            uint16_t numBlocks, std::vector<uint32_t> &crc, uint8_t *crcData,
 	                            const uint8_t *buffer, bool isFromReplication = false) = 0;
 
 	/// Writes the Chunk header into the device

--- a/src/chunkserver/chunkserver-common/disk_interface.h
+++ b/src/chunkserver/chunkserver-common/disk_interface.h
@@ -217,9 +217,9 @@ public:
 	/// Writes the data and the CRC for a number of full blocks
 	/// \returns number of written bytes on success or the negative of the error code on failure.
 	/// If the written bytes are less than expected, it is IO error.
-	virtual int writeBlocksAndCrcs(IChunk *chunk, const uint8_t *buffer, uint16_t startBlock,
-	                               uint16_t numBlocks, const uint8_t *crcBuff, uint8_t *crcData,
-	                               bool isNewBlock, const char *errorMsg) = 0;
+	virtual int writeFullBlocksAndCrcs(IChunk *chunk, const uint8_t *buffer, uint16_t startBlock,
+	                                   uint16_t numBlocks, const uint8_t *crcBuff, uint8_t *crcData,
+	                                   bool areNewBlocks, const char *errorMsg) = 0;
 
 	/// Writes a Chunk block
 	/// \return SAUNAFS_STATUS_OK on success or specific SAUNAFS_ error code


### PR DESCRIPTION
When replicating very fast, several chunk parts could be replicated at
the same time to the same drive. The blocks of those parts are then
written block by block, which could make the drive perform poor if the
number of simultaneous chunk parts written if high enough.

The proposed changes addressed the issue by sending all the data to be
written at once to the new writeChunkBlocks function, which will try to
use a single pwrite call to write all the data.

Signed-off-by: Dave <dave@leil.io>