### PR TITLE
fix(chunkserver): Don't clear chunkserver output packets

### DIFF
--- a/src/chunkserver/master_connection.cc
+++ b/src/chunkserver/master_connection.cc
@@ -688,7 +688,6 @@ void MasterConn::releaseResources() {
 	}
 }
 
-void MasterConn::resetPackets() {
+void MasterConn::resetInputPackets() {
 	inputPacket_.reset();
-	outputPackets_.clear();
 }

--- a/src/chunkserver/master_connection.h
+++ b/src/chunkserver/master_connection.h
@@ -158,7 +158,7 @@ public:
 
 	void releaseResources();
 
-	void resetPackets();
+	void resetInputPackets();
 
 	// Inline getters and setters
 

--- a/src/chunkserver/masterconn.cc
+++ b/src/chunkserver/masterconn.cc
@@ -189,11 +189,11 @@ void masterconn_send_status() {
 
 void masterconn_serve(const std::vector<pollfd> &pdesc) {
 	LOG_AVG_TILL_END_OF_SCOPE0("master_serve");
-	
+
 	MasterConn *eptr = gMasterConnSingleton.get();
 
 	eptr->handlePollErrors(pdesc);
-	
+
 	// Check if there are any background jobs to process.
 	if (eptr->mode() == ConnectionMode::CONNECTED) {
 		if (gJobFDpDescPos >= 0 && (pdesc[gJobFDpDescPos].revents & POLLIN)) {
@@ -219,7 +219,7 @@ void masterconn_serve(const std::vector<pollfd> &pdesc) {
 		gJobPool->disableAndChangeCallbackAll(masterconn_unwantedjobfinished);
 		gReplicationJobPool->disableAndChangeCallbackAll(masterconn_unwantedjobfinished);
 		tcpclose(eptr->socketFD());
-		eptr->resetPackets();
+		eptr->resetInputPackets();
 		eptr->setMode(ConnectionMode::FREE);
 	}
 }


### PR DESCRIPTION
When the master connection was closed (for example, when it's demoting), it could cause inconsistent state with the master. If a chunkserver received a packet, to create a chunk for example, it will finish it but not reply to master. This could lead to lost data if there were active writes happening at the same time.

This fix ensures that when chunkserver reconnects with master, the chunkserver will always send the register packet first, and then send the remaining output packets still remained in the output packets when the disconnect happened.