### PR TITLE
fix(mds): Add init function to metadata backends

### DIFF
--- a/src/master/filesystem.cc
+++ b/src/master/filesystem.cc
@@ -227,41 +227,10 @@ void fs_erase_message_from_lockfile() {
 int fs_loadall(void) {
 	fs_strinit();
 	chunk_strinit();
-	if (fs::exists(kMetadataTmpFilename)) {
-		throw MetadataFsConsistencyException(
-		    "temporary metadata file (" + std::string(kMetadataTmpFilename) + ") exists,"
-		    " metadata directory is in dirty state");
-	}
-	std::string metadataFile;
-	bool metadataFileExists = fs::exists(kMetadataFilename);
-	bool legacyMetadataFileExists = fs::exists(kMetadataLegacyFilename);
-	if (metadataFileExists) {
-		metadataFile = kMetadataFilename;
-	}
-	if(metadataFileExists && legacyMetadataFileExists) {
-		metadataFile = kMetadataFilename;
-		safs_pretty_syslog(LOG_WARNING, "There are two metadata files in the data path: %s and %s."
-		                   " Please remove the legacy one (%s) to avoid damage to your storage.",
-		                   kMetadataFilename, kMetadataLegacyFilename, kMetadataLegacyFilename);
-	}
-	if (!metadataFileExists && legacyMetadataFileExists) {
-		metadataFile = kMetadataLegacyFilename;
-		safs_pretty_syslog(LOG_WARNING, "Only Legacy metadata file %s found and will be loaded instead."
-		                   " You should delete legacy metadata %s on next restart after new metadata %s is created ",
-		                   metadataFile.c_str(), kMetadataLegacyFilename, kMetadataFilename);
-	}
-	if (metadataserver::isMaster() && !metadataFileExists && !legacyMetadataFileExists) {
-		fs_unlock();
-		std::string currentPath = fs::getCurrentWorkingDirectoryNoThrow();
-		throw FilesystemException("can't open metadata file "+ currentPath + "/" + kMetadataFilename
-					+ ": if this is a new installation create empty metadata by copying "
-					+ currentPath + "/" + kMetadataFilename + ".empty to " + currentPath
-					+ "/" + kMetadataFilename);
-	}
 
 	{
 		auto scopedTimer = util::ScopedTimer("metadata load time");
-		gMetadataBackend->loadall(metadataFile, 0);
+		gMetadataBackend->loadall(0);
 	}
 
 	bool autoRecovery = fs_can_do_auto_recovery();
@@ -422,17 +391,20 @@ int fs_init(bool doLoad) {
 	}
 
 	if (!gMetadataLockfile) {
-		gMetadataLockfile.reset(new Lockfile(kMetadataFilename + std::string(".lock")));
+		gMetadataLockfile = std::make_unique<Lockfile>(kMetadataFilename + std::string(".lock"));
 	}
+
 	if (!gMetadataLockfile->isLocked()) {
 		try {
-			gMetadataLockfile->lock((fs_can_do_auto_recovery() || !metadataserver::isMaster()) ?
-					Lockfile::StaleLock::kSwallow : Lockfile::StaleLock::kReject);
-		} catch (const LockfileException& e) {
+			gMetadataLockfile->lock((fs_can_do_auto_recovery() || !metadataserver::isMaster())
+			                            ? Lockfile::StaleLock::kSwallow
+			                            : Lockfile::StaleLock::kReject);
+		} catch (const LockfileException &e) {
 			if (e.reason() == LockfileException::Reason::kStaleLock) {
 				throw LockfileException(
-						std::string(e.what()) + ", consider running `sfsmetarestore -a' to fix problems with your datadir.",
-						LockfileException::Reason::kStaleLock);
+				    std::string(e.what()) +
+				        ", consider running `sfsmetarestore -a' to fix problems with your datadir.",
+				    LockfileException::Reason::kStaleLock);
 			}
 			throw;
 		}
@@ -443,18 +415,23 @@ int fs_init(bool doLoad) {
 	if (doLoad || (metadataserver::isMaster())) {
 		fs_loadall();
 	}
+
 	eventloop_reloadregister(fs_reload);
 	metadataserver::registerFunctionCalledOnPromotion(fs_become_master);
 	auto metadataDumpPeriod = cfg_getint32("METADATA_DUMP_PERIOD_SECONDS", 3600);
+
 	if (metadataDumpPeriod > 0) {  /// 0 means disabled periodic metadata dumps
 		eventloop_timeregister(TIMEMODE_RUN_LATE, metadataDumpPeriod, 0,
 		                       fs_periodic_storeall);
 	}
+
 	if (metadataserver::isMaster()) {
 		fs_become_master();
 	}
+
 	eventloop_pollregister(metadataPollDesc, metadataPollServe);
 	eventloop_destructregister(fs_term);
+
 	return 0;
 }
 
@@ -466,8 +443,9 @@ int fs_init() {
 }
 
 #else   // METARESTORE mode
-int fs_init(const char *fname,int ignoreflag, bool noLock) {
+int fs_init(const char *fname, int ignoreflag, bool noLock) {
 	gMetadataBackend = std::make_unique<MetadataBackendFile>();
+	dynamic_cast<MetadataBackendFile *>(gMetadataBackend.get())->setMetadataFile(fname);
 
 	if (!noLock) {
 		gMetadataLockfile.reset(new Lockfile(fs::dirname(fname) + "/" + kMetadataFilename + ".lock"));
@@ -475,7 +453,7 @@ int fs_init(const char *fname,int ignoreflag, bool noLock) {
 	}
 	fs_strinit();
 	chunk_strinit();
-	gMetadataBackend->loadall(fname,ignoreflag);
+	gMetadataBackend->loadall(ignoreflag);
 	return 0;
 }
 #endif  // #ifndef METARESTORE

--- a/src/master/init.h
+++ b/src/master/init.h
@@ -58,6 +58,7 @@ inline int metadata_backend_init() {
 	if (gMetadataBackend == nullptr) {
 		try {
 			gMetadataBackend = std::make_unique<MetadataBackendFile>();
+			gMetadataBackend->init();
 		} catch (const std::exception &e) {
 			constexpr auto kErrorMessage = "Failed to initialize metadata backend";
 			safs::log_err("{}: {}", kErrorMessage, e.what());

--- a/src/master/metadata_backend_file.cc
+++ b/src/master/metadata_backend_file.cc
@@ -987,8 +987,8 @@ static bool checkMetadataSignature(const std::shared_ptr<MemoryMappedFile> &meta
 	return true;
 }
 
-void MetadataBackendFile::loadall(const std::string &fname, int ignoreflag) {
-	auto metadataFile = std::make_shared<MemoryMappedFile>(fname);
+void MetadataBackendFile::loadall(int ignoreflag) {
+	auto metadataFile = std::make_shared<MemoryMappedFile>(metadataFile_);
 	if (!checkMetadataSignature(metadataFile)) { return; }
 	if (fs_load(metadataFile, ignoreflag) != kOpSuccess) {
 		throw MetadataConsistencyException(MetadataStructureReadErrorMsg);
@@ -1009,7 +1009,7 @@ void MetadataBackendFile::loadall(const std::string &fname, int ignoreflag) {
 	    metadataFile->filename().c_str(), gMetadata->nodes, gMetadata->dirnodes,
 	    gMetadata->filenodes, gMetadata->linknodes, chunk_count());
 #else
-	safs_pretty_syslog(LOG_INFO, "metadata file %s read", fname.c_str());
+	safs::log_info("metadata file {} read", metadataFile_);
 #endif
 }
 
@@ -1439,6 +1439,53 @@ void MetadataBackendFile::store_fd(FILE *fd) {
 }
 
 #endif  // #ifndef METALOGGER
+
+void MetadataBackendFile::init() {
+	if (fs::exists(kMetadataTmpFilename)) {
+		throw MetadataFsConsistencyException(
+		    "temporary metadata file (" + std::string(kMetadataTmpFilename) + ") exists,"
+		    " metadata directory is in dirty state");
+	}
+
+	std::string metadataFile;
+	bool metadataFileExists = fs::exists(kMetadataFilename);
+	bool legacyMetadataFileExists = fs::exists(kMetadataLegacyFilename);
+
+	if (metadataFileExists) { metadataFile = kMetadataFilename; }
+
+	if (metadataFileExists && legacyMetadataFileExists) {
+		metadataFile = kMetadataFilename;
+		safs_pretty_syslog(LOG_WARNING,
+		                   "There are two metadata files in the data path: %s and %s."
+		                   " Please remove the legacy one (%s) to avoid damage to your storage.",
+		                   kMetadataFilename, kMetadataLegacyFilename, kMetadataLegacyFilename);
+	}
+
+	if (!metadataFileExists && legacyMetadataFileExists) {
+		metadataFile = kMetadataLegacyFilename;
+		safs_pretty_syslog(
+		    LOG_WARNING,
+		    "Only Legacy metadata file %s found and will be loaded instead."
+		    " You should delete legacy metadata %s on next restart after new metadata %s is created ",
+		    metadataFile.c_str(), kMetadataLegacyFilename, kMetadataFilename);
+	}
+
+	metadataFile_ = metadataFile;
+
+#if !defined(METALOGGER) && !defined(METARESTORE)
+	if (!metadataserver::isMaster() && metadataFile_.empty()) {
+		metadataFile_ = kMetadataFilename;
+	}
+
+	if (metadataserver::isMaster() && !metadataFileExists && !legacyMetadataFileExists) {
+		std::string currentPath = fs::getCurrentWorkingDirectoryNoThrow();
+		throw FilesystemException(
+		    "can't open metadata file " + currentPath + "/" + kMetadataFilename +
+		    ": if this is a new installation create empty metadata by copying " + currentPath +
+		    "/" + kMetadataFilename + ".empty to " + currentPath + "/" + kMetadataFilename);
+	}
+#endif
+}
 
 uint64_t MetadataBackendFile::getVersion(const std::string& file) {
 	int fd;

--- a/src/master/metadata_backend_file.h
+++ b/src/master/metadata_backend_file.h
@@ -29,6 +29,11 @@ class MetadataBackendFile : public IMetadataBackend {
 public:
 	MetadataBackendFile();
 
+	/// Initializes the metadata backend.
+	/// This method should be called before any other methods of the backend.
+	/// This concrete implementation finds the metadata file to use.
+	void init() override;
+
 	/// Returns version of a metadata file.
 	/// Throws MetadataCheckException if the file is corrupted, ie. contains
 	/// wrong header or end marker.
@@ -37,13 +42,16 @@ public:
 
 	std::string backendType() override { return "MetadataBackendFile"; }
 
+	void setMetadataFile(const std::string &metadataFile) {
+		metadataFile_ = metadataFile;
+	}
+
 #ifndef METALOGGER
 	/// Store metadata to the given file descriptor.
 	void store_fd(FILE *fd) override;
 
-	/// Load complete metadata from the given file.
-	/// @param fname -- path to the metadata file.
-	void loadall(const std::string &fname, int ignoreflag) override;
+	/// Load complete metadata.
+	void loadall(int ignoreflag) override;
 #endif  // #ifndef METALOGGER
 
 #if !defined(METARESTORE) && !defined(METALOGGER)
@@ -121,4 +129,6 @@ private:
 
 	std::unique_ptr<IMetadataDumper> dumper_;
 #endif  // #ifndef METARESTORE
+
+	std::string metadataFile_;
 };

--- a/src/master/metadata_backend_interface.h
+++ b/src/master/metadata_backend_interface.h
@@ -73,6 +73,10 @@ public:
 	IMetadataBackend& operator=(const IMetadataBackend&) = delete;
 	IMetadataBackend& operator=(IMetadataBackend&&) = delete;
 
+	/// Initializes the metadata backend.
+	/// This method should be called before any other methods of the backend.
+	virtual void init() = 0;
+
 	/// Returns the current metadata version
 	virtual uint64_t getVersion(const std::string& file) = 0;
 
@@ -87,10 +91,8 @@ public:
 	/// gradually from this interface.
 	virtual void store_fd(FILE *fd) = 0;
 
-	/// Load complete metadata from the given file.
-	/// @param fname -- path hint to the metadata file, directory or database
-	///                 (to be defined by the concrete implementation)
-	virtual void loadall(const std::string &fname, int ignoreflag) = 0;
+	/// Load complete metadata.
+	virtual void loadall(int ignoreflag) = 0;
 #endif  // #ifndef METALOGGER
 
 // Available for master and shadow only


### PR DESCRIPTION
This commit reduces the concrete code depending on specific metadata file based backend, like references to `metadata.sfs`, and delegates it to the concrete backend implementation, by using the new `init` member function.

This way, the dependencies on specific filenames for the metadata, outside of the concrete backend implementations, are reduced. Implementing and integrating new backends should be easier now.