### PR TITLE
fix: Fix Windows compilation issues about charts

### DIFF
--- a/src/common/charts.cc
+++ b/src/common/charts.cc
@@ -36,7 +36,9 @@
 #include <sys/time.h>
 #include <time.h>
 #include <unistd.h>
+#ifndef _WIN32
 #include <csignal>
+#endif
 #include <string>
 
 #include "common/crc.h"
@@ -1999,6 +2001,7 @@ void charts_get_png(uint8_t *buff) {
 	compsize=0;
 }
 
+#ifndef _WIN32
 int initializeTimerSignalHandlers(void (*handler)(int)) {
 	struct sigaction signalAction{};
 	sigemptyset(&signalAction.sa_mask);
@@ -2021,3 +2024,4 @@ int initializeTimerSignalHandlers(void (*handler)(int)) {
 
 	return 0;
 }
+#endif

--- a/src/common/charts.h
+++ b/src/common/charts.h
@@ -144,9 +144,11 @@ void charts_store (void);
 int charts_init (const uint32_t *calcs,const statdef *stats,const estatdef *estats,const char *filename);
 void charts_term (void);
 
+#ifndef _WIN32
 /**
  * @brief Initializes timer signal handlers for SIGPROF and SIGVTALRM
  * @param handler Signal handler function to install
  * @return 0 on success, -1 on error
  */
 int initializeTimerSignalHandlers(void (*handler)(int));
+#endif


### PR DESCRIPTION
Recent changes to charts.cc and charts.h caused compilation issues on
Windows due to using POSIX-specific signal handling functions. This
commit removes the problematic from Windows builds.

Signed-off-by: Dave <dave@leil.io>