### PR TITLE
feat: Memory charts for chunkservers

### DIFF
--- a/src/chunkserver/chartsdata.cc
+++ b/src/chunkserver/chartsdata.cc
@@ -39,6 +39,7 @@
 #include "chunkserver/network_stats.h"
 #include "common/charts.h"
 #include "common/event_loop.h"
+#include "slogger/slogger.h"
 
 #define CHARTS_FILENAME "csstats.sfs"
 
@@ -72,8 +73,11 @@
 #define CHARTS_TEST 27
 #define CHARTS_CHUNKIOJOBS 28
 #define CHARTS_CHUNKOPJOBS 29
+#define CHARTS_MEMORY 30
 
-#define CHARTS_NUMBER 30
+#define CHARTS_NUMBER 31
+
+const unsigned long kLinuxMaxrssSize = 1024UL;
 
 /* name , join mode , percent , scale , multiplier , divisor */
 #define STATDEFS { \
@@ -107,6 +111,7 @@
 	{"test"             ,CHARTS_MODE_ADD,0,CHARTS_SCALE_NONE ,   1, 1}, \
 	{"chunkiojobs"      ,CHARTS_MODE_MAX,0,CHARTS_SCALE_NONE ,   1, 1}, \
 	{"chunkopjobs"      ,CHARTS_MODE_MAX,0,CHARTS_SCALE_NONE ,   1, 1}, \
+	{"memory"           ,CHARTS_MODE_MAX,0,CHARTS_SCALE_NONE ,   1, 1}, \
 	{NULL               ,0              ,0,0                 ,   0, 0}  \
 };
 
@@ -135,6 +140,23 @@ static struct itimerval it_set;
 
 inline uint32_t toMicroSeconds(struct itimerval &itimer) {
     return itimer.it_value.tv_sec * 1000000 + itimer.it_value.tv_usec;
+}
+
+// NOLINTNEXTLINE(misc-use-anonymous-namespace)
+static uint64_t GetMemUsage() {
+	struct rusage resUse{};
+	int err = getrusage(RUSAGE_SELF, &resUse);
+	if (err != -1) {
+#ifdef __APPLE__
+		return resUse.ru_maxrss;
+#else
+		// NOLINTNEXTLINE(cppcoreguidelines-pro-type-union-access)
+		return resUse.ru_maxrss * kLinuxMaxrssSize;
+#endif
+	} else {
+		safs::log_error_code(errno, "could not get memory usage for chartsdata");
+		return 0;
+	}
 }
 
 void chartsdata_refresh(void) {
@@ -187,6 +209,8 @@ void chartsdata_refresh(void) {
 	} else {
 		procTimeMicroSeconds = 0;
 	}
+
+	data[CHARTS_MEMORY] = GetMemUsage();
 
 	data[CHARTS_UCPU] = userTimeMicroSeconds;
 	data[CHARTS_SCPU] = procTimeMicroSeconds;


### PR DESCRIPTION
Previously, chunkservers did not have charts for memory usage. This commits copies the memory code from src/master/chartsdata.cc and removes some redundant #ifdefs and rename some variables.