### PR TITLE
feat(cs): Release old iobuffers

### DIFF
--- a/src/chunkserver/buffers_pool.h
+++ b/src/chunkserver/buffers_pool.h
@@ -20,8 +20,13 @@
 
 #include "common/platform.h"
 
+#include <map>
 #include <memory>
+#include <mutex>
 #include <queue>
+
+#include "common/time_utils.h"
+#include "slogger/slogger.h"
 
 /**
  * BuffersPool is a thread-safe pool of buffers.
@@ -67,7 +72,7 @@ public:
 		}
 
 		auto &buffers = it->second;
-		auto buffer = buffers.front();
+		auto buffer = buffers.front().getBuffer();
 
 		buffers.pop();
 		buffer->clear();
@@ -96,14 +101,48 @@ public:
 
 		if (currentNumberOfBlocks_ + numBlocks <= kMaxNumberOfBlocks) {
 			buffer->clear();
-			buffers.push(std::move(buffer));
+			buffers.emplace(std::move(buffer));
 			currentNumberOfBlocks_ += numBlocks;
 		}
 		// To make sure the deallocation is not done under the lock.
 		lock.unlock();
 	}
 
+	/**
+	 * Release entries older than expirationTime_ms milliseconds.
+	 * @param expirationTime_ms Time threshold to release entries from (in ms).
+	 */
+	void releaseOldBuffers(uint32_t expirationTime_ms) {
+		std::unique_lock lock(mutex_);
+		std::vector<std::shared_ptr<T>> buffersToRelease;
+		for (auto &[_, buffers] : buffersMap_) {
+			// Queue behavior ensures older entries are at the front
+			while (!buffers.empty() && buffers.front().expired(expirationTime_ms)) {
+				auto buffer = buffers.front().getBuffer();
+				buffers.pop();
+				buffersToRelease.emplace_back(std::move(buffer));
+			}
+		}
+		// To make sure the releasing is performed outside the lock
+		lock.unlock();
+
+		// Destructor of the vector should release the last copy of the buffers
+	}
+
 private:
+	struct BufferPoolEntry {
+		std::shared_ptr<T> entry_;
+		Timer timer_;
+
+		BufferPoolEntry(std::shared_ptr<T> &&entry) : entry_(std::move(entry)) {}
+
+		bool expired(uint32_t expirationTime_ms) const {
+			return timer_.elapsed_ms() >= expirationTime_ms;
+		}
+
+		std::shared_ptr<T> &&getBuffer() { return std::move(entry_); }
+	};
+
 	/// How many operations should pass between two log messages.
 	static constexpr size_t kLogAfterEveryXTimes = 1000;
 	/// Number of operations since last log message.
@@ -113,7 +152,7 @@ private:
 	/// Current number of buffers in the pool.
 	size_t currentNumberOfBlocks_ = 0;
 	/// Buffers pool map: a queue of buffers for each type of buffer.
-	std::map<std::pair<size_t, size_t>, std::queue<std::shared_ptr<T>>> buffersMap_;
+	std::map<std::pair<size_t, size_t>, std::queue<BufferPoolEntry>> buffersMap_;
 	/// Mutex to protect the pool.
 	std::mutex mutex_;
 };

--- a/src/chunkserver/chunk_replicator.cc
+++ b/src/chunkserver/chunk_replicator.cc
@@ -33,6 +33,7 @@
 #include "common/read_plan_executor.h"
 #include "common/saunafs_version.h"
 #include "common/sockets.h"
+#include "io_buffers.h"
 #include "protocol/cstocs.h"
 
 static ConnectionPool gPool;
@@ -149,55 +150,54 @@ void ChunkReplicator::replicate(ChunkFileCreator& fileCreator,
 	SliceRecoveryPlanner planner;
 	ReadPlanExecutor::ChunkTypeLocations locations;
 	SliceRecoveryPlanner::PartsContainer available_parts;
-#ifdef SAUNAFS_HAVE_THREAD_LOCAL
-	static thread_local std::vector<uint8_t, AlignedAllocator<uint8_t, disk::kIoBlockSize>> buffer;
-#else
-	std::vector<uint8_t, AlignedAllocator<uint8_t, disk::kIoBlockSize>> buffer;
-#endif
+	auto buffer = getReplicateBuffersPool().get(kReplicatorBufferHeaderSize, batchSize);
 
-	for (const auto& source : sources) {
-		available_parts.push_back(source.chunk_type);
+	try {
+		for (const auto &source : sources) {
+			available_parts.push_back(source.chunk_type);
 
-		if (locations.count(source.chunk_type)) {
-			continue;
-		}
-		locations[source.chunk_type] = source;
-	}
-
-	fileCreator.create();
-	const SteadyDuration max_wait_time = std::chrono::milliseconds(total_timeout_ms_);
-	Timeout timeout{max_wait_time};
-	for (int firstBlock = 0; firstBlock < blocks; firstBlock += batchSize) {
-		int nrOfBlocks = std::min(blocks - firstBlock, batchSize);
-
-		planner.prepare(fileCreator.chunkType(), firstBlock, nrOfBlocks, available_parts);
-		if (!planner.isReadingPossible()) {
-			throw Exception("No copies to read from");
+			if (locations.count(source.chunk_type)) { continue; }
+			locations[source.chunk_type] = source;
 		}
 
-		// Wait for limit to be assigned
-		uint8_t status = replicationBandwidthLimiter().wait(nrOfBlocks * SFSBLOCKSIZE, max_wait_time);
-		if (status != SAUNAFS_STATUS_OK) {
-			throw Exception("Replication limiting error", status);
-		}
+		fileCreator.create();
+		const SteadyDuration max_wait_time = std::chrono::milliseconds(total_timeout_ms_);
+		Timeout timeout{max_wait_time};
+		for (int firstBlock = 0; firstBlock < blocks; firstBlock += batchSize) {
+			int nrOfBlocks = std::min(blocks - firstBlock, batchSize);
 
-		// Build and execute the plan
-		buffer.clear();
-		ReadPlanExecutor executor(chunkserverStats_,
-				fileCreator.chunkId(), fileCreator.chunkVersion(),
-				planner.buildPlan());
-		executor.executePlan(buffer, locations, connector_, timeout.remaining_ms(), wave_timeout_ms_, timeout);
+			planner.prepare(fileCreator.chunkType(), firstBlock, nrOfBlocks, available_parts);
+			if (!planner.isReadingPossible()) { throw Exception("No copies to read from"); }
 
-		std::vector<uint32_t> crcData;
-		for (int i = 0; i < nrOfBlocks; ++i) {
-			uint32_t offset = i * SFSBLOCKSIZE;
-			const uint8_t* dataBlock = buffer.data() + offset;
-			uint32_t crc = mycrc32(0, dataBlock, SFSBLOCKSIZE);
-			crcData.push_back(crc);
+			// Wait for limit to be assigned
+			uint8_t status =
+			    replicationBandwidthLimiter().wait(nrOfBlocks * SFSBLOCKSIZE, max_wait_time);
+			if (status != SAUNAFS_STATUS_OK) {
+				throw Exception("Replication limiting error", status);
+			}
+
+			// Build and execute the plan
+			buffer->clear();
+			ReadPlanExecutor executor(chunkserverStats_, fileCreator.chunkId(),
+			                          fileCreator.chunkVersion(), planner.buildPlan());
+			executor.executePlan(buffer->getBlockBuffer(), locations, connector_,
+			                     timeout.remaining_ms(), wave_timeout_ms_, timeout);
+
+			std::vector<uint32_t> crcData;
+			for (int i = 0; i < nrOfBlocks; ++i) {
+				uint32_t offset = i * SFSBLOCKSIZE;
+				const uint8_t *dataBlock = buffer->data() + offset;
+				uint32_t crc = mycrc32(0, dataBlock, SFSBLOCKSIZE);
+				crcData.push_back(crc);
+			}
+			fileCreator.write(static_cast<const uint8_t *>(buffer->data()),
+			                  static_cast<uint16_t>(firstBlock), static_cast<uint16_t>(nrOfBlocks),
+			                  crcData);
 		}
-		fileCreator.write(static_cast<const uint8_t *>(buffer.data()),
-		                  static_cast<uint16_t>(firstBlock), static_cast<uint16_t>(nrOfBlocks),
-		                  crcData);
+		getReplicateBuffersPool().put(std::move(buffer));
+	} catch (...) {
+		getReplicateBuffersPool().put(std::move(buffer));
+		throw;
 	}
 
 	fileCreator.commit();

--- a/src/chunkserver/hddspacemgr.cc
+++ b/src/chunkserver/hddspacemgr.cc
@@ -2446,6 +2446,7 @@ void hddDisksThread() {
 
 void hddFreeResourcesThread() {
 	static const int kDelayedStep = 2;
+	static const uint32_t kOldIoBuffersExpirationTimeMs = kDelayedStep * 1000;
 	static const int kMaxFreeUnused = 1024;
 	TRACETHIS();
 
@@ -2455,6 +2456,9 @@ void hddFreeResourcesThread() {
 		gOpenChunks.freeUnused(eventloop_time(), gChunksMapMutex,
 		                       kMaxFreeUnused);
 		ChunkTrashManager::collectGarbage();
+		/// Release buffers older than kDelayedStep seconds
+		releaseOldIoBuffers(kOldIoBuffersExpirationTimeMs);
+
 		sleep(kDelayedStep);
 	}
 }

--- a/src/chunkserver/io_buffers.h
+++ b/src/chunkserver/io_buffers.h
@@ -507,8 +507,47 @@ protected:
 	std::vector<WriteInfo> writeInfo_;
 };
 
+/// @brief The size of the header for the replicator buffer.
+/// The 0 is picked for simplicity, main goal is to make it a single value.
+constexpr size_t kReplicatorBufferHeaderSize = 0;
+
+/**
+ * @class ReplicatorBuffer
+ * @brief Wraps an IO aligned buffer for the replicator to fit the BuffersPool interface.
+ */
+class ReplicatorBuffer {
+public:
+	/// @brief Constructs a ReplicatorBuffer with the given number of blocks.
+	/// @param headerSize The size of the header (not used, but required for compatibility).
+	/// @param numBlocks The number of blocks the buffer can hold.
+	ReplicatorBuffer(size_t headerSize, size_t numBlocks) : numBlocks_(numBlocks) {
+		(void)headerSize;
+	}
+
+	/// @brief Clears the buffer.
+	void clear() { blockBuffer_.clear(); }
+
+	/// @brief Returns the actual block buffer.
+	std::vector<uint8_t, AlignedAllocator<uint8_t, disk::kIoBlockSize>> &getBlockBuffer() {
+		return blockBuffer_;
+	}
+
+	/// @brief Returns the start of the block buffer.
+	const uint8_t *data() const { return blockBuffer_.data(); }
+
+	/// @brief Returns the type of the buffer.
+	std::pair<size_t, size_t> type() const { return {kReplicatorBufferHeaderSize, numBlocks_}; }
+
+private:
+	const size_t numBlocks_;  ///< The number of blocks.
+
+	/// The buffer for the block data.
+	std::vector<uint8_t, AlignedAllocator<uint8_t, disk::kIoBlockSize>> blockBuffer_{};
+};
+
 using OutputBufferPool = BuffersPool<OutputBuffer>;
 using InputBufferPool = BuffersPool<InputBuffer>;
+using ReplicatorBufferPool = BuffersPool<ReplicatorBuffer>;
 
 /// @brief Returns the read output buffer pool.
 /// It is a singleton.
@@ -522,4 +561,11 @@ inline OutputBufferPool &getReadOutputBufferPool() {
 inline InputBufferPool &getWriteInputBufferPool() {
 	static InputBufferPool writeInputBuffersPool;
 	return writeInputBuffersPool;
+}
+
+/// @brief Returns the replicate buffer pool.
+/// It is a singleton.
+inline ReplicatorBufferPool &getReplicateBuffersPool() {
+	static ReplicatorBufferPool replicateBuffersPool;
+	return replicateBuffersPool;
 }

--- a/src/chunkserver/io_buffers.h
+++ b/src/chunkserver/io_buffers.h
@@ -569,3 +569,9 @@ inline ReplicatorBufferPool &getReplicateBuffersPool() {
 	static ReplicatorBufferPool replicateBuffersPool;
 	return replicateBuffersPool;
 }
+
+inline void releaseOldIoBuffers(uint32_t expirationTime_ms) {
+	getReadOutputBufferPool().releaseOldBuffers(expirationTime_ms);
+	getWriteInputBufferPool().releaseOldBuffers(expirationTime_ms);
+	getReplicateBuffersPool().releaseOldBuffers(expirationTime_ms);
+}


### PR DESCRIPTION
The current behavior of the chunkserver keeps in memory at most 512MB
in the readOutputBuffersPool and the writeInputBuffersPool regardless
of whether the chunkserver is performing any operations. Plus, the
buffers used in replication (at most 64MB each of them) are thread
local, which means no releasing as well.

This change targets releasing old buffer from the IO buffers
(replicate/read/write ops). The release is performed by the
hddFreeResourcesThread and outside of the buffers pool mutexes
protection, so very low contention overhead is expected.

To make this possible, it was necessary to fit the buffer used in replications
into the same interface the other Output/InputBuffer has. This allows
get/put them to the generic buffers pool already defined.

Signed-off-by: Dave <dave@leil.io>