### PR TITLE
chore(master): Improve logging for oversized packet

### DIFF
--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -6203,12 +6203,14 @@ void matoclserv_read(matoclserventry *eptr) {
 		}
 
 		if (eptr->mode == ClientConnectionMode::HEADER) {
-			ptr = eptr->headerBuffer + 4;
+			ptr = eptr->headerBuffer;
+			get32bit(&ptr, type);
 			get32bit(&ptr, size);
 			if (size > 0) {
 				if (size > MaxPacketSize) {
-					safs::log_warn("main master server module: packet too long ({}/{})", size,
-					               MaxPacketSize);
+					safs::log_warn(
+					    "main master server module: packet {} received from peer {}:{} is too long ({}/{})",
+					    type, ipToString(eptr->peerIpAddress), eptr->peerPort, size, MaxPacketSize);
 					eptr->mode = ClientConnectionMode::KILL;
 					return;
 				}


### PR DESCRIPTION
This commit improves the log message in the master server by including the peer's IP address and the packet type when an oversized packet is received. This makes debugging easier by identifying the client source.

It also introduces a helper function to convert the IPv4 address from matoclserventry::peerIpAddress to a readable string.