### PR TITLE
fix: Handle SIGPROF and SIGVTALRM signals

### DIFF
--- a/src/chunkserver/chartsdata.cc
+++ b/src/chunkserver/chartsdata.cc
@@ -28,6 +28,7 @@
 #include <syslog.h>
 #include <unistd.h>
 #include <cerrno>
+#include <csignal>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -138,6 +139,13 @@ static const estatdef estatdefs[]=ESTATDEFS
 
 static struct itimerval it_set;
 
+// Signal handler that prevents process termination from timer signals
+static void timerSignalHandler(int /*signal*/) {
+	// Reset both timers to prevent future signals from killing the process
+	setitimer(ITIMER_PROF, &it_set, nullptr);
+	setitimer(ITIMER_VIRTUAL, &it_set, nullptr);
+}
+
 inline uint32_t toMicroSeconds(struct itimerval &itimer) {
     return itimer.it_value.tv_sec * 1000000 + itimer.it_value.tv_usec;
 }
@@ -198,7 +206,7 @@ void chartsdata_refresh(void) {
 		procTime.it_value.tv_usec = 999999 - procTime.it_value.tv_usec;
 	} else {
 		procTime.it_value.tv_sec = 0;
-		userTime.it_value.tv_usec = 0;
+		procTime.it_value.tv_usec = 0;
 	}
 
 	userTimeMicroSeconds = toMicroSeconds(userTime);
@@ -275,6 +283,13 @@ int chartsdata_init(void) {
 	it_set.it_interval.tv_usec = 0;
 	it_set.it_value.tv_sec = 999;
 	it_set.it_value.tv_usec = 999999;
+
+	// Install timer signal handlers for SIGVTALRM and SIGPROF
+	if (initializeTimerSignalHandlers(timerSignalHandler) != 0) {
+		safs::log_err("{} failed to initialize timer signal handlers", __func__);
+		return -1;
+	}
+
 	setitimer(ITIMER_VIRTUAL, &it_set, &userTime); // user time
 	setitimer(ITIMER_PROF, &it_set, &procTime);    // user time + system time
 

--- a/src/common/charts.cc
+++ b/src/common/charts.cc
@@ -36,6 +36,7 @@
 #include <sys/time.h>
 #include <time.h>
 #include <unistd.h>
+#include <csignal>
 #include <string>
 
 #include "common/crc.h"
@@ -1996,4 +1997,27 @@ void charts_get_png(uint8_t *buff) {
 		charts_fill_crc(buff,sizeof(png_header)+compsize+sizeof(png_tailer));
 	}
 	compsize=0;
+}
+
+int initializeTimerSignalHandlers(void (*handler)(int)) {
+	struct sigaction signalAction{};
+	sigemptyset(&signalAction.sa_mask);
+	signalAction.sa_handler = handler;
+	signalAction.sa_flags = SA_RESTART;  // Automatically restart interrupted system calls
+
+	// Handle SIGPROF (ITIMER_PROF - signal 27)
+	if (sigaction(SIGPROF, &signalAction, nullptr) == -1) {
+		safs::log_err("{}: failed to install SIGPROF handler using sigaction with error {}",
+		              __func__, strerror(errno));
+		return -1;
+	}
+
+	// Handle SIGVTALRM (ITIMER_VIRTUAL - signal 26)
+	if (sigaction(SIGVTALRM, &signalAction, nullptr) == -1) {
+		safs::log_err("{}: failed to install SIGVTALRM handler using sigaction with error {}",
+		              __func__, strerror(errno));
+		return -1;
+	}
+
+	return 0;
 }

--- a/src/common/charts.h
+++ b/src/common/charts.h
@@ -143,3 +143,10 @@ void charts_add (uint64_t *data,uint32_t datats);
 void charts_store (void);
 int charts_init (const uint32_t *calcs,const statdef *stats,const estatdef *estats,const char *filename);
 void charts_term (void);
+
+/**
+ * @brief Initializes timer signal handlers for SIGPROF and SIGVTALRM
+ * @param handler Signal handler function to install
+ * @return 0 on success, -1 on error
+ */
+int initializeTimerSignalHandlers(void (*handler)(int));

--- a/src/master/chartsdata.cc
+++ b/src/master/chartsdata.cc
@@ -55,6 +55,7 @@
 
 #if defined(SAUNAFS_HAVE_SETITIMER)
 #  include <sys/time.h>
+#  include <csignal>
 #  ifndef ITIMER_REAL
 #    define ITIMER_REAL 0
 #  endif
@@ -143,6 +144,14 @@ static const estatdef estatdefs[]=ESTATDEFS
 
 #ifdef CPU_USAGE
 static struct itimerval it_set;
+
+// Signal handler that prevents process termination from timer signals
+static void timerSignalHandler(int /*signal*/) {
+	// Reset both timers to prevent future signals from killing the process
+	setitimer(ITIMER_PROF, &it_set, nullptr);
+	setitimer(ITIMER_VIRTUAL, &it_set, nullptr);
+}
+
 #endif
 
 #ifdef MEMORY_USAGE
@@ -189,7 +198,7 @@ void chartsdata_refresh(void) {
 		pc.it_value.tv_usec = 999999-pc.it_value.tv_usec;
 	} else {
 		pc.it_value.tv_sec = 0;
-		uc.it_value.tv_usec = 0;
+		pc.it_value.tv_usec = 0;
 	}
 
 	ucusec = uc.it_value.tv_sec*1000000U+uc.it_value.tv_usec;
@@ -267,6 +276,13 @@ int chartsdata_init (void) {
 	it_set.it_interval.tv_usec = 0;
 	it_set.it_value.tv_sec = 999;
 	it_set.it_value.tv_usec = 999999;
+
+	// Install timer signal handlers for SIGVTALRM and SIGPROF
+	if (initializeTimerSignalHandlers(timerSignalHandler) != 0) {
+		safs::log_err("{} failed to initialize timer signal handlers", __func__);
+		return -1;
+	}
+
 	setitimer(ITIMER_VIRTUAL,&it_set,&uc);             // user time
 	setitimer(ITIMER_PROF,&it_set,&pc);                // user time + system time
 #endif

--- a/tests/test_suites/SanityChecks/test_handle_sigprof_and_sigvtalrm.sh
+++ b/tests/test_suites/SanityChecks/test_handle_sigprof_and_sigvtalrm.sh
@@ -1,0 +1,74 @@
+timeout_set 45 seconds
+
+CHUNKSERVERS=1 \
+	MASTERSERVERS=2 \
+	USE_RAMDISK="YES" \
+	setup_local_empty_saunafs info
+
+# Function to validate signal handling
+validate_signal_handling() {
+	local component="$1"
+	local pid="$2"
+	local signal="$3"
+
+	echo "Sending ${signal} signal to ${component} (PID: ${pid})..."
+	kill -s "${signal}" "${pid}"
+
+	# Wait a moment for signal handling
+	sleep 2
+
+	# Verify process is still alive
+	if ! kill -0 "${pid}" 2>/dev/null; then
+		echo "ERROR: ${component} process ${pid} died after receiving ${signal}"
+		return 1
+	fi
+
+	echo "${component} survived ${signal} signal correctly"
+	return 0
+}
+
+# Add a shadow master and wait until it's fully synchronized
+saunafs_master_n 1 start
+assert_eventually "saunafs_shadow_synchronized 1"
+
+# Generate some changes to ensure shadow is actively working
+touch "${info[mount0]}"/test_file_before_signals
+assert_eventually "saunafs_shadow_synchronized 1"
+
+# Test SIGPROF and SIGVTALRM on shadow master
+shadow_pid=$(saunafs_master_n 1 test | sed 's/.*: //')
+assert_matches "^[0-9]+$" "$shadow_pid"
+
+echo "Testing shadow master signal handling (PID: ${shadow_pid})"
+validate_signal_handling "shadow_master" "${shadow_pid}" "SIGPROF"
+validate_signal_handling "shadow_master" "${shadow_pid}" "SIGVTALRM"
+
+# Test signals on primary master
+master_pid=$(saunafs_master_daemon test | sed 's/.*: //')
+assert_matches "^[0-9]+$" "$master_pid"
+
+echo "Testing primary master signal handling (PID: ${master_pid})"
+validate_signal_handling "primary_master" "${master_pid}" "SIGPROF"
+validate_signal_handling "primary_master" "${master_pid}" "SIGVTALRM"
+
+# Test signals on chunkserver
+chunkserver_pid=$(saunafs_chunkserver_daemon 0 test | sed 's/.*pid: //')
+assert_matches "^[0-9]+$" "$chunkserver_pid"
+
+echo "Testing chunkserver signal handling (PID: ${chunkserver_pid})"
+validate_signal_handling "chunkserver" "${chunkserver_pid}" "SIGPROF"
+validate_signal_handling "chunkserver" "${chunkserver_pid}" "SIGVTALRM"
+
+# Verify all components are still functional after signal testing
+echo "Verifying system functionality after signal testing..."
+
+# Generate more changes to test master functionality
+touch "${info[mount0]}"/test_file_after_signals
+assert_eventually "saunafs_shadow_synchronized 1"
+
+# Test file operations through chunkserver
+echo "test_data" > "${info[mount0]}"/test_file_write
+assert_success test -f "${info[mount0]}"/test_file_write
+assert_equals "test_data" "$(cat "${info[mount0]}"/test_file_write)"
+
+echo "All signal handling tests completed successfully"


### PR DESCRIPTION
Previously, SaunaFS did not handled properly SIGPROF and SIGVTALRM signals. Therefore, during CPU-intensive operations, like metadata loading, the kernel could deliver SIGPROF or SIGVTALRM signals, causing the master or chunkserver processes to terminate unexpectedly.

This commit introduces handlers for SIGPROF and SIGVTALRM signals for master and chunkserver. The handlers resets ITIMER_PROF and ITIMER_VIRTUAL timers, ensuring both processes remain stable under heavy CPU load.