### PR TITLE
Refactor filesystem metadata

### DIFF
--- a/src/master/changelog.cc
+++ b/src/master/changelog.cc
@@ -335,7 +335,7 @@ void load_changelog(const std::string &path) {
 	std::ifstream changelog(path);
 	std::string line;
 	size_t end = 0;
-	sassert(gMetadata->metaversion > 0);
+	sassert(gMetadata->metadataVersion > 0);
 
 	uint64_t first = 0;
 	uint64_t id = 0;

--- a/src/master/filesystem.cc
+++ b/src/master/filesystem.cc
@@ -157,7 +157,7 @@ void fs_term(void) {
 		// which tells that the lockfile is not left because of a crash, but because we have been
 		// asked to stop without saving metadata. Include information about version of metadata
 		// which can be recovered using our changelogs.
-		auto message = "quick_stop: " + std::to_string(gMetadata->metaversion) + "\n";
+		auto message = "quick_stop: " + std::to_string(gMetadata->metadataVersion) + "\n";
 		gMetadataLockfile->writeMessage(message);
 	} else {
 		// We will leave the lockfile present to indicate, that our metadata.sfs file should not be

--- a/src/master/filesystem.h
+++ b/src/master/filesystem.h
@@ -215,9 +215,9 @@ void fs_disable_checksum_verification(bool value);
 
 // Functions which modify metadata or return some information.
 // To be used by the master server with personality == kMaster
-void fs_info(uint64_t *totalspace, uint64_t *availspace, uint64_t *trspace, inode_t *trnodes,
-             uint64_t *respace, inode_t *renodes, inode_t *inodes, inode_t *dnodes, inode_t *fnodes,
-             inode_t *lnodes);
+void fs_info(uint64_t *totalSpace, uint64_t *availableSpace, uint64_t *trashSpace,
+             inode_t *trashNodes, uint64_t *reservedSpace, inode_t *reservedNodes, inode_t *inodes,
+             inode_t *directoryNodes, inode_t *fileNodes, inode_t *linkNodes);
 uint32_t fs_getdirpath_size(inode_t inode);
 void fs_getdirpath_data(inode_t inode, uint8_t *buff, uint32_t size);
 uint8_t fs_getrootinode(inode_t *rootinode, const uint8_t *path);

--- a/src/master/filesystem_checksum.cc
+++ b/src/master/filesystem_checksum.cc
@@ -119,7 +119,7 @@ static void fsnodes_recalculate_checksum() {
 	gMetadata->fsNodesChecksum = NODECHECKSUMSEED;  // arbitrary number
 	// nodes
 	for (uint32_t i = 0; i < NODEHASHSIZE; i++) {
-		for (const auto& node : gMetadata->nodehash[i]) {
+		for (const auto& node : gMetadata->nodeHash[i]) {
 			node->checksum = fsnodes_checksum(node, true);
 			addToChecksum(gMetadata->fsNodesChecksum, node->checksum);
 		}
@@ -128,17 +128,17 @@ static void fsnodes_recalculate_checksum() {
 
 uint64_t fs_checksum(ChecksumMode mode) {
 	uint64_t checksum = 0x1251;
-	hashCombine(checksum, gMetadata->maxnodeid);
-	hashCombine(checksum, gMetadata->metaversion);
-	hashCombine(checksum, gMetadata->nextsessionid);
+	hashCombine(checksum, gMetadata->maxInodeId);
+	hashCombine(checksum, gMetadata->metadataVersion);
+	hashCombine(checksum, gMetadata->nextSessionId);
 	if (mode == ChecksumMode::kForceRecalculate) {
 		fsnodes_recalculate_checksum();
 		xattr_recalculate_checksum();
-		gMetadata->quota_checksum = gMetadata->quota_database.checksum();
+		gMetadata->quotaChecksum = gMetadata->quotaDatabase.checksum();
 	}
 	hashCombine(checksum, gMetadata->fsNodesChecksum);
 	hashCombine(checksum, gMetadata->xattrChecksum);
-	hashCombine(checksum, gMetadata->quota_checksum);
+	hashCombine(checksum, gMetadata->quotaChecksum);
 	hashCombine(checksum, chunk_checksum(mode));
 	return checksum;
 }

--- a/src/master/filesystem_checksum.cc
+++ b/src/master/filesystem_checksum.cc
@@ -119,7 +119,7 @@ static void fsnodes_recalculate_checksum() {
 	gMetadata->fsNodesChecksum = NODECHECKSUMSEED;  // arbitrary number
 	// nodes
 	for (uint32_t i = 0; i < NODEHASHSIZE; i++) {
-		for (FSNode *node = gMetadata->nodehash[i]; node; node = node->next) {
+		for (const auto& node : gMetadata->nodehash[i]) {
 			node->checksum = fsnodes_checksum(node, true);
 			addToChecksum(gMetadata->fsNodesChecksum, node->checksum);
 		}

--- a/src/master/filesystem_checksum_background_updater.cc
+++ b/src/master/filesystem_checksum_background_updater.cc
@@ -89,7 +89,7 @@ bool ChecksumBackgroundUpdater::isXattrIncluded(XAttributeDataEntry *xattrDataEn
 	}
 
 	if (step_ == ChecksumRecalculatingStep::kXattrs &&
-	    get_xattr_data_hash(xattrDataEntry->inode, xattrDataEntry->attributeNameLength,
+	    get_xattr_data_hash(xattrDataEntry->inode, xattrDataEntry->attributeName.size(),
 	                        xattrDataEntry->attributeName.data()) < position_) {
 		ret = true;
 	}

--- a/src/master/filesystem_checksum_background_updater.cc
+++ b/src/master/filesystem_checksum_background_updater.cc
@@ -88,7 +88,7 @@ bool ChecksumBackgroundUpdater::isXattrIncluded(xattr_data_entry *xde) {
 		ret = true;
 	}
 	if (step_ == ChecksumRecalculatingStep::kXattrs &&
-	    xattr_data_hash_fn(xde->inode, xde->anleng, xde->attrname) < position_) {
+	    xattr_data_hash_fn(xde->inode, xde->anleng, xde->attributeName.data()) < position_) {
 		ret = true;
 	}
 	if (ret) {

--- a/src/master/filesystem_checksum_background_updater.cc
+++ b/src/master/filesystem_checksum_background_updater.cc
@@ -82,20 +82,24 @@ bool ChecksumBackgroundUpdater::isNodeIncluded(FSNode *node) {
 	return ret;
 }
 
-bool ChecksumBackgroundUpdater::isXattrIncluded(xattr_data_entry *xde) {
+bool ChecksumBackgroundUpdater::isXattrIncluded(XAttributeDataEntry *xattrDataEntry) {
 	auto ret = false;
 	if (step_ > ChecksumRecalculatingStep::kXattrs) {
 		ret = true;
 	}
+
 	if (step_ == ChecksumRecalculatingStep::kXattrs &&
-	    xattr_data_hash_fn(xde->inode, xde->anleng, xde->attributeName.data()) < position_) {
+	    get_xattr_data_hash(xattrDataEntry->inode, xattrDataEntry->attributeNameLength,
+	                        xattrDataEntry->attributeName.data()) < position_) {
 		ret = true;
 	}
+
 	if (ret) {
 		safs::log_trace("master.fs.checksum.changing_recalculated_xattr");
 	} else {
 		safs::log_trace("master.fs.checksum.changing_not_recalculated_xattr");
 	}
+
 	return ret;
 }
 

--- a/src/master/filesystem_checksum_background_updater.h
+++ b/src/master/filesystem_checksum_background_updater.h
@@ -79,7 +79,7 @@ public:
 	bool isNodeIncluded(FSNode *node);
 
 	// is xattr already included in the background checksum?
-	bool isXattrIncluded(xattr_data_entry *xde);
+	bool isXattrIncluded(XAttributeDataEntry *xattrDataEntry);
 
 	void setSpeedLimit(uint32_t value);
 

--- a/src/master/filesystem_checksum_updater.h
+++ b/src/master/filesystem_checksum_updater.h
@@ -40,7 +40,7 @@ public:
 	}
 
 	~ChecksumUpdater() {
-		if (gMetadata->metaversion > lastEntry_ + period_) {
+		if (gMetadata->metadataVersion > lastEntry_ + period_) {
 			writeToChangelog(ts_);
 		}
 	}
@@ -51,7 +51,7 @@ public:
 
 protected:
 	static void writeToChangelog(uint32_t ts) {
-		lastEntry_ = gMetadata->metaversion;
+		lastEntry_ = gMetadata->metadataVersion;
 		if (metadataserver::isMaster() && !gChecksumBackgroundUpdater.inProgress()) {
 			std::string versionString = saunafsVersionToString(SAUNAFS_VERSHEX);
 			uint64_t checksum = fs_checksum(ChecksumMode::kGetCurrent);

--- a/src/master/filesystem_dump.cc
+++ b/src/master/filesystem_dump.cc
@@ -119,11 +119,9 @@ void fs_dumpnode(FSNode *f) {
 }
 
 void fs_dumpnodes() {
-	uint32_t i;
-	FSNode *p;
-	for (i = 0; i < NODEHASHSIZE; i++) {
-		for (p = gMetadata->nodehash[i]; p; p = p->next) {
-			fs_dumpnode(p);
+	for (uint32_t i = 0; i < NODEHASHSIZE; i++) {
+		for (const auto &node : gMetadata->nodehash[i]) {
+			fs_dumpnode(node);
 		}
 	}
 }

--- a/src/master/filesystem_dump.cc
+++ b/src/master/filesystem_dump.cc
@@ -120,7 +120,7 @@ void fs_dumpnode(FSNode *f) {
 
 void fs_dumpnodes() {
 	for (uint32_t i = 0; i < NODEHASHSIZE; i++) {
-		for (const auto &node : gMetadata->nodehash[i]) {
+		for (const auto &node : gMetadata->nodeHash[i]) {
 			fs_dumpnode(node);
 		}
 	}
@@ -170,17 +170,22 @@ void fs_dumpedges(FSNodeDirectory *parent) {
 }
 
 void fs_dumpfree() {
-	for (const auto &n : gMetadata->inode_pool) {
+	for (const auto &n : gMetadata->inodePool) {
 		printf("I|i:%10" PRIiNode "|f:%10" PRIu32 "\n", n.id, n.ts);
 	}
 }
 
 void xattr_dump() {
 	for (auto i = 0; i < XATTR_DATA_HASH_SIZE; i++) {
-		for (const auto &xa : gMetadata->xattr_data_hash[i]) {
-			printf("X|i:%10" PRIiNode "|n:%s|v:%s\n", xa->inode,
-			       fsnodes_escape_name(std::string((char*)xa->attributeName.data(), xa->anleng)).c_str(),
-			       fsnodes_escape_name(std::string((char*)xa->attributeValue.data(), xa->avleng)).c_str());
+		for (const auto &xattrDataEntry : gMetadata->xattrDataHash[i]) {
+			printf(
+			    "X|i:%10" PRIiNode "|n:%s|v:%s\n", xattrDataEntry.get()->inode,
+			    fsnodes_escape_name(std::string((char *)xattrDataEntry.get()->attributeName.data(),
+			                                    xattrDataEntry.get()->attributeNameLength))
+			        .c_str(),
+			    fsnodes_escape_name(std::string((char *)xattrDataEntry.get()->attributeValue.data(),
+			                                    xattrDataEntry.get()->attributeValueLength))
+			        .c_str());
 		}
 	}
 }

--- a/src/master/filesystem_dump.cc
+++ b/src/master/filesystem_dump.cc
@@ -181,10 +181,10 @@ void xattr_dump() {
 			printf(
 			    "X|i:%10" PRIiNode "|n:%s|v:%s\n", xattrDataEntry.get()->inode,
 			    fsnodes_escape_name(std::string((char *)xattrDataEntry.get()->attributeName.data(),
-			                                    xattrDataEntry.get()->attributeNameLength))
+			                                    xattrDataEntry.get()->attributeName.size()))
 			        .c_str(),
 			    fsnodes_escape_name(std::string((char *)xattrDataEntry.get()->attributeValue.data(),
-			                                    xattrDataEntry.get()->attributeValueLength))
+			                                    xattrDataEntry.get()->attributeValue.size()))
 			        .c_str());
 		}
 	}

--- a/src/master/filesystem_dump.cc
+++ b/src/master/filesystem_dump.cc
@@ -176,11 +176,8 @@ void fs_dumpfree() {
 }
 
 void xattr_dump() {
-	uint32_t i;
-	xattr_data_entry *xa;
-
-	for (i = 0; i < XATTR_DATA_HASH_SIZE; i++) {
-		for (xa = gMetadata->xattr_data_hash[i]; xa; xa = xa->next) {
+	for (auto i = 0; i < XATTR_DATA_HASH_SIZE; i++) {
+		for (const auto &xa : gMetadata->xattr_data_hash[i]) {
 			printf("X|i:%10" PRIiNode "|n:%s|v:%s\n", xa->inode,
 			       fsnodes_escape_name(std::string((char*)xa->attributeName.data(), xa->anleng)).c_str(),
 			       fsnodes_escape_name(std::string((char*)xa->attributeValue.data(), xa->avleng)).c_str());

--- a/src/master/filesystem_dump.cc
+++ b/src/master/filesystem_dump.cc
@@ -184,8 +184,8 @@ void xattr_dump() {
 	for (i = 0; i < XATTR_DATA_HASH_SIZE; i++) {
 		for (xa = gMetadata->xattr_data_hash[i]; xa; xa = xa->next) {
 			printf("X|i:%10" PRIiNode "|n:%s|v:%s\n", xa->inode,
-			       fsnodes_escape_name(std::string((char*)xa->attrname, xa->anleng)).c_str(),
-			       fsnodes_escape_name(std::string((char*)xa->attrvalue, xa->avleng)).c_str());
+			       fsnodes_escape_name(std::string((char*)xa->attributeName.data(), xa->anleng)).c_str(),
+			       fsnodes_escape_name(std::string((char*)xa->attributeValue.data(), xa->avleng)).c_str());
 		}
 	}
 }

--- a/src/master/filesystem_freenode.cc
+++ b/src/master/filesystem_freenode.cc
@@ -25,14 +25,14 @@
 #include "master/filesystem_metadata.h"
 
 inode_t fsnodes_get_next_id(uint32_t ts, inode_t req_inode) {
-	if(req_inode == 0 || !gMetadata->inode_pool.markAsAcquired(req_inode,ts)) {
-		req_inode = gMetadata->inode_pool.acquire(ts);
+	if(req_inode == 0 || !gMetadata->inodePool.markAsAcquired(req_inode,ts)) {
+		req_inode = gMetadata->inodePool.acquire(ts);
 	}
 	if (req_inode == 0) {
 		mabort("Out of free inode numbers");
 	}
-	if (req_inode > gMetadata->maxnodeid) {
-		gMetadata->maxnodeid = req_inode;
+	if (req_inode > gMetadata->maxInodeId) {
+		gMetadata->maxInodeId = req_inode;
 	}
 
 	return req_inode;
@@ -40,6 +40,6 @@ inode_t fsnodes_get_next_id(uint32_t ts, inode_t req_inode) {
 
 uint8_t fs_apply_freeinodes(uint32_t /*ts*/, inode_t /*freeinodes*/) {
 	// left for compatibility when reading from old metadata change log
-	gMetadata->metaversion++;
+	gMetadata->metadataVersion++;
 	return 0;
 }

--- a/src/master/filesystem_metadata.h
+++ b/src/master/filesystem_metadata.h
@@ -37,6 +37,8 @@
 using xattr_inode_entry_pointer = std::unique_ptr<xattr_inode_entry>;
 using xattr_inode_entry_list = std::list<xattr_inode_entry_pointer>;
 
+using FSNodePointerList = std::list<FSNode*>;
+
 /** Metadata of the filesystem.
  *  All the static variables managed by function in this file which form metadata of the filesystem.
  */
@@ -50,7 +52,7 @@ public:
 	TrashPathContainer trash;
 	ReservedPathContainer reserved;
 	FSNodeDirectory *root;
-	FSNode *nodehash[NODEHASHSIZE];
+	std::array<FSNodePointerList, NODEHASHSIZE> nodehash;
 	TaskManager task_manager;
 	FileLocks flock_locks;
 	FileLocks posix_locks;
@@ -116,12 +118,10 @@ public:
 
 		// Free memory allocated in nodehash hashmap
 		for (uint32_t i = 0; i < NODEHASHSIZE; ++i) {
-			FSNode *node = nodehash[i];
-			while (node != nullptr) {
-				FSNode *next = node->next;
+			for (const auto &node : nodehash[i]) {
 				FSNode::destroy(node);
-				node = next;
 			}
+			nodehash[i].clear();
 		}
 	}
 

--- a/src/master/filesystem_metadata.h
+++ b/src/master/filesystem_metadata.h
@@ -37,6 +37,9 @@
 using xattr_inode_entry_pointer = std::unique_ptr<xattr_inode_entry>;
 using xattr_inode_entry_list = std::list<xattr_inode_entry_pointer>;
 
+using xattr_data_entry_pointer = std::unique_ptr<xattr_data_entry>;
+using xattr_data_entry_list = std::list<xattr_data_entry_pointer>;
+
 using FSNodePointerList = std::list<FSNode*>;
 
 /** Metadata of the filesystem.
@@ -45,7 +48,7 @@ using FSNodePointerList = std::list<FSNode*>;
 struct FilesystemMetadata {
 public:
 	std::array<xattr_inode_entry_list, XATTR_INODE_HASH_SIZE> xattr_inode_hash;
-	xattr_data_entry *xattr_data_hash[XATTR_DATA_HASH_SIZE];
+	std::array<xattr_data_entry_list, XATTR_DATA_HASH_SIZE> xattr_data_hash;
 	// TODO(Guillex): Check implications of using 64 bits for inode_t in this structure.
 	IdPoolDetainer<inode_t, uint32_t> inode_pool;
 	AclStorage acl_storage;
@@ -113,7 +116,7 @@ public:
 
 		// Free memory allocated in xattr_data_hash hashmap
 		for (uint32_t i = 0; i < XATTR_DATA_HASH_SIZE; ++i) {
-			deleteListConnectedUsingNext(xattr_data_hash[i]);
+			xattr_data_hash[i].clear();
 		}
 
 		// Free memory allocated in nodehash hashmap

--- a/src/master/filesystem_metadata.h
+++ b/src/master/filesystem_metadata.h
@@ -34,12 +34,15 @@
 #include "master/locks.h"
 #include "master/task_manager.h"
 
+using xattr_inode_entry_pointer = std::unique_ptr<xattr_inode_entry>;
+using xattr_inode_entry_list = std::list<xattr_inode_entry_pointer>;
+
 /** Metadata of the filesystem.
  *  All the static variables managed by function in this file which form metadata of the filesystem.
  */
 struct FilesystemMetadata {
 public:
-	xattr_inode_entry *xattr_inode_hash[XATTR_INODE_HASH_SIZE];
+	std::array<xattr_inode_entry_list, XATTR_INODE_HASH_SIZE> xattr_inode_hash;
 	xattr_data_entry *xattr_data_hash[XATTR_DATA_HASH_SIZE];
 	// TODO(Guillex): Check implications of using 64 bits for inode_t in this structure.
 	IdPoolDetainer<inode_t, uint32_t> inode_pool;
@@ -103,7 +106,7 @@ public:
 	~FilesystemMetadata() {
 		// Free memory allocated in xattr_inode_hash hashmap
 		for (uint32_t i = 0; i < XATTR_INODE_HASH_SIZE; ++i) {
-			freeListConnectedUsingNext(xattr_inode_hash[i]);
+			xattr_inode_hash[i].clear();
 		}
 
 		// Free memory allocated in xattr_data_hash hashmap

--- a/src/master/filesystem_metadata.h
+++ b/src/master/filesystem_metadata.h
@@ -34,11 +34,11 @@
 #include "master/locks.h"
 #include "master/task_manager.h"
 
-using xattr_inode_entry_pointer = std::unique_ptr<xattr_inode_entry>;
-using xattr_inode_entry_list = std::list<xattr_inode_entry_pointer>;
+using XAttributeInodeEntryPointer = std::unique_ptr<XAttributeInodeEntry>;
+using XAttributeInodeEntryList = std::list<XAttributeInodeEntryPointer>;
 
-using xattr_data_entry_pointer = std::unique_ptr<xattr_data_entry>;
-using xattr_data_entry_list = std::list<xattr_data_entry_pointer>;
+using XAttributeDataEntryPointer = std::unique_ptr<XAttributeDataEntry>;
+using XAttributeDataEntryList = std::list<XAttributeDataEntryPointer>;
 
 using FSNodePointerList = std::list<FSNode*>;
 
@@ -47,107 +47,63 @@ using FSNodePointerList = std::list<FSNode*>;
  */
 struct FilesystemMetadata {
 public:
-	std::array<xattr_inode_entry_list, XATTR_INODE_HASH_SIZE> xattr_inode_hash;
-	std::array<xattr_data_entry_list, XATTR_DATA_HASH_SIZE> xattr_data_hash;
+	std::array<XAttributeInodeEntryList, XATTR_INODE_HASH_SIZE> xattrInodeHash;
+	std::array<XAttributeDataEntryList, XATTR_DATA_HASH_SIZE> xattrDataHash;
 	// TODO(Guillex): Check implications of using 64 bits for inode_t in this structure.
-	IdPoolDetainer<inode_t, uint32_t> inode_pool;
-	AclStorage acl_storage;
+	IdPoolDetainer<inode_t, uint32_t> inodePool;
+	AclStorage aclStorage;
 	TrashPathContainer trash;
 	ReservedPathContainer reserved;
-	FSNodeDirectory *root;
-	std::array<FSNodePointerList, NODEHASHSIZE> nodehash;
-	TaskManager task_manager;
-	FileLocks flock_locks;
-	FileLocks posix_locks;
+	FSNodeDirectory *root{};
+	std::array<FSNodePointerList, NODEHASHSIZE> nodeHash;
+	TaskManager taskManager;
+	FileLocks flockLocks;
+	FileLocks posixLocks;
 
-	inode_t maxnodeid;
-	uint32_t nextsessionid;
-	inode_t nodes;
-	uint64_t metaversion;
-	uint64_t trashspace;
-	uint64_t reservedspace;
-	inode_t trashnodes;
-	inode_t reservednodes;
-	inode_t filenodes;
-	inode_t dirnodes;
-	inode_t linknodes;
+	inode_t maxInodeId{};
+	uint32_t nextSessionId{};
+	inode_t nodes{};
+	uint64_t metadataVersion{};
+	uint64_t trashSpace{};
+	uint64_t reservedSpace{};
+	inode_t trashNodes{};
+	inode_t reservedNodes{};
+	inode_t fileNodes{};
+	inode_t dirNodes{};
+	inode_t linkNodes{};
 
-	QuotaDatabase quota_database;
+	QuotaDatabase quotaDatabase;
 
-	uint64_t fsNodesChecksum;
-	uint64_t xattrChecksum;
-	uint64_t quota_checksum;
+	uint64_t fsNodesChecksum{};
+	uint64_t xattrChecksum{};
+	uint64_t quotaChecksum{quotaDatabase.checksum()};
 
 	FilesystemMetadata()
-	    : xattr_inode_hash{},
-	      xattr_data_hash{},
-	      inode_pool{SFS_INODE_REUSE_DELAY, 12,
-	                 MAX_REGULAR_INODE, MAX_REGULAR_INODE,
-	                 32 * 8 * 1024, 8 * 1024, 10},
-	      trash{},
-	      reserved{},
-	      root{},
-	      nodehash{},
-	      task_manager{},
-	      flock_locks{},
-	      posix_locks{},
-	      maxnodeid{},
-	      nextsessionid{},
-	      nodes{},
-	      metaversion{},
-	      trashspace{},
-	      reservedspace{},
-	      trashnodes{},
-	      reservednodes{},
-	      filenodes{},
-	      dirnodes{},
-	      linknodes{},
-	      quota_database{},
-	      fsNodesChecksum{},
-	      xattrChecksum{},
-	      quota_checksum{quota_database.checksum()} {
-	}
+	    : inodePool{SFS_INODE_REUSE_DELAY,
+	                12,
+	                MAX_REGULAR_INODE,
+	                MAX_REGULAR_INODE,
+	                32 * 8 * 1024,
+	                8 * 1024,
+	                10} {}
 
 	~FilesystemMetadata() {
 		// Free memory allocated in xattr_inode_hash hashmap
 		for (uint32_t i = 0; i < XATTR_INODE_HASH_SIZE; ++i) {
-			xattr_inode_hash[i].clear();
+			xattrInodeHash[i].clear();
 		}
 
 		// Free memory allocated in xattr_data_hash hashmap
 		for (uint32_t i = 0; i < XATTR_DATA_HASH_SIZE; ++i) {
-			xattr_data_hash[i].clear();
+			xattrDataHash[i].clear();
 		}
 
 		// Free memory allocated in nodehash hashmap
 		for (uint32_t i = 0; i < NODEHASHSIZE; ++i) {
-			for (const auto &node : nodehash[i]) {
+			for (const auto &node : nodeHash[i]) {
 				FSNode::destroy(node);
 			}
-			nodehash[i].clear();
-		}
-	}
-
-private:
-	// Frees a C-style list with elements connected using e->next pointer and allocated using
-	// malloc
-	template <typename T>
-	void freeListConnectedUsingNext(T *&list) {
-		while (list != nullptr) {
-			T *next = list->next;
-			free(list);
-			list = next;
-		}
-	}
-
-	// Frees a C-style list with elements connected using e->next pointer and allocated using
-	// new
-	template <typename T>
-	void deleteListConnectedUsingNext(T *&list) {
-		while (list != nullptr) {
-			T *next = list->next;
-			delete list;
-			list = next;
+			nodeHash[i].clear();
 		}
 	}
 };

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -22,6 +22,7 @@
 
 #include "filesystem_node.h"
 
+#include <algorithm>
 #include <cassert>
 #include <cstdint>
 #include <cstdlib>
@@ -637,15 +638,18 @@ FSNode *fsnodes_create_node(uint32_t ts, FSNodeDirectory *parent, const HString 
 	} else {
 		node->gid = gid;
 	}
+
 	uint32_t nodepos = NODEHASHPOS(node->id);
-	node->next = gMetadata->nodehash[nodepos];
-	gMetadata->nodehash[nodepos] = node;
+	gMetadata->nodehash[nodepos].push_front(node);
+
 	fsnodes_update_checksum(node);
 	fsnodes_link(ts, parent, node, name);
 	fsnodes_quota_update(node, {{QuotaResource::kInodes, +1}});
+
 	if (type == FSNode::kFile) {
 		fsnodes_quota_update(node, {{QuotaResource::kSize, +fsnodes_get_size(node)}});
 	}
+
 	return node;
 }
 
@@ -1303,14 +1307,13 @@ static inline void fsnodes_remove_node(uint32_t ts, FSNode *toremove) {
 	}
 	// remove from idhash
 	uint32_t nodepos = NODEHASHPOS(toremove->id);
-	FSNode **ptr = &(gMetadata->nodehash[nodepos]);
-	while (*ptr) {
-		if (*ptr == toremove) {
-			*ptr = toremove->next;
-			break;
-		}
-		ptr = &((*ptr)->next);
-	}
+	auto start = gMetadata->nodehash[nodepos].begin();
+	auto end = gMetadata->nodehash[nodepos].end();
+
+	auto found = std::find_if(start, end, [&](const auto &node) {
+		return node == toremove;
+	});
+
 	if (gChecksumBackgroundUpdater.isNodeIncluded(toremove)) {
 		removeFromChecksum(gChecksumBackgroundUpdater.fsNodesChecksum, toremove->checksum);
 	}
@@ -1349,6 +1352,9 @@ static inline void fsnodes_remove_node(uint32_t ts, FSNode *toremove) {
 	dcm_modify(toremove->id, 0);
 #endif
 	FSNode::destroy(toremove);
+	if (found != gMetadata->nodehash[nodepos].end()) {
+		gMetadata->nodehash[nodepos].erase(found);
+	}
 }
 
 void fsnodes_unlink(uint32_t ts, FSNodeDirectory *parent, const HString &child_name, FSNode *child) {

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -590,13 +590,13 @@ FSNode *fsnodes_create_node(uint32_t ts, FSNodeDirectory *parent, const HString 
 	FSNode *node = FSNode::create(type);
 	gMetadata->nodes++;
 	if (type == FSNode::kDirectory) {
-		gMetadata->dirnodes++;
+		gMetadata->dirNodes++;
 	}
 	if (type == FSNode::kFile) {
-		gMetadata->filenodes++;
+		gMetadata->fileNodes++;
 	}
 	if (type == FSNode::kSymlink) {
-		gMetadata->linknodes++;
+		gMetadata->linkNodes++;
 	}
 	/* create node */
 	node->id = fsnodes_get_next_id(ts, req_inode);
@@ -616,12 +616,12 @@ FSNode *fsnodes_create_node(uint32_t ts, FSNodeDirectory *parent, const HString 
 	}
 	// If desired, node inherits permissions from parent's default ACL
 	const RichACL *parent_acl = (inheritacl == AclInheritance::kInheritAcl)
-	                       ? gMetadata->acl_storage.get(parent->id) : nullptr;
+	                       ? gMetadata->aclStorage.get(parent->id) : nullptr;
 	if (parent_acl) {
 		RichACL acl;
 		uint16_t mode = node->mode;
 		if (RichACL::inheritInode(*parent_acl, mode, acl, umask, type == FSNode::kDirectory)) {
-			gMetadata->acl_storage.set(node->id, std::move(acl));
+			gMetadata->aclStorage.set(node->id, std::move(acl));
 		}
 		// Set effective permissions as the intersection of mode and ACL
 		node->mode &= mode | ~0777;
@@ -640,7 +640,7 @@ FSNode *fsnodes_create_node(uint32_t ts, FSNodeDirectory *parent, const HString 
 	}
 
 	uint32_t nodepos = NODEHASHPOS(node->id);
-	gMetadata->nodehash[nodepos].push_front(node);
+	gMetadata->nodeHash[nodepos].push_front(node);
 
 	fsnodes_update_checksum(node);
 	fsnodes_link(ts, parent, node, name);
@@ -1198,11 +1198,11 @@ uint8_t fsnodes_appendchunks(uint32_t ts, FSNodeFile *dst, FSNodeFile *src) {
 	uint64_t length =
 	    (static_cast<uint64_t>(dst_chunks) << SFSCHUNKBITS) + src->length;
 	if (dst->type == FSNode::kTrash) {
-		gMetadata->trashspace -= dst->length;
-		gMetadata->trashspace += length;
+		gMetadata->trashSpace -= dst->length;
+		gMetadata->trashSpace += length;
 	} else if (dst->type == FSNode::kReserved) {
-		gMetadata->reservedspace -= dst->length;
-		gMetadata->reservedspace += length;
+		gMetadata->reservedSpace -= dst->length;
+		gMetadata->reservedSpace += length;
 	}
 	dst->length = length;
 	fsnodes_get_stats(dst, &nsr);
@@ -1246,11 +1246,11 @@ void fsnodes_setlength(FSNodeFile *obj, uint64_t length, bool eraseFurtherChunks
 	statsrecord psr, nsr;
 	fsnodes_get_stats(obj, &psr);
 	if (obj->type == FSNode::kTrash) {
-		gMetadata->trashspace -= obj->length;
-		gMetadata->trashspace += length;
+		gMetadata->trashSpace -= obj->length;
+		gMetadata->trashSpace += length;
 	} else if (obj->type == FSNode::kReserved) {
-		gMetadata->reservedspace -= obj->length;
-		gMetadata->reservedspace += length;
+		gMetadata->reservedSpace -= obj->length;
+		gMetadata->reservedSpace += length;
 	}
 	obj->length = length;
 
@@ -1307,8 +1307,8 @@ static inline void fsnodes_remove_node(uint32_t ts, FSNode *toremove) {
 	}
 	// remove from idhash
 	uint32_t nodepos = NODEHASHPOS(toremove->id);
-	auto start = gMetadata->nodehash[nodepos].begin();
-	auto end = gMetadata->nodehash[nodepos].end();
+	auto start = gMetadata->nodeHash[nodepos].begin();
+	auto end = gMetadata->nodeHash[nodepos].end();
 
 	auto found = std::find_if(start, end, [&](const auto &node) {
 		return node == toremove;
@@ -1320,14 +1320,14 @@ static inline void fsnodes_remove_node(uint32_t ts, FSNode *toremove) {
 	removeFromChecksum(gMetadata->fsNodesChecksum, toremove->checksum);
 	// and free
 	gMetadata->nodes--;
-	gMetadata->acl_storage.erase(toremove->id);
+	gMetadata->aclStorage.erase(toremove->id);
 	if (toremove->type == FSNode::kDirectory) {
-		gMetadata->dirnodes--;
+		gMetadata->dirNodes--;
 	}
 	if (toremove->type == FSNode::kFile || toremove->type == FSNode::kTrash ||
 	    toremove->type == FSNode::kReserved) {
 		fsnodes_quota_update(toremove, {{QuotaResource::kSize, -fsnodes_get_size(toremove)}});
-		gMetadata->filenodes--;
+		gMetadata->fileNodes--;
 		for (uint32_t i = 0; i < static_cast<FSNodeFile*>(toremove)->chunks.size(); ++i) {
 			uint64_t chunkid = static_cast<FSNodeFile*>(toremove)->chunks[i];
 			if (chunkid > 0) {
@@ -1341,9 +1341,9 @@ static inline void fsnodes_remove_node(uint32_t ts, FSNode *toremove) {
 		}
 	}
 	if (toremove->type == FSNode::kSymlink) {
-		gMetadata->linknodes--;
+		gMetadata->linkNodes--;
 	}
-	gMetadata->inode_pool.release(toremove->id, ts, true);
+	gMetadata->inodePool.release(toremove->id, ts, true);
 	xattr_removeinode(toremove->id);
 	fsnodes_quota_update(toremove, {{QuotaResource::kInodes, -1}});
 	fsnodes_quota_remove(QuotaOwnerType::kInode, toremove->id);
@@ -1352,8 +1352,8 @@ static inline void fsnodes_remove_node(uint32_t ts, FSNode *toremove) {
 	dcm_modify(toremove->id, 0);
 #endif
 	FSNode::destroy(toremove);
-	if (found != gMetadata->nodehash[nodepos].end()) {
-		gMetadata->nodehash[nodepos].erase(found);
+	if (found != gMetadata->nodeHash[nodepos].end()) {
+		gMetadata->nodeHash[nodepos].erase(found);
 	}
 }
 
@@ -1383,16 +1383,16 @@ void fsnodes_unlink(uint32_t ts, FSNodeDirectory *parent, const HString &child_n
 
 			gMetadata->trash.insert({TrashPathKey(child), hstorage::Handle(path)});
 
-			gMetadata->trashspace += file_node->length;
-			gMetadata->trashnodes++;
+			gMetadata->trashSpace += file_node->length;
+			gMetadata->trashNodes++;
 		} else if (!file_node->sessionid.empty()) {
 			child->type = FSNode::kReserved;
 			fsnodes_update_checksum(child);
 
 			gMetadata->reserved.insert({child->id, hstorage::Handle(path)});
 
-			gMetadata->reservedspace += file_node->length;
-			gMetadata->reservednodes++;
+			gMetadata->reservedSpace += file_node->length;
+			gMetadata->reservedNodes++;
 		} else {
 			fsnodes_remove_node(ts, child);
 		}
@@ -1404,14 +1404,14 @@ void fsnodes_unlink(uint32_t ts, FSNodeDirectory *parent, const HString &child_n
 int fsnodes_purge(uint32_t ts, FSNode *p) {
 	if (p->type == FSNode::kTrash) {
 		FSNodeFile *file_node = static_cast<FSNodeFile*>(p);
-		gMetadata->trashspace -= file_node->length;
-		gMetadata->trashnodes--;
+		gMetadata->trashSpace -= file_node->length;
+		gMetadata->trashNodes--;
 
 		if (!file_node->sessionid.empty()) {
 			file_node->type = FSNode::kReserved;
 			fsnodes_update_checksum(file_node);
-			gMetadata->reservedspace += file_node->length;
-			gMetadata->reservednodes++;
+			gMetadata->reservedSpace += file_node->length;
+			gMetadata->reservedNodes++;
 			hstorage::Handle name_handle = std::move(gMetadata->trash.at(TrashPathKey(p)));
 			gMetadata->trash.erase(TrashPathKey(p));
 
@@ -1430,8 +1430,8 @@ int fsnodes_purge(uint32_t ts, FSNode *p) {
 	} else if (p->type == FSNode::kReserved) {
 		FSNodeFile *file_node = static_cast<FSNodeFile*>(p);
 
-		gMetadata->reservedspace -= file_node->length;
-		gMetadata->reservednodes--;
+		gMetadata->reservedSpace -= file_node->length;
+		gMetadata->reservedNodes--;
 
 		gMetadata->reserved.erase(file_node->id);
 
@@ -1524,8 +1524,8 @@ uint8_t fsnodes_undel(uint32_t ts, FSNodeFile *node) {
 			node->ctime = ts;
 			fsnodes_update_checksum(node);
 			fsnodes_link(ts, p, node, name);
-			gMetadata->trashspace -= node->length;
-			gMetadata->trashnodes--;
+			gMetadata->trashSpace -= node->length;
+			gMetadata->trashNodes--;
 			return SAUNAFS_STATUS_OK;
 		} else {
 			if (is_new == 0) {
@@ -1733,9 +1733,9 @@ void fsnodes_seteattr_recursive(FSNode *node, uint32_t ts, uint32_t uid, uint8_t
 		}
 		if (neweattr != (node->mode >> 12)) {
 			node->mode = (node->mode & 0xFFF) | (((uint16_t)neweattr) << 12);
-			const RichACL *node_acl = gMetadata->acl_storage.get(node->id);
+			const RichACL *node_acl = gMetadata->aclStorage.get(node->id);
 			if (node_acl) {
-				gMetadata->acl_storage.setMode(node->id, node->mode, node->type == FSNode::kDirectory);
+				gMetadata->aclStorage.setMode(node->id, node->mode, node->type == FSNode::kDirectory);
 			}
 			(*sinodes)++;
 			fsnodes_update_ctime(node, ts);
@@ -1755,32 +1755,32 @@ void fsnodes_seteattr_recursive(FSNode *node, uint32_t ts, uint32_t uid, uint8_t
 
 uint8_t fsnodes_deleteacl(FSNode *p, AclType type, uint32_t ts) {
 	if (type == AclType::kRichACL) {
-		gMetadata->acl_storage.erase(p->id);
+		gMetadata->aclStorage.erase(p->id);
 	} else if (type == AclType::kDefault) {
 		if (p->type != FSNode::kDirectory) {
 			return SAUNAFS_ERROR_ENOTSUP;
 		}
-		const RichACL *node_acl = gMetadata->acl_storage.get(p->id);
+		const RichACL *node_acl = gMetadata->aclStorage.get(p->id);
 		if (node_acl) {
 			RichACL new_acl = *node_acl;
 			new_acl.createExplicitInheritance();
 			new_acl.removeInheritOnly(true);
 			if (new_acl.size() == 0) {
-				gMetadata->acl_storage.erase(p->id);
+				gMetadata->aclStorage.erase(p->id);
 			} else {
-				gMetadata->acl_storage.set(p->id, std::move(new_acl));
+				gMetadata->aclStorage.set(p->id, std::move(new_acl));
 			}
 		}
 	} else if (type == AclType::kAccess) {
-		const RichACL *node_acl = gMetadata->acl_storage.get(p->id);
+		const RichACL *node_acl = gMetadata->aclStorage.get(p->id);
 		if (node_acl) {
 			RichACL new_acl = *node_acl;
 			new_acl.createExplicitInheritance();
 			new_acl.removeInheritOnly(false);
 			if (new_acl.size() == 0) {
-				gMetadata->acl_storage.erase(p->id);
+				gMetadata->aclStorage.erase(p->id);
 			} else {
-				gMetadata->acl_storage.set(p->id, std::move(new_acl));
+				gMetadata->aclStorage.set(p->id, std::move(new_acl));
 			}
 		}
 	} else {
@@ -1793,7 +1793,7 @@ uint8_t fsnodes_deleteacl(FSNode *p, AclType type, uint32_t ts) {
 
 #ifndef METARESTORE
 uint8_t fsnodes_getacl(FSNode *p, RichACL &acl) {
-	const RichACL *richacl = gMetadata->acl_storage.get(p->id);
+	const RichACL *richacl = gMetadata->aclStorage.get(p->id);
 	if (!richacl) {
 		return SAUNAFS_ERROR_ENOATTR;
 	}
@@ -1811,7 +1811,7 @@ uint8_t fsnodes_setacl(FSNode *p, const RichACL &acl, uint32_t ts) {
 	uint16_t mode = p->mode;
 	if (RichACL::equivMode(acl, mode, p->type == FSNode::kDirectory)) {
 		p->mode = (p->mode & ~0777) | (mode & 0777);
-		gMetadata->acl_storage.erase(p->id);
+		gMetadata->aclStorage.erase(p->id);
 	} else {
 		if (!acl.isAutoSetMode()) {
 			p->mode = (p->mode & ~0777) | (acl.getMode() & 0777);
@@ -1821,7 +1821,7 @@ uint8_t fsnodes_setacl(FSNode *p, const RichACL &acl, uint32_t ts) {
 			new_acl.setFlags(new_acl.getFlags() & ~RichACL::kAutoSetMode);
 			new_acl.setMode(p->mode, p->type == FSNode::kDirectory);
 		}
-		gMetadata->acl_storage.set(p->id, std::move(new_acl));
+		gMetadata->aclStorage.set(p->id, std::move(new_acl));
 	}
 
 	fsnodes_update_ctime(p, ts);
@@ -1838,7 +1838,7 @@ uint8_t fsnodes_setacl(FSNode *p, AclType type, const AccessControlList &acl, ui
 		return SAUNAFS_ERROR_ENOTSUP;
 	}
 
-	const RichACL *node_acl = gMetadata->acl_storage.get(p->id);
+	const RichACL *node_acl = gMetadata->aclStorage.get(p->id);
 	RichACL new_acl;
 
 	if (node_acl) {
@@ -1854,7 +1854,7 @@ uint8_t fsnodes_setacl(FSNode *p, AclType type, const AccessControlList &acl, ui
 		new_acl.appendPosixACL(acl, p->type == FSNode::kDirectory);
 		p->mode = (p->mode & ~0777) | (new_acl.getMode() & 0777);
 	}
-	gMetadata->acl_storage.set(p->id, std::move(new_acl));
+	gMetadata->aclStorage.set(p->id, std::move(new_acl));
 
 	fsnodes_update_ctime(p, ts);
 	fsnodes_update_checksum(p);
@@ -1887,7 +1887,7 @@ int fsnodes_access(const FsContext &context, FSNode *node, uint8_t modemask) {
 	if ((context.sesflags() & SESFLAG_NOMASTERPERMCHECK) || context.uid() == 0) {
 		return 1;
 	}
-	const RichACL *node_acl = gMetadata->acl_storage.get(node->id);
+	const RichACL *node_acl = gMetadata->aclStorage.get(node->id);
 	if (node_acl) {
 		assert((node->mode & 0777) == node_acl->getMode());
 

--- a/src/master/filesystem_node.h
+++ b/src/master/filesystem_node.h
@@ -33,7 +33,7 @@ namespace detail {
 inline FSNode *fsnodes_id_to_node_internal(inode_t id) {
 	uint32_t nodepos = NODEHASHPOS(id);
 
-	for (const auto& node : gMetadata->nodehash[nodepos]) {
+	for (const auto& node : gMetadata->nodeHash[nodepos]) {
 		if (node->id == id) {
 			return node;
 		}

--- a/src/master/filesystem_node.h
+++ b/src/master/filesystem_node.h
@@ -31,13 +31,14 @@
 namespace detail {
 
 inline FSNode *fsnodes_id_to_node_internal(inode_t id) {
-	FSNode *p;
 	uint32_t nodepos = NODEHASHPOS(id);
-	for (p = gMetadata->nodehash[nodepos]; p; p = p->next) {
-		if (p->id == id) {
-			return p;
+
+	for (const auto& node : gMetadata->nodehash[nodepos]) {
+		if (node->id == id) {
+			return node;
 		}
 	}
+
 	return nullptr;
 }
 

--- a/src/master/filesystem_node_types.h
+++ b/src/master/filesystem_node_types.h
@@ -122,12 +122,10 @@ struct FSNode {
 	ParentsCompactVector parent; /*!< Parent nodes ids + handles of entries of this node in those
 	               parents. To reduce memory usage ids are stored instead of pointers to FSNode. */
 
-	FSNode   *next; /*!< Next field used for storing FSNode in hash map. */
 	uint64_t checksum; /*!< Node checksum. */
 
 	FSNode(uint8_t t) {
 		type = t;
-		next = nullptr;
 		checksum = 0;
 	}
 

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -105,7 +105,7 @@ void fs_changelog(uint32_t ts, const char *format, ...) {
 		entryLength++;
 	}
 
-	uint64_t version = gMetadata->metaversion++;
+	uint64_t version = gMetadata->metadataVersion++;
 	changelog(version, entry);
 	matomlserv_broadcast_logstring(version, (uint8_t *)entry, tsLength + entryLength);
 #endif
@@ -225,7 +225,7 @@ uint8_t fs_settrashpath(const FsContext &context, inode_t inode, const std::stri
 		fs_changelog(context.ts(), "SETPATH(%" PRIiNode ",%s)", p->id,
 		             fsnodes_escape_name(path).c_str());
 	} else {
-		gMetadata->metaversion++;
+		gMetadata->metadataVersion++;
 	}
 	return SAUNAFS_STATUS_OK;
 }
@@ -251,7 +251,7 @@ uint8_t fs_undel(const FsContext &context, inode_t inode) {
 			fs_changelog(context.ts(), "UNDEL(%" PRIiNode ")", p->id);
 		}
 	} else {
-		gMetadata->metaversion++;
+		gMetadata->metadataVersion++;
 	}
 	return status;
 }
@@ -277,25 +277,25 @@ uint8_t fs_purge(const FsContext &context, inode_t inode) {
 	if (context.isPersonalityMaster()) {
 		fs_changelog(context.ts(), "PURGE(%" PRIiNode ")", purged_inode);
 	} else {
-		gMetadata->metaversion++;
+		gMetadata->metadataVersion++;
 	}
 	return SAUNAFS_STATUS_OK;
 }
 
 #ifndef METARESTORE
-void fs_info(uint64_t *totalspace, uint64_t *availspace, uint64_t *trspace,
-             inode_t *trnodes, uint64_t *respace, inode_t *renodes,
-             inode_t *inodes, inode_t *dnodes, inode_t *fnodes,
-             inode_t *lnodes) {
-	matocsserv_getspace(totalspace, availspace);
-	*trspace = gMetadata->trashspace;
-	*trnodes = gMetadata->trashnodes;
-	*respace = gMetadata->reservedspace;
-	*renodes = gMetadata->reservednodes;
+void fs_info(uint64_t *totalSpace, uint64_t *availableSpace, uint64_t *trashSpace,
+             inode_t *trashNodes, uint64_t *reservedSpace, inode_t *reservedNodes,
+             inode_t *inodes, inode_t *directoryNodes, inode_t *fileNodes,
+             inode_t *linkNodes) {
+	matocsserv_getspace(totalSpace, availableSpace);
+	*trashSpace = gMetadata->trashSpace;
+	*trashNodes = gMetadata->trashNodes;
+	*reservedSpace = gMetadata->reservedSpace;
+	*reservedNodes = gMetadata->reservedNodes;
 	*inodes = gMetadata->nodes;
-	*dnodes = gMetadata->dirnodes;
-	*fnodes = gMetadata->filenodes;
-	*lnodes = gMetadata->linknodes;
+	*directoryNodes = gMetadata->dirNodes;
+	*fileNodes = gMetadata->fileNodes;
+	*linkNodes = gMetadata->linkNodes;
 }
 
 uint8_t fs_getrootinode(inode_t *rootinode, const uint8_t *path) {
@@ -339,8 +339,8 @@ void fs_statfs(const FsContext &context, uint64_t *totalspace, uint64_t *availsp
 	FSNode *rn;
 	statsrecord sr;
 	if (context.rootinode() == SPECIAL_INODE_ROOT) {
-		*trspace = gMetadata->trashspace;
-		*respace = gMetadata->reservedspace;
+		*trspace = gMetadata->trashSpace;
+		*respace = gMetadata->reservedSpace;
 		rn = gMetadata->root;
 	} else {
 		*trspace = 0;
@@ -365,7 +365,7 @@ void fs_statfs(const FsContext &context, uint64_t *totalspace, uint64_t *availsp
 uint8_t fs_apply_checksum(const std::string &version, uint64_t checksum) {
 	std::string versionString = saunafsVersionToString(SAUNAFS_VERSHEX);
 	uint64_t computedChecksum = fs_checksum(ChecksumMode::kGetCurrent);
-	gMetadata->metaversion++;
+	gMetadata->metadataVersion++;
 	if (!gDisableChecksumVerification && (version == versionString)) {
 		if (checksum != computedChecksum) {
 			return SAUNAFS_ERROR_BADMETADATACHECKSUM;
@@ -382,7 +382,7 @@ uint8_t fs_apply_access(uint32_t ts, inode_t inode) {
 	}
 	p->atime = ts;
 	fsnodes_update_checksum(p);
-	gMetadata->metaversion++;
+	gMetadata->metadataVersion++;
 	return SAUNAFS_STATUS_OK;
 }
 
@@ -645,7 +645,7 @@ uint8_t fs_apply_trunc(uint32_t ts, inode_t inode, uint32_t indx, uint64_t chunk
 		return SAUNAFS_ERROR_MISMATCH;
 	}
 	p->chunks[indx] = nchunkid;
-	gMetadata->metaversion++;
+	gMetadata->metadataVersion++;
 	fsnodes_update_checksum(p);
 	return SAUNAFS_STATUS_OK;
 }
@@ -658,7 +658,7 @@ uint8_t fs_set_nextchunkid(const FsContext &context, uint64_t nextChunkId) {
 			fs_changelog(context.ts(), "NEXTCHUNKID(%" PRIu64 ")", nextChunkId);
 		}
 	} else {
-		gMetadata->metaversion++;
+		gMetadata->metadataVersion++;
 	}
 	return status;
 }
@@ -673,7 +673,7 @@ uint8_t fs_end_setlength(uint64_t chunkid) {
 #endif
 
 uint8_t fs_apply_unlock(uint64_t chunkid) {
-	gMetadata->metaversion++;
+	gMetadata->metadataVersion++;
 	return chunk_unlock(chunkid);
 }
 
@@ -822,7 +822,7 @@ uint8_t fs_setattr(const FsContext &context, inode_t inode, uint8_t setmask, uin
 	}
 	if (setmask & SET_MODE_FLAG) {
 		p->mode = (attrmode & 07777) | (p->mode & 0xF000);
-		gMetadata->acl_storage.setMode(p->id, p->mode, p->type == FSNode::kDirectory);
+		gMetadata->aclStorage.setMode(p->id, p->mode, p->type == FSNode::kDirectory);
 	}
 	if (setmask & (SET_UID_FLAG | SET_GID_FLAG)) {
 		fsnodes_change_uid_gid(p, ((setmask & SET_UID_FLAG) ? attruid : p->uid),
@@ -859,7 +859,7 @@ uint8_t fs_apply_attr(uint32_t ts, inode_t inode, uint32_t mode, uint32_t uid, u
 		return SAUNAFS_ERROR_EINVAL;
 	}
 	p->mode = mode | (p->mode & 0xF000);
-	gMetadata->acl_storage.setMode(p->id, p->mode, p->type == FSNode::kDirectory);
+	gMetadata->aclStorage.setMode(p->id, p->mode, p->type == FSNode::kDirectory);
 	if (p->uid != uid || p->gid != gid) {
 		fsnodes_change_uid_gid(p, uid, gid);
 	}
@@ -867,7 +867,7 @@ uint8_t fs_apply_attr(uint32_t ts, inode_t inode, uint32_t mode, uint32_t uid, u
 	p->mtime = mtime;
 	fsnodes_update_ctime(p, ts);
 	fsnodes_update_checksum(p);
-	gMetadata->metaversion++;
+	gMetadata->metadataVersion++;
 	return SAUNAFS_STATUS_OK;
 }
 
@@ -883,7 +883,7 @@ uint8_t fs_apply_length(uint32_t ts, inode_t inode, uint64_t length, bool eraseF
 	p->mtime = ts;
 	fsnodes_update_ctime(p, ts);
 	fsnodes_update_checksum(p);
-	gMetadata->metaversion++;
+	gMetadata->metadataVersion++;
 	return SAUNAFS_STATUS_OK;
 }
 
@@ -981,7 +981,7 @@ uint8_t fs_symlink(const FsContext &context, inode_t parent, const HString &name
 		if (*inode != p->id) {
 			return SAUNAFS_ERROR_MISMATCH;
 		}
-		gMetadata->metaversion++;
+		gMetadata->metadataVersion++;
 	}
 #ifndef METARESTORE
 	++gFsStatsArray[FsStats::Symlink];
@@ -1127,7 +1127,7 @@ uint8_t fs_apply_create(uint32_t ts, inode_t parent, const HString &name,
 		// if inode!=p->id then requested inode number was already acquired
 		return SAUNAFS_ERROR_MISMATCH;
 	}
-	gMetadata->metaversion++;
+	gMetadata->metadataVersion++;
 	return SAUNAFS_STATUS_OK;
 }
 
@@ -1196,7 +1196,7 @@ uint8_t fs_recursive_remove(const FsContext &context, inode_t parent,
 	std::string node_name;
 
 	fsnodes_getpath(static_cast<FSNodeDirectory*>(wd_tmp), child, node_name);
-	return gMetadata->task_manager.submitTask(job_id, context.ts(), kInitialTaskBatchSize,
+	return gMetadata->taskManager.submitTask(job_id, context.ts(), kInitialTaskBatchSize,
 	                                          task, RemoveTask::generateDescription(node_name),
 	                                          callback);
 }
@@ -1263,7 +1263,7 @@ uint8_t fs_apply_unlink(uint32_t ts, inode_t parent, const HString &name,
 		return SAUNAFS_ERROR_ENOTEMPTY;
 	}
 	fsnodes_unlink(ts, static_cast<FSNodeDirectory*>(wd), name, child);
-	gMetadata->metaversion++;
+	gMetadata->metadataVersion++;
 	return SAUNAFS_STATUS_OK;
 }
 
@@ -1362,7 +1362,7 @@ uint8_t fs_rename(const FsContext &context, inode_t parent_src, const HString &n
 		             fsnodes_escape_name(name_src).c_str(), dwd->id,
 		             fsnodes_escape_name(name_dst).c_str(), se_child->id);
 	} else {
-		gMetadata->metaversion++;
+		gMetadata->metadataVersion++;
 	}
 #ifndef METARESTORE
 	++gFsStatsArray[FsStats::Rename];
@@ -1410,7 +1410,7 @@ uint8_t fs_link(const FsContext &context, inode_t inode_src, inode_t parent_dst,
 		fs_changelog(context.ts(), "LINK(%" PRIiNode ",%" PRIiNode ",%s)", sp->id, dwd->id,
 		             fsnodes_escape_name(name_dst).c_str());
 	} else {
-		gMetadata->metaversion++;
+		gMetadata->metadataVersion++;
 	}
 #ifndef METARESTORE
 	++gFsStatsArray[FsStats::Link];
@@ -1449,7 +1449,7 @@ uint8_t fs_append(const FsContext &context, inode_t inode, inode_t inode_src) {
 	if (context.isPersonalityMaster()) {
 		fs_changelog(context.ts(), "APPEND(%" PRIiNode ",%" PRIiNode ")", p->id, sp->id);
 	} else {
-		gMetadata->metaversion++;
+		gMetadata->metadataVersion++;
 	}
 	return status;
 }
@@ -1480,7 +1480,7 @@ int fs_posixlock_probe(const FsContext &context, inode_t inode, uint64_t start, 
 		return status;
 	}
 
-	FileLocks &locks = gMetadata->posix_locks;
+	FileLocks &locks = gMetadata->posixLocks;
 	const FileLocks::Lock *collision;
 
 	collision = locks.findCollision(inode, static_cast<FileLocks::Lock::Type>(op), start, end,
@@ -1559,13 +1559,13 @@ int fs_flock_op(const FsContext &context, inode_t inode, uint64_t owner, uint32_
 		uint32_t reqid, uint32_t msgid, uint16_t op, bool nonblocking,
 		std::vector<FileLocks::Owner> &applied) {
 	ChecksumUpdater cu(context.ts());
-	int ret = fs_lock_op(context, gMetadata->flock_locks, inode, 0, 1, owner, sessionid,
+	int ret = fs_lock_op(context, gMetadata->flockLocks, inode, 0, 1, owner, sessionid,
 			reqid, msgid, op, nonblocking, applied);
 	if (context.isPersonalityMaster()) {
 		fs_changelog(context.ts(), "FLCK(%" PRIu8 ",%" PRIiNode ",0,1,%" PRIu64 ",%" PRIu32 ",%" PRIu16 ")",
 				(uint8_t)safs_locks::Type::kFlock, inode, owner, sessionid, op);
 	} else {
-		gMetadata->metaversion++;
+		gMetadata->metadataVersion++;
 	}
 	return ret;
 }
@@ -1574,13 +1574,13 @@ int fs_posixlock_op(const FsContext &context, inode_t inode, uint64_t start, uin
 		uint64_t owner, uint32_t sessionid, uint32_t reqid, uint32_t msgid, uint16_t op,
 		bool nonblocking, std::vector<FileLocks::Owner> &applied) {
 	ChecksumUpdater cu(context.ts());
-	int ret = fs_lock_op(context, gMetadata->posix_locks, inode, start, end, owner, sessionid,
+	int ret = fs_lock_op(context, gMetadata->posixLocks, inode, start, end, owner, sessionid,
 			reqid, msgid, op, nonblocking, applied);
 	if (context.isPersonalityMaster()) {
 		fs_changelog(context.ts(), "FLCK(%" PRIu8 ",%" PRIiNode ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu32 ",%" PRIu16 ")",
 				(uint8_t)safs_locks::Type::kPosix, inode, start, end, owner, sessionid, op);
 	} else {
-		gMetadata->metaversion++;
+		gMetadata->metadataVersion++;
 	}
 	return ret;
 }
@@ -1594,8 +1594,8 @@ int fs_locks_clear_session(const FsContext &context, uint8_t type, inode_t inode
 
 	ChecksumUpdater cu(context.ts());
 
-	FileLocks *locks = type == (uint8_t)safs_locks::Type::kFlock ? &gMetadata->flock_locks
-	                                                             : &gMetadata->posix_locks;
+	FileLocks *locks = type == (uint8_t)safs_locks::Type::kFlock ? &gMetadata->flockLocks
+	                                                             : &gMetadata->posixLocks;
 
 	locks->removePending(inode, [sessionid](const FileLocks::Lock &lock) {
 		return lock.owner().sessionid == sessionid;
@@ -1616,7 +1616,7 @@ int fs_locks_clear_session(const FsContext &context, uint8_t type, inode_t inode
 		fs_changelog(context.ts(), "CLRLCK(%" PRIu8 ",%" PRIiNode ",%" PRIu32 ")", type, inode,
 		             sessionid);
 	} else {
-		gMetadata->metaversion++;
+		gMetadata->metadataVersion++;
 	}
 
 	return SAUNAFS_STATUS_OK;
@@ -1627,9 +1627,9 @@ int fs_locks_list_all(const FsContext &context, uint8_t type, bool pending, uint
 	(void)context;
 	FileLocks *locks;
 	if (type == (uint8_t)safs_locks::Type::kFlock) {
-		locks = &gMetadata->flock_locks;
+		locks = &gMetadata->flockLocks;
 	} else if (type == (uint8_t)safs_locks::Type::kPosix) {
-		locks = &gMetadata->posix_locks;
+		locks = &gMetadata->posixLocks;
 	} else {
 		return SAUNAFS_ERROR_EINVAL;
 	}
@@ -1649,9 +1649,9 @@ int fs_locks_list_inode(const FsContext &context, uint8_t type, bool pending, in
 	FileLocks *locks;
 
 	if (type == (uint8_t)safs_locks::Type::kFlock) {
-		locks = &gMetadata->flock_locks;
+		locks = &gMetadata->flockLocks;
 	} else if (type == (uint8_t)safs_locks::Type::kPosix) {
-		locks = &gMetadata->posix_locks;
+		locks = &gMetadata->posixLocks;
 	} else {
 		return SAUNAFS_ERROR_EINVAL;
 	}
@@ -1681,11 +1681,11 @@ int fs_locks_unlock_inode(const FsContext &context, uint8_t type, inode_t inode,
 	ChecksumUpdater cu(context.ts());
 
 	if (type == (uint8_t)safs_locks::Type::kFlock) {
-		gMetadata->flock_locks.unlock(inode);
-		fs_manage_lock_try_lock_pending(gMetadata->flock_locks, inode, 0, 1, applied);
+		gMetadata->flockLocks.unlock(inode);
+		fs_manage_lock_try_lock_pending(gMetadata->flockLocks, inode, 0, 1, applied);
 	} else if (type == (uint8_t)safs_locks::Type::kPosix) {
-		gMetadata->posix_locks.unlock(inode);
-		fs_manage_lock_try_lock_pending(gMetadata->posix_locks, inode, 0,
+		gMetadata->posixLocks.unlock(inode);
+		fs_manage_lock_try_lock_pending(gMetadata->posixLocks, inode, 0,
 		                                std::numeric_limits<uint64_t>::max(), applied);
 	} else {
 		return SAUNAFS_ERROR_EINVAL;
@@ -1694,7 +1694,7 @@ int fs_locks_unlock_inode(const FsContext &context, uint8_t type, inode_t inode,
 	if (context.isPersonalityMaster()) {
 		fs_changelog(context.ts(), "FLCKINODE(%" PRIu8 ",%" PRIiNode ")", type, inode);
 	} else {
-		gMetadata->metaversion++;
+		gMetadata->metadataVersion++;
 	}
 
 	return SAUNAFS_STATUS_OK;
@@ -1707,9 +1707,9 @@ int fs_locks_remove_pending(const FsContext &context, uint8_t type, uint64_t own
 	FileLocks *locks;
 
 	if (type == (uint8_t)safs_locks::Type::kFlock) {
-		locks = &gMetadata->flock_locks;
+		locks = &gMetadata->flockLocks;
 	} else if (type == (uint8_t)safs_locks::Type::kPosix) {
-		locks = &gMetadata->posix_locks;
+		locks = &gMetadata->posixLocks;
 	} else {
 		return SAUNAFS_ERROR_EINVAL;
 	}
@@ -1731,7 +1731,7 @@ int fs_locks_remove_pending(const FsContext &context, uint8_t type, uint64_t own
 			     "RMPLOCK(%" PRIu8 ",%" PRIu64",%" PRIu32 ",%" PRIiNode ",%" PRIu64")",
 			     type, ownerid, sessionid, inode, reqid);
 	} else {
-		gMetadata->metaversion++;
+		gMetadata->metadataVersion++;
 	}
 
 	return SAUNAFS_STATUS_OK;
@@ -1883,7 +1883,7 @@ uint8_t fs_acquire(const FsContext &context, inode_t inode, uint32_t sessionid) 
 	if (context.isPersonalityMaster()) {
 		fs_changelog(context.ts(), "ACQUIRE(%" PRIiNode ",%" PRIu32 ")", inode, sessionid);
 	} else {
-		gMetadata->metaversion++;
+		gMetadata->metadataVersion++;
 	}
 	return SAUNAFS_STATUS_OK;
 }
@@ -1913,7 +1913,7 @@ uint8_t fs_release(const FsContext &context, inode_t inode, uint32_t sessionid) 
 		if (context.isPersonalityMaster()) {
 			fs_changelog(context.ts(), "RELEASE(%" PRIiNode ",%" PRIu32 ")", inode, sessionid);
 		} else {
-			gMetadata->metaversion++;
+			gMetadata->metadataVersion++;
 		}
 		return SAUNAFS_STATUS_OK;
 	}
@@ -1927,16 +1927,16 @@ uint8_t fs_release(const FsContext &context, inode_t inode, uint32_t sessionid) 
 uint32_t fs_newsessionid(void) {
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
-	fs_changelog(ts, "SESSION():%" PRIu32, gMetadata->nextsessionid);
-	return gMetadata->nextsessionid++;
+	fs_changelog(ts, "SESSION():%" PRIu32, gMetadata->nextSessionId);
+	return gMetadata->nextSessionId++;
 }
 #endif
 uint8_t fs_apply_session(uint32_t sessionid) {
-	if (sessionid != gMetadata->nextsessionid) {
+	if (sessionid != gMetadata->nextSessionId) {
 		return SAUNAFS_ERROR_MISMATCH;
 	}
-	gMetadata->metaversion++;
-	gMetadata->nextsessionid++;
+	gMetadata->metadataVersion++;
+	gMetadata->nextSessionId++;
 	return SAUNAFS_STATUS_OK;
 }
 
@@ -2081,7 +2081,7 @@ uint8_t fs_writechunk(const FsContext &context, inode_t inode, uint32_t indx, bo
 		             "WRITE(%" PRIiNode ",%" PRIu32 ",%" PRIu8 ",%" PRIu32 "):%" PRIu64,
 		             inode, indx, *opflag, *lockid, nchunkid);
 	} else {
-		gMetadata->metaversion++;
+		gMetadata->metadataVersion++;
 	}
 	p->mtime = context.ts();
 	fsnodes_update_ctime(p, context.ts());
@@ -2135,7 +2135,7 @@ void fs_incversion(uint64_t chunkid) {
 #endif
 
 uint8_t fs_apply_incversion(uint64_t chunkid) {
-	gMetadata->metaversion++;
+	gMetadata->metadataVersion++;
 	return chunk_increase_version(chunkid);
 }
 
@@ -2230,7 +2230,7 @@ uint8_t fs_apply_repair(uint32_t ts, inode_t inode, uint32_t indx, uint32_t nver
 		fsnodes_add_sub_stats(parent, &nsr, &psr);
 	}
 	fsnodes_quota_update(p, {{QuotaResource::kSize, nsr.size - psr.size}});
-	gMetadata->metaversion++;
+	gMetadata->metadataVersion++;
 	p->mtime = ts;
 	fsnodes_update_ctime(p, ts);
 	fsnodes_update_checksum(p);
@@ -2359,7 +2359,7 @@ uint8_t fs_setgoal(const FsContext &context, inode_t inode, uint8_t goal, uint8_
 #else
 	goal_name = "goal id: " + std::to_string(goal);
 #endif
-	return gMetadata->task_manager.submitTask(context.ts(), kInitialTaskBatchSize,
+	return gMetadata->taskManager.submitTask(context.ts(), kInitialTaskBatchSize,
 						  task, SetGoalTask::generateDescription(node_name, goal_name),
 						  callback);
 }
@@ -2393,7 +2393,7 @@ uint8_t fs_apply_setgoal(const FsContext &context, inode_t inode, uint8_t goal, 
 	SetGoalTask task(context.uid(), goal, smode);
 	uint32_t my_result = task.setGoal(p, context.ts());
 
-	gMetadata->metaversion++;
+	gMetadata->metadataVersion++;
 	if (master_result != my_result) {
 		return SAUNAFS_ERROR_MISMATCH;
 	}
@@ -2432,7 +2432,7 @@ uint8_t fs_settrashtime(const FsContext &context, inode_t inode, uint32_t trasht
 	std::string node_name;
 	FSNodeDirectory *parent = fsnodes_get_first_parent(p);
 	fsnodes_getpath(parent, p, node_name);
-	return gMetadata->task_manager.submitTask(context.ts(), kInitialTaskBatchSize,
+	return gMetadata->taskManager.submitTask(context.ts(), kInitialTaskBatchSize,
 	                                          task, SetTrashtimeTask::generateDescription(node_name, trashtime),
 	                                          callback);
 }
@@ -2464,7 +2464,7 @@ uint8_t fs_apply_settrashtime(const FsContext &context, inode_t inode, uint32_t 
 	SetTrashtimeTask task(context.uid(), trashtime, smode);
 	uint32_t my_result = task.setTrashtime(p, context.ts());
 
-	gMetadata->metaversion++;
+	gMetadata->metadataVersion++;
 	if (master_result != my_result) {
 		return SAUNAFS_ERROR_MISMATCH;
 	}
@@ -2506,7 +2506,7 @@ uint8_t fs_seteattr(const FsContext &context, inode_t inode, uint8_t eattr, uint
 		                           "):%" PRIiNode ",%" PRIiNode ",%" PRIiNode,
 		             p->id, context.uid(), eattr, smode, si, nci, nsi);
 	} else {
-		gMetadata->metaversion++;
+		gMetadata->metadataVersion++;
 		if ((*sinodes != si) || (*ncinodes != nci) || (*nsinodes != nsi)) {
 			return SAUNAFS_ERROR_MISMATCH;
 		}
@@ -2532,7 +2532,7 @@ uint8_t fs_listxattr_leng(const FsContext &context, inode_t inode, uint8_t opene
 	}
 
 	*xasize = sizeof(kAclXattrs);
-	return xattr_listattr_leng(p->id, xanode, xasize);
+	return get_xattrs_length_for_inode(p->id, xanode, xasize);
 }
 
 void fs_listxattr_data(void *xanode, uint8_t *xabuff) {
@@ -2620,7 +2620,7 @@ uint8_t fs_apply_setxattr(uint32_t ts, inode_t inode, uint32_t anleng, const uin
 		return status;
 	}
 	fsnodes_update_ctime(p, ts);
-	gMetadata->metaversion++;
+	gMetadata->metadataVersion++;
 	fsnodes_update_checksum(p);
 	return status;
 }
@@ -2649,7 +2649,7 @@ uint8_t fs_deleteacl(const FsContext &context, inode_t inode, AclType type) {
 			fs_changelog(context.ts(), "DELETEACL(%" PRIiNode ",%c)", p->id, acl_type[std::min(3, (int)type)]);
 		}
 	} else {
-		gMetadata->metaversion++;
+		gMetadata->metadataVersion++;
 	}
 	return status;
 }
@@ -2675,7 +2675,7 @@ uint8_t fs_setacl(const FsContext &context, inode_t inode, const RichACL &acl) {
 			fs_changelog(context.ts(), "SETRICHACL(%" PRIiNode ",%s)", p->id, acl_string.c_str());
 		}
 	} else {
-		gMetadata->metaversion++;
+		gMetadata->metadataVersion++;
 	}
 	return status;
 }
@@ -2700,7 +2700,7 @@ uint8_t fs_setacl(const FsContext &context, inode_t inode, AclType type, const A
 						 (type == AclType::kAccess ? 'a' : 'd'), acl_string.c_str());
 		}
 	} else {
-		gMetadata->metaversion++;
+		gMetadata->metadataVersion++;
 	}
 	return status;
 
@@ -2740,7 +2740,7 @@ uint8_t fs_apply_setacl(uint32_t ts, inode_t inode, char aclType, const char *ac
 	}
 	uint8_t status = fsnodes_setacl(p, aclTypeEnum, std::move(acl), ts);
 	if (status == SAUNAFS_STATUS_OK) {
-		gMetadata->metaversion++;
+		gMetadata->metadataVersion++;
 	}
 	return status;
 }
@@ -2758,7 +2758,7 @@ uint8_t fs_apply_setrichacl(uint32_t ts, inode_t inode, const std::string &acl_s
 	}
 	uint8_t status = fsnodes_setacl(p, std::move(acl), ts);
 	if (status == SAUNAFS_STATUS_OK) {
-		gMetadata->metaversion++;
+		gMetadata->metadataVersion++;
 	}
 	return status;
 }
@@ -2868,7 +2868,7 @@ uint8_t fs_get_chunkid(const FsContext &context, inode_t inode, uint32_t index,
 
 void fs_add_files_to_chunks() {
 	for (uint32_t i = 0; i < NODEHASHSIZE; i++) {
-		for (const auto &node : gMetadata->nodehash[i]) {
+		for (const auto &node : gMetadata->nodeHash[i]) {
 			if (node->type == FSNode::kFile || node->type == FSNode::kTrash ||
 			    node->type == FSNode::kReserved) {
 				for (const auto &chunkid : static_cast<FSNodeFile*>(node)->chunks) {
@@ -2885,7 +2885,7 @@ uint64_t fs_getversion() {
 	if (!gMetadata) {
 		throw NoMetadataException();
 	}
-	return gMetadata->metaversion;
+	return gMetadata->metadataVersion;
 }
 
 #ifndef METARESTORE
@@ -2898,11 +2898,11 @@ const Goal &fs_get_goal_definition(uint8_t goalId) {
 }
 
 std::vector<JobInfo> fs_get_current_tasks_info() {
-	return gMetadata->task_manager.getCurrentJobsInfo();
+	return gMetadata->taskManager.getCurrentJobsInfo();
 }
 
 uint8_t fs_cancel_job(uint32_t job_id) {
-	if (gMetadata->task_manager.cancelJob(job_id)) {
+	if (gMetadata->taskManager.cancelJob(job_id)) {
 		return SAUNAFS_STATUS_OK;
 	} else {
 		return SAUNAFS_ERROR_EINVAL;
@@ -2910,7 +2910,7 @@ uint8_t fs_cancel_job(uint32_t job_id) {
 }
 
 uint32_t fs_reserve_job_id() {
-	return gMetadata->task_manager.reserveJobId();
+	return gMetadata->taskManager.reserveJobId();
 }
 
 uint8_t fs_getchunksinfo(const FsContext& context, uint32_t current_ip, inode_t inode,

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -2867,14 +2867,13 @@ uint8_t fs_get_chunkid(const FsContext &context, inode_t inode, uint32_t index,
 #endif
 
 void fs_add_files_to_chunks() {
-	FSNode *f;
 	for (uint32_t i = 0; i < NODEHASHSIZE; i++) {
-		for (f = gMetadata->nodehash[i]; f; f = f->next) {
-			if (f->type == FSNode::kFile || f->type == FSNode::kTrash ||
-			    f->type == FSNode::kReserved) {
-				for (const auto &chunkid : static_cast<FSNodeFile*>(f)->chunks) {
+		for (const auto &node : gMetadata->nodehash[i]) {
+			if (node->type == FSNode::kFile || node->type == FSNode::kTrash ||
+			    node->type == FSNode::kReserved) {
+				for (const auto &chunkid : static_cast<FSNodeFile*>(node)->chunks) {
 					if (chunkid > 0) {
-						chunk_add_file(chunkid, f->goal);
+						chunk_add_file(chunkid, node->goal);
 					}
 				}
 			}

--- a/src/master/filesystem_periodic.cc
+++ b/src/master/filesystem_periodic.cc
@@ -84,11 +84,11 @@ static const size_t kMaxNodeEntries = 1000000;
 static DefectiveNodesMap gDefectiveNodes;
 
 void fs_background_task_manager_work() {
-	if (gMetadata->task_manager.workAvailable()) {
+	if (gMetadata->taskManager.workAvailable()) {
 		uint32_t ts = eventloop_time();
 		ChecksumUpdater cu(ts);
-		gMetadata->task_manager.processJobs(ts, gTasksBatchSize);
-		if (gMetadata->task_manager.workAvailable()) {
+		gMetadata->taskManager.processJobs(ts, gTasksBatchSize);
+		if (gMetadata->taskManager.workAvailable()) {
 			eventloop_make_next_poll_nonblocking();
 		}
 	}
@@ -276,7 +276,7 @@ void fs_background_checksum_recalculation_a_bit() {
 		// Nodes are in a hashtable, therefore they can be recalculated in multiple steps.
 		while (gChecksumBackgroundUpdater.getPosition() < NODEHASHSIZE) {
 			auto checkSumPosition = gChecksumBackgroundUpdater.getPosition();
-			for (const auto &node : gMetadata->nodehash[checkSumPosition]) {
+			for (const auto &node : gMetadata->nodeHash[checkSumPosition]) {
 				fsnodes_checksum_add_to_background(node);
 				++recalculated;
 			}
@@ -293,7 +293,7 @@ void fs_background_checksum_recalculation_a_bit() {
 		// Xattrs are in a hashtable, therefore they can be recalculated in multiple steps.
 		while (gChecksumBackgroundUpdater.getPosition() < XATTR_DATA_HASH_SIZE) {
 			auto checksumPosition = gChecksumBackgroundUpdater.getPosition();
-			for (const auto &xde : gMetadata->xattr_data_hash[checksumPosition]) {
+			for (const auto &xde : gMetadata->xattrDataHash[checksumPosition]) {
 				xattr_checksum_add_to_background(xde.get());
 				++recalculated;
 			}
@@ -387,7 +387,7 @@ void fs_process_file_test() {
 			return;
 		}
 
-		for (const auto &node : gMetadata->nodehash[gFileTestLoopIndex]) {
+		for (const auto &node : gMetadata->nodeHash[gFileTestLoopIndex]) {
 			node_error_flag = 0;
 
 			if (node->type == FSNode::kFile || node->type == FSNode::kTrash ||

--- a/src/master/filesystem_periodic.cc
+++ b/src/master/filesystem_periodic.cc
@@ -275,9 +275,8 @@ void fs_background_checksum_recalculation_a_bit() {
 	case ChecksumRecalculatingStep::kNodes:
 		// Nodes are in a hashtable, therefore they can be recalculated in multiple steps.
 		while (gChecksumBackgroundUpdater.getPosition() < NODEHASHSIZE) {
-			for (FSNode *node =
-			             gMetadata->nodehash[gChecksumBackgroundUpdater.getPosition()];
-			     node; node = node->next) {
+			auto checkSumPosition = gChecksumBackgroundUpdater.getPosition();
+			for (const auto &node : gMetadata->nodehash[checkSumPosition]) {
 				fsnodes_checksum_add_to_background(node);
 				++recalculated;
 			}
@@ -341,8 +340,6 @@ void fs_process_file_test() {
 	static inode_t unavailtrashfiles = 0;
 	static inode_t unavailreservedfiles = 0;
 
-	FSNode *f;
-
 	if (gFileTestLoopIndex == 0) {
 		if (unavailfiles > 0) {
 			safs::log_err("Currently unavailable files: {}", unavailfiles);
@@ -392,12 +389,12 @@ void fs_process_file_test() {
 			return;
 		}
 
-		for (f = gMetadata->nodehash[gFileTestLoopIndex]; f; f = f->next) {
+		for (const auto &node : gMetadata->nodehash[gFileTestLoopIndex]) {
 			node_error_flag = 0;
 
-			if (f->type == FSNode::kFile || f->type == FSNode::kTrash ||
-			    f->type == FSNode::kReserved) {
-				for (const auto &chunkid : static_cast<FSNodeFile *>(f)->chunks) {
+			if (node->type == FSNode::kFile || node->type == FSNode::kTrash ||
+			    node->type == FSNode::kReserved) {
+				for (const auto &chunkid : static_cast<FSNodeFile *>(node)->chunks) {
 					if (chunkid == 0) {
 						continue;
 					}
@@ -426,20 +423,20 @@ void fs_process_file_test() {
 				}
 			}
 
-			if (f->type == FSNode::kDirectory) {
+			if (node->type == FSNode::kDirectory) {
 				for (const auto &entry :
-				     static_cast<FSNodeDirectory *>(f)->entries) {
-					FSNode *node = entry.second;
+				     static_cast<FSNodeDirectory *>(node)->entries) {
+					FSNode *childNode = entry.second;
 
-					if (!node) {
+					if (!childNode) {
 						// the node points to invalid memory
 						node_error_flag |=
 						        static_cast<int>(kStructureError);
 					} else {
 						auto parentInChildPtr = std::find_if(
-						    node->parent.begin(), node->parent.end(),
-						    [f](const std::pair<inode_t, const hstorage::Handle *> &p) {
-							    return p.first == f->id;
+						    childNode->parent.begin(), childNode->parent.end(),
+						    [node](const std::pair<inode_t, const hstorage::Handle *> &p) {
+							    return p.first == node->id;
 						    });
 						// the node doesn't have a parent entry pointing to the
 						// current directory
@@ -451,7 +448,7 @@ void fs_process_file_test() {
 			}
 
 			if (node_error_flag == 0) {
-				auto it = gDefectiveNodes.find(f->id);
+				auto it = gDefectiveNodes.find(node->id);
 				if (it != gDefectiveNodes.end()) {
 					gDefectiveNodes.erase(it);
 				}
@@ -459,17 +456,17 @@ void fs_process_file_test() {
 			}
 
 			if (node_error_flag & kChunkUnavailable) {
-				if (f->type == FSNode::kTrash) {
+				if (node->type == FSNode::kTrash) {
 					unavailtrashfiles++;
-				} else if (f->type == FSNode::kReserved) {
+				} else if (node->type == FSNode::kReserved) {
 					unavailreservedfiles++;
 				} else {
-					unavailfiles += f->parent.size();
+					unavailfiles += node->parent.size();
 				}
 
-				auto it = gDefectiveNodes.find(f->id);
+				auto it = gDefectiveNodes.find(node->id);
 				if (it == gDefectiveNodes.end()) {
-					std::string name = get_node_info(f);
+					std::string name = get_node_info(node);
 					safs::log_trace("Chunks unavailable in {}",
 					                   name);
 				}
@@ -478,18 +475,18 @@ void fs_process_file_test() {
 				ugfiles++;
 			}
 			if (node_error_flag & kStructureError) {
-				auto it = gDefectiveNodes.find(f->id);
+				auto it = gDefectiveNodes.find(node->id);
 				if (it == gDefectiveNodes.end()) {
-					std::string name = get_node_info(f);
+					std::string name = get_node_info(node);
 					safs_pretty_syslog(LOG_ERR, "Structure error in %s",
 					                   name.c_str());
 				}
 			}
 
 			if (gDefectiveNodes.size() < kMaxNodeEntries) {
-				gDefectiveNodes[f->id] = node_error_flag;
+				gDefectiveNodes[node->id] = node_error_flag;
 			} else {
-				auto it = gDefectiveNodes.find(f->id);
+				auto it = gDefectiveNodes.find(node->id);
 				if (it != gDefectiveNodes.end()) {
 					(*it).second = node_error_flag;
 				}

--- a/src/master/filesystem_periodic.cc
+++ b/src/master/filesystem_periodic.cc
@@ -292,11 +292,9 @@ void fs_background_checksum_recalculation_a_bit() {
 	case ChecksumRecalculatingStep::kXattrs:
 		// Xattrs are in a hashtable, therefore they can be recalculated in multiple steps.
 		while (gChecksumBackgroundUpdater.getPosition() < XATTR_DATA_HASH_SIZE) {
-			for (xattr_data_entry *xde =
-			             gMetadata->xattr_data_hash[gChecksumBackgroundUpdater
-			                                                .getPosition()];
-			     xde; xde = xde->next) {
-				xattr_checksum_add_to_background(xde);
+			auto checksumPosition = gChecksumBackgroundUpdater.getPosition();
+			for (const auto &xde : gMetadata->xattr_data_hash[checksumPosition]) {
+				xattr_checksum_add_to_background(xde.get());
 				++recalculated;
 			}
 			gChecksumBackgroundUpdater.incPosition();

--- a/src/master/filesystem_quota.cc
+++ b/src/master/filesystem_quota.cc
@@ -72,7 +72,7 @@ uint8_t fs_quota_get_all(const FsContext &context, std::vector<QuotaEntry> &resu
 	if (context.uid() != 0 && !(context.sesflags() & SESFLAG_ALLCANCHANGEQUOTA)) {
 		return SAUNAFS_ERROR_EPERM;
 	}
-	results = gMetadata->quota_database.getEntriesWithStats();
+	results = gMetadata->quotaDatabase.getEntriesWithStats();
 
 	for (auto &entry : results) {
 		if (entry.entryKey.owner.ownerType != QuotaOwnerType::kInode ||
@@ -130,7 +130,7 @@ uint8_t fs_quota_get(const FsContext &context,
 				return SAUNAFS_ERROR_EINVAL;
 			}
 		}
-		auto result = gMetadata->quota_database.get(owner.ownerType, owner.ownerId);
+		auto result = gMetadata->quotaDatabase.get(owner.ownerType, owner.ownerId);
 		if (result) {
 			for (auto rigor : {QuotaRigor::kSoft, QuotaRigor::kHard, QuotaRigor::kUsed}) {
 				if (owner.ownerType == QuotaOwnerType::kInode && rigor == QuotaRigor::kUsed) {
@@ -244,10 +244,10 @@ uint8_t fs_quota_set(const FsContext &context, const std::vector<QuotaEntry> &en
 
 	for (const QuotaEntry &entry : entries) {
 		const QuotaOwner &owner = entry.entryKey.owner;
-		gMetadata->quota_database.set(owner.ownerType, owner.ownerId, entry.entryKey.rigor,
+		gMetadata->quotaDatabase.set(owner.ownerType, owner.ownerId, entry.entryKey.rigor,
 		                              entry.entryKey.resource, entry.limit);
-		gMetadata->quota_database.removeEmpty(owner.ownerType, owner.ownerId);
-		gMetadata->quota_checksum = gMetadata->quota_database.checksum();
+		gMetadata->quotaDatabase.removeEmpty(owner.ownerType, owner.ownerId);
+		gMetadata->quotaChecksum = gMetadata->quotaDatabase.checksum();
 		fs_changelog(ts, "SETQUOTA(%c,%c,%c,%" PRIiNode ",%" PRIu64 ")",
 		             rigor_name[(int)entry.entryKey.rigor],
 		             resource_name[(int)entry.entryKey.resource], owner_name[(int)owner.ownerType],
@@ -272,10 +272,10 @@ uint8_t fs_apply_setquota(char rigor, char resource, char owner_type, inode_t ow
 	if (!valid) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
-	gMetadata->metaversion++;
-	gMetadata->quota_database.set(quotaOwnerType, owner_id, quotaRigor, quotaResource, limit);
-	gMetadata->quota_database.removeEmpty(quotaOwnerType, owner_id);
-	gMetadata->quota_checksum = gMetadata->quota_database.checksum();
+	gMetadata->metadataVersion++;
+	gMetadata->quotaDatabase.set(quotaOwnerType, owner_id, quotaRigor, quotaResource, limit);
+	gMetadata->quotaDatabase.removeEmpty(quotaOwnerType, owner_id);
+	gMetadata->quotaChecksum = gMetadata->quotaDatabase.checksum();
 	return SAUNAFS_STATUS_OK;
 }
 
@@ -344,7 +344,7 @@ static bool fsnodes_test_dir_quota_noparents(FSNode *node,
 	}
 
 	const QuotaDatabase::Limits *entry =
-	    gMetadata->quota_database.get(QuotaOwnerType::kInode, node->id);
+	    gMetadata->quotaDatabase.get(QuotaOwnerType::kInode, node->id);
 	if (!entry) {
 		return false;
 	}
@@ -377,8 +377,8 @@ static bool fsnodes_test_dir_quota_noparents(FSNode *node,
 
 bool fsnodes_quota_exceeded_ug(uint32_t uid, uint32_t gid,
 		const std::initializer_list<std::pair<QuotaResource, int64_t>> &resource_list) {
-	return gMetadata->quota_database.exceeds(QuotaOwnerType::kUser, uid, QuotaRigor::kHard, resource_list) ||
-	       gMetadata->quota_database.exceeds(QuotaOwnerType::kGroup, gid, QuotaRigor::kHard, resource_list);
+	return gMetadata->quotaDatabase.exceeds(QuotaOwnerType::kUser, uid, QuotaRigor::kHard, resource_list) ||
+	       gMetadata->quotaDatabase.exceeds(QuotaOwnerType::kGroup, gid, QuotaRigor::kHard, resource_list);
 }
 
 bool fsnodes_quota_exceeded_ug(FSNode *node,
@@ -468,16 +468,16 @@ void fsnodes_quota_update(FSNode *node,
 		if (resource.second == 0) {
 			continue;
 		}
-		gMetadata->quota_database.update(QuotaOwnerType::kUser, node->uid, QuotaRigor::kUsed,
+		gMetadata->quotaDatabase.update(QuotaOwnerType::kUser, node->uid, QuotaRigor::kUsed,
 		                                 resource.first, resource.second);
-		gMetadata->quota_database.update(QuotaOwnerType::kGroup, node->gid, QuotaRigor::kUsed,
+		gMetadata->quotaDatabase.update(QuotaOwnerType::kGroup, node->gid, QuotaRigor::kUsed,
 		                                 resource.first, resource.second);
 	}
 }
 
 void fsnodes_quota_remove(QuotaOwnerType owner_type, uint32_t owner_id) {
-	gMetadata->quota_database.remove(owner_type, owner_id);
-	gMetadata->quota_checksum = gMetadata->quota_database.checksum();
+	gMetadata->quotaDatabase.remove(owner_type, owner_id);
+	gMetadata->quotaChecksum = gMetadata->quotaDatabase.checksum();
 }
 
 void fsnodes_quota_adjust_space(FSNode * /*node*/, uint64_t & /*total_space*/,

--- a/src/master/filesystem_snapshot.cc
+++ b/src/master/filesystem_snapshot.cc
@@ -81,7 +81,7 @@ uint8_t fs_snapshot(const FsContext &context, inode_t inode_src, inode_t parent_
 		initial_batch_size = gInitialSnapshotTaskBatch;
 	}
 	initial_batch_size = std::min(initial_batch_size, gSnapshotTaskBatchLimit);
-	return gMetadata->task_manager.submitTask(job_id, context.ts(), initial_batch_size,
+	return gMetadata->taskManager.submitTask(job_id, context.ts(), initial_batch_size,
 						  task, SnapshotTask::generateDescription(src_path, dst_path),
 						  callback);
 }

--- a/src/master/filesystem_store_acl.cc
+++ b/src/master/filesystem_store_acl.cc
@@ -52,8 +52,8 @@ static void fs_store_acl(inode_t id, const RichACL &acl, FILE *fd) {
 
 void fs_store_acls(FILE *fd) {
 	for (uint32_t i = 0; i < NODEHASHSIZE; ++i) {
-		for (const auto &node : gMetadata->nodehash[i]) {
-			const RichACL *node_acl = gMetadata->acl_storage.get(node->id);
+		for (const auto &node : gMetadata->nodeHash[i]) {
+			const RichACL *node_acl = gMetadata->aclStorage.get(node->id);
 			if (node_acl) {
 				fs_store_acl(node->id, *node_acl, fd);
 			}
@@ -111,7 +111,7 @@ static int fs_load_posix_acl(const std::shared_ptr<MemoryMappedFile> &metadataFi
 			throw Exception("unknown inode: " + std::to_string(inode));
 		}
 
-		const RichACL *node_acl = gMetadata->acl_storage.get(p->id);
+		const RichACL *node_acl = gMetadata->aclStorage.get(p->id);
 		if (node_acl != nullptr) {
 			RichACL new_acl = *node_acl;
 			if (default_acl) {
@@ -125,7 +125,7 @@ static int fs_load_posix_acl(const std::shared_ptr<MemoryMappedFile> &metadataFi
 				new_acl.appendPosixACL(posix_acl, p->type == FSNode::kDirectory);
 				p->mode = (p->mode & ~0777) | (new_acl.getMode() & 0777);
 			}
-			gMetadata->acl_storage.set(p->id, std::move(new_acl));
+			gMetadata->aclStorage.set(p->id, std::move(new_acl));
 		}
 	} catch (Exception &ex) {
 		safs_pretty_syslog(LOG_ERR, "loading acl: %s", ex.what());
@@ -192,7 +192,7 @@ static int fs_load_legacy_acl(const std::shared_ptr<MemoryMappedFile> &metadataF
 			new_acl.appendDefaultPosixACL(posix_acl);
 		}
 		if (new_acl.size() > 0) {
-			gMetadata->acl_storage.set(p->id, std::move(new_acl));
+			gMetadata->aclStorage.set(p->id, std::move(new_acl));
 		}
 		return 0;
 	} catch (Exception &ex) {
@@ -279,7 +279,7 @@ int fs_load_acl(const std::shared_ptr<MemoryMappedFile> &metadataFile, size_t &o
 		if (!p) {
 			throw Exception("unknown inode: " + std::to_string(inode));
 		}
-		gMetadata->acl_storage.set(p->id, std::move(acl));
+		gMetadata->aclStorage.set(p->id, std::move(acl));
 		return 0;
 	} catch (Exception &ex) {
 		safs_pretty_syslog(LOG_ERR, "loading acl: %s", ex.what());

--- a/src/master/filesystem_store_acl.cc
+++ b/src/master/filesystem_store_acl.cc
@@ -52,10 +52,10 @@ static void fs_store_acl(inode_t id, const RichACL &acl, FILE *fd) {
 
 void fs_store_acls(FILE *fd) {
 	for (uint32_t i = 0; i < NODEHASHSIZE; ++i) {
-		for (FSNode *p = gMetadata->nodehash[i]; p; p = p->next) {
-			const RichACL *node_acl = gMetadata->acl_storage.get(p->id);
+		for (const auto &node : gMetadata->nodehash[i]) {
+			const RichACL *node_acl = gMetadata->acl_storage.get(node->id);
 			if (node_acl) {
-				fs_store_acl(p->id, *node_acl, fd);
+				fs_store_acl(node->id, *node_acl, fd);
 			}
 		}
 	}

--- a/src/master/filesystem_xattr.cc
+++ b/src/master/filesystem_xattr.cc
@@ -86,25 +86,28 @@ void xattr_recalculate_checksum() {
 }
 
 void xattr_removeinode(inode_t inode) {
-	xattr_inode_entry *ih, **ihp;
+	xattr_inode_entry *ih;
 
-	ihp = &(gMetadata->xattr_inode_hash[xattr_inode_hash_fn(inode)]);
-	while ((ih = *ihp)) {
+	auto hash = xattr_inode_hash_fn(inode);
+	auto start = gMetadata->xattr_inode_hash[hash].begin();
+	auto end = gMetadata->xattr_inode_hash[hash].end();
+
+	for (auto attributeIterator = start; attributeIterator != end;) {
+		ih = attributeIterator->get();
 		if (ih->inode == inode) {
 			while (ih->data_head) {
 				xattr_removeentry(ih->data_head);
 			}
-			*ihp = ih->next;
-			free(ih);
+			attributeIterator = gMetadata->xattr_inode_hash[hash].erase(attributeIterator);
 		} else {
-			ihp = &(ih->next);
+			++attributeIterator;
 		}
 	}
 }
 
 uint8_t xattr_setattr(inode_t inode, uint8_t anleng, const uint8_t *attrname, uint32_t avleng,
 			const uint8_t *attrvalue, uint8_t mode) {
-	xattr_inode_entry *ih;
+	xattr_inode_entry *ih = nullptr;
 	xattr_data_entry *xa;
 	uint32_t hash, ihash;
 
@@ -120,7 +123,14 @@ uint8_t xattr_setattr(inode_t inode, uint8_t anleng, const uint8_t *attrname, ui
 	}
 
 	ihash = xattr_inode_hash_fn(inode);
-	for (ih = gMetadata->xattr_inode_hash[ihash]; ih && ih->inode != inode; ih = ih->next) {
+	auto start = gMetadata->xattr_inode_hash[ihash].begin();
+	auto end = gMetadata->xattr_inode_hash[ihash].end();
+
+	for (auto attributeIterator = start; attributeIterator != end; ++attributeIterator) {
+		ih = attributeIterator->get();
+		if (ih->inode == inode) {
+			break;
+		}
 	}
 
 	hash = xattr_data_hash_fn(inode, anleng, attrname);
@@ -204,16 +214,15 @@ uint8_t xattr_setattr(inode_t inode, uint8_t anleng, const uint8_t *attrname, ui
 		ih->anleng += anleng + 1U;
 		ih->avleng += avleng;
 	} else {
-		ih = (xattr_inode_entry *)malloc(sizeof(xattr_inode_entry));
-		passert(ih);
-		ih->inode = inode;
-		xa->nextinode = NULL;
-		xa->previnode = &(ih->data_head);
-		ih->data_head = xa;
-		ih->anleng = anleng + 1U;
-		ih->avleng = avleng;
-		ih->next = gMetadata->xattr_inode_hash[ihash];
-		gMetadata->xattr_inode_hash[ihash] = ih;
+		auto xattrInodeEntry = std::make_unique<xattr_inode_entry>();
+		passert(xattrInodeEntry);
+		xattrInodeEntry->inode = inode;
+		xa->nextinode = nullptr;
+		xa->previnode = &(xattrInodeEntry->data_head);
+		xattrInodeEntry->data_head = xa;
+		xattrInodeEntry->anleng = anleng + 1U;
+		xattrInodeEntry->avleng = avleng;
+		gMetadata->xattr_inode_hash[ihash].push_front(std::move(xattrInodeEntry));
 	}
 	xa->checksum = 0;
 	xattr_update_checksum(xa);
@@ -242,8 +251,12 @@ uint8_t xattr_getattr(inode_t inode, uint8_t anleng, const uint8_t *attrname, ui
 uint8_t xattr_listattr_leng(inode_t inode, void **xanode, uint32_t *xasize) {
 	xattr_inode_entry *ih;
 	xattr_data_entry *xa;
+	auto hash = xattr_inode_hash_fn(inode);
+	auto start = gMetadata->xattr_inode_hash[hash].begin();
+	auto end =  gMetadata->xattr_inode_hash[hash].end();
 
-	for (ih = gMetadata->xattr_inode_hash[xattr_inode_hash_fn(inode)]; ih; ih = ih->next) {
+	for (auto attributeIterator = start; attributeIterator != end;) {
+		ih = attributeIterator->get();
 		if (ih->inode == inode) {
 			*xanode = ih;
 			for (xa = ih->data_head; xa; xa = xa->nextinode) {

--- a/src/master/filesystem_xattr.cc
+++ b/src/master/filesystem_xattr.cc
@@ -29,8 +29,8 @@ static uint64_t xattr_checksum(const xattr_data_entry *xde) {
 		return 0;
 	}
 	uint64_t seed = 645819511511147ULL;
-	hashCombine(seed, xde->inode, ByteArray(xde->attrname, xde->anleng),
-	            ByteArray(xde->attrvalue, xde->avleng));
+	hashCombine(seed, xde->inode, ByteArray(xde->attributeName.data(), xde->anleng),
+	            ByteArray(xde->attributeValue.data(), xde->avleng));
 	return seed;
 }
 
@@ -126,7 +126,7 @@ uint8_t xattr_setattr(inode_t inode, uint8_t anleng, const uint8_t *attrname, ui
 	hash = xattr_data_hash_fn(inode, anleng, attrname);
 	for (xa = gMetadata->xattr_data_hash[hash]; xa; xa = xa->next) {
 		if (xa->inode == inode && xa->anleng == anleng &&
-		    memcmp(xa->attrname, attrname, anleng) == 0) {
+		    memcmp(xa->attributeName.data(), attrname, anleng) == 0) {
 			passert(ih);
 			if (mode == XATTR_SMODE_CREATE_ONLY) {  // create only
 				return SAUNAFS_ERROR_EEXIST;
@@ -148,15 +148,15 @@ uint8_t xattr_setattr(inode_t inode, uint8_t anleng, const uint8_t *attrname, ui
 				return SAUNAFS_STATUS_OK;
 			}
 			ih->avleng -= xa->avleng;
-			if (xa->attrvalue) {
-				free(xa->attrvalue);
+			if (!xa->attributeValue.empty()) {
+				xa->attributeValue.clear();
 			}
 			if (avleng > 0) {
-				xa->attrvalue = (uint8_t *)malloc(avleng);
-				passert(xa->attrvalue);
-				memcpy(xa->attrvalue, attrvalue, avleng);
+				xa->attributeValue.resize(avleng);
+				passert(xa->attributeValue.data());
+				memcpy(xa->attributeValue.data(), attrvalue, avleng);
 			} else {
-				xa->attrvalue = NULL;
+				xa->attributeValue.clear();
 			}
 			xa->avleng = avleng;
 			ih->avleng += avleng;
@@ -175,16 +175,16 @@ uint8_t xattr_setattr(inode_t inode, uint8_t anleng, const uint8_t *attrname, ui
 
 	xa = new xattr_data_entry;
 	xa->inode = inode;
-	xa->attrname = (uint8_t *)malloc(anleng);
-	passert(xa->attrname);
-	memcpy(xa->attrname, attrname, anleng);
+	xa->attributeName.resize(anleng);
+	passert(xa->attributeName.data());
+	memcpy(xa->attributeName.data(), attrname, anleng);
 	xa->anleng = anleng;
 	if (avleng > 0) {
-		xa->attrvalue = (uint8_t *)malloc(avleng);
-		passert(xa->attrvalue);
-		memcpy(xa->attrvalue, attrvalue, avleng);
+		xa->attributeValue.resize(avleng);
+		passert(xa->attributeValue.data());
+		memcpy(xa->attributeValue.data(), attrvalue, avleng);
 	} else {
-		xa->attrvalue = NULL;
+		xa->attributeValue.clear();
 	}
 	xa->avleng = avleng;
 	xa->next = gMetadata->xattr_data_hash[hash];
@@ -227,11 +227,11 @@ uint8_t xattr_getattr(inode_t inode, uint8_t anleng, const uint8_t *attrname, ui
 	for (xa = gMetadata->xattr_data_hash[xattr_data_hash_fn(inode, anleng, attrname)]; xa;
 	     xa = xa->next) {
 		if (xa->inode == inode && xa->anleng == anleng &&
-		    memcmp(xa->attrname, attrname, anleng) == 0) {
+		    memcmp(xa->attributeName.data(), attrname, anleng) == 0) {
 			if (xa->avleng > SFS_XATTR_SIZE_MAX) {
 				return SAUNAFS_ERROR_ERANGE;
 			}
-			*attrvalue = xa->attrvalue;
+			*attrvalue = xa->attributeValue.data();
 			*avleng = xa->avleng;
 			return SAUNAFS_STATUS_OK;
 		}
@@ -267,7 +267,7 @@ void xattr_listattr_data(void *xanode, uint8_t *xabuff) {
 	l = 0;
 	if (ih) {
 		for (xa = ih->data_head; xa; xa = xa->nextinode) {
-			memcpy(xabuff + l, xa->attrname, xa->anleng);
+			memcpy(xabuff + l, xa->attributeName.data(), xa->anleng);
 			l += xa->anleng;
 			xabuff[l++] = 0;
 		}

--- a/src/master/filesystem_xattr.cc
+++ b/src/master/filesystem_xattr.cc
@@ -49,11 +49,10 @@ static void xattr_update_checksum(xattr_data_entry *xde) {
 	addToChecksum(gMetadata->xattrChecksum, xde->checksum);
 }
 
-static inline void xattr_removeentry(xattr_data_entry *xa) {
-	*(xa->previnode) = xa->nextinode;
-	if (xa->nextinode) {
-		xa->nextinode->previnode = xa->previnode;
-	}
+static inline void xattr_removeentry(xattr_inode_entry *entry, xattr_data_entry *xa) {
+	// Remove the data from the xattr_inode_entry
+	entry->xattrDataList.remove(xa);
+
 	*(xa->prev) = xa->next;
 	if (xa->next) {
 		xa->next->prev = xa->prev;
@@ -95,8 +94,8 @@ void xattr_removeinode(inode_t inode) {
 	for (auto attributeIterator = start; attributeIterator != end;) {
 		ih = attributeIterator->get();
 		if (ih->inode == inode) {
-			while (ih->data_head) {
-				xattr_removeentry(ih->data_head);
+			while (!ih->xattrDataList.empty()) {
+				xattr_removeentry(ih, ih->xattrDataList.front());
 			}
 			attributeIterator = gMetadata->xattr_inode_hash[hash].erase(attributeIterator);
 		} else {
@@ -107,9 +106,9 @@ void xattr_removeinode(inode_t inode) {
 
 uint8_t xattr_setattr(inode_t inode, uint8_t anleng, const uint8_t *attrname, uint32_t avleng,
 			const uint8_t *attrvalue, uint8_t mode) {
-	xattr_inode_entry *ih = nullptr;
-	xattr_data_entry *xa;
-	uint32_t hash, ihash;
+	xattr_inode_entry *xattrInodeEntry = nullptr;
+	xattr_data_entry *xattrDataEntry;
+	uint32_t hash;
 
 	if (avleng > SFS_XATTR_SIZE_MAX) {
 		return SAUNAFS_ERROR_ERANGE;
@@ -122,55 +121,63 @@ uint8_t xattr_setattr(inode_t inode, uint8_t anleng, const uint8_t *attrname, ui
 		return SAUNAFS_ERROR_EINVAL;
 	}
 
-	ihash = xattr_inode_hash_fn(inode);
+	auto ihash = xattr_inode_hash_fn(inode);
 	auto start = gMetadata->xattr_inode_hash[ihash].begin();
 	auto end = gMetadata->xattr_inode_hash[ihash].end();
 
 	for (auto attributeIterator = start; attributeIterator != end; ++attributeIterator) {
-		ih = attributeIterator->get();
-		if (ih->inode == inode) {
+		xattrInodeEntry = attributeIterator->get();
+		if (xattrInodeEntry->inode == inode) {
 			break;
 		}
 	}
 
 	hash = xattr_data_hash_fn(inode, anleng, attrname);
-	for (xa = gMetadata->xattr_data_hash[hash]; xa; xa = xa->next) {
-		if (xa->inode == inode && xa->anleng == anleng &&
-		    memcmp(xa->attributeName.data(), attrname, anleng) == 0) {
-			passert(ih);
+	for (xattrDataEntry = gMetadata->xattr_data_hash[hash]; xattrDataEntry;
+	     xattrDataEntry = xattrDataEntry->next) {
+		if (xattrDataEntry->inode == inode && xattrDataEntry->anleng == anleng &&
+		    memcmp(xattrDataEntry->attributeName.data(), attrname, anleng) == 0) {
+			passert(xattrInodeEntry);
+
 			if (mode == XATTR_SMODE_CREATE_ONLY) {  // create only
 				return SAUNAFS_ERROR_EEXIST;
 			}
+
 			if (mode == XATTR_SMODE_REMOVE) {  // remove
-				ih->anleng -= anleng + 1U;
-				ih->avleng -= xa->avleng;
-				xattr_removeentry(xa);
-				if (ih->data_head == NULL) {
-					if (ih->anleng != 0 || ih->avleng != 0) {
+				xattrInodeEntry->anleng -= anleng + 1U;
+				xattrInodeEntry->avleng -= xattrDataEntry->avleng;
+				xattr_removeentry(xattrInodeEntry, xattrDataEntry);
+
+				if (xattrInodeEntry->xattrDataList.empty()) {
+					if (xattrInodeEntry->anleng != 0 || xattrInodeEntry->avleng != 0) {
 						safs_pretty_syslog(LOG_WARNING,
 						       "xattr non zero lengths on remove "
 						       "(inode:%" PRIiNode ",anleng:%" PRIu32
 						       ",avleng:%" PRIu32 ")",
-						       ih->inode, ih->anleng, ih->avleng);
+						       xattrInodeEntry->inode, xattrInodeEntry->anleng, xattrInodeEntry->avleng);
 					}
 					xattr_removeinode(inode);
 				}
 				return SAUNAFS_STATUS_OK;
 			}
-			ih->avleng -= xa->avleng;
-			if (!xa->attributeValue.empty()) {
-				xa->attributeValue.clear();
+
+			xattrInodeEntry->avleng -= xattrDataEntry->avleng;
+
+			if (!xattrDataEntry->attributeValue.empty()) {
+				xattrDataEntry->attributeValue.clear();
 			}
+
 			if (avleng > 0) {
-				xa->attributeValue.resize(avleng);
-				passert(xa->attributeValue.data());
-				memcpy(xa->attributeValue.data(), attrvalue, avleng);
+				xattrDataEntry->attributeValue.resize(avleng);
+				passert(xattrDataEntry->attributeValue.data());
+				memcpy(xattrDataEntry->attributeValue.data(), attrvalue, avleng);
 			} else {
-				xa->attributeValue.clear();
+				xattrDataEntry->attributeValue.clear();
 			}
-			xa->avleng = avleng;
-			ih->avleng += avleng;
-			xattr_update_checksum(xa);
+
+			xattrDataEntry->avleng = avleng;
+			xattrInodeEntry->avleng += avleng;
+			xattr_update_checksum(xattrDataEntry);
 			return SAUNAFS_STATUS_OK;
 		}
 	}
@@ -179,53 +186,51 @@ uint8_t xattr_setattr(inode_t inode, uint8_t anleng, const uint8_t *attrname, ui
 		return SAUNAFS_ERROR_ENOATTR;
 	}
 
-	if (ih && ih->anleng + anleng + 1 > SFS_XATTR_LIST_MAX) {
+	if (xattrInodeEntry && xattrInodeEntry->anleng + anleng + 1 > SFS_XATTR_LIST_MAX) {
 		return SAUNAFS_ERROR_ERANGE;
 	}
 
-	xa = new xattr_data_entry;
-	xa->inode = inode;
-	xa->attributeName.resize(anleng);
-	passert(xa->attributeName.data());
-	memcpy(xa->attributeName.data(), attrname, anleng);
-	xa->anleng = anleng;
-	if (avleng > 0) {
-		xa->attributeValue.resize(avleng);
-		passert(xa->attributeValue.data());
-		memcpy(xa->attributeValue.data(), attrvalue, avleng);
-	} else {
-		xa->attributeValue.clear();
-	}
-	xa->avleng = avleng;
-	xa->next = gMetadata->xattr_data_hash[hash];
-	if (xa->next) {
-		xa->next->prev = &(xa->next);
-	}
-	xa->prev = gMetadata->xattr_data_hash + hash;
-	gMetadata->xattr_data_hash[hash] = xa;
+	xattrDataEntry = new xattr_data_entry;
+	xattrDataEntry->inode = inode;
+	xattrDataEntry->attributeName.resize(anleng);
+	passert(xattrDataEntry->attributeName.data());
+	memcpy(xattrDataEntry->attributeName.data(), attrname, anleng);
+	xattrDataEntry->anleng = anleng;
 
-	if (ih) {
-		xa->nextinode = ih->data_head;
-		if (xa->nextinode) {
-			xa->nextinode->previnode = &(xa->nextinode);
-		}
-		xa->previnode = &(ih->data_head);
-		ih->data_head = xa;
-		ih->anleng += anleng + 1U;
-		ih->avleng += avleng;
+	if (avleng > 0) {
+		xattrDataEntry->attributeValue.resize(avleng);
+		passert(xattrDataEntry->attributeValue.data());
+		memcpy(xattrDataEntry->attributeValue.data(), attrvalue, avleng);
+	} else {
+		xattrDataEntry->attributeValue.clear();
+	}
+
+	xattrDataEntry->avleng = avleng;
+	xattrDataEntry->next = gMetadata->xattr_data_hash[hash];
+
+	if (xattrDataEntry->next) {
+		xattrDataEntry->next->prev = &(xattrDataEntry->next);
+	}
+
+	xattrDataEntry->prev = gMetadata->xattr_data_hash + hash;
+	gMetadata->xattr_data_hash[hash] = xattrDataEntry;
+
+	if (xattrInodeEntry) {
+		xattrInodeEntry->xattrDataList.push_back(xattrDataEntry);
+		xattrInodeEntry->anleng += anleng + 1U;
+		xattrInodeEntry->avleng += avleng;
 	} else {
 		auto xattrInodeEntry = std::make_unique<xattr_inode_entry>();
 		passert(xattrInodeEntry);
 		xattrInodeEntry->inode = inode;
-		xa->nextinode = nullptr;
-		xa->previnode = &(xattrInodeEntry->data_head);
-		xattrInodeEntry->data_head = xa;
+		xattrInodeEntry->xattrDataList.push_back(xattrDataEntry);
 		xattrInodeEntry->anleng = anleng + 1U;
 		xattrInodeEntry->avleng = avleng;
 		gMetadata->xattr_inode_hash[ihash].push_front(std::move(xattrInodeEntry));
 	}
-	xa->checksum = 0;
-	xattr_update_checksum(xa);
+
+	xattrDataEntry->checksum = 0;
+	xattr_update_checksum(xattrDataEntry);
 	return SAUNAFS_STATUS_OK;
 }
 
@@ -249,18 +254,17 @@ uint8_t xattr_getattr(inode_t inode, uint8_t anleng, const uint8_t *attrname, ui
 }
 
 uint8_t xattr_listattr_leng(inode_t inode, void **xanode, uint32_t *xasize) {
-	xattr_inode_entry *ih;
-	xattr_data_entry *xa;
+	xattr_inode_entry *xattrInodeEntry;
 	auto hash = xattr_inode_hash_fn(inode);
 	auto start = gMetadata->xattr_inode_hash[hash].begin();
 	auto end =  gMetadata->xattr_inode_hash[hash].end();
 
 	for (auto attributeIterator = start; attributeIterator != end;) {
-		ih = attributeIterator->get();
-		if (ih->inode == inode) {
-			*xanode = ih;
-			for (xa = ih->data_head; xa; xa = xa->nextinode) {
-				*xasize += xa->anleng + 1U;
+		xattrInodeEntry = attributeIterator->get();
+		if (xattrInodeEntry->inode == inode) {
+			*xanode = xattrInodeEntry;
+			for (const auto &xattrDataEntry : xattrInodeEntry->xattrDataList) {
+				*xasize += xattrDataEntry->anleng + 1U;
 			}
 			if (*xasize > SFS_XATTR_LIST_MAX) {
 				return SAUNAFS_ERROR_ERANGE;
@@ -268,21 +272,21 @@ uint8_t xattr_listattr_leng(inode_t inode, void **xanode, uint32_t *xasize) {
 			return SAUNAFS_STATUS_OK;
 		}
 	}
-	*xanode = NULL;
+
+	*xanode = nullptr;
 	return SAUNAFS_STATUS_OK;
 }
 
-void xattr_listattr_data(void *xanode, uint8_t *xabuff) {
-	xattr_inode_entry *ih = (xattr_inode_entry *)xanode;
-	xattr_data_entry *xa;
-	uint32_t l;
+void xattr_listattr_data(void *xattrInodeEntry, uint8_t *xabuff) {
+	auto *xattrEntry = static_cast<xattr_inode_entry *>(xattrInodeEntry);
 
-	l = 0;
-	if (ih) {
-		for (xa = ih->data_head; xa; xa = xa->nextinode) {
-			memcpy(xabuff + l, xa->attributeName.data(), xa->anleng);
-			l += xa->anleng;
-			xabuff[l++] = 0;
+	uint32_t entryLength = 0;
+	if (xattrEntry) {
+		passert(xabuff);
+		for (const auto &xattrDataEntry : xattrEntry->xattrDataList) {
+			memcpy(xabuff + entryLength, xattrDataEntry->attributeName.data(), xattrDataEntry->anleng);
+			entryLength += xattrDataEntry->anleng;
+			xabuff[entryLength++] = 0;
 		}
 	}
 }

--- a/src/master/filesystem_xattr.cc
+++ b/src/master/filesystem_xattr.cc
@@ -53,15 +53,22 @@ static inline void xattr_removeentry(xattr_inode_entry *entry, xattr_data_entry 
 	// Remove the data from the xattr_inode_entry
 	entry->xattrDataList.remove(xa);
 
-	*(xa->prev) = xa->next;
-	if (xa->next) {
-		xa->next->prev = xa->prev;
-	}
 	if (gChecksumBackgroundUpdater.isXattrIncluded(xa)) {
 		removeFromChecksum(gChecksumBackgroundUpdater.xattrChecksum, xa->checksum);
 	}
 	removeFromChecksum(gMetadata->xattrChecksum, xa->checksum);
-	delete xa;
+
+	// Delete the entry from the hash bucket
+	auto hash = xattr_data_hash_fn(entry->inode, xa->anleng, xa->attributeName.data());
+	auto start = gMetadata->xattr_data_hash[hash].begin();
+	auto end = gMetadata->xattr_data_hash[hash].end();
+
+	auto entryIt = std::find_if(
+	    start, end, [xa](const std::unique_ptr<xattr_data_entry> &ptr) { return ptr.get() == xa; });
+
+	if (entryIt != end) {
+		gMetadata->xattr_data_hash[hash].remove(*entryIt);
+	}
 }
 
 void xattr_checksum_add_to_background(xattr_data_entry *xde) {
@@ -77,8 +84,8 @@ void xattr_checksum_add_to_background(xattr_data_entry *xde) {
 void xattr_recalculate_checksum() {
 	gMetadata->xattrChecksum = XATTRCHECKSUMSEED;
 	for (int i = 0; i < XATTR_DATA_HASH_SIZE; ++i) {
-		for (xattr_data_entry *xde = gMetadata->xattr_data_hash[i]; xde; xde = xde->next) {
-			xde->checksum = xattr_checksum(xde);
+		for (const auto &xde : gMetadata->xattr_data_hash[i]) {
+			xde->checksum = xattr_checksum(xde.get());
 			addToChecksum(gMetadata->xattrChecksum, xde->checksum);
 		}
 	}
@@ -107,7 +114,6 @@ void xattr_removeinode(inode_t inode) {
 uint8_t xattr_setattr(inode_t inode, uint8_t anleng, const uint8_t *attrname, uint32_t avleng,
 			const uint8_t *attrvalue, uint8_t mode) {
 	xattr_inode_entry *xattrInodeEntry = nullptr;
-	xattr_data_entry *xattrDataEntry;
 	uint32_t hash;
 
 	if (avleng > SFS_XATTR_SIZE_MAX) {
@@ -133,8 +139,7 @@ uint8_t xattr_setattr(inode_t inode, uint8_t anleng, const uint8_t *attrname, ui
 	}
 
 	hash = xattr_data_hash_fn(inode, anleng, attrname);
-	for (xattrDataEntry = gMetadata->xattr_data_hash[hash]; xattrDataEntry;
-	     xattrDataEntry = xattrDataEntry->next) {
+	for (const auto &xattrDataEntry : gMetadata->xattr_data_hash[hash]) {
 		if (xattrDataEntry->inode == inode && xattrDataEntry->anleng == anleng &&
 		    memcmp(xattrDataEntry->attributeName.data(), attrname, anleng) == 0) {
 			passert(xattrInodeEntry);
@@ -146,7 +151,8 @@ uint8_t xattr_setattr(inode_t inode, uint8_t anleng, const uint8_t *attrname, ui
 			if (mode == XATTR_SMODE_REMOVE) {  // remove
 				xattrInodeEntry->anleng -= anleng + 1U;
 				xattrInodeEntry->avleng -= xattrDataEntry->avleng;
-				xattr_removeentry(xattrInodeEntry, xattrDataEntry);
+
+				xattr_removeentry(xattrInodeEntry, xattrDataEntry.get());
 
 				if (xattrInodeEntry->xattrDataList.empty()) {
 					if (xattrInodeEntry->anleng != 0 || xattrInodeEntry->avleng != 0) {
@@ -177,7 +183,7 @@ uint8_t xattr_setattr(inode_t inode, uint8_t anleng, const uint8_t *attrname, ui
 
 			xattrDataEntry->avleng = avleng;
 			xattrInodeEntry->avleng += avleng;
-			xattr_update_checksum(xattrDataEntry);
+			xattr_update_checksum(xattrDataEntry.get());
 			return SAUNAFS_STATUS_OK;
 		}
 	}
@@ -190,7 +196,7 @@ uint8_t xattr_setattr(inode_t inode, uint8_t anleng, const uint8_t *attrname, ui
 		return SAUNAFS_ERROR_ERANGE;
 	}
 
-	xattrDataEntry = new xattr_data_entry;
+	auto xattrDataEntry = std::make_unique<xattr_data_entry>();
 	xattrDataEntry->inode = inode;
 	xattrDataEntry->attributeName.resize(anleng);
 	passert(xattrDataEntry->attributeName.data());
@@ -206,47 +212,41 @@ uint8_t xattr_setattr(inode_t inode, uint8_t anleng, const uint8_t *attrname, ui
 	}
 
 	xattrDataEntry->avleng = avleng;
-	xattrDataEntry->next = gMetadata->xattr_data_hash[hash];
+	xattrDataEntry->checksum = 0;
+	xattr_update_checksum(xattrDataEntry.get());
 
-	if (xattrDataEntry->next) {
-		xattrDataEntry->next->prev = &(xattrDataEntry->next);
-	}
-
-	xattrDataEntry->prev = gMetadata->xattr_data_hash + hash;
-	gMetadata->xattr_data_hash[hash] = xattrDataEntry;
+	gMetadata->xattr_data_hash[hash].push_back(std::move(xattrDataEntry));
+	auto *xattrDataEntryPointer = gMetadata->xattr_data_hash[hash].back().get();
 
 	if (xattrInodeEntry) {
-		xattrInodeEntry->xattrDataList.push_back(xattrDataEntry);
+		xattrInodeEntry->xattrDataList.push_back(xattrDataEntryPointer);
 		xattrInodeEntry->anleng += anleng + 1U;
 		xattrInodeEntry->avleng += avleng;
 	} else {
 		auto xattrInodeEntry = std::make_unique<xattr_inode_entry>();
 		passert(xattrInodeEntry);
 		xattrInodeEntry->inode = inode;
-		xattrInodeEntry->xattrDataList.push_back(xattrDataEntry);
+		xattrInodeEntry->xattrDataList.push_back(xattrDataEntryPointer);
 		xattrInodeEntry->anleng = anleng + 1U;
 		xattrInodeEntry->avleng = avleng;
 		gMetadata->xattr_inode_hash[ihash].push_front(std::move(xattrInodeEntry));
 	}
 
-	xattrDataEntry->checksum = 0;
-	xattr_update_checksum(xattrDataEntry);
 	return SAUNAFS_STATUS_OK;
 }
 
 uint8_t xattr_getattr(inode_t inode, uint8_t anleng, const uint8_t *attrname, uint32_t *avleng,
 			uint8_t **attrvalue) {
-	xattr_data_entry *xa;
 
-	for (xa = gMetadata->xattr_data_hash[xattr_data_hash_fn(inode, anleng, attrname)]; xa;
-	     xa = xa->next) {
-		if (xa->inode == inode && xa->anleng == anleng &&
-		    memcmp(xa->attributeName.data(), attrname, anleng) == 0) {
-			if (xa->avleng > SFS_XATTR_SIZE_MAX) {
+	auto hash = xattr_data_hash_fn(inode, anleng, attrname);
+	for (const auto &xattrDataEntry : gMetadata->xattr_data_hash[hash]) {
+		if (xattrDataEntry->inode == inode && xattrDataEntry->anleng == anleng &&
+		    memcmp(xattrDataEntry->attributeName.data(), attrname, anleng) == 0) {
+			if (xattrDataEntry->avleng > SFS_XATTR_SIZE_MAX) {
 				return SAUNAFS_ERROR_ERANGE;
 			}
-			*attrvalue = xa->attributeValue.data();
-			*avleng = xa->avleng;
+			*attrvalue = xattrDataEntry->attributeValue.data();
+			*avleng = xattrDataEntry->avleng;
 			return SAUNAFS_STATUS_OK;
 		}
 	}

--- a/src/master/filesystem_xattr.cc
+++ b/src/master/filesystem_xattr.cc
@@ -24,112 +24,124 @@
 #include <master/filesystem_metadata.h>
 #include <master/filesystem_xattr.h>
 
-static uint64_t xattr_checksum(const xattr_data_entry *xde) {
-	if (!xde) {
+static uint64_t xattr_checksum(const XAttributeDataEntry *xattrDataEntry) {
+	if (!xattrDataEntry) {
 		return 0;
 	}
+
 	uint64_t seed = 645819511511147ULL;
-	hashCombine(seed, xde->inode, ByteArray(xde->attributeName.data(), xde->anleng),
-	            ByteArray(xde->attributeValue.data(), xde->avleng));
+	hashCombine(
+	    seed, xattrDataEntry->inode,
+	    ByteArray(xattrDataEntry->attributeName.data(), xattrDataEntry->attributeNameLength),
+	    ByteArray(xattrDataEntry->attributeValue.data(), xattrDataEntry->attributeValueLength));
+
 	return seed;
 }
 
-static void xattr_update_checksum(xattr_data_entry *xde) {
-	if (!xde) {
+static void xattr_update_checksum(XAttributeDataEntry *xattrDataEntry) {
+	if (!xattrDataEntry) {
 		return;
 	}
-	if (gChecksumBackgroundUpdater.isXattrIncluded(xde)) {
-		removeFromChecksum(gChecksumBackgroundUpdater.xattrChecksum, xde->checksum);
+
+	if (gChecksumBackgroundUpdater.isXattrIncluded(xattrDataEntry)) {
+		removeFromChecksum(gChecksumBackgroundUpdater.xattrChecksum, xattrDataEntry->checksum);
 	}
-	removeFromChecksum(gMetadata->xattrChecksum, xde->checksum);
-	xde->checksum = xattr_checksum(xde);
-	if (gChecksumBackgroundUpdater.isXattrIncluded(xde)) {
-		addToChecksum(gChecksumBackgroundUpdater.xattrChecksum, xde->checksum);
+
+	removeFromChecksum(gMetadata->xattrChecksum, xattrDataEntry->checksum);
+	xattrDataEntry->checksum = xattr_checksum(xattrDataEntry);
+
+	if (gChecksumBackgroundUpdater.isXattrIncluded(xattrDataEntry)) {
+		addToChecksum(gChecksumBackgroundUpdater.xattrChecksum, xattrDataEntry->checksum);
 	}
-	addToChecksum(gMetadata->xattrChecksum, xde->checksum);
+
+	addToChecksum(gMetadata->xattrChecksum, xattrDataEntry->checksum);
 }
 
-static inline void xattr_removeentry(xattr_inode_entry *entry, xattr_data_entry *xa) {
+static inline void xattr_removeentry(XAttributeInodeEntry *entry,
+                                     XAttributeDataEntry *xattrDataEntry) {
 	// Remove the data from the xattr_inode_entry
-	entry->xattrDataList.remove(xa);
+	entry->xattrDataList.remove(xattrDataEntry);
 
-	if (gChecksumBackgroundUpdater.isXattrIncluded(xa)) {
-		removeFromChecksum(gChecksumBackgroundUpdater.xattrChecksum, xa->checksum);
+	if (gChecksumBackgroundUpdater.isXattrIncluded(xattrDataEntry)) {
+		removeFromChecksum(gChecksumBackgroundUpdater.xattrChecksum, xattrDataEntry->checksum);
 	}
-	removeFromChecksum(gMetadata->xattrChecksum, xa->checksum);
+
+	removeFromChecksum(gMetadata->xattrChecksum, xattrDataEntry->checksum);
 
 	// Delete the entry from the hash bucket
-	auto hash = xattr_data_hash_fn(entry->inode, xa->anleng, xa->attributeName.data());
-	auto start = gMetadata->xattr_data_hash[hash].begin();
-	auto end = gMetadata->xattr_data_hash[hash].end();
+	auto hash = get_xattr_data_hash(entry->inode, xattrDataEntry->attributeNameLength,
+	                                xattrDataEntry->attributeName.data());
+	auto start = gMetadata->xattrDataHash[hash].begin();
+	auto end = gMetadata->xattrDataHash[hash].end();
 
-	auto entryIt = std::find_if(
-	    start, end, [xa](const std::unique_ptr<xattr_data_entry> &ptr) { return ptr.get() == xa; });
+	auto entryIt =
+	    std::find_if(start, end, [xattrDataEntry](const std::unique_ptr<XAttributeDataEntry> &ptr) {
+		    return ptr.get() == xattrDataEntry;
+	    });
 
 	if (entryIt != end) {
-		gMetadata->xattr_data_hash[hash].remove(*entryIt);
+		gMetadata->xattrDataHash[hash].remove(*entryIt);
 	}
 }
 
-void xattr_checksum_add_to_background(xattr_data_entry *xde) {
-	if (!xde) {
-		return;
-	}
-	removeFromChecksum(gMetadata->xattrChecksum, xde->checksum);
-	xde->checksum = xattr_checksum(xde);
-	addToChecksum(gMetadata->xattrChecksum, xde->checksum);
-	addToChecksum(gChecksumBackgroundUpdater.xattrChecksum, xde->checksum);
+void xattr_checksum_add_to_background(XAttributeDataEntry *xattrDataEntry) {
+	if (!xattrDataEntry) { return; }
+
+	removeFromChecksum(gMetadata->xattrChecksum, xattrDataEntry->checksum);
+	xattrDataEntry->checksum = xattr_checksum(xattrDataEntry);
+
+	addToChecksum(gMetadata->xattrChecksum, xattrDataEntry->checksum);
+	addToChecksum(gChecksumBackgroundUpdater.xattrChecksum, xattrDataEntry->checksum);
 }
 
 void xattr_recalculate_checksum() {
 	gMetadata->xattrChecksum = XATTRCHECKSUMSEED;
 	for (int i = 0; i < XATTR_DATA_HASH_SIZE; ++i) {
-		for (const auto &xde : gMetadata->xattr_data_hash[i]) {
-			xde->checksum = xattr_checksum(xde.get());
-			addToChecksum(gMetadata->xattrChecksum, xde->checksum);
+		for (const auto &xattrDataEntry : gMetadata->xattrDataHash[i]) {
+			xattrDataEntry->checksum = xattr_checksum(xattrDataEntry.get());
+			addToChecksum(gMetadata->xattrChecksum, xattrDataEntry->checksum);
 		}
 	}
 }
 
 void xattr_removeinode(inode_t inode) {
-	xattr_inode_entry *ih;
+	XAttributeInodeEntry *xattrInodeEntry = nullptr;
 
-	auto hash = xattr_inode_hash_fn(inode);
-	auto start = gMetadata->xattr_inode_hash[hash].begin();
-	auto end = gMetadata->xattr_inode_hash[hash].end();
+	auto hash = get_xattr_inode_hash(inode);
+	auto start = gMetadata->xattrInodeHash[hash].begin();
+	auto end = gMetadata->xattrInodeHash[hash].end();
 
 	for (auto attributeIterator = start; attributeIterator != end;) {
-		ih = attributeIterator->get();
-		if (ih->inode == inode) {
-			while (!ih->xattrDataList.empty()) {
-				xattr_removeentry(ih, ih->xattrDataList.front());
+		xattrInodeEntry = attributeIterator->get();
+		if (xattrInodeEntry->inode == inode) {
+			while (!xattrInodeEntry->xattrDataList.empty()) {
+				xattr_removeentry(xattrInodeEntry, xattrInodeEntry->xattrDataList.front());
 			}
-			attributeIterator = gMetadata->xattr_inode_hash[hash].erase(attributeIterator);
+			attributeIterator = gMetadata->xattrInodeHash[hash].erase(attributeIterator);
 		} else {
 			++attributeIterator;
 		}
 	}
 }
 
-uint8_t xattr_setattr(inode_t inode, uint8_t anleng, const uint8_t *attrname, uint32_t avleng,
-			const uint8_t *attrvalue, uint8_t mode) {
-	xattr_inode_entry *xattrInodeEntry = nullptr;
-	uint32_t hash;
+uint8_t xattr_setattr(inode_t inode, uint8_t attributeNameLength, const uint8_t *attributeName,
+                      uint32_t attributeValueLength, const uint8_t *attributeValue, uint8_t mode) {
+	XAttributeInodeEntry *xattrInodeEntry = nullptr;
 
-	if (avleng > SFS_XATTR_SIZE_MAX) {
+	if (attributeValueLength > SFS_XATTR_SIZE_MAX) {
 		return SAUNAFS_ERROR_ERANGE;
 	}
 #if SFS_XATTR_NAME_MAX < 255
-	if (anleng == 0U || anleng > SFS_XATTR_NAME_MAX) {
+	if (attributeNameLength == 0U || attributeNameLength > SFS_XATTR_NAME_MAX) {
 #else
-	if (anleng == 0U) {
+	if (attributeNameLength == 0U) {
 #endif
 		return SAUNAFS_ERROR_EINVAL;
 	}
 
-	auto ihash = xattr_inode_hash_fn(inode);
-	auto start = gMetadata->xattr_inode_hash[ihash].begin();
-	auto end = gMetadata->xattr_inode_hash[ihash].end();
+	auto inodeHash = get_xattr_inode_hash(inode);
+	auto start = gMetadata->xattrInodeHash[inodeHash].begin();
+	auto end = gMetadata->xattrInodeHash[inodeHash].end();
 
 	for (auto attributeIterator = start; attributeIterator != end; ++attributeIterator) {
 		xattrInodeEntry = attributeIterator->get();
@@ -138,10 +150,11 @@ uint8_t xattr_setattr(inode_t inode, uint8_t anleng, const uint8_t *attrname, ui
 		}
 	}
 
-	hash = xattr_data_hash_fn(inode, anleng, attrname);
-	for (const auto &xattrDataEntry : gMetadata->xattr_data_hash[hash]) {
-		if (xattrDataEntry->inode == inode && xattrDataEntry->anleng == anleng &&
-		    memcmp(xattrDataEntry->attributeName.data(), attrname, anleng) == 0) {
+	auto dataHash = get_xattr_data_hash(inode, attributeNameLength, attributeName);
+	for (const auto &xattrDataEntry : gMetadata->xattrDataHash[dataHash]) {
+		if (xattrDataEntry->inode == inode &&
+		    xattrDataEntry->attributeNameLength == attributeNameLength &&
+		    memcmp(xattrDataEntry->attributeName.data(), attributeName, attributeNameLength) == 0) {
 			passert(xattrInodeEntry);
 
 			if (mode == XATTR_SMODE_CREATE_ONLY) {  // create only
@@ -149,40 +162,42 @@ uint8_t xattr_setattr(inode_t inode, uint8_t anleng, const uint8_t *attrname, ui
 			}
 
 			if (mode == XATTR_SMODE_REMOVE) {  // remove
-				xattrInodeEntry->anleng -= anleng + 1U;
-				xattrInodeEntry->avleng -= xattrDataEntry->avleng;
+				xattrInodeEntry->attributeNameLength -= attributeNameLength + 1U;
+				xattrInodeEntry->attributeValueLength -= xattrDataEntry->attributeValueLength;
 
 				xattr_removeentry(xattrInodeEntry, xattrDataEntry.get());
 
 				if (xattrInodeEntry->xattrDataList.empty()) {
-					if (xattrInodeEntry->anleng != 0 || xattrInodeEntry->avleng != 0) {
-						safs_pretty_syslog(LOG_WARNING,
-						       "xattr non zero lengths on remove "
-						       "(inode:%" PRIiNode ",anleng:%" PRIu32
-						       ",avleng:%" PRIu32 ")",
-						       xattrInodeEntry->inode, xattrInodeEntry->anleng, xattrInodeEntry->avleng);
+					if (xattrInodeEntry->attributeNameLength != 0 ||
+					    xattrInodeEntry->attributeValueLength != 0) {
+						safs_pretty_syslog(
+						    LOG_WARNING,
+						    "xattr non zero lengths on remove "
+						    "(inode:%" PRIiNode ",anleng:%" PRIu32 ",avleng:%" PRIu32 ")",
+						    xattrInodeEntry->inode, xattrInodeEntry->attributeNameLength,
+						    xattrInodeEntry->attributeValueLength);
 					}
 					xattr_removeinode(inode);
 				}
 				return SAUNAFS_STATUS_OK;
 			}
 
-			xattrInodeEntry->avleng -= xattrDataEntry->avleng;
+			xattrInodeEntry->attributeValueLength -= xattrDataEntry->attributeValueLength;
 
 			if (!xattrDataEntry->attributeValue.empty()) {
 				xattrDataEntry->attributeValue.clear();
 			}
 
-			if (avleng > 0) {
-				xattrDataEntry->attributeValue.resize(avleng);
+			if (attributeValueLength > 0) {
+				xattrDataEntry->attributeValue.resize(attributeValueLength);
 				passert(xattrDataEntry->attributeValue.data());
-				memcpy(xattrDataEntry->attributeValue.data(), attrvalue, avleng);
+				memcpy(xattrDataEntry->attributeValue.data(), attributeValue, attributeValueLength);
 			} else {
 				xattrDataEntry->attributeValue.clear();
 			}
 
-			xattrDataEntry->avleng = avleng;
-			xattrInodeEntry->avleng += avleng;
+			xattrDataEntry->attributeValueLength = attributeValueLength;
+			xattrInodeEntry->attributeValueLength += attributeValueLength;
 			xattr_update_checksum(xattrDataEntry.get());
 			return SAUNAFS_STATUS_OK;
 		}
@@ -192,102 +207,109 @@ uint8_t xattr_setattr(inode_t inode, uint8_t anleng, const uint8_t *attrname, ui
 		return SAUNAFS_ERROR_ENOATTR;
 	}
 
-	if (xattrInodeEntry && xattrInodeEntry->anleng + anleng + 1 > SFS_XATTR_LIST_MAX) {
+	if (xattrInodeEntry != nullptr &&
+	    xattrInodeEntry->attributeNameLength + attributeNameLength + 1 > SFS_XATTR_LIST_MAX) {
 		return SAUNAFS_ERROR_ERANGE;
 	}
 
-	auto xattrDataEntry = std::make_unique<xattr_data_entry>();
+	auto xattrDataEntry = std::make_unique<XAttributeDataEntry>();
 	xattrDataEntry->inode = inode;
-	xattrDataEntry->attributeName.resize(anleng);
+	xattrDataEntry->attributeName.resize(attributeNameLength);
 	passert(xattrDataEntry->attributeName.data());
-	memcpy(xattrDataEntry->attributeName.data(), attrname, anleng);
-	xattrDataEntry->anleng = anleng;
+	memcpy(xattrDataEntry->attributeName.data(), attributeName, attributeNameLength);
+	xattrDataEntry->attributeNameLength = attributeNameLength;
 
-	if (avleng > 0) {
-		xattrDataEntry->attributeValue.resize(avleng);
+	if (attributeValueLength > 0) {
+		xattrDataEntry->attributeValue.resize(attributeValueLength);
 		passert(xattrDataEntry->attributeValue.data());
-		memcpy(xattrDataEntry->attributeValue.data(), attrvalue, avleng);
+		memcpy(xattrDataEntry->attributeValue.data(), attributeValue, attributeValueLength);
 	} else {
 		xattrDataEntry->attributeValue.clear();
 	}
 
-	xattrDataEntry->avleng = avleng;
+	xattrDataEntry->attributeValueLength = attributeValueLength;
 	xattrDataEntry->checksum = 0;
 	xattr_update_checksum(xattrDataEntry.get());
 
-	gMetadata->xattr_data_hash[hash].push_back(std::move(xattrDataEntry));
-	auto *xattrDataEntryPointer = gMetadata->xattr_data_hash[hash].back().get();
+	gMetadata->xattrDataHash[dataHash].push_back(std::move(xattrDataEntry));
+	auto *xattrDataEntryPointer = gMetadata->xattrDataHash[dataHash].back().get();
 
 	if (xattrInodeEntry) {
 		xattrInodeEntry->xattrDataList.push_back(xattrDataEntryPointer);
-		xattrInodeEntry->anleng += anleng + 1U;
-		xattrInodeEntry->avleng += avleng;
+		xattrInodeEntry->attributeNameLength += attributeNameLength + 1U;
+		xattrInodeEntry->attributeValueLength += attributeValueLength;
 	} else {
-		auto xattrInodeEntry = std::make_unique<xattr_inode_entry>();
+		auto xattrInodeEntry = std::make_unique<XAttributeInodeEntry>();
 		passert(xattrInodeEntry);
 		xattrInodeEntry->inode = inode;
 		xattrInodeEntry->xattrDataList.push_back(xattrDataEntryPointer);
-		xattrInodeEntry->anleng = anleng + 1U;
-		xattrInodeEntry->avleng = avleng;
-		gMetadata->xattr_inode_hash[ihash].push_front(std::move(xattrInodeEntry));
+		xattrInodeEntry->attributeNameLength = attributeNameLength + 1U;
+		xattrInodeEntry->attributeValueLength = attributeValueLength;
+		gMetadata->xattrInodeHash[inodeHash].push_front(std::move(xattrInodeEntry));
 	}
 
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t xattr_getattr(inode_t inode, uint8_t anleng, const uint8_t *attrname, uint32_t *avleng,
-			uint8_t **attrvalue) {
+uint8_t xattr_getattr(inode_t inode, uint8_t attributeNameLength, const uint8_t *attributeName,
+                      uint32_t *attributeValueLength, uint8_t **attributeValue) {
 
-	auto hash = xattr_data_hash_fn(inode, anleng, attrname);
-	for (const auto &xattrDataEntry : gMetadata->xattr_data_hash[hash]) {
-		if (xattrDataEntry->inode == inode && xattrDataEntry->anleng == anleng &&
-		    memcmp(xattrDataEntry->attributeName.data(), attrname, anleng) == 0) {
-			if (xattrDataEntry->avleng > SFS_XATTR_SIZE_MAX) {
+	auto hash = get_xattr_data_hash(inode, attributeNameLength, attributeName);
+
+	auto xattrDataEntryHasAttribute = [&](const auto &entry) {
+		return entry->inode == inode && entry->attributeNameLength == attributeNameLength &&
+		       memcmp(entry->attributeName.data(), attributeName, attributeNameLength) == 0;
+	};
+
+	for (const auto &xattrDataEntry : gMetadata->xattrDataHash[hash]) {
+		if (xattrDataEntryHasAttribute(xattrDataEntry)) {
+			if (xattrDataEntry->attributeValueLength > SFS_XATTR_SIZE_MAX) {
 				return SAUNAFS_ERROR_ERANGE;
 			}
-			*attrvalue = xattrDataEntry->attributeValue.data();
-			*avleng = xattrDataEntry->avleng;
+
+			*attributeValue = xattrDataEntry->attributeValue.data();
+			*attributeValueLength = xattrDataEntry->attributeValueLength;
 			return SAUNAFS_STATUS_OK;
 		}
 	}
 	return SAUNAFS_ERROR_ENOATTR;
 }
 
-uint8_t xattr_listattr_leng(inode_t inode, void **xanode, uint32_t *xasize) {
-	xattr_inode_entry *xattrInodeEntry;
-	auto hash = xattr_inode_hash_fn(inode);
-	auto start = gMetadata->xattr_inode_hash[hash].begin();
-	auto end =  gMetadata->xattr_inode_hash[hash].end();
+uint8_t get_xattrs_length_for_inode(inode_t inode, void **xattrInodePointer, uint32_t *xattrSize) {
+	XAttributeInodeEntry *xattrInodeEntry;
+	auto hash = get_xattr_inode_hash(inode);
+	auto start = gMetadata->xattrInodeHash[hash].begin();
+	auto end =  gMetadata->xattrInodeHash[hash].end();
 
 	for (auto attributeIterator = start; attributeIterator != end;) {
 		xattrInodeEntry = attributeIterator->get();
 		if (xattrInodeEntry->inode == inode) {
-			*xanode = xattrInodeEntry;
+			*xattrInodePointer = xattrInodeEntry;
 			for (const auto &xattrDataEntry : xattrInodeEntry->xattrDataList) {
-				*xasize += xattrDataEntry->anleng + 1U;
+				*xattrSize += xattrDataEntry->attributeNameLength + 1U;
 			}
-			if (*xasize > SFS_XATTR_LIST_MAX) {
+			if (*xattrSize > SFS_XATTR_LIST_MAX) {
 				return SAUNAFS_ERROR_ERANGE;
 			}
 			return SAUNAFS_STATUS_OK;
 		}
 	}
 
-	*xanode = nullptr;
+	*xattrInodePointer = nullptr;
 	return SAUNAFS_STATUS_OK;
 }
 
-void xattr_listattr_data(void *xattrInodeEntry, uint8_t *xabuff) {
-	auto *xattrEntry = static_cast<xattr_inode_entry *>(xattrInodeEntry);
+void xattr_listattr_data(void *xattrInodeEntry, uint8_t *xattrDataBuffer) {
+	auto *xattrEntry = static_cast<XAttributeInodeEntry *>(xattrInodeEntry);
 
 	uint32_t entryLength = 0;
 	if (xattrEntry) {
-		passert(xabuff);
+		passert(xattrDataBuffer);
 		for (const auto &xattrDataEntry : xattrEntry->xattrDataList) {
-			memcpy(xabuff + entryLength, xattrDataEntry->attributeName.data(), xattrDataEntry->anleng);
-			entryLength += xattrDataEntry->anleng;
-			xabuff[entryLength++] = 0;
+			memcpy(xattrDataBuffer + entryLength, xattrDataEntry->attributeName.data(),
+			       xattrDataEntry->attributeNameLength);
+			entryLength += xattrDataEntry->attributeNameLength;
+			xattrDataBuffer[entryLength++] = 0;
 		}
 	}
 }
-

--- a/src/master/filesystem_xattr.cc
+++ b/src/master/filesystem_xattr.cc
@@ -32,8 +32,8 @@ static uint64_t xattr_checksum(const XAttributeDataEntry *xattrDataEntry) {
 	uint64_t seed = 645819511511147ULL;
 	hashCombine(
 	    seed, xattrDataEntry->inode,
-	    ByteArray(xattrDataEntry->attributeName.data(), xattrDataEntry->attributeNameLength),
-	    ByteArray(xattrDataEntry->attributeValue.data(), xattrDataEntry->attributeValueLength));
+	    ByteArray(xattrDataEntry->attributeName.data(), xattrDataEntry->attributeName.size()),
+	    ByteArray(xattrDataEntry->attributeValue.data(), xattrDataEntry->attributeValue.size()));
 
 	return seed;
 }
@@ -69,7 +69,7 @@ static inline void xattr_removeentry(XAttributeInodeEntry *entry,
 	removeFromChecksum(gMetadata->xattrChecksum, xattrDataEntry->checksum);
 
 	// Delete the entry from the hash bucket
-	auto hash = get_xattr_data_hash(entry->inode, xattrDataEntry->attributeNameLength,
+	auto hash = get_xattr_data_hash(entry->inode, xattrDataEntry->attributeName.size(),
 	                                xattrDataEntry->attributeName.data());
 	auto start = gMetadata->xattrDataHash[hash].begin();
 	auto end = gMetadata->xattrDataHash[hash].end();
@@ -140,11 +140,8 @@ uint8_t xattr_setattr(inode_t inode, uint8_t attributeNameLength, const uint8_t 
 	}
 
 	auto inodeHash = get_xattr_inode_hash(inode);
-	auto start = gMetadata->xattrInodeHash[inodeHash].begin();
-	auto end = gMetadata->xattrInodeHash[inodeHash].end();
-
-	for (auto attributeIterator = start; attributeIterator != end; ++attributeIterator) {
-		xattrInodeEntry = attributeIterator->get();
+	for (const auto &xattrEntry : gMetadata->xattrInodeHash[inodeHash]) {
+		xattrInodeEntry = xattrEntry.get();
 		if (xattrInodeEntry->inode == inode) {
 			break;
 		}
@@ -153,7 +150,7 @@ uint8_t xattr_setattr(inode_t inode, uint8_t attributeNameLength, const uint8_t 
 	auto dataHash = get_xattr_data_hash(inode, attributeNameLength, attributeName);
 	for (const auto &xattrDataEntry : gMetadata->xattrDataHash[dataHash]) {
 		if (xattrDataEntry->inode == inode &&
-		    xattrDataEntry->attributeNameLength == attributeNameLength &&
+		    xattrDataEntry->attributeName.size() == attributeNameLength &&
 		    memcmp(xattrDataEntry->attributeName.data(), attributeName, attributeNameLength) == 0) {
 			passert(xattrInodeEntry);
 
@@ -163,26 +160,24 @@ uint8_t xattr_setattr(inode_t inode, uint8_t attributeNameLength, const uint8_t 
 
 			if (mode == XATTR_SMODE_REMOVE) {  // remove
 				xattrInodeEntry->attributeNameLength -= attributeNameLength + 1U;
-				xattrInodeEntry->attributeValueLength -= xattrDataEntry->attributeValueLength;
+				xattrInodeEntry->attributeValueLength -= xattrDataEntry->attributeValue.size();
 
 				xattr_removeentry(xattrInodeEntry, xattrDataEntry.get());
 
 				if (xattrInodeEntry->xattrDataList.empty()) {
 					if (xattrInodeEntry->attributeNameLength != 0 ||
 					    xattrInodeEntry->attributeValueLength != 0) {
-						safs_pretty_syslog(
-						    LOG_WARNING,
-						    "xattr non zero lengths on remove "
-						    "(inode:%" PRIiNode ",anleng:%" PRIu32 ",avleng:%" PRIu32 ")",
-						    xattrInodeEntry->inode, xattrInodeEntry->attributeNameLength,
-						    xattrInodeEntry->attributeValueLength);
+						safs::log_warn("xattr non zero lengths on remove (inode:%" PRIiNode
+						               ", attributeNameLength: {}, attributeValueLength: {})",
+						               xattrInodeEntry->inode, xattrInodeEntry->attributeNameLength,
+						               xattrInodeEntry->attributeValueLength);
 					}
 					xattr_removeinode(inode);
 				}
 				return SAUNAFS_STATUS_OK;
 			}
 
-			xattrInodeEntry->attributeValueLength -= xattrDataEntry->attributeValueLength;
+			xattrInodeEntry->attributeValueLength -= xattrDataEntry->attributeValue.size();
 
 			if (!xattrDataEntry->attributeValue.empty()) {
 				xattrDataEntry->attributeValue.clear();
@@ -196,7 +191,6 @@ uint8_t xattr_setattr(inode_t inode, uint8_t attributeNameLength, const uint8_t 
 				xattrDataEntry->attributeValue.clear();
 			}
 
-			xattrDataEntry->attributeValueLength = attributeValueLength;
 			xattrInodeEntry->attributeValueLength += attributeValueLength;
 			xattr_update_checksum(xattrDataEntry.get());
 			return SAUNAFS_STATUS_OK;
@@ -217,7 +211,6 @@ uint8_t xattr_setattr(inode_t inode, uint8_t attributeNameLength, const uint8_t 
 	xattrDataEntry->attributeName.resize(attributeNameLength);
 	passert(xattrDataEntry->attributeName.data());
 	memcpy(xattrDataEntry->attributeName.data(), attributeName, attributeNameLength);
-	xattrDataEntry->attributeNameLength = attributeNameLength;
 
 	if (attributeValueLength > 0) {
 		xattrDataEntry->attributeValue.resize(attributeValueLength);
@@ -227,7 +220,6 @@ uint8_t xattr_setattr(inode_t inode, uint8_t attributeNameLength, const uint8_t 
 		xattrDataEntry->attributeValue.clear();
 	}
 
-	xattrDataEntry->attributeValueLength = attributeValueLength;
 	xattrDataEntry->checksum = 0;
 	xattr_update_checksum(xattrDataEntry.get());
 
@@ -239,12 +231,9 @@ uint8_t xattr_setattr(inode_t inode, uint8_t attributeNameLength, const uint8_t 
 		xattrInodeEntry->attributeNameLength += attributeNameLength + 1U;
 		xattrInodeEntry->attributeValueLength += attributeValueLength;
 	} else {
-		auto xattrInodeEntry = std::make_unique<XAttributeInodeEntry>();
-		passert(xattrInodeEntry);
-		xattrInodeEntry->inode = inode;
+		auto xattrInodeEntry =
+		    XAttributeInodeEntry::create(inode, attributeNameLength + 1U, attributeValueLength);
 		xattrInodeEntry->xattrDataList.push_back(xattrDataEntryPointer);
-		xattrInodeEntry->attributeNameLength = attributeNameLength + 1U;
-		xattrInodeEntry->attributeValueLength = attributeValueLength;
 		gMetadata->xattrInodeHash[inodeHash].push_front(std::move(xattrInodeEntry));
 	}
 
@@ -257,18 +246,18 @@ uint8_t xattr_getattr(inode_t inode, uint8_t attributeNameLength, const uint8_t 
 	auto hash = get_xattr_data_hash(inode, attributeNameLength, attributeName);
 
 	auto xattrDataEntryHasAttribute = [&](const auto &entry) {
-		return entry->inode == inode && entry->attributeNameLength == attributeNameLength &&
+		return entry->inode == inode && entry->attributeName.size() == attributeNameLength &&
 		       memcmp(entry->attributeName.data(), attributeName, attributeNameLength) == 0;
 	};
 
 	for (const auto &xattrDataEntry : gMetadata->xattrDataHash[hash]) {
 		if (xattrDataEntryHasAttribute(xattrDataEntry)) {
-			if (xattrDataEntry->attributeValueLength > SFS_XATTR_SIZE_MAX) {
+			if (xattrDataEntry->attributeValue.size() > SFS_XATTR_SIZE_MAX) {
 				return SAUNAFS_ERROR_ERANGE;
 			}
 
 			*attributeValue = xattrDataEntry->attributeValue.data();
-			*attributeValueLength = xattrDataEntry->attributeValueLength;
+			*attributeValueLength = xattrDataEntry->attributeValue.size();
 			return SAUNAFS_STATUS_OK;
 		}
 	}
@@ -276,17 +265,12 @@ uint8_t xattr_getattr(inode_t inode, uint8_t attributeNameLength, const uint8_t 
 }
 
 uint8_t get_xattrs_length_for_inode(inode_t inode, void **xattrInodePointer, uint32_t *xattrSize) {
-	XAttributeInodeEntry *xattrInodeEntry;
 	auto hash = get_xattr_inode_hash(inode);
-	auto start = gMetadata->xattrInodeHash[hash].begin();
-	auto end =  gMetadata->xattrInodeHash[hash].end();
-
-	for (auto attributeIterator = start; attributeIterator != end;) {
-		xattrInodeEntry = attributeIterator->get();
+	for (const auto &xattrInodeEntry : gMetadata->xattrInodeHash[hash]) {
 		if (xattrInodeEntry->inode == inode) {
-			*xattrInodePointer = xattrInodeEntry;
+			*xattrInodePointer = xattrInodeEntry.get();
 			for (const auto &xattrDataEntry : xattrInodeEntry->xattrDataList) {
-				*xattrSize += xattrDataEntry->attributeNameLength + 1U;
+				*xattrSize += xattrDataEntry->attributeName.size() + 1U;
 			}
 			if (*xattrSize > SFS_XATTR_LIST_MAX) {
 				return SAUNAFS_ERROR_ERANGE;
@@ -307,8 +291,8 @@ void xattr_listattr_data(void *xattrInodeEntry, uint8_t *xattrDataBuffer) {
 		passert(xattrDataBuffer);
 		for (const auto &xattrDataEntry : xattrEntry->xattrDataList) {
 			memcpy(xattrDataBuffer + entryLength, xattrDataEntry->attributeName.data(),
-			       xattrDataEntry->attributeNameLength);
-			entryLength += xattrDataEntry->attributeNameLength;
+			       xattrDataEntry->attributeName.size());
+			entryLength += xattrDataEntry->attributeName.size();
 			xattrDataBuffer[entryLength++] = 0;
 		}
 	}

--- a/src/master/filesystem_xattr.cc
+++ b/src/master/filesystem_xattr.cc
@@ -80,7 +80,7 @@ static inline void xattr_removeentry(XAttributeInodeEntry *entry,
 	    });
 
 	if (entryIt != end) {
-		gMetadata->xattrDataHash[hash].remove(*entryIt);
+		gMetadata->xattrDataHash[hash].erase(entryIt);
 	}
 }
 

--- a/src/master/filesystem_xattr.h
+++ b/src/master/filesystem_xattr.h
@@ -24,6 +24,7 @@
 
 #include <cstdint>
 #include <cstdlib>
+#include <list>
 #include <vector>
 
 #define XATTR_INODE_HASH_SIZE 65536
@@ -37,7 +38,6 @@ struct xattr_data_entry {
 	std::vector<uint8_t> attributeName;
 	std::vector<uint8_t> attributeValue;
 	uint64_t checksum;
-	struct xattr_data_entry **previnode, *nextinode;
 	struct xattr_data_entry **prev, *next;
 
 	xattr_data_entry() = default;
@@ -53,7 +53,7 @@ struct xattr_inode_entry {
 	inode_t inode;
 	uint32_t anleng;
 	uint32_t avleng;
-	struct xattr_data_entry *data_head;
+	std::list<xattr_data_entry *> xattrDataList;
 };
 
 #ifndef METARESTORE
@@ -83,7 +83,7 @@ static inline uint32_t xattr_inode_hash_fn(inode_t inode) {
 }
 
 void xattr_checksum_add_to_background(xattr_data_entry *xde);
-void xattr_listattr_data(void *xanode, uint8_t *xabuff);
+void xattr_listattr_data(void *xattrInodeEntry, uint8_t *xabuff);
 void xattr_recalculate_checksum();
 void xattr_removeinode(inode_t inode);
 

--- a/src/master/filesystem_xattr.h
+++ b/src/master/filesystem_xattr.h
@@ -54,7 +54,6 @@ struct xattr_inode_entry {
 	uint32_t anleng;
 	uint32_t avleng;
 	struct xattr_data_entry *data_head;
-	struct xattr_inode_entry *next;
 };
 
 #ifndef METARESTORE

--- a/src/master/filesystem_xattr.h
+++ b/src/master/filesystem_xattr.h
@@ -24,6 +24,7 @@
 
 #include <cstdint>
 #include <cstdlib>
+#include <vector>
 
 #define XATTR_INODE_HASH_SIZE 65536
 #define XATTR_DATA_HASH_SIZE 524288
@@ -33,18 +34,17 @@ struct xattr_data_entry {
 	inode_t inode;
 	uint8_t anleng;
 	uint32_t avleng;
-	uint8_t *attrname;
-	uint8_t *attrvalue;
+	std::vector<uint8_t> attributeName;
+	std::vector<uint8_t> attributeValue;
 	uint64_t checksum;
 	struct xattr_data_entry **previnode, *nextinode;
 	struct xattr_data_entry **prev, *next;
 
-	xattr_data_entry() : attrname(nullptr), attrvalue(nullptr) {
-	}
+	xattr_data_entry() = default;
 
 	~xattr_data_entry() {
-		free(attrname);
-		free(attrvalue);
+		attributeName.clear();
+		attributeValue.clear();
 	}
 };
 void free(xattr_data_entry *);  // disable freeing using free at link time :)

--- a/src/master/filesystem_xattr.h
+++ b/src/master/filesystem_xattr.h
@@ -40,11 +40,7 @@ struct XAttributeDataEntry {
 	uint64_t checksum;
 
 	XAttributeDataEntry() = default;
-
-	~XAttributeDataEntry() {
-		attributeName.clear();
-		attributeValue.clear();
-	}
+	~XAttributeDataEntry() = default;
 };
 
 struct XAttributeInodeEntry {

--- a/src/master/filesystem_xattr.h
+++ b/src/master/filesystem_xattr.h
@@ -25,7 +25,11 @@
 #include <cstdint>
 #include <cstdlib>
 #include <list>
+#include <memory>
 #include <vector>
+
+#include "common/massert.h"
+#include "common/type_defs.h"
 
 #define XATTR_INODE_HASH_SIZE 65536
 #define XATTR_DATA_HASH_SIZE 524288
@@ -33,8 +37,6 @@
 
 struct XAttributeDataEntry {
 	inode_t inode;
-	uint8_t attributeNameLength;
-	uint32_t attributeValueLength;
 	std::vector<uint8_t> attributeName;
 	std::vector<uint8_t> attributeValue;
 	uint64_t checksum;
@@ -48,6 +50,16 @@ struct XAttributeInodeEntry {
 	uint32_t attributeNameLength;
 	uint32_t attributeValueLength;
 	std::list<XAttributeDataEntry *> xattrDataList;
+
+	static std::unique_ptr<XAttributeInodeEntry> create(inode_t inode, uint32_t attributeNameLength,
+	                                                    uint32_t attributeValueLength) {
+		auto entry = std::make_unique<XAttributeInodeEntry>();
+		passert(entry);
+		entry->inode = inode;
+		entry->attributeNameLength = attributeNameLength;
+		entry->attributeValueLength = attributeValueLength;
+		return entry;
+	}
 };
 
 #ifndef METARESTORE

--- a/src/master/filesystem_xattr.h
+++ b/src/master/filesystem_xattr.h
@@ -38,7 +38,6 @@ struct xattr_data_entry {
 	std::vector<uint8_t> attributeName;
 	std::vector<uint8_t> attributeValue;
 	uint64_t checksum;
-	struct xattr_data_entry **prev, *next;
 
 	xattr_data_entry() = default;
 

--- a/src/master/filesystem_xattr.h
+++ b/src/master/filesystem_xattr.h
@@ -31,35 +31,33 @@
 #define XATTR_DATA_HASH_SIZE 524288
 #define XATTRCHECKSUMSEED 29857986791741783ULL
 
-struct xattr_data_entry {
+struct XAttributeDataEntry {
 	inode_t inode;
-	uint8_t anleng;
-	uint32_t avleng;
+	uint8_t attributeNameLength;
+	uint32_t attributeValueLength;
 	std::vector<uint8_t> attributeName;
 	std::vector<uint8_t> attributeValue;
 	uint64_t checksum;
 
-	xattr_data_entry() = default;
+	XAttributeDataEntry() = default;
 
-	~xattr_data_entry() {
+	~XAttributeDataEntry() {
 		attributeName.clear();
 		attributeValue.clear();
 	}
 };
-void free(xattr_data_entry *);  // disable freeing using free at link time :)
 
-struct xattr_inode_entry {
+struct XAttributeInodeEntry {
 	inode_t inode;
-	uint32_t anleng;
-	uint32_t avleng;
-	std::list<xattr_data_entry *> xattrDataList;
+	uint32_t attributeNameLength;
+	uint32_t attributeValueLength;
+	std::list<XAttributeDataEntry *> xattrDataList;
 };
 
 #ifndef METARESTORE
-static inline int xattr_namecheck(uint8_t anleng, const uint8_t *attrname) {
-	uint32_t i;
-	for (i = 0; i < anleng; i++) {
-		if (attrname[i] == '\0') {
+static inline int xattr_namecheck(uint8_t attributeNameLength, const uint8_t *attributeName) {
+	for (uint32_t i = 0; i < attributeNameLength; i++) {
+		if (attributeName[i] == '\0') {
 			return -1;
 		}
 	}
@@ -67,27 +65,31 @@ static inline int xattr_namecheck(uint8_t anleng, const uint8_t *attrname) {
 }
 #endif /* METARESTORE */
 
-static inline uint32_t xattr_data_hash_fn(inode_t inode, uint8_t anleng, const uint8_t *attrname) {
+static inline uint32_t get_xattr_data_hash(inode_t inode, uint8_t attributeNameLength,
+                                           const uint8_t *attributeName) {
 	uint32_t hash = inode * 5381U;
-	while (anleng) {
-		hash = (hash * 33U) + (*attrname);
-		attrname++;
-		anleng--;
+	while (attributeNameLength) {
+		hash = (hash * 33U) + (*attributeName);
+		attributeName++;
+		attributeNameLength--;
 	}
 	return (hash & (XATTR_DATA_HASH_SIZE - 1));
 }
 
-static inline uint32_t xattr_inode_hash_fn(inode_t inode) {
+static inline uint32_t get_xattr_inode_hash(inode_t inode) {
 	return ((inode * 0x72B5F387U) & (XATTR_INODE_HASH_SIZE - 1));
 }
 
-void xattr_checksum_add_to_background(xattr_data_entry *xde);
-void xattr_listattr_data(void *xattrInodeEntry, uint8_t *xabuff);
+void xattr_checksum_add_to_background(XAttributeDataEntry *xattrDataEntry);
+void xattr_listattr_data(void *xattrInodeEntry, uint8_t *xattrDataBuffer);
 void xattr_recalculate_checksum();
 void xattr_removeinode(inode_t inode);
 
-uint8_t xattr_getattr(inode_t inode, uint8_t anleng, const uint8_t *attrname, uint32_t *avleng,
-			uint8_t **attrvalue);
-uint8_t xattr_listattr_leng(inode_t inode, void **xanode, uint32_t *xasize);
-uint8_t xattr_setattr(inode_t inode, uint8_t anleng, const uint8_t *attrname, uint32_t avleng,
-			const uint8_t *attrvalue, uint8_t mode);
+uint8_t xattr_getattr(inode_t inode, uint8_t attributeNameLength, const uint8_t *attributeName,
+                      uint32_t *attributeValueLength, uint8_t **attributeValue);
+
+uint8_t get_xattrs_length_for_inode(inode_t inode, void **xattrInodePointer, uint32_t *xattrSize);
+
+uint8_t xattr_setattr(inode_t inode, uint8_t attributeNameLength, const uint8_t *attributeName,
+                      uint32_t attributeValueLength, const uint8_t *attributeValueBuffer,
+                      uint8_t mode);

--- a/src/master/metadata_backend_file.cc
+++ b/src/master/metadata_backend_file.cc
@@ -290,22 +290,22 @@ static bool xattr_load(MetadataLoader::Options options) {
 
 		xa = new xattr_data_entry;
 		xa->inode = inode;
-		xa->attrname = (uint8_t *)malloc(anleng);
-		passert(xa->attrname);
-		memcpy(xa->attrname, ptr, anleng);
+		xa->attributeName.resize(anleng);
+		passert(xa->attributeName.data());
+		memcpy(xa->attributeName.data(), ptr, anleng);
 		ptr+=anleng;
 		xa->anleng = anleng;
 		if (avleng > 0) {
-			xa->attrvalue = (uint8_t *)malloc(avleng);
-			passert(xa->attrvalue);
-			memcpy(xa->attrvalue, ptr, avleng);
+			xa->attributeValue.resize(avleng);
+			passert(xa->attributeValue.data());
+			memcpy(xa->attributeValue.data(), ptr, avleng);
 			ptr+=avleng;
 		} else {
-			xa->attrvalue = NULL;
+			xa->attributeValue.clear();
 		}
 		options.offset = options.metadataFile->offset(ptr);
 		xa->avleng = avleng;
-		hash = xattr_data_hash_fn(inode, xa->anleng, xa->attrname);
+		hash = xattr_data_hash_fn(inode, xa->anleng, xa->attributeName.data());
 		xa->next = gMetadata->xattr_data_hash[hash];
 		if (xa->next) {
 			xa->next->prev = &(xa->next);
@@ -1267,14 +1267,12 @@ void MetadataBackendFile::xattr_store(FILE *fd) {
 				safs_pretty_syslog(LOG_NOTICE, "fwrite error");
 				return;
 			}
-			if (fwrite(xa->attrname, 1, xa->anleng, fd) !=
-			    (size_t)(xa->anleng)) {
+			if (fwrite(xa->attributeName.data(), 1, xa->anleng, fd) != (size_t)(xa->anleng)) {
 				safs_pretty_syslog(LOG_NOTICE, "fwrite error");
 				return;
 			}
 			if (xa->avleng > 0) {
-				if (fwrite(xa->attrvalue, 1, xa->avleng, fd) !=
-				    (size_t)(xa->avleng)) {
+				if (fwrite(xa->attributeValue.data(), 1, xa->avleng, fd) != (size_t)(xa->avleng)) {
 					safs_pretty_syslog(LOG_NOTICE, "fwrite error");
 					return;
 				}

--- a/src/master/metadata_backend_file.cc
+++ b/src/master/metadata_backend_file.cc
@@ -242,7 +242,7 @@ static bool xattr_load(MetadataLoader::Options options) {
 	uint8_t anleng;
 	uint32_t avleng;
 	xattr_data_entry *xa;
-	xattr_inode_entry *ih;
+	xattr_inode_entry *ih = nullptr;
 	uint32_t hash, ihash;
 
 	while (true) {
@@ -275,9 +275,14 @@ static bool xattr_load(MetadataLoader::Options options) {
 		}
 
 		ihash = xattr_inode_hash_fn(inode);
-		ih = gMetadata->xattr_inode_hash[ihash];
-		while (ih && ih->inode != inode) {
-			ih = ih->next;
+		auto start = gMetadata->xattr_inode_hash[ihash].begin();
+		auto end = gMetadata->xattr_inode_hash[ihash].end();
+
+		for (auto attributeIterator = start; attributeIterator != end; attributeIterator++) {
+			ih = attributeIterator->get();
+			if (ih->inode == inode) {
+				break;
+			}
 		}
 
 		if (ih && ih->anleng + anleng + 1 > SFS_XATTR_LIST_MAX) {
@@ -323,16 +328,15 @@ static bool xattr_load(MetadataLoader::Options options) {
 			ih->anleng += anleng + 1U;
 			ih->avleng += avleng;
 		} else {
-			ih = (xattr_inode_entry *)malloc(sizeof(xattr_inode_entry));
-			passert(ih);
-			ih->inode = inode;
-			xa->nextinode = NULL;
-			xa->previnode = &(ih->data_head);
-			ih->data_head = xa;
-			ih->anleng = anleng + 1U;
-			ih->avleng = avleng;
-			ih->next = gMetadata->xattr_inode_hash[ihash];
-			gMetadata->xattr_inode_hash[ihash] = ih;
+			auto xattrInodeEntry = std::make_unique<xattr_inode_entry>();
+			passert(xattrInodeEntry);
+			xattrInodeEntry->inode = inode;
+			xa->nextinode = nullptr;
+			xa->previnode = &(xattrInodeEntry->data_head);
+			xattrInodeEntry->data_head = xa;
+			xattrInodeEntry->anleng = anleng + 1U;
+			xattrInodeEntry->avleng = avleng;
+			gMetadata->xattr_inode_hash[ihash].push_front(std::move(xattrInodeEntry));
 		}
 	}
 }

--- a/src/master/metadata_backend_file.cc
+++ b/src/master/metadata_backend_file.cc
@@ -239,10 +239,9 @@ uint8_t MetadataBackendFile::fs_storeall(DumpType dumpType) {
 static bool xattr_load(MetadataLoader::Options options) {
 	const uint8_t *ptr;
 	inode_t inode;
-	uint8_t anleng;
-	uint32_t avleng;
-	xattr_inode_entry *xattrInodeEntry = nullptr;
-	uint32_t hash;
+	uint8_t attributeNameLength;
+	uint32_t attributeValueLength;
+	XAttributeInodeEntry *xattrInodeEntry = nullptr;
 
 	while (true) {
 		try {
@@ -251,21 +250,23 @@ static bool xattr_load(MetadataLoader::Options options) {
 			safs_pretty_syslog(LOG_ERR, "loading xattr: can't read xattr");
 			return false;
 		}
+
 		getINode(&ptr, inode);
-		anleng = get8bit(&ptr);
-		get32bit(&ptr, avleng);
+		attributeNameLength = get8bit(&ptr);
+		get32bit(&ptr, attributeValueLength);
 		options.offset = options.metadataFile->offset(ptr);
-		if (inode == 0) {
-			return true;
-		}
-		if (anleng == 0) {
+
+		if (inode == 0) { return true; }
+
+		if (attributeNameLength == 0) {
 			safs_pretty_syslog(LOG_ERR, "loading xattr: empty name");
 			if (options.ignoreFlag) {
 				continue;
 			}
 			return false;
 		}
-		if (avleng > SFS_XATTR_SIZE_MAX) {
+
+		if (attributeValueLength > SFS_XATTR_SIZE_MAX) {
 			safs_pretty_syslog(LOG_ERR, "loading xattr: value oversized");
 			if (options.ignoreFlag) {
 				continue;
@@ -273,9 +274,9 @@ static bool xattr_load(MetadataLoader::Options options) {
 			return false;
 		}
 
-		auto ihash = xattr_inode_hash_fn(inode);
-		auto start = gMetadata->xattr_inode_hash[ihash].begin();
-		auto end = gMetadata->xattr_inode_hash[ihash].end();
+		auto inodeHash = get_xattr_inode_hash(inode);
+		auto start = gMetadata->xattrInodeHash[inodeHash].begin();
+		auto end = gMetadata->xattrInodeHash[inodeHash].end();
 
 		for (auto attributeIterator = start; attributeIterator != end; attributeIterator++) {
 			xattrInodeEntry = attributeIterator->get();
@@ -284,7 +285,8 @@ static bool xattr_load(MetadataLoader::Options options) {
 			}
 		}
 
-		if (xattrInodeEntry && xattrInodeEntry->anleng + anleng + 1 > SFS_XATTR_LIST_MAX) {
+		if (xattrInodeEntry != nullptr &&
+		    xattrInodeEntry->attributeNameLength + attributeNameLength + 1 > SFS_XATTR_LIST_MAX) {
 			safs_pretty_syslog(LOG_ERR, "loading xattr: name list too long");
 			if (options.ignoreFlag) {
 				continue;
@@ -292,42 +294,44 @@ static bool xattr_load(MetadataLoader::Options options) {
 			return false;
 		}
 
-		auto xattrEntry = std::make_unique<xattr_data_entry>();
+		auto xattrEntry = std::make_unique<XAttributeDataEntry>();
 		xattrEntry->inode = inode;
-		xattrEntry->attributeName.resize(anleng);
+		xattrEntry->attributeName.resize(attributeNameLength);
+		xattrEntry->attributeNameLength = attributeNameLength;
 		passert(xattrEntry->attributeName.data());
-		memcpy(xattrEntry->attributeName.data(), ptr, anleng);
-		ptr += anleng;
-		xattrEntry->anleng = anleng;
+		memcpy(xattrEntry->attributeName.data(), ptr, attributeNameLength);
+		ptr += attributeNameLength;
 
-		if (avleng > 0) {
-			xattrEntry->attributeValue.resize(avleng);
+		if (attributeValueLength > 0) {
+			xattrEntry->attributeValue.resize(attributeValueLength);
 			passert(xattrEntry->attributeValue.data());
-			memcpy(xattrEntry->attributeValue.data(), ptr, avleng);
-			ptr += avleng;
+			memcpy(xattrEntry->attributeValue.data(), ptr, attributeValueLength);
+			ptr += attributeValueLength;
 		} else {
 			xattrEntry->attributeValue.clear();
 		}
 
 		options.offset = options.metadataFile->offset(ptr);
-		xattrEntry->avleng = avleng;
+		xattrEntry->attributeValueLength = attributeValueLength;
 
-		hash = xattr_data_hash_fn(inode, xattrEntry->anleng, xattrEntry->attributeName.data());
-		gMetadata->xattr_data_hash[hash].push_back(std::move(xattrEntry));
-		auto xattrEntryPointer = gMetadata->xattr_data_hash[hash].back().get();
+		auto dataHash = get_xattr_data_hash(inode, xattrEntry->attributeNameLength,
+		                                    xattrEntry->attributeName.data());
+
+		gMetadata->xattrDataHash[dataHash].push_back(std::move(xattrEntry));
+		auto xattrEntryPointer = gMetadata->xattrDataHash[dataHash].back().get();
 
 		if (xattrInodeEntry) {
 			xattrInodeEntry->xattrDataList.push_back(xattrEntryPointer);
-			xattrInodeEntry->anleng += anleng + 1U;
-			xattrInodeEntry->avleng += avleng;
+			xattrInodeEntry->attributeNameLength += attributeNameLength + 1U;
+			xattrInodeEntry->attributeValueLength += attributeValueLength;
 		} else {
-			auto xattrInodeEntry = std::make_unique<xattr_inode_entry>();
+			auto xattrInodeEntry = std::make_unique<XAttributeInodeEntry>();
 			passert(xattrInodeEntry);
 			xattrInodeEntry->inode = inode;
 			xattrInodeEntry->xattrDataList.push_back(xattrEntryPointer);
-			xattrInodeEntry->anleng = anleng + 1U;
-			xattrInodeEntry->avleng = avleng;
-			gMetadata->xattr_inode_hash[ihash].push_front(std::move(xattrInodeEntry));
+			xattrInodeEntry->attributeNameLength = attributeNameLength + 1U;
+			xattrInodeEntry->attributeValueLength = attributeValueLength;
+			gMetadata->xattrInodeHash[inodeHash].push_front(std::move(xattrInodeEntry));
 		}
 	}
 }
@@ -418,13 +422,12 @@ static int8_t fs_parseEdge(const std::shared_ptr<MemoryMappedFile> &metadataFile
 		if (child->type == FSNode::kTrash) {
 			gMetadata->trash.insert(
 			    {TrashPathKey(child), hstorage::Handle(name)});
-			gMetadata->trashspace += static_cast<FSNodeFile *>(child)->length;
-			gMetadata->trashnodes++;
+			gMetadata->trashSpace += static_cast<FSNodeFile *>(child)->length;
+			gMetadata->trashNodes++;
 		} else if (child->type == FSNode::kReserved) {
 			gMetadata->reserved.insert({child->id, hstorage::Handle(name)});
-			gMetadata->reservedspace +=
-			    static_cast<FSNodeFile *>(child)->length;
-			gMetadata->reservednodes++;
+			gMetadata->reservedSpace += static_cast<FSNodeFile *>(child)->length;
+			gMetadata->reservedNodes++;
 		} else {
 			safs_pretty_syslog(LOG_ERR,
 			                   "loading edge: %" PRIiNode ",%s->%" PRIiNode
@@ -577,7 +580,7 @@ static int8_t fs_parseNode(const std::shared_ptr<MemoryMappedFile> &metadataFile
 
 	switch (type) {
 	case FSNode::kDirectory:
-		gMetadata->dirnodes++;
+		gMetadata->dirNodes++;
 		break;
 	case FSNode::kSocket:
 	case FSNode::kFifo:  /// No extra info to Parse
@@ -595,7 +598,7 @@ static int8_t fs_parseNode(const std::shared_ptr<MemoryMappedFile> &metadataFile
 			static_cast<FSNodeSymlink *>(node)->path = HString(pSrc, pSrc + nodeNameLength);
 			pSrc += nodeNameLength;
 		}
-		gMetadata->linknodes++;
+		gMetadata->linkNodes++;
 		break;
 	case FSNode::kFile:
 	case FSNode::kTrash:
@@ -627,7 +630,7 @@ static int8_t fs_parseNode(const std::shared_ptr<MemoryMappedFile> &metadataFile
 		}
 
 		fsnodes_quota_update(node, {{QuotaResource::kSize, +fsnodes_get_size(node)}});
-		gMetadata->filenodes++;
+		gMetadata->fileNodes++;
 		break;
 	default:
 		safs_pretty_syslog(LOG_ERR, "loading node: unrecognized node type: %c",
@@ -637,8 +640,8 @@ static int8_t fs_parseNode(const std::shared_ptr<MemoryMappedFile> &metadataFile
 		return kError;
 	}
 	uint32_t nodeIndex = NODEHASHPOS(node->id);
-	gMetadata->nodehash[nodeIndex].push_front(node);
-	gMetadata->inode_pool.markAsAcquired(node->id);
+	gMetadata->nodeHash[nodeIndex].push_front(node);
+	gMetadata->inodePool.markAsAcquired(node->id);
 	gMetadata->nodes++;
 	fsnodes_quota_update(node, {{QuotaResource::kInodes, +1}});
 	sectionOffset = metadataFile->offset(pSrc);
@@ -668,7 +671,7 @@ static int fs_lostnode(FSNode *p) {
 
 int fs_checknodes(int ignoreflag) {
 	for (auto i = 0; i < NODEHASHSIZE; i++) {
-		for (const auto &node : gMetadata->nodehash[i]) {
+		for (const auto &node : gMetadata->nodeHash[i]) {
 			if (node->parent.empty() && node != gMetadata->root &&
 			    (node->type != FSNode::kTrash) && (node->type != FSNode::kReserved)) {
 				safs_pretty_syslog(LOG_ERR, "found orphaned inode: %" PRIiNode, node->id);
@@ -716,11 +719,11 @@ static bool fs_loadquotas(MetadataLoader::Options options) {
 		std::vector<QuotaEntry> entries;
 		fs_load_generic(options.metadataFile, options.offset, entries);
 		for (const auto &entry : entries) {
-			gMetadata->quota_database.set(
+			gMetadata->quotaDatabase.set(
 			    entry.entryKey.owner.ownerType, entry.entryKey.owner.ownerId,
 			    entry.entryKey.rigor, entry.entryKey.resource, entry.limit);
 		}
-		gMetadata->quota_checksum = gMetadata->quota_database.checksum();
+		gMetadata->quotaChecksum = gMetadata->quotaDatabase.checksum();
 	} catch (Exception &ex) {
 		safs_pretty_syslog(LOG_ERR, "loading quotas: %s", ex.what());
 		if (!options.ignoreFlag || ex.status() != SAUNAFS_STATUS_OK) {
@@ -732,8 +735,8 @@ static bool fs_loadquotas(MetadataLoader::Options options) {
 
 static bool fs_loadlocks(MetadataLoader::Options options) {
 	try {
-		gMetadata->flock_locks.load(options.metadataFile, options.offset);
-		gMetadata->posix_locks.load(options.metadataFile, options.offset);
+		gMetadata->flockLocks.load(options.metadataFile, options.offset);
+		gMetadata->posixLocks.load(options.metadataFile, options.offset);
 	} catch (Exception &ex) {
 		safs_pretty_syslog(LOG_ERR, "loading locks: %s", ex.what());
 		if (!options.ignoreFlag || ex.status() != SAUNAFS_STATUS_OK) {
@@ -779,7 +782,7 @@ bool fs_loadfree(MetadataLoader::Options options) {
 		}
 		getINode(&ptr, inode);
 		get32bit(&ptr, timestamp);
-		gMetadata->inode_pool.detain(inode, timestamp, true);
+		gMetadata->inodePool.detain(inode, timestamp, true);
 		freeNodesToLoad--;
 		freeNodesNumber--;
 	}
@@ -825,9 +828,9 @@ static int fs_load(const std::shared_ptr<MemoryMappedFile> &metadataFile, int ig
 	/// Skip File Signature
 	const uint8_t *metadataHeaderPtr= metadataFile->seek(kMetadataHeaderOffset);
 
-	getINode(&metadataHeaderPtr, gMetadata->maxnodeid);
-	gMetadata->metaversion = get64bit(&metadataHeaderPtr);
-	get32bit(&metadataHeaderPtr, gMetadata->nextsessionid);
+	getINode(&metadataHeaderPtr, gMetadata->maxInodeId);
+	gMetadata->metadataVersion = get64bit(&metadataHeaderPtr);
+	get32bit(&metadataHeaderPtr, gMetadata->nextSessionId);
 
 	size_t offsetBegin = metadataFile->offset(metadataHeaderPtr);
 
@@ -904,9 +907,9 @@ static int fs_load(const std::shared_ptr<MemoryMappedFile> &metadataFile, int ig
 
 void fs_new(void) {
 	uint32_t nodepos;
-	gMetadata->maxnodeid = SPECIAL_INODE_ROOT;
-	gMetadata->metaversion = 1;
-	gMetadata->nextsessionid = 1;
+	gMetadata->maxInodeId = SPECIAL_INODE_ROOT;
+	gMetadata->metadataVersion = 1;
+	gMetadata->nextSessionId = 1;
 	auto *rootDirectory = FSNode::create(FSNode::kDirectory);
 	gMetadata->root = static_cast<FSNodeDirectory *>(rootDirectory);
 	gMetadata->root->id = SPECIAL_INODE_ROOT;
@@ -919,12 +922,12 @@ void fs_new(void) {
 	gMetadata->root->uid = 0;
 	gMetadata->root->gid = 0;
 	nodepos = NODEHASHPOS(gMetadata->root->id);
-	gMetadata->nodehash[nodepos].push_front(gMetadata->root);
-	gMetadata->inode_pool.markAsAcquired(gMetadata->root->id);
+	gMetadata->nodeHash[nodepos].push_front(gMetadata->root);
+	gMetadata->inodePool.markAsAcquired(gMetadata->root->id);
 	chunk_newfs();
 	gMetadata->nodes = 1;
-	gMetadata->dirnodes = 1;
-	gMetadata->filenodes = 0;
+	gMetadata->dirNodes = 1;
+	gMetadata->fileNodes = 0;
 	fs_checksum(ChecksumMode::kForceRecalculate);
 	fsnodes_quota_update(gMetadata->root, {{QuotaResource::kInodes, +1}});
 }
@@ -997,8 +1000,8 @@ void MetadataBackendFile::loadall(int ignoreflag) {
 	    "metadata file %s read (%" PRIiNode " inodes including %" PRIiNode
 	    " directory inodes, %" PRIiNode " file inodes, %" PRIiNode
 	    " symlink inodes and %" PRIu32 " chunks)",
-	    metadataFile->filename().c_str(), gMetadata->nodes, gMetadata->dirnodes,
-	    gMetadata->filenodes, gMetadata->linknodes, chunk_count());
+	    metadataFile->filename().c_str(), gMetadata->nodes, gMetadata->dirNodes,
+	    gMetadata->fileNodes, gMetadata->linkNodes, chunk_count());
 #else
 	safs::log_info("metadata file {} read", metadataFile_);
 #endif
@@ -1120,7 +1123,7 @@ void MetadataBackendFile::storenode(FSNode *f, FILE *fd) {
 
 void MetadataBackendFile::storenodes(FILE *fd) {
 	for (uint32_t i = 0; i < NODEHASHSIZE; i++) {
-		for (const auto &node : gMetadata->nodehash[i]) {
+		for (const auto &node : gMetadata->nodeHash[i]) {
 			storenode(node, fd);
 		}
 	}
@@ -1198,7 +1201,7 @@ void MetadataBackendFile::storefree(FILE *fd) {
 
 	uint8_t wbuff[kFreeFullBatchSize], *ptr;
 
-	inode_t totalFreeNodes = gMetadata->inode_pool.detainedCount();
+	inode_t totalFreeNodes = gMetadata->inodePool.detainedCount();
 
 	ptr = wbuff;
 	putINode(&ptr, totalFreeNodes);
@@ -1211,7 +1214,7 @@ void MetadataBackendFile::storefree(FILE *fd) {
 	uint32_t batchCursor = 0;
 	ptr = wbuff;
 
-	for (const auto &n : gMetadata->inode_pool) {
+	for (const auto &n : gMetadata->inodePool) {
 		if (batchCursor == kFreeBatchSize) {
 			if (fwrite(wbuff, 1, kFreeFullBatchSize, fd) != kFreeFullBatchSize) {
 				safs_pretty_syslog(LOG_NOTICE, "fwrite error");
@@ -1238,36 +1241,44 @@ void MetadataBackendFile::storefree(FILE *fd) {
 // XAttr
 
 void MetadataBackendFile::xattr_store(FILE *fd) {
-	constexpr uint32_t kHdrSize =
-	    kinode_t_size + sizeof(xattr_data_entry::anleng) + sizeof(xattr_data_entry::avleng);
-	uint8_t hdrbuff[kHdrSize];
+	constexpr uint32_t kHdrSize = kinode_t_size + sizeof(XAttributeDataEntry::attributeNameLength) +
+	                              sizeof(XAttributeDataEntry::attributeValueLength);
+	uint8_t headerBuffer[kHdrSize];
 	uint8_t *ptr;
 
 	for (auto i = 0; i < XATTR_DATA_HASH_SIZE; i++) {
-		for (const auto &xa : gMetadata->xattr_data_hash[i]) {
-			ptr = hdrbuff;
-			putINode(&ptr, xa->inode);
-			put8bit(&ptr, xa->anleng);
-			put32bit(&ptr, xa->avleng);
-			if (fwrite(hdrbuff, 1, kHdrSize, fd) != (size_t)(kHdrSize)) {
-				safs_pretty_syslog(LOG_NOTICE, "fwrite error");
+		for (const auto &xattrDataEntry : gMetadata->xattrDataHash[i]) {
+			ptr = headerBuffer;
+			putINode(&ptr, xattrDataEntry->inode);
+			put8bit(&ptr, xattrDataEntry->attributeNameLength);
+			put32bit(&ptr, xattrDataEntry->attributeValueLength);
+
+			if (fwrite(headerBuffer, 1, kHdrSize, fd) != (size_t)(kHdrSize)) {
+				safs::log_info("{}: fwrite error failed writing header", __func__);
 				return;
 			}
-			if (fwrite(xa->attributeName.data(), 1, xa->anleng, fd) != (size_t)(xa->anleng)) {
-				safs_pretty_syslog(LOG_NOTICE, "fwrite error");
+
+			auto attributeNameData = xattrDataEntry->attributeName.data();
+			auto nameLength = xattrDataEntry->attributeNameLength;
+			if (fwrite(attributeNameData, 1, nameLength, fd) != (size_t)(nameLength)) {
+				safs::log_info("{}: fwrite error failed writing attribute name", __func__);
 				return;
 			}
-			if (xa->avleng > 0) {
-				if (fwrite(xa->attributeValue.data(), 1, xa->avleng, fd) != (size_t)(xa->avleng)) {
-					safs_pretty_syslog(LOG_NOTICE, "fwrite error");
+
+			auto attributeValueData = xattrDataEntry->attributeValue.data();
+			auto valueLength = xattrDataEntry->attributeValueLength;
+			if (xattrDataEntry->attributeValueLength > 0) {
+				if (fwrite(attributeValueData, 1, valueLength, fd) != (size_t)(valueLength)) {
+					safs::log_info("{}: fwrite error failed writing attribute value", __func__);
 					return;
 				}
 			}
 		}
 	}
-	memset(hdrbuff, 0, kHdrSize);
-	if (fwrite(hdrbuff, 1, kHdrSize, fd) != (size_t)(kHdrSize)) {
-		safs_pretty_syslog(LOG_NOTICE, "fwrite error");
+
+	memset(headerBuffer, 0, kHdrSize);
+	if (fwrite(headerBuffer, 1, kHdrSize, fd) != (size_t)(kHdrSize)) {
+		safs::log_info("{}: fwrite error failed writing header for end marker", __func__);
 		return;
 	}
 }
@@ -1288,15 +1299,15 @@ static void fs_store_generic(FILE *fd, Args &&...args) {
 
 void MetadataBackendFile::storequotas(FILE *fd) {
 	const std::vector<QuotaEntry> &entries =
-	    gMetadata->quota_database.getEntries();
+	    gMetadata->quotaDatabase.getEntries();
 	fs_store_generic(fd, entries);
 }
 
 // Locks
 
 void MetadataBackendFile::storelocks(FILE *fd) {
-	gMetadata->flock_locks.store(fd);
-	gMetadata->posix_locks.store(fd);
+	gMetadata->flockLocks.store(fd);
+	gMetadata->posixLocks.store(fd);
 }
 
 // Full FS
@@ -1319,9 +1330,9 @@ int MetadataBackendFile::process_section(const char *label, uint8_t (&hdr)[kSect
 }
 
 void MetadataBackendFile::store(FILE *fd, uint8_t fver) {
-	constexpr uint8_t kHeaderSize = sizeof(FilesystemMetadata::maxnodeid) +
-	                                sizeof(FilesystemMetadata::metaversion) +
-	                                sizeof(FilesystemMetadata::nextsessionid);
+	constexpr uint8_t kHeaderSize = sizeof(FilesystemMetadata::maxInodeId) +
+	                                sizeof(FilesystemMetadata::metadataVersion) +
+	                                sizeof(FilesystemMetadata::nextSessionId);
 	uint8_t header[kHeaderSize];
 
 	uint8_t sectionHeader[kSectionSize];
@@ -1330,9 +1341,9 @@ void MetadataBackendFile::store(FILE *fd, uint8_t fver) {
 	off_t offend;
 
 	ptr = header;
-	putINode(&ptr, gMetadata->maxnodeid);
-	put64bit(&ptr, gMetadata->metaversion);
-	put32bit(&ptr, gMetadata->nextsessionid);
+	putINode(&ptr, gMetadata->maxInodeId);
+	put64bit(&ptr, gMetadata->metadataVersion);
+	put32bit(&ptr, gMetadata->nextSessionId);
 
 	if (fwrite(header, 1, kHeaderSize, fd) != kHeaderSize) {
 		safs_pretty_syslog(LOG_NOTICE, "fwrite error");

--- a/src/master/metadata_backend_file.cc
+++ b/src/master/metadata_backend_file.cc
@@ -241,7 +241,6 @@ static bool xattr_load(MetadataLoader::Options options) {
 	inode_t inode;
 	uint8_t anleng;
 	uint32_t avleng;
-	xattr_data_entry *xattrEntry = nullptr;
 	xattr_inode_entry *xattrInodeEntry = nullptr;
 	uint32_t hash;
 
@@ -293,7 +292,7 @@ static bool xattr_load(MetadataLoader::Options options) {
 			return false;
 		}
 
-		xattrEntry = new xattr_data_entry;
+		auto xattrEntry = std::make_unique<xattr_data_entry>();
 		xattrEntry->inode = inode;
 		xattrEntry->attributeName.resize(anleng);
 		passert(xattrEntry->attributeName.data());
@@ -312,23 +311,20 @@ static bool xattr_load(MetadataLoader::Options options) {
 
 		options.offset = options.metadataFile->offset(ptr);
 		xattrEntry->avleng = avleng;
+
 		hash = xattr_data_hash_fn(inode, xattrEntry->anleng, xattrEntry->attributeName.data());
-		xattrEntry->next = gMetadata->xattr_data_hash[hash];
-		if (xattrEntry->next) {
-			xattrEntry->next->prev = &(xattrEntry->next);
-		}
-		xattrEntry->prev = gMetadata->xattr_data_hash + hash;
-		gMetadata->xattr_data_hash[hash] = xattrEntry;
+		gMetadata->xattr_data_hash[hash].push_back(std::move(xattrEntry));
+		auto xattrEntryPointer = gMetadata->xattr_data_hash[hash].back().get();
 
 		if (xattrInodeEntry) {
-			xattrInodeEntry->xattrDataList.push_back(xattrEntry);
+			xattrInodeEntry->xattrDataList.push_back(xattrEntryPointer);
 			xattrInodeEntry->anleng += anleng + 1U;
 			xattrInodeEntry->avleng += avleng;
 		} else {
 			auto xattrInodeEntry = std::make_unique<xattr_inode_entry>();
 			passert(xattrInodeEntry);
 			xattrInodeEntry->inode = inode;
-			xattrInodeEntry->xattrDataList.push_back(xattrEntry);
+			xattrInodeEntry->xattrDataList.push_back(xattrEntryPointer);
 			xattrInodeEntry->anleng = anleng + 1U;
 			xattrInodeEntry->avleng = avleng;
 			gMetadata->xattr_inode_hash[ihash].push_front(std::move(xattrInodeEntry));
@@ -1242,16 +1238,13 @@ void MetadataBackendFile::storefree(FILE *fd) {
 // XAttr
 
 void MetadataBackendFile::xattr_store(FILE *fd) {
-	uint32_t i;
-	xattr_data_entry *xa;
-
 	constexpr uint32_t kHdrSize =
 	    kinode_t_size + sizeof(xattr_data_entry::anleng) + sizeof(xattr_data_entry::avleng);
 	uint8_t hdrbuff[kHdrSize];
 	uint8_t *ptr;
 
-	for (i = 0; i < XATTR_DATA_HASH_SIZE; i++) {
-		for (xa = gMetadata->xattr_data_hash[i]; xa; xa = xa->next) {
+	for (auto i = 0; i < XATTR_DATA_HASH_SIZE; i++) {
+		for (const auto &xa : gMetadata->xattr_data_hash[i]) {
 			ptr = hdrbuff;
 			putINode(&ptr, xa->inode);
 			put8bit(&ptr, xa->anleng);

--- a/src/master/metadata_backend_file.cc
+++ b/src/master/metadata_backend_file.cc
@@ -238,16 +238,18 @@ uint8_t MetadataBackendFile::fs_storeall(DumpType dumpType) {
 
 static bool xattr_load(MetadataLoader::Options options) {
 	const uint8_t *ptr;
-	inode_t inode;
-	uint8_t attributeNameLength;
-	uint32_t attributeValueLength;
+	inode_t inode = 0;
+	uint8_t attributeNameLength = 0;
+	uint32_t attributeValueLength = 0;
 	XAttributeInodeEntry *xattrInodeEntry = nullptr;
 
 	while (true) {
+		xattrInodeEntry = nullptr;  // Reset pointer to avoid stale values
+
 		try {
 			ptr = options.metadataFile->seek(options.offset);
 		} catch (const std::exception &e) {
-			safs_pretty_syslog(LOG_ERR, "loading xattr: can't read xattr");
+			safs::log_err("loading xattr: can't read xattr");
 			return false;
 		}
 
@@ -259,7 +261,7 @@ static bool xattr_load(MetadataLoader::Options options) {
 		if (inode == 0) { return true; }
 
 		if (attributeNameLength == 0) {
-			safs_pretty_syslog(LOG_ERR, "loading xattr: empty name");
+			safs::log_err("loading xattr: empty name");
 			if (options.ignoreFlag) {
 				continue;
 			}
@@ -267,7 +269,7 @@ static bool xattr_load(MetadataLoader::Options options) {
 		}
 
 		if (attributeValueLength > SFS_XATTR_SIZE_MAX) {
-			safs_pretty_syslog(LOG_ERR, "loading xattr: value oversized");
+			safs::log_err("loading xattr: value oversized");
 			if (options.ignoreFlag) {
 				continue;
 			}
@@ -287,7 +289,7 @@ static bool xattr_load(MetadataLoader::Options options) {
 
 		if (xattrInodeEntry != nullptr &&
 		    xattrInodeEntry->attributeNameLength + attributeNameLength + 1 > SFS_XATTR_LIST_MAX) {
-			safs_pretty_syslog(LOG_ERR, "loading xattr: name list too long");
+			safs::log_err("loading xattr: name list too long");
 			if (options.ignoreFlag) {
 				continue;
 			}
@@ -320,7 +322,7 @@ static bool xattr_load(MetadataLoader::Options options) {
 		gMetadata->xattrDataHash[dataHash].push_back(std::move(xattrEntry));
 		auto xattrEntryPointer = gMetadata->xattrDataHash[dataHash].back().get();
 
-		if (xattrInodeEntry) {
+		if (xattrInodeEntry != nullptr) {
 			xattrInodeEntry->xattrDataList.push_back(xattrEntryPointer);
 			xattrInodeEntry->attributeNameLength += attributeNameLength + 1U;
 			xattrInodeEntry->attributeValueLength += attributeValueLength;

--- a/src/master/metadata_backend_file.cc
+++ b/src/master/metadata_backend_file.cc
@@ -241,9 +241,9 @@ static bool xattr_load(MetadataLoader::Options options) {
 	inode_t inode;
 	uint8_t anleng;
 	uint32_t avleng;
-	xattr_data_entry *xa;
-	xattr_inode_entry *ih = nullptr;
-	uint32_t hash, ihash;
+	xattr_data_entry *xattrEntry = nullptr;
+	xattr_inode_entry *xattrInodeEntry = nullptr;
+	uint32_t hash;
 
 	while (true) {
 		try {
@@ -274,18 +274,18 @@ static bool xattr_load(MetadataLoader::Options options) {
 			return false;
 		}
 
-		ihash = xattr_inode_hash_fn(inode);
+		auto ihash = xattr_inode_hash_fn(inode);
 		auto start = gMetadata->xattr_inode_hash[ihash].begin();
 		auto end = gMetadata->xattr_inode_hash[ihash].end();
 
 		for (auto attributeIterator = start; attributeIterator != end; attributeIterator++) {
-			ih = attributeIterator->get();
-			if (ih->inode == inode) {
+			xattrInodeEntry = attributeIterator->get();
+			if (xattrInodeEntry->inode == inode) {
 				break;
 			}
 		}
 
-		if (ih && ih->anleng + anleng + 1 > SFS_XATTR_LIST_MAX) {
+		if (xattrInodeEntry && xattrInodeEntry->anleng + anleng + 1 > SFS_XATTR_LIST_MAX) {
 			safs_pretty_syslog(LOG_ERR, "loading xattr: name list too long");
 			if (options.ignoreFlag) {
 				continue;
@@ -293,47 +293,42 @@ static bool xattr_load(MetadataLoader::Options options) {
 			return false;
 		}
 
-		xa = new xattr_data_entry;
-		xa->inode = inode;
-		xa->attributeName.resize(anleng);
-		passert(xa->attributeName.data());
-		memcpy(xa->attributeName.data(), ptr, anleng);
-		ptr+=anleng;
-		xa->anleng = anleng;
-		if (avleng > 0) {
-			xa->attributeValue.resize(avleng);
-			passert(xa->attributeValue.data());
-			memcpy(xa->attributeValue.data(), ptr, avleng);
-			ptr+=avleng;
-		} else {
-			xa->attributeValue.clear();
-		}
-		options.offset = options.metadataFile->offset(ptr);
-		xa->avleng = avleng;
-		hash = xattr_data_hash_fn(inode, xa->anleng, xa->attributeName.data());
-		xa->next = gMetadata->xattr_data_hash[hash];
-		if (xa->next) {
-			xa->next->prev = &(xa->next);
-		}
-		xa->prev = gMetadata->xattr_data_hash + hash;
-		gMetadata->xattr_data_hash[hash] = xa;
+		xattrEntry = new xattr_data_entry;
+		xattrEntry->inode = inode;
+		xattrEntry->attributeName.resize(anleng);
+		passert(xattrEntry->attributeName.data());
+		memcpy(xattrEntry->attributeName.data(), ptr, anleng);
+		ptr += anleng;
+		xattrEntry->anleng = anleng;
 
-		if (ih) {
-			xa->nextinode = ih->data_head;
-			if (xa->nextinode) {
-				xa->nextinode->previnode = &(xa->nextinode);
-			}
-			xa->previnode = &(ih->data_head);
-			ih->data_head = xa;
-			ih->anleng += anleng + 1U;
-			ih->avleng += avleng;
+		if (avleng > 0) {
+			xattrEntry->attributeValue.resize(avleng);
+			passert(xattrEntry->attributeValue.data());
+			memcpy(xattrEntry->attributeValue.data(), ptr, avleng);
+			ptr += avleng;
+		} else {
+			xattrEntry->attributeValue.clear();
+		}
+
+		options.offset = options.metadataFile->offset(ptr);
+		xattrEntry->avleng = avleng;
+		hash = xattr_data_hash_fn(inode, xattrEntry->anleng, xattrEntry->attributeName.data());
+		xattrEntry->next = gMetadata->xattr_data_hash[hash];
+		if (xattrEntry->next) {
+			xattrEntry->next->prev = &(xattrEntry->next);
+		}
+		xattrEntry->prev = gMetadata->xattr_data_hash + hash;
+		gMetadata->xattr_data_hash[hash] = xattrEntry;
+
+		if (xattrInodeEntry) {
+			xattrInodeEntry->xattrDataList.push_back(xattrEntry);
+			xattrInodeEntry->anleng += anleng + 1U;
+			xattrInodeEntry->avleng += avleng;
 		} else {
 			auto xattrInodeEntry = std::make_unique<xattr_inode_entry>();
 			passert(xattrInodeEntry);
 			xattrInodeEntry->inode = inode;
-			xa->nextinode = nullptr;
-			xa->previnode = &(xattrInodeEntry->data_head);
-			xattrInodeEntry->data_head = xa;
+			xattrInodeEntry->xattrDataList.push_back(xattrEntry);
 			xattrInodeEntry->anleng = anleng + 1U;
 			xattrInodeEntry->avleng = avleng;
 			gMetadata->xattr_inode_hash[ihash].push_front(std::move(xattrInodeEntry));
@@ -635,8 +630,7 @@ static int8_t fs_parseNode(const std::shared_ptr<MemoryMappedFile> &metadataFile
 			sessionIds--;
 		}
 
-		fsnodes_quota_update(node,
-		                     {{QuotaResource::kSize, +fsnodes_get_size(node)}});
+		fsnodes_quota_update(node, {{QuotaResource::kSize, +fsnodes_get_size(node)}});
 		gMetadata->filenodes++;
 		break;
 	default:
@@ -647,8 +641,7 @@ static int8_t fs_parseNode(const std::shared_ptr<MemoryMappedFile> &metadataFile
 		return kError;
 	}
 	uint32_t nodeIndex = NODEHASHPOS(node->id);
-	node->next = gMetadata->nodehash[nodeIndex];
-	gMetadata->nodehash[nodeIndex] = node;
+	gMetadata->nodehash[nodeIndex].push_front(node);
 	gMetadata->inode_pool.markAsAcquired(node->id);
 	gMetadata->nodes++;
 	fsnodes_quota_update(node, {{QuotaResource::kInodes, +1}});
@@ -677,16 +670,14 @@ static int fs_lostnode(FSNode *p) {
 	return -1;
 }
 
-static int fs_checknodes(int ignoreflag) {
-	uint32_t i;
-	FSNode *p;
-	for (i = 0; i < NODEHASHSIZE; i++) {
-		for (p = gMetadata->nodehash[i]; p; p = p->next) {
-			if (p->parent.empty() && p != gMetadata->root &&
-			    (p->type != FSNode::kTrash) && (p->type != FSNode::kReserved)) {
-				safs_pretty_syslog(LOG_ERR, "found orphaned inode: %" PRIiNode, p->id);
+int fs_checknodes(int ignoreflag) {
+	for (auto i = 0; i < NODEHASHSIZE; i++) {
+		for (const auto &node : gMetadata->nodehash[i]) {
+			if (node->parent.empty() && node != gMetadata->root &&
+			    (node->type != FSNode::kTrash) && (node->type != FSNode::kReserved)) {
+				safs_pretty_syslog(LOG_ERR, "found orphaned inode: %" PRIiNode, node->id);
 				if (ignoreflag) {
-					if (fs_lostnode(p) < 0) {
+					if (fs_lostnode(node) < 0) {
 						return -1;
 					}
 				} else {
@@ -920,19 +911,19 @@ void fs_new(void) {
 	gMetadata->maxnodeid = SPECIAL_INODE_ROOT;
 	gMetadata->metaversion = 1;
 	gMetadata->nextsessionid = 1;
-	gMetadata->root =
-	    static_cast<FSNodeDirectory *>(FSNode::create(FSNode::kDirectory));
+	auto *rootDirectory = FSNode::create(FSNode::kDirectory);
+	gMetadata->root = static_cast<FSNodeDirectory *>(rootDirectory);
 	gMetadata->root->id = SPECIAL_INODE_ROOT;
-	gMetadata->root->ctime = gMetadata->root->mtime = gMetadata->root->atime =
-	    eventloop_time();
+	gMetadata->root->atime = eventloop_time();
+	gMetadata->root->mtime = gMetadata->root->atime;
+	gMetadata->root->ctime = gMetadata->root->mtime;
 	gMetadata->root->goal = DEFAULT_GOAL;
 	gMetadata->root->trashtime = kDefaultTrashTime;
 	gMetadata->root->mode = 0777;
 	gMetadata->root->uid = 0;
 	gMetadata->root->gid = 0;
 	nodepos = NODEHASHPOS(gMetadata->root->id);
-	gMetadata->root->next = gMetadata->nodehash[nodepos];
-	gMetadata->nodehash[nodepos] = gMetadata->root;
+	gMetadata->nodehash[nodepos].push_front(gMetadata->root);
 	gMetadata->inode_pool.markAsAcquired(gMetadata->root->id);
 	chunk_newfs();
 	gMetadata->nodes = 1;
@@ -1132,14 +1123,12 @@ void MetadataBackendFile::storenode(FSNode *f, FILE *fd) {
 }
 
 void MetadataBackendFile::storenodes(FILE *fd) {
-	uint32_t i;
-	FSNode *p;
-	for (i = 0; i < NODEHASHSIZE; i++) {
-		for (p = gMetadata->nodehash[i]; p; p = p->next) {
-			storenode(p, fd);
+	for (uint32_t i = 0; i < NODEHASHSIZE; i++) {
+		for (const auto &node : gMetadata->nodehash[i]) {
+			storenode(node, fd);
 		}
 	}
-	storenode(NULL, fd);  // end marker
+	storenode(nullptr, fd);  // end marker
 }
 
 //Edges

--- a/src/master/metadata_backend_file.cc
+++ b/src/master/metadata_backend_file.cc
@@ -249,7 +249,7 @@ static bool xattr_load(MetadataLoader::Options options) {
 		try {
 			ptr = options.metadataFile->seek(options.offset);
 		} catch (const std::exception &e) {
-			safs::log_err("loading xattr: can't read xattr");
+			safs::log_exception(e, "loading xattr: can't read xattr");
 			return false;
 		}
 
@@ -277,11 +277,8 @@ static bool xattr_load(MetadataLoader::Options options) {
 		}
 
 		auto inodeHash = get_xattr_inode_hash(inode);
-		auto start = gMetadata->xattrInodeHash[inodeHash].begin();
-		auto end = gMetadata->xattrInodeHash[inodeHash].end();
-
-		for (auto attributeIterator = start; attributeIterator != end; attributeIterator++) {
-			xattrInodeEntry = attributeIterator->get();
+		for (const auto &xattrEntry : gMetadata->xattrInodeHash[inodeHash]) {
+			xattrInodeEntry = xattrEntry.get();
 			if (xattrInodeEntry->inode == inode) {
 				break;
 			}
@@ -299,7 +296,6 @@ static bool xattr_load(MetadataLoader::Options options) {
 		auto xattrEntry = std::make_unique<XAttributeDataEntry>();
 		xattrEntry->inode = inode;
 		xattrEntry->attributeName.resize(attributeNameLength);
-		xattrEntry->attributeNameLength = attributeNameLength;
 		passert(xattrEntry->attributeName.data());
 		memcpy(xattrEntry->attributeName.data(), ptr, attributeNameLength);
 		ptr += attributeNameLength;
@@ -314,25 +310,21 @@ static bool xattr_load(MetadataLoader::Options options) {
 		}
 
 		options.offset = options.metadataFile->offset(ptr);
-		xattrEntry->attributeValueLength = attributeValueLength;
 
-		auto dataHash = get_xattr_data_hash(inode, xattrEntry->attributeNameLength,
+		auto dataHash = get_xattr_data_hash(inode, xattrEntry->attributeName.size(),
 		                                    xattrEntry->attributeName.data());
 
 		gMetadata->xattrDataHash[dataHash].push_back(std::move(xattrEntry));
-		auto xattrEntryPointer = gMetadata->xattrDataHash[dataHash].back().get();
+		auto *xattrEntryPointer = gMetadata->xattrDataHash[dataHash].back().get();
 
 		if (xattrInodeEntry != nullptr) {
 			xattrInodeEntry->xattrDataList.push_back(xattrEntryPointer);
 			xattrInodeEntry->attributeNameLength += attributeNameLength + 1U;
 			xattrInodeEntry->attributeValueLength += attributeValueLength;
 		} else {
-			auto xattrInodeEntry = std::make_unique<XAttributeInodeEntry>();
-			passert(xattrInodeEntry);
-			xattrInodeEntry->inode = inode;
+			auto xattrInodeEntry =
+			    XAttributeInodeEntry::create(inode, attributeNameLength + 1U, attributeValueLength);
 			xattrInodeEntry->xattrDataList.push_back(xattrEntryPointer);
-			xattrInodeEntry->attributeNameLength = attributeNameLength + 1U;
-			xattrInodeEntry->attributeValueLength = attributeValueLength;
 			gMetadata->xattrInodeHash[inodeHash].push_front(std::move(xattrInodeEntry));
 		}
 	}
@@ -676,15 +668,13 @@ int fs_checknodes(int ignoreflag) {
 		for (const auto &node : gMetadata->nodeHash[i]) {
 			if (node->parent.empty() && node != gMetadata->root &&
 			    (node->type != FSNode::kTrash) && (node->type != FSNode::kReserved)) {
-				safs_pretty_syslog(LOG_ERR, "found orphaned inode: %" PRIiNode, node->id);
+				safs::log_err("found orphaned inode: %" PRIiNode, node->id);
 				if (ignoreflag) {
 					if (fs_lostnode(node) < 0) {
 						return -1;
 					}
 				} else {
-					safs_pretty_syslog(LOG_ERR,
-					                   "use sfsmetarestore (option -i) to "
-					                   "attach this node to root dir\n");
+					safs::log_err("use sfsmetarestore (option -i) to attach this node to root dir");
 					return -1;
 				}
 			}
@@ -1243,8 +1233,10 @@ void MetadataBackendFile::storefree(FILE *fd) {
 // XAttr
 
 void MetadataBackendFile::xattr_store(FILE *fd) {
-	constexpr uint32_t kHdrSize = kinode_t_size + sizeof(XAttributeDataEntry::attributeNameLength) +
-	                              sizeof(XAttributeDataEntry::attributeValueLength);
+	constexpr uint8_t kXAttributeNameLengthSize = 0;
+	constexpr uint32_t kXAttributeValueLengthSize = 0;
+	constexpr uint32_t kHdrSize = kinode_t_size + sizeof(kXAttributeNameLengthSize) +
+	                              sizeof(kXAttributeValueLengthSize);
 	uint8_t headerBuffer[kHdrSize];
 	uint8_t *ptr;
 
@@ -1252,24 +1244,24 @@ void MetadataBackendFile::xattr_store(FILE *fd) {
 		for (const auto &xattrDataEntry : gMetadata->xattrDataHash[i]) {
 			ptr = headerBuffer;
 			putINode(&ptr, xattrDataEntry->inode);
-			put8bit(&ptr, xattrDataEntry->attributeNameLength);
-			put32bit(&ptr, xattrDataEntry->attributeValueLength);
+			put8bit(&ptr, xattrDataEntry->attributeName.size());
+			put32bit(&ptr, static_cast<uint32_t>(xattrDataEntry->attributeValue.size()));
 
 			if (fwrite(headerBuffer, 1, kHdrSize, fd) != (size_t)(kHdrSize)) {
 				safs::log_info("{}: fwrite error failed writing header", __func__);
 				return;
 			}
 
-			auto attributeNameData = xattrDataEntry->attributeName.data();
-			auto nameLength = xattrDataEntry->attributeNameLength;
+			auto *attributeNameData = xattrDataEntry->attributeName.data();
+			auto nameLength = xattrDataEntry->attributeName.size();
 			if (fwrite(attributeNameData, 1, nameLength, fd) != (size_t)(nameLength)) {
 				safs::log_info("{}: fwrite error failed writing attribute name", __func__);
 				return;
 			}
 
-			auto attributeValueData = xattrDataEntry->attributeValue.data();
-			auto valueLength = xattrDataEntry->attributeValueLength;
-			if (xattrDataEntry->attributeValueLength > 0) {
+			auto *attributeValueData = xattrDataEntry->attributeValue.data();
+			auto valueLength = xattrDataEntry->attributeValue.size();
+			if (valueLength > 0) {
 				if (fwrite(attributeValueData, 1, valueLength, fd) != (size_t)(valueLength)) {
 					safs::log_info("{}: fwrite error failed writing attribute value", __func__);
 					return;

--- a/src/master/snapshot_task.cc
+++ b/src/master/snapshot_task.cc
@@ -197,7 +197,7 @@ void SnapshotTask::cloneSymlinkData(FSNodeSymlink *src_node, FSNodeSymlink *dst_
 
 void SnapshotTask::emitChangelog(uint32_t ts, inode_t dst_inode) {
 	if (!emit_changelog_) {
-		gMetadata->metaversion++;
+		gMetadata->metadataVersion++;
 		return;
 	}
 


### PR DESCRIPTION
This PR refactors filesystem metadata files with the following changes:
- Replace raw uint8_t pointers used to manage extended attributes.
- Replace custom C-linked list used to store extended attributes (xattr_inode_entry_list)
  with an array of std::list of smart pointers.
- Replace custom C-linked lists used in FilesystemMetadata to store extended attributes.
- Remove unused code left over after the refactoring.
- Rename variables to use more meaningful names.
- Apply code style formatting to modified functions.

Signed-off-by: Crash <crash@leil.io>