### PR TITLE
chore: Add logging for iolimits file not found

### DIFF
--- a/src/mount/sauna_client.cc
+++ b/src/mount/sauna_client.cc
@@ -3641,7 +3641,21 @@ void fs_init(FsInitParams &params) {
 	try {
 		IoLimitsConfigLoader loader;
 		if (!params.io_limits_config_file.empty()) {
-			loader.load(std::ifstream(params.io_limits_config_file.c_str()));
+			std::ifstream ifs(params.io_limits_config_file);
+			if (!ifs.is_open()) {
+				const char *strError = std::strerror(errno);
+				safs::log_warn(
+				    "fs_init: cannot open I/O limits configuration file '{}': {}; using master-provided limits if available, otherwise no client-side limiting.",
+				    params.io_limits_config_file.c_str(), strError);
+			} else {
+				try {
+					loader.load(std::move(ifs));
+				} catch (const Exception &ex) {
+					safs::log_warn(
+					    "fs_init: failed to parse I/O limits configuration file '{}': {}; using master-provided limits if available, otherwise no client-side limiting.",
+					    params.io_limits_config_file.c_str(), ex.what());
+				}
+			}
 		}
 		gMountLimiter().loadConfiguration(loader);
 	} catch (Exception &ex) {


### PR DESCRIPTION
Previously, there was no logging when the iolimits file was not found. Which could lead to confusion when debugging issues related to I/O limits if some error occurred while accessing the file. This commit fixes that issue.