### PR TITLE
feat(common): Add initial signal-slots support

### DIFF
--- a/src/common/observable_property.h
+++ b/src/common/observable_property.h
@@ -1,0 +1,108 @@
+/*
+   Copyright 2023      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "common/platform.h"
+
+#include <concepts>
+#include <functional>
+#include <string>
+#include <utility>
+#include <vector>
+
+/// @file Implements a signal-slot mechanism to decouple property changes from their observers.
+
+/// @brief Variadic template Signal that can handle variable type parameters
+/// @tparam Args Types of parameters that the signal can emit.
+/// @note This class is not thread-safe yet.
+template <typename... Args>
+class Signal {
+public:
+	using SlotType = std::function<void(Args...)>;
+
+	/// Adds a new observer (slot) to the signal.
+	/// @param slot The function to be called when the signal is emitted
+	void connect(SlotType slot) { slots_.push_back(std::move(slot)); }
+
+	/// Emits the signal, calling all connected slots with the provided arguments.
+	/// @param args Arguments to pass to the connected slots
+	/// @note All slots are called in the order they were connected.
+	void emit(Args... args) {
+		for (auto &slot : slots_) { slot(args...); }
+	}
+
+	/// Clears all connected slots.
+	void clear() { slots_.clear(); }
+
+	/// Returns the number of connected slots.
+	size_t size() const { return slots_.size(); }
+
+private:
+	/// List of connected slots (observers)
+	std::vector<SlotType> slots_;
+};
+
+/// @brief Observable property that emits signals when its value changes.
+/// @tparam T Type of the property value, must be equality comparable.
+/// @note This class is not thread-safe yet.
+template <typename T>
+    requires std::equality_comparable<T>
+class ObservableProperty {
+public:
+	using SignalType = Signal<const T &, const T &>;  // Signal with old and new values
+	using SlotType = typename SignalType::SlotType;
+
+	ObservableProperty(std::string name, T initialValue)
+	    : name_(std::move(name)), value_(std::move(initialValue)), signal_() {}
+
+	/// Sets a new value for the property and emits a signal if the value has changed.
+	/// @param newValue The new value to set
+	void setValue(T newValue) {
+		if (value_ == newValue) { return; }
+
+		T oldValue = std::move(value_);
+		value_ = std::move(newValue);
+		signal_.emit(oldValue, value_);
+	}
+
+	/// Retrieves the current value of the property.
+	const T &getValue() const { return value_; }
+
+	/// Returns the name of the property.
+	const std::string &getName() const { return name_; }
+
+	/// Returns a reference to the signal associated with this property.
+	SignalType &getSignal() { return signal_; }
+
+	/// Connects a slot to the signal, allowing it to be notified of changes.
+	/// @param slot The function to be called when the property changes.
+	/// @note The slot receives the old and new values of the property.
+	/// @note The slot can be a lambda or any callable that matches the signature.
+	void connect(SlotType slot) { signal_.connect(std::move(slot)); }
+
+	/// Convenience method for slots that don't need the old/new values
+	void connectSimple(const std::function<void()> &slot) {
+		signal_.connect([slot](const T &, const T &) { slot(); });
+	}
+
+private:
+	std::string name_;   ///< Property name, could be used as key for database or logging
+	T value_;            ///< Current value of the property
+	SignalType signal_;  ///< Signal to notify observers about changes
+};

--- a/src/common/observable_property_unittest.cc
+++ b/src/common/observable_property_unittest.cc
@@ -1,0 +1,167 @@
+/*
+   Copyright 2023      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "common/platform.h"
+
+#include <gtest/gtest.h>
+
+#include "common/observable_property.h"
+
+TEST(SignalSlotTest, BasicSignalWithNoParameters) {
+	Signal<> signal;
+	int callCount = 0;
+
+	signal.connect([&callCount]() { callCount++; });
+
+	EXPECT_EQ(callCount, 0);
+	signal.emit();
+	EXPECT_EQ(callCount, 1);
+	signal.emit();
+	EXPECT_EQ(callCount, 2);
+}
+
+TEST(SignalSlotTest, SignalWithSingleParameter) {
+	Signal<std::string> signal;
+	std::string receivedMessage;
+
+	signal.connect([&receivedMessage](const std::string &msg) { receivedMessage = msg; });
+
+	signal.emit("Hello World");
+	EXPECT_EQ(receivedMessage, "Hello World");
+}
+
+TEST(SignalSlotTest, SignalWithMultipleParameters) {
+	Signal<int, const std::string &, bool> signal;
+	int receivedInt = 0;
+	std::string receivedString;
+	bool receivedBool = false;
+
+	signal.connect([&](int i, const std::string &s, bool b) {
+		receivedInt = i;
+		receivedString = s;
+		receivedBool = b;
+	});
+
+	signal.emit(42, "test", true);
+	EXPECT_EQ(receivedInt, 42);
+	EXPECT_EQ(receivedString, "test");
+	EXPECT_TRUE(receivedBool);
+}
+
+TEST(SignalSlotTest, MultipleSlots) {
+	Signal<int> signal;
+	int slot1Value = 0;
+	int slot2Value = 0;
+
+	signal.connect([&slot1Value](int value) { slot1Value = value * 2; });
+
+	signal.connect([&slot2Value](int value) { slot2Value = value + 10; });
+
+	signal.emit(5);
+	EXPECT_EQ(slot1Value, 10);
+	EXPECT_EQ(slot2Value, 15);
+}
+
+TEST(SignalSlotTest, ObservablePropertyBasic) {
+	ObservableProperty<int> property("test_int", 100);
+
+	EXPECT_EQ(property.getValue(), 100);
+
+	int oldValue = -1;
+	int newValue = -1;
+	property.connect([&](const int &oldVal, const int &newVal) {
+		oldValue = oldVal;
+		newValue = newVal;
+	});
+
+	property.setValue(200);
+	EXPECT_EQ(property.getValue(), 200);
+	EXPECT_EQ(oldValue, 100);
+	EXPECT_EQ(newValue, 200);
+}
+
+TEST(SignalSlotTest, ObservablePropertySimpleSlot) {
+	ObservableProperty<std::string> property("test_string", "initial");
+	int changeCount = 0;
+
+	property.connectSimple([&changeCount]() { changeCount++; });
+
+	property.setValue("changed1");
+	EXPECT_EQ(changeCount, 1);
+	property.setValue("changed2");
+	EXPECT_EQ(changeCount, 2);
+}
+
+TEST(SignalSlotTest, ObservablePropertyMultipleObservers) {
+	ObservableProperty<bool> property("test_bool", false);
+	int observer1Count = 0;
+	int observer2Count = 0;
+
+	property.connect([&observer1Count](const bool &, const bool &) { observer1Count++; });
+
+	property.connectSimple([&observer2Count]() { observer2Count++; });
+
+	property.setValue(true);
+	EXPECT_EQ(observer1Count, 1);
+	EXPECT_EQ(observer2Count, 1);
+
+	property.setValue(false);
+	EXPECT_EQ(observer1Count, 2);
+	EXPECT_EQ(observer2Count, 2);
+}
+
+TEST(SignalSlotTest, SignalClearAndSize) {
+	Signal<> signal;
+	int callCount = 0;
+
+	EXPECT_EQ(signal.size(), 0UL);
+
+	signal.connect([&callCount]() { callCount++; });
+	signal.connect([&callCount]() { callCount++; });
+	EXPECT_EQ(signal.size(), 2UL);
+
+	signal.emit();
+	EXPECT_EQ(callCount, 2);
+
+	signal.clear();
+	EXPECT_EQ(signal.size(), 0UL);
+
+	signal.emit();
+	EXPECT_EQ(callCount, 2);  // Should not change after clear
+}
+
+TEST(SignalSlotTest, ComplexTypeSignal) {
+	struct TestData {
+		int id;
+		std::string name;
+		bool operator==(const TestData &other) const {
+			return id == other.id && name == other.name;
+		}
+	};
+
+	Signal<const TestData &> signal;
+	TestData receivedData{.id = 0, .name = ""};
+
+	signal.connect([&receivedData](const TestData &data) { receivedData = data; });
+
+	TestData testData{.id = 123, .name = "test_name"};
+	signal.emit(testData);
+
+	EXPECT_EQ(receivedData.id, 123);
+	EXPECT_EQ(receivedData.name, "test_name");
+}


### PR DESCRIPTION
Adds an initial implementation of observable properties using a signal-slot mechanism. With this approach, the observed object doesn’t need to know its observers. For example, the metadata version in gMetadata could be an ObservableProperty, and at runtime different observers would be notified and react to changes.

This will be used by the FoundationDB metadata backend to persist changes immediately in the database instead of relying on the current dump mechanism.

Notes for reviewers:
- The class is only used so far in unit tests, I will use it soon for the FoundationDB backend.
- Better explanation about the pattern is here: https://doc.qt.io/qt-6/signalsandslots.html