### PR TITLE
test: Patch pylint error on deprecated modules

### DIFF
--- a/tests/test_suites/SanityChecks/test_cgi_using_pylint.sh
+++ b/tests/test_suites/SanityChecks/test_cgi_using_pylint.sh
@@ -7,7 +7,8 @@ else
 fi
 
 # Get paths to sfs.cgi, chart.cgi and the CGI server
-files=$(echo $SAUNAFS_ROOT/share/sfscgi/*.cgi $SAUNAFS_ROOT/sbin/saunafs-cgiserver)
+mapfile -t files < <(find "${SAUNAFS_ROOT}/share/sfscgi/" -name '*.cgi')
+files+=("${SAUNAFS_ROOT}/sbin/saunafs-cgiserver")
 
 # Validate all found files using pylint
-expect_empty "$($pylintexec -E $files || true)"
+expect_empty "$(${pylintexec} -E --ignored-modules=cgi,cgitb "${files[@]}" || true)"


### PR DESCRIPTION
cgi and cgitb modules have been deprecated on Python3.13, therefore pylint checks are complaining on module imports.
This commit patches the test not to complain on this modules while a more persistent solution is provided.