### PR TITLE
chore: Add initial Copilot instructions

### DIFF
--- a/.github/instructions/cpp.instructions.md
+++ b/.github/instructions/cpp.instructions.md
@@ -1,0 +1,22 @@
+---
+applyTo: '**/*.{c,cc,cpp,h,hpp}'
+---
+
+# C/C++ standard
+
+* The C code should be written using C23 standard.
+* The C++ code should be written using C++23 standard.
+
+# Header inclusions
+
+* All files should include `common/platform.h` as the first include followed by a new line.
+  This header is required for platform-specific definitions and configurations.
+* Then all the system and external libraries should be included in a separate group.
+* Then all the project-specific headers should be included in a separate group.
+* The project-specific headers inclusions are relative to the `src` directory.
+  For instance, the header in `src/common/foo.h` should be included as `#include "common/foo.h"`.
+* All groups should be sorted alphabetically.
+
+# Code style
+
+* The code style for C and C++ is defined in the file `.clang-format` in the root of the project.


### PR DESCRIPTION
This commit adds the directory for Copilot instructions with initial content about C/C++ style.

The new directory is expected to grow in the near future with more instruction files about other languages and git related style.