### PR TITLE
Fix random segfault in SaunaFS FSAL lock operations

### DIFF
--- a/src/mount/client/saunafs_c_api.cc
+++ b/src/mount/client/saunafs_c_api.cc
@@ -172,7 +172,7 @@ void sau_destroy_context(sau_context_t **ctx) {
 }
 
 void sau_set_lock_owner(sau_fileinfo_t *fileinfo, uint64_t lock_owner) {
-	if (fileinfo == NULL) {
+	if (fileinfo == nullptr) {
 		return;
 	}
 	Client::FileInfo *fi = (Client::FileInfo *)fileinfo;
@@ -414,7 +414,7 @@ ssize_t sau_write(sau_t *instance, sau_context_t *ctx, sau_fileinfo *fileinfo,
 }
 
 int sau_release(sau_t *instance, sau_fileinfo *fileinfo) {
-	if (fileinfo == NULL) {
+	if (fileinfo == nullptr) {
 		gLastErrorCode = SAUNAFS_ERROR_EBADF;
 		return -1;
 	}
@@ -426,7 +426,7 @@ int sau_release(sau_t *instance, sau_fileinfo *fileinfo) {
 }
 
 int sau_flush(sau_t *instance, sau_context_t *ctx, sau_fileinfo *fileinfo) {
-	if (fileinfo == NULL) {
+	if (fileinfo == nullptr) {
 		gLastErrorCode = SAUNAFS_ERROR_EBADF;
 		return -1;
 	}
@@ -477,7 +477,7 @@ int sau_readdir(sau_t *instance, sau_context_t *ctx,
 	std::error_code ec;
 
 	if (max_entries > 0) {
-		buf->name = NULL;
+		buf->name = nullptr;
 	} else {
 		gLastErrorCode = SAUNAFS_ERROR_EINVAL;
 		return -1;
@@ -949,7 +949,7 @@ int sau_get_chunks_info(sau_t *instance, sau_context_t *ctx, sau_inode_t inode,
 	Client::Context &context = *(Client::Context *)ctx;
 
 	if (buffer_size > 0) {
-		buffer->parts = NULL;
+		buffer->parts = nullptr;
 	} else {
 		gLastErrorCode = SAUNAFS_ERROR_EINVAL;
 		return -1;
@@ -981,7 +981,7 @@ int sau_get_chunks_info(sau_t *instance, sau_context_t *ctx, sau_inode_t inode,
 
 	auto totalSize = parts_table_size + strings_size;
 	uint8_t *data_buffer = (uint8_t *)std::malloc(totalSize);
-	if (data_buffer == NULL) {
+	if (data_buffer == nullptr) {
 		gLastErrorCode = SAUNAFS_ERROR_OUTOFMEMORY;
 		return -1;
 	}
@@ -1074,7 +1074,7 @@ void sau_destroy_chunks_info(sau_chunk_info_t *buffer) {
 int sau_setlk(sau_t *instance, sau_context_t *ctx, sau_fileinfo_t *fileinfo,
               const sau_lock_info *lock, sau_lock_register_interrupt_t handler,
               void *priv) {
-	if (fileinfo == NULL) {
+	if (fileinfo == nullptr) {
 		gLastErrorCode = SAUNAFS_ERROR_EBADF;
 		return -1;
 	}
@@ -1107,7 +1107,7 @@ int sau_setlk(sau_t *instance, sau_context_t *ctx, sau_fileinfo_t *fileinfo,
 
 int sau_getlk(sau_t *instance, sau_context_t *ctx, sau_fileinfo_t *fileinfo,
               sau_lock_info *lock) {
-	if (fileinfo == NULL) {
+	if (fileinfo == nullptr) {
 		gLastErrorCode = SAUNAFS_ERROR_EBADF;
 		return -1;
 	}

--- a/src/mount/client/saunafs_c_api.cc
+++ b/src/mount/client/saunafs_c_api.cc
@@ -172,6 +172,9 @@ void sau_destroy_context(sau_context_t **ctx) {
 }
 
 void sau_set_lock_owner(sau_fileinfo_t *fileinfo, uint64_t lock_owner) {
+	if (fileinfo == NULL) {
+		return;
+	}
 	Client::FileInfo *fi = (Client::FileInfo *)fileinfo;
 	fi->lock_owner = lock_owner;
 }
@@ -411,6 +414,10 @@ ssize_t sau_write(sau_t *instance, sau_context_t *ctx, sau_fileinfo *fileinfo,
 }
 
 int sau_release(sau_t *instance, sau_fileinfo *fileinfo) {
+	if (fileinfo == NULL) {
+		gLastErrorCode = SAUNAFS_ERROR_EBADF;
+		return -1;
+	}
 	Client &client = *(Client *)instance;
 	std::error_code ec;
 	client.release((Client::FileInfo *)fileinfo, ec);
@@ -419,6 +426,10 @@ int sau_release(sau_t *instance, sau_fileinfo *fileinfo) {
 }
 
 int sau_flush(sau_t *instance, sau_context_t *ctx, sau_fileinfo *fileinfo) {
+	if (fileinfo == NULL) {
+		gLastErrorCode = SAUNAFS_ERROR_EBADF;
+		return -1;
+	}
 	Client &client = *(Client *)instance;
 	Client::Context &context = *(Client::Context *)ctx;
 	std::error_code ec;
@@ -1063,6 +1074,10 @@ void sau_destroy_chunks_info(sau_chunk_info_t *buffer) {
 int sau_setlk(sau_t *instance, sau_context_t *ctx, sau_fileinfo_t *fileinfo,
               const sau_lock_info *lock, sau_lock_register_interrupt_t handler,
               void *priv) {
+	if (fileinfo == NULL) {
+		gLastErrorCode = SAUNAFS_ERROR_EBADF;
+		return -1;
+	}
 	Client &client = *(Client *)instance;
 	Client::Context &context = *(Client::Context *)ctx;
 	Client::FileInfo *fi = (Client::FileInfo *)fileinfo;
@@ -1092,6 +1107,10 @@ int sau_setlk(sau_t *instance, sau_context_t *ctx, sau_fileinfo_t *fileinfo,
 
 int sau_getlk(sau_t *instance, sau_context_t *ctx, sau_fileinfo_t *fileinfo,
               sau_lock_info *lock) {
+	if (fileinfo == NULL) {
+		gLastErrorCode = SAUNAFS_ERROR_EBADF;
+		return -1;
+	}
 	Client &client = *(Client *)instance;
 	Client::Context &context = *(Client::Context *)ctx;
 	Client::FileInfo *fi = (Client::FileInfo *)fileinfo;

--- a/src/nfs-ganesha/context_wrap.c
+++ b/src/nfs-ganesha/context_wrap.c
@@ -62,6 +62,11 @@ ssize_t saunafs_read(sau_t *instance, struct user_cred *cred,
                      fileinfo_t *fileinfo, off_t offset, size_t size,
                      char *buffer) {
 	sau_context_t *context __attribute__((cleanup(sau_destroy_context))) = NULL;
+
+	if (fileinfo == NULL) {
+		return -1;
+	}
+
 	context = createContext(instance, cred);
 
 	if (context == NULL) {
@@ -75,6 +80,11 @@ ssize_t saunafs_write(sau_t *instance, struct user_cred *cred,
                       fileinfo_t *fileinfo, off_t offset, size_t size,
                       const char *buffer) {
 	sau_context_t *context __attribute__((cleanup(sau_destroy_context))) = NULL;
+
+	if (fileinfo == NULL) {
+		return -1;
+	}
+
 	context = createContext(instance, cred);
 
 	if (context == NULL) {
@@ -87,6 +97,11 @@ ssize_t saunafs_write(sau_t *instance, struct user_cred *cred,
 int saunafs_flush(sau_t *instance, struct user_cred *cred,
                   fileinfo_t *fileinfo) {
 	sau_context_t *context __attribute__((cleanup(sau_destroy_context))) = NULL;
+
+	if (fileinfo == NULL) {
+		return -1;
+	}
+
 	context = createContext(instance, cred);
 
 	if (context == NULL) {
@@ -289,6 +304,11 @@ int saunafs_getacl(sau_t *instance, struct user_cred *cred, sau_inode_t inode,
 int saunafs_setlock(sau_t *instance, struct user_cred *cred,
                     fileinfo_t *fileinfo, const sau_lock_info_t *lock) {
 	sau_context_t *context __attribute__((cleanup(sau_destroy_context))) = NULL;
+
+	if (fileinfo == NULL) {
+		return -1;
+	}
+
 	context = createContext(instance, cred);
 
 	if (context == NULL) {
@@ -300,7 +320,13 @@ int saunafs_setlock(sau_t *instance, struct user_cred *cred,
 
 int saunafs_getlock(sau_t *instance, struct user_cred *cred,
                     fileinfo_t *fileinfo, sau_lock_info_t *lock) {
-	sau_context_t *context = createContext(instance, cred);
+	sau_context_t *context __attribute__((cleanup(sau_destroy_context))) = NULL;
+
+	if (fileinfo == NULL) {
+		return -1;
+	}
+
+	context = createContext(instance, cred);
 
 	if (context == NULL) {
 		return -1;

--- a/src/nfs-ganesha/handle.c
+++ b/src/nfs-ganesha/handle.c
@@ -769,6 +769,14 @@ static fsal_status_t findFileDescriptor(struct SaunaFSFd *saunafsFd,
 	                 state, openflags, openFunction, closeFunction, hasLock,
 	                 closeFileDescriptor, openForLocks, &canReuseOpenedFd);
 
+	// Ensure we have a valid file descriptor before dereferencing
+	if (FSAL_IS_ERROR(status) || usableFd == NULL) {
+		// Initialize saunafsFd to a safe state
+		saunafsFd->openflags = FSAL_O_CLOSED;
+		saunafsFd->fd = NULL;
+		return status;
+	}
+
 	*saunafsFd = *usableFd;
 	return status;
 }
@@ -1621,6 +1629,17 @@ fsal_status_t lock_op2(struct fsal_obj_handle *objectHandle,
 	}
 
 	fileinfo = saunafsFd.fd;
+	
+	// Defensive check: ensure we have a valid file descriptor before proceeding
+	if (fileinfo == NULL) {
+		LogCrit(COMPONENT_FSAL, "Lock operation called with NULL file descriptor");
+		
+		if (closeFd) { closeFileDescriptor(container_of(objectHandle, struct SaunaFSHandle, handle), &saunafsFd); }
+		if (hasLock) { PTHREAD_RWLOCK_unlock(&objectHandle->obj_lock); }
+		
+		return fsalstat(ERR_FSAL_FAULT, EFAULT);
+	}
+	
 	sau_set_lock_owner(fileinfo, (uint64_t)owner);
 
 	if (lockOperation == FSAL_OP_LOCKT) {
@@ -1635,7 +1654,7 @@ fsal_status_t lock_op2(struct fsal_obj_handle *objectHandle,
 	if (retval < 0) {
 		lastError = sau_last_err();
 
-		if (closeFd) { sau_release(export->fsInstance, fileinfo); }
+		if (closeFd && fileinfo != NULL) { sau_release(export->fsInstance, fileinfo); }
 
 		if (hasLock) { PTHREAD_RWLOCK_unlock(&objectHandle->obj_lock); }
 
@@ -1657,7 +1676,7 @@ fsal_status_t lock_op2(struct fsal_obj_handle *objectHandle,
 		}
 	}
 
-	if (closeFd) {
+	if (closeFd && fileinfo != NULL) {
 		sau_release(export->fsInstance, fileinfo);
 	}
 

--- a/src/nfs-ganesha/handle.c
+++ b/src/nfs-ganesha/handle.c
@@ -771,7 +771,7 @@ static fsal_status_t findFileDescriptor(struct SaunaFSFd *saunafsFd,
 
 	// Ensure we have a valid file descriptor before dereferencing
 	if (FSAL_IS_ERROR(status) || usableFd == NULL) {
-		// Initialize saunafsFd to a safe state
+		// Initialize SaunaFS file descriptor to a safe state
 		saunafsFd->openflags = FSAL_O_CLOSED;
 		saunafsFd->fd = NULL;
 		return status;
@@ -1655,7 +1655,6 @@ fsal_status_t lock_op2(struct fsal_obj_handle *objectHandle,
 		lastError = sau_last_err();
 
 		if (closeFd && fileinfo != NULL) { sau_release(export->fsInstance, fileinfo); }
-
 		if (hasLock) { PTHREAD_RWLOCK_unlock(&objectHandle->obj_lock); }
 
 		LogFullDebug(COMPONENT_FSAL, "Returning error %d", lastError);


### PR DESCRIPTION
This PR fixes a random segfault that occurs during the cthon test #3 (LFS locking)
in low-resource environments like GitHub runners.

The relevant changes are:

- Fix null pointer dereference in SaunaFS FSAL in the functions used
  to find the file descriptor and perform a lock operation.
   
- Add defensive null pointer checks to prevent segfaults when the file
  descriptor passed as parameter is NULL in the Ganesha wrapper functions.
    
- Add defensive null checks to SaunaFS API functions that handle file
  descriptor parameters and return appropriate error codes.

This commit fixes issue https://github.com/leil-io/saunafs/issues/499.
    
Co-authored-by: Copilot <copilot@github.com>

Signed-off-by: Crash <crash@leil.io>

For more information, see PR #500.