### PR TITLE
fix: Fix upgrade master switch write algo test

### DIFF
--- a/tests/test_suites/ShortSystemTests/test_admin_list_mounts.sh
+++ b/tests/test_suites/ShortSystemTests/test_admin_list_mounts.sh
@@ -5,7 +5,7 @@ MOUNTS=4 \
 mounts=$(saunafs_admin_command list-mounts --porcelain --verbose localhost "${info[matocl]}")
 expect_equals "4" $(wc -l <<< "$mounts")
 for i in {1..4}; do
-	if is_windows_system; then
+	if [[ ${info[is_windows_system]} -eq 1 ]]; then
 		expect_equals \
 			"$i $(echo -n $i | tr '[1-9]' '[F-N]'): $SAUNAFS_VERSION / 0 0 999 999 no yes no no no 1 40 - -" \
 			"$(sed -n "${i}p" <<< "$mounts" | cut -d' ' -f 1,3-)"

--- a/tests/test_suites/ShortSystemTests/test_auto_recovery_incversion.sh
+++ b/tests/test_suites/ShortSystemTests/test_auto_recovery_incversion.sh
@@ -28,7 +28,7 @@ assert_success rm "$chunk"
 truncate -s 1 dir/file
 assert_awk_finds '/INCVERSION/' "$(cat "${info[master_data_path]}"/changelog.sfs)"
 echo b > something_more  # To make sure that after INCVERSION we are able to apply other changes
-if is_windows_system; then
+if [[ ${info[is_windows_system]} -eq 1 ]]; then
 	# On Windows, we need to wait for the metadata to be dumped
 	sleep 0.5
 fi

--- a/tests/test_suites/ShortSystemTests/test_cs_failure_recovery_speed.sh
+++ b/tests/test_suites/ShortSystemTests/test_cs_failure_recovery_speed.sh
@@ -14,7 +14,7 @@ wait_if_windows
 
 # Stop one of chunkservers which has one copy of each chunk and
 # immediately start overwriting all the chunks.
-if is_windows_system; then
+if [[ ${info[is_windows_system]} -eq 1 ]]; then
 	saunafs_chunkserver_daemon 0 stop
 else
 	kill -s SIGSTOP "$(saunafs_chunkserver_daemon 0 test | sed 's/.*pid: //')"

--- a/tests/test_suites/ShortSystemTests/test_custom_goal_migration_during_delay_disconnect.sh
+++ b/tests/test_suites/ShortSystemTests/test_custom_goal_migration_during_delay_disconnect.sh
@@ -40,7 +40,7 @@ saunafs setgoal raid_goal "${info[mount0]}"/* > /dev/null
 
 # Chunks should be replicated only on 'raid' server.
 # Replication to other servers is delayed because of disconnected chunkserver 2.
-if is_windows_system; then
+if [[ ${info[is_windows_system]} -eq 1 ]]; then
 	assert_eventually_prints 20 'find_chunkserver_metadata_chunks 0 | wc -l' '25 seconds'
 else
 	assert_eventually_prints 20 'find_chunkserver_metadata_chunks 0 | wc -l' '5 seconds'
@@ -53,7 +53,7 @@ assert_equals 20 $(saunafs checkfile "${info[mount0]}"/* | grep 'with 2 copies:'
 assert_equals 0 $(find_chunkserver_metadata_chunks 1 | wc -l)
 
 # Expect one copy of each chunk to migrate to the last unlabeled server.
-if is_windows_system; then
+if [[ ${info[is_windows_system]} -eq 1 ]]; then
 	assert_eventually_prints 20 'find_chunkserver_metadata_chunks 1 | wc -l' '100 seconds'
 else
 	assert_eventually_prints 20 'find_chunkserver_metadata_chunks 1 | wc -l' '20 seconds'

--- a/tests/test_suites/ShortSystemTests/test_defective_files_tool.sh
+++ b/tests/test_suites/ShortSystemTests/test_defective_files_tool.sh
@@ -14,7 +14,7 @@ FILE_SIZE=$((3*64*1024)) BLOCK_SIZE=1024 file-generate dir_ec/file
 
 saunafs_chunkserver_daemon 0 stop
 
-if is_windows_system; then
+if [[ ${info[is_windows_system]} -eq 1 ]]; then
 	assert_eventually_prints 1 "saunafs_admin_master list-defective-files --undergoal --porcelain | wc -l" '75 seconds'
 else
 	assert_eventually_prints 1 "saunafs_admin_master list-defective-files --undergoal --porcelain | wc -l"
@@ -26,7 +26,7 @@ for CS in {1..2}; do
 	saunafs_chunkserver_daemon $CS stop
 done
 
-if is_windows_system; then
+if [[ ${info[is_windows_system]} -eq 1 ]]; then
 	assert_eventually_prints 1 "saunafs_admin_master list-defective-files --unavailable --porcelain | wc -l" '75 seconds'
 else
 	assert_eventually_prints 1 "saunafs_admin_master list-defective-files --unavailable --porcelain | wc -l"
@@ -38,7 +38,7 @@ for CS in {0..2}; do
 	saunafs_chunkserver_daemon $CS start
 done
 
-if is_windows_system; then
+if [[ ${info[is_windows_system]} -eq 1 ]]; then
 	assert_eventually_prints 0 "saunafs_admin_master list-defective-files --unavailable --porcelain | wc -l" '75 seconds'
 else
 	assert_eventually_prints 0 "saunafs_admin_master list-defective-files --unavailable --porcelain | wc -l"

--- a/tests/test_suites/ShortSystemTests/test_ec_goal_with_labels.sh
+++ b/tests/test_suites/ShortSystemTests/test_ec_goal_with_labels.sh
@@ -44,7 +44,7 @@ assert_equals 3 "$(count_chunks_on_chunkservers {6..8})"
 assert_equals 3 "$(count_chunks_on_chunkservers {0..11})"
 
 saunafs setgoal ec33_hdd dir/file
-if is_windows_system; then
+if [[ ${info[is_windows_system]} -eq 1 ]]; then
 	assert_eventually_prints '6 ec3_3' 'chunks_state' '4 minutes'
 else
 	assert_eventually_prints '6 ec3_3' 'chunks_state' '2 minutes'
@@ -53,7 +53,7 @@ assert_equals 3 "$(count_chunks_on_chunkservers {3..5})"
 assert_equals 6 "$(count_chunks_on_chunkservers {0..11})"
 
 saunafs setgoal ec22_mix dir/file
-if is_windows_system; then
+if [[ ${info[is_windows_system]} -eq 1 ]]; then
 	assert_eventually_prints '4 ec2_2' 'chunks_state' '4 minutes'
 else
 	assert_eventually_prints '4 ec2_2' 'chunks_state' '2 minutes'
@@ -63,7 +63,7 @@ assert_equals 2 "$(count_chunks_on_chunkservers {6..8})"
 
 saunafs setgoal ec36_mix dir/file
 saunafs fileinfo dir/*
-if is_windows_system; then
+if [[ ${info[is_windows_system]} -eq 1 ]]; then
 	assert_eventually_prints '9 ec3_6' 'chunks_state' '4 minutes'
 else
 	assert_eventually_prints '9 ec3_6' 'chunks_state' '2 minutes'

--- a/tests/test_suites/ShortSystemTests/test_file_repair_correct_only_chunk_missing.sh
+++ b/tests/test_suites/ShortSystemTests/test_file_repair_correct_only_chunk_missing.sh
@@ -30,7 +30,7 @@ cd ..
 # Unmount old SaunaFS client 0:
 assert_success saunafs_mount_unmount 0
 # Mount SaunaFS client 0:
-if is_windows_system; then
+if [[ ${info[is_windows_system]} -eq 1 ]]; then
 	saunafs_mount_start 0
 else
 	assert_success saunafs_mount_start 0
@@ -59,7 +59,7 @@ cd ..
 # Unmount old SaunaFS client 0:
 assert_success saunafs_mount_unmount 0
 # Mount SaunaFS client 0:
-if is_windows_system; then
+if [[ ${info[is_windows_system]} -eq 1 ]]; then
 	saunafs_mount_start 0
 else
 	assert_success saunafs_mount_start 0

--- a/tests/test_suites/ShortSystemTests/test_file_repair_correct_only_chunk_parts_missing.sh
+++ b/tests/test_suites/ShortSystemTests/test_file_repair_correct_only_chunk_parts_missing.sh
@@ -30,7 +30,7 @@ cd ..
 # Unmount old SaunaFS client 0:
 assert_success saunafs_mount_unmount 0
 # Mount SaunaFS client 0:
-if is_windows_system; then
+if [[ ${info[is_windows_system]} -eq 1 ]]; then
 	saunafs_mount_start 0
 else
 	assert_success saunafs_mount_start 0
@@ -59,7 +59,7 @@ cd ..
 # Unmount old SaunaFS client 0:
 assert_success saunafs_mount_unmount 0
 # Mount SaunaFS client 0:
-if is_windows_system; then
+if [[ ${info[is_windows_system]} -eq 1 ]]; then
 	saunafs_mount_start 0
 else
 	assert_success saunafs_mount_start 0

--- a/tests/test_suites/ShortSystemTests/test_io_limits.sh
+++ b/tests/test_suites/ShortSystemTests/test_io_limits.sh
@@ -12,7 +12,7 @@ CHUNKSERVERS=3 \
 cd "${info[mount0]}"
 
 rescale_value() {
-	if valgrind_enabled || is_windows_system ; then
+	if valgrind_enabled || [[ ${info[is_windows_system]} -eq 1 ]]; then
 		echo $((4 * $1))
 	else
 		echo "$1"

--- a/tests/test_suites/ShortSystemTests/test_migrating_between_labels.sh
+++ b/tests/test_suites/ShortSystemTests/test_migrating_between_labels.sh
@@ -38,7 +38,7 @@ wait
 
 # Change goal of all files, verify
 saunafs setgoal two_hdds dir/file*
-if is_windows_system; then
+if [[ ${info[is_windows_system]} -eq 1 ]]; then
 	expect_eventually_prints 20 'count_chunks_on_chunkservers {3..5}' '75 seconds'
 	assert_eventually_prints 20 'find_all_metadata_chunks | wc -l' '75 seconds'
 else
@@ -48,7 +48,7 @@ fi
 
 # Change goal of some files, verify
 saunafs setgoal two_flops dir/file{1..4}
-if is_windows_system; then
+if [[ ${info[is_windows_system]} -eq 1 ]]; then
 	expect_eventually_prints 8 'count_chunks_on_chunkservers {6..8}' '75 seconds'
 	expect_eventually_prints 12 'count_chunks_on_chunkservers {3..5}' '75 seconds'
 	assert_eventually_prints 20 'find_all_metadata_chunks | wc -l' '75 seconds'

--- a/tests/test_suites/ShortSystemTests/test_replication_delay_disconnect.sh
+++ b/tests/test_suites/ShortSystemTests/test_replication_delay_disconnect.sh
@@ -36,7 +36,7 @@ saunafs_wait_for_ready_chunkservers 5
 
 # All chunks has 4 missing copies but 2 chunkservers are disconnected,
 # so only two new copies should be created
-if is_windows_system; then
+if [[ ${info[is_windows_system]} -eq 1 ]]; then
 	assert_eventually_prints 20 'saunafs checkfile "${info[mount0]}"/* | grep "with 3 copies:" | wc -l' '15 seconds'
 else
 	assert_eventually_prints 20 'saunafs checkfile "${info[mount0]}"/* | grep "with 3 copies:" | wc -l' '5 seconds'
@@ -47,7 +47,7 @@ sleep 10
 assert_equals 20 $(saunafs checkfile "${info[mount0]}"/* | grep 'with 3 copies:' | wc -l)
 
 # Expect two more copies of each chunk to migrate to the two empty servers
-if is_windows_system; then
+if [[ ${info[is_windows_system]} -eq 1 ]]; then
 	assert_eventually_prints 20 'saunafs checkfile "${info[mount0]}"/* | grep "with 3 copies:" | wc -l' '60 seconds'
 else
 	assert_eventually_prints 20 'saunafs checkfile "${info[mount0]}"/* | grep "with 3 copies:" | wc -l' '20 seconds'

--- a/tests/test_suites/ShortSystemTests/test_saunafs_mount_info.sh
+++ b/tests/test_suites/ShortSystemTests/test_saunafs_mount_info.sh
@@ -18,7 +18,7 @@ compare_dates() {
 USE_RAMDISK=YES \
     setup_local_empty_saunafs info
 
-if is_windows_system; then
+if [[ ${info[is_windows_system]} -eq 1 ]]; then
     # Get the PID and username of the sfsmount process on Windows
     tasklist_output=$(tasklist.exe /FI "IMAGENAME eq sfsmount.exe" 2>&1)
     sfsmount_pid=$(echo "$tasklist_output" | awk '/sfsmount.exe/ {print $2}')
@@ -41,7 +41,7 @@ mount_info=$(cat "${info[mount0]}/.saunafs_mount_info")
 # Check if the contents match the expected values
 actual_started_date=$(echo "$mount_info" | egrep "STARTED DATE" | awk '{print $3}')
 compare_dates "$expected_started_date" "$actual_started_date" 5
-if is_windows_system; then
+if [[ ${info[is_windows_system]} -eq 1 ]]; then
     assert_success $(echo "$mount_info" | grep -q "$expected_sid")
 else
     assert_success $(echo "$mount_info" | grep -q "$expected_uid")

--- a/tests/test_suites/ShortSystemTests/test_upgrade_master_switch_write_algo.sh
+++ b/tests/test_suites/ShortSystemTests/test_upgrade_master_switch_write_algo.sh
@@ -51,20 +51,20 @@ assert_success file-validate new_mount_old_master_file
 # Test if all files produced so far are readable on legacy mount:
 cd "${info[mount0]}/from_new_mount"
 assert_success file-validate new_mount_old_master_file
+cd ${TEMP_DIR} # Change to temp directory to avoid issues with CWD on mount during master restart
 
 saunafsXX_master_daemon stop
 
 # Force the master to create new sessions (and clients to connect instead of reconnect)
 rm $(get_current_master_sessions_file)
 
-# Don't know why, but we have to bypass the saunafs_master_daemon function
-assert_success sfsmaster -c "${info[master0_cfg]}" start
+assert_success saunafs_master_daemon start
 
 saunafs_wait_for_all_ready_chunkservers
 
 # Ensure that we can still read and write files from new and old SaunaFS mounts
 
-# We were at "${info[mount0]}/from_new_mount"
+cd "${info[mount0]}/from_new_mount"
 assert_success file-validate new_mount_old_master_file
 
 cd "../from_old_mount"

--- a/tests/test_suites/TestTemplates/test_path_by_inode.inc
+++ b/tests/test_suites/TestTemplates/test_path_by_inode.inc
@@ -54,7 +54,7 @@ assert_equals "data7" "$(cat file4)"
 cd ..
 saunafs_mount_unmount 0
 echo "sfssubfolder=folder/folder2" >> "${info[mount0_cfg]}"
-if is_windows_system; then
+if [[ ${info[is_windows_system]} -eq 1 ]]; then
 	saunafs_mount_start 0
 else
 	assert_success saunafs_mount_start 0
@@ -79,7 +79,7 @@ assert_failure cat .saunafs_path_by_inode/7 # corresponding to file4
 cd ..
 saunafs_mount_unmount 0
 echo "sfssubfolder=/" >> "${info[mount0_cfg]}"
-if is_windows_system; then
+if [[ ${info[is_windows_system]} -eq 1 ]]; then
 	saunafs_mount_start 0
 else
 	assert_success saunafs_mount_start 0

--- a/tests/tools/saunafs.sh
+++ b/tests/tools/saunafs.sh
@@ -30,6 +30,12 @@ setup_local_empty_saunafs() {
 	saunafs_info_[chunkserver_count]=$number_of_chunkservers
 	saunafs_info_[admin_password]=${ADMIN_PASSWORD:-password}
 
+	if is_windows_system; then
+		saunafs_info_[is_windows_system]=1
+	else
+		saunafs_info_[is_windows_system]=0
+	fi
+
 	init_metadata_backend
 
 	# Enable always ramdisk for zoned devices
@@ -109,7 +115,7 @@ setup_local_empty_saunafs() {
 	if [[ $auto_shadow_master == YES && $number_of_masterservers == 1 ]]; then
 		add_metadata_server_ auto "shadow"
 		saunafs_master_n auto start ${shadow_start_param}
-		if ! is_windows_system; then
+		if ! [[ ${saunafs_info_[is_windows_system]} -eq 1 ]]; then
 			assert_eventually 'saunafs_shadow_synchronized auto'
 		fi
 	fi
@@ -145,7 +151,7 @@ init_metadata_backend() {
 }
 
 saunafs_admin_command() {
-	if is_windows_system; then
+	if [[ ${saunafs_info_[is_windows_system]} -eq 1 ]]; then
 		${SAFS_ADMIN_COMMAND} "$@" | tr -d '\r'
 	else
 		saunafs-admin "$@"
@@ -154,7 +160,7 @@ saunafs_admin_command() {
 }
 
 saunafs_command() {
-	if is_windows_system; then
+	if [[ ${saunafs_info_[is_windows_system]} -eq 1 ]]; then
 		${SAFS_SAUNAFS_COMMAND} "$@" | tr -d '\r'
 	else
 		saunafs "$@"
@@ -183,7 +189,7 @@ windows_server_aux(){
 saunafs_chunkserver_daemon() {
 	local id=$1
 	shift
-	if is_windows_system; then
+	if [[ ${saunafs_info_[is_windows_system]} -eq 1 ]]; then
 		windows_server_aux "sfschunkserver -c ${saunafs_info_[chunkserver${id}_cfg]}" "$@"
 	else
 		sfschunkserver -c "${saunafs_info_[chunkserver${id}_cfg]}" "$@" | cat
@@ -192,7 +198,7 @@ saunafs_chunkserver_daemon() {
 }
 
 saunafs_master_daemon() {
-	if is_windows_system; then
+	if [[ ${saunafs_info_[is_windows_system]} -eq 1 ]]; then
 		windows_server_aux "sfsmaster -c ${saunafs_info_[master${saunafs_info_[current_master]}_cfg]}" "$@"
 	else
 		sfsmaster -c "${saunafs_info_[master${saunafs_info_[current_master]}_cfg]}" "$@" | cat
@@ -204,7 +210,7 @@ saunafs_master_daemon() {
 saunafs_master_n() {
 	local id=$1
 	shift
-	if is_windows_system; then
+	if [[ ${saunafs_info_[is_windows_system]} -eq 1 ]]; then
 		windows_server_aux "sfsmaster -c ${saunafs_info_[master${id}_cfg]}" "$@"
 	else
 		sfsmaster -c "${saunafs_info_[master${id}_cfg]}" "$@" | cat
@@ -214,7 +220,7 @@ saunafs_master_n() {
 
 # saunafs_metalogger_daemon start|stop|restart|kill|tests|isalive|...
 saunafs_metalogger_daemon() {
-	if is_windows_system; then
+	if [[ ${saunafs_info_[is_windows_system]} -eq 1 ]]; then
 		windows_server_aux "sfsmetalogger -c ${saunafs_info_[metalogger_cfg]}" "$@"
 	else
 		sfsmetalogger -c "${saunafs_info_[metalogger_cfg]}" "$@" | cat
@@ -226,7 +232,7 @@ saunafs_metalogger_daemon() {
 saunafs_mount_unmount_async() {
 	local mount_id=$1
 	local mount_dir=${saunafs_info_[mount${mount_id}]}
-	if is_windows_system; then
+	if [[ ${saunafs_info_[is_windows_system]} -eq 1 ]]; then
 		${saunafs_info_[umountcall${mount_id}]}
 	else
 		saunafs_fusermount -u ${mount_dir}
@@ -254,7 +260,7 @@ saunafs_mount_start() {
 	if [[ $mount_cmd ]]; then
 		configure_mount_ ${mount_id} ${mount_cmd}
 	fi
-	if is_windows_system; then
+	if [[ ${saunafs_info_[is_windows_system]} -eq 1 ]]; then
 		${saunafs_info_[mntcall${mount_id}]}
 	else
 		do_mount_ ${mount_id}
@@ -773,7 +779,7 @@ add_mount_() {
 	local user_id=$2
 	local group_id=$3
 
-	if is_windows_system; then
+	if [[ ${saunafs_info_[is_windows_system]} -eq 1 ]]; then
 		windows_prepare_mount_ $mount_id $user_id $group_id
 	else
 		unix_prepare_mount_ $mount_id


### PR DESCRIPTION
It was noticed that master was not restarting in some failed runs of
the test test_upgrade_master_switch_write_algo. This commit makes sure
that test uses the usual saunafs_master_daemon.

The main change was to avoid calling again the is_windows_system
function, so it was stored at the begining of the
setup_local_empty_saunafs. This way many tests were changed the way it
used the new stored value.

Signed-off-by: Dave <dave@leil.io>