### PR TITLE
fix: Fix write algorithm in delayed init mode

### DIFF
--- a/src/mount/mastercomm.cc
+++ b/src/mount/mastercomm.cc
@@ -60,6 +60,7 @@
 #include "mount/exports.h"
 #include "mount/notification_area_logging.h"
 #include "mount/stats.h"
+#include "mount/writedata.h"
 #include "protocol/SFSCommunication.h"
 #include "protocol/cltoma.h"
 #include "protocol/matocl.h"
@@ -131,6 +132,7 @@ static pthread_t rpthid,npthid;
 static std::mutex fdMutex, recMutex;
 
 static uint32_t sessionid;
+static uint32_t masterversion;
 
 static char masterstrip[17];
 static uint32_t masterip=0;
@@ -140,6 +142,8 @@ static uint32_t srcip=0;
 
 static uint8_t fterm;
 static std::atomic<bool> gIsKilled(false);
+
+static SaunaClient::FsInitParams gSaunaFSInitParams;
 
 typedef std::unordered_map<PacketHeader::Type, PacketHandler*> PerTypePacketHandlers;
 static PerTypePacketHandlers perTypePacketHandlers;
@@ -195,6 +199,70 @@ struct InitParams {
 };
 
 static InitParams gInitParams;
+
+void wrap_write_init(bool isFromMainThread) {
+	bool useInodeBasedWriteAlgorithm = gSaunaFSInitParams.use_inode_based_write_algorithm;
+
+	// Dangerous case, using chunk based algorithm by params and master does not support it.
+	if (!gSaunaFSInitParams.use_inode_based_write_algorithm &&
+	    masterversion < kFirstVersionWithChunkBasedWriteAlgorithm) {
+		if (isFromMainThread) {
+			fprintf(stderr,
+			        "Metadata server version v%s is too old, using inode based write algorithm"
+			        "(sfsuseinodebasedwritealgorithm=1). "
+			        "Required minimum version for chunk based write algorithm is v%s.\n",
+			        saunafsVersionToString(masterversion).c_str(),
+			        saunafsVersionToString(kFirstVersionWithChunkBasedWriteAlgorithm).c_str());
+		} else {
+			safs::log_warn(
+			    "Metadata server version v{} is too old, using inode based write algorithm"
+			    "(sfsuseinodebasedwritealgorithm=1). "
+			    "Required minimum version for chunk based write algorithm is v{}.",
+			    saunafsVersionToString(masterversion),
+			    saunafsVersionToString(kFirstVersionWithChunkBasedWriteAlgorithm));
+		}
+		useInodeBasedWriteAlgorithm = true;
+
+		if (isChunkBasedWriteAlgorithmInitialized()) {
+			massert(!getUseInodeBasedWriteAlgorithm(),
+			        "Inode based write algorithm should not be in use.");
+			write_data_term();
+		}
+	}
+
+	// If we were using inode based algorithm before but new connected master allows chunk based
+	// algorithm and it is intended by params, then we should use it.
+	if (isChunkBasedWriteAlgorithmInitialized() && getUseInodeBasedWriteAlgorithm() &&
+	    !gSaunaFSInitParams.use_inode_based_write_algorithm &&
+	    masterversion >= kFirstVersionWithChunkBasedWriteAlgorithm) {
+		if (isFromMainThread) {
+			fprintf(stderr,
+			        "New metadata server supports chunk based write algorithm "
+			        "(current master version: %s, required: %s).\n",
+			        saunafsVersionToString(masterversion).c_str(),
+			        saunafsVersionToString(kFirstVersionWithChunkBasedWriteAlgorithm).c_str());
+		} else {
+			safs::log_warn(
+			    "New metadata server supports chunk based write algorithm "
+			    "(current master version: {}, required: {}).",
+			    saunafsVersionToString(masterversion),
+			    saunafsVersionToString(kFirstVersionWithChunkBasedWriteAlgorithm));
+		}
+
+		massert(getUseInodeBasedWriteAlgorithm() && isChunkBasedWriteAlgorithmInitialized(),
+		        "Inode based write algorithm initialization status changed unexpectedly.");
+		write_data_term();
+	}
+
+	setUseInodeBasedWriteAlgorithm(useInodeBasedWriteAlgorithm);
+
+	// Won't do anything if already initialized
+	write_data_init(gSaunaFSInitParams.write_cache_size, gSaunaFSInitParams.io_retries,
+	                gSaunaFSInitParams.write_workers, gSaunaFSInitParams.write_window_size,
+	                gSaunaFSInitParams.chunkserver_write_timeout_ms,
+	                gSaunaFSInitParams.cache_per_inode_percentage,
+	                gSaunaFSInitParams.write_wave_timeout_ms);
+}
 
 uint32_t getSafeSleepTimeDivisor() {
 	uint32_t safeSleepTimeDivisor = mastercommSleepTimeDivisor.load();
@@ -1349,6 +1417,7 @@ void* fs_receive_thread(void *) {
 					sessionlost=0;
 					fdLock.unlock();
 					fs_register_config();
+					wrap_write_init(false);
 					fdLock.lock();
 				}
 			} else {        // if other problem occurred then try to resolve hostname and portname then try to reconnect using the same session id
@@ -1467,6 +1536,7 @@ int fs_init_master_connection(SaunaClient::FsInitParams &params
 	master_statsptr_init();
 
 	gInitParams = params;
+	gSaunaFSInitParams = params;
 	std::fill(params.password_digest.begin(), params.password_digest.end(), 0);
 
 	fd = -1;
@@ -1485,6 +1555,8 @@ int fs_init_master_connection(SaunaClient::FsInitParams &params
 	int connectResult = fs_connect(params.verbose);
 	if (connectResult == 0) {
 		fs_register_config();
+
+		wrap_write_init(true);
 	}
 	return connectResult;
 }

--- a/src/mount/mastercomm.h
+++ b/src/mount/mastercomm.h
@@ -48,8 +48,6 @@ inline std::mutex acquiredFileMutex;
 using AcquiredFileMap = std::map<inode_t, uint32_t>;
 inline AcquiredFileMap acquiredFiles;
 
-inline uint32_t masterversion;
-
 void fs_getmasterlocation(uint8_t loc[14]);
 uint32_t fs_getsrcip(void);
 

--- a/src/mount/sauna_client.cc
+++ b/src/mount/sauna_client.cc
@@ -3672,22 +3672,6 @@ void fs_init(FsInitParams &params) {
 			params.prefetch_xor_stripes,
 			std::max(params.bandwidth_overuse, 1.));
 
-	if (!params.use_inode_based_write_algorithm &&
-	    masterversion < kFirstVersionWithChunkBasedWriteAlgorithm) {
-		fprintf(stderr,
-		        "Metadata server version v%s is too old, using inode-based write algorithm"
-		        "(sfsuseinodebasedwritealgorithm=1). "
-		        "Required minimum version for chunk based algorithm is v%s.\n",
-		        saunafsVersionToString(masterversion).c_str(),
-		        saunafsVersionToString(kFirstVersionWithChunkBasedWriteAlgorithm).c_str());
-		params.use_inode_based_write_algorithm = true;
-	}
-
-	gUseInodeBasedWriteAlgorithm = params.use_inode_based_write_algorithm;
-	write_data_init(
-	    params.write_cache_size, params.io_retries, params.write_workers,
-	    params.write_window_size, params.chunkserver_write_timeout_ms,
-	    params.cache_per_inode_percentage, params.write_wave_timeout_ms);
 #ifdef _WIN32
 	set_debug_mode(params.debug_mode);
 #endif

--- a/src/mount/writedata.cc
+++ b/src/mount/writedata.cc
@@ -66,6 +66,8 @@
 #define NO_INODEDATA nullptr
 #define NO_CHUNKDATA nullptr
 
+static bool gUseInodeBasedWriteAlgorithm = false;
+
 namespace InodeBasedWriteAlgorithm {
 
 struct inodedata {
@@ -207,6 +209,8 @@ struct DelayedQueueEntry {
 	DelayedQueueEntry(inodedata *inodeData, int32_t ticksLeft)
 	    : inodeData(inodeData), ticksLeft(ticksLeft) {}
 };
+
+static bool gIsInitialized = false;
 
 static std::atomic<uint32_t> maxretries;
 static std::atomic<uint32_t> gWriteWaveTimeout;
@@ -709,6 +713,8 @@ void write_data_init(uint32_t cachesize, uint32_t retries, uint32_t workers,
 	std::lock_guard lock(gMountInfoMtx);
 	gTweaks.registerVariable("WriteMaxRetries", maxretries, "sfsioretries (write)");
 	gTweaks.registerVariable("WriteWaveTimeout", gWriteWaveTimeout, "sfschunkserverwavewriteto");
+
+	gIsInitialized = true;
 }
 
 void write_data_term(void) {
@@ -724,6 +730,8 @@ void write_data_term(void) {
 	jobsQueue.reset();
 	for (const auto &[_, id] : inodedataMap) { delete id; }
 	inodedataMap.clear();
+
+	gIsInitialized = false;
 }
 
 /* glock: UNLOCKED */
@@ -1171,6 +1179,8 @@ struct DelayedQueueEntry {
 	DelayedQueueEntry(ChunkData *chunkData, int32_t ticksLeft)
 	    : chunkData(chunkData), ticksLeft(ticksLeft) {}
 };
+
+static bool gIsInitialized = false;
 
 static std::atomic<uint32_t> maxretries;
 static std::atomic<uint32_t> gWriteWaveTimeout;
@@ -1766,6 +1776,8 @@ void write_data_init(uint32_t cachesize, uint32_t retries, uint32_t workers,
 
 	gTweaks.registerVariable("WriteMaxRetries", maxretries, "sfsioretries (write)");
 	gTweaks.registerVariable("WriteWaveTimeout", gWriteWaveTimeout, "sfschunkserverwavewriteto");
+
+	gIsInitialized = true;
 }
 
 void write_data_term(void) {
@@ -1781,6 +1793,9 @@ void write_data_term(void) {
 	jobsQueue.reset();
 	for (const auto &[_, id] : inodedataMap) { delete id; }
 	inodedataMap.clear();
+	truncateLocatorsData.clear();
+
+	gIsInitialized = false;
 }
 
 /* inodeLock: UNLOCKED */
@@ -2167,10 +2182,14 @@ void write_data_init(uint32_t cachesize, uint32_t retries, uint32_t workers,
                      uint32_t writewindowsize, uint32_t chunkserverTimeout_ms,
                      uint32_t cachePerInodePercentage, uint32_t waveTimeout) {
 	if (gUseInodeBasedWriteAlgorithm) {
+		if (InodeBasedWriteAlgorithm::gIsInitialized) { return; }
+
 		InodeBasedWriteAlgorithm::write_data_init(cachesize, retries, workers, writewindowsize,
 		                                          chunkserverTimeout_ms, cachePerInodePercentage,
 		                                          waveTimeout);
 	} else {
+		if (ChunkBasedWriteAlgorithm::gIsInitialized) { return; }
+
 		ChunkBasedWriteAlgorithm::write_data_init(cachesize, retries, workers, writewindowsize,
 		                                          chunkserverTimeout_ms, cachePerInodePercentage,
 		                                          waveTimeout);
@@ -2227,4 +2246,20 @@ int write_data(void *vid, uint64_t offset, uint32_t size, const uint8_t *buff, s
 		return InodeBasedWriteAlgorithm::write_data(vid, offset, size, buff, currentSize);
 	}
 	return ChunkBasedWriteAlgorithm::write_data(vid, offset, size, buff, currentSize);
+}
+
+bool isChunkBasedWriteAlgorithmInitialized() {
+	return ChunkBasedWriteAlgorithm::gIsInitialized;
+}
+
+bool isInodeBasedWriteAlgorithmInitialized() {
+	return InodeBasedWriteAlgorithm::gIsInitialized;
+}
+
+void setUseInodeBasedWriteAlgorithm(bool useInodeBasedWriteAlgorithm) {
+	gUseInodeBasedWriteAlgorithm = useInodeBasedWriteAlgorithm;
+}
+
+bool getUseInodeBasedWriteAlgorithm() {
+	return gUseInodeBasedWriteAlgorithm;
 }

--- a/src/mount/writedata.h
+++ b/src/mount/writedata.h
@@ -28,8 +28,6 @@
 #include "common/attributes.h"
 #include "common/type_defs.h"
 
-inline bool gUseInodeBasedWriteAlgorithm;
-
 void write_data_init(uint32_t cachesize, uint32_t retries, uint32_t workers,
                      uint32_t writewindowsize, uint32_t chunkserverTimeout_ms,
                      uint32_t cachePerInodePercentage, uint32_t waveTimeout);
@@ -42,3 +40,8 @@ int write_data_flush_inode(inode_t inode);
 int write_data_truncate(inode_t inode, bool opened, uint32_t uid, uint32_t gid, uint64_t length,
                         Attributes &attr);
 int write_data(void *vid, uint64_t offset, uint32_t size, const uint8_t *buff, size_t currentSize);
+
+bool isChunkBasedWriteAlgorithmInitialized();
+bool isInodeBasedWriteAlgorithmInitialized();
+void setUseInodeBasedWriteAlgorithm(bool useInodeBasedWriteAlgorithm);
+bool getUseInodeBasedWriteAlgorithm();

--- a/tests/test_suites/ShortSystemTests/test_mount_delayed_init_basic.sh
+++ b/tests/test_suites/ShortSystemTests/test_mount_delayed_init_basic.sh
@@ -1,0 +1,49 @@
+timeout_set 30 seconds
+
+CHUNKSERVERS=1 \
+  MOUNTS=2 \
+  USE_RAMDISK=YES \
+  MOUNT_0_EXTRA_CONFIG="sfscachemode=NEVER" \
+  MOUNT_1_EXTRA_CONFIG="sfscachemode=NEVER,sfsdelayedinit" \
+  setup_local_empty_saunafs info
+
+# Stop master and clients and check which client starts faster
+assert_success saunafs_mount_unmount 0
+assert_success saunafs_mount_unmount 1
+saunafs_master_daemon stop
+
+# Start client with delayed init first
+assert_eventually "saunafs_mount_start 1" "1 second"
+
+saunafs_mount_start 0 &
+pid=$!
+
+# Wait a while to check if mount 0 starts
+sleep 10
+
+if ps -p $pid > /dev/null; then
+	echo "Process still running after 10 seconds, starting master"
+	saunafs_master_daemon start
+	saunafs_wait_for_all_ready_chunkservers
+else
+	test_fail "Mount 0 started without master, but it should not have started yet"
+fi
+
+# Now mount 0 should start
+sleep 1
+if ps -p $pid > /dev/null; then
+	test_fail "Process still running after 1 seconds while master is available"
+fi
+
+# Both mounts should be available now, let's perform some basic checks
+cd "${info[mount0]}"
+BLOCK_SIZE=456789 FILE_SIZE=123456789 file-generate file0
+assert_success file-validate file0
+
+cd "${info[mount1]}"
+BLOCK_SIZE=567890 FILE_SIZE=234567890 file-generate file1
+assert_success file-validate file0
+assert_success file-validate file1
+
+cd "${info[mount0]}"
+assert_success file-validate file1

--- a/tests/test_suites/ShortSystemTests/test_upgrade_master_switch_write_algo.sh
+++ b/tests/test_suites/ShortSystemTests/test_upgrade_master_switch_write_algo.sh
@@ -1,0 +1,85 @@
+timeout_set 50 seconds
+
+# Test checks if new SaunaFS mount works with legacy versions of master and chunkservers
+# and if it can read and write files created on legacy SaunaFS mount.
+
+export SAFS_MOUNT_COMMAND="sfsmount"
+
+CHUNKSERVERS=2 \
+  MOUNTS=2 \
+  START_WITH_LEGACY_SAUNAFS=YES \
+  USE_RAMDISK=YES \
+  MOUNT_EXTRA_CONFIG="sfscachemode=NEVER" \
+  MASTER_EXTRA_CONFIG="CHUNKS_LOOP_TIME = 1|OPERATIONS_DELAY_INIT = 0" \
+  setup_local_empty_saunafs info
+
+# Start test with master, 2 chunkservers and 2 mounts running legacy SaunaFS code
+# Ensure that we work on legacy version
+assert_equals 1 $(saunafs_old_admin_master info | grep $SAUNAFSXX_TAG | wc -l)
+assert_equals 2 $(saunafs_old_admin_master list-chunkservers | grep $SAUNAFSXX_TAG | wc -l)
+assert_equals 2 $(saunafs_old_admin_master list-mounts | grep $SAUNAFSXX_TAG | wc -l)
+
+# Unmount old SaunaFS client 1:
+assert_success saunafs_mount_unmount 1
+# Mount SaunaFS client 1:
+assert_success saunafs_mount_start 1
+
+cd "${info[mount0]}"
+mkdir from_old_mount
+cd from_old_mount
+
+function generate_file {
+  FILE_SIZE=234567890 BLOCK_SIZE=56789 file-generate $1
+}
+
+# Test if reading and writing on old SaunaFS works:
+assert_success generate_file old_mount_old_master_file
+assert_success file-validate old_mount_old_master_file
+
+cd "${info[mount1]}/from_old_mount"
+
+# Test if file created on legacy version is readable
+assert_success file-validate old_mount_old_master_file
+
+cd ..
+mkdir from_new_mount
+cd from_new_mount
+# Test if reading and writing on new SaunaFS mount works:
+assert_success generate_file new_mount_old_master_file
+assert_success file-validate new_mount_old_master_file
+
+# Test if all files produced so far are readable on legacy mount:
+cd "${info[mount0]}/from_new_mount"
+assert_success file-validate new_mount_old_master_file
+
+saunafsXX_master_daemon stop
+
+# Force the master to create new sessions (and clients to connect instead of reconnect)
+rm $(get_current_master_sessions_file)
+
+# Don't know why, but we have to bypass the saunafs_master_daemon function
+assert_success sfsmaster -c "${info[master0_cfg]}" start
+
+saunafs_wait_for_all_ready_chunkservers
+
+# Ensure that we can still read and write files from new and old SaunaFS mounts
+
+# We were at "${info[mount0]}/from_new_mount"
+assert_success file-validate new_mount_old_master_file
+
+cd "../from_old_mount"
+assert_success file-validate old_mount_old_master_file
+assert_success generate_file old_mount_new_master_file
+assert_success file-validate old_mount_new_master_file
+
+cd "${info[mount1]}/from_old_mount"
+assert_success file-validate old_mount_old_master_file
+assert_success file-validate old_mount_new_master_file
+
+cd "../from_new_mount"
+assert_success file-validate new_mount_old_master_file
+assert_success generate_file new_mount_new_master_file
+assert_success file-validate new_mount_new_master_file
+
+cd "${info[mount0]}/from_new_mount"
+assert_success file-validate new_mount_new_master_file

--- a/tests/test_suites/ShortSystemTests/test_upgrade_new_mount_with_old_saunafs.sh
+++ b/tests/test_suites/ShortSystemTests/test_upgrade_new_mount_with_old_saunafs.sh
@@ -1,4 +1,4 @@
-timeout_set 45 seconds
+timeout_set 1 minute
 
 # Test checks if both legacy, and new SaunaFS mount
 # work with legacy versions of master and chunkservers
@@ -25,7 +25,7 @@ assert_success saunafsXX saunafs setgoal 2 dir0
 cd dir0
 
 function generate_file {
-	FILE_SIZE=12345678 BLOCK_SIZE=12345 file-generate $1
+	FILE_SIZE=123456789 BLOCK_SIZE=56789 file-generate $1
 }
 
 # Test if reading and writing on old SaunaFS works:

--- a/tests/tools/saunafs.sh
+++ b/tests/tools/saunafs.sh
@@ -831,6 +831,10 @@ get_data_path() {
 	echo $(cat $1 | sed -e 's/*//' -e 's/zonefs://' | cut -d '|' -f 2)
 }
 
+get_current_master_sessions_file() {
+  echo "${saunafs_info_[master${saunafs_info_[current_master]}_data_path]}/sessions.sfs"
+}
+
 # print absolute paths of all chunk files on selected server, one per line
 find_chunkserver_chunks() {
 	local chunkserver_number=$1


### PR DESCRIPTION
This PR targets fixing the inconsistent selection of write
algorithm when using the `sfsdelayedinit` option in client.

Main feature of sfsdelayedinit option is to be able to start the mount
without an available master, which means it is not expected after short
notice to know the master version. This means client is not supposed to
display any warning message right after mounting and select the
appropiate write algorithm after knowing the current master version.

Implements the support for the client to switch the
write algorithm used when needed depending on master version.

An integration was added and another one was enhanced in order
to test the proposed changes. Also, a specific test for the
`sfsdelayedinit` option was added in order to check its expected
behavior.

Signed-off-by: Dave <dave@leil.io>