### PR TITLE
fix: Fix writes during crashes/stops

### DIFF
--- a/src/master/chunks.cc
+++ b/src/master/chunks.cc
@@ -801,6 +801,15 @@ void chunk_emergency_increase_version(Chunk *c) {
 	fs_incversion(c->chunkid);
 }
 
+void chunk_finalize_failed_operation(Chunk *c) {
+	if (c->operation == Chunk::CREATE) {
+		matoclserv_chunk_status(c->chunkid, SAUNAFS_ERROR_CHUNKLOST, true);
+	} else {
+		matoclserv_chunk_status(c->chunkid, SAUNAFS_ERROR_NOTDONE);
+	}
+	c->operation = Chunk::NONE;
+}
+
 void chunk_handle_disconnected_copies(Chunk *c) {
 	auto it = std::remove_if(c->parts.begin(), c->parts.end(), [](const ChunkPart &part) {
 		return csdb_find(part.csid)->eptr == nullptr;
@@ -823,8 +832,7 @@ void chunk_handle_disconnected_copies(Chunk *c) {
 			if (c->isWritable()) {
 				chunk_emergency_increase_version(c);
 			} else {
-				matoclserv_chunk_status(c->chunkid,SAUNAFS_ERROR_NOTDONE);
-				c->operation = Chunk::NONE;
+				chunk_finalize_failed_operation(c);
 			}
 		}
 	}
@@ -1754,8 +1762,7 @@ void chunk_operation_status(Chunk *c, ChunkPartType chunkType, uint8_t status,ma
 				c->needverincrease = 0;
 			}
 		} else {
-			matoclserv_chunk_status(c->chunkid,SAUNAFS_ERROR_NOTDONE);
-			c->operation = Chunk::NONE;
+			chunk_finalize_failed_operation(c);
 		}
 	}
 }

--- a/src/master/filesystem.h
+++ b/src/master/filesystem.h
@@ -123,6 +123,7 @@ uint8_t fs_mknod(const FsContext &context, inode_t parent, const HString &name, 
                  uint16_t mode, uint16_t umask, uint32_t rdev, inode_t *inode, Attributes &attr);
 uint8_t fs_mkdir(const FsContext &context, inode_t parent, const HString &name, uint16_t mode,
                  uint16_t umask, uint8_t copysgid, inode_t *inode, Attributes &attr);
+uint8_t fs_remove_chunk_from_file(const FsContext &context, inode_t inode, uint64_t chunkId);
 uint8_t fs_repair(const FsContext &context, inode_t inode, uint8_t correct_only,
                   uint32_t *notchanged, uint32_t *erased, uint32_t *repaired);
 uint8_t fs_rmdir(const FsContext &context, inode_t parent, const HString &name);

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -2159,6 +2159,53 @@ uint8_t fs_apply_incversion(uint64_t chunkid) {
 }
 
 #ifndef METARESTORE
+uint8_t fs_remove_chunk_from_file(const FsContext &context, inode_t inode, uint64_t chunkId) {
+	uint32_t ts = eventloop_time();
+	ChecksumUpdater cu(ts);
+	StatsRecord psr, nsr;
+	FSNode *p;
+
+	if (chunkId == 0) { return SAUNAFS_ERROR_NOCHUNK; }
+
+	uint8_t status = verify_session(context, OperationMode::kReadWrite, SessionType::kAny);
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+
+	status =
+	    fsnodes_get_node_for_operation(context, ExpectedNodeType::kFile, MODE_MASK_W, inode, &p);
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+
+	auto *node_file = dynamic_cast<FSNodeFile *>(p);
+	fsnodes_get_stats(p, &psr);
+	auto it = std::ranges::find(node_file->chunks, chunkId);
+	uint32_t indx = (it == node_file->chunks.end()) ? node_file->chunks.size()
+	                                                : std::distance(node_file->chunks.begin(), it);
+
+	// not found
+	if (indx == node_file->chunks.size()) { return SAUNAFS_ERROR_NOCHUNK; }
+
+	status = chunk_delete_file(chunkId, p->goal);
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+
+	node_file->chunks[indx] = 0;
+	p->mtime = ts;
+	fsnodes_update_ctime(p, ts);
+
+	// Log the repair operation with new version 0 (indicating deletion)
+	uint32_t nversion = 0;
+	fs_changelog(ts, "REPAIR(%" PRIiNode ",%" PRIu32 "):%" PRIu32, inode, indx, nversion);
+
+	fsnodes_get_stats(p, &nsr);
+	for (const auto &[parentId, _] : p->parents) {
+		auto *parent = fsnodes_id_to_node_verify<FSNodeDirectory>(parentId);
+		fsnodes_add_sub_stats(parent, &nsr, &psr);
+	}
+	fsnodes_quota_update(p, {{QuotaResource::kSize, nsr.size - psr.size}});
+	fsnodes_update_checksum(p);
+	return SAUNAFS_STATUS_OK;
+}
+#endif /* #ifndef METARESTORE */
+
+#ifndef METARESTORE
 uint8_t fs_repair(const FsContext &context, inode_t inode,
 		uint8_t correct_only, uint32_t *notchanged, uint32_t *erased, uint32_t *repaired) {
 	uint32_t ts = eventloop_time();

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -1150,7 +1150,7 @@ uint8_t matoclserv_fuse_write_chunk_respond(matoclserventry *eptr,
 	return status;
 }
 
-void matoclserv_chunk_status(uint64_t chunkId, uint8_t status) {
+void matoclserv_chunk_status(uint64_t chunkId, uint8_t status, bool isFailedCreateOperation) {
 	DelayedChunkOperation *operation;
 	const PacketSerializer *serializer;
 
@@ -1208,6 +1208,9 @@ void matoclserv_chunk_status(uint64_t chunkId, uint8_t status) {
 	switch (operationType) {
 	case FUSE_WRITE:
 		if (status != SAUNAFS_STATUS_OK) {
+			if (isFailedCreateOperation) {
+				fs_remove_chunk_from_file(context, inode, chunkId);
+			}
 			serializer->serializeFuseWriteChunk(reply, messageId, status);
 			matoclserv_createpacket(eptr, std::move(reply));
 		} else {

--- a/src/master/matoclserv.h
+++ b/src/master/matoclserv.h
@@ -37,7 +37,10 @@ void matoclserv_stats(uint64_t stats[5]);
 /// Sends the status of a delayed operation associated with a chunk over the network.
 /// @param chunkId The ID of the chunk associated with the delayed operation
 /// @param status  The status of the operation, (e.g., SAUNAFS_STATUS_OK, SAUNAFS_ERROR_NOTDONE)
-void matoclserv_chunk_status(uint64_t chunkId, uint8_t status);
+/// @param isFailedCreateOperation True if the operation was a failed create operation, false
+/// otherwise
+void matoclserv_chunk_status(uint64_t chunkId, uint8_t status,
+                             bool isFailedCreateOperation = false);
 
 /// Adds an open file to the list of open files for a given session.
 /// @param sessionId The ID of the session to which the open file will be added


### PR DESCRIPTION
It was noticed during some upgrade tests that chunks were lost after
restarting the master while writing to the cluster. This issue is
related to the scarse failures of the test
test_network_partition_during_writes. Both of those issues should be
fixed with the proposed changes.

The troublesome situation is the following:
- during the creation of a chunk, the master needs to ask the
chunkservers to create the chunk parts and waits for it.
- when the replies arrive, if succesful, the master replies with OK
status to the client, but if that is not the case then it replies
SAUNAFS_ERROR_NOTDONE.
- this makes the write operation in the client to fail and leaves a
chunk lost behind.

The proposed solution changes the master behavior in the case of a
failed chunk creation:
- the function that replies to the client also removes the chunk from
the file list of chunks.
- the returned status was changed to SAUNAFS_ERROR_CHUNKLOST,
allowing the retry from client side.

The chunk structure deletion in master will come in the next chunks
loop (it does not have any files pointing to it) and in chunkserver
side right after it.

Co-authored-by: Urmas Rist <urmas@leil.io>
Signed-off-by: Dave <dave@leil.io>