### PR TITLE
ci: Disable concurrent builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -136,6 +136,12 @@ def slackGoodMessage(userMsg) {
     }
 }
 
+if(env.BRANCH_NAME?.equals("dev")) {
+    properties([disableConcurrentBuilds()])
+} else {
+    properties([disableConcurrentBuilds(abortPrevious: true)])
+}
+
 pipeline {
     agent none
 


### PR DESCRIPTION
It will also abort previous running builds on other branches.

Should help reduce the load on the CI