### PR TITLE
chore(master): Refactor FSNode related enums

### DIFF
--- a/src/common/datapack.h
+++ b/src/common/datapack.h
@@ -23,6 +23,7 @@
 #include "common/platform.h"
 
 #include <cstdint>
+#include <type_traits>
 
 #include <common/type_defs.h>
 
@@ -70,6 +71,13 @@ static inline void put16bit(uint8_t **ptr,uint16_t val) {
 static inline void put8bit(uint8_t **ptr,uint8_t val) {
 	(*ptr)[0]=(val)&0xFF;
 	(*ptr)++;
+}
+
+// Overload for enum classes with underlying uint8_t
+template <typename E>
+    requires std::is_enum_v<E> && std::is_same_v<std::underlying_type_t<E>, uint8_t>
+static inline void put8bit(uint8_t **ptr, E val) {
+	put8bit(ptr, static_cast<uint8_t>(val));
 }
 
 static inline uint64_t get64bit(const uint8_t **ptr) {

--- a/src/common/hashfn.h
+++ b/src/common/hashfn.h
@@ -26,6 +26,7 @@
 #include <numeric>
 #include <stdexcept>
 #include <tuple>
+#include <type_traits>
 
 #include "common/integer_sequence.h"
 
@@ -115,6 +116,13 @@ HASH_PRIMITIVE64(long)
 HASH_PRIMITIVE64(unsigned long)
 HASH_PRIMITIVE64(long long)
 HASH_PRIMITIVE64(unsigned long long)
+
+// Generic specialization for enum types with underlying uint8_t
+template <typename E>
+    requires std::is_enum_v<E> && std::is_same_v<std::underlying_type_t<E>, uint8_t>
+inline uint64_t hash(E val) {
+	return hash<uint8_t>(static_cast<uint8_t>(val));
+}
 
 // takes the hash, not an arbitrary object instance
 static inline void hashCombineRaw(uint64_t& seed, uint64_t hash) {

--- a/src/master/filesystem.h
+++ b/src/master/filesystem.h
@@ -119,7 +119,7 @@ uint8_t fs_setattr(const FsContext &context, inode_t inode, uint8_t setmask, uin
 uint8_t fs_readlink(const FsContext &context, inode_t inode, std::string &path);
 void fs_statfs(const FsContext &context, uint64_t *totalspace, uint64_t *availspace,
                uint64_t *trashspace, uint64_t *reservedspace, inode_t *inodes);
-uint8_t fs_mknod(const FsContext &context, inode_t parent, const HString &name, uint8_t type,
+uint8_t fs_mknod(const FsContext &context, inode_t parent, const HString &name, FSNodeType type,
                  uint16_t mode, uint16_t umask, uint32_t rdev, inode_t *inode, Attributes &attr);
 uint8_t fs_mkdir(const FsContext &context, inode_t parent, const HString &name, uint16_t mode,
                  uint16_t umask, uint8_t copysgid, inode_t *inode, Attributes &attr);
@@ -172,8 +172,8 @@ uint8_t fs_getchunksinfo(const FsContext &context, uint32_t current_ip, inode_t 
 
 // Functions which apply changes from changelog, only for shadow master and metarestore
 uint8_t fs_apply_checksum(const std::string &version, uint64_t checksum);
-uint8_t fs_apply_create(uint32_t ts, inode_t parent, const HString &name, uint8_t type, uint32_t mode,
-                        uint32_t uid, uint32_t gid, uint32_t rdev, inode_t inode);
+uint8_t fs_apply_create(uint32_t ts, inode_t parent, const HString &name, FSNodeType type,
+                        uint32_t mode, uint32_t uid, uint32_t gid, uint32_t rdev, inode_t inode);
 uint8_t fs_apply_access(uint32_t ts, inode_t inode);
 uint8_t fs_apply_attr(uint32_t ts, inode_t inode, uint32_t mode, uint32_t uid, uint32_t gid,
                       uint32_t atime, uint32_t mtime);

--- a/src/master/filesystem_checksum.cc
+++ b/src/master/filesystem_checksum.cc
@@ -35,10 +35,11 @@ static uint64_t fsnodes_checksum(FSNode *node, bool full_update = false) {
 		return 0;
 	}
 	uint64_t seed = 0x4660fe60565ba616;  // random number
-	hashCombine(seed, node->type, node->id, node->goal, node->mode, node->uid, node->gid,
-	            node->atime, node->mtime, node->ctime, node->trashtime);
+	hashCombine(seed, node->type, node->id, node->goal, node->mode, node->uid,
+	            node->gid, node->atime, node->mtime, node->ctime, node->trashtime);
+
 	switch (node->type) {
-	case FSNode::kDirectory:
+	case FSNodeType::kDirectory:
 		if (full_update) {
 			static_cast<FSNodeDirectory*>(node)->entries_hash = 0;
 			for (const auto &entry : *static_cast<FSNodeDirectory *>(node)) {
@@ -59,19 +60,19 @@ static uint64_t fsnodes_checksum(FSNode *node, bool full_update = false) {
 		hashCombine(seed, static_cast<const FSNodeDirectory*>(node)->entries_hash);
 		hashCombine(seed, static_cast<const FSNodeDirectory*>(node)->lowerCaseEntriesHash);
 		break;
-	case FSNode::kSocket:
-	case FSNode::kFifo:
+	case FSNodeType::kSocket:
+	case FSNodeType::kFifo:
 		break;
-	case FSNode::kBlockDev:
-	case FSNode::kCharDev:
+	case FSNodeType::kBlockDev:
+	case FSNodeType::kCharDev:
 		hashCombine(seed, static_cast<const FSNodeDevice*>(node)->rdev);
 		break;
-	case FSNode::kSymlink:
+	case FSNodeType::kSymlink:
 		hashCombine(seed, static_cast<const FSNodeSymlink*>(node)->path.hash());
 		break;
-	case FSNode::kFile:
-	case FSNode::kTrash:
-	case FSNode::kReserved:
+	case FSNodeType::kFile:
+	case FSNodeType::kTrash:
+	case FSNodeType::kReserved: {
 		hashCombine(seed, static_cast<const FSNodeFile*>(node)->length);
 		// first chunk's id
 		if (static_cast<const FSNodeFile*>(node)->length == 0 || static_cast<const FSNodeFile*>(node)->chunks.size() == 0) {
@@ -86,6 +87,11 @@ static uint64_t fsnodes_checksum(FSNode *node, bool full_update = false) {
 		} else {
 			hashCombine(seed, static_cast<const FSNodeFile*>(node)->chunks[lastchunk]);
 		}
+		break;
+	}
+	default:
+		safs::log_err("fsnodes_checksum: unexpected node type {}", static_cast<char>(node->type));
+		break;
 	}
 	return seed;
 }

--- a/src/master/filesystem_dump.cc
+++ b/src/master/filesystem_dump.cc
@@ -28,10 +28,10 @@
 
 void fs_dumpedge(FSNodeDirectory *parent, FSNode *child, const std::string &name) {
 	if (parent == NULL) {
-		if (child->type == FSNode::kTrash) {
+		if (child->type == FSNodeType::kTrash) {
 			printf("E|p:     TRASH|c:%10" PRIiNode "|n:%s\n", child->id,
 			       fsnodes_escape_name(name).c_str());
-		} else if (child->type == FSNode::kReserved) {
+		} else if (child->type == FSNodeType::kReserved) {
 			printf("E|p:  RESERVED|c:%10" PRIiNode "|n:%s\n", child->id,
 			       fsnodes_escape_name(name).c_str());
 		} else {
@@ -50,32 +50,34 @@ void fs_dumpnode(FSNode *f) {
 
 	c = '?';
 	switch (f->type) {
-	case FSNode::kDirectory:
+	case FSNodeType::kDirectory:
 		c = 'D';
 		break;
-	case FSNode::kSocket:
+	case FSNodeType::kSocket:
 		c = 'S';
 		break;
-	case FSNode::kFifo:
+	case FSNodeType::kFifo:
 		c = 'F';
 		break;
-	case FSNode::kBlockDev:
+	case FSNodeType::kBlockDev:
 		c = 'B';
 		break;
-	case FSNode::kCharDev:
+	case FSNodeType::kCharDev:
 		c = 'C';
 		break;
-	case FSNode::kSymlink:
+	case FSNodeType::kSymlink:
 		c = 'L';
 		break;
-	case FSNode::kFile:
+	case FSNodeType::kFile:
 		c = '-';
 		break;
-	case FSNode::kTrash:
+	case FSNodeType::kTrash:
 		c = 'T';
 		break;
-	case FSNode::kReserved:
+	case FSNodeType::kReserved:
 		c = 'R';
+		break;
+	case FSNodeType::kUnknown:
 		break;
 	}
 
@@ -84,12 +86,13 @@ void fs_dumpnode(FSNode *f) {
 	       c, f->id, f->goal, (uint16_t)(f->mode >> 12), (uint16_t)(f->mode & 0xFFF), f->uid,
 	       f->gid, f->atime, f->mtime, f->ctime, f->trashtime);
 
-	if (f->type == FSNode::kBlockDev || f->type == FSNode::kCharDev) {
+	if (f->type == FSNodeType::kBlockDev || f->type == FSNodeType::kCharDev) {
 		printf("|d:%5" PRIu32 ",%5" PRIu32 "\n", static_cast<FSNodeDevice*>(f)->rdev >> 16,
 		       static_cast<FSNodeDevice*>(f)->rdev & 0xFFFF);
-	} else if (f->type == FSNode::kSymlink) {
+	} else if (f->type == FSNodeType::kSymlink) {
 		printf("|p:%s\n", fsnodes_escape_name((std::string)static_cast<FSNodeSymlink*>(f)->path).c_str());
-	} else if (f->type == FSNode::kFile || f->type == FSNode::kTrash || f->type == FSNode::kReserved) {
+	} else if (f->type == FSNodeType::kFile || f->type == FSNodeType::kTrash ||
+	           f->type == FSNodeType::kReserved) {
 		FSNodeFile *node_file = static_cast<FSNodeFile*>(f);
 		printf("|l:%20" PRIu64 "|c:(", node_file->length);
 		ch = node_file->chunkCount();
@@ -155,14 +158,14 @@ void fs_dumpedges(FSNodeDirectory *parent) {
 	fs_dumpedgelist(parent);
 	for (const auto &entry : parent->entries) {
 		FSNode *child = entry.second;
-		if (child->type == FSNode::kDirectory) {
+		if (child->type == FSNodeType::kDirectory) {
 			fs_dumpedges(static_cast<FSNodeDirectory*>(child));
 		}
 	}
 	if (parent->case_insensitive) {
 		for (const auto &entry : parent->lowerCaseEntries) {
 			FSNode *child = entry.second;
-			if (child->type == FSNode::kDirectory) {
+			if (child->type == FSNodeType::kDirectory) {
 				fs_dumpedges(static_cast<FSNodeDirectory *>(child));
 			}
 		}

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -37,6 +37,7 @@
 #include "master/filesystem_checksum.h"
 #include "master/filesystem_freenode.h"
 #include "master/filesystem_metadata.h"
+#include "master/filesystem_node_types.h"
 #include "master/filesystem_operations.h"
 #include "master/filesystem_periodic.h"
 #include "master/filesystem_quota.h"
@@ -52,22 +53,23 @@
 #define MAXFNAMELENG 255
 
 
-FSNode *FSNode::create(uint8_t type) {
+FSNode *FSNode::create(FSNodeType type) {
 	switch (type) {
-	case kFile:
-	case kTrash:
-	case kReserved:
+	case FSNodeType::kFile:
+	case FSNodeType::kTrash:
+	case FSNodeType::kReserved:
 		return new FSNodeFile(type);
-	case kDirectory:
+	case FSNodeType::kDirectory:
 		return new FSNodeDirectory();
-	case kSymlink:
+	case FSNodeType::kSymlink:
 		return new FSNodeSymlink();
-	case kFifo:
-	case kSocket:
+	case FSNodeType::kFifo:
+	case FSNodeType::kSocket:
 		return new FSNode(type);
-	case kBlockDev:
-	case kCharDev:
+	case FSNodeType::kBlockDev:
+	case FSNodeType::kCharDev:
 		return new FSNodeDevice(type);
+	case FSNodeType::kUnknown:
 	default:
 		assert(!"invalid node type");
 	}
@@ -79,23 +81,23 @@ void FSNode::destroy(FSNode *node) {
 		delete handlePtr;
 	}
 	switch (node->type) {
-	case kFile:
-	case kTrash:
-	case kReserved:
+	case FSNodeType::kFile:
+	case FSNodeType::kTrash:
+	case FSNodeType::kReserved:
 		delete static_cast<FSNodeFile *>(node);
 		break;
-	case kDirectory:
+	case FSNodeType::kDirectory:
 		delete static_cast<FSNodeDirectory *>(node);
 		break;
-	case kSymlink:
+	case FSNodeType::kSymlink:
 		delete static_cast<FSNodeSymlink *>(node);
 		break;
-	case kFifo:
-	case kSocket:
+	case FSNodeType::kFifo:
+	case FSNodeType::kSocket:
 		delete node;
 		break;
-	case kBlockDev:
-	case kCharDev:
+	case FSNodeType::kBlockDev:
+	case FSNodeType::kCharDev:
 		delete static_cast<FSNodeDevice *>(node);
 		break;
 	default:
@@ -259,7 +261,7 @@ bool fsnodes_isancestor(FSNodeDirectory *ancestor, FSNode *node) {
  */
 bool fsnodes_isancestor_or_node_reserved_or_trash(FSNodeDirectory *ancestor, FSNode *node) {
 	// Return true if file is reserved:
-	if (node && (node->type == FSNode::kReserved || node->type == FSNode::kTrash)) {
+	if (node && (node->type == FSNodeType::kReserved || node->type == FSNodeType::kTrash)) {
 		return true;
 	}
 	// Or if ancestor is ancestor of node
@@ -270,14 +272,14 @@ bool fsnodes_isancestor_or_node_reserved_or_trash(FSNodeDirectory *ancestor, FSN
 
 void fsnodes_get_stats(FSNode *node, statsrecord *sr) {
 	switch (node->type) {
-	case FSNode::kDirectory:
+	case FSNodeType::kDirectory:
 		*sr = static_cast<FSNodeDirectory*>(node)->stats;
 		sr->inodes++;
 		sr->dirs++;
 		break;
-	case FSNode::kFile:
-	case FSNode::kTrash:
-	case FSNode::kReserved:
+	case FSNodeType::kFile:
+	case FSNodeType::kTrash:
+	case FSNodeType::kReserved:
 		sr->inodes = 1;
 		sr->dirs = 0;
 		sr->files = 1;
@@ -287,7 +289,7 @@ void fsnodes_get_stats(FSNode *node, statsrecord *sr) {
 		sr->size = file_size(static_cast<FSNodeFile*>(node), sr->chunks);
 		sr->realsize = file_realsize(static_cast<FSNodeFile*>(node), sr->chunks, sr->size);
 		break;
-	case FSNode::kSymlink:
+	case FSNodeType::kSymlink:
 		sr->inodes = 1;
 		sr->links = 1;
 		sr->files = 0;
@@ -394,8 +396,8 @@ void fsnodes_fill_attr(FSNode *node, FSNode *parent, uint32_t uid, uint32_t gid,
 	uint32_t nlink;
 	(void)sesflags;
 	ptr = attr.data();
-	if (node->type == FSNode::kTrash || node->type == FSNode::kReserved) {
-		put8bit(&ptr, FSNode::kFile);
+	if (node->type == FSNodeType::kTrash || node->type == FSNodeType::kReserved) {
+		put8bit(&ptr, FSNodeType::kFile);
 	} else {
 		put8bit(&ptr, node->type);
 	}
@@ -443,18 +445,18 @@ void fsnodes_fill_attr(FSNode *node, FSNode *parent, uint32_t uid, uint32_t gid,
 	put32bit(&ptr, node->ctime);
 	nlink = node->parent.size();
 	switch (node->type) {
-	case FSNode::kFile:
-	case FSNode::kTrash:
-	case FSNode::kReserved:
+	case FSNodeType::kFile:
+	case FSNodeType::kTrash:
+	case FSNodeType::kReserved:
 		put32bit(&ptr, nlink);
 		put64bit(&ptr, static_cast<FSNodeFile*>(node)->length);
 		break;
-	case FSNode::kDirectory:
+	case FSNodeType::kDirectory:
 		put32bit(&ptr, static_cast<FSNodeDirectory*>(node)->nlink);
 		put64bit(&ptr, static_cast<FSNodeDirectory*>(node)->stats.length >>
 		                       30);  // Rescale length to GB (reduces size to 32-bit length)
 		break;
-	case FSNode::kSymlink:
+	case FSNodeType::kSymlink:
 		put32bit(&ptr, nlink);
 		*ptr++ = 0;
 		*ptr++ = 0;
@@ -462,8 +464,8 @@ void fsnodes_fill_attr(FSNode *node, FSNode *parent, uint32_t uid, uint32_t gid,
 		*ptr++ = 0;
 		put32bit(&ptr, static_cast<FSNodeSymlink*>(node)->path_length);
 		break;
-	case FSNode::kBlockDev:
-	case FSNode::kCharDev:
+	case FSNodeType::kBlockDev:
+	case FSNodeType::kCharDev:
 		put32bit(&ptr, nlink);
 		put32bit(&ptr, static_cast<FSNodeDevice*>(node)->rdev);
 		*ptr++ = 0;
@@ -518,7 +520,7 @@ void fsnodes_remove_edge(uint32_t ts, FSNodeDirectory *parent, const HString &na
 	fsnodes_get_stats(node, &sr);
 	fsnodes_sub_stats(parent, &sr);
 	parent->mtime = parent->ctime = ts;
-	if (node->type == FSNode::kDirectory) {
+	if (node->type == FSNodeType::kDirectory) {
 		parent->nlink--;
 	}
 
@@ -544,7 +546,7 @@ void fsnodes_remove_edge(uint32_t ts, FSNodeDirectory *parent, const HString &na
 	// done.
 	delete handlePtrToErase;
 
-	assert(node->type != FSNode::kTrash);
+	assert(node->type != FSNodeType::kTrash);
 	node->ctime = ts;
 	fsnodes_update_checksum(node);
 }
@@ -566,7 +568,7 @@ void fsnodes_link(uint32_t ts, FSNodeDirectory *parent, FSNode *child, const HSt
 
 	child->parent.push_back({parent->id, handlePtr});
 
-	if (child->type == FSNode::kDirectory) {
+	if (child->type == FSNodeType::kDirectory) {
 		parent->nlink++;
 	}
 
@@ -576,40 +578,41 @@ void fsnodes_link(uint32_t ts, FSNodeDirectory *parent, FSNode *child, const HSt
 	if (ts > 0) {
 		parent->mtime = parent->ctime = ts;
 		fsnodes_update_checksum(parent);
-		assert(child->type != FSNode::kTrash);
+		assert(child->type != FSNodeType::kTrash);
 		child->ctime = ts;
 		fsnodes_update_checksum(child);
 	}
 }
 
-FSNode *fsnodes_create_node(uint32_t ts, FSNodeDirectory *parent, const HString &name, uint8_t type,
-                            uint16_t mode, uint16_t umask, uint32_t uid, uint32_t gid,
-                            uint8_t copysgid, AclInheritance inheritacl, inode_t req_inode) {
-	assert(type != FSNode::kTrash);
+FSNode *fsnodes_create_node(uint32_t ts, FSNodeDirectory *parent, const HString &name,
+                            FSNodeType type, uint16_t mode, uint16_t umask, uint32_t uid,
+                            uint32_t gid, uint8_t copysgid, AclInheritance inheritacl,
+                            inode_t req_inode) {
+	assert(type != FSNodeType::kTrash);
 
 	FSNode *node = FSNode::create(type);
 	gMetadata->nodes++;
-	if (type == FSNode::kDirectory) {
+	if (type == FSNodeType::kDirectory) {
 		gMetadata->dirNodes++;
 	}
-	if (type == FSNode::kFile) {
+	if (type == FSNodeType::kFile) {
 		gMetadata->fileNodes++;
 	}
-	if (type == FSNode::kSymlink) {
+	if (type == FSNodeType::kSymlink) {
 		gMetadata->linkNodes++;
 	}
 	/* create node */
 	node->id = fsnodes_get_next_id(ts, req_inode);
 
 	node->ctime = node->mtime = node->atime = ts;
-	if (type == FSNode::kDirectory || type == FSNode::kFile) {
+	if (type == FSNodeType::kDirectory || type == FSNodeType::kFile) {
 		node->goal = parent->goal;
 		node->trashtime = parent->trashtime;
 	} else {
 		node->goal = DEFAULT_GOAL;
 		node->trashtime = kDefaultTrashTime;
 	}
-	if (type == FSNode::kDirectory) {
+	if (type == FSNodeType::kDirectory) {
 		node->mode = (mode & 07777) | (parent->mode & 0xF000);
 	} else {
 		node->mode = (mode & 07777) | (parent->mode & (0xF000 & (~(EATTR_NOECACHE << 12))));
@@ -620,7 +623,7 @@ FSNode *fsnodes_create_node(uint32_t ts, FSNodeDirectory *parent, const HString 
 	if (parent_acl) {
 		RichACL acl;
 		uint16_t mode = node->mode;
-		if (RichACL::inheritInode(*parent_acl, mode, acl, umask, type == FSNode::kDirectory)) {
+		if (RichACL::inheritInode(*parent_acl, mode, acl, umask, type == FSNodeType::kDirectory)) {
 			gMetadata->aclStorage.set(node->id, std::move(acl));
 		}
 		// Set effective permissions as the intersection of mode and ACL
@@ -632,7 +635,7 @@ FSNode *fsnodes_create_node(uint32_t ts, FSNodeDirectory *parent, const HString 
 	node->uid = uid;
 	if ((parent->mode & 02000) == 02000) {  // set gid flag is set in the parent directory ?
 		node->gid = parent->gid;
-		if (copysgid && type == FSNode::kDirectory) {
+		if (copysgid && type == FSNodeType::kDirectory) {
 			node->mode |= 02000;
 		}
 	} else {
@@ -646,7 +649,7 @@ FSNode *fsnodes_create_node(uint32_t ts, FSNodeDirectory *parent, const HString 
 	fsnodes_link(ts, parent, node, name);
 	fsnodes_quota_update(node, {{QuotaResource::kInodes, +1}});
 
-	if (type == FSNode::kFile) {
+	if (type == FSNodeType::kFile) {
 		fsnodes_quota_update(node, {{QuotaResource::kSize, +fsnodes_get_size(node)}});
 	}
 
@@ -886,7 +889,7 @@ void fsnodes_getdirdata(inode_t rootinode, uint32_t uid, uint32_t gid, uint32_t 
 		::memcpy(dbuff, attr.data(), attr.size());
 		dbuff += attr.size();
 	} else {
-		put8bit(&dbuff, FSNode::kDirectory);
+		put8bit(&dbuff, static_cast<uint8_t>(FSNodeType::kDirectory));
 	}
 	// '..' - parent
 	dbuff[0] = 2;
@@ -900,7 +903,7 @@ void fsnodes_getdirdata(inode_t rootinode, uint32_t uid, uint32_t gid, uint32_t 
 			::memcpy(dbuff, attr.data(), attr.size());
 			dbuff += attr.size();
 		} else {
-			put8bit(&dbuff, FSNode::kDirectory);
+			put8bit(&dbuff, static_cast<uint8_t>(FSNodeType::kDirectory));
 		}
 	} else {
 		if (!p->parent.empty() && p->parent[0].first != rootinode) {
@@ -934,7 +937,7 @@ void fsnodes_getdirdata(inode_t rootinode, uint32_t uid, uint32_t gid, uint32_t 
 			}
 			dbuff += attr.size();
 		} else {
-			put8bit(&dbuff, FSNode::kDirectory);
+			put8bit(&dbuff, static_cast<uint8_t>(FSNodeType::kDirectory));
 		}
 	}
 	// entries
@@ -951,7 +954,7 @@ void fsnodes_getdirdata(inode_t rootinode, uint32_t uid, uint32_t gid, uint32_t 
 			::memcpy(dbuff, attr.data(), attr.size());
 			dbuff += attr.size();
 		} else {
-			put8bit(&dbuff, entry.second->type);
+			put8bit(&dbuff, static_cast<uint8_t>(entry.second->type));
 		}
 	}
 }
@@ -1197,10 +1200,10 @@ uint8_t fsnodes_appendchunks(uint32_t ts, FSNodeFile *dst, FSNodeFile *src) {
 
 	uint64_t length =
 	    (static_cast<uint64_t>(dst_chunks) << SFSCHUNKBITS) + src->length;
-	if (dst->type == FSNode::kTrash) {
+	if (dst->type == FSNodeType::kTrash) {
 		gMetadata->trashSpace -= dst->length;
 		gMetadata->trashSpace += length;
-	} else if (dst->type == FSNode::kReserved) {
+	} else if (dst->type == FSNodeType::kReserved) {
 		gMetadata->reservedSpace -= dst->length;
 		gMetadata->reservedSpace += length;
 	}
@@ -1245,10 +1248,10 @@ void fsnodes_setlength(FSNodeFile *obj, uint64_t length, bool eraseFurtherChunks
 	uint32_t chunks;
 	statsrecord psr, nsr;
 	fsnodes_get_stats(obj, &psr);
-	if (obj->type == FSNode::kTrash) {
+	if (obj->type == FSNodeType::kTrash) {
 		gMetadata->trashSpace -= obj->length;
 		gMetadata->trashSpace += length;
-	} else if (obj->type == FSNode::kReserved) {
+	} else if (obj->type == FSNodeType::kReserved) {
 		gMetadata->reservedSpace -= obj->length;
 		gMetadata->reservedSpace += length;
 	}
@@ -1289,14 +1292,16 @@ void fsnodes_setlength(FSNodeFile *obj, uint64_t length, bool eraseFurtherChunks
 void fsnodes_change_uid_gid(FSNode *p, uint32_t uid, uint32_t gid) {
 	int64_t size = 0;
 	fsnodes_quota_update(p, {{QuotaResource::kInodes, -1}});
-	if (p->type == FSNode::kFile || p->type == FSNode::kTrash || p->type == FSNode::kReserved) {
+	if (p->type == FSNodeType::kFile || p->type == FSNodeType::kTrash ||
+	    p->type == FSNodeType::kReserved) {
 		size = fsnodes_get_size(p);
 		fsnodes_quota_update(p, {{QuotaResource::kSize, -size}});
 	}
 	p->uid = uid;
 	p->gid = gid;
 	fsnodes_quota_update(p, {{QuotaResource::kInodes, +1}});
-	if (p->type == FSNode::kFile || p->type == FSNode::kTrash || p->type == FSNode::kReserved) {
+	if (p->type == FSNodeType::kFile || p->type == FSNodeType::kTrash ||
+	    p->type == FSNodeType::kReserved) {
 		fsnodes_quota_update(p, {{QuotaResource::kSize, +size}});
 	}
 }
@@ -1316,12 +1321,12 @@ static inline void fsnodes_remove_node(uint32_t ts, FSNode *node) {
 	gMetadata->nodes--;
 	gMetadata->aclStorage.erase(node->id);
 
-	if (node->type == FSNode::kDirectory) {
+	if (node->type == FSNodeType::kDirectory) {
 		gMetadata->dirNodes--;
 	}
 
-	if (node->type == FSNode::kFile || node->type == FSNode::kTrash ||
-	    node->type == FSNode::kReserved) {
+	if (node->type == FSNodeType::kFile || node->type == FSNodeType::kTrash ||
+	    node->type == FSNodeType::kReserved) {
 		fsnodes_quota_update(node, {{QuotaResource::kSize, -fsnodes_get_size(node)}});
 		gMetadata->fileNodes--;
 		for (uint32_t i = 0; i < static_cast<FSNodeFile*>(node)->chunks.size(); ++i) {
@@ -1336,7 +1341,7 @@ static inline void fsnodes_remove_node(uint32_t ts, FSNode *node) {
 		}
 	}
 
-	if (node->type == FSNode::kSymlink) {
+	if (node->type == FSNodeType::kSymlink) {
 		gMetadata->linkNodes--;
 	}
 
@@ -1367,7 +1372,7 @@ void fsnodes_unlink(uint32_t ts, FSNodeDirectory *parent, const HString &child_n
 	std::string path;
 
 	if (child->parent.size() == 1) {  // last link
-		if (child->type == FSNode::kFile &&
+		if (child->type == FSNodeType::kFile &&
 		    (child->trashtime > 0 ||
 		     !static_cast<FSNodeFile*>(child)->sessionid.empty())) {  // go to trash or reserved ? - get path
 			fsnodes_getpath(parent, child, path);
@@ -1380,10 +1385,10 @@ void fsnodes_unlink(uint32_t ts, FSNodeDirectory *parent, const HString &child_n
 	}
 
 	// last link
-	if (child->type == FSNode::kFile) {
+	if (child->type == FSNodeType::kFile) {
 		FSNodeFile *file_node = static_cast<FSNodeFile*>(child);
 		if (child->trashtime > 0) {
-			child->type = FSNode::kTrash;
+			child->type = FSNodeType::kTrash;
 			child->ctime = ts;
 			fsnodes_update_checksum(child);
 
@@ -1392,7 +1397,7 @@ void fsnodes_unlink(uint32_t ts, FSNodeDirectory *parent, const HString &child_n
 			gMetadata->trashSpace += file_node->length;
 			gMetadata->trashNodes++;
 		} else if (!file_node->sessionid.empty()) {
-			child->type = FSNode::kReserved;
+			child->type = FSNodeType::kReserved;
 			fsnodes_update_checksum(child);
 
 			gMetadata->reserved.insert({child->id, hstorage::Handle(path)});
@@ -1408,13 +1413,13 @@ void fsnodes_unlink(uint32_t ts, FSNodeDirectory *parent, const HString &child_n
 }
 
 int fsnodes_purge(uint32_t ts, FSNode *p) {
-	if (p->type == FSNode::kTrash) {
+	if (p->type == FSNodeType::kTrash) {
 		FSNodeFile *file_node = static_cast<FSNodeFile*>(p);
 		gMetadata->trashSpace -= file_node->length;
 		gMetadata->trashNodes--;
 
 		if (!file_node->sessionid.empty()) {
-			file_node->type = FSNode::kReserved;
+			file_node->type = FSNodeType::kReserved;
 			fsnodes_update_checksum(file_node);
 			gMetadata->reservedSpace += file_node->length;
 			gMetadata->reservedNodes++;
@@ -1433,7 +1438,7 @@ int fsnodes_purge(uint32_t ts, FSNode *p) {
 
 			return 1;
 		}
-	} else if (p->type == FSNode::kReserved) {
+	} else if (p->type == FSNodeType::kReserved) {
 		FSNodeFile *file_node = static_cast<FSNodeFile*>(p);
 
 		gMetadata->reservedSpace -= file_node->length;
@@ -1454,10 +1459,10 @@ uint8_t fsnodes_undel(uint32_t ts, FSNodeFile *node) {
 	uint32_t i, partleng, dots;
 	/* check path */
 	std::string path_str;
-	if (node->type == FSNode::kTrash) {
+	if (node->type == FSNodeType::kTrash) {
 		path_str = (std::string)gMetadata->trash.at(TrashPathKey(node));
 	} else {
-		assert(node->type == FSNode::kReserved);
+		assert(node->type == FSNodeType::kReserved);
 		path_str = (std::string)gMetadata->reserved.at(node->id);
 	}
 
@@ -1520,13 +1525,13 @@ uint8_t fsnodes_undel(uint32_t ts, FSNodeFile *node) {
 				return SAUNAFS_ERROR_EEXIST;
 			}
 			// remove from trash and link to new parent
-			if (node->type == FSNode::kTrash) {
+			if (node->type == FSNodeType::kTrash) {
 				gMetadata->trash.erase(TrashPathKey(node));
 			} else {
 				gMetadata->reserved.erase(node->id);
 			}
 
-			node->type = FSNode::kFile;
+			node->type = FSNodeType::kFile;
 			node->ctime = ts;
 			fsnodes_update_checksum(node);
 			fsnodes_link(ts, p, node, name);
@@ -1539,13 +1544,13 @@ uint8_t fsnodes_undel(uint32_t ts, FSNodeFile *node) {
 				if (n == nullptr) {
 					is_new = 1;
 				} else {
-					if (n->type != FSNode::kDirectory) {
+					if (n->type != FSNodeType::kDirectory) {
 						return SAUNAFS_ERROR_CANTCREATEPATH;
 					}
 				}
 			}
 			if (is_new == 1) {
-				n = fsnodes_create_node(ts, p, name, FSNode::kDirectory, 0755,
+				n = fsnodes_create_node(ts, p, name, FSNodeType::kDirectory, 0755,
 				                        0, 0, 0, 0,
 				                        AclInheritance::kDontInheritAcl);
 
@@ -1553,14 +1558,15 @@ uint8_t fsnodes_undel(uint32_t ts, FSNodeFile *node) {
 				assert(metadataserver::isMaster());
 #endif
 
-				fs_changelog(ts, "CREATE(%" PRIiNode ",%s,%c,%d,%" PRIu32 ",%" PRIu32
-				                 ",%" PRIu32 "):%" PRIiNode,
+				fs_changelog(ts,
+				             "CREATE(%" PRIiNode ",%s,%c,%d,%" PRIu32 ",%" PRIu32 ",%" PRIu32
+				             "):%" PRIiNode,
 				             p->id, fsnodes_escape_name(name).c_str(),
-				             FSNode::kDirectory, n->mode & 07777, (uint32_t)0,
-				             (uint32_t)0, (uint32_t)0, n->id);
+				             static_cast<char>(FSNodeType::kDirectory), n->mode & 07777,
+				             (uint32_t)0, (uint32_t)0, (uint32_t)0, n->id);
 			}
 			p = static_cast<FSNodeDirectory*>(n);
-			assert(n->type == FSNode::kDirectory);
+			assert(n->type == FSNodeType::kDirectory);
 		}
 		path += partleng + 1;
 		pleng -= partleng + 1;
@@ -1571,14 +1577,15 @@ uint8_t fsnodes_undel(uint32_t ts, FSNodeFile *node) {
 
 void fsnodes_getgoal_recursive(FSNode *node, uint8_t gmode, GoalStatistics &fgtab,
                                GoalStatistics &dgtab) {
-	if (node->type == FSNode::kFile || node->type == FSNode::kTrash || node->type == FSNode::kReserved) {
+	if (node->type == FSNodeType::kFile || node->type == FSNodeType::kTrash ||
+	    node->type == FSNodeType::kReserved) {
 		if (!GoalId::isValid(node->goal)) {
 			safs_pretty_syslog(LOG_WARNING, "file inode %" PRIiNode ": unknown goal !!! - fixing",
 			       node->id);
 			fsnodes_changefilegoal(static_cast<FSNodeFile*>(node), DEFAULT_GOAL);
 		}
 		fgtab[node->goal]++;
-	} else if (node->type == FSNode::kDirectory) {
+	} else if (node->type == FSNodeType::kDirectory) {
 		if (!GoalId::isValid(node->goal)) {
 			safs_pretty_syslog(LOG_WARNING,
 			       "directory inode %" PRIiNode ": unknown goal !!! - fixing", node->id);
@@ -1596,10 +1603,10 @@ void fsnodes_getgoal_recursive(FSNode *node, uint8_t gmode, GoalStatistics &fgta
 
 void fsnodes_gettrashtime_recursive(FSNode *node, uint8_t gmode,
 	TrashtimeMap &fileTrashtimes, TrashtimeMap &dirTrashtimes) {
-
-	if (node->type == FSNode::kFile || node->type == FSNode::kTrash || node->type == FSNode::kReserved) {
+	if (node->type == FSNodeType::kFile || node->type == FSNodeType::kTrash ||
+	    node->type == FSNodeType::kReserved) {
 		fileTrashtimes[node->trashtime] += 1;
-	} else if (node->type == FSNode::kDirectory) {
+	} else if (node->type == FSNodeType::kDirectory) {
 		dirTrashtimes[node->trashtime] += 1;
 		if (gmode == GMODE_RECURSIVE) {
 			const FSNodeDirectory *dir_node = static_cast<const FSNodeDirectory*>(node);
@@ -1613,7 +1620,7 @@ void fsnodes_gettrashtime_recursive(FSNode *node, uint8_t gmode,
 void fsnodes_geteattr_recursive(FSNode *node, uint8_t gmode, uint32_t feattrtab[16],
 				uint32_t deattrtab[16]) {
 
-	if (node->type != FSNode::kDirectory) {
+	if (node->type != FSNodeType::kDirectory) {
 		feattrtab[(node->mode >> 12) &
 		          (EATTR_NOOWNER | EATTR_NOACACHE | EATTR_NODATACACHE)]++;
 	} else {
@@ -1630,13 +1637,13 @@ void fsnodes_geteattr_recursive(FSNode *node, uint8_t gmode, uint32_t feattrtab[
 
 void fsnodes_setgoal_recursive(FSNode *node, uint32_t ts, uint32_t uid, uint8_t goal, uint8_t smode,
                                inode_t *sinodes, inode_t *ncinodes, inode_t *nsinodes) {
-	if (node->type == FSNode::kFile || node->type == FSNode::kDirectory || node->type == FSNode::kTrash ||
-	    node->type == FSNode::kReserved) {
+	if (node->type == FSNodeType::kFile || node->type == FSNodeType::kDirectory ||
+	    node->type == FSNodeType::kTrash || node->type == FSNodeType::kReserved) {
 		if ((node->mode & (EATTR_NOOWNER << 12)) == 0 && uid != 0 && node->uid != uid) {
 			(*nsinodes)++;
 		} else {
 			if ((smode & SMODE_TMASK) == SMODE_SET && node->goal != goal) {
-				if (node->type != FSNode::kDirectory) {
+				if (node->type != FSNodeType::kDirectory) {
 					fsnodes_changefilegoal(static_cast<FSNodeFile*>(node), goal);
 					(*sinodes)++;
 				} else {
@@ -1649,7 +1656,7 @@ void fsnodes_setgoal_recursive(FSNode *node, uint32_t ts, uint32_t uid, uint8_t 
 				(*ncinodes)++;
 			}
 		}
-		if (node->type == FSNode::kDirectory && (smode & SMODE_RMASK)) {
+		if (node->type == FSNodeType::kDirectory && (smode & SMODE_RMASK)) {
 			for (const auto &entry : static_cast<const FSNodeDirectory*>(node)->entries) {
 				fsnodes_setgoal_recursive(entry.second, ts, uid, goal, smode, sinodes,
 				                          ncinodes, nsinodes);
@@ -1663,8 +1670,8 @@ void fsnodes_settrashtime_recursive(FSNode *node, uint32_t ts, uint32_t uid, uin
                                     inode_t *nsinodes) {
 	uint8_t set;
 
-	if (node->type == FSNode::kFile || node->type == FSNode::kDirectory || node->type == FSNode::kTrash ||
-	    node->type == FSNode::kReserved) {
+	if (node->type == FSNodeType::kFile || node->type == FSNodeType::kDirectory ||
+	    node->type == FSNodeType::kTrash || node->type == FSNodeType::kReserved) {
 		if ((node->mode & (EATTR_NOOWNER << 12)) == 0 && uid != 0 && node->uid != uid) {
 			(*nsinodes)++;
 		} else {
@@ -1693,7 +1700,7 @@ void fsnodes_settrashtime_recursive(FSNode *node, uint32_t ts, uint32_t uid, uin
 			if (set) {
 				(*sinodes)++;
 				node->ctime = ts;
-				if (node->type == FSNode::kTrash) {
+				if (node->type == FSNodeType::kTrash) {
 					hstorage::Handle path = std::move(gMetadata->trash.at(old_trash_key));
 					gMetadata->trash.erase(old_trash_key);
 					gMetadata->trash.insert({TrashPathKey(node), std::move(path)});
@@ -1703,7 +1710,7 @@ void fsnodes_settrashtime_recursive(FSNode *node, uint32_t ts, uint32_t uid, uin
 				(*ncinodes)++;
 			}
 		}
-		if (node->type == FSNode::kDirectory && (smode & SMODE_RMASK)) {
+		if (node->type == FSNodeType::kDirectory && (smode & SMODE_RMASK)) {
 			for(const auto &entry : static_cast<const FSNodeDirectory*>(node)->entries) {
 				fsnodes_settrashtime_recursive(entry.second, ts, uid, trashtime, smode,
 				                               sinodes, ncinodes, nsinodes);
@@ -1721,7 +1728,7 @@ void fsnodes_seteattr_recursive(FSNode *node, uint32_t ts, uint32_t uid, uint8_t
 		(*nsinodes)++;
 	} else {
 		seattr = eattr;
-		if (node->type != FSNode::kDirectory) {
+		if (node->type != FSNodeType::kDirectory) {
 			node->mode &= ~(EATTR_NOECACHE << 12);
 			seattr &= ~(EATTR_NOECACHE);
 		}
@@ -1741,7 +1748,8 @@ void fsnodes_seteattr_recursive(FSNode *node, uint32_t ts, uint32_t uid, uint8_t
 			node->mode = (node->mode & 0xFFF) | (((uint16_t)neweattr) << 12);
 			const RichACL *node_acl = gMetadata->aclStorage.get(node->id);
 			if (node_acl) {
-				gMetadata->aclStorage.setMode(node->id, node->mode, node->type == FSNode::kDirectory);
+				gMetadata->aclStorage.setMode(node->id, node->mode,
+				                              node->type == FSNodeType::kDirectory);
 			}
 			(*sinodes)++;
 			fsnodes_update_ctime(node, ts);
@@ -1749,7 +1757,7 @@ void fsnodes_seteattr_recursive(FSNode *node, uint32_t ts, uint32_t uid, uint8_t
 			(*ncinodes)++;
 		}
 	}
-	if (node->type == FSNode::kDirectory && (smode & SMODE_RMASK)) {
+	if (node->type == FSNodeType::kDirectory && (smode & SMODE_RMASK)) {
 		const FSNodeDirectory *dir_node = static_cast<const FSNodeDirectory*>(node);
 		for (const auto &entry : dir_node->entries) {
 			fsnodes_seteattr_recursive(entry.second, ts, uid, eattr, smode, sinodes,
@@ -1763,7 +1771,7 @@ uint8_t fsnodes_deleteacl(FSNode *p, AclType type, uint32_t ts) {
 	if (type == AclType::kRichACL) {
 		gMetadata->aclStorage.erase(p->id);
 	} else if (type == AclType::kDefault) {
-		if (p->type != FSNode::kDirectory) {
+		if (p->type != FSNodeType::kDirectory) {
 			return SAUNAFS_ERROR_ENOTSUP;
 		}
 		const RichACL *node_acl = gMetadata->aclStorage.get(p->id);
@@ -1810,12 +1818,12 @@ uint8_t fsnodes_getacl(FSNode *p, RichACL &acl) {
 #endif
 
 uint8_t fsnodes_setacl(FSNode *p, const RichACL &acl, uint32_t ts) {
-	if (!acl.checkInheritFlags(p->type == FSNode::kDirectory)) {
+	if (!acl.checkInheritFlags(p->type == FSNodeType::kDirectory)) {
 		return SAUNAFS_ERROR_ENOTSUP;
 	}
 
 	uint16_t mode = p->mode;
-	if (RichACL::equivMode(acl, mode, p->type == FSNode::kDirectory)) {
+	if (RichACL::equivMode(acl, mode, p->type == FSNodeType::kDirectory)) {
 		p->mode = (p->mode & ~0777) | (mode & 0777);
 		gMetadata->aclStorage.erase(p->id);
 	} else {
@@ -1825,7 +1833,7 @@ uint8_t fsnodes_setacl(FSNode *p, const RichACL &acl, uint32_t ts) {
 		RichACL new_acl = acl;
 		if (acl.isAutoSetMode()) {
 			new_acl.setFlags(new_acl.getFlags() & ~RichACL::kAutoSetMode);
-			new_acl.setMode(p->mode, p->type == FSNode::kDirectory);
+			new_acl.setMode(p->mode, p->type == FSNodeType::kDirectory);
 		}
 		gMetadata->aclStorage.set(p->id, std::move(new_acl));
 	}
@@ -1840,7 +1848,7 @@ uint8_t fsnodes_setacl(FSNode *p, AclType type, const AccessControlList &acl, ui
 		return SAUNAFS_ERROR_EINVAL;
 	}
 
-	if (type == AclType::kDefault && p->type != FSNode::kDirectory) {
+	if (type == AclType::kDefault && p->type != FSNodeType::kDirectory) {
 		return SAUNAFS_ERROR_ENOTSUP;
 	}
 
@@ -1857,7 +1865,7 @@ uint8_t fsnodes_setacl(FSNode *p, AclType type, const AccessControlList &acl, ui
 		new_acl.appendDefaultPosixACL(acl);
 		new_acl.setMode(p->mode, true);
 	} else {
-		new_acl.appendPosixACL(acl, p->type == FSNode::kDirectory);
+		new_acl.appendPosixACL(acl, p->type == FSNodeType::kDirectory);
 		p->mode = (p->mode & ~0777) | (new_acl.getMode() & 0777);
 	}
 	gMetadata->aclStorage.set(p->id, std::move(new_acl));
@@ -1898,7 +1906,7 @@ int fsnodes_access(const FsContext &context, FSNode *node, uint8_t modemask) {
 		assert((node->mode & 0777) == node_acl->getMode());
 
 		uint32_t mask = RichACL::convertMode2Mask(modemask);
-		if (node->type != FSNode::kDirectory) {
+		if (node->type != FSNodeType::kDirectory) {
 			mask &= ~RichACL::Ace::kDeleteChild;
 		}
 		return node_acl->checkPermission(mask, node->uid, node->gid, context.uid(), context.groups());
@@ -1972,12 +1980,13 @@ uint8_t fsnodes_get_node_for_operation(const FsContext &context, ExpectedNodeTyp
 		if (!p) {
 			return SAUNAFS_ERROR_ENOENT;
 		}
-		if (context.rootinode() == 0 && p->type != FSNode::kTrash && p->type != FSNode::kReserved) {
+		if (context.rootinode() == 0 && p->type != FSNodeType::kTrash &&
+		    p->type != FSNodeType::kReserved) {
 			return SAUNAFS_ERROR_EPERM;
 		}
 	} else {
 		rn = fsnodes_id_to_node<FSNodeDirectory>(context.rootinode());
-		if (!rn || rn->type != FSNode::kDirectory) {
+		if (!rn || rn->type != FSNodeType::kDirectory) {
 			return SAUNAFS_ERROR_ENOENT;
 		}
 		if (inode == SPECIAL_INODE_ROOT) {
@@ -1992,18 +2001,20 @@ uint8_t fsnodes_get_node_for_operation(const FsContext &context, ExpectedNodeTyp
 			}
 		}
 	}
-	if ((expectedNodeType == ExpectedNodeType::kDirectory) && (p->type != FSNode::kDirectory)) {
+	if ((expectedNodeType == ExpectedNodeType::kDirectory) && (p->type != FSNodeType::kDirectory)) {
 		return SAUNAFS_ERROR_ENOTDIR;
 	}
-	if ((expectedNodeType == ExpectedNodeType::kNotDirectory) && (p->type == FSNode::kDirectory)) {
+	if ((expectedNodeType == ExpectedNodeType::kNotDirectory) &&
+	    (p->type == FSNodeType::kDirectory)) {
 		return SAUNAFS_ERROR_EPERM;
 	}
-	if ((expectedNodeType == ExpectedNodeType::kFile) && (p->type != FSNode::kFile) &&
-	    (p->type != FSNode::kReserved) && (p->type != FSNode::kTrash)) {
+	if ((expectedNodeType == ExpectedNodeType::kFile) && (p->type != FSNodeType::kFile) &&
+	    (p->type != FSNodeType::kReserved) && (p->type != FSNodeType::kTrash)) {
 		return SAUNAFS_ERROR_EPERM;
 	}
-	if ((expectedNodeType == ExpectedNodeType::kFileOrDirectory) && (p->type != FSNode::kDirectory)
-		&& (p->type != FSNode::kFile) && (p->type != FSNode::kReserved) && (p->type != FSNode::kTrash)) {
+	if ((expectedNodeType == ExpectedNodeType::kFileOrDirectory) &&
+	    (p->type != FSNodeType::kDirectory) && (p->type != FSNodeType::kFile) &&
+	    (p->type != FSNodeType::kReserved) && (p->type != FSNodeType::kTrash)) {
 		return SAUNAFS_ERROR_EPERM;
 	}
 	if (context.canCheckPermissions() &&

--- a/src/master/filesystem_node.h
+++ b/src/master/filesystem_node.h
@@ -51,25 +51,26 @@ inline void fsnodes_check_node_type(const NodeType *node) {
 
 template<>
 inline void fsnodes_check_node_type(const FSNodeFile *node) {
-	assert(node && (node->type == FSNode::kFile || node->type == FSNode::kTrash || node->type == FSNode::kReserved));
+	assert(node && (node->type == FSNodeType::kFile || node->type == FSNodeType::kTrash ||
+	                node->type == FSNodeType::kReserved));
 	(void)node;
 }
 
 template<>
 inline void fsnodes_check_node_type(const FSNodeDirectory *node) {
-	assert(node && node->type == FSNode::kDirectory);
+	assert(node && node->type == FSNodeType::kDirectory);
 	(void)node;
 }
 
 template<>
 inline void fsnodes_check_node_type(const FSNodeSymlink *node) {
-	assert(node && node->type == FSNode::kSymlink);
+	assert(node && node->type == FSNodeType::kSymlink);
 	(void)node;
 }
 
 template<>
 inline void fsnodes_check_node_type(const FSNodeDevice *node) {
-	assert(node && (node->type == FSNode::kBlockDev || node->type == FSNode::kCharDev));
+	assert(node && (node->type == FSNodeType::kBlockDev || node->type == FSNodeType::kCharDev));
 	(void)node;
 }
 
@@ -98,7 +99,7 @@ inline NodeType *fsnodes_id_to_node(inode_t id) {
 }
 
 inline void fsnodes_update_ctime(FSNode *node, uint32_t ctime) {
-	if (node->type == FSNode::kTrash && node->ctime != ctime) {
+	if (node->type == FSNodeType::kTrash && node->ctime != ctime) {
 		auto old_key = TrashPathKey(node);
 		node->ctime = ctime;
 		auto it = gMetadata->trash.find(old_key);
@@ -143,9 +144,10 @@ void fsnodes_change_uid_gid(FSNode *p, uint32_t uid, uint32_t gid);
 int fsnodes_nameisused(FSNodeDirectory *node, const HString &name);
 bool fsnodes_inode_quota_exceeded(uint32_t uid, uint32_t gid);
 
-FSNode *fsnodes_create_node(uint32_t ts, FSNodeDirectory *node, const HString &name, uint8_t type,
-                            uint16_t mode, uint16_t umask, uint32_t uid, uint32_t gid,
-                            uint8_t copysgid, AclInheritance inheritacl, inode_t req_inode = 0);
+FSNode *fsnodes_create_node(uint32_t ts, FSNodeDirectory *node, const HString &name,
+                            FSNodeType type, uint16_t mode, uint16_t umask, uint32_t uid,
+                            uint32_t gid, uint8_t copysgid, AclInheritance inheritacl,
+                            inode_t req_inode = 0);
 
 void fsnodes_add_stats(FSNodeDirectory *parent, statsrecord *sr);
 int fsnodes_sticky_access(FSNode *parent, FSNode *node, uint32_t uid);

--- a/src/master/filesystem_node_types.h
+++ b/src/master/filesystem_node_types.h
@@ -59,12 +59,30 @@
 
 #define MAX_INDEX 0x7FFFFFFF
 
-enum class AclInheritance { kInheritAcl, kDontInheritAcl };
+enum class AclInheritance : std::uint8_t {
+	kInheritAcl,
+	kDontInheritAcl
+};
 
 // Arguments for verify_session
-enum class SessionType { kNotMeta, kOnlyMeta, kAny };
-enum class OperationMode { kReadWrite, kReadOnly };
-enum class ExpectedNodeType { kFile, kDirectory, kNotDirectory, kFileOrDirectory, kAny };
+enum class SessionType : std::uint8_t {
+	kNotMeta,
+	kOnlyMeta,
+	kAny
+};
+
+enum class OperationMode : std::uint8_t {
+	kReadWrite,
+	kReadOnly
+};
+
+enum class ExpectedNodeType : std::uint8_t {
+	kFile,
+	kDirectory,
+	kNotDirectory,
+	kFileOrDirectory,
+	kAny
+};
 
 using TrashtimeMap = std::unordered_map<uint32_t, uint32_t>;
 using GoalStatistics = std::array<inode_t, GoalId::kMax + 1>;
@@ -81,6 +99,19 @@ struct statsrecord {
 	uint64_t realsize;
 };
 
+enum class FSNodeType : std::uint8_t {
+	kFile = TYPE_FILE,
+	kDirectory = TYPE_DIRECTORY,
+	kSymlink = TYPE_SYMLINK,
+	kFifo = TYPE_FIFO,
+	kBlockDev = TYPE_BLOCKDEV,
+	kCharDev = TYPE_CHARDEV,
+	kSocket = TYPE_SOCKET,
+	kTrash = TYPE_TRASH,
+	kReserved = TYPE_RESERVED,
+	kUnknown = TYPE_UNKNOWN
+};
+
 /*! \brief Node containing common meta data for each file system object (file or directory).
  *
  * Node size = 64B
@@ -93,24 +124,11 @@ struct statsrecord {
  * 4G files will occupy 600GB
  */
 struct FSNode {
-	enum {
-		kFile = TYPE_FILE,
-		kDirectory = TYPE_DIRECTORY,
-		kSymlink = TYPE_SYMLINK,
-		kFifo = TYPE_FIFO,
-		kBlockDev = TYPE_BLOCKDEV,
-		kCharDev = TYPE_CHARDEV,
-		kSocket = TYPE_SOCKET,
-		kTrash = TYPE_TRASH,
-		kReserved = TYPE_RESERVED,
-		kUnknown = TYPE_UNKNOWN
-	};
-
 	inode_t id; /*!< Unique number identifying node. */
 	uint32_t ctime; /*!< Change time. */
 	uint32_t mtime; /*!< Modification time. */
 	uint32_t atime; /*!< Access time. */
-	uint8_t type; /*!< Node type. (file, directory, symlink, ...) */
+	FSNodeType type; /*!< Node type. (file, directory, symlink, ...) */
 	uint8_t goal; /*!< Goal id. */
 	uint16_t mode;  /*!< Only 12 lowest bits are used for mode, in unix standard upper 4 are used
 	                 for object type, but since there is field "type" this bits can be used as
@@ -124,7 +142,7 @@ struct FSNode {
 
 	uint64_t checksum; /*!< Node checksum. */
 
-	FSNode(uint8_t t) {
+	FSNode(FSNodeType t) {
 		type = t;
 		checksum = 0;
 	}
@@ -133,7 +151,7 @@ struct FSNode {
 	 * \param type Type of node to create.
 	 * \return Pointer to created node.
 	 */
-	static FSNode *create(uint8_t type);
+	static FSNode *create(FSNodeType type);
 
 	/*! \brief Static function used for erasing node (uses node's type
 	 * for correct invocation of destructors).
@@ -155,8 +173,8 @@ struct FSNodeFile : public FSNode {
 	compact_vector<uint32_t> sessionid;
 	compact_vector<uint64_t, uint32_t> chunks;
 
-	explicit FSNodeFile(uint8_t t) : FSNode(t) {
-		assert(t == kFile || t == kTrash || t == kReserved);
+	explicit FSNodeFile(FSNodeType t) : FSNode(t) {
+		assert(t == FSNodeType::kFile || t == FSNodeType::kTrash || t == FSNodeType::kReserved);
 	}
 
 	uint32_t chunkCount() const {
@@ -178,7 +196,7 @@ struct FSNodeSymlink : public FSNode {
 	hstorage::Handle path;
 	uint16_t path_length{};
 
-	explicit FSNodeSymlink() : FSNode(kSymlink) {
+	explicit FSNodeSymlink() : FSNode(FSNodeType::kSymlink) {
 	}
 };
 
@@ -189,7 +207,7 @@ struct FSNodeSymlink : public FSNode {
 struct FSNodeDevice : public FSNode {
 	uint32_t rdev;
 
-	FSNodeDevice(uint8_t device_type) : FSNode(device_type), rdev() {
+	FSNodeDevice(FSNodeType device_type) : FSNode(device_type), rdev() {
 	}
 };
 
@@ -226,7 +244,7 @@ struct FSNodeDirectory : public FSNode {
 	uint16_t entries_hash;
 	uint16_t lowerCaseEntriesHash;
 
-	FSNodeDirectory() : FSNode(kDirectory) {
+	FSNodeDirectory() : FSNode(FSNodeType::kDirectory) {
 		memset(&stats, 0, sizeof(stats));
 		nlink = 2;
 		entries_hash = 0;

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -29,13 +29,14 @@
 #include "common/attributes.h"
 #include "common/event_loop.h"
 #include "errors/saunafs_error_codes.h"
-#include "filesystem_metadata.h"
 #include "master/changelog.h"
 #include "master/chunks.h"
 #include "master/filesystem.h"
 #include "master/filesystem_checksum.h"
 #include "master/filesystem_checksum_updater.h"
+#include "master/filesystem_metadata.h"
 #include "master/filesystem_node.h"
+#include "master/filesystem_node_types.h"
 #include "master/filesystem_quota.h"
 #include "master/fs_context.h"
 #include "master/locks.h"
@@ -166,13 +167,13 @@ uint8_t fs_getdetachedattr(inode_t rootinode, uint8_t sesflags, inode_t inode, A
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
-	if (p->type != FSNode::kTrash && p->type != FSNode::kReserved) {
+	if (p->type != FSNodeType::kTrash && p->type != FSNodeType::kReserved) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
-	if (dtype == DTYPE_TRASH && p->type == FSNode::kReserved) {
+	if (dtype == DTYPE_TRASH && p->type == FSNodeType::kReserved) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
-	if (dtype == DTYPE_RESERVED && p->type == FSNode::kTrash) {
+	if (dtype == DTYPE_RESERVED && p->type == FSNodeType::kTrash) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
 	fsnodes_fill_attr(p, NULL, p->uid, p->gid, p->uid, p->gid, sesflags, attr);
@@ -189,7 +190,7 @@ uint8_t fs_gettrashpath(inode_t rootinode, uint8_t sesflags, inode_t inode, std:
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
-	if (p->type != FSNode::kTrash) {
+	if (p->type != FSNodeType::kTrash) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
 	path = (std::string)gMetadata->trash.at(TrashPathKey(p));
@@ -208,7 +209,7 @@ uint8_t fs_settrashpath(const FsContext &context, inode_t inode, const std::stri
 	                                        inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
-	} else if (p->type != FSNode::kTrash) {
+	} else if (p->type != FSNodeType::kTrash) {
 		return SAUNAFS_ERROR_ENOENT;
 	} else if (path.length() == 0) {
 		return SAUNAFS_ERROR_EINVAL;
@@ -241,7 +242,7 @@ uint8_t fs_undel(const FsContext &context, inode_t inode) {
 	                                        inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
-	} else if (p->type != FSNode::kTrash) {
+	} else if (p->type != FSNodeType::kTrash) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
 
@@ -267,7 +268,7 @@ uint8_t fs_purge(const FsContext &context, inode_t inode) {
 	                                        inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
-	} else if (p->type != FSNode::kTrash) {
+	} else if (p->type != FSNodeType::kTrash) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
 	// This should be equal to inode, because p is not a directory
@@ -326,7 +327,7 @@ uint8_t fs_getrootinode(inode_t *rootinode, const uint8_t *path) {
 		if (!child) {
 			return SAUNAFS_ERROR_ENOENT;
 		}
-		if (child->type != FSNode::kDirectory) {
+		if (child->type != FSNodeType::kDirectory) {
 			return SAUNAFS_ERROR_ENOTDIR;
 		}
 		parent = static_cast<FSNodeDirectory*>(child);
@@ -347,7 +348,7 @@ void fs_statfs(const FsContext &context, uint64_t *totalspace, uint64_t *availsp
 		*respace = 0;
 		rn = fsnodes_id_to_node(context.rootinode());
 	}
-	if (!rn || rn->type != FSNode::kDirectory) {
+	if (!rn || rn->type != FSNodeType::kDirectory) {
 		*totalspace = 0;
 		*availspace = 0;
 		*inodes = 0;
@@ -513,10 +514,10 @@ uint8_t fs_full_path_by_inode(const FsContext &context, inode_t initial_inode,
 
 	while (current_inode != context.rootinode()) {
 		if (!current_node || current_node->parent.empty()) {
-			if (current_node->parent.empty() &&
-			    (current_node->type == FSNode::kReserved || current_node->type == FSNode::kTrash)) {
+			if (current_node->parent.empty() && (current_node->type == FSNodeType::kReserved ||
+			                                     current_node->type == FSNodeType::kTrash)) {
 				current_name =
-				    current_node->type == FSNode::kTrash
+				    current_node->type == FSNodeType::kTrash
 				        ? gMetadata->trash.at(TrashPathKey(current_node)).get() + " (trash)"
 				        : gMetadata->reserved.at(current_inode).get() + " (reserved)";
 				fullPath = current_name;
@@ -623,7 +624,8 @@ uint8_t fs_apply_trunc(uint32_t ts, inode_t inode, uint32_t indx, uint64_t chunk
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
-	if (p->type != FSNode::kFile && p->type != FSNode::kTrash && p->type != FSNode::kReserved) {
+	if (p->type != FSNodeType::kFile && p->type != FSNodeType::kTrash &&
+	    p->type != FSNodeType::kReserved) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
 	if (indx > MAX_INDEX) {
@@ -790,7 +792,7 @@ uint8_t fs_setattr(const FsContext &context, inode_t inode, uint8_t setmask, uin
 			}
 			break;
 		case SugidClearMode::kExt:
-			if (p->type != FSNode::kDirectory) {
+			if (p->type != FSNodeType::kDirectory) {
 				if (p->mode & 010) {  // when group exec is set - clear both bits
 					p->mode &= 0171777;
 					attrmode &= 01777;
@@ -801,7 +803,7 @@ uint8_t fs_setattr(const FsContext &context, inode_t inode, uint8_t setmask, uin
 			}
 			break;
 		case SugidClearMode::kSfs:
-			if (p->type != FSNode::kDirectory) {  // similar to EXT3, but unprivileged users
+			if (p->type != FSNodeType::kDirectory) {  // similar to EXT3, but unprivileged users
 				                          // also clear suid/sgid bits on
 				                          // directories
 				if (p->mode & 010) {
@@ -822,7 +824,7 @@ uint8_t fs_setattr(const FsContext &context, inode_t inode, uint8_t setmask, uin
 	}
 	if (setmask & SET_MODE_FLAG) {
 		p->mode = (attrmode & 07777) | (p->mode & 0xF000);
-		gMetadata->aclStorage.setMode(p->id, p->mode, p->type == FSNode::kDirectory);
+		gMetadata->aclStorage.setMode(p->id, p->mode, p->type == FSNodeType::kDirectory);
 	}
 	if (setmask & (SET_UID_FLAG | SET_GID_FLAG)) {
 		fsnodes_change_uid_gid(p, ((setmask & SET_UID_FLAG) ? attruid : p->uid),
@@ -859,7 +861,7 @@ uint8_t fs_apply_attr(uint32_t ts, inode_t inode, uint32_t mode, uint32_t uid, u
 		return SAUNAFS_ERROR_EINVAL;
 	}
 	p->mode = mode | (p->mode & 0xF000);
-	gMetadata->aclStorage.setMode(p->id, p->mode, p->type == FSNode::kDirectory);
+	gMetadata->aclStorage.setMode(p->id, p->mode, p->type == FSNodeType::kDirectory);
 	if (p->uid != uid || p->gid != gid) {
 		fsnodes_change_uid_gid(p, uid, gid);
 	}
@@ -876,7 +878,8 @@ uint8_t fs_apply_length(uint32_t ts, inode_t inode, uint64_t length, bool eraseF
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
-	if (p->type != FSNode::kFile && p->type != FSNode::kTrash && p->type != FSNode::kReserved) {
+	if (p->type != FSNodeType::kFile && p->type != FSNodeType::kTrash &&
+	    p->type != FSNodeType::kReserved) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
 	fsnodes_setlength(static_cast<FSNodeFile *>(p), length, eraseFurtherChunks);
@@ -914,7 +917,7 @@ uint8_t fs_readlink(const FsContext &context, inode_t inode, std::string &path) 
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	if (p->type != FSNode::kSymlink) {
+	if (p->type != FSNodeType::kSymlink) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
 
@@ -959,7 +962,7 @@ uint8_t fs_symlink(const FsContext &context, inode_t parent, const HString &name
 		return SAUNAFS_ERROR_QUOTA;
 	}
 	FSNodeSymlink *p = static_cast<FSNodeSymlink *>(fsnodes_create_node(
-	    context.ts(), static_cast<FSNodeDirectory *>(wd), name, FSNode::kSymlink, 0777, 0,
+	    context.ts(), static_cast<FSNodeDirectory *>(wd), name, FSNodeType::kSymlink, 0777, 0,
 	    context.uid(), context.gid(), 0, AclInheritance::kDontInheritAcl, *inode));
 	p->path = HString(path);
 	p->path_length = path.length();
@@ -992,7 +995,7 @@ uint8_t fs_symlink(const FsContext &context, inode_t parent, const HString &name
 
 #ifndef METARESTORE
 uint8_t fs_mknod(const FsContext &context, inode_t parent, const HString &name,
-		uint8_t type, uint16_t mode, uint16_t umask, uint32_t rdev, inode_t *inode,
+		FSNodeType type, uint16_t mode, uint16_t umask, uint32_t rdev, inode_t *inode,
 		Attributes &attr) {
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
@@ -1005,8 +1008,8 @@ uint8_t fs_mknod(const FsContext &context, inode_t parent, const HString &name,
 		return status;
 	}
 
-	if (type != FSNode::kFile && type != FSNode::kSocket && type != FSNode::kFifo &&
-	    type != FSNode::kBlockDev && type != FSNode::kCharDev) {
+	if (type != FSNodeType::kFile && type != FSNodeType::kSocket && type != FSNodeType::kFifo &&
+	    type != FSNodeType::kBlockDev && type != FSNodeType::kCharDev) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
 
@@ -1031,15 +1034,15 @@ uint8_t fs_mknod(const FsContext &context, inode_t parent, const HString &name,
 	    context.sesflags() & SESFLAG_CASEINSENSITIVE;
 	p = fsnodes_create_node(ts, static_cast<FSNodeDirectory*>(wd), name, type, mode, umask, context.uid(), context.gid(), 0,
 	                        AclInheritance::kInheritAcl);
-	if (type == FSNode::kBlockDev || type == FSNode::kCharDev) {
+	if (type == FSNodeType::kBlockDev || type == FSNodeType::kCharDev) {
 		static_cast<FSNodeDevice*>(p)->rdev = rdev;
 	}
 	*inode = p->id;
 	fsnodes_fill_attr(p, wd, context.uid(), context.gid(), context.auid(), context.agid(), context.sesflags(), attr);
 	fs_changelog(ts,
 	             "CREATE(%" PRIiNode ",%s,%c,%d,%" PRIu32 ",%" PRIu32 ",%" PRIu32 "):%" PRIiNode,
-	             wd->id, fsnodes_escape_name(name).c_str(), type, p->mode & 07777, context.uid(), context.gid(),
-	             rdev, p->id);
+	             wd->id, fsnodes_escape_name(name).c_str(), static_cast<char>(type),
+	             p->mode & 07777, context.uid(), context.gid(), rdev, p->id);
 	++gFsStatsArray[FsStats::Mknod];
 	metrics::Counter::increment(metrics::Counter::Master::FS_MKNOD);
 	fsnodes_update_checksum(p);
@@ -1085,32 +1088,35 @@ uint8_t fs_mkdir(const FsContext &context, inode_t parent, const HString &name, 
 
 	static_cast<FSNodeDirectory *>(wd)->case_insensitive =
 	    context.sesflags() & SESFLAG_CASEINSENSITIVE;
-	p = fsnodes_create_node(ts, static_cast<FSNodeDirectory *>(wd), name, FSNode::kDirectory, mode,
-	                        umask, context.uid(), context.gid(), copysgid, AclInheritance::kInheritAcl);
+	p = fsnodes_create_node(ts, static_cast<FSNodeDirectory *>(wd), name, FSNodeType::kDirectory,
+	                        mode, umask, context.uid(), context.gid(), copysgid,
+	                        AclInheritance::kInheritAcl);
 	*inode = p->id;
-	fsnodes_fill_attr(p, wd, context.uid(), context.gid(), context.auid(), context.agid(), context.sesflags(), attr);
-	fs_changelog(ts, "CREATE(%" PRIiNode ",%s,%c,%d,%" PRIu32 ",%" PRIu32 ",%" PRIu32 "):%" PRIiNode,
-	             wd->id, fsnodes_escape_name(name).c_str(), FSNode::kDirectory, p->mode & 07777,
-	             context.uid(), context.gid(), 0, p->id);
+	fsnodes_fill_attr(p, wd, context.uid(), context.gid(), context.auid(), context.agid(),
+	                  context.sesflags(), attr);
+	fs_changelog(
+	    ts, "CREATE(%" PRIiNode ",%s,%c,%d,%" PRIu32 ",%" PRIu32 ",%" PRIu32 "):%" PRIiNode, wd->id,
+	    fsnodes_escape_name(name).c_str(), static_cast<char>(FSNodeType::kDirectory),
+	    p->mode & 07777, context.uid(), context.gid(), 0, p->id);
 	++gFsStatsArray[FsStats::Mkdir];
 	metrics::Counter::increment(metrics::Counter::Master::FS_MKDIR);
 	return SAUNAFS_STATUS_OK;
 }
 #endif
 
-uint8_t fs_apply_create(uint32_t ts, inode_t parent, const HString &name,
-		uint8_t type, uint32_t mode, uint32_t uid, uint32_t gid, uint32_t rdev,
-		inode_t inode) {
+uint8_t fs_apply_create(uint32_t ts, inode_t parent, const HString &name, FSNodeType type,
+                        uint32_t mode, uint32_t uid, uint32_t gid, uint32_t rdev, inode_t inode) {
 	FSNode *wd, *p;
-	if (type != FSNode::kFile && type != FSNode::kSocket && type != FSNode::kFifo &&
-	    type != FSNode::kBlockDev && type != FSNode::kCharDev && type != FSNode::kDirectory) {
+	if (type != FSNodeType::kFile && type != FSNodeType::kSocket && type != FSNodeType::kFifo &&
+	    type != FSNodeType::kBlockDev && type != FSNodeType::kCharDev &&
+	    type != FSNodeType::kDirectory) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
 	wd = fsnodes_id_to_node(parent);
 	if (!wd) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
-	if (wd->type != FSNode::kDirectory) {
+	if (wd->type != FSNodeType::kDirectory) {
 		return SAUNAFS_ERROR_ENOTDIR;
 	}
 	if (fsnodes_nameisused(static_cast<FSNodeDirectory*>(wd), name)) {
@@ -1119,7 +1125,7 @@ uint8_t fs_apply_create(uint32_t ts, inode_t parent, const HString &name,
 	// we pass requested inode number here
 	p = fsnodes_create_node(ts, static_cast<FSNodeDirectory*>(wd), name, type, mode, 0, uid, gid, 0,
 	                        AclInheritance::kInheritAcl, inode);
-	if (type == FSNode::kBlockDev || type == FSNode::kCharDev) {
+	if (type == FSNodeType::kBlockDev || type == FSNodeType::kCharDev) {
 		static_cast<FSNodeDevice*>(p)->rdev = rdev;
 		fsnodes_update_checksum(p);
 	}
@@ -1158,7 +1164,7 @@ uint8_t fs_unlink(const FsContext &context, inode_t parent, const HString &name)
 	if (!fsnodes_sticky_access(wd, child, context.uid())) {
 		return SAUNAFS_ERROR_EPERM;
 	}
-	if (child->type == FSNode::kDirectory) {
+	if (child->type == FSNodeType::kDirectory) {
 		return SAUNAFS_ERROR_EPERM;
 	}
 	fs_changelog(ts, "UNLINK(%" PRIiNode ",%s):%" PRIiNode, wd->id,
@@ -1227,7 +1233,7 @@ uint8_t fs_rmdir(const FsContext &context, inode_t parent, const HString &name) 
 	if (!fsnodes_sticky_access(wd, child, context.uid())) {
 		return SAUNAFS_ERROR_EPERM;
 	}
-	if (child->type != FSNode::kDirectory) {
+	if (child->type != FSNodeType::kDirectory) {
 		return SAUNAFS_ERROR_ENOTDIR;
 	}
 	if (!static_cast<FSNodeDirectory*>(child)->entries.empty()) {
@@ -1249,7 +1255,7 @@ uint8_t fs_apply_unlink(uint32_t ts, inode_t parent, const HString &name,
 	if (!wd) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
-	if (wd->type != FSNode::kDirectory) {
+	if (wd->type != FSNodeType::kDirectory) {
 		return SAUNAFS_ERROR_ENOTDIR;
 	}
 	FSNode *child = fsnodes_lookup(static_cast<FSNodeDirectory*>(wd), name);
@@ -1259,7 +1265,8 @@ uint8_t fs_apply_unlink(uint32_t ts, inode_t parent, const HString &name,
 	if (child->id != inode) {
 		return SAUNAFS_ERROR_MISMATCH;
 	}
-	if (child->type == FSNode::kDirectory && !static_cast<FSNodeDirectory*>(child)->entries.empty()) {
+	if (child->type == FSNodeType::kDirectory &&
+	    !static_cast<FSNodeDirectory *>(child)->entries.empty()) {
 		return SAUNAFS_ERROR_ENOTEMPTY;
 	}
 	fsnodes_unlink(ts, static_cast<FSNodeDirectory*>(wd), name, child);
@@ -1303,13 +1310,13 @@ uint8_t fs_rename(const FsContext &context, inode_t parent_src, const HString &n
 		*inode = se_child->id;
 	}
 	std::array<int64_t, 2> quota_delta = {{1, 1}};
-	if (se_child->type == FSNode::kDirectory) {
+	if (se_child->type == FSNodeType::kDirectory) {
 		if (fsnodes_isancestor(static_cast<FSNodeDirectory*>(se_child), dwd)) {
 			return SAUNAFS_ERROR_EINVAL;
 		}
 		const statsrecord &stats = static_cast<FSNodeDirectory*>(se_child)->stats;
 		quota_delta = {{(int64_t)stats.inodes, (int64_t)stats.size}};
-	} else if (se_child->type == FSNode::kFile) {
+	} else if (se_child->type == FSNodeType::kFile) {
 		quota_delta[(int)QuotaResource::kSize] = fsnodes_get_size(se_child);
 	}
 	if (fsnodes_namecheck(name_dst) < 0) {
@@ -1322,18 +1329,19 @@ uint8_t fs_rename(const FsContext &context, inode_t parent_src, const HString &n
 	}
 
 	if (de_child) {
-		if (de_child->type == FSNode::kDirectory && !static_cast<FSNodeDirectory*>(de_child)->entries.empty()) {
+		if (de_child->type == FSNodeType::kDirectory &&
+		    !static_cast<FSNodeDirectory *>(de_child)->entries.empty()) {
 			return SAUNAFS_ERROR_ENOTEMPTY;
 		}
 		if (context.canCheckPermissions() &&
 		    !fsnodes_sticky_access(dwd, de_child, context.uid())) {
 			return SAUNAFS_ERROR_EPERM;
 		}
-		if (de_child->type == TYPE_DIRECTORY) {
+		if (de_child->type == FSNodeType::kDirectory) {
 			const statsrecord &stats = static_cast<FSNodeDirectory*>(de_child)->stats;
 			quota_delta[(int)QuotaResource::kInodes] -= stats.inodes;
 			quota_delta[(int)QuotaResource::kSize] -= stats.size;
-		} else if (de_child->type == TYPE_FILE) {
+		} else if (de_child->type == FSNodeType::kFile) {
 			quota_delta[(int)QuotaResource::kInodes] -= 1;
 			quota_delta[(int)QuotaResource::kSize] -= fsnodes_get_size(static_cast<FSNodeFile*>(de_child));
 		} else {
@@ -1390,7 +1398,7 @@ uint8_t fs_link(const FsContext &context, inode_t inode_src, inode_t parent_dst,
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	if (sp->type == FSNode::kTrash || sp->type == FSNode::kReserved) {
+	if (sp->type == FSNodeType::kTrash || sp->type == FSNodeType::kReserved) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
 	if (fsnodes_namecheck(name_dst) < 0) {
@@ -1872,7 +1880,8 @@ uint8_t fs_acquire(const FsContext &context, inode_t inode, uint32_t sessionid) 
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
-	if (p->type != FSNode::kFile && p->type != FSNode::kTrash && p->type != FSNode::kReserved) {
+	if (p->type != FSNodeType::kFile && p->type != FSNodeType::kTrash &&
+	    p->type != FSNodeType::kReserved) {
 		return SAUNAFS_ERROR_EPERM;
 	}
 	if (std::find(p->sessionid.begin(), p->sessionid.end(), sessionid) != p->sessionid.end()) {
@@ -1894,13 +1903,14 @@ uint8_t fs_release(const FsContext &context, inode_t inode, uint32_t sessionid) 
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
-	if (p->type != FSNode::kFile && p->type != FSNode::kTrash && p->type != FSNode::kReserved) {
+	if (p->type != FSNodeType::kFile && p->type != FSNodeType::kTrash &&
+	    p->type != FSNodeType::kReserved) {
 		return SAUNAFS_ERROR_EPERM;
 	}
 	auto it = std::find(p->sessionid.begin(), p->sessionid.end(), sessionid);
 	if (it != p->sessionid.end()) {
 		p->sessionid.erase(it);
-		if (p->type == FSNode::kReserved && p->sessionid.empty()) {
+		if (p->type == FSNodeType::kReserved && p->sessionid.empty()) {
 			fsnodes_purge(context.ts(), p);
 		} else {
 			fsnodes_update_checksum(p);
@@ -1969,7 +1979,8 @@ uint8_t fs_readchunk(inode_t inode, uint32_t indx, uint64_t *chunkid, uint64_t *
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
-	if (p->type != FSNode::kFile && p->type != FSNode::kTrash && p->type != FSNode::kReserved) {
+	if (p->type != FSNodeType::kFile && p->type != FSNodeType::kTrash &&
+	    p->type != FSNodeType::kReserved) {
 		return SAUNAFS_ERROR_EPERM;
 	}
 	if (indx > MAX_INDEX) {
@@ -2106,7 +2117,8 @@ uint8_t fs_writeend(inode_t inode, uint64_t length, uint64_t chunkid, uint32_t l
 		if (!p) {
 			return SAUNAFS_ERROR_ENOENT;
 		}
-		if (p->type != FSNode::kFile && p->type != FSNode::kTrash && p->type != FSNode::kReserved) {
+		if (p->type != FSNodeType::kFile && p->type != FSNodeType::kTrash &&
+		    p->type != FSNodeType::kReserved) {
 			return SAUNAFS_ERROR_EPERM;
 		}
 		if (length > p->length) {
@@ -2202,7 +2214,8 @@ uint8_t fs_apply_repair(uint32_t ts, inode_t inode, uint32_t indx, uint32_t nver
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
-	if (p->type != FSNode::kFile && p->type != FSNode::kTrash && p->type != FSNode::kReserved) {
+	if (p->type != FSNodeType::kFile && p->type != FSNodeType::kTrash &&
+	    p->type != FSNodeType::kReserved) {
 		return SAUNAFS_ERROR_EPERM;
 	}
 	if (indx > MAX_INDEX) {
@@ -2338,8 +2351,8 @@ uint8_t fs_setgoal(const FsContext &context, inode_t inode, uint8_t goal, uint8_
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	if (p->type != FSNode::kDirectory && p->type != FSNode::kFile &&
-	    p->type != FSNode::kTrash && p->type != FSNode::kReserved) {
+	if (p->type != FSNodeType::kDirectory && p->type != FSNodeType::kFile &&
+	    p->type != FSNodeType::kTrash && p->type != FSNodeType::kReserved) {
 		return SAUNAFS_ERROR_EPERM;
 	}
 	sassert(context.hasUidGidData());
@@ -2384,8 +2397,8 @@ uint8_t fs_apply_setgoal(const FsContext &context, inode_t inode, uint8_t goal, 
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	if (p->type != FSNode::kDirectory && p->type != FSNode::kFile &&
-	    p->type != FSNode::kTrash && p->type != FSNode::kReserved) {
+	if (p->type != FSNodeType::kDirectory && p->type != FSNodeType::kFile &&
+	    p->type != FSNodeType::kTrash && p->type != FSNodeType::kReserved) {
 		return SAUNAFS_ERROR_EPERM;
 	}
 	sassert(context.hasUidGidData());
@@ -2418,8 +2431,8 @@ uint8_t fs_settrashtime(const FsContext &context, inode_t inode, uint32_t trasht
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	if (p->type != FSNode::kDirectory && p->type != FSNode::kFile && p->type != FSNode::kTrash &&
-	    p->type != FSNode::kReserved) {
+	if (p->type != FSNodeType::kDirectory && p->type != FSNodeType::kFile &&
+	    p->type != FSNodeType::kTrash && p->type != FSNodeType::kReserved) {
 		return SAUNAFS_ERROR_EPERM;
 	}
 	sassert(context.hasUidGidData());
@@ -2455,8 +2468,8 @@ uint8_t fs_apply_settrashtime(const FsContext &context, inode_t inode, uint32_t 
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	if (p->type != FSNode::kDirectory && p->type != FSNode::kFile && p->type != FSNode::kTrash &&
-	    p->type != FSNode::kReserved) {
+	if (p->type != FSNodeType::kDirectory && p->type != FSNodeType::kFile &&
+	    p->type != FSNodeType::kTrash && p->type != FSNodeType::kReserved) {
 		return SAUNAFS_ERROR_EPERM;
 	}
 	sassert(context.hasUidGidData());
@@ -2768,7 +2781,7 @@ uint32_t fs_getdirpath_size(inode_t inode) {
 	FSNode *node;
 	node = fsnodes_id_to_node(inode);
 	if (node) {
-		if (node->type != FSNode::kDirectory) {
+		if (node->type != FSNodeType::kDirectory) {
 			return 15;  // "(not directory)"
 		} else {
 			FSNodeDirectory *parent = nullptr;
@@ -2788,7 +2801,7 @@ void fs_getdirpath_data(inode_t inode, uint8_t *buff, uint32_t size) {
 	FSNode *node;
 	node = fsnodes_id_to_node(inode);
 	if (node) {
-		if (node->type != FSNode::kDirectory) {
+		if (node->type != FSNodeType::kDirectory) {
 			if (size >= 15) {
 				memcpy(buff, "(not directory)", 15);
 				return;
@@ -2869,8 +2882,8 @@ uint8_t fs_get_chunkid(const FsContext &context, inode_t inode, uint32_t index,
 void fs_add_files_to_chunks() {
 	for (uint32_t i = 0; i < NODEHASHSIZE; i++) {
 		for (const auto &node : gMetadata->nodeHash[i]) {
-			if (node->type == FSNode::kFile || node->type == FSNode::kTrash ||
-			    node->type == FSNode::kReserved) {
+			if (node->type == FSNodeType::kFile || node->type == FSNodeType::kTrash ||
+			    node->type == FSNodeType::kReserved) {
 				for (const auto &chunkid : static_cast<FSNodeFile*>(node)->chunks) {
 					if (chunkid > 0) {
 						chunk_add_file(chunkid, node->goal);

--- a/src/master/filesystem_periodic.cc
+++ b/src/master/filesystem_periodic.cc
@@ -99,13 +99,13 @@ static std::string get_node_info(FSNode *node) {
 	if (node == nullptr) {
 		return name;
 	}
-	if (node->type == FSNode::kTrash) {
+	if (node->type == FSNodeType::kTrash) {
 		name = "file in trash " + std::to_string(node->id) + ": " +
 		       (std::string)gMetadata->trash.at(TrashPathKey(node));
-	} else if (node->type == FSNode::kReserved) {
+	} else if (node->type == FSNodeType::kReserved) {
 		name = "reserved file " + std::to_string(node->id) + ": " +
 		       (std::string)gMetadata->reserved.at(node->id);
-	} else if (node->type == FSNode::kFile) {
+	} else if (node->type == FSNodeType::kFile) {
 		name = "file " + std::to_string(node->id) + ": ";
 		bool first = true;
 		for (const auto &[parentId, _] : node->parent) {
@@ -120,7 +120,7 @@ static std::string get_node_info(FSNode *node) {
 			}
 			first = false;
 		}
-	} else if (node->type == FSNode::kDirectory) {
+	} else if (node->type == FSNodeType::kDirectory) {
 		name = "directory " + std::to_string(node->id) + ": ";
 		std::string path;
 		FSNodeDirectory *parent = nullptr;
@@ -177,8 +177,8 @@ void fs_test_getdata(uint32_t &loopstart, uint32_t &loopend, inode_t &files, ino
 			continue;
 		}
 
-		if (node->type == FSNode::kFile || node->type == FSNode::kTrash ||
-		    node->type == FSNode::kReserved) {
+		if (node->type == FSNodeType::kFile || node->type == FSNodeType::kTrash ||
+		    node->type == FSNodeType::kReserved) {
 			FSNodeFile *file_node = static_cast<FSNodeFile *>(node);
 			for (std::size_t j = 0; j < file_node->chunks.size(); ++j) {
 				auto chunkid = file_node->chunks[j];
@@ -206,12 +206,12 @@ void fs_test_getdata(uint32_t &loopstart, uint32_t &loopend, inode_t &files, ino
 		}
 
 		if (entry.second & kChunkUnavailable) {
-			assert(node->type == FSNode::kFile || node->type == FSNode::kTrash ||
-			       node->type == FSNode::kReserved);
+			assert(node->type == FSNodeType::kFile || node->type == FSNodeType::kTrash ||
+			       node->type == FSNodeType::kReserved);
 			std::string name = get_node_info(node);
-			if (node->type == FSNode::kTrash) {
+			if (node->type == FSNodeType::kTrash) {
 				report << "-";
-			} else if (node->type == FSNode::kReserved) {
+			} else if (node->type == FSNodeType::kReserved) {
 				report << "+";
 			} else {
 				report << "*";
@@ -390,8 +390,8 @@ void fs_process_file_test() {
 		for (const auto &node : gMetadata->nodeHash[gFileTestLoopIndex]) {
 			node_error_flag = 0;
 
-			if (node->type == FSNode::kFile || node->type == FSNode::kTrash ||
-			    node->type == FSNode::kReserved) {
+			if (node->type == FSNodeType::kFile || node->type == FSNodeType::kTrash ||
+			    node->type == FSNodeType::kReserved) {
 				for (const auto &chunkid : static_cast<FSNodeFile *>(node)->chunks) {
 					if (chunkid == 0) {
 						continue;
@@ -421,7 +421,7 @@ void fs_process_file_test() {
 				}
 			}
 
-			if (node->type == FSNode::kDirectory) {
+			if (node->type == FSNodeType::kDirectory) {
 				for (const auto &entry :
 				     static_cast<FSNodeDirectory *>(node)->entries) {
 					FSNode *childNode = entry.second;
@@ -454,9 +454,9 @@ void fs_process_file_test() {
 			}
 
 			if (node_error_flag & kChunkUnavailable) {
-				if (node->type == FSNode::kTrash) {
+				if (node->type == FSNodeType::kTrash) {
 					unavailtrashfiles++;
-				} else if (node->type == FSNode::kReserved) {
+				} else if (node->type == FSNodeType::kReserved) {
 					unavailreservedfiles++;
 				} else {
 					unavailfiles += node->parent.size();
@@ -547,7 +547,7 @@ static void fs_do_emptytrash(uint32_t ts) {
 			continue;
 		}
 
-		assert(node->type == FSNode::kTrash);
+		assert(node->type == FSNodeType::kTrash);
 
 		auto node_id = node->id;
 		fsnodes_purge(ts, node);
@@ -582,7 +582,7 @@ static void fs_do_emptyreserved(uint32_t ts) {
 			continue;
 		}
 
-		assert(node->type == FSNode::kReserved);
+		assert(node->type == FSNodeType::kReserved);
 
 		auto node_id = node->id;
 		fsnodes_purge(ts, node);

--- a/src/master/filesystem_quota.cc
+++ b/src/master/filesystem_quota.cc
@@ -81,7 +81,7 @@ uint8_t fs_quota_get_all(const FsContext &context, std::vector<QuotaEntry> &resu
 		}
 
 		FSNodeDirectory *node = fsnodes_id_to_node<FSNodeDirectory>(entry.entryKey.owner.ownerId);
-		if (!node || node->type != FSNode::kDirectory) {
+		if (!node || node->type != FSNodeType::kDirectory) {
 			continue;
 		}
 
@@ -119,7 +119,7 @@ uint8_t fs_quota_get(const FsContext &context,
 				break;
 			case QuotaOwnerType::kInode:
 				node = fsnodes_id_to_node<FSNodeDirectory>(owner.ownerId);
-				if (!node || node->type != FSNode::kDirectory) {
+				if (!node || node->type != FSNodeType::kDirectory) {
 					return SAUNAFS_ERROR_EINVAL;
 				}
 				if (node->uid != context.uid() || (node->gid != context.gid() && !(context.sesflags() & SESFLAG_IGNOREGID))) {
@@ -339,7 +339,7 @@ static FSNode *fsnodes_find_common_ancestor(FSNodeDirectory *a, FSNodeDirectory 
 
 static bool fsnodes_test_dir_quota_noparents(FSNode *node,
 		const std::initializer_list<std::pair<QuotaResource, int64_t>> &resource_list) {
-	if (!node || node->type != FSNode::kDirectory) {
+	if (!node || node->type != FSNodeType::kDirectory) {
 		return false;
 	}
 
@@ -400,7 +400,7 @@ bool fsnodes_quota_exceeded_dir(FSNode *node,
 		return true;
 	}
 
-	if (node->type == FSNode::kDirectory) {
+	if (node->type == FSNodeType::kDirectory) {
 		// Directory can have only one parent, so we get rid of recursion.
 		while(!node->parent.empty()) {
 			FSNodeDirectory *parent =

--- a/src/master/filesystem_snapshot.cc
+++ b/src/master/filesystem_snapshot.cc
@@ -54,7 +54,7 @@ uint8_t fs_snapshot(const FsContext &context, inode_t inode_src, inode_t parent_
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	if (src_node->type == FSNode::kDirectory) {
+	if (src_node->type == FSNodeType::kDirectory) {
 		if (src_node == dst_parent_node ||
 		    fsnodes_isancestor(static_cast<FSNodeDirectory *>(src_node), dst_parent_node)) {
 			return SAUNAFS_ERROR_EINVAL;

--- a/src/master/filesystem_store_acl.cc
+++ b/src/master/filesystem_store_acl.cc
@@ -115,14 +115,14 @@ static int fs_load_posix_acl(const std::shared_ptr<MemoryMappedFile> &metadataFi
 		if (node_acl != nullptr) {
 			RichACL new_acl = *node_acl;
 			if (default_acl) {
-				if (p->type != FSNode::kDirectory) {
+				if (p->type != FSNodeType::kDirectory) {
 					throw Exception(
 						"Trying to set default acl for non-directory inode: " +
 						std::to_string(inode));
 				}
 				new_acl.appendDefaultPosixACL(posix_acl);
 			} else {
-				new_acl.appendPosixACL(posix_acl, p->type == FSNode::kDirectory);
+				new_acl.appendPosixACL(posix_acl, p->type == FSNodeType::kDirectory);
 				p->mode = (p->mode & ~0777) | (new_acl.getMode() & 0777);
 			}
 			gMetadata->aclStorage.set(p->id, std::move(new_acl));
@@ -184,10 +184,10 @@ static int fs_load_legacy_acl(const std::shared_ptr<MemoryMappedFile> &metadataF
 		RichACL new_acl;
 		if (extended_acl) {
 			auto posix_acl = AccessControlList{*extended_acl};
-			new_acl.appendPosixACL(posix_acl, p->type == FSNode::kDirectory);
+			new_acl.appendPosixACL(posix_acl, p->type == FSNodeType::kDirectory);
 			p->mode = (p->mode & ~0777) | (new_acl.getMode() & 0777);
 		}
-		if (default_acl && p->type == FSNode::kDirectory) {
+		if (default_acl && p->type == FSNodeType::kDirectory) {
 			auto posix_acl = AccessControlList{*default_acl};
 			new_acl.appendDefaultPosixACL(posix_acl);
 		}

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -74,6 +74,7 @@
 #include "master/exports.h"
 #include "master/filesystem.h"
 #include "master/filesystem_node.h"
+#include "master/filesystem_node_types.h"
 #include "master/filesystem_operations.h"
 #include "master/filesystem_periodic.h"
 #include "master/filesystem_snapshot.h"
@@ -2476,7 +2477,7 @@ void matoclserv_sau_get_self_quota(matoclserventry *eptr, const uint8_t *data, u
 
 	auto foundContextRootInodeResult = [&](inode_t rootInode) {
 		for (const auto &result : results) {
-			if (result.entryKey.owner.ownerType == QuotaOwnerType::kInode && 
+			if (result.entryKey.owner.ownerType == QuotaOwnerType::kInode &&
 				result.entryKey.owner.ownerId == rootInode) {
 				return true;
 			}
@@ -2958,8 +2959,8 @@ void matoclserv_fuse_mknod(matoclserventry *eptr, PacketHeader header, const uin
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
 
-		status = fs_mknod(context, inode, HString(std::move(name)), type, mode, umask, rdev,
-		                  &newinode, attr);
+		status = fs_mknod(context, inode, HString(std::move(name)), static_cast<FSNodeType>(type),
+		                  mode, umask, rdev, &newinode, attr);
 	}
 
 	MessageBuffer reply;
@@ -6059,7 +6060,7 @@ void matoclserv_gotpacket(matoclserventry *eptr, uint32_t type, const uint8_t *d
 					break;
 				case SAU_CLTOMA_FUSE_GET_SELF_QUOTA:
 					matoclserv_sau_get_self_quota(eptr, data, length);
-					break;	
+					break;
 				case SAU_CLTOMA_CSERV_LIST:
 					matoclserv_sau_cserv_list(eptr, data, length);
 					break;

--- a/src/master/metadata_backend_file.cc
+++ b/src/master/metadata_backend_file.cc
@@ -22,10 +22,11 @@
 
 #include "master/metadata_backend_file.h"
 
-#include <fcntl.h> // for open and O_RDONLY
+#include <fcntl.h>  // for open and O_RDONLY
+#include <sys/mman.h>
+#include <sys/stat.h>
 #include <cstdint>
 #include <memory>
-#include <sys/mman.h>
 
 #include <common/cwrap.h>
 #include <common/event_loop.h>
@@ -38,6 +39,7 @@
 #include <master/filesystem.h>
 #include <master/filesystem_metadata.h>
 #include <master/filesystem_node.h>
+#include <master/filesystem_node_types.h>
 #include <master/filesystem_operations.h>
 #include <master/filesystem_quota.h>
 #include <master/filesystem_store_acl.h>
@@ -413,21 +415,18 @@ static int8_t fs_parseEdge(const std::shared_ptr<MemoryMappedFile> &metadataFile
 		return kError;
 	}
 	if (!parentId) {
-		if (child->type == FSNode::kTrash) {
+		if (child->type == FSNodeType::kTrash) {
 			gMetadata->trash.insert(
 			    {TrashPathKey(child), hstorage::Handle(name)});
 			gMetadata->trashSpace += static_cast<FSNodeFile *>(child)->length;
 			gMetadata->trashNodes++;
-		} else if (child->type == FSNode::kReserved) {
+		} else if (child->type == FSNodeType::kReserved) {
 			gMetadata->reserved.insert({child->id, hstorage::Handle(name)});
 			gMetadata->reservedSpace += static_cast<FSNodeFile *>(child)->length;
 			gMetadata->reservedNodes++;
 		} else {
-			safs_pretty_syslog(LOG_ERR,
-			                   "loading edge: %" PRIiNode ",%s->%" PRIiNode
-			                   " error: bad child type (%c)\n",
-			                   parentId, fsnodes_escape_name(name).c_str(),
-			                   childId, child->type);
+			safs::log_err("loading edge: {}, {}->{} error: bad child type ({})", parentId,
+			              fsnodes_escape_name(name), childId, static_cast<char>(child->type));
 			return kError;
 		}
 	} else {
@@ -441,7 +440,7 @@ static int8_t fs_parseEdge(const std::shared_ptr<MemoryMappedFile> &metadataFile
 			if (ignoreFlag) {
 				parent =
 				    fsnodes_id_to_node<FSNodeDirectory>(SPECIAL_INODE_ROOT);
-				if (!parent || parent->type != FSNode::kDirectory) {
+				if (!parent || parent->type != FSNodeType::kDirectory) {
 					safs_pretty_syslog(
 					    LOG_ERR,
 					    "loading edge: %" PRIiNode ",%s->%" PRIiNode
@@ -463,16 +462,13 @@ static int8_t fs_parseEdge(const std::shared_ptr<MemoryMappedFile> &metadataFile
 				return kError;
 			}
 		}
-		if (parent->type != FSNode::kDirectory) {
-			safs_pretty_syslog(LOG_ERR,
-			                   "loading edge: %" PRIiNode ",%s->%" PRIiNode
-			                   " error: bad parent type (%c)",
-			                   parentId, fsnodes_escape_name(name).c_str(),
-			                   childId, parent->type);
+		if (parent->type != FSNodeType::kDirectory) {
+			safs::log_err("loading edge: {}, {}->{} error: bad parent type ({})", parentId,
+			              fsnodes_escape_name(name), childId, static_cast<char>(parent->type));
 			if (ignoreFlag) {
 				parent =
 				    fsnodes_id_to_node<FSNodeDirectory>(SPECIAL_INODE_ROOT);
-				if (!parent || parent->type != FSNode::kDirectory) {
+				if (!parent || parent->type != FSNodeType::kDirectory) {
 					safs_pretty_syslog(
 					    LOG_ERR,
 					    "loading edge: %" PRIiNode ",%s->%" PRIiNode
@@ -520,7 +516,7 @@ static int8_t fs_parseEdge(const std::shared_ptr<MemoryMappedFile> &metadataFile
 		}
 
 		child->parent.push_back({parent->id, handlePtr});
-		if (child->type == FSNode::kDirectory) {
+		if (child->type == FSNodeType::kDirectory) {
 			parent->nlink++;
 		}
 
@@ -542,16 +538,17 @@ static int8_t fs_parseNode(const std::shared_ptr<MemoryMappedFile> &metadataFile
 	static const int8_t kError = -1;
 	static const int8_t kSuccess = 0;
 	static const int8_t kLastNode = 1;
-	uint8_t type;
-	FSNode *node;
+
 	const uint8_t *pSrc = metadataFile->seek(sectionOffset);
-	type = get8bit(&pSrc);
-	if (!type) {
+	uint8_t typeU8 = get8bit(&pSrc);
+
+	if (!typeU8) {
 		sectionOffset = metadataFile->offset(pSrc);
 		return kLastNode;
 	}
 
-	node = FSNode::create(type);
+	auto type = static_cast<FSNodeType>(typeU8);
+	FSNode *node = FSNode::create(type);
 	passert(node);
 	getINode(&pSrc, node->id);
 	node->goal = get8bit(&pSrc);
@@ -573,19 +570,19 @@ static int8_t fs_parseNode(const std::shared_ptr<MemoryMappedFile> &metadataFile
 	constexpr uint32_t kChunkSize = (1 << 16);
 
 	switch (type) {
-	case FSNode::kDirectory:
+	case FSNodeType::kDirectory:
 		gMetadata->dirNodes++;
 		break;
-	case FSNode::kSocket:
-	case FSNode::kFifo:  /// No extra info to Parse
+	case FSNodeType::kSocket:
+	case FSNodeType::kFifo:  /// No extra info to Parse
 		break;
-	case FSNode::kBlockDev:
-	case FSNode::kCharDev:
+	case FSNodeType::kBlockDev:
+	case FSNodeType::kCharDev:
 		uint32_t tempRDev;
 		get32bit(&pSrc, tempRDev);
 		static_cast<FSNodeDevice *>(node)->rdev = tempRDev;
 		break;
-	case FSNode::kSymlink:
+	case FSNodeType::kSymlink:
 		get32bit(&pSrc, nodeNameLength);
 		static_cast<FSNodeSymlink *>(node)->path_length = nodeNameLength;
 		if (nodeNameLength > 0) {
@@ -594,9 +591,9 @@ static int8_t fs_parseNode(const std::shared_ptr<MemoryMappedFile> &metadataFile
 		}
 		gMetadata->linkNodes++;
 		break;
-	case FSNode::kFile:
-	case FSNode::kTrash:
-	case FSNode::kReserved:
+	case FSNodeType::kFile:
+	case FSNodeType::kTrash:
+	case FSNodeType::kReserved:
 		nodeFile->length = get64bit(&pSrc);
 		get32bit(&pSrc, chunkAmount);
 		sessionIds = get16bit(&pSrc);
@@ -627,8 +624,7 @@ static int8_t fs_parseNode(const std::shared_ptr<MemoryMappedFile> &metadataFile
 		gMetadata->fileNodes++;
 		break;
 	default:
-		safs_pretty_syslog(LOG_ERR, "loading node: unrecognized node type: %c",
-		                   type);
+		safs::log_err("loading node: unrecognized node type: {}", static_cast<char>(type));
 		fsnodes_quota_update(node, {{QuotaResource::kInodes, +1}});
 		sectionOffset = metadataFile->offset(pSrc);
 		return kError;
@@ -669,7 +665,7 @@ int fs_checknodes(int ignoreflag) {
 	for (auto i = 0; i < NODEHASHSIZE; i++) {
 		for (const auto &node : gMetadata->nodeHash[i]) {
 			if (node->parent.empty() && node != gMetadata->root &&
-			    (node->type != FSNode::kTrash) && (node->type != FSNode::kReserved)) {
+			    (node->type != FSNodeType::kTrash) && (node->type != FSNodeType::kReserved)) {
 				safs::log_err("found orphaned inode: %" PRIiNode, node->id);
 				if (ignoreflag) {
 					if (fs_lostnode(node) < 0) {
@@ -886,7 +882,7 @@ static int fs_load(const std::shared_ptr<MemoryMappedFile> &metadataFile, int ig
 		                   "error reading metadata (root node not found)");
 		return kOpFailure;
 	}
-	if (gMetadata->root->type != FSNode::kDirectory) {
+	if (gMetadata->root->type != FSNodeType::kDirectory) {
 		safs_pretty_syslog(
 		    LOG_ERR, "error reading metadata (root node not a directory)");
 		return kOpFailure;
@@ -904,7 +900,7 @@ void fs_new(void) {
 	gMetadata->metadataVersion = 1;
 	gMetadata->nextSessionId = 1;
 
-	auto *rootDirectory = FSNode::create(FSNode::kDirectory);
+	auto *rootDirectory = FSNode::create(FSNodeType::kDirectory);
 	gMetadata->root = static_cast<FSNodeDirectory *>(rootDirectory);
 	gMetadata->root->id = SPECIAL_INODE_ROOT;
 	gMetadata->root->atime = eventloop_time();
@@ -1016,8 +1012,9 @@ void MetadataBackendFile::storenode(FSNode *f, FILE *fd) {
 		fputc(0, fd);
 		return;
 	}
+
 	ptr = gNodeStoreBuffer;
-	put8bit(&ptr, f->type);
+	put8bit(&ptr, static_cast<uint8_t>(f->type));
 	putINode(&ptr, f->id);
 	put8bit(&ptr, f->goal);
 	put16bit(&ptr, f->mode);
@@ -1031,17 +1028,17 @@ void MetadataBackendFile::storenode(FSNode *f, FILE *fd) {
 	auto *node_file = static_cast<FSNodeFile *>(f);
 
 	switch (f->type) {
-	case FSNode::kDirectory:
-	case FSNode::kSocket:
-	case FSNode::kFifo:
+	case FSNodeType::kDirectory:
+	case FSNodeType::kSocket:
+	case FSNodeType::kFifo:
 		if (fwrite(gNodeStoreBuffer, 1, kNodeHeaderSize, fd) !=
 		    (size_t)(kNodeHeaderSize)) {
 			safs_pretty_syslog(LOG_NOTICE, "fwrite error");
 			return;
 		}
 		break;
-	case FSNode::kBlockDev:
-	case FSNode::kCharDev:
+	case FSNodeType::kBlockDev:
+	case FSNodeType::kCharDev:
 		put32bit(&ptr, static_cast<FSNodeDevice *>(f)->rdev);
 		if (fwrite(gNodeStoreBuffer, 1, kNodeHeaderSize + 4, fd) !=
 		    (size_t)(kNodeHeaderSize + 4)) {
@@ -1049,7 +1046,7 @@ void MetadataBackendFile::storenode(FSNode *f, FILE *fd) {
 			return;
 		}
 		break;
-	case FSNode::kSymlink:
+	case FSNodeType::kSymlink:
 		name = (std::string) static_cast<FSNodeSymlink *>(f)->path;
 		// Safe cast, the length should always fit
 		put32bit(&ptr, static_cast<uint32_t>(name.length()));
@@ -1064,9 +1061,9 @@ void MetadataBackendFile::storenode(FSNode *f, FILE *fd) {
 			return;
 		}
 		break;
-	case FSNode::kFile:
-	case FSNode::kTrash:
-	case FSNode::kReserved:
+	case FSNodeType::kFile:
+	case FSNodeType::kTrash:
+	case FSNodeType::kReserved:
 		put64bit(&ptr, node_file->length);
 		ch = node_file->chunkCount();
 		put32bit(&ptr, ch);
@@ -1116,6 +1113,11 @@ void MetadataBackendFile::storenode(FSNode *f, FILE *fd) {
 			safs_pretty_syslog(LOG_NOTICE, "fwrite error");
 			return;
 		}
+		break;
+	default:
+		safs::log_err("MetadataBackendFile::storenode: unexpected node type {}",
+		              static_cast<char>(f->type));
+		break;
 	}
 }
 
@@ -1177,7 +1179,7 @@ void MetadataBackendFile::storeedgelist(const ReservedPathContainer &data, FILE 
 void MetadataBackendFile::storeedges_rec(FSNodeDirectory *f, FILE *fd) {
 	storeedgelist(f, fd);
 	for (const auto &entry : f->entries) {
-		if (entry.second->type == FSNode::kDirectory) {
+		if (entry.second->type == FSNodeType::kDirectory) {
 			storeedges_rec(static_cast<FSNodeDirectory *>(entry.second), fd);
 		}
 	}

--- a/src/master/recursive_remove_task.cc
+++ b/src/master/recursive_remove_task.cc
@@ -60,9 +60,8 @@ int RemoveTask::execute(uint32_t ts, intrusive_list<Task> &work_queue) {
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	if (child->type == FSNode::kDirectory &&
-	    !static_cast<FSNodeDirectory*>(child)->entries.empty()) {
-
+	if (child->type == FSNodeType::kDirectory &&
+	    !static_cast<FSNodeDirectory *>(child)->entries.empty()) {
 		SubtaskContainer subtasks;
 		subtasks.reserve(
 			  static_cast<const FSNodeDirectory*>(child)->entries.size());
@@ -70,16 +69,14 @@ int RemoveTask::execute(uint32_t ts, intrusive_list<Task> &work_queue) {
 				static_cast<FSNodeDirectory*>(child)->entries) {
 			subtasks.push_back(static_cast<HString>(*entry.first));
 		}
-		auto task = new RemoveTask(std::move(subtasks),
-					    child->id, context_);
+		auto *task = new RemoveTask(std::move(subtasks), child->id, context_);
 		work_queue.push_front(*task);
 		if (++repeat_counter_ >= kMaxRepeatCounter) {
 			// something keeps adding files to a folder which is being deleted
 			return SAUNAFS_ERROR_ENOTEMPTY;
 		}
 	} else {
-		++gFsStatsArray[child->type == FSNode::kDirectory ?
-		                FsStats::Rmdir : FsStats::Unlink];
+		++gFsStatsArray[child->type == FSNodeType::kDirectory ? FsStats::Rmdir : FsStats::Unlink];
 		doUnlink(ts, wd, child);
 		++current_subtask_;
 		repeat_counter_ = 0;

--- a/src/master/restore.cc
+++ b/src/master/restore.cc
@@ -30,6 +30,7 @@
 #include "common/type_defs.h"
 #include "errors/saunafs_error_codes.h"
 #include "master/filesystem.h"
+#include "master/filesystem_node_types.h"
 #include "master/filesystem_operations.h"
 #include "master/filesystem_snapshot.h"
 #include "protocol/SFSCommunication.h"
@@ -284,7 +285,8 @@ int do_create(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
 	EAT(ptr,filename,lv,')');
 	EAT(ptr,filename,lv,':');
 	GETINODE(inode,ptr);
-	return fs_apply_create(ts, parent, HString((const char*)name), type, mode, uid, gid, rdev, inode);
+	return fs_apply_create(ts, parent, HString((const char *)name), static_cast<FSNodeType>(type),
+	                       mode, uid, gid, rdev, inode);
 }
 
 int do_session(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {

--- a/src/master/setgoal_task.cc
+++ b/src/master/setgoal_task.cc
@@ -39,7 +39,7 @@ int SetGoalTask::execute(uint32_t ts, intrusive_list<Task> &work_queue) {
 	uint8_t result = setGoal(node, ts);
 
 	if (result != kNoAction) {
-		if (node->type == FSNode::kDirectory && (smode_ & SMODE_RMASK) &&
+		if (node->type == FSNodeType::kDirectory && (smode_ & SMODE_RMASK) &&
 		    !static_cast<const FSNodeDirectory *>(node)->entries.empty()) {
 			std::vector<inode_t> inode_list;
 			inode_list.reserve(static_cast<const FSNodeDirectory *>(node)->entries.size());
@@ -68,13 +68,13 @@ bool SetGoalTask::isFinished() const {
 }
 
 uint8_t SetGoalTask::setGoal(FSNode *node, uint32_t ts) {
-	if (node->type == FSNode::kFile || node->type == FSNode::kDirectory ||
-	    node->type == FSNode::kTrash || node->type == FSNode::kReserved) {
+	if (node->type == FSNodeType::kFile || node->type == FSNodeType::kDirectory ||
+	    node->type == FSNodeType::kTrash || node->type == FSNodeType::kReserved) {
 		if ((node->mode & (EATTR_NOOWNER << 12)) == 0 && uid_ != 0 && node->uid != uid_) {
 			return SetGoalTask::kNotPermitted;
 		} else {
 			if ((smode_ & SMODE_TMASK) == SMODE_SET && node->goal != goal_) {
-				if (node->type != FSNode::kDirectory) {
+				if (node->type != FSNodeType::kDirectory) {
 					fsnodes_changefilegoal(static_cast<FSNodeFile *>(node), goal_);
 				} else {
 					node->goal = goal_;

--- a/src/master/settrashtime_task.cc
+++ b/src/master/settrashtime_task.cc
@@ -39,7 +39,7 @@ int SetTrashtimeTask::execute(uint32_t ts, intrusive_list<Task> &work_queue) {
 	uint8_t result = setTrashtime(node, ts);
 
 	if (result != kNoAction) {
-		if (node->type == FSNode::kDirectory && (smode_ & SMODE_RMASK) &&
+		if (node->type == FSNodeType::kDirectory && (smode_ & SMODE_RMASK) &&
 		    !static_cast<const FSNodeDirectory *>(node)->entries.empty()) {
 			std::vector<inode_t> inode_list;
 			inode_list.reserve(static_cast<const FSNodeDirectory *>(node)->entries.size());
@@ -71,8 +71,8 @@ bool SetTrashtimeTask::isFinished() const {
 uint8_t SetTrashtimeTask::setTrashtime(FSNode *node, uint32_t ts) {
 	uint8_t set;
 
-	if (node->type == FSNode::kFile || node->type == FSNode::kDirectory ||
-	    node->type == FSNode::kTrash || node->type == FSNode::kReserved) {
+	if (node->type == FSNodeType::kFile || node->type == FSNodeType::kDirectory ||
+	    node->type == FSNodeType::kTrash || node->type == FSNodeType::kReserved) {
 		if ((node->mode & (EATTR_NOOWNER << 12)) == 0 && uid_ != 0 && node->uid != uid_) {
 			return SetTrashtimeTask::kNotPermitted;
 		} else {
@@ -100,7 +100,7 @@ uint8_t SetTrashtimeTask::setTrashtime(FSNode *node, uint32_t ts) {
 			}
 			if (set) {
 				node->ctime = ts;
-				if (node->type == FSNode::kTrash) {
+				if (node->type == FSNodeType::kTrash) {
 					hstorage::Handle path =
 					        std::move(gMetadata->trash.at(old_trash_key));
 					gMetadata->trash.erase(old_trash_key);

--- a/src/master/snapshot_task.cc
+++ b/src/master/snapshot_task.cc
@@ -33,7 +33,7 @@ int SnapshotTask::cloneNodeTest(FSNode *src_node, FSNode *dst_node, FSNodeDirect
 	    fsnodes_quota_exceeded_dir(dst_parent, {{QuotaResource::kInodes, 1}})) {
 		return SAUNAFS_ERROR_QUOTA;
 	}
-	if (src_node->type == FSNode::kFile &&
+	if (src_node->type == FSNodeType::kFile &&
 	    (fsnodes_quota_exceeded_ug(src_node, {{QuotaResource::kSize, 1}}) ||
 	     fsnodes_quota_exceeded_dir(dst_parent, {{QuotaResource::kSize, 1}}))) {
 		return SAUNAFS_ERROR_QUOTA;
@@ -45,7 +45,7 @@ int SnapshotTask::cloneNodeTest(FSNode *src_node, FSNode *dst_node, FSNodeDirect
 		if (dst_node->type != src_node->type) {
 			return SAUNAFS_ERROR_EPERM;
 		}
-		if (src_node->type != FSNode::kDirectory && !can_overwrite_) {
+		if (src_node->type != FSNodeType::kDirectory && !can_overwrite_) {
 			return SAUNAFS_ERROR_EEXIST;
 		}
 	}
@@ -57,22 +57,25 @@ FSNode *SnapshotTask::cloneToExistingNode(uint32_t ts, FSNode *src_node,
 	assert(src_node->type == dst_node->type);
 
 	switch (src_node->type) {
-	case FSNode::kDirectory:
+	case FSNodeType::kDirectory:
 		cloneDirectoryData(static_cast<const FSNodeDirectory *>(src_node),
 		                   static_cast<FSNodeDirectory *>(dst_node));
 		break;
-	case FSNode::kFile:
+	case FSNodeType::kFile:
 		dst_node = cloneToExistingFileNode(ts, static_cast<FSNodeFile *>(src_node),
 		                                   dst_parent, static_cast<FSNodeFile *>(dst_node));
 		break;
-	case FSNode::kSymlink:
+	case FSNodeType::kSymlink:
 		cloneSymlinkData(static_cast<FSNodeSymlink *>(src_node),
 		                 static_cast<FSNodeSymlink *>(dst_node), dst_parent);
 		break;
-	case FSNode::kBlockDev:
-	case FSNode::kCharDev:
-		static_cast<FSNodeDevice *>(dst_node)->rdev =
-		        static_cast<FSNodeDevice *>(src_node)->rdev;
+	case FSNodeType::kBlockDev:
+	case FSNodeType::kCharDev:
+		static_cast<FSNodeDevice *>(dst_node)->rdev = static_cast<FSNodeDevice *>(src_node)->rdev;
+		break;
+	default:
+		// No additional data to clone for these types
+		break;
 	}
 
 	dst_node->mode = src_node->mode;
@@ -97,22 +100,25 @@ FSNode *SnapshotTask::cloneToNewNode(uint32_t ts, FSNode *src_node, FSNodeDirect
 	dst_node->mtime = src_node->mtime;
 
 	switch (src_node->type) {
-	case FSNode::kDirectory:
+	case FSNodeType::kDirectory:
 		cloneDirectoryData(static_cast<const FSNodeDirectory *>(src_node),
 		                   static_cast<FSNodeDirectory *>(dst_node));
 		break;
-	case FSNode::kFile:
+	case FSNodeType::kFile:
 		cloneChunkData(static_cast<FSNodeFile *>(src_node),
 		               static_cast<FSNodeFile *>(dst_node), dst_parent);
 		break;
-	case FSNode::kSymlink:
+	case FSNodeType::kSymlink:
 		cloneSymlinkData(static_cast<FSNodeSymlink *>(src_node),
 		                 static_cast<FSNodeSymlink *>(dst_node), dst_parent);
 		break;
-	case FSNode::kBlockDev:
-	case FSNode::kCharDev:
-		static_cast<FSNodeDevice *>(dst_node)->rdev =
-		        static_cast<FSNodeDevice *>(src_node)->rdev;
+	case FSNodeType::kBlockDev:
+	case FSNodeType::kCharDev:
+		static_cast<FSNodeDevice *>(dst_node)->rdev = static_cast<FSNodeDevice *>(src_node)->rdev;
+		break;
+	default:
+		// No additional data to clone for these types
+		break;
 	}
 
 	return dst_node;
@@ -128,7 +134,7 @@ FSNodeFile *SnapshotTask::cloneToExistingFileNode(uint32_t ts, FSNodeFile *src_n
 
 	fsnodes_unlink(ts, dst_parent, current_subtask_->second, dst_node);
 	dst_node = static_cast<FSNodeFile *>(fsnodes_create_node(
-	        ts, dst_parent, current_subtask_->second, FSNode::kFile, src_node->mode, 0,
+	        ts, dst_parent, current_subtask_->second, FSNodeType::kFile, src_node->mode, 0,
 	        src_node->uid, src_node->gid, 0, AclInheritance::kDontInheritAcl, dst_inode_));
 
 	cloneChunkData(src_node, dst_node, dst_parent);
@@ -210,10 +216,11 @@ int SnapshotTask::cloneNode(uint32_t ts) {
 	FSNode *src_node = fsnodes_id_to_node(current_subtask_->first);
 	FSNodeDirectory *dst_parent = fsnodes_id_to_node<FSNodeDirectory>(dst_parent_inode_);
 
-	if (!src_node || src_node->type == FSNode::kTrash || src_node->type == FSNode::kReserved) {
+	if (!src_node || src_node->type == FSNodeType::kTrash ||
+	    src_node->type == FSNodeType::kReserved) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
-	if (!dst_parent || dst_parent->type != FSNode::kDirectory) {
+	if (!dst_parent || dst_parent->type != FSNodeType::kDirectory) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
 


### PR DESCRIPTION
The enums inherit now from std::uint8_t to use only one byte instead of four bytes. All enums are now enum class, which improves the type safety at compile time.