### PR TITLE
feat(mds): Select correct FDB version at install

### DIFF
--- a/tests/ci_build/install-foundationdb.sh
+++ b/tests/ci_build/install-foundationdb.sh
@@ -25,7 +25,16 @@ if [ "$(id -u)" -ne 0 ]; then
 	die "This script must be run as root. Please use sudo."
 fi
 
-fdb_version="7.3.63"
+FDB_VERSION_AVX2="7.3.63"
+FDB_VERSION_NO_AVX2="7.3.62"
+
+fdb_version="${FDB_VERSION_AVX2}"
+
+# Use a version without AVX2 requirement if the CPU does not support it (like some Proxmox VMs)
+if ! grep -q -w avx2 /proc/cpuinfo; then
+	fdb_version="${FDB_VERSION_NO_AVX2}"
+	echo "AVX2 not detected. Falling back to FoundationDB version ${fdb_version}."
+fi
 
 # Check if FoundationDB is already installed by using fdbcli
 if command -v fdbcli &> /dev/null; then


### PR DESCRIPTION
FoundationDB version 7.3.63 requieres processors with AVX2 support. This change uses version 7.3.62 (built without AVX2) if the CPU does not support AVX2, like some Proxmox VMs with default kvm64 processors.