### PR TITLE
feat(mds): Separate changelogs from metadata backend

### DIFF
--- a/src/master/changelog.cc
+++ b/src/master/changelog.cc
@@ -22,18 +22,33 @@
 
 #include "master/changelog.h"
 
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
 #include <syslog.h>
 #include <unistd.h>
 #include <cstdio>
 
-#include <common/exceptions.h>
+#include "common/cwrap.h"
 #include "common/event_loop.h"
+#include "common/exceptions.h"
 #include "common/rotate_files.h"
 #include "config/cfg.h"
+#include "master/metadata_backend_common.h"
 #include "slogger/slogger.h"
 
+#if !defined(METARESTORE) && !defined(METALOGGER)
+#include <fstream>
+
+#include "common/setup.h"
+#include "master/exceptions.h"
+#include "master/filesystem.h"
+#include "master/filesystem_metadata.h"
+#include "master/restore.h"
+#endif  // #if !defined(METARESTORE) && !defined(METALOGGER)
+
 /// Base name of a changelog file.
-/// Sometthing like "changelog.sfs" or "changelog_ml.sfs"
+/// Something like "changelog.sfs" or "changelog_ml.sfs"
 static std::string gChangelogFilename;
 
 /// Minimal acceptable value of BACK_LOGS config entry.
@@ -42,7 +57,7 @@ static uint32_t gMinBackLogsNumber = 0;
 /// Maximal acceptable value of BACK_LOGS config entry.
 static uint32_t gMaxBackLogsNumber = 50;
 
-static uint32_t BackLogsNumber;
+static uint32_t gBackLogsNumber;
 static FILE *fd = nullptr;
 static bool gFlush = true;
 
@@ -51,8 +66,8 @@ void changelog_rotate() {
 		fclose(fd);
 		fd=NULL;
 	}
-	if (BackLogsNumber>0) {
-		rotateFiles(gChangelogFilename, BackLogsNumber);
+	if (gBackLogsNumber > 0) {
+		rotateFiles(gChangelogFilename, gBackLogsNumber);
 	} else {
 		unlink(gChangelogFilename.c_str());
 	}
@@ -75,7 +90,7 @@ void changelog(uint64_t version, const char* entry) {
 }
 
 static void changelog_reload(void) {
-	BackLogsNumber = cfg_get_minmaxvalue<uint32_t>("BACK_LOGS", 50,
+	gBackLogsNumber = cfg_get_minmaxvalue<uint32_t>("BACK_LOGS", 50,
 			gMinBackLogsNumber, gMaxBackLogsNumber);
 }
 
@@ -84,12 +99,12 @@ void changelog_init(std::string changelogFilename,
 	gChangelogFilename = std::move(changelogFilename);
 	gMinBackLogsNumber = minBackLogsNumber;
 	gMaxBackLogsNumber = maxBackLogsNumber;
-	BackLogsNumber = cfg_getuint32("BACK_LOGS", 50);
-	if (BackLogsNumber > gMaxBackLogsNumber) {
+	gBackLogsNumber = cfg_getuint32("BACK_LOGS", 50);
+	if (gBackLogsNumber > gMaxBackLogsNumber) {
 		throw InitializeException(cfg_filename() + ": BACK_LOGS value too big, "
 				"maximum allowed is " + std::to_string(gMaxBackLogsNumber));
 	}
-	if (BackLogsNumber < gMinBackLogsNumber) {
+	if (gBackLogsNumber < gMinBackLogsNumber) {
 		throw InitializeException(cfg_filename() + ": BACK_LOGS value too low, "
 				"minimum allowed is " + std::to_string(gMinBackLogsNumber));
 	}
@@ -97,7 +112,7 @@ void changelog_init(std::string changelogFilename,
 }
 
 uint32_t changelog_get_back_logs_config_value() {
-	return BackLogsNumber;
+	return gBackLogsNumber;
 }
 
 void changelog_flush(void) {
@@ -114,3 +129,244 @@ void changelog_enable_flush(void) {
 	gFlush = true;
 	changelog_flush();
 }
+
+#ifndef METALOGGER
+
+uint64_t changelogGetFirstLogVersion(const std::string &fname) {
+	uint8_t buff[50];
+	int32_t s, p;
+	uint64_t fv;
+	int fd;
+
+	fd = open(fname.c_str(), O_RDONLY);
+	if (fd < 0) { return 0; }
+	s = read(fd, buff, 50);
+	close(fd);
+	if (s <= 0) { return 0; }
+	fv = 0;
+	p = 0;
+	while (p < s && buff[p] >= '0' && buff[p] <= '9') {
+		fv *= 10;
+		fv += buff[p] - '0';
+		p++;
+	}
+	if (p >= s || buff[p] != ':') { return 0; }
+	return fv;
+}
+
+uint64_t changelogGetLastLogVersion(const std::string &fname) {
+	struct stat st;
+
+	FileDescriptor fd(open(fname.c_str(), O_RDONLY));
+	if (fd.get() < 0) {
+		throw FilesystemException("open " + fname + " failed: " + errorString(errno));
+	}
+
+	::fstat(fd.get(), &st);
+
+	size_t fileSize = st.st_size;
+	if (fileSize == 0) { return 0; }
+
+	const char *fileContent =
+	    (const char *)mmap(NULL, fileSize, PROT_READ, MAP_PRIVATE, fd.get(), 0);
+	if (fileContent == MAP_FAILED) {
+		throw FilesystemException("mmap(" + fname + ") failed: " + errorString(errno));
+	}
+	uint64_t lastLogVersion = 0;
+	// first LF is (should be) the last byte of the file
+	if (fileSize == 0 || fileContent[fileSize - 1] != '\n') {
+		throw ParseException("truncated changelog " + fname +
+		                     " (no LF at the end of the last line)");
+	} else {
+		size_t pos = fileSize - 1;
+		while (pos > 0) {
+			--pos;
+			if (fileContent[pos] == '\n') { break; }
+		}
+		char *endPtr = NULL;
+		lastLogVersion = strtoull(fileContent + pos, &endPtr, 10);
+		if (*endPtr != ':') {
+			throw ParseException("malformed changelog " + fname +
+			                     " (expected colon after change number)");
+		}
+	}
+	if (munmap((void *)fileContent, fileSize)) {
+		safs_pretty_errlog(LOG_WARNING, "munmap(%s) failed", fname.c_str());
+	}
+	return lastLogVersion;
+}
+
+#else  // #ifndef METALOGGER
+
+uint64_t findLastLogVersion() {
+	struct stat st;
+	uint8_t buff[32800];  // 32800 = 32768 + 32
+	uint64_t size;
+	uint32_t buffpos;
+	uint64_t lastnewline;
+	int fd;
+	uint64_t lastlogversion = 0;
+
+	if ((stat(kMetadataMlFilename, &st) < 0) || (st.st_size == 0) ||
+	    ((st.st_mode & S_IFMT) != S_IFREG)) {
+		return 0;
+	}
+
+	fd = open(kChangelogMlFilename, O_RDWR);
+	if (fd < 0) { return 0; }
+
+	::fstat(fd, &st);
+	size = st.st_size;
+	memset(buff, 0, 32);
+	lastnewline = 0;
+
+	while (size > 0 && size + 200000 > (uint64_t)(st.st_size)) {
+		if (size > 32768) {
+			memcpy(buff + 32768, buff, 32);
+			size -= 32768;
+			lseek(fd, size, SEEK_SET);
+			if (read(fd, buff, 32768) != 32768) {
+				lastlogversion = 0;
+				close(fd);
+				return lastlogversion;
+			}
+			buffpos = 32768;
+		} else {
+			memmove(buff + size, buff, 32);
+			lseek(fd, 0, SEEK_SET);
+			if (read(fd, buff, size) != (ssize_t)size) {
+				lastlogversion = 0;
+				close(fd);
+				return lastlogversion;
+			}
+			buffpos = size;
+			size = 0;
+		}
+		// size = position in file of first byte in buff
+		// buffpos = position of last byte in buff to search
+		while (buffpos > 0) {
+			buffpos--;
+			if (buff[buffpos] == '\n') {
+				if (lastnewline == 0) {
+					lastnewline = size + buffpos;
+				} else {
+					if (lastnewline + 1 !=
+					    (uint64_t)(st.st_size)) {  // garbage at the end of file - truncate
+						if (ftruncate(fd, lastnewline + 1) < 0) {
+							lastlogversion = 0;
+							close(fd);
+							return lastlogversion;
+						}
+					}
+					buffpos++;
+					while (buffpos < 32800 && buff[buffpos] >= '0' && buff[buffpos] <= '9') {
+						lastlogversion *= 10;
+						lastlogversion += buff[buffpos] - '0';
+						buffpos++;
+					}
+					if (buffpos == 32800 || buff[buffpos] != ':') { lastlogversion = 0; }
+					close(fd);
+					return lastlogversion;
+				}
+			}
+		}
+	}
+
+	close(fd);
+
+	return lastlogversion;
+}
+
+#endif  // #ifndef METALOGGER
+
+#if !defined(METARESTORE) && !defined(METALOGGER)
+
+void load_changelogs() {
+	/*
+	 * We need to load 3 changelog files in extreme case.
+	 * If we are being run as Shadow we need to download two
+	 * changelog files:
+	 * 1 - current changelog => "changelog.sfs.1"
+	 * 2 - previous changelog in case Shadow connects during metadata dump,
+	 *     that is "changelog.sfs.2"
+	 * Beside this we received changelog lines that we stored in
+	 * yet another changelog file => "changelog.sfs"
+	 *
+	 * If we are master we only really care for:
+	 * "changelog.sfs.1" and "changelog.sfs" files.
+	 */
+	static const std::string changelogs[]{
+	    std::string(kChangelogFilename) + ".2",
+	    std::string(kChangelogFilename) + ".1", kChangelogFilename};
+	restore_setverblevel(gVerbosity);
+	bool oldExists = false;
+	try {
+		for (const std::string &s : changelogs) {
+			std::string fullFileName = fs::getCurrentWorkingDirectoryNoThrow() + "/" + s;
+			if (fs::exists(s)) {
+				oldExists = true;
+				uint64_t first = changelogGetFirstLogVersion(s);
+				uint64_t last = changelogGetLastLogVersion(s);
+				if (last >= first) {
+					if (last >= fs_getversion()) {
+						load_changelog(s);
+					}
+				} else {
+					throw InitializeException(
+					    "changelog " + fullFileName +
+					    " inconsistent, "
+					    "use sfsmetarestore to recover the filesystem; "
+					    "current fs version: " +
+					    std::to_string(fs_getversion()) +
+					    ", first change in the file: " + std::to_string(first));
+				}
+			} else if (oldExists && s != kChangelogFilename) {
+				safs_pretty_syslog(LOG_WARNING, "changelog `%s' missing",
+				                   fullFileName.c_str());
+			}
+		}
+	} catch (const FilesystemException &ex) {
+		throw FilesystemException("error loading changelogs: " + ex.message());
+	}
+}
+
+void load_changelog(const std::string &path) {
+	std::string fullFileName = fs::getCurrentWorkingDirectoryNoThrow() + "/" + path;
+	std::ifstream changelog(path);
+	std::string line;
+	size_t end = 0;
+	sassert(gMetadata->metaversion > 0);
+
+	uint64_t first = 0;
+	uint64_t id = 0;
+	uint64_t skippedEntries = 0;
+	uint64_t appliedEntries = 0;
+	while (std::getline(changelog, line).good()) {
+		id = std::stoull(line, &end);
+		if (id < fs_getversion()) {
+			++skippedEntries;
+			continue;
+		} else if (!first) {
+			first = id;
+		}
+		++appliedEntries;
+		uint8_t status =
+		    restore(path.c_str(), id, line.c_str() + end, RestoreRigor::kIgnoreParseErrors);
+		if (status != SAUNAFS_STATUS_OK) {
+			throw MetadataConsistencyException("can't apply changelog " + fullFileName, status);
+		}
+	}
+	if (appliedEntries > 0) {
+		safs_pretty_syslog_attempt(LOG_NOTICE,
+		                           "%s: %" PRIu64 " changes applied (%" PRIu64 " to %" PRIu64
+		                           "), %" PRIu64 " skipped",
+		                           fullFileName.c_str(), appliedEntries, first, id, skippedEntries);
+	} else if (skippedEntries > 0) {
+		safs_pretty_syslog_attempt(LOG_NOTICE, "%s: skipped all %" PRIu64 " entries",
+		                           fullFileName.c_str(), skippedEntries);
+	} else {
+		safs_pretty_syslog_attempt(LOG_NOTICE, "%s: file empty (ignored)", fullFileName.c_str());
+	}
+}
+
+#endif  // !defined(METARESTORE) && !defined(METALOGGER)

--- a/src/master/changelog.h
+++ b/src/master/changelog.h
@@ -53,3 +53,25 @@ void changelog_disable_flush();
 
 /// Enables flushing the current changelog after each \p changelog call
 void changelog_enable_flush();
+
+#ifndef METALOGGER
+/// Returns version of the first entry in a changelog.
+/// @param file -- path to the changelog file
+/// @return 0 in case of any error.
+uint64_t changelogGetFirstLogVersion(const std::string &fname);
+
+/// Returns version of the last entry in a changelog.
+/// @param file -- path to the changelog file
+/// @return 0 in case of any error.
+uint64_t changelogGetLastLogVersion(const std::string &fname);
+#else   // #ifndef METALOGGER
+uint64_t findLastLogVersion();
+#endif  // #ifndef METALOGGER
+
+#if !defined(METARESTORE) && !defined(METALOGGER)
+/// Load and apply changelogs.
+void load_changelogs();
+
+/// Load and apply given changelog file.
+void load_changelog(const std::string &path);
+#endif  // !defined(METARESTORE) && !defined(METALOGGER)

--- a/src/master/exceptions.h
+++ b/src/master/exceptions.h
@@ -1,0 +1,30 @@
+/*
+   Copyright 2023      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "common/platform.h"
+
+#include "common/exception.h"
+
+// Metadata related exceptions
+SAUNAFS_CREATE_EXCEPTION_CLASS(MetadataCheckException, Exception);
+SAUNAFS_CREATE_EXCEPTION_CLASS(MetadataException, Exception);
+SAUNAFS_CREATE_EXCEPTION_CLASS(MetadataFsConsistencyException,
+                               MetadataException);
+SAUNAFS_CREATE_EXCEPTION_CLASS(MetadataConsistencyException, MetadataException);

--- a/src/master/filesystem.cc
+++ b/src/master/filesystem.cc
@@ -265,13 +265,29 @@ int fs_loadall(void) {
 	}
 
 	bool autoRecovery = fs_can_do_auto_recovery();
+
 	if (autoRecovery || (metadataserver::getPersonality() == metadataserver::Personality::kShadow)) {
-		safs_pretty_syslog_attempt(LOG_INFO, "%s - applying changelogs from %s",
-				(autoRecovery ? "AUTO_RECOVERY enabled" : "running in shadow mode"),
-				fs::getCurrentWorkingDirectoryNoThrow().c_str());
-		gMetadataBackend->load_changelogs();
-		safs_pretty_syslog(LOG_INFO, "all needed changelogs applied successfully");
+		safs::log_info("{} - applying changelogs from {}",
+		               (autoRecovery ? "AUTO_RECOVERY enabled" : "running in shadow mode"),
+		               fs::getCurrentWorkingDirectoryNoThrow().c_str());
+
+		// Save the current personality
+		metadataserver::Personality personality = metadataserver::getPersonality();
+		// Force shadow personality to avoid permission issues and possible changes broadcasting
+		metadataserver::setPersonality(metadataserver::Personality::kShadow);
+
+		// Load the changelogs
+		load_changelogs();
+		safs::log_info("all needed changelogs applied successfully");
+
+		// Dump the new metadata
+		gMetadataBackend->fs_storeall(DumpType::kForegroundDump);
+		safs::log_info("Metadata dumped successfully after applying changelogs");
+
+		// Restore the original personality
+		metadataserver::setPersonality(personality);
 	}
+
 	return 0;
 }
 
@@ -421,6 +437,7 @@ int fs_init(bool doLoad) {
 			throw;
 		}
 	}
+
 	changelog_init(kChangelogFilename, 0, 50);
 
 	if (doLoad || (metadataserver::isMaster())) {

--- a/src/master/masterconn.cc
+++ b/src/master/masterconn.cc
@@ -1287,7 +1287,7 @@ int masterconn_init(void) {
 #endif /* #ifdef METALOGGER */
 
 #ifdef METALOGGER
-	eptr->lastLogVersion = gMetadataBackend->findLastLogVersion();
+	eptr->lastLogVersion = findLastLogVersion();
 #endif /* #ifdef METALOGGER */
 	if (eptr->initConnect() < 0) { return -1; }
 	eventloop_pollregister(masterconn_desc, masterconn_serve);

--- a/src/master/metadata_backend_file.cc
+++ b/src/master/metadata_backend_file.cc
@@ -24,7 +24,6 @@
 
 #include <fcntl.h> // for open and O_RDONLY
 #include <cstdint>
-#include <fstream>
 #include <memory>
 #include <sys/mman.h>
 
@@ -159,104 +158,6 @@ void MetadataBackendFile::broadcast_metadata_saved(uint8_t status) {
 	matoclserv_broadcast_metadata_saved(status);
 }
 
-void MetadataBackendFile::load_changelogs() {
-	metadataserver::Personality personality = metadataserver::getPersonality();
-	metadataserver::setPersonality(metadataserver::Personality::kShadow);
-	/*
-	 * We need to load 3 changelog files in extreme case.
-	 * If we are being run as Shadow we need to download two
-	 * changelog files:
-	 * 1 - current changelog => "changelog.sfs.1"
-	 * 2 - previous changelog in case Shadow connects during metadata dump,
-	 *     that is "changelog.sfs.2"
-	 * Beside this we received changelog lines that we stored in
-	 * yet another changelog file => "changelog.sfs"
-	 *
-	 * If we are master we only really care for:
-	 * "changelog.sfs.1" and "changelog.sfs" files.
-	 */
-	static const std::string changelogs[]{
-	    std::string(kChangelogFilename) + ".2",
-	    std::string(kChangelogFilename) + ".1", kChangelogFilename};
-	restore_setverblevel(gVerbosity);
-	bool oldExists = false;
-	try {
-		for (const std::string &s : changelogs) {
-			std::string fullFileName =
-			    fs::getCurrentWorkingDirectoryNoThrow() + "/" + s;
-			if (fs::exists(s)) {
-				oldExists = true;
-				uint64_t first = changelogGetFirstLogVersion(s);
-				uint64_t last = changelogGetLastLogVersion(s);
-				if (last >= first) {
-					if (last >= fs_getversion()) {
-						load_changelog(s);
-					}
-				} else {
-					throw InitializeException(
-					    "changelog " + fullFileName +
-					    " inconsistent, "
-					    "use sfsmetarestore to recover the filesystem; "
-					    "current fs version: " +
-					    std::to_string(fs_getversion()) +
-					    ", first change in the file: " + std::to_string(first));
-				}
-			} else if (oldExists && s != kChangelogFilename) {
-				safs_pretty_syslog(LOG_WARNING, "changelog `%s' missing",
-				                   fullFileName.c_str());
-			}
-		}
-	} catch (const FilesystemException &ex) {
-		throw FilesystemException("error loading changelogs: " + ex.message());
-	}
-	gMetadataBackend->fs_storeall(DumpType::kForegroundDump);
-	metadataserver::setPersonality(personality);
-}
-
-void MetadataBackendFile::load_changelog(const std::string &path) {
-	std::string fullFileName =
-	    fs::getCurrentWorkingDirectoryNoThrow() + "/" + path;
-	std::ifstream changelog(path);
-	std::string line;
-	size_t end = 0;
-	sassert(gMetadata->metaversion > 0);
-
-	uint64_t first = 0;
-	uint64_t id = 0;
-	uint64_t skippedEntries = 0;
-	uint64_t appliedEntries = 0;
-	while (std::getline(changelog, line).good()) {
-		id = std::stoull(line, &end);
-		if (id < fs_getversion()) {
-			++skippedEntries;
-			continue;
-		} else if (!first) {
-			first = id;
-		}
-		++appliedEntries;
-		uint8_t status = restore(path.c_str(), id, line.c_str() + end,
-		                         RestoreRigor::kIgnoreParseErrors);
-		if (status != SAUNAFS_STATUS_OK) {
-			throw MetadataConsistencyException(
-			    "can't apply changelog " + fullFileName, status);
-		}
-	}
-	if (appliedEntries > 0) {
-		safs_pretty_syslog_attempt(LOG_NOTICE,
-		                           "%s: %" PRIu64 " changes applied (%" PRIu64
-		                           " to %" PRIu64 "), %" PRIu64 " skipped",
-		                           fullFileName.c_str(), appliedEntries, first,
-		                           id, skippedEntries);
-	} else if (skippedEntries > 0) {
-		safs_pretty_syslog_attempt(LOG_NOTICE,
-		                           "%s: skipped all %" PRIu64 " entries",
-		                           fullFileName.c_str(), skippedEntries);
-	} else {
-		safs_pretty_syslog_attempt(LOG_NOTICE, "%s: file empty (ignored)",
-		                           fullFileName.c_str());
-	}
-}
-
 uint8_t MetadataBackendFile::fs_storeall(DumpType dumpType) {
 	if (gMetadata == nullptr) {
 		// Periodic dump in shadow master or a request from saunafs-admin
@@ -277,8 +178,7 @@ uint8_t MetadataBackendFile::fs_storeall(DumpType dumpType) {
 	matomlserv_broadcast_logrotate();
 	// child == true says that we forked
 	// bg may be changed to dump in foreground in case of a fork error
-	bool child = dumper()->start(
-	    dumpType, fs_checksum(ChecksumMode::kGetCurrent));
+	bool child = dumper()->start(dumpType, fs_checksum(ChecksumMode::kGetCurrent));
 	uint8_t status = SAUNAFS_STATUS_OK;
 
 	if (dumpType == DumpType::kForegroundDump) {
@@ -335,78 +235,6 @@ uint8_t MetadataBackendFile::fs_storeall(DumpType dumpType) {
 #endif  // #if !defined(METARESTORE) && !defined(METALOGGER)
 
 #ifndef METALOGGER
-
-uint64_t MetadataBackendFile::changelogGetFirstLogVersion(const std::string& fname) {
-	uint8_t buff[50];
-	int32_t s,p;
-	uint64_t fv;
-	int fd;
-
-	fd = open(fname.c_str(), O_RDONLY);
-	if (fd<0) {
-		return 0;
-	}
-	s = read(fd,buff,50);
-	close(fd);
-	if (s<=0) {
-		return 0;
-	}
-	fv = 0;
-	p = 0;
-	while (p<s && buff[p]>='0' && buff[p]<='9') {
-		fv *= 10;
-		fv += buff[p]-'0';
-		p++;
-	}
-	if (p>=s || buff[p]!=':') {
-		return 0;
-	}
-	return fv;
-}
-
-uint64_t MetadataBackendFile::changelogGetLastLogVersion(const std::string& fname) {
-	struct stat st;
-
-	FileDescriptor fd(open(fname.c_str(), O_RDONLY));
-	if (fd.get() < 0) {
-		throw FilesystemException("open " + fname + " failed: " + errorString(errno));
-	}
-	fstat(fd.get(), &st);
-
-	size_t fileSize = st.st_size;
-	if (fileSize == 0) {
-		return 0;
-	}
-
-	const char* fileContent = (const char*) mmap(NULL, fileSize, PROT_READ, MAP_PRIVATE, fd.get(), 0);
-	if (fileContent == MAP_FAILED) {
-		throw FilesystemException("mmap(" + fname + ") failed: " + errorString(errno));
-	}
-	uint64_t lastLogVersion = 0;
-	// first LF is (should be) the last byte of the file
-	if (fileSize == 0 || fileContent[fileSize - 1] != '\n') {
-		throw ParseException("truncated changelog " + fname +
-				" (no LF at the end of the last line)");
-	} else {
-		size_t pos = fileSize - 1;
-		while (pos > 0) {
-			--pos;
-			if (fileContent[pos] == '\n') {
-				break;
-			}
-		}
-		char *endPtr = NULL;
-		lastLogVersion = strtoull(fileContent + pos, &endPtr, 10);
-		if (*endPtr != ':') {
-			throw ParseException("malformed changelog " + fname +
-					" (expected colon after change number)");
-		}
-	}
-	if (munmap((void*) fileContent, fileSize)) {
-		safs_pretty_errlog(LOG_WARNING, "munmap(%s) failed", fname.c_str());
-	}
-	return lastLogVersion;
-}
 
 static bool xattr_load(MetadataLoader::Options options) {
 	const uint8_t *ptr;
@@ -1608,89 +1436,6 @@ void MetadataBackendFile::store_fd(FILE *fd) {
 	} else {
 		store(fd, metadataVersion);
 	}
-}
-
-#else   // #ifndef METALOGGER
-
-uint64_t MetadataBackendFile::findLastLogVersion() {
-	struct stat st;
-	uint8_t buff[32800];    // 32800 = 32768 + 32
-	uint64_t size;
-	uint32_t buffpos;
-	uint64_t lastnewline;
-	int fd;
-	uint64_t lastlogversion = 0;
-
-	if ((stat(kMetadataMlFilename, &st) < 0) || (st.st_size == 0) || ((st.st_mode & S_IFMT) != S_IFREG)) {
-		return 0;
-	}
-
-	fd = open(kChangelogMlFilename, O_RDWR);
-	if (fd<0) {
-		return 0;
-	}
-
-	::fstat(fd, &st);
-	size = st.st_size;
-	memset(buff,0,32);
-	lastnewline = 0;
-
-	while (size>0 && size+200000>(uint64_t)(st.st_size)) {
-		if (size>32768) {
-			memcpy(buff+32768,buff,32);
-			size-=32768;
-			lseek(fd,size,SEEK_SET);
-			if (read(fd,buff,32768)!=32768) {
-				lastlogversion = 0;
-				close(fd);
-				return lastlogversion;
-			}
-			buffpos = 32768;
-		} else {
-			memmove(buff+size,buff,32);
-			lseek(fd,0,SEEK_SET);
-			if (read(fd,buff,size)!=(ssize_t)size) {
-				lastlogversion = 0;
-				close(fd);
-				return lastlogversion;
-			}
-			buffpos = size;
-			size = 0;
-		}
-		// size = position in file of first byte in buff
-		// buffpos = position of last byte in buff to search
-		while (buffpos>0) {
-			buffpos--;
-			if (buff[buffpos]=='\n') {
-				if (lastnewline==0) {
-					lastnewline = size + buffpos;
-				} else {
-					if (lastnewline+1 != (uint64_t)(st.st_size)) {  // garbage at the end of file - truncate
-						if (ftruncate(fd,lastnewline+1)<0) {
-							lastlogversion = 0;
-							close(fd);
-							return lastlogversion;
-						}
-					}
-					buffpos++;
-					while (buffpos<32800 && buff[buffpos]>='0' && buff[buffpos]<='9') {
-						lastlogversion *= 10;
-						lastlogversion += buff[buffpos]-'0';
-						buffpos++;
-					}
-					if (buffpos==32800 || buff[buffpos]!=':') {
-						lastlogversion = 0;
-					}
-					close(fd);
-					return lastlogversion;
-				}
-			}
-		}
-	}
-
-	close(fd);
-
-	return lastlogversion;
 }
 
 #endif  // #ifndef METALOGGER

--- a/src/master/metadata_backend_file.h
+++ b/src/master/metadata_backend_file.h
@@ -44,28 +44,12 @@ public:
 	/// Load complete metadata from the given file.
 	/// @param fname -- path to the metadata file.
 	void loadall(const std::string &fname, int ignoreflag) override;
-
-	/// Returns version of the first entry in a changelog.
-	/// @param file -- path to the changelog file
-	/// @return 0 in case of any error.
-	uint64_t changelogGetFirstLogVersion(const std::string &fname) override;
-	/// Returns version of the last entry in a changelog.
-	/// @param file -- path to the changelog file
-	/// @return 0 in case of any error.
-	uint64_t changelogGetLastLogVersion(const std::string& fname) override;
-#else   // #ifndef METALOGGER
-	uint64_t findLastLogVersion() override;
 #endif  // #ifndef METALOGGER
 
 #if !defined(METARESTORE) && !defined(METALOGGER)
 	/// Broadcasts information about status of the freshly finished
 	/// metadata save process to interested modules.
 	void broadcast_metadata_saved(uint8_t status) override;
-
-	/// Load and apply changelogs.
-	void load_changelogs() override;
-	/// Load and apply given changelog file.
-	void load_changelog(const std::string &path) override;
 
 	/// Commits the metadata dump by rotating the metadata files and renaming
 	/// the temporary file.

--- a/src/master/metadata_backend_interface.h
+++ b/src/master/metadata_backend_interface.h
@@ -25,15 +25,9 @@
 #include <cstdint>
 
 #include <common/exceptions.h>
+#include <master/exceptions.h>
 #include <master/filesystem_node_types.h>
 #include <master/metadata_dumper_interface.h>
-
-// Metadata related exceptions
-SAUNAFS_CREATE_EXCEPTION_CLASS(MetadataCheckException, Exception);
-SAUNAFS_CREATE_EXCEPTION_CLASS(MetadataException, Exception);
-SAUNAFS_CREATE_EXCEPTION_CLASS(MetadataFsConsistencyException,
-                               MetadataException);
-SAUNAFS_CREATE_EXCEPTION_CLASS(MetadataConsistencyException, MetadataException);
 
 // Constants
 constexpr uint16_t kEdgeNameMaxSize = 65535;
@@ -41,18 +35,16 @@ constexpr uint8_t kEdgeHeaderSize =
     sizeof(FSNode::id) + sizeof(FSNode::id) + sizeof(kEdgeNameMaxSize);
 
 constexpr uint8_t kNodeHeaderSize =
-    sizeof(FSNode::type) + sizeof(FSNode::id) + sizeof(FSNode::goal) +
-    sizeof(FSNode::mode) + sizeof(FSNode::uid) + sizeof(FSNode::gid) +
-    sizeof(FSNode::atime) + sizeof(FSNode::mtime) + sizeof(FSNode::ctime) +
-    sizeof(FSNode::trashtime);
+    sizeof(FSNode::type) + sizeof(FSNode::id) + sizeof(FSNode::goal) + sizeof(FSNode::mode) +
+    sizeof(FSNode::uid) + sizeof(FSNode::gid) + sizeof(FSNode::atime) + sizeof(FSNode::mtime) +
+    sizeof(FSNode::ctime) + sizeof(FSNode::trashtime);
 // FSNodeFile is the longer type of FSNode, so we use it as the buffer size
 constexpr uint8_t kFileSpecificHeaderSize =
     sizeof(FSNodeFile::length) + sizeof(uint32_t) + sizeof(uint16_t);
 constexpr uint32_t kChunksBucketSize = 65536;
 constexpr uint16_t kMaxSessionSize = 65535;
 constexpr uint32_t kFileSpecificExtraSize =
-    (sizeof(uint64_t) * kChunksBucketSize) +
-    (sizeof(uint32_t) * kMaxSessionSize);
+    (sizeof(uint64_t) * kChunksBucketSize) + (sizeof(uint32_t) * kMaxSessionSize);
 
 // TODO (Baldor): Review the need for these constants below
 constexpr uint8_t kMetadataVersionLegacy = 0x15;
@@ -61,15 +53,13 @@ constexpr uint8_t kMetadataVersionWithSections = 0x20;
 constexpr uint8_t kMetadataVersionWithLockIds = 0x29;
 constexpr int8_t kOpSuccess = 0;
 constexpr int8_t kOpFailure = -1;
-constexpr char const MetadataStructureReadErrorMsg[] =
-    "error reading metadata (structure)";
+constexpr char const MetadataStructureReadErrorMsg[] = "error reading metadata (structure)";
 
 // Global variables
 inline uint8_t gEdgeStoreBuffer[kEdgeHeaderSize + kEdgeNameMaxSize];
-inline uint8_t gNodeStoreBuffer[kNodeHeaderSize + kFileSpecificHeaderSize +
-                                kFileSpecificExtraSize];
+inline uint8_t gNodeStoreBuffer[kNodeHeaderSize + kFileSpecificHeaderSize + kFileSpecificExtraSize];
 
-// Number of changelog file versions
+// Number of metadata file versions to keep
 inline uint32_t gStoredPreviousBackMetaCopies;
 
 class IMetadataBackend {
@@ -101,17 +91,6 @@ public:
 	/// @param fname -- path hint to the metadata file, directory or database
 	///                 (to be defined by the concrete implementation)
 	virtual void loadall(const std::string &fname, int ignoreflag) = 0;
-
-	/// Returns version of the first entry in a changelog.
-	/// @param file -- path to the changelog file
-	/// @return 0 in case of any error.
-	virtual uint64_t changelogGetFirstLogVersion(const std::string& fname) = 0;
-	/// Returns version of the last entry in a changelog.
-	/// @param file -- path to the changelog file
-	/// @return 0 in case of any error.
-	virtual uint64_t changelogGetLastLogVersion(const std::string& fname) = 0;
-#else   // #ifndef METALOGGER
-	virtual uint64_t findLastLogVersion() = 0;
 #endif  // #ifndef METALOGGER
 
 // Available for master and shadow only
@@ -119,11 +98,6 @@ public:
 	/// Broadcasts information about status of the freshly finished
 	/// metadata save process to interested modules.
 	virtual void broadcast_metadata_saved(uint8_t status) = 0;
-
-	/// Load and apply changelogs.
-	virtual void load_changelogs() = 0;
-	/// Load and apply given changelog file.
-	virtual void load_changelog(const std::string &path) = 0;
 
 	/// Commits the metadata dump by rotating the metadata according the the
 	/// concrete implementation.

--- a/src/metarestore/CMakeLists.txt
+++ b/src/metarestore/CMakeLists.txt
@@ -18,7 +18,8 @@ add_library(metarestore ${METARESTORE_SOURCES} ${METARESTORE_MASTER_SOURCES} ${M
   ${METARESTORE_BACKEND_SOURCES}
   ../master/acl_storage.cc ../master/chunks.cc ../common/quota_database.cc ../master/chunk_goal_counters.cc
   ../master/restore.cc ../master/locks.cc ../master/task_manager.cc ../master/snapshot_task.cc
-  ../master/metadata_loader.cc ../master/setgoal_task.cc ../master/settrashtime_task.cc)
+  ../master/metadata_loader.cc ../master/setgoal_task.cc ../master/settrashtime_task.cc
+  ../master/changelog.cc)
 
 target_link_libraries(metarestore metrics sfscommon)
 if(JUDY_LIBRARY)

--- a/src/metarestore/main.cc
+++ b/src/metarestore/main.cc
@@ -37,6 +37,7 @@
 #include "common/cwrap.h"
 #include "common/rotate_files.h"
 #include "common/setup.h"
+#include "master/changelog.h"
 #include "master/chunks.h"
 #include "master/filesystem.h"
 #include "master/hstring_memstorage.h"
@@ -160,8 +161,8 @@ void meta_version_on_disk(std::string path) {
 		try {
 			if (fs::exists(fullFileName)) {
 				oldExists = true;
-				uint64_t first = gMetadataBackend->changelogGetFirstLogVersion(fullFileName);
-				uint64_t last = gMetadataBackend->changelogGetLastLogVersion(fullFileName);
+				uint64_t first = changelogGetFirstLogVersion(fullFileName);
+				uint64_t last = changelogGetLastLogVersion(fullFileName);
 				if (last >= first  && first <= metadata_version) {
 					if (last >= metadata_version) {
 						metadata_version = last + 1;
@@ -370,9 +371,9 @@ int main(int argc,char **argv) {
 		while ((dp = readdir(dd)) != NULL) {
 			if (changelog_checkname(dp->d_name)) {
 				filenames.push_back(datapath + "/" + dp->d_name);
-				firstlv = gMetadataBackend->changelogGetFirstLogVersion(filenames.back());
+				firstlv = changelogGetFirstLogVersion(filenames.back());
 				try {
-					lastlv = gMetadataBackend->changelogGetLastLogVersion(filenames.back());
+					lastlv = changelogGetLastLogVersion(filenames.back());
 				} catch (const Exception& ex) {
 					safs_pretty_syslog(LOG_WARNING, "%s", ex.what());
 					lastlv = 0;
@@ -419,9 +420,9 @@ int main(int argc,char **argv) {
 		std::vector<std::string> filenames;
 
 		for (pos=0 ; (int32_t)pos<argc ; pos++) {
-			firstlv = gMetadataBackend->changelogGetFirstLogVersion(argv[pos]);
+			firstlv = changelogGetFirstLogVersion(argv[pos]);
 			try {
-				lastlv = gMetadataBackend->changelogGetLastLogVersion(argv[pos]);
+				lastlv = changelogGetLastLogVersion(argv[pos]);
 			} catch (const Exception& ex) {
 				safs_pretty_syslog(LOG_WARNING, "%s", ex.what());
 				lastlv = 0;


### PR DESCRIPTION
Some of the functions related to changelogs were not correctly declared in IMetadataBackend and implemented in MetadataBackendFile.

This change moves those functions to the proper place, which improves the modularity and simplifies the interface for metadata backends.

The code was just moved with minimal changes to ease the review. The logic remains the same.