### PR TITLE
fix(chunkserver): Use malloc_trim to reduce RAM usage

### DIFF
--- a/doc/sfschunkserver.cfg.5.adoc
+++ b/doc/sfschunkserver.cfg.5.adoc
@@ -44,6 +44,11 @@ it may also lead to contention and reduced parallelism in multi-threaded
 applications. Use it in constrained memory environments, recommended values are
 4 or 8. (default is 0: disabled or let glibc decide)
 
+*MALLOC_TRIM_INTERVAL*:: interval in seconds at which the chunkserver will attempt
+to release unused memory back to the OS using malloc_trim(). This can help reduce
+the process's memory footprint by returning free memory to the system more
+frequently. (default is 3600, minimum is 1)
+
 *NICE_LEVEL*:: nice level to run daemon with (default is -19 if possible; note:
 process must be started as root to increase priority)
 

--- a/doc/sfschunkserver.cfg.5.adoc
+++ b/doc/sfschunkserver.cfg.5.adoc
@@ -47,7 +47,7 @@ applications. Use it in constrained memory environments, recommended values are
 *MALLOC_TRIM_INTERVAL*:: interval in seconds at which the chunkserver will attempt
 to release unused memory back to the OS using malloc_trim(). This can help reduce
 the process's memory footprint by returning free memory to the system more
-frequently. (default is 3600, minimum is 1)
+frequently. Set to 0 to disable memory trimming entirely. (default is 0, 0 = disabled)
 
 *NICE_LEVEL*:: nice level to run daemon with (default is -19 if possible; note:
 process must be started as root to increase priority)

--- a/src/chunkserver/chunkserver-common/memory_manager.cc
+++ b/src/chunkserver/chunkserver-common/memory_manager.cc
@@ -1,0 +1,78 @@
+/*
+   Copyright 2023      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "common/platform.h"
+
+#include "chunkserver-common/memory_manager.h"
+
+#include <malloc.h>
+
+#include "common/event_loop.h"
+#include "config/cfg.h"
+#include "slogger/slogger.h"
+
+// Static members initialization
+
+std::atomic_uint32_t MemoryManager::effectiveInterval_{
+    MemoryManager::kDefaultMallocTrimIntervalSeconds};
+
+bool MemoryManager::initialized_ = false;
+
+EventLoopTimerHandle MemoryManager::eventLoopHandle_ = nullptr;
+
+// MemoryManager functions
+
+void MemoryManager::trimMemory() {
+	if (malloc_trim(0) == 1) {
+		safs::log_info("Memory trimmed successfully.");
+	}  // 0 is not an error, it just means no memory was trimmed
+}
+
+void MemoryManager::reload() {
+	auto interval = cfg_get_minvalue<uint32_t>(
+	    "MALLOC_TRIM_INTERVAL", kDefaultMallocTrimIntervalSeconds, kMinMallocTrimIntervalSeconds);
+
+	// No change
+	if (interval == effectiveInterval_.load() && initialized_) { return; }
+
+	effectiveInterval_.store(interval, std::memory_order_relaxed);
+
+	if (initialized_) {
+		eventloop_timechange(eventLoopHandle_, TIMEMODE_RUN_LATE, interval, 0);
+	} else {
+		eventLoopHandle_ = eventloop_timeregister(TIMEMODE_RUN_LATE, interval, 0,
+		                                          []() { MemoryManager::trimMemory(); });
+
+		if (eventLoopHandle_ == nullptr) {
+			safs::log_err("Failed to register memory trim event loop handler.");
+			return;
+		}
+	}
+
+	safs::log_info("Effective MALLOC_TRIM_INTERVAL: {} seconds", interval);
+
+	if (!initialized_) { initialized_ = true; }
+}
+
+int MemoryManager::init() {
+	reload();
+
+	eventloop_reloadregister(MemoryManager::reload);
+
+	return 0;
+}

--- a/src/chunkserver/chunkserver-common/memory_manager.cc
+++ b/src/chunkserver/chunkserver-common/memory_manager.cc
@@ -34,8 +34,7 @@
 
 std::atomic_uint32_t MemoryManager::effectiveInterval_{
     MemoryManager::kDefaultMallocTrimIntervalSeconds};
-bool MemoryManager::initialized_ = false;
-EventLoopTimerHandle MemoryManager::eventLoopHandle_ = nullptr;
+bool MemoryManager::isThreadRunning_ = false;
 std::jthread MemoryManager::trimThread_;
 std::condition_variable_any MemoryManager::trimCv_;
 std::mutex MemoryManager::trimMutex_;
@@ -43,8 +42,15 @@ std::mutex MemoryManager::trimMutex_;
 // MemoryManager functions
 
 void MemoryManager::trimThreadFunc(std::stop_token stoken) {
+	pthread_setname_np(pthread_self(), "malloc_trim");
+
 	while (!stoken.stop_requested()) {
 		uint32_t interval = MemoryManager::effectiveInterval();
+
+		// If interval is 0, the feature is disabled, exit the thread
+		if (interval == kDisableTrimmingInterval) {
+			break;
+		}
 
 		// Wait for the interval or until stop is requested or config changes (reload)
 		std::unique_lock lock(MemoryManager::trimMutex_);
@@ -74,24 +80,47 @@ void MemoryManager::trimMemory() {
 }
 
 void MemoryManager::reload() {
-	auto interval = cfg_get_minvalue<uint32_t>(
-	    "MALLOC_TRIM_INTERVAL", kDefaultMallocTrimIntervalSeconds, kMinMallocTrimIntervalSeconds);
+	auto interval = cfg_getuint32("MALLOC_TRIM_INTERVAL", kDefaultMallocTrimIntervalSeconds);
 
-	if (interval == effectiveInterval_.load() && initialized_) { return; }
+	// interval == 0 here will mean to disable the trimming, including the thread
+	uint32_t currentInterval = effectiveInterval_.load();
+	bool wasThreadRunning = isThreadRunning_;
+
+	if (interval == currentInterval && wasThreadRunning == (interval > 0)) {
+		return;
+	}
 
 	effectiveInterval_.store(interval, std::memory_order_relaxed);
 
-	// Notify the thread in case the interval changed
-	trimCv_.notify_all();
+	// Handle thread lifecycle based on interval
+	if (interval == kDisableTrimmingInterval) {
+		// Stop the thread if it's running
+		if (isThreadRunning_ && trimThread_.joinable()) {
+			trimThread_.request_stop();
+			trimCv_.notify_all();
+			trimThread_.join();
+			isThreadRunning_ = false;
+			safs::log_info("Memory trimming disabled - thread stopped");
+		}
+	} else {
+		// Start the thread if it's not running
+		if (!isThreadRunning_) {
+			trimThread_ = std::jthread(MemoryManager::trimThreadFunc);
+			isThreadRunning_ = true;
+			safs::log_info("Memory trimming enabled - thread started");
+		} else {
+			// Thread is already running, just notify about interval change
+			trimCv_.notify_all();
+		}
+	}
 
-	safs::log_info("Effective MALLOC_TRIM_INTERVAL: {} seconds", interval);
-
-	if (!initialized_) { initialized_ = true; }
+	if (interval > kDisableTrimmingInterval) {
+		safs::log_info("Effective MALLOC_TRIM_INTERVAL: {} seconds", interval);
+	}
 }
 
 int MemoryManager::init() {
 	reload();
-	trimThread_ = std::jthread(MemoryManager::trimThreadFunc);
 	eventloop_reloadregister(MemoryManager::reload);
 	eventloop_destructregister(MemoryManager::shutdown);
 
@@ -103,5 +132,6 @@ void MemoryManager::shutdown() {
 		trimThread_.request_stop();
 		trimCv_.notify_all();
 		trimThread_.join();
+		isThreadRunning_ = false;
 	}
 }

--- a/src/chunkserver/chunkserver-common/memory_manager.cc
+++ b/src/chunkserver/chunkserver-common/memory_manager.cc
@@ -21,6 +21,10 @@
 #include "chunkserver-common/memory_manager.h"
 
 #include <malloc.h>
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
 
 #include "common/event_loop.h"
 #include "config/cfg.h"
@@ -30,39 +34,55 @@
 
 std::atomic_uint32_t MemoryManager::effectiveInterval_{
     MemoryManager::kDefaultMallocTrimIntervalSeconds};
-
 bool MemoryManager::initialized_ = false;
-
 EventLoopTimerHandle MemoryManager::eventLoopHandle_ = nullptr;
+std::jthread MemoryManager::trimThread_;
+std::condition_variable_any MemoryManager::trimCv_;
+std::mutex MemoryManager::trimMutex_;
 
 // MemoryManager functions
 
+void MemoryManager::trimThreadFunc(std::stop_token stoken) {
+	while (!stoken.stop_requested()) {
+		uint32_t interval = MemoryManager::effectiveInterval();
+
+		// Wait for the interval or until stop is requested or config changes (reload)
+		std::unique_lock lock(MemoryManager::trimMutex_);
+		bool timeout = !MemoryManager::trimCv_.wait_for(lock, std::chrono::seconds(interval), [&] {
+			return stoken.stop_requested() || MemoryManager::effectiveInterval() != interval;
+		});
+
+		if (stoken.stop_requested()) { break; }
+
+		// Trim if we timed out OR if this is the initial run after config change
+		if (timeout) { MemoryManager::trimMemory(); }
+	}
+}
+
 void MemoryManager::trimMemory() {
-	if (malloc_trim(0) == 1) {
-		safs::log_info("Memory trimmed successfully.");
-	}  // 0 is not an error, it just means no memory was trimmed
+	auto start = std::chrono::high_resolution_clock::now();
+	int result = malloc_trim(0);
+	auto end = std::chrono::high_resolution_clock::now();
+
+	auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+
+	if (result == 1) {
+		safs::log_info("Memory trimmed successfully in {} us.", duration.count());
+	} else {
+		safs::log_info("Memory trim returned {} (0 means no memory was trimmed).", result);
+	}
 }
 
 void MemoryManager::reload() {
 	auto interval = cfg_get_minvalue<uint32_t>(
 	    "MALLOC_TRIM_INTERVAL", kDefaultMallocTrimIntervalSeconds, kMinMallocTrimIntervalSeconds);
 
-	// No change
 	if (interval == effectiveInterval_.load() && initialized_) { return; }
 
 	effectiveInterval_.store(interval, std::memory_order_relaxed);
 
-	if (initialized_) {
-		eventloop_timechange(eventLoopHandle_, TIMEMODE_RUN_LATE, interval, 0);
-	} else {
-		eventLoopHandle_ = eventloop_timeregister(TIMEMODE_RUN_LATE, interval, 0,
-		                                          []() { MemoryManager::trimMemory(); });
-
-		if (eventLoopHandle_ == nullptr) {
-			safs::log_err("Failed to register memory trim event loop handler.");
-			return;
-		}
-	}
+	// Notify the thread in case the interval changed
+	trimCv_.notify_all();
 
 	safs::log_info("Effective MALLOC_TRIM_INTERVAL: {} seconds", interval);
 
@@ -71,8 +91,17 @@ void MemoryManager::reload() {
 
 int MemoryManager::init() {
 	reload();
-
+	trimThread_ = std::jthread(MemoryManager::trimThreadFunc);
 	eventloop_reloadregister(MemoryManager::reload);
+	eventloop_destructregister(MemoryManager::shutdown);
 
 	return 0;
+}
+
+void MemoryManager::shutdown() {
+	if (trimThread_.joinable()) {
+		trimThread_.request_stop();
+		trimCv_.notify_all();
+		trimThread_.join();
+	}
 }

--- a/src/chunkserver/chunkserver-common/memory_manager.h
+++ b/src/chunkserver/chunkserver-common/memory_manager.h
@@ -26,12 +26,19 @@
 #include <mutex>
 #include <thread>
 
-using EventLoopTimerHandle = void *;
-
 /// \brief MemoryManager class handles memory management tasks.
 ///  The initial implementation focuses on trimming unused memory and managing the trim interval.
-class MemoryManager {
+class MemoryManager final {
 public:
+	// This class is not meant to be instantiated or copied.
+	// The interface is provided by static methods.
+	MemoryManager() = delete;
+	MemoryManager(const MemoryManager &) = delete;
+	MemoryManager(MemoryManager &&) = delete;
+	MemoryManager &operator=(const MemoryManager &) = delete;
+	MemoryManager &operator=(MemoryManager &&) = delete;
+	~MemoryManager() = delete;
+
 	/// Does the actual memory trimming.
 	/// This function is registered in the event loop and called periodically.
 	static void trimMemory();
@@ -53,12 +60,10 @@ private:
 	/// Background thread function for memory trimming
 	static void trimThreadFunc(std::stop_token stoken);
 
-	static constexpr uint32_t kMinMallocTrimIntervalSeconds = 1;
-	static constexpr uint32_t kDefaultMallocTrimIntervalSeconds = 3600;
+	static constexpr uint32_t kDisableTrimmingInterval = 0;
+	static constexpr uint32_t kDefaultMallocTrimIntervalSeconds = kDisableTrimmingInterval;
 
-	static bool initialized_;  ///< Whether the trimMemory function was registered in the event loop
-	static EventLoopTimerHandle eventLoopHandle_;  ///< Handle for the registered function
-
+	static bool isThreadRunning_;  ///< Whether the trim thread is currently running
 	static std::atomic_uint32_t effectiveInterval_;  ///< Interval in seconds for malloc_trim
 
 	// Threading

--- a/src/chunkserver/chunkserver-common/memory_manager.h
+++ b/src/chunkserver/chunkserver-common/memory_manager.h
@@ -21,7 +21,10 @@
 #include "common/platform.h"
 
 #include <atomic>
+#include <condition_variable>
 #include <cstdint>
+#include <mutex>
+#include <thread>
 
 using EventLoopTimerHandle = void *;
 
@@ -39,7 +42,17 @@ public:
 	/// RunTab for the init.h file
 	static int init();
 
+	/// For clean shutdown
+	static void shutdown();
+
+	static uint32_t effectiveInterval() {
+		return effectiveInterval_.load(std::memory_order_relaxed);
+	}
+
 private:
+	/// Background thread function for memory trimming
+	static void trimThreadFunc(std::stop_token stoken);
+
 	static constexpr uint32_t kMinMallocTrimIntervalSeconds = 1;
 	static constexpr uint32_t kDefaultMallocTrimIntervalSeconds = 3600;
 
@@ -47,4 +60,9 @@ private:
 	static EventLoopTimerHandle eventLoopHandle_;  ///< Handle for the registered function
 
 	static std::atomic_uint32_t effectiveInterval_;  ///< Interval in seconds for malloc_trim
+
+	// Threading
+	static std::jthread trimThread_;
+	static std::condition_variable_any trimCv_;
+	static std::mutex trimMutex_;
 };

--- a/src/chunkserver/chunkserver-common/memory_manager.h
+++ b/src/chunkserver/chunkserver-common/memory_manager.h
@@ -1,0 +1,50 @@
+/*
+   Copyright 2023      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "common/platform.h"
+
+#include <atomic>
+#include <cstdint>
+
+using EventLoopTimerHandle = void *;
+
+/// \brief MemoryManager class handles memory management tasks.
+///  The initial implementation focuses on trimming unused memory and managing the trim interval.
+class MemoryManager {
+public:
+	/// Does the actual memory trimming.
+	/// This function is registered in the event loop and called periodically.
+	static void trimMemory();
+
+	/// Reloads the memory trim interval from configuration and updates the event loop registration.
+	static void reload();
+
+	/// RunTab for the init.h file
+	static int init();
+
+private:
+	static constexpr uint32_t kMinMallocTrimIntervalSeconds = 1;
+	static constexpr uint32_t kDefaultMallocTrimIntervalSeconds = 3600;
+
+	static bool initialized_;  ///< Whether the trimMemory function was registered in the event loop
+	static EventLoopTimerHandle eventLoopHandle_;  ///< Handle for the registered function
+
+	static std::atomic_uint32_t effectiveInterval_;  ///< Interval in seconds for malloc_trim
+};

--- a/src/chunkserver/init.h
+++ b/src/chunkserver/init.h
@@ -22,6 +22,7 @@
 
 #include <vector>
 
+#include "chunkserver-common/memory_manager.h"
 #include "chunkserver/chartsdata.h"
 #include "chunkserver/hddspacemgr.h"
 #include "chunkserver/masterconn.h"
@@ -35,6 +36,7 @@ inline const std::vector<RunTab> earlyRunTabs = {};
 /// Functions to call during normal startup
 inline const std::vector<RunTab> runTabs = {
     RunTab{rnd_init, "random generator"},
+    RunTab{MemoryManager::init, "memory manager"},
     RunTab{initDiskManager, "disk manager"},  // Always before "plugin manager"
     RunTab{loadPlugins, "plugin manager"}, RunTab{hddInit, "hdd space manager"},
     // Has to be before "masterconn"

--- a/src/data/sfschunkserver.cfg.in
+++ b/src/data/sfschunkserver.cfg.in
@@ -25,6 +25,13 @@
 ## (default is 0: disabled or let glibc decide)
 # LIMIT_GLIBC_MALLOC_ARENAS = 0
 
+
+## Interval in seconds at which the chunkserver will attempt to release unused
+## memory back to the OS using malloc_trim(). This can help reduce the process's
+## memory footprint by returning free memory to the system more frequently.
+## (Default: 3600, Minimum: 1)
+# MALLOC_TRIM_INTERVAL = 3600
+
 ## Nice level to run daemon with (default is -19 if possible).
 # NICE_LEVEL = -19
 

--- a/src/data/sfschunkserver.cfg.in
+++ b/src/data/sfschunkserver.cfg.in
@@ -29,8 +29,9 @@
 ## Interval in seconds at which the chunkserver will attempt to release unused
 ## memory back to the OS using malloc_trim(). This can help reduce the process's
 ## memory footprint by returning free memory to the system more frequently.
-## (Default: 3600, Minimum: 1)
-# MALLOC_TRIM_INTERVAL = 3600
+## Set to 0 to disable memory trimming entirely.
+## (Default: 0, 0 = disabled)
+# MALLOC_TRIM_INTERVAL = 0
 
 ## Nice level to run daemon with (default is -19 if possible).
 # NICE_LEVEL = -19

--- a/tests/test_suites/ShortSystemTests/test_malloc_trim_interval_chunkserver.sh
+++ b/tests/test_suites/ShortSystemTests/test_malloc_trim_interval_chunkserver.sh
@@ -1,10 +1,10 @@
-timeout_set "3 minutes"
+timeout_set "1 minute"
 
 CHUNKSERVERS=3 \
 	MASTER_CUSTOM_GOALS="1 ec21: \$ec(2,1)" \
 	AUTO_SHADOW_MASTER="NO" \
 	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER" \
-	CHUNKSERVER_EXTRA_CONFIG="MAGIC_DEBUG_LOG = $TEMP_DIR/log|LOG_FLUSH_ON=DEBUG" \
+	CHUNKSERVER_EXTRA_CONFIG="MALLOC_TRIM_INTERVAL=0|MAGIC_DEBUG_LOG = $TEMP_DIR/log|LOG_FLUSH_ON=DEBUG" \
 	setup_local_empty_saunafs info
 
 cd "${info[mount0]}"
@@ -42,19 +42,19 @@ generateAndValidateFiles
 
 ### Test MALLOC_TRIM_INTERVAL configuration and functionality ###
 
-trimInterval=5  # 5 seconds for quick testing
+trimInterval=3  # 3 seconds for quick testing
 
 # Get initial memory values for chunkserver 0
 cs0Pid=$(saunafs_chunkserver_daemon 0 test | tr -d '\0' | awk '{print $NF}')
 residentMemoryCS0=$(getResidentMemoryForPid ${cs0Pid})
 echo "CS0 PID: ${cs0Pid} - Initial resident memory: ${residentMemoryCS0} KB"
 
-# Configure MALLOC_TRIM_INTERVAL and restart chunkserver
+# Configure MALLOC_TRIM_INTERVAL and reload chunkserver
 echo "MALLOC_TRIM_INTERVAL = ${trimInterval}" >> "${info[chunkserver0_cfg]}"
 saunafs_chunkserver_daemon 0 reload
 
 # Let the chunkserver reload
-sleep 5
+sleep $(timeout_rescale_seconds 3)
 
 # Check if the trim interval was set correctly
 effectiveTrimInterval=$(getMallocTrimIntervalFromLog)
@@ -62,8 +62,9 @@ assert_equals ${trimInterval} ${effectiveTrimInterval}
 echo "MALLOC_TRIM_INTERVAL set to ${effectiveTrimInterval} seconds for chunkserver 0"
 
 # Wait for at least one trim cycle plus buffer time
-echo "Waiting for memory trim to occur (waiting $((trimInterval + 2)) seconds)..."
-sleep $((trimInterval + 2))
+sleepTime=$(timeout_rescale_seconds $((trimInterval + 2)))
+echo "Waiting for memory trim to occur (waiting ${sleepTime} seconds)..."
+sleep "${sleepTime}"
 
 # Check if memory trimming actually occurred
 if checkMemoryTrimmedFromLog; then
@@ -77,43 +78,21 @@ cs0PidAfter=$(saunafs_chunkserver_daemon 0 test | tr -d '\0' | awk '{print $NF}'
 residentMemoryCS0After=$(getResidentMemoryForPid ${cs0PidAfter})
 echo "CS0 PID: ${cs0PidAfter} - Resident memory after trim period: ${residentMemoryCS0After} KB"
 
-### Test with different chunkserver (chunkserver 1) ###
+### Test disabling the feature #
 
-# Test chunkserver 1 with a different trim interval
-trimInterval2=3
-cs1Pid=$(saunafs_chunkserver_daemon 1 test | tr -d '\0' | awk '{print $NF}')
-residentMemoryCS1=$(getResidentMemoryForPid ${cs1Pid})
-echo "CS1 PID: ${cs1Pid} - Initial resident memory: ${residentMemoryCS1} KB"
-
-# Clear log again for clean testing
+# Clear the log
 > "${TEMP_DIR}/log"
 
-# Configure different MALLOC_TRIM_INTERVAL for chunkserver 1
-echo "MALLOC_TRIM_INTERVAL = ${trimInterval2}" >> "${info[chunkserver1_cfg]}"
-saunafs_chunkserver_daemon 1 reload
+echo "Disabling MALLOC_TRIM_INTERVAL by setting it to 0 in the configuration"
+# Modify MALLOC_TRIM_INTERVAL and reload chunkserver
+trimInterval=0
+sed -i s/"^MALLOC_TRIM_INTERVAL = .*"/"MALLOC_TRIM_INTERVAL = ${trimInterval}"/g "${info[chunkserver0_cfg]}"
+saunafs_chunkserver_daemon 0 reload
 
 # Let the chunkserver reload
-sleep 5
+echo "Waiting for chunkserver to reload"
+sleep $(timeout_rescale_seconds 3)
 
-# Verify the new interval is set
-effectiveTrimInterval2=$(getMallocTrimIntervalFromLog)
-assert_equals ${trimInterval2} ${effectiveTrimInterval2}
-echo "MALLOC_TRIM_INTERVAL set to ${effectiveTrimInterval2} seconds for chunkserver 1"
-
-### Test minimum value constraint ###
-
-# Test that the minimum value (1 second) is enforced
-trimIntervalMin=1
-echo "MALLOC_TRIM_INTERVAL = 0" >> "${info[chunkserver2_cfg]}"
-
-# Clear log for minimum test
-> "${TEMP_DIR}/log}"
-
-saunafs_chunkserver_daemon 2 reload
-
-# Let the chunkserver reload
-sleep 5
-
-effectiveTrimIntervalMin=$(getMallocTrimIntervalFromLog)
-assert_equals ${trimIntervalMin} ${effectiveTrimIntervalMin}
-echo "Minimum MALLOC_TRIM_INTERVAL (${effectiveTrimIntervalMin} seconds) correctly enforced"
+# Check that the thread was stopped
+assert_success grep -q "Memory trimming disabled" "${TEMP_DIR}/log"
+echo "Memory trimming thread was stopped"

--- a/tests/test_suites/ShortSystemTests/test_malloc_trim_interval_chunkserver.sh
+++ b/tests/test_suites/ShortSystemTests/test_malloc_trim_interval_chunkserver.sh
@@ -1,0 +1,119 @@
+timeout_set "3 minutes"
+
+CHUNKSERVERS=3 \
+	MASTER_CUSTOM_GOALS="1 ec21: \$ec(2,1)" \
+	AUTO_SHADOW_MASTER="NO" \
+	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER" \
+	CHUNKSERVER_EXTRA_CONFIG="MAGIC_DEBUG_LOG = $TEMP_DIR/log|LOG_FLUSH_ON=DEBUG" \
+	setup_local_empty_saunafs info
+
+cd "${info[mount0]}"
+
+# Generates some files in parallel to create memory pressure
+function generateAndValidateFiles() {
+	echo "Generating files to create memory pressure"
+
+	for file in $(seq 1 100); do
+		size=$((file * 1024))
+		FILE_SIZE=${size} assert_success file-generate "file.${file}" &
+	done
+
+	wait
+}
+
+function getMallocTrimIntervalFromLog() {
+	grep -ioP '(?<=Effective MALLOC_TRIM_INTERVAL: )[0-9]+' "${TEMP_DIR}/log" | tail -n 1
+}
+
+function checkMemoryTrimmedFromLog() {
+	grep -q "Memory trimmed successfully" "${TEMP_DIR}/log"
+}
+
+function getResidentMemoryForPid() {
+	pid=${1}
+	ps -o rss= -p ${pid}
+}
+
+# Generate some files to create memory pressure
+generateAndValidateFiles
+
+# Clear log to have clean state for testing
+> "${TEMP_DIR}/log"
+
+### Test MALLOC_TRIM_INTERVAL configuration and functionality ###
+
+trimInterval=5  # 5 seconds for quick testing
+
+# Get initial memory values for chunkserver 0
+cs0Pid=$(saunafs_chunkserver_daemon 0 test | tr -d '\0' | awk '{print $NF}')
+residentMemoryCS0=$(getResidentMemoryForPid ${cs0Pid})
+echo "CS0 PID: ${cs0Pid} - Initial resident memory: ${residentMemoryCS0} KB"
+
+# Configure MALLOC_TRIM_INTERVAL and restart chunkserver
+echo "MALLOC_TRIM_INTERVAL = ${trimInterval}" >> "${info[chunkserver0_cfg]}"
+saunafs_chunkserver_daemon 0 reload
+
+# Let the chunkserver reload
+sleep 5
+
+# Check if the trim interval was set correctly
+effectiveTrimInterval=$(getMallocTrimIntervalFromLog)
+assert_equals ${trimInterval} ${effectiveTrimInterval}
+echo "MALLOC_TRIM_INTERVAL set to ${effectiveTrimInterval} seconds for chunkserver 0"
+
+# Wait for at least one trim cycle plus buffer time
+echo "Waiting for memory trim to occur (waiting $((trimInterval + 2)) seconds)..."
+sleep $((trimInterval + 2))
+
+# Check if memory trimming actually occurred
+if checkMemoryTrimmedFromLog; then
+	echo "Memory trimming successfully executed"
+else
+	echo "Warning: Memory trimming log message not found - this may be normal if no memory needed trimming"
+fi
+
+# Get memory values after trimming period
+cs0PidAfter=$(saunafs_chunkserver_daemon 0 test | tr -d '\0' | awk '{print $NF}')
+residentMemoryCS0After=$(getResidentMemoryForPid ${cs0PidAfter})
+echo "CS0 PID: ${cs0PidAfter} - Resident memory after trim period: ${residentMemoryCS0After} KB"
+
+### Test with different chunkserver (chunkserver 1) ###
+
+# Test chunkserver 1 with a different trim interval
+trimInterval2=3
+cs1Pid=$(saunafs_chunkserver_daemon 1 test | tr -d '\0' | awk '{print $NF}')
+residentMemoryCS1=$(getResidentMemoryForPid ${cs1Pid})
+echo "CS1 PID: ${cs1Pid} - Initial resident memory: ${residentMemoryCS1} KB"
+
+# Clear log again for clean testing
+> "${TEMP_DIR}/log"
+
+# Configure different MALLOC_TRIM_INTERVAL for chunkserver 1
+echo "MALLOC_TRIM_INTERVAL = ${trimInterval2}" >> "${info[chunkserver1_cfg]}"
+saunafs_chunkserver_daemon 1 reload
+
+# Let the chunkserver reload
+sleep 5
+
+# Verify the new interval is set
+effectiveTrimInterval2=$(getMallocTrimIntervalFromLog)
+assert_equals ${trimInterval2} ${effectiveTrimInterval2}
+echo "MALLOC_TRIM_INTERVAL set to ${effectiveTrimInterval2} seconds for chunkserver 1"
+
+### Test minimum value constraint ###
+
+# Test that the minimum value (1 second) is enforced
+trimIntervalMin=1
+echo "MALLOC_TRIM_INTERVAL = 0" >> "${info[chunkserver2_cfg]}"
+
+# Clear log for minimum test
+> "${TEMP_DIR}/log}"
+
+saunafs_chunkserver_daemon 2 reload
+
+# Let the chunkserver reload
+sleep 5
+
+effectiveTrimIntervalMin=$(getMallocTrimIntervalFromLog)
+assert_equals ${trimIntervalMin} ${effectiveTrimIntervalMin}
+echo "Minimum MALLOC_TRIM_INTERVAL (${effectiveTrimIntervalMin} seconds) correctly enforced"


### PR DESCRIPTION
Introduce a MemoryManager class that, if enabled by configuration, periodically calls malloc_trim to release unused heap memory.

The trimming interval is configurable via MALLOC_TRIM_INTERVAL and defaults to 0 (disabled).

The trimming runs on its own thread, which is started/stopped on demand at reload/restart time.

On RAM-constrained systems, this feature could be useful to reduce memory footprint.