### PR TITLE
fix(mount): Redirect info messages to stdout

### DIFF
--- a/src/mount/fuse/sfs_meta_fuse.cc
+++ b/src/mount/fuse/sfs_meta_fuse.cc
@@ -860,6 +860,7 @@ void sfs_meta_init(int debug_mode_in,double entry_cache_timeout_in,double attr_c
 	entry_cache_timeout = entry_cache_timeout_in;
 	attr_cache_timeout = attr_cache_timeout_in;
 	if (debug_mode) {
-		fprintf(stderr,"cache parameters: entry_cache_timeout=%.2f attr_cache_timeout=%.2f\n",entry_cache_timeout,attr_cache_timeout);
+		fprintf(stdout, "cache parameters: entry_cache_timeout=%.2f attr_cache_timeout=%.2f\n",
+		        entry_cache_timeout, attr_cache_timeout);
 	}
 }

--- a/src/mount/mastercomm.cc
+++ b/src/mount/mastercomm.cc
@@ -557,7 +557,7 @@ void fs_trashtime_values_checks(uint8_t mingoal, uint8_t maxgoal, uint32_t &mint
 			}
 			infoToPrint << ")";
 		}
-		fprintf(stderr, "%s", infoToPrint.str().c_str());
+		fprintf(stdout, "%s", infoToPrint.str().c_str());
 	}
 }
 
@@ -650,7 +650,7 @@ void fs_session_flags_users_groups_checks(uint8_t sesflags, uint32_t rootuid, ui
 			nonRootAllowedToUseMeta() = false;
 		}
 	}
-	fprintf(stderr, "%s", infoToPrint.str().c_str());
+	fprintf(stdout, "%s", infoToPrint.str().c_str());
 }
 
 int fs_open_master_connection(bool verbose) {
@@ -1036,10 +1036,10 @@ int fs_connect(bool verbose) {
 	}
 
 	if (verbose) {
-		fprintf(stderr, "sfsmaster accepted connection with parameters: ");
+		fprintf(stdout, "sfsmaster accepted connection with parameters: ");
 		fs_session_flags_users_groups_checks(sesflags, rootuid, rootgid, mapalluid, mapallgid);
 		fs_trashtime_values_checks(mingoal, maxgoal, mintrashtime, maxtrashtime);
-		fprintf(stderr, "\n");
+		fprintf(stdout, "\n");
 	}
 	return 0;
 }


### PR DESCRIPTION
Previously, some info messages during registration process of the client were being sent to stderr, which is not accurate given that these messages are not errors but rather informational. This commit fixes that issue.