### PR TITLE
fix(mount): Fix readahead under high latency

### DIFF
--- a/src/mount/readdata.cc
+++ b/src/mount/readdata.cc
@@ -125,6 +125,7 @@ uint32_t getBytesToBeReadFromCS(uint32_t index, uint32_t offset, uint32_t size,
 
 RequestConditionVariablePair *ReadaheadRequests::append(
     ReadaheadRequestPtr readaheadRequestPtr) {
+	readaheadRequestPtr->entry->isPendingNotify = true;
 	pendingRequests_.emplace_back(readaheadRequestPtr);
 	return &pendingRequests_.back();
 }
@@ -199,8 +200,19 @@ void ReadaheadRequests::discardAllPendingRequests() {
 		    req.requestPtr->entry->refcount <= 1) {
 			req.requestPtr->state = ReadaheadRequestState::kDiscarded;
 		}
+		req.requestPtr->entry->isPendingNotify = false;
 	}
 	pendingRequests_.clear();
+}
+
+ReadaheadRequests::~ReadaheadRequests() {
+	if (!pendingRequests_.empty()) {
+		safs::log_warn(
+		    "ReadaheadRequests destructor called with pending requests, "
+		    "this should not happen, pending requests: {}",
+		    toString().str());
+		discardAllPendingRequests();
+	}
 }
 
 bool ReadaheadOperationsManager::request(

--- a/src/mount/readdata.h
+++ b/src/mount/readdata.h
@@ -93,6 +93,7 @@ struct RequestConditionVariablePair {
 	// inodeLock: LOCKED
 	void notify() {
 		cvPtr->notify_all();
+		requestPtr->entry->isPendingNotify = false;
 	}
 };
 
@@ -185,6 +186,14 @@ struct ReadaheadRequests {
 	 * inodeLock: LOCKED
 	 */
 	void discardAllPendingRequests();
+
+	/** \brief Make sure pending requests are no longer being waited for.
+	 *
+	 * This is necessary to avoid those entries being not properly released in some unexpected
+	 * situations, because when the destruction comes, the pending requests are not supposed to
+	 * exist anymore.
+	 */
+	~ReadaheadRequests();
 
 private:
 	using RequestsContainer = std::list<RequestConditionVariablePair>;

--- a/src/mount/readdata_cache.cc
+++ b/src/mount/readdata_cache.cc
@@ -123,6 +123,16 @@ ReadCache::Size ReadCache::Result::copyToBuffer(uint8_t *output, Offset real_off
 	uint64_t offset = real_offset;
 	Size bytes_left = real_size;
 	for (const auto &entry_ptr : entries) {
+		if (entry_ptr->inEntriesPool) {
+			safs::log_err(
+			    "(ReadCache::Result::copyToBuffer) Copying entry that is in the entries "
+			    "pool, this should not happen, refcount: {}, offset: {}, size: {}",
+			    entry_ptr->refcount.load(), entry_ptr->offset, entry_ptr->buffer.size());
+
+			// This should not happen, but if it does, we just return 0
+			return 0;
+		}
+
 		const ReadCache::Entry &entry = *entry_ptr;
 		if (bytes_left <= 0) { break; }
 		// Special case: Read request was past the end of the file
@@ -152,6 +162,14 @@ void ReadCache::Result::release() {
 }
 
 void ReadCache::Result::add(Entry &entry) {
+	if (entry.inEntriesPool) {
+		safs::log_err(
+		    "(ReadCache::Result::add) Adding entry that is in the entries pool, this should "
+		    "not happen, refcount: {}, offset: {}, size: {}",
+		    entry.refcount.load(), entry.offset, entry.buffer.size());
+		return;
+	}
+
 	entry.acquire();
 	assert(entries.empty() || endOffset() >= entry.offset);
 	entries.push_back(std::addressof(entry));
@@ -420,6 +438,7 @@ ReadCache::Entry *ReadCacheEntriesPool::getEntry(size_t offset, size_t size) {
 	entry->refcount = 0;
 	entry->requested_size = size;
 	entry->done = false;
+	entry->inEntriesPool = false;
 
 	return entry;
 }
@@ -428,6 +447,7 @@ void ReadCacheEntriesPool::putEntry(ReadCache::Entry *entry) {
 	assert(entry != nullptr);
 	std::unique_lock<std::mutex> lock(mutex_);
 	entriesMap_[entry->buffer.size()].emplace_front(entry);
+	entry->inEntriesPool = true;
 }
 
 void ReadCacheEntriesPool::cleanerThreadFunc_(std::stop_token stopToken) {

--- a/src/mount/readdata_cache.cc
+++ b/src/mount/readdata_cache.cc
@@ -320,7 +320,7 @@ ReadCache::EntrySet::iterator ReadCache::erase(EntrySet::iterator it) {
 	Entry *e = std::addressof(*it);
 	auto ret = entries_.erase(it);
 	lru_.erase(lru_.iterator_to(*e));
-	if (e->refcount > 0) {
+	if (e->refcount > 0 || e->isPendingNotify) {
 		reserved_entries_.push_back(*e);
 	} else {
 		assert(e->refcount == 0);
@@ -342,7 +342,7 @@ void ReadCache::clearReserved(unsigned count) {
 	std::unique_lock<std::mutex> usedMemoryLock(gReadCacheMemoryMutex, std::defer_lock);
 	while (!reserved_entries_.empty() && count-- > 0) {
 		Entry *e = std::addressof(reserved_entries_.front());
-		if (e->refcount == 0) {
+		if (e->refcount == 0 && !e->isPendingNotify) {
 			usedMemoryLock.lock();
 			decreaseUsedReadCacheMemory(e->buffer.size());
 			usedMemoryLock.unlock();

--- a/src/mount/readdata_cache.h
+++ b/src/mount/readdata_cache.h
@@ -24,6 +24,7 @@
 
 #include "common/small_vector.h"
 #include "common/time_utils.h"
+#include "slogger/slogger.h"
 
 #include <atomic>
 #include <cassert>
@@ -74,6 +75,7 @@ public:
 		std::atomic<Timer> timer;
 		std::atomic<int> refcount = 0;
 		std::atomic<bool> isPendingNotify = false;
+		std::atomic<bool> inEntriesPool = false;
 		std::atomic<Size> requested_size;
 		std::atomic<bool> done = false;
 		boost::intrusive::set_member_hook<> set_member_hook;
@@ -157,6 +159,17 @@ public:
 			uint64_t offset = real_offset;
 			Size bytes_left = real_size;
 			for (const auto &entry_ptr : entries) {
+				if (entry_ptr->inEntriesPool) {
+					safs::log_err(
+					    "(ReadCache::Result::toIoVec) Serializing entry that is in the entries "
+					    "pool, this should not happen, refcount: {}, offset: {}, size: {}",
+					    entry_ptr->refcount.load(), entry_ptr->offset, entry_ptr->buffer.size());
+
+					// This should not happen, but if it does, we just return 0
+					output.clear();
+					return 0;
+				}
+
 				const ReadCache::Entry &entry = *entry_ptr;
 				if (bytes_left <= 0) { break; }
 				// Special case: Read request was past the end of the file

--- a/src/mount/readdata_cache.h
+++ b/src/mount/readdata_cache.h
@@ -73,6 +73,7 @@ public:
 		std::vector<uint8_t> buffer;
 		std::atomic<Timer> timer;
 		std::atomic<int> refcount = 0;
+		std::atomic<bool> isPendingNotify = false;
 		std::atomic<Size> requested_size;
 		std::atomic<bool> done = false;
 		boost::intrusive::set_member_hook<> set_member_hook;


### PR DESCRIPTION
This change targets fixing some crashes of the clients while using the
readahead algorithm on some slow-to-respond clusters. These crashes
were caused in older versions due to accessing invalid cache entries
and in the current state of the code due to reuse of some cache entries
that make its state inconsistent.

The main case where this happened was the following:
- some ReadRecord scheduled several read requests in advance.
- the first read requests to be satisfied is not the one with least
offset (and first in the order of schedule), so it needs to wait until
all the previous ones get satisfied.
- that first resolved request waits too much and gets expired, and the
released (or sent to the entries pool), but not taken away from the
ReadRecords pending requests container.
- it is then added to some read reply (from the pending requests
container) while being invalid.

The proposed solution is to remove this kind of entries from the cache
(such that they won't appear for queries) but keeping them alive for as
long as they are not removed from the pending requests container.

Some consistency checks were also added.

Co-authored-by: Rolando Sánchez Ramos <rolysr@leil.io>
Signed-off-by: Dave <dave@leil.io>