### PR TITLE
fix: Check master version for write algorithm

### DIFF
--- a/src/common/saunafs_version.h
+++ b/src/common/saunafs_version.h
@@ -50,4 +50,5 @@ constexpr uint32_t kEC2Version = saunafsVersion(3, 13, 0);
 constexpr uint32_t kFirstVersionWithPathByInodeHiddenFile = saunafsVersion(4, 8, 0);
 constexpr uint32_t kFirstVersionWithUseQuotaInVolumeSize = saunafsVersion(4, 9, 0);
 constexpr uint32_t kFirstVersionWithMountInfoOnMonitoring = saunafsVersion(5, 0, 0);
+constexpr uint32_t kFirstVersionWithChunkBasedWriteAlgorithm = saunafsVersion(5, 0, 0);
 constexpr uint32_t kFirstVersionWithClusterId = saunafsVersion(5, 0, 0);

--- a/src/mount/mastercomm.cc
+++ b/src/mount/mastercomm.cc
@@ -131,7 +131,6 @@ static pthread_t rpthid,npthid;
 static std::mutex fdMutex, recMutex;
 
 static uint32_t sessionid;
-static uint32_t masterversion;
 
 static char masterstrip[17];
 static uint32_t masterip=0;

--- a/src/mount/mastercomm.h
+++ b/src/mount/mastercomm.h
@@ -48,6 +48,8 @@ inline std::mutex acquiredFileMutex;
 using AcquiredFileMap = std::map<inode_t, uint32_t>;
 inline AcquiredFileMap acquiredFiles;
 
+inline uint32_t masterversion;
+
 void fs_getmasterlocation(uint8_t loc[14]);
 uint32_t fs_getsrcip(void);
 

--- a/src/mount/sauna_client.cc
+++ b/src/mount/sauna_client.cc
@@ -49,6 +49,7 @@
 #include "common/datapack.h"
 #include "common/errno_defs.h"
 #include "common/lru_cache.h"
+#include "common/saunafs_version.h"
 #include "errors/sfserr.h"
 #include "common/richacl_converter.h"
 #include "slogger/slogger.h"
@@ -3670,6 +3671,17 @@ void fs_init(FsInitParams &params) {
 			params.max_readahead_requests,
 			params.prefetch_xor_stripes,
 			std::max(params.bandwidth_overuse, 1.));
+
+	if (!params.use_inode_based_write_algorithm &&
+	    masterversion < kFirstVersionWithChunkBasedWriteAlgorithm) {
+		fprintf(stderr,
+		        "Metadata server version v%s is too old, using inode-based write algorithm"
+		        "(sfsuseinodebasedwritealgorithm=1). "
+		        "Required minimum version for chunk based algorithm is v%s.\n",
+		        saunafsVersionToString(masterversion).c_str(),
+		        saunafsVersionToString(kFirstVersionWithChunkBasedWriteAlgorithm).c_str());
+		params.use_inode_based_write_algorithm = true;
+	}
 
 	gUseInodeBasedWriteAlgorithm = params.use_inode_based_write_algorithm;
 	write_data_init(


### PR DESCRIPTION
Previous version of the code was connecting to old master and using
chunk based write algorithm, which is very unsafe. The proposed fix is
to forcefully set the write algorithm to inode based one and log the
change.

Signed-off-by: Dave <dave@leil.io>