### PR TITLE
fix(charts): Fix wrong range value for CSV

### DIFF
--- a/src/common/charts.cc
+++ b/src/common/charts.cc
@@ -1852,6 +1852,10 @@ uint32_t charts_make_csv(uint32_t number) {
 
 	type = number / 10;
 	range = number % kNumberRangeModulus;
+	if (range >= RANGES) {
+		safs::log_warn("wrong range for chart {}", number);
+		return 0;
+	}
 	charts_filltab(c1dispdata, range, type, 1);
 	charts_filltab(c2dispdata, range, type, 2);
 	charts_filltab(c3dispdata, range, type, 3);

--- a/src/common/charts.cc
+++ b/src/common/charts.cc
@@ -1837,6 +1837,7 @@ int charts_fake_compress(uint8_t *src,uint32_t srcsize,uint8_t *dst,uint32_t *ds
 
 
 uint32_t charts_make_csv(uint32_t number) {
+	const int kNumberRangeModulus = 10;
 	uint32_t type, range;
 	uint32_t tm_year, tm_mon, tm_day, tm_hour, tm_min, tm_sec;
 	uint64_t c1dispdata[LENG];
@@ -1850,7 +1851,7 @@ uint32_t charts_make_csv(uint32_t number) {
 	tm_year = tm_mon = tm_day = tm_hour = tm_min = tm_sec = 0;
 
 	type = number / 10;
-	range = number % RANGES;
+	range = number % kNumberRangeModulus;
 	charts_filltab(c1dispdata, range, type, 1);
 	charts_filltab(c2dispdata, range, type, 2);
 	charts_filltab(c3dispdata, range, type, 3);


### PR DESCRIPTION
Using modulo with the size of RANGE did not work correctly. It would give incorrect chart ranges for CSV (for example, chart id 90031 (medium range) would give 90033 (very long) instead).

The previous commit to this line explained that this fixed a compiler warning regarding array subscripting, however no such compiler warning appears for GCC 15.1.1. So it may have been a false positive.