### PR TITLE
feat(mount): Add IO details to .stats hidden file

### DIFF
--- a/src/mount/readdata.cc
+++ b/src/mount/readdata.cc
@@ -44,6 +44,7 @@
 #include "mount/notification_area_logging.h"
 #include "mount/readahead_adviser.h"
 #include "mount/readdata_cache.h"
+#include "mount/stats.h"
 #include "mount/tweaks.h"
 #include "protocol/SFSCommunication.h"
 #include "slogger/slogger.h"
@@ -64,6 +65,48 @@ constexpr uint32_t kMinCacheExpirationTime = 1;
 constexpr uint32_t kMinTryCounterToShowReadErrorMessage = 9;
 constexpr int64_t kDelayedOpsTimeout_us = 166667;
 constexpr int64_t kMinDelayedOpsSleepTime_us = 50000;
+
+enum class ReadStats : uint8_t {
+	SERVED_READ_BYTES,       ///< Total number of bytes read (served from cache or requested)
+	REQ_READ_BYTES,          ///< Total number of bytes actually read from chunkservers
+	CACHE_HITS_BYTES,        ///< Number of bytes read from cache
+	REQ_TO_SATISFY_BYTES,    ///< Number of bytes that had to be requested to satisfy read
+	READ_FROM_CACHE,         ///< Number of read operations satisfied from cache
+	READ_FROM_REQUESTED,     ///< Number of read operations satisfied with upcoming requests
+	READ_FROM_NEW_REQ,       ///< Number of read operations satisfied with a new request
+	NON_EXPIRED_RREC,        ///< Number of current non-expired read records
+	TOTAL_WAIT_TIME_ms,      ///< Total time spent waiting for read operations to complete
+	ACTIVE_WORKERS_TIME_ms,  ///< Sum of time read workers were actively reading
+	STATNODES
+};
+
+static std::vector<uint64_t *> statsPtr(static_cast<uint8_t>(ReadStats::STATNODES));
+
+void readStatsInit() {
+	statsnode *s = stats_get_subnode(nullptr, "read_details", 0);
+	auto init_stat = [&](ReadStats stat, const char *name) {
+		statsPtr[static_cast<uint8_t>(stat)] = stats_get_counterptr(stats_get_subnode(s, name, 0));
+	};
+
+	init_stat(ReadStats::SERVED_READ_BYTES, "served_read_bytes");
+	init_stat(ReadStats::REQ_READ_BYTES, "req_read_bytes");
+	init_stat(ReadStats::CACHE_HITS_BYTES, "cache_hits_bytes");
+	init_stat(ReadStats::REQ_TO_SATISFY_BYTES, "req_to_satisfy_bytes");
+	init_stat(ReadStats::READ_FROM_CACHE, "read_from_cache");
+	init_stat(ReadStats::READ_FROM_REQUESTED, "read_from_requested");
+	init_stat(ReadStats::READ_FROM_NEW_REQ, "read_from_new_req");
+	init_stat(ReadStats::NON_EXPIRED_RREC, "non_expired_rrec");
+	init_stat(ReadStats::TOTAL_WAIT_TIME_ms, "total_wait_time_ms");
+	init_stat(ReadStats::ACTIVE_WORKERS_TIME_ms, "active_workers_time_ms");
+}
+
+void statsAdd(ReadStats type, int64_t value = 1) {
+	if (value < 0) {
+		::stats_dec(static_cast<uint8_t>(type), statsPtr, static_cast<uint64_t>(-value));
+		return;
+	}
+	::stats_inc(static_cast<uint8_t>(type), statsPtr, static_cast<uint64_t>(value));
+}
 
 std::unique_ptr<IMemoryInfo> createMemoryInfo() {
     std::unique_ptr<IMemoryInfo> memoryInfo;
@@ -232,6 +275,8 @@ bool ReadaheadOperationsManager::request(
 	if (!result.empty() && result.frontOffset() <= offset &&
 	    offset + size <= result.endOffset()) {
 		// this query can be directly served from cache
+		statsAdd(ReadStats::READ_FROM_CACHE);
+		statsAdd(ReadStats::CACHE_HITS_BYTES, fuseSize);
 		addExtraRequests_(rrec, offset, recommendedSize, result.endOffset());
 		return false;
 	}
@@ -243,6 +288,9 @@ bool ReadaheadOperationsManager::request(
 	}
 
 	uint64_t cachedOffset = result.empty() ? offset : result.endOffset();
+	if (cachedOffset > static_cast<uint64_t>(fuseOffset)) {
+		statsAdd(ReadStats::CACHE_HITS_BYTES, cachedOffset - fuseOffset);
+	}
 
 	// check if this data is already in process
 	uint64_t maximumRequestedOffset =
@@ -252,6 +300,7 @@ bool ReadaheadOperationsManager::request(
 	if (maximumRequestedOffset == offset + size) {
 		// this query can be directly served after succeeding at some
 		// pending read requests
+		statsAdd(ReadStats::READ_FROM_REQUESTED);
 		addExtraRequests_(rrec, offset, recommendedSize,
 		                  maximumRequestedOffset);
 		return true;
@@ -274,6 +323,10 @@ bool ReadaheadOperationsManager::request(
 	// Let's check if we very recently finished the request we've been waiting
 	// for
 	if (!result.back()->done) {
+		statsAdd(ReadStats::READ_FROM_NEW_REQ);
+		if (maximumRequestedOffset < offset + size) {
+			statsAdd(ReadStats::REQ_TO_SATISFY_BYTES, offset + size - maximumRequestedOffset);
+		}
 		rcvpPtr = addRequest_(rrec, result.back(), 0);
 	}
 
@@ -532,10 +585,12 @@ void* read_worker(void *arg) {
 		request->state = ReadaheadRequestState::kProcessing;
 
 		uint64_t bytes_read = 0;
+		Timer readTimer;
 		int error_code =
 		    read_to_buffer(readRecord, request->request_offset(),
 		                   request->bytes_to_read_left(), entry->buffer,
 		                   &bytes_read, reader, entryLock);
+		statsAdd(ReadStats::ACTIVE_WORKERS_TIME_ms, readTimer.elapsed_ms());
 
 		entry->release();
 		entry->reset_timer();
@@ -583,6 +638,7 @@ ReadRecord *read_data_new(inode_t inode) {
 
 	gActiveReadRecords.emplace(inode, rrec);
 
+	statsAdd(ReadStats::NON_EXPIRED_RREC, +1);
 	return rrec;
 }
 
@@ -594,6 +650,7 @@ void read_data_end(ReadRecord *rrec) {
 
 	std::unique_lock gMutexLock(gMutex);
 	rrec->expired = true;
+	statsAdd(ReadStats::NON_EXPIRED_RREC, -1);
 }
 
 void read_data_init(uint32_t retries,
@@ -618,6 +675,8 @@ void read_data_init(uint32_t retries,
 	// remain valid until the program terminates.
 	gReadCacheEntriesPool = std::make_unique<ReadCacheEntriesPool>(read_buffers_expiration_time_ms);
 	clear_active_read_records();
+
+	readStatsInit();
 
 	maxRetries = retries;
 	gChunkserverConnectTimeout_ms = chunkserverConnectTimeout_ms;
@@ -837,6 +896,7 @@ int read_to_buffer(ReadRecord *rrec, uint64_t current_offset, uint64_t bytes_to_
 			try_counter++;
 		}
 	}
+	statsAdd(ReadStats::REQ_READ_BYTES, *bytes_read);
 	return SAUNAFS_STATUS_OK;
 }
 
@@ -861,27 +921,37 @@ int read_data(ReadRecord *rrec, off_t fuseOffset, size_t fuseSize,
 		inodeLock.unlock();
 
 		if (insertedEntry != nullptr) {
+			statsAdd(ReadStats::READ_FROM_NEW_REQ);
 			std::unique_lock entryLock(insertedEntry->mutex);
 			uint64_t requestOffset = result.remainingOffset();
 			uint64_t bytesToReadLeft = round_up_to_blocksize(
 			    size - (requestOffset - offset));
+			statsAdd(ReadStats::REQ_TO_SATISFY_BYTES, bytesToReadLeft);
+			if (requestOffset > offset) {
+				statsAdd(ReadStats::CACHE_HITS_BYTES, requestOffset - fuseOffset);
+			}
 
 			ChunkReader reader(gChunkConnector, gBandwidthOveruse);
 
 			uint64_t bytesRead = 0;
 
+			Timer readTimer;
 			int errorCode = read_to_buffer(rrec,
 			                               requestOffset,
 			                               bytesToReadLeft,
 			                               result.inputBuffer(),
 			                               &bytesRead,
 			                               reader, entryLock);
+			statsAdd(ReadStats::TOTAL_WAIT_TIME_ms, readTimer.elapsed_ms());
 			result.back()->done = true;
 
 			if (errorCode != SAUNAFS_STATUS_OK) {
 				result.inputBuffer().clear();
 				return errorCode;
 			}
+		} else {
+			statsAdd(ReadStats::READ_FROM_CACHE);
+			statsAdd(ReadStats::CACHE_HITS_BYTES, fuseSize);
 		}
 	} else {
 		// use the read operations manager to process the request
@@ -896,7 +966,9 @@ int read_data(ReadRecord *rrec, off_t fuseOffset, size_t fuseSize,
 			auto requestPtr = rcvpPtr->requestPtr;
 			auto waitingCVPtr = rcvpPtr->cvPtr;
 
+			Timer waitTimer;
 			waitingCVPtr->wait(inodeLock);
+			statsAdd(ReadStats::TOTAL_WAIT_TIME_ms, waitTimer.elapsed_ms());
 
 			int error_code = requestPtr->error_code;
 			if (error_code != SAUNAFS_STATUS_OK) {
@@ -906,5 +978,6 @@ int read_data(ReadRecord *rrec, off_t fuseOffset, size_t fuseSize,
 	}
 
 	ret = std::move(result);
+	statsAdd(ReadStats::SERVED_READ_BYTES, fuseSize);
 	return SAUNAFS_STATUS_OK;
 }

--- a/src/mount/stats.cc
+++ b/src/mount/stats.cc
@@ -180,9 +180,9 @@ void stats_inc(uint8_t id, std::vector<uint64_t *> &statsptr, uint64_t inc) {
 	}
 }
 
-void stats_dec(uint8_t id, std::vector<uint64_t *> &statsptr) {
+void stats_dec(uint8_t id, std::vector<uint64_t *> &statsptr, uint64_t dec) {
 	if (id < statsptr.size()) {
 		std::lock_guard lock(glock);
-		(*statsptr[id])--;
+		(*statsptr[id]) -= dec;
 	}
 }

--- a/src/mount/stats.h
+++ b/src/mount/stats.h
@@ -43,4 +43,4 @@ void stats_reset_all(void);
 void stats_show_all(char **buff, uint32_t *leng);
 void stats_term(void);
 void stats_inc(uint8_t id, std::vector<uint64_t *> &statsptr, uint64_t inc = 1);
-void stats_dec(uint8_t id, std::vector<uint64_t *> &statsptr);
+void stats_dec(uint8_t id, std::vector<uint64_t *> &statsptr, uint64_t dec = 1);

--- a/src/mount/writedata.cc
+++ b/src/mount/writedata.cc
@@ -56,6 +56,7 @@
 #include "mount/mastercomm.h"
 #include "mount/mount_info.h"
 #include "mount/readdata.h"
+#include "mount/stats.h"
 #include "mount/tweaks.h"
 #include "mount/notification_area_logging.h"
 #include "mount/write_cache_block.h"
@@ -65,6 +66,64 @@
 #define IDLE_CONNECTION_TIMEOUT 6
 #define NO_INODEDATA nullptr
 #define NO_CHUNKDATA nullptr
+
+enum class WriteStats : uint8_t {
+	CACHED_BYTES,            ///< Total number of bytes written to cache
+	FREE_CACHE_AVG_kb,       ///< Average number of free cache KB in last few seconds
+	TOTAL_FLUSH_TIME_ms,     ///< Total time spent waiting for flush to complete
+	ACTIVE_WORKERS_TIME_ms,  ///< Sum of time write workers were actively writing
+	STATNODES
+};
+
+// Around 2s of history with usual granularity (kTicksPerSecond = 10)
+constexpr uint32_t kFCBHistorySize = 20;
+static std::list<uint64_t> gFCBHistory;
+std::atomic<uint64_t> gCachedBytes = 0;
+static std::vector<uint64_t *> statsPtr(static_cast<uint8_t>(WriteStats::STATNODES));
+
+static void writeStatsInit() {
+	statsnode *s = stats_get_subnode(nullptr, "write_details", 0);
+	auto init_stat = [&](WriteStats stat, const char *name) {
+		statsPtr[static_cast<uint8_t>(stat)] = stats_get_counterptr(stats_get_subnode(s, name, 0));
+	};
+
+	init_stat(WriteStats::CACHED_BYTES, "cached_bytes");
+	init_stat(WriteStats::FREE_CACHE_AVG_kb, "free_cache_avg_kb");
+	init_stat(WriteStats::TOTAL_FLUSH_TIME_ms, "total_flush_time_ms");
+	init_stat(WriteStats::ACTIVE_WORKERS_TIME_ms, "active_workers_time_ms");
+}
+
+static void statsAdd(WriteStats type, int64_t value = 1) {
+	if (value < 0) {
+		::stats_dec(static_cast<uint8_t>(type), statsPtr, static_cast<uint64_t>(-value));
+		return;
+	}
+	::stats_inc(static_cast<uint8_t>(type), statsPtr, static_cast<uint64_t>(value));
+}
+
+static void updateStats(uint32_t freeCacheBlocks) {
+	// Update FCB average
+	gFCBHistory.push_back(freeCacheBlocks);
+
+	if (gFCBHistory.size() > kFCBHistorySize) {
+		gFCBHistory.pop_front();
+	}
+
+	int64_t prevAvg = *statsPtr[static_cast<uint8_t>(WriteStats::FREE_CACHE_AVG_kb)];
+	int64_t newAvg = 0;
+	for (const auto &v : gFCBHistory) {
+		newAvg += v;
+	}
+	newAvg *= (SFSBLOCKSIZE / 1024);  // in KB
+	newAvg /= gFCBHistory.size();
+
+	if (prevAvg != newAvg) {
+		statsAdd(WriteStats::FREE_CACHE_AVG_kb, newAvg - prevAvg);
+	}
+
+	// Update cached bytes
+	statsAdd(WriteStats::CACHED_BYTES, gCachedBytes.exchange(0));
+}
 
 static bool gUseInodeBasedWriteAlgorithm = false;
 
@@ -316,6 +375,10 @@ void *delayed_queue_worker(void *) {
 				++it;
 			}
 		}
+
+		// Update the write stats
+		updateStats(freecacheblocks);
+
 		lock.unlock();
 		usleep(timeout.remaining_us());
 	}
@@ -678,7 +741,9 @@ void *write_worker(void *) {
 
 		// process the job
 		LOG_AVG_TILL_END_OF_SCOPE0("write_worker#working");
+		Timer writeTimer;
 		inodeDataWriter.processJob((inodedata *)data);
+		statsAdd(WriteStats::ACTIVE_WORKERS_TIME_ms, writeTimer.elapsed_ms());
 	}
 	return NULL;
 }
@@ -700,6 +765,8 @@ void write_data_init(uint32_t cachesize, uint32_t retries, uint32_t workers,
 
 	freecacheblocks = cacheblockcount;
 	gCachePerInodePercentage = cachePerInodePercentage;
+
+	writeStatsInit();
 
 	jobsQueue = std::make_unique<ProducerConsumerQueue>(0, deleterByType<inodedata>);
 
@@ -783,6 +850,8 @@ int write_blocks(inodedata *id, uint64_t offset, uint32_t size, const uint8_t *d
 			if (write_block(id, chindx, pos, from, SFSBLOCKSIZE, data) < 0) {
 				return SAUNAFS_ERROR_IO;
 			}
+
+			gCachedBytes += (SFSBLOCKSIZE - from);
 			size -= (SFSBLOCKSIZE - from);
 			data += (SFSBLOCKSIZE - from);
 			from = 0;
@@ -795,6 +864,8 @@ int write_blocks(inodedata *id, uint64_t offset, uint32_t size, const uint8_t *d
 			if (write_block(id, chindx, pos, from, from + size, data) < 0) {
 				return SAUNAFS_ERROR_IO;
 			}
+
+			gCachedBytes += size;
 			size = 0;
 		}
 	}
@@ -860,6 +931,7 @@ void *write_data_new(inode_t inode) {
 }
 
 static int write_data_flush(void *vid, Glock &lock) {
+	Timer flushTimer;
 	inodedata *id = (inodedata *)vid;
 	if (id == NULL) { return SAUNAFS_ERROR_IO; }
 
@@ -869,6 +941,7 @@ static int write_data_flush(void *vid, Glock &lock) {
 	// Wait for the data to be flushed
 	while (id->inqueue) { id->flushcond.wait(lock); }
 	write_data_flushwaiting_decrease(id, lock);
+	statsAdd(WriteStats::TOTAL_FLUSH_TIME_ms, flushTimer.elapsed_ms());
 	return id->status;
 }
 
@@ -1366,6 +1439,10 @@ void *delayed_queue_worker(void *) {
 			}
 		}
 		globalLock.unlock();
+
+		// Update the write stats
+		updateStats(freecacheblocks);
+
 		usleep(timeout.remaining_us());
 	}
 	return NULL;
@@ -1742,7 +1819,9 @@ void *write_worker(void *) {
 
 		// process the job
 		LOG_AVG_TILL_END_OF_SCOPE0("write_worker#working");
+		Timer writeTimer;
 		chunkJobWriter.processJob((ChunkData *)data);
+		statsAdd(WriteStats::ACTIVE_WORKERS_TIME_ms, writeTimer.elapsed_ms());
 	}
 	return NULL;
 }
@@ -1764,6 +1843,8 @@ void write_data_init(uint32_t cachesize, uint32_t retries, uint32_t workers,
 
 	freecacheblocks = cacheblockcount;
 	gCachePerInodePercentage = cachePerInodePercentage;
+
+	writeStatsInit();
 
 	jobsQueue = std::make_unique<ProducerConsumerQueue>(0, deleterByType<ChunkData>);
 
@@ -1871,6 +1952,8 @@ int write_blocks(inodedata *id, uint64_t offset, uint32_t size, const uint8_t *d
 				chunkData->writesCount--;
 				return SAUNAFS_ERROR_IO;
 			}
+
+			gCachedBytes += (SFSBLOCKSIZE - from);
 			size -= (SFSBLOCKSIZE - from);
 			data += (SFSBLOCKSIZE - from);
 			from = 0;
@@ -1884,6 +1967,8 @@ int write_blocks(inodedata *id, uint64_t offset, uint32_t size, const uint8_t *d
 				chunkData->writesCount--;
 				return SAUNAFS_ERROR_IO;
 			}
+
+			gCachedBytes += size;
 			size = 0;
 		}
 		chunkData->writesCount--;
@@ -1971,6 +2056,7 @@ void *write_data_new(inode_t inode) {
 
 /* globalLock: LOCKED */
 static int write_data_flush(void *vid, Lock &globalLock) {
+	Timer flushTimer;
 	inodedata *id = (inodedata *)vid;
 	if (id == NO_INODEDATA) { return SAUNAFS_ERROR_IO; }
 	globalLock.unlock();
@@ -1998,6 +2084,7 @@ static int write_data_flush(void *vid, Lock &globalLock) {
 	inodeLock.unlock();
 
 	globalLock.lock();
+	statsAdd(WriteStats::TOTAL_FLUSH_TIME_ms, flushTimer.elapsed_ms());
 	return id->status;
 }
 


### PR DESCRIPTION
This commit adds the following entries to the .stats hidden file:
- read_details.active_workers_time_ms
- read_details.total_wait_time_ms
- read_details.non_expired_rrec
- read_details.read_from_new_req
- read_details.read_from_requested
- read_details.read_from_cache
- read_details.req_to_satisfy_bytes
- read_details.cache_hits_bytes
- read_details.req_read_bytes
- read_details.served_read_bytes
- write_details.active_workers_time_ms
- write_details.total_flush_time_ms
- write_details.free_cache_blocks_avg
- write_details.cached_bytes

Main goal is to the have a better idea of the IO algorithms behavior 
without extra debugging

Signed-off-by: Dave <dave@leil.io>