### PR TITLE
fix(chunkserver): Fallback to old registration if needed

### DIFF
--- a/src/chunkserver/master_connection.cc
+++ b/src/chunkserver/master_connection.cc
@@ -132,35 +132,55 @@ void MasterConn::sendRegister() {
 	uint32_t myip = mainNetworkThreadGetListenIp();
 	uint16_t myport = mainNetworkThreadGetListenPort();
 
-	createAttachedPacket(
-	    cstoma::registerHost::build(myip, myport, gTimeout_ms, SAUNAFS_VERSHEX, clusterId_));
+	if (isVersionLessThan5_) {  // Preserve compatibility with masters < 5.0
+		createAttachedPacket(
+		    cstoma::registerHost::build(myip, myport, gTimeout_ms, SAUNAFS_VERSHEX));
 
-	safs::log_info("MasterConn: registering to MDS: {}", address_.toString());
+		safs::log_warn("MasterConn: using old master registration to {}", address_.toString());
 
-	registrationStatus_ = RegistrationStatus::kRegistrationRequested;
+		registrationStatus_ = RegistrationStatus::kHostRegistered;
+
+		onRegistered({});
+	} else {
+		createAttachedPacket(
+		    cstoma::registerHost::build(myip, myport, gTimeout_ms, SAUNAFS_VERSHEX, clusterId_));
+
+		safs::log_info("MasterConn: registering to MDS: {}", address_.toString());
+
+		registrationStatus_ = RegistrationStatus::kRegistrationRequested;
+	}
 }
 
 void MasterConn::onRegistered(const std::vector<uint8_t> &data) {
-	uint8_t status{};
-	uint32_t version{};
-	std::string clusterId;
-	matocs::registerHost::deserialize(data, status, version, clusterId);
+	if (isVersionLessThan5_) {
+		(void)data;  // Not used
+		version_ = saunafsVersion(0, 0, 0);  // The version is unknown at this point
+	} else {
+		uint8_t status{};
+		uint32_t version{};
+		std::string clusterId;
+		matocs::registerHost::deserialize(data, status, version, clusterId);
 
-	if (status != SAUNAFS_STATUS_OK) {
-		safs::log_err(
-		    "MasterConn: registration to {} failed with status: {}, version: {}, clusterId: {}",
-		    address_.toString(), saunafs_error_string(status), saunafsVersionToString(version),
-		    clusterId);
-		setMode(ConnectionMode::KILL);
-		return;
+		if (status != SAUNAFS_STATUS_OK) {
+			safs::log_err(
+			    "MasterConn: registration to {} failed with status: {}, version: {}, clusterId: {}",
+			    address_.toString(), saunafs_error_string(status), saunafsVersionToString(version),
+			    clusterId);
+			setMode(ConnectionMode::KILL);
+			return;
+		}
+
+		version_ = version;
+
+		safs::log_info("MasterConn: registered to MDS: {}, version: {}, clusterId: {}",
+		               address_.toString(), saunafsVersionToString(version), clusterId);
+
+		registrationStatus_ = RegistrationStatus::kHostRegistered;
 	}
 
-	version_ = version;
-
-	safs::log_info("MasterConn: registered to MDS: {}, version: {}, clusterId: {}",
-	               address_.toString(), saunafsVersionToString(version), clusterId);
-
-	registrationStatus_ = RegistrationStatus::kHostRegistered;
+	// Reset registration parameters for future reconnections to use the new protocol first
+	isVersionLessThan5_ = false;
+	registrationAttempts_ = 0;
 
 	hddForeachChunkInBulks([this](const std::vector<ChunkWithVersionAndType> &chunksBulk) {
 		createAttachedPacket(cstoma::registerChunks::build(chunksBulk));
@@ -184,6 +204,25 @@ void MasterConn::onRegistered(const std::vector<uint8_t> &data) {
 	sendRegisterLabel();
 
 	sendConfig();
+}
+
+void MasterConn::handleRegistrationAttempt() {
+	if (registrationAttempts_ < kMaxRegistrationAttemptsToBeConsideredOldMaster) {
+		if (registrationStatus_ == RegistrationStatus::kRegistrationRequested) {
+			safs::log_warn(
+			    "MasterConn: Master server did not answer the registration request; make sure Master is at least version {} (attempt {}/{})",
+			    saunafsVersionToString(kFirstVersionWithClusterId), registrationAttempts_ + 1,
+			    kMaxRegistrationAttemptsToBeConsideredOldMaster);
+			++registrationAttempts_;
+		}
+
+		// Reconnection will be retried as usual
+	} else {
+		safs::log_warn("MasterConn: reached max registration attempts, considering old master");
+		// Assume the master is not answering because it is an old version
+		// The old protocol will be tried on the next reconnection
+		isVersionLessThan5_ = true;
+	}
 }
 
 int MasterConn::initConnect() {
@@ -364,6 +403,7 @@ void MasterConn::readFromSocket() {
 
 		if (ret == 0) {
 			safs::log_info("MasterConn: connection reset by Master: {}", address_.toString());
+			handleRegistrationAttempt();
 			setMode(ConnectionMode::KILL);
 			return;
 		}

--- a/src/chunkserver/master_connection.h
+++ b/src/chunkserver/master_connection.h
@@ -209,6 +209,12 @@ private:
 	std::string clusterId_;                      ///< Cluster ID for this connection.
 	std::shared_ptr<JobPool> jobPool_;           ///< Shared reference to the JobPool.
 
+	// For compatibility with old masters (version < 5.0)
+	void handleRegistrationAttempt();
+	static constexpr uint8_t kMaxRegistrationAttemptsToBeConsideredOldMaster = 3;
+	uint32_t registrationAttempts_{0};  ///< Number of registration attempts.
+	bool isVersionLessThan5_{false};    ///< Indicates if the master server is an old version.
+
 	ConnectionMode mode_{ConnectionMode::FREE};  ///< Current mode of the connection to this master.
 	/// Registration status to this MDS.
 	RegistrationStatus registrationStatus_{RegistrationStatus::kUnregistered};

--- a/tests/test_suites/ShortSystemTests/test_upgrade_new_chunkserver_with_old_saunafs.sh
+++ b/tests/test_suites/ShortSystemTests/test_upgrade_new_chunkserver_with_old_saunafs.sh
@@ -1,0 +1,43 @@
+timeout_set 45 seconds
+
+# Tests if chunkservers print correct when trying to connect to old masters (v4.*)
+
+export SAFS_MOUNT_COMMAND="sfsmount"
+
+CHUNKSERVERS=1 \
+	MOUNTS=1 \
+	START_WITH_LEGACY_SAUNAFS=YES \
+	USE_RAMDISK=YES \
+	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER" \
+	CHUNKSERVER_EXTRA_CONFIG="MASTER_RECONNECTION_DELAY=2|MAGIC_DEBUG_LOG=$TEMP_DIR/log|LOG_FLUSH_ON=DEBUG" \
+	setup_local_empty_saunafs info
+
+# Start test with master, 1 chunkserver and 1 mount running legacy SaunaFS code
+# Ensure that we work on legacy version
+assert_equals 1 $(saunafs_old_admin_master info | grep $SAUNAFSXX_TAG | wc -l)
+assert_equals 1 $(saunafs_old_admin_master list-chunkservers | grep $SAUNAFSXX_TAG | wc -l)
+assert_equals 1 $(saunafs_old_admin_master list-mounts | grep $SAUNAFSXX_TAG | wc -l)
+
+cd "${info[mount0]}"
+
+# Stop old chunkserver and start the new one
+saunafsXX_chunkserver_daemon 0 stop
+saunafs_chunkserver_daemon 0 start
+
+saunafs_wait_for_all_ready_chunkservers
+
+# Check if chunkserver log contains the expected messages
+
+logsNum=$(grep -c "Master server did not answer the registration request" "${TEMP_DIR}/log")
+assert_not_equal 0 ${logsNum}
+
+oldRegistrationAttempts=$(grep -c "using old master registration" "${TEMP_DIR}/log")
+assert_equals 1 ${oldRegistrationAttempts}
+
+# Restart the master to trigger a chunkserver reconnection
+saunafsXX_master_daemon stop
+saunafsXX_master_daemon start
+
+saunafs_wait_for_all_ready_chunkservers
+
+echo "Chunkserver reconnected successfully after Master restart"


### PR DESCRIPTION
Fixes new Chunkservers connecting to Master in versions 4.x.

Starting from v5.0.0, chunkservers register with the Master and expect a response containing status and version. Old Masters (v4.x) simply disconnect on the unknown registration message. 

Previously, chunkservers would just retry the connection. Now we log a warning when no registration response is received, so users see the likely cause of the failure.

This change also introduces a retry and fallback mechanism to detect possible registration attempts to old Master and then uses the old registration procedure.

A test was added to cover the initial old Master rejection, the succesfull Chunkserver reconnection using the old procedure and a reconnection after Master restarts.
