### PR TITLE
feat(cmake): Make FDB optional

### DIFF
--- a/.github/workflows/run-unit-and-ganesha-tests.yml
+++ b/.github/workflows/run-unit-and-ganesha-tests.yml
@@ -81,6 +81,7 @@ jobs:
                   -DCODE_COVERAGE=OFF \
                   -DSAUNAFS_TEST_POINTER_OBFUSCATION=ON \
                   -DENABLE_WERROR=ON \
+                  -DENABLE_FOUNDATIONDB=ON \
                   "${GITHUB_WORKSPACE}"
                   make -j"$(nproc)" install
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ option(ENABLE_COMPILE_COMMANDS  "Enable generation of compile_commands.json"    
 option(ENABLE_PROMETHEUS        "Enable prometheus metrics"                              ON)
 # Experimental
 option(ENABLE_INODE64           "Enable 64 bits for inode numbers and quantities"        OFF)
+option(ENABLE_FOUNDATIONDB      "Enable FoundationDB experimental support"               OFF)
 
 option(GENERATE_GIT_INFO "Generate git info from current repository (for version commands)" ON)
 
@@ -148,6 +149,7 @@ message(STATUS "USE_LEGACY_READ_MESSAGES: ${USE_LEGACY_READ_MESSAGES}")
 message(STATUS "ENABLE_NFS_GANESHA: ${ENABLE_NFS_GANESHA}")
 message(STATUS "ENABLE_COMPILE_COMMANDS: ${CMAKE_EXPORT_COMPILE_COMMANDS}")
 message(STATUS "ENABLE_INODE64: ${ENABLE_INODE64}")
+message(STATUS "ENABLE_FOUNDATIONDB: ${ENABLE_FOUNDATIONDB}")
 
 if(ENABLE_INODE64)
   add_definitions(-DSAUNAFS_USE_INODE64)
@@ -420,7 +422,9 @@ if(NOT MINGW)
   endif()
   add_subdirectory(src/chunkserver)
   add_subdirectory(src/kv)
-  add_subdirectory(src/fdb)
+  if(ENABLE_FOUNDATIONDB)
+    add_subdirectory(src/fdb)
+  endif()
   add_subdirectory(src/master)
   add_subdirectory(src/metadump)
   add_subdirectory(src/metalogger)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -22,7 +22,8 @@
                 "ENABLE_WERROR": "ON",
                 "GSH_CAN_HOST_LOCAL_FS": "ON",
                 "SAUNAFS_TEST_POINTER_OBFUSCATION": "ON",
-                "ENABLE_INODE64": "OFF"
+                "ENABLE_INODE64": "OFF",
+                "ENABLE_FOUNDATIONDB": "ON"
             },
             "hidden": true
         },
@@ -55,7 +56,8 @@
 				"ENABLE_NFS_ACL_SUPPORT": "OFF",
 				"CODE_COVERAGE": "OFF",
 				"SAUNAFS_TEST_POINTER_OBFUSCATION": "OFF",
-				"ENABLE_WERROR": "ON"
+				"ENABLE_WERROR": "ON",
+				"ENABLE_FOUNDATIONDB": "OFF"
 			}
 		},
         {
@@ -85,7 +87,8 @@
                 "CMAKE_INSTALL_PREFIX": "/",
                 "ENABLE_TESTS": "OFF",
                 "ENABLE_WERROR": "OFF",
-                "SAUNAFS_TEST_POINTER_OBFUSCATION": "OFF"
+                "SAUNAFS_TEST_POINTER_OBFUSCATION": "OFF",
+                "ENABLE_FOUNDATIONDB": "OFF"
             },
             "inherits": "default"
         },

--- a/tests/docker/Dockerfile.clang
+++ b/tests/docker/Dockerfile.clang
@@ -56,6 +56,7 @@ RUN mkdir -p /saunafs/build && ls /saunafs && \
     -DENABLE_TESTS=1 \
     -DENABLE_NFS_GANESHA=1 \
     -DENABLE_CLIENT_LIB=ON \
+    -DENABLE_FOUNDATIONDB=ON \
     ..;
 
 # TODO: Use CMake presets

--- a/tests/docker/Dockerfile.test
+++ b/tests/docker/Dockerfile.test
@@ -75,6 +75,7 @@ RUN mkdir -p /saunafs/build && ls /saunafs && \
     -DENABLE_CLIENT_LIB=ON \
     -DENABLE_URAFT=ON \
     -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+    -DENABLE_FOUNDATIONDB=ON \
     ..;
 
 # TODO: Use CMake presets

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -72,10 +72,12 @@ install(TARGETS readdir-unlink-test RUNTIME DESTINATION ${BIN_SUBDIR})
 add_executable(big-session-metadata-benchmark big_session_metadata_benchmark.cc)
 install(TARGETS big-session-metadata-benchmark RUNTIME DESTINATION ${BIN_SUBDIR})
 
-# sfs-test-fdb Checks if the expected FDB database is operable
-add_executable(sfs-test-fdb sfs_test_fdb.cc)
-target_link_libraries(sfs-test-fdb slogger fdb)
-install(TARGETS sfs-test-fdb RUNTIME DESTINATION ${BIN_SUBDIR})
+if(ENABLE_FOUNDATIONDB)
+  # sfs-test-fdb Checks if the expected FDB database is operable
+  add_executable(sfs-test-fdb sfs_test_fdb.cc)
+  target_link_libraries(sfs-test-fdb slogger fdb)
+  install(TARGETS sfs-test-fdb RUNTIME DESTINATION ${BIN_SUBDIR})
+endif()
 
 add_library(slow_chunk_scan SHARED slow_chunk_scan.c)
 if(NOT CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")


### PR DESCRIPTION
FoundationDB support is at an early/experimental stage. This commit allows to use it via the new ENABLE_FOUNDATIONDB cmake option.