### PR TITLE
test(chunkserver): Fix flaky AddJob unit test

### DIFF
--- a/src/chunkserver/bgjobs_unittest.cc
+++ b/src/chunkserver/bgjobs_unittest.cc
@@ -103,7 +103,11 @@ protected:
 
 // Test job addition
 TEST_F(JobPoolTest, AddJob) {
+	// Create a JobPool instance without workers to disable automatic job dispatching
+	auto jobPool = std::make_unique<JobPool>("TestPool", 0, 5, kNrListeners, wakeupDescVec);
+
 	jobPool->addJob(JobPool::ChunkOperation::Read, mockJobCallback, &counters[0], mockProcessJob);
+
 	EXPECT_EQ(jobPool->getJobCount(), 1U);
 }
 


### PR DESCRIPTION
This commit fixes a flaky AddJob unit test in the JobPoolTest suite.
The test occasionally failed due to a race condition where the job was
processed by the JobPool before the test could assert its presence.

To eliminate the race, the test now disables automatic job dispatching,
ensuring that the job always remains in the pool. This makes the test
deterministic and the assertion reliable.