### PR TITLE
chores: Translate Polish strings to English

### DIFF
--- a/src/common/serializable_range_unittest.cc
+++ b/src/common/serializable_range_unittest.cc
@@ -26,10 +26,10 @@
 #include <gtest/gtest.h>
 
 TEST(SerializableRangeTests, MakeSerializableRange) {
-	std::string a = "lubie placuszki";
-	std::string b = "ala ma kota";
+	std::string a = "i like pancakes";
+	std::string b = "Ala has a cat";
 	std::string c = "";
-	std::string d = "feniks fs";
+	std::string d = "phoenix fs";
 	typedef std::vector<std::string> Vector;
 	Vector numbers = {a, b, c, d};
 	std::vector<uint8_t> actualBuffer, expectedBuffer;

--- a/src/common/serialization_macros_unittest.cc
+++ b/src/common/serialization_macros_unittest.cc
@@ -32,9 +32,9 @@
 
 #define SAU_STATIC_ASSERT(cond) static_assert(cond, #cond)
 
-SAU_STATIC_ASSERT(MORE_THEN_ONE_ARG(0, 1, "ala")                 == 0);
-SAU_STATIC_ASSERT(MORE_THEN_ONE_ARG(0, 1, "ala", "ma")           == 1);
-SAU_STATIC_ASSERT(MORE_THEN_ONE_ARG(0, 1, "ala", "ma", "costam") == 1);
+SAU_STATIC_ASSERT(MORE_THEN_ONE_ARG(0, 1, "that")                 == 0);
+SAU_STATIC_ASSERT(MORE_THEN_ONE_ARG(0, 1, "that", "me")           == 1);
+SAU_STATIC_ASSERT(MORE_THEN_ONE_ARG(0, 1, "that", "me", "something") == 1);
 
 SAU_STATIC_ASSERT(COUNT_ARGS(a, b, c) == 3);
 SAU_STATIC_ASSERT(COUNT_ARGS(a, b)    == 2);
@@ -79,8 +79,8 @@ SERIALIZABLE_CLASS_BODY(
 	}
 SERIALIZABLE_CLASS_END;
 TEST(SerializableClassTests, Serialize) {
-	std::vector<std::string> tmpVector {"kogo", "ma", "ala", "?"};
-	Class tmpC {1, 20, 300, "ala ma kota", tmpVector};
+	std::vector<std::string> tmpVector {"Who", "has", "a", "cat", "?"};
+	Class tmpC {1, 20, 300, "Alice has a cat", tmpVector};
 
 	SAUNAFS_DEFINE_INOUT_PAIR(Class, c, tmpC, Class());
 	ASSERT_NE(cIn, cOut);
@@ -111,7 +111,7 @@ TEST(PacketSerializationTests, SerializeAndDeserialize) {
 	ASSERT_EQ(3210U, somebodyToSomebodyElse::communicate::kNonEmptyVersion);
 	SAUNAFS_DEFINE_INOUT_PAIR(uint32_t, messageId, 65432, 0);
 	SAUNAFS_DEFINE_INOUT_PAIR(inode_t, inode, 36, 0);
-	SAUNAFS_DEFINE_INOUT_PAIR(LegacyString<uint8_t>, name, "kobyla ma maly bok", "");
+	SAUNAFS_DEFINE_INOUT_PAIR(LegacyString<uint8_t>, name, "mare has a small side", "");
 	SAUNAFS_DEFINE_INOUT_PAIR(uint8_t, nodeType, 0xF1, 0x00);
 	SAUNAFS_DEFINE_INOUT_PAIR(uint16_t, mode, 0725, 0000);
 	SAUNAFS_DEFINE_INOUT_PAIR(uint16_t, umask, 0351, 0000);

--- a/src/common/serialization_unittest.cc
+++ b/src/common/serialization_unittest.cc
@@ -26,7 +26,7 @@
 #include "unittests/serialization.h"
 
 TEST(SerializationTests, SerializeString) {
-	serializeTest<std::string>("jajeczniczka ze szczypiorkiem");
+	serializeTest<std::string>("scrambled eggs with chives");
 }
 
 TEST(SerializationTests, SerializeUint32Vector) {
@@ -34,7 +34,7 @@ TEST(SerializationTests, SerializeUint32Vector) {
 }
 
 TEST(SerializationTests, SerializeStringVector) {
-	serializeTest(std::vector<std::string>{"jajeczniczka", "ze", "szczypiorkiem"});
+	serializeTest(std::vector<std::string>{"scrambled", "eggs", "with", "chives"});
 }
 
 TEST(SerializationTests, SerializeMapOfMapsOfSets) {
@@ -58,7 +58,7 @@ struct MyStringAllocator : public std::allocator<std::string> {
 };
 TEST(SerializationTests, SerializeVectorWithCustomAllocator) {
 	serializeTest<std::vector<std::string, MyStringAllocator>>(
-			std::vector<std::string, MyStringAllocator>{"dwa", "jajka", "na", "kielbasie"});
+			std::vector<std::string, MyStringAllocator>{"two", "eggs", "on", "sausage"});
 }
 
 TEST(SerializationTests, DeserializeStringNonEmptyVariable) {
@@ -71,7 +71,7 @@ TEST(SerializationTests, DeserializeStringNonEmptyVariable) {
 
 TEST(SerializationTests, SerializeUniquePtr) {
 	SAUNAFS_DEFINE_INOUT_PAIR(std::unique_ptr<std::string>, ptr,
-			new std::string("wyrob czekoladopodobny"), nullptr);
+			new std::string("chocolate-like product"), nullptr);
 
 	std::vector<uint8_t> buffer;
 	ASSERT_NO_THROW(serialize(buffer, ptrIn));
@@ -104,11 +104,11 @@ TEST(SerializationTests, SerializeStringArray) {
 
 TEST(SerializationTests, SerializeSet) {
 	serializeTest<std::set<std::string>>(
-			std::set<std::string>{"lubie", "dajmy", "na", "to", "-", "placuszki"});
+			std::set<std::string>{"I", "like", "to", "eat", "-", "pancakes"});
 }
 
 TEST(SerializationTests, SerializeMap) {
 	serializeTest<std::map<std::string, std::string>>(
 			std::map<std::string, std::string>{
-					{"lubie", "dajmy"}, {"na", "to"}, {"-", "placuszki"}});
+					{"I", "like"}, {"to", "eat"}, {"-", "pancakes"}});
 }


### PR DESCRIPTION
Replace all Polish language strings in test cases with proper English translations to maintain consistency across the codebase. This change ensures all test strings are in English while preserving the original test functionality and logic.


Co-authored-by: AI Assistant