### PR TITLE
fix(ganesha): Fix lock type conversion in setlk 

### DIFF
--- a/src/mount/client/saunafs_c_api.cc
+++ b/src/mount/client/saunafs_c_api.cc
@@ -27,6 +27,7 @@
 #include "common/md5.h"
 #include "common/small_vector.h"
 #include "mount/client/iovec_traits.h"
+#include "mount/fuse/lock_conversion.h"
 
 #include "client.h"
 
@@ -1084,7 +1085,8 @@ int sau_setlk(sau_t *instance, sau_context_t *ctx, sau_fileinfo_t *fileinfo,
 	gLastErrorCode = 0;
 
 	safs_locks::FlockWrapper flock_wrapper;
-	flock_wrapper.l_type = lock->l_type;
+	// Convert the lock type to the correct POSIX equivalent
+	flock_wrapper.l_type = safs_locks::posixOpConv(lock->l_type, true);
 	flock_wrapper.l_start = lock->l_start;
 	flock_wrapper.l_len = lock->l_len;
 	flock_wrapper.l_pid = lock->l_pid;

--- a/src/mount/client/saunafs_c_api.cc
+++ b/src/mount/client/saunafs_c_api.cc
@@ -1085,7 +1085,7 @@ int sau_setlk(sau_t *instance, sau_context_t *ctx, sau_fileinfo_t *fileinfo,
 	gLastErrorCode = 0;
 
 	safs_locks::FlockWrapper flock_wrapper;
-	// Convert the lock type to the correct POSIX equivalent
+	// Convert the POSIX lock type to the internal safs_locks equivalent
 	flock_wrapper.l_type = safs_locks::posixOpConv(lock->l_type, true);
 	flock_wrapper.l_start = lock->l_start;
 	flock_wrapper.l_len = lock->l_len;

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_concurrent_shared_and_exclusive_locks.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_concurrent_shared_and_exclusive_locks.sh
@@ -1,0 +1,115 @@
+timeout_set 2 minutes
+
+USE_RAMDISK=YES \
+	setup_local_empty_saunafs info
+
+test_error_cleanup() {
+	cd ${TEMP_DIR}
+	sudo umount -l ${TEMP_DIR}/mnt/ganesha
+	sudo pkill -9 ganesha.nfsd
+}
+
+create_ganesha_pid_file
+
+mkdir -p ${TEMP_DIR}/mnt/ganesha
+
+cat <<EOF > ${TEMP_DIR}/ganesha.conf
+NFSV4 {
+	Grace_Period = 5;
+	Lease_Lifetime = 5;
+}
+EXPORT
+{
+	Attr_Expiration_Time = 10;
+	Export_Id = 2;
+	Path = /;
+	Pseudo = /;
+	Access_Type = RW;
+	FSAL {
+		Name = SaunaFS;
+		hostname = localhost;
+		port = ${saunafs_info_[matocl]};
+	}
+	Protocols = 4;
+}
+EOF
+
+sudo /usr/bin/ganesha.nfsd -f "${TEMP_DIR}/ganesha.conf"
+
+check_rpc_service
+sudo mount -vvvv localhost:/ "${TEMP_DIR}/mnt/ganesha"
+
+mkdir "${TEMP_DIR}/mnt/ganesha/dir"
+FILE_SIZE="10M" assert_success file-generate "${TEMP_DIR}/mnt/ganesha/dir/file_test"
+
+operations=0
+
+function assert_operation_performed() {
+	operations=$((operations + 1))
+	assert_eventually_prints "$1" "sed -n ${operations}p ${TEMP_DIR}/posixlock.log"
+}
+
+function assert_operation_not_performed() {
+	assert_eventually_prints "" "sed -n ${1}p ${TEMP_DIR}/posixlock.log"
+}
+
+function readlock() {
+	posixlockcmd $1 r $2 $3 >> "${TEMP_DIR}/posixlock.log" &
+	assert_operation_performed "read  open:   $1"
+}
+
+function writelock() {
+	posixlockcmd $1 w $2 $3 >> "${TEMP_DIR}/posixlock.log" &
+	assert_operation_performed "write open:   $1"
+}
+
+function unlock() {
+	kill -s SIGUSR1 $1
+}
+
+declare -a sharedLocks
+declare -a exclusiveLocks
+
+declare -a lockIndexes=(1 2 3)
+
+# Go to the Ganesha mount point
+cd "${TEMP_DIR}/mnt/ganesha"
+
+# Acquire 3 shared locks on [100, 200]
+for i in "${lockIndexes[@]}"; do
+	readlock "dir/file_test" 100 100
+    sharedLocks[$i]=$!
+    assert_operation_performed "read  lock:   dir/file_test"
+done
+
+# Attempt exclusive lock on [100, 200] (should block/fail)
+writelock "dir/file_test" 100 100
+exclusiveLocks[1]=$!
+assert_operation_not_performed $((operations+1)) # Should not acquire
+
+# Release shared locks
+for i in "${lockIndexes[@]}"; do
+    unlock "${sharedLocks[$i]}"
+	assert_operation_performed "read  unlock: dir/file_test"
+done
+
+# Now exclusive lock should be acquired
+assert_operation_performed "write lock:   dir/file_test"
+
+# Attempt shared lock while exclusive lock is held (should block/fail)
+readlock "dir/file_test" 100 100
+sharedLocks[4]=$!
+assert_operation_not_performed $((operations+1)) # Should not acquire
+
+# Release exclusive lock
+unlock "${exclusiveLocks[1]}"
+assert_operation_performed "write unlock: dir/file_test"
+
+# Now shared lock should be acquired
+assert_operation_performed "read  lock:   dir/file_test"
+
+# Release shared lock
+unlock "${sharedLocks[4]}"
+assert_operation_performed "read  unlock: dir/file_test"
+
+test_error_cleanup

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_concurrent_shared_and_exclusive_locks.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_concurrent_shared_and_exclusive_locks.sh
@@ -78,8 +78,8 @@ cd "${TEMP_DIR}/mnt/ganesha"
 # Acquire 3 shared locks on [100, 200]
 for i in "${lockIndexes[@]}"; do
 	readlock "dir/file_test" 100 100
-    sharedLocks[$i]=$!
-    assert_operation_performed "read  lock:   dir/file_test"
+	sharedLocks[$i]=$!
+	assert_operation_performed "read  lock:   dir/file_test"
 done
 
 # Attempt exclusive lock on [100, 200] (should block/fail)
@@ -89,7 +89,7 @@ assert_operation_not_performed $((operations+1)) # Should not acquire
 
 # Release shared locks
 for i in "${lockIndexes[@]}"; do
-    unlock "${sharedLocks[$i]}"
+	unlock "${sharedLocks[$i]}"
 	assert_operation_performed "read  unlock: dir/file_test"
 done
 

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_posix_file_locks.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_posix_file_locks.sh
@@ -49,6 +49,15 @@ function assert_operation_performed() {
 	assert_eventually_prints "$1" "sed -n ${opcount}p ${TEMP_DIR}/posixlock.log"
 }
 
+function assert_operation_not_performed() {
+	assert_eventually_prints "" "sed -n ${1}p ${TEMP_DIR}/posixlock.log"
+}
+
+function readlock() {
+	posixlockcmd $1 r $2 $3 >> "${TEMP_DIR}/posixlock.log" &
+	assert_operation_performed "read  open:   $1"
+}
+
 function writelock() {
 	posixlockcmd $1 w $2 $3 >> "${TEMP_DIR}/posixlock.log" &
 	assert_operation_performed "write open:   $1"
@@ -58,32 +67,54 @@ function unlock() {
 	kill -s SIGUSR1 $1
 }
 
+declare -a readlocks
 declare -a writelocks
 
 # Go to the Ganesha mount point
 cd "${TEMP_DIR}/mnt/ganesha"
 
-# Lock byte range [0, 5]
-writelock "dir/file_100M" 0 5
+readlock "dir/file_100M" 0 100
+readlocks[1]=$!
+assert_operation_performed "read  lock:   dir/file_100M"
+
+readlock "dir/file_100M" 0 100
+readlocks[2]=$!
+
+assert_operation_performed "read  lock:   dir/file_100M"
+
+# Lock byte range [200, 300]
+writelock "dir/file_100M" 200 100
 writelocks[1]=$!
 assert_operation_performed "write lock:   dir/file_100M"
 
-# Lock byte range [10, 20]
-writelock "dir/file_100M" 10 20
+unlock ${readlocks[1]}
+assert_operation_performed "read  unlock: dir/file_100M"
+
+# Lock byte range [50, 150]
+writelock "dir/file_100M" 50 100
 writelocks[2]=$!
+
+unlock ${readlocks[2]}
+assert_operation_performed "read  unlock: dir/file_100M"
+
 assert_operation_performed "write lock:   dir/file_100M"
-
-# Unlock byte range [0, 5]
-unlock ${writelocks[1]}
-assert_operation_performed "write unlock: dir/file_100M"
-
-# Unlock byte range [10, 20]
-unlock ${writelocks[2]}
-assert_operation_performed "write unlock: dir/file_100M"
 
 # Lock byte range [0, 0] is equivalent to locking the whole file
 writelock "dir/file_100M" 0 0
 writelocks[3]=$!
+
+# It's not possible to acquire the lock because range [50, 150] is locked
+assert_operation_not_performed $((opcount+1))
+
+# Unlock byte range [200, 300]
+unlock ${writelocks[1]}
+assert_operation_performed "write unlock: dir/file_100M"
+
+# Unlock byte range [50, 150]
+unlock ${writelocks[2]}
+assert_operation_performed "write unlock: dir/file_100M"
+
+# Now, it's possible to lock the whole file
 assert_operation_performed "write lock:   dir/file_100M"
 
 # Unlock byte range [0, 0]


### PR DESCRIPTION
This PR fixes an issue in `sau_setlk` function, where the lock type was not
properly converted to its POSIX equivalent before setting the lock.
As a result, shared (read) locks could not be acquired correctly and `fcntl()`
failed with invalid argument.

This resolves unexpected behavior when trying to acquire F_RDLCK locks
via the SaunaFS C API.

Additionally, it was improved the locking test coverage in Ganesha by adding
scenarios including shared locks (`F_RDLCK`), mixed shared/exclusive locks
and concurrent locking on overlapping by ranges.

Signed-off-by: Crash <crash@leil.io>