### PR TITLE
fix(cs): Fix release of read jobs and CS reloads

### DIFF
--- a/src/chunkserver/bgjobs.cc
+++ b/src/chunkserver/bgjobs.cc
@@ -364,7 +364,10 @@ uint32_t job_read(JobPool &jobPool, JobPool::JobCallback callback, void *extra, 
 		uint8_t status = SAUNAFS_STATUS_OK;
 		if (performHddOpen) {
 			status = hddOpen(chunkId, chunkType);
-			if (status != SAUNAFS_STATUS_OK) { return status; }
+			if (status != SAUNAFS_STATUS_OK) {
+				outputBuffer->setStatus(status);
+				return status;
+			}
 		}
 
 		status = hddRead(chunkId, version, chunkType, offset, size, maxBlocksToBeReadBehind,

--- a/src/chunkserver/chunkserver_entry.cc
+++ b/src/chunkserver/chunkserver_entry.cc
@@ -368,10 +368,15 @@ void ChunkserverEntry::prepareDiscardReadJobs() {
 	while (!pendingReadJobIds.empty()) {
 		// pendingReadJobIds and pendingReadDataPackets should have the related elements in the
 		// correct order
-		toDiscardReadJobIds.push_back(pendingReadJobIds.front());
-		pendingReadJobIds.pop_front();
+		if (pendingReadDataPackets.front()->outputBuffer->getStatus() == kNotSaunafsStatus) {
+			toDiscardReadJobIds.push_back(pendingReadJobIds.front());
+			toDiscardReadDataPackets.emplace_back(std::move(pendingReadDataPackets.front()));
+		} else {
+			// Already processed packets, can be moved to the pool
+			getReadOutputBufferPool().put(std::move(pendingReadDataPackets.front()->outputBuffer));
+		}
 
-		toDiscardReadDataPackets.emplace_back(std::move(pendingReadDataPackets.front()));
+		pendingReadJobIds.pop_front();
 		pendingReadDataPackets.pop_front();
 	}
 	assert(pendingReadJobIds.empty());

--- a/src/chunkserver/hddspacemgr.cc
+++ b/src/chunkserver/hddspacemgr.cc
@@ -103,6 +103,20 @@ constexpr uint32_t startingOffsetOfBlock(uint32_t blocknum) { return blocknum * 
 
 inline std::atomic_bool gCheckCrcWhenReading{true};
 
+static std::mutex gDisksToBeDeletedWithPendingChunksMutex;
+static std::vector<std::pair<std::unique_ptr<IDisk>, std::vector<ChunkWithType>>>
+    gDisksToBeDeletedWithPendingChunks;
+static std::vector<std::pair<IDisk *, std::vector<ChunkWithType>>>
+    gNewDisksToBeDeletedWithPendingChunks;
+
+/// @enum SendDataToMasterMode
+/// @brief Represents the reason of sending data to the master server.
+enum class SendDataToMasterMode : uint8_t {
+	ForDiskRemoval,
+	ForDamagedDisk,
+	ForNewChunk
+};
+
 void hddGetDamagedChunks(std::vector<ChunkWithType>& chunks,
                          std::size_t limit) {
 	TRACETHIS();
@@ -223,7 +237,55 @@ static IChunk *hddChunkCreate(IDisk *disk, uint64_t chunkId,
 	return chunk;
 }
 
-void hddSendDataToMaster(IDisk *disk, bool isForRemoval) {
+void hddReleaseDisksToBeDeleted() {
+	std::lock_guard diskToBeDeletedLock(gDisksToBeDeletedWithPendingChunksMutex);
+	std::unique_lock chunksMapLock(gChunksMapMutex, std::defer_lock);
+
+	std::vector<IDisk *> disksToDelete;
+	for (auto &diskToDelWithPendingChunks : gDisksToBeDeletedWithPendingChunks) {
+		auto *disk = diskToDelWithPendingChunks.first.get();
+		auto &pendingChunks = diskToDelWithPendingChunks.second;
+
+		while (!pendingChunks.empty()) {
+			auto &chunkIdentifier = pendingChunks.back();
+			bool isChunkPending = true;
+
+			chunksMapLock.lock();
+			auto chunkIter =
+			    gChunksMap.find(makeChunkKey(chunkIdentifier.id, chunkIdentifier.type));
+			if (chunkIter == gChunksMap.end() || chunkIter->second->owner() != disk) {
+				// Chunk not found or not owned by this disk
+				isChunkPending = false;
+			}
+			chunksMapLock.unlock();
+
+			if (!isChunkPending) {
+				// Remove the chunk from the disk's pending chunks
+				pendingChunks.pop_back();
+			} else {
+				// Stop if we found a chunk that is still present
+				break;
+			}
+		}
+
+		if (pendingChunks.empty()) {
+			// No pending chunks, we can delete the disk
+			disksToDelete.push_back(disk);
+		}
+	}
+
+	for (auto *disk : disksToDelete) {
+		safs::log_info("({}) Deleting disk {} with no pending chunks", __func__,
+		               disk->getPaths().c_str());
+		gDisksToBeDeletedWithPendingChunks.erase(
+		    std::remove_if(gDisksToBeDeletedWithPendingChunks.begin(),
+		                   gDisksToBeDeletedWithPendingChunks.end(),
+		                   [disk](const auto &pair) { return pair.first.get() == disk; }),
+		    gDisksToBeDeletedWithPendingChunks.end());
+	}
+}
+
+void hddSendDataToMaster(IDisk *disk, SendDataToMasterMode mode) {
 	TRACETHIS();
 	bool markedForDeletion = disk->isMarkedForDeletion();
 
@@ -236,7 +298,7 @@ void hddSendDataToMaster(IDisk *disk, bool isForRemoval) {
 	// outside the loop.
 	std::vector<IChunk *> chunksToRemove;
 
-	if (isForRemoval) {
+	if (mode != SendDataToMasterMode::ForNewChunk) {
 		chunksToRemove.reserve(disk->chunks().size());
 	}
 
@@ -244,7 +306,7 @@ void hddSendDataToMaster(IDisk *disk, bool isForRemoval) {
 		IChunk *chunk = chunkEntry.second.get();
 
 		if (chunk->owner() == disk) {
-			if (isForRemoval) {
+			if (mode != SendDataToMasterMode::ForNewChunk) {
 				chunksToRemove.push_back(chunk);
 			} else {
 				hddReportNewChunkToMaster(chunk->id(), chunk->version(),
@@ -253,6 +315,7 @@ void hddSendDataToMaster(IDisk *disk, bool isForRemoval) {
 		}
 	}
 
+	std::vector<ChunkWithType> pendingChunks;
 	for (auto chunk : chunksToRemove) {
 		hddReportLostChunk(chunk->id(), chunk->type());
 
@@ -261,8 +324,19 @@ void hddSendDataToMaster(IDisk *disk, bool isForRemoval) {
 			chunk->owner()->chunks().remove(chunk);
 			gChunksMap.erase(chunkToKey(*chunk));
 		} else if (chunk->state() == ChunkState::Locked) {
+			// Some hdd worker is doing something with this chunk,
+			// so we just mark it for deletion.
 			chunk->setState(ChunkState::ToBeDeleted);
+			if (mode == SendDataToMasterMode::ForDiskRemoval) {
+				pendingChunks.emplace_back(chunk->id(), chunk->type());
+			}
 		}
+	}
+
+	if (mode == SendDataToMasterMode::ForDiskRemoval) {
+		// Only for disk removal we need to store pending chunks: those disks are supposed to be
+		// deleted after all pending chunks are removed.
+		gNewDisksToBeDeletedWithPendingChunks.emplace_back(disk, std::move(pendingChunks));
 	}
 }
 
@@ -288,8 +362,6 @@ void hddCheckDisks() {
 		return;
 	}
 
-	std::vector<IDisk *> disksToRemove;
-
 	for (auto &disk : gDisks) {
 		if (disk->wasRemovedFromConfig()) {
 			switch (disk->scanState()) {
@@ -304,7 +376,7 @@ void hddCheckDisks() {
 				disk->setScanState(IDisk::ScanState::kWorking);
 				/* fallthrough */
 			case IDisk::ScanState::kWorking:
-				hddSendDataToMaster(disk.get(), true);
+				hddSendDataToMaster(disk.get(), SendDataToMasterMode::ForDiskRemoval);
 				changed = 1;
 				disk->setWasRemovedFromConfig(false);
 				break;
@@ -317,22 +389,28 @@ void hddCheckDisks() {
 				safs_pretty_syslog(LOG_NOTICE, "Disk %s successfully removed",
 				                   disk->getPaths().c_str());
 
-				disksToRemove.push_back(disk.get());
 				gResetTester = true;
 			}
 		}
 	}
 
-	for (const auto &diskToDel : disksToRemove) {
+	std::unique_lock diskToBeDeletedLock(gDisksToBeDeletedWithPendingChunksMutex);
+	for (auto &diskToDelWithPendingChunks : gNewDisksToBeDeletedWithPendingChunks) {
 		for (auto it = gDisks.begin(); it != gDisks.end(); ++it) {
-			if (diskToDel == it->get()) {
+			if (diskToDelWithPendingChunks.first == it->get()) {
+				if (!diskToDelWithPendingChunks.second.empty()) {
+					// Pending chunks
+					gDisksToBeDeletedWithPendingChunks.emplace_back(
+					    std::move(*it), std::move(diskToDelWithPendingChunks.second));
+				}
 				gDisks.erase(it);
 				break;
 			}
 		}
 	}
+	diskToBeDeletedLock.unlock();
 
-	disksToRemove.clear();
+	gNewDisksToBeDeletedWithPendingChunks.clear();
 
 	for (auto &disk : gDisks) {
 		if (disk->isDamaged() || disk->wasRemovedFromConfig()) {
@@ -352,7 +430,7 @@ void hddCheckDisks() {
 			changed = 1;
 			break;
 		case IDisk::ScanState::kSendNeeded:
-			hddSendDataToMaster(disk.get(), false);
+			hddSendDataToMaster(disk.get(), SendDataToMasterMode::ForNewChunk);
 			disk->setScanState(IDisk::ScanState::kWorking);
 			disk->refreshDataDiskUsage();
 			disk->setNeedRefresh(false);
@@ -373,7 +451,7 @@ void hddCheckDisks() {
 				safs_pretty_syslog(
 				    LOG_WARNING, "%u errors occurred in %u seconds on disk: %s",
 				    err, kLastErrorTime, disk->getPaths().c_str());
-				hddSendDataToMaster(disk.get(), true);
+				hddSendDataToMaster(disk.get(), SendDataToMasterMode::ForDamagedDisk);
 				disk->setIsDamaged(true);
 				changed = 1;
 			} else {
@@ -2456,6 +2534,7 @@ void hddFreeResourcesThread() {
 		gOpenChunks.freeUnused(eventloop_time(), gChunksMapMutex,
 		                       kMaxFreeUnused);
 		ChunkTrashManager::collectGarbage();
+		hddReleaseDisksToBeDeleted();
 		/// Release buffers older than kDelayedStep seconds
 		releaseOldIoBuffers(kOldIoBuffersExpirationTimeMs);
 
@@ -2548,6 +2627,9 @@ void hddTerminate(void) {
 	gChunksMap.clear();
 	gOpenChunks.freeUnused(eventloop_time(), gChunksMapMutex);
 	gDisks.clear();
+	// Destroy the disks-to-be-deleted related structures
+	gNewDisksToBeDeletedWithPendingChunks.clear();
+	gDisksToBeDeletedWithPendingChunks.clear();
 }
 
 void hddReload(void) {

--- a/src/chunkserver/io_buffers.cc
+++ b/src/chunkserver/io_buffers.cc
@@ -36,7 +36,9 @@ OutputBuffer::OutputBuffer(size_t headerSize, size_t numBlocks)
       numBlocks_(numBlocks),
       blockBuffer_(numBlocks * SFSBLOCKSIZE, disk::kIoBlockSize),
       crcBuffer_(numBlocks * kCrcSize),
-      headerBuffer_(numBlocks * headerSize) {}
+      headerBuffer_(numBlocks * headerSize) {
+	gCurrentTotalOutputBufferBlocks += numBlocks_;
+}
 
 OutputBuffer::WriteStatus OutputBuffer::writeOutToAFileDescriptor(int outputFileDescriptor) {
 	// Let's write block by block
@@ -156,7 +158,9 @@ InputBuffer::InputBuffer(size_t headerSize, size_t numBlocks)
 	: headerSize_(headerSize),
 	  numBlocks_(numBlocks),
 	  blockBuffer_(numBlocks * SFSBLOCKSIZE, disk::kIoBlockSize),
-	  headerBuffer_(numBlocks * headerSize) {}
+	  headerBuffer_(numBlocks * headerSize) {
+	gCurrentTotalInputBufferBlocks += numBlocks_;
+}
 
 ssize_t InputBuffer::readFromSocket(int sock, size_t bytesToRead) {
 	ssize_t bytesRead = 0;
@@ -435,4 +439,33 @@ void InputBuffer::setFinished() { state_.store(WriteState::Finished); }
 
 bool InputBuffer::isHeaderSizeValid() const {
 	return headerBuffer_.totalBytesPutInBuffer() == writeInfo_.size() * headerSize_;
+}
+
+void releaseOldIoBuffers(uint32_t expirationTime_ms) {
+	auto initialTotalOutputBufferBlocks = gCurrentTotalOutputBufferBlocks.load();
+	auto initialTotalInputBufferBlocks = gCurrentTotalInputBufferBlocks.load();
+	auto initialTotalReplicatorBufferBlocks = gCurrentTotalReplicatorBufferBlocks.load();
+
+	getReadOutputBufferPool().releaseOldBuffers(expirationTime_ms);
+	getWriteInputBufferPool().releaseOldBuffers(expirationTime_ms);
+	getReplicateBuffersPool().releaseOldBuffers(expirationTime_ms);
+
+	// Calculate the number of released blocks. Please note that the number of released
+	// could be negative because some buffers could be added to the pools in the meantime.
+	int releasedOutputBuffers =
+	    initialTotalOutputBufferBlocks - gCurrentTotalOutputBufferBlocks.load();
+	int releasedInputBuffers =
+	    initialTotalInputBufferBlocks - gCurrentTotalInputBufferBlocks.load();
+	int releasedReplicatorBuffers =
+	    initialTotalReplicatorBufferBlocks - gCurrentTotalReplicatorBufferBlocks.load();
+	// Log the number of released buffers.
+	safs::log_debug("({}) Released buffer blocks per operation: read {}, write {}, replicate {}",
+	                __func__, releasedOutputBuffers, releasedInputBuffers,
+	                releasedReplicatorBuffers);
+
+	// Log the current amount of blocks buffers per operation.
+	safs::log_debug(
+	    "({}) Current total buffer blocks per operation: read {}, write {}, replicate {}",
+	    __func__, gCurrentTotalOutputBufferBlocks.load(), gCurrentTotalInputBufferBlocks.load(),
+	    gCurrentTotalReplicatorBufferBlocks.load());
 }

--- a/src/chunkserver/io_buffers.h
+++ b/src/chunkserver/io_buffers.h
@@ -34,6 +34,10 @@
 
 constexpr uint8_t kNotSaunafsStatus = 255;
 
+inline std::atomic<uint32_t> gCurrentTotalOutputBufferBlocks = 0;
+inline std::atomic<uint32_t> gCurrentTotalInputBufferBlocks = 0;
+inline std::atomic<uint32_t> gCurrentTotalReplicatorBufferBlocks = 0;
+
 /// @class Buffer
 /// @brief Manages a data buffer.
 template <typename ContainerType = std::vector<uint8_t>>
@@ -222,8 +226,10 @@ public:
 	/// @param numBlocks The number of blocks.
 	explicit OutputBuffer(size_t headerSize, size_t numBlocks);
 
-	/// @brief Default destructor.
-	~OutputBuffer() = default;
+	/// @brief Destructor only decreases the global counter of output buffers blocks.
+	~OutputBuffer() {
+		gCurrentTotalOutputBufferBlocks -= numBlocks_;
+	}
 
 	/// @brief Checks the CRC of the data inside the block buffer.
 	/// @param bytes The number of bytes to check.
@@ -390,8 +396,10 @@ public:
 	/// @param numBlocks The number of blocks.
 	explicit InputBuffer(size_t headerSize, size_t numBlocks);
 
-	/// @brief Default destructor.
-	~InputBuffer() = default;
+	/// @brief Destructor only decreases the global counter of input buffers blocks.
+	~InputBuffer() {
+		gCurrentTotalInputBufferBlocks -= numBlocks_;
+	}
 
 	/// @brief Reads at most `bytesToRead` bytes from the socket.
 	/// It puts the data into the header buffer if not already filled considering the
@@ -522,6 +530,12 @@ public:
 	/// @param numBlocks The number of blocks the buffer can hold.
 	ReplicatorBuffer(size_t headerSize, size_t numBlocks) : numBlocks_(numBlocks) {
 		(void)headerSize;
+		gCurrentTotalReplicatorBufferBlocks += numBlocks_;
+	}
+
+	/// @brief Destructor only decreases the global counter of replicator buffers blocks.
+	~ReplicatorBuffer() {
+		gCurrentTotalReplicatorBufferBlocks -= numBlocks_;
 	}
 
 	/// @brief Clears the buffer.
@@ -570,8 +584,4 @@ inline ReplicatorBufferPool &getReplicateBuffersPool() {
 	return replicateBuffersPool;
 }
 
-inline void releaseOldIoBuffers(uint32_t expirationTime_ms) {
-	getReadOutputBufferPool().releaseOldBuffers(expirationTime_ms);
-	getWriteInputBufferPool().releaseOldBuffers(expirationTime_ms);
-	getReplicateBuffersPool().releaseOldBuffers(expirationTime_ms);
-}
+void releaseOldIoBuffers(uint32_t expirationTime_ms);

--- a/src/main/main.cc
+++ b/src/main/main.cc
@@ -195,13 +195,14 @@ const std::string& set_syslog_ident() {
 }
 
 void main_reload() {
-	// Reload SYSLOG_IDENT
-	safs_pretty_syslog(LOG_NOTICE, "Changing SYSLOG_IDENT to %s",
-			cfg_get("SYSLOG_IDENT", STR(APPNAME)).c_str());
-	set_syslog_ident();
-
 	// Reload MAGIC_DEBUG_LOG
 	safs::setup_logs();
+
+	// Reload SYSLOG_IDENT
+	safs_pretty_syslog(LOG_NOTICE, "Changing SYSLOG_IDENT to %s",
+	                   cfg_get("SYSLOG_IDENT", STR(APPNAME)).c_str());
+	set_syslog_ident();
+
 	safs_silent_syslog(LOG_DEBUG, "main.reload");
 }
 

--- a/tests/test_suites/LongSystemTests/test_concurrent_replications.sh
+++ b/tests/test_suites/LongSystemTests/test_concurrent_replications.sh
@@ -1,0 +1,74 @@
+timeout_set 15 minutes
+
+# Create an installation with 7 chunkservers, 2 disks each.
+USE_RAMDISK=YES \
+	MOUNTS=1
+	CHUNKSERVERS=7 \
+	DISK_PER_CHUNKSERVER=2 \
+	CHUNKSERVER_EXTRA_CONFIG="HDD_TEST_FREQ = 10000|MASTER_REPLICATION_NR_OF_WORKERS=10" \
+	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER" \
+	MASTER_CUSTOM_GOALS="10 ec_5_2: \$ec(5,2)" \
+	MASTER_EXTRA_CONFIG="CHUNKS_LOOP_MIN_TIME = 1`
+			`|CHUNKS_LOOP_MAX_CPU = 90`
+			`|CHUNKS_LOOP_PERIOD = 10`
+			`|ACCEPTABLE_DIFFERENCE = 1.0`
+			`|CHUNKS_WRITE_REP_LIMIT = 50`
+			`|CHUNKS_READ_REP_LIMIT = 50`
+			`|OPERATIONS_DELAY_INIT = 0`
+			`|OPERATIONS_DELAY_DISCONNECT = 0" \
+	setup_local_empty_saunafs info
+
+chunkserver_count=7
+
+# The expected state of the system is that each file has a part in each chunkserver.
+check_expected_state() {
+	check_nr_part_per_cs=$1
+	checked_files=0
+	for file in *; do
+		if [[ check_nr_part_per_cs -eq 1 ]]; then
+			# Check that each chunkserver has a part of the file
+			for ((csid=0; csid < chunkserver_count; csid++)); do
+				assert_eventually_prints 1 "saunafs fileinfo '${file}' | grep ':${info[chunkserver${csid}_port]}' | wc -l" "3 minutes"
+			done
+		fi
+		assert_eventually_prints ${chunkserver_count} "saunafs fileinfo '${file}' | grep copy | wc -l" "3 minutes"
+
+		checked_files=$((checked_files + 1))
+		if (( checked_files % 100 == 0 )); then
+			echo "Successfully checked ${checked_files} files"
+		fi
+	done
+}
+
+cd "${info[mount0]}"
+mkdir ec52_dir
+saunafs setgoal ec_5_2 ec52_dir
+
+cd ec52_dir
+# Create 1000 files 14 blocks long
+file_size=$((14 * SAUNAFS_BLOCK_SIZE))
+for i in {1..1000}; do
+	FILE_SIZE=${file_size} file-generate "file_${i}"
+done
+
+disable_chunkserver_disk 0 0 &
+disable_chunkserver_disk 1 0 &
+wait
+
+# Replication should start immediately, so we can read the files.
+check_expected_state 1
+
+reenable_chunkserver_disk 0 0 &
+reenable_chunkserver_disk 1 0 &
+wait
+
+# Wait for the deletion of the extra files to finish.
+# While deleting the extra parts, the number of parts per chunkserver may not be exactly one.
+check_expected_state 0
+
+# Validate the files to ensure they are correct.
+for i in {1..1000}; do
+	file-validate "file_${i}"
+done
+
+sfschunkserver_check_no_buffer_in_use

--- a/tests/tools/saunafs.sh
+++ b/tests/tools/saunafs.sh
@@ -543,6 +543,33 @@ create_emulated_zoned_devices_for_cs_number_() {
 	done
 }
 
+disable_chunkserver_disk() {
+	chunkserver_id=$1
+	disk_id=$2
+	hdd_file="${saunafs_info_[chunkserver${chunkserver_id}_hdd]}"
+	line_num=$((disk_id + 1))
+	sed -i "${line_num}s/^/# /" "$hdd_file"
+	saunafs_chunkserver_daemon "${chunkserver_id}" reload || {
+		echo "Failed to reload chunkserver ${chunkserver_id} after disabling disk ${disk_id}"
+		return 1
+	}
+	echo "Disabled disk ${disk_id} for chunkserver ${chunkserver_id}"
+}
+
+reenable_chunkserver_disk() {
+	chunkserver_id=$1
+	disk_id=$2
+	hdd_file="${saunafs_info_[chunkserver${chunkserver_id}_hdd]}"
+	line_num=$((disk_id + 1))
+	# Remove "# " at the start of the line
+	sed -i "${line_num}s/^# //" "$hdd_file"
+	saunafs_chunkserver_daemon "${chunkserver_id}" reload || {
+		echo "Failed to reload chunkserver ${chunkserver_id} after re-enabling disk ${disk_id}"
+		return 1
+	}
+	echo "Re-enabled disk ${disk_id} for chunkserver ${chunkserver_id}"
+}
+
 create_sfshdd_cfg_() {
 	local n=$disks_per_chunkserver
 	local zoned_prefix=""
@@ -584,6 +611,13 @@ create_sfshdd_cfg_() {
 create_chunkserver_label_entry_() {
 	local csid=$1
 	tr '|' "\n" <<<"${CHUNKSERVER_LABELS-}" | awk -F: '$1~/(^|,)'$csid'(,|$)/ {print "LABEL = "$2}'
+}
+
+add_lines_sfschunkserver_cfg_() {
+	lines=$1
+	chunkserver_id=$2
+	lines_with_newline=$(echo "${lines}" | tr '|' '\n')
+	echo "${lines_with_newline}" >> "${saunafs_info_[chunkserver${chunkserver_id}_cfg]}"
 }
 
 create_sfschunkserver_cfg_() {
@@ -1026,4 +1060,35 @@ function is_zoned_device() {
 	else
 		echo false
 	fi
+}
+
+# Checks no iobuffers are in use in the chunkservers.
+# Adds around 15s to the test.
+sfschunkserver_check_no_buffer_in_use() {
+	# Make sure some time passes to get dead csentries cleaned up
+	sleep 10
+
+	chunkserver_count=${saunafs_info_[chunkserver_count]}
+	# Add the MAGIC_DEBUG_LOG option to the chunkservers and reload
+	for ((i=0; i<chunkserver_count; ++i)); do
+		add_lines_sfschunkserver_cfg_ "MAGIC_DEBUG_LOG=${TEMP_DIR}/log|`
+			`LOG_LEVEL=debug|LOG_FLUSH_ON=DEBUG|HDD_TEST_FREQ=10000" ${i}
+		saunafs_chunkserver_daemon ${i} reload
+	done
+
+	sleep 5
+
+	# Assert that the last 5 seconds of log contains chunkserver_count lines with:
+	# "Current total buffer blocks per operation: read 0, write 0, replicate 0"
+	# Plus, the last chunkserver_count lines should be unique disregarding the timestamp.
+	# The difference should be the CS pid. This means that the buffers were released correctly.
+	last_total_entries=$(
+		grep '(releaseOldIoBuffers) Current total' "${TEMP_DIR}/log" | tail -n \
+			${chunkserver_count} | awk '{for(i=4;i<=NF;++i) printf "%s%s", $i, (i<NF?" ":"\n")}'
+	)
+	full_zeroes=$(echo "${last_total_entries}" | grep -c 'read 0, write 0, replicate 0')
+	unique_count=$(echo "${last_total_entries}" | sort | uniq | wc -l)
+
+	assert_equals "${chunkserver_count}" "${full_zeroes}"
+	assert_equals "${chunkserver_count}" "${unique_count}"
 }


### PR DESCRIPTION
This change was motivated by a high memory consumption of the
chunkserver processes in some scenarios where some failed reads are
involved.

Some issues were fixed in the process:
- the CS is now able to release the structures related to failed reads.
- to test the motivating case, it was necessary to fix the case when
some disk is being removed from the CS hdd file and the CS is reloaded,
it was crashing from time to time.
- during that process, it was fixed the reload of the SYSLOG_IDENT
parameter and the thread id.

The changes were tested in a new test `test_concurrent_replications`.

Signed-off-by: Dave <dave@leil.io>