### PR TITLE
fix(mount): Fix path by inode consistency

### DIFF
--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -1989,7 +1989,7 @@ uint8_t fsnodes_get_node_for_operation(const FsContext &context, ExpectedNodeTyp
 		if (!rn || rn->type != FSNodeType::kDirectory) {
 			return SAUNAFS_ERROR_ENOENT;
 		}
-		if (inode == SPECIAL_INODE_ROOT) {
+		if (inode == SPECIAL_INODE_ROOT || inode == context.rootinode()) {
 			p = rn;
 		} else {
 			p = fsnodes_id_to_node(inode);

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -512,6 +512,11 @@ uint8_t fs_full_path_by_inode(const FsContext &context, inode_t initial_inode,
 	                                        initial_inode, &current_node);
 	if (status != SAUNAFS_STATUS_OK) { return status; }
 
+	if (current_inode == SPECIAL_INODE_ROOT) {
+		fullPath = "";
+		return SAUNAFS_STATUS_OK;
+	}
+
 	while (current_inode != context.rootinode()) {
 		if (!current_node || current_node->parent.empty()) {
 			if (current_node->parent.empty() && (current_node->type == FSNodeType::kReserved ||

--- a/tests/test_suites/TestTemplates/test_path_by_inode.inc
+++ b/tests/test_suites/TestTemplates/test_path_by_inode.inc
@@ -48,6 +48,36 @@ assert_equals "data5" "$(cat folder/file2)"
 assert_equals "data6" "$(cat folder/folder2/file3)"
 assert_equals "data7" "$(cat file4)"
 
+# check if root inode is accessible with the .saunafs_path_by_inode
+# special file with id 1 and real underlying id on the filesystem
+# when mounting client on a sfssubfolder created before
+cd ..
+saunafs_mount_unmount 0
+echo "sfssubfolder=folder/folder2" >> "${info[mount0_cfg]}"
+assert_success saunafs_mount_start 0
+cd "${info[mount0]}"
+
+assert_equals "" "$(cat .saunafs_path_by_inode/1)"
+assert_equals "" "$(cat .saunafs_path_by_inode/5)"
+
+# check that accessing a file path by inode inside the 
+# mounted subfolder will return the corresponding path
+# without including the subfolder as part of it.
+assert_equals "file3" "$(cat .saunafs_path_by_inode/6)"
+
+# check that it is not possible to access the path by inode
+# result of inodes outside the mounted subfolder that were
+# created before or after it.
+assert_failure cat .saunafs_path_by_inode/4 # corresponding to folder/file2
+assert_failure cat .saunafs_path_by_inode/7 # corresponding to file4
+
+# mount client back to initial root folder
+cd ..
+saunafs_mount_unmount 0
+echo "sfssubfolder=/" >> "${info[mount0_cfg]}"
+assert_success saunafs_mount_start 0
+cd "${info[mount0]}"
+
 # check removing files by their path
 # first check the case when the file was deleted but
 # is still on the filesystem trash


### PR DESCRIPTION
Previous versions of the .saunafs_path_by_inode hidden directory did not correctly resolve inode paths for mount points nested in pre-existing subfolders. In particular, lookups for certain inodes—such as the root inode (ID 1) and valid inodes within that folder—caused the master to hang and returned no result respectively.