### PR TITLE
test: Fix path by inode test on Windows

### DIFF
--- a/tests/test_suites/TestTemplates/test_path_by_inode.inc
+++ b/tests/test_suites/TestTemplates/test_path_by_inode.inc
@@ -54,7 +54,11 @@ assert_equals "data7" "$(cat file4)"
 cd ..
 saunafs_mount_unmount 0
 echo "sfssubfolder=folder/folder2" >> "${info[mount0_cfg]}"
-assert_success saunafs_mount_start 0
+if is_windows_system; then
+	saunafs_mount_start 0
+else
+	assert_success saunafs_mount_start 0
+fi
 cd "${info[mount0]}"
 
 assert_equals "" "$(cat .saunafs_path_by_inode/1)"
@@ -75,7 +79,11 @@ assert_failure cat .saunafs_path_by_inode/7 # corresponding to file4
 cd ..
 saunafs_mount_unmount 0
 echo "sfssubfolder=/" >> "${info[mount0_cfg]}"
-assert_success saunafs_mount_start 0
+if is_windows_system; then
+	saunafs_mount_start 0
+else
+	assert_success saunafs_mount_start 0
+fi
 cd "${info[mount0]}"
 
 # check removing files by their path


### PR DESCRIPTION
Due to client unmount logic introduced in the path-by-inode related test in commit ebc58a61, this test was failing in the Windows client test suite. On WSL1, the return value from assert_success was not handled correctly when the client was restarted. Additionally, asserting that specific call is unnecessary, as the test will fail if the client is not mounted or does not include the required option for mounting to the given subfolder. This commit resolves these issues.