### PR TITLE
fix: Fix Windows client build from refactor

### DIFF
--- a/src/common/attributes.h
+++ b/src/common/attributes.h
@@ -32,6 +32,7 @@
 
 typedef std::array<uint8_t, 35> Attributes;
 
+#ifndef _WIN32
 constexpr int saunaFileTypeToPosix(unsigned char type) {
 	switch (type) {
 	case TYPE_BLOCKDEV:
@@ -80,3 +81,4 @@ struct PosixFileAttributes {
 		return fileStat;
 	}
 };
+#endif

--- a/src/mount/sauna_client.h
+++ b/src/mount/sauna_client.h
@@ -26,10 +26,12 @@
 #include <unistd.h>
 
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 #include "common/chunk_with_address_and_label.h"
 #include "common/exception.h"
+#include "common/stat32.h"
 #include "common/stat_defs.h"
 #include "common/type_defs.h"
 #include "mount/group_cache.h"


### PR DESCRIPTION
Changes introduced on commit 542c65ea were not allowing the Windows client to build due to missing includes and non-Windows compatible code. This commit fixes that issue.