### PR TITLE
ci: Ignore non-numbered when updating NEWS file

### DIFF
--- a/ci/update-news.sh
+++ b/ci/update-news.sh
@@ -2,19 +2,49 @@
 
 set -eux
 
-gitChangelog=$(./ci/get-changelog.sh)
+headCommit="${2:-HEAD}"
+gitChangelog=$(./ci/get-changelog.sh "${1:-stable}" "${headCommit}")
 version=$(sed -nE 's/^set\(DEFAULT_MIN_VERSION "([^"]+)"\).*/\1/p' ./CMakeLists.txt)
 
 
 newsEntry="* SaunaFS (${version}) ($(date '+%Y-%m-%d' -u))\n"
 
-while read -r _ title message; do
+isPartOfMerge() {
+	commit="$1"
+	commit=$(git rev-parse "$commit")
+
+	if git rev-list --first-parent "$headCommit" | grep -qx "$commit"; then
+		return 1;
+	else
+		return 0;
+	fi
+}
+
+declare -a entries
+
+while read -r shortHash title message; do
 	case $title in
 		chore*|style*|refactor*|test*|"Merge"|ci*)
 			continue
 		;;
 	esac
-	newsEntry+=" - $title $message\n"
+
+	if [[ ! "$title $message" =~ \(#[0-9]+\) ]]; then
+		if isPartOfMerge "$shortHash"; then
+			# Ignore commits that are part of merges (they will be
+			# summarized by the merge commit)
+			continue
+		fi
+	fi
+
+	entries+=(" - $title $message\n")
 done <<< "${gitChangelog}"
+
+IFS=$'\n' sortedEntries=($(sort <<<"${entries[*]}"))
+unset IFS
+
+for entry in "${sortedEntries[@]}"; do
+	newsEntry+="${entry}"
+done
 
 sed -i "3i ${newsEntry}" NEWS


### PR DESCRIPTION
Due to inconsistent use of merge commits, often there are duplicate
entries that say the same thing. This change will now ignore
non-numbered commits to stay consistent. However, an exception is made
if a commit is not part of a merge commit.


* Add alphabetical sorting to the entries
* Allow passing branch names to the script