### PR TITLE
feat: Add a dedicated jobPool for replications

### DIFF
--- a/doc/sfschunkserver.cfg.5.adoc
+++ b/doc/sfschunkserver.cfg.5.adoc
@@ -70,6 +70,10 @@ the master server after disconnection (default is 5)
 to process operations on chunks, like create, duplicate, replicate and truncate
 (default is 10, minimum is 2)
 
+*MASTER_REPLICATION_NR_OF_WORKERS*:: number of threads that the connection to
+master may use to process replications operations on chunks.
+(default is 5, minimum in 1)
+
 *BIND_HOST*:: local address to use for connecting with the master server
 (default is ***, i.e. default local address)
 

--- a/src/chunkserver/master_connection.cc
+++ b/src/chunkserver/master_connection.cc
@@ -51,6 +51,8 @@
 #include "protocol/packet.h"
 #include "slogger/slogger.h"
 
+static constexpr uint32_t kMaxBackgroundJobsThreshold = (kMaxBackgroundJobsCount * 9) / 10;
+
 MasterConn::~MasterConn() {
 	if (socketFD_ >= 0) { tcpclose(socketFD_); }
 }
@@ -327,7 +329,8 @@ void MasterConn::providePollDescriptors(std::vector<pollfd> &pdesc) {
 	if (mode_ == ConnectionMode::FREE || socketFD_ < 0) { return; }
 
 	if (mode_ == ConnectionMode::CONNECTED) {
-		if (jobPool_->getJobCount() < (kMaxBackgroundJobsCount * 9) / 10) {
+		if (jobPool_->getJobCount() < kMaxBackgroundJobsThreshold ||
+		    replicationJobPool_->getJobCount() < kMaxBackgroundJobsThreshold) {
 			pdesc.emplace_back(socketFD_, POLLIN, 0);
 			pDescPos_ = static_cast<int32_t>(pdesc.size() - 1);
 		}
@@ -395,8 +398,11 @@ void MasterConn::readFromSocket() {
 	watchdog.start();
 
 	while (mode_ != ConnectionMode::KILL) {
-		// If the job pool is too busy, do not read more data.
-		if (jobPool_->getJobCount() >= (kMaxBackgroundJobsCount * 9) / 10) { return; }
+		// If any job pool is too busy, do not read more data.
+		if (jobPool_->getJobCount() >= kMaxBackgroundJobsThreshold ||
+		    replicationJobPool_->getJobCount() >= kMaxBackgroundJobsThreshold) {
+			return;
+		}
 
 		uint32_t bytesToRead = inputPacket_.bytesToBeRead();
 		ssize_t ret = ::read(socketFD_, inputPacket_.pointerToBeReadInto(), bytesToRead);
@@ -643,11 +649,12 @@ void MasterConn::replicateChunk(const std::vector<uint8_t> &data) {
 		// Disk scan in progress - replication is not possible
 		sauJobFinished(SAUNAFS_ERROR_WAITING, outputPacket);
 	} else {
-		if (jobPool_) {
-			job_replicate(*jobPool_, sauJobFinished(this), outputPacket, chunkId, chunkVersion,
-			              chunkType, sourcesBufferSize, sourcesBuffer);
+		if (replicationJobPool_) {
+			// If replication job pool is available, use it to handle the replication job
+			job_replicate(*replicationJobPool_, sauJobFinished(this), outputPacket, chunkId,
+			              chunkVersion, chunkType, sourcesBufferSize, sourcesBuffer);
 		} else {
-			safs::log_err("MasterConn::replicateChunk: jobPool is null.");
+			safs::log_err("MasterConn::replicateChunk: replicationJobPool is null.");
 			delete outputPacket;
 		}
 	}

--- a/src/chunkserver/master_connection.h
+++ b/src/chunkserver/master_connection.h
@@ -67,11 +67,13 @@ enum class RegistrationStatus : std::uint8_t {
 class MasterConn {
 public:
 	explicit MasterConn(const std::string &masterHostStr, const std::string &masterPortStr,
-	                    const std::string &clusterId, const std::shared_ptr<JobPool> &jobPool)
+	                    const std::string &clusterId, const std::shared_ptr<JobPool> &jobPool,
+	                    const std::shared_ptr<JobPool> &replicationJobPool)
 	    : masterHostStr_(masterHostStr),
 	      masterPortStr_(masterPortStr),
 	      clusterId_(clusterId),
-	      jobPool_(jobPool) {}
+	      jobPool_(jobPool),
+	      replicationJobPool_(replicationJobPool) {}
 
 	// Disable unneeded copying and moving of the connection objects.
 	MasterConn(const MasterConn &) = delete;
@@ -203,11 +205,12 @@ public:
 	const std::string &clusterId() const { return clusterId_; }
 
 private:
-	std::string masterHostStr_;                  ///< Hostname of the master server.
-	std::string masterPortStr_;                  ///< Port of the master server.
-	uint32_t version_{saunafsVersion(0, 0, 0)};  ///< Version of the master server.
-	std::string clusterId_;                      ///< Cluster ID for this connection.
-	std::shared_ptr<JobPool> jobPool_;           ///< Shared reference to the JobPool.
+	std::string masterHostStr_;                     ///< Hostname of the master server.
+	std::string masterPortStr_;                     ///< Port of the master server.
+	uint32_t version_{saunafsVersion(0, 0, 0)};     ///< Version of the master server.
+	std::string clusterId_;                         ///< Cluster ID for this connection.
+	std::shared_ptr<JobPool> jobPool_;              ///< Shared reference to the JobPool.
+	std::shared_ptr<JobPool> replicationJobPool_;   ///< Shared reference to the ReplicationJobPool.
 
 	// For compatibility with old masters (version < 5.0)
 	void handleRegistrationAttempt();

--- a/src/chunkserver/masterconn.cc
+++ b/src/chunkserver/masterconn.cc
@@ -58,16 +58,24 @@ static const uint64_t kSendStatusDelay = 5;
 
 //  JobPool shared between all connections to MDSs
 static std::shared_ptr<JobPool> gJobPool;
+static std::shared_ptr<JobPool> gReplicationJobPool;
 
 //  Singleton for the MasterConn instance (will become a list of connections in the future)
 static std::unique_ptr<MasterConn> gMasterConnSingleton = nullptr;
 
 static int gJobFD{-1};  ///< File descriptor for the job pool notifications
 static int32_t gJobFDpDescPos{-1};  ///< Position in the pollfd array for the job pool notifications
+static int gReplicationJobFD{-1}; ///< File descriptor for the replication job pool notifications
+/// Position in the pollfd array for the replication job pool notifications
+static int32_t gReplicationJobFDpDescPos{-1};
 
 constexpr uint32_t kDefaultNumberOfWorkers = 10;
 constexpr uint32_t kMinNumberOfWorkers = 2;
 static uint32_t gNumberOfWorkers = kDefaultNumberOfWorkers;
+
+constexpr uint32_t kDefaultReplicationNumberOfWorkers = 5;
+constexpr uint32_t kMinReplicationNumberOfWorkers = 1;
+static uint32_t gReplicationNumberOfWorkers = kDefaultReplicationNumberOfWorkers;
 
 static void* gReconnectHook;
 
@@ -137,7 +145,8 @@ void masterconn_term(void) {
 	eptr->releaseResources();
 	gMasterConnSingleton.reset();
 
-	//  Now reset the last reference to the job pool.
+	//  Now reset the last reference to the job pools.
+	gReplicationJobPool.reset();
 	gJobPool.reset();
 }
 
@@ -149,10 +158,17 @@ void masterconn_desc(std::vector<pollfd> &pdesc) {
 
 	// Add the descriptor for listening for background jobs finishing.
 	gJobFDpDescPos = -1;
+	gReplicationJobFDpDescPos = -1;
 
 	if (eptr->mode() == ConnectionMode::CONNECTED) {
-		pdesc.emplace_back(gJobFD, POLLIN, 0);
-		gJobFDpDescPos = static_cast<int32_t>(pdesc.size() - 1);
+		if(gJobFD >= 0) {
+			pdesc.emplace_back(gJobFD, POLLIN, 0);
+			gJobFDpDescPos = static_cast<int32_t>(pdesc.size() - 1);
+		}
+		if(gReplicationJobFD >= 0) {
+			pdesc.emplace_back(gReplicationJobFD, POLLIN, 0);
+			gReplicationJobFDpDescPos = static_cast<int32_t>(pdesc.size() - 1);
+		}
 	}
 
 	eptr->providePollDescriptors(pdesc);
@@ -179,9 +195,13 @@ void masterconn_serve(const std::vector<pollfd> &pdesc) {
 	eptr->handlePollErrors(pdesc);
 	
 	// Check if there are any background jobs to process.
-	if ((eptr->mode() == ConnectionMode::CONNECTED) && gJobFDpDescPos >= 0 &&
-	    (pdesc[gJobFDpDescPos].revents & POLLIN)) {
-		gJobPool->processCompletedJobs();
+	if (eptr->mode() == ConnectionMode::CONNECTED) {
+		if (gJobFDpDescPos >= 0 && (pdesc[gJobFDpDescPos].revents & POLLIN)) {
+			gJobPool->processCompletedJobs();
+		}
+		if (gReplicationJobFDpDescPos >= 0 && (pdesc[gReplicationJobFDpDescPos].revents & POLLIN)) {
+			gReplicationJobPool->processCompletedJobs();
+		}
 	}
 
 	// For each connection to master (currently only one), process its socket.
@@ -189,13 +209,15 @@ void masterconn_serve(const std::vector<pollfd> &pdesc) {
 
 	// Update general statistics
 	if (eptr->mode() == ConnectionMode::CONNECTED) {
-		uint32_t jobscnt = gJobPool->getJobCount();
-		stats_maxjobscnt = std::max(jobscnt, stats_maxjobscnt);
+		uint32_t totalJobCount = 0;
+		totalJobCount += (gJobPool->getJobCount() + gReplicationJobPool->getJobCount());
+		stats_maxjobscnt = std::max(totalJobCount, stats_maxjobscnt);
 	}
 
 	// If the connection is in KILL mode, disable the job pool and close the socket.
 	if (eptr->mode() == ConnectionMode::KILL) {
 		gJobPool->disableAndChangeCallbackAll(masterconn_unwantedjobfinished);
+		gReplicationJobPool->disableAndChangeCallbackAll(masterconn_unwantedjobfinished);
 		tcpclose(eptr->socketFD());
 		eptr->resetPackets();
 		eptr->setMode(ConnectionMode::FREE);
@@ -270,8 +292,8 @@ int masterconn_init(void) {
 	if (!masterconn_load_label()) { return -1; }
 
 	// Create the connections (only one at this point)
-	gMasterConnSingleton =
-	    std::make_unique<MasterConn>(gMasterHost, gMasterPort, clusterId, gJobPool);
+	gMasterConnSingleton = std::make_unique<MasterConn>(gMasterHost, gMasterPort, clusterId,
+	                                                    gJobPool, gReplicationJobPool);
 	MasterConn *eptr = gMasterConnSingleton.get();
 	passert(eptr);
 
@@ -314,6 +336,33 @@ int masterconn_init_threads(void) {
 	}
 
 	safs::log_info("master connection: {} background workers created", gNumberOfWorkers);
+
+	gReplicationNumberOfWorkers = cfg_get_minvalue<uint32_t>("MASTER_REPLICATION_NR_OF_WORKERS",
+		kDefaultReplicationNumberOfWorkers, kMinReplicationNumberOfWorkers);
+
+	try {
+		// Create the ReplicationJobPool instance with the specified number of workers, it would be
+		// serving only this master network thread, thus the number of listeners is 1.
+		std::vector<int> replicationJobPoolFDs(1);
+		gReplicationJobPool =
+		    std::make_shared<JobPool>("ma_repl", gReplicationNumberOfWorkers,
+		                              kMaxBackgroundJobsCount, 1, replicationJobPoolFDs);
+		gReplicationJobFD = replicationJobPoolFDs[0];
+	} catch (const std::exception &e) {
+		safs::log_err("masterconn_init_threads: Failed to create ReplicationJobPool instance: {}",
+		              e.what());
+		return -1;
+	}
+
+	if (gReplicationJobPool == nullptr) {
+		safs::log_err(
+		    "masterconn_init_threads: replicationJobPool is null. Unable to create "
+		    "replication worker threads.");
+		return -1;
+	}
+
+	safs::log_info("master connection: {} replication background workers created",
+	               gReplicationNumberOfWorkers);
 
 	return 0;
 }

--- a/src/data/sfschunkserver.cfg.in
+++ b/src/data/sfschunkserver.cfg.in
@@ -68,6 +68,11 @@
 ## (Default: 10, Minimum: 2)
 # MASTER_NR_OF_WORKERS = 10
 
+## Number of threads that the connection to master may use to process replications operations on
+## chunks.
+## (Default: 5, Minimum: 1)
+# MASTER_REPLICATION_NR_OF_WORKERS = 5
+
 ## IP address to listen on for client (sfsmount) connections:
 # CSSERV_LISTEN_HOST = *
 

--- a/tests/test_suites/ShortSystemTests/test_chunkserver_masterconn_workers.sh
+++ b/tests/test_suites/ShortSystemTests/test_chunkserver_masterconn_workers.sh
@@ -25,13 +25,22 @@ function generateAndValidateFiles() {
 }
 
 function getActualWorkers() {
-	grep -oP '(?<=master connection: )[0-9]+' "${TEMP_DIR}/log" | tail -n 1
+	grep -oP '(?<=master connection: )[0-9]+(?= background workers created)' "${TEMP_DIR}/log" | \
+	tail -n 1
+}
+
+function getActualReplicationWorkers() {
+	grep -oP '(?<=master connection: )[0-9]+' "${TEMP_DIR}/log" | \
+	tail -n 1
 }
 
 lastChunkserver=2
 
 # Minimum workers
 minimumWorkers=2
+
+# Default replication workers
+defaultReplicationWorkers=5
 
 ## Set number of workers to 0 by configuration in all chunkservers and restart
 for cs in $(seq 0 ${lastChunkserver}); do
@@ -47,6 +56,7 @@ generateAndValidateFiles
 ## Even if set to 0, the minimum number of workers is 2 in the code
 actualWorkers=$(getActualWorkers)
 assert_equals "${minimumWorkers}" "${actualWorkers}"
+assert_equals "${defaultReplicationWorkers}" "$(getActualReplicationWorkers)"
 
 # High number of workers
 highWorkers=50


### PR DESCRIPTION
This feature introduce a separated jobPool for Chunk replication operations. The goal is to improve master server performance by ensuring that routine maintenance chunk operations do not unduly interfere with time-sensitive operations.