### PR TITLE
feat(meta): Add limitless meta mounts readdirs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ if(ENABLE_CCACHE AND CCACHE_FOUND)
   message(STATUS "Using ccache")
 endif()
 
-set(DEFAULT_MIN_VERSION "5.2.0")
+set(DEFAULT_MIN_VERSION "5.3.0")
 
 include(GNUInstallDirs)
 

--- a/src/common/saunafs_version.h
+++ b/src/common/saunafs_version.h
@@ -52,3 +52,4 @@ constexpr uint32_t kFirstVersionWithUseQuotaInVolumeSize = saunafsVersion(4, 9, 
 constexpr uint32_t kFirstVersionWithMountInfoOnMonitoring = saunafsVersion(5, 0, 0);
 constexpr uint32_t kFirstVersionWithChunkBasedWriteAlgorithm = saunafsVersion(5, 0, 0);
 constexpr uint32_t kFirstVersionWithClusterId = saunafsVersion(5, 0, 0);
+constexpr uint32_t kFirstVersionWithReadTrashReservedByHandleOffset = saunafsVersion(5, 3, 0);

--- a/src/master/filesystem.h
+++ b/src/master/filesystem.h
@@ -39,6 +39,7 @@
 #include "master/setgoal_task.h"
 #include "master/settrashtime_task.h"
 #include "protocol/directory_entry.h"
+#include "protocol/handle_inode_entry.h"
 #include "protocol/named_inode_entry.h"
 #include "protocol/quota.h"
 
@@ -235,11 +236,15 @@ uint32_t fs_newsessionid(void);
 uint8_t fs_readreserved_size(inode_t rootinode, uint8_t sesflags, uint32_t *dbuffsize);
 void fs_readreserved_data(inode_t rootinode, uint8_t sesflags, uint8_t *dbuff);
 void fs_readreserved(uint32_t off, uint32_t max_entries, std::vector<NamedInodeEntry> &entries);
+void fs_readreserved(uint64_t handleOffset, uint32_t maxEntries,
+                     std::vector<HandleInodeEntry> &entries);
 
 // TRASH
 uint8_t fs_readtrash_size(inode_t rootinode, uint8_t sesflags, uint32_t *dbuffsize);
 void fs_readtrash_data(inode_t rootinode, uint8_t sesflags, uint8_t *dbuff);
 void fs_readtrash(uint32_t off, uint32_t max_entries, std::vector<NamedInodeEntry> &entries);
+void fs_readtrash(uint64_t handleOffset, uint32_t maxEntries,
+                  std::vector<HandleInodeEntry> &entries);
 uint8_t fs_gettrashpath(inode_t rootinode, uint8_t sesflags, inode_t inode, std::string &path);
 
 // RESERVED+TRASH

--- a/src/master/filesystem_metadata.h
+++ b/src/master/filesystem_metadata.h
@@ -33,6 +33,7 @@
 #include "master/acl_storage.h"
 #include "master/filesystem_checksum_background_updater.h"
 #include "master/filesystem_node_types.h"
+#include "master/filesystem_trash_reserved_files.h"
 #include "master/filesystem_xattr.h"
 #include "master/hstring_storage.h"
 #include "master/id_generator_interface.h"
@@ -58,8 +59,11 @@ public:
 	// TODO(Guillex): Check implications of using 64 bits for inode_t in this structure.
 	IdPoolDetainer<inode_t, uint32_t> inodePool;
 	AclStorage aclStorage;
+	TrashReservedToIdContainer trashReservedToId;
 	TrashPathContainer trash;
+	HandleIndexContainer trashHandlesIndex;
 	ReservedPathContainer reserved;
+	HandleIndexContainer reservedHandlesIndex;
 	FSNodeDirectory *root{};
 	std::array<FSNodePointerVector, NODEHASHSIZE> nodeHash;
 	TaskManager taskManager;

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -816,6 +816,32 @@ void fsnodes_getdetacheddata(const TrashPathContainer &data, uint32_t off, uint3
 	}
 }
 
+// This function returns entries from a HandleIndexContainer starting at a given handleOffset.
+// The offset provided by the client (e.g., FUSE readdir) is always non-negative (sign bit 0).
+// Internally, the server may store offsets with the sign bit set (bit 63 = 1).
+// All lookups are enforced to be done ignoring the sign bit by setting it to 0.
+void fsnodes_getdetacheddata(const HandleIndexContainer &data, uint64_t handleOffset,
+                             uint32_t maxEntries, std::vector<HandleInodeEntry> &entries,
+                             bool fromTrash) {
+	uint64_t start = (handleOffset & ~k64SignBitMask);
+	auto it = data.lower_bound(HandleIndexKey(start));
+
+	for (; maxEntries > 0 && it != data.end(); --maxEntries, ++it) {
+		// Ensure we only return entries with the sign bit cleared
+		// to the client to avoid sending negative offsets to fuse
+		// when requesting next one
+		uint64_t handleValueForClient = (*it).first.data & ~k64SignBitMask;
+		std::string nameForClient = "";
+		if (fromTrash) {
+			FSNode *node = fsnodes_id_to_node((*it).second);
+			nameForClient = gMetadata->trash.at(TrashPathKey(node)).get().c_str();
+		} else {
+			nameForClient = gMetadata->reserved.at((*it).second).get().c_str();
+		}
+		entries.emplace_back(handleValueForClient, nameForClient, (*it).second);
+	}
+}
+
 uint32_t fsnodes_getdetachedsize(const ReservedPathContainer &data) {
 	return getdetachedsize(data);
 }
@@ -1361,7 +1387,8 @@ void fsnodes_unlink(uint32_t ts, FSNodeDirectory *parent, const HString &child_n
 			child->ctime = ts;
 			fsnodes_update_checksum(child);
 
-			gMetadata->trash.insert({TrashPathKey(child), hstorage::Handle(path)});
+			addTrashEntry(gMetadata->trash, gMetadata->trashHandlesIndex,
+			              gMetadata->trashReservedToId, child, path);
 
 			gMetadata->trashSpace += file_node->length;
 			gMetadata->trashNodes++;
@@ -1369,7 +1396,8 @@ void fsnodes_unlink(uint32_t ts, FSNodeDirectory *parent, const HString &child_n
 			child->type = FSNodeType::kReserved;
 			fsnodes_update_checksum(child);
 
-			gMetadata->reserved.insert({child->id, hstorage::Handle(path)});
+			addReservedEntry(gMetadata->reserved, gMetadata->reservedHandlesIndex,
+			                 gMetadata->trashReservedToId, child, path);
 
 			gMetadata->reservedSpace += file_node->length;
 			gMetadata->reservedNodes++;
@@ -1392,15 +1420,15 @@ int fsnodes_purge(uint32_t ts, FSNode *p) {
 			fsnodes_update_checksum(file_node);
 			gMetadata->reservedSpace += file_node->length;
 			gMetadata->reservedNodes++;
-			hstorage::Handle name_handle = std::move(gMetadata->trash.at(TrashPathKey(p)));
-			gMetadata->trash.erase(TrashPathKey(p));
 
-			gMetadata->reserved.insert({file_node->id, std::move(name_handle)});
+			moveTrashToReservedEntry(gMetadata->trash, gMetadata->trashHandlesIndex,
+			                         gMetadata->reserved, gMetadata->reservedHandlesIndex,
+			                         gMetadata->trashReservedToId, p);
 
 			return 0;
 		} else {
-			gMetadata->trash.erase(TrashPathKey(p));
-
+			removeTrashEntry(gMetadata->trash, gMetadata->trashHandlesIndex,
+			                 gMetadata->trashReservedToId, p);
 			p->ctime = ts;
 			fsnodes_update_checksum(p);
 			fsnodes_remove_node(ts, p);
@@ -1413,7 +1441,8 @@ int fsnodes_purge(uint32_t ts, FSNode *p) {
 		gMetadata->reservedSpace -= file_node->length;
 		gMetadata->reservedNodes--;
 
-		gMetadata->reserved.erase(file_node->id);
+		removeReservedEntry(gMetadata->reserved, gMetadata->reservedHandlesIndex,
+		                    gMetadata->trashReservedToId, p);
 
 		file_node->ctime = ts;
 		fsnodes_update_checksum(file_node);
@@ -1495,9 +1524,11 @@ uint8_t fsnodes_undel(uint32_t ts, FSNodeFile *node) {
 			}
 			// remove from trash and link to new parent
 			if (node->type == FSNodeType::kTrash) {
-				gMetadata->trash.erase(TrashPathKey(node));
+				removeTrashEntry(gMetadata->trash, gMetadata->trashHandlesIndex,
+				                 gMetadata->trashReservedToId, node);
 			} else {
-				gMetadata->reserved.erase(node->id);
+				removeReservedEntry(gMetadata->reserved, gMetadata->reservedHandlesIndex,
+				                    gMetadata->trashReservedToId, node);
 			}
 
 			node->type = FSNodeType::kFile;
@@ -1671,9 +1702,7 @@ void fsnodes_settrashtime_recursive(FSNode *node, uint32_t ts, uint32_t uid, uin
 				(*sinodes)++;
 				node->ctime = ts;
 				if (node->type == FSNodeType::kTrash) {
-					hstorage::Handle path = std::move(gMetadata->trash.at(old_trash_key));
-					gMetadata->trash.erase(old_trash_key);
-					gMetadata->trash.insert({TrashPathKey(node), std::move(path)});
+					updateTrashFromOldEntry(gMetadata->trash, node, old_trash_key);
 				}
 				fsnodes_update_checksum(node);
 			} else {

--- a/src/master/filesystem_node.h
+++ b/src/master/filesystem_node.h
@@ -25,6 +25,7 @@
 #include "master/filesystem_metadata.h"
 #include "master/filesystem_node_types.h"
 #include "master/fs_context.h"
+#include "protocol/handle_inode_entry.h"
 #include "protocol/directory_entry.h"
 #include "protocol/named_inode_entry.h"
 
@@ -104,9 +105,7 @@ inline void fsnodes_update_ctime(FSNode *node, uint32_t ctime) {
 		node->ctime = ctime;
 		auto it = gMetadata->trash.find(old_key);
 		if (it != gMetadata->trash.end()) {
-			hstorage::Handle path = std::move((*it).second);
-			gMetadata->trash.erase(it);
-			gMetadata->trash.insert({TrashPathKey(node), std::move(path)});
+			updateTrashFromOldEntry(gMetadata->trash, node, old_key);
 		}
 	} else {
 		node->ctime = ctime;
@@ -121,6 +120,9 @@ void fsnodes_getdetacheddata(const TrashPathContainer &data, uint32_t off, uint3
 uint32_t fsnodes_getdetachedsize(const ReservedPathContainer &data);
 void fsnodes_getdetacheddata(const ReservedPathContainer &data, uint8_t *dbuff);
 void fsnodes_getdetacheddata(const ReservedPathContainer &data, uint32_t off, uint32_t max_entries, std::vector<NamedInodeEntry> &entries);
+void fsnodes_getdetacheddata(const HandleIndexContainer &data, uint64_t handleOffset,
+                             uint32_t maxEntries, std::vector<HandleInodeEntry> &entries,
+                             bool fromTrash);
 void fsnodes_getpath(FSNodeDirectory *parent, FSNode *child, std::string &path);
 void fsnodes_fill_attr(FSNode *node, FSNode *parent, uint32_t uid, uint32_t gid, uint32_t auid,
 	uint32_t agid, uint8_t sesflags, Attributes &attr);

--- a/src/master/filesystem_node_types.h
+++ b/src/master/filesystem_node_types.h
@@ -36,17 +36,6 @@
 #include "common/type_defs.h"
 #include "protocol/SFSCommunication.h"
 
-#if defined(SAUNAFS_HAVE_64BIT_JUDY) &&               \
-    (!defined(DISABLE_JUDY_FOR_TRASHPATHCONTAINER) || \
-     !defined(DISABLE_JUDY_FOR_RESERVEDPATHCONTAINER))
-#include "common/judy_map.h"
-#endif
-#if !defined(SAUNAFS_HAVE_64BIT_JUDY) ||            \
-    defined(DISABLE_JUDY_FOR_TRASHPATHCONTAINER) || \
-    defined(DISABLE_JUDY_FOR_RESERVEDPATHCONTAINER)
-#include <map>
-#endif
-
 #include <ext/pb_ds/assoc_container.hpp>
 #include <ext/pb_ds/tree_policy.hpp>
 
@@ -89,7 +78,6 @@ enum class ExpectedNodeType : std::uint8_t {
 	kAny
 };
 
-using TrashtimeMap = std::unordered_map<uint32_t, uint32_t>;
 using GoalStatistics = std::array<inode_t, GoalId::kMax + 1>;
 using ParentsCompactVector = compact_vector<std::pair<inode_t, const hstorage::Handle *>, uint32_t>;
 
@@ -535,42 +523,3 @@ public:
 		FSNode::deserialize(source);
 	}
 };
-
-struct TrashPathKey {
-	explicit TrashPathKey(const FSNode *node) :
-#ifdef WORDS_BIGENDIAN
-	    timestamp(std::min((uint64_t)node->ctime + node->trashtime, (uint64_t)UINT32_MAX)),
-	    id(node->id)
-#else
-	    id(node->id),
-	    timestamp(std::min((uint64_t)node->ctime + node->trashtime, (uint64_t)UINT32_MAX))
-#endif
-	{}
-
-	bool operator<(const TrashPathKey &other) const {
-		return std::make_pair(timestamp, id) < std::make_pair(other.timestamp, other.id);
-	}
-
-#ifdef WORDS_BIGENDIAN
-	uint32_t timestamp;
-	// inode_t id;
-	uint32_t id;
-#else
-	// TODO(Guillex): the type should be inode_t, but there is an issue with Judy
-	// inode_t id;
-	uint32_t id;
-	uint32_t timestamp;
-#endif
-};
-
-#if defined(SAUNAFS_HAVE_64BIT_JUDY) && !defined(DISABLE_JUDY_FOR_TRASHPATHCONTAINER)
-using TrashPathContainer = judy_map<TrashPathKey, hstorage::Handle>;
-#else
-using TrashPathContainer = std::map<TrashPathKey, hstorage::Handle>;
-#endif
-
-#if defined(SAUNAFS_HAVE_64BIT_JUDY) && !defined(DISABLE_JUDY_FOR_RESERVEDPATHCONTAINER)
-using ReservedPathContainer = judy_map<inode_t, hstorage::Handle>;
-#else
-using ReservedPathContainer = std::map<inode_t, hstorage::Handle>;
-#endif

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -133,6 +133,11 @@ void fs_readreserved(uint32_t off, uint32_t max_entries, std::vector<NamedInodeE
 	fsnodes_getdetacheddata(gMetadata->reserved, off, max_entries, entries);
 }
 
+void fs_readreserved(uint64_t handleOffset, uint32_t maxEntries,
+                     std::vector<HandleInodeEntry> &entries) {
+	fsnodes_getdetacheddata(gMetadata->reservedHandlesIndex, handleOffset, maxEntries, entries, false);
+}
+
 uint8_t fs_readtrash_size(inode_t rootinode, uint8_t sesflags, uint32_t *dbuffsize) {
 	if (rootinode != 0) {
 		return SAUNAFS_ERROR_EPERM;
@@ -150,6 +155,11 @@ void fs_readtrash_data(inode_t rootinode, uint8_t sesflags, uint8_t *dbuff) {
 
 void fs_readtrash(uint32_t off, uint32_t max_entries, std::vector<NamedInodeEntry> &entries) {
 	fsnodes_getdetacheddata(gMetadata->trash, off, max_entries, entries);
+}
+
+void fs_readtrash(uint64_t handleOffset, uint32_t maxEntries,
+                  std::vector<HandleInodeEntry> &entries) {
+	fsnodes_getdetacheddata(gMetadata->trashHandlesIndex, handleOffset, maxEntries, entries, true);
 }
 
 /* common procedure for trash and reserved files */
@@ -221,7 +231,8 @@ uint8_t fs_settrashpath(const FsContext &context, inode_t inode, const std::stri
 		}
 	}
 
-	gMetadata->trash[TrashPathKey(p)] = HString(path);
+	updateTrashNameEntry(gMetadata->trash, gMetadata->trashHandlesIndex,
+	                     gMetadata->trashReservedToId, p, path);
 
 	if (context.isPersonalityMaster()) {
 		fs_changelog(context.ts(), "SETPATH(%" PRIiNode ",%s)", p->id,

--- a/src/master/filesystem_periodic.cc
+++ b/src/master/filesystem_periodic.cc
@@ -537,7 +537,9 @@ static void fs_do_emptytrash(uint32_t ts) {
 		FSNodeFile *node = fsnodes_id_to_node_verify<FSNodeFile>((*it).first.id);
 
 		if (!node) {
-			gMetadata->trash.erase(it);
+			std::string pathName = (*it).second.get();
+			removeTrashEntry(gMetadata->trash, gMetadata->trashHandlesIndex,
+			                 gMetadata->trashReservedToId, node);
 			it = gMetadata->trash.begin();
 			continue;
 		}
@@ -572,7 +574,8 @@ static void fs_do_emptyreserved(uint32_t ts) {
 		FSNodeFile *node = fsnodes_id_to_node_verify<FSNodeFile>((*it).first);
 
 		if (!node) {
-			gMetadata->reserved.erase(it);
+			removeReservedEntry(gMetadata->reserved, gMetadata->reservedHandlesIndex,
+			                    gMetadata->trashReservedToId, node);
 			it = gMetadata->reserved.begin();
 			continue;
 		}

--- a/src/master/filesystem_trash_reserved_files.h
+++ b/src/master/filesystem_trash_reserved_files.h
@@ -1,0 +1,211 @@
+/*
+   Copyright 2023      Leil Storage OÜ
+
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "common/platform.h"
+
+#include "master/filesystem_node_types.h"
+
+#if defined(SAUNAFS_HAVE_64BIT_JUDY) &&               \
+    (!defined(DISABLE_JUDY_FOR_TRASHPATHCONTAINER) || \
+     !defined(DISABLE_JUDY_FOR_RESERVEDPATHCONTAINER))
+#include "common/judy_map.h"
+#endif
+#if !defined(SAUNAFS_HAVE_64BIT_JUDY) ||            \
+    defined(DISABLE_JUDY_FOR_TRASHPATHCONTAINER) || \
+    defined(DISABLE_JUDY_FOR_RESERVEDPATHCONTAINER)
+#include <map>
+#endif
+
+// Maximum identifier value for trash or reserved names in the
+// TrashReservedToIdContainer struct, the idea is to avoid using
+// unsigned integer values with most significant bit set, as it
+// is needed for offset querying for reserved/trash entries from
+// the HandleIndexContainer consistently.
+constexpr uint64_t kMaxIdForTrashOrReservedName = 0x7FFFFFFFFFFFFFFF;
+
+// Sign bit mask for 64-bit unsigned integers. This is used to
+// mark offsets with the sign bit off (bit 63 = 0) internally in the HandleIndexContainer,
+// for consistent offset querying by lower_bound operations as client always provides
+// offsets with sign bit off (bit 63 = 0) and keys space is limited to 63 bits only.
+constexpr uint64_t k64SignBitMask = (1ULL << 63ULL);
+
+using TrashtimeMap = std::unordered_map<uint32_t, uint32_t>;
+
+struct TrashPathKey {
+	explicit TrashPathKey(const FSNode *node)
+	    :
+#ifdef WORDS_BIGENDIAN
+	      timestamp(std::min((uint64_t)node->ctime + node->trashtime, (uint64_t)UINT32_MAX)),
+	      id(node->id)
+#else
+	      id(node->id),
+	      timestamp(std::min((uint64_t)node->ctime + node->trashtime, (uint64_t)UINT32_MAX))
+#endif
+	{
+	}
+
+	bool operator<(const TrashPathKey &other) const {
+		return std::make_pair(timestamp, id) < std::make_pair(other.timestamp, other.id);
+	}
+
+#ifdef WORDS_BIGENDIAN
+	uint32_t timestamp;
+	// inode_t id;
+	uint32_t id;
+#else
+	// TODO(Guillex): the type should be inode_t, but there is an issue with Judy
+	// inode_t id;
+	uint32_t id;
+	uint32_t timestamp;
+#endif
+};
+
+#if defined(SAUNAFS_HAVE_64BIT_JUDY) && !defined(DISABLE_JUDY_FOR_TRASHPATHCONTAINER)
+using TrashPathContainer = judy_map<TrashPathKey, hstorage::Handle>;
+#else
+using TrashPathContainer = std::map<TrashPathKey, hstorage::Handle>;
+#endif
+
+#if defined(SAUNAFS_HAVE_64BIT_JUDY) && !defined(DISABLE_JUDY_FOR_RESERVEDPATHCONTAINER)
+using ReservedPathContainer = judy_map<inode_t, hstorage::Handle>;
+#else
+using ReservedPathContainer = std::map<inode_t, hstorage::Handle>;
+#endif
+
+/*! \brief Used as unique id generator for Trash/Reserved entries
+ * This struct is used as global identifier generator for trash and reserved
+ * path names handle hashes for ordering them in the HandleIndexContainer and
+ * then performing lower_bound requests to that container using these identifiers as initial
+ * lookup offsets.
+ */
+struct TrashReservedToIdContainer {
+	// Key a handle hash to avoid collisions when the same name is used
+	// for different inodes (which is possible, as names are not unique in trash/reserved)
+	// Value is unique identifier for that handleHash
+	// This unique identifier is used as part of the key in the HandleIndexContainer
+	// for ordering and lower_bound queries.
+	// TODO: Add mutex locking mechanism to make this struct thread-safe when
+	// multi-master implementation is done.
+	std::map<uint64_t, uint64_t> nameToId;
+	uint64_t counter{0};
+
+	uint64_t getOrAdd(uint64_t handle) {
+		auto it = nameToId.find(handle);
+		if (it != nameToId.end()) { return it->second; }
+		uint64_t newId =
+		    counter >= kMaxIdForTrashOrReservedName ? kMaxIdForTrashOrReservedName : ++counter;
+		nameToId[handle] = newId;
+		return newId;
+	}
+
+	void erase(uint64_t handle) { nameToId.erase(handle); }
+};
+
+struct HandleIndexKey {
+	uint64_t data;
+
+	HandleIndexKey(uint64_t d) : data(d) {}
+
+	// For map lookup, you may want operator< or a custom comparator
+	bool operator<(const HandleIndexKey &other) const {
+		// Compare by last 63-bits from data field
+		return (data & ~k64SignBitMask) < (other.data & ~k64SignBitMask);
+	}
+};
+
+// Auxiliary index for Trash/Reserved entries, ordered by HandleIndexKey
+// Used for readdir batching from meta mountpoints: lower_bound / upper_bound
+// on Handle offset and retrieving the next N entries. Each handle maps to an inode_t.
+using HandleIndexContainer = std::map<HandleIndexKey, inode_t>;
+
+inline void addTrashEntry(TrashPathContainer &trash, HandleIndexContainer &trashHandlesIndex,
+                          TrashReservedToIdContainer &trashReservedToId, FSNode *node,
+                          const std::string &path) {
+	TrashPathKey key(node);
+	trash.insert({key, hstorage::Handle(path)});
+	uint64_t handleHash = trash.at(key).data();
+	uint64_t pathId = trashReservedToId.getOrAdd(handleHash);
+	trashHandlesIndex.insert({HandleIndexKey(pathId), node->id});
+}
+
+inline void removeTrashEntry(TrashPathContainer &trash, HandleIndexContainer &trashHandlesIndex,
+                             TrashReservedToIdContainer &trashReservedToId, FSNode *node) {
+	TrashPathKey key(node);
+	uint64_t handleHash = trash.at(key).data();
+	uint64_t pathId = trashReservedToId.getOrAdd(handleHash);
+	trashHandlesIndex.erase(HandleIndexKey(pathId));
+	trashReservedToId.erase(handleHash);
+	trash.erase(key);
+}
+
+inline void addReservedEntry(ReservedPathContainer &reserved,
+                             HandleIndexContainer &reservedHandlesIndex,
+                             TrashReservedToIdContainer &trashReservedToId, FSNode *node,
+                             const std::string &path) {
+	reserved.insert({node->id, hstorage::Handle(path)});
+	uint64_t handleHash = reserved.at(node->id).data();
+	uint64_t pathId = trashReservedToId.getOrAdd(handleHash);
+	reservedHandlesIndex.insert({HandleIndexKey(pathId), node->id});
+}
+
+inline void removeReservedEntry(ReservedPathContainer &reserved,
+                                HandleIndexContainer &reservedHandlesIndex,
+                                TrashReservedToIdContainer &trashReservedToId, FSNode *node) {
+	uint64_t handleHash = reserved.at(node->id).data();
+	uint64_t pathId = trashReservedToId.getOrAdd(handleHash);
+	reservedHandlesIndex.erase(HandleIndexKey(pathId));
+	trashReservedToId.erase(handleHash);
+	reserved.erase(node->id);
+}
+
+inline void moveTrashToReservedEntry(TrashPathContainer &trash,
+                                     HandleIndexContainer &trashHandlesIndex,
+                                     ReservedPathContainer &reserved,
+                                     HandleIndexContainer &reservedHandlesIndex,
+                                     TrashReservedToIdContainer &trashReservedToId, FSNode *node) {
+	TrashPathKey key(node);
+	uint64_t handleHash = trash.at(key).data();
+	uint64_t idFromName = trashReservedToId.getOrAdd(handleHash);
+
+	trashHandlesIndex.erase(HandleIndexKey(idFromName));
+	hstorage::Handle nameHandle = std::move(trash.at(key));
+	trash.erase(key);
+
+	reserved.insert({node->id, std::move(nameHandle)});
+	reservedHandlesIndex.insert({HandleIndexKey(idFromName), node->id});
+}
+
+inline void updateTrashNameEntry(TrashPathContainer &trash, HandleIndexContainer &trashHandlesIndex,
+                                 TrashReservedToIdContainer &trashReservedToId, FSNode *node,
+                                 const std::string &newPath) {
+	uint64_t oldHash = trash[TrashPathKey(node)].data();
+	trashHandlesIndex.erase(HandleIndexKey(trashReservedToId.getOrAdd(oldHash)));
+	trashReservedToId.erase(oldHash);
+
+	trash[TrashPathKey(node)] = HString(newPath);
+	uint64_t newHash = trash[TrashPathKey(node)].data();
+	trashHandlesIndex.insert({HandleIndexKey(trashReservedToId.getOrAdd(newHash)), node->id});
+}
+
+inline void updateTrashFromOldEntry(TrashPathContainer &trash, FSNode *node,
+                                    const TrashPathKey &oldKey) {
+	hstorage::Handle path = std::move(trash.at(oldKey));
+	trash.erase(oldKey);
+	trash.insert({TrashPathKey(node), std::move(path)});
+}

--- a/src/master/filesystem_trash_reserved_files_unittest.cc
+++ b/src/master/filesystem_trash_reserved_files_unittest.cc
@@ -1,0 +1,207 @@
+/*
+   Copyright 2023      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "common/platform.h"
+
+#include <gtest/gtest.h>
+
+#include "master/filesystem_trash_reserved_files.h"
+#include "master/hstring_memstorage.h"
+
+using namespace hstorage;
+
+class FilesystemTrashReservedTests : public ::testing::Test {
+protected:
+	void SetUp() override {
+		Storage::reset(new MemStorage());
+		EXPECT_EQ(Storage::instance().name(), "MemStorage");
+	}
+	void TearDown() override {}
+
+	static FSNode *createFSNode(int index, FSNodeType type) {
+		FSNode *node = FSNode::create(type);
+		node->id = index;
+		node->ctime = kRandomTime + index;
+		node->mtime = kRandomTime + index;
+		node->atime = kRandomTime + index;
+		node->goal = kRandomGoal + index;
+		node->mode = kRandomMode;
+		node->uid = kRandomUid + index;
+		node->gid = kRandomGid + index;
+		node->trashtime = kRandomTrashTime + index;
+
+		return node;
+	}
+
+	static constexpr uint32_t kRandomTime = 12345U;
+	static constexpr uint8_t kRandomGoal = 1U;
+	static constexpr uint16_t kRandomMode = 0755U;
+	static constexpr uint32_t kRandomUid = 1000U;
+	static constexpr uint32_t kRandomGid = 1000U;
+	static constexpr uint32_t kRandomTrashTime = 3600U;
+};
+
+TEST_F(FilesystemTrashReservedTests, AddAndRemoveTrashEntryFromContainers) {
+	TrashPathContainer trash;
+	HandleIndexContainer trashHandlesIndex;
+	TrashReservedToIdContainer trashReservedToId;
+	FSNode *node = createFSNode(1, FSNodeType::kFile);
+
+	std::string path = "/path/to/file";
+
+	// Add to trash
+	addTrashEntry(trash, trashHandlesIndex, trashReservedToId, node, path);
+
+	ASSERT_EQ(trash.size(), 1U);
+	ASSERT_EQ(trashHandlesIndex.size(), 1U);
+	ASSERT_EQ(trashReservedToId.counter, 1U);
+
+	// Remove from trash
+	removeTrashEntry(trash, trashHandlesIndex, trashReservedToId, node);
+
+	ASSERT_EQ(trash.size(), 0U);
+	ASSERT_EQ(trashHandlesIndex.size(), 0U);
+	ASSERT_EQ(trashReservedToId.counter, 1U);
+
+	FSNode::destroy(node);
+}
+
+TEST_F(FilesystemTrashReservedTests, AddAndRemoveReservedEntryFromContainers) {
+	ReservedPathContainer reserved;
+	HandleIndexContainer reservedHandlesIndex;
+	TrashReservedToIdContainer reservedReservedToId;
+	FSNode *node = createFSNode(1, FSNodeType::kFile);
+
+	std::string path = "/path/to/file";
+
+	// Add to reserved
+	addReservedEntry(reserved, reservedHandlesIndex, reservedReservedToId, node, path);
+
+	ASSERT_EQ(reserved.size(), 1U);
+	ASSERT_EQ(reservedHandlesIndex.size(), 1U);
+	ASSERT_EQ(reservedReservedToId.counter, 1U);
+
+	// Remove from reserved
+	removeReservedEntry(reserved, reservedHandlesIndex, reservedReservedToId, node);
+
+	ASSERT_EQ(reserved.size(), 0U);
+	ASSERT_EQ(reservedHandlesIndex.size(), 0U);
+	ASSERT_EQ(reservedReservedToId.counter, 1U);
+
+	FSNode::destroy(node);
+}
+
+TEST_F(FilesystemTrashReservedTests, MoveTrashToReservedContainer) {
+	TrashPathContainer trash;
+	HandleIndexContainer trashHandlesIndex;
+	ReservedPathContainer reserved;
+	HandleIndexContainer reservedHandlesIndex;
+	TrashReservedToIdContainer trashReservedToId;
+
+	FSNode *node = createFSNode(1, FSNodeType::kFile);
+
+	std::string path = "/path/to/file";
+
+	// Add to trash
+	addTrashEntry(trash, trashHandlesIndex, trashReservedToId, node, path);
+
+	ASSERT_EQ(trash.size(), 1U);
+	ASSERT_EQ(trashHandlesIndex.size(), 1U);
+	ASSERT_EQ(trashReservedToId.counter, 1U);
+
+	// Move from trash to reserved
+	moveTrashToReservedEntry(trash, trashHandlesIndex, reserved, reservedHandlesIndex,
+	                         trashReservedToId, node);
+
+	ASSERT_EQ(trash.size(), 0U);
+	ASSERT_EQ(trashHandlesIndex.size(), 0U);
+	ASSERT_EQ(reserved.size(), 1U);
+	ASSERT_EQ(reservedHandlesIndex.size(), 1U);
+	ASSERT_EQ(trashReservedToId.counter, 1U);
+
+	FSNode::destroy(node);
+}
+
+TEST_F(FilesystemTrashReservedTests, UpdateTrashNameEntry) {
+	TrashPathContainer trash;
+	HandleIndexContainer trashHandlesIndex;
+	TrashReservedToIdContainer trashReservedToId;
+
+	FSNode *node = createFSNode(1, FSNodeType::kFile);
+
+	std::string path1 = "/path/to/file1";
+	std::string path2 = "/path/to/file2";
+
+	// Add to trash
+	addTrashEntry(trash, trashHandlesIndex, trashReservedToId, node, path1);
+
+	ASSERT_EQ(trash.size(), 1U);
+	ASSERT_EQ(trashHandlesIndex.size(), 1U);
+	ASSERT_EQ(trashReservedToId.counter, 1U);
+
+	// Update trash name entry
+	updateTrashNameEntry(trash, trashHandlesIndex, trashReservedToId, node, path2);
+
+	ASSERT_EQ(trash.size(), 1U);
+	ASSERT_EQ(trashHandlesIndex.size(), 1U);
+	ASSERT_EQ(trashReservedToId.counter, 2U);
+
+	std::string retrievedPath = static_cast<std::string>(trash.at(TrashPathKey(node)));
+	ASSERT_EQ(retrievedPath, path2);
+
+	FSNode::destroy(node);
+}
+
+TEST_F(FilesystemTrashReservedTests, UpdateTrashFromOldEntry) {
+	TrashPathContainer trash;
+	HandleIndexContainer trashHandlesIndex;
+	TrashReservedToIdContainer trashReservedToId;
+
+	FSNode *node1 = createFSNode(1, FSNodeType::kFile);
+
+	std::string path = "/path/to/file";
+
+	// Add to trash
+	addTrashEntry(trash, trashHandlesIndex, trashReservedToId, node1, path);
+
+	ASSERT_EQ(trash.size(), 1U);
+	ASSERT_EQ(trashHandlesIndex.size(), 1U);
+	ASSERT_EQ(trashReservedToId.counter, 1U);
+
+	uint32_t retrivedCTime = (*trash.begin()).first.timestamp;
+	ASSERT_EQ(retrivedCTime,
+	          std::min((uint64_t)node1->ctime + node1->trashtime, (uint64_t)UINT32_MAX));
+
+	TrashPathKey oldKey(node1);
+
+	// Update node1 creation time
+	node1->ctime += 100;
+
+	// Update trash from old entry
+	updateTrashFromOldEntry(trash, node1, oldKey);
+
+	ASSERT_EQ(trash.size(), 1U);
+	ASSERT_EQ(trashHandlesIndex.size(), 1U);
+	ASSERT_EQ(trashReservedToId.counter, 1U);
+
+	retrivedCTime = (*trash.begin()).first.timestamp;
+	ASSERT_EQ(retrivedCTime,
+	          std::min((uint64_t)node1->ctime + node1->trashtime, (uint64_t)UINT32_MAX));
+
+	FSNode::destroy(node1);
+}

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -4525,13 +4525,30 @@ void matoclserv_fuse_gettrash(matoclserventry *eptr, const uint8_t *data, uint32
 
 void matoclserv_fuse_gettrash(matoclserventry *eptr, const PacketHeader &header,
                               const uint8_t *data) {
-	uint32_t off, max_entries, msg_id;
-	cltoma::fuseGetTrash::deserialize(data, header.length, msg_id, off, max_entries);
-	std::vector<NamedInodeEntry> entries;
-	fs_readtrash(off,
-	             std::min<uint32_t>(max_entries, matocl::fuseGetDir::kMaxNumberOfDirectoryEntries),
-	             entries);
-	matoclserv_createpacket(eptr, matocl::fuseGetTrash::build(msg_id, entries));
+	uint32_t maxEntries, msgId;
+	PacketVersion version;
+	deserializePacketVersionNoHeader(data, header.length, version);
+
+	if (version == cltoma::fuseGetTrash::kClientPositionOffset) {
+		uint32_t off;
+		cltoma::fuseGetTrash::deserialize(data, header.length, msgId, off, maxEntries);
+		std::vector<NamedInodeEntry> entries;
+		fs_readtrash(
+		    off, std::min<uint32_t>(maxEntries, matocl::fuseGetDir::kMaxNumberOfDirectoryEntries),
+		    entries);
+		matoclserv_createpacket(eptr, matocl::fuseGetTrash::build(msgId, entries));
+	} else if (version == cltoma::fuseGetTrash::kClientHandleOffset) {
+		uint64_t off;
+		cltoma::fuseGetTrash::deserialize(data, header.length, msgId, off, maxEntries);
+		std::vector<HandleInodeEntry> entries;
+		fs_readtrash(
+		    off, std::min<uint32_t>(maxEntries, matocl::fuseGetDir::kMaxNumberOfDirectoryEntries),
+		    entries);
+		matoclserv_createpacket(eptr, matocl::fuseGetTrash::build(msgId, entries));
+	} else {
+		throw IncorrectDeserializationException(
+		    "Unknown packet version for matoclserv_fuse_gettrash: " + std::to_string(version));
+	}
 }
 
 void matoclserv_fuse_getdetachedattr(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
@@ -4750,13 +4767,30 @@ void matoclserv_fuse_getreserved(matoclserventry *eptr, const uint8_t *data, uin
 
 void matoclserv_fuse_getreserved(matoclserventry *eptr, const PacketHeader &header,
                                  const uint8_t *data) {
-	uint32_t off, max_entries, msg_id;
-	cltoma::fuseGetReserved::deserialize(data, header.length, msg_id, off, max_entries);
-	std::vector<NamedInodeEntry> entries;
-	fs_readreserved(
-	    off, std::min<uint32_t>(max_entries, matocl::fuseGetDir::kMaxNumberOfDirectoryEntries),
-	    entries);
-	matoclserv_createpacket(eptr, matocl::fuseGetReserved::build(msg_id, entries));
+	uint32_t maxEntries, msgId;
+	PacketVersion version;
+	deserializePacketVersionNoHeader(data, header.length, version);
+
+	if (version == cltoma::fuseGetReserved::kClientPositionOffset) {
+		uint32_t off;
+		cltoma::fuseGetReserved::deserialize(data, header.length, msgId, off, maxEntries);
+		std::vector<NamedInodeEntry> entries;
+		fs_readreserved(
+		    off, std::min<uint32_t>(maxEntries, matocl::fuseGetDir::kMaxNumberOfDirectoryEntries),
+		    entries);
+		matoclserv_createpacket(eptr, matocl::fuseGetReserved::build(msgId, entries));
+	} else if (version == cltoma::fuseGetReserved::kClientHandleOffset) {
+		uint64_t off;
+		cltoma::fuseGetReserved::deserialize(data, header.length, msgId, off, maxEntries);
+		std::vector<HandleInodeEntry> entries;
+		fs_readreserved(
+		    off, std::min<uint32_t>(maxEntries, matocl::fuseGetDir::kMaxNumberOfDirectoryEntries),
+		    entries);
+		matoclserv_createpacket(eptr, matocl::fuseGetReserved::build(msgId, entries));
+	} else {
+		throw IncorrectDeserializationException(
+		    "Unknown packet version for matoclserv_fuse_gettreserved: " + std::to_string(version));
+	}
 }
 
 void matoclserv_fuse_deleteacl(matoclserventry *eptr, const uint8_t *data, uint32_t length) {

--- a/src/master/metadata_backend_file.cc
+++ b/src/master/metadata_backend_file.cc
@@ -422,12 +422,13 @@ static int8_t fs_parseEdge(const std::shared_ptr<MemoryMappedFile> &metadataFile
 	}
 	if (!parentId) {
 		if (child->type == FSNodeType::kTrash) {
-			gMetadata->trash.insert(
-			    {TrashPathKey(child), hstorage::Handle(name)});
+			addTrashEntry(gMetadata->trash, gMetadata->trashHandlesIndex,
+			              gMetadata->trashReservedToId, child, name);
 			gMetadata->trashSpace += static_cast<FSNodeFile *>(child)->length;
 			gMetadata->trashNodes++;
 		} else if (child->type == FSNodeType::kReserved) {
-			gMetadata->reserved.insert({child->id, hstorage::Handle(name)});
+			addReservedEntry(gMetadata->reserved, gMetadata->reservedHandlesIndex,
+			                 gMetadata->trashReservedToId, child, name);
 			gMetadata->reservedSpace += static_cast<FSNodeFile *>(child)->length;
 			gMetadata->reservedNodes++;
 		} else {

--- a/src/master/settrashtime_task.cc
+++ b/src/master/settrashtime_task.cc
@@ -101,11 +101,7 @@ uint8_t SetTrashtimeTask::setTrashtime(FSNode *node, uint32_t ts) {
 			if (set) {
 				node->ctime = ts;
 				if (node->type == FSNodeType::kTrash) {
-					hstorage::Handle path =
-					        std::move(gMetadata->trash.at(old_trash_key));
-					gMetadata->trash.erase(old_trash_key);
-					gMetadata->trash.insert(
-					        {TrashPathKey(node), std::move(path)});
+					updateTrashFromOldEntry(gMetadata->trash, node, old_trash_key);
 				}
 				fsnodes_update_checksum(node);
 				return SetTrashtimeTask::kChanged;

--- a/src/master/settrashtime_task.h
+++ b/src/master/settrashtime_task.h
@@ -22,6 +22,7 @@
 #include "common/platform.h"
 
 #include "master/filesystem_node_types.h"
+#include "master/filesystem_trash_reserved_files.h"
 #include "master/task_manager.h"
 
 class SetTrashtimeTask : public TaskManager::Task {

--- a/src/mount/fuse/sfs_meta_fuse.cc
+++ b/src/mount/fuse/sfs_meta_fuse.cc
@@ -44,6 +44,7 @@
 #include "mount/mastercomm.h"
 #include "mount/masterproxy.h"
 #include "protocol/SFSCommunication.h"
+#include "protocol/handle_inode_entry.h"
 #include "slogger/slogger.h"
 
 static_assert(FUSE_ROOT_ID == SPECIAL_INODE_ROOT, "invalid value of FUSE_ROOT_ID");
@@ -71,10 +72,29 @@ constexpr mode_t kMaxFilePermissions = 07777;
 // processed at once, to avoid excessive memory usage.
 constexpr uint64_t kMaxEntriesToCache = 100000;
 
+// Sign bit mask for 64-bit unsigned integers.
+// Used to ensure offsets sent to the kernel (e.g., readdir cookies) are always non-negative.
+// This prevents userland applications and filesystems from misinterpreting offsets as negative
+// values.
+constexpr uint64_t k64SignBitMask = (1ULL << 63ULL);
+
 constexpr uint64_t kStatfsFilesBase = 1'000'000'000 + PKGVERSION;
 
-struct DirectoryBuffer {
-	bool wasRead = false;
+/**
+ * @brief Caches directory entries and their read state for reserved and trash directories.
+ *
+ * This struct maintains a list of cached entries and a buffer for serialized data.
+ * It enables efficient serving of directory read requests in batches, up to kMaxEntriesToCache
+ * entries.
+ */
+struct DirectoryBufferCache {
+	bool wasRead{false};
+	/// Current offset to read from the buffer with bytes from cached entries.
+	off_t currentByteOffsetFromCachedEntries{0};
+	/// Current index of the entry to read from cached entries.
+	uint64_t currentReadIndexFromCachedEntries{0};
+	/// Cached entries for the reserved/trash directory.
+	std::vector<HandleInodeEntry> entries;
 	std::vector<uint8_t> buffer;
 	std::mutex lock;
 };
@@ -330,6 +350,16 @@ static uint32_t getDirMetaEntriesSize(inode_t ino) {
 	return 0;
 }
 
+bool isMetaEntryName(const char *name, size_t len) {
+	static const char *meta_names[] = {".", "..", SPECIAL_FILE_NAME_META_TRASH,
+	                                   SPECIAL_FILE_NAME_META_UNDEL,
+	                                   SPECIAL_FILE_NAME_META_RESERVED};
+	for (const char *meta : meta_names) {
+		if (strlen(meta) == len && std::memcmp(name, meta, len) == 0) { return true; }
+	}
+	return false;
+}
+
 static void fillDirMetaEntries(uint8_t *buff, inode_t ino) {
 	uint8_t nameLength;
 	switch (ino) {
@@ -409,14 +439,13 @@ static void fillDirMetaEntries(uint8_t *buff, inode_t ino) {
 	}
 }
 
-static uint32_t getDirDataEntriesSize(const std::vector<NamedInodeEntry> &entries) {
-	uint8_t nameLength;
-	uint32_t totalSize = 0;
-
+template <typename EntryT>
+static uint32_t getDirDataEntriesSize(const std::vector<EntryT> &entries) {
 	if (entries.empty()) { return 0; }
 
+	uint32_t totalSize = 0;
 	for (const auto &entry : entries) {
-		nameLength = entry.name.size();
+		uint8_t nameLength = entry.name.size();
 		if (nameLength > NAME_MAX - kDirEntryHexPreffixSize) {
 			totalSize += kDirEntryStride + NAME_MAX;
 		} else {
@@ -427,7 +456,8 @@ static uint32_t getDirDataEntriesSize(const std::vector<NamedInodeEntry> &entrie
 	return totalSize;
 }
 
-static void convertDirDataEntries(uint8_t *buff, const std::vector<NamedInodeEntry> &entries) {
+template <typename EntryT>
+static void convertDirDataEntries(uint8_t *buff, const std::vector<EntryT> &entries) {
 	const uint8_t *name{};
 	uint8_t nameLength{};
 	uint8_t inodeLength{};
@@ -469,9 +499,7 @@ void sfs_meta_opendir(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
 	};
 
 	if (isValidMetaMountInode(ino)) {
-		auto *dirinfo = new DirectoryBuffer();
-		dirinfo->buffer.clear();
-		dirinfo->wasRead = false;
+		auto *dirinfo = new DirectoryBufferCache();
 		fi->fh = reinterpret_cast<uintptr_t>(dirinfo);
 
 		if (fuse_reply_open(req, fi) != 0) {
@@ -513,7 +541,7 @@ void replyDirReadRoot(fuse_req_t request, off_t offset, size_t maxsize) {
 	fuse_reply_buf(request, buffer.data(), size);
 }
 
-void fillDirEntryBuffer(fuse_req_t req, DirectoryBuffer *dirinfo, off_t &off, char *dirEntryBuffer,
+void fillDirEntryBuffer(fuse_req_t req, DirectoryBufferCache *dirinfo, off_t &off, char *dirEntryBuffer,
                         size_t &size, size_t &writePos) {
 	char *entryName;
 	char nameTerminator;
@@ -525,7 +553,12 @@ void fillDirEntryBuffer(fuse_req_t req, DirectoryBuffer *dirinfo, off_t &off, ch
 	uint8_t done = 0;
 
 	size = std::min<size_t>(size, READDIR_BUFFSIZE);
-	const uint8_t *entryPtr = reinterpret_cast<const uint8_t *>(dirinfo->buffer.data()) + off;
+
+	off_t startOffset = masterVersion < kFirstVersionWithReadTrashReservedByHandleOffset
+	                        ? off
+	                        : dirinfo->currentByteOffsetFromCachedEntries;
+
+	const uint8_t *entryPtr = reinterpret_cast<const uint8_t *>(dirinfo->buffer.data()) + startOffset;
 	const uint8_t *endPtr =
 	    reinterpret_cast<const uint8_t *>(dirinfo->buffer.data()) + dirinfo->buffer.size();
 
@@ -534,7 +567,18 @@ void fillDirEntryBuffer(fuse_req_t req, DirectoryBuffer *dirinfo, off_t &off, ch
 		entryPtr++;
 		entryName = (char *)entryPtr;
 		entryPtr += nameLength;
-		off += nameLength + kDirEntryStride;
+
+		if (masterVersion < kFirstVersionWithReadTrashReservedByHandleOffset) {
+			off += nameLength + kDirEntryStride;
+		} else {
+			if (!isMetaEntryName(entryName, nameLength)) {
+				off = dirinfo->entries[dirinfo->currentReadIndexFromCachedEntries].data;
+			} else {
+				off = dirinfo->entries.empty() ? off + nameLength + kDirEntryStride
+				                               : dirinfo->entries[0].data;
+			}
+		}
+
 		if (entryPtr + kDirEntryMetaSize <= endPtr) {
 			getINode(&entryPtr, inode);
 			type = get8bit(&entryPtr);
@@ -547,62 +591,132 @@ void fillDirEntryBuffer(fuse_req_t req, DirectoryBuffer *dirinfo, off_t &off, ch
 			if (writePos + entryLength > size) {
 				done = 1;
 			} else {
+				if (!isMetaEntryName(entryName, nameLength)) {
+					dirinfo->currentReadIndexFromCachedEntries++;
+				}
+				dirinfo->currentByteOffsetFromCachedEntries += nameLength + kDirEntryStride;
 				writePos += entryLength;
 			}
 		}
 	}
 }
 
-void getDirectoryEntriesLimited(DirectoryBuffer *dirinfo, inode_t ino, off_t byteOffset,
-                                size_t maxByteSize) {
+template <typename OffsetT, typename EntryT>
+bool getEntriesFromMaster(inode_t ino, OffsetT offVal, DirectoryBufferCache *dirinfo,
+                          uint32_t entriesSize, uint32_t metaEntriesSize,
+                          std::vector<uint8_t> &bufData, std::vector<EntryT> &entries) {
 	uint8_t status = 0;
+
+	if (ino == SPECIAL_INODE_META_TRASH) {
+		status = fs_gettrash(offVal, entriesSize, entries);
+	} else if (ino == SPECIAL_INODE_META_RESERVED) {
+		status = fs_getreserved(offVal, entriesSize, entries);
+	}
+
+	uint32_t dataEntriesSize = getDirDataEntriesSize(entries);
+
+	if (status != SAUNAFS_STATUS_OK || dataEntriesSize == 0) {
+		dirinfo->buffer = bufData;
+		return false;
+	}
+
+	bufData.resize(dataEntriesSize + (offVal == 0 ? metaEntriesSize : 0));
+	convertDirDataEntries(bufData.data() + (offVal == 0 ? metaEntriesSize : 0), entries);
+
+	dirinfo->buffer = bufData;
+	return true;
+}
+
+void getDirectoryEntriesLimited(DirectoryBufferCache *dirinfo, inode_t ino, off_t offset,
+                                size_t maxByteSize) {
 	uint32_t entriesSize = 0;
 	uint32_t metaEntriesSize = 0;
-	uint32_t dataEntriesSize = 0;
 	std::vector<uint8_t> bufData;
 
-	// Check if the directory has already been read and cached
-	if (dirinfo->wasRead) { return; }
+	// If the directory has already been read and cached, we may be able to skip.
+	// Behavior depends on the master version.
+	if (masterVersion < kFirstVersionWithReadTrashReservedByHandleOffset) {
+		// For older versions, it’s enough to check if the directory was read.
+		if (dirinfo->wasRead) { return; }
+	} else {
+		// For newer versions, we need to check that the cached offset is valid.
+		uint64_t requestedOffset =
+		    (static_cast<std::make_unsigned_t<off_t>>(offset) & ~k64SignBitMask);
+		uint64_t lastCachedOffset =
+		    dirinfo->entries.empty() ? 0 : (dirinfo->entries.back().data & ~k64SignBitMask);
 
-	if (byteOffset == 0) {
+		// First, check if the requested offset and sized are cached, which means:
+		// 1 - There are elements on the entries container for the dirinfo instance
+		// 2 - The requested offset is less than or equal to the last cached entry offset
+		// 3 - The current read index and is on the bounds of the current cached entries.
+		if (!dirinfo->entries.empty() && requestedOffset <= lastCachedOffset &&
+		    dirinfo->currentReadIndexFromCachedEntries < dirinfo->entries.size()) {
+			return;
+		}
+
+		// If the requested offset is not cached, we need to determine the new offset to read from.
+		// There are three possible cases:
+		// 1 - The requested offset is greater than the last cached entry offset then we start from
+		// the requested offset.
+		// 2 - The requested offset is equal than the last cached entry offset then we start from
+		// the next offset (last cached entry offset + 1). This second conditions is true when the
+		// currentReadIndexFromCachedEntries is equal to the size of the entries container, which
+		// means all cached entries were read). If there are no cached entries, we start from offset 0.
+		// 3 - The requested offset is less than the last cached entry offset. This scenario occurs
+		// only when the remaining bytes to read from cached buffer is less than the requested size,
+		// in which case we start reading from the requested offset.
+		if (!dirinfo->entries.empty() &&
+		    dirinfo->currentReadIndexFromCachedEntries == dirinfo->entries.size() &&
+		    (requestedOffset == lastCachedOffset)) {
+			offset = lastCachedOffset + 1ULL;
+		}
+	}
+
+	// Empty dirinfo main fields for new cached batch of entries
+	dirinfo->wasRead = false;
+	dirinfo->currentByteOffsetFromCachedEntries = 0;
+	dirinfo->currentReadIndexFromCachedEntries = 0;
+	dirinfo->entries.clear();
+	dirinfo->buffer.clear();
+
+	if (offset == 0) {
 		metaEntriesSize = getDirMetaEntriesSize(ino);
-		if (metaEntriesSize > 0 && byteOffset < metaEntriesSize) {
+		if (metaEntriesSize > 0 && offset < metaEntriesSize) {
 			std::vector<uint8_t> metaBuf(metaEntriesSize);
 			fillDirMetaEntries(metaBuf.data(), ino);
-			size_t start = byteOffset;
-			size_t toCopy = std::min(maxByteSize, metaEntriesSize - start);
-			bufData.insert(bufData.end(), metaBuf.begin() + start,
-			               metaBuf.begin() + start + toCopy);
+			size_t toCopy = std::min(maxByteSize, static_cast<size_t>(metaEntriesSize));
+			bufData.insert(bufData.end(), metaBuf.begin(), metaBuf.begin() + toCopy);
 		}
 	}
 
 	// Offset is in data entries
 	entriesSize = kMaxEntriesToCache;
 
-	std::vector<NamedInodeEntry> entries;
-	if (ino == SPECIAL_INODE_META_TRASH) {
-		status = fs_gettrash(0, entriesSize, entries);
-	} else if (ino == SPECIAL_INODE_META_RESERVED) {
-		status = fs_getreserved(0, entriesSize, entries);
+	if (masterVersion < kFirstVersionWithReadTrashReservedByHandleOffset) {
+		std::vector<NamedInodeEntry> entries;
+		if (!getEntriesFromMaster(ino, static_cast<uint32_t>(0), dirinfo, entriesSize,
+		                          metaEntriesSize, bufData, entries)) {
+			return;
+		}
+		dirinfo->wasRead = true;
+	} else {
+		// For newer versions, we read entries starting from the given offset.
+		uint64_t startOff = static_cast<std::make_unsigned<off_t>::type>(offset);
+		// type to cast to should be the same size to avoid potential sign-extension
+		// (SaunaFS's offset can be interpreted as negative on signed integer types (e.g. off_t used
+		// by libfuse), as it is 64bit unsigned int on master)
+		std::vector<HandleInodeEntry> entries;
+		if (!getEntriesFromMaster(ino, startOff, dirinfo, entriesSize, metaEntriesSize, bufData,
+		                          entries)) {
+			return;
+		}
+		dirinfo->entries = entries;
 	}
-
-	dataEntriesSize = getDirDataEntriesSize(entries);
-
-	if (status != SAUNAFS_STATUS_OK || dataEntriesSize == 0) {
-		dirinfo->buffer = bufData;
-		return;
-	}
-
-	bufData.resize(dataEntriesSize + (byteOffset == 0 ? metaEntriesSize : 0));
-	convertDirDataEntries(bufData.data() + (byteOffset == 0 ? metaEntriesSize : 0), entries);
-
-	dirinfo->buffer = bufData;
-	dirinfo->wasRead = true;
 }
 
 void sfs_meta_readdir(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off,
                       struct fuse_file_info *fi) {
-	auto *dirinfo = reinterpret_cast<DirectoryBuffer *>(fi->fh);
+	auto *dirinfo = reinterpret_cast<DirectoryBufferCache *>(fi->fh);
 	if (dirinfo == nullptr) {
 		fuse_reply_err(req, ENOENT);
 		return;
@@ -621,7 +735,9 @@ void sfs_meta_readdir(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off,
 
 	getDirectoryEntriesLimited(dirinfo, ino, off, size);
 
-	if (dirinfo->buffer.empty() || size == 0) {
+	if (dirinfo->buffer.empty() || size == 0 ||
+	    (masterVersion >= kFirstVersionWithReadTrashReservedByHandleOffset &&
+	     dirinfo->entries.empty() && dirinfo->currentByteOffsetFromCachedEntries > 0)) {
 		fuse_reply_buf(req, nullptr, 0);
 		return;
 	}
@@ -634,7 +750,7 @@ void sfs_meta_readdir(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off,
 
 void sfs_meta_releasedir(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi) {
 	(void)ino;
-	auto *dirinfo = reinterpret_cast<DirectoryBuffer *>(fi->fh);
+	auto *dirinfo = reinterpret_cast<DirectoryBufferCache *>(fi->fh);
 	dirinfo->lock.lock();
 	dirinfo->lock.unlock();
 	delete dirinfo;

--- a/src/mount/mastercomm.cc
+++ b/src/mount/mastercomm.cc
@@ -132,7 +132,6 @@ static pthread_t rpthid,npthid;
 static std::mutex fdMutex, recMutex;
 
 static uint32_t sessionid;
-static uint32_t masterversion;
 
 static char masterstrip[17];
 static uint32_t masterip=0;
@@ -155,7 +154,7 @@ void fs_getmasterlocation(uint8_t loc[14]) {
 	put32bit(&loc,masterip);
 	put16bit(&loc,masterport);
 	put32bit(&loc,sessionid);
-	put32bit(&loc,masterversion);
+	put32bit(&loc,masterVersion.load());
 }
 
 uint32_t fs_getsrcip() {
@@ -205,20 +204,20 @@ void wrap_write_init(bool isFromMainThread) {
 
 	// Dangerous case, using chunk based algorithm by params and master does not support it.
 	if (!gSaunaFSInitParams.use_inode_based_write_algorithm &&
-	    masterversion < kFirstVersionWithChunkBasedWriteAlgorithm) {
+	    masterVersion < kFirstVersionWithChunkBasedWriteAlgorithm) {
 		if (isFromMainThread) {
 			fprintf(stderr,
 			        "Metadata server version v%s is too old, using inode based write algorithm"
 			        "(sfsuseinodebasedwritealgorithm=1). "
 			        "Required minimum version for chunk based write algorithm is v%s.\n",
-			        saunafsVersionToString(masterversion).c_str(),
+			        saunafsVersionToString(masterVersion).c_str(),
 			        saunafsVersionToString(kFirstVersionWithChunkBasedWriteAlgorithm).c_str());
 		} else {
 			safs::log_warn(
 			    "Metadata server version v{} is too old, using inode based write algorithm"
 			    "(sfsuseinodebasedwritealgorithm=1). "
 			    "Required minimum version for chunk based write algorithm is v{}.",
-			    saunafsVersionToString(masterversion),
+			    saunafsVersionToString(masterVersion),
 			    saunafsVersionToString(kFirstVersionWithChunkBasedWriteAlgorithm));
 		}
 		useInodeBasedWriteAlgorithm = true;
@@ -234,18 +233,18 @@ void wrap_write_init(bool isFromMainThread) {
 	// algorithm and it is intended by params, then we should use it.
 	if (isChunkBasedWriteAlgorithmInitialized() && getUseInodeBasedWriteAlgorithm() &&
 	    !gSaunaFSInitParams.use_inode_based_write_algorithm &&
-	    masterversion >= kFirstVersionWithChunkBasedWriteAlgorithm) {
+	    masterVersion >= kFirstVersionWithChunkBasedWriteAlgorithm) {
 		if (isFromMainThread) {
 			fprintf(stderr,
 			        "New metadata server supports chunk based write algorithm "
 			        "(current master version: %s, required: %s).\n",
-			        saunafsVersionToString(masterversion).c_str(),
+			        saunafsVersionToString(masterVersion).c_str(),
 			        saunafsVersionToString(kFirstVersionWithChunkBasedWriteAlgorithm).c_str());
 		} else {
 			safs::log_warn(
 			    "New metadata server supports chunk based write algorithm "
 			    "(current master version: {}, required: {}).",
-			    saunafsVersionToString(masterversion),
+			    saunafsVersionToString(masterVersion),
 			    saunafsVersionToString(kFirstVersionWithChunkBasedWriteAlgorithm));
 		}
 
@@ -995,9 +994,9 @@ int fs_register_with_new_session(std::vector<std::uint8_t> &registrationMessageB
 	    messageValueIterator == kNewMetaSessionDataLengthWithGoalsAndTrashtimes ||
 	    messageValueIterator == kNewSessionDataLengthGoalsAndTrashtimes ||
 	    messageValueIterator == kNewSessionDataLengthWithIoLimits) {
-		get32bit(&messageFromMaster, masterversion);
+		get32bit(&messageFromMaster, masterVersion);
 	} else {
-		masterversion = 0;
+		masterVersion = 0;
 	}
 
 	get32bit(&messageFromMaster, sessionid);
@@ -1305,7 +1304,7 @@ void* fs_nop_thread(void *arg) {
 				free(inodespacket);
 			}
 
-			if (masterversion >= kFirstVersionWithMountInfoOnMonitoring && !disconnect &&
+			if (masterVersion >= kFirstVersionWithMountInfoOnMonitoring && !disconnect &&
 			    (gChangedTweaksValue || lastDisconnectedStatus)) {
 				gChangedTweaksValue = false;
 				std::string mountInfoStr;
@@ -1777,7 +1776,7 @@ uint8_t fs_setattr(inode_t inode, uint32_t uid, uint32_t gid, uint8_t setmask, u
 	    sizeof(attruid) + sizeof(attrgid) + sizeof(attratime) + sizeof(attrmtime);
 	constexpr uint32_t kPacketSizeWithSugid = kPacketSize + sizeof(sugidclearmode);
 
-	if (masterversion < 0x010619) {
+	if (masterVersion < 0x010619) {
 		wptr = fs_createpacket(rec, CLTOMA_FUSE_SETATTR, kPacketSize);
 	} else {
 		wptr = fs_createpacket(rec, CLTOMA_FUSE_SETATTR, kPacketSizeWithSugid);
@@ -1795,7 +1794,7 @@ uint8_t fs_setattr(inode_t inode, uint32_t uid, uint32_t gid, uint8_t setmask, u
 	put32bit(&wptr,attrgid);
 	put32bit(&wptr,attratime);
 	put32bit(&wptr,attrmtime);
-	if (masterversion>=0x010619) {
+	if (masterVersion>=0x010619) {
 		put8bit(&wptr,sugidclearmode);
 	}
 
@@ -2765,7 +2764,7 @@ uint8_t fs_getxattr(inode_t inode, uint8_t opened, uint32_t uid, uint32_t gid, u
 	uint8_t ret;
 	threc *rec = fs_get_my_threc();
 
-	if (masterversion < saunafsVersion(1, 6, 29)) { return SAUNAFS_ERROR_ENOTSUP; }
+	if (masterVersion < saunafsVersion(1, 6, 29)) { return SAUNAFS_ERROR_ENOTSUP; }
 
 	constexpr uint32_t kPacketHeaderSize =
 	    sizeof(inode) + sizeof(opened) + sizeof(uid) + sizeof(gid) + sizeof(nleng) + sizeof(mode);
@@ -2817,7 +2816,7 @@ uint8_t fs_listxattr(inode_t inode, uint8_t opened, uint32_t uid, uint32_t gid, 
 	uint8_t ret;
 	threc *rec = fs_get_my_threc();
 
-	if (masterversion < saunafsVersion(1, 6, 29)) { return SAUNAFS_ERROR_ENOTSUP; }
+	if (masterVersion < saunafsVersion(1, 6, 29)) { return SAUNAFS_ERROR_ENOTSUP; }
 
 	constexpr uint32_t kPacketSize =
 	    sizeof(inode) + sizeof(opened) + sizeof(uid) + sizeof(gid) + sizeof(uint8_t) + sizeof(mode);
@@ -2866,7 +2865,7 @@ uint8_t fs_setxattr(inode_t inode, uint8_t opened, uint32_t uid, uint32_t gid, u
 	uint8_t ret;
 	threc *rec = fs_get_my_threc();
 
-	if (masterversion < saunafsVersion(1, 6, 29)) { return SAUNAFS_ERROR_ENOTSUP; }
+	if (masterVersion < saunafsVersion(1, 6, 29)) { return SAUNAFS_ERROR_ENOTSUP; }
 
 	if (mode >= XATTR_SMODE_REMOVE) { return SAUNAFS_ERROR_EINVAL; }
 
@@ -2911,7 +2910,7 @@ uint8_t fs_removexattr(inode_t inode, uint8_t opened, uint32_t uid, uint32_t gid
 	uint8_t ret;
 	threc *rec = fs_get_my_threc();
 
-	if (masterversion < saunafsVersion(1, 6, 29)) { return SAUNAFS_ERROR_ENOTSUP; }
+	if (masterVersion < saunafsVersion(1, 6, 29)) { return SAUNAFS_ERROR_ENOTSUP; }
 
 	constexpr uint32_t kPacketHeaderSize = sizeof(inode) + sizeof(opened) + sizeof(uid) +
 	                                       sizeof(gid) + sizeof(nleng) + sizeof(uint32_t) +
@@ -3045,11 +3044,11 @@ uint8_t fs_setacl(inode_t inode, uint32_t uid, uint32_t gid, AclType type,
 
 uint8_t fs_fullpath(inode_t inode, uint32_t uid, uint32_t gid, std::string &fullPath) {
 	threc *rec = fs_get_my_threc();
-	if (masterversion < kFirstVersionWithPathByInodeHiddenFile) {
+	if (masterVersion < kFirstVersionWithPathByInodeHiddenFile) {
 		safs::log_warn(
 		    "fs_fullpath: Operation not supported for current master version: {}, for this operation "
 		    "master version should be {} or higher",
-		    saunafsVersionToString(masterversion),
+		    saunafsVersionToString(masterVersion),
 		    saunafsVersionToString(kFirstVersionWithPathByInodeHiddenFile));
 		return SAUNAFS_ERROR_ENOTSUP;
 	}
@@ -3383,11 +3382,11 @@ uint8_t fs_makesnapshot(inode_t src_inode, inode_t dst_inode, const std::string 
 uint8_t fs_get_self_quota(uint32_t uid, uint32_t gid, inode_t inode,
                           std::vector<QuotaEntry> &quotaEntries) {
 	threc *rec = fs_get_my_threc();
-	if (masterversion < kFirstVersionWithUseQuotaInVolumeSize) {
+	if (masterVersion < kFirstVersionWithUseQuotaInVolumeSize) {
 		safs::log_warn(
 		    "fs_get_self_quota: Operation not supported for current master version: {}, for this operation "
 		    "master version should be {} or higher",
-		    saunafsVersionToString(masterversion),
+		    saunafsVersionToString(masterVersion),
 		    saunafsVersionToString(kFirstVersionWithUseQuotaInVolumeSize));
 		return SAUNAFS_ERROR_ENOTSUP;
 	}

--- a/src/mount/mastercomm.cc
+++ b/src/mount/mastercomm.cc
@@ -2566,16 +2566,16 @@ uint8_t fs_gettrash(const uint8_t **dbuff,uint32_t *dbuffsize) {
 	return ret;
 }
 
-uint8_t fs_getreserved(SaunaClient::NamedInodeOffset off, SaunaClient::NamedInodeOffset max_entries,
-	               std::vector<NamedInodeEntry> &entries) {
+template <typename OffsetT, typename EntryT>
+uint8_t fs_getreserved(OffsetT off, uint32_t max_entries, std::vector<EntryT> &entries) {
 	threc *rec = fs_get_my_threc();
 	auto message = cltoma::fuseGetReserved::build(rec->packetId, off, max_entries);
-	if (!fs_saucreatepacket(rec, message)) {
-		return SAUNAFS_ERROR_IO;
-	}
+	if (!fs_saucreatepacket(rec, message)) { return SAUNAFS_ERROR_IO; }
+
 	if (!fs_sausendandreceive(rec, SAU_MATOCL_FUSE_GETRESERVED, message)) {
 		return SAUNAFS_ERROR_IO;
 	}
+
 	try {
 		PacketVersion dummy_packet_version;
 		uint32_t dummy_message_id;
@@ -2588,16 +2588,17 @@ uint8_t fs_getreserved(SaunaClient::NamedInodeOffset off, SaunaClient::NamedInod
 	}
 }
 
-uint8_t fs_gettrash(SaunaClient::NamedInodeOffset off, SaunaClient::NamedInodeOffset max_entries,
-	            std::vector<NamedInodeEntry> &entries) {
+template uint8_t fs_getreserved<SaunaClient::NamedInodeOffset, NamedInodeEntry>(
+    SaunaClient::NamedInodeOffset, uint32_t, std::vector<NamedInodeEntry> &);
+template uint8_t fs_getreserved<uint64_t, HandleInodeEntry>(uint64_t, uint32_t,
+                                                            std::vector<HandleInodeEntry> &);
+
+template <typename OffsetT, typename EntryT>
+uint8_t fs_gettrash(OffsetT off, uint32_t max_entries, std::vector<EntryT> &entries) {
 	threc *rec = fs_get_my_threc();
 	auto message = cltoma::fuseGetTrash::build(rec->packetId, off, max_entries);
-	if (!fs_saucreatepacket(rec, message)) {
-		return SAUNAFS_ERROR_IO;
-	}
-	if (!fs_sausendandreceive(rec, SAU_MATOCL_FUSE_GETTRASH, message)) {
-		return SAUNAFS_ERROR_IO;
-	}
+	if (!fs_saucreatepacket(rec, message)) { return SAUNAFS_ERROR_IO; }
+	if (!fs_sausendandreceive(rec, SAU_MATOCL_FUSE_GETTRASH, message)) { return SAUNAFS_ERROR_IO; }
 	try {
 		PacketVersion dummy_packet_version;
 		uint32_t dummy_message_id;
@@ -2609,6 +2610,11 @@ uint8_t fs_gettrash(SaunaClient::NamedInodeOffset off, SaunaClient::NamedInodeOf
 		return SAUNAFS_ERROR_IO;
 	}
 }
+
+template uint8_t fs_gettrash<SaunaClient::NamedInodeOffset, NamedInodeEntry>(
+    SaunaClient::NamedInodeOffset, uint32_t, std::vector<NamedInodeEntry> &);
+template uint8_t fs_gettrash<uint64_t, HandleInodeEntry>(uint64_t, uint32_t,
+                                                         std::vector<HandleInodeEntry> &);
 
 uint8_t fs_getdetachedattr(inode_t inode, Attributes &attr) {
 	uint8_t *wptr;

--- a/src/mount/mastercomm.h
+++ b/src/mount/mastercomm.h
@@ -43,6 +43,8 @@
 inline std::atomic_bool gIsDisconnectedFromMaster;
 #endif
 
+inline std::atomic<uint32_t> masterVersion;
+
 inline std::mutex acquiredFileMutex;
 // <inode, cnt> and sorted by inode
 using AcquiredFileMap = std::map<inode_t, uint32_t>;

--- a/src/mount/mastercomm.h
+++ b/src/mount/mastercomm.h
@@ -34,10 +34,11 @@
 #ifdef _WIN32
 #include "mount/acquired_files_last_time_used.h"
 #endif
-#include "protocol/packet.h"
-#include "protocol/lock_info.h"
 #include "protocol/directory_entry.h"
+#include "protocol/handle_inode_entry.h"
+#include "protocol/lock_info.h"
 #include "protocol/named_inode_entry.h"
+#include "protocol/packet.h"
 
 #ifdef _WIN32
 inline std::atomic_bool gIsDisconnectedFromMaster;
@@ -114,11 +115,11 @@ uint8_t fs_setacl(inode_t inode, uint32_t uid, uint32_t gid, AclType type,
 uint8_t fs_fullpath(inode_t inode, uint32_t uid, uint32_t gid, std::string &fullPath);
 
 uint8_t fs_getreserved(const uint8_t **dbuff, uint32_t *dbuffsize);
-uint8_t fs_getreserved(SaunaClient::NamedInodeOffset off, SaunaClient::NamedInodeOffset max_entries,
-                       std::vector<NamedInodeEntry> &entries);
+template <typename OffsetT, typename EntryT>
+uint8_t fs_getreserved(OffsetT off, uint32_t max_entries, std::vector<EntryT> &entries);
 uint8_t fs_gettrash(const uint8_t **dbuff, uint32_t *dbuffsize);
-uint8_t fs_gettrash(SaunaClient::NamedInodeOffset off, SaunaClient::NamedInodeOffset max_entries,
-                    std::vector<NamedInodeEntry> &entries);
+template <typename OffsetT, typename EntryT>
+uint8_t fs_gettrash(OffsetT off, uint32_t max_entries, std::vector<EntryT> &entries);
 uint8_t fs_getdetachedattr(inode_t inode, Attributes &attr);
 uint8_t fs_gettrashpath(inode_t inode, const uint8_t **path);
 uint8_t fs_settrashpath(inode_t inode, const uint8_t *path);

--- a/src/protocol/cltoma.h
+++ b/src/protocol/cltoma.h
@@ -397,15 +397,27 @@ SAUNAFS_DEFINE_PACKET_SERIALIZATION(cltoma, fuseGetDir, SAU_CLTOMA_FUSE_GETDIR, 
 		uint64_t, first_entry,
 		uint64_t, number_of_entries)
 
-SAUNAFS_DEFINE_PACKET_SERIALIZATION(cltoma, fuseGetReserved, SAU_CLTOMA_FUSE_GETRESERVED, 0,
+SAUNAFS_DEFINE_PACKET_VERSION(cltoma, fuseGetReserved, kClientPositionOffset, 0)
+SAUNAFS_DEFINE_PACKET_VERSION(cltoma, fuseGetReserved, kClientHandleOffset, 1)
+SAUNAFS_DEFINE_PACKET_SERIALIZATION(cltoma, fuseGetReserved, SAU_CLTOMA_FUSE_GETRESERVED, kClientPositionOffset,
 		uint32_t, msgid,
 		uint32_t, off,
 		uint32_t, max_entries)
+SAUNAFS_DEFINE_PACKET_SERIALIZATION(cltoma, fuseGetReserved, SAU_CLTOMA_FUSE_GETRESERVED, kClientHandleOffset,
+		uint32_t, msgid,
+		uint64_t, handleOffset,
+		uint32_t, maxEntries)
 
-SAUNAFS_DEFINE_PACKET_SERIALIZATION(cltoma, fuseGetTrash, SAU_CLTOMA_FUSE_GETTRASH, 0,
+SAUNAFS_DEFINE_PACKET_VERSION(cltoma, fuseGetTrash, kClientPositionOffset, 0)
+SAUNAFS_DEFINE_PACKET_VERSION(cltoma, fuseGetTrash, kClientHandleOffset, 1)
+SAUNAFS_DEFINE_PACKET_SERIALIZATION(cltoma, fuseGetTrash, SAU_CLTOMA_FUSE_GETTRASH, kClientPositionOffset,
 		uint32_t, msgid,
 		uint32_t, off,
 		uint32_t, max_entries)
+SAUNAFS_DEFINE_PACKET_SERIALIZATION(cltoma, fuseGetTrash, SAU_CLTOMA_FUSE_GETTRASH, kClientHandleOffset,
+		uint32_t, msgid,
+		uint64_t, handleOffset,
+		uint32_t, maxEntries)
 
 SAUNAFS_DEFINE_PACKET_SERIALIZATION(
 		cltoma, listTasks, SAU_CLTOMA_LIST_TASKS, 0,

--- a/src/protocol/handle_inode_entry.h
+++ b/src/protocol/handle_inode_entry.h
@@ -1,0 +1,29 @@
+/*
+   Copyright 2023 Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "common/platform.h"
+
+#include "common/serialization_macros.h"
+#include "common/type_defs.h"
+
+SAUNAFS_DEFINE_SERIALIZABLE_CLASS(HandleInodeEntry,
+	uint64_t, data,
+	std::string, name,
+	inode_t, inode);

--- a/src/protocol/matocl.h
+++ b/src/protocol/matocl.h
@@ -40,6 +40,7 @@
 #include "common/serialized_goal.h"
 #include "protocol/chunkserver_list_entry.h"
 #include "protocol/directory_entry.h"
+#include "protocol/handle_inode_entry.h"
 #include "protocol/lock_info.h"
 #include "protocol/named_inode_entry.h"
 #include "protocol/mount_info_entry.h"
@@ -462,15 +463,27 @@ SAUNAFS_DEFINE_PACKET_SERIALIZATION(
 		uint64_t, first_entry_index, //TODO remove (not needed)
 		std::vector<DirectoryEntry>, dir_entry)
 
+SAUNAFS_DEFINE_PACKET_VERSION(matocl, fuseGetReserved, kResponseNamedInodeEntry, 0)
+SAUNAFS_DEFINE_PACKET_VERSION(matocl, fuseGetReserved, kResponseHandleInodeEntry, 1)
 SAUNAFS_DEFINE_PACKET_SERIALIZATION(
-		matocl, fuseGetReserved, SAU_MATOCL_FUSE_GETRESERVED, 0,
+		matocl, fuseGetReserved, SAU_MATOCL_FUSE_GETRESERVED, kResponseNamedInodeEntry,
 		uint32_t, msgid,
 		std::vector<NamedInodeEntry>, entries)
+SAUNAFS_DEFINE_PACKET_SERIALIZATION(
+		matocl, fuseGetReserved, SAU_MATOCL_FUSE_GETRESERVED, kResponseHandleInodeEntry,
+		uint32_t, msgid,
+		std::vector<HandleInodeEntry>, entries)
 
+SAUNAFS_DEFINE_PACKET_VERSION(matocl, fuseGetTrash, kResponseNamedInodeEntry, 0)
+SAUNAFS_DEFINE_PACKET_VERSION(matocl, fuseGetTrash, kResponseHandleInodeEntry, 1)
 SAUNAFS_DEFINE_PACKET_SERIALIZATION(
-		matocl, fuseGetTrash, SAU_MATOCL_FUSE_GETTRASH, 0,
+		matocl, fuseGetTrash, SAU_MATOCL_FUSE_GETTRASH, kResponseNamedInodeEntry,
 		uint32_t, msgid,
 		std::vector<NamedInodeEntry>, entries)
+SAUNAFS_DEFINE_PACKET_SERIALIZATION(
+		matocl, fuseGetTrash, SAU_MATOCL_FUSE_GETTRASH, kResponseHandleInodeEntry,
+		uint32_t, msgid,
+		std::vector<HandleInodeEntry>, entries)
 
 SAUNAFS_DEFINE_PACKET_SERIALIZATION(
 		matocl, listTasks, SAU_MATOCL_LIST_TASKS, 0,

--- a/tests/test_suites/ShortSystemTests/test_trash_long_readdir.sh
+++ b/tests/test_suites/ShortSystemTests/test_trash_long_readdir.sh
@@ -1,0 +1,22 @@
+timeout_set "5 minutes"
+
+# Mount1 will be used for meta operations
+MOUNTS=2 \
+	CHUNKSERVERS=1 \
+	USE_RAMDISK=YES \
+	SFSEXPORTS_META_EXTRA_OPTIONS="nonrootmeta" \
+	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER" \
+	MOUNT_1_EXTRA_CONFIG="sfsmeta" \
+	setup_local_empty_saunafs info
+
+trash="${info[mount1]}/trash"
+
+# Create a folder and set long trashtime on it
+# which will be (1 hour before freeing trashed files)
+mkdir "${info[mount0]}/dir"
+saunafs setgoal 1 "${info[mount0]}/dir"
+saunafs settrashtime 3600 "${info[mount0]}/dir"
+
+big-session-metadata-benchmark "${info[mount0]}/dir" "200000" "--create-delete-only"
+
+assert_eventually_prints "200001" "ls $trash | wc -l"

--- a/utils/big_session_metadata_benchmark.cc
+++ b/utils/big_session_metadata_benchmark.cc
@@ -32,7 +32,7 @@ void showHelpMessageAndExit(char *progName, int status) {
 	    << "Usage:\n"
 	       "    "
 	    << progName
-	    << " <TESTING_PATH> <NUMBER_OF_FILES> [--rev|--rand]\n\n"
+	    << " <TESTING_PATH> <NUMBER_OF_FILES> [--rev|--rand|--create-delete-only]\n\n"
 	       "    Performs the following operations:\n"
 	       "       - create a folder "
 	       "'big_sessions_metadata_benchmark_<TIMESTAMP>' in the provided "
@@ -47,7 +47,8 @@ void showHelpMessageAndExit(char *progName, int status) {
 	       "        --rev     Reverse the order of closing and deleting the "
 	       "files.\n"
 	       "        --rand    Randomize the order of closing and deleting the "
-	       "files.\n\n"
+	       "files.\n"
+	       "        --create-delete-only  Only create and delete files.\n\n"
 	       "    Note: NUMBER_OF_FILES must be positive.\n"
 	    << std::endl;
 	exit(status);
@@ -62,12 +63,15 @@ int main(int argc, char **argv) {
 	int numberOfFiles = atoi(argv[2]);
 	bool reverseLastOperations = false;
 	bool randomizeLastOperations = false;
+	bool onlyCreateDeleteFiles = false;
 
 	if (argc == 4) {
 		if (strcmp(argv[3], "--rev") == 0) {
 			reverseLastOperations = true;
 		} else if (strcmp(argv[3], "--rand") == 0) {
 			randomizeLastOperations = true;
+		} else if (strcmp(argv[3], "--create-delete-only") == 0) {
+			onlyCreateDeleteFiles = true;
 		} else {
 			showHelpMessageAndExit(argv[0], 1);
 		}
@@ -111,6 +115,13 @@ int main(int argc, char **argv) {
 			          << " seconds.\n";
 			chunkStart = chunkEnd;
 		}
+
+		if (onlyCreateDeleteFiles) {
+			if (close(testFilesFds[i]) == -1) {
+				std::cerr << "Failed to close file '" << filePath << "'." << std::endl;
+				return 1;
+			}
+		}
 	}
 	auto afterOpen = std::chrono::high_resolution_clock::now();
 	std::chrono::duration<double> elapsedTime = afterOpen - start;
@@ -125,17 +136,19 @@ int main(int argc, char **argv) {
 		std::shuffle(filesOrder.begin(), filesOrder.end(), rng);
 	}
 
-	// to make sure the reversing or randomizing is not included
-	afterOpen = std::chrono::high_resolution_clock::now();
+	if (!onlyCreateDeleteFiles) {
+		// to make sure the reversing or randomizing is not included
+		afterOpen = std::chrono::high_resolution_clock::now();
 
-	for (int i = 0; i < numberOfFiles; i++) {
-		// closing the filesOrder[i]-th file
-		auto fd = testFilesFds[filesOrder[i]];
+		for (int i = 0; i < numberOfFiles; i++) {
+			// closing the filesOrder[i]-th file
+			auto fd = testFilesFds[filesOrder[i]];
 
-		if (close(fd) == -1) {
-			std::cerr << "Failed to close file '" << folderPath << "/file_"
-			          << filesOrder[i] << "'." << std::endl;
-			return 1;
+			if (close(fd) == -1) {
+				std::cerr << "Failed to close file '" << folderPath << "/file_" << filesOrder[i]
+				          << "'." << std::endl;
+				return 1;
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR improves the listing of trash and reserved files for meta mountpoints. Previously, the meta client requested a fixed batch of up to 100,000 entries from the trash or reserved containers, always starting from the beginning. This limited the ability to efficiently list all entries in large directories.

To address this, new data structures were introduced on the master side to maintain trash and reserved entries ordered by unique generated ID value. Each entry in these structures contains the corresponding name and inode, allowing efficient lookups and ordered traversal.

The FUSE readdir implementation for meta mountpoints now uses a unique generated ID of the next entry as the offset, enabling efficient batched listing. Entries are cached in batches of 100,000 on the meta mountpoint, and if more entries are needed, additional batches are requested using the last hash as the offset.

For compatibility with userland expectations (which require non-decreasing positive offsets), only the lower 63 bits of the unique generated IDs are used for offsets, reducing the id space by half but avoiding issues with negative values on the offsets.