### PR TITLE
chore: Ignore Windows client tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,7 @@ src/chunkserver/plugins/ice_disk_energy_manager
 tests/ci_build/run-smr-tests.sh
 tests/test_suites/SMRTests
 tests/test_suites/ICETests
+tests/test_suites/WindowsClientTests
 
 # Windows #
 ###########


### PR DESCRIPTION
The Windows client test suite should be ignored in order to avoid unintended commit file additions as these files are maintained on a separate repo.