### PR TITLE
feat(common): Add ObservableIntegralProperty template

### DIFF
--- a/src/common/observable_property.h
+++ b/src/common/observable_property.h
@@ -22,7 +22,10 @@
 
 #include <concepts>
 #include <functional>
+#include <limits>
+#include <stdexcept>
 #include <string>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -105,4 +108,90 @@ private:
 	std::string name_;   ///< Property name, could be used as key for database or logging
 	T value_;            ///< Current value of the property
 	SignalType signal_;  ///< Signal to notify observers about changes
+};
+
+/// @brief Adds support for incrementing and decrementing integral properties.
+template <typename T>
+    requires std::integral<T>
+class ObservableIntegralProperty : public ObservableProperty<T> {
+public:
+	ObservableIntegralProperty(std::string name, T initialValue)
+	    : ObservableProperty<T>(std::move(name), initialValue) {}
+
+	/// Increments the property value by the specified amount, with overflow check.
+	void increment(T amount = 1) {
+		if (amount == 0) { return; }
+
+		T current = this->getValue();
+
+		if constexpr (std::is_unsigned_v<T>) {
+			// Unsigned: only non-negative amounts; check for overflow on addition.
+			if (current > std::numeric_limits<T>::max() - amount) {
+				throw std::overflow_error("Integral property overflow on increment.");
+			}
+			this->setValue(static_cast<T>(current + amount));
+		} else {
+			if (amount > 0) {
+				// Overflow check: current + amount > max -> current > max - amount
+				if (current > static_cast<T>(std::numeric_limits<T>::max() - amount)) {
+					throw std::overflow_error("Integral property overflow on increment.");
+				}
+			} else {  // amount < 0 -> effectively a decrement by -amount
+				// Underflow check: current + amount < min -> current < min - amount (amount
+				// negative)
+				if (current < static_cast<T>(std::numeric_limits<T>::min() - amount)) {
+					throw std::underflow_error(
+					    "Integral property underflow on increment with negative amount.");
+				}
+			}
+
+			this->setValue(static_cast<T>(current + amount));
+		}
+	}
+
+	/// Decrements the property value by the specified amount, with underflow check.
+	void decrement(T amount = 1) {
+		if (amount == 0) { return; }
+
+		T current = this->getValue();
+
+		if constexpr (std::is_unsigned_v<T>) {
+			// Only non-negative amounts are meaningful for unsigned types
+			if (current < amount) {
+				throw std::underflow_error("Integral property underflow on decrement.");
+			}
+			this->setValue(static_cast<T>(current - amount));
+		} else {
+			if (amount > 0) {
+				// Underflow check: current - amount < min -> current < min + amount
+				if (current < static_cast<T>(std::numeric_limits<T>::min() + amount)) {
+					throw std::underflow_error("Integral property underflow on decrement.");
+				}
+			} else {  // amount < 0 -> effectively an increment by -amount
+				// Overflow check: current - amount > max  <=> current > max + amount (amount
+				// negative)
+				if (current > static_cast<T>(std::numeric_limits<T>::max() + amount)) {
+					throw std::overflow_error(
+					    "Integral property overflow on decrement with negative amount.");
+				}
+			}
+
+			this->setValue(static_cast<T>(current - amount));
+		}
+	}
+
+	/// Pre-increments the property value by one.
+	ObservableIntegralProperty<T> &operator++() {
+		increment(1);
+		return *this;
+	}
+
+	/// Pre-decrements the property value by one.
+	ObservableIntegralProperty<T> &operator--() {
+		decrement(1);
+		return *this;
+	}
+
+	/// Convenience function to returns the type size in bytes.
+	static constexpr size_t typeSize() { return sizeof(T); }
 };

--- a/src/common/observable_property_unittest.cc
+++ b/src/common/observable_property_unittest.cc
@@ -19,8 +19,10 @@
 #include "common/platform.h"
 
 #include <gtest/gtest.h>
+#include <cstdint>
 
 #include "common/observable_property.h"
+#include "common/type_defs.h"
 
 TEST(SignalSlotTest, BasicSignalWithNoParameters) {
 	Signal<> signal;
@@ -164,4 +166,76 @@ TEST(SignalSlotTest, ComplexTypeSignal) {
 
 	EXPECT_EQ(receivedData.id, 123);
 	EXPECT_EQ(receivedData.name, "test_name");
+}
+
+// ObservableIntegralProperty tests
+
+TEST(SignalSlotTest, ObservableIntegralPropertyIncrementDecrement) {
+	ObservableIntegralProperty<int> property("test_int", 10);
+
+	EXPECT_EQ(property.getValue(), 10);
+
+	property.increment();
+	EXPECT_EQ(property.getValue(), 11);
+
+	property.decrement();
+	EXPECT_EQ(property.getValue(), 10);
+
+	property.increment(5);
+	EXPECT_EQ(property.getValue(), 15);
+
+	property.decrement(3);
+	EXPECT_EQ(property.getValue(), 12);
+}
+
+TEST(SignalSlotTest, ObservableIntegralPropertyBounds) {
+	// Unsigned
+
+	ObservableIntegralProperty<uint8_t> ui8("test_uint8_t", 0);
+	EXPECT_EQ(ui8.getValue(), 0);
+
+	// Decrements
+	EXPECT_THROW(ui8.decrement(), std::underflow_error);
+	EXPECT_THROW(--ui8, std::underflow_error);
+	ui8.setValue(5);
+	EXPECT_THROW(ui8.decrement(6), std::underflow_error);
+
+	// Increments
+	ui8.setValue(1);
+	EXPECT_THROW(ui8.increment(std::numeric_limits<uint8_t>::max()), std::overflow_error);
+	ui8.setValue(std::numeric_limits<uint8_t>::max());
+	EXPECT_THROW(++ui8, std::overflow_error);
+
+	// Signed
+
+	int16_t initialValue = 0;
+	ObservableIntegralProperty<int16_t> i16("test_int16_t", initialValue);
+	EXPECT_EQ(i16.getValue(), initialValue);
+
+	// Increments
+	EXPECT_NO_THROW(++i16);
+	EXPECT_NO_THROW(i16.increment(5));
+	EXPECT_EQ(i16.getValue(), initialValue + 6);
+	EXPECT_THROW(i16.increment(std::numeric_limits<int16_t>::max()), std::overflow_error);
+	i16.setValue(initialValue);
+	EXPECT_NO_THROW(i16.increment(std::numeric_limits<int16_t>::max()));
+	EXPECT_EQ(i16.getValue(), std::numeric_limits<int16_t>::max());
+
+	// Decrements
+	i16.setValue(initialValue);
+	EXPECT_NO_THROW(--i16);
+	EXPECT_NO_THROW(i16.decrement(5));
+	EXPECT_EQ(i16.getValue(), initialValue - 6);
+	// Notice that ::min here is a negative number
+	EXPECT_THROW(i16.increment(std::numeric_limits<int16_t>::min()), std::underflow_error);
+	i16.setValue(initialValue);
+	EXPECT_NO_THROW(i16.increment(std::numeric_limits<int16_t>::min()));
+	EXPECT_EQ(i16.getValue(), std::numeric_limits<int16_t>::min());
+}
+
+TEST(SignalSlotTest, ObservableIntegralPropertyTypeSize) {
+	EXPECT_EQ(ObservableIntegralProperty<uint8_t>::typeSize(), sizeof(uint8_t));
+	EXPECT_EQ(ObservableIntegralProperty<int32_t>::typeSize(), sizeof(int32_t));
+	EXPECT_EQ(ObservableIntegralProperty<short>::typeSize(), sizeof(short));
+	EXPECT_EQ(ObservableIntegralProperty<inode_t>::typeSize(), sizeof(inode_t));
 }


### PR DESCRIPTION
This commit extends the ObservableProperty family to support integral types with increment and decrement capabilities. Concrete instances will be used to replace plain FilesystemMetadata members like: nextInodeId, nextSessionId and most likely metadataVersion.

Inherited from the hierarchy, ObservableProperty instances allow unknown observers to react to value changes (like updating it in a database), which provides good extensibility without modifying the existing code (Observer pattern based on signals and slots).

For reviewers:
It is used in the branch: feat-add-new-mds, like this:
```cpp
// In class FilesystemMetadata
ObservableIntegralProperty<inode_t> maxInodeId_{"META_MAX_INODE_ID", 0};
ObservableIntegralProperty<uint32_t> nextSessionId_{"META_NEXT_SESSION", 0};
```

Then, you can subscribe to changes like:
```cpp
// In the FDB backend implementation
gMetadata->maxInodeId().connect([this](inode_t oldMaxInodeId, inode_t newMaxInodeId) {
	auto transaction = kvEngine_->createReadWriteTransaction();
	kv::Key maxInodeKey{kv::toU8Vector(gMetadata->maxInodeId().getName())};
	kv::Value maxInodeValue;
	serialize(maxInodeValue, newMaxInodeId);
	transaction->set(maxInodeKey, maxInodeValue);

	if (!transaction->commit()) {
		safs::log_err("Failed to store max inode ID: {}", newMaxInodeId);
	}
});
```
