### PR TITLE
feat: Upgrade SaunaFS FSAL to Ganesha v6.5

### DIFF
--- a/.github/workflows/run-unit-and-ganesha-tests.yml
+++ b/.github/workflows/run-unit-and-ganesha-tests.yml
@@ -31,10 +31,81 @@ jobs:
             #- name: Setup a new (or from cache) vcpkg
             #  uses: lukka/run-vcpkg@v11
 
-            - name: Install nfs-ganesha v4.3 from Ubuntu repository
+            - name: Build and install Ganesha v6.5
               run: |
-                  sudo apt update
-                  sudo apt install -y nfs-common nfs-ganesha nfs-ganesha-vfs
+                set -eux
+                # Install build dependencies
+                sudo apt update
+                sudo apt install -y --no-install-recommends \
+                    acl \
+                    asciidoc \
+                    bison \
+                    build-essential \
+                    byacc \
+                    cmake \
+                    dbus \
+                    docbook \
+                    docbook-xml \
+                    doxygen \
+                    fio \
+                    flex \
+                    krb5-user \
+                    libacl1-dev \
+                    libblkid-dev \
+                    libboost-filesystem-dev \
+                    libboost-iostreams-dev \
+                    libboost-program-options-dev \
+                    libboost-system-dev \
+                    libcap-dev \
+                    libdbus-1-dev \
+                    libgssapi-krb5-2 \
+                    libjemalloc-dev \
+                    libjudy-dev \
+                    libkrb5-dev \
+                    libkrb5support0 \
+                    libnfsidmap-dev \
+                    libnsl-dev \
+                    libsqlite3-dev \
+                    libtirpc-dev \
+                    liburcu-dev \
+                    nfs-common \
+                    pkg-config \
+                    pv \
+                    wget \
+                    unzip \
+                    rpcbind
+
+                # Clone and build ntirpc
+                cd $GITHUB_WORKSPACE
+                wget https://github.com/nfs-ganesha/ntirpc/archive/v6.3.zip
+                unzip v6.3.zip
+                cd ntirpc-6.3
+                mkdir build
+                cmake -B build . -DCMAKE_INSTALL_PREFIX=/usr
+                sudo cmake --build build --target install
+
+                # Clone and build Ganesha v6.5
+                cd $GITHUB_WORKSPACE
+                wget https://github.com/nfs-ganesha/nfs-ganesha/archive/V6.5.zip
+                unzip V6.5.zip
+                ln -s $GITHUB_WORKSPACE/ntirpc-6.3 $GITHUB_WORKSPACE/nfs-ganesha-6.5/src/libntirpc
+                cd nfs-ganesha-6.5
+                mkdir $GITHUB_WORKSPACE/ganesha-build
+                cmake -B $GITHUB_WORKSPACE/ganesha-build src \
+                    -DCMAKE_INSTALL_PREFIX=/usr \
+                    -DUSE_FSAL_CEPH=OFF \
+                    -DUSE_FSAL_GLUSTER=OFF \
+                    -DUSE_FSAL_GPFS=OFF \
+                    -DUSE_FSAL_KVSFS=OFF \
+                    -DUSE_FSAL_LIZARDFS=OFF \
+                    -DUSE_FSAL_LUSTRE=OFF \
+                    -DUSE_FSAL_PROXY_V3=OFF \
+                    -DUSE_FSAL_PROXY_V4=OFF \
+                    -DUSE_FSAL_RGW=OFF \
+                    -DUSE_FSAL_XFS=OFF \
+                    -DUSE_GSS=OFF \
+                    -DUSE_SYSTEM_NTIRPC=ON
+                sudo cmake --build $GITHUB_WORKSPACE/ganesha-build --target install
 
             - name: Set up Python
               uses: actions/setup-python@v4

--- a/README.md
+++ b/README.md
@@ -111,6 +111,12 @@ events.
 
 Join us and be part of the discussion.
 
+## Licensing
+
+Most of the software is licensed under GPLv3, except the Ganesha FSAL, which is
+licensed LGPLv3 and located under `src/nfs-ganesha/`. See the [FSAL LICENSE
+file](src/nfs-ganesha/LICENSE) for more info.
+
 ### Other ways to contact us
 | Method                     | Link                                                          |
 |----------------------------|---------------------------------------------------------------|

--- a/cmake/Libraries.cmake
+++ b/cmake/Libraries.cmake
@@ -156,10 +156,10 @@ message(STATUS "ISAL PIC LIBRARY: ${ISAL_PIC_LIBRARY}")
 
 # Download nfs-ganesha
 if(ENABLE_NFS_GANESHA)
-  download_external(NFS_GANESHA "nfs-ganesha-4.3"
-                    "https://github.com/nfs-ganesha/nfs-ganesha/archive/V4.3.zip")
-  download_external(NTIRPC "ntirpc-4.3"
-                    "https://github.com/nfs-ganesha/ntirpc/archive/v4.3.zip")
+  download_external(NFS_GANESHA "nfs-ganesha-6.5"
+                    "https://github.com/nfs-ganesha/nfs-ganesha/archive/V6.5.zip")
+  download_external(NTIRPC "ntirpc-6.3"
+                    "https://github.com/nfs-ganesha/ntirpc/archive/v6.3.zip")
 endif()
 
 # Find Prometheus

--- a/src/nfs-ganesha/LICENSE
+++ b/src/nfs-ganesha/LICENSE
@@ -1,0 +1,165 @@
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.

--- a/src/nfs-ganesha/context_wrap.c
+++ b/src/nfs-ganesha/context_wrap.c
@@ -1,22 +1,24 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
 /*
 
    Copyright 2017 Skytechnology sp. z o.o.
    Copyright 2023 Leil Storage OÜ
 
-   This file is part of SaunaFS.
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 3 of the License, or (at your option) any later version.
 
-   SaunaFS is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, version 3.
-
-   SaunaFS is distributed in the hope that it will be useful,
+   This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
 
-   You should have received a copy of the GNU General Public License
-   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
- */
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301 USA
+*/
 
 #include "context_wrap.h"
 #include "saunafs_internal.h"

--- a/src/nfs-ganesha/context_wrap.c
+++ b/src/nfs-ganesha/context_wrap.c
@@ -20,11 +20,12 @@
    02110-1301 USA
 */
 
-#include "context_wrap.h"
-#include "saunafs_internal.h"
+#include "nfs-ganesha/context_wrap.h"
 
-int saunafs_lookup(sau_t *instance, struct user_cred *cred, sau_inode_t parent,
-                   const char *path, struct sau_entry *entry) {
+#include "nfs-ganesha/saunafs_internal.h"
+
+int saunafs_lookup(sau_t *instance, struct user_cred *cred, sau_inode_t parent, const char *path,
+                   struct sau_entry *entry) {
 	sau_context_t *context __attribute__((cleanup(sau_destroy_context))) = NULL;
 	context = createContext(instance, cred);
 
@@ -35,9 +36,8 @@ int saunafs_lookup(sau_t *instance, struct user_cred *cred, sau_inode_t parent,
 	return sau_lookup(instance, context, parent, path, entry);
 }
 
-int saunafs_mknode(sau_t *instance, struct user_cred *cred, sau_inode_t parent,
-                   const char *path, mode_t mode, dev_t rdev,
-                   struct sau_entry *entry) {
+int saunafs_mknode(sau_t *instance, struct user_cred *cred, sau_inode_t parent, const char *path,
+                   mode_t mode, dev_t rdev, struct sau_entry *entry) {
 	sau_context_t *context __attribute__((cleanup(sau_destroy_context))) = NULL;
 	context = createContext(instance, cred);
 
@@ -48,8 +48,7 @@ int saunafs_mknode(sau_t *instance, struct user_cred *cred, sau_inode_t parent,
 	return sau_mknod(instance, context, parent, path, mode, rdev, entry);
 }
 
-fileinfo_t *saunafs_open(sau_t *instance, struct user_cred *cred,
-                         sau_inode_t inode, int flags) {
+fileinfo_t *saunafs_open(sau_t *instance, struct user_cred *cred, sau_inode_t inode, int flags) {
 	sau_context_t *context __attribute__((cleanup(sau_destroy_context))) = NULL;
 	context = createContext(instance, cred);
 
@@ -60,9 +59,8 @@ fileinfo_t *saunafs_open(sau_t *instance, struct user_cred *cred,
 	return sau_open(instance, context, inode, flags);
 }
 
-ssize_t saunafs_read(sau_t *instance, struct user_cred *cred,
-                     fileinfo_t *fileinfo, off_t offset, size_t size,
-                     char *buffer) {
+ssize_t saunafs_read(sau_t *instance, struct user_cred *cred, fileinfo_t *fileinfo, off_t offset,
+                     size_t size, char *buffer) {
 	sau_context_t *context __attribute__((cleanup(sau_destroy_context))) = NULL;
 
 	if (fileinfo == NULL) {
@@ -78,9 +76,8 @@ ssize_t saunafs_read(sau_t *instance, struct user_cred *cred,
 	return sau_read(instance, context, fileinfo, offset, size, buffer);
 }
 
-ssize_t saunafs_write(sau_t *instance, struct user_cred *cred,
-                      fileinfo_t *fileinfo, off_t offset, size_t size,
-                      const char *buffer) {
+ssize_t saunafs_write(sau_t *instance, struct user_cred *cred, fileinfo_t *fileinfo, off_t offset,
+                      size_t size, const char *buffer) {
 	sau_context_t *context __attribute__((cleanup(sau_destroy_context))) = NULL;
 
 	if (fileinfo == NULL) {
@@ -96,8 +93,7 @@ ssize_t saunafs_write(sau_t *instance, struct user_cred *cred,
 	return sau_write(instance, context, fileinfo, offset, size, buffer);
 }
 
-int saunafs_flush(sau_t *instance, struct user_cred *cred,
-                  fileinfo_t *fileinfo) {
+int saunafs_flush(sau_t *instance, struct user_cred *cred, fileinfo_t *fileinfo) {
 	sau_context_t *context __attribute__((cleanup(sau_destroy_context))) = NULL;
 
 	if (fileinfo == NULL) {
@@ -125,8 +121,7 @@ int saunafs_getattr(sau_t *instance, struct user_cred *cred, sau_inode_t inode,
 	return sau_getattr(instance, context, inode, reply);
 }
 
-fileinfo_t *saunafs_opendir(sau_t *instance, struct user_cred *cred,
-                            sau_inode_t inode) {
+fileinfo_t *saunafs_opendir(sau_t *instance, struct user_cred *cred, sau_inode_t inode) {
 	sau_context_t *context __attribute__((cleanup(sau_destroy_context))) = NULL;
 	context = createContext(instance, cred);
 
@@ -137,9 +132,8 @@ fileinfo_t *saunafs_opendir(sau_t *instance, struct user_cred *cred,
 	return sau_opendir(instance, context, inode);
 }
 
-int saunafs_readdir(sau_t *instance, struct user_cred *cred,
-                    struct sau_fileinfo *fileinfo, off_t offset,
-                    size_t max_entries, struct sau_direntry *buf,
+int saunafs_readdir(sau_t *instance, struct user_cred *cred, struct sau_fileinfo *fileinfo,
+                    off_t offset, size_t max_entries, struct sau_direntry *buf,
                     size_t *num_entries) {
 	sau_context_t *context __attribute__((cleanup(sau_destroy_context))) = NULL;
 	context = createContext(instance, cred);
@@ -148,12 +142,11 @@ int saunafs_readdir(sau_t *instance, struct user_cred *cred,
 		return -1;
 	}
 
-	return sau_readdir(instance, context, fileinfo, offset, max_entries, buf,
-	                   num_entries);
+	return sau_readdir(instance, context, fileinfo, offset, max_entries, buf, num_entries);
 }
 
-int saunafs_mkdir(sau_t *instance, struct user_cred *cred, sau_inode_t parent,
-                  const char *name, mode_t mode, struct sau_entry *out_entry) {
+int saunafs_mkdir(sau_t *instance, struct user_cred *cred, sau_inode_t parent, const char *name,
+                  mode_t mode, struct sau_entry *out_entry) {
 	sau_context_t *context __attribute__((cleanup(sau_destroy_context))) = NULL;
 	context = createContext(instance, cred);
 
@@ -164,8 +157,7 @@ int saunafs_mkdir(sau_t *instance, struct user_cred *cred, sau_inode_t parent,
 	return sau_mkdir(instance, context, parent, name, mode, out_entry);
 }
 
-int saunafs_rmdir(sau_t *instance, struct user_cred *cred, sau_inode_t parent,
-                  const char *name) {
+int saunafs_rmdir(sau_t *instance, struct user_cred *cred, sau_inode_t parent, const char *name) {
 	sau_context_t *context __attribute__((cleanup(sau_destroy_context))) = NULL;
 	context = createContext(instance, cred);
 
@@ -176,8 +168,7 @@ int saunafs_rmdir(sau_t *instance, struct user_cred *cred, sau_inode_t parent,
 	return sau_rmdir(instance, context, parent, name);
 }
 
-int saunafs_unlink(sau_t *instance, struct user_cred *cred, sau_inode_t parent,
-                   const char *name) {
+int saunafs_unlink(sau_t *instance, struct user_cred *cred, sau_inode_t parent, const char *name) {
 	sau_context_t *context __attribute__((cleanup(sau_destroy_context))) = NULL;
 	context = createContext(instance, cred);
 
@@ -188,9 +179,8 @@ int saunafs_unlink(sau_t *instance, struct user_cred *cred, sau_inode_t parent,
 	return sau_unlink(instance, context, parent, name);
 }
 
-int saunafs_setattr(sau_t *instance, struct user_cred *cred, sau_inode_t inode,
-                    struct stat *stbuf, int to_set,
-                    struct sau_attr_reply *reply) {
+int saunafs_setattr(sau_t *instance, struct user_cred *cred, sau_inode_t inode, struct stat *stbuf,
+                    int to_set, struct sau_attr_reply *reply) {
 	sau_context_t *context __attribute__((cleanup(sau_destroy_context))) = NULL;
 	context = createContext(instance, cred);
 
@@ -201,8 +191,7 @@ int saunafs_setattr(sau_t *instance, struct user_cred *cred, sau_inode_t inode,
 	return sau_setattr(instance, context, inode, stbuf, to_set, reply);
 }
 
-int saunafs_fsync(sau_t *instance, struct user_cred *cred,
-                  struct sau_fileinfo *fileinfo) {
+int saunafs_fsync(sau_t *instance, struct user_cred *cred, struct sau_fileinfo *fileinfo) {
 	sau_context_t *context __attribute__((cleanup(sau_destroy_context))) = NULL;
 	context = createContext(instance, cred);
 
@@ -213,9 +202,8 @@ int saunafs_fsync(sau_t *instance, struct user_cred *cred,
 	return sau_fsync(instance, context, fileinfo);
 }
 
-int saunafs_rename(sau_t *instance, struct user_cred *cred, sau_inode_t parent,
-                   const char *name, sau_inode_t new_parent,
-                   const char *new_name) {
+int saunafs_rename(sau_t *instance, struct user_cred *cred, sau_inode_t parent, const char *name,
+                   sau_inode_t new_parent, const char *new_name) {
 	sau_context_t *context __attribute__((cleanup(sau_destroy_context))) = NULL;
 	context = createContext(instance, cred);
 
@@ -226,9 +214,8 @@ int saunafs_rename(sau_t *instance, struct user_cred *cred, sau_inode_t parent,
 	return sau_rename(instance, context, parent, name, new_parent, new_name);
 }
 
-int saunafs_symlink(sau_t *instance, struct user_cred *cred, const char *link,
-                    sau_inode_t parent, const char *name,
-                    struct sau_entry *entry) {
+int saunafs_symlink(sau_t *instance, struct user_cred *cred, const char *link, sau_inode_t parent,
+                    const char *name, struct sau_entry *entry) {
 	sau_context_t *context __attribute__((cleanup(sau_destroy_context))) = NULL;
 	context = createContext(instance, cred);
 
@@ -239,8 +226,8 @@ int saunafs_symlink(sau_t *instance, struct user_cred *cred, const char *link,
 	return sau_symlink(instance, context, link, parent, name, entry);
 }
 
-int saunafs_readlink(sau_t *instance, struct user_cred *cred, sau_inode_t inode,
-                     char *buf, size_t size) {
+int saunafs_readlink(sau_t *instance, struct user_cred *cred, sau_inode_t inode, char *buf,
+                     size_t size) {
 	sau_context_t *context __attribute__((cleanup(sau_destroy_context))) = NULL;
 	context = createContext(instance, cred);
 
@@ -251,9 +238,8 @@ int saunafs_readlink(sau_t *instance, struct user_cred *cred, sau_inode_t inode,
 	return sau_readlink(instance, context, inode, buf, size);
 }
 
-int saunafs_link(sau_t *instance, struct user_cred *cred, sau_inode_t inode,
-                 sau_inode_t parent, const char *name,
-                 struct sau_entry *entry) {
+int saunafs_link(sau_t *instance, struct user_cred *cred, sau_inode_t inode, sau_inode_t parent,
+                 const char *name, struct sau_entry *entry) {
 	sau_context_t *context __attribute__((cleanup(sau_destroy_context))) = NULL;
 	context = createContext(instance, cred);
 
@@ -264,9 +250,8 @@ int saunafs_link(sau_t *instance, struct user_cred *cred, sau_inode_t inode,
 	return sau_link(instance, context, inode, parent, name, entry);
 }
 
-int saunafs_get_chunks_info(sau_t *instance, struct user_cred *cred,
-                            sau_inode_t inode, uint32_t chunk_index,
-                            sau_chunk_info_t *buffer, uint32_t buffer_size,
+int saunafs_get_chunks_info(sau_t *instance, struct user_cred *cred, sau_inode_t inode,
+                            uint32_t chunk_index, sau_chunk_info_t *buffer, uint32_t buffer_size,
                             uint32_t *reply_size) {
 	sau_context_t *context __attribute__((cleanup(sau_destroy_context))) = NULL;
 	context = createContext(instance, cred);
@@ -275,12 +260,11 @@ int saunafs_get_chunks_info(sau_t *instance, struct user_cred *cred,
 		return -1;
 	}
 
-	return sau_get_chunks_info(instance, context, inode, chunk_index, buffer,
-	                           buffer_size, reply_size);
+	return sau_get_chunks_info(instance, context, inode, chunk_index, buffer, buffer_size,
+	                           reply_size);
 }
 
-int saunafs_setacl(sau_t *instance, struct user_cred *cred, sau_inode_t inode,
-                   sau_acl_t *acl) {
+int saunafs_setacl(sau_t *instance, struct user_cred *cred, sau_inode_t inode, sau_acl_t *acl) {
 	sau_context_t *context __attribute__((cleanup(sau_destroy_context))) = NULL;
 	context = createContext(instance, cred);
 
@@ -291,8 +275,7 @@ int saunafs_setacl(sau_t *instance, struct user_cred *cred, sau_inode_t inode,
 	return sau_setacl(instance, context, inode, acl);
 }
 
-int saunafs_getacl(sau_t *instance, struct user_cred *cred, sau_inode_t inode,
-                   sau_acl_t **acl) {
+int saunafs_getacl(sau_t *instance, struct user_cred *cred, sau_inode_t inode, sau_acl_t **acl) {
 	sau_context_t *context __attribute__((cleanup(sau_destroy_context))) = NULL;
 	context = createContext(instance, cred);
 
@@ -303,8 +286,8 @@ int saunafs_getacl(sau_t *instance, struct user_cred *cred, sau_inode_t inode,
 	return sau_getacl(instance, context, inode, acl);
 }
 
-int saunafs_setlock(sau_t *instance, struct user_cred *cred,
-                    fileinfo_t *fileinfo, const sau_lock_info_t *lock) {
+int saunafs_setlock(sau_t *instance, struct user_cred *cred, fileinfo_t *fileinfo,
+                    const sau_lock_info_t *lock) {
 	sau_context_t *context __attribute__((cleanup(sau_destroy_context))) = NULL;
 
 	if (fileinfo == NULL) {
@@ -320,8 +303,8 @@ int saunafs_setlock(sau_t *instance, struct user_cred *cred,
 	return sau_setlk(instance, context, fileinfo, lock, NULL, NULL);
 }
 
-int saunafs_getlock(sau_t *instance, struct user_cred *cred,
-                    fileinfo_t *fileinfo, sau_lock_info_t *lock) {
+int saunafs_getlock(sau_t *instance, struct user_cred *cred, fileinfo_t *fileinfo,
+                    sau_lock_info_t *lock) {
 	sau_context_t *context __attribute__((cleanup(sau_destroy_context))) = NULL;
 
 	if (fileinfo == NULL) {
@@ -337,9 +320,8 @@ int saunafs_getlock(sau_t *instance, struct user_cred *cred,
 	return sau_getlk(instance, context, fileinfo, lock);
 }
 
-int saunafs_getxattr(sau_t *instance, struct user_cred *cred, sau_inode_t ino,
-                     const char *name, size_t size, size_t *out_size,
-                     uint8_t *buf) {
+int saunafs_getxattr(sau_t *instance, struct user_cred *cred, sau_inode_t ino, const char *name,
+                     size_t size, size_t *out_size, uint8_t *buf) {
 	sau_context_t *context __attribute__((cleanup(sau_destroy_context))) = NULL;
 	context = createContext(instance, cred);
 
@@ -350,9 +332,8 @@ int saunafs_getxattr(sau_t *instance, struct user_cred *cred, sau_inode_t ino,
 	return sau_getxattr(instance, context, ino, name, size, out_size, buf);
 }
 
-int saunafs_setxattr(sau_t *instance, struct user_cred *cred, sau_inode_t ino,
-                     const char *name, const uint8_t *value, size_t size,
-                     int flags) {
+int saunafs_setxattr(sau_t *instance, struct user_cred *cred, sau_inode_t ino, const char *name,
+                     const uint8_t *value, size_t size, int flags) {
 	sau_context_t *context __attribute__((cleanup(sau_destroy_context))) = NULL;
 	context = createContext(instance, cred);
 
@@ -363,8 +344,8 @@ int saunafs_setxattr(sau_t *instance, struct user_cred *cred, sau_inode_t ino,
 	return sau_setxattr(instance, context, ino, name, value, size, flags);
 }
 
-int saunafs_listxattr(sau_t *instance, struct user_cred *cred, sau_inode_t ino,
-                      size_t size, size_t *out_size, char *buf) {
+int saunafs_listxattr(sau_t *instance, struct user_cred *cred, sau_inode_t ino, size_t size,
+                      size_t *out_size, char *buf) {
 	sau_context_t *context __attribute__((cleanup(sau_destroy_context))) = NULL;
 	context = createContext(instance, cred);
 
@@ -375,8 +356,8 @@ int saunafs_listxattr(sau_t *instance, struct user_cred *cred, sau_inode_t ino,
 	return sau_listxattr(instance, context, ino, size, out_size, buf);
 }
 
-int saunafs_removexattr(sau_t *instance, struct user_cred *cred,
-                        sau_inode_t ino, const char *name) {
+int saunafs_removexattr(sau_t *instance, struct user_cred *cred, sau_inode_t ino,
+                        const char *name) {
 	sau_context_t *context __attribute__((cleanup(sau_destroy_context))) = NULL;
 	context = createContext(instance, cred);
 

--- a/src/nfs-ganesha/context_wrap.h
+++ b/src/nfs-ganesha/context_wrap.h
@@ -1,22 +1,24 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
 /*
 
    Copyright 2017 Skytechnology sp. z o.o.
    Copyright 2023 Leil Storage OÜ
 
-   This file is part of SaunaFS.
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 3 of the License, or (at your option) any later version.
 
-   SaunaFS is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, version 3.
-
-   SaunaFS is distributed in the hope that it will be useful,
+   This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
 
-   You should have received a copy of the GNU General Public License
-   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
- */
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301 USA
+*/
 
 #pragma once
 

--- a/src/nfs-ganesha/context_wrap.h
+++ b/src/nfs-ganesha/context_wrap.h
@@ -24,97 +24,78 @@
 
 #include <fsal_types.h>
 
-#include "saunafs_fsal_types.h"
+#include "nfs-ganesha/saunafs_fsal_types.h"
 
-int saunafs_lookup(sau_t *instance, struct user_cred *cred, sau_inode_t parent,
-                   const char *path, struct sau_entry *entry);
-
-int saunafs_mknode(sau_t *instance, struct user_cred *cred, sau_inode_t parent,
-                   const char *path, mode_t mode, dev_t rdev,
+int saunafs_lookup(sau_t *instance, struct user_cred *cred, sau_inode_t parent, const char *path,
                    struct sau_entry *entry);
 
-fileinfo_t *saunafs_open(sau_t *instance, struct user_cred *cred,
-                         sau_inode_t inode, int flags);
+int saunafs_mknode(sau_t *instance, struct user_cred *cred, sau_inode_t parent, const char *path,
+                   mode_t mode, dev_t rdev, struct sau_entry *entry);
 
-ssize_t saunafs_read(sau_t *instance, struct user_cred *cred,
-                     fileinfo_t *fileinfo, off_t offset, size_t size,
-                     char *buffer);
+fileinfo_t *saunafs_open(sau_t *instance, struct user_cred *cred, sau_inode_t inode, int flags);
 
-ssize_t saunafs_write(sau_t *instance, struct user_cred *cred,
-                      fileinfo_t *fileinfo, off_t offset, size_t size,
-                      const char *buffer);
+ssize_t saunafs_read(sau_t *instance, struct user_cred *cred, fileinfo_t *fileinfo, off_t offset,
+                     size_t size, char *buffer);
 
-int saunafs_flush(sau_t *instance, struct user_cred *cred,
-                  fileinfo_t *fileinfo);
+ssize_t saunafs_write(sau_t *instance, struct user_cred *cred, fileinfo_t *fileinfo, off_t offset,
+                      size_t size, const char *buffer);
+
+int saunafs_flush(sau_t *instance, struct user_cred *cred, fileinfo_t *fileinfo);
 
 int saunafs_getattr(sau_t *instance, struct user_cred *cred, sau_inode_t inode,
                     struct sau_attr_reply *reply);
 
-fileinfo_t *saunafs_opendir(sau_t *instance, struct user_cred *cred,
-                            sau_inode_t inode);
+fileinfo_t *saunafs_opendir(sau_t *instance, struct user_cred *cred, sau_inode_t inode);
 
-int saunafs_readdir(sau_t *instance, struct user_cred *cred,
-                    struct sau_fileinfo *fileinfo, off_t offset,
-                    size_t max_entries, struct sau_direntry *buf,
+int saunafs_readdir(sau_t *instance, struct user_cred *cred, struct sau_fileinfo *fileinfo,
+                    off_t offset, size_t max_entries, struct sau_direntry *buf,
                     size_t *num_entries);
 
-int saunafs_mkdir(sau_t *instance, struct user_cred *cred, sau_inode_t parent,
-                  const char *name, mode_t mode, struct sau_entry *out_entry);
+int saunafs_mkdir(sau_t *instance, struct user_cred *cred, sau_inode_t parent, const char *name,
+                  mode_t mode, struct sau_entry *out_entry);
 
-int saunafs_rmdir(sau_t *instance, struct user_cred *cred, sau_inode_t parent,
-                  const char *name);
+int saunafs_rmdir(sau_t *instance, struct user_cred *cred, sau_inode_t parent, const char *name);
 
-int saunafs_unlink(sau_t *instance, struct user_cred *cred, sau_inode_t parent,
-                   const char *name);
+int saunafs_unlink(sau_t *instance, struct user_cred *cred, sau_inode_t parent, const char *name);
 
-int saunafs_setattr(sau_t *instance, struct user_cred *cred, sau_inode_t inode,
-                    struct stat *stbuf, int to_set,
-                    struct sau_attr_reply *reply);
+int saunafs_setattr(sau_t *instance, struct user_cred *cred, sau_inode_t inode, struct stat *stbuf,
+                    int to_set, struct sau_attr_reply *reply);
 
-int saunafs_fsync(sau_t *instance, struct user_cred *cred,
-                  struct sau_fileinfo *fileinfo);
+int saunafs_fsync(sau_t *instance, struct user_cred *cred, struct sau_fileinfo *fileinfo);
 
-int saunafs_rename(sau_t *instance, struct user_cred *cred, sau_inode_t parent,
-                   const char *name, sau_inode_t new_parent,
-                   const char *new_name);
+int saunafs_rename(sau_t *instance, struct user_cred *cred, sau_inode_t parent, const char *name,
+                   sau_inode_t new_parent, const char *new_name);
 
-int saunafs_symlink(sau_t *instance, struct user_cred *cred, const char *link,
-                    sau_inode_t parent, const char *name,
-                    struct sau_entry *entry);
+int saunafs_symlink(sau_t *instance, struct user_cred *cred, const char *link, sau_inode_t parent,
+                    const char *name, struct sau_entry *entry);
 
-int saunafs_readlink(sau_t *instance, struct user_cred *cred, sau_inode_t inode,
-                     char *buf, size_t size);
+int saunafs_readlink(sau_t *instance, struct user_cred *cred, sau_inode_t inode, char *buf,
+                     size_t size);
 
-int saunafs_link(sau_t *instance, struct user_cred *cred, sau_inode_t inode,
-                 sau_inode_t parent, const char *name, struct sau_entry *entry);
+int saunafs_link(sau_t *instance, struct user_cred *cred, sau_inode_t inode, sau_inode_t parent,
+                 const char *name, struct sau_entry *entry);
 
-int saunafs_get_chunks_info(sau_t *instance, struct user_cred *cred,
-                            sau_inode_t inode, uint32_t chunk_index,
-                            sau_chunk_info_t *buffer, uint32_t buffer_size,
+int saunafs_get_chunks_info(sau_t *instance, struct user_cred *cred, sau_inode_t inode,
+                            uint32_t chunk_index, sau_chunk_info_t *buffer, uint32_t buffer_size,
                             uint32_t *reply_size);
 
-int saunafs_setacl(sau_t *instance, struct user_cred *cred, sau_inode_t inode,
-                   sau_acl_t *acl);
+int saunafs_setacl(sau_t *instance, struct user_cred *cred, sau_inode_t inode, sau_acl_t *acl);
 
-int saunafs_getacl(sau_t *instance, struct user_cred *cred, sau_inode_t inode,
-                   sau_acl_t **acl);
+int saunafs_getacl(sau_t *instance, struct user_cred *cred, sau_inode_t inode, sau_acl_t **acl);
 
-int saunafs_setlock(sau_t *instance, struct user_cred *cred,
-                    fileinfo_t *fileinfo, const sau_lock_info_t *lock);
+int saunafs_setlock(sau_t *instance, struct user_cred *cred, fileinfo_t *fileinfo,
+                    const sau_lock_info_t *lock);
 
-int saunafs_getlock(sau_t *instance, struct user_cred *cred,
-                    fileinfo_t *fileinfo, sau_lock_info_t *lock);
+int saunafs_getlock(sau_t *instance, struct user_cred *cred, fileinfo_t *fileinfo,
+                    sau_lock_info_t *lock);
 
-int saunafs_getxattr(sau_t *instance, struct user_cred *cred, sau_inode_t ino,
-                     const char *name, size_t size, size_t *out_size,
-                     uint8_t *buf);
+int saunafs_getxattr(sau_t *instance, struct user_cred *cred, sau_inode_t ino, const char *name,
+                     size_t size, size_t *out_size, uint8_t *buf);
 
-int saunafs_setxattr(sau_t *instance, struct user_cred *cred, sau_inode_t ino,
-                     const char *name, const uint8_t *value, size_t size,
-                     int flags);
+int saunafs_setxattr(sau_t *instance, struct user_cred *cred, sau_inode_t ino, const char *name,
+                     const uint8_t *value, size_t size, int flags);
 
-int saunafs_listxattr(sau_t *instance, struct user_cred *cred, sau_inode_t ino,
-                      size_t size, size_t *out_size, char *buf);
+int saunafs_listxattr(sau_t *instance, struct user_cred *cred, sau_inode_t ino, size_t size,
+                      size_t *out_size, char *buf);
 
-int saunafs_removexattr(sau_t *instance, struct user_cred *cred,
-                        sau_inode_t ino, const char *name);
+int saunafs_removexattr(sau_t *instance, struct user_cred *cred, sau_inode_t ino, const char *name);

--- a/src/nfs-ganesha/ds.c
+++ b/src/nfs-ganesha/ds.c
@@ -1,22 +1,24 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
 /*
 
    Copyright 2017 Skytechnology sp. z o.o.
    Copyright 2023 Leil Storage OÜ
 
-   This file is part of SaunaFS.
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 3 of the License, or (at your option) any later version.
 
-   SaunaFS is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, version 3.
-
-   SaunaFS is distributed in the hope that it will be useful,
+   This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
 
-   You should have received a copy of the GNU General Public License
-   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
- */
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301 USA
+*/
 
 #include "fsal.h"
 #include "fsal_api.h"

--- a/src/nfs-ganesha/ds.c
+++ b/src/nfs-ganesha/ds.c
@@ -26,10 +26,10 @@
 #include "../FSAL/fsal_private.h"
 #include "nfs_exports.h"
 
-#include "context_wrap.h"
-#include "fileinfo_cache.h"
-#include "saunafs_fsal_types.h"
-#include "saunafs_internal.h"
+#include "nfs-ganesha/context_wrap.h"
+#include "nfs-ganesha/fileinfo_cache.h"
+#include "nfs-ganesha/saunafs_fsal_types.h"
+#include "nfs-ganesha/saunafs_internal.h"
 
 /**
  * @brief Remove count expired instances from cache.
@@ -72,11 +72,9 @@ static void dsh_release(struct fsal_ds_handle *const dataServerHandle) {
 	struct SaunaFSExport *export;
 	struct DataServerHandle *dataServer;
 
-	export = container_of(op_ctx->ctx_pnfs_ds->mds_fsal_export,
-	                      struct SaunaFSExport, export);
+	export = container_of(op_ctx->ctx_pnfs_ds->mds_fsal_export, struct SaunaFSExport, export);
 
-	dataServer =
-	    container_of(dataServerHandle, struct DataServerHandle, handle);
+	dataServer = container_of(dataServerHandle, struct DataServerHandle, handle);
 
 	assert(export->cache);
 
@@ -98,8 +96,7 @@ static void dsh_release(struct fsal_ds_handle *const dataServerHandle) {
  *
  * @returns: nfsstat4 status returned after opening the file
  */
-static nfsstat4 openfile(struct SaunaFSExport *export,
-                         struct DataServerHandle *dataServer) {
+static nfsstat4 openfile(struct SaunaFSExport *export, struct DataServerHandle *dataServer) {
 	if (export == NULL) {
 		return NFS4ERR_IO;
 	}
@@ -124,8 +121,7 @@ static nfsstat4 openfile(struct SaunaFSExport *export,
 		return NFS4_OK;
 	}
 
-	fileHandle =
-	    saunafs_open(export->fsInstance, NULL, dataServer->inode, O_RDWR);
+	fileHandle = saunafs_open(export->fsInstance, NULL, dataServer->inode, O_RDWR);
 
 	if (fileHandle == NULL) {
 		eraseFileInfoCache(export->cache, dataServer->cacheHandle);
@@ -158,9 +154,8 @@ static nfsstat4 openfile(struct SaunaFSExport *export,
  *
  * @returns: An NFSv4.1 status code.
  */
-static nfsstat4 dsh_read(struct fsal_ds_handle *const dataServerHandle,
-                         const stateid4 *stateid, const offset4 offset,
-                         const count4 requestedLength, void *const buffer,
+static nfsstat4 dsh_read(struct fsal_ds_handle *const dataServerHandle, const stateid4 *stateid,
+                         const offset4 offset, const count4 requestedLength, void *const buffer,
                          count4 *const suppliedLength, bool *const eof) {
 	(void) stateid;
 
@@ -168,11 +163,9 @@ static nfsstat4 dsh_read(struct fsal_ds_handle *const dataServerHandle,
 	struct DataServerHandle *dataServer = NULL;
 	fileinfo_t *fileHandle = NULL;
 
-	export = container_of(op_ctx->ctx_pnfs_ds->mds_fsal_export,
-	                      struct SaunaFSExport, export);
+	export = container_of(op_ctx->ctx_pnfs_ds->mds_fsal_export, struct SaunaFSExport, export);
 
-	dataServer =
-	    container_of(dataServerHandle, struct DataServerHandle, handle);
+	dataServer = container_of(dataServerHandle, struct DataServerHandle, handle);
 
 	LogFullDebug(COMPONENT_FSAL,
 	             "export=%" PRIu16 " inode=%" PRIiNode " offset=%" PRIu64
@@ -186,8 +179,8 @@ static nfsstat4 dsh_read(struct fsal_ds_handle *const dataServerHandle,
 	}
 
 	fileHandle = extractFileInfo(dataServer->cacheHandle);
-	ssize_t bytes = saunafs_read(export->fsInstance, NULL, fileHandle, offset,
-	                             requestedLength, buffer);
+	ssize_t bytes =
+	    saunafs_read(export->fsInstance, NULL, fileHandle, offset, requestedLength, buffer);
 
 	if (bytes < 0) {
 		return nfs4LastError();
@@ -221,13 +214,10 @@ static nfsstat4 dsh_read(struct fsal_ds_handle *const dataServerHandle,
  *
  * @returns: An NFSv4.1 status code.
  */
-static nfsstat4 dsh_write(struct fsal_ds_handle *const dataServerHandle,
-                          const stateid4 *stateid, const offset4 offset,
-                          const count4 writeLength, const void *buffer,
-                          const stable_how4 stability,
-                          count4 *const writtenLength,
-                          verifier4 *const writeVerifier,
-                          stable_how4 *const stabilityGot) {
+static nfsstat4 dsh_write(struct fsal_ds_handle *const dataServerHandle, const stateid4 *stateid,
+                          const offset4 offset, const count4 writeLength, const void *buffer,
+                          const stable_how4 stability, count4 *const writtenLength,
+                          verifier4 *const writeVerifier, stable_how4 *const stabilityGot) {
 	(void) stateid;
 	(void) writeVerifier;
 
@@ -237,11 +227,9 @@ static nfsstat4 dsh_write(struct fsal_ds_handle *const dataServerHandle,
 	fileinfo_t *fileHandle = NULL;
 	int status = 0;
 
-	export = container_of(op_ctx->ctx_pnfs_ds->mds_fsal_export,
-	                      struct SaunaFSExport, export);
+	export = container_of(op_ctx->ctx_pnfs_ds->mds_fsal_export, struct SaunaFSExport, export);
 
-	dataServer =
-	    container_of(dataServerHandle, struct DataServerHandle, handle);
+	dataServer = container_of(dataServerHandle, struct DataServerHandle, handle);
 
 	LogFullDebug(COMPONENT_FSAL,
 	             "export=%" PRIu16 " inode=%" PRIiNode " offset=%" PRIu64
@@ -254,8 +242,8 @@ static nfsstat4 dsh_write(struct fsal_ds_handle *const dataServerHandle,
 	}
 
 	fileHandle = extractFileInfo(dataServer->cacheHandle);
-	ssize_t bytes = saunafs_write(export->fsInstance, NULL, fileHandle, offset,
-	                              writeLength, buffer);
+	ssize_t bytes =
+	    saunafs_write(export->fsInstance, NULL, fileHandle, offset, writeLength, buffer);
 
 	if (bytes < 0) {
 		return nfs4LastError();
@@ -285,20 +273,17 @@ static nfsstat4 dsh_write(struct fsal_ds_handle *const dataServerHandle,
  *
  * @returns: An NFSv4.1 status code.
  */
-static nfsstat4 dsh_commit(struct fsal_ds_handle *const dataServerHandle,
-                           const offset4 offset, const count4 count,
-                           verifier4 *const writeVerifier) {
+static nfsstat4 dsh_commit(struct fsal_ds_handle *const dataServerHandle, const offset4 offset,
+                           const count4 count, verifier4 *const writeVerifier) {
 	struct SaunaFSExport *export = NULL;
 	struct DataServerHandle *dataServer = NULL;
 	fileinfo_t *fileHandle = NULL;
 
 	memset(writeVerifier, 0, NFS4_VERIFIER_SIZE);
 
-	export = container_of(op_ctx->ctx_pnfs_ds->mds_fsal_export,
-	                      struct SaunaFSExport, export);
+	export = container_of(op_ctx->ctx_pnfs_ds->mds_fsal_export, struct SaunaFSExport, export);
 
-	dataServer =
-	    container_of(dataServerHandle, struct DataServerHandle, handle);
+	dataServer = container_of(dataServerHandle, struct DataServerHandle, handle);
 
 	LogFullDebug(COMPONENT_FSAL,
 	             "export=%" PRIu16 " inode=%" PRIiNode " offset=%" PRIu64
@@ -349,8 +334,7 @@ static nfsstat4 dsh_commit(struct fsal_ds_handle *const dataServerHandle,
 static nfsstat4 dsh_read_plus(struct fsal_ds_handle *const dataServerHandle,
                               const stateid4 *stateid, const offset4 offset,
                               const count4 requestedLength, void *const buffer,
-                              const count4 suppliedLength, bool *const eof,
-                              struct io_info *info) {
+                              const count4 suppliedLength, bool *const eof, struct io_info *info) {
 	(void) dataServerHandle;
 	(void) stateid;
 	(void) offset;
@@ -380,8 +364,7 @@ static nfsstat4 dsh_read_plus(struct fsal_ds_handle *const dataServerHandle,
  */
 static nfsstat4 make_ds_handle(struct fsal_pnfs_ds *const pnfsDataServer,
                                const struct gsh_buffdesc *const buffer,
-                               struct fsal_ds_handle **const handle,
-                               int flags) {
+                               struct fsal_ds_handle **const handle, int flags) {
 	(void) pnfsDataServer;
 
 	struct DSWire *dataServerWire = NULL;
@@ -427,8 +410,7 @@ static nfsstat4 make_ds_handle(struct fsal_pnfs_ds *const pnfsDataServer,
  *
  * @returns: NFSv4.1 error codes: NFS4_OK, NFS4ERR_ACCESS, NFS4ERR_WRONGSEC
  */
-static nfsstat4 ds_permissions(struct fsal_pnfs_ds *const pnfsDataServer,
-                               struct svc_req *request) {
+static nfsstat4 ds_permissions(struct fsal_pnfs_ds *const pnfsDataServer, struct svc_req *request) {
 	(void) pnfsDataServer;
 	(void) request;
 

--- a/src/nfs-ganesha/ds.c
+++ b/src/nfs-ganesha/ds.c
@@ -42,6 +42,7 @@ static void clearFileInfoCache(struct SaunaFSExport *export, int count) {
 
 	for (int i = 0; i < count; ++i) {
 		FileInfoEntry_t *cacheHandle = NULL;
+
 		cacheHandle = popExpiredFileInfoCache(export->cache);
 
 		if (cacheHandle == NULL) {
@@ -49,6 +50,7 @@ static void clearFileInfoCache(struct SaunaFSExport *export, int count) {
 		}
 
 		fileinfo_t *fileHandle = extractFileInfo(cacheHandle);
+
 		sau_release(export->fsInstance, fileHandle);
 		fileInfoEntryFree(cacheHandle);
 	}
@@ -59,16 +61,19 @@ static void clearFileInfoCache(struct SaunaFSExport *export, int count) {
  *
  * DS handle Lifecycle management.
  * This function cleans up private resources associated with a filehandle
- * and deallocates it. Implement this method or you will leak. This function
- * should not be called directly.
+ * and deallocates it. Implement this method or you will leak. This
+ * function should not be called directly.
  *
  * @param[in] dataServerHandle     Handle to release
  */
 static void dsh_release(struct fsal_ds_handle *const dataServerHandle) {
-	struct SaunaFSExport *export = container_of(
-	    op_ctx->ctx_pnfs_ds->mds_fsal_export, struct SaunaFSExport, export);
+	struct SaunaFSExport *export;
+	struct DataServerHandle *dataServer;
 
-	struct DataServerHandle *dataServer =
+	export = container_of(op_ctx->ctx_pnfs_ds->mds_fsal_export,
+	                      struct SaunaFSExport, export);
+
+	dataServer =
 	    container_of(dataServerHandle, struct DataServerHandle, handle);
 
 	assert(export->cache);
@@ -104,6 +109,7 @@ static nfsstat4 openfile(struct SaunaFSExport *export,
 	clearFileInfoCache(export, 2);
 
 	struct FileInfoEntry *entry = NULL;
+
 	entry = acquireFileInfoCache(export->cache, dataServer->inode);
 
 	dataServer->cacheHandle = entry;
@@ -134,14 +140,16 @@ static nfsstat4 openfile(struct SaunaFSExport *export,
  *
  * DS handle I/O Functions
  *
- * NFSv4.1 data server handles are disjount from normal filehandles (in Ganesha,
- * there is a ds_flag in the filehandle_v4_t structure) and do not get loaded
- * into mdcache or processed the normal way.
+ * NFSv4.1 data server handles are disjount from normal filehandles (in
+ * Ganesha, there is a ds_flag in the filehandle_v4_t structure) and do not
+ * get loaded into mdcache or processed the normal way.
  *
  * @param[in] dataServerHandle      Handle to release
- * @param[in] stateid               The stateid supplied with the READ operation, for validation
+ * @param[in] stateid               The stateid supplied with the READ
+ *                                  operation, for validation
  * @param[in] offset                The offset at which to read
- * @param[in] requestedLength       Length of read requested (and size of buffer)
+ * @param[in] requestedLength       Length of read requested (and size of
+ *                                  buffer)
  * @param[out] buffer               The buffer to which to store read data
  * @param[out] suppliedLength       Length of data read
  * @param[out] eof                  true on end of file
@@ -192,19 +200,22 @@ static nfsstat4 dsh_read(struct fsal_ds_handle *const dataServerHandle,
 /**
  * @brief Write to a data-server handle.
  *
- * NFSv4.1 data server filehandles are disjount from normal filehandles (in Ganesha,
- * there is a ds_flag in the filehandle_v4_t structure) and do not get loaded into
- * mdcache or processed the normal way.
+ * NFSv4.1 data server filehandles are disjount from normal filehandles (in
+ * Ganesha, there is a ds_flag in the filehandle_v4_t structure) and do not
+ * get loaded into mdcache or processed the normal way.
  *
  * @param[in] dataServerHandle      FSAL DS handle
- * @param[in] stateid               The stateid supplied with the READ operation, for validation
+ * @param[in] stateid               The stateid supplied with the READ
+ *                                  operation, for validation
  * @param[in] offset                The offset at which to read
- * @param[in] writeLength           Length of write requested (and size of buffer)
+ * @param[in] writeLength           Length of write requested (and size of
+ *                                  buffer)
  * @param[out] buffer               The buffer to which to store read data
  * @param[in] stability             wanted Stability of write
  * @param[out] writtenLength        Length of data written
  * @param[out] writeVerifier        Write verifier
- * @param[out] stabilityGot         Stability used for write (must be as or more stable than request)
+ * @param[out] stabilityGot         Stability used for write (must be as or
+ *                                  more stable than request)
  *
  * @returns: An NFSv4.1 status code.
  */
@@ -261,9 +272,9 @@ static nfsstat4 dsh_write(struct fsal_ds_handle *const dataServerHandle,
 /**
  * @brief Commit a byte range to a DS handle.
  *
- * NFSv4.1 data server filehandles are disjount from normal filehandles (in Ganesha,
- * there is a ds_flag in the filehandle_v4_t structure) and do not get loaded into
- * mdcache or processed the normal way.
+ * NFSv4.1 data server filehandles are disjount from normal filehandles (in
+ * Ganesha, there is a ds_flag in the filehandle_v4_t structure) and do not
+ * get loaded into mdcache or processed the normal way.
  *
  * @param[in] dataServerHandle      FSAL DS handle
  * @param[in] offset                Start of commit window
@@ -295,8 +306,9 @@ static nfsstat4 dsh_commit(struct fsal_ds_handle *const dataServerHandle,
 	nfsstat4 nfsStatus = openfile(export, dataServer);
 
 	if (nfsStatus != NFS4_OK) {
-		// If we failed here then there is no opened SaunaFS file descriptor,
-		// which implies that we don't need to flush anything
+		/* If we failed here then there is no opened SaunaFS file
+		 * descriptor, which implies that we don't need to flush
+		 * anything */
 		return NFS4_OK;
 	}
 
@@ -315,13 +327,13 @@ static nfsstat4 dsh_commit(struct fsal_ds_handle *const dataServerHandle,
 /**
  * @brief Read plus from a data-server handle.
  *
- * NFSv4.2 data server handles are disjount from normal filehandles (in Ganesha,
- * there is a ds_flag in the filehandle_v4_t structure) and do not get loaded
- * into mdcache or processed the normal way.
+ * NFSv4.2 data server handles are disjount from normal filehandles (in
+ * Ganesha, there is a ds_flag in the filehandle_v4_t structure) and do not
+ * get loaded into mdcache or processed the normal way.
  *
  * @param[in]  dataServerHandle      FSAL DS handle
- * @param[in]  stateid               Stateid supplied with the READ operation,
- *                                   for validation
+ * @param[in]  stateid               Stateid supplied with the READ
+ *                                   operation, for validation
  * @param[in]  offset                The offset at which to read
  * @param[in]  requestedLength       Length of read requested (and size of
  *                                   buffer)
@@ -353,14 +365,14 @@ static nfsstat4 dsh_read_plus(struct fsal_ds_handle *const dataServerHandle,
 /**
  * @brief Create a FSAL data server handle from a wire handle.
  *
- * This function creates a FSAL data server handle from a client supplied "wire"
- * handle.
+ * This function creates a FSAL data server handle from a client supplied
+ * "wire" handle.
  *
  * @param[in]  pnfsDataServer       FSAL pNFS DS
  * @param[in]  buffer               Buffer from which to create the struct
  * @param[out] handle               FSAL DS handle
- * @param[out] flags                Flags used to create the FSAL data server
- *                                  handle
+ * @param[out] flags                Flags used to create the FSAL data
+ *                                  server handle
  *
  * @returns: NFSv4.1 error codes.
  */
@@ -371,6 +383,7 @@ static nfsstat4 make_ds_handle(struct fsal_pnfs_ds *const pnfsDataServer,
 	(void) pnfsDataServer;
 
 	struct DSWire *dataServerWire = NULL;
+
 	dataServerWire = (struct DSWire *)buffer->addr;
 
 	struct DataServerHandle *dataServerHandle = NULL;
@@ -393,8 +406,7 @@ static nfsstat4 make_ds_handle(struct fsal_pnfs_ds *const pnfsDataServer,
 #else
 		dataServerHandle->inode = dataServerWire->inode;
 #endif
-	}
-	else {
+	} else {
 #if (BYTE_ORDER == BIG_ENDIAN)
 		dataServerHandle->inode = bswap_32(dataServerWire->inode);
 #else

--- a/src/nfs-ganesha/export.c
+++ b/src/nfs-ganesha/export.c
@@ -1,22 +1,23 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
 /*
-
    Copyright 2017 Skytechnology sp. z o.o.
    Copyright 2023 Leil Storage OÜ
 
-   This file is part of SaunaFS.
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 3 of the License, or (at your option) any later version.
 
-   SaunaFS is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, version 3.
-
-   SaunaFS is distributed in the hope that it will be useful,
+   This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
 
-   You should have received a copy of the GNU General Public License
-   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
- */
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301 USA
+*/
 
 #include "FSAL/fsal_commonlib.h"
 #include "FSAL/fsal_config.h"

--- a/src/nfs-ganesha/export.c
+++ b/src/nfs-ganesha/export.c
@@ -24,9 +24,9 @@
 #include "fsal_convert.h"
 #include "nfs_exports.h"
 
-#include "saunafs_fsal_types.h"
-#include "context_wrap.h"
-#include "saunafs_internal.h"
+#include "nfs-ganesha/context_wrap.h"
+#include "nfs-ganesha/saunafs_fsal_types.h"
+#include "nfs-ganesha/saunafs_internal.h"
 
 /* Flags to determine if ACLs are supported */
 #define NFSv4_ACL_SUPPORT (!op_ctx_export_has_option(EXPORT_OPTION_DISABLE_ACL))
@@ -98,16 +98,14 @@ static void release(struct fsal_export *exportHandle) {
  * @returns: FSAL status
  */
 fsal_status_t lookup_path(struct fsal_export *exportHandle, const char *path,
-                          struct fsal_obj_handle **handle,
-                          struct fsal_attrlist *attributes) {
+                          struct fsal_obj_handle **handle, struct fsal_attrlist *attributes) {
 	static const char *rootDirPath = "/";
 
 	struct SaunaFSExport *export = NULL;
 	struct SaunaFSHandle *objectHandle = NULL;
 	const char *realPath = NULL;
 
-	LogFullDebug(COMPONENT_FSAL, "export_id=%" PRIu16 " path=%s",
-	             exportHandle->export_id, path);
+	LogFullDebug(COMPONENT_FSAL, "export_id=%" PRIu16 " path=%s", exportHandle->export_id, path);
 
 	export = container_of(exportHandle, struct SaunaFSExport, export);
 
@@ -150,8 +148,8 @@ fsal_status_t lookup_path(struct fsal_export *exportHandle, const char *path,
 	}
 
 	sau_entry_t entry;
-	int status = saunafs_lookup(export->fsInstance, &op_ctx->creds,
-	                            SPECIAL_INODE_ROOT, realPath, &entry);
+	int status =
+	    saunafs_lookup(export->fsInstance, &op_ctx->creds, SPECIAL_INODE_ROOT, realPath, &entry);
 
 	if (status < 0) {
 		return fsalLastError();
@@ -237,18 +235,16 @@ void fs_free_state(struct state_t *state) {
  *
  * @returns: a state structure.
  */
-struct state_t *allocate_state(struct fsal_export *export,
-                               enum state_type stateType,
+struct state_t *allocate_state(struct fsal_export *export, enum state_type stateType,
                                struct state_t *relatedState) {
 	(void )export; /* Not used */
 	struct state_t *state = NULL;
 	struct SaunaFSFd *fileDescriptor = NULL;
 
-	state = init_state(gsh_calloc(1, sizeof(struct SaunaFSStateFd)),
-	                   fs_free_state, stateType, relatedState);
+	state = init_state(gsh_calloc(1, sizeof(struct SaunaFSStateFd)), fs_free_state, stateType,
+	                   relatedState);
 
-	fileDescriptor =
-		&container_of(state, struct SaunaFSStateFd, state)->saunafsFd;
+	fileDescriptor = &container_of(state, struct SaunaFSStateFd, state)->saunafsFd;
 
 	init_fsal_fd(&fileDescriptor->fsalFd, FSAL_FD_STATE, op_ctx->fsal_export);
 	fileDescriptor->fd = NULL;
@@ -277,8 +273,7 @@ struct state_t *allocate_state(struct fsal_export *export,
  *
  * @returns: FSAL type.
  */
-static fsal_status_t wire_to_host(struct fsal_export *export,
-                                  fsal_digesttype_t protocol,
+static fsal_status_t wire_to_host(struct fsal_export *export, fsal_digesttype_t protocol,
                                   struct gsh_buffdesc *buffer, int flags) {
 	(void) protocol;
 	(void) export;
@@ -303,8 +298,7 @@ static fsal_status_t wire_to_host(struct fsal_export *export,
 	}
 
 	if (buffer->len != sizeof(sau_inode_t)) {
-		LogMajor(COMPONENT_FSAL,
-		         "Size mismatch for handle. Should be %zu, got %zu",
+		LogMajor(COMPONENT_FSAL, "Size mismatch for handle. Should be %zu, got %zu",
 		         sizeof(sau_inode_t), buffer->len);
 		return fsalstat(ERR_FSAL_SERVERFAULT, 0);
 	}
@@ -328,8 +322,7 @@ static fsal_status_t wire_to_host(struct fsal_export *export,
  *                            key has to be placed at the beginning of the
  *                            buffer.
  */
-fsal_status_t host_to_key(struct fsal_export *export,
-                          struct gsh_buffdesc *buffer) {
+fsal_status_t host_to_key(struct fsal_export *export, struct gsh_buffdesc *buffer) {
 	(void) export;
 	struct SaunaFSHandleKey *key = buffer->addr;
 	/*
@@ -360,8 +353,7 @@ fsal_status_t host_to_key(struct fsal_export *export,
  *
  * @returns: FSAL status
  */
-fsal_status_t create_handle(struct fsal_export *exportHandle,
-                            struct gsh_buffdesc *buffer,
+fsal_status_t create_handle(struct fsal_export *exportHandle, struct gsh_buffdesc *buffer,
                             struct fsal_obj_handle **publicHandle,
                             struct fsal_attrlist *attributes) {
 	struct SaunaFSExport *export = NULL;
@@ -377,8 +369,7 @@ fsal_status_t create_handle(struct fsal_export *exportHandle,
 	}
 
 	sau_attr_reply_t result;
-	int status =
-	    saunafs_getattr(export->fsInstance, &op_ctx->creds, *inode, &result);
+	int status = saunafs_getattr(export->fsInstance, &op_ctx->creds, *inode, &result);
 
 	if (status < 0) {
 		return fsalLastError();
@@ -444,8 +435,8 @@ static attrmask_t fs_supported_attrs(struct fsal_export *export) {
  *
  * @return the fsal_obj_handle.
  */
-void get_fsal_obj_hdl(struct fsal_export * export, struct fsal_fd * fd,
-	                  struct fsal_obj_handle * *handle) {
+void get_fsal_obj_hdl(struct fsal_export *export, struct fsal_fd *fd,
+                      struct fsal_obj_handle **handle) {
 	(void)export; /* Not used */
 	struct SaunaFSFd *saunafsFd = NULL;
 	struct SaunaFSHandle *myself = NULL;

--- a/src/nfs-ganesha/export.c
+++ b/src/nfs-ganesha/export.c
@@ -21,9 +21,9 @@
 #include "FSAL/fsal_commonlib.h"
 #include "FSAL/fsal_config.h"
 #include "fsal_convert.h"
-#include "nfs-ganesha/saunafs_fsal_types.h"
 #include "nfs_exports.h"
 
+#include "saunafs_fsal_types.h"
 #include "context_wrap.h"
 #include "saunafs_internal.h"
 
@@ -42,6 +42,7 @@
  */
 static void release(struct fsal_export *exportHandle) {
 	struct SaunaFSExport *export = NULL;
+
 	export = container_of(exportHandle, struct SaunaFSExport, export);
 
 	deleteHandle(export->root);
@@ -111,7 +112,8 @@ fsal_status_t lookup_path(struct fsal_export *exportHandle, const char *path,
 
 	*handle = NULL;
 
-	// set the real path to the path without the prefix from ctx_export->fullpath
+	/* set the real path to the path without the prefix from
+	 * ctx_export->fullpath */
 	if (*path != '/') {
 		realPath = strchr(path, ':');
 		if (realPath == NULL) {
@@ -121,8 +123,7 @@ fsal_status_t lookup_path(struct fsal_export *exportHandle, const char *path,
 		if (*realPath != '/') {
 			return fsalstat(ERR_FSAL_INVAL, 0);
 		}
-	}
-	else {
+	} else {
 		realPath = path;
 	}
 
@@ -137,7 +138,7 @@ fsal_status_t lookup_path(struct fsal_export *exportHandle, const char *path,
 
 	LogFullDebug(COMPONENT_FSAL, "real path = %s", realPath);
 
-	// special case the root
+	/* special case the root */
 	if (strcmp(realPath, "/") == 0) {
 		assert(export->root);
 		*handle = &export->root->handle;
@@ -186,14 +187,13 @@ static fsal_status_t get_dynamic_info(struct fsal_export *exportHandle,
 	(void) objectHandle;
 
 	struct SaunaFSExport *export = NULL;
+
 	export = container_of(exportHandle, struct SaunaFSExport, export);
 
 	sau_stat_t statfsEntry;
 	int status = sau_statfs(export->fsInstance, &statfsEntry);
 
-	if (status < 0) {
-		return fsalLastError();
-	}
+	if (status < 0) { return fsalLastError(); }
 
 	memset(info, 0, sizeof(fsal_dynamicfsinfo_t));
 	info->total_bytes = statfsEntry.total_space;
@@ -211,6 +211,20 @@ static fsal_status_t get_dynamic_info(struct fsal_export *exportHandle,
 }
 
 /**
+ * @brief Free a state_t structure.
+ *
+ * @param[in] state      state_t structure to free
+ */
+void fs_free_state(struct state_t *state) {
+	struct SaunaFSFd *fd = NULL;
+
+	fd = &container_of(state, struct SaunaFSStateFd, state)->saunafsFd;
+
+	destroy_fsal_fd(&fd->fsalFd);
+	gsh_free(state);
+}
+
+/**
  * @brief Allocate a state_t structure.
  *
  * Note that this is not expected to fail since memory allocation is
@@ -225,34 +239,20 @@ static fsal_status_t get_dynamic_info(struct fsal_export *exportHandle,
 struct state_t *allocate_state(struct fsal_export *export,
                                enum state_type stateType,
                                struct state_t *relatedState) {
+	(void )export; /* Not used */
 	struct state_t *state = NULL;
 	struct SaunaFSFd *fileDescriptor = NULL;
 
 	state = init_state(gsh_calloc(1, sizeof(struct SaunaFSStateFd)),
-	                   export, stateType, relatedState);
+	                   fs_free_state, stateType, relatedState);
 
 	fileDescriptor =
-	    &container_of(state, struct SaunaFSStateFd, state)->saunafsFd;
+		&container_of(state, struct SaunaFSStateFd, state)->saunafsFd;
 
+	init_fsal_fd(&fileDescriptor->fsalFd, FSAL_FD_STATE, op_ctx->fsal_export);
 	fileDescriptor->fd = NULL;
-	fileDescriptor->openflags = FSAL_O_CLOSED;
+
 	return state;
-}
-
-/**
- * @brief Free a state_t structure.
- *
- * @param[in] export     Export state_t is associated with
- * @param[in] state      state_t structure to free
- *
- * @returns: NULL on failure otherwise a state structure.
- */
-void free_state(struct fsal_export *export, struct state_t *state) {
-	(void) export;
-
-	struct SaunaFSStateFd *stateFd = NULL;
-	stateFd = container_of(state, struct SaunaFSStateFd, state);
-	gsh_free(stateFd);
 }
 
 /**
@@ -266,10 +266,12 @@ void free_state(struct fsal_export *export, struct state_t *state) {
  * @param[in]     protocol           Protocol through which buffer was received.
  * @param[in]     flags              Flags to describe the wire handle. Example,
  *                                   if the handle is a big endian handle.
- * @param[in,out] buffer             Buffer descriptor. The address of the buffer is
- *                                   given in bufferDescriptor->buf and must not be changed.
- *                                   bufferDescriptor->len is the length of the data contained
- *                                   in the buffer, bufferDescriptor->len must be updated to
+ * @param[in,out] buffer             Buffer descriptor. The address of the
+ *                                   buffer is given in bufferDescriptor->buf
+ *                                   and must not be changed.
+ *                                   bufferDescriptor->len is the length of the
+ *                                   data contained in the buffer,
+ *                                   bufferDescriptor->len must be updated to
  *                                   the correct host handle size.
  *
  * @returns: FSAL type.
@@ -331,8 +333,10 @@ fsal_status_t host_to_key(struct fsal_export *export,
 	struct SaunaFSHandleKey *key = buffer->addr;
 	/*
 	 * Ganesha automatically mixes the export_id in with the actual wire
-	 * filehandle and strips that out before transforming it to a host handle.
-	 * This method is called on a host handle which doesn't have the export_id.
+	 * filehandle and strips that out before transforming it to a host
+	 * handle.
+	 * This method is called on a host handle which doesn't have the
+	 * export_id.
 	 */
 	key->exportId = op_ctx->ctx_export->export_id;
 	buffer->len = sizeof(*key);
@@ -416,16 +420,39 @@ static fsal_aclsupp_t fs_acl_support(struct fsal_export *export) {
  */
 static attrmask_t fs_supported_attrs(struct fsal_export *export) {
 	attrmask_t supported_mask = 0;
+
 	supported_mask = fsal_supported_attrs(&export->fsal->fs_info);
 
-	// Fixup supported_mask to indicate if ACL is supported for this export
+	/* Fixup supported_mask to indicate if ACL is supported for
+	 * this export */
 	if (NFSv4_ACL_SUPPORT) {
-		supported_mask |=  (attrmask_t)ATTR_ACL;
-	}
-	else {
+		supported_mask |= (attrmask_t)ATTR_ACL;
+	} else {
 		supported_mask &= ~(attrmask_t)ATTR_ACL;
 	}
+
 	return supported_mask;
+}
+
+/**
+ * @brief Function to get the fsal_obj_handle that has fsal_fd as its global fd.
+ *
+ * @param[in]     export    The export in which the handle exists
+ * @param[in]     fd        File descriptor in question
+ * @param[out]    handle    FSAL object handle
+ *
+ * @return the fsal_obj_handle.
+ */
+void get_fsal_obj_hdl(struct fsal_export * export, struct fsal_fd * fd,
+	                  struct fsal_obj_handle * *handle) {
+	(void)export; /* Not used */
+	struct SaunaFSFd *saunafsFd = NULL;
+	struct SaunaFSHandle *myself = NULL;
+
+	saunafsFd = container_of(fd, struct SaunaFSFd, fsalFd);
+	myself = container_of(saunafsFd, struct SaunaFSHandle, fd);
+
+	*handle = &myself->handle;
 }
 
 /**
@@ -446,6 +473,6 @@ void exportOperationsInit(struct export_ops *ops) {
 	ops->fs_supported_attrs = fs_supported_attrs;
 	ops->fs_acl_support = fs_acl_support;
 	ops->alloc_state = allocate_state;
-	ops->free_state = free_state;
+	ops->get_fsal_obj_hdl = get_fsal_obj_hdl;
 	exportOperationsPnfs(ops);
 }

--- a/src/nfs-ganesha/fileinfo_cache.c
+++ b/src/nfs-ganesha/fileinfo_cache.c
@@ -1,21 +1,23 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
 /*
 
    Copyright 2017 Skytechnology sp. z o.o.
    Copyright 2023 Leil Storage OÜ
 
-   This file is part of SaunaFS.
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 3 of the License, or (at your option) any later version.
 
-   SaunaFS is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, version 3.
-
-   SaunaFS is distributed in the hope that it will be useful,
+   This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
 
-   You should have received a copy of the GNU General Public License
-   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301 USA
 */
 
 #include "fileinfo_cache.h"

--- a/src/nfs-ganesha/fileinfo_cache.c
+++ b/src/nfs-ganesha/fileinfo_cache.c
@@ -46,7 +46,7 @@ struct FileInfoCache {
 
 	int entry_count;
 
-	unsigned max_entries;
+	unsigned int max_entries;
 	int min_timeout_ms;
 
 	pthread_mutex_t lock;
@@ -54,6 +54,7 @@ struct FileInfoCache {
 
 static uint64_t get_time_ms() {
 	struct timespec time_;
+
 	timespec_get(&time_, TIME_UTC);
 
 	return (uint64_t)time_.tv_sec * kMillisecondsInOneSecond +
@@ -88,6 +89,7 @@ static int cacheEntryCompareFunction(const struct avltree_node *nodeA,
 FileInfoCache_t *createFileInfoCache(unsigned maxEntries,
                                      int minTimeoutMilliseconds) {
 	FileInfoCache_t *cache = gsh_calloc(1, sizeof(FileInfoCache_t));
+
 	cache->max_entries = maxEntries;
 	cache->min_timeout_ms = minTimeoutMilliseconds;
 	PTHREAD_MUTEX_init(&cache->lock, NULL);
@@ -148,8 +150,7 @@ FileInfoEntry_t *acquireFileInfoCache(FileInfoCache_t *cache,
 		glist_del(&entry->list_hook);
 		glist_add(&cache->used_list, &entry->list_hook);
 		avltree_remove(node, &cache->entry_lookup);
-	}
-	else {
+	} else {
 		entry = gsh_calloc(1, sizeof(FileInfoEntry_t));
 		glist_add(&cache->used_list, &entry->list_hook);
 		cache->entry_count++;
@@ -204,8 +205,7 @@ FileInfoEntry_t *popExpiredFileInfoCache(FileInfoCache_t *cache) {
 		glist_del(&entry->list_hook);
 		avltree_remove(&entry->tree_hook, &cache->entry_lookup);
 		cache->entry_count--;
-	}
-	else {
+	} else {
 		entry = NULL;
 	}
 

--- a/src/nfs-ganesha/fileinfo_cache.c
+++ b/src/nfs-ganesha/fileinfo_cache.c
@@ -20,8 +20,8 @@
    02110-1301 USA
 */
 
-#include "fileinfo_cache.h"
-#include "saunafs_fsal_types.h"
+#include "nfs-ganesha/fileinfo_cache.h"
+#include "nfs-ganesha/saunafs_fsal_types.h"
 
 #include <abstract_mem.h>
 #include <avltree.h>
@@ -65,10 +65,8 @@ static uint64_t get_time_ms() {
 
 static int cacheEntryCompareFunction(const struct avltree_node *nodeA,
                                      const struct avltree_node *nodeB) {
-	FileInfoEntry_t *entryA =
-	    avltree_container_of(nodeA, FileInfoEntry_t, tree_hook);
-	FileInfoEntry_t *entryB =
-	    avltree_container_of(nodeB, FileInfoEntry_t, tree_hook);
+	FileInfoEntry_t *entryA = avltree_container_of(nodeA, FileInfoEntry_t, tree_hook);
+	FileInfoEntry_t *entryB = avltree_container_of(nodeB, FileInfoEntry_t, tree_hook);
 
 	if (entryA->inode < entryB->inode) {
 		return -1;
@@ -88,8 +86,7 @@ static int cacheEntryCompareFunction(const struct avltree_node *nodeA,
 	return 0;
 }
 
-FileInfoCache_t *createFileInfoCache(unsigned maxEntries,
-                                     int minTimeoutMilliseconds) {
+FileInfoCache_t *createFileInfoCache(unsigned maxEntries, int minTimeoutMilliseconds) {
 	FileInfoCache_t *cache = gsh_calloc(1, sizeof(FileInfoCache_t));
 
 	cache->max_entries = maxEntries;
@@ -118,14 +115,12 @@ void destroyFileInfoCache(FileInfoCache_t *cache) {
 		return;
 	}
 
-	while ((entry = glist_first_entry(&cache->used_list, FileInfoEntry_t,
-	                                  list_hook))) {
+	while ((entry = glist_first_entry(&cache->used_list, FileInfoEntry_t, list_hook))) {
 		glist_del(&entry->list_hook);
 		gsh_free(entry);
 	}
 
-	while ((entry = glist_first_entry(&cache->lru_list, FileInfoEntry_t,
-	                                  list_hook))) {
+	while ((entry = glist_first_entry(&cache->lru_list, FileInfoEntry_t, list_hook))) {
 		glist_del(&entry->list_hook);
 		gsh_free(entry);
 	}
@@ -133,8 +128,7 @@ void destroyFileInfoCache(FileInfoCache_t *cache) {
 	gsh_free(cache);
 }
 
-FileInfoEntry_t *acquireFileInfoCache(FileInfoCache_t *cache,
-                                      sau_inode_t inode) {
+FileInfoEntry_t *acquireFileInfoCache(FileInfoCache_t *cache, sau_inode_t inode) {
 	FileInfoEntry_t key;
 	FileInfoEntry_t *entry = NULL;
 
@@ -142,8 +136,7 @@ FileInfoEntry_t *acquireFileInfoCache(FileInfoCache_t *cache,
 	key.lookup = true;
 	PTHREAD_MUTEX_lock(&cache->lock);
 
-	struct avltree_node *node =
-	    avltree_lookup(&key.tree_hook, &cache->entry_lookup);
+	struct avltree_node *node = avltree_lookup(&key.tree_hook, &cache->entry_lookup);
 
 	if (node) {
 		entry = avltree_container_of(node, FileInfoEntry_t, tree_hook);
@@ -191,8 +184,7 @@ void eraseFileInfoCache(FileInfoCache_t *cache, FileInfoEntry_t *entry) {
 FileInfoEntry_t *popExpiredFileInfoCache(FileInfoCache_t *cache) {
 	PTHREAD_MUTEX_lock(&cache->lock);
 
-	FileInfoEntry_t *entry =
-	    glist_first_entry(&cache->lru_list, FileInfoEntry_t, list_hook);
+	FileInfoEntry_t *entry = glist_first_entry(&cache->lru_list, FileInfoEntry_t, list_hook);
 
 	if (!entry) {
 		PTHREAD_MUTEX_unlock(&cache->lock);

--- a/src/nfs-ganesha/fileinfo_cache.h
+++ b/src/nfs-ganesha/fileinfo_cache.h
@@ -1,21 +1,23 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
 /*
 
    Copyright 2017 Skytechnology sp. z o.o.
    Copyright 2023 Leil Storage OÜ
 
-   This file is part of SaunaFS.
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 3 of the License, or (at your option) any later version.
 
-   SaunaFS is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, version 3.
-
-   SaunaFS is distributed in the hope that it will be useful,
+   This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
 
-   You should have received a copy of the GNU General Public License
-   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301 USA
 */
 
 #pragma once

--- a/src/nfs-ganesha/fileinfo_cache.h
+++ b/src/nfs-ganesha/fileinfo_cache.h
@@ -41,8 +41,7 @@ typedef struct FileInfoEntry FileInfoEntry_t;
  * \return                        pointer to FileInfoCache_t structure
  * \post                          Destroy with destroyFileInfoCache function
  */
-FileInfoCache_t *createFileInfoCache(unsigned maxEntries,
-                                     int minTimeoutMilliseconds);
+FileInfoCache_t *createFileInfoCache(unsigned maxEntries, int minTimeoutMilliseconds);
 
 /*!
  * \brief Reset cache parameters
@@ -70,8 +69,7 @@ void destroyFileInfoCache(FileInfoCache_t *cache);
  * \post Set fileinfo to a valid pointer after opening a file with
  *       sau_attach_fileinfo
  */
-FileInfoEntry_t *acquireFileInfoCache(FileInfoCache_t *cache,
-                                      sau_inode_t inode);
+FileInfoEntry_t *acquireFileInfoCache(FileInfoCache_t *cache, sau_inode_t inode);
 
 /*!
  * \brief Release fileinfo from cache

--- a/src/nfs-ganesha/fileinfo_cache_unittest.cc
+++ b/src/nfs-ganesha/fileinfo_cache_unittest.cc
@@ -1,21 +1,23 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
 /*
 
    Copyright 2017 Skytechnology sp. z o.o.
    Copyright 2023 Leil Storage OÜ
 
-   This file is part of SaunaFS.
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 3 of the License, or (at your option) any later version.
 
-   SaunaFS is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, version 3.
-
-   SaunaFS is distributed in the hope that it will be useful,
+   This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
 
-   You should have received a copy of the GNU General Public License
-   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301 USA
 */
 
 #include "fileinfo_cache.h"

--- a/src/nfs-ganesha/fileinfo_cache_unittest.cc
+++ b/src/nfs-ganesha/fileinfo_cache_unittest.cc
@@ -20,7 +20,7 @@
    02110-1301 USA
 */
 
-#include "fileinfo_cache.h"
+#include "nfs-ganesha/fileinfo_cache.h"
 
 #include <gtest/gtest.h>
 
@@ -105,7 +105,7 @@ TEST(FileInfoCache, Reset) {
 	auto *entry1 = acquireFileInfoCache(cache, 1);
 	releaseFileInfoCache(cache, entry1);
 
-	auto expired = popExpiredFileInfoCache(cache);
+	auto *expired = popExpiredFileInfoCache(cache);
 	ASSERT_EQ(expired, nullptr);
 
 	resetFileInfoCacheParameters(cache, 0, 0);

--- a/src/nfs-ganesha/handle.c
+++ b/src/nfs-ganesha/handle.c
@@ -17,9 +17,7 @@
    along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "config.h"
 #include "fsal_types.h"
-#include "saunafs_fsal_types.h"
 
 #ifdef LINUX
 #include <linux/falloc.h>  /* for fallocate  */
@@ -30,9 +28,11 @@
 #include "fsal_convert.h"
 #include "FSAL/fsal_commonlib.h"
 
+#include "config.h"
 #include "errors/saunafs_error_codes.h"
-#include "context_wrap.h"
-#include "saunafs_internal.h"
+#include "nfs-ganesha/context_wrap.h"
+#include "nfs-ganesha/saunafs_fsal_types.h"
+#include "nfs-ganesha/saunafs_internal.h"
 
 /**
  * @brief Clean up a filehandle.
@@ -82,8 +82,7 @@ static fsal_status_t lookup(struct fsal_obj_handle *dirHandle, const char *path,
 	export = container_of(op_ctx->fsal_export, struct SaunaFSExport, export);
 	directory = container_of(dirHandle, struct SaunaFSHandle, handle);
 
-	int status = saunafs_lookup(export->fsInstance, &op_ctx->creds,
-	                            directory->inode, path, &node);
+	int status = saunafs_lookup(export->fsInstance, &op_ctx->creds, directory->inode, path, &node);
 
 	if (status < 0) {
 		return fsalLastError();
@@ -116,10 +115,9 @@ static fsal_status_t lookup(struct fsal_obj_handle *dirHandle, const char *path,
  *
  * @returns: FSAL status
  */
-static fsal_status_t readdir_(struct fsal_obj_handle *dirHandle,
-                              fsal_cookie_t *whence, void *dirState,
-                              fsal_readdir_cb readdirCb,
-                              attrmask_t attributesMask, bool *eof) {
+static fsal_status_t readdir_(struct fsal_obj_handle *dirHandle, fsal_cookie_t *whence,
+                              void *dirState, fsal_readdir_cb readdirCb, attrmask_t attributesMask,
+                              bool *eof) {
 	static const int batchSize = 100;
 	struct sau_direntry buffer[batchSize];
 
@@ -154,18 +152,16 @@ static fsal_status_t readdir_(struct fsal_obj_handle *dirHandle,
 		size_t totalEntries = 0;
 		size_t entry = 0;
 
-		status = sau_readdir(export->fsInstance, context, saunafsFd,
-		                     direntryOffset, batchSize, buffer, &totalEntries);
+		status = sau_readdir(export->fsInstance, context, saunafsFd, direntryOffset, batchSize,
+		                     buffer, &totalEntries);
 
 		if (status < 0) {
 			return fsalLastError();
 		}
 
 		result = DIR_CONTINUE;
-		for (entry = 0; entry < totalEntries && result != DIR_TERMINATE;
-		     ++entry) {
-			if (strcmp(buffer[entry].name, ".")  == 0 ||
-			    strcmp(buffer[entry].name, "..") == 0) {
+		for (entry = 0; entry < totalEntries && result != DIR_TERMINATE; ++entry) {
+			if (strcmp(buffer[entry].name, ".") == 0 || strcmp(buffer[entry].name, "..") == 0) {
 				continue;
 			}
 
@@ -176,8 +172,8 @@ static fsal_status_t readdir_(struct fsal_obj_handle *dirHandle,
 
 			direntryOffset = buffer[entry].next_entry_offset;
 
-			result = readdirCb(buffer[entry].name, &handle->handle,
-			                   &attributes, dirState, direntryOffset + 1);
+			result = readdirCb(buffer[entry].name, &handle->handle, &attributes, dirState,
+			                   direntryOffset + 1);
 
 			fsal_release_attrs(&attributes);
 		}
@@ -225,8 +221,8 @@ static fsal_status_t getattrs(struct fsal_obj_handle *objectHandle,
 	LogFullDebug(COMPONENT_FSAL, " export = %" PRIu16 " inode = %" PRIiNode,
 	             export->export.export_id, handle->inode);
 
-	int status = saunafs_getattr(export->fsInstance, &op_ctx->creds,
-	                             handle->inode, &posixAttributes);
+	int status =
+	    saunafs_getattr(export->fsInstance, &op_ctx->creds, handle->inode, &posixAttributes);
 
 	if (status < 0) {
 		if (attributes->request_mask & ATTR_RDATTR_ERR) {
@@ -240,8 +236,7 @@ static fsal_status_t getattrs(struct fsal_obj_handle *objectHandle,
 #ifdef ENABLE_NFS_ACL_SUPPORT
 	if (attributes->request_mask & (attrmask_t)ATTR_ACL) {
 		fsal_status_t status =
-		    getACL(export, handle->inode, posixAttributes.attr.st_uid,
-		           &attributes->acl);
+		    getACL(export, handle->inode, posixAttributes.attr.st_uid, &attributes->acl);
 
 		if (!FSAL_IS_ERROR(status)) {
 			attributes->valid_mask |= (attrmask_t)ATTR_ACL;
@@ -265,19 +260,16 @@ static fsal_status_t getattrs(struct fsal_obj_handle *objectHandle,
  *
  * @returns: FSAL status
  */
-static fsal_status_t handle_to_wire(const struct fsal_obj_handle *objectHandle,
-                                    uint32_t outputType,
+static fsal_status_t handle_to_wire(const struct fsal_obj_handle *objectHandle, uint32_t outputType,
                                     struct gsh_buffdesc *buffer) {
 	(void)outputType;
-	struct SaunaFSHandle *handle = NULL;
 
-	handle = container_of(objectHandle, struct SaunaFSHandle, handle);
+	struct SaunaFSHandle *handle = container_of(objectHandle, struct SaunaFSHandle, handle);
 
 	sau_inode_t inode = handle->inode;
 
 	if (buffer->len < sizeof(sau_inode_t)) {
-		LogMajor(COMPONENT_FSAL,
-		         "Space too small for handle. Need  %zu, have %zu",
+		LogMajor(COMPONENT_FSAL, "Space too small for handle. Need  %zu, have %zu",
 		         sizeof(sau_inode_t), buffer->len);
 		return fsalstat(ERR_FSAL_TOOSMALL, 0);
 	}
@@ -294,16 +286,12 @@ static fsal_status_t handle_to_wire(const struct fsal_obj_handle *objectHandle,
  * Indicate the unique part of the handle that should be used for hashing.
  *
  * @param [in]  objectHandle     Handle whose key is to be got
- * @param [out] buffer           Address and length giving sub-region of
- *                               handle to be used as key.
+ * @param [out] buffer           Address and length giving sub-region of handle to be used as key.
  *
  * @returns: FSAL status
  */
-static void handle_to_key(struct fsal_obj_handle *objectHandle,
-                          struct gsh_buffdesc *buffer) {
-	struct SaunaFSHandle *handle = NULL;
-
-	handle = container_of(objectHandle, struct SaunaFSHandle, handle);
+static void handle_to_key(struct fsal_obj_handle *objectHandle, struct gsh_buffdesc *buffer) {
+	struct SaunaFSHandle *handle = container_of(objectHandle, struct SaunaFSHandle, handle);
 
 	buffer->addr = &handle->key;
 	buffer->len = sizeof(struct SaunaFSHandleKey);
@@ -347,8 +335,8 @@ static fsal_status_t closeFileDescriptor(struct SaunaFSHandle *handle,
  *
  * @return FSAL status.
  */
-fsal_status_t reopen_func(struct fsal_obj_handle *objectHandle,
-                          fsal_openflags_t openflags, struct fsal_fd *fsalFd) {
+fsal_status_t reopen_func(struct fsal_obj_handle *objectHandle, fsal_openflags_t openflags,
+                          struct fsal_fd *fsalFd) {
 	struct SaunaFSHandle *handle = NULL;
 	struct SaunaFSFd *fileDescriptor = NULL;
 	struct sau_fileinfo *saunafsFD = NULL;
@@ -363,30 +351,24 @@ fsal_status_t reopen_func(struct fsal_obj_handle *objectHandle,
 
 	export = container_of(op_ctx->fsal_export, struct SaunaFSExport, export);
 
-	LogFullDebug(COMPONENT_FSAL,
-	             "fd = %p fd->fd = %p openflags = %x, posixFlags = %x",
+	LogFullDebug(COMPONENT_FSAL, "fd = %p fd->fd = %p openflags = %x, posixFlags = %x",
 	             fileDescriptor, fileDescriptor->fd, openflags, posixFlags);
 
 	assert(fileDescriptor->fd == NULL &&
 	       fileDescriptor->fsalFd.openflags == FSAL_O_CLOSED && openflags != 0);
 
-	saunafsFD = saunafs_open(export->fsInstance, &op_ctx->creds, handle->inode,
-	                         posixFlags);
+	saunafsFD = saunafs_open(export->fsInstance, &op_ctx->creds, handle->inode, posixFlags);
 
 	if (saunafsFD == NULL) {
-		LogFullDebug(COMPONENT_FSAL, "open failed with %s",
-		             sau_error_string(sau_last_err()));
+		LogFullDebug(COMPONENT_FSAL, "open failed with %s", sau_error_string(sau_last_err()));
 		return fsalLastError();
 	}
 
-	if (fileDescriptor->fd != NULL &&
-	    fileDescriptor->fsalFd.openflags != FSAL_O_CLOSED) {
-		int retvalue =
-		    sau_release(handle->export->fsInstance, fileDescriptor->fd);
+	if (fileDescriptor->fd != NULL && fileDescriptor->fsalFd.openflags != FSAL_O_CLOSED) {
+		int retvalue = sau_release(handle->export->fsInstance, fileDescriptor->fd);
 
 		if (retvalue < 0) {
-			LogFullDebug(COMPONENT_FSAL, "close failed with %s",
-			             sau_error_string(sau_last_err()));
+			LogFullDebug(COMPONENT_FSAL, "close failed with %s", sau_error_string(sau_last_err()));
 			status = fsalLastError();
 		}
 	}
@@ -404,19 +386,14 @@ fsal_status_t reopen_func(struct fsal_obj_handle *objectHandle,
  * @param [in] state                         state_t to use for this operation
  * @param [in] openflags                     Mode for open
  * @param [in] createmode                    Mode for create
- * @param [in] verifier                      Verifier to use for exclusive
- *                                           create
- * @param [in] attributes                    Attributes to set on created
- *                                           file
+ * @param [in] verifier                      Verifier to use for exclusive create
+ * @param [in] attributes                    Attributes to set on created file
  *
  * @returns: FSAL status
  */
-static fsal_status_t openByHandle(struct fsal_obj_handle *objectHandle,
-                                  struct state_t *state,
-                                  fsal_openflags_t openflags,
-                                  enum fsal_create_mode createmode,
-                                  fsal_verifier_t verifier,
-                                  struct fsal_attrlist *attributes) {
+static fsal_status_t openByHandle(struct fsal_obj_handle *objectHandle, struct state_t *state,
+                                  fsal_openflags_t openflags, enum fsal_create_mode createmode,
+                                  fsal_verifier_t verifier, struct fsal_attrlist *attributes) {
 	struct SaunaFSExport *export = NULL;
 	struct SaunaFSHandle *handle = NULL;
 	struct SaunaFSFd *saunafsFd = NULL;
@@ -431,117 +408,102 @@ static fsal_status_t openByHandle(struct fsal_obj_handle *objectHandle,
 	export = container_of(op_ctx->fsal_export, struct SaunaFSExport, export);
 
 	if (state != NULL) {
-		saunafsFd =
-		    &container_of(state, struct SaunaFSStateFd, state)->saunafsFd;
+		saunafsFd = &container_of(state, struct SaunaFSStateFd, state)->saunafsFd;
 	} else {
-		/* We need to use the global file descriptor to continue */
+		// We need to use the global file descriptor to continue
 		saunafsFd = &handle->fd;
 	}
 
 	fsalFd = &saunafsFd->fsalFd;
 
-	/* Indicate we want to do fd work (can't fail since not reclaiming) */
+	// Indicate we want to do fd work (can't fail since not reclaiming)
 	(void)fsal_start_fd_work(fsalFd, false);
 
 	oldOpenflags = saunafsFd->fsalFd.openflags;
 
 	if (state != NULL) {
-		/* Prepare to take the share reservation, but only if we are
-		 * called with a valid state (if state is NULL the caller is a
-		 * stateless create such as NFS v3 CREATE and we're just going
-		 * to ignore share reservation stuff).
-		 */
+		// Prepare to take the share reservation, but only if we are called with a valid state
+		// (if state is NULL the caller is a stateless create such as NFS v3 CREATE and we're just
+		// going to ignore share reservation stuff).
 
-		/* Now that we have the mutex, and no I/O is in progress so we
-		 * have exclusive access to the share's fsal_fd, we can look
-		 * at its openflags. We also need to work the share reservation
-		 * so take the obj_lock.
-		 * NOTE: This is the ONLY sequence where both a work_mutex and
-		 * the obj_lock are taken, so there is no opportunity for ABBA
-		 * deadlock.
-		 *
-		 * Note that we do hold the obj_lock over an open and a close
-		 * which is longer than normal, but the previous iteration
-		 * of the code held the obj lock (read granted) over whole
-		 * I/O operations. We don't block over I/O because we've assured
-		 * that no I/O is in progress or can start before proceeding
-		 * past the above while loop.
-		 */
+		// Now that we have the mutex, and no I/O is in progress so we have exclusive access to the
+		// share's fsal_fd, we can look at its openflags. We also need to work the share reservation
+		// so take the obj_lock.
+		// NOTE: This is the ONLY sequence where both a work_mutex and the obj_lock are taken, so
+		// there is no opportunity for ABBA deadlock.
+
+		// Note that we do hold the obj_lock over an open and a close which is longer than normal,
+		// but the previous iteration of the code held the obj lock (read granted) over whole
+		// I/O operations. We don't block over I/O because we've assured that no I/O is in progress
+		// or can start before proceeding past the above while loop.
 		PTHREAD_RWLOCK_wrlock(&objectHandle->obj_lock);
 
-		/* Now check the new share. */
+		// Now check the new share.
 		status = check_share_conflict(&handle->share, openflags, false);
 
 		if (FSAL_IS_ERROR(status)) {
-			LogDebug(COMPONENT_FSAL, "check_share_conflict returned %s",
-			         fsal_err_txt(status));
+			LogDebug(COMPONENT_FSAL, "check_share_conflict returned %s", fsal_err_txt(status));
 
 			if (state != NULL) {
 				if (!FSAL_IS_ERROR(status)) {
-					/* Success, establish the new share. */
-					update_share_counters(&handle->share, oldOpenflags,
-					                      openflags);
+					// Success, establish the new share.
+					update_share_counters(&handle->share, oldOpenflags, openflags);
 				}
 
 				/* Release obj_lock. */
 				PTHREAD_RWLOCK_unlock(&objectHandle->obj_lock);
 			}
 
-			/* Indicate we are done with fd work and signal
-			 * any waiters. */
+			// Indicate we are done with fd work and signal any waiters.
 			fsal_complete_fd_work(fsalFd);
 
 			return status;
 		}
 	}
 
-	/* Check for a genuine no-op open. That means we aren't trying to
-	 * create, the file is already open in the same mode with the same deny
-	 * flags, and we aren't trying to truncate. In this case we want to
-	 * avoid bouncing the fd. In the case of JUST changing the deny mode or
-	 * a replayed exclusive create, we might bounce the fd when we could
-	 * have avoided that, but those scenarios are much less common.
-	 */
+	// Check for a genuine no-op open. That means we aren't trying to create, the file is already
+	// open in the same mode with the same deny flags, and we aren't trying to truncate.
+	// In this case we want to avoid bouncing the fd. In the case of JUST changing the deny mode or
+	// a replayed exclusive create, we might bounce the fd when we could have avoided that, but
+	// those scenarios are much less common.
 	if (FSAL_O_NFS_FLAGS(openflags) == FSAL_O_NFS_FLAGS(oldOpenflags) &&
 	    truncated == false && createmode == FSAL_NO_CREATE) {
-		LogFullDebug(COMPONENT_FSAL,
-		             "no-op reopen2 saunafsFd->fd = %p openflags = %x",
+		LogFullDebug(COMPONENT_FSAL, "no-op reopen2 saunafsFd->fd = %p openflags = %x",
 		             saunafsFd->fd, openflags);
 
 		if (state != NULL) {
 			if (!FSAL_IS_ERROR(status)) {
-				/* Success, establish the new share. */
+				// Success, establish the new share.
 				update_share_counters(&handle->share, oldOpenflags, openflags);
 			}
 
-			/* Release obj_lock. */
+			// Release obj_lock.
 			PTHREAD_RWLOCK_unlock(&objectHandle->obj_lock);
 		}
 
-		/* Indicate we are done with fd work and signal any waiters. */
+		// Indicate we are done with fd work and signal any waiters.
 		fsal_complete_fd_work(fsalFd);
 
 		return status;
 	}
 
-	/* No share conflict, re-open the share fd */
+	// No share conflict, re-open the share fd
 	status = reopen_func(objectHandle, openflags, fsalFd);
 
 	if (FSAL_IS_ERROR(status)) {
-		LogDebug(COMPONENT_FSAL, "reopen_func returned %s",
-		         fsal_err_txt(status));
+		LogDebug(COMPONENT_FSAL, "reopen_func returned %s", fsal_err_txt(status));
 
 		if (state != NULL) {
 			if (!FSAL_IS_ERROR(status)) {
-				/* Success, establish the new share. */
+				// Success, establish the new share.
 				update_share_counters(&handle->share, oldOpenflags, openflags);
 			}
 
-			/* Release obj_lock. */
+			// Release obj_lock.
 			PTHREAD_RWLOCK_unlock(&objectHandle->obj_lock);
 		}
 
-		/* Indicate we are done with fd work and signal any waiters. */
+		// Indicate we are done with fd work and signal any waiters.
 		fsal_complete_fd_work(fsalFd);
 
 		return status;
@@ -550,16 +512,15 @@ static fsal_status_t openByHandle(struct fsal_obj_handle *objectHandle,
 	fsal2posix_openflags(openflags, &posixFlags);
 
 	if (createmode >= FSAL_EXCLUSIVE || attributes) {
-		/* NOTE: won't come in here when called from saunafs_reopen2...
-		 *       truncated might be set, but attrs_out will be NULL.
-		 *       We don't need to look at truncated since other callers
-		 *       are interested in attrs_out.
-		 */
+		// NOTE: won't come in here when called from saunafs_reopen2...
+		//       truncated might be set, but attrs_out will be NULL.
+		//       We don't need to look at truncated since other callers
+		//       are interested in attrs_out.
 
-		/* Refresh the attributes */
+		// Refresh the attributes
 		struct sau_attr_reply attributesValues;
-		int retvalue = saunafs_getattr(export->fsInstance, &op_ctx->creds,
-		                               handle->inode, &attributesValues);
+		int retvalue =
+		    saunafs_getattr(export->fsInstance, &op_ctx->creds, handle->inode, &attributesValues);
 
 		if (retvalue == 0) {
 			LogFullDebug(COMPONENT_FSAL, "New size = %" PRIx64,
@@ -571,7 +532,7 @@ static fsal_status_t openByHandle(struct fsal_obj_handle *objectHandle,
 		if (!FSAL_IS_ERROR(status) && createmode >= FSAL_EXCLUSIVE &&
 		    createmode != FSAL_EXCLUSIVE_9P &&
 		    !check_verifier_stat(&attributesValues.attr, verifier, false)) {
-			/* Verifier didn't match, return EEXIST */
+			// Verifier didn't match, return EEXIST
 			status = fsalstat(posix2fsal_error(EEXIST), EEXIST);
 		}
 
@@ -581,21 +542,21 @@ static fsal_status_t openByHandle(struct fsal_obj_handle *objectHandle,
 	}
 
 	if (FSAL_IS_ERROR(status)) {
-		/* close fd */
+		// close fd
 		(void)closeFileDescriptor(handle, saunafsFd);
 	}
 
 	if (state != NULL) {
 		if (!FSAL_IS_ERROR(status)) {
-			/* Success, establish the new share. */
+			// Success, establish the new share.
 			update_share_counters(&handle->share, oldOpenflags, openflags);
 		}
 
-		/* Release obj_lock. */
+		// Release obj_lock.
 		PTHREAD_RWLOCK_unlock(&objectHandle->obj_lock);
 	}
 
-	/* Indicate we are done with fd work and signal any waiters. */
+	// Indicate we are done with fd work and signal any waiters.
 	fsal_complete_fd_work(fsalFd);
 
 	return status;
@@ -605,54 +566,45 @@ static fsal_status_t openByHandle(struct fsal_obj_handle *objectHandle,
  * @brief Open a file using its name.
  *
  * @param [in] objectHandle                  File handle to open
- * @param [in] state                         state_t to use for this
- *                                           operation
+ * @param [in] state                         state_t to use for this operation
  * @param [in] openflags                     Mode for open
  * @param [in] name                          Name of the file
- * @param [in] verifier                      Verifier to use for exclusive
- *                                           create
- * @param [in] attributes                    Attributes to set on created
- *                                           file
+ * @param [in] verifier                      Verifier to use for exclusive create
+ * @param [in] attributes                    Attributes to set on created file
  *
  * @returns: FSAL status
  */
-static fsal_status_t openByName(struct fsal_obj_handle *objectHandle,
-                                struct state_t *state,
+static fsal_status_t openByName(struct fsal_obj_handle *objectHandle, struct state_t *state,
                                 fsal_openflags_t openflags, const char *name,
-                                fsal_verifier_t verifier,
-                                struct fsal_attrlist *attributes) {
+                                fsal_verifier_t verifier, struct fsal_attrlist *attributes) {
 	struct fsal_obj_handle *temp = NULL;
 	fsal_status_t status;
 
-	/* Ganesha doesn't has open by name, so we need to get the name with
-	 * lookup */
+	// Ganesha doesn't has open by name, so we need to get the name with lookup
 	status = objectHandle->obj_ops->lookup(objectHandle, name, &temp, NULL);
 
 	if (FSAL_IS_ERROR(status)) {
-		LogFullDebug(COMPONENT_FSAL, "lookup returned %s",
-		             fsal_err_txt(status));
+		LogFullDebug(COMPONENT_FSAL, "lookup returned %s", fsal_err_txt(status));
 		return status;
 	}
 
 	if (temp->type != REGULAR_FILE) {
 		if (temp->type == DIRECTORY) {
-			/* Trying to open2 a directory */
+			// Trying to open2 a directory
 			status = fsalstat(ERR_FSAL_ISDIR, 0);
 		} else {
-			/* Trying to open2 any other non-regular file */
+			// Trying to open2 any other non-regular file
 			status = fsalstat(ERR_FSAL_SYMLINK, 0);
 		}
 
-		/* Release the object we found by lookup */
+		// Release the object we found by lookup
 		temp->obj_ops->release(temp);
-		LogFullDebug(COMPONENT_FSAL, "open2 returning %s",
-		             fsal_err_txt(status));
+		LogFullDebug(COMPONENT_FSAL, "open2 returning %s", fsal_err_txt(status));
 
 		return status;
 	}
 
-	status = openByHandle(temp, state, openflags, FSAL_NO_CREATE, verifier,
-	                      attributes);
+	status = openByHandle(temp, state, openflags, FSAL_NO_CREATE, verifier, attributes);
 
 	if (FSAL_IS_ERROR(status)) {
 		temp->obj_ops->release(temp);
@@ -680,51 +632,39 @@ static fsal_status_t openByName(struct fsal_obj_handle *objectHandle,
  * @param [in]  state                        state_t to use for this operation
  * @param [in]  openflags                    Mode for open
  * @param [in]  createmode                   Mode for create
- * @param [in]  name                         Name for file if being created
- *                                           or opened
- * @param [in]  attributesToSet              Attributes to set on created
- *                                           file
- * @param [in]  verifier                     Verifier to use for exclusive
- *                                           create
+ * @param [in]  name                         Name for file if being created or opened
+ * @param [in]  attributesToSet              Attributes to set on created file
+ * @param [in]  verifier                     Verifier to use for exclusive create
  * @param [in,out] createdObject             Newly created object
- * @param [in,out] attributes                Optional attributes for newly
- *                                           created object
- * @param [in,out] callerPermissionCheck     The caller must do a
- *                                           permission check
- * @param[in,out] parentPreAttributes        Optional attributes for parent dir
- *                                           before the operation.
+ * @param [in,out] attributes                Optional attributes for newly created object
+ * @param [in,out] callerPermissionCheck     The caller must do a permission check
+ * @param[in,out] parentPreAttributes        Optional attributes for parent dir before the operation.
  *                                           Should be atomic.
- * @param[in,out] parentPostAttributes       Optional attributes for parent dir
- *                                           after the operation.
+ * @param[in,out] parentPostAttributes       Optional attributes for parent dir after the operation.
  *                                           Should be atomic.
  *
  * @returns: FSAL status
  */
-static fsal_status_t open2(struct fsal_obj_handle *objectHandle,
-                           struct state_t *state, fsal_openflags_t openflags,
-                           enum fsal_create_mode createmode, const char *name,
-                           struct fsal_attrlist *attributesToSet,
-                           fsal_verifier_t verifier,
-                           struct fsal_obj_handle **createdObject,
-                           struct fsal_attrlist *attributes,
-                           bool *callerPermissionCheck,
+static fsal_status_t open2(struct fsal_obj_handle *objectHandle, struct state_t *state,
+                           fsal_openflags_t openflags, enum fsal_create_mode createmode,
+                           const char *name, struct fsal_attrlist *attributesToSet,
+                           fsal_verifier_t verifier, struct fsal_obj_handle **createdObject,
+                           struct fsal_attrlist *attributes, bool *callerPermissionCheck,
                            struct fsal_attrlist *parentPreAttributes,
                            struct fsal_attrlist *parentPostAttributes) {
 	struct SaunaFSExport *export = NULL;
 	struct SaunaFSHandle *handle = NULL;
 	fsal_status_t status = fsalstat(ERR_FSAL_NO_ERROR, 0);
 
-	LogAttrlist(COMPONENT_FSAL, NIV_FULL_DEBUG, "attrs ", attributesToSet,
-	            false);
+	LogAttrlist(COMPONENT_FSAL, NIV_FULL_DEBUG, "attrs ", attributesToSet, false);
 
 	if (createmode >= FSAL_EXCLUSIVE) {
-		/* Now fixup attrs for verifier if exclusive create */
+		// Now fixup attrs for verifier if exclusive create
 		set_common_verifier(attributesToSet, verifier, false);
 	}
 
 	if (name == NULL) {
-		status = openByHandle(objectHandle, state, openflags, createmode,
-		                      verifier, attributes);
+		status = openByHandle(objectHandle, state, openflags, createmode, verifier, attributes);
 		*callerPermissionCheck = FSAL_IS_SUCCESS(status);
 		return status;
 	}
@@ -732,47 +672,40 @@ static fsal_status_t open2(struct fsal_obj_handle *objectHandle,
 	*callerPermissionCheck = (createmode == FSAL_NO_CREATE);
 
 	if (createmode == FSAL_NO_CREATE) {
-		return openByName(objectHandle, state, openflags, name, verifier,
-		                  attributes);
+		return openByName(objectHandle, state, openflags, name, verifier, attributes);
 	}
 
-	/* Create file */
+	// Create file
 	export = container_of(op_ctx->fsal_export, struct SaunaFSExport, export);
 	handle = container_of(objectHandle, struct SaunaFSHandle, handle);
 
-	/* Fetch the mode attribute to use in the openat system call */
-	mode_t unix_mode =
-	    fsal2unix_mode(attributesToSet->mode) &
-	    ~op_ctx->fsal_export->exp_ops.fs_umask(op_ctx->fsal_export);
+	// Fetch the mode attribute to use in the openat system call
+	mode_t unix_mode = fsal2unix_mode(attributesToSet->mode) &
+	                   ~op_ctx->fsal_export->exp_ops.fs_umask(op_ctx->fsal_export);
 
-	/* Don't set the mode if we later set the attributes */
+	// Don't set the mode if we later set the attributes
 	FSAL_UNSET_MASK(attributesToSet->valid_mask, (attrmask_t)ATTR_MODE);
 
 	struct sau_entry posixAttributes;
-	int retval =
-	    saunafs_mknode(export->fsInstance, &op_ctx->creds, handle->inode, name,
-	                   unix_mode, 0, &posixAttributes);
+	int retval = saunafs_mknode(export->fsInstance, &op_ctx->creds, handle->inode, name, unix_mode,
+	                            0, &posixAttributes);
 
-	if (retval < 0 && sau_last_err() == SAUNAFS_ERROR_EEXIST &&
-	    createmode == FSAL_UNCHECKED) {
-		return openByName(objectHandle, state, openflags, name, verifier,
-		                  attributes);
+	if (retval < 0 && sau_last_err() == SAUNAFS_ERROR_EEXIST && createmode == FSAL_UNCHECKED) {
+		return openByName(objectHandle, state, openflags, name, verifier, attributes);
 	}
 
 	if (retval < 0) { return fsalLastError(); }
 
-	/* File has been created by us. */
+	// File has been created by us.
 	*callerPermissionCheck = false;
 
-	struct SaunaFSHandle *newHandle =
-	    allocateHandle(&posixAttributes.attr, export);
+	struct SaunaFSHandle *newHandle = allocateHandle(&posixAttributes.attr, export);
 
 	if (newHandle == NULL) {
 		(*createdObject)->obj_ops->release(*createdObject);
 		*createdObject = NULL;
 
-		retval = saunafs_unlink(export->fsInstance, &op_ctx->creds,
-		                        handle->inode, name);
+		retval = saunafs_unlink(export->fsInstance, &op_ctx->creds, handle->inode, name);
 
 		if (retval < 0) { return fsalLastError(); }
 
@@ -782,14 +715,12 @@ static fsal_status_t open2(struct fsal_obj_handle *objectHandle,
 	*createdObject = &newHandle->handle;
 
 	if (attributesToSet->valid_mask != 0) {
-		status = (*createdObject)->obj_ops->setattr2(*createdObject, false,
-		                                             state, attributesToSet);
+		status = (*createdObject)->obj_ops->setattr2(*createdObject, false, state, attributesToSet);
 		if (FSAL_IS_ERROR(status)) {
 			(*createdObject)->obj_ops->release(*createdObject);
 			*createdObject = NULL;
 
-			retval = saunafs_unlink(export->fsInstance, &op_ctx->creds,
-			                        handle->inode, name);
+			retval = saunafs_unlink(export->fsInstance, &op_ctx->creds, handle->inode, name);
 
 			if (retval < 0) { return fsalLastError(); }
 
@@ -797,16 +728,14 @@ static fsal_status_t open2(struct fsal_obj_handle *objectHandle,
 		}
 
 		if (attributes != NULL) {
-			status =
-			    (*createdObject)->obj_ops->getattrs(*createdObject, attributes);
+			status = (*createdObject)->obj_ops->getattrs(*createdObject, attributes);
 
 			if (FSAL_IS_ERROR(status) &&
 			    (attributes->request_mask & ATTR_RDATTR_ERR) == 0) {
 				(*createdObject)->obj_ops->release(*createdObject);
 				*createdObject = NULL;
 
-				retval = saunafs_unlink(export->fsInstance, &op_ctx->creds,
-				                        handle->inode, name);
+				retval = saunafs_unlink(export->fsInstance, &op_ctx->creds, handle->inode, name);
 
 				if (retval < 0) { return fsalLastError(); }
 
@@ -835,16 +764,14 @@ static fsal_status_t open2(struct fsal_obj_handle *objectHandle,
  * complete, the done callback is called with the results.
  *
  * @param [in]     objectHandle     File on which to operate
- * @param [in]     bypass           If state doesn't indicate a share
- *                                  reservation, bypass any deny read
+ * @param [in]     bypass           If state doesn't indicate a share reservation,
+ *                                  bypass any deny read
  * @param [in,out] doneCb           Callback to call when I/O is done
- * @param [in,out] readArg          Info about read, passed back in
- *                                  callback
+ * @param [in,out] readArg          Info about read, passed back in callback
  * @param [in,out] callerArg        Opaque arg from the caller for callback
  */
-static void read2(struct fsal_obj_handle *objectHandle, bool bypass,
-                  fsal_async_cb doneCb, struct fsal_io_arg *readArg,
-                  void *callerArg) {
+static void read2(struct fsal_obj_handle *objectHandle, bool bypass, fsal_async_cb doneCb,
+                  struct fsal_io_arg *readArg, void *callerArg) {
 	struct SaunaFSExport *export = NULL;
 	struct SaunaFSHandle *handle = NULL;
 
@@ -861,8 +788,7 @@ static void read2(struct fsal_obj_handle *objectHandle, bool bypass,
 	export = container_of(op_ctx->fsal_export, struct SaunaFSExport, export);
 	handle = container_of(objectHandle, struct SaunaFSHandle, handle);
 
-	LogFullDebug(COMPONENT_FSAL,
-	             "export = %" PRIu16 " inode = %" PRIiNode " offset=%" PRIu64,
+	LogFullDebug(COMPONENT_FSAL, "export = %" PRIu16 " inode = %" PRIiNode " offset=%" PRIu64,
 	             export->export.export_id, handle->inode, offset);
 
 	if (readArg->info != NULL) {
@@ -873,12 +799,11 @@ static void read2(struct fsal_obj_handle *objectHandle, bool bypass,
 
 	// Indicate a desire to start io and get a usable file descriptor
 	status = fsal_start_io(&outFileDescriptor, objectHandle, &handle->fd.fsalFd,
-	                       &emptyFileDescriptor.fsalFd, readArg->state,
-	                       FSAL_O_READ, false, NULL, bypass, &handle->share);
+	                       &emptyFileDescriptor.fsalFd, readArg->state, FSAL_O_READ, false, NULL,
+	                       bypass, &handle->share);
 
 	if (FSAL_IS_ERROR(status)) {
-		LogFullDebug(COMPONENT_FSAL, "fsal_start_io failed returning %s",
-		             fsal_err_txt(status));
+		LogFullDebug(COMPONENT_FSAL, "fsal_start_io failed returning %s", fsal_err_txt(status));
 
 		doneCb(objectHandle, status, readArg, callerArg);
 		return;
@@ -888,9 +813,8 @@ static void read2(struct fsal_obj_handle *objectHandle, bool bypass,
 
 	readArg->io_amount = 0;
 	for (int i = 0; i < readArg->iov_count; i++) {
-		bytes = saunafs_read(export->fsInstance, &op_ctx->creds, saunafsFd->fd,
-		                     offset, readArg->iov[i].iov_len,
-		                     readArg->iov[i].iov_base);
+		bytes = saunafs_read(export->fsInstance, &op_ctx->creds, saunafsFd->fd, offset,
+		                     readArg->iov[i].iov_len, readArg->iov[i].iov_base);
 
 		if (bytes == 0) {
 			readArg->end_of_file = true;
@@ -900,18 +824,15 @@ static void read2(struct fsal_obj_handle *objectHandle, bool bypass,
 			status = fsalLastError();
 
 			status2 = fsal_complete_io(objectHandle, outFileDescriptor);
-			LogFullDebug(COMPONENT_FSAL, "fsal_complete_io returned %s",
-			             fsal_err_txt(status2));
+			LogFullDebug(COMPONENT_FSAL, "fsal_complete_io returned %s", fsal_err_txt(status2));
 
 			if (readArg->state == NULL) {
-				/* We did I/O without a state so we need
-				 * to release the temp share
-				 * reservation acquired. */
+				// We did I/O without a state so we need to release the temp share
+				// reservation acquired.
 
-				/* Release the share reservation now by
-				 * updating the counters. */
-				update_share_counters_locked(objectHandle, &handle->share,
-				                             FSAL_O_READ, FSAL_O_CLOSED);
+				// Release the share reservation now by updating the counters.
+				update_share_counters_locked(objectHandle, &handle->share, FSAL_O_READ,
+				                             FSAL_O_CLOSED);
 			}
 
 			doneCb(objectHandle, status, readArg, callerArg);
@@ -923,17 +844,13 @@ static void read2(struct fsal_obj_handle *objectHandle, bool bypass,
 	}
 
 	status2 = fsal_complete_io(objectHandle, outFileDescriptor);
-	LogFullDebug(COMPONENT_FSAL, "fsal_complete_io returned %s",
-	             fsal_err_txt(status2));
+	LogFullDebug(COMPONENT_FSAL, "fsal_complete_io returned %s", fsal_err_txt(status2));
 
 	if (readArg->state == NULL) {
-		/* We did I/O without a state so we need to release the temp
-		 * share reservation acquired. */
+		// We did I/O without a state so we need to release the temp share reservation acquired.
 
-		/* Release the share reservation now by updating
-		 * the counters. */
-		update_share_counters_locked(objectHandle, &handle->share, FSAL_O_READ,
-		                             FSAL_O_CLOSED);
+		// Release the share reservation now by updating the counters.
+		update_share_counters_locked(objectHandle, &handle->share, FSAL_O_READ, FSAL_O_CLOSED);
 	}
 
 	doneCb(objectHandle, status, readArg, callerArg);
@@ -943,25 +860,21 @@ static void read2(struct fsal_obj_handle *objectHandle, bool bypass,
  *
  * Creation operations. This function creates a new directory.
  *
- * @param [in]     directoryHandle     Directory in which to create the
- *                                     directory
+ * @param [in]     directoryHandle     Directory in which to create the directory
  * @param [in]     name                Name of directory to create
- * @param [in]     attributesToSet     Attributes to set on newly created
- *                                     object
+ * @param [in]     attributesToSet     Attributes to set on newly created object
  * @param [out]    createdObject       Newly created object
- * @param [in,out] attributes          Optional attributes for newly
- *                                     created object
- * @param[in,out] parentPreAttributes  Optional attributes for parent dir
- *                                     before the operation. Should be atomic.
- * @param[in,out] parentPostAttributes Optional attributes for parent dir
- *                                     after the operation. Should be atomic.
+ * @param [in,out] attributes          Optional attributes for newly created object
+ * @param[in,out] parentPreAttributes  Optional attributes for parent dir before the operation.
+ *                                     Should be atomic.
+ * @param[in,out] parentPostAttributes Optional attributes for parent dir after the operation.
+ *                                     Should be atomic.
  *
  * \see fsal_api.h for more information
  *
  * @returns: FSAL status
  */
-static fsal_status_t mkdir_(struct fsal_obj_handle *directoryHandle,
-                            const char *name,
+static fsal_status_t mkdir_(struct fsal_obj_handle *directoryHandle, const char *name,
                             struct fsal_attrlist *attributesToSet,
                             struct fsal_obj_handle **createdObject,
                             struct fsal_attrlist *attributes,
@@ -976,17 +889,15 @@ static fsal_status_t mkdir_(struct fsal_obj_handle *directoryHandle,
 	export = container_of(op_ctx->fsal_export, struct SaunaFSExport, export);
 	directory = container_of(directoryHandle, struct SaunaFSHandle, handle);
 
-	LogFullDebug(COMPONENT_FSAL, "export = %" PRIu16 " parent_inode = %"
-	             PRIiNode " mode = %" PRIo32 " name = %s",
-	             export->export.export_id, directory->inode,
-	             attributesToSet->mode, name);
+	LogFullDebug(COMPONENT_FSAL,
+	             "export = %" PRIu16 " parent_inode = %" PRIiNode " mode = %" PRIo32 " name = %s",
+	             export->export.export_id, directory->inode, attributesToSet->mode, name);
 
 	mode_t unix_mode = fsal2unix_mode(attributesToSet->mode) &
-	        ~op_ctx->fsal_export->exp_ops.fs_umask(op_ctx->fsal_export);
+	                   ~op_ctx->fsal_export->exp_ops.fs_umask(op_ctx->fsal_export);
 
-	int retvalue =
-	    saunafs_mkdir(export->fsInstance, &op_ctx->creds, directory->inode,
-	                  name, unix_mode, &directoryEntry);
+	int retvalue = saunafs_mkdir(export->fsInstance, &op_ctx->creds, directory->inode, name,
+	                             unix_mode, &directoryEntry);
 
 	if (retvalue < 0) {
 		return fsalLastError();
@@ -998,27 +909,23 @@ static fsal_status_t mkdir_(struct fsal_obj_handle *directoryHandle,
 	FSAL_UNSET_MASK(attributesToSet->valid_mask, (attrmask_t)ATTR_MODE);
 
 	if (attributesToSet->valid_mask) {
-		status = (*createdObject)->obj_ops->setattr2(*createdObject, false,
-		                                             NULL, attributesToSet);
+		status = (*createdObject)->obj_ops->setattr2(*createdObject, false, NULL, attributesToSet);
 
 		if (FSAL_IS_ERROR(status)) {
-			LogFullDebug(COMPONENT_FSAL, "setattr2 status=%s",
-			             fsal_err_txt(status));
+			LogFullDebug(COMPONENT_FSAL, "setattr2 status=%s", fsal_err_txt(status));
 
-			/* Release the handle we just allocate */
+			// Release the handle we just allocate
 			(*createdObject)->obj_ops->release(*createdObject);
 			*createdObject = NULL;
 		} else if (attributes != NULL) {
-			/* We ignore errors here. The mkdir and setattr
-			 * succeeded, so we don't want to return error
-			 * if the getattrs fails.
-			 * We'll just return no attributes in that case. */
+			// We ignore errors here. The mkdir and setattr succeeded, so we don't want to return
+			// error if the getattrs fails.
+			// We'll just return no attributes in that case.
 			(*createdObject)->obj_ops->getattrs(*createdObject, attributes);
 		}
 	} else if (attributes != NULL) {
-		/* Since we haven't set any attributes other than what
-		 * was set on create, just use the stat results we used
-		 * to create the fsal_obj_handle. */
+		// Since we haven't set any attributes other than what was set on create, just use the
+		// stat results we used to create the fsal_obj_handle.
 		posix2fsal_attributes_all(&directoryEntry.attr, attributes);
 	}
 
@@ -1032,15 +939,13 @@ static fsal_status_t mkdir_(struct fsal_obj_handle *directoryHandle,
  * This function creates a new name for an existing object.
  *
  * @param [in] objectHandle             Object to be linked to
- * @param [in] destinationDirHandle     Directory in which to create the
- *                                      link
+ * @param [in] destinationDirHandle     Directory in which to create the link
  * @param [in] name                     Name for link
  *
  * @returns: FSAL status
  */
 static fsal_status_t link_(struct fsal_obj_handle *objectHandle,
-                           struct fsal_obj_handle *destinationDirHandle,
-                           const char *name,
+                           struct fsal_obj_handle *destinationDirHandle, const char *name,
                            struct fsal_attrlist *destdirPreAttributes,
                            struct fsal_attrlist *destdirPostAttributes) {
 	struct SaunaFSExport *export = NULL;
@@ -1052,10 +957,9 @@ static fsal_status_t link_(struct fsal_obj_handle *objectHandle,
 
 	destinationHandle = container_of(destinationDirHandle, struct SaunaFSHandle, handle);
 
-	LogFullDebug(COMPONENT_FSAL, "export = %"
-	             PRIu16 " inode = %" PRIiNode " dest_inode = %" PRIiNode
-	             " name = %s", export->export.export_id,
-	             handle->inode, destinationHandle->inode, name);
+	LogFullDebug(COMPONENT_FSAL,
+	             "export = %" PRIu16 " inode = %" PRIiNode " dest_inode = %" PRIiNode " name = %s",
+	             export->export.export_id, handle->inode, destinationHandle->inode, name);
 
 	sau_entry_t entry;
 	int retvalue = saunafs_link(export->fsInstance, &op_ctx->creds, handle->inode,
@@ -1071,8 +975,8 @@ static fsal_status_t link_(struct fsal_obj_handle *objectHandle,
 /**
  * @brief Rename a file.
  *
- * This function renames a file (technically it changes the name of one
- * link, which may be the only link to the file.)
+ * This function renames a file (technically it changes the name of one link,
+ * which may be the only link to the file.)
  *
  * @param [in] oldParentHandle     Source directory
  * @param [in] oldName             Original name
@@ -1090,10 +994,8 @@ static fsal_status_t link_(struct fsal_obj_handle *objectHandle,
  * @returns: FSAL status
  */
 static fsal_status_t rename_(struct fsal_obj_handle *objectHandle,
-                             struct fsal_obj_handle *oldParentHandle,
-                             const char *oldName,
-                             struct fsal_obj_handle *newParentHandle,
-                             const char *newName,
+                             struct fsal_obj_handle *oldParentHandle, const char *oldName,
+                             struct fsal_obj_handle *newParentHandle, const char *newName,
                              struct fsal_attrlist *oldParentPreAttributes,
                              struct fsal_attrlist *oldParentPostAttributes,
                              struct fsal_attrlist *newParentPreAttributes,
@@ -1107,10 +1009,10 @@ static fsal_status_t rename_(struct fsal_obj_handle *objectHandle,
 	oldDir = container_of(oldParentHandle, struct SaunaFSHandle, handle);
 	newDir = container_of(newParentHandle, struct SaunaFSHandle, handle);
 
-	LogFullDebug(COMPONENT_FSAL, "export=%" PRIu16 " old_inode=%" PRIiNode
-	             " new_inode=%" PRIiNode " old_name=%s new_name=%s",
-	             export->export.export_id, oldDir->inode,
-	             newDir->inode, oldName, newName);
+	LogFullDebug(COMPONENT_FSAL,
+	             "export=%" PRIu16 " old_inode=%" PRIiNode " new_inode=%" PRIiNode
+	             " old_name=%s new_name=%s",
+	             export->export.export_id, oldDir->inode, newDir->inode, oldName, newName);
 
 	int status = saunafs_rename(export->fsInstance, &op_ctx->creds, oldDir->inode, oldName,
 	                            newDir->inode, newName);
@@ -1125,23 +1027,20 @@ static fsal_status_t rename_(struct fsal_obj_handle *objectHandle,
 /**
  * @brief Remove a name from a directory.
  *
- * This function removes a name from a directory and possibly deletes the
- * file so named.
+ * This function removes a name from a directory and possibly deletes the file so named.
  *
- * @param [in] directoryHandle     The directory from which to remove the
- *                                 name
- * @param [in] objectHandle        The object being removed
- * @param [in] name                The name to remove
- * @param[in,out] parentPreAttributes  Optional attributes for parent dir
- *                                     before the operation. Should be atomic.
- * @param[in,out] parentPostAttributes Optional attributes for parent dir
- *                                     after the operation. Should be atomic.
+ * @param [in] directoryHandle         The directory from which to remove the name
+ * @param [in] objectHandle            The object being removed
+ * @param [in] name                    The name to remove
+ * @param[in,out] parentPreAttributes  Optional attributes for parent dir before the operation.
+ *                                     Should be atomic.
+ * @param[in,out] parentPostAttributes Optional attributes for parent dir after the operation.
+ *                                     Should be atomic.
  *
  * @returns: FSAL status
  */
 static fsal_status_t unlink_(struct fsal_obj_handle *directoryHandle,
-                             struct fsal_obj_handle *objectHandle,
-                             const char *name,
+                             struct fsal_obj_handle *objectHandle, const char *name,
                              struct fsal_attrlist *parentPreAttributes,
                              struct fsal_attrlist *parentPostAttributes) {
 	struct SaunaFSExport *export = NULL;
@@ -1151,9 +1050,9 @@ static fsal_status_t unlink_(struct fsal_obj_handle *directoryHandle,
 	export = container_of(op_ctx->fsal_export, struct SaunaFSExport, export);
 	directory = container_of(directoryHandle, struct SaunaFSHandle, handle);
 
-	LogFullDebug(COMPONENT_FSAL, "export = %" PRIu16 " parent_inode = %"
-	             PRIiNode " name = %s type = %s", export->export.export_id,
-	             directory->inode, name,
+	LogFullDebug(COMPONENT_FSAL,
+	             "export = %" PRIu16 " parent_inode = %" PRIiNode " name = %s type = %s",
+	             export->export.export_id, directory->inode, name,
 	             object_file_type_to_str(objectHandle->type));
 
 	if (objectHandle->type != DIRECTORY) {
@@ -1176,12 +1075,10 @@ static fsal_status_t unlink_(struct fsal_obj_handle *directoryHandle,
  * @returns: FSAL status
  */
 static fsal_status_t close_(struct fsal_obj_handle *objectHandle) {
-	struct SaunaFSHandle *handle = NULL;
+	struct SaunaFSHandle *handle = container_of(objectHandle, struct SaunaFSHandle, handle);
 
-	handle = container_of(objectHandle, struct SaunaFSHandle, handle);
-
-	LogFullDebug(COMPONENT_FSAL, "export=%" PRIu16 " inode=%" PRIiNode,
-	             handle->key.exportId, handle->inode);
+	LogFullDebug(COMPONENT_FSAL, "export=%" PRIu16 " inode=%" PRIiNode, handle->key.exportId,
+	             handle->inode);
 
 	return close_fsal_fd(objectHandle, &handle->fd.fsalFd, false);
 }
@@ -1201,17 +1098,14 @@ static fsal_status_t close_(struct fsal_obj_handle *objectHandle) {
  * callback is called.
  *
  * @param [in]     objectHandle     File on which to operate
- * @param [in]     bypass           If state doesn't indicate a share
- *                                  reservation,
+ * @param [in]     bypass           If state doesn't indicate a share reservation,
  *                                  bypass any non-mandatory deny write
  * @param [in,out] doneCb           Callback to call when I/O is done
- * @param [in,out] writeArg         Info about write, passed back in
- *                                  callback
+ * @param [in,out] writeArg         Info about write, passed back in callback
  * @param [in,out] callerArg        Opaque arg from the caller for callback
  */
-static void write2(struct fsal_obj_handle *objectHandle, bool bypass,
-                   fsal_async_cb doneCb, struct fsal_io_arg *writeArg,
-                   void *callerArg) {
+static void write2(struct fsal_obj_handle *objectHandle, bool bypass, fsal_async_cb doneCb,
+                   struct fsal_io_arg *writeArg, void *callerArg) {
 	struct SaunaFSExport *export = NULL;
 	struct SaunaFSHandle *handle = NULL;
 
@@ -1228,24 +1122,21 @@ static void write2(struct fsal_obj_handle *objectHandle, bool bypass,
 	export = container_of(op_ctx->fsal_export, struct SaunaFSExport, export);
 	handle = container_of(objectHandle, struct SaunaFSHandle, handle);
 
-	LogFullDebug(COMPONENT_FSAL, "export=%" PRIu16 " inode=%" PRIiNode
-	             " offset=%" PRIu64, export->export.export_id,
-	             handle->inode, offset);
+	LogFullDebug(COMPONENT_FSAL, "export=%" PRIu16 " inode=%" PRIiNode " offset=%" PRIu64,
+	             export->export.export_id, handle->inode, offset);
 
 	if (writeArg->info) {
-		doneCb(objectHandle, fsalstat(ERR_FSAL_NOTSUPP, 0), writeArg,
-		       callerArg);
+		doneCb(objectHandle, fsalstat(ERR_FSAL_NOTSUPP, 0), writeArg, callerArg);
 		return;
 	}
 
-	/* Indicate a desire to start io and get a usable file descritor */
+	// Indicate a desire to start io and get a usable file descriptor
 	status = fsal_start_io(&outFileDescriptor, objectHandle, &handle->fd.fsalFd,
-	                       &emptyFileDescriptor.fsalFd, writeArg->state,
-	                       FSAL_O_WRITE, false, NULL, bypass, &handle->share);
+	                       &emptyFileDescriptor.fsalFd, writeArg->state, FSAL_O_WRITE, false, NULL,
+	                       bypass, &handle->share);
 
 	if (FSAL_IS_ERROR(status)) {
-		LogFullDebug(COMPONENT_FSAL, "fsal_start_io failed returning %s",
-		             fsal_err_txt(status));
+		LogFullDebug(COMPONENT_FSAL, "fsal_start_io failed returning %s", fsal_err_txt(status));
 
 		doneCb(objectHandle, status, writeArg, callerArg);
 		return;
@@ -1254,9 +1145,8 @@ static void write2(struct fsal_obj_handle *objectHandle, bool bypass,
 	saunafsFd = container_of(outFileDescriptor, struct SaunaFSFd, fsalFd);
 
 	for (int i = 0; i < writeArg->iov_count; i++) {
-		bytes = saunafs_write(export->fsInstance, &op_ctx->creds, saunafsFd->fd,
-		                      offset, writeArg->iov[i].iov_len,
-		                      writeArg->iov[i].iov_base);
+		bytes = saunafs_write(export->fsInstance, &op_ctx->creds, saunafsFd->fd, offset,
+		                      writeArg->iov[i].iov_len, writeArg->iov[i].iov_base);
 
 		if (bytes == 0) {
 			break;
@@ -1265,18 +1155,15 @@ static void write2(struct fsal_obj_handle *objectHandle, bool bypass,
 			status = fsalLastError();
 			status2 = fsal_complete_io(objectHandle, outFileDescriptor);
 
-			LogFullDebug(COMPONENT_FSAL, "fsal_complete_io returned %s",
-			             fsal_err_txt(status2));
+			LogFullDebug(COMPONENT_FSAL, "fsal_complete_io returned %s", fsal_err_txt(status2));
 
 			if (writeArg->state == NULL) {
-				/* We did I/O without a state so we need
-				 * to release the temp share reservation
-				 * acquired. */
+				// We did I/O without a state so we need to release the temp share reservation
+				// acquired.
 
-				/* Release the share reservation now by
-				 *  updating the counters. */
-				update_share_counters_locked(objectHandle, &handle->share,
-				                             FSAL_O_WRITE, FSAL_O_CLOSED);
+				// Release the share reservation now by updating the counters.
+				update_share_counters_locked(objectHandle, &handle->share, FSAL_O_WRITE,
+				                             FSAL_O_CLOSED);
 			}
 
 			doneCb(objectHandle, status, writeArg, callerArg);
@@ -1288,8 +1175,7 @@ static void write2(struct fsal_obj_handle *objectHandle, bool bypass,
 	}
 
 	if (writeArg->fsal_stable) {
-		int retvalue =
-		    saunafs_fsync(export->fsInstance, &op_ctx->creds, saunafsFd->fd);
+		int retvalue = saunafs_fsync(export->fsInstance, &op_ctx->creds, saunafsFd->fd);
 
 		if (retvalue < 0) {
 			status = fsalLastError();
@@ -1299,17 +1185,13 @@ static void write2(struct fsal_obj_handle *objectHandle, bool bypass,
 
 	status2 = fsal_complete_io(objectHandle, outFileDescriptor);
 
-	LogFullDebug(COMPONENT_FSAL, "fsal_complete_io returned %s",
-	             fsal_err_txt(status2));
+	LogFullDebug(COMPONENT_FSAL, "fsal_complete_io returned %s", fsal_err_txt(status2));
 
 	if (writeArg->state == NULL) {
-		/* We did I/O without a state so we need to release the temp
-		 * share reservation acquired. */
+		// We did I/O without a state so we need to release the temp share reservation acquired.
 
-		/* Release the share reservation now by updating
-		 * the counters. */
-		update_share_counters_locked(objectHandle, &handle->share, FSAL_O_WRITE,
-		                             FSAL_O_CLOSED);
+		// Release the share reservation now by updating the counters.
+		update_share_counters_locked(objectHandle, &handle->share, FSAL_O_WRITE, FSAL_O_CLOSED);
 	}
 
 	doneCb(objectHandle, status, writeArg, callerArg);
@@ -1330,8 +1212,7 @@ static void write2(struct fsal_obj_handle *objectHandle, bool bypass,
  *
  * @returns: FSAL status
  */
-static fsal_status_t commit2(struct fsal_obj_handle *objectHandle, off_t offset,
-                             size_t length) {
+static fsal_status_t commit2(struct fsal_obj_handle *objectHandle, off_t offset, size_t length) {
 	struct SaunaFSExport *export = NULL;
 	struct SaunaFSHandle *handle = NULL;
 
@@ -1345,31 +1226,28 @@ static fsal_status_t commit2(struct fsal_obj_handle *objectHandle, off_t offset,
 	export = container_of(op_ctx->fsal_export, struct SaunaFSExport, export);
 	handle = container_of(objectHandle, struct SaunaFSHandle, handle);
 
-	LogFullDebug(COMPONENT_FSAL, "export = %" PRIu16 " inode = %" PRIiNode
-	             " offset = %lli len = %zu", export->export.export_id,
-	             handle->inode, (long long)offset, length);
+	LogFullDebug(COMPONENT_FSAL,
+	             "export = %" PRIu16 " inode = %" PRIiNode " offset = %lli len = %zu",
+	             export->export.export_id, handle->inode, (long long)offset, length);
 
-	/* Make sure file is open in appropriate mode.
-	 * Do not check share reservation. */
-	status = fsal_start_global_io(&outFileDescriptor, objectHandle,
-	                              &handle->fd.fsalFd, &emptyFd.fsalFd,
-	                              FSAL_O_ANY, false, NULL);
+	// Make sure file is open in appropriate mode.
+	// Do not check share reservation.
+	status = fsal_start_global_io(&outFileDescriptor, objectHandle, &handle->fd.fsalFd,
+	                              &emptyFd.fsalFd, FSAL_O_ANY, false, NULL);
 
 	if (FSAL_IS_ERROR(status)) { return status; }
 
 	saunafsFd = container_of(outFileDescriptor, struct SaunaFSFd, fsalFd);
 
-	int retvalue =
-	    saunafs_fsync(export->fsInstance, &op_ctx->creds, saunafsFd->fd);
+	int retvalue = saunafs_fsync(export->fsInstance, &op_ctx->creds, saunafsFd->fd);
 
 	if (retvalue < 0) { status = fsalLastError(); }
 
 	status2 = fsal_complete_io(objectHandle, outFileDescriptor);
 
-	LogFullDebug(COMPONENT_FSAL, "fsal_complete_io returned %s",
-	             fsal_err_txt(status2));
+	LogFullDebug(COMPONENT_FSAL, "fsal_complete_io returned %s", fsal_err_txt(status2));
 
-	/* We did not do share reservation stuff... */
+	// We did not do share reservation stuff...
 	return status;
 }
 
@@ -1385,8 +1263,7 @@ static fsal_status_t commit2(struct fsal_obj_handle *objectHandle, off_t offset,
  * inherited ACL.
  *
  * @param [in] objectHandle     File on which to operate
- * @param [in] bypass           If state doesn't indicate a share
- *                              reservation,
+ * @param [in] bypass           If state doesn't indicate a share reservation,
  *                              bypass any non-mandatory deny write
  * @param [in] state            state_t to use for this operation
  * @param [in] attributes       Attributes to set
@@ -1394,8 +1271,7 @@ static fsal_status_t commit2(struct fsal_obj_handle *objectHandle, off_t offset,
  * @returns: FSAL status
  */
 static fsal_status_t setattr2(struct fsal_obj_handle *objectHandle, bool bypass,
-                              struct state_t *state,
-                              struct fsal_attrlist *attributes) {
+                              struct state_t *state, struct fsal_attrlist *attributes) {
 	struct SaunaFSExport *export = NULL;
 	struct SaunaFSHandle *handle = NULL;
 
@@ -1408,8 +1284,7 @@ static fsal_status_t setattr2(struct fsal_obj_handle *objectHandle, bool bypass,
 	LogAttrlist(COMPONENT_FSAL, NIV_FULL_DEBUG, "attrs ", attributes, false);
 
 	if (FSAL_TEST_MASK(attributes->valid_mask, (attrmask_t)ATTR_MODE)) {
-		attributes->mode &=
-		    ~op_ctx->fsal_export->exp_ops.fs_umask(op_ctx->fsal_export);
+		attributes->mode &= ~op_ctx->fsal_export->exp_ops.fs_umask(op_ctx->fsal_export);
 	}
 
 	if (FSAL_TEST_MASK(attributes->valid_mask, (attrmask_t)ATTR_SIZE)) {
@@ -1419,11 +1294,9 @@ static fsal_status_t setattr2(struct fsal_obj_handle *objectHandle, bool bypass,
 		}
 
 		if (state == NULL) {
-			/* Check share reservation and if OK,
-			 * update the counters. */
-			status = check_share_conflict_and_update_locked(
-			    objectHandle, &handle->share, FSAL_O_CLOSED, FSAL_O_WRITE,
-			    bypass);
+			// Check share reservation and if OK, update the counters.
+			status = check_share_conflict_and_update_locked(objectHandle, &handle->share,
+			                                                FSAL_O_CLOSED, FSAL_O_WRITE, bypass);
 
 			if (FSAL_IS_ERROR(status)) {
 				LogDebug(COMPONENT_FSAL, "check_share_conflict failed with %s",
@@ -1444,8 +1317,7 @@ static fsal_status_t setattr2(struct fsal_obj_handle *objectHandle, bool bypass,
 	if (FSAL_TEST_MASK(attributes->valid_mask, (attrmask_t)ATTR_SIZE)) {
 		mask |= SAU_SET_ATTR_SIZE;
 		posixAttributes.st_size = (__off_t)(attributes->filesize);
-		LogFullDebug(COMPONENT_FSAL, "setting size to %lld",
-		             (long long)posixAttributes.st_size);
+		LogFullDebug(COMPONENT_FSAL, "setting size to %lld", (long long)posixAttributes.st_size);
 	}
 
 	if (FSAL_TEST_MASK(attributes->valid_mask, (attrmask_t)ATTR_MODE)) {
@@ -1482,18 +1354,15 @@ static fsal_status_t setattr2(struct fsal_obj_handle *objectHandle, bool bypass,
 	}
 
 	sau_attr_reply_t reply;
-	int retvalue =
-	    saunafs_setattr(export->fsInstance, &op_ctx->creds, handle->inode,
-	                    &posixAttributes, mask, &reply);
+	int retvalue = saunafs_setattr(export->fsInstance, &op_ctx->creds, handle->inode,
+	                               &posixAttributes, mask, &reply);
 
 	if (retvalue < 0) {
 		status = fsalLastError();
 
 		if (hasShare) {
-			/* Release the share reservation now by updating
-			 * the counters. */
-			update_share_counters_locked(objectHandle, &handle->share,
-			                             FSAL_O_RDWR, FSAL_O_CLOSED);
+			// Release the share reservation now by updating the counters.
+			update_share_counters_locked(objectHandle, &handle->share, FSAL_O_RDWR, FSAL_O_CLOSED);
 		}
 
 		return status;
@@ -1501,16 +1370,13 @@ static fsal_status_t setattr2(struct fsal_obj_handle *objectHandle, bool bypass,
 
 #ifdef ENABLE_NFS_ACL_SUPPORT
 	if (FSAL_TEST_MASK(attributes->valid_mask, (attrmask_t)ATTR_ACL)) {
-		status =
-		    setACL(export, handle->inode, attributes->acl, reply.attr.st_mode);
+		status = setACL(export, handle->inode, attributes->acl, reply.attr.st_mode);
 	}
 #endif
 
 	if (hasShare) {
-		/* Release the share reservation now by updating
-		 * the counters. */
-		update_share_counters_locked(objectHandle, &handle->share, FSAL_O_RDWR,
-		                             FSAL_O_CLOSED);
+		// Release the share reservation now by updating the counters.
+		update_share_counters_locked(objectHandle, &handle->share, FSAL_O_RDWR, FSAL_O_CLOSED);
 	}
 
 	return status;
@@ -1529,11 +1395,8 @@ static fsal_status_t setattr2(struct fsal_obj_handle *objectHandle, bool bypass,
  *
  * @returns: FSAL status
  */
-static fsal_status_t close2(struct fsal_obj_handle *objectHandle,
-                            struct state_t *state) {
-	struct SaunaFSHandle *handle = NULL;
-
-	handle = container_of(objectHandle, struct SaunaFSHandle, handle);
+static fsal_status_t close2(struct fsal_obj_handle *objectHandle, struct state_t *state) {
+	struct SaunaFSHandle *handle = container_of(objectHandle, struct SaunaFSHandle, handle);
 
 	struct SaunaFSFd *fileDescriptor =
 	    &container_of(state, struct SaunaFSStateFd, state)->saunafsFd;
@@ -1541,11 +1404,9 @@ static fsal_status_t close2(struct fsal_obj_handle *objectHandle,
 	LogFullDebug(COMPONENT_FSAL, "export = %" PRIu16 " inode = %" PRIiNode, handle->key.exportId,
 	             handle->inode);
 
-	if (state->state_type == STATE_TYPE_SHARE ||
-	    state->state_type == STATE_TYPE_NLM_SHARE ||
+	if (state->state_type == STATE_TYPE_SHARE || state->state_type == STATE_TYPE_NLM_SHARE ||
 	    state->state_type == STATE_TYPE_9P_FID) {
-		update_share_counters_locked(objectHandle, &handle->share,
-		                             handle->fd.fsalFd.openflags,
+		update_share_counters_locked(objectHandle, &handle->share, handle->fd.fsalFd.openflags,
 		                             FSAL_O_CLOSED);
 	}
 
@@ -1560,23 +1421,20 @@ static fsal_status_t close2(struct fsal_obj_handle *objectHandle,
  * @param [in] directoryHandle      Directory in which to create the object
  * @param [in] name                 Name of object to create
  * @param [in] symbolicLinkPath     Content of symbolic link
- * @param [in] attributesToSet      Attributes to set on newly created
- *                                  object
+ * @param [in] attributesToSet      Attributes to set on newly created object
  * @param [out] createdObject       Newly created object
- * @param [in,out] attributes       Optional attributes for newly created
- *                                  object
- * @param[in,out] parentPreAttributes  Optional attributes for parent dir
- *                                     before the operation. Should be atomic.
- * @param[in,out] parentPostAttributes Optional attributes for parent dir
- *                                     after the operation. Should be atomic.
+ * @param [in,out] attributes       Optional attributes for newly created object
+ * @param[in,out] parentPreAttributes  Optional attributes for parent dir before the operation.
+ *                                     Should be atomic.
+ * @param[in,out] parentPostAttributes Optional attributes for parent dir after the operation.
+ *                                     Should be atomic.
  *
  * \see fsal_api.h for more information
  *
  * @returns: FSAL status
  */
-static fsal_status_t symlink_(struct fsal_obj_handle *directoryHandle,
-                              const char *name, const char *symbolicLinkPath,
-                              struct fsal_attrlist *attributesToSet,
+static fsal_status_t symlink_(struct fsal_obj_handle *directoryHandle, const char *name,
+                              const char *symbolicLinkPath, struct fsal_attrlist *attributesToSet,
                               struct fsal_obj_handle **createdObject,
                               struct fsal_attrlist *attributes,
                               struct fsal_attrlist *parentPreAttributes,
@@ -1588,13 +1446,11 @@ static fsal_status_t symlink_(struct fsal_obj_handle *directoryHandle,
 	export = container_of(op_ctx->fsal_export, struct SaunaFSExport, export);
 	directory = container_of(directoryHandle, struct SaunaFSHandle, handle);
 
-	LogFullDebug(COMPONENT_FSAL, "export = %" PRIu16 " parent_inode = %"
-	             PRIiNode " name = %s", export->export.export_id,
-	             directory->inode, name);
+	LogFullDebug(COMPONENT_FSAL, "export = %" PRIu16 " parent_inode = %" PRIiNode " name = %s",
+	             export->export.export_id, directory->inode, name);
 
-	int retvalue =
-	    saunafs_symlink(export->fsInstance, &op_ctx->creds, symbolicLinkPath,
-	                    directory->inode, name, &entry);
+	int retvalue = saunafs_symlink(export->fsInstance, &op_ctx->creds, symbolicLinkPath,
+	                               directory->inode, name, &entry);
 
 	if (retvalue < 0) {
 		return fsalLastError();
@@ -1603,22 +1459,19 @@ static fsal_status_t symlink_(struct fsal_obj_handle *directoryHandle,
 	struct SaunaFSHandle *handle = allocateHandle(&entry.attr, export);
 	*createdObject = &handle->handle;
 
-	/* We handled the mode above */
+	// We handled the mode above
 	FSAL_UNSET_MASK(attributesToSet->valid_mask, (attrmask_t)ATTR_MODE);
 
 	if (attributesToSet->valid_mask) {
 		fsal_status_t status;
 
-		/* Now per support_ex API, if there are any other
-		 * attributes set, go ahead and get them set now */
-		status = (*createdObject)
-		             ->obj_ops->setattr2(*createdObject, false, NULL,
-		                                 attributesToSet);
+		// Now per support_ex API, if there are any other attributes set, go ahead and get them set
+		// now
+		status = (*createdObject)->obj_ops->setattr2(*createdObject, false, NULL, attributesToSet);
 
 		if (FSAL_IS_ERROR(status)) {
-			/* Release the handle we just allocated */
-			LogFullDebug(COMPONENT_FSAL, "setattr2 status = %s",
-			             fsal_err_txt(status));
+			// Release the handle we just allocated
+			LogFullDebug(COMPONENT_FSAL, "setattr2 status = %s", fsal_err_txt(status));
 
 			(*createdObject)->obj_ops->release(*createdObject);
 			*createdObject = NULL;
@@ -1649,10 +1502,8 @@ static fsal_status_t symlink_(struct fsal_obj_handle *directoryHandle,
  *
  * @returns: FSAL status
  */
-fsal_status_t lock_op2(struct fsal_obj_handle *objectHandle,
-                       struct state_t *state, void *owner,
-                       fsal_lock_op_t lockOperation,
-                       fsal_lock_param_t *requestedLock,
+fsal_status_t lock_op2(struct fsal_obj_handle *objectHandle, struct state_t *state, void *owner,
+                       fsal_lock_op_t lockOperation, fsal_lock_param_t *requestedLock,
                        fsal_lock_param_t *conflictingLock) {
 	struct SaunaFSHandle *handle = NULL;
 	struct SaunaFSExport *export = NULL;
@@ -1675,9 +1526,9 @@ fsal_status_t lock_op2(struct fsal_obj_handle *objectHandle,
 	export = container_of(op_ctx->fsal_export, struct SaunaFSExport, export);
 	handle = container_of(objectHandle, struct SaunaFSHandle, handle);
 
-	LogFullDebug(COMPONENT_FSAL, "op:%d type:%d start:%" PRIu64 " length:%"
-	             PRIu64 " ", lockOperation, requestedLock->lock_type,
-	             requestedLock->lock_start, requestedLock->lock_length);
+	LogFullDebug(COMPONENT_FSAL, "op:%d type:%d start:%" PRIu64 " length:%" PRIu64 " ",
+	             lockOperation, requestedLock->lock_type, requestedLock->lock_start,
+	             requestedLock->lock_length);
 
 	if (objectHandle == NULL) {
 		LogCrit(COMPONENT_FSAL, "objectHandle arg is NULL.");
@@ -1690,7 +1541,7 @@ fsal_status_t lock_op2(struct fsal_obj_handle *objectHandle,
 	}
 
 	if (lockOperation == FSAL_OP_LOCKT) {
-		/* We may end up using global fd, don't fail on a deny mode */
+		// We may end up using global fd, don't fail on a deny mode
 		bypass = true;
 		openflags = FSAL_O_ANY;
 	} else if (lockOperation == FSAL_OP_LOCK) {
@@ -1703,8 +1554,7 @@ fsal_status_t lock_op2(struct fsal_obj_handle *objectHandle,
 		openflags = FSAL_O_ANY;
 	} else {
 		LogFullDebug(COMPONENT_FSAL,
-		             "ERROR: Lock operation requested "
-		             "was not TEST, READ, or WRITE.");
+		             "ERROR: Lock operation requested was not TEST, READ, or WRITE.");
 
 		return fsalstat(ERR_FSAL_NOTSUPP, 0);
 	}
@@ -1719,9 +1569,7 @@ fsal_status_t lock_op2(struct fsal_obj_handle *objectHandle,
 	} else if (requestedLock->lock_type == FSAL_LOCK_W) {
 		lockInfo.l_type = F_WRLCK;
 	} else {
-		LogFullDebug(COMPONENT_FSAL,
-		             "ERROR: The requested lock type was not "
-		             "read or write.");
+		LogFullDebug(COMPONENT_FSAL, "ERROR: The requested lock type was not read or write.");
 
 		return fsalstat(ERR_FSAL_NOTSUPP, 0);
 	}
@@ -1746,12 +1594,11 @@ fsal_status_t lock_op2(struct fsal_obj_handle *objectHandle,
 
 	// Indicate a desire to start io and get a usable file descriptor
 	status = fsal_start_io(&outFileDescriptor, objectHandle, &handle->fd.fsalFd,
-	                       &emptyFileDescriptor.fsalFd, state, openflags, true,
-	                       NULL, bypass, &handle->share);
+	                       &emptyFileDescriptor.fsalFd, state, openflags, true, NULL, bypass,
+	                       &handle->share);
 
 	if (FSAL_IS_ERROR(status)) {
-		LogCrit(COMPONENT_FSAL, "fsal_start_io failed returning %s",
-		        fsal_err_txt(status));
+		LogCrit(COMPONENT_FSAL, "fsal_start_io failed returning %s", fsal_err_txt(status));
 
 		return status;
 	}
@@ -1761,11 +1608,9 @@ fsal_status_t lock_op2(struct fsal_obj_handle *objectHandle,
 	sau_set_lock_owner(fileinfo, (uint64_t)owner);
 
 	if (lockOperation == FSAL_OP_LOCKT) {
-		retval = saunafs_getlock(export->fsInstance, &op_ctx->creds, fileinfo,
-		                         &lockInfo);
+		retval = saunafs_getlock(export->fsInstance, &op_ctx->creds, fileinfo, &lockInfo);
 	} else {
-		retval = saunafs_setlock(export->fsInstance, &op_ctx->creds, fileinfo,
-		                         &lockInfo);
+		retval = saunafs_setlock(export->fsInstance, &op_ctx->creds, fileinfo, &lockInfo);
 	}
 
 	if (retval < 0) {
@@ -1773,23 +1618,19 @@ fsal_status_t lock_op2(struct fsal_obj_handle *objectHandle,
 		LogFullDebug(COMPONENT_FSAL, "Returning error %d", lastError);
 
 		status2 = fsal_complete_io(objectHandle, outFileDescriptor);
-		LogFullDebug(COMPONENT_FSAL, "fsal_complete_io returned %s",
-		             fsal_err_txt(status2));
+		LogFullDebug(COMPONENT_FSAL, "fsal_complete_io returned %s", fsal_err_txt(status2));
 
 		if (state == NULL) {
-			/* We did I/O without a state so we need to release
-			 * the temp share reservation acquired. */
+			// We did I/O without a state so we need to release the temp share reservation acquired.
 
-			/* Release the share reservation now by updating
-			 * the counters. */
-			update_share_counters_locked(objectHandle, &handle->share,
-			                             openflags, FSAL_O_CLOSED);
+			// Release the share reservation now by updating the counters.
+			update_share_counters_locked(objectHandle, &handle->share, openflags, FSAL_O_CLOSED);
 		}
 
 		return saunafsToFsalError(lastError);
 	}
 
-	/* F_UNLCK is returned then the tested operation would be possible */
+	// F_UNLCK is returned then the tested operation would be possible
 	if (conflictingLock != NULL) {
 		if (lockOperation == FSAL_OP_LOCKT && lockInfo.l_type != F_UNLCK) {
 			conflictingLock->lock_length = lockInfo.l_len;
@@ -1805,17 +1646,13 @@ fsal_status_t lock_op2(struct fsal_obj_handle *objectHandle,
 	lastError = sau_last_err();
 	status2 = fsal_complete_io(objectHandle, outFileDescriptor);
 
-	LogFullDebug(COMPONENT_FSAL, "fsal_complete_io returned %s",
-	             fsal_err_txt(status2));
+	LogFullDebug(COMPONENT_FSAL, "fsal_complete_io returned %s", fsal_err_txt(status2));
 
 	if (state == NULL) {
-		/* We did I/O without a state so we need to release the temp
-		 * share reservation acquired. */
+		// We did I/O without a state so we need to release the temp share reservation acquired.
 
-		/* Release the share reservation now by updating
-		 * the counters. */
-		update_share_counters_locked(objectHandle, &handle->share, openflags,
-		                             FSAL_O_CLOSED);
+		// Release the share reservation now by updating the counters.
+		update_share_counters_locked(objectHandle, &handle->share, openflags, FSAL_O_CLOSED);
 	}
 
 	return status;
@@ -1837,8 +1674,7 @@ fsal_status_t lock_op2(struct fsal_obj_handle *objectHandle,
  *
  * @returns: FSAL status
  */
-static fsal_status_t reopen2(struct fsal_obj_handle *objectHandle,
-                             struct state_t *state,
+static fsal_status_t reopen2(struct fsal_obj_handle *objectHandle, struct state_t *state,
                              fsal_openflags_t openflags) {
 	return openByHandle(objectHandle, state, openflags, FSAL_NO_CREATE, NULL, NULL);
 }
@@ -1851,23 +1687,20 @@ static fsal_status_t reopen2(struct fsal_obj_handle *objectHandle,
  * @param [in] directoryHandle     Directory in which to create the object
  * @param [in] name                Name of object to create
  * @param [in] nodeType            Type of special file to create
- * @param [in] attributesToSet     Attributes to set on newly created
- *                                 object
+ * @param [in] attributesToSet     Attributes to set on newly created object
  * @param [in] createdObject       Newly created object
- * @param [in] attributes          Optional attributes for newly created
- *                                 object
- * @param[in,out] parentPreAttributes  Optional attributes for parent dir
- *                                     before the operation. Should be atomic.
- * @param[in,out] parentPostAttributes Optional attributes for parent dir
- *                                     after the operation. Should be atomic.
+ * @param [in] attributes          Optional attributes for newly created object
+ * @param[in,out] parentPreAttributes  Optional attributes for parent dir before the operation.
+ *                                     Should be atomic.
+ * @param[in,out] parentPostAttributes Optional attributes for parent dir after the operation.
+ *                                     Should be atomic.
  *
  * \see fsal_api.h for more information
  *
  * @returns: FSAL status
  */
-static fsal_status_t mknode(struct fsal_obj_handle *directoryHandle,
-                            const char *name, object_file_type_t nodeType,
-                            struct fsal_attrlist *attributesToSet,
+static fsal_status_t mknode(struct fsal_obj_handle *directoryHandle, const char *name,
+                            object_file_type_t nodeType, struct fsal_attrlist *attributesToSet,
                             struct fsal_obj_handle **createdObject,
                             struct fsal_attrlist *attributes,
                             struct fsal_attrlist *parentPreAttributes,
@@ -1883,9 +1716,8 @@ static fsal_status_t mknode(struct fsal_obj_handle *directoryHandle,
 	directory = container_of(directoryHandle, struct SaunaFSHandle, handle);
 
 	LogFullDebug(COMPONENT_FSAL,
-	             "export = %" PRIu16 " parent_inode = %" PRIiNode " mode = %"
-	             PRIo32 " name = %s", export->export.export_id,
-	             directory->inode, attributesToSet->mode, name);
+	             "export = %" PRIu16 " parent_inode = %" PRIiNode " mode = %" PRIo32 " name = %s",
+	             export->export.export_id, directory->inode, attributesToSet->mode, name);
 
 	unixMode = fsal2unix_mode(attributesToSet->mode) &
 	           ~op_ctx->fsal_export->exp_ops.fs_umask(op_ctx->fsal_export);
@@ -1893,13 +1725,11 @@ static fsal_status_t mknode(struct fsal_obj_handle *directoryHandle,
 	switch (nodeType) {
 	case BLOCK_FILE:
 		unixMode |= S_IFBLK;
-		unixDev = makedev(attributesToSet->rawdev.major,
-		                  attributesToSet->rawdev.minor);
+		unixDev = makedev(attributesToSet->rawdev.major, attributesToSet->rawdev.minor);
 		break;
 	case CHARACTER_FILE:
 		unixMode |= S_IFCHR;
-		unixDev = makedev(attributesToSet->rawdev.major,
-		                  attributesToSet->rawdev.minor);
+		unixDev = makedev(attributesToSet->rawdev.major, attributesToSet->rawdev.minor);
 		break;
 	case FIFO_FILE:
 		unixMode |= S_IFIFO;
@@ -1908,15 +1738,13 @@ static fsal_status_t mknode(struct fsal_obj_handle *directoryHandle,
 		unixMode |= S_IFSOCK;
 		break;
 	default:
-		LogMajor(COMPONENT_FSAL, "Invalid node type in FSAL_mknode: %d",
-		         nodeType);
+		LogMajor(COMPONENT_FSAL, "Invalid node type in FSAL_mknode: %d", nodeType);
 
 		return fsalstat(ERR_FSAL_INVAL, EINVAL);
 	}
 
-	int retvalue =
-	    saunafs_mknode(export->fsInstance, &op_ctx->creds, directory->inode,
-	                   name, unixMode, unixDev, &entry);
+	int retvalue = saunafs_mknode(export->fsInstance, &op_ctx->creds, directory->inode, name,
+	                              unixMode, unixDev, &entry);
 
 	if (retvalue < 0) {
 		return fsalLastError();
@@ -1925,28 +1753,24 @@ static fsal_status_t mknode(struct fsal_obj_handle *directoryHandle,
 	handle = allocateHandle(&entry.attr, export);
 	*createdObject = &handle->handle;
 
-	/* We handled the mode above */
+	// We handled the mode above
 	FSAL_UNSET_MASK(attributesToSet->valid_mask, (attrmask_t)ATTR_MODE);
 
 	if (attributesToSet->valid_mask) {
 		fsal_status_t status;
-		/* Setting attributes for the created object */
-		status = (*createdObject)
-		             ->obj_ops->setattr2(*createdObject, false, NULL,
-		                                 attributesToSet);
+		// Setting attributes for the created object
+		status = (*createdObject)->obj_ops->setattr2(*createdObject, false, NULL, attributesToSet);
 
 		if (FSAL_IS_ERROR(status)) {
-			LogFullDebug(COMPONENT_FSAL, "setattr2 status = %s",
-			             fsal_err_txt(status));
+			LogFullDebug(COMPONENT_FSAL, "setattr2 status = %s", fsal_err_txt(status));
 
-			/* Release the handle we just allocated */
+			// Release the handle we just allocated
 			(*createdObject)->obj_ops->release(*createdObject);
 			*createdObject = NULL;
 		}
 	} else if (attributes != NULL) {
-		/* Since we haven't set any attributes other than what was set
-		 * on create, just use the stat results we used to create the
-		 * fsal_obj_handle */
+		// Since we haven't set any attributes other than what was set on create,
+		// just use the stat results we used to create the fsal_obj_handle
 		posix2fsal_attributes_all(&entry.attr, attributes);
 	}
 
@@ -1975,8 +1799,8 @@ static fsal_status_t mknode(struct fsal_obj_handle *directoryHandle,
  *
  * @returns: FSAL status
  */
-static fsal_status_t readlink_(struct fsal_obj_handle *objectHandle,
-                               struct gsh_buffdesc *buffer, bool refresh) {
+static fsal_status_t readlink_(struct fsal_obj_handle *objectHandle, struct gsh_buffdesc *buffer,
+                               bool refresh) {
 	(void)refresh;
 	struct SaunaFSExport *export = NULL;
 	struct SaunaFSHandle *handle = NULL;
@@ -1992,12 +1816,11 @@ static fsal_status_t readlink_(struct fsal_obj_handle *objectHandle,
 	LogFullDebug(COMPONENT_FSAL, "export = %" PRIu16 " inode = %" PRIiNode,
 	             export->export.export_id, handle->inode);
 
-	int size =
-	    saunafs_readlink(export->fsInstance, &op_ctx->creds, handle->inode,
-	                     result, SAUNAFS_MAX_READLINK_LENGTH);
+	int size = saunafs_readlink(export->fsInstance, &op_ctx->creds, handle->inode, result,
+	                            SAUNAFS_MAX_READLINK_LENGTH);
 
-	/* saunafs_readlink() returns the size of the read link if succeed.
-	 * Otherwise returns -1 to indicate an error occurred */
+	// saunafs_readlink() returns the size of the read link if succeed.
+	// Otherwise returns -1 to indicate an error occurred.
 	if (size < 0) { return fsalLastError(); }
 
 	size = MIN(size, SAUNAFS_MAX_READLINK_LENGTH);
@@ -2017,8 +1840,7 @@ static fsal_status_t readlink_(struct fsal_obj_handle *objectHandle,
  *
  * @returns: Flags representing current open status
  */
-static fsal_openflags_t status2(struct fsal_obj_handle *objectHandle,
-                                struct state_t *state) {
+static fsal_openflags_t status2(struct fsal_obj_handle *objectHandle, struct state_t *state) {
 	(void)objectHandle;
 	struct SaunaFSFd *sfsFd = &((struct SaunaFSStateFd *)state)->saunafsFd;
 
@@ -2044,17 +1866,16 @@ static fsal_status_t merge(struct fsal_obj_handle *originalHandle,
                            struct fsal_obj_handle *toMergeHandle) {
 	fsal_status_t status = fsalstat(ERR_FSAL_NO_ERROR, 0);
 
-	if (originalHandle->type == REGULAR_FILE &&
-	    toMergeHandle->type == REGULAR_FILE) {
-		/* We need to merge the share reservations on this file.
-		 * This could result in ERR_FSAL_SHARE_DENIED. */
+	if (originalHandle->type == REGULAR_FILE && toMergeHandle->type == REGULAR_FILE) {
+		// We need to merge the share reservations on this file.
+		// This could result in ERR_FSAL_SHARE_DENIED.
 		struct SaunaFSHandle *original = NULL;
 		struct SaunaFSHandle *toMerge = NULL;
 
 		original = container_of(originalHandle, struct SaunaFSHandle, handle);
 		toMerge = container_of(toMergeHandle, struct SaunaFSHandle, handle);
 
-		/* This can block over an I/O operation */
+		// This can block over an I/O operation
 		status = merge_share(originalHandle, &original->share, &toMerge->share);
 	}
 
@@ -2065,17 +1886,15 @@ static fsal_status_t merge(struct fsal_obj_handle *originalHandle,
  * @brief Reserve/Deallocate space in a region of a file.
  *
  * @param [in] objectHandle     File to which bytes should be allocated
- * @param [in] state            Open stateid under which to do the
- *                              allocation
+ * @param [in] state            Open stateid under which to do the allocation
  * @param [in] offset           Offset at which to begin the allocation
  * @param [in] length           Length of the data to be allocated
  * @param [in] allocate         Should space be allocated or deallocated?
  *
  * @returns: FSAL status
  */
-static fsal_status_t fallocate(struct fsal_obj_handle *objectHandle,
-                               struct state_t *state, uint64_t offset,
-                               uint64_t length, bool allocate) {
+static fsal_status_t fallocate(struct fsal_obj_handle *objectHandle, struct state_t *state,
+                               uint64_t offset, uint64_t length, bool allocate) {
 	struct SaunaFSExport *export = NULL;
 	struct SaunaFSHandle *handle = NULL;
 
@@ -2091,12 +1910,11 @@ static fsal_status_t fallocate(struct fsal_obj_handle *objectHandle,
 
 	// Indicate a desire to start io and get a usable file descriptor
 	status = fsal_start_io(&outFileDescriptor, objectHandle, &handle->fd.fsalFd,
-	                       &emptyFileDescriptor.fsalFd, state, FSAL_O_WRITE,
-	                       false, NULL, false, &handle->share);
+	                       &emptyFileDescriptor.fsalFd, state, FSAL_O_WRITE, false, NULL, false,
+	                       &handle->share);
 
 	if (FSAL_IS_ERROR(status)) {
-		LogFullDebug(COMPONENT_FSAL, "fsal_start_io failed returning %s",
-		             fsal_err_txt(status));
+		LogFullDebug(COMPONENT_FSAL, "fsal_start_io failed returning %s", fsal_err_txt(status));
 
 		return status;
 	}
@@ -2105,29 +1923,24 @@ static fsal_status_t fallocate(struct fsal_obj_handle *objectHandle,
 
 	memset(&posixAttributes, 0, sizeof(posixAttributes));
 
-	posixAttributes.st_mode =
-	    allocate ? 0 : FALLOC_FL_KEEP_SIZE | FALLOC_FL_PUNCH_HOLE;
+	posixAttributes.st_mode = allocate ? 0 : FALLOC_FL_KEEP_SIZE | FALLOC_FL_PUNCH_HOLE;
 
-	/* Get stat to obtain the current size */
+	// Get stat to obtain the current size
 	sau_attr_reply_t currentStats;
 	sau_attr_reply_t reply;
 
-	int retvalue = saunafs_getattr(export->fsInstance, &op_ctx->creds,
-	                               handle->inode, &currentStats);
+	int retvalue =
+	    saunafs_getattr(export->fsInstance, &op_ctx->creds, handle->inode, &currentStats);
 
 	if (retvalue < 0) {
 		status2 = fsal_complete_io(objectHandle, outFileDescriptor);
-		LogFullDebug(COMPONENT_FSAL, "fsal_complete_io returned %s",
-		             fsal_err_txt(status2));
+		LogFullDebug(COMPONENT_FSAL, "fsal_complete_io returned %s", fsal_err_txt(status2));
 
 		if (state == NULL) {
-			/* We did I/O without a state so we need to release
-			 * the temp share reservation acquired. */
+			// We did I/O without a state so we need to release the temp share reservation acquired.
 
-			/* Release the share reservation now by updating
-			 * the counters. */
-			update_share_counters_locked(objectHandle, &handle->share,
-			                             FSAL_O_WRITE, FSAL_O_CLOSED);
+			// Release the share reservation now by updating the counters.
+			update_share_counters_locked(objectHandle, &handle->share, FSAL_O_WRITE, FSAL_O_CLOSED);
 		}
 
 		return fsalLastError();
@@ -2136,116 +1949,97 @@ static fsal_status_t fallocate(struct fsal_obj_handle *objectHandle,
 	fileDescriptor = container_of(outFileDescriptor, struct SaunaFSFd, fsalFd);
 
 	if (allocate) {
-		/* Allocate */
+		// Allocate
 		if (offset + length > currentStats.attr.st_size) {
 			posixAttributes.st_size = offset + length;
 
-			retvalue = saunafs_setattr(export->fsInstance, &op_ctx->creds,
-			                           handle->inode, &posixAttributes,
-			                           SAU_SET_ATTR_SIZE, &reply);
+			retvalue = saunafs_setattr(export->fsInstance, &op_ctx->creds, handle->inode,
+			                           &posixAttributes, SAU_SET_ATTR_SIZE, &reply);
 
 			if (retvalue < 0) {
 				status2 = fsal_complete_io(objectHandle, outFileDescriptor);
-				LogFullDebug(COMPONENT_FSAL, "fsal_complete_io returned %s",
-				             fsal_err_txt(status2));
+				LogFullDebug(COMPONENT_FSAL, "fsal_complete_io returned %s", fsal_err_txt(status2));
 
 				if (state == NULL) {
-					/* We did I/O without a state so we need
-					 * to release the
-					 * temp share reservation acquired. */
+					// We did I/O without a state so we need to release the
+					// temp share reservation acquired.
 
-					/* Release the share reservation now by
-					 * updating the counters. */
-					update_share_counters_locked(objectHandle, &handle->share,
-					                             FSAL_O_WRITE, FSAL_O_CLOSED);
+					// Release the share reservation now by updating the counters.
+					update_share_counters_locked(objectHandle, &handle->share, FSAL_O_WRITE,
+					                             FSAL_O_CLOSED);
 				}
 
 				return fsalLastError();
 			}
 
-			retvalue = saunafs_fsync(export->fsInstance, &op_ctx->creds,
-			                         fileDescriptor->fd);
+			retvalue = saunafs_fsync(export->fsInstance, &op_ctx->creds, fileDescriptor->fd);
 
 			if (retvalue < 0) { status = fsalLastError(); }
 		}
 	} else if (allocate == false) {
-		/* Deallocate */
-		/* Initialize the zero-buffer */
+		// Deallocate
+		// Initialize the zero-buffer
 		void *buffer = malloc(length);
 
 		memset(buffer, 0, length);
 
-		/* Write the interval [offset..offset + length] with zeros */
-		ssize_t bytes =
-		    saunafs_write(export->fsInstance, &op_ctx->creds,
-		                  fileDescriptor->fd, offset, length, buffer);
+		// Write the interval [offset..offset + length] with zeros
+		ssize_t bytes = saunafs_write(export->fsInstance, &op_ctx->creds, fileDescriptor->fd,
+		                              offset, length, buffer);
 
 		free(buffer);
 
 		if (bytes < 0) {
 			status2 = fsal_complete_io(objectHandle, outFileDescriptor);
-			LogFullDebug(COMPONENT_FSAL, "fsal_complete_io returned %s",
-			             fsal_err_txt(status2));
+			LogFullDebug(COMPONENT_FSAL, "fsal_complete_io returned %s", fsal_err_txt(status2));
 
 			if (state == NULL) {
-				/* We did I/O without a state so we need
-				 * to release the
-				 * temp share reservation acquired. */
+				// We did I/O without a state so we need to release the temp share reservation
+				// acquired.
 
-				/* Release the share reservation now by
-				 * updating the counters. */
-				update_share_counters_locked(objectHandle, &handle->share,
-				                             FSAL_O_WRITE, FSAL_O_CLOSED);
+				// Release the share reservation now by updating the counters.
+				update_share_counters_locked(objectHandle, &handle->share, FSAL_O_WRITE,
+				                             FSAL_O_CLOSED);
 			}
 
 			return fsalLastError();
 		}
 
-		/* Set the original size because deallocation must not change
-		 * file size */
+		// Set the original size because deallocation must not change file size
 		posixAttributes.st_size = currentStats.attr.st_size;
 
-		retvalue =
-		    saunafs_setattr(export->fsInstance, &op_ctx->creds, handle->inode,
-		                    &posixAttributes, SAU_SET_ATTR_SIZE, &reply);
+		retvalue = saunafs_setattr(export->fsInstance, &op_ctx->creds, handle->inode,
+		                           &posixAttributes, SAU_SET_ATTR_SIZE, &reply);
 
 		if (retvalue < 0) {
 			status2 = fsal_complete_io(objectHandle, outFileDescriptor);
-			LogFullDebug(COMPONENT_FSAL, "fsal_complete_io returned %s",
-			             fsal_err_txt(status2));
+			LogFullDebug(COMPONENT_FSAL, "fsal_complete_io returned %s", fsal_err_txt(status2));
 
 			if (state == NULL) {
-				/* We did I/O without a state so we need
-				 * to release the
-				 * temp share reservation acquired. */
+				// We did I/O without a state so we need to release the temp share reservation
+				// acquired.
 
-				/* Release the share reservation now by
-				 * updating the counters. */
-				update_share_counters_locked(objectHandle, &handle->share,
-				                             FSAL_O_WRITE, FSAL_O_CLOSED);
+				// Release the share reservation now by updating the counters.
+				update_share_counters_locked(objectHandle, &handle->share, FSAL_O_WRITE,
+				                             FSAL_O_CLOSED);
 			}
 
 			return fsalLastError();
 		}
 
-		retvalue = saunafs_fsync(export->fsInstance, &op_ctx->creds,
-		                         fileDescriptor->fd);
+		retvalue = saunafs_fsync(export->fsInstance, &op_ctx->creds, fileDescriptor->fd);
 
 		if (retvalue < 0) { status = fsalLastError(); }
 	}
 
 	status2 = fsal_complete_io(objectHandle, outFileDescriptor);
-	LogFullDebug(COMPONENT_FSAL, "fsal_complete_io returned %s",
-	             fsal_err_txt(status2));
+	LogFullDebug(COMPONENT_FSAL, "fsal_complete_io returned %s", fsal_err_txt(status2));
 
 	if (state == NULL) {
-		/* We did I/O without a state so we need to release the temp
-		 * share reservation acquired. */
+		// We did I/O without a state so we need to release the temp share reservation acquired.
 
-		/* Release the share reservation now by updating
-		 * the counters. */
-		update_share_counters_locked(objectHandle, &handle->share, FSAL_O_WRITE,
-		                             FSAL_O_CLOSED);
+		// Release the share reservation now by updating the counters.
+		update_share_counters_locked(objectHandle, &handle->share, FSAL_O_WRITE, FSAL_O_CLOSED);
 	}
 
 	return status;
@@ -2259,11 +2053,8 @@ static fsal_status_t fallocate(struct fsal_obj_handle *objectHandle,
  *
  * @return FSAL status.
  */
-static fsal_status_t close_func(struct fsal_obj_handle *objectHandle,
-                                struct fsal_fd *fd) {
-	struct SaunaFSHandle *handle = NULL;
-
-	handle = container_of(objectHandle, struct SaunaFSHandle, handle);
+static fsal_status_t close_func(struct fsal_obj_handle *objectHandle, struct fsal_fd *fd) {
+	struct SaunaFSHandle *handle = container_of(objectHandle, struct SaunaFSHandle, handle);
 	return closeFileDescriptor(handle, (struct SaunaFSFd *)fd);
 }
 
@@ -2278,32 +2069,27 @@ static fsal_status_t close_func(struct fsal_obj_handle *objectHandle,
  *
  * @returns: FSAL status
  */
-static fsal_status_t getxattrs(struct fsal_obj_handle *objectHandle,
-                               xattrkey4 *xattributeName,
+static fsal_status_t getxattrs(struct fsal_obj_handle *objectHandle, xattrkey4 *xattributeName,
                                xattrvalue4 *xattributeValue) {
 	struct SaunaFSExport *export = NULL;
 	export = container_of(op_ctx->fsal_export, struct SaunaFSExport, export);
 
-	struct SaunaFSHandle *handle = NULL;
-
-	handle = container_of(objectHandle, struct SaunaFSHandle, handle);
+	struct SaunaFSHandle *handle = container_of(objectHandle, struct SaunaFSHandle, handle);
 
 	size_t curr_size = 0;
-	int retvalue = saunafs_getxattr(
-	    export->fsInstance, &op_ctx->creds, handle->inode,
-	    xattributeName->utf8string_val, xattributeValue->utf8string_len,
-	    &curr_size, (uint8_t *)xattributeValue->utf8string_val);
+	int retvalue = saunafs_getxattr(export->fsInstance, &op_ctx->creds, handle->inode,
+	                                xattributeName->utf8string_val, xattributeValue->utf8string_len,
+	                                &curr_size, (uint8_t *)xattributeValue->utf8string_val);
 
 	if (retvalue < 0) {
-		LogFullDebug(COMPONENT_FSAL, "GETXATTRS failed returned rc = %d ",
-		             retvalue);
+		LogFullDebug(COMPONENT_FSAL, "GETXATTRS failed returned rc = %d ", retvalue);
 		return saunafsToFsalError(retvalue);
 	}
 
 	if (curr_size && curr_size <= xattributeValue->utf8string_len) {
-		/* Updating the real size */
+		// Updating the real size
 		xattributeValue->utf8string_len = curr_size;
-		/* Make sure utf8string is NULL terminated */
+		// Make sure utf8string is NULL terminated
 		xattributeValue->utf8string_val[curr_size] = '\0';
 	}
 
@@ -2322,22 +2108,15 @@ static fsal_status_t getxattrs(struct fsal_obj_handle *objectHandle,
  *
  * @returns: FSAL status
  */
-static fsal_status_t setxattrs(struct fsal_obj_handle *objectHandle,
-                               setxattr_option4 option,
-                               xattrkey4 *xattributeName,
-                               xattrvalue4 *xattributeValue) {
-	struct SaunaFSExport *export = NULL;
-	export = container_of(op_ctx->fsal_export, struct SaunaFSExport, export);
+static fsal_status_t setxattrs(struct fsal_obj_handle *objectHandle, setxattr_option4 option,
+                               xattrkey4 *xattributeName, xattrvalue4 *xattributeValue) {
+	struct SaunaFSExport *export = container_of(op_ctx->fsal_export, struct SaunaFSExport, export);
 
-	struct SaunaFSHandle *handle = NULL;
+	struct SaunaFSHandle *handle = container_of(objectHandle, struct SaunaFSHandle, handle);
 
-	handle = container_of(objectHandle, struct SaunaFSHandle, handle);
-
-	int retvalue =
-	    saunafs_setxattr(export->fsInstance, &op_ctx->creds, handle->inode,
-	                     xattributeName->utf8string_val,
-	                     (const uint8_t *)xattributeValue->utf8string_val,
-	                     xattributeValue->utf8string_len, option);
+	int retvalue = saunafs_setxattr(
+	    export->fsInstance, &op_ctx->creds, handle->inode, xattributeName->utf8string_val,
+	    (const uint8_t *)xattributeValue->utf8string_val, xattributeValue->utf8string_len, option);
 
 	if (retvalue < 0) {
 		LogDebug(COMPONENT_FSAL, "SETXATTRS returned rc %d", retvalue);
@@ -2353,55 +2132,47 @@ static fsal_status_t setxattrs(struct fsal_obj_handle *objectHandle,
  * This function lists the extended attributes of an object.
  *
  * @param [in]     objectHandle         Input object to list
- * @param [in]     maximumNameSize      Input maximum number of bytes for
- *                                      names
+ * @param [in]     maximumNameSize      Input maximum number of bytes for names
  * @param [in,out] cookie               In/out cookie
- * @param [out]    eof                  Output eof set if no more extended
- *                                      attributes
- * @param [out]    xattributesNames     Output list of extended attribute
- *                                      names this buffer size is double the
- *                                      size of maximumNameSize to allow
+ * @param [out]    eof                  Output eof set if no more extended attributes
+ * @param [out]    xattributesNames     Output list of extended attribute names this buffer size is
+ *                                      double the size of maximumNameSize to allow
  *                                      for component4 overhead
  *
  * @returns: FSAL status
  */
-static fsal_status_t listxattrs(struct fsal_obj_handle *objectHandle,
-                                count4 maximumNameSize, nfs_cookie4 *cookie,
-                                bool_t *eof, xattrlist4 *xattributesNames) {
+static fsal_status_t listxattrs(struct fsal_obj_handle *objectHandle, count4 maximumNameSize,
+                                nfs_cookie4 *cookie, bool_t *eof, xattrlist4 *xattributesNames) {
 	char *buffer = NULL;
 	fsal_status_t status = fsalstat(ERR_FSAL_NO_ERROR, 0);
 
 	struct SaunaFSExport *export = NULL;
 	export = container_of(op_ctx->fsal_export, struct SaunaFSExport, export);
 
-	struct SaunaFSHandle *handle = NULL;
+	struct SaunaFSHandle *handle = container_of(objectHandle, struct SaunaFSHandle, handle);
 
-	handle = container_of(objectHandle, struct SaunaFSHandle, handle);
+	LogFullDebug(COMPONENT_FSAL, "in cookie %llu length %d", (unsigned long long)*cookie,
+	             maximumNameSize);
 
-	LogFullDebug(COMPONENT_FSAL, "in cookie %llu length %d",
-	             (unsigned long long)*cookie, maximumNameSize);
-
-	/* Size of list of extended attributes */
+	// Size of list of extended attributes
 	size_t curr_size = 0;
 
-	/* First time, the function is called to get the size of xattr list */
-	int retvalue = saunafs_listxattr(export->fsInstance, &op_ctx->creds,
-	                                 handle->inode, 0, &curr_size, NULL);
+	// First time, the function is called to get the size of xattr list
+	int retvalue =
+	    saunafs_listxattr(export->fsInstance, &op_ctx->creds, handle->inode, 0, &curr_size, NULL);
 
 	if (retvalue < 0) {
 		LogDebug(COMPONENT_FSAL, "LISTXATTRS returned rc %d", retvalue);
 		return saunafsToFsalError(retvalue);
 	}
 
-	/* If xattr were retrieved and they can be allocated */
+	// If xattr were retrieved and they can be allocated
 	if (curr_size && curr_size < maximumNameSize) {
 		buffer = gsh_malloc(curr_size);
 
-		/* Second time the function is called to retrieve
-		 * the xattr list */
-		retvalue =
-		    saunafs_listxattr(export->fsInstance, &op_ctx->creds, handle->inode,
-		                      curr_size, &curr_size, buffer);
+		// Second time the function is called to retrieve the xattr list
+		retvalue = saunafs_listxattr(export->fsInstance, &op_ctx->creds, handle->inode, curr_size,
+		                             &curr_size, buffer);
 
 		if (retvalue < 0) {
 			LogDebug(COMPONENT_FSAL, "LISTXATTRS returned rc %d", retvalue);
@@ -2409,11 +2180,11 @@ static fsal_status_t listxattrs(struct fsal_obj_handle *objectHandle,
 			return saunafsToFsalError(retvalue);
 		}
 
-		/* Setting retrieved extended attributes to Ganesha */
-		status = fsal_listxattr_helper(buffer, curr_size, maximumNameSize,
-		                               cookie, eof, xattributesNames);
+		// Setting retrieved extended attributes to Ganesha
+		status = fsal_listxattr_helper(buffer, curr_size, maximumNameSize, cookie, eof,
+		                               xattributesNames);
 
-		/* Releasing allocated buffer */
+		// Releasing allocated buffer
 		gsh_free(buffer);
 	}
 
@@ -2430,18 +2201,14 @@ static fsal_status_t listxattrs(struct fsal_obj_handle *objectHandle,
  *
  * @returns: FSAL status
  */
-static fsal_status_t removexattrs(struct fsal_obj_handle *objectHandle,
-                                  xattrkey4 *xattributeName) {
+static fsal_status_t removexattrs(struct fsal_obj_handle *objectHandle, xattrkey4 *xattributeName) {
 	struct SaunaFSExport *export = NULL;
 	export = container_of(op_ctx->fsal_export, struct SaunaFSExport, export);
 
-	struct SaunaFSHandle *handle = NULL;
+	struct SaunaFSHandle *handle = container_of(objectHandle, struct SaunaFSHandle, handle);
 
-	handle = container_of(objectHandle, struct SaunaFSHandle, handle);
-
-	int retvalue =
-	    saunafs_removexattr(export->fsInstance, &op_ctx->creds, handle->inode,
-	                        xattributeName->utf8string_val);
+	int retvalue = saunafs_removexattr(export->fsInstance, &op_ctx->creds, handle->inode,
+	                                   xattributeName->utf8string_val);
 
 	if (retvalue < 0) {
 		LogFullDebug(COMPONENT_FSAL, "REMOVEXATTR returned rc %d", retvalue);
@@ -2498,19 +2265,16 @@ void handleOperationsInit(struct fsal_obj_ops *ops) {
  *
  * @returns: saunafs_handle instance or NULL.
  */
-struct SaunaFSHandle *allocateHandle(const struct stat *attribute,
-                                     struct SaunaFSExport *export) {
-	struct SaunaFSHandle *result = NULL;
-
-	result = gsh_calloc(1, sizeof(struct SaunaFSHandle));
+struct SaunaFSHandle *allocateHandle(const struct stat *attribute, struct SaunaFSExport *export) {
+	struct SaunaFSHandle *result = gsh_calloc(1, sizeof(struct SaunaFSHandle));
 
 	result->inode = attribute->st_ino;
 	result->key.moduleId = FSAL_ID_SAUNAFS;
 	result->key.exportId = export->export.export_id;
 	result->key.inode = attribute->st_ino;
 
-	fsal_obj_handle_init(&result->handle, &export->export,
-	                     posix2fsal_type(attribute->st_mode), true);
+	fsal_obj_handle_init(&result->handle, &export->export, posix2fsal_type(attribute->st_mode),
+	                     true);
 
 	result->handle.obj_ops = &SaunaFS.handleOperations;
 	result->handle.fsid = posix2fsal_fsid(attribute->st_dev);

--- a/src/nfs-ganesha/handle.c
+++ b/src/nfs-ganesha/handle.c
@@ -16,8 +16,10 @@
    You should have received a copy of the GNU General Public License
    along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
  */
+
 #include "config.h"
 #include "fsal_types.h"
+#include "saunafs_fsal_types.h"
 
 #ifdef LINUX
 #include <linux/falloc.h>  /* for fallocate  */
@@ -35,8 +37,8 @@
 /**
  * @brief Clean up a filehandle.
  *
- * This function cleans up private resources associated with a filehandle and
- * deallocates it.
+ * This function cleans up private resources associated with a filehandle
+ * and deallocates it.
  *
  * Implement this method or you will leak. Refcount (if used) should be 1.
  *
@@ -45,6 +47,10 @@
 static void release(struct fsal_obj_handle *objectHandle) {
 	struct SaunaFSHandle *handle = NULL;
 	handle = container_of(objectHandle, struct SaunaFSHandle, handle);
+
+	if (handle->handle.type == REGULAR_FILE) {
+		destroy_fsal_fd(&handle->fd.fsalFd);
+	}
 
 	if (handle != handle->export->root) {
 		deleteHandle(handle);
@@ -96,13 +102,16 @@ static fsal_status_t lookup(struct fsal_obj_handle *dirHandle, const char *path,
 /**
  * @brief Read a directory.
  *
- * This function reads directory entries from the FSAL and supplies them to a callback.
+ * This function reads directory entries from the FSAL and supplies them to
+ * a callback.
  *
  * @param [in]  dirHandle          Directory to read
- * @param [in]  whence             Point at which to start reading. NULL to start at beginning
+ * @param [in]  whence             Point at which to start reading. NULL to
+ *                                 start at beginning
  * @param [in]  dirState           Opaque pointer to be passed to callback
  * @param [in]  readdirCb          Callback to receive names
- * @param [in]  attributesMask     Indicate which attributes the caller is interested in
+ * @param [in]  attributesMask     Indicate which attributes the caller is
+ *                                 interested in
  * @param [out] eof                true if the last entry was reached
  *
  * @returns: FSAL status
@@ -260,11 +269,12 @@ static fsal_status_t handle_to_wire(const struct fsal_obj_handle *objectHandle,
                                     uint32_t outputType,
                                     struct gsh_buffdesc *buffer) {
 	(void)outputType;
-
 	struct SaunaFSHandle *handle = NULL;
+
 	handle = container_of(objectHandle, struct SaunaFSHandle, handle);
 
 	sau_inode_t inode = handle->inode;
+
 	if (buffer->len < sizeof(sau_inode_t)) {
 		LogMajor(COMPONENT_FSAL,
 		         "Space too small for handle. Need  %zu, have %zu",
@@ -284,14 +294,15 @@ static fsal_status_t handle_to_wire(const struct fsal_obj_handle *objectHandle,
  * Indicate the unique part of the handle that should be used for hashing.
  *
  * @param [in]  objectHandle     Handle whose key is to be got
- * @param [out] buffer           Address and length giving sub-region of handle
- *                               to be used as key.
+ * @param [out] buffer           Address and length giving sub-region of
+ *                               handle to be used as key.
  *
  * @returns: FSAL status
  */
 static void handle_to_key(struct fsal_obj_handle *objectHandle,
                           struct gsh_buffdesc *buffer) {
 	struct SaunaFSHandle *handle = NULL;
+
 	handle = container_of(objectHandle, struct SaunaFSHandle, handle);
 
 	buffer->addr = &handle->key;
@@ -299,51 +310,10 @@ static void handle_to_key(struct fsal_obj_handle *objectHandle,
 }
 
 /**
- * @brief Open a SaunaFS file descriptor.
- *
- * @param [in] handle            SaunaFS internal object handle
- * @param [in] openflags         Mode for open
- * @param [in] saunafsFd         SaunaFS file descriptor to open
- * @param [in] noAccessCheck     Whether the caller checked access or not
- *
- * @returns: FSAL status
- */
-static fsal_status_t openFileDescriptor(struct SaunaFSHandle *handle,
-                                        fsal_openflags_t openflags,
-                                        struct SaunaFSFd *saunafsFd,
-                                        bool noAccessCheck) {
-	struct SaunaFSExport *export = NULL;
-	int posixFlags = 0;
-
-	fsal2posix_openflags(openflags, &posixFlags);
-	if (noAccessCheck) {
-		posixFlags |= O_CREAT;
-	}
-
-	export = container_of(op_ctx->fsal_export, struct SaunaFSExport, export);
-
-	LogFullDebug(COMPONENT_FSAL,
-	             "fd = %p fd->fd = %p openflags = %x, posix_flags = %x",
-	             saunafsFd, saunafsFd->fd, openflags, posixFlags);
-
-	assert(saunafsFd->fd == NULL && saunafsFd->openflags == FSAL_O_CLOSED &&
-	       openflags != 0);
-
-	saunafsFd->fd = saunafs_open(export->fsInstance, &op_ctx->creds,
-	                             handle->inode, posixFlags);
-
-	if (!saunafsFd->fd) {
-		LogFullDebug(COMPONENT_FSAL, "open failed with %s",
-		             sau_error_string(sau_last_err()));
-		return fsalLastError();
-	}
-
-	saunafsFd->openflags = openflags;
-	return fsalstat(ERR_FSAL_NO_ERROR, 0);
-}
-
-/**
  * @brief Close a SaunaFS file descriptor.
+ *
+ * This function closes a file. This should return ERR_FSAL_NOT_OPENED if
+ * the global FD for this obj was not open.
  *
  * @param [in] handle         SaunaFS internal object handle
  * @param [in] saunafsFd      SaunaFS file descriptor to open
@@ -352,18 +322,79 @@ static fsal_status_t openFileDescriptor(struct SaunaFSHandle *handle,
  */
 static fsal_status_t closeFileDescriptor(struct SaunaFSHandle *handle,
                                          struct SaunaFSFd *saunafsFd) {
-	if (saunafsFd->fd != NULL && saunafsFd->openflags != FSAL_O_CLOSED) {
+	fsal_status_t status = fsalstat(ERR_FSAL_NO_ERROR, 0);
+
+	if (saunafsFd->fd != NULL && saunafsFd->fsalFd.openflags != FSAL_O_CLOSED) {
 		int status = sau_release(handle->export->fsInstance, saunafsFd->fd);
 
 		saunafsFd->fd = NULL;
-		saunafsFd->openflags = FSAL_O_CLOSED;
+		saunafsFd->fsalFd.openflags = FSAL_O_CLOSED;
 
-		if (status < 0) {
-			return fsalLastError();
+		if (status < 0) { return fsalLastError(); }
+	} else {
+		status = fsalstat(ERR_FSAL_NOT_OPENED, 0);
+	}
+
+	return status;
+}
+
+/**
+ * @brief Function to open or reopen a fsal_fd.
+ *
+ * @param[in]  objectHandle     File on which to operate
+ * @param[in]  openflags        New mode for open
+ * @param[out] fsalFd           File descriptor that is to be used
+ *
+ * @return FSAL status.
+ */
+fsal_status_t reopen_func(struct fsal_obj_handle *objectHandle,
+                          fsal_openflags_t openflags, struct fsal_fd *fsalFd) {
+	struct SaunaFSHandle *handle = NULL;
+	struct SaunaFSFd *fileDescriptor = NULL;
+	struct sau_fileinfo *saunafsFD = NULL;
+	struct SaunaFSExport *export = NULL;
+	int posixFlags = 0;
+	fsal_status_t status = {ERR_FSAL_NO_ERROR, 0};
+
+	handle = container_of(objectHandle, struct SaunaFSHandle, handle);
+	fileDescriptor = container_of(fsalFd, struct SaunaFSFd, fsalFd);
+
+	fsal2posix_openflags(openflags, &posixFlags);
+
+	export = container_of(op_ctx->fsal_export, struct SaunaFSExport, export);
+
+	LogFullDebug(COMPONENT_FSAL,
+	             "fd = %p fd->fd = %p openflags = %x, posixFlags = %x",
+	             fileDescriptor, fileDescriptor->fd, openflags, posixFlags);
+
+	assert(fileDescriptor->fd == NULL &&
+	       fileDescriptor->fsalFd.openflags == FSAL_O_CLOSED && openflags != 0);
+
+	saunafsFD = saunafs_open(export->fsInstance, &op_ctx->creds, handle->inode,
+	                         posixFlags);
+
+	if (saunafsFD == NULL) {
+		LogFullDebug(COMPONENT_FSAL, "open failed with %s",
+		             sau_error_string(sau_last_err()));
+		return fsalLastError();
+	}
+
+	if (fileDescriptor->fd != NULL &&
+	    fileDescriptor->fsalFd.openflags != FSAL_O_CLOSED) {
+		int retvalue =
+		    sau_release(handle->export->fsInstance, fileDescriptor->fd);
+
+		if (retvalue < 0) {
+			LogFullDebug(COMPONENT_FSAL, "close failed with %s",
+			             sau_error_string(sau_last_err()));
+			status = fsalLastError();
 		}
 	}
 
-	return fsalstat(ERR_FSAL_NO_ERROR, 0);
+	fileDescriptor->fd = saunafsFD;
+	fileDescriptor->fsalFd.openflags = FSAL_O_NFS_FLAGS(openflags);
+
+	return status;
 }
 
 /**
@@ -373,11 +404,10 @@ static fsal_status_t closeFileDescriptor(struct SaunaFSHandle *handle,
  * @param [in] state                         state_t to use for this operation
  * @param [in] openflags                     Mode for open
  * @param [in] createmode                    Mode for create
- * @param [in] verifier                      Verifier to use for exclusive create
- * @param [in] attributes                    Attributes to set on created file
- * @param [in,out] callerPermissionCheck     The caller must do a permission check
- * @param [in] afterMknode                   The file is opened after performing
- *                                           a makenode operation
+ * @param [in] verifier                      Verifier to use for exclusive
+ *                                           create
+ * @param [in] attributes                    Attributes to set on created
+ *                                           file
  *
  * @returns: FSAL status
  */
@@ -386,118 +416,187 @@ static fsal_status_t openByHandle(struct fsal_obj_handle *objectHandle,
                                   fsal_openflags_t openflags,
                                   enum fsal_create_mode createmode,
                                   fsal_verifier_t verifier,
-                                  struct fsal_attrlist *attributes,
-                                  bool *callerPermissionCheck,
-                                  bool afterMknode) {
+                                  struct fsal_attrlist *attributes) {
 	struct SaunaFSExport *export = NULL;
 	struct SaunaFSHandle *handle = NULL;
 	struct SaunaFSFd *saunafsFd = NULL;
+	struct fsal_fd *fsalFd = NULL;
 	fsal_status_t status = fsalstat(ERR_FSAL_NO_ERROR, 0);
 	int posixFlags = 0;
+
+	fsal_openflags_t oldOpenflags = 0;
+	bool truncated = openflags & FSAL_O_TRUNC;
 
 	handle = container_of(objectHandle, struct SaunaFSHandle, handle);
 	export = container_of(op_ctx->fsal_export, struct SaunaFSExport, export);
 
-	PTHREAD_RWLOCK_wrlock(&objectHandle->obj_lock);
-
 	if (state != NULL) {
 		saunafsFd =
 		    &container_of(state, struct SaunaFSStateFd, state)->saunafsFd;
-
-		// Prepare to take the share reservation, but only if we
-		// are called with a valid state
-
-		// Check share reservation conflicts
-		status = check_share_conflict(&handle->share, openflags, false);
-
-		if (FSAL_IS_ERROR(status)) {
-			PTHREAD_RWLOCK_unlock(&objectHandle->obj_lock);
-			return status;
-		}
-
-		// Take the share reservation now by updating the counters
-		update_share_counters(&handle->share, FSAL_O_CLOSED, openflags);
-		PTHREAD_RWLOCK_unlock(&objectHandle->obj_lock);
-	}
-	else {
-		// We need to use the global file descriptor to continue
+	} else {
+		/* We need to use the global file descriptor to continue */
 		saunafsFd = &handle->fd;
 	}
 
-	status = openFileDescriptor(handle, openflags, saunafsFd, afterMknode);
-	if (FSAL_IS_ERROR(status)) {
-		if (state != NULL) {
-			// On error we need to release our share reservation
-			// and undo the update of the share counters
-			PTHREAD_RWLOCK_wrlock(&objectHandle->obj_lock);
-			update_share_counters(&handle->share, openflags, FSAL_O_CLOSED);
-			PTHREAD_RWLOCK_unlock(&objectHandle->obj_lock);
+	fsalFd = &saunafsFd->fsalFd;
+
+	/* Indicate we want to do fd work (can't fail since not reclaiming) */
+	(void)fsal_start_fd_work(fsalFd, false);
+
+	oldOpenflags = saunafsFd->fsalFd.openflags;
+
+	if (state != NULL) {
+		/* Prepare to take the share reservation, but only if we are
+		 * called with a valid state (if state is NULL the caller is a
+		 * stateless create such as NFS v3 CREATE and we're just going
+		 * to ignore share reservation stuff).
+		 */
+
+		/* Now that we have the mutex, and no I/O is in progress so we
+		 * have exclusive access to the share's fsal_fd, we can look
+		 * at its openflags. We also need to work the share reservation
+		 * so take the obj_lock.
+		 * NOTE: This is the ONLY sequence where both a work_mutex and
+		 * the obj_lock are taken, so there is no opportunity for ABBA
+		 * deadlock.
+		 *
+		 * Note that we do hold the obj_lock over an open and a close
+		 * which is longer than normal, but the previous iteration
+		 * of the code held the obj lock (read granted) over whole
+		 * I/O operations. We don't block over I/O because we've assured
+		 * that no I/O is in progress or can start before proceeding
+		 * past the above while loop.
+		 */
+		PTHREAD_RWLOCK_wrlock(&objectHandle->obj_lock);
+
+		/* Now check the new share. */
+		status = check_share_conflict(&handle->share, openflags, false);
+
+		if (FSAL_IS_ERROR(status)) {
+			LogDebug(COMPONENT_FSAL, "check_share_conflict returned %s",
+			         fsal_err_txt(status));
+
+			if (state != NULL) {
+				if (!FSAL_IS_ERROR(status)) {
+					/* Success, establish the new share. */
+					update_share_counters(&handle->share, oldOpenflags,
+					                      openflags);
+				}
+
+				/* Release obj_lock. */
+				PTHREAD_RWLOCK_unlock(&objectHandle->obj_lock);
+			}
+
+			/* Indicate we are done with fd work and signal
+			 * any waiters. */
+			fsal_complete_fd_work(fsalFd);
 
 			return status;
 		}
+	}
 
-		PTHREAD_RWLOCK_unlock(&objectHandle->obj_lock);
+	/* Check for a genuine no-op open. That means we aren't trying to
+	 * create, the file is already open in the same mode with the same deny
+	 * flags, and we aren't trying to truncate. In this case we want to
+	 * avoid bouncing the fd. In the case of JUST changing the deny mode or
+	 * a replayed exclusive create, we might bounce the fd when we could
+	 * have avoided that, but those scenarios are much less common.
+	 */
+	if (FSAL_O_NFS_FLAGS(openflags) == FSAL_O_NFS_FLAGS(oldOpenflags) &&
+	    truncated == false && createmode == FSAL_NO_CREATE) {
+		LogFullDebug(COMPONENT_FSAL,
+		             "no-op reopen2 saunafsFd->fd = %p openflags = %x",
+		             saunafsFd->fd, openflags);
+
+		if (state != NULL) {
+			if (!FSAL_IS_ERROR(status)) {
+				/* Success, establish the new share. */
+				update_share_counters(&handle->share, oldOpenflags, openflags);
+			}
+
+			/* Release obj_lock. */
+			PTHREAD_RWLOCK_unlock(&objectHandle->obj_lock);
+		}
+
+		/* Indicate we are done with fd work and signal any waiters. */
+		fsal_complete_fd_work(fsalFd);
+
+		return status;
+	}
+
+	/* No share conflict, re-open the share fd */
+	status = reopen_func(objectHandle, openflags, fsalFd);
+
+	if (FSAL_IS_ERROR(status)) {
+		LogDebug(COMPONENT_FSAL, "reopen_func returned %s",
+		         fsal_err_txt(status));
+
+		if (state != NULL) {
+			if (!FSAL_IS_ERROR(status)) {
+				/* Success, establish the new share. */
+				update_share_counters(&handle->share, oldOpenflags, openflags);
+			}
+
+			/* Release obj_lock. */
+			PTHREAD_RWLOCK_unlock(&objectHandle->obj_lock);
+		}
+
+		/* Indicate we are done with fd work and signal any waiters. */
+		fsal_complete_fd_work(fsalFd);
+
 		return status;
 	}
 
 	fsal2posix_openflags(openflags, &posixFlags);
-	bool truncated = (posixFlags & O_TRUNC) != 0;
 
-	bool validFile = (createmode >= FSAL_EXCLUSIVE || truncated || attributes);
+	if (createmode >= FSAL_EXCLUSIVE || attributes) {
+		/* NOTE: won't come in here when called from saunafs_reopen2...
+		 *       truncated might be set, but attrs_out will be NULL.
+		 *       We don't need to look at truncated since other callers
+		 *       are interested in attrs_out.
+		 */
 
-	if (validFile) {
-		struct sau_attr_reply safs_attrs;
-
+		/* Refresh the attributes */
+		struct sau_attr_reply attributesValues;
 		int retvalue = saunafs_getattr(export->fsInstance, &op_ctx->creds,
-		                               handle->inode, &safs_attrs);
+		                               handle->inode, &attributesValues);
 
 		if (retvalue == 0) {
 			LogFullDebug(COMPONENT_FSAL, "New size = %" PRIx64,
-			             (int64_t)safs_attrs.attr.st_size);
-		}
-		else {
+			             (int64_t)attributesValues.attr.st_size);
+		} else {
 			status = fsalLastError();
 		}
 
-		if (!FSAL_IS_ERROR(status)) {
-			// Now check verifier for exclusive
-			if (createmode >= FSAL_EXCLUSIVE &&
-			    createmode != FSAL_EXCLUSIVE_9P &&
-			    !check_verifier_stat(&safs_attrs.attr, verifier, false)) {
-				// Verifier didn't match, return EEXIST
-				status = fsalstat(posix2fsal_error(EEXIST), EEXIST);
-			}
+		if (!FSAL_IS_ERROR(status) && createmode >= FSAL_EXCLUSIVE &&
+		    createmode != FSAL_EXCLUSIVE_9P &&
+		    !check_verifier_stat(&attributesValues.attr, verifier, false)) {
+			/* Verifier didn't match, return EEXIST */
+			status = fsalstat(posix2fsal_error(EEXIST), EEXIST);
 		}
 
 		if (!FSAL_IS_ERROR(status) && attributes) {
-			posix2fsal_attributes_all(&safs_attrs.attr, attributes);
+			posix2fsal_attributes_all(&attributesValues.attr, attributes);
 		}
 	}
 
-	if (state == NULL) {
+	if (FSAL_IS_ERROR(status)) {
+		/* close fd */
+		(void)closeFileDescriptor(handle, saunafsFd);
+	}
+
+	if (state != NULL) {
+		if (!FSAL_IS_ERROR(status)) {
+			/* Success, establish the new share. */
+			update_share_counters(&handle->share, oldOpenflags, openflags);
+		}
+
+		/* Release obj_lock. */
 		PTHREAD_RWLOCK_unlock(&objectHandle->obj_lock);
-
-		// If success, we haven't done any permission check so ask the
-		// caller to do so
-		*callerPermissionCheck = !FSAL_IS_ERROR(status);
-
-		// If no state, return status
-		return status;
 	}
 
-	if (!FSAL_IS_ERROR(status)) {
-		// Return success. We haven't done any permission check so ask
-		// the caller to do so.
-		*callerPermissionCheck = true;
-		return status;
-	}
-
-	closeFileDescriptor(handle, saunafsFd);
-
-	// Release our share reservation and undo the update of the share counters
-	PTHREAD_RWLOCK_wrlock(&objectHandle->obj_lock);
-	update_share_counters(&handle->share, openflags, FSAL_O_CLOSED);
-	PTHREAD_RWLOCK_unlock(&objectHandle->obj_lock);
+	/* Indicate we are done with fd work and signal any waiters. */
+	fsal_complete_fd_work(fsalFd);
 
 	return status;
 }
@@ -506,28 +605,27 @@ static fsal_status_t openByHandle(struct fsal_obj_handle *objectHandle,
  * @brief Open a file using its name.
  *
  * @param [in] objectHandle                  File handle to open
- * @param [in] state                         state_t to use for this operation
+ * @param [in] state                         state_t to use for this
+ *                                           operation
  * @param [in] openflags                     Mode for open
  * @param [in] name                          Name of the file
- * @param [in] verifier                      Verifier to use for exclusive create
- * @param [in] attributes                    Attributes to set on created file
- * @param [in,out] callerPermissionCheck     The caller must do a permission check
- * @param [in] afterMknode                   The file is opened after performing
- *                                           a makenode operation
+ * @param [in] verifier                      Verifier to use for exclusive
+ *                                           create
+ * @param [in] attributes                    Attributes to set on created
+ *                                           file
  *
  * @returns: FSAL status
  */
 static fsal_status_t openByName(struct fsal_obj_handle *objectHandle,
                                 struct state_t *state,
-                                fsal_openflags_t openflags,
-                                const char *name,
+                                fsal_openflags_t openflags, const char *name,
                                 fsal_verifier_t verifier,
-                                struct fsal_attrlist *attributes,
-                                bool *callerPermissionCheck) {
+                                struct fsal_attrlist *attributes) {
 	struct fsal_obj_handle *temp = NULL;
 	fsal_status_t status;
 
-	// Ganesha doesn't has open by name, so we need to get the name with lookup
+	/* Ganesha doesn't has open by name, so we need to get the name with
+	 * lookup */
 	status = objectHandle->obj_ops->lookup(objectHandle, name, &temp, NULL);
 
 	if (FSAL_IS_ERROR(status)) {
@@ -536,13 +634,29 @@ static fsal_status_t openByName(struct fsal_obj_handle *objectHandle,
 		return status;
 	}
 
+	if (temp->type != REGULAR_FILE) {
+		if (temp->type == DIRECTORY) {
+			/* Trying to open2 a directory */
+			status = fsalstat(ERR_FSAL_ISDIR, 0);
+		} else {
+			/* Trying to open2 any other non-regular file */
+			status = fsalstat(ERR_FSAL_SYMLINK, 0);
+		}
+
+		/* Release the object we found by lookup */
+		temp->obj_ops->release(temp);
+		LogFullDebug(COMPONENT_FSAL, "open2 returning %s",
+		             fsal_err_txt(status));
+
+		return status;
+	}
+
 	status = openByHandle(temp, state, openflags, FSAL_NO_CREATE, verifier,
-	                      attributes, callerPermissionCheck, false);
+	                      attributes);
 
 	if (FSAL_IS_ERROR(status)) {
 		temp->obj_ops->release(temp);
-		LogFullDebug(COMPONENT_FSAL, "open returned %s",
-		             fsal_err_txt(status));
+		LogFullDebug(COMPONENT_FSAL, "open returned %s", fsal_err_txt(status));
 	}
 
 	return status;
@@ -552,9 +666,9 @@ static fsal_status_t openByName(struct fsal_obj_handle *objectHandle,
  * @brief Open a file descriptor for read or write and possibly create.
  *
  * Extended API functions.
- * With these new operations, the FSAL becomes responsible for managing share
- * reservations. The FSAL is also granted more control over the state of a "file
- * descriptor" and has more control of what a "file descriptor" even is.
+ * With these new operations, the FSAL becomes responsible for managing
+ * share reservations. The FSAL is also granted more control over the state of
+ * a "file descriptor" and has more control of what a "file descriptor" even is.
  * Ultimately, it is whatever the FSAL needs in order to manage the share
  * reservations and lock state.
 
@@ -566,16 +680,23 @@ static fsal_status_t openByName(struct fsal_obj_handle *objectHandle,
  * @param [in]  state                        state_t to use for this operation
  * @param [in]  openflags                    Mode for open
  * @param [in]  createmode                   Mode for create
- * @param [in]  name                         Name for file if being created or
- *                                           opened
- * @param [in]  attributesToSet              Attributes to set on created file
+ * @param [in]  name                         Name for file if being created
+ *                                           or opened
+ * @param [in]  attributesToSet              Attributes to set on created
+ *                                           file
  * @param [in]  verifier                     Verifier to use for exclusive
  *                                           create
  * @param [in,out] createdObject             Newly created object
  * @param [in,out] attributes                Optional attributes for newly
-                                             created object
- * @param [in,out] callerPermissionCheck     The caller must do a permission
- *                                           check
+ *                                           created object
+ * @param [in,out] callerPermissionCheck     The caller must do a
+ *                                           permission check
+ * @param[in,out] parentPreAttributes        Optional attributes for parent dir
+ *                                           before the operation.
+ *                                           Should be atomic.
+ * @param[in,out] parentPostAttributes       Optional attributes for parent dir
+ *                                           after the operation.
+ *                                           Should be atomic.
  *
  * @returns: FSAL status
  */
@@ -586,7 +707,9 @@ static fsal_status_t open2(struct fsal_obj_handle *objectHandle,
                            fsal_verifier_t verifier,
                            struct fsal_obj_handle **createdObject,
                            struct fsal_attrlist *attributes,
-                           bool *callerPermissionCheck) {
+                           bool *callerPermissionCheck,
+                           struct fsal_attrlist *parentPreAttributes,
+                           struct fsal_attrlist *parentPostAttributes) {
 	struct SaunaFSExport *export = NULL;
 	struct SaunaFSHandle *handle = NULL;
 	fsal_status_t status = fsalstat(ERR_FSAL_NO_ERROR, 0);
@@ -595,29 +718,34 @@ static fsal_status_t open2(struct fsal_obj_handle *objectHandle,
 	            false);
 
 	if (createmode >= FSAL_EXCLUSIVE) {
-		// Now fixup attrs for verifier if exclusive create
+		/* Now fixup attrs for verifier if exclusive create */
 		set_common_verifier(attributesToSet, verifier, false);
 	}
 
 	if (name == NULL) {
-		return openByHandle(objectHandle, state, openflags, createmode,
-		                    verifier, attributes, callerPermissionCheck, false);
+		status = openByHandle(objectHandle, state, openflags, createmode,
+		                      verifier, attributes);
+		*callerPermissionCheck = FSAL_IS_SUCCESS(status);
+		return status;
 	}
+
+	*callerPermissionCheck = (createmode == FSAL_NO_CREATE);
 
 	if (createmode == FSAL_NO_CREATE) {
 		return openByName(objectHandle, state, openflags, name, verifier,
-		                  attributes, callerPermissionCheck);
+		                  attributes);
 	}
 
-	// Create file
+	/* Create file */
 	export = container_of(op_ctx->fsal_export, struct SaunaFSExport, export);
 	handle = container_of(objectHandle, struct SaunaFSHandle, handle);
 
-	// Fetch the mode attribute to use in the openat system call
-	mode_t unix_mode = fsal2unix_mode(attributesToSet->mode) &
-	        ~op_ctx->fsal_export->exp_ops.fs_umask(op_ctx->fsal_export);
+	/* Fetch the mode attribute to use in the openat system call */
+	mode_t unix_mode =
+	    fsal2unix_mode(attributesToSet->mode) &
+	    ~op_ctx->fsal_export->exp_ops.fs_umask(op_ctx->fsal_export);
 
-	// Don't set the mode if we later set the attributes
+	/* Don't set the mode if we later set the attributes */
 	FSAL_UNSET_MASK(attributesToSet->valid_mask, (attrmask_t)ATTR_MODE);
 
 	struct sau_entry posixAttributes;
@@ -628,12 +756,12 @@ static fsal_status_t open2(struct fsal_obj_handle *objectHandle,
 	if (retval < 0 && sau_last_err() == SAUNAFS_ERROR_EEXIST &&
 	    createmode == FSAL_UNCHECKED) {
 		return openByName(objectHandle, state, openflags, name, verifier,
-		                  attributes, callerPermissionCheck);
+		                  attributes);
 	}
 
 	if (retval < 0) { return fsalLastError(); }
 
-	// File has been created by us.
+	/* File has been created by us. */
 	*callerPermissionCheck = false;
 
 	struct SaunaFSHandle *newHandle =
@@ -693,108 +821,25 @@ static fsal_status_t open2(struct fsal_obj_handle *objectHandle,
 		posix2fsal_attributes_all(&posixAttributes.attr, attributes);
 	}
 
-	return openByHandle(*createdObject, state, openflags, createmode, verifier,
-	                    NULL, callerPermissionCheck, true);
-}
-
-/**
- * @brief Function to open an fsal_obj_handle's global file descriptor.
- *
- * @param[in]  objectHandle       File on which to operate
- * @param[in]  openflags          Mode for open
- * @param[out] fileDescriptor     File descriptor that is to be used
- *
- * @return FSAL status.
- */
-static fsal_status_t openFunction(struct fsal_obj_handle *objectHandle,
-                                  fsal_openflags_t openflags,
-                                  struct fsal_fd *fileDescriptor) {
-	struct SaunaFSHandle *handle = NULL;
-	handle = container_of(objectHandle, struct SaunaFSHandle, handle);
-	return openFileDescriptor(handle, openflags,
-	                          (struct SaunaFSFd *)fileDescriptor, true);
-}
-
-/**
- * @brief Function to close an fsal_obj_handle's global file descriptor.
- *
- * @param[in] objectHandle       File on which to operate
- * @param[in] fileDescriptor     File handle to close
- *
- * @return FSAL status.
- */
-static fsal_status_t closeFunction(struct fsal_obj_handle *objectHandle,
-                                   struct fsal_fd *fileDescriptor) {
-	struct SaunaFSHandle *handle = NULL;
-	handle = container_of(objectHandle, struct SaunaFSHandle, handle);
-	return closeFileDescriptor(handle, (struct SaunaFSFd *)fileDescriptor);
-}
-
-/**
- * @brief Find a usable file descriptor for a regular file.
- *
- * This function is a wrapper that initializes the needed variables before calling
- * fsal_find_fd function passing the expected attributes.
- *
- * @param[in,out] fileDescriptor       Usable file descriptor found
- * @param[in] objectHandle             File on which to operate
- * @param[in] bypass                   If state doesn't indicate a share reservation, bypass any deny read
- * @param[in] state                    state_t to use for this operation
- * @param[in] openflags                Mode for open
- * @param[out] hasLock                 Indicates that objectHandle->obj_lock is held read
- * @param[out] closeFileDescriptor     Indicates that file descriptor must be closed
- * @param[out] openForLocks            Indicates file is open for locks
- *
- * @return FSAL status.
- */
-static fsal_status_t findFileDescriptor(struct SaunaFSFd *saunafsFd,
-                                        struct fsal_obj_handle *objectHandle,
-                                        bool bypass, struct state_t *state,
-                                        fsal_openflags_t openflags,
-                                        bool *hasLock,
-                                        bool *closeFileDescriptor,
-                                        bool openForLocks) {
-	struct SaunaFSHandle *handle = NULL;
-	handle = container_of(objectHandle, struct SaunaFSHandle, handle);
-
-	struct SaunaFSFd emptyFd = {0, NULL};
-	struct SaunaFSFd *usableFd = &emptyFd;
-
-	fsal_status_t status;
-
-	bool canReuseOpenedFd = false;
-	status =
-	    fsal_find_fd((struct fsal_fd **)&usableFd, objectHandle,
-	                 (struct fsal_fd *)&handle->fd, &handle->share, bypass,
-	                 state, openflags, openFunction, closeFunction, hasLock,
-	                 closeFileDescriptor, openForLocks, &canReuseOpenedFd);
-
-	// Ensure we have a valid file descriptor before dereferencing
-	if (FSAL_IS_ERROR(status) || usableFd == NULL) {
-		// Initialize SaunaFS file descriptor to a safe state
-		saunafsFd->openflags = FSAL_O_CLOSED;
-		saunafsFd->fd = NULL;
-		return status;
-	}
-
-	*saunafsFd = *usableFd;
-	return status;
+	return openByHandle(*createdObject, state, openflags, createmode, verifier, NULL);
 }
 
 /**
  * @brief Read data from a file.
  *
- * This function reads data from the given file. The FSAL must be able to perform the read
- * whether a state is presented or not.
+ * This function reads data from the given file. The FSAL must be able to
+ * perform the read whether a state is presented or not.
  *
- * This function also is expected to handle properly bypassing or not share reservations.
- * This is an (optionally) asynchronous call. When the I/O is complete, the done callback
- * is called with the results.
+ * This function also is expected to handle properly bypassing or not share
+ * reservations. This is an (optionally) asynchronous call. When the I/O is
+ * complete, the done callback is called with the results.
  *
  * @param [in]     objectHandle     File on which to operate
- * @param [in]     bypass           If state doesn't indicate a share reservation, bypass any deny read
+ * @param [in]     bypass           If state doesn't indicate a share
+ *                                  reservation, bypass any deny read
  * @param [in,out] doneCb           Callback to call when I/O is done
- * @param [in,out] readArg          Info about read, passed back in callback
+ * @param [in,out] readArg          Info about read, passed back in
+ *                                  callback
  * @param [in,out] callerArg        Opaque arg from the caller for callback
  */
 static void read2(struct fsal_obj_handle *objectHandle, bool bypass,
@@ -802,11 +847,14 @@ static void read2(struct fsal_obj_handle *objectHandle, bool bypass,
                   void *callerArg) {
 	struct SaunaFSExport *export = NULL;
 	struct SaunaFSHandle *handle = NULL;
-	struct SaunaFSFd saunafsFd;
-	fsal_status_t status = fsalstat(ERR_FSAL_NO_ERROR, 0);
 
-	bool hasLock = false;
-	bool closeFd = false;
+	struct SaunaFSFd *saunafsFd = NULL;
+	struct SaunaFSFd emptyFileDescriptor = {FSAL_FD_INIT, NULL};
+
+	struct fsal_fd *outFileDescriptor = NULL;
+	fsal_status_t status = fsalstat(ERR_FSAL_NO_ERROR, 0);
+	fsal_status_t status2;
+
 	ssize_t bytes = 0;
 	uint64_t offset = readArg->offset;
 
@@ -823,22 +871,24 @@ static void read2(struct fsal_obj_handle *objectHandle, bool bypass,
 		return;
 	}
 
-	status =
-	    findFileDescriptor(&saunafsFd, objectHandle, bypass, readArg->state,
-	                       FSAL_O_READ, &hasLock, &closeFd, false);
+	// Indicate a desire to start io and get a usable file descriptor
+	status = fsal_start_io(&outFileDescriptor, objectHandle, &handle->fd.fsalFd,
+	                       &emptyFileDescriptor.fsalFd, readArg->state,
+	                       FSAL_O_READ, false, NULL, bypass, &handle->share);
 
 	if (FSAL_IS_ERROR(status)) {
-		if (closeFd) { closeFileDescriptor(handle, &saunafsFd); }
-
-		if (hasLock) { PTHREAD_RWLOCK_unlock(&objectHandle->obj_lock); }
+		LogFullDebug(COMPONENT_FSAL, "fsal_start_io failed returning %s",
+		             fsal_err_txt(status));
 
 		doneCb(objectHandle, status, readArg, callerArg);
 		return;
 	}
 
+	saunafsFd = container_of(outFileDescriptor, struct SaunaFSFd, fsalFd);
+
 	readArg->io_amount = 0;
 	for (int i = 0; i < readArg->iov_count; i++) {
-		bytes = saunafs_read(export->fsInstance, &op_ctx->creds, saunafsFd.fd,
+		bytes = saunafs_read(export->fsInstance, &op_ctx->creds, saunafsFd->fd,
 		                     offset, readArg->iov[i].iov_len,
 		                     readArg->iov[i].iov_base);
 
@@ -849,9 +899,20 @@ static void read2(struct fsal_obj_handle *objectHandle, bool bypass,
 		if (bytes < 0) {
 			status = fsalLastError();
 
-			if (closeFd) { closeFileDescriptor(handle, &saunafsFd); }
+			status2 = fsal_complete_io(objectHandle, outFileDescriptor);
+			LogFullDebug(COMPONENT_FSAL, "fsal_complete_io returned %s",
+			             fsal_err_txt(status2));
 
-			if (hasLock) { PTHREAD_RWLOCK_unlock(&objectHandle->obj_lock); }
+			if (readArg->state == NULL) {
+				/* We did I/O without a state so we need
+				 * to release the temp share
+				 * reservation acquired. */
+
+				/* Release the share reservation now by
+				 * updating the counters. */
+				update_share_counters_locked(objectHandle, &handle->share,
+				                             FSAL_O_READ, FSAL_O_CLOSED);
+			}
 
 			doneCb(objectHandle, status, readArg, callerArg);
 			return;
@@ -861,9 +922,19 @@ static void read2(struct fsal_obj_handle *objectHandle, bool bypass,
 		offset += bytes;
 	}
 
-	if (closeFd) { closeFileDescriptor(handle, &saunafsFd); }
+	status2 = fsal_complete_io(objectHandle, outFileDescriptor);
+	LogFullDebug(COMPONENT_FSAL, "fsal_complete_io returned %s",
+	             fsal_err_txt(status2));
 
-	if (hasLock) { PTHREAD_RWLOCK_unlock(&objectHandle->obj_lock); }
+	if (readArg->state == NULL) {
+		/* We did I/O without a state so we need to release the temp
+		 * share reservation acquired. */
+
+		/* Release the share reservation now by updating
+		 * the counters. */
+		update_share_counters_locked(objectHandle, &handle->share, FSAL_O_READ,
+		                             FSAL_O_CLOSED);
+	}
 
 	doneCb(objectHandle, status, readArg, callerArg);
 }
@@ -872,11 +943,18 @@ static void read2(struct fsal_obj_handle *objectHandle, bool bypass,
  *
  * Creation operations. This function creates a new directory.
  *
- * @param [in]     directoryHandle     Directory in which to create the directory
+ * @param [in]     directoryHandle     Directory in which to create the
+ *                                     directory
  * @param [in]     name                Name of directory to create
- * @param [in]     attributesToSet     Attributes to set on newly created object
+ * @param [in]     attributesToSet     Attributes to set on newly created
+ *                                     object
  * @param [out]    createdObject       Newly created object
- * @param [in,out] attributes          Optional attributes for newly created object
+ * @param [in,out] attributes          Optional attributes for newly
+ *                                     created object
+ * @param[in,out] parentPreAttributes  Optional attributes for parent dir
+ *                                     before the operation. Should be atomic.
+ * @param[in,out] parentPostAttributes Optional attributes for parent dir
+ *                                     after the operation. Should be atomic.
  *
  * \see fsal_api.h for more information
  *
@@ -886,7 +964,9 @@ static fsal_status_t mkdir_(struct fsal_obj_handle *directoryHandle,
                             const char *name,
                             struct fsal_attrlist *attributesToSet,
                             struct fsal_obj_handle **createdObject,
-                            struct fsal_attrlist *attributes) {
+                            struct fsal_attrlist *attributes,
+                            struct fsal_attrlist *parentPreAttributes,
+                            struct fsal_attrlist *parentPostAttributes) {
 	struct SaunaFSExport *export = NULL;
 	struct SaunaFSHandle *directory = NULL;
 	struct SaunaFSHandle *handle = NULL;
@@ -925,21 +1005,20 @@ static fsal_status_t mkdir_(struct fsal_obj_handle *directoryHandle,
 			LogFullDebug(COMPONENT_FSAL, "setattr2 status=%s",
 			             fsal_err_txt(status));
 
-			// Release the handle we just allocate
+			/* Release the handle we just allocate */
 			(*createdObject)->obj_ops->release(*createdObject);
 			*createdObject = NULL;
-		}
-		else if (attributes != NULL) {
-			// We ignore errors here. The mkdir and setattr succeeded,
-			// so we don't want to return error if the getattrs fails.
-			// We'll just return no attributes in that case.
+		} else if (attributes != NULL) {
+			/* We ignore errors here. The mkdir and setattr
+			 * succeeded, so we don't want to return error
+			 * if the getattrs fails.
+			 * We'll just return no attributes in that case. */
 			(*createdObject)->obj_ops->getattrs(*createdObject, attributes);
 		}
-	}
-	else if (attributes != NULL) {
-		// Since we haven't set any attributes other than what
-		// was set on create, just use the stat results we used
-		// to create the fsal_obj_handle.
+	} else if (attributes != NULL) {
+		/* Since we haven't set any attributes other than what
+		 * was set on create, just use the stat results we used
+		 * to create the fsal_obj_handle. */
 		posix2fsal_attributes_all(&directoryEntry.attr, attributes);
 	}
 
@@ -953,14 +1032,17 @@ static fsal_status_t mkdir_(struct fsal_obj_handle *directoryHandle,
  * This function creates a new name for an existing object.
  *
  * @param [in] objectHandle             Object to be linked to
- * @param [in] destinationDirHandle     Directory in which to create the link
+ * @param [in] destinationDirHandle     Directory in which to create the
+ *                                      link
  * @param [in] name                     Name for link
  *
  * @returns: FSAL status
  */
 static fsal_status_t link_(struct fsal_obj_handle *objectHandle,
                            struct fsal_obj_handle *destinationDirHandle,
-                           const char *name) {
+                           const char *name,
+                           struct fsal_attrlist *destdirPreAttributes,
+                           struct fsal_attrlist *destdirPostAttributes) {
 	struct SaunaFSExport *export = NULL;
 	struct SaunaFSHandle *handle = NULL;
 	struct SaunaFSHandle *destinationHandle = NULL;
@@ -968,8 +1050,7 @@ static fsal_status_t link_(struct fsal_obj_handle *objectHandle,
 	export = container_of(op_ctx->fsal_export, struct SaunaFSExport, export);
 	handle = container_of(objectHandle, struct SaunaFSHandle, handle);
 
-	destinationHandle =
-	    container_of(destinationDirHandle, struct SaunaFSHandle, handle);
+	destinationHandle = container_of(destinationDirHandle, struct SaunaFSHandle, handle);
 
 	LogFullDebug(COMPONENT_FSAL, "export = %"
 	             PRIu16 " inode = %" PRIiNode " dest_inode = %" PRIiNode
@@ -977,9 +1058,8 @@ static fsal_status_t link_(struct fsal_obj_handle *objectHandle,
 	             handle->inode, destinationHandle->inode, name);
 
 	sau_entry_t entry;
-	int retvalue =
-	    saunafs_link(export->fsInstance, &op_ctx->creds, handle->inode,
-	                 destinationHandle->inode, name, &entry);
+	int retvalue = saunafs_link(export->fsInstance, &op_ctx->creds, handle->inode,
+	                            destinationHandle->inode, name, &entry);
 
 	if (retvalue < 0) {
 		return fsalLastError();
@@ -991,13 +1071,21 @@ static fsal_status_t link_(struct fsal_obj_handle *objectHandle,
 /**
  * @brief Rename a file.
  *
- * This function renames a file (technically it changes the name of one link,
- * which may be the only link to the file.)
+ * This function renames a file (technically it changes the name of one
+ * link, which may be the only link to the file.)
  *
  * @param [in] oldParentHandle     Source directory
  * @param [in] oldName             Original name
  * @param [in] newParentHandle     Destination directory
  * @param [in] newName             New name
+ * @param[in,out] oldParentPreAttributes  Optional attributes for olddParent
+ *                                      before the operation. Should be atomic.
+ * @param[in,out] oldParentPostAttributes Optional attributes for oldParent
+ *                                      after the operation. Should be atomic.
+ * @param[in,out] newParentPreAttributes  Optional attributes for newParent
+ *                                      before the operation. Should be atomic.
+ * @param[in,out] newParentPostAttributes Optional attributes for newParent
+ *                                      after the operation. Should be atomic.
  *
  * @returns: FSAL status
  */
@@ -1005,7 +1093,11 @@ static fsal_status_t rename_(struct fsal_obj_handle *objectHandle,
                              struct fsal_obj_handle *oldParentHandle,
                              const char *oldName,
                              struct fsal_obj_handle *newParentHandle,
-                             const char *newName) {
+                             const char *newName,
+                             struct fsal_attrlist *oldParentPreAttributes,
+                             struct fsal_attrlist *oldParentPostAttributes,
+                             struct fsal_attrlist *newParentPreAttributes,
+                             struct fsal_attrlist *newParentPostAttributes) {
 	(void)objectHandle;
 	struct SaunaFSExport *export = NULL;
 	struct SaunaFSHandle *oldDir = NULL;
@@ -1020,8 +1112,8 @@ static fsal_status_t rename_(struct fsal_obj_handle *objectHandle,
 	             export->export.export_id, oldDir->inode,
 	             newDir->inode, oldName, newName);
 
-	int status = saunafs_rename(export->fsInstance, &op_ctx->creds,
-	                            oldDir->inode, oldName, newDir->inode, newName);
+	int status = saunafs_rename(export->fsInstance, &op_ctx->creds, oldDir->inode, oldName,
+	                            newDir->inode, newName);
 
 	if (status < 0) {
 		return fsalLastError();
@@ -1033,18 +1125,25 @@ static fsal_status_t rename_(struct fsal_obj_handle *objectHandle,
 /**
  * @brief Remove a name from a directory.
  *
- * This function removes a name from a directory and possibly deletes the file
- * so named.
+ * This function removes a name from a directory and possibly deletes the
+ * file so named.
  *
- * @param [in] directoryHandle     The directory from which to remove the name
+ * @param [in] directoryHandle     The directory from which to remove the
+ *                                 name
  * @param [in] objectHandle        The object being removed
  * @param [in] name                The name to remove
+ * @param[in,out] parentPreAttributes  Optional attributes for parent dir
+ *                                     before the operation. Should be atomic.
+ * @param[in,out] parentPostAttributes Optional attributes for parent dir
+ *                                     after the operation. Should be atomic.
  *
  * @returns: FSAL status
  */
 static fsal_status_t unlink_(struct fsal_obj_handle *directoryHandle,
                              struct fsal_obj_handle *objectHandle,
-                             const char *name) {
+                             const char *name,
+                             struct fsal_attrlist *parentPreAttributes,
+                             struct fsal_attrlist *parentPostAttributes) {
 	struct SaunaFSExport *export = NULL;
 	struct SaunaFSHandle *directory = NULL;
 	int status = 0;
@@ -1058,17 +1157,13 @@ static fsal_status_t unlink_(struct fsal_obj_handle *directoryHandle,
 	             object_file_type_to_str(objectHandle->type));
 
 	if (objectHandle->type != DIRECTORY) {
-		status = saunafs_unlink(export->fsInstance, &op_ctx->creds,
-		                        directory->inode, name);
+		status = saunafs_unlink(export->fsInstance, &op_ctx->creds, directory->inode, name);
 	}
 	else {
-		status = saunafs_rmdir(export->fsInstance, &op_ctx->creds,
-		                       directory->inode, name);
+		status = saunafs_rmdir(export->fsInstance, &op_ctx->creds, directory->inode, name);
 	}
 
-	if (status < 0) {
-		return fsalLastError();
-	}
+	if (status < 0) { return fsalLastError(); }
 
 	return fsalstat(ERR_FSAL_NO_ERROR, 0);
 }
@@ -1076,52 +1171,42 @@ static fsal_status_t unlink_(struct fsal_obj_handle *directoryHandle,
 /**
  * @brief Close a file.
  *
- * This function closes a file. This should return ERR_FSAL_NOT_OPENED if the
- * global FD for this obj was not open.
- *
  * @param [in] objectHandle     File to close
  *
  * @returns: FSAL status
  */
 static fsal_status_t close_(struct fsal_obj_handle *objectHandle) {
-	fsal_status_t status;
 	struct SaunaFSHandle *handle = NULL;
+
 	handle = container_of(objectHandle, struct SaunaFSHandle, handle);
 
 	LogFullDebug(COMPONENT_FSAL, "export=%" PRIu16 " inode=%" PRIiNode,
 	             handle->key.exportId, handle->inode);
 
-	PTHREAD_RWLOCK_wrlock(&objectHandle->obj_lock);
-
-	if (handle->fd.openflags == FSAL_O_CLOSED) {
-		status = fsalstat(ERR_FSAL_NOT_OPENED, 0);
-	}
-	else {
-		status = closeFileDescriptor(handle, &handle->fd);
-	}
-
-	PTHREAD_RWLOCK_unlock(&objectHandle->obj_lock);
-
-	return status;
+	return close_fsal_fd(objectHandle, &handle->fd.fsalFd, false);
 }
 
 /**
  * @brief Write data to a file.
  *
- * This function writes data to a file. The FSAL must be able to perform the
- * write whether a state is presented or not. This function also is expected
- * to handle properly bypassing or not share reservations.
- * Even with bypass == true, it will enforce a mandatory (NFSv4) deny_write if
- * an appropriate state is not passed).
+ * This function writes data to a file. The FSAL must be able to perform
+ * the write whether a state is presented or not. This function also is
+ * expected to handle properly bypassing or not share reservations.
+ *
+ * Even with bypass == true, it will enforce a mandatory (NFSv4) deny_write
+ * if an appropriate state is not passed).
 
- * The FSAL is expected to enforce sync if necessary. This is an (optionally)
- * asynchronous call. When the I/O is complete, the done_cb callback is called.
+ * The FSAL is expected to enforce sync if necessary. This is an
+ * (optionally) asynchronous call. When the I/O is complete, the done_cb
+ * callback is called.
  *
  * @param [in]     objectHandle     File on which to operate
- * @param [in]     bypass           If state doesn't indicate a share reservation,
+ * @param [in]     bypass           If state doesn't indicate a share
+ *                                  reservation,
  *                                  bypass any non-mandatory deny write
  * @param [in,out] doneCb           Callback to call when I/O is done
- * @param [in,out] writeArg         Info about write, passed back in callback
+ * @param [in,out] writeArg         Info about write, passed back in
+ *                                  callback
  * @param [in,out] callerArg        Opaque arg from the caller for callback
  */
 static void write2(struct fsal_obj_handle *objectHandle, bool bypass,
@@ -1129,11 +1214,13 @@ static void write2(struct fsal_obj_handle *objectHandle, bool bypass,
                    void *callerArg) {
 	struct SaunaFSExport *export = NULL;
 	struct SaunaFSHandle *handle = NULL;
-	struct SaunaFSFd saunafsFd;
+
+	struct SaunaFSFd *saunafsFd = NULL;
+	struct SaunaFSFd emptyFileDescriptor = {FSAL_FD_INIT, NULL};
+	struct fsal_fd *outFileDescriptor = NULL;
 
 	fsal_status_t status;
-	bool hasLock = false;
-	bool closeFd = false;
+	fsal_status_t status2;
 
 	ssize_t bytes = 0;
 	uint64_t offset = writeArg->offset;
@@ -1151,21 +1238,23 @@ static void write2(struct fsal_obj_handle *objectHandle, bool bypass,
 		return;
 	}
 
-	status =
-	    findFileDescriptor(&saunafsFd, objectHandle, bypass, writeArg->state,
-	                       FSAL_O_WRITE, &hasLock, &closeFd, false);
+	/* Indicate a desire to start io and get a usable file descritor */
+	status = fsal_start_io(&outFileDescriptor, objectHandle, &handle->fd.fsalFd,
+	                       &emptyFileDescriptor.fsalFd, writeArg->state,
+	                       FSAL_O_WRITE, false, NULL, bypass, &handle->share);
 
 	if (FSAL_IS_ERROR(status)) {
-		if (closeFd) { closeFileDescriptor(handle, &saunafsFd); }
-
-		if (hasLock) { PTHREAD_RWLOCK_unlock(&objectHandle->obj_lock); }
+		LogFullDebug(COMPONENT_FSAL, "fsal_start_io failed returning %s",
+		             fsal_err_txt(status));
 
 		doneCb(objectHandle, status, writeArg, callerArg);
 		return;
 	}
 
+	saunafsFd = container_of(outFileDescriptor, struct SaunaFSFd, fsalFd);
+
 	for (int i = 0; i < writeArg->iov_count; i++) {
-		bytes = saunafs_write(export->fsInstance, &op_ctx->creds, saunafsFd.fd,
+		bytes = saunafs_write(export->fsInstance, &op_ctx->creds, saunafsFd->fd,
 		                      offset, writeArg->iov[i].iov_len,
 		                      writeArg->iov[i].iov_base);
 
@@ -1174,9 +1263,21 @@ static void write2(struct fsal_obj_handle *objectHandle, bool bypass,
 		}
 		if (bytes < 0) {
 			status = fsalLastError();
-			if (closeFd) { closeFileDescriptor(handle, &saunafsFd); }
+			status2 = fsal_complete_io(objectHandle, outFileDescriptor);
 
-			if (hasLock) { PTHREAD_RWLOCK_unlock(&objectHandle->obj_lock); }
+			LogFullDebug(COMPONENT_FSAL, "fsal_complete_io returned %s",
+			             fsal_err_txt(status2));
+
+			if (writeArg->state == NULL) {
+				/* We did I/O without a state so we need
+				 * to release the temp share reservation
+				 * acquired. */
+
+				/* Release the share reservation now by
+				 *  updating the counters. */
+				update_share_counters_locked(objectHandle, &handle->share,
+				                             FSAL_O_WRITE, FSAL_O_CLOSED);
+			}
 
 			doneCb(objectHandle, status, writeArg, callerArg);
 			return;
@@ -1188,7 +1289,7 @@ static void write2(struct fsal_obj_handle *objectHandle, bool bypass,
 
 	if (writeArg->fsal_stable) {
 		int retvalue =
-		    saunafs_fsync(export->fsInstance, &op_ctx->creds, saunafsFd.fd);
+		    saunafs_fsync(export->fsInstance, &op_ctx->creds, saunafsFd->fd);
 
 		if (retvalue < 0) {
 			status = fsalLastError();
@@ -1196,9 +1297,20 @@ static void write2(struct fsal_obj_handle *objectHandle, bool bypass,
 		}
 	}
 
-	if (closeFd) { closeFileDescriptor(handle, &saunafsFd); }
+	status2 = fsal_complete_io(objectHandle, outFileDescriptor);
 
-	if (hasLock) { PTHREAD_RWLOCK_unlock(&objectHandle->obj_lock); }
+	LogFullDebug(COMPONENT_FSAL, "fsal_complete_io returned %s",
+	             fsal_err_txt(status2));
+
+	if (writeArg->state == NULL) {
+		/* We did I/O without a state so we need to release the temp
+		 * share reservation acquired. */
+
+		/* Release the share reservation now by updating
+		 * the counters. */
+		update_share_counters_locked(objectHandle, &handle->share, FSAL_O_WRITE,
+		                             FSAL_O_CLOSED);
+	}
 
 	doneCb(objectHandle, status, writeArg, callerArg);
 }
@@ -1206,10 +1318,11 @@ static void write2(struct fsal_obj_handle *objectHandle, bool bypass,
 /**
  * @brief Commit written data.
  *
- * This function flushes possibly buffered data to a file. This method differs
- * from commit due to the need to interact with share reservations and the fact
- * that the FSAL manages the state of "file descriptors". The FSAL must be able
- * to perform this operation without being passed a specific state.
+ * This function flushes possibly buffered data to a file. This method
+ * differs from commit due to the need to interact with share reservations
+ * and the fact that the FSAL manages the state of "file descriptors". The
+ * FSAL must be able to perform this operation without being passed a
+ * specific state.
  *
  * @param [in] objectHandle     File on which to operate
  * @param [in] offset           Start of range to commit
@@ -1222,12 +1335,12 @@ static fsal_status_t commit2(struct fsal_obj_handle *objectHandle, off_t offset,
 	struct SaunaFSExport *export = NULL;
 	struct SaunaFSHandle *handle = NULL;
 
-	struct SaunaFSFd emptyFd = {0, NULL};
-	struct SaunaFSFd *saunafsFd = &emptyFd;
-
 	fsal_status_t status;
-	bool hasLock = false;
-	bool closeFd = false;
+	fsal_status_t status2;
+
+	struct SaunaFSFd emptyFd = {FSAL_FD_INIT, NULL};
+	struct SaunaFSFd *saunafsFd = NULL;
+	struct fsal_fd *outFileDescriptor = NULL;
 
 	export = container_of(op_ctx->fsal_export, struct SaunaFSExport, export);
 	handle = container_of(objectHandle, struct SaunaFSHandle, handle);
@@ -1236,47 +1349,44 @@ static fsal_status_t commit2(struct fsal_obj_handle *objectHandle, off_t offset,
 	             " offset = %lli len = %zu", export->export.export_id,
 	             handle->inode, (long long)offset, length);
 
-	status = fsal_reopen_obj(objectHandle, false, false, FSAL_O_WRITE,
-	                         (struct fsal_fd *)&handle->fd, &handle->share,
-	                         openFunction, closeFunction,
-	                         (struct fsal_fd **)&saunafsFd, &hasLock, &closeFd);
+	/* Make sure file is open in appropriate mode.
+	 * Do not check share reservation. */
+	status = fsal_start_global_io(&outFileDescriptor, objectHandle,
+	                              &handle->fd.fsalFd, &emptyFd.fsalFd,
+	                              FSAL_O_ANY, false, NULL);
 
-	if (!FSAL_IS_ERROR(status)) {
-		int retvalue =
-		    saunafs_fsync(export->fsInstance, &op_ctx->creds, saunafsFd->fd);
+	if (FSAL_IS_ERROR(status)) { return status; }
 
-		if (retvalue < 0) {
-			status = fsalLastError();
-		}
-	}
+	saunafsFd = container_of(outFileDescriptor, struct SaunaFSFd, fsalFd);
 
-	if (closeFd) {
-		int retvalue = sau_release(export->fsInstance, saunafsFd->fd);
+	int retvalue =
+	    saunafs_fsync(export->fsInstance, &op_ctx->creds, saunafsFd->fd);
 
-		if (retvalue < 0) {
-			status = fsalLastError();
-		}
-	}
+	if (retvalue < 0) { status = fsalLastError(); }
 
-	if (hasLock) {
-		PTHREAD_RWLOCK_unlock(&objectHandle->obj_lock);
-	}
+	status2 = fsal_complete_io(objectHandle, outFileDescriptor);
 
+	LogFullDebug(COMPONENT_FSAL, "fsal_complete_io returned %s",
+	             fsal_err_txt(status2));
+
+	/* We did not do share reservation stuff... */
 	return status;
 }
 
 /**
  * @brief Set attributes on an object.
  *
- * This function sets attributes on an object. Which attributes are set is determined
- * by attrib_set->mask. The FSAL must manage bypass or not of share reservations, and
- * a state may be passed.
+ * This function sets attributes on an object. Which attributes are set is
+ * determined by attrib_set->mask. The FSAL must manage bypass or not of share
+ * reservations, and a state may be passed.
 
- * The caller is expected to invoke fsal_release_attrs to release any resources held
- * by the set attributes. The FSAL layer MAY have added an inherited ACL.
+ * The caller is expected to invoke fsal_release_attrs to release any
+ * resources held by the set attributes. The FSAL layer MAY have added an
+ * inherited ACL.
  *
  * @param [in] objectHandle     File on which to operate
- * @param [in] bypass           If state doesn't indicate a share reservation,
+ * @param [in] bypass           If state doesn't indicate a share
+ *                              reservation,
  *                              bypass any non-mandatory deny write
  * @param [in] state            state_t to use for this operation
  * @param [in] attributes       Attributes to set
@@ -1289,9 +1399,8 @@ static fsal_status_t setattr2(struct fsal_obj_handle *objectHandle, bool bypass,
 	struct SaunaFSExport *export = NULL;
 	struct SaunaFSHandle *handle = NULL;
 
-	bool hasLock = false;
-	bool closeFd = false;
 	fsal_status_t status = fsalstat(ERR_FSAL_NO_ERROR, 0);
+	bool hasShare = false;
 
 	export = container_of(op_ctx->fsal_export, struct SaunaFSExport, export);
 	handle = container_of(objectHandle, struct SaunaFSHandle, handle);
@@ -1300,34 +1409,36 @@ static fsal_status_t setattr2(struct fsal_obj_handle *objectHandle, bool bypass,
 
 	if (FSAL_TEST_MASK(attributes->valid_mask, (attrmask_t)ATTR_MODE)) {
 		attributes->mode &=
-		        ~op_ctx->fsal_export->exp_ops.fs_umask(op_ctx->fsal_export);
+		    ~op_ctx->fsal_export->exp_ops.fs_umask(op_ctx->fsal_export);
 	}
 
 	if (FSAL_TEST_MASK(attributes->valid_mask, (attrmask_t)ATTR_SIZE)) {
 		if (objectHandle->type != REGULAR_FILE) {
-			LogFullDebug(COMPONENT_FSAL,
-			             "Setting size on non-regular file");
+			LogFullDebug(COMPONENT_FSAL, "Setting size on non-regular file");
 			return fsalstat(ERR_FSAL_INVAL, EINVAL);
 		}
 
-		bool canReuseOpenedFd = false;
-		status = fsal_find_fd(NULL, objectHandle, NULL, &handle->share,
-		                      bypass, state, FSAL_O_RDWR, NULL, NULL,
-		                      &hasLock, &closeFd, false,
-		                      &canReuseOpenedFd);
+		if (state == NULL) {
+			/* Check share reservation and if OK,
+			 * update the counters. */
+			status = check_share_conflict_and_update_locked(
+			    objectHandle, &handle->share, FSAL_O_CLOSED, FSAL_O_WRITE,
+			    bypass);
 
-		if (FSAL_IS_ERROR(status)) {
-			LogFullDebug(COMPONENT_FSAL, "fsal_find_fd status = %s",
-			             fsal_err_txt(status));
+			if (FSAL_IS_ERROR(status)) {
+				LogDebug(COMPONENT_FSAL, "check_share_conflict failed with %s",
+				         fsal_err_txt(status));
 
-			if (hasLock) { PTHREAD_RWLOCK_unlock(&objectHandle->obj_lock); }
+				return status;
+			}
 
-			return status;
+			hasShare = true;
 		}
 	}
 
 	struct stat posixAttributes;
 	uint mask = 0;
+
 	memset(&posixAttributes, 0, sizeof(posixAttributes));
 
 	if (FSAL_TEST_MASK(attributes->valid_mask, (attrmask_t)ATTR_SIZE)) {
@@ -1378,7 +1489,12 @@ static fsal_status_t setattr2(struct fsal_obj_handle *objectHandle, bool bypass,
 	if (retvalue < 0) {
 		status = fsalLastError();
 
-		if (hasLock) { PTHREAD_RWLOCK_unlock(&objectHandle->obj_lock); }
+		if (hasShare) {
+			/* Release the share reservation now by updating
+			 * the counters. */
+			update_share_counters_locked(objectHandle, &handle->share,
+			                             FSAL_O_RDWR, FSAL_O_CLOSED);
+		}
 
 		return status;
 	}
@@ -1390,8 +1506,11 @@ static fsal_status_t setattr2(struct fsal_obj_handle *objectHandle, bool bypass,
 	}
 #endif
 
-	if (hasLock) {
-		PTHREAD_RWLOCK_unlock(&objectHandle->obj_lock);
+	if (hasShare) {
+		/* Release the share reservation now by updating
+		 * the counters. */
+		update_share_counters_locked(objectHandle, &handle->share, FSAL_O_RDWR,
+		                             FSAL_O_CLOSED);
 	}
 
 	return status;
@@ -1400,9 +1519,10 @@ static fsal_status_t setattr2(struct fsal_obj_handle *objectHandle, bool bypass,
 /**
  * @brief Manage closing a file when a state is no longer needed.
  *
- * When the upper layers are ready to dispense with a state, this method is called
- * to allow the FSAL to close any file descriptors or release any other resources
- * associated with the state. A call to free_state should be assumed to follow soon.
+ * When the upper layers are ready to dispense with a state, this method is
+ * called to allow the FSAL to close any file descriptors or release any
+ * other resources associated with the state. A call to free_state should
+ * be assumed to follow soon.
  *
  * @param [in] objectHandle     File on which to operate
  * @param [in] state            state_t to use for this operation
@@ -1412,25 +1532,24 @@ static fsal_status_t setattr2(struct fsal_obj_handle *objectHandle, bool bypass,
 static fsal_status_t close2(struct fsal_obj_handle *objectHandle,
                             struct state_t *state) {
 	struct SaunaFSHandle *handle = NULL;
+
 	handle = container_of(objectHandle, struct SaunaFSHandle, handle);
 
-	LogFullDebug(COMPONENT_FSAL, "export = %" PRIu16 " inode = %" PRIiNode,
-	             handle->key.exportId, handle->inode);
+	struct SaunaFSFd *fileDescriptor =
+	    &container_of(state, struct SaunaFSStateFd, state)->saunafsFd;
+
+	LogFullDebug(COMPONENT_FSAL, "export = %" PRIu16 " inode = %" PRIiNode, handle->key.exportId,
+	             handle->inode);
 
 	if (state->state_type == STATE_TYPE_SHARE ||
 	    state->state_type == STATE_TYPE_NLM_SHARE ||
 	    state->state_type == STATE_TYPE_9P_FID) {
-		// This is a share state, we must update the share counters
-		// This can block over an I/O operation
-		PTHREAD_RWLOCK_wrlock(&objectHandle->obj_lock);
-
-		update_share_counters(&handle->share, handle->fd.openflags,
-		                      FSAL_O_CLOSED);
-
-		PTHREAD_RWLOCK_unlock(&objectHandle->obj_lock);
+		update_share_counters_locked(objectHandle, &handle->share,
+		                             handle->fd.fsalFd.openflags,
+		                             FSAL_O_CLOSED);
 	}
 
-	return closeFileDescriptor(handle, &handle->fd);
+	return close_fsal_fd(objectHandle, &fileDescriptor->fsalFd, false);
 }
 
 /**
@@ -1441,9 +1560,15 @@ static fsal_status_t close2(struct fsal_obj_handle *objectHandle,
  * @param [in] directoryHandle      Directory in which to create the object
  * @param [in] name                 Name of object to create
  * @param [in] symbolicLinkPath     Content of symbolic link
- * @param [in] attributesToSet      Attributes to set on newly created object
+ * @param [in] attributesToSet      Attributes to set on newly created
+ *                                  object
  * @param [out] createdObject       Newly created object
- * @param [in,out] attributes       Optional attributes for newly created object
+ * @param [in,out] attributes       Optional attributes for newly created
+ *                                  object
+ * @param[in,out] parentPreAttributes  Optional attributes for parent dir
+ *                                     before the operation. Should be atomic.
+ * @param[in,out] parentPostAttributes Optional attributes for parent dir
+ *                                     after the operation. Should be atomic.
  *
  * \see fsal_api.h for more information
  *
@@ -1453,7 +1578,9 @@ static fsal_status_t symlink_(struct fsal_obj_handle *directoryHandle,
                               const char *name, const char *symbolicLinkPath,
                               struct fsal_attrlist *attributesToSet,
                               struct fsal_obj_handle **createdObject,
-                              struct fsal_attrlist *attributes) {
+                              struct fsal_attrlist *attributes,
+                              struct fsal_attrlist *parentPreAttributes,
+                              struct fsal_attrlist *parentPostAttributes) {
 	struct SaunaFSExport *export = NULL;
 	struct SaunaFSHandle *directory = NULL;
 	struct sau_entry entry;
@@ -1476,28 +1603,27 @@ static fsal_status_t symlink_(struct fsal_obj_handle *directoryHandle,
 	struct SaunaFSHandle *handle = allocateHandle(&entry.attr, export);
 	*createdObject = &handle->handle;
 
-	// We handled the mode above
+	/* We handled the mode above */
 	FSAL_UNSET_MASK(attributesToSet->valid_mask, (attrmask_t)ATTR_MODE);
 
 	if (attributesToSet->valid_mask) {
 		fsal_status_t status;
 
-		// Now per support_ex API, if there are any other attributes set,
-		// go ahead and get them set now
-		status = (*createdObject)->obj_ops->setattr2(*createdObject,
-		                                             false, NULL,
-		                                             attributesToSet);
+		/* Now per support_ex API, if there are any other
+		 * attributes set, go ahead and get them set now */
+		status = (*createdObject)
+		             ->obj_ops->setattr2(*createdObject, false, NULL,
+		                                 attributesToSet);
 
 		if (FSAL_IS_ERROR(status)) {
-			// Release the handle we just allocated
+			/* Release the handle we just allocated */
 			LogFullDebug(COMPONENT_FSAL, "setattr2 status = %s",
 			             fsal_err_txt(status));
 
 			(*createdObject)->obj_ops->release(*createdObject);
 			*createdObject = NULL;
 		}
-	}
-	else if (attributes != NULL) {
+	} else if (attributes != NULL) {
 		posix2fsal_attributes_all(&entry.attr, attributes);
 	}
 
@@ -1528,6 +1654,7 @@ fsal_status_t lock_op2(struct fsal_obj_handle *objectHandle,
                        fsal_lock_op_t lockOperation,
                        fsal_lock_param_t *requestedLock,
                        fsal_lock_param_t *conflictingLock) {
+	struct SaunaFSHandle *handle = NULL;
 	struct SaunaFSExport *export = NULL;
 
 	sau_err_t lastError = 0;
@@ -1535,16 +1662,18 @@ fsal_status_t lock_op2(struct fsal_obj_handle *objectHandle,
 	sau_lock_info_t lockInfo;
 
 	fsal_status_t status = {0, 0};
+	fsal_status_t status2 = {0, 0};
 	int retval = 0;
 
-	struct SaunaFSFd saunafsFd;
+	struct SaunaFSFd *saunafsFd = NULL;
 	fsal_openflags_t openflags = FSAL_O_RDWR;
 
-	bool hasLock = false;
-	bool closeFd = false;
+	struct SaunaFSFd emptyFileDescriptor = { FSAL_FD_INIT, NULL };
+	struct fsal_fd *outFileDescriptor = NULL;
 	bool bypass = false;
 
 	export = container_of(op_ctx->fsal_export, struct SaunaFSExport, export);
+	handle = container_of(objectHandle, struct SaunaFSHandle, handle);
 
 	LogFullDebug(COMPONENT_FSAL, "op:%d type:%d start:%" PRIu64 " length:%"
 	             PRIu64 " ", lockOperation, requestedLock->lock_type,
@@ -1561,24 +1690,21 @@ fsal_status_t lock_op2(struct fsal_obj_handle *objectHandle,
 	}
 
 	if (lockOperation == FSAL_OP_LOCKT) {
-		// We may end up using global fd, don't fail on a deny mode
+		/* We may end up using global fd, don't fail on a deny mode */
 		bypass = true;
 		openflags = FSAL_O_ANY;
-	}
-	else if (lockOperation == FSAL_OP_LOCK) {
+	} else if (lockOperation == FSAL_OP_LOCK) {
 		if (requestedLock->lock_type == FSAL_LOCK_R) {
 			openflags = FSAL_O_READ;
-		}
-		else if (requestedLock->lock_type == FSAL_LOCK_W) {
+		} else if (requestedLock->lock_type == FSAL_LOCK_W) {
 			openflags = FSAL_O_WRITE;
 		}
-	}
-	else if (lockOperation == FSAL_OP_UNLOCK) {
+	} else if (lockOperation == FSAL_OP_UNLOCK) {
 		openflags = FSAL_O_ANY;
-	}
-	else {
-		LogFullDebug(COMPONENT_FSAL, "ERROR: Lock operation requested "
-		                             "was not TEST, READ, or WRITE.");
+	} else {
+		LogFullDebug(COMPONENT_FSAL,
+		             "ERROR: Lock operation requested "
+		             "was not TEST, READ, or WRITE.");
 
 		return fsalstat(ERR_FSAL_NOTSUPP, 0);
 	}
@@ -1590,11 +1716,9 @@ fsal_status_t lock_op2(struct fsal_obj_handle *objectHandle,
 
 	if (requestedLock->lock_type == FSAL_LOCK_R) {
 		lockInfo.l_type = F_RDLCK;
-	}
-	else if (requestedLock->lock_type == FSAL_LOCK_W) {
+	} else if (requestedLock->lock_type == FSAL_LOCK_W) {
 		lockInfo.l_type = F_WRLCK;
-	}
-	else {
+	} else {
 		LogFullDebug(COMPONENT_FSAL,
 		             "ERROR: The requested lock type was not "
 		             "read or write.");
@@ -1610,90 +1734,102 @@ fsal_status_t lock_op2(struct fsal_obj_handle *objectHandle,
 	lockInfo.l_len = requestedLock->lock_length;
 	lockInfo.l_start = requestedLock->lock_start;
 
-	// Get a usable file descriptor
-	status = findFileDescriptor(&saunafsFd, objectHandle, bypass, state,
-	                            openflags, &hasLock, &closeFd, true);
-
-	// IF find_fd returned DELAY, then fd caching in mdcache is
-	// turned off, which means that the consecutive attempt is very likely
-	// to succeed immediately.
-	if (status.major == ERR_FSAL_DELAY) {
-		status = findFileDescriptor(&saunafsFd, objectHandle, bypass, state,
-		                            openflags, &hasLock, &closeFd, true);
+	// Prevent locking an unintended range in case requested lock length is too large and mapped
+	// to negative values, as POSIX locks can accept negative l_len values.
+	if (lockInfo.l_len < 0) {
+		LogCrit(COMPONENT_FSAL,
+		        "Requested lock length is out of range - lockInfo.l_len(%lu), "
+		        "requested length(%" PRIu64 ")",
+		        lockInfo.l_len, requestedLock->lock_length);
+		return fsalstat(ERR_FSAL_BAD_RANGE, 0);
 	}
 
+	// Indicate a desire to start io and get a usable file descriptor
+	status = fsal_start_io(&outFileDescriptor, objectHandle, &handle->fd.fsalFd,
+	                       &emptyFileDescriptor.fsalFd, state, openflags, true,
+	                       NULL, bypass, &handle->share);
+
 	if (FSAL_IS_ERROR(status)) {
-		LogCrit(COMPONENT_FSAL, "Unable to find fd for lock operation");
+		LogCrit(COMPONENT_FSAL, "fsal_start_io failed returning %s",
+		        fsal_err_txt(status));
 
 		return status;
 	}
 
-	fileinfo = saunafsFd.fd;
-	
-	// Defensive check: ensure we have a valid file descriptor before proceeding
-	if (fileinfo == NULL) {
-		LogCrit(COMPONENT_FSAL, "Lock operation called with NULL file descriptor");
-		
-		if (closeFd) { closeFileDescriptor(container_of(objectHandle, struct SaunaFSHandle, handle), &saunafsFd); }
-		if (hasLock) { PTHREAD_RWLOCK_unlock(&objectHandle->obj_lock); }
-		
-		return fsalstat(ERR_FSAL_FAULT, EFAULT);
-	}
-	
+	saunafsFd = container_of(outFileDescriptor, struct SaunaFSFd, fsalFd);
+	fileinfo = saunafsFd->fd;
 	sau_set_lock_owner(fileinfo, (uint64_t)owner);
 
 	if (lockOperation == FSAL_OP_LOCKT) {
 		retval = saunafs_getlock(export->fsInstance, &op_ctx->creds, fileinfo,
 		                         &lockInfo);
-	}
-	else {
+	} else {
 		retval = saunafs_setlock(export->fsInstance, &op_ctx->creds, fileinfo,
 		                         &lockInfo);
 	}
 
 	if (retval < 0) {
 		lastError = sau_last_err();
-
-		if (closeFd && fileinfo != NULL) { sau_release(export->fsInstance, fileinfo); }
-		if (hasLock) { PTHREAD_RWLOCK_unlock(&objectHandle->obj_lock); }
-
 		LogFullDebug(COMPONENT_FSAL, "Returning error %d", lastError);
+
+		status2 = fsal_complete_io(objectHandle, outFileDescriptor);
+		LogFullDebug(COMPONENT_FSAL, "fsal_complete_io returned %s",
+		             fsal_err_txt(status2));
+
+		if (state == NULL) {
+			/* We did I/O without a state so we need to release
+			 * the temp share reservation acquired. */
+
+			/* Release the share reservation now by updating
+			 * the counters. */
+			update_share_counters_locked(objectHandle, &handle->share,
+			                             openflags, FSAL_O_CLOSED);
+		}
+
 		return saunafsToFsalError(lastError);
 	}
 
-	// F_UNLCK is returned then the tested operation would be possible
+	/* F_UNLCK is returned then the tested operation would be possible */
 	if (conflictingLock != NULL) {
 		if (lockOperation == FSAL_OP_LOCKT && lockInfo.l_type != F_UNLCK) {
 			conflictingLock->lock_length = lockInfo.l_len;
 			conflictingLock->lock_start = lockInfo.l_start;
 			conflictingLock->lock_type = lockInfo.l_type;
-		}
-		else {
+		} else {
 			conflictingLock->lock_length = 0;
 			conflictingLock->lock_start = 0;
 			conflictingLock->lock_type = FSAL_NO_LOCK;
 		}
 	}
 
-	if (closeFd && fileinfo != NULL) {
-		sau_release(export->fsInstance, fileinfo);
+	lastError = sau_last_err();
+	status2 = fsal_complete_io(objectHandle, outFileDescriptor);
+
+	LogFullDebug(COMPONENT_FSAL, "fsal_complete_io returned %s",
+	             fsal_err_txt(status2));
+
+	if (state == NULL) {
+		/* We did I/O without a state so we need to release the temp
+		 * share reservation acquired. */
+
+		/* Release the share reservation now by updating
+		 * the counters. */
+		update_share_counters_locked(objectHandle, &handle->share, openflags,
+		                             FSAL_O_CLOSED);
 	}
 
-	if (hasLock) {
-		PTHREAD_RWLOCK_unlock(&objectHandle->obj_lock);
-	}
-
-	return fsalstat(ERR_FSAL_NO_ERROR, 0);
+	return status;
 }
 
 /**
  * @brief Re-open a file that may be already opened.
  *
- * This function supports changing the access mode of a share reservation and
- * thus should only be called with a share state. The st_lock must be held.
+ * This function supports changing the access mode of a share reservation
+ * and thus should only be called with a share state. The st_lock must be
+ * held.
  *
- * This MAY be used to open a file the first time if there is no need for open
- * by name or create semantics. One example would be 9P lopen.
+ * This MAY be used to open a file the first time if there is no need for
+ * open by name or create semantics. One example would be 9P lopen.
  *
  * @param [in] objectHandle     File on which to operate
  * @param [in] state            state_t to use for this operation
@@ -1704,54 +1840,7 @@ fsal_status_t lock_op2(struct fsal_obj_handle *objectHandle,
 static fsal_status_t reopen2(struct fsal_obj_handle *objectHandle,
                              struct state_t *state,
                              fsal_openflags_t openflags) {
-	struct SaunaFSHandle *handle = NULL;
-	struct SaunaFSFd *sharedFd = NULL;
-	fsal_status_t status;
-
-	handle = container_of(objectHandle, struct SaunaFSHandle, handle);
-	sharedFd = &container_of(state, struct SaunaFSStateFd, state)->saunafsFd;
-
-	LogFullDebug(COMPONENT_FSAL, "export = %" PRIu16 " inode = %" PRIiNode,
-	             handle->key.exportId, handle->inode);
-
-	struct SaunaFSFd saunafsFd = { FSAL_O_CLOSED, NULL };
-
-	// This can block over an I/O operation
-	PTHREAD_RWLOCK_wrlock(&objectHandle->obj_lock);
-
-	fsal_openflags_t oldOpenflags = sharedFd->openflags;
-
-	// We can conflict with old share, so go ahead and check now
-	status = check_share_conflict(&handle->share, openflags, false);
-
-	if (FSAL_IS_ERROR(status)) {
-		PTHREAD_RWLOCK_unlock(&objectHandle->obj_lock);
-		return status;
-	}
-
-	// Set up the new share so we can drop the lock and not have a
-	// conflicting share be asserted, updating the share counters
-	update_share_counters(&handle->share, oldOpenflags, openflags);
-
-	PTHREAD_RWLOCK_unlock(&objectHandle->obj_lock);
-
-	status = openFileDescriptor(handle, openflags, &saunafsFd, true);
-
-	if (!FSAL_IS_ERROR(status)) {
-		closeFileDescriptor(handle, sharedFd);
-		*sharedFd = saunafsFd;
-	}
-	else {
-		// We had a failure on open - we need to revert the share.
-		// This can block over an I/O operation
-		PTHREAD_RWLOCK_wrlock(&objectHandle->obj_lock);
-
-		update_share_counters(&handle->share, openflags, oldOpenflags);
-
-		PTHREAD_RWLOCK_unlock(&objectHandle->obj_lock);
-	}
-
-	return status;
+	return openByHandle(objectHandle, state, openflags, FSAL_NO_CREATE, NULL, NULL);
 }
 
 /**
@@ -1762,9 +1851,15 @@ static fsal_status_t reopen2(struct fsal_obj_handle *objectHandle,
  * @param [in] directoryHandle     Directory in which to create the object
  * @param [in] name                Name of object to create
  * @param [in] nodeType            Type of special file to create
- * @param [in] attributesToSet     Attributes to set on newly created object
+ * @param [in] attributesToSet     Attributes to set on newly created
+ *                                 object
  * @param [in] createdObject       Newly created object
- * @param [in] attributes          Optional attributes for newly created object
+ * @param [in] attributes          Optional attributes for newly created
+ *                                 object
+ * @param[in,out] parentPreAttributes  Optional attributes for parent dir
+ *                                     before the operation. Should be atomic.
+ * @param[in,out] parentPostAttributes Optional attributes for parent dir
+ *                                     after the operation. Should be atomic.
  *
  * \see fsal_api.h for more information
  *
@@ -1774,7 +1869,9 @@ static fsal_status_t mknode(struct fsal_obj_handle *directoryHandle,
                             const char *name, object_file_type_t nodeType,
                             struct fsal_attrlist *attributesToSet,
                             struct fsal_obj_handle **createdObject,
-                            struct fsal_attrlist *attributes) {
+                            struct fsal_attrlist *attributes,
+                            struct fsal_attrlist *parentPreAttributes,
+                            struct fsal_attrlist *parentPostAttributes) {
 	struct SaunaFSExport *export = NULL;
 	struct SaunaFSHandle *directory = NULL;
 	struct SaunaFSHandle *handle = NULL;
@@ -1791,7 +1888,7 @@ static fsal_status_t mknode(struct fsal_obj_handle *directoryHandle,
 	             directory->inode, attributesToSet->mode, name);
 
 	unixMode = fsal2unix_mode(attributesToSet->mode) &
-	        ~op_ctx->fsal_export->exp_ops.fs_umask(op_ctx->fsal_export);
+	           ~op_ctx->fsal_export->exp_ops.fs_umask(op_ctx->fsal_export);
 
 	switch (nodeType) {
 	case BLOCK_FILE:
@@ -1828,28 +1925,28 @@ static fsal_status_t mknode(struct fsal_obj_handle *directoryHandle,
 	handle = allocateHandle(&entry.attr, export);
 	*createdObject = &handle->handle;
 
-	// We handled the mode above
+	/* We handled the mode above */
 	FSAL_UNSET_MASK(attributesToSet->valid_mask, (attrmask_t)ATTR_MODE);
 
 	if (attributesToSet->valid_mask) {
 		fsal_status_t status;
-		// Setting attributes for the created object
-		status = (*createdObject)->obj_ops->setattr2(*createdObject,
-		                                             false, NULL,
-		                                             attributesToSet);
+		/* Setting attributes for the created object */
+		status = (*createdObject)
+		             ->obj_ops->setattr2(*createdObject, false, NULL,
+		                                 attributesToSet);
 
 		if (FSAL_IS_ERROR(status)) {
 			LogFullDebug(COMPONENT_FSAL, "setattr2 status = %s",
 			             fsal_err_txt(status));
 
-			// Release the handle we just allocated
+			/* Release the handle we just allocated */
 			(*createdObject)->obj_ops->release(*createdObject);
 			*createdObject = NULL;
 		}
-	}
-	else if (attributes != NULL) {
-		// Since we haven't set any attributes other than what was set on create,
-		// just use the stat results we used to create the fsal_obj_handle
+	} else if (attributes != NULL) {
+		/* Since we haven't set any attributes other than what was set
+		 * on create, just use the stat results we used to create the
+		 * fsal_obj_handle */
 		posix2fsal_attributes_all(&entry.attr, attributes);
 	}
 
@@ -1861,19 +1958,20 @@ static fsal_status_t mknode(struct fsal_obj_handle *directoryHandle,
  * @brief Read the content of a link.
  *
  * File object operations.
- * This function reads the content of a symbolic link. The FSAL will allocate a
- * buffer and store its address and the link length in the link_content
- * gsh_buffdesc. The caller must free this buffer with gsh_free.
+ * This function reads the content of a symbolic link. The FSAL will
+ * allocate a buffer and store its address and the link length in the
+ * link_content gsh_buffdesc. The caller must free this buffer with
+ * gsh_free.
  *
  * The symlink content passed back must be null terminated and the length
  * indicated in the buffer description must include the terminator.
  *
  * @param [in]  objectHandle  Link to read
- * @param [out] buffer        Buffer descriptor to which the FSAL will store the
- *                            address of the buffer holding the link and the
- *                            link length
- * @param [out] refresh       true if the content are to be retrieved from the
- *                            underlying filesystem rather than cache
+ * @param [out] buffer        Buffer descriptor to which the FSAL will
+ *                            store the address of the buffer holding the link
+ *                            and the link length
+ * @param [out] refresh       true if the content are to be retrieved from
+ *                            the underlying filesystem rather than cache
  *
  * @returns: FSAL status
  */
@@ -1898,11 +1996,9 @@ static fsal_status_t readlink_(struct fsal_obj_handle *objectHandle,
 	    saunafs_readlink(export->fsInstance, &op_ctx->creds, handle->inode,
 	                     result, SAUNAFS_MAX_READLINK_LENGTH);
 
-	// saunafs_readlink() returns the size of the read link if succeed.
-	// Otherwise returns -1 to indicate an error occurred
-	if (size < 0) {
-		return fsalLastError();
-	}
+	/* saunafs_readlink() returns the size of the read link if succeed.
+	 * Otherwise returns -1 to indicate an error occurred */
+	if (size < 0) { return fsalLastError(); }
 
 	size = MIN(size, SAUNAFS_MAX_READLINK_LENGTH);
 	buffer->addr = gsh_strldup(result, size, &buffer->len);
@@ -1924,9 +2020,9 @@ static fsal_status_t readlink_(struct fsal_obj_handle *objectHandle,
 static fsal_openflags_t status2(struct fsal_obj_handle *objectHandle,
                                 struct state_t *state) {
 	(void)objectHandle;
-	struct SaunaFSFd *saunafsFd = NULL;
-	saunafsFd = &container_of(state, struct SaunaFSStateFd, state)->saunafsFd;
-	return saunafsFd->openflags;
+	struct SaunaFSFd *sfsFd = &((struct SaunaFSStateFd *)state)->saunafsFd;
+
+	return sfsFd->fsalFd.openflags;
 }
 
 /**
@@ -1950,15 +2046,15 @@ static fsal_status_t merge(struct fsal_obj_handle *originalHandle,
 
 	if (originalHandle->type == REGULAR_FILE &&
 	    toMergeHandle->type == REGULAR_FILE) {
-		// We need to merge the share reservations on this file.
-		// This could result in ERR_FSAL_SHARE_DENIED.
+		/* We need to merge the share reservations on this file.
+		 * This could result in ERR_FSAL_SHARE_DENIED. */
 		struct SaunaFSHandle *original = NULL;
 		struct SaunaFSHandle *toMerge = NULL;
 
 		original = container_of(originalHandle, struct SaunaFSHandle, handle);
 		toMerge = container_of(toMergeHandle, struct SaunaFSHandle, handle);
 
-		// This can block over an I/O operation
+		/* This can block over an I/O operation */
 		status = merge_share(originalHandle, &original->share, &toMerge->share);
 	}
 
@@ -1969,7 +2065,8 @@ static fsal_status_t merge(struct fsal_obj_handle *originalHandle,
  * @brief Reserve/Deallocate space in a region of a file.
  *
  * @param [in] objectHandle     File to which bytes should be allocated
- * @param [in] state            Open stateid under which to do the allocation
+ * @param [in] state            Open stateid under which to do the
+ *                              allocation
  * @param [in] offset           Offset at which to begin the allocation
  * @param [in] length           Length of the data to be allocated
  * @param [in] allocate         Should space be allocated or deallocated?
@@ -1981,33 +2078,37 @@ static fsal_status_t fallocate(struct fsal_obj_handle *objectHandle,
                                uint64_t length, bool allocate) {
 	struct SaunaFSExport *export = NULL;
 	struct SaunaFSHandle *handle = NULL;
-	struct SaunaFSFd saunafsFd;
 
-	fsal_status_t status;
-	bool hasLock = false;
-	bool closeFd = false;
+	fsal_status_t status = {0, 0};
+	fsal_status_t status2 = {0, 0};
+
+	struct SaunaFSFd *fileDescriptor = NULL;
+	struct SaunaFSFd emptyFileDescriptor = { FSAL_FD_INIT, NULL };
+	struct fsal_fd *outFileDescriptor = NULL;
 
 	export = container_of(op_ctx->fsal_export, struct SaunaFSExport, export);
 	handle = container_of(objectHandle, struct SaunaFSHandle, handle);
 
-	status = findFileDescriptor(&saunafsFd, objectHandle, false, state,
-	                            FSAL_O_WRITE, &hasLock, &closeFd, false);
+	// Indicate a desire to start io and get a usable file descriptor
+	status = fsal_start_io(&outFileDescriptor, objectHandle, &handle->fd.fsalFd,
+	                       &emptyFileDescriptor.fsalFd, state, FSAL_O_WRITE,
+	                       false, NULL, false, &handle->share);
 
 	if (FSAL_IS_ERROR(status)) {
-		if (closeFd) { closeFileDescriptor(handle, &saunafsFd); }
-
-		if (hasLock) { PTHREAD_RWLOCK_unlock(&objectHandle->obj_lock); }
+		LogFullDebug(COMPONENT_FSAL, "fsal_start_io failed returning %s",
+		             fsal_err_txt(status));
 
 		return status;
 	}
 
 	struct stat posixAttributes;
+
 	memset(&posixAttributes, 0, sizeof(posixAttributes));
 
 	posixAttributes.st_mode =
 	    allocate ? 0 : FALLOC_FL_KEEP_SIZE | FALLOC_FL_PUNCH_HOLE;
 
-	// Get stat to obtain the current size
+	/* Get stat to obtain the current size */
 	sau_attr_reply_t currentStats;
 	sau_attr_reply_t reply;
 
@@ -2015,14 +2116,27 @@ static fsal_status_t fallocate(struct fsal_obj_handle *objectHandle,
 	                               handle->inode, &currentStats);
 
 	if (retvalue < 0) {
-		if (closeFd) { closeFileDescriptor(handle, &saunafsFd); }
+		status2 = fsal_complete_io(objectHandle, outFileDescriptor);
+		LogFullDebug(COMPONENT_FSAL, "fsal_complete_io returned %s",
+		             fsal_err_txt(status2));
 
-		if (hasLock) { PTHREAD_RWLOCK_unlock(&objectHandle->obj_lock); }
+		if (state == NULL) {
+			/* We did I/O without a state so we need to release
+			 * the temp share reservation acquired. */
+
+			/* Release the share reservation now by updating
+			 * the counters. */
+			update_share_counters_locked(objectHandle, &handle->share,
+			                             FSAL_O_WRITE, FSAL_O_CLOSED);
+		}
 
 		return fsalLastError();
 	}
 
+	fileDescriptor = container_of(outFileDescriptor, struct SaunaFSFd, fsalFd);
+
 	if (allocate) {
+		/* Allocate */
 		if (offset + length > currentStats.attr.st_size) {
 			posixAttributes.st_size = offset + length;
 
@@ -2031,40 +2145,64 @@ static fsal_status_t fallocate(struct fsal_obj_handle *objectHandle,
 			                           SAU_SET_ATTR_SIZE, &reply);
 
 			if (retvalue < 0) {
-				if (closeFd) { closeFileDescriptor(handle, &saunafsFd); }
+				status2 = fsal_complete_io(objectHandle, outFileDescriptor);
+				LogFullDebug(COMPONENT_FSAL, "fsal_complete_io returned %s",
+				             fsal_err_txt(status2));
 
-				if (hasLock) { PTHREAD_RWLOCK_unlock(&objectHandle->obj_lock); }
+				if (state == NULL) {
+					/* We did I/O without a state so we need
+					 * to release the
+					 * temp share reservation acquired. */
+
+					/* Release the share reservation now by
+					 * updating the counters. */
+					update_share_counters_locked(objectHandle, &handle->share,
+					                             FSAL_O_WRITE, FSAL_O_CLOSED);
+				}
 
 				return fsalLastError();
 			}
 
-			retvalue =
-			    saunafs_fsync(export->fsInstance, &op_ctx->creds, saunafsFd.fd);
+			retvalue = saunafs_fsync(export->fsInstance, &op_ctx->creds,
+			                         fileDescriptor->fd);
 
 			if (retvalue < 0) { status = fsalLastError(); }
 		}
-	}
-	else if (allocate == false) { // Deallocate
-		// Initialize the zero-buffer
+	} else if (allocate == false) {
+		/* Deallocate */
+		/* Initialize the zero-buffer */
 		void *buffer = malloc(length);
 
 		memset(buffer, 0, length);
 
-		// Write the interval [offset..offset + length] with zeros
-		ssize_t bytes = saunafs_write(export->fsInstance, &op_ctx->creds,
-		                              saunafsFd.fd, offset, length, buffer);
+		/* Write the interval [offset..offset + length] with zeros */
+		ssize_t bytes =
+		    saunafs_write(export->fsInstance, &op_ctx->creds,
+		                  fileDescriptor->fd, offset, length, buffer);
 
 		free(buffer);
 
 		if (bytes < 0) {
-			if (closeFd) { closeFileDescriptor(handle, &saunafsFd); }
+			status2 = fsal_complete_io(objectHandle, outFileDescriptor);
+			LogFullDebug(COMPONENT_FSAL, "fsal_complete_io returned %s",
+			             fsal_err_txt(status2));
 
-			if (hasLock) { PTHREAD_RWLOCK_unlock(&objectHandle->obj_lock); }
+			if (state == NULL) {
+				/* We did I/O without a state so we need
+				 * to release the
+				 * temp share reservation acquired. */
+
+				/* Release the share reservation now by
+				 * updating the counters. */
+				update_share_counters_locked(objectHandle, &handle->share,
+				                             FSAL_O_WRITE, FSAL_O_CLOSED);
+			}
 
 			return fsalLastError();
 		}
 
-		// Set the original size because deallocation must not change file size
+		/* Set the original size because deallocation must not change
+		 * file size */
 		posixAttributes.st_size = currentStats.attr.st_size;
 
 		retvalue =
@@ -2072,24 +2210,61 @@ static fsal_status_t fallocate(struct fsal_obj_handle *objectHandle,
 		                    &posixAttributes, SAU_SET_ATTR_SIZE, &reply);
 
 		if (retvalue < 0) {
-			if (closeFd) { closeFileDescriptor(handle, &saunafsFd); }
+			status2 = fsal_complete_io(objectHandle, outFileDescriptor);
+			LogFullDebug(COMPONENT_FSAL, "fsal_complete_io returned %s",
+			             fsal_err_txt(status2));
 
-			if (hasLock) { PTHREAD_RWLOCK_unlock(&objectHandle->obj_lock); }
+			if (state == NULL) {
+				/* We did I/O without a state so we need
+				 * to release the
+				 * temp share reservation acquired. */
+
+				/* Release the share reservation now by
+				 * updating the counters. */
+				update_share_counters_locked(objectHandle, &handle->share,
+				                             FSAL_O_WRITE, FSAL_O_CLOSED);
+			}
 
 			return fsalLastError();
 		}
 
-		retvalue =
-		    saunafs_fsync(export->fsInstance, &op_ctx->creds, saunafsFd.fd);
+		retvalue = saunafs_fsync(export->fsInstance, &op_ctx->creds,
+		                         fileDescriptor->fd);
 
 		if (retvalue < 0) { status = fsalLastError(); }
 	}
 
-	if (closeFd) { closeFileDescriptor(handle, &saunafsFd); }
+	status2 = fsal_complete_io(objectHandle, outFileDescriptor);
+	LogFullDebug(COMPONENT_FSAL, "fsal_complete_io returned %s",
+	             fsal_err_txt(status2));
 
-	if (hasLock) { PTHREAD_RWLOCK_unlock(&objectHandle->obj_lock); }
+	if (state == NULL) {
+		/* We did I/O without a state so we need to release the temp
+		 * share reservation acquired. */
+
+		/* Release the share reservation now by updating
+		 * the counters. */
+		update_share_counters_locked(objectHandle, &handle->share, FSAL_O_WRITE,
+		                             FSAL_O_CLOSED);
+	}
 
 	return status;
+}
+
+/**
+ * @brief Function to close a file for a given handle.
+ *
+ * @param[in]  objectHandle     File on which to operate
+ * @param[in]  fd               File descriptor to be closed
+ *
+ * @return FSAL status.
+ */
+static fsal_status_t close_func(struct fsal_obj_handle *objectHandle,
+                                struct fsal_fd *fd) {
+	struct SaunaFSHandle *handle = NULL;
+
+	handle = container_of(objectHandle, struct SaunaFSHandle, handle);
+	return closeFileDescriptor(handle, (struct SaunaFSFd *)fd);
 }
 
 /**
@@ -2110,6 +2285,7 @@ static fsal_status_t getxattrs(struct fsal_obj_handle *objectHandle,
 	export = container_of(op_ctx->fsal_export, struct SaunaFSExport, export);
 
 	struct SaunaFSHandle *handle = NULL;
+
 	handle = container_of(objectHandle, struct SaunaFSHandle, handle);
 
 	size_t curr_size = 0;
@@ -2125,9 +2301,9 @@ static fsal_status_t getxattrs(struct fsal_obj_handle *objectHandle,
 	}
 
 	if (curr_size && curr_size <= xattributeValue->utf8string_len) {
-		// Updating the real size
+		/* Updating the real size */
 		xattributeValue->utf8string_len = curr_size;
-		// Make sure utf8string is NUL terminated
+		/* Make sure utf8string is NULL terminated */
 		xattributeValue->utf8string_val[curr_size] = '\0';
 	}
 
@@ -2154,6 +2330,7 @@ static fsal_status_t setxattrs(struct fsal_obj_handle *objectHandle,
 	export = container_of(op_ctx->fsal_export, struct SaunaFSExport, export);
 
 	struct SaunaFSHandle *handle = NULL;
+
 	handle = container_of(objectHandle, struct SaunaFSHandle, handle);
 
 	int retvalue =
@@ -2176,12 +2353,15 @@ static fsal_status_t setxattrs(struct fsal_obj_handle *objectHandle,
  * This function lists the extended attributes of an object.
  *
  * @param [in]     objectHandle         Input object to list
- * @param [in]     maximumNameSize      Input maximum number of bytes for names
+ * @param [in]     maximumNameSize      Input maximum number of bytes for
+ *                                      names
  * @param [in,out] cookie               In/out cookie
- * @param [out]    eof                  Output eof set if no more extended attributes
- * @param [out]    xattributesNames     Output list of extended attribute names this
- *                                      buffer size is double the size of maximumNameSize
- *                                      to allow for component4 overhead
+ * @param [out]    eof                  Output eof set if no more extended
+ *                                      attributes
+ * @param [out]    xattributesNames     Output list of extended attribute
+ *                                      names this buffer size is double the
+ *                                      size of maximumNameSize to allow
+ *                                      for component4 overhead
  *
  * @returns: FSAL status
  */
@@ -2195,15 +2375,16 @@ static fsal_status_t listxattrs(struct fsal_obj_handle *objectHandle,
 	export = container_of(op_ctx->fsal_export, struct SaunaFSExport, export);
 
 	struct SaunaFSHandle *handle = NULL;
+
 	handle = container_of(objectHandle, struct SaunaFSHandle, handle);
 
 	LogFullDebug(COMPONENT_FSAL, "in cookie %llu length %d",
 	             (unsigned long long)*cookie, maximumNameSize);
 
-	// Size of list of extended attributes
+	/* Size of list of extended attributes */
 	size_t curr_size = 0;
 
-	// First time, the function is called to get the size of xattr list
+	/* First time, the function is called to get the size of xattr list */
 	int retvalue = saunafs_listxattr(export->fsInstance, &op_ctx->creds,
 	                                 handle->inode, 0, &curr_size, NULL);
 
@@ -2212,11 +2393,12 @@ static fsal_status_t listxattrs(struct fsal_obj_handle *objectHandle,
 		return saunafsToFsalError(retvalue);
 	}
 
-	// If xattr were retrieved and they can be allocated
+	/* If xattr were retrieved and they can be allocated */
 	if (curr_size && curr_size < maximumNameSize) {
 		buffer = gsh_malloc(curr_size);
 
-		// Second time, the function is called to retrieve the xattr list
+		/* Second time the function is called to retrieve
+		 * the xattr list */
 		retvalue =
 		    saunafs_listxattr(export->fsInstance, &op_ctx->creds, handle->inode,
 		                      curr_size, &curr_size, buffer);
@@ -2227,11 +2409,11 @@ static fsal_status_t listxattrs(struct fsal_obj_handle *objectHandle,
 			return saunafsToFsalError(retvalue);
 		}
 
-		// Setting retrieved extended attributes to Ganesha
+		/* Setting retrieved extended attributes to Ganesha */
 		status = fsal_listxattr_helper(buffer, curr_size, maximumNameSize,
 		                               cookie, eof, xattributesNames);
 
-		// Releasing allocated buffer
+		/* Releasing allocated buffer */
 		gsh_free(buffer);
 	}
 
@@ -2254,6 +2436,7 @@ static fsal_status_t removexattrs(struct fsal_obj_handle *objectHandle,
 	export = container_of(op_ctx->fsal_export, struct SaunaFSExport, export);
 
 	struct SaunaFSHandle *handle = NULL;
+
 	handle = container_of(objectHandle, struct SaunaFSHandle, handle);
 
 	int retvalue =
@@ -2289,6 +2472,8 @@ void handleOperationsInit(struct fsal_obj_ops *ops) {
 	ops->close2 = close2;
 	ops->symlink = symlink_;
 	ops->lock_op2 = lock_op2;
+	ops->close_func = close_func;
+	ops->reopen_func = reopen_func;
 	ops->reopen2 = reopen2;
 	ops->mknode = mknode;
 	ops->readlink = readlink_;
@@ -2316,20 +2501,26 @@ void handleOperationsInit(struct fsal_obj_ops *ops) {
 struct SaunaFSHandle *allocateHandle(const struct stat *attribute,
                                      struct SaunaFSExport *export) {
 	struct SaunaFSHandle *result = NULL;
+
 	result = gsh_calloc(1, sizeof(struct SaunaFSHandle));
 
 	result->inode = attribute->st_ino;
-	result->key.moduleId = FSAL_ID_EXPERIMENTAL;
+	result->key.moduleId = FSAL_ID_SAUNAFS;
 	result->key.exportId = export->export.export_id;
 	result->key.inode = attribute->st_ino;
 
 	fsal_obj_handle_init(&result->handle, &export->export,
-	                     posix2fsal_type(attribute->st_mode));
+	                     posix2fsal_type(attribute->st_mode), true);
 
 	result->handle.obj_ops = &SaunaFS.handleOperations;
 	result->handle.fsid = posix2fsal_fsid(attribute->st_dev);
 	result->handle.fileid = attribute->st_ino;
 	result->export = export;
+
+	if (result->handle.type == REGULAR_FILE) {
+		init_fsal_fd(&result->fd.fsalFd, FSAL_FD_GLOBAL, op_ctx->fsal_export);
+	}
+
 	return result;
 }
 
@@ -2339,6 +2530,6 @@ struct SaunaFSHandle *allocateHandle(const struct stat *attribute,
  * @param[in] object     Handle to release
  */
 void deleteHandle(struct SaunaFSHandle *object) {
-	fsal_obj_handle_fini(&object->handle);
+	fsal_obj_handle_fini(&object->handle, true);
 	gsh_free(object);
 }

--- a/src/nfs-ganesha/handle.c
+++ b/src/nfs-ganesha/handle.c
@@ -1526,7 +1526,7 @@ fsal_status_t lock_op2(struct fsal_obj_handle *objectHandle, struct state_t *sta
 	export = container_of(op_ctx->fsal_export, struct SaunaFSExport, export);
 	handle = container_of(objectHandle, struct SaunaFSHandle, handle);
 
-	LogFullDebug(COMPONENT_FSAL, "op:%d type:%d start:%" PRIu64 " length:%" PRIu64 " ",
+	LogFullDebug(COMPONENT_FSAL, "Locking: op:%d type:%d start:%" PRIu64 " length:%" PRIu64 " ",
 	             lockOperation, requestedLock->lock_type, requestedLock->lock_start,
 	             requestedLock->lock_length);
 
@@ -1537,6 +1537,11 @@ fsal_status_t lock_op2(struct fsal_obj_handle *objectHandle, struct state_t *sta
 
 	if (owner == NULL) {
 		LogCrit(COMPONENT_FSAL, "owner arg is NULL.");
+		return fsalstat(ERR_FSAL_FAULT, 0);
+	}
+
+	if (conflictingLock == NULL && lockOperation == FSAL_OP_LOCKT) {
+		LogDebug(COMPONENT_FSAL, "conflictingLock argument can't be NULL for operation LOCKT");
 		return fsalstat(ERR_FSAL_FAULT, 0);
 	}
 
@@ -1570,7 +1575,6 @@ fsal_status_t lock_op2(struct fsal_obj_handle *objectHandle, struct state_t *sta
 		lockInfo.l_type = F_WRLCK;
 	} else {
 		LogFullDebug(COMPONENT_FSAL, "ERROR: The requested lock type was not read or write.");
-
 		return fsalstat(ERR_FSAL_NOTSUPP, 0);
 	}
 
@@ -1639,7 +1643,6 @@ fsal_status_t lock_op2(struct fsal_obj_handle *objectHandle, struct state_t *sta
 
 		if (state == NULL) {
 			// We did I/O without a state so we need to release the temp share reservation acquired.
-
 			// Release the share reservation now by updating the counters.
 			update_share_counters_locked(objectHandle, &handle->share, openflags, FSAL_O_CLOSED);
 		}
@@ -1660,14 +1663,11 @@ fsal_status_t lock_op2(struct fsal_obj_handle *objectHandle, struct state_t *sta
 		}
 	}
 
-	lastError = sau_last_err();
 	status2 = fsal_complete_io(objectHandle, outFileDescriptor);
-
 	LogFullDebug(COMPONENT_FSAL, "fsal_complete_io returned %s", fsal_err_txt(status2));
 
 	if (state == NULL) {
 		// We did I/O without a state so we need to release the temp share reservation acquired.
-
 		// Release the share reservation now by updating the counters.
 		update_share_counters_locked(objectHandle, &handle->share, openflags, FSAL_O_CLOSED);
 	}

--- a/src/nfs-ganesha/handle.c
+++ b/src/nfs-ganesha/handle.c
@@ -1605,6 +1605,23 @@ fsal_status_t lock_op2(struct fsal_obj_handle *objectHandle, struct state_t *sta
 
 	saunafsFd = container_of(outFileDescriptor, struct SaunaFSFd, fsalFd);
 	fileinfo = saunafsFd->fd;
+
+	// Defensive check: ensure we have a valid file descriptor before proceeding
+	if (fileinfo == NULL) {
+		LogCrit(COMPONENT_FSAL, "Lock operation called with NULL file descriptor");
+
+		status2 = fsal_complete_io(objectHandle, outFileDescriptor);
+		LogFullDebug(COMPONENT_FSAL, "fsal_complete_io returned %s", fsal_err_txt(status2));
+
+		if (state == NULL) {
+			// We did I/O without a state so we need to release the temp share reservation acquired.
+			// Release the share reservation now by updating the counters.
+			update_share_counters_locked(objectHandle, &handle->share, openflags, FSAL_O_CLOSED);
+		}
+
+		return fsalstat(ERR_FSAL_FAULT, EFAULT);
+	}
+
 	sau_set_lock_owner(fileinfo, (uint64_t)owner);
 
 	if (lockOperation == FSAL_OP_LOCKT) {

--- a/src/nfs-ganesha/handle.c
+++ b/src/nfs-ganesha/handle.c
@@ -49,6 +49,13 @@ static void release(struct fsal_obj_handle *objectHandle) {
 	handle = container_of(objectHandle, struct SaunaFSHandle, handle);
 
 	if (handle->handle.type == REGULAR_FILE) {
+		fsal_status_t status = close_fsal_fd(objectHandle, &handle->fd.fsalFd, false);
+
+		if (FSAL_IS_ERROR(status)) {
+			LogCrit(COMPONENT_FSAL, "Could not close handle 0x%p, status %s error %s(%d)",
+			        objectHandle, fsal_err_txt(status), strerror(status.minor), status.minor);
+		}
+
 		destroy_fsal_fd(&handle->fd.fsalFd);
 	}
 
@@ -417,7 +424,7 @@ static fsal_status_t openByHandle(struct fsal_obj_handle *objectHandle, struct s
 	fsalFd = &saunafsFd->fsalFd;
 
 	// Indicate we want to do fd work (can't fail since not reclaiming)
-	(void)fsal_start_fd_work(fsalFd, false);
+	fsal_start_fd_work_no_reclaim(fsalFd);
 
 	oldOpenflags = saunafsFd->fsalFd.openflags;
 
@@ -509,6 +516,15 @@ static fsal_status_t openByHandle(struct fsal_obj_handle *objectHandle, struct s
 		return status;
 	}
 
+	// Inserts to fd_lru only if open succeeds
+	if (oldOpenflags == FSAL_O_CLOSED) {
+		// This is actually an open, need to increment appropriate counter and insert into LRU.
+		insert_fd_lru(fsalFd);
+	} else {
+		// Bump up the FD in fd_lru as it was already in fd lru.
+		bump_fd_lru(fsalFd);
+	}
+
 	fsal2posix_openflags(openflags, &posixFlags);
 
 	if (createmode >= FSAL_EXCLUSIVE || attributes) {
@@ -542,6 +558,11 @@ static fsal_status_t openByHandle(struct fsal_obj_handle *objectHandle, struct s
 	}
 
 	if (FSAL_IS_ERROR(status)) {
+		if (oldOpenflags == FSAL_O_CLOSED) {
+			// Now that we have decided to close this FD, let's clean it off from fd_lru and
+			// ensure counters are decremented.
+			remove_fd_lru(fsalFd);
+		}
 		// close fd
 		(void)closeFileDescriptor(handle, saunafsFd);
 	}

--- a/src/nfs-ganesha/handle.c
+++ b/src/nfs-ganesha/handle.c
@@ -1,20 +1,23 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
 /*
+
    Copyright 2017 Skytechnology sp. z o.o.
    Copyright 2023 Leil Storage OÜ
 
-   This file is part of SaunaFS.
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 3 of the License, or (at your option) any later version.
 
-   SaunaFS is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, version 3.
-
-   SaunaFS is distributed in the hope that it will be useful,
+   This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+   Lesser General Public License for more details.
 
-   You should have received a copy of the GNU General Public License
-   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301 USA.
  */
 
 #include "fsal_types.h"

--- a/src/nfs-ganesha/main.c
+++ b/src/nfs-ganesha/main.c
@@ -1,22 +1,25 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
 /*
 
    Copyright 2017 Skytechnology sp. z o.o.
    Copyright 2023 Leil Storage OÜ
 
-   This file is part of SaunaFS.
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 3 of the License, or (at your option) any later version.
 
-   SaunaFS is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, version 3.
-
-   SaunaFS is distributed in the hope that it will be useful,
+   This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
 
-   You should have received a copy of the GNU General Public License
-   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
- */
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301 USA
+*/
+
 
 #include "fsal_pnfs.h"
 #include "fsal_types.h"

--- a/src/nfs-ganesha/main.c
+++ b/src/nfs-ganesha/main.c
@@ -28,9 +28,9 @@
 #include "fsal_api.h"
 #include "pnfs_utils.h"
 
-#include "context_wrap.h"
-#include "saunafs_fsal_types.h"
-#include "saunafs_internal.h"
+#include "nfs-ganesha/context_wrap.h"
+#include "nfs-ganesha/saunafs_fsal_types.h"
+#include "nfs-ganesha/saunafs_internal.h"
 
 /* FSAL name determines name of shared library: libfsalsaunafs.so */
 static const char *const module = "SaunaFS";
@@ -58,8 +58,7 @@ struct SaunaFSModule SaunaFS = {
                  .named_attr = true,
                  .unique_handles = true,
 #ifdef ENABLE_NFS_ACL_SUPPORT
-                 .acl_support = (unsigned)FSAL_ACLSUPPORT_ALLOW |
-                                (unsigned)FSAL_ACLSUPPORT_DENY,
+                 .acl_support = (unsigned)FSAL_ACLSUPPORT_ALLOW | (unsigned)FSAL_ACLSUPPORT_DENY,
 #else
                  .acl_support = 0,
 #endif
@@ -81,15 +80,13 @@ struct SaunaFSModule SaunaFS = {
 static struct config_item export_params[] = {
     CONF_ITEM_MODE("umask", 0, fsal_staticfsinfo_t, umask),
     CONF_ITEM_BOOL("link_support", true, fsal_staticfsinfo_t, link_support),
-    CONF_ITEM_BOOL("symlink_support", true, fsal_staticfsinfo_t,
-                   symlink_support),
+    CONF_ITEM_BOOL("symlink_support", true, fsal_staticfsinfo_t, symlink_support),
     CONF_ITEM_BOOL("cansettime", true, fsal_staticfsinfo_t, cansettime),
-    CONF_ITEM_BOOL("auth_xdev_export", false, fsal_staticfsinfo_t,
-                   auth_exportpath_xdev),
-    CONF_ITEM_UI64("maxread", 512, (uint64_t)FSAL_MAXIOSIZE,
-                   (uint64_t)FSAL_MAXIOSIZE, fsal_staticfsinfo_t, maxread),
-    CONF_ITEM_UI64("maxwrite", 512, (uint64_t)FSAL_MAXIOSIZE,
-                   (uint64_t)FSAL_MAXIOSIZE, fsal_staticfsinfo_t, maxwrite),
+    CONF_ITEM_BOOL("auth_xdev_export", false, fsal_staticfsinfo_t, auth_exportpath_xdev),
+    CONF_ITEM_UI64("maxread", 512, (uint64_t)FSAL_MAXIOSIZE, (uint64_t)FSAL_MAXIOSIZE,
+                   fsal_staticfsinfo_t, maxread),
+    CONF_ITEM_UI64("maxwrite", 512, (uint64_t)FSAL_MAXIOSIZE, (uint64_t)FSAL_MAXIOSIZE,
+                   fsal_staticfsinfo_t, maxwrite),
     CONF_ITEM_BOOL("PNFS_MDS", false, fsal_staticfsinfo_t, pnfs_mds),
     CONF_ITEM_BOOL("PNFS_DS", false, fsal_staticfsinfo_t, pnfs_ds),
     CONF_ITEM_BOOL("fsal_trace", true, fsal_staticfsinfo_t, fsal_trace),
@@ -108,38 +105,29 @@ static struct config_block export_param = {
 
 static struct config_item fsal_export_params[] = {
     CONF_ITEM_NOOP("name"),
-    CONF_MAND_STR("hostname", 1, MAXPATHLEN, NULL, SaunaFSExport,
-                  parameters.host),
-    CONF_ITEM_STR("port", 1, MAXPATHLEN, "9421", SaunaFSExport,
-                  parameters.port),
-    CONF_ITEM_STR("mountpoint", 1, MAXPATHLEN, "nfs-ganesha", SaunaFSExport,
-                  parameters.mountpoint),
-    CONF_ITEM_STR("subfolder", 1, MAXPATHLEN, "/", SaunaFSExport,
-                  parameters.subfolder),
-    CONF_ITEM_BOOL("delayed_init", false, SaunaFSExport,
-                   parameters.delayed_init),
-    CONF_ITEM_UI32("io_retries", 0, 1024, 30, SaunaFSExport,
-                   parameters.io_retries),
+    CONF_MAND_STR("hostname", 1, MAXPATHLEN, NULL, SaunaFSExport, parameters.host),
+    CONF_ITEM_STR("port", 1, MAXPATHLEN, "9421", SaunaFSExport, parameters.port),
+    CONF_ITEM_STR("mountpoint", 1, MAXPATHLEN, "nfs-ganesha", SaunaFSExport, parameters.mountpoint),
+    CONF_ITEM_STR("subfolder", 1, MAXPATHLEN, "/", SaunaFSExport, parameters.subfolder),
+    CONF_ITEM_BOOL("delayed_init", false, SaunaFSExport, parameters.delayed_init),
+    CONF_ITEM_UI32("io_retries", 0, 1024, 30, SaunaFSExport, parameters.io_retries),
     CONF_ITEM_UI32("chunkserver_round_time_ms", 0, 65536, 200, SaunaFSExport,
                    parameters.chunkserver_round_time_ms),
-    CONF_ITEM_UI32("chunkserver_connect_timeout_ms", 0, 65536, 2000,
-                   SaunaFSExport, parameters.chunkserver_connect_timeout_ms),
-    CONF_ITEM_UI32("chunkserver_wave_read_timeout_ms", 0, 65536, 500,
-                   SaunaFSExport, parameters.chunkserver_wave_read_timeout_ms),
+    CONF_ITEM_UI32("chunkserver_connect_timeout_ms", 0, 65536, 2000, SaunaFSExport,
+                   parameters.chunkserver_connect_timeout_ms),
+    CONF_ITEM_UI32("chunkserver_wave_read_timeout_ms", 0, 65536, 500, SaunaFSExport,
+                   parameters.chunkserver_wave_read_timeout_ms),
     CONF_ITEM_UI32("total_read_timeout_ms", 0, 65536, 2000, SaunaFSExport,
                    parameters.total_read_timeout_ms),
     CONF_ITEM_UI32("cache_expiration_time_ms", 0, 65536, 1000, SaunaFSExport,
                    parameters.cache_expiration_time_ms),
-    CONF_ITEM_UI32("readahead_max_window_size_kB", 0, 65536, 16384,
-                   SaunaFSExport, parameters.readahead_max_window_size_kB),
-    CONF_ITEM_UI32("write_cache_size", 0, 1024, 64, SaunaFSExport,
-                   parameters.write_cache_size),
-    CONF_ITEM_UI32("write_workers", 0, 32, 10, SaunaFSExport,
-                   parameters.write_workers),
-    CONF_ITEM_UI32("write_window_size", 0, 256, 32, SaunaFSExport,
-                   parameters.write_window_size),
-    CONF_ITEM_UI32("chunkserver_write_timeout_ms", 0, 60000, 5000,
-                   SaunaFSExport, parameters.chunkserver_write_timeout_ms),
+    CONF_ITEM_UI32("readahead_max_window_size_kB", 0, 65536, 16384, SaunaFSExport,
+                   parameters.readahead_max_window_size_kB),
+    CONF_ITEM_UI32("write_cache_size", 0, 1024, 64, SaunaFSExport, parameters.write_cache_size),
+    CONF_ITEM_UI32("write_workers", 0, 32, 10, SaunaFSExport, parameters.write_workers),
+    CONF_ITEM_UI32("write_window_size", 0, 256, 32, SaunaFSExport, parameters.write_window_size),
+    CONF_ITEM_UI32("chunkserver_write_timeout_ms", 0, 60000, 5000, SaunaFSExport,
+                   parameters.chunkserver_write_timeout_ms),
     CONF_ITEM_UI32("cache_per_inode_percentage", 0, 80, 25, SaunaFSExport,
                    parameters.cache_per_inode_percentage),
     CONF_ITEM_UI32("symlink_cache_timeout_s", 0, 60000, 3600, SaunaFSExport,
@@ -147,14 +135,10 @@ static struct config_item fsal_export_params[] = {
     CONF_ITEM_BOOL("debug_mode", false, SaunaFSExport, parameters.debug_mode),
     CONF_ITEM_I32("keep_cache", 0, 2, 0, SaunaFSExport, parameters.keep_cache),
     CONF_ITEM_BOOL("verbose", false, SaunaFSExport, parameters.verbose),
-    CONF_ITEM_UI32("fileinfo_cache_timeout", 1, 3600, 60, SaunaFSExport,
-                   cacheTimeout),
-    CONF_ITEM_UI32("fileinfo_cache_max_size", 100, 1000000, 1000,
-                   SaunaFSExport, cacheMaximumSize),
-    CONF_ITEM_STR("password", 1, 128, NULL, SaunaFSExport,
-                  parameters.password),
-    CONF_ITEM_STR("md5_pass", 32, 32, NULL, SaunaFSExport,
-                  parameters.md5_pass),
+    CONF_ITEM_UI32("fileinfo_cache_timeout", 1, 3600, 60, SaunaFSExport, cacheTimeout),
+    CONF_ITEM_UI32("fileinfo_cache_max_size", 100, 1000000, 1000, SaunaFSExport, cacheMaximumSize),
+    CONF_ITEM_STR("password", 1, 128, NULL, SaunaFSExport, parameters.password),
+    CONF_ITEM_STR("md5_pass", 32, 32, NULL, SaunaFSExport, parameters.md5_pass),
     CONFIG_EOL};
 
 static struct config_block fsal_export_param_block = {
@@ -219,12 +203,11 @@ static fsal_status_t createExport(struct fsal_module *module, void *parseNode,
 	sau_set_default_init_params(&export->parameters, "", "", "");
 
 	if (parseNode) {
-		retvalue = load_config_from_node(parseNode, &fsal_export_param_block,
-		                                 export, true, errorType);
+		retvalue =
+		    load_config_from_node(parseNode, &fsal_export_param_block, export, true, errorType);
 
 		if (retvalue != 0) {
-			LogCrit(COMPONENT_FSAL,
-			        "Failed to parse export configuration for %s",
+			LogCrit(COMPONENT_FSAL, "Failed to parse export configuration for %s",
 			        CTX_FULLPATH(op_ctx));
 
 			releaseExport(export);
@@ -236,16 +219,14 @@ static fsal_status_t createExport(struct fsal_module *module, void *parseNode,
 	export->fsInstance = sau_init_with_params(&export->parameters);
 
 	if (export->fsInstance == NULL) {
-		LogCrit(COMPONENT_FSAL, "Unable to mount SaunaFS cluster for %s.",
-		        CTX_FULLPATH(op_ctx));
+		LogCrit(COMPONENT_FSAL, "Unable to mount SaunaFS cluster for %s.", CTX_FULLPATH(op_ctx));
 
 		releaseExport(export);
 		return fsalstat(ERR_FSAL_SERVERFAULT, 0);
 	}
 
 	if (fsal_attach_export(module, &export->export.exports) != 0) {
-		LogCrit(COMPONENT_FSAL, "Unable to attach export for %s.",
-		        CTX_FULLPATH(op_ctx));
+		LogCrit(COMPONENT_FSAL, "Unable to attach export for %s.", CTX_FULLPATH(op_ctx));
 
 		releaseExport(export);
 		return fsalstat(ERR_FSAL_SERVERFAULT, 0);
@@ -258,9 +239,8 @@ static fsal_status_t createExport(struct fsal_module *module, void *parseNode,
 	    &export->export, fso_pnfs_ds_supported);
 
 	if (export->pnfsDsEnabled) {
-		export->cache = createFileInfoCache(
-		    export->cacheMaximumSize,
-		    (int)export->cacheTimeout * millisecondsInOneSecond);
+		export->cache = createFileInfoCache(export->cacheMaximumSize,
+		                                    (int)export->cacheTimeout * millisecondsInOneSecond);
 
 		if (export->cache == NULL) {
 			LogCrit(COMPONENT_FSAL, "Unable to create fileinfo cache for %s.",
@@ -283,8 +263,7 @@ static fsal_status_t createExport(struct fsal_module *module, void *parseNode,
 		pnfsDs->mds_fsal_export = &export->export;
 
 		if (!pnfs_ds_insert(pnfsDs)) {
-			LogCrit(COMPONENT_CONFIG, "Server id %d already in use.",
-			        pnfsDs->id_servers);
+			LogCrit(COMPONENT_CONFIG, "Server id %d already in use.", pnfsDs->id_servers);
 
 			status.major = ERR_FSAL_EXIST;
 
@@ -295,16 +274,14 @@ static fsal_status_t createExport(struct fsal_module *module, void *parseNode,
 			return status;
 		}
 
-		LogDebug(COMPONENT_PNFS, "pnfs ds was enabled for [%s]",
-		         CTX_FULLPATH(op_ctx));
+		LogDebug(COMPONENT_PNFS, "pnfs ds was enabled for [%s]", CTX_FULLPATH(op_ctx));
 	}
 
-	export->pnfsMdsEnabled = export->export.exp_ops.fs_supports(
-	    &export->export, fso_pnfs_mds_supported);
+	export->pnfsMdsEnabled =
+	    export->export.exp_ops.fs_supports(&export->export, fso_pnfs_mds_supported);
 
 	if (export->pnfsMdsEnabled) {
-		LogDebug(COMPONENT_PNFS, "pnfs mds was enabled for [%s]",
-		         CTX_FULLPATH(op_ctx));
+		LogDebug(COMPONENT_PNFS, "pnfs mds was enabled for [%s]", CTX_FULLPATH(op_ctx));
 
 		exportOperationsPnfs(&export->export.exp_ops);
 	}
@@ -312,8 +289,7 @@ static fsal_status_t createExport(struct fsal_module *module, void *parseNode,
 	/* get attributes for root inode */
 	sau_attr_reply_t reply;
 
-	retvalue = saunafs_getattr(export->fsInstance, &op_ctx->creds,
-	                           SPECIAL_INODE_ROOT, &reply);
+	retvalue = saunafs_getattr(export->fsInstance, &op_ctx->creds, SPECIAL_INODE_ROOT, &reply);
 
 	if (retvalue < 0) {
 		status = fsalLastError();
@@ -349,15 +325,14 @@ static fsal_status_t createExport(struct fsal_module *module, void *parseNode,
  *
  * @returns: FSAL status
  */
-static fsal_status_t initialize(struct fsal_module *module,
-                                config_file_t configFile,
+static fsal_status_t initialize(struct fsal_module *module, config_file_t configFile,
                                 struct config_error_type *errorType) {
 	struct SaunaFSModule *myself = NULL;
 
 	myself = container_of(module, struct SaunaFSModule, fsal);
 
-	(void)load_config_from_parse(configFile, &export_param,
-	                             &myself->filesystemInfo, true, errorType);
+	(void)load_config_from_parse(configFile, &export_param, &myself->filesystemInfo, true,
+	                             errorType);
 
 	if (!config_error_is_harmless(errorType)) {
 		LogDebug(COMPONENT_FSAL, "config_error_is_harmless failed.");
@@ -366,8 +341,7 @@ static fsal_status_t initialize(struct fsal_module *module,
 
 	display_fsinfo(&myself->fsal);
 
-	LogDebug(COMPONENT_FSAL,
-	         "FSAL INIT: Supported attributes mask = 0x%" PRIx64,
+	LogDebug(COMPONENT_FSAL, "FSAL INIT: Supported attributes mask = 0x%" PRIx64,
 	         myself->fsal.fs_info.supported_attrs);
 
 	return fsalstat(ERR_FSAL_NO_ERROR, 0);
@@ -383,8 +357,8 @@ static fsal_status_t initialize(struct fsal_module *module,
 MODULE_INIT void initializeSaunaFS(void) {
 	struct fsal_module *myself = &SaunaFS.fsal;
 
-	int retval = register_fsal(myself, module, FSAL_MAJOR_VERSION,
-	                           FSAL_MINOR_VERSION, FSAL_ID_SAUNAFS);
+	int retval =
+	    register_fsal(myself, module, FSAL_MAJOR_VERSION, FSAL_MINOR_VERSION, FSAL_ID_SAUNAFS);
 
 	if (retval) {
 		LogCrit(COMPONENT_FSAL, "SaunaFS module failed to register.");
@@ -411,8 +385,7 @@ MODULE_FINI void finish(void) {
 	int retval = unregister_fsal(&SaunaFS.fsal);
 
 	if (retval != 0) {
-		LogCrit(COMPONENT_FSAL,
-		        "Unable to unload SaunaFS FSAL. Dying with extreme prejudice.");
+		LogCrit(COMPONENT_FSAL, "Unable to unload SaunaFS FSAL. Dying with extreme prejudice.");
 		abort();
 	}
 }

--- a/src/nfs-ganesha/mds_export.c
+++ b/src/nfs-ganesha/mds_export.c
@@ -1,22 +1,24 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
 /*
 
    Copyright 2017 Skytechnology sp. z o.o.
    Copyright 2023 Leil Storage OÜ
 
-   This file is part of SaunaFS.
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 3 of the License, or (at your option) any later version.
 
-   SaunaFS is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, version 3.
-
-   SaunaFS is distributed in the hope that it will be useful,
+   This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
 
-   You should have received a copy of the GNU General Public License
-   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
- */
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301 USA
+*/
 
 #include "gsh_config.h"
 #include "saunafs_fsal_types.h"

--- a/src/nfs-ganesha/mds_export.c
+++ b/src/nfs-ganesha/mds_export.c
@@ -21,11 +21,11 @@
 */
 
 #include "gsh_config.h"
-#include "saunafs_fsal_types.h"
 #include "pnfs_utils.h"
 #include <stdlib.h>
 
-#include "context_wrap.h"
+#include "nfs-ganesha/context_wrap.h"
+#include "nfs-ganesha/saunafs_fsal_types.h"
 #include "mount/client/saunafs_c_api.h"
 
 const int MaxBufferSize = 0x100;
@@ -46,12 +46,9 @@ const int ChunkDataOverhead = 32;
  * @retval value > 0: chunkserverA's ip is greater than chunkserverB's ip
  * @retval         0: Both chunkservers have the same ip
  */
-static int ascendingIpCompare(const void *chunkserverA,
-                              const void *chunkserverB) {
-	uint32_t ipFromChunkserverA = ((const sau_chunkserver_info_t *)
-	                               chunkserverA)->ip;
-	uint32_t ipFromChunkserverB = ((const sau_chunkserver_info_t *)
-	                               chunkserverB)->ip;
+static int ascendingIpCompare(const void *chunkserverA, const void *chunkserverB) {
+	uint32_t ipFromChunkserverA = ((const sau_chunkserver_info_t *)chunkserverA)->ip;
+	uint32_t ipFromChunkserverB = ((const sau_chunkserver_info_t *)chunkserverB)->ip;
 
 	return ipFromChunkserverA - ipFromChunkserverB;
 }
@@ -107,16 +104,13 @@ static int adjacentChunkserversWithSameIp(const void *chunkserver, void *base) {
  * @returns: Number of removed elements.
  */
 static size_t remove_if(void *data, size_t size, size_t itemSize,
-                        int (*predicate)(const void *chunkserver,
-                                         void *targetData),
+                        int (*predicate)(const void *chunkserver, void *targetData),
                         void *targetData) {
 	size_t step = 0;
 
 	for (size_t i = 0; i < size; ++i) {
 		if (!predicate((uint8_t *)data + i * itemSize, targetData)) {
-			memcpy((uint8_t *)data + i * itemSize,
-			       (uint8_t *)data + step * itemSize,
-			       itemSize);
+			memcpy((uint8_t *)data + i * itemSize, (uint8_t *)data + step * itemSize, itemSize);
 			step++;
 		}
 	}
@@ -143,8 +137,7 @@ static void shuffle(void *data, size_t size, size_t itemSize) {
 
 		memcpy(temp, (uint8_t *)data + index * itemSize, itemSize);
 
-		memcpy((uint8_t *)data + index * itemSize,
-		       (uint8_t *)data + start * itemSize, itemSize);
+		memcpy((uint8_t *)data + index * itemSize, (uint8_t *)data + start * itemSize, itemSize);
 
 		memcpy((uint8_t *)data + start * itemSize, temp, itemSize);
 	}
@@ -158,16 +151,14 @@ static void shuffle(void *data, size_t size, size_t itemSize) {
  *
  * @returns: Randomized chunkservers list.
  */
-static sau_chunkserver_info_t *randomizedChunkserverList(
-    struct SaunaFSExport *export, uint32_t *chunkserverCount) {
+static sau_chunkserver_info_t *randomizedChunkserverList(struct SaunaFSExport *export,
+                                                         uint32_t *chunkserverCount) {
 	sau_chunkserver_info_t *chunkserverInfo = NULL;
 
-	chunkserverInfo = gsh_malloc(SAUNAFS_BIGGEST_STRIPE_COUNT *
-	                             sizeof(sau_chunkserver_info_t));
+	chunkserverInfo = gsh_malloc(SAUNAFS_BIGGEST_STRIPE_COUNT * sizeof(sau_chunkserver_info_t));
 
-	int retvalue = sau_get_chunkservers_info(
-	    export->fsInstance, chunkserverInfo, SAUNAFS_BIGGEST_STRIPE_COUNT,
-	    chunkserverCount);
+	int retvalue = sau_get_chunkservers_info(export->fsInstance, chunkserverInfo,
+	                                         SAUNAFS_BIGGEST_STRIPE_COUNT, chunkserverCount);
 
 	if (retvalue < 0) {
 		*chunkserverCount = 0;
@@ -175,25 +166,22 @@ static sau_chunkserver_info_t *randomizedChunkserverList(
 		return NULL;
 	}
 
-	/* Free labels, we don't need them. */
+	// Free labels, we don't need them.
 	sau_destroy_chunkservers_info(chunkserverInfo);
 
-	/* remove disconnected */
+	// remove disconnected
 	*chunkserverCount = remove_if(chunkserverInfo, *chunkserverCount,
-	                              sizeof(sau_chunkserver_info_t),
-	                              isChunkserverDisconnected, NULL);
+	                              sizeof(sau_chunkserver_info_t), isChunkserverDisconnected, NULL);
 
-	/* sorting chunkservers based on its ip attribute */
-	qsort(chunkserverInfo, *chunkserverCount,
-	      sizeof(sau_chunkserver_info_t), ascendingIpCompare);
+	// sorting chunkservers based on its ip attribute
+	qsort(chunkserverInfo, *chunkserverCount, sizeof(sau_chunkserver_info_t), ascendingIpCompare);
 
-	/* remove entries with the same ip */
-	*chunkserverCount = remove_if(chunkserverInfo, *chunkserverCount,
-	                              sizeof(sau_chunkserver_info_t),
-	                              adjacentChunkserversWithSameIp,
-	                              chunkserverInfo);
+	// remove entries with the same ip
+	*chunkserverCount =
+	    remove_if(chunkserverInfo, *chunkserverCount, sizeof(sau_chunkserver_info_t),
+	              adjacentChunkserversWithSameIp, chunkserverInfo);
 
-	/* randomize */
+	// randomize
 	shuffle(chunkserverInfo, *chunkserverCount, sizeof(sau_chunkserver_info_t));
 
 	return chunkserverInfo;
@@ -210,11 +198,9 @@ static sau_chunkserver_info_t *randomizedChunkserverList(
  * @retval   0: Successful operation
  * @retval  -1: Failing operation
  */
-static int fillChunkDataServerList(XDR *da_addr_body,
-                                   sau_chunk_info_t *chunkInfo,
-                                   sau_chunkserver_info_t *chunkserverInfo,
-                                   uint32_t chunkCount, uint32_t stripeCount,
-                                   uint32_t chunkserverCount,
+static int fillChunkDataServerList(XDR *da_addr_body, sau_chunk_info_t *chunkInfo,
+                                   sau_chunkserver_info_t *chunkserverInfo, uint32_t chunkCount,
+                                   uint32_t stripeCount, uint32_t chunkserverCount,
                                    uint32_t *chunkserverIndex) {
 	fsal_multipath_member_t host[SAUNAFS_EXPECTED_BACKUP_DS_COUNT];
 	uint32_t size = MIN(chunkCount, stripeCount);
@@ -226,9 +212,8 @@ static int fillChunkDataServerList(XDR *da_addr_body,
 
 		memset(host, 0, upperBound * sizeof(fsal_multipath_member_t));
 
-		/* prefer std chunk part type */
-		for (size_t i = 0; i < chunk->parts_size && serverCount < upperBound;
-		     ++i) {
+		// prefer std chunk part type
+		for (size_t i = 0; i < chunk->parts_size && serverCount < upperBound; ++i) {
 			if (chunk->parts[i].part_type_id != SAUNAFS_STD_CHUNK_PART_TYPE) {
 				continue;
 			}
@@ -239,8 +224,7 @@ static int fillChunkDataServerList(XDR *da_addr_body,
 			++serverCount;
 		}
 
-		for (size_t i = 0; i < chunk->parts_size && serverCount < upperBound;
-		     ++i) {
+		for (size_t i = 0; i < chunk->parts_size && serverCount < upperBound; ++i) {
 			if (chunk->parts[i].part_type_id == SAUNAFS_STD_CHUNK_PART_TYPE) {
 				continue;
 			}
@@ -251,8 +235,7 @@ static int fillChunkDataServerList(XDR *da_addr_body,
 			++serverCount;
 		}
 
-		/* fill unused entries with the servers from randomized
-		 * chunkserver list */
+		// fill unused entries with the servers from randomized chunkserver list
 		while (serverCount < upperBound) {
 			host[serverCount].proto = TCP_PROTO_NUMBER;
 			host[serverCount].addr = chunkserverInfo[*chunkserverIndex].ip;
@@ -262,9 +245,8 @@ static int fillChunkDataServerList(XDR *da_addr_body,
 			*chunkserverIndex = (*chunkserverIndex + 1) % chunkserverCount;
 		}
 
-		/* encode ds entry */
-		nfsstat4 status =
-		    FSAL_encode_v4_multipath(da_addr_body, serverCount, host);
+		// encode ds entry
+		nfsstat4 status = FSAL_encode_v4_multipath(da_addr_body, serverCount, host);
 
 		if (status != NFS4_OK) {
 			return kNFS4_ERROR;
@@ -275,8 +257,7 @@ static int fillChunkDataServerList(XDR *da_addr_body,
 }
 
 /**
- * @brief Fill unused part of DS list with servers from randomized chunkserver
- *        list.
+ * @brief Fill unused part of DS list with servers from randomized chunkserver list.
  *
  * @param[in] xdrStream             XDR stream
  * @param[in] chunkserverInfo       Collection of chunkservers
@@ -290,11 +271,9 @@ static int fillChunkDataServerList(XDR *da_addr_body,
  * @retval   0: Successful operation
  * @retval  -1: Failing operation
  */
-static int fillUnusedDataServerList(XDR *xdrStream,
-                                    sau_chunkserver_info_t *chunkserverInfo,
+static int fillUnusedDataServerList(XDR *xdrStream, sau_chunkserver_info_t *chunkserverInfo,
                                     uint32_t chunkCount, uint32_t stripeCount,
-                                    uint32_t chunkserverCount,
-                                    uint32_t *chunkserverIndex) {
+                                    uint32_t chunkserverCount, uint32_t *chunkserverIndex) {
 	fsal_multipath_member_t host[SAUNAFS_EXPECTED_BACKUP_DS_COUNT];
 	uint32_t size = MIN(chunkCount, stripeCount);
 	const int upperBound = SAUNAFS_EXPECTED_BACKUP_DS_COUNT;
@@ -329,13 +308,11 @@ static int fillUnusedDataServerList(XDR *xdrStream,
 /**
  * @brief Release resources.
  *
- * @param[in] chunkInfo             Chunk information including id, type and all
- *                                  parts
- * @param[in] chunkserverInfo       Chunkserver information including version,
- *                                  ip, port, used space and total space
+ * @param[in] chunkInfo             Chunk information including id, type and all parts
+ * @param[in] chunkserverInfo       Chunkserver information including version, ip, port, used space
+ *                                  and total space
  */
-static void releaseResources(sau_chunk_info_t *chunkInfo,
-                             sau_chunkserver_info_t *chunkserverInfo) {
+static void releaseResources(sau_chunk_info_t *chunkInfo, sau_chunkserver_info_t *chunkserverInfo) {
 	if (chunkInfo) {
 		sau_destroy_chunks_info(chunkInfo);
 		gsh_free(chunkInfo);
@@ -354,9 +331,9 @@ static void releaseResources(sau_chunk_info_t *chunkInfo,
  *
  * The function converts SaunaFS file's chunk information to pNFS device info.
  *
- * Linux pNFS client imposes limit on stripe size (SAUNAFS_BIGGEST_STRIPE_COUNT
- * = 4096). If we would use straight forward approach of converting each chunk
- * to stripe entry, we would be limited to file size of 256 GB (4096 * 64MB).
+ * Linux pNFS client imposes limit on stripe size (SAUNAFS_BIGGEST_STRIPE_COUNT = 4096).
+ * If we would use straight forward approach of converting each chunk to stripe entry,
+ * we would be limited to file size of 256 GB (4096 * 64MB).
  *
  * To avoid this problem each DS can read/write data from any chunk (Remember
  * that pNFS client takes DS address from DS list in round robin fashion). Of
@@ -370,22 +347,19 @@ static void releaseResources(sau_chunk_info_t *chunkInfo,
  * chunkservers storing this chunk. If there is less chunkservers than
  * SAUNAFS_EXPECTED_BACKUP_DS_COUNT then we use chunkservers from RCSL.
  *
- * If we didn't use all the possible space in DS list
- * (SAUNAFS_BIGGEST_STRIPE_COUNT), then we fill rest of the stripe entries with
- * addresses from RCSL (again SAUNAFS_EXPECTED_BACKUP_DS_COUNT addresses for
- * each stripe entry).
+ * If we didn't use all the possible space in DS list (SAUNAFS_BIGGEST_STRIPE_COUNT),
+ * then we fill rest of the stripe entries with addresses from RCSL (again
+ * SAUNAFS_EXPECTED_BACKUP_DS_COUNT addresses for each stripe entry).
  *
  * @param[in]  module         FSAL module
  * @param[out] xdrStream      XDR stream to which the FSAL is to write the
- *                            layout type-specific information corresponding to
- *                            the deviceid.
+ *                            layout type-specific information corresponding to the deviceid.
  * @param[in]  type           The type of layout that specified the device
  * @param[in]  deviceid       The device to look up
  *
  * @returns: Valid error codes in RFC 5661, p. 365.
  */
-static nfsstat4 getdeviceinfo(struct fsal_module *module, XDR *xdrStream,
-                              const layouttype4 type,
+static nfsstat4 getdeviceinfo(struct fsal_module *module, XDR *xdrStream, const layouttype4 type,
                               const struct pnfs_deviceid *deviceid) {
 	struct fsal_export *exportHandle = NULL;
 	struct SaunaFSExport *export = NULL;
@@ -418,24 +392,21 @@ static nfsstat4 getdeviceinfo(struct fsal_module *module, XDR *xdrStream,
 	}
 
 	if (!export) {
-		LogCrit(COMPONENT_PNFS, "Couldn't find export with id: %"
-		        PRIu16, export_id);
+		LogCrit(COMPONENT_PNFS, "Couldn't find export with id: %" PRIu16, export_id);
 
 		return NFS4ERR_SERVERFAULT;
 	}
 
-	/* get the chunk list for file */
-	chunkInfo =
-	    gsh_malloc(SAUNAFS_BIGGEST_STRIPE_COUNT * sizeof(sau_chunk_info_t));
+	// get the chunk list for file
+	chunkInfo = gsh_malloc(SAUNAFS_BIGGEST_STRIPE_COUNT * sizeof(sau_chunk_info_t));
 
-	int retvalue = saunafs_get_chunks_info(
-	    export->fsInstance, &op_ctx->creds, deviceid->devid, 0, chunkInfo,
-	    SAUNAFS_BIGGEST_STRIPE_COUNT, &chunkCount);
+	int retvalue = saunafs_get_chunks_info(export->fsInstance, &op_ctx->creds, deviceid->devid, 0,
+	                                       chunkInfo, SAUNAFS_BIGGEST_STRIPE_COUNT, &chunkCount);
 
 	if (retvalue < 0) {
 		LogCrit(COMPONENT_PNFS,
-		        "Failed to get SaunaFS layout for export = %"
-		        PRIu16 " inode = %" PRIu64, export_id, deviceid->devid);
+		        "Failed to get SaunaFS layout for export = %" PRIu16 " inode = %" PRIu64, export_id,
+		        deviceid->devid);
 
 		releaseResources(chunkInfo, chunkserverInfo);
 		return NFS4ERR_SERVERFAULT;
@@ -445,21 +416,19 @@ static nfsstat4 getdeviceinfo(struct fsal_module *module, XDR *xdrStream,
 
 	if (chunkserverInfo == NULL || chunkserverCount == 0) {
 		LogCrit(COMPONENT_PNFS,
-		        "Failed to get SaunaFS layout for export = %" PRIu16
-		        " inode = %" PRIu64, export_id, deviceid->devid);
+		        "Failed to get SaunaFS layout for export = %" PRIu16 " inode = %" PRIu64, export_id,
+		        deviceid->devid);
 
 		releaseResources(chunkInfo, chunkserverInfo);
 		return NFS4ERR_SERVERFAULT;
 	}
 
 	chunkserverIndex = 0;
-	stripeCount =
-	    MIN(chunkCount + chunkserverCount, SAUNAFS_BIGGEST_STRIPE_COUNT);
+	stripeCount = MIN(chunkCount + chunkserverCount, SAUNAFS_BIGGEST_STRIPE_COUNT);
 
 	if (!inline_xdr_u_int32_t(xdrStream, &stripeCount)) {
 		LogCrit(COMPONENT_PNFS,
-		        "Failed to encode device information for export = %" PRIu16
-		        " inode = %" PRIu64,
+		        "Failed to encode device information for export = %" PRIu16 " inode = %" PRIu64,
 		        export_id, deviceid->devid);
 
 		releaseResources(chunkInfo, chunkserverInfo);
@@ -469,8 +438,7 @@ static nfsstat4 getdeviceinfo(struct fsal_module *module, XDR *xdrStream,
 	for (uint32_t chunkIndex = 0; chunkIndex < stripeCount; ++chunkIndex) {
 		if (!inline_xdr_u_int32_t(xdrStream, &chunkIndex)) {
 			LogCrit(COMPONENT_PNFS,
-			        "Failed to encode device information for export = %" PRIu16
-			        " inode = %" PRIu64,
+			        "Failed to encode device information for export = %" PRIu16 " inode = %" PRIu64,
 			        export_id, deviceid->devid);
 
 			releaseResources(chunkInfo, chunkserverInfo);
@@ -480,36 +448,31 @@ static nfsstat4 getdeviceinfo(struct fsal_module *module, XDR *xdrStream,
 
 	if (!inline_xdr_u_int32_t(xdrStream, &stripeCount)) {
 		LogCrit(COMPONENT_PNFS,
-		        "Failed to encode device information for export = %" PRIu16
-		        " inode = %" PRIu64,
+		        "Failed to encode device information for export = %" PRIu16 " inode = %" PRIu64,
 		        export_id, deviceid->devid);
 
 		releaseResources(chunkInfo, chunkserverInfo);
 		return NFS4ERR_SERVERFAULT;
 	}
 
-	retvalue = fillChunkDataServerList(xdrStream, chunkInfo, chunkserverInfo,
-	                                   chunkCount, stripeCount,
-	                                   chunkserverCount, &chunkserverIndex);
+	retvalue = fillChunkDataServerList(xdrStream, chunkInfo, chunkserverInfo, chunkCount,
+	                                   stripeCount, chunkserverCount, &chunkserverIndex);
 
 	if (retvalue < 0) {
 		LogCrit(COMPONENT_PNFS,
-		        "Failed to encode device information for export = %" PRIu16
-		        " inode = %" PRIu64,
+		        "Failed to encode device information for export = %" PRIu16 " inode = %" PRIu64,
 		        export_id, deviceid->devid);
 
 		releaseResources(chunkInfo, chunkserverInfo);
 		return NFS4ERR_SERVERFAULT;
 	}
 
-	retvalue = fillUnusedDataServerList(xdrStream, chunkserverInfo, chunkCount,
-	                                    stripeCount, chunkserverCount,
-	                                    &chunkserverIndex);
+	retvalue = fillUnusedDataServerList(xdrStream, chunkserverInfo, chunkCount, stripeCount,
+	                                    chunkserverCount, &chunkserverIndex);
 
 	if (retvalue < 0) {
 		LogCrit(COMPONENT_PNFS,
-		        "Failed to encode device information for export = %" PRIu16
-		        " inode = %" PRIu64,
+		        "Failed to encode device information for export = %" PRIu16 " inode = %" PRIu64,
 		        export_id, deviceid->devid);
 
 		releaseResources(chunkInfo, chunkserverInfo);
@@ -529,15 +492,12 @@ static nfsstat4 getdeviceinfo(struct fsal_module *module, XDR *xdrStream,
  *
  * This function should populate calls cb values representing the low quad of
  * deviceids it wishes to make the available to the caller. it should continue
- * calling cb until cb returns false or it runs out of deviceids to make
- * available.
+ * calling cb until cb returns false or it runs out of deviceids to make available.
  *
  * If cb returns false, it should assume that cb has not stored the most recent
- * deviceid and set res->cookie to a value that will begin with the most
- * recently provided.
+ * deviceid and set res->cookie to a value that will begin with the most recently provided.
  *
- * If it wishes to return no deviceids, it may set res->eof to true without
- * calling cb at all.
+ * If it wishes to return no deviceids, it may set res->eof to true without calling cb at all.
  *
  * @param[in] exportHandle     Export handle
  * @param[in] type             Type of layout to get devices for
@@ -547,10 +507,8 @@ static nfsstat4 getdeviceinfo(struct fsal_module *module, XDR *xdrStream,
  *
  * @returns: Valid error codes in RFC 5661, p. 365-6.
  */
-static nfsstat4 getdevicelist(struct fsal_export *exportHandle,
-                              layouttype4 type, void *opaque,
-                              bool (*callback)(void *opaque,
-                                               const uint64_t identifier),
+static nfsstat4 getdevicelist(struct fsal_export *exportHandle, layouttype4 type, void *opaque,
+                              bool (*callback)(void *opaque, const uint64_t identifier),
                               struct fsal_getdevicelist_res *res) {
 	(void)exportHandle;
 	(void)type;
@@ -564,14 +522,12 @@ static nfsstat4 getdevicelist(struct fsal_export *exportHandle,
 /**
  * @brief Get layout types supported by export.
  *
- * This function is the handler of the NFS4.1 FATTR4_FS_LAYOUT_TYPES file
- * attribute.
+ * This function is the handler of the NFS4.1 FATTR4_FS_LAYOUT_TYPES file attribute.
  *
  * @param[in]  exportHandle      Filesystem to interrogate
  * @param[out] count             Number of layout types in array
- * @param[out] types             Static array of layout types that must not be
- *                               freed or modified and must not be dereferenced
- *                               after export reference is relinquished.
+ * @param[out] types             Static array of layout types that must not be freed or modified and
+ *                               must not be dereferenced after export reference is relinquished.
  */
 static void fs_layouttypes(struct fsal_export *exportHandle, int32_t *count,
                            const layouttype4 **types) {
@@ -659,8 +615,8 @@ static size_t fs_da_addr_size(struct fsal_module *module) {
 	 * takes 37 bytes (we use 40 for safety) we add 32 bytes of overhead
 	 * (includes stripe count and DS count) */
 	return SAUNAFS_BIGGEST_STRIPE_COUNT *
-	      (4 + (4 + SAUNAFS_EXPECTED_BACKUP_DS_COUNT * ChunkAddressSizeInBytes))
-	      + ChunkDataOverhead;
+	           (4 + (4 + SAUNAFS_EXPECTED_BACKUP_DS_COUNT * ChunkAddressSizeInBytes)) +
+	       ChunkDataOverhead;
 }
 
 /**

--- a/src/nfs-ganesha/mds_handle.c
+++ b/src/nfs-ganesha/mds_handle.c
@@ -1,22 +1,24 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
 /*
 
    Copyright 2017 Skytechnology sp. z o.o.
    Copyright 2023 Leil Storage OÜ
 
-   This file is part of SaunaFS.
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 3 of the License, or (at your option) any later version.
 
-   SaunaFS is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, version 3.
-
-   SaunaFS is distributed in the hope that it will be useful,
+   This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
 
-   You should have received a copy of the GNU General Public License
-   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
- */
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301 USA
+*/
 
 #include "pnfs_utils.h"
 

--- a/src/nfs-ganesha/mds_handle.c
+++ b/src/nfs-ganesha/mds_handle.c
@@ -32,20 +32,16 @@
  *
  * This function is called by nfs41_op_layoutget.
  * It may be called multiple times, to satisfy a request with multiple segments.
- * The FSAL may track state (what portion of the request has been or remains
- * to be satisfied or any other information it wishes) in the bookkeeper member
- * of res. Each segment may have FSAL-specific information associated with its
- * segid.
- * This segid will be supplied to the FSAL when the segment is committed or
- * returned.
+ * The FSAL may track state (what portion of the request has been or remains to be satisfied
+ * or any other information it wishes) in the bookkeeper member of res.
+ * Each segment may have FSAL-specific information associated with its segid.
+ * This segid will be supplied to the FSAL when the segment is committed or returned.
  *
  * When the granting the last segment it intends to grant, the FSAL must set the
  * last_segment flag in res.
  *
- * @param[in] objectHandle      The handle of the file on which the layout is
- *                              requested
- * @param[out] xdrStream        An XDR stream to which the FSAL must encode the
- *                              layout
+ * @param[in] objectHandle      The handle of the file on which the layout is requested
+ * @param[out] xdrStream        An XDR stream to which the FSAL must encode the layout
  *                              specific portion of the granted layout segment
  * @param[in] arguments         Input arguments of the function
  * @param[in,out] output        In/out and output arguments of the function
@@ -70,15 +66,13 @@ static nfsstat4 layoutget(struct fsal_obj_handle *objectHandle, XDR *xdrStream,
 	handle = container_of(objectHandle, struct SaunaFSHandle, handle);
 
 	if (arguments->type != LAYOUT4_NFSV4_1_FILES) {
-		LogMajor(COMPONENT_PNFS, "Unsupported layout type: %x",
-		         arguments->type);
+		LogMajor(COMPONENT_PNFS, "Unsupported layout type: %x", arguments->type);
 
 		return NFS4ERR_UNKNOWN_LAYOUTTYPE;
 	}
 
-	LogDebug(COMPONENT_PNFS, "will issue layout offset: %" PRIu64
-	         " length: %" PRIu64, output->segment.offset,
-	         output->segment.length);
+	LogDebug(COMPONENT_PNFS, "will issue layout offset: %" PRIu64 " length: %" PRIu64,
+	         output->segment.offset, output->segment.length);
 
 	deviceid.device_id2 = handle->export->export.export_id;
 	deviceid.devid = handle->inode;
@@ -108,31 +102,25 @@ static nfsstat4 layoutget(struct fsal_obj_handle *objectHandle, XDR *xdrStream,
  * layouts corresponding to a given stateid on last close, lease expiry, or
  * a layoutreturn with a return-type of FSID or ALL. Whether it is called in
  * the former or latter case is indicated by the synthetic flag in the arg
- * structure, with synthetic being true in the case of last-close or lease
- * expiry.
+ * structure, with synthetic being true in the case of last-close or lease expiry.
  *
- * If arg->dispose is true, all resources associated with the layout must be
- * freed.
+ * If arg->dispose is true, all resources associated with the layout must be freed.
  *
  * @param[in] objectHandle      The object on which a segment is to be returned
- * @param[in] xdrStream         In the case of a non-synthetic return, this is
- *                              an XDR stream corresponding to the layout
- *                              type-specific argument to LAYOUTRETURN. In the
- *                              case of a synthetic or bulk return, this is a
- *                              NULL pointer.
+ * @param[in] xdrStream         In the case of a non-synthetic return, this is an XDR stream
+ *                              corresponding to the layout type-specific argument to LAYOUTRETURN.
+ *                              In the case of a synthetic or bulk return, this is a NULL pointer.
  * @param[in] arguments         Input arguments of the function
  *
  * @returns: Valid error codes in RFC 5661, p. 367.
  */
-static nfsstat4 layoutreturn(struct fsal_obj_handle *objectHandle,
-                             XDR *xdrStream,
+static nfsstat4 layoutreturn(struct fsal_obj_handle *objectHandle, XDR *xdrStream,
                              const struct fsal_layoutreturn_arg *arguments) {
 	(void) objectHandle;
 	(void) xdrStream;
 
 	if (arguments->lo_type != LAYOUT4_NFSV4_1_FILES) {
-		LogDebug(COMPONENT_PNFS, "Unsupported layout type: %x",
-		         arguments->lo_type);
+		LogDebug(COMPONENT_PNFS, "Unsupported layout type: %x", arguments->lo_type);
 
 		return NFS4ERR_UNKNOWN_LAYOUTTYPE;
 	}
@@ -151,8 +139,7 @@ static nfsstat4 layoutreturn(struct fsal_obj_handle *objectHandle,
  */
 bool isOffsetChangedByClient(const struct fsal_layoutcommit_arg *arguments,
                              struct sau_attr_reply previousReply) {
-	return arguments->new_offset &&
-	       previousReply.attr.st_size < (long)arguments->last_write + 1;
+	return arguments->new_offset && previousReply.attr.st_size < (long)arguments->last_write + 1;
 }
 
 /**
@@ -169,8 +156,7 @@ bool hasRecentModificationTime(const struct fsal_layoutcommit_arg *arguments,
 	return arguments->time_changed &&
 	       (arguments->new_time.seconds > previousReply.attr.st_mtim.tv_sec ||
 	        (arguments->new_time.seconds == previousReply.attr.st_mtim.tv_sec &&
-	         arguments->new_time.nseconds >
-	             previousReply.attr.st_mtim.tv_nsec));
+	         arguments->new_time.nseconds > previousReply.attr.st_mtim.tv_nsec));
 }
 
 /**
@@ -184,16 +170,14 @@ bool hasRecentModificationTime(const struct fsal_layoutcommit_arg *arguments,
  * or new_size until after the last call to FSAL_layoutcommit.
  *
  * @param[in] objectHandle      The object on which to commit
- * @param[in] xdrStream         An XDR stream containing the layout
- *                              type-specific portion of the LAYOUTCOMMIT
- *                              arguments
+ * @param[in] xdrStream         An XDR stream containing the layout type-specific portion of the
+ *                              LAYOUTCOMMIT arguments
  * @param[in] arguments         Input arguments of the function
  * @param[in,out] output        In/out and output arguments of the function
  *
  * @returns: Valid error codes in RFC 5661, p. 366.
  */
-static nfsstat4 layoutcommit(struct fsal_obj_handle *objectHandle,
-                             XDR *xdrStream,
+static nfsstat4 layoutcommit(struct fsal_obj_handle *objectHandle, XDR *xdrStream,
                              const struct fsal_layoutcommit_arg *arguments,
                              struct fsal_layoutcommit_res *output) {
 	(void) xdrStream;
@@ -210,14 +194,12 @@ static nfsstat4 layoutcommit(struct fsal_obj_handle *objectHandle,
 	export = container_of(op_ctx->fsal_export, struct SaunaFSExport, export);
 	handle = container_of(objectHandle, struct SaunaFSHandle, handle);
 
-	int retvalue = saunafs_getattr(export->fsInstance, &op_ctx->creds,
-	                               handle->inode, &previousReply);
+	int retvalue =
+	    saunafs_getattr(export->fsInstance, &op_ctx->creds, handle->inode, &previousReply);
 
 	if (retvalue < 0) {
-		LogCrit(COMPONENT_PNFS, "Error '%s' in attempt to get "
-		        "attributes of file %lli.",
-		        sau_error_string(sau_last_err()),
-		        (long long)handle->inode);
+		LogCrit(COMPONENT_PNFS, "Error '%s' in attempt to get attributes of file %lli.",
+		        sau_error_string(sau_last_err()), (long long)handle->inode);
 
 		return nfs4LastError();
 	}
@@ -236,20 +218,19 @@ static nfsstat4 layoutcommit(struct fsal_obj_handle *objectHandle,
 
 	if (hasRecentModificationTime(arguments, previousReply)) {
 		posixAttributes.st_mtim.tv_sec = arguments->new_time.seconds;
-		posixAttributes.st_mtim.tv_sec = arguments->new_time.nseconds;
+		posixAttributes.st_mtim.tv_nsec = arguments->new_time.nseconds;
 		mask |= SAU_SET_ATTR_MTIME;
 		mask = (unsigned int)mask | SAU_SET_ATTR_MTIME;
 	}
 
 	sau_attr_reply_t reply;
-	retvalue =
-	    saunafs_setattr(export->fsInstance, &op_ctx->creds, handle->inode,
-	                    &posixAttributes, (int)mask, &reply);
+	retvalue = saunafs_setattr(export->fsInstance, &op_ctx->creds, handle->inode, &posixAttributes,
+	                           (int)mask, &reply);
 
 	if (retvalue < 0) {
-		LogCrit(COMPONENT_PNFS, "Error '%s' in attempt to set attributes "
-		        "of file %lli.", sau_error_string(sau_last_err()),
-		        (long long)handle->inode);
+		LogCrit(COMPONENT_PNFS, "Error '%s' in attempt to set attributes of file %lli.",
+		        sau_error_string(sau_last_err()), (long long)handle->inode);
+
 		return nfs4LastError();
 	}
 

--- a/src/nfs-ganesha/mds_handle.c
+++ b/src/nfs-ganesha/mds_handle.c
@@ -21,7 +21,6 @@
 #include "pnfs_utils.h"
 
 #include "context_wrap.h"
-#include "protocol/SFSCommunication.h"
 #include "saunafs_internal.h"
 
 /**
@@ -29,18 +28,22 @@
  *
  * pNFS functions.
  *
- * This function is called by nfs41_op_layoutget. It may be called multiple times,
- * to satisfy a request with multiple segments. The FSAL may track state (what
- * portion of the request has been or remains to be satisfied or any other
- * information it wishes) in the bookkeeper member of res. Each segment may have
- * FSAL-specific information associated with it its segid. This segid will be
- * supplied to the FSAL when the segment is committed or returned.
+ * This function is called by nfs41_op_layoutget.
+ * It may be called multiple times, to satisfy a request with multiple segments.
+ * The FSAL may track state (what portion of the request has been or remains
+ * to be satisfied or any other information it wishes) in the bookkeeper member
+ * of res. Each segment may have FSAL-specific information associated with its
+ * segid.
+ * This segid will be supplied to the FSAL when the segment is committed or
+ * returned.
  *
  * When the granting the last segment it intends to grant, the FSAL must set the
  * last_segment flag in res.
  *
- * @param[in] objectHandle      The handle of the file on which the layout is requested
- * @param[out] xdrStream        An XDR stream to which the FSAL must encode the layout
+ * @param[in] objectHandle      The handle of the file on which the layout is
+ *                              requested
+ * @param[out] xdrStream        An XDR stream to which the FSAL must encode the
+ *                              layout
  *                              specific portion of the granted layout segment
  * @param[in] arguments         Input arguments of the function
  * @param[in,out] output        In/out and output arguments of the function
@@ -58,7 +61,7 @@ static nfsstat4 layoutget(struct fsal_obj_handle *objectHandle, XDR *xdrStream,
 		.len = sizeof(struct DSWire)
 	};
 
-	struct pnfs_deviceid deviceid = DEVICE_ID_INIT_ZERO(FSAL_ID_EXPERIMENTAL);
+	struct pnfs_deviceid deviceid = DEVICE_ID_INIT_ZERO(FSAL_ID_SAUNAFS);
 	nfl_util4 layoutUtil = 0;
 	nfsstat4 status = NFS4_OK;
 
@@ -81,9 +84,8 @@ static nfsstat4 layoutget(struct fsal_obj_handle *objectHandle, XDR *xdrStream,
 	dataServerWire.inode = handle->inode;
 	layoutUtil = SFSCHUNKSIZE;
 
-	status =
-	    FSAL_encode_file_layout(xdrStream, &deviceid, layoutUtil, 0, 0,
-	                            &op_ctx->ctx_export->export_id, 1, &dsBuffer);
+	status = FSAL_encode_file_layout(xdrStream, &deviceid, layoutUtil, 0, 0,
+	                                 &op_ctx->ctx_export->export_id, 1, &dsBuffer, false);
 
 	if (status) {
 		LogMajor(COMPONENT_PNFS, "Failed to encode nfsv4_1_file_layout.");
@@ -180,8 +182,9 @@ bool hasRecentModificationTime(const struct fsal_layoutcommit_arg *arguments,
  * or new_size until after the last call to FSAL_layoutcommit.
  *
  * @param[in] objectHandle      The object on which to commit
- * @param[in] xdrStream         An XDR stream containing the layout type-specific
- *                              portion of the LAYOUTCOMMIT arguments
+ * @param[in] xdrStream         An XDR stream containing the layout
+ *                              type-specific portion of the LAYOUTCOMMIT
+ *                              arguments
  * @param[in] arguments         Input arguments of the function
  * @param[in,out] output        In/out and output arguments of the function
  *
@@ -233,7 +236,7 @@ static nfsstat4 layoutcommit(struct fsal_obj_handle *objectHandle,
 		posixAttributes.st_mtim.tv_sec = arguments->new_time.seconds;
 		posixAttributes.st_mtim.tv_sec = arguments->new_time.nseconds;
 		mask |= SAU_SET_ATTR_MTIME;
-		mask = (unsigned)mask | SAU_SET_ATTR_MTIME;
+		mask = (unsigned int)mask | SAU_SET_ATTR_MTIME;
 	}
 
 	sau_attr_reply_t reply;

--- a/src/nfs-ganesha/saunafs_acl.c
+++ b/src/nfs-ganesha/saunafs_acl.c
@@ -1,22 +1,24 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
 /*
 
    Copyright 2017 Skytechnology sp. z o.o.
    Copyright 2023 Leil Storage OÜ
 
-   This file is part of SaunaFS.
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 3 of the License, or (at your option) any later version.
 
-   SaunaFS is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, version 3.
-
-   SaunaFS is distributed in the hope that it will be useful,
+   This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
 
-   You should have received a copy of the GNU General Public License
-   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
- */
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301 USA
+*/
 
 #include "context_wrap.h"
 #include "saunafs_internal.h"

--- a/src/nfs-ganesha/saunafs_acl.c
+++ b/src/nfs-ganesha/saunafs_acl.c
@@ -57,14 +57,14 @@ sau_acl_t *convertFsalACLToSaunafsACL(const fsal_acl_t *fsalACL,
 		}
 
 		sau_acl_ace_t ace;
+
 		ace.flags = fsalACE->flag & ByteMaxValue;
 		ace.mask  = fsalACE->perm;
 		ace.type  = fsalACE->type;
 
 		if (IS_FSAL_ACE_GROUP_ID(*fsalACE)) {
 			ace.id = GET_FSAL_ACE_GROUP(*fsalACE);
-		}
-		else {
+		} else {
 			ace.id = GET_FSAL_ACE_USER(*fsalACE);
 		}
 
@@ -136,8 +136,7 @@ fsal_acl_t *convertSaunafsACLToFsalACL(const sau_acl_t *saunafsACL) {
 
 		if (IS_FSAL_ACE_GROUP_ID(*fsalACE)) {
 			fsalACE->who.gid = saunafsACE.id;
-		}
-		else {
+		} else {
 			fsalACE->who.uid = saunafsACE.id;
 		}
 

--- a/src/nfs-ganesha/saunafs_acl.c
+++ b/src/nfs-ganesha/saunafs_acl.c
@@ -20,25 +20,22 @@
    02110-1301 USA
 */
 
-#include "context_wrap.h"
-#include "saunafs_internal.h"
+#include "nfs-ganesha/context_wrap.h"
+#include "nfs-ganesha/saunafs_internal.h"
 
 const uint ByteMaxValue = 0xFF;
 
 /**
  * @brief Convert a given ACL in FSAL format to the corresponding SaunaFS ACL.
  * The mode is used to create a default ACL and set POSIX permission flags.
- * The new ACL is filled with the ACEs from the original ACL to have the same
- * permissions and flags.
+ * The new ACL is filled with the ACEs from the original ACL to have the same permissions and flags.
  *
  * @param[in] fsalACL     FSAL ACL
- * @param[in] mode        Mode used to create the acl and set POSIX permission
- *                        flags
+ * @param[in] mode        Mode used to create the acl and set POSIX permission flags
  *
  * @returns: SaunaFS ACL
  */
-sau_acl_t *convertFsalACLToSaunafsACL(const fsal_acl_t *fsalACL,
-                                      unsigned int mode) {
+sau_acl_t *convertFsalACLToSaunafsACL(const fsal_acl_t *fsalACL, unsigned int mode) {
 	sau_acl_t *saunafsACL = NULL;
 
 	if (!fsalACL || (!fsalACL->aces && fsalACL->naces > 0)) {
@@ -53,10 +50,7 @@ sau_acl_t *convertFsalACLToSaunafsACL(const fsal_acl_t *fsalACL,
 	for (unsigned int i = 0; i < fsalACL->naces; ++i) {
 		fsal_ace_t *fsalACE = fsalACL->aces + i;
 
-		if (!(IS_FSAL_ACE_ALLOW(*fsalACE) ||
-		      IS_FSAL_ACE_DENY(*fsalACE))) {
-			continue;
-		}
+		if (!(IS_FSAL_ACE_ALLOW(*fsalACE) || IS_FSAL_ACE_DENY(*fsalACE))) { continue; }
 
 		sau_acl_ace_t ace;
 
@@ -83,8 +77,7 @@ sau_acl_t *convertFsalACLToSaunafsACL(const fsal_acl_t *fsalACL,
 				ace.id = SAU_ACL_EVERYONE_SPECIAL_ID;
 				break;
 			default:
-				LogFullDebug(COMPONENT_FSAL,
-				             "Invalid FSAL ACE special id type (%d)",
+				LogFullDebug(COMPONENT_FSAL, "Invalid FSAL ACE special id type (%d)",
 				             (int)GET_FSAL_ACE_USER(*fsalACE));
 				continue;
 			}
@@ -131,9 +124,8 @@ fsal_acl_t *convertSaunafsACLToFsalACL(const sau_acl_t *saunafsACL) {
 
 		fsalACE->type  = saunafsACE.type;
 		fsalACE->flag  = saunafsACE.flags & ByteMaxValue;
-		fsalACE->iflag = (saunafsACE.flags & (unsigned)SAU_ACL_SPECIAL_WHO)
-		                      ? FSAL_ACE_IFLAG_SPECIAL_ID
-		                      : 0;
+		fsalACE->iflag =
+		    (saunafsACE.flags & (unsigned)SAU_ACL_SPECIAL_WHO) ? FSAL_ACE_IFLAG_SPECIAL_ID : 0;
 		fsalACE->perm = saunafsACE.mask;
 
 		if (IS_FSAL_ACE_GROUP_ID(*fsalACE)) {
@@ -155,8 +147,7 @@ fsal_acl_t *convertSaunafsACLToFsalACL(const sau_acl_t *saunafsACL) {
 				break;
 			default:
 				fsalACE->who.uid = FSAL_ACE_NORMAL_WHO;
-				LogWarn(COMPONENT_FSAL,
-				        "Invalid SaunaFS ACE special id type (%u)",
+				LogWarn(COMPONENT_FSAL, "Invalid SaunaFS ACE special id type (%u)",
 				        (unsigned int)saunafsACE.id);
 			}
 		}
@@ -185,14 +176,11 @@ fsal_status_t getACL(struct SaunaFSExport *export, inode_t inode, uint32_t owner
 	}
 
 	sau_acl_t *saunafsACL = NULL;
-	int status =
-	    saunafs_getacl(export->fsInstance, &op_ctx->creds, inode, &saunafsACL);
+	int status = saunafs_getacl(export->fsInstance, &op_ctx->creds, inode, &saunafsACL);
 
 	if (status < 0) {
-		LogFullDebug(COMPONENT_FSAL,
-		             "getacl status = %s export=%" PRIu16 " inode=%" PRIiNode,
-		             sau_error_string(sau_last_err()), export->export.export_id,
-		             inode);
+		LogFullDebug(COMPONENT_FSAL, "getacl status = %s export=%" PRIu16 " inode=%" PRIiNode,
+		             sau_error_string(sau_last_err()), export->export.export_id, inode);
 
 		return fsalLastError();
 	}
@@ -204,8 +192,8 @@ fsal_status_t getACL(struct SaunaFSExport *export, inode_t inode, uint32_t owner
 
 	if (*acl == NULL) {
 		LogFullDebug(COMPONENT_FSAL,
-		             "Failed to convert saunafs acl to nfs4 acl, export=%"
-		             PRIu16 " inode=%" PRIiNode,
+		             "Failed to convert saunafs acl to nfs4 acl, export=%" PRIu16
+		             " inode=%" PRIiNode,
 		             export->export.export_id, inode);
 		return fsalstat(ERR_FSAL_FAULT, 0);
 	}
@@ -222,8 +210,7 @@ fsal_status_t getACL(struct SaunaFSExport *export, inode_t inode, uint32_t owner
  * @param[in] export      SaunaFS export instance
  * @param[in] inode       Inode of the file
  * @param[in] acl         FSAL ACL to set
- * @param[in] mode        Mode used to create the acl and set POSIX permission
- *                        flags
+ * @param[in] mode        Mode used to create the acl and set POSIX permission flags
  *
  * @returns: FSAL status.
  */
@@ -240,8 +227,7 @@ fsal_status_t setACL(struct SaunaFSExport *export, inode_t inode, const fsal_acl
 		return fsalstat(ERR_FSAL_FAULT, 0);
 	}
 
-	int status =
-	    saunafs_setacl(export->fsInstance, &op_ctx->creds, inode, saunafsACL);
+	int status = saunafs_setacl(export->fsInstance, &op_ctx->creds, inode, saunafsACL);
 	sau_destroy_acl(saunafsACL);
 
 	if (status < 0) {

--- a/src/nfs-ganesha/saunafs_fsal_types.h
+++ b/src/nfs-ganesha/saunafs_fsal_types.h
@@ -1,20 +1,23 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
 /*
+
    Copyright 2023 Leil Storage OÜ
 
-   This file is part of SaunaFS.
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 3 of the License, or (at your option) any later version.
 
-   SaunaFS is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, version 3.
-
-   SaunaFS is distributed in the hope that it will be useful,
+   This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
 
-   You should have received a copy of the GNU General Public License
-   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
- */
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301 USA
+*/
 
 #pragma once
 

--- a/src/nfs-ganesha/saunafs_fsal_types.h
+++ b/src/nfs-ganesha/saunafs_fsal_types.h
@@ -1,11 +1,19 @@
-/**
- * @file   saunafs_fsal_types.h
- * @author Crash <crash@leil.io>
- *
- * @brief File System Abstraction Layer types and constants.
- *
- * This file includes declarations of data types, variables and constants
- * for SaunaFS FSAL.
+/*
+   Copyright 2023 Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
  */
 
 #pragma once
@@ -23,9 +31,12 @@
 
 static const int kNFS4_ERROR = -1;
 
+// Global SaunaFS constants
 #ifndef SFSBLOCKSIZE
 #define SFSBLOCKSIZE 65536
 #endif
+#define SFSBLOCKSINCHUNK 1024
+#define SFSCHUNKSIZE (SFSBLOCKSIZE * SFSBLOCKSINCHUNK)
 
 #define SPECIAL_INODE_BASE 0xFFFFFFF0U
 #define SPECIAL_INODE_ROOT 0x01U
@@ -62,7 +73,7 @@ inline void bswap_sau_inode_t(sau_inode_t *inode) {
  *
  * @brief SaunaFS Main global module object.
  *
- * SaunaFSModule contains the global module object, FSAL object
+ * SaunaFSModule contains the global module object, the
  * operations vector and parameters of the filesystem info.
  */
 struct SaunaFSModule {
@@ -85,18 +96,18 @@ struct SaunaFSHandle;
  * to the master server, the cache used and the pNFS support.
  */
 struct SaunaFSExport {
-	struct fsal_export export; /// Export object
-	struct SaunaFSHandle *root; /// root handle of export
+	struct fsal_export export;  /* Export object */
+	struct SaunaFSHandle *root; /* root handle of export */
 
-	sau_t *fsInstance; /// Filesystem instance
-	sau_init_params_t parameters; /// Initial parameters
-	FileInfoCache_t *cache; /// Export cache
+	sau_t *fsInstance;            /* Filesystem instance */
+	sau_init_params_t parameters; /* Initial parameters */
+	FileInfoCache_t *cache;       /* Export cache */
 
-	bool pnfsMdsEnabled; /// pNFS Metadata Server enabled
-	bool pnfsDsEnabled;  /// pNFS Data Server enabled
+	bool pnfsMdsEnabled; /* pNFS Metadata Server enabled */
+	bool pnfsDsEnabled;  /* pNFS Data Server enabled */
 
-	uint32_t cacheTimeout; /// Timeout for entries at cache
-	uint32_t cacheMaximumSize; /// Maximum size of cache
+	uint32_t cacheTimeout;     /* Timeout for entries at cache */
+	uint32_t cacheMaximumSize; /* Maximum size of cache */
 };
 
 /**
@@ -108,8 +119,8 @@ struct SaunaFSExport {
  * file descriptor and its flags associated like open and share mode.
  */
 struct SaunaFSFd {
-	fsal_openflags_t openflags; /// The open and share mode
-	struct sau_fileinfo *fd; /// SaunaFS file descriptor
+	struct fsal_fd fsalFd;   /* The open and share mode plus fd management */
+	struct sau_fileinfo *fd; /* SaunaFS file descriptor */
 };
 
 /**
@@ -118,16 +129,15 @@ struct SaunaFSFd {
  * @brief Associates a single NFSv4 state structure with a file descriptor.
  */
 struct SaunaFSStateFd {
-	/// Structure representing a single NFSv4 state
-	struct state_t state;
-	/// SaunaFS file descriptor associated with the state
-	struct SaunaFSFd saunafsFd;
+	/* state MUST be first to use default free_state */
+	struct state_t state; /* Structure representing a single NFSv4 state */
+	struct SaunaFSFd saunafsFd; /* SaunaFS file descriptor */
 };
 
 struct SaunaFSHandleKey {
-	uint16_t moduleId; /// module id
-	uint16_t exportId; /// export id
-	sau_inode_t inode; /// inode
+	uint16_t moduleId; /* module id */
+	uint16_t exportId; /* export id */
+	sau_inode_t inode; /* inode */
 };
 
 /**
@@ -139,12 +149,12 @@ struct SaunaFSHandleKey {
  * filesystem and its operations.
  */
 struct SaunaFSHandle {
-	struct fsal_obj_handle handle; /// Public handle
-	struct SaunaFSFd fd; /// SaunaFS FSAL file descriptor
-	sau_inode_t inode; /// inode of file
-	struct SaunaFSHandleKey key; /// Handle key
-	struct SaunaFSExport *export; /// Export to which the handle belongs
-	struct fsal_share share; /// The ref counted share reservation state
+	struct fsal_obj_handle handle; /* Public handle */
+	struct SaunaFSFd fd;           /* SaunaFS FSAL file descriptor */
+	sau_inode_t inode;             /* inode of file */
+	struct SaunaFSHandleKey key;   /* Handle key */
+	struct SaunaFSExport *export;  /* Export to which the handle belongs */
+	struct fsal_share share;       /* The ref counted share reservation state */
 };
 
 struct DSWire {

--- a/src/nfs-ganesha/saunafs_fsal_types.h
+++ b/src/nfs-ganesha/saunafs_fsal_types.h
@@ -23,11 +23,10 @@
 
 #include "fsal_api.h"
 
-#include "fileinfo_cache.h"
 #include "mount/client/saunafs_c_api.h"
+#include "nfs-ganesha/fileinfo_cache.h"
 
-#define SAUNAFS_VERSION(major, minor, micro) \
-                (0x010000 * major + 0x0100 * minor + micro)
+#define SAUNAFS_VERSION(major, minor, micro) (0x010000 * major + 0x0100 * minor + micro)
 #define kDisconnectedChunkServerVersion SAUNAFS_VERSION(256, 0, 0)
 
 #define SFS_NAME_MAX 255
@@ -76,8 +75,8 @@ inline void bswap_sau_inode_t(sau_inode_t *inode) {
  *
  * @brief SaunaFS Main global module object.
  *
- * SaunaFSModule contains the global module object, the
- * operations vector and parameters of the filesystem info.
+ * SaunaFSModule contains the global module object, the operations vector and parameters
+ * of the filesystem info.
  */
 struct SaunaFSModule {
 	struct fsal_module fsal;
@@ -99,18 +98,18 @@ struct SaunaFSHandle;
  * to the master server, the cache used and the pNFS support.
  */
 struct SaunaFSExport {
-	struct fsal_export export;  /* Export object */
-	struct SaunaFSHandle *root; /* root handle of export */
+	struct fsal_export export;  /// Export object
+	struct SaunaFSHandle *root; /// root handle of export
 
-	sau_t *fsInstance;            /* Filesystem instance */
-	sau_init_params_t parameters; /* Initial parameters */
-	FileInfoCache_t *cache;       /* Export cache */
+	sau_t *fsInstance;            /// Filesystem instance
+	sau_init_params_t parameters; /// Initial parameters
+	FileInfoCache_t *cache;       /// Export cache
 
-	bool pnfsMdsEnabled; /* pNFS Metadata Server enabled */
-	bool pnfsDsEnabled;  /* pNFS Data Server enabled */
+	bool pnfsMdsEnabled; /// pNFS Metadata Server enabled
+	bool pnfsDsEnabled;  /// pNFS Data Server enabled
 
-	uint32_t cacheTimeout;     /* Timeout for entries at cache */
-	uint32_t cacheMaximumSize; /* Maximum size of cache */
+	uint32_t cacheTimeout;     /// Timeout for entries at cache
+	uint32_t cacheMaximumSize; /// Maximum size of cache
 };
 
 /**
@@ -122,8 +121,8 @@ struct SaunaFSExport {
  * file descriptor and its flags associated like open and share mode.
  */
 struct SaunaFSFd {
-	struct fsal_fd fsalFd;   /* The open and share mode plus fd management */
-	struct sau_fileinfo *fd; /* SaunaFS file descriptor */
+	struct fsal_fd fsalFd;   /// The open and share mode plus fd management
+	struct sau_fileinfo *fd; /// SaunaFS file descriptor
 };
 
 /**
@@ -132,15 +131,15 @@ struct SaunaFSFd {
  * @brief Associates a single NFSv4 state structure with a file descriptor.
  */
 struct SaunaFSStateFd {
-	/* state MUST be first to use default free_state */
-	struct state_t state; /* Structure representing a single NFSv4 state */
-	struct SaunaFSFd saunafsFd; /* SaunaFS file descriptor */
+	/// state MUST be first to use default free_state
+	struct state_t state; /// Structure representing a single NFSv4 state
+	struct SaunaFSFd saunafsFd; /// SaunaFS file descriptor
 };
 
 struct SaunaFSHandleKey {
-	uint16_t moduleId; /* module id */
-	uint16_t exportId; /* export id */
-	sau_inode_t inode; /* inode */
+	uint16_t moduleId; /// module id
+	uint16_t exportId; /// export id
+	sau_inode_t inode; /// inode
 };
 
 /**
@@ -148,16 +147,16 @@ struct SaunaFSHandleKey {
  *
  * @brief SaunaFS FSAL handle.
  *
- * SaunaFSHandle contains information related with the public structure of the
- * filesystem and its operations.
+ * SaunaFSHandle contains information related with the public structure of the filesystem and
+ * its operations.
  */
 struct SaunaFSHandle {
-	struct fsal_obj_handle handle; /* Public handle */
-	struct SaunaFSFd fd;           /* SaunaFS FSAL file descriptor */
-	sau_inode_t inode;             /* inode of file */
-	struct SaunaFSHandleKey key;   /* Handle key */
-	struct SaunaFSExport *export;  /* Export to which the handle belongs */
-	struct fsal_share share;       /* The ref counted share reservation state */
+	struct fsal_obj_handle handle; /// Public handle
+	struct SaunaFSFd fd;           /// SaunaFS FSAL file descriptor
+	sau_inode_t inode;             /// inode of file
+	struct SaunaFSHandleKey key;   /// Handle key
+	struct SaunaFSExport *export;  /// Export to which the handle belongs
+	struct fsal_share share;       /// The ref counted share reservation state
 };
 
 struct DSWire {

--- a/src/nfs-ganesha/saunafs_internal.c
+++ b/src/nfs-ganesha/saunafs_internal.c
@@ -1,9 +1,21 @@
-/**
- * @file   saunafs_internal.c
- * @author Crash <crash@leil.io>
- *
- * @brief Function definitions for SaunaFS FSAL
+/*
+   Copyright 2023 Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
  */
+
 #include "fsal_convert.h"
 #include "pnfs_utils.h"
 
@@ -25,11 +37,12 @@ sau_context_t *createContext(sau_t *instance, struct user_cred *cred) {
 	}
 
 	if (cred->caller_glen > 0) {
-		gid_t *garray = malloc((cred->caller_glen + 1) * sizeof(gid_t));
+		gid_t *garray = gsh_malloc((cred->caller_glen + 1) * sizeof(gid_t));
 
 		if (garray != NULL) {
 			garray[0] = gid;
 			size_t size = sizeof(gid_t) * cred->caller_glen;
+
 			memcpy(garray + 1, cred->caller_garray, size);
 			sau_update_groups(instance, ctx, garray, cred->caller_glen + 1);
 			free(garray);

--- a/src/nfs-ganesha/saunafs_internal.c
+++ b/src/nfs-ganesha/saunafs_internal.c
@@ -1,20 +1,23 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
 /*
+
    Copyright 2023 Leil Storage OÜ
 
-   This file is part of SaunaFS.
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 3 of the License, or (at your option) any later version.
 
-   SaunaFS is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, version 3.
-
-   SaunaFS is distributed in the hope that it will be useful,
+   This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
 
-   You should have received a copy of the GNU General Public License
-   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
- */
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301 USA
+*/
 
 #include "fsal_convert.h"
 #include "pnfs_utils.h"

--- a/src/nfs-ganesha/saunafs_internal.c
+++ b/src/nfs-ganesha/saunafs_internal.c
@@ -46,7 +46,7 @@ sau_context_t *createContext(sau_t *instance, struct user_cred *cred) {
 
 			memcpy(garray + 1, cred->caller_garray, size);
 			sau_update_groups(instance, ctx, garray, cred->caller_glen + 1);
-			free(garray);
+			gsh_free(garray);
 		}
 	}
 

--- a/src/nfs-ganesha/saunafs_internal.c
+++ b/src/nfs-ganesha/saunafs_internal.c
@@ -22,17 +22,15 @@
 #include "fsal_convert.h"
 #include "pnfs_utils.h"
 
-#include "saunafs_internal.h"
+#include "nfs-ganesha/saunafs_internal.h"
 
 sau_context_t *createContext(sau_t *instance, struct user_cred *cred) {
 	if (cred == NULL) {
 		return sau_create_user_context(0, 0, 0, 0);
 	}
 
-	uid_t uid = (cred->caller_uid == op_ctx->export_perms.anonymous_uid)
-	        ? 0 : cred->caller_uid;
-	gid_t gid = (cred->caller_gid == op_ctx->export_perms.anonymous_gid)
-	        ? 0 : cred->caller_gid;
+	uid_t uid = (cred->caller_uid == op_ctx->export_perms.anonymous_uid) ? 0 : cred->caller_uid;
+	gid_t gid = (cred->caller_gid == op_ctx->export_perms.anonymous_gid) ? 0 : cred->caller_gid;
 
 	sau_context_t *ctx = sau_create_user_context(uid, gid, 0, 0);
 	if (!ctx) {

--- a/src/nfs-ganesha/saunafs_internal.h
+++ b/src/nfs-ganesha/saunafs_internal.h
@@ -1,20 +1,23 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
 /*
+
    Copyright 2023 Leil Storage OÜ
 
-   This file is part of SaunaFS.
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 3 of the License, or (at your option) any later version.
 
-   SaunaFS is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, version 3.
-
-   SaunaFS is distributed in the hope that it will be useful,
+   This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
 
-   You should have received a copy of the GNU General Public License
-   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
- */
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301 USA
+*/
 
 #pragma once
 

--- a/src/nfs-ganesha/saunafs_internal.h
+++ b/src/nfs-ganesha/saunafs_internal.h
@@ -21,7 +21,6 @@
 
 #pragma once
 
-#include "FSAL/fsal_localfs.h"
 #include "saunafs_fsal_types.h"
 
 sau_context_t *createContext(sau_t *instance, struct user_cred *cred);
@@ -29,25 +28,22 @@ sau_context_t *createContext(sau_t *instance, struct user_cred *cred);
 void exportOperationsInit(struct export_ops *ops);
 void handleOperationsInit(struct fsal_obj_ops *ops);
 
-/* Functions for allocating/deleting handles */
-struct SaunaFSHandle *allocateHandle(const struct stat *attribute,
-                                     struct SaunaFSExport *export);
-
+// Functions for allocating/deleting handles
+struct SaunaFSHandle *allocateHandle(const struct stat *attribute, struct SaunaFSExport *export);
 void deleteHandle(struct SaunaFSHandle *object);
 
 // Functions for ACL
-fsal_status_t getACL(struct SaunaFSExport *export, inode_t inode,
-                     uint32_t ownerId, fsal_acl_t **acl);
+fsal_status_t getACL(struct SaunaFSExport *export, inode_t inode, uint32_t ownerId,
+                     fsal_acl_t **acl);
+fsal_status_t setACL(struct SaunaFSExport *export, inode_t inode, const fsal_acl_t *acl,
+                     unsigned int mode);
 
-fsal_status_t setACL(struct SaunaFSExport *export, inode_t inode,
-                     const fsal_acl_t *acl, unsigned int mode);
-
-/* Functions for handling errors */
+// Functions for handling errors
 fsal_status_t saunafsToFsalError(sau_err_t errorCode);
 fsal_status_t fsalLastError(void);
 nfsstat4 nfs4LastError(void);
 
-/* Functions for pNFS */
+// Functions for pNFS
 void pnfsMdsOperationsInit(struct fsal_ops *ops);
 void exportOperationsPnfs(struct export_ops *ops);
 

--- a/src/nfs-ganesha/saunafs_internal.h
+++ b/src/nfs-ganesha/saunafs_internal.h
@@ -1,8 +1,19 @@
-/**
- * @file   saunafs_internal.h
- * @author Crash <crash@leil.io>
- *
- * @brief Function definitions for SaunaFS FSAL
+/*
+   Copyright 2023 Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
  */
 
 #pragma once
@@ -15,7 +26,7 @@ sau_context_t *createContext(sau_t *instance, struct user_cred *cred);
 void exportOperationsInit(struct export_ops *ops);
 void handleOperationsInit(struct fsal_obj_ops *ops);
 
-/// Functions for allocating/deleting handles
+/* Functions for allocating/deleting handles */
 struct SaunaFSHandle *allocateHandle(const struct stat *attribute,
                                      struct SaunaFSExport *export);
 
@@ -28,12 +39,12 @@ fsal_status_t getACL(struct SaunaFSExport *export, inode_t inode,
 fsal_status_t setACL(struct SaunaFSExport *export, inode_t inode,
                      const fsal_acl_t *acl, unsigned int mode);
 
-// Functions for handling errors
+/* Functions for handling errors */
 fsal_status_t saunafsToFsalError(sau_err_t errorCode);
 fsal_status_t fsalLastError(void);
 nfsstat4 nfs4LastError(void);
 
-// Functions for pNFS
+/* Functions for pNFS */
 void pnfsMdsOperationsInit(struct fsal_ops *ops);
 void exportOperationsPnfs(struct export_ops *ops);
 

--- a/tests/ci_build/ganesha/Dockerfile
+++ b/tests/ci_build/ganesha/Dockerfile
@@ -20,9 +20,9 @@ HEALTHCHECK --interval=30s --timeout=3s \
 
 FROM base AS ganesha-builder
 
-ARG GANESHA_VERSION=4.3
+ARG GANESHA_VERSION=6.5
 ENV GANESHA_VERSION=${GANESHA_VERSION}
-ARG NTIRPC_VERSION=4.3
+ARG NTIRPC_VERSION=6.3
 ENV NTIRPC_VERSION=${NTIRPC_VERSION}
 
 # install ganesha from sources
@@ -98,6 +98,8 @@ RUN set -e ; \
     mkdir -p /tmp/dependencies; \
     find /usr/ -name ganesha.nfsd -type f -exec ldd {} \; | \
         grep -oP '(/usr)?(/local)?/lib(64)?/.*\s' | sed 's/\s*$//' | sort -u | \
+        xargs -I{} cp -v --parents {} /tmp/dependencies; \
+    find /usr/ -name 'libboost_*.so*' -type f | grep -oP '(/usr)?(/local)?/lib(64)?/.*' | sort -u | \
         xargs -I{} cp -v --parents {} /tmp/dependencies;
 
 FROM base AS dbus
@@ -138,6 +140,7 @@ COPY --from=ganesha-builder /etc/ganesha /etc/ganesha
 COPY --from=ganesha-builder /usr/lib/ganesha /usr/lib/ganesha
 COPY --from=ganesha-builder /tmp/dependencies/lib /lib
 COPY --from=ganesha-builder /tmp/dependencies/lib64 /lib64
+COPY --from=ganesha-builder /tmp/dependencies/usr/lib /usr/lib
 
 RUN set -e ; \
     apt update; \

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_allocate_large_file.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_allocate_large_file.sh
@@ -27,9 +27,6 @@ create_ganesha_pid_file
 cd ${info[mount0]}
 
 cat <<EOF > ${info[mount0]}/ganesha.conf
-NFS_KRB5 {
-	Active_krb5=false;
-}
 NFSV4 {
 	Grace_Period = 5;
 }

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_append_data_until_exhausting_space.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_append_data_until_exhausting_space.sh
@@ -27,9 +27,6 @@ create_ganesha_pid_file
 cd ${info[mount0]}
 
 cat <<EOF > ${info[mount0]}/ganesha.conf
-NFS_KRB5 {
-	Active_krb5=false;
-}
 NFSV4 {
 	Grace_Period = 5;
 }

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_concurrent_shared_and_exclusive_locks.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_concurrent_shared_and_exclusive_locks.sh
@@ -1,10 +1,12 @@
-timeout_set 2 minutes
+timeout_set 1 minute
 
 USE_RAMDISK=YES \
 	setup_local_empty_saunafs info
 
 test_error_cleanup() {
 	cd ${TEMP_DIR}
+	# Kill any remaining posixlockcmd processes
+	pkill -f posixlockcmd 2>/dev/null || true
 	sudo umount -l ${TEMP_DIR}/mnt/ganesha
 	sudo pkill -9 ganesha.nfsd
 }
@@ -49,10 +51,6 @@ function assert_operation_performed() {
 	assert_eventually_prints "$1" "sed -n ${operations}p ${TEMP_DIR}/posixlock.log"
 }
 
-function assert_operation_not_performed() {
-	assert_eventually_prints "" "sed -n ${1}p ${TEMP_DIR}/posixlock.log"
-}
-
 function readlock() {
 	posixlockcmd $1 r $2 $3 >> "${TEMP_DIR}/posixlock.log" &
 	assert_operation_performed "read  open:   $1"
@@ -67,49 +65,97 @@ function unlock() {
 	kill -s SIGUSR1 $1
 }
 
+# helper to assert master-level lock state (order-independent)
+#
+# manage-locks <master ip> <master port> [list/unlock] [flock/posix/all]
+locks_active_count() {
+	saunafs_admin_master manage-locks list posix --porcelain --active | wc -l
+}
+
+assert_active_eq() {
+	local expected="$1"
+	local actual=$(($(locks_active_count) - 1))  # Subtract header line
+	if [ "$actual" -eq "$expected" ]; then
+		echo "✓ Active locks: $actual (expected: $expected)"
+		return 0
+	else
+		echo "✗ Expected $expected active locks, got $actual"
+		test_error_cleanup
+		return 1
+	fi
+}
+
 declare -a sharedLocks
 declare -a exclusiveLocks
-
-declare -a lockIndexes=(1 2 3)
 
 # Go to the Ganesha mount point
 cd "${TEMP_DIR}/mnt/ganesha"
 
-# Acquire 3 shared locks on [100, 200]
-for i in "${lockIndexes[@]}"; do
-	readlock "dir/file_test" 100 100
-	sharedLocks[$i]=$!
-	assert_operation_performed "read  lock:   dir/file_test"
-done
+echo "Acquire a shared lock on the range [0, 100] in dir/file_test"
+readlock "dir/file_test" 0 100
+sharedLocks[1]=$!
+assert_operation_performed "read  lock:   dir/file_test"
 
-# Attempt exclusive lock on [100, 200] (should block/fail)
-writelock "dir/file_test" 100 100
+echo "Acquire an exclusive lock on the range [200, 300] in dir/file_test"
+writelock "dir/file_test" 200 100
 exclusiveLocks[1]=$!
-assert_operation_not_performed $((operations+1)) # Should not acquire
-
-# Release shared locks
-for i in "${lockIndexes[@]}"; do
-	unlock "${sharedLocks[$i]}"
-	assert_operation_performed "read  unlock: dir/file_test"
-done
-
-# Now exclusive lock should be acquired
 assert_operation_performed "write lock:   dir/file_test"
 
-# Attempt shared lock while exclusive lock is held (should block/fail)
-readlock "dir/file_test" 100 100
-sharedLocks[4]=$!
-assert_operation_not_performed $((operations+1)) # Should not acquire
+# Verify 2 locks are active: one shared lock and an exclusive one
+assert_active_eq 2
+saunafs_admin_master manage-locks list posix --porcelain --active
 
-# Release exclusive lock
+# Acquire a shared lock on [200, 250] (should block/fail due to overlapping with exclusive lock)
+echo "Attempt to acquire a shared lock on the range [200, 250] in dir/file_test"
+readlock "dir/file_test" 200 50
+sharedLocks[2]=$!
+
+# Wait a little bit for the server to queue the shared lock
+sleep 2
+
+# Verify 2 locks are active: one shared lock and an exclusive one
+assert_active_eq 2
+saunafs_admin_master manage-locks list posix --porcelain --active
+
+# In Ganesha v6.5, sometimes reopen_func is not called on time by all the threads.
+# This prevents the renewal of the fd, making the fcntl() function to fail at the
+# moment of releasing the exclusive lock. This behavior makes the test flaky.
+# Reading the file triggers a reopen_func and a renewal of the fd, reducing the likelihood
+# of the previous flaky behavior.
+md5sum dir/file_test > /dev/null
+
+echo "Release exclusive lock on the range [200, 300] in dir/file_test"
 unlock "${exclusiveLocks[1]}"
 assert_operation_performed "write unlock: dir/file_test"
 
-# Now shared lock should be acquired
+# After releasing exclusive lock, second shared lock should be acquired
 assert_operation_performed "read  lock:   dir/file_test"
 
-# Release shared lock
-unlock "${sharedLocks[4]}"
+# Wait a little bit for the server to process the lock/unlock operations
+sleep 2
+
+# Verify there are 2 active shared locks
+assert_active_eq 2
+saunafs_admin_master manage-locks list posix --porcelain --active
+
+echo "Release shared lock on the range [0, 100] in dir/file_test"
+unlock "${sharedLocks[1]}"
 assert_operation_performed "read  unlock: dir/file_test"
+
+# Wait a little bit for the server to process the lock/unlock operations
+sleep 2
+
+# Verify only 1 lock is active (the shared one)
+assert_active_eq 1
+saunafs_admin_master manage-locks list posix --porcelain --active
+
+echo "Release shared lock on the range [200, 250] in dir/file_test"
+unlock "${sharedLocks[2]}"
+assert_operation_performed "read  unlock: dir/file_test"
+
+# Final verification
+assert_active_eq 0
+saunafs_admin_master manage-locks list posix --porcelain --active
+echo "Concurrent locking test passed successfully!!!"
 
 test_error_cleanup

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_connectathon_nfs_suite.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_connectathon_nfs_suite.sh
@@ -30,7 +30,9 @@ cd ${info[mount0]}
 
 cat <<EOF > ${info[mount0]}/ganesha.conf
 NFSV4 {
-	Grace_Period = 5;
+	Grace_Period = 10;
+	Lease_Lifetime = 20;
+	Delegations = false;        # Reduce recall/stateid churn
 }
 EXPORT
 {
@@ -53,15 +55,17 @@ EXPORT
 	}
 }
 SaunaFS {
-	PNFS_DS = true;
-	PNFS_MDS = true;
+	PNFS_DS = false;
+	PNFS_MDS = false;
 }
 EOF
 
 sudo /usr/bin/ganesha.nfsd -f ${info[mount0]}/ganesha.conf
 
 check_rpc_service
-sudo mount -vvvv localhost:/data $TEMP_DIR/mnt/ganesha
+# Hardened mount: single TCP connection, long timeouts so the client retries LOCK/LOCKU
+# instead of surfacing EIO
+sudo mount -t nfs -o hard,timeo=600,retrans=2,nconnect=1 -vvvv localhost:/data $TEMP_DIR/mnt/ganesha
 
 mkdir ${TEMP_DIR}/mnt/ganesha/cthon_tests
 export NFSTESTDIR="${TEMP_DIR}/mnt/ganesha/cthon_tests"

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_connectathon_nfs_suite.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_connectathon_nfs_suite.sh
@@ -63,11 +63,11 @@ sudo /usr/bin/ganesha.nfsd -f ${info[mount0]}/ganesha.conf
 check_rpc_service
 sudo mount -vvvv localhost:/data $TEMP_DIR/mnt/ganesha
 
-# Run connectathon nfs suite
-cd $TEMP_DIR/mnt/ganesha
+mkdir ${TEMP_DIR}/mnt/ganesha/cthon_tests
+export NFSTESTDIR="${TEMP_DIR}/mnt/ganesha/cthon_tests"
 
-mkdir cthon_tests
-export NFSTESTDIR=$TEMP_DIR/mnt/ganesha/cthon_tests
+# Run connectathon nfs suite
+cd ${TEMP_DIR}
 
 git clone https://github.com/leil-io/cthon04.git
 cd cthon04

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_connectathon_nfs_suite.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_connectathon_nfs_suite.sh
@@ -29,9 +29,6 @@ create_ganesha_pid_file
 cd ${info[mount0]}
 
 cat <<EOF > ${info[mount0]}/ganesha.conf
-NFS_KRB5 {
-	Active_krb5=false;
-}
 NFSV4 {
 	Grace_Period = 5;
 }

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_copy_file.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_copy_file.sh
@@ -28,9 +28,6 @@ create_ganesha_pid_file
 cd ${info[mount0]}
 
 cat <<EOF > ${info[mount0]}/ganesha.conf
-NFS_KRB5 {
-	Active_krb5=false;
-}
 NFSV4 {
 	Grace_Period = 5;
 }

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_copy_file_without_enough_space.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_copy_file_without_enough_space.sh
@@ -27,9 +27,6 @@ create_ganesha_pid_file
 cd ${info[mount0]}
 
 cat <<EOF > ${info[mount0]}/ganesha.conf
-NFS_KRB5 {
-	Active_krb5=false;
-}
 NFSV4 {
 	Grace_Period = 5;
 }

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_dbench.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_dbench.sh
@@ -18,9 +18,6 @@ create_ganesha_pid_file
 cd ${info[mount0]}
 
 cat <<EOF > ${info[mount0]}/ganesha.conf
-NFS_KRB5 {
-	Active_krb5=false;
-}
 NFSV4 {
 	Grace_Period = 5;
 }

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_file_corruption_on_master_failover.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_file_corruption_on_master_failover.sh
@@ -41,9 +41,6 @@ create_ganesha_pid_file
 cd "${info[mount0]}"
 
 cat <<EOF > "${info[mount0]}/ganesha.conf"
-NFS_KRB5 {
-	Active_krb5=false;
-}
 NFSV4 {
 	Grace_Period = ${grace_period};
 	Lease_Lifetime = ${grace_period};

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_fio_random_mix_reads_writes.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_fio_random_mix_reads_writes.sh
@@ -32,9 +32,6 @@ create_ganesha_pid_file
 cd ${info[mount0]}
 
 cat <<EOF > ${info[mount0]}/ganesha.conf
-NFS_KRB5 {
-	Active_krb5=false;
-}
 NFSV4 {
 	Grace_Period = 5;
 }
@@ -75,7 +72,7 @@ cd ${TEMP_DIR}/mnt/ganesha
 
 # Run fio random mix of read and write on top of Ganesha Client
 fio --name=fiotest_random_mix_read_write --directory=${TEMP_DIR}/mnt/ganesha \
-    --size=200M --rw=randrw --numjobs=5 --ioengine=psync --group_reporting   \
+    --size=200M --rw=randrw --numjobs=5 --ioengine=libaio --group_reporting   \
     --bs=4M --direct=1 --iodepth=1
 
 echo ""

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_fio_random_reads.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_fio_random_reads.sh
@@ -32,9 +32,6 @@ create_ganesha_pid_file
 cd ${info[mount0]}
 
 cat <<EOF > ${info[mount0]}/ganesha.conf
-NFS_KRB5 {
-	Active_krb5=false;
-}
 NFSV4 {
 	Grace_Period = 5;
 }

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_fio_random_writes.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_fio_random_writes.sh
@@ -32,9 +32,6 @@ create_ganesha_pid_file
 cd ${info[mount0]}
 
 cat <<EOF > ${info[mount0]}/ganesha.conf
-NFS_KRB5 {
-	Active_krb5=false;
-}
 NFSV4 {
 	Grace_Period = 5;
 }

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_fio_sequential_mix_reads_writes.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_fio_sequential_mix_reads_writes.sh
@@ -33,9 +33,6 @@ create_ganesha_pid_file
 cd ${info[mount0]}
 
 cat <<EOF > ${info[mount0]}/ganesha.conf
-NFS_KRB5 {
-	Active_krb5=false;
-}
 NFSV4 {
 	Grace_Period = 5;
 }
@@ -76,7 +73,7 @@ cd ${TEMP_DIR}/mnt/ganesha
 
 # Run fio sequential mix of read and write on top of Ganesha Client
 fio --name=fiotest_seq_mix_read_write --directory=${TEMP_DIR}/mnt/ganesha \
-    --size=200M --rw=rw --numjobs=5 --ioengine=psync --group_reporting    \
+    --size=200M --rw=rw --numjobs=5 --ioengine=libaio --group_reporting    \
     --bs=4M --direct=1 --iodepth=1
 
 echo ""

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_fio_sequential_reads.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_fio_sequential_reads.sh
@@ -33,9 +33,6 @@ create_ganesha_pid_file
 cd ${info[mount0]}
 
 cat <<EOF > ${info[mount0]}/ganesha.conf
-NFS_KRB5 {
-	Active_krb5=false;
-}
 NFSV4 {
 	Grace_Period = 5;
 }

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_fio_sequential_writes.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_fio_sequential_writes.sh
@@ -34,9 +34,6 @@ create_ganesha_pid_file
 cd ${info[mount0]}
 
 cat <<EOF > ${info[mount0]}/ganesha.conf
-NFS_KRB5 {
-	Active_krb5=false;
-}
 NFSV4 {
 	Grace_Period = 5;
 }

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_iozone.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_iozone.sh
@@ -19,9 +19,6 @@ create_ganesha_pid_file
 cd ${info[mount0]}
 
 cat <<EOF > ${info[mount0]}/ganesha.conf
-NFS_KRB5 {
-	Active_krb5=false;
-}
 NFSV4 {
 	Grace_Period = 5;
 	Lease_Lifetime = 5;

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_pynfs.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_pynfs.sh
@@ -11,9 +11,6 @@ create_ganesha_pid_file
 cd ${info[mount0]}
 
 cat <<EOF > ${info[mount0]}/ganesha.conf
-NFS_KRB5 {
-	Active_krb5=false;
-}
 NFSV4 {
 	Grace_Period = 5;
 	Lease_Lifetime = 5;

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_small_files.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_small_files.sh
@@ -16,9 +16,6 @@ create_ganesha_pid_file
 cd ${info[mount0]}
 
 cat <<EOF > ${info[mount0]}/ganesha.conf
-NFS_KRB5 {
-	Active_krb5=false;
-}
 NFSV4 {
 	Grace_Period = 5;
 	Lease_Lifetime = 5;

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_truncate_file_to_big_size.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_truncate_file_to_big_size.sh
@@ -27,9 +27,6 @@ create_ganesha_pid_file
 cd ${info[mount0]}
 
 cat <<EOF > ${info[mount0]}/ganesha.conf
-NFS_KRB5 {
-	Active_krb5=false;
-}
 NFSV4 {
 	Grace_Period = 5;
 }

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_vs_linux_client_dd_read.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_vs_linux_client_dd_read.sh
@@ -32,9 +32,6 @@ create_ganesha_pid_file
 cd ${info[mount0]}
 
 cat <<EOF > ${info[mount0]}/ganesha.conf
-NFS_KRB5 {
-	Active_krb5=false;
-}
 NFSV4 {
 	Grace_Period = 5;
 }

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_vs_linux_client_dd_write.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_vs_linux_client_dd_write.sh
@@ -33,9 +33,6 @@ create_ganesha_pid_file
 cd ${info[mount0]}
 
 cat <<EOF > ${info[mount0]}/ganesha.conf
-NFS_KRB5 {
-	Active_krb5=false;
-}
 NFSV4 {
 	Grace_Period = 5;
 }

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_vs_linux_client_random_mix_rw.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_vs_linux_client_random_mix_rw.sh
@@ -34,9 +34,6 @@ create_ganesha_pid_file
 cd ${info[mount0]}
 
 cat <<EOF > ${info[mount0]}/ganesha.conf
-NFS_KRB5 {
-	Active_krb5=false;
-}
 NFSV4 {
 	Grace_Period = 5;
 }

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_vs_linux_client_sequential_read.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_vs_linux_client_sequential_read.sh
@@ -34,9 +34,6 @@ create_ganesha_pid_file
 cd ${info[mount0]}
 
 cat <<EOF > ${info[mount0]}/ganesha.conf
-NFS_KRB5 {
-	Active_krb5=false;
-}
 NFSV4 {
 	Grace_Period = 5;
 }

--- a/tests/test_suites/GaneshaTests/test_nfs_ganesha_vs_linux_client_sequential_write.sh
+++ b/tests/test_suites/GaneshaTests/test_nfs_ganesha_vs_linux_client_sequential_write.sh
@@ -34,9 +34,6 @@ create_ganesha_pid_file
 cd ${info[mount0]}
 
 cat <<EOF > ${info[mount0]}/ganesha.conf
-NFS_KRB5 {
-	Active_krb5=false;
-}
 NFSV4 {
 	Grace_Period = 5;
 }


### PR DESCRIPTION
This PR upgrades the SaunaFS FSAL from Ganesha v4.3 (EOL) to Ganesha v6.5 (current stable).
Ganesha v4.x is already unsupported and will soon disappear from major Linux distributions, making this migration essential for long-term compatibility.

**Summary of changes**

This PR introduces several categories of modifications:

**1) FSAL API / compatibility updates**

- Adapted FSAL sources to new v6.5 APIs and lifecycle hooks.
- Added explicit calls to `fsal_start_io()` and `fsal_complete_io()` to manage file descriptors around read/write operations.
- These functions are new in v6.5 and ensure async I/O operations are tracked, cancellable, and properly integrated with Ganesha.
- In v4.3, I/O went directly to the FSAL without these lifecycle steps.
- Updated function signatures, headers, and error handling to align with Ganesha v6.5 expectations.

**2) Licensing**

- Re-licensed the SaunaFS FSAL under LGPLv3 to match Ganesha’s current licensing terms.

This ensures compatibility with upstream and simplifies future syncs.

**3) CI / build system**

- Updated GitHub Actions pipelines to build and test against Ganesha v6.5.
- Adjusted build flags and dependencies accordingly.

**4) Tests**

- Fixed or stabilized tests that broke after the migration, mostly due to:
   - Different async I/O timing introduced in v6.5.
   - Stricter lock and delegation semantics.
   - Removal of support for running `git clone` on an NFS mountpoint, which required adjustments in the cthon test.
- Enhanced logging and added helper utilities to reduce flakiness and simplify debugging.

**5) Code quality**

- Applied consistent formatting and reduced responsibilities in several functions for clarity.
- Integrated upstream FSAL patches that were missing from our repo to stay in sync with community fixes.

Co-authored-by: Urmas Rist <<urmas@leil.io>>
Signed-off-by: Crash <<crash@leil.io>>