### PR TITLE
Feat use properties and signals in medatada

### DIFF
--- a/src/master/changelog.cc
+++ b/src/master/changelog.cc
@@ -47,6 +47,11 @@
 #include "master/restore.h"
 #endif  // #if !defined(METARESTORE) && !defined(METALOGGER)
 
+Signal<ChangelogEvent> &getChangelogSignal() {
+	static Signal<ChangelogEvent> gChangelogSignal;
+	return gChangelogSignal;
+}
+
 /// Base name of a changelog file.
 /// Something like "changelog.sfs" or "changelog_ml.sfs"
 static std::string gChangelogFilename;

--- a/src/master/changelog.h
+++ b/src/master/changelog.h
@@ -25,7 +25,17 @@
 #include <cstdint>
 #include <string>
 
+#include "common/observable_property.h"
+
 constexpr uint32_t kMaxLogLineSize = 200000;
+
+struct ChangelogEvent {
+	uint64_t version;
+	std::string entry;
+};
+
+/// Accessor for the global changelog signal to avoid the warning about non-const global
+Signal<ChangelogEvent> &getChangelogSignal();
 
 /// Initializes changelog module.
 /// \param changelogFilename - base name of changelog files, e.g. "changelog_ml.sfs"

--- a/src/master/filesystem_checksum.cc
+++ b/src/master/filesystem_checksum.cc
@@ -134,9 +134,9 @@ static void fsnodes_recalculate_checksum() {
 
 uint64_t fs_checksum(ChecksumMode mode) {
 	uint64_t checksum = 0x1251;
-	hashCombine(checksum, gMetadata->maxInodeId);
+	hashCombine(checksum, gMetadata->maxInodeId().getValue());
 	hashCombine(checksum, gMetadata->metadataVersion);
-	hashCombine(checksum, gMetadata->nextSessionId);
+	hashCombine(checksum, gMetadata->nextSessionId().getValue());
 	if (mode == ChecksumMode::kForceRecalculate) {
 		fsnodes_recalculate_checksum();
 		xattr_recalculate_checksum();

--- a/src/master/filesystem_freenode.cc
+++ b/src/master/filesystem_freenode.cc
@@ -31,8 +31,8 @@ inode_t fsnodes_get_next_id(uint32_t ts, inode_t req_inode) {
 	if (req_inode == 0) {
 		mabort("Out of free inode numbers");
 	}
-	if (req_inode > gMetadata->maxInodeId) {
-		gMetadata->maxInodeId = req_inode;
+	if (req_inode > gMetadata->maxInodeId().getValue()) {
+		gMetadata->maxInodeId().setValue(req_inode);
 	}
 
 	return req_inode;

--- a/src/master/filesystem_metadata.h
+++ b/src/master/filesystem_metadata.h
@@ -59,6 +59,7 @@ public:
 	ReservedPathContainer reserved;
 	FSNodeDirectory *root{};
 	std::array<FSNodePointerVector, NODEHASHSIZE> nodeHash;
+	Signal<FSNode *> nodeChangedSignal;  ///< Signal emitted when a node changes
 	TaskManager taskManager;
 	FileLocks flockLocks;
 	FileLocks posixLocks;
@@ -115,6 +116,16 @@ public:
 	static constexpr uint8_t kHeaderSize = sizeof(metadataVersion) +
 	                                       ObservableIntegralProperty<inode_t>::typeSize() +
 	                                       ObservableIntegralProperty<uint32_t>::typeSize();
+
+	/// Adds the node to the hash and emits the signal if not from scan
+	void addNode(FSNode *node, bool isFromScan = false) {
+		uint32_t nodeHashIndex = NODEHASHPOS(node->id);
+		nodeHash[nodeHashIndex].push_back(node);
+
+		if (!isFromScan) {
+			nodeChangedSignal.emit(node);
+		}
+	}
 
 private:
 	ObservableIntegralProperty<inode_t> maxInodeId_{"META_MAX_INODE_ID", 0};

--- a/src/master/filesystem_metadata.h
+++ b/src/master/filesystem_metadata.h
@@ -22,10 +22,13 @@
 
 #include "common/platform.h"
 
+#include <cstdint>
 #include <map>
 
-#include "common/special_inode_defs.h"
+#include "common/observable_property.h"
 #include "common/quota_database.h"
+#include "common/special_inode_defs.h"
+#include "common/type_defs.h"
 #include "master/acl_storage.h"
 #include "master/filesystem_checksum_background_updater.h"
 #include "master/filesystem_node_types.h"
@@ -45,7 +48,7 @@ using FSNodePointerVector = std::vector<FSNode*>;
 /** Metadata of the filesystem.
  *  All the static variables managed by function in this file which form metadata of the filesystem.
  */
-struct FilesystemMetadata {
+class FilesystemMetadata {
 public:
 	std::array<XAttributeInodeEntryVector, XATTR_INODE_HASH_SIZE> xattrInodeHash;
 	std::array<XAttributeDataEntryVector, XATTR_DATA_HASH_SIZE> xattrDataHash;
@@ -60,8 +63,6 @@ public:
 	FileLocks flockLocks;
 	FileLocks posixLocks;
 
-	inode_t maxInodeId{};
-	uint32_t nextSessionId{};
 	inode_t nodes{};
 	uint64_t metadataVersion{};
 	uint64_t trashSpace{};
@@ -106,6 +107,18 @@ public:
 			nodeHash[i].clear();
 		}
 	}
+
+	ObservableIntegralProperty<inode_t> &maxInodeId() { return maxInodeId_; }
+
+	ObservableIntegralProperty<uint32_t> &nextSessionId() { return nextSessionId_; }
+
+	static constexpr uint8_t kHeaderSize = sizeof(metadataVersion) +
+	                                       ObservableIntegralProperty<inode_t>::typeSize() +
+	                                       ObservableIntegralProperty<uint32_t>::typeSize();
+
+private:
+	ObservableIntegralProperty<inode_t> maxInodeId_{"META_MAX_INODE_ID", 0};
+	ObservableIntegralProperty<uint32_t> nextSessionId_{"META_NEXT_SESSION", 0};
 };
 
 extern FilesystemMetadata *gMetadata;

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -616,8 +616,7 @@ FSNode *fsnodes_create_node(uint32_t ts, FSNodeDirectory *parent, const HString 
 		node->gid = gid;
 	}
 
-	uint32_t nodeHashIndex = NODEHASHPOS(node->id);
-	gMetadata->nodeHash[nodeHashIndex].push_back(node);
+	gMetadata->addNode(node);
 
 	fsnodes_update_checksum(node);
 	fsnodes_link(ts, parent, node, name);

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -108,6 +108,7 @@ void fs_changelog(uint32_t ts, const char *format, ...) {
 
 	uint64_t version = gMetadata->metadataVersion++;
 	changelog(version, entry);
+	getChangelogSignal().emit({.version=version, .entry=entry});
 	matomlserv_broadcast_logstring(version, (uint8_t *)entry, tsLength + entryLength);
 #endif
 }
@@ -1942,16 +1943,18 @@ uint8_t fs_release(const FsContext &context, inode_t inode, uint32_t sessionid) 
 uint32_t fs_newsessionid(void) {
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
-	fs_changelog(ts, "SESSION():%" PRIu32, gMetadata->nextSessionId);
-	return gMetadata->nextSessionId++;
+	const uint32_t current = gMetadata->nextSessionId().getValue();
+	fs_changelog(ts, "SESSION():%" PRIu32, current);
+	gMetadata->nextSessionId().increment();
+	return current;
 }
 #endif
 uint8_t fs_apply_session(uint32_t sessionid) {
-	if (sessionid != gMetadata->nextSessionId) {
+	if (sessionid != gMetadata->nextSessionId().getValue()) {
 		return SAUNAFS_ERROR_MISMATCH;
 	}
 	gMetadata->metadataVersion++;
-	gMetadata->nextSessionId++;
+	gMetadata->nextSessionId().increment();
 	return SAUNAFS_STATUS_OK;
 }
 

--- a/src/master/metadata_backend_file.cc
+++ b/src/master/metadata_backend_file.cc
@@ -4,6 +4,7 @@
    Copyright 2013-2015 Skytechnology sp. z o.o.
    Copyright 2023      Leil Storage OÜ
 
+   This file is part of SaunaFS.
 
    SaunaFS is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -31,6 +32,7 @@
 
 #include <common/cwrap.h>
 #include <common/event_loop.h>
+#include <common/observable_property.h>
 #include <common/rotate_files.h>
 #include <common/saunafs_version.h>
 #include <common/setup.h>
@@ -784,9 +786,13 @@ static int fs_load(const std::shared_ptr<MemoryMappedFile> &metadataFile, int ig
 	/// Skip File Signature
 	const uint8_t *metadataHeaderPtr= metadataFile->seek(kMetadataHeaderOffset);
 
-	getINode(&metadataHeaderPtr, gMetadata->maxInodeId);
+	inode_t maxInodeId{};
+	getINode(&metadataHeaderPtr, maxInodeId);
+	gMetadata->maxInodeId().setValue(maxInodeId);
 	gMetadata->metadataVersion = get64bit(&metadataHeaderPtr);
-	get32bit(&metadataHeaderPtr, gMetadata->nextSessionId);
+	uint32_t session{};
+	get32bit(&metadataHeaderPtr, session);
+	gMetadata->nextSessionId().setValue(session);
 
 	size_t offsetBegin = metadataFile->offset(metadataHeaderPtr);
 
@@ -862,9 +868,9 @@ static int fs_load(const std::shared_ptr<MemoryMappedFile> &metadataFile, int ig
 #ifndef METARESTORE
 
 void fs_new(void) {
-	gMetadata->maxInodeId = SPECIAL_INODE_ROOT;
+	gMetadata->maxInodeId().setValue(SPECIAL_INODE_ROOT);
 	gMetadata->metadataVersion = 1;
-	gMetadata->nextSessionId = 1;
+	gMetadata->nextSessionId().setValue(1);
 
 	auto *rootDirectory = FSNode::create(FSNodeType::kDirectory);
 	gMetadata->root = static_cast<FSNodeDirectory *>(rootDirectory);
@@ -1272,10 +1278,7 @@ int MetadataBackendFile::process_section(const char *label, uint8_t (&hdr)[kSect
 }
 
 void MetadataBackendFile::store(FILE *fd, uint8_t fver) {
-	constexpr uint8_t kHeaderSize = sizeof(FilesystemMetadata::maxInodeId) +
-	                                sizeof(FilesystemMetadata::metadataVersion) +
-	                                sizeof(FilesystemMetadata::nextSessionId);
-	uint8_t header[kHeaderSize];
+	uint8_t header[FilesystemMetadata::kHeaderSize];
 
 	uint8_t sectionHeader[kSectionSize];
 	uint8_t *ptr;
@@ -1283,11 +1286,11 @@ void MetadataBackendFile::store(FILE *fd, uint8_t fver) {
 	off_t offend;
 
 	ptr = header;
-	putINode(&ptr, gMetadata->maxInodeId);
+	putINode(&ptr, gMetadata->maxInodeId().getValue());
 	put64bit(&ptr, gMetadata->metadataVersion);
-	put32bit(&ptr, gMetadata->nextSessionId);
+	put32bit(&ptr, gMetadata->nextSessionId().getValue());
 
-	if (fwrite(header, 1, kHeaderSize, fd) != kHeaderSize) {
+	if (fwrite(header, 1, FilesystemMetadata::kHeaderSize, fd) != FilesystemMetadata::kHeaderSize) {
 		safs_pretty_syslog(LOG_NOTICE, "fwrite error");
 		return;
 	}

--- a/src/master/metadata_backend_file.h
+++ b/src/master/metadata_backend_file.h
@@ -4,6 +4,7 @@
    Copyright 2013-2015 Skytechnology sp. z o.o.
    Copyright 2023      Leil Storage OÜ
 
+   This file is part of SaunaFS.
 
    SaunaFS is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
This commit replaces some initial plain members of FilesystemMetadata to be ObservableProperty instances, in order to react to changes without modifying the existing code (like from the FDB backend).

The metadata now also emits a signal on metadata nodes changes, enabling external observers to react on these changes (like updating them in the database).

For reviewers:
The new properties and signals are used in the branch: feat-add-new-mds.