### PR TITLE
refactor(build): improve CMakePresets.json structure

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -15,51 +15,69 @@
                 "CODE_COVERAGE": "OFF",
                 "ENABLE_CLIENT_LIB": "ON",
                 "ENABLE_DOCS": "ON",
+                "ENABLE_FOUNDATIONDB": "ON",
+                "ENABLE_INODE64": "OFF",
                 "ENABLE_NFS_GANESHA": "ON",
                 "ENABLE_POLONAISE": "OFF",
                 "ENABLE_TESTS": "ON",
                 "ENABLE_URAFT": "ON",
                 "ENABLE_WERROR": "ON",
                 "GSH_CAN_HOST_LOCAL_FS": "ON",
-                "SAUNAFS_TEST_POINTER_OBFUSCATION": "ON",
-                "ENABLE_INODE64": "OFF",
-                "ENABLE_FOUNDATIONDB": "ON"
+                "SAUNAFS_TEST_POINTER_OBFUSCATION": "ON"
             },
-            "hidden": true
+            "hidden": true,
+            "condition": {
+                "type": "notEquals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
         },
         {
             "name": "vcpkg",
             "toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
             "hidden": true
         },
-		{
-			"name": "windows",
-            "inherits": ["default", "vcpkg"],
-			"generator": "MinGW Makefiles",
-			"cacheVariables": {
-				"CMAKE_MAKE_PROGRAM": "C:/msys64/mingw64/bin/mingw32-make.exe",
-				"CMAKE_C_COMPILER": "C:/msys64/mingw64/bin/gcc.exe",
-				"CMAKE_CXX_COMPILER": "C:/msys64/mingw64/bin/g++.exe",
-				"SOCKET_LIBRARIES": "C:/msys64/mingw64/lib/libws2_32.a",
-				"VCPKG_TARGET_TRIPLET": "x64-mingw-static",
-				"VCPKG_DEFAULT_TRIPLET": "x64-mingw-static",
-				"VCPKG_HOST_TRIPLET": "x64-mingw-static",
-				"CMAKE_BUILD_TYPE": "RelWithDebInfo",
-				"ENABLE_DOCS": "OFF",
-				"ENABLE_CLIENT_LIB": "OFF",
-				"ENABLE_URAFT": "OFF",
-				"ENABLE_NFS_GANESHA": "OFF",
-				"GSH_CAN_HOST_LOCAL_FS": "OFF",
-				"ENABLE_POLONAISE": "OFF",
-				"ENABLE_TESTS": "OFF",
-				"ENABLE_PROMETHEUS": "OFF",
-				"ENABLE_NFS_ACL_SUPPORT": "OFF",
-				"CODE_COVERAGE": "OFF",
-				"SAUNAFS_TEST_POINTER_OBFUSCATION": "OFF",
-				"ENABLE_WERROR": "ON",
-				"ENABLE_FOUNDATIONDB": "OFF"
-			}
-		},
+        {
+            "name": "windows-default",
+            "generator": "MinGW Makefiles",
+            "binaryDir": "${sourceDir}/build/saunafs",
+            "installDir": "${sourceDir}/install/saunafs/",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+                "CMAKE_CXX_COMPILER": "C:/msys64/mingw64/bin/g++.exe",
+                "CMAKE_C_COMPILER": "C:/msys64/mingw64/bin/gcc.exe",
+                "CMAKE_MAKE_PROGRAM": "C:/msys64/mingw64/bin/mingw32-make.exe",
+                "CODE_COVERAGE": "OFF",
+                "ENABLE_CLIENT_LIB": "OFF",
+                "ENABLE_DOCS": "OFF",
+                "ENABLE_FOUNDATIONDB": "OFF",
+                "ENABLE_NFS_ACL_SUPPORT": "OFF",
+                "ENABLE_NFS_GANESHA": "OFF",
+                "ENABLE_POLONAISE": "OFF",
+                "ENABLE_PROMETHEUS": "OFF",
+                "ENABLE_TESTS": "OFF",
+                "ENABLE_URAFT": "OFF",
+                "ENABLE_WERROR": "ON",
+                "GSH_CAN_HOST_LOCAL_FS": "OFF",
+                "SAUNAFS_TEST_POINTER_OBFUSCATION": "OFF",
+                "SOCKET_LIBRARIES": "C:/msys64/mingw64/lib/libws2_32.a"
+            },
+            "hidden": true,
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
+        },
+        {
+            "name": "windows",
+            "inherits": ["windows-default", "vcpkg"],
+            "cacheVariables": {
+                "VCPKG_DEFAULT_TRIPLET": "x64-mingw-static",
+                "VCPKG_HOST_TRIPLET": "x64-mingw-static",
+                "VCPKG_TARGET_TRIPLET": "x64-mingw-static"
+            }
+        },
         {
             "name": "debug",
             "binaryDir": "${sourceDir}/build/saunafs/debug",


### PR DESCRIPTION
Previously, the CMake presets were not properly scoped to their respective platforms, leading to issues where presets intended for specific platforms (e.g., Windows) were visible or active on other platforms. This commit addresses this issue by the following changes:

- Move common Windows settings to the new "windows-default" preset to ease preset management via inheritance.
- Add conditions to the "default" and "windows-default" presets to make them platform-specific.
- Update the "windows" preset to inherit from "windows-default" and "vcpkg".
- Sort the variables alphabetically to make them easier to navigate.
- Remove tab-based indentation for consistency and readability.