### PR TITLE
refactor(master): Replace std::list in hash buckets

### DIFF
--- a/src/master/filesystem_metadata.h
+++ b/src/master/filesystem_metadata.h
@@ -35,27 +35,27 @@
 #include "master/task_manager.h"
 
 using XAttributeInodeEntryPointer = std::unique_ptr<XAttributeInodeEntry>;
-using XAttributeInodeEntryList = std::list<XAttributeInodeEntryPointer>;
+using XAttributeInodeEntryVector = std::vector<XAttributeInodeEntryPointer>;
 
 using XAttributeDataEntryPointer = std::unique_ptr<XAttributeDataEntry>;
-using XAttributeDataEntryList = std::list<XAttributeDataEntryPointer>;
+using XAttributeDataEntryVector = std::vector<XAttributeDataEntryPointer>;
 
-using FSNodePointerList = std::list<FSNode*>;
+using FSNodePointerVector = std::vector<FSNode*>;
 
 /** Metadata of the filesystem.
  *  All the static variables managed by function in this file which form metadata of the filesystem.
  */
 struct FilesystemMetadata {
 public:
-	std::array<XAttributeInodeEntryList, XATTR_INODE_HASH_SIZE> xattrInodeHash;
-	std::array<XAttributeDataEntryList, XATTR_DATA_HASH_SIZE> xattrDataHash;
+	std::array<XAttributeInodeEntryVector, XATTR_INODE_HASH_SIZE> xattrInodeHash;
+	std::array<XAttributeDataEntryVector, XATTR_DATA_HASH_SIZE> xattrDataHash;
 	// TODO(Guillex): Check implications of using 64 bits for inode_t in this structure.
 	IdPoolDetainer<inode_t, uint32_t> inodePool;
 	AclStorage aclStorage;
 	TrashPathContainer trash;
 	ReservedPathContainer reserved;
 	FSNodeDirectory *root{};
-	std::array<FSNodePointerList, NODEHASHSIZE> nodeHash;
+	std::array<FSNodePointerVector, NODEHASHSIZE> nodeHash;
 	TaskManager taskManager;
 	FileLocks flockLocks;
 	FileLocks posixLocks;

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -1328,10 +1328,9 @@ static inline void fsnodes_remove_node(uint32_t ts, FSNode *node) {
 			uint64_t chunkid = static_cast<FSNodeFile*>(node)->chunks[i];
 			if (chunkid > 0) {
 				if (chunk_delete_file(chunkid, node->goal) != SAUNAFS_STATUS_OK) {
-					safs_pretty_syslog(LOG_ERR,
-					                   "structure error - chunk %016" PRIX64
-					                   " not found (inode: %" PRIiNode " ; index: %" PRIu32 ")",
-					                   chunkid, node->id, i);
+					safs::log_err(
+					    "structure error - chunk {:#016x} not found (inode: {} ; index: {})",
+					    chunkid, node->id, i);
 				}
 			}
 		}
@@ -1358,7 +1357,9 @@ static inline void fsnodes_remove_node(uint32_t ts, FSNode *node) {
 	FSNode::destroy(node);
 
 	if (nodeIterator != gMetadata->nodeHash[nodeHashIndex].end()) {
-		gMetadata->nodeHash[nodeHashIndex].erase(nodeIterator);
+		auto lastElement = gMetadata->nodeHash[nodeHashIndex].end() - 1;
+		std::iter_swap(nodeIterator, lastElement); // Swap with last element to avoid erase: O(1)
+		gMetadata->nodeHash[nodeHashIndex].pop_back(); // Remove the last element: O(1)
 	}
 }
 

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -639,8 +639,8 @@ FSNode *fsnodes_create_node(uint32_t ts, FSNodeDirectory *parent, const HString 
 		node->gid = gid;
 	}
 
-	uint32_t nodepos = NODEHASHPOS(node->id);
-	gMetadata->nodeHash[nodepos].push_front(node);
+	uint32_t nodeHashIndex = NODEHASHPOS(node->id);
+	gMetadata->nodeHash[nodeHashIndex].push_back(node);
 
 	fsnodes_update_checksum(node);
 	fsnodes_link(ts, parent, node, name);
@@ -1301,59 +1301,64 @@ void fsnodes_change_uid_gid(FSNode *p, uint32_t uid, uint32_t gid) {
 	}
 }
 
-static inline void fsnodes_remove_node(uint32_t ts, FSNode *toremove) {
-	if (!toremove->parent.empty()) {
+static inline void fsnodes_remove_node(uint32_t ts, FSNode *node) {
+	if (!node->parent.empty()) {
 		return;
 	}
-	// remove from idhash
-	uint32_t nodepos = NODEHASHPOS(toremove->id);
-	auto start = gMetadata->nodeHash[nodepos].begin();
-	auto end = gMetadata->nodeHash[nodepos].end();
 
-	auto found = std::find_if(start, end, [&](const auto &node) {
-		return node == toremove;
-	});
-
-	if (gChecksumBackgroundUpdater.isNodeIncluded(toremove)) {
-		removeFromChecksum(gChecksumBackgroundUpdater.fsNodesChecksum, toremove->checksum);
+	if (gChecksumBackgroundUpdater.isNodeIncluded(node)) {
+		removeFromChecksum(gChecksumBackgroundUpdater.fsNodesChecksum, node->checksum);
 	}
-	removeFromChecksum(gMetadata->fsNodesChecksum, toremove->checksum);
+
+	removeFromChecksum(gMetadata->fsNodesChecksum, node->checksum);
+
 	// and free
 	gMetadata->nodes--;
-	gMetadata->aclStorage.erase(toremove->id);
-	if (toremove->type == FSNode::kDirectory) {
+	gMetadata->aclStorage.erase(node->id);
+
+	if (node->type == FSNode::kDirectory) {
 		gMetadata->dirNodes--;
 	}
-	if (toremove->type == FSNode::kFile || toremove->type == FSNode::kTrash ||
-	    toremove->type == FSNode::kReserved) {
-		fsnodes_quota_update(toremove, {{QuotaResource::kSize, -fsnodes_get_size(toremove)}});
+
+	if (node->type == FSNode::kFile || node->type == FSNode::kTrash ||
+	    node->type == FSNode::kReserved) {
+		fsnodes_quota_update(node, {{QuotaResource::kSize, -fsnodes_get_size(node)}});
 		gMetadata->fileNodes--;
-		for (uint32_t i = 0; i < static_cast<FSNodeFile*>(toremove)->chunks.size(); ++i) {
-			uint64_t chunkid = static_cast<FSNodeFile*>(toremove)->chunks[i];
+		for (uint32_t i = 0; i < static_cast<FSNodeFile*>(node)->chunks.size(); ++i) {
+			uint64_t chunkid = static_cast<FSNodeFile*>(node)->chunks[i];
 			if (chunkid > 0) {
-				if (chunk_delete_file(chunkid, toremove->goal) != SAUNAFS_STATUS_OK) {
-					safs_pretty_syslog(LOG_ERR, "structure error - chunk %016" PRIX64
-					                " not found (inode: %" PRIiNode
-					                " ; index: %" PRIu32 ")",
-					       chunkid, toremove->id, i);
+				if (chunk_delete_file(chunkid, node->goal) != SAUNAFS_STATUS_OK) {
+					safs_pretty_syslog(LOG_ERR,
+					                   "structure error - chunk %016" PRIX64
+					                   " not found (inode: %" PRIiNode " ; index: %" PRIu32 ")",
+					                   chunkid, node->id, i);
 				}
 			}
 		}
 	}
-	if (toremove->type == FSNode::kSymlink) {
+
+	if (node->type == FSNode::kSymlink) {
 		gMetadata->linkNodes--;
 	}
-	gMetadata->inodePool.release(toremove->id, ts, true);
-	xattr_removeinode(toremove->id);
-	fsnodes_quota_update(toremove, {{QuotaResource::kInodes, -1}});
-	fsnodes_quota_remove(QuotaOwnerType::kInode, toremove->id);
+
+	gMetadata->inodePool.release(node->id, ts, true);
+	xattr_removeinode(node->id);
+	fsnodes_quota_update(node, {{QuotaResource::kInodes, -1}});
+	fsnodes_quota_remove(QuotaOwnerType::kInode, node->id);
 #ifndef METARESTORE
-	fsnodes_periodic_remove(toremove->id);
-	dcm_modify(toremove->id, 0);
+	fsnodes_periodic_remove(node->id);
+	dcm_modify(node->id, 0);
 #endif
-	FSNode::destroy(toremove);
-	if (found != gMetadata->nodeHash[nodepos].end()) {
-		gMetadata->nodeHash[nodepos].erase(found);
+
+	// remove node from nodeHash
+	uint32_t nodeHashIndex = NODEHASHPOS(node->id);
+	auto nodeIterator = std::find(gMetadata->nodeHash[nodeHashIndex].begin(),
+	                              gMetadata->nodeHash[nodeHashIndex].end(), node);
+
+	FSNode::destroy(node);
+
+	if (nodeIterator != gMetadata->nodeHash[nodeHashIndex].end()) {
+		gMetadata->nodeHash[nodeHashIndex].erase(nodeIterator);
 	}
 }
 

--- a/src/master/filesystem_node.h
+++ b/src/master/filesystem_node.h
@@ -31,9 +31,10 @@
 namespace detail {
 
 inline FSNode *fsnodes_id_to_node_internal(inode_t id) {
-	uint32_t nodepos = NODEHASHPOS(id);
+	// Find the node with the given id
+	uint32_t nodeHashIndex = NODEHASHPOS(id);
 
-	for (const auto& node : gMetadata->nodeHash[nodepos]) {
+	for (const auto &node : gMetadata->nodeHash[nodeHashIndex]) {
 		if (node->id == id) {
 			return node;
 		}

--- a/src/master/filesystem_xattr.cc
+++ b/src/master/filesystem_xattr.cc
@@ -61,6 +61,11 @@ static void xattr_update_checksum(XAttributeDataEntry *xattrDataEntry) {
 
 static inline void xattr_removeentry(XAttributeInodeEntry *entry,
                                      XAttributeDataEntry *xattrDataEntry) {
+	if (xattrDataEntry == nullptr || entry == nullptr) {
+		safs::log_err("{}: xattrDataEntry or entry is nullptr", __func__);
+		return;
+	}
+
 	// Remove the data from the xattr_inode_entry
 	entry->xattrDataEntries.erase(
 	    std::remove(entry->xattrDataEntries.begin(), entry->xattrDataEntries.end(), xattrDataEntry),

--- a/src/master/filesystem_xattr.cc
+++ b/src/master/filesystem_xattr.cc
@@ -20,6 +20,8 @@
 
 #include "common/platform.h"
 
+#include <algorithm>
+
 #include <common/hashfn.h>
 #include <master/filesystem_metadata.h>
 #include <master/filesystem_xattr.h>
@@ -60,7 +62,9 @@ static void xattr_update_checksum(XAttributeDataEntry *xattrDataEntry) {
 static inline void xattr_removeentry(XAttributeInodeEntry *entry,
                                      XAttributeDataEntry *xattrDataEntry) {
 	// Remove the data from the xattr_inode_entry
-	entry->xattrDataList.remove(xattrDataEntry);
+	entry->xattrDataEntries.erase(
+	    std::remove(entry->xattrDataEntries.begin(), entry->xattrDataEntries.end(), xattrDataEntry),
+	    entry->xattrDataEntries.end());
 
 	if (gChecksumBackgroundUpdater.isXattrIncluded(xattrDataEntry)) {
 		removeFromChecksum(gChecksumBackgroundUpdater.xattrChecksum, xattrDataEntry->checksum);
@@ -114,8 +118,8 @@ void xattr_removeinode(inode_t inode) {
 	for (auto attributeIterator = start; attributeIterator != end;) {
 		xattrInodeEntry = attributeIterator->get();
 		if (xattrInodeEntry->inode == inode) {
-			while (!xattrInodeEntry->xattrDataList.empty()) {
-				xattr_removeentry(xattrInodeEntry, xattrInodeEntry->xattrDataList.front());
+			while (!xattrInodeEntry->xattrDataEntries.empty()) {
+				xattr_removeentry(xattrInodeEntry, xattrInodeEntry->xattrDataEntries.front());
 			}
 			attributeIterator = gMetadata->xattrInodeHash[hash].erase(attributeIterator);
 		} else {
@@ -164,7 +168,7 @@ uint8_t xattr_setattr(inode_t inode, uint8_t attributeNameLength, const uint8_t 
 
 				xattr_removeentry(xattrInodeEntry, xattrDataEntry.get());
 
-				if (xattrInodeEntry->xattrDataList.empty()) {
+				if (xattrInodeEntry->xattrDataEntries.empty()) {
 					if (xattrInodeEntry->attributeNameLength != 0 ||
 					    xattrInodeEntry->attributeValueLength != 0) {
 						safs::log_warn("xattr non zero lengths on remove (inode:%" PRIiNode
@@ -227,14 +231,14 @@ uint8_t xattr_setattr(inode_t inode, uint8_t attributeNameLength, const uint8_t 
 	auto *xattrDataEntryPointer = gMetadata->xattrDataHash[dataHash].back().get();
 
 	if (xattrInodeEntry) {
-		xattrInodeEntry->xattrDataList.push_back(xattrDataEntryPointer);
+		xattrInodeEntry->xattrDataEntries.push_back(xattrDataEntryPointer);
 		xattrInodeEntry->attributeNameLength += attributeNameLength + 1U;
 		xattrInodeEntry->attributeValueLength += attributeValueLength;
 	} else {
 		auto xattrInodeEntry =
 		    XAttributeInodeEntry::create(inode, attributeNameLength + 1U, attributeValueLength);
-		xattrInodeEntry->xattrDataList.push_back(xattrDataEntryPointer);
-		gMetadata->xattrInodeHash[inodeHash].push_front(std::move(xattrInodeEntry));
+		xattrInodeEntry->xattrDataEntries.push_back(xattrDataEntryPointer);
+		gMetadata->xattrInodeHash[inodeHash].push_back(std::move(xattrInodeEntry));
 	}
 
 	return SAUNAFS_STATUS_OK;
@@ -269,7 +273,7 @@ uint8_t get_xattrs_length_for_inode(inode_t inode, void **xattrInodePointer, uin
 	for (const auto &xattrInodeEntry : gMetadata->xattrInodeHash[hash]) {
 		if (xattrInodeEntry->inode == inode) {
 			*xattrInodePointer = xattrInodeEntry.get();
-			for (const auto &xattrDataEntry : xattrInodeEntry->xattrDataList) {
+			for (const auto &xattrDataEntry : xattrInodeEntry->xattrDataEntries) {
 				*xattrSize += xattrDataEntry->attributeName.size() + 1U;
 			}
 			if (*xattrSize > SFS_XATTR_LIST_MAX) {
@@ -289,7 +293,7 @@ void xattr_listattr_data(void *xattrInodeEntry, uint8_t *xattrDataBuffer) {
 	uint32_t entryLength = 0;
 	if (xattrEntry) {
 		passert(xattrDataBuffer);
-		for (const auto &xattrDataEntry : xattrEntry->xattrDataList) {
+		for (const auto &xattrDataEntry : xattrEntry->xattrDataEntries) {
 			memcpy(xattrDataBuffer + entryLength, xattrDataEntry->attributeName.data(),
 			       xattrDataEntry->attributeName.size());
 			entryLength += xattrDataEntry->attributeName.size();

--- a/src/master/filesystem_xattr.h
+++ b/src/master/filesystem_xattr.h
@@ -24,7 +24,6 @@
 
 #include <cstdint>
 #include <cstdlib>
-#include <list>
 #include <memory>
 #include <vector>
 
@@ -49,7 +48,7 @@ struct XAttributeInodeEntry {
 	inode_t inode;
 	uint32_t attributeNameLength;
 	uint32_t attributeValueLength;
-	std::list<XAttributeDataEntry *> xattrDataList;
+	std::vector<XAttributeDataEntry *> xattrDataEntries;
 
 	static std::unique_ptr<XAttributeInodeEntry> create(inode_t inode, uint32_t attributeNameLength,
 	                                                    uint32_t attributeValueLength) {

--- a/src/master/metadata_backend_file.cc
+++ b/src/master/metadata_backend_file.cc
@@ -916,7 +916,7 @@ void fs_new(void) {
 	gMetadata->root->uid = 0;
 	gMetadata->root->gid = 0;
 
-	auto hashRootIndex = NODEHASHPOS(gMetadata->root->id);
+	uint32_t hashRootIndex = NODEHASHPOS(gMetadata->root->id);
 	gMetadata->nodeHash[hashRootIndex].push_back(gMetadata->root);
 	gMetadata->inodePool.markAsAcquired(gMetadata->root->id);
 

--- a/src/master/metadata_backend_file.cc
+++ b/src/master/metadata_backend_file.cc
@@ -318,14 +318,14 @@ static bool xattr_load(MetadataLoader::Options options) {
 		auto *xattrEntryPointer = gMetadata->xattrDataHash[dataHash].back().get();
 
 		if (xattrInodeEntry != nullptr) {
-			xattrInodeEntry->xattrDataList.push_back(xattrEntryPointer);
+			xattrInodeEntry->xattrDataEntries.push_back(xattrEntryPointer);
 			xattrInodeEntry->attributeNameLength += attributeNameLength + 1U;
 			xattrInodeEntry->attributeValueLength += attributeValueLength;
 		} else {
 			auto xattrInodeEntry =
 			    XAttributeInodeEntry::create(inode, attributeNameLength + 1U, attributeValueLength);
-			xattrInodeEntry->xattrDataList.push_back(xattrEntryPointer);
-			gMetadata->xattrInodeHash[inodeHash].push_front(std::move(xattrInodeEntry));
+			xattrInodeEntry->xattrDataEntries.push_back(xattrEntryPointer);
+			gMetadata->xattrInodeHash[inodeHash].push_back(std::move(xattrInodeEntry));
 		}
 	}
 }
@@ -633,8 +633,10 @@ static int8_t fs_parseNode(const std::shared_ptr<MemoryMappedFile> &metadataFile
 		sectionOffset = metadataFile->offset(pSrc);
 		return kError;
 	}
-	uint32_t nodeIndex = NODEHASHPOS(node->id);
-	gMetadata->nodeHash[nodeIndex].push_front(node);
+
+	uint32_t nodeHashIndex = NODEHASHPOS(node->id);
+	gMetadata->nodeHash[nodeHashIndex].push_back(node);
+
 	gMetadata->inodePool.markAsAcquired(node->id);
 	gMetadata->nodes++;
 	fsnodes_quota_update(node, {{QuotaResource::kInodes, +1}});
@@ -898,10 +900,10 @@ static int fs_load(const std::shared_ptr<MemoryMappedFile> &metadataFile, int ig
 #ifndef METARESTORE
 
 void fs_new(void) {
-	uint32_t nodepos;
 	gMetadata->maxInodeId = SPECIAL_INODE_ROOT;
 	gMetadata->metadataVersion = 1;
 	gMetadata->nextSessionId = 1;
+
 	auto *rootDirectory = FSNode::create(FSNode::kDirectory);
 	gMetadata->root = static_cast<FSNodeDirectory *>(rootDirectory);
 	gMetadata->root->id = SPECIAL_INODE_ROOT;
@@ -913,13 +915,17 @@ void fs_new(void) {
 	gMetadata->root->mode = 0777;
 	gMetadata->root->uid = 0;
 	gMetadata->root->gid = 0;
-	nodepos = NODEHASHPOS(gMetadata->root->id);
-	gMetadata->nodeHash[nodepos].push_front(gMetadata->root);
+
+	auto hashRootIndex = NODEHASHPOS(gMetadata->root->id);
+	gMetadata->nodeHash[hashRootIndex].push_back(gMetadata->root);
 	gMetadata->inodePool.markAsAcquired(gMetadata->root->id);
+
 	chunk_newfs();
+
 	gMetadata->nodes = 1;
 	gMetadata->dirNodes = 1;
 	gMetadata->fileNodes = 0;
+
 	fs_checksum(ChecksumMode::kForceRecalculate);
 	fsnodes_quota_update(gMetadata->root, {{QuotaResource::kInodes, +1}});
 }


### PR DESCRIPTION
Since PR #473, some hash buckets in FilesystemMetadata, use `std::list` to store their elements. This creates a bigger memory overhead than other STL containers like `std::vector`.

This commit replaces `std::list` with `std::vector` in the affected buckets, aiming to reduce the memory overhead.

The screenshots below illustrate the memory consumption of different container types used to store filesystem metadata attributes. All tests were run using a 32 GiB metadata file containing over 194 million chunks, representing approximately 150 million files.

**1. Before PR #473 — Custom C-style linked lists with raw pointers.**
<img width="2993" height="1578" alt="05-sfsmaster-before-PR-473" src="https://github.com/user-attachments/assets/4ad9e507-e3fd-4571-b2cc-f50250135e59" />

This version has the lowest memory footprint, as it relies on raw pointers and custom linked lists.
However, the implementation is more error-prone and harder to maintain, requiring manual pointer manipulation and explicit list traversal.

### &nbsp;
**2. After PR #473 — std::list with smart pointers (current dev)**
<img width="2995" height="1577" alt="05-sfsmaster-after-PR-473" src="https://github.com/user-attachments/assets/42e11d77-51b8-4aeb-9358-f0b1a1cbc364" />

This version adopts modern C++ features like smart pointers and `std::list` for storing metadata entries in hash buckets.
While improving code safety and maintainability, it introduces **higher memory overhead**, mainly due to the allocation cost of every node in the `std::list` (~16–24 bytes per entry).

### &nbsp;
**3. This PR — Replace std::list with std::vector**
<img width="2998" height="1578" alt="05-sfsmaster-update-nodeHash-with-std-vector" src="https://github.com/user-attachments/assets/ffe21aab-c7e8-4040-abe3-2ad2c58dc07c" />

This version replaces `std::list` with `std::vector` in the relevant hash buckets of FilesystemMetadata.
The change reduces memory consumption of sfsmaster by eliminating the per-node overhead of `std::list`, while preserving safety and simplifying the data structure.