### PR TITLE
feat(master): Refactor the FSNode family

### DIFF
--- a/src/common/serializable_interface.h
+++ b/src/common/serializable_interface.h
@@ -1,0 +1,50 @@
+/*
+   Copyright 2023      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "common/platform.h"
+
+#include <cstddef>
+#include <cstdint>
+
+/// Interface for serializable objects.
+class ISerializable {
+public:
+	// Default constructor
+	ISerializable() = default;
+
+	// virtual destructor for polymorphic deletion
+	virtual ~ISerializable() = default;
+
+	ISerializable(const ISerializable &) = delete;
+	ISerializable &operator=(const ISerializable &) = delete;
+	ISerializable(ISerializable &&) = delete;
+	ISerializable &operator=(ISerializable &&) = delete;
+
+	/// Returns the size of the serialized object in bytes.
+	virtual size_t serializedSize() const = 0;
+
+	/// Serializes the object into the provided destination buffer.
+	/// The function assumes that the destination buffer has enough space allocated.
+	/// Use serializedSize in the caller to ensure sufficient space.
+	virtual void serialize(uint8_t **destination) const = 0;
+
+	/// Deserializes the object from the provided source buffer.
+	virtual void deserialize(const uint8_t **source) = 0;
+};

--- a/src/master/filesystem_dump.cc
+++ b/src/master/filesystem_dump.cc
@@ -108,7 +108,7 @@ void fs_dumpnode(FSNode *f) {
 		}
 		printf(")|r:(");
 		i = 0;
-		for(const auto &sessionid : node_file->sessionid) {
+		for(const auto &sessionid : node_file->sessionIds) {
 			if (i > 0) {
 				printf(",");
 			}

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -77,32 +77,11 @@ FSNode *FSNode::create(FSNodeType type) {
 }
 
 void FSNode::destroy(FSNode *node) {
-	for (auto const &[_, handlePtr] : node->parent) {
+	for (auto const &[_, handlePtr] : node->parents) {
 		delete handlePtr;
 	}
-	switch (node->type) {
-	case FSNodeType::kFile:
-	case FSNodeType::kTrash:
-	case FSNodeType::kReserved:
-		delete static_cast<FSNodeFile *>(node);
-		break;
-	case FSNodeType::kDirectory:
-		delete static_cast<FSNodeDirectory *>(node);
-		break;
-	case FSNodeType::kSymlink:
-		delete static_cast<FSNodeSymlink *>(node);
-		break;
-	case FSNodeType::kFifo:
-	case FSNodeType::kSocket:
-		delete node;
-		break;
-	case FSNodeType::kBlockDev:
-	case FSNodeType::kCharDev:
-		delete static_cast<FSNodeDevice *>(node);
-		break;
-	default:
-		assert(!"invalid node type");
-	}
+
+	delete node;
 }
 
 // number of blocks in the last chunk before EOF
@@ -233,20 +212,18 @@ int fsnodes_nameisused(FSNodeDirectory *node, const HString &name) {
 
 /*! \brief Returns true iff \param ancestor is ancestor of \param node. */
 bool fsnodes_isancestor(FSNodeDirectory *ancestor, FSNode *node) {
-	for (const auto &[parentId, _] : node->parent) {
-		FSNodeDirectory *dir_node =
-		    fsnodes_id_to_node_verify<FSNodeDirectory>(parentId);
+	for (const auto &[parentId, _] : node->parents) {
+		auto *dir_node = fsnodes_id_to_node_verify<FSNodeDirectory>(parentId);
 
 		while(dir_node) {
 			if (ancestor == dir_node) {
 				return true;
 			}
 
-			assert(dir_node->parent.size() <= 1);
+			assert(dir_node->parents.size() <= 1);
 
-			if (!dir_node->parent.empty()) {
-				dir_node = fsnodes_id_to_node_verify<FSNodeDirectory>(
-				    dir_node->parent[0].first);
+			if (!dir_node->parents.empty()) {
+				dir_node = fsnodes_id_to_node_verify<FSNodeDirectory>(dir_node->parents[0].first);
 			} else {
 				dir_node = nullptr;
 			}
@@ -270,7 +247,7 @@ bool fsnodes_isancestor_or_node_reserved_or_trash(FSNodeDirectory *ancestor, FSN
 
 // stats
 
-void fsnodes_get_stats(FSNode *node, statsrecord *sr) {
+void fsnodes_get_stats(FSNode *node, StatsRecord *sr) {
 	switch (node->type) {
 	case FSNodeType::kDirectory:
 		*sr = static_cast<FSNodeDirectory*>(node)->stats;
@@ -312,7 +289,7 @@ void fsnodes_get_stats(FSNode *node, statsrecord *sr) {
 }
 
 int64_t fsnodes_get_size(FSNode *node) {
-	statsrecord sr;
+	StatsRecord sr;
 	fsnodes_get_stats(node, &sr);
 	return sr.size;
 }
@@ -320,17 +297,16 @@ int64_t fsnodes_get_size(FSNode *node) {
 FSNodeDirectory *fsnodes_get_first_parent(FSNode *node) {
 	assert(node);
 	FSNodeDirectory *parent;
-	if (!node->parent.empty()) {
-		parent =
-		    fsnodes_id_to_node_verify<FSNodeDirectory>(node->parent[0].first);
+	if (!node->parents.empty()) {
+		parent = fsnodes_id_to_node_verify<FSNodeDirectory>(node->parents[0].first);
 	} else {
 		parent = gMetadata->root;
 	}
 	return parent;
 }
 
-static inline void fsnodes_sub_stats(FSNodeDirectory *parent, statsrecord *sr) {
-	statsrecord *psr;
+static inline void fsnodes_sub_stats(FSNodeDirectory *parent, StatsRecord *sr) {
+	StatsRecord *psr;
 	if (parent) {
 		psr = &parent->stats;
 		psr->inodes -= sr->inodes;
@@ -342,17 +318,16 @@ static inline void fsnodes_sub_stats(FSNodeDirectory *parent, statsrecord *sr) {
 		psr->size -= sr->size;
 		psr->realsize -= sr->realsize;
 		if (parent != gMetadata->root) {
-			for (auto const &[parentId, _] : parent->parent) {
-				FSNodeDirectory *node =
-				    fsnodes_id_to_node_verify<FSNodeDirectory>(parentId);
+			for (auto const &[parentId, _] : parent->parents) {
+				auto *node = fsnodes_id_to_node_verify<FSNodeDirectory>(parentId);
 				fsnodes_sub_stats(node, sr);
 			}
 		}
 	}
 }
 
-void fsnodes_add_stats(FSNodeDirectory *parent, statsrecord *sr) {
-	statsrecord *psr;
+void fsnodes_add_stats(FSNodeDirectory *parent, StatsRecord *sr) {
+	StatsRecord *psr;
 	if (parent) {
 		psr = &parent->stats;
 		psr->inodes += sr->inodes;
@@ -364,17 +339,16 @@ void fsnodes_add_stats(FSNodeDirectory *parent, statsrecord *sr) {
 		psr->size += sr->size;
 		psr->realsize += sr->realsize;
 		if (parent != gMetadata->root) {
-			for (auto const &[parentId, _] : parent->parent) {
-				FSNodeDirectory *node =
-				    fsnodes_id_to_node_verify<FSNodeDirectory>(parentId);
+			for (auto const &[parentId, _] : parent->parents) {
+				auto *node = fsnodes_id_to_node_verify<FSNodeDirectory>(parentId);
 				fsnodes_add_stats(node, sr);
 			}
 		}
 	}
 }
 
-void fsnodes_add_sub_stats(FSNodeDirectory *parent, statsrecord *newsr, statsrecord *prevsr) {
-	statsrecord sr;
+void fsnodes_add_sub_stats(FSNodeDirectory *parent, StatsRecord *newsr, StatsRecord *prevsr) {
+	StatsRecord sr;
 	sr.inodes = newsr->inodes - prevsr->inodes;
 	sr.dirs = newsr->dirs - prevsr->dirs;
 	sr.files = newsr->files - prevsr->files;
@@ -443,7 +417,7 @@ void fsnodes_fill_attr(FSNode *node, FSNode *parent, uint32_t uid, uint32_t gid,
 	put32bit(&ptr, node->atime);
 	put32bit(&ptr, node->mtime);
 	put32bit(&ptr, node->ctime);
-	nlink = node->parent.size();
+	nlink = node->parents.size();
 	switch (node->type) {
 	case FSNodeType::kFile:
 	case FSNodeType::kTrash:
@@ -515,7 +489,7 @@ void fsnodes_remove_edge(uint32_t ts, FSNodeDirectory *parent, const HString &na
 		}
 	}
 
-	statsrecord sr;
+	StatsRecord sr;
 
 	fsnodes_get_stats(node, &sr);
 	fsnodes_sub_stats(parent, &sr);
@@ -531,15 +505,15 @@ void fsnodes_remove_edge(uint32_t ts, FSNodeDirectory *parent, const HString &na
 	}
 
 	auto it = std::find_if(
-	    node->parent.begin(), node->parent.end(),
+	    node->parents.begin(), node->parents.end(),
 	    [parent, currentName](const std::pair<inode_t, const hstorage::Handle *> &p) {
 		    return p.first == parent->id &&
 		           (parent->case_insensitive ? HString::hstringToLowerCase(p.second->get())
 		                                     : p.second->get()) == currentName;
 	    });
 
-	if (it != node->parent.end()) {
-		node->parent.erase(it);
+	if (it != node->parents.end()) {
+		node->parents.erase(it);
 	}
 
 	// Delete the handle after the check in the parent vector in the son is
@@ -566,13 +540,13 @@ void fsnodes_link(uint32_t ts, FSNodeDirectory *parent, FSNode *child, const HSt
 		parent->lowerCaseEntriesHash ^= lowerCaseName.hash();
 	}
 
-	child->parent.push_back({parent->id, handlePtr});
+	child->parents.push_back({parent->id, handlePtr});
 
 	if (child->type == FSNodeType::kDirectory) {
 		parent->nlink++;
 	}
 
-	statsrecord sr;
+	StatsRecord sr;
 	fsnodes_get_stats(child, &sr);
 	fsnodes_add_stats(parent, &sr);
 	if (ts > 0) {
@@ -667,11 +641,10 @@ uint32_t fsnodes_getpath_size(FSNodeDirectory *parent, FSNode *child) {
 	name = parent->getChildName(child);
 	size = name.length();
 
-	while (parent != gMetadata->root && !parent->parent.empty()) {
+	while (parent != gMetadata->root && !parent->parents.empty()) {
 		child = parent;
-		assert(child->parent.size() == 1);
-		parent =
-		    fsnodes_id_to_node_verify<FSNodeDirectory>(child->parent[0].first);
+		assert(child->parents.size() == 1);
+		parent = fsnodes_id_to_node_verify<FSNodeDirectory>(child->parents[0].first);
 		name = parent->getChildName(child);
 		size += name.length() + 1;
 	}
@@ -698,11 +671,10 @@ void fsnodes_getpath_data(FSNodeDirectory *parent, FSNode *child, uint8_t *path,
 	if (size > 0) {
 		path[--size] = '/';
 	}
-	while (parent != gMetadata->root && !parent->parent.empty()) {
+	while (parent != gMetadata->root && !parent->parents.empty()) {
 		child = parent;
-		assert(child->parent.size() == 1);
-		parent =
-		    fsnodes_id_to_node_verify<FSNodeDirectory>(child->parent[0].first);
+		assert(child->parents.size() == 1);
+		parent = fsnodes_id_to_node_verify<FSNodeDirectory>(child->parents[0].first);
 		name = parent->getChildName(child);
 		if (size >= name.length()) {
 			size -= name.length();
@@ -906,15 +878,14 @@ void fsnodes_getdirdata(inode_t rootinode, uint32_t uid, uint32_t gid, uint32_t 
 			put8bit(&dbuff, static_cast<uint8_t>(FSNodeType::kDirectory));
 		}
 	} else {
-		if (!p->parent.empty() && p->parent[0].first != rootinode) {
-			putINode(&dbuff, p->parent[0].first);
+		if (!p->parents.empty() && p->parents[0].first != rootinode) {
+			putINode(&dbuff, p->parents[0].first);
 		} else {
 			putINode(&dbuff, SPECIAL_INODE_ROOT);
 		}
 		if (withattr) {
-			if (!p->parent.empty()) {
-				FSNode *parent =
-				    fsnodes_id_to_node_verify<FSNode>(p->parent[0].first);
+			if (!p->parents.empty()) {
+				auto *parent = fsnodes_id_to_node_verify<FSNode>(p->parents[0].first);
 				fsnodes_fill_attr(parent, p, uid, gid, auid, agid,
 				                  sesflags, attr);
 				::memcpy(dbuff, attr.data(), attr.size());
@@ -977,7 +948,7 @@ void fsnodes_getdir(inode_t rootinode, uint32_t uid, uint32_t gid, uint32_t auid
 	if (first_entry == 0 && number_of_entries >= 1) {
 		inode = p->id != rootinode ? p->id : SPECIAL_INODE_ROOT;
 		parent = fsnodes_id_to_node_verify<FSNodeDirectory>(
-		    p->parent.empty() ? SPECIAL_INODE_ROOT : p->parent[0].first);
+		    p->parents.empty() ? SPECIAL_INODE_ROOT : p->parents[0].first);
 		fsnodes_fill_attr(p, parent, uid, gid, auid, agid, sesflags, attr);
 		dir_entries.emplace_back(std::move(inode), std::string("."), std::move(attr));
 
@@ -989,21 +960,20 @@ void fsnodes_getdir(inode_t rootinode, uint32_t uid, uint32_t gid, uint32_t auid
 		if (p->id == rootinode) {
 			inode = SPECIAL_INODE_ROOT;
 			parent = fsnodes_id_to_node_verify<FSNodeDirectory>(
-			    p->parent.empty() ? SPECIAL_INODE_ROOT : p->parent[0].first);
+			    p->parents.empty() ? SPECIAL_INODE_ROOT : p->parents[0].first);
 			fsnodes_fill_attr(p, parent, uid, gid, auid, agid, sesflags, attr);
 		} else {
-			if (!p->parent.empty() && p->parent[0].first != rootinode) {
-				inode = p->parent[0].first;
+			if (!p->parents.empty() && p->parents[0].first != rootinode) {
+				inode = p->parents[0].first;
 			} else {
 				inode = SPECIAL_INODE_ROOT;
 			}
 
 			FSNodeDirectory *grandparent;
 			parent = fsnodes_id_to_node_verify<FSNodeDirectory>(
-			    p->parent.empty() ? SPECIAL_INODE_ROOT : p->parent[0].first);
+			    p->parents.empty() ? SPECIAL_INODE_ROOT : p->parents[0].first);
 			grandparent = fsnodes_id_to_node_verify<FSNodeDirectory>(
-			    parent->parent.empty() ? SPECIAL_INODE_ROOT
-			                           : parent->parent[0].first);
+			    parent->parents.empty() ? SPECIAL_INODE_ROOT : parent->parents[0].first);
 			fsnodes_fill_attr(parent, grandparent, uid, gid, auid, agid, sesflags,
 			                  attr);
 		}
@@ -1062,7 +1032,7 @@ void fsnodes_getdir(inode_t rootinode, uint32_t uid, uint32_t gid, uint32_t auid
 	if (first_entry == kDotEntryIndex && number_of_entries >= 1) {
 		inode = p->id != rootinode ? p->id : SPECIAL_INODE_ROOT;
 		parent = fsnodes_id_to_node_verify<FSNodeDirectory>(
-		    p->parent.empty() ? SPECIAL_INODE_ROOT : p->parent[0].first);
+		    p->parents.empty() ? SPECIAL_INODE_ROOT : p->parents[0].first);
 		fsnodes_fill_attr(p, parent, uid, gid, auid, agid, sesflags, attr);
 		dir_entries.emplace_back(kDotEntryIndex, kDotDotEntryIndex, std::move(inode), std::string("."), std::move(attr));
 
@@ -1074,21 +1044,20 @@ void fsnodes_getdir(inode_t rootinode, uint32_t uid, uint32_t gid, uint32_t auid
 		if (p->id == rootinode) {
 			inode = SPECIAL_INODE_ROOT;
 			parent = fsnodes_id_to_node_verify<FSNodeDirectory>(
-			    p->parent.empty() ? SPECIAL_INODE_ROOT : p->parent[0].first);
+			    p->parents.empty() ? SPECIAL_INODE_ROOT : p->parents[0].first);
 			fsnodes_fill_attr(p, parent, uid, gid, auid, agid, sesflags, attr);
 		} else {
-			if (!p->parent.empty() && p->parent[0].first != rootinode) {
-				inode = p->parent[0].first;
+			if (!p->parents.empty() && p->parents[0].first != rootinode) {
+				inode = p->parents[0].first;
 			} else {
 				inode = SPECIAL_INODE_ROOT;
 			}
 
 			FSNodeDirectory *grandparent;
 			parent = fsnodes_id_to_node_verify<FSNodeDirectory>(
-			    p->parent.empty() ? SPECIAL_INODE_ROOT : p->parent[0].first);
+			    p->parents.empty() ? SPECIAL_INODE_ROOT : p->parents[0].first);
 			grandparent = fsnodes_id_to_node_verify<FSNodeDirectory>(
-			    parent->parent.empty() ? SPECIAL_INODE_ROOT
-			                           : parent->parent[0].first);
+			    parent->parents.empty() ? SPECIAL_INODE_ROOT : parent->parents[0].first);
 			fsnodes_fill_attr(parent, grandparent, uid, gid, auid, agid, sesflags,
 			                  attr);
 		}
@@ -1179,7 +1148,7 @@ uint8_t fsnodes_appendchunks(uint32_t ts, FSNodeFile *dst, FSNodeFile *src) {
 		return SAUNAFS_ERROR_INDEXTOOBIG;
 	}
 
-	statsrecord psr, nsr;
+	StatsRecord psr, nsr;
 	fsnodes_get_stats(dst, &psr);
 
 	uint32_t result_chunks = src_chunks + dst_chunks;
@@ -1210,9 +1179,8 @@ uint8_t fsnodes_appendchunks(uint32_t ts, FSNodeFile *dst, FSNodeFile *src) {
 	dst->length = length;
 	fsnodes_get_stats(dst, &nsr);
 	fsnodes_quota_update(dst, {{QuotaResource::kSize, nsr.size - psr.size}});
-	for (const auto &[parentId, _] : dst->parent) {
-		FSNodeDirectory *parent_node =
-		    fsnodes_id_to_node_verify<FSNodeDirectory>(parentId);
+	for (const auto &[parentId, _] : dst->parents) {
+		auto *parent_node = fsnodes_id_to_node_verify<FSNodeDirectory>(parentId);
 		fsnodes_add_sub_stats(parent_node, &nsr, &psr);
 	}
 	dst->mtime = ts;
@@ -1225,15 +1193,14 @@ uint8_t fsnodes_appendchunks(uint32_t ts, FSNodeFile *dst, FSNodeFile *src) {
 
 void fsnodes_changefilegoal(FSNodeFile *obj, uint8_t goal) {
 	uint8_t old_goal = obj->goal;
-	statsrecord psr, nsr;
+	StatsRecord psr, nsr;
 
 	fsnodes_get_stats(obj, &psr);
 	obj->goal = goal;
 	nsr = psr;
 	nsr.realsize = file_realsize(obj, nsr.chunks, nsr.size);
-	for (const auto &[parentId, _] : obj->parent) {
-		FSNodeDirectory *parent_node =
-		    fsnodes_id_to_node_verify<FSNodeDirectory>(parentId);
+	for (const auto &[parentId, _] : obj->parents) {
+		auto *parent_node = fsnodes_id_to_node_verify<FSNodeDirectory>(parentId);
 		fsnodes_add_sub_stats(parent_node, &nsr, &psr);
 	}
 	for (const auto &chunkid : obj->chunks) {
@@ -1246,7 +1213,7 @@ void fsnodes_changefilegoal(FSNodeFile *obj, uint8_t goal) {
 
 void fsnodes_setlength(FSNodeFile *obj, uint64_t length, bool eraseFurtherChunks) {
 	uint32_t chunks;
-	statsrecord psr, nsr;
+	StatsRecord psr, nsr;
 	fsnodes_get_stats(obj, &psr);
 	if (obj->type == FSNodeType::kTrash) {
 		gMetadata->trashSpace -= obj->length;
@@ -1281,9 +1248,8 @@ void fsnodes_setlength(FSNodeFile *obj, uint64_t length, bool eraseFurtherChunks
 
 	fsnodes_get_stats(obj, &nsr);
 	fsnodes_quota_update(obj, {{QuotaResource::kSize, nsr.size - psr.size}});
-	for (const auto &[parentId, _] : obj->parent) {
-		FSNodeDirectory *parent_node =
-		    fsnodes_id_to_node_verify<FSNodeDirectory>(parentId);
+	for (const auto &[parentId, _] : obj->parents) {
+		auto *parent_node = fsnodes_id_to_node_verify<FSNodeDirectory>(parentId);
 		fsnodes_add_sub_stats(parent_node, &nsr, &psr);
 	}
 	fsnodes_update_checksum(obj);
@@ -1307,7 +1273,7 @@ void fsnodes_change_uid_gid(FSNode *p, uint32_t uid, uint32_t gid) {
 }
 
 static inline void fsnodes_remove_node(uint32_t ts, FSNode *node) {
-	if (!node->parent.empty()) {
+	if (!node->parents.empty()) {
 		return;
 	}
 
@@ -1371,22 +1337,22 @@ static inline void fsnodes_remove_node(uint32_t ts, FSNode *node) {
 void fsnodes_unlink(uint32_t ts, FSNodeDirectory *parent, const HString &child_name, FSNode *child) {
 	std::string path;
 
-	if (child->parent.size() == 1) {  // last link
+	if (child->parents.size() == 1) {  // last link
 		if (child->type == FSNodeType::kFile &&
 		    (child->trashtime > 0 ||
-		     !static_cast<FSNodeFile*>(child)->sessionid.empty())) {  // go to trash or reserved ? - get path
+		     !static_cast<FSNodeFile*>(child)->sessionIds.empty())) {  // go to trash or reserved ? - get path
 			fsnodes_getpath(parent, child, path);
 		}
 	}
 
 	fsnodes_remove_edge(ts, parent, child_name, child);
-	if (!child->parent.empty()) {
+	if (!child->parents.empty()) {
 		return;
 	}
 
 	// last link
 	if (child->type == FSNodeType::kFile) {
-		FSNodeFile *file_node = static_cast<FSNodeFile*>(child);
+		auto *file_node = static_cast<FSNodeFile*>(child);
 		if (child->trashtime > 0) {
 			child->type = FSNodeType::kTrash;
 			child->ctime = ts;
@@ -1396,7 +1362,7 @@ void fsnodes_unlink(uint32_t ts, FSNodeDirectory *parent, const HString &child_n
 
 			gMetadata->trashSpace += file_node->length;
 			gMetadata->trashNodes++;
-		} else if (!file_node->sessionid.empty()) {
+		} else if (!file_node->sessionIds.empty()) {
 			child->type = FSNodeType::kReserved;
 			fsnodes_update_checksum(child);
 
@@ -1418,7 +1384,7 @@ int fsnodes_purge(uint32_t ts, FSNode *p) {
 		gMetadata->trashSpace -= file_node->length;
 		gMetadata->trashNodes--;
 
-		if (!file_node->sessionid.empty()) {
+		if (!file_node->sessionIds.empty()) {
 			file_node->type = FSNodeType::kReserved;
 			fsnodes_update_checksum(file_node);
 			gMetadata->reservedSpace += file_node->length;

--- a/src/master/filesystem_node.h
+++ b/src/master/filesystem_node.h
@@ -135,7 +135,7 @@ uint8_t fsnodes_get_node_for_operation(const FsContext &context, ExpectedNodeTyp
 uint8_t fsnodes_undel(uint32_t ts, FSNodeFile *node);
 
 int fsnodes_namecheck(const std::string &name);
-void fsnodes_get_stats(FSNode *node, statsrecord *sr);
+void fsnodes_get_stats(FSNode *node, StatsRecord *sr);
 bool fsnodes_isancestor_or_node_reserved_or_trash(FSNodeDirectory *f, FSNode *p);
 int fsnodes_access(const FsContext &context, FSNode *node, uint8_t modemask);
 
@@ -149,7 +149,7 @@ FSNode *fsnodes_create_node(uint32_t ts, FSNodeDirectory *node, const HString &n
                             uint32_t gid, uint8_t copysgid, AclInheritance inheritacl,
                             inode_t req_inode = 0);
 
-void fsnodes_add_stats(FSNodeDirectory *parent, statsrecord *sr);
+void fsnodes_add_stats(FSNodeDirectory *parent, StatsRecord *sr);
 int fsnodes_sticky_access(FSNode *parent, FSNode *node, uint32_t uid);
 void fsnodes_unlink(uint32_t ts, FSNodeDirectory *parent, const HString &node_name, FSNode *node);
 bool fsnodes_isancestor(FSNodeDirectory *f, FSNode *p);
@@ -176,7 +176,7 @@ void fsnodes_getdir(inode_t rootinode, uint32_t uid, uint32_t gid, uint32_t auid
 void fsnodes_checkfile(FSNodeFile *p, uint32_t chunkcount[CHUNK_MATRIX_SIZE]);
 
 bool fsnodes_has_tape_goal(FSNode *node);
-void fsnodes_add_sub_stats(FSNodeDirectory *parent, statsrecord *newsr, statsrecord *prevsr);
+void fsnodes_add_sub_stats(FSNodeDirectory *parent, StatsRecord *newsr, StatsRecord *prevsr);
 
 void fsnodes_getgoal_recursive(FSNode *node, uint8_t gmode, GoalStatistics &fgtab,
                                GoalStatistics &dgtab);

--- a/src/master/filesystem_node_types.h
+++ b/src/master/filesystem_node_types.h
@@ -23,11 +23,16 @@
 #include "common/platform.h"
 
 #include <array>
+#include <cstddef>
 #include <cstdint>
+#include <cstring>
+#include <string>
 #include <unordered_map>
 
-#include "common/goal.h"
 #include "common/compact_vector.h"
+#include "common/datapack.h"
+#include "common/goal.h"
+#include "common/serializable_interface.h"
 #include "common/type_defs.h"
 #include "protocol/SFSCommunication.h"
 
@@ -88,7 +93,7 @@ using TrashtimeMap = std::unordered_map<uint32_t, uint32_t>;
 using GoalStatistics = std::array<inode_t, GoalId::kMax + 1>;
 using ParentsCompactVector = compact_vector<std::pair<inode_t, const hstorage::Handle *>, uint32_t>;
 
-struct statsrecord {
+struct StatsRecord {
 	inode_t inodes;
 	inode_t dirs;
 	inode_t files;
@@ -123,29 +128,33 @@ enum class FSNodeType : std::uint8_t {
  * 1G files will occupy 150GB
  * 4G files will occupy 600GB
  */
-struct FSNode {
-	inode_t id; /*!< Unique number identifying node. */
-	uint32_t ctime; /*!< Change time. */
-	uint32_t mtime; /*!< Modification time. */
-	uint32_t atime; /*!< Access time. */
-	FSNodeType type; /*!< Node type. (file, directory, symlink, ...) */
-	uint8_t goal; /*!< Goal id. */
-	uint16_t mode;  /*!< Only 12 lowest bits are used for mode, in unix standard upper 4 are used
-	                 for object type, but since there is field "type" this bits can be used as
-	                 extra flags. */
-	uint32_t uid; /*!< User id. */
-	uint32_t gid; /*!< Group id. */
-	uint32_t trashtime; /*!< Trash time. */
+class FSNode : public ISerializable {
+public:
+	inode_t id{};       ///< Unique number identifying node.
+	uint32_t ctime{};   ///< Change time.
+	uint32_t mtime{};   ///< Modification time.
+	uint32_t atime{};   ///< Access time.
+	FSNodeType type{};  ///< Node type. (file, directory, symlink, ...)
+	uint8_t goal{};     ///< Goal id.
 
-	ParentsCompactVector parent; /*!< Parent nodes ids + handles of entries of this node in those
-	               parents. To reduce memory usage ids are stored instead of pointers to FSNode. */
+	/// Only 12 lowest bits are used for mode, in unix standard upper 4 are used for object type,
+	/// but since there is field "type" these bits can be used as extra flags.
+	uint16_t mode{};
+	uint32_t uid{};        ///< User id.
+	uint32_t gid{};        ///< Group id.
+	uint32_t trashtime{};  ///< Trash time.
 
-	uint64_t checksum; /*!< Node checksum. */
+	/// Parent nodes ids + handles of entries of this node in those parents.
+	/// To reduce memory usage ids are stored instead of pointers to FSNode.
+	ParentsCompactVector parents;
 
-	FSNode(FSNodeType t) {
-		type = t;
-		checksum = 0;
-	}
+	uint64_t checksum{};  ///< Node checksum.
+
+	static constexpr size_t kNodeHeaderSize =
+	    sizeof(type) + sizeof(id) + sizeof(goal) + sizeof(mode) + sizeof(uid) + sizeof(gid) +
+	    sizeof(atime) + sizeof(mtime) + sizeof(ctime) + sizeof(trashtime);
+
+	explicit FSNode(FSNodeType type_) : type(type_) {}
 
 	/*! \brief Static function used for creating proper node for given type.
 	 * \param type Type of node to create.
@@ -159,32 +168,141 @@ struct FSNode {
 	 * \param node Pointer to node that should be erased.
 	 */
 	static void destroy(FSNode *node);
+
+	/// Serializes the common data of FSNode
+	void serializeCommon(uint8_t **destination) const {
+		FSNode::serialize(destination);
+	}
+
+	// Serializable interface
+
+	/// Returns the size of the serialized object in bytes.
+	size_t serializedSize() const override { return kNodeHeaderSize; }
+
+	/// Serializes the object into the provided destination buffer.
+	/// The function assumes that the destination buffer has enough space allocated.
+	/// Use serializedSize in the caller to ensure sufficient space.
+	void serialize(uint8_t **destination) const override {
+		put8bit(destination, static_cast<uint8_t>(type));
+		putINode(destination, id);
+		put8bit(destination, goal);
+		put16bit(destination, mode);
+		put32bit(destination, uid);
+		put32bit(destination, gid);
+		put32bit(destination, atime);
+		put32bit(destination, mtime);
+		put32bit(destination, ctime);
+		put32bit(destination, trashtime);
+	}
+
+	/// Deserializes the object from the provided source buffer.
+	void deserialize(const uint8_t **source) override {
+		uint8_t typeTemp{};
+		typeTemp = get8bit(source);
+		type = static_cast<FSNodeType>(typeTemp);
+		getINode(source, id);
+		goal = get8bit(source);
+		mode = get16bit(source);
+		get32bit(source, uid);
+		get32bit(source, gid);
+		get32bit(source, atime);
+		get32bit(source, mtime);
+		get32bit(source, ctime);
+		get32bit(source, trashtime);
+	}
 };
 
-constexpr FSNode* kUnknownNode = nullptr;
+constexpr FSNode *kUnknownNode = nullptr;
 
 /*! \brief Node used for storing file object.
  *
  * Node size = 64B + 40B + 8 * chunks_count + 4 * session_count
  * Avg size (assuming 1 chunk and session id) = 104 + 8 + 4 ~ 120B
  */
-struct FSNodeFile : public FSNode {
+class FSNodeFile : public FSNode {
+public:
 	uint64_t length{};
-	compact_vector<uint32_t> sessionid;
+	compact_vector<uint32_t> sessionIds;
 	compact_vector<uint64_t, uint32_t> chunks;
 
-	explicit FSNodeFile(FSNodeType t) : FSNode(t) {
-		assert(t == FSNodeType::kFile || t == FSNodeType::kTrash || t == FSNodeType::kReserved);
+	// Constants
+
+	static constexpr uint16_t kMaxSessionSize = 65535;
+	static constexpr uint32_t kChunksBucketSize = 65536;
+
+	/// Extra fixed size in the header
+	using chunk_count_t = uint32_t;
+	static constexpr size_t kFileExtraHeaderSize =
+	    sizeof(FSNodeFile::length) + sizeof(chunk_count_t) + sizeof(kMaxSessionSize);
+
+	/// Full header size, including the FSNode members
+	static constexpr size_t kFileHeaderSize = FSNode::kNodeHeaderSize + kFileExtraHeaderSize;
+
+	/// Maximum extra size of the serialized object
+	static constexpr size_t kFileMaxExtraBufferSize =
+	    (sizeof(uint64_t) * kChunksBucketSize) + (sizeof(uint32_t) * kMaxSessionSize);
+
+	/// Maximum buffer size for serialized objects
+	static constexpr size_t kMaxBufferSize = kFileHeaderSize + kFileMaxExtraBufferSize;
+
+	explicit FSNodeFile(FSNodeType type_) : FSNode(type_) {
+		assert(type_ == FSNodeType::kFile || type_ == FSNodeType::kTrash ||
+		       type_ == FSNodeType::kReserved);
 	}
 
 	uint32_t chunkCount() const {
-		for(uint32_t i = chunks.size(); i > 0; --i) {
-			if (chunks[i-1] != 0) {
-				return i;
-			}
+		for (uint32_t i = chunks.size(); i > 0; --i) {
+			if (chunks[i - 1] != 0) { return i; }
 		}
 
 		return 0;
+	}
+
+	// Serializable interface
+
+	/// Returns the size of the serialized object in bytes.
+	size_t serializedSize() const override {
+		auto sessionsCount = std::min<size_t>(sessionIds.size(), kMaxSessionSize);
+		return kFileHeaderSize + (sizeof(uint64_t) * chunkCount()) +
+		       (sizeof(uint32_t) * sessionsCount);
+	}
+
+	/// Serializes the object into the provided destination buffer.
+	/// The function assumes that the destination buffer has enough space allocated.
+	/// Use serializedSize in the caller to ensure sufficient space.
+	void serialize(uint8_t **destination) const override {
+		FSNode::serialize(destination);
+
+		put64bit(destination, length);
+		auto chunkAmount = chunkCount();
+		put32bit(destination, chunkAmount);
+		auto sessionsCount = std::min<int>(sessionIds.size(), kMaxSessionSize);
+		put16bit(destination, sessionsCount);
+
+		for (size_t i = 0; i < chunkAmount; ++i) { put64bit(destination, chunks[i]); }
+
+		for (int i = 0; i < sessionsCount; ++i) { put32bit(destination, sessionIds[i]); }
+	}
+
+	/// Deserializes the object from the provided source buffer.
+	void deserialize(const uint8_t **source) override {
+		FSNode::deserialize(source);
+		length = get64bit(source);
+		uint32_t chunkAmount{};
+		get32bit(source, chunkAmount);
+		auto sessionsAmount = get16bit(source);
+
+		// Chunks
+
+		chunks.resize(chunkAmount);
+
+		for (size_t i = 0; i < chunkAmount; ++i) { chunks[i] = get64bit(source); }
+
+		// Sessions
+
+		sessionIds.resize(sessionsAmount);
+
+		for (size_t i = 0; i < sessionsAmount; ++i) { get32bit(source, sessionIds[i]); }
 	}
 };
 
@@ -192,11 +310,40 @@ struct FSNodeFile : public FSNode {
  *
  * Node size = 64 + 16 = 80B
  */
-struct FSNodeSymlink : public FSNode {
+class FSNodeSymlink : public FSNode {
+public:
 	hstorage::Handle path;
 	uint16_t path_length{};
 
-	explicit FSNodeSymlink() : FSNode(FSNodeType::kSymlink) {
+	// It is stored as uint32_t
+	using serialized_path_length_t = uint32_t;
+
+	static constexpr size_t kSymlinkHeaderSize =
+	    FSNode::kNodeHeaderSize + sizeof(serialized_path_length_t);
+
+	explicit FSNodeSymlink() : FSNode(FSNodeType::kSymlink) {}
+
+	// Serializable interface
+
+	/// Returns the size of the serialized object in bytes.
+	size_t serializedSize() const override { return kSymlinkHeaderSize + path_length; }
+
+	/// Serializes the object into the provided destination buffer.
+	/// The function assumes that the destination buffer has enough space allocated.
+	/// Use serializedSize in the caller to ensure sufficient space.
+	void serialize(uint8_t **destination) const override {
+		FSNode::serialize(destination);
+		HString::serialize(destination, path.get());
+	}
+
+	/// Deserializes the object from the provided source buffer.
+	void deserialize(const uint8_t **source) override {
+		FSNode::deserialize(source);
+
+		HString pathString;
+		HString::deserialize(source, pathString);
+		path = hstorage::Handle(pathString);
+		path_length = static_cast<uint16_t>(pathString.length());
 	}
 };
 
@@ -204,10 +351,31 @@ struct FSNodeSymlink : public FSNode {
  *
  * Node size = 64 + 8 = 72B
  */
-struct FSNodeDevice : public FSNode {
-	uint32_t rdev;
+class FSNodeDevice : public FSNode {
+public:
+	uint32_t rdev{};
 
-	FSNodeDevice(FSNodeType device_type) : FSNode(device_type), rdev() {
+	static constexpr size_t kDeviceHeaderSize = FSNode::kNodeHeaderSize + sizeof(rdev);
+
+	FSNodeDevice(FSNodeType device_type) : FSNode(device_type) {}
+
+	// Serializable interface
+
+	/// Returns the size of the serialized object in bytes.
+	size_t serializedSize() const override { return kDeviceHeaderSize; }
+
+	/// Serializes the object into the provided destination buffer.
+	/// The function assumes that the destination buffer has enough space allocated.
+	/// Use serializedSize in the caller to ensure sufficient space.
+	void serialize(uint8_t **destination) const override {
+		FSNode::serialize(destination);
+		put32bit(destination, rdev);
+	}
+
+	/// Deserializes the object from the provided source buffer.
+	void deserialize(const uint8_t **source) override {
+		FSNode::deserialize(source);
+		get32bit(source, rdev);
 	}
 };
 
@@ -216,7 +384,8 @@ struct FSNodeDevice : public FSNode {
  * Node size = 64 + 56 + 16 * entries_count
  * Avg size (10 files) ~ 280B (28B per file)
  */
-struct FSNodeDirectory : public FSNode {
+class FSNodeDirectory : public FSNode {
+public:
 	struct HandleCompare {
 		bool operator()(const std::pair<hstorage::Handle *, FSNode *> &a,
 		                const std::pair<hstorage::Handle *, FSNode *> &b) const {
@@ -234,26 +403,18 @@ struct FSNodeDirectory : public FSNode {
 	using iterator = EntriesContainer::iterator;
 	using const_iterator = EntriesContainer::const_iterator;
 
-	EntriesContainer entries; /*!< Directory entries (entry: name + pointer to child node). */
-	EntriesContainer
-	    lowerCaseEntries; /*!< Directory entries with lowe case name (entry:
-	                         name + pointer to child node). */
-	bool case_insensitive = false;
-	statsrecord stats; /*!< Directory statistics (including subdirectories). */
-	uint32_t nlink; /*!< Number of directories linking to this directory. */
-	uint16_t entries_hash;
-	uint16_t lowerCaseEntriesHash;
+	EntriesContainer entries;  ///< Directory entries (entry: name + pointer to child node).
+	/// Directory entries with lower case name (entry: name + pointer to child node).
+	EntriesContainer lowerCaseEntries;
+	bool case_insensitive = false;  ///< Flag for case insensitive search.
+	StatsRecord stats;              ///< Directory statistics (including subdirectories).
+	uint32_t nlink{2};              ///< Number of directories linking to this directory.
+	uint16_t entries_hash{};
+	uint16_t lowerCaseEntriesHash{};
 
-	FSNodeDirectory() : FSNode(FSNodeType::kDirectory) {
+	explicit FSNodeDirectory() : FSNode(FSNodeType::kDirectory) {
 		memset(&stats, 0, sizeof(stats));
-		nlink = 2;
-		entries_hash = 0;
-		lowerCaseEntriesHash = 0;
 	}
-
-	~FSNodeDirectory() {
-	}
-
 
 	/*! \brief Find directory entry with given name.
 	 *
@@ -261,39 +422,31 @@ struct FSNodeDirectory : public FSNode {
 	 * \return If node is found returns iterator pointing to directory entry containing node,
 	 *         otherwise entries.end().
 	 */
-	iterator find(const HString& name) {
+	iterator find(const HString &name) {
 		uint64_t name_hash = (hstorage::Handle::HashType)name.hash();
 
 		if (case_insensitive) {
 			HString lowerCaseNameHandle = HString::hstringToLowerCase(name);
 			name_hash = (hstorage::Handle::HashType)lowerCaseNameHandle.hash();
-			auto tmp_handle =
-			    hstorage::Handle(name_hash << hstorage::Handle::kHashShift);
+			auto tmp_handle = hstorage::Handle(name_hash << hstorage::Handle::kHashShift);
 			auto pair_to_find = std::make_pair(&tmp_handle, kUnknownNode);
 			auto lowerCaseIt = lowerCaseEntries.lower_bound(pair_to_find);
 
 			for (; lowerCaseIt != lowerCaseEntries.end(); ++lowerCaseIt) {
-				if ((*lowerCaseIt).first->hash() != name_hash) {
-					break;
-				}
+				if ((*lowerCaseIt).first->hash() != name_hash) { break; }
 				if (*((*lowerCaseIt).first) == lowerCaseNameHandle) {
 					auto it = find((*lowerCaseIt).second);
 					return it;
 				}
 			}
 		} else {
-			auto tmp_handle =
-			    hstorage::Handle(name_hash << hstorage::Handle::kHashShift);
+			auto tmp_handle = hstorage::Handle(name_hash << hstorage::Handle::kHashShift);
 			auto pair_to_find = std::make_pair(&tmp_handle, kUnknownNode);
 			auto it = entries.lower_bound(pair_to_find);
 
 			for (; it != entries.end(); ++it) {
-				if ((*it).first->hash() != name_hash) {
-					break;
-				}
-				if (*((*it).first) == name) {
-					return it;
-				}
+				if ((*it).first->hash() != name_hash) { break; }
+				if (*((*it).first) == name) { return it; }
 			}
 		}
 
@@ -306,18 +459,13 @@ struct FSNodeDirectory : public FSNode {
 		if (case_insensitive) {
 			HString lowerCaseNameHandle = HString::hstringToLowerCase(name);
 			name_hash = (hstorage::Handle::HashType)lowerCaseNameHandle.hash();
-			auto tmp_handle =
-			    hstorage::Handle(name_hash << hstorage::Handle::kHashShift);
+			auto tmp_handle = hstorage::Handle(name_hash << hstorage::Handle::kHashShift);
 			auto pair_to_find = std::make_pair(&tmp_handle, kUnknownNode);
 			auto lowerCaseIt = lowerCaseEntries.lower_bound(pair_to_find);
 
 			for (; lowerCaseIt != lowerCaseEntries.end(); ++lowerCaseIt) {
-				if ((*lowerCaseIt).first->hash() != name_hash) {
-					break;
-				}
-				if (*((*lowerCaseIt).first) == lowerCaseNameHandle) {
-					return lowerCaseIt;
-				}
+				if ((*lowerCaseIt).first->hash() != name_hash) { break; }
+				if (*((*lowerCaseIt).first) == lowerCaseNameHandle) { return lowerCaseIt; }
 			}
 		}
 
@@ -333,24 +481,17 @@ struct FSNodeDirectory : public FSNode {
 	iterator find(const FSNode *node) {
 		HString name = HString(getChildName(node));
 		uint64_t name_hash = (hstorage::Handle::HashType)name.hash();
-		auto tmp_handle =
-		    hstorage::Handle(name_hash << hstorage::Handle::kHashShift);
+		auto tmp_handle = hstorage::Handle(name_hash << hstorage::Handle::kHashShift);
 		auto pair_to_find = std::make_pair(&tmp_handle, kUnknownNode);
 		auto it = entries.lower_bound(pair_to_find);
 		for (; it != entries.end(); ++it) {
-			if ((*it).first->hash() != name_hash) {
-				break;
-			}
-			if (*((*it).first) == name) {
-				return it;
-			}
+			if ((*it).first->hash() != name_hash) { break; }
+			if (*((*it).first) == name) { return it; }
 		}
 		return entries.end();
 	}
 
-	iterator find_nth(EntriesContainer::size_type nth) {
-		return entries.find_by_order(nth);
-	}
+	iterator find_nth(EntriesContainer::size_type nth) { return entries.find_by_order(nth); }
 
 	const_iterator find_nth(EntriesContainer::size_type nth) const {
 		return entries.find_by_order(nth);
@@ -363,28 +504,35 @@ struct FSNodeDirectory : public FSNode {
 	 *         otherwise returns empty string.
 	 */
 	std::string getChildName(const FSNode *node) const {
-		for (const auto &[parentId, hstring] : node->parent) {
-			if (parentId == this->id) {
-				return hstring->get();
-			}
+		for (const auto &[parentId, hstring] : node->parents) {
+			if (parentId == this->id) { return hstring->get(); }
 		}
-		return std::string();
+		return {};
 	}
 
-	iterator begin() {
-		return entries.begin();
+	iterator begin() { return entries.begin(); }
+
+	iterator end() { return entries.end(); }
+
+	const_iterator begin() const { return entries.begin(); }
+
+	const_iterator end() const { return entries.end(); }
+
+	// Serializable interface
+
+	/// Returns the size of the serialized object in bytes.
+	size_t serializedSize() const override { return kNodeHeaderSize; }
+
+	/// Serializes the object into the provided destination buffer.
+	/// The function assumes that the destination buffer has enough space allocated.
+	/// Use serializedSize in the caller to ensure sufficient space.
+	void serialize(uint8_t **destination) const override {
+		FSNode::serialize(destination);
 	}
 
-	iterator end() {
-		return entries.end();
-	}
-
-	const_iterator begin() const {
-		return entries.begin();
-	}
-
-	const_iterator end() const {
-		return entries.end();
+	/// Deserializes the object from the provided source buffer.
+	void deserialize(const uint8_t **source) override {
+		FSNode::deserialize(source);
 	}
 };
 

--- a/src/master/filesystem_node_types_unittest.cc
+++ b/src/master/filesystem_node_types_unittest.cc
@@ -1,0 +1,246 @@
+/*
+   Copyright 2023      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "common/platform.h"
+
+#include "master/filesystem_node_types.h"
+
+#include <gtest/gtest.h>
+#include <sys/types.h>
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "common/datapack.h"
+#include "master/hstring_memstorage.h"
+
+using namespace hstorage;
+
+class FilesystemNodeTypesTest : public ::testing::Test {
+protected:
+	void SetUp() override {
+		Storage::reset(new MemStorage());
+		EXPECT_EQ(Storage::instance().name(), "MemStorage");
+	}
+
+	void TearDown() override {
+		for (auto *node : nodes) { FSNode::destroy(node); }
+
+		nodes.clear();
+	}
+
+	static bool areEqual(FSNode *first, FSNode *second) {
+		if (first->type != second->type) { return false; }
+		if (first->id != second->id) { return false; }
+		if (first->ctime != second->ctime) { return false; }
+		if (first->mtime != second->mtime) { return false; }
+		if (first->atime != second->atime) { return false; }
+		if (first->goal != second->goal) { return false; }
+		if (first->mode != second->mode) { return false; }
+		if (first->uid != second->uid) { return false; }
+		if (first->gid != second->gid) { return false; }
+		if (first->trashtime != second->trashtime) { return false; }
+
+		return true;
+	}
+
+	static FSNode *createFSNode(int index, FSNodeType type) {
+		FSNode *node = FSNode::create(type);
+		node->id = index;
+		node->ctime = kRandomTime + index;
+		node->mtime = kRandomTime + index;
+		node->atime = kRandomTime + index;
+		node->goal = kRandomGoal + index;
+		node->mode = kRandomMode;
+		node->uid = kRandomUid + index;
+		node->gid = kRandomGid + index;
+		node->trashtime = kRandomTrashTime + index;
+
+		return node;
+	}
+
+	static constexpr uint32_t kRandomTime = 12345U;
+	static constexpr uint8_t kRandomGoal = 1U;
+	static constexpr uint16_t kRandomMode = 0755U;
+	static constexpr uint32_t kRandomUid = 1000U;
+	static constexpr uint32_t kRandomGid = 1000U;
+	static constexpr uint32_t kRandomTrashTime = 3600U;
+
+	std::vector<FSNode *> nodes;
+
+	static constexpr uint32_t kMaxSize =
+	    FSNodeFile::kFileHeaderSize + FSNodeFile::kFileMaxExtraBufferSize;
+
+	std::array<uint8_t, kMaxSize> serializeBuffer;
+};
+
+TEST_F(FilesystemNodeTypesTest, SerializeFSNodeDirectory) {
+	constexpr int finalNode = 12;
+
+	for (int i = 2; i < finalNode; ++i) {
+		FSNode *node = createFSNode(i, FSNodeType::kDirectory);
+		nodes.push_back(node);
+	}
+
+	uint8_t *buffer = serializeBuffer.data();
+
+	for (auto *node : nodes) {
+		node->serialize(&buffer);
+
+		// Rewind the buffer to the beginning and get the serialized type
+		buffer = serializeBuffer.data();
+		const uint8_t *readPtrForType = buffer;
+		auto type = static_cast<FSNodeType>(get8bit(&readPtrForType));
+
+		// Create a new FSNode of the deserialized type
+		const uint8_t *readPtr = buffer;
+		auto *deserializedNode = FSNode::create(type);
+		deserializedNode->deserialize(&readPtr);
+
+		ASSERT_TRUE(areEqual(node, deserializedNode));
+		FSNode::destroy(deserializedNode);
+	}
+}
+
+TEST_F(FilesystemNodeTypesTest, SerializeFSNodeSymlink) {
+	constexpr int finalNode = 12;
+
+	for (int i = 2; i < finalNode; ++i) {
+		FSNode *node = createFSNode(i, FSNodeType::kSymlink);
+
+		auto *symlinkNode = static_cast<FSNodeSymlink *>(node);
+		std::string target = "/path/to/target_" + std::to_string(i);
+		symlinkNode->path = HString(target);
+		symlinkNode->path_length = target.length();
+
+		nodes.push_back(node);
+	}
+
+	uint8_t *buffer = serializeBuffer.data();
+
+	for (auto *node : nodes) {
+		node->serialize(&buffer);
+
+		// Rewind the buffer to the beginning and get the serialized type
+		buffer = serializeBuffer.data();
+		const uint8_t *readPtrForType = buffer;
+		auto type = static_cast<FSNodeType>(get8bit(&readPtrForType));
+
+		// Create a new FSNode of the deserialized type
+		const uint8_t *readPtr = buffer;
+		auto *deserializedNode = FSNode::create(type);
+		deserializedNode->deserialize(&readPtr);
+
+		ASSERT_TRUE(areEqual(node, deserializedNode));
+
+		auto *originalSymlinkNode = static_cast<FSNodeSymlink *>(node);
+		auto *deserializedSymlinkNode = static_cast<FSNodeSymlink *>(deserializedNode);
+		ASSERT_EQ(originalSymlinkNode->path.get(), deserializedSymlinkNode->path.get());
+		ASSERT_EQ(originalSymlinkNode->path_length, deserializedSymlinkNode->path_length);
+
+		FSNode::destroy(deserializedNode);
+	}
+}
+
+TEST_F(FilesystemNodeTypesTest, SerializeFSNodeDevice) {
+	constexpr int finalNode = 12;
+
+	for (int i = 2; i < finalNode; ++i) {
+		FSNode *node = createFSNode(i, FSNodeType::kBlockDev);
+
+		auto *deviceNode = static_cast<FSNodeDevice *>(node);
+		deviceNode->rdev = static_cast<uint32_t>(i);
+
+		nodes.push_back(node);
+	}
+
+	uint8_t *buffer = serializeBuffer.data();
+
+	for (auto *node : nodes) {
+		node->serialize(&buffer);
+
+		// Rewind the buffer to the beginning and get the serialized type
+		buffer = serializeBuffer.data();
+		const uint8_t *readPtrForType = buffer;
+		auto type = static_cast<FSNodeType>(get8bit(&readPtrForType));
+
+		// Create a new FSNode of the deserialized type
+		const uint8_t *readPtr = buffer;
+		auto *deserializedNode = FSNode::create(type);
+		deserializedNode->deserialize(&readPtr);
+
+		ASSERT_TRUE(areEqual(node, deserializedNode));
+
+		auto *originalDeviceNode = static_cast<FSNodeDevice *>(node);
+		auto *deserializedDeviceNode = static_cast<FSNodeDevice *>(deserializedNode);
+		ASSERT_EQ(originalDeviceNode->rdev, deserializedDeviceNode->rdev);
+
+		FSNode::destroy(deserializedNode);
+	}
+}
+
+TEST_F(FilesystemNodeTypesTest, SerializeFSNodeFile) {
+	constexpr int finalNode = 12;
+
+	for (int i = 2; i < finalNode; ++i) {
+		FSNode *node = createFSNode(i, FSNodeType::kFile);
+
+		auto *fileNode = static_cast<FSNodeFile *>(node);
+
+		fileNode->length = static_cast<uint64_t>(i * 10) * 1024 * 1024; // Increasing file size
+		auto chunks = static_cast<uint32_t>(fileNode->length / static_cast<uint32_t>(SFSCHUNKSIZE));
+
+		for (uint32_t j = 0; j < chunks; ++j) {
+			fileNode->chunks.push_back(static_cast<uint64_t>(j + 1) * 1000); // Dummy chunk IDs
+		}
+
+		for (int j = 0; j < i; ++j) {
+			fileNode->sessionIds.push_back(j + 1); // Dummy session IDs
+		}
+
+		nodes.push_back(node);
+	}
+
+	uint8_t *buffer = serializeBuffer.data();
+
+	for (auto *node : nodes) {
+		node->serialize(&buffer);
+
+		// Rewind the buffer to the beginning and get the serialized type
+		buffer = serializeBuffer.data();
+		const uint8_t *readPtrForType = buffer;
+		auto type = static_cast<FSNodeType>(get8bit(&readPtrForType));
+
+		// Create a new FSNode of the deserialized type
+		const uint8_t *readPtr = buffer;
+		auto *deserializedNode = FSNode::create(type);
+		deserializedNode->deserialize(&readPtr);
+
+		ASSERT_TRUE(areEqual(node, deserializedNode));
+
+		auto *originalFileNode = static_cast<FSNodeFile *>(node);
+		auto *deserializedFileNode = static_cast<FSNodeFile *>(deserializedNode);
+		ASSERT_EQ(originalFileNode->length, deserializedFileNode->length);
+		ASSERT_EQ(originalFileNode->chunks, deserializedFileNode->chunks);
+		ASSERT_EQ(originalFileNode->sessionIds, deserializedFileNode->sessionIds);
+
+		FSNode::destroy(deserializedNode);
+	}
+}

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -338,7 +338,7 @@ uint8_t fs_getrootinode(inode_t *rootinode, const uint8_t *path) {
 void fs_statfs(const FsContext &context, uint64_t *totalspace, uint64_t *availspace,
                uint64_t *trspace, uint64_t *respace, inode_t *inodes) {
 	FSNode *rn;
-	statsrecord sr;
+	StatsRecord sr;
 	if (context.rootinode() == SPECIAL_INODE_ROOT) {
 		*trspace = gMetadata->trashSpace;
 		*respace = gMetadata->reservedSpace;
@@ -435,13 +435,13 @@ uint8_t fs_lookup(const FsContext &context, inode_t parent, const HString &name,
 				*inode = SPECIAL_INODE_ROOT;
 				fsnodes_fill_attr(wd, wd, context.uid(), context.gid(), context.auid(), context.agid(), context.sesflags(), attr);
 			} else {
-				if (!wd->parent.empty()) {
-					if (wd->parent[0].first == context.rootinode()) {
+				if (!wd->parents.empty()) {
+					if (wd->parents[0].first == context.rootinode()) {
 						*inode = SPECIAL_INODE_ROOT;
 					} else {
-						*inode = wd->parent[0].first;
+						*inode = wd->parents[0].first;
 					}
-					FSNode *pp = fsnodes_id_to_node(wd->parent[0].first);
+					FSNode *pp = fsnodes_id_to_node(wd->parents[0].first);
 					fsnodes_fill_attr(pp, wd, context.uid(), context.gid(), context.auid(),
 					                  context.agid(), context.sesflags(), attr);
 				} else {
@@ -518,8 +518,8 @@ uint8_t fs_full_path_by_inode(const FsContext &context, inode_t initial_inode,
 	}
 
 	while (current_inode != context.rootinode()) {
-		if (!current_node || current_node->parent.empty()) {
-			if (current_node->parent.empty() && (current_node->type == FSNodeType::kReserved ||
+		if (!current_node || current_node->parents.empty()) {
+			if (current_node->parents.empty() && (current_node->type == FSNodeType::kReserved ||
 			                                     current_node->type == FSNodeType::kTrash)) {
 				current_name =
 				    current_node->type == FSNodeType::kTrash
@@ -530,7 +530,7 @@ uint8_t fs_full_path_by_inode(const FsContext &context, inode_t initial_inode,
 			}
 			return SAUNAFS_ERROR_ENOENT;
 		}
-		auto [parentId, nameHandle] = current_node->parent[0];
+		auto [parentId, nameHandle] = current_node->parents[0];
 		if (!nameHandle) { return SAUNAFS_ERROR_ENOENT; }
 		status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny, MODE_MASK_R,
 		                                        parentId, &parent_node);
@@ -972,8 +972,8 @@ uint8_t fs_symlink(const FsContext &context, inode_t parent, const HString &name
 	p->path = HString(path);
 	p->path_length = path.length();
 	fsnodes_update_checksum(p);
-	statsrecord sr;
-	memset(&sr, 0, sizeof(statsrecord));
+	StatsRecord sr;
+	memset(&sr, 0, sizeof(StatsRecord));
 	sr.length = path.length();
 	fsnodes_add_stats(static_cast<FSNodeDirectory *>(wd), &sr);
 	if (attr != NULL) {
@@ -1319,7 +1319,7 @@ uint8_t fs_rename(const FsContext &context, inode_t parent_src, const HString &n
 		if (fsnodes_isancestor(static_cast<FSNodeDirectory*>(se_child), dwd)) {
 			return SAUNAFS_ERROR_EINVAL;
 		}
-		const statsrecord &stats = static_cast<FSNodeDirectory*>(se_child)->stats;
+		const StatsRecord &stats = static_cast<FSNodeDirectory*>(se_child)->stats;
 		quota_delta = {{(int64_t)stats.inodes, (int64_t)stats.size}};
 	} else if (se_child->type == FSNodeType::kFile) {
 		quota_delta[(int)QuotaResource::kSize] = fsnodes_get_size(se_child);
@@ -1343,7 +1343,7 @@ uint8_t fs_rename(const FsContext &context, inode_t parent_src, const HString &n
 			return SAUNAFS_ERROR_EPERM;
 		}
 		if (de_child->type == FSNodeType::kDirectory) {
-			const statsrecord &stats = static_cast<FSNodeDirectory*>(de_child)->stats;
+			const StatsRecord &stats = static_cast<FSNodeDirectory*>(de_child)->stats;
 			quota_delta[(int)QuotaResource::kInodes] -= stats.inodes;
 			quota_delta[(int)QuotaResource::kSize] -= stats.size;
 		} else if (de_child->type == FSNodeType::kFile) {
@@ -1889,10 +1889,10 @@ uint8_t fs_acquire(const FsContext &context, inode_t inode, uint32_t sessionid) 
 	    p->type != FSNodeType::kReserved) {
 		return SAUNAFS_ERROR_EPERM;
 	}
-	if (std::find(p->sessionid.begin(), p->sessionid.end(), sessionid) != p->sessionid.end()) {
+	if (std::find(p->sessionIds.begin(), p->sessionIds.end(), sessionid) != p->sessionIds.end()) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
-	p->sessionid.push_back(sessionid);
+	p->sessionIds.push_back(sessionid);
 	fsnodes_update_checksum(p);
 	if (context.isPersonalityMaster()) {
 		fs_changelog(context.ts(), "ACQUIRE(%" PRIiNode ",%" PRIu32 ")", inode, sessionid);
@@ -1912,10 +1912,10 @@ uint8_t fs_release(const FsContext &context, inode_t inode, uint32_t sessionid) 
 	    p->type != FSNodeType::kReserved) {
 		return SAUNAFS_ERROR_EPERM;
 	}
-	auto it = std::find(p->sessionid.begin(), p->sessionid.end(), sessionid);
-	if (it != p->sessionid.end()) {
-		p->sessionid.erase(it);
-		if (p->type == FSNodeType::kReserved && p->sessionid.empty()) {
+	auto it = std::find(p->sessionIds.begin(), p->sessionIds.end(), sessionid);
+	if (it != p->sessionIds.end()) {
+		p->sessionIds.erase(it);
+		if (p->type == FSNodeType::kReserved && p->sessionIds.empty()) {
 			fsnodes_purge(context.ts(), p);
 		} else {
 			fsnodes_update_checksum(p);
@@ -2035,7 +2035,7 @@ uint8_t fs_writechunk(const FsContext &context, inode_t inode, uint32_t indx, bo
 #endif
 
 	const bool quota_exceeded = fsnodes_quota_exceeded(p, {{QuotaResource::kSize, 1}});
-	statsrecord psr;
+	StatsRecord psr;
 	fsnodes_get_stats(p, &psr);
 
 	/* resize chunks structure */
@@ -2081,11 +2081,10 @@ uint8_t fs_writechunk(const FsContext &context, inode_t inode, uint32_t indx, bo
 	}
 	p->chunks[indx] = nchunkid;
 	*chunkid = nchunkid;
-	statsrecord nsr;
+	StatsRecord nsr;
 	fsnodes_get_stats(p, &nsr);
-	for (const auto &[parentId, _] : p->parent) {
-		FSNodeDirectory *parent =
-		    fsnodes_id_to_node_verify<FSNodeDirectory>(parentId);
+	for (const auto &[parentId, _] : p->parents) {
+		auto *parent = fsnodes_id_to_node_verify<FSNodeDirectory>(parentId);
 		fsnodes_add_sub_stats(parent, &nsr, &psr);
 	}
 	fsnodes_quota_update(p, {{QuotaResource::kSize, nsr.size - psr.size}});
@@ -2162,7 +2161,7 @@ uint8_t fs_repair(const FsContext &context, inode_t inode,
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
 	uint32_t nversion, indx;
-	statsrecord psr, nsr;
+	StatsRecord psr, nsr;
 	FSNode *p;
 
 	*notchanged = 0;
@@ -2199,7 +2198,7 @@ uint8_t fs_repair(const FsContext &context, inode_t inode,
 		}
 	}
 	fsnodes_get_stats(p, &nsr);
-	for (const auto &[parentId, _] : p->parent) {
+	for (const auto &[parentId, _] : p->parents) {
 		FSNodeDirectory *parent =
 		    fsnodes_id_to_node_verify<FSNodeDirectory>(parentId);
 		fsnodes_add_sub_stats(parent, &nsr, &psr);
@@ -2213,7 +2212,7 @@ uint8_t fs_repair(const FsContext &context, inode_t inode,
 uint8_t fs_apply_repair(uint32_t ts, inode_t inode, uint32_t indx, uint32_t nversion) {
 	FSNodeFile *p;
 	uint8_t status;
-	statsrecord psr, nsr;
+	StatsRecord psr, nsr;
 
 	p = fsnodes_id_to_node<FSNodeFile>(inode);
 	if (!p) {
@@ -2242,9 +2241,8 @@ uint8_t fs_apply_repair(uint32_t ts, inode_t inode, uint32_t indx, uint32_t nver
 		status = chunk_set_version(p->chunks[indx], nversion);
 	}
 	fsnodes_get_stats(p, &nsr);
-	for (const auto &[parentId, _] : p->parent) {
-		FSNodeDirectory *parent =
-		    fsnodes_id_to_node_verify<FSNodeDirectory>(parentId);
+	for (const auto &[parentId, _] : p->parents) {
+		auto *parent = fsnodes_id_to_node_verify<FSNodeDirectory>(parentId);
 		fsnodes_add_sub_stats(parent, &nsr, &psr);
 	}
 	fsnodes_quota_update(p, {{QuotaResource::kSize, nsr.size - psr.size}});
@@ -2790,9 +2788,8 @@ uint32_t fs_getdirpath_size(inode_t inode) {
 			return 15;  // "(not directory)"
 		} else {
 			FSNodeDirectory *parent = nullptr;
-			if (!node->parent.empty()) {
-				parent = fsnodes_id_to_node_verify<FSNodeDirectory>(
-				    node->parent[0].first);
+			if (!node->parents.empty()) {
+				parent = fsnodes_id_to_node_verify<FSNodeDirectory>(node->parents[0].first);
 			}
 			return 1 + fsnodes_getpath_size(parent, node);
 		}
@@ -2814,9 +2811,8 @@ void fs_getdirpath_data(inode_t inode, uint8_t *buff, uint32_t size) {
 		} else {
 			if (size > 0) {
 				FSNodeDirectory *parent = nullptr;
-				if (!node->parent.empty()) {
-					parent = fsnodes_id_to_node_verify<FSNodeDirectory>(
-					    node->parent[0].first);
+				if (!node->parents.empty()) {
+					parent = fsnodes_id_to_node_verify<FSNodeDirectory>(node->parents[0].first);
 				}
 
 				buff[0] = '/';
@@ -2837,7 +2833,7 @@ uint8_t fs_get_dir_stats(const FsContext &context, inode_t inode,
                          inode_t *links, uint32_t *chunks, uint64_t *length,
                          uint64_t *size, uint64_t *rsize) {
 	FSNode *p;
-	statsrecord sr;
+	StatsRecord sr;
 
 	uint8_t status = verify_session(context, OperationMode::kReadOnly, SessionType::kAny);
 	if (status != SAUNAFS_STATUS_OK) {

--- a/src/master/filesystem_periodic.cc
+++ b/src/master/filesystem_periodic.cc
@@ -108,10 +108,9 @@ static std::string get_node_info(FSNode *node) {
 	} else if (node->type == FSNodeType::kFile) {
 		name = "file " + std::to_string(node->id) + ": ";
 		bool first = true;
-		for (const auto &[parentId, _] : node->parent) {
+		for (const auto &[parentId, _] : node->parents) {
 			std::string path;
-			FSNodeDirectory *parent =
-			    fsnodes_id_to_node_verify<FSNodeDirectory>(parentId);
+			auto *parent = fsnodes_id_to_node_verify<FSNodeDirectory>(parentId);
 			fsnodes_getpath(parent, node, path);
 			if (!first) {
 				name += "|" + path;
@@ -124,9 +123,8 @@ static std::string get_node_info(FSNode *node) {
 		name = "directory " + std::to_string(node->id) + ": ";
 		std::string path;
 		FSNodeDirectory *parent = nullptr;
-		if (!node->parent.empty()) {
-			parent = fsnodes_id_to_node_verify<FSNodeDirectory>(
-			    node->parent.front().first);
+		if (!node->parents.empty()) {
+			parent = fsnodes_id_to_node_verify<FSNodeDirectory>(node->parents.front().first);
 		}
 		fsnodes_getpath(parent, node, path);
 		name += path;
@@ -422,23 +420,20 @@ void fs_process_file_test() {
 			}
 
 			if (node->type == FSNodeType::kDirectory) {
-				for (const auto &entry :
-				     static_cast<FSNodeDirectory *>(node)->entries) {
+				for (const auto &entry : static_cast<FSNodeDirectory *>(node)->entries) {
 					FSNode *childNode = entry.second;
 
 					if (!childNode) {
 						// the node points to invalid memory
-						node_error_flag |=
-						        static_cast<int>(kStructureError);
+						node_error_flag |= static_cast<int>(kStructureError);
 					} else {
 						auto parentInChildPtr = std::find_if(
-						    childNode->parent.begin(), childNode->parent.end(),
+						    childNode->parents.begin(), childNode->parents.end(),
 						    [node](const std::pair<inode_t, const hstorage::Handle *> &p) {
 							    return p.first == node->id;
 						    });
-						// the node doesn't have a parent entry pointing to the
-						// current directory
-						if (parentInChildPtr == node->parent.end()) {
+						// the node doesn't have a parent entry pointing to the current directory
+						if (parentInChildPtr == childNode->parents.end()) {
 							node_error_flag |= static_cast<int>(kStructureError);
 						}
 					}
@@ -459,7 +454,7 @@ void fs_process_file_test() {
 				} else if (node->type == FSNodeType::kReserved) {
 					unavailreservedfiles++;
 				} else {
-					unavailfiles += node->parent.size();
+					unavailfiles += node->parents.size();
 				}
 
 				auto it = gDefectiveNodes.find(node->id);

--- a/src/master/filesystem_quota.cc
+++ b/src/master/filesystem_quota.cc
@@ -166,10 +166,9 @@ static void fsnodes_getpath(inode_t root_inode, FSNode *node, std::string &ret) 
 
 	p = node;
 	size = 0;
-	while (p != gMetadata->root && !p->parent.empty() && p->id != root_inode) {
+	while (p != gMetadata->root && !p->parents.empty() && p->id != root_inode) {
 		// get first parent
-		FSNodeDirectory *parent =
-		    fsnodes_id_to_node_verify<FSNodeDirectory>(p->parent[0].first);
+		auto *parent = fsnodes_id_to_node_verify<FSNodeDirectory>(p->parents[0].first);
 		size += parent->getChildName(p).length() + 1;
 		p = parent;
 	}
@@ -181,9 +180,8 @@ static void fsnodes_getpath(inode_t root_inode, FSNode *node, std::string &ret) 
 	ret.resize(size);
 
 	p = node;
-	while (p != gMetadata->root && !p->parent.empty()) {
-		FSNodeDirectory *parent =
-		    fsnodes_id_to_node_verify<FSNodeDirectory>(p->parent[0].first);
+	while (p != gMetadata->root && !p->parents.empty()) {
+		auto *parent = fsnodes_id_to_node_verify<FSNodeDirectory>(p->parents[0].first);
 		std::string name = parent->getChildName(p);
 		if (size >= name.length()) {
 			size -= name.length();
@@ -282,8 +280,8 @@ uint8_t fs_apply_setquota(char rigor, char resource, char owner_type, inode_t ow
 static int fsnodes_find_depth(FSNodeDirectory *a) {
 	assert(a);
 	int depth = 1;
-	while (!a->parent.empty()) {
-		a = fsnodes_id_to_node_verify<FSNodeDirectory>(a->parent[0].first);
+	while (!a->parents.empty()) {
+		a = fsnodes_id_to_node_verify<FSNodeDirectory>(a->parents[0].first);
 		++depth;
 	}
 
@@ -309,13 +307,13 @@ static FSNode *fsnodes_find_common_ancestor(FSNodeDirectory *a, FSNodeDirectory 
 
 	if (depth_a > depth_b) {
 		for(;depth_a > depth_b;--depth_a) {
-			assert(a && !a->parent.empty());
-			a = fsnodes_id_to_node_verify<FSNodeDirectory>(a->parent[0].first);
+			assert(a && !a->parents.empty());
+			a = fsnodes_id_to_node_verify<FSNodeDirectory>(a->parents[0].first);
 		}
 	} else if (depth_b > depth_a) {
 		for(;depth_b > depth_a;--depth_b) {
-			assert(b && !b->parent.empty());
-			b = fsnodes_id_to_node_verify<FSNodeDirectory>(b->parent[0].first);
+			assert(b && !b->parents.empty());
+			b = fsnodes_id_to_node_verify<FSNodeDirectory>(b->parents[0].first);
 		}
 	}
 
@@ -323,11 +321,11 @@ static FSNode *fsnodes_find_common_ancestor(FSNodeDirectory *a, FSNodeDirectory 
 		return a;
 	}
 
-	while(!a->parent.empty()) {
-		assert(!b->parent.empty());
+	while(!a->parents.empty()) {
+		assert(!b->parents.empty());
 
-		a = fsnodes_id_to_node_verify<FSNodeDirectory>(a->parent[0].first);
-		b = fsnodes_id_to_node_verify<FSNodeDirectory>(b->parent[0].first);
+		a = fsnodes_id_to_node_verify<FSNodeDirectory>(a->parents[0].first);
+		b = fsnodes_id_to_node_verify<FSNodeDirectory>(b->parents[0].first);
 
 		if (a == b) {
 			return a;
@@ -349,7 +347,7 @@ static bool fsnodes_test_dir_quota_noparents(FSNode *node,
 		return false;
 	}
 
-	const statsrecord &stats = static_cast<FSNodeDirectory*>(node)->stats;
+	const StatsRecord &stats = static_cast<FSNodeDirectory*>(node)->stats;
 	uint64_t limit;
 
 	for (const auto &resource : resource_list) {
@@ -402,19 +400,16 @@ bool fsnodes_quota_exceeded_dir(FSNode *node,
 
 	if (node->type == FSNodeType::kDirectory) {
 		// Directory can have only one parent, so we get rid of recursion.
-		while(!node->parent.empty()) {
-			FSNodeDirectory *parent =
-			    fsnodes_id_to_node_verify<FSNodeDirectory>(
-			        node->parent[0].first);
+		while(!node->parents.empty()) {
+			auto *parent = fsnodes_id_to_node_verify<FSNodeDirectory>(node->parents[0].first);
 			if (fsnodes_test_dir_quota_noparents(parent, resource_list)) {
 				return true;
 			}
 			node = parent;
 		}
 	} else {
-		for (const auto &[parentId, _] : node->parent) {
-			FSNodeDirectory *parent =
-			    fsnodes_id_to_node_verify<FSNodeDirectory>(parentId);
+		for (const auto &[parentId, _] : node->parents) {
+			auto *parent = fsnodes_id_to_node_verify<FSNodeDirectory>(parentId);
 			if (fsnodes_quota_exceeded_dir(parent, resource_list)) {
 				return true;
 			}
@@ -438,9 +433,8 @@ bool fsnodes_quota_exceeded_dir(FSNodeDirectory *node, FSNodeDirectory* prev_nod
 	}
 
 	// node is directory so it has only one parent.
-	while(!node->parent.empty()) {
-		FSNodeDirectory *parent =
-		    fsnodes_id_to_node<FSNodeDirectory>(node->parent[0].first);
+	while(!node->parents.empty()) {
+		auto *parent = fsnodes_id_to_node<FSNodeDirectory>(node->parents[0].first);
 
 		if (parent == common) {
 			return false;

--- a/src/master/hstring.h
+++ b/src/master/hstring.h
@@ -5,7 +5,10 @@
 #include <algorithm>
 #include <cassert>
 #include <cstdint>
+#include <cstring>
 #include <string>
+
+#include "common/datapack.h"
 
 /*! \brief String class keeping an additional field - precomputed hash.
  *
@@ -72,6 +75,24 @@ public:
 		std::string str = input.c_str();
 		std::transform(str.begin(), str.end(), str.begin(), ::tolower);
 		return HString(str);
+	}
+
+	/// Serializes the length as uint32_t and then the string without adding extra null terminator
+	static void serialize(uint8_t **destination, const HString &hstring) {
+		put32bit(destination, uint32_t(hstring.length()));
+		::memcpy(*destination, hstring.data(), hstring.length());
+		*destination += hstring.length();
+	}
+
+	/// Deserializes the length as uint32_t and then the string
+	static void deserialize(const uint8_t **source, HString &hstring) {
+		uint32_t length{};
+		get32bit(source, length);
+		hstring.resize(length);
+		::memcpy(hstring.data(), *source, length);
+		*source += length;
+
+		hstring.computeHash();
 	}
 
 private:

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -2505,7 +2505,7 @@ void matoclserv_sau_get_self_quota(matoclserventry *eptr, const uint8_t *data, u
 
 		if (inode == context.rootinode() && !foundContextRootInodeResult(inode)) {
 			auto ino = fsnodes_id_to_node(inode);
-			statsrecord rootInodeStatRec;
+			StatsRecord rootInodeStatRec;
 			fsnodes_get_stats(ino, &rootInodeStatRec);
 			results.emplace_back(QuotaEntry{QuotaEntryKey{QuotaOwner{QuotaOwnerType::kInode, inode},
 			                                              QuotaRigor::kUsed, QuotaResource::kSize},

--- a/src/master/metadata_backend_file.cc
+++ b/src/master/metadata_backend_file.cc
@@ -25,6 +25,7 @@
 #include <fcntl.h>  // for open and O_RDONLY
 #include <sys/mman.h>
 #include <sys/stat.h>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 
@@ -515,12 +516,12 @@ static int8_t fs_parseEdge(const std::shared_ptr<MemoryMappedFile> &metadataFile
 			parent->lowerCaseEntriesHash ^= (*it).first->hash();
 		}
 
-		child->parent.push_back({parent->id, handlePtr});
+		child->parents.push_back({parent->id, handlePtr});
 		if (child->type == FSNodeType::kDirectory) {
 			parent->nlink++;
 		}
 
-		statsrecord sr;
+		StatsRecord sr;
 		fsnodes_get_stats(child, &sr);
 		fsnodes_add_stats(parent, &sr);
 	}
@@ -535,9 +536,9 @@ static int8_t fs_parseEdge(const std::shared_ptr<MemoryMappedFile> &metadataFile
  */
 static int8_t fs_parseNode(const std::shared_ptr<MemoryMappedFile> &metadataFile,
                            size_t &sectionOffset) {
-	static const int8_t kError = -1;
-	static const int8_t kSuccess = 0;
-	static const int8_t kLastNode = 1;
+	static constexpr int8_t kError = -1;
+	static constexpr int8_t kSuccess = 0;
+	static constexpr int8_t kLastNode = 1;
 
 	const uint8_t *pSrc = metadataFile->seek(sectionOffset);
 	uint8_t typeU8 = get8bit(&pSrc);
@@ -550,76 +551,41 @@ static int8_t fs_parseNode(const std::shared_ptr<MemoryMappedFile> &metadataFile
 	auto type = static_cast<FSNodeType>(typeU8);
 	FSNode *node = FSNode::create(type);
 	passert(node);
-	getINode(&pSrc, node->id);
-	node->goal = get8bit(&pSrc);
-	node->mode = get16bit(&pSrc);
-	get32bit(&pSrc, node->uid);
-	get32bit(&pSrc, node->gid);
-	get32bit(&pSrc, node->atime);
-	get32bit(&pSrc, node->mtime);
-	get32bit(&pSrc, node->ctime);
-	get32bit(&pSrc, node->trashtime);
+
+	// Move the pointer back by 1 byte (type), because deserialize will read it
+	pSrc--;
+
+	// Deserialize the node
+	node->deserialize(&pSrc);
+
+	// Update the offset for next nodes
 	sectionOffset = metadataFile->offset(pSrc);
+
+#ifndef METARESTORE
 	auto *nodeFile = static_cast<FSNodeFile *>(node);
-
-	uint32_t nodeNameLength;
-	uint32_t chunkAmount;
-	uint16_t sessionIds;
-
-	uint32_t index;
-	constexpr uint32_t kChunkSize = (1 << 16);
+#endif
 
 	switch (type) {
 	case FSNodeType::kDirectory:
 		gMetadata->dirNodes++;
 		break;
 	case FSNodeType::kSocket:
-	case FSNodeType::kFifo:  /// No extra info to Parse
-		break;
+	case FSNodeType::kFifo:
 	case FSNodeType::kBlockDev:
 	case FSNodeType::kCharDev:
-		uint32_t tempRDev;
-		get32bit(&pSrc, tempRDev);
-		static_cast<FSNodeDevice *>(node)->rdev = tempRDev;
+		// Nothing extra to do
 		break;
 	case FSNodeType::kSymlink:
-		get32bit(&pSrc, nodeNameLength);
-		static_cast<FSNodeSymlink *>(node)->path_length = nodeNameLength;
-		if (nodeNameLength > 0) {
-			static_cast<FSNodeSymlink *>(node)->path = HString(pSrc, pSrc + nodeNameLength);
-			pSrc += nodeNameLength;
-		}
 		gMetadata->linkNodes++;
 		break;
 	case FSNodeType::kFile:
 	case FSNodeType::kTrash:
 	case FSNodeType::kReserved:
-		nodeFile->length = get64bit(&pSrc);
-		get32bit(&pSrc, chunkAmount);
-		sessionIds = get16bit(&pSrc);
-
-		nodeFile->chunks.resize(chunkAmount);
-
-		index = 0;
-		while (chunkAmount > kChunkSize) {
-			for (uint32_t i = 0; i < kChunkSize; i++) {
-				nodeFile->chunks[index++] = get64bit(&pSrc);
-			}
-			chunkAmount -= kChunkSize;
-		}
-		for (uint32_t i = 0; i < chunkAmount; i++) {
-			nodeFile->chunks[index++] = get64bit(&pSrc);
-		}
-		while (sessionIds) {
-			uint32_t sessionId;
-			get32bit(&pSrc, sessionId);
-			nodeFile->sessionid.push_back(sessionId);
 #ifndef METARESTORE
+		for (const auto &sessionId : nodeFile->sessionIds) {
 			matoclserv_add_open_file(sessionId, node->id);
-#endif
-			sessionIds--;
 		}
-
+#endif
 		fsnodes_quota_update(node, {{QuotaResource::kSize, +fsnodes_get_size(node)}});
 		gMetadata->fileNodes++;
 		break;
@@ -664,7 +630,7 @@ static int fs_lostnode(FSNode *p) {
 int fs_checknodes(int ignoreflag) {
 	for (auto i = 0; i < NODEHASHSIZE; i++) {
 		for (const auto &node : gMetadata->nodeHash[i]) {
-			if (node->parent.empty() && node != gMetadata->root &&
+			if (node->parents.empty() && node != gMetadata->root &&
 			    (node->type != FSNodeType::kTrash) && (node->type != FSNodeType::kReserved)) {
 				safs::log_err("found orphaned inode: %" PRIiNode, node->id);
 				if (ignoreflag) {
@@ -1004,121 +970,95 @@ void MetadataBackendFile::loadall(int ignoreflag) {
 //Nodes
 
 void MetadataBackendFile::storenode(FSNode *f, FILE *fd) {
-	uint8_t *ptr, *chptr;
-	uint32_t i, indx, ch, sessionids;
-	std::string name;
-
-	if (f == NULL) {  // last node
+	if (f == nullptr) {  // last node
 		fputc(0, fd);
 		return;
 	}
 
-	ptr = gNodeStoreBuffer;
-	put8bit(&ptr, static_cast<uint8_t>(f->type));
-	putINode(&ptr, f->id);
-	put8bit(&ptr, f->goal);
-	put16bit(&ptr, f->mode);
-	put32bit(&ptr, f->uid);
-	put32bit(&ptr, f->gid);
-	put32bit(&ptr, f->atime);
-	put32bit(&ptr, f->mtime);
-	put32bit(&ptr, f->ctime);
-	put32bit(&ptr, f->trashtime);
+	auto serializedSize = f->serializedSize();
 
-	auto *node_file = static_cast<FSNodeFile *>(f);
+	if (serializedSize == 0) {
+		safs::log_err("FSNode with serializedSize == 0");
+		return;
+	}
 
-	switch (f->type) {
-	case FSNodeType::kDirectory:
-	case FSNodeType::kSocket:
-	case FSNodeType::kFifo:
-		if (fwrite(gNodeStoreBuffer, 1, kNodeHeaderSize, fd) !=
-		    (size_t)(kNodeHeaderSize)) {
-			safs_pretty_syslog(LOG_NOTICE, "fwrite error");
-			return;
-		}
-		break;
-	case FSNodeType::kBlockDev:
-	case FSNodeType::kCharDev:
-		put32bit(&ptr, static_cast<FSNodeDevice *>(f)->rdev);
-		if (fwrite(gNodeStoreBuffer, 1, kNodeHeaderSize + 4, fd) !=
-		    (size_t)(kNodeHeaderSize + 4)) {
-			safs_pretty_syslog(LOG_NOTICE, "fwrite error");
-			return;
-		}
-		break;
-	case FSNodeType::kSymlink:
-		name = (std::string) static_cast<FSNodeSymlink *>(f)->path;
-		// Safe cast, the length should always fit
-		put32bit(&ptr, static_cast<uint32_t>(name.length()));
-		if (fwrite(gNodeStoreBuffer, 1, kNodeHeaderSize + 4, fd) !=
-		    (size_t)(kNodeHeaderSize + 4)) {
-			safs_pretty_syslog(LOG_NOTICE, "fwrite error");
-			return;
-		}
-		if (fwrite(name.c_str(), 1, name.length(), fd) !=
-		    (size_t)(static_cast<FSNodeSymlink *>(f)->path_length)) {
-			safs_pretty_syslog(LOG_NOTICE, "fwrite error");
-			return;
-		}
-		break;
-	case FSNodeType::kFile:
-	case FSNodeType::kTrash:
-	case FSNodeType::kReserved:
-		put64bit(&ptr, node_file->length);
-		ch = node_file->chunkCount();
-		put32bit(&ptr, ch);
-		sessionids =
-		    std::min<int>(node_file->sessionid.size(), kMaxSessionSize);
-		put16bit(&ptr, sessionids);
+	uint8_t *ptr = gNodeStoreBuffer;
 
-		if (fwrite(gNodeStoreBuffer, 1,
-		           kNodeHeaderSize + kFileSpecificHeaderSize,
-		           fd) != (size_t)(kNodeHeaderSize + kFileSpecificHeaderSize)) {
-			safs_pretty_syslog(LOG_NOTICE, "fwrite error");
+	if (serializedSize <= FSNodeFile::kMaxBufferSize) {  // Relatively small FSNode
+		f->serialize(&ptr);
+
+		if (fwrite(gNodeStoreBuffer, 1, serializedSize, fd) != serializedSize) {
+			safs::log_err("fwrite error");
+			return;
+		}
+	} else {  // Large FSNodeFile not fitting into gNodeStoreBuffer
+		f->serializeCommon(&ptr);  // Common FSNode members
+
+		// Only FSNodeFile are expected to reach this point
+		auto *fileNode = dynamic_cast<FSNodeFile *>(f);
+		passert(fileNode);
+
+		put64bit(&ptr, fileNode->length);
+		uint32_t chunkAmount = fileNode->chunkCount();
+		put32bit(&ptr, chunkAmount);
+		auto sessionsCount =
+		    std::min<size_t>(fileNode->sessionIds.size(), FSNodeFile::kMaxSessionSize);
+		put16bit(&ptr, static_cast<uint16_t>(sessionsCount));
+
+		if (fwrite(gNodeStoreBuffer, 1, FSNodeFile::kFileHeaderSize, fd) !=
+		FSNodeFile::kFileHeaderSize) {
+			safs::log_err("fwrite error");
 			return;
 		}
 
-		indx = 0;
-		while (ch > kChunksBucketSize) {
+		// Write the chunk ids in batches of maximum kChunksBucketSize
+
+		uint32_t indx = 0;
+		uint8_t *chptr = ptr;
+
+		while (chunkAmount >= FSNodeFile::kChunksBucketSize) {
 			chptr = ptr;
-			for (i = 0; i < kChunksBucketSize; i++) {
-				put64bit(&chptr, node_file->chunks[indx]);
+			for (uint32_t i = 0; i < FSNodeFile::kChunksBucketSize; i++) {
+				put64bit(&chptr, fileNode->chunks[indx]);
 				indx++;
 			}
-			if (fwrite(ptr, 1, 8 * kChunksBucketSize, fd) !=
-			    (size_t)(8 * kChunksBucketSize)) {
-				safs_pretty_syslog(LOG_NOTICE, "fwrite error");
+
+			if (fwrite(ptr, 1, sizeof(uint64_t) * FSNodeFile::kChunksBucketSize, fd) !=
+			    sizeof(uint64_t) * FSNodeFile::kChunksBucketSize) {
+				safs::log_err("fwrite error");
 				return;
 			}
-			ch -= kChunksBucketSize;
+
+			chunkAmount -= FSNodeFile::kChunksBucketSize;
 		}
 
+		// Write remaining chunks
 		chptr = ptr;
-		for (i = 0; i < ch; i++) {
-			put64bit(&chptr, node_file->chunks[indx]);
+
+		for (uint32_t i = 0; i < chunkAmount; i++) {
+			put64bit(&chptr, fileNode->chunks[indx]);
 			indx++;
 		}
 
-		sessionids = 0;
-		for (const auto &sid : node_file->sessionid) {
-			if (sessionids >= kMaxSessionSize) {
+		// Write session IDs
+		uint32_t includedSessions = 0;
+
+		for (const auto &sid : fileNode->sessionIds) {
+			if (includedSessions >= FSNodeFile::kMaxSessionSize) {
 				break;
 			}
 			put32bit(&chptr, sid);
-			sessionids++;
+			includedSessions++;
 		}
 
-		if (fwrite(ptr, 1, 8 * ch + 4 * sessionids, fd) !=
-		    (size_t)(8 * ch + 4 * sessionids)) {
-			safs_pretty_syslog(LOG_NOTICE, "fwrite error");
+		auto fwriteSize = (sizeof(uint64_t) * chunkAmount) + (sizeof(uint32_t) * includedSessions);
+
+		if (fwrite(ptr, 1, fwriteSize, fd) != fwriteSize) {
+			safs::log_err("fwrite error");
 			return;
 		}
-		break;
-	default:
-		safs::log_err("MetadataBackendFile::storenode: unexpected node type {}",
-		              static_cast<char>(f->type));
-		break;
 	}
+
 }
 
 void MetadataBackendFile::storenodes(FILE *fd) {

--- a/src/master/metadata_backend_interface.h
+++ b/src/master/metadata_backend_interface.h
@@ -34,18 +34,6 @@ constexpr uint16_t kEdgeNameMaxSize = 65535;
 constexpr uint8_t kEdgeHeaderSize =
     sizeof(FSNode::id) + sizeof(FSNode::id) + sizeof(kEdgeNameMaxSize);
 
-constexpr uint8_t kNodeHeaderSize =
-    sizeof(FSNode::type) + sizeof(FSNode::id) + sizeof(FSNode::goal) + sizeof(FSNode::mode) +
-    sizeof(FSNode::uid) + sizeof(FSNode::gid) + sizeof(FSNode::atime) + sizeof(FSNode::mtime) +
-    sizeof(FSNode::ctime) + sizeof(FSNode::trashtime);
-// FSNodeFile is the longer type of FSNode, so we use it as the buffer size
-constexpr uint8_t kFileSpecificHeaderSize =
-    sizeof(FSNodeFile::length) + sizeof(uint32_t) + sizeof(uint16_t);
-constexpr uint32_t kChunksBucketSize = 65536;
-constexpr uint16_t kMaxSessionSize = 65535;
-constexpr uint32_t kFileSpecificExtraSize =
-    (sizeof(uint64_t) * kChunksBucketSize) + (sizeof(uint32_t) * kMaxSessionSize);
-
 // TODO (Baldor): Review the need for these constants below
 constexpr uint8_t kMetadataVersionLegacy = 0x15;
 constexpr uint8_t kMetadataVersionSaunaFS = 0x16;
@@ -57,7 +45,7 @@ constexpr char const MetadataStructureReadErrorMsg[] = "error reading metadata (
 
 // Global variables
 inline uint8_t gEdgeStoreBuffer[kEdgeHeaderSize + kEdgeNameMaxSize];
-inline uint8_t gNodeStoreBuffer[kNodeHeaderSize + kFileSpecificHeaderSize + kFileSpecificExtraSize];
+inline uint8_t gNodeStoreBuffer[FSNodeFile::kMaxBufferSize];
 
 // Number of metadata file versions to keep
 inline uint32_t gStoredPreviousBackMetaCopies;

--- a/src/master/snapshot_task.cc
+++ b/src/master/snapshot_task.cc
@@ -144,7 +144,7 @@ FSNodeFile *SnapshotTask::cloneToExistingFileNode(uint32_t ts, FSNodeFile *src_n
 
 void SnapshotTask::cloneChunkData(const FSNodeFile *src_node, FSNodeFile *dst_node,
 		FSNodeDirectory *dst_parent) {
-	statsrecord psr, nsr;
+	StatsRecord psr, nsr;
 
 	fsnodes_get_stats(dst_node, &psr);
 
@@ -190,7 +190,7 @@ void SnapshotTask::cloneDirectoryData(const FSNodeDirectory *src_node, FSNodeDir
 
 void SnapshotTask::cloneSymlinkData(FSNodeSymlink *src_node, FSNodeSymlink *dst_node,
 		FSNodeDirectory *dst_parent) {
-	statsrecord psr, nsr;
+	StatsRecord psr, nsr;
 
 	fsnodes_get_stats(dst_node, &psr);
 


### PR DESCRIPTION
The FSNode family (FSNode, FSNodeFile, FSNodeDirectory, FSNodeSymlink, and FSNodeDevice) plays a central role in the filesystem metadata. Even if they were a struct hierarchy, some of their responsibilities were implemented in unexpected or not centralized places (like concrete metadata backends).

This change aims to improve the hierarchy by:
- Introduce an ISerializable interface to unify serialization/deserialization. Previously it was done in different places (backend, metadump, etc.).
- Implement own serialization/deserialization (all data is known) and expose it, so any custom backend could use it without reimplementing.
- Add the serializedSize function, that will be useful for example for the FDB backend.
- Reduce the `switch` statements asking for custom behavior depending on the node type, which simplifies the code by using polymorphism.
- Move the constants related to header sizes to the closest class.
- Convert the structs into classes (other commits will improve the visibility).

Related changes:
- Rename struct `statsrecord` to be StatsRecord, for readability.
- Rename collections like `parent` to be `parents` for better consistency.
- Apply the code style in modified places.
- Use auto to not repeat the type in casts.

Next steps:
- Preffer dynamic_cast were considered better fit.
- Provide a toString function for better logging.