### PR TITLE
test(ganesha): Add POSIX file locking tests

### DIFF
--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_file_locks_ping_pong.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_file_locks_ping_pong.sh
@@ -1,0 +1,73 @@
+timeout_set 3 minutes
+
+CHUNKSERVERS=5 \
+	USE_RAMDISK=YES \
+	setup_local_empty_saunafs info
+
+test_error_cleanup() {
+	cd ${TEMP_DIR}
+	for x in "${nfs_mounts[@]}"; do
+		sudo umount -l "${TEMP_DIR}/mnt/nfs${x}"
+	done
+	sudo pkill -9 ganesha.nfsd
+}
+
+create_ganesha_pid_file
+
+# Create mountpoints for testing
+mkdir "${TEMP_DIR}/mnt/nfs"{2,3,5,7,11}
+
+cat <<EOF > "${TEMP_DIR}/ganesha.conf"
+NFSV4 {
+	Grace_Period = 5;
+	Lease_Lifetime = 5;
+}
+EOF
+
+for id in 2 3 5 7 11; do
+	cat <<EOF_EXPORT >> "${TEMP_DIR}/ganesha.conf"
+EXPORT
+{
+	Attr_Expiration_Time = 10;
+	Export_Id = ${id};
+	Path = /;
+	Pseudo = /export${id};
+	Access_Type = RW;
+	FSAL {
+		Name = SaunaFS;
+		hostname = localhost;
+		port = ${saunafs_info_[matocl]};
+	}
+	Protocols = 4;
+}
+EOF_EXPORT
+done
+
+sudo /usr/bin/ganesha.nfsd -f "${TEMP_DIR}/ganesha.conf" -L /tmp/ganesha.log
+
+check_rpc_service
+
+nfs_mounts=(2 3 5 7 11)
+
+for x in "${nfs_mounts[@]}"; do
+	sudo mount localhost:/export${x} "${TEMP_DIR}/mnt/nfs${x}"
+done
+
+touch "${TEMP_DIR}/mnt/nfs2/lockfile"
+
+declare -a ping_pongs
+
+# Launch ping pong instances
+for x in "${nfs_mounts[@]}"; do
+	cd "${TEMP_DIR}/mnt/nfs${x}"
+	safs_ping_pong -rw lockfile 6&
+	ping_pongs[$x]=$!
+done
+
+# Ensure that all ping pong tests finished with no errors
+for x in "${nfs_mounts[@]}"; do
+	wait ${ping_pongs[$x]}
+	assert_equals 0 $?
+done
+
+test_error_cleanup

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_posix_file_locks.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_posix_file_locks.sh
@@ -1,0 +1,93 @@
+timeout_set 1 minute
+
+USE_RAMDISK=YES \
+	setup_local_empty_saunafs info
+
+test_error_cleanup() {
+	cd ${TEMP_DIR}
+	sudo umount -l ${TEMP_DIR}/mnt/ganesha
+	sudo pkill -9 ganesha.nfsd
+}
+
+create_ganesha_pid_file
+
+mkdir -p ${TEMP_DIR}/mnt/ganesha
+
+cat <<EOF > ${TEMP_DIR}/ganesha.conf
+NFSV4 {
+	Grace_Period = 5;
+	Lease_Lifetime = 5;
+}
+EXPORT
+{
+	Attr_Expiration_Time = 10;
+	Export_Id = 2;
+	Path = /;
+	Pseudo = /;
+	Access_Type = RW;
+	FSAL {
+		Name = SaunaFS;
+		hostname = localhost;
+		port = ${saunafs_info_[matocl]};
+	}
+	Protocols = 4;
+}
+EOF
+
+sudo /usr/bin/ganesha.nfsd -f "${TEMP_DIR}/ganesha.conf"
+
+check_rpc_service
+sudo mount -vvvv localhost:/ "${TEMP_DIR}/mnt/ganesha"
+
+mkdir "${TEMP_DIR}/mnt/ganesha/dir"
+FILE_SIZE="100M" assert_success file-generate "${TEMP_DIR}/mnt/ganesha/dir/file_100M"
+
+opcount=0
+
+function assert_operation_performed() {
+	opcount=$((opcount + 1))
+	assert_eventually_prints "$1" "sed -n ${opcount}p ${TEMP_DIR}/posixlock.log"
+}
+
+function writelock() {
+	posixlockcmd $1 w $2 $3 >> "${TEMP_DIR}/posixlock.log" &
+	assert_operation_performed "write open:   $1"
+}
+
+function unlock() {
+	kill -s SIGUSR1 $1
+}
+
+declare -a writelocks
+
+# Go to the Ganesha mount point
+cd "${TEMP_DIR}/mnt/ganesha"
+
+# Lock byte range [0, 5]
+writelock "dir/file_100M" 0 5
+writelocks[1]=$!
+assert_operation_performed "write lock:   dir/file_100M"
+
+# Lock byte range [10, 20]
+writelock "dir/file_100M" 10 20
+writelocks[2]=$!
+assert_operation_performed "write lock:   dir/file_100M"
+
+# Unlock byte range [0, 5]
+unlock ${writelocks[1]}
+assert_operation_performed "write unlock: dir/file_100M"
+
+# Unlock byte range [10, 20]
+unlock ${writelocks[2]}
+assert_operation_performed "write unlock: dir/file_100M"
+
+# Lock byte range [0, 0] is equivalent to locking the whole file
+writelock "dir/file_100M" 0 0
+writelocks[3]=$!
+assert_operation_performed "write lock:   dir/file_100M"
+
+# Unlock byte range [0, 0]
+unlock ${writelocks[3]}
+assert_operation_performed "write unlock: dir/file_100M"
+
+test_error_cleanup


### PR DESCRIPTION
This commit introduces two tests to verify POSIX file locking in the Ganesha suite:

- `test_nfs_ganesha_file_locks_ping_pong`: Verifies correct lock handling across multiple NFS exports using SaunaFS by performing concurrent read/write operations with the `safs_ping_pong` tool.

- `test_nfs_ganesha_posix_file_locks`: Tests POSIX byte-range locking through the NFS-Ganesha mount using `posixlockcmd` tool.