### PR TITLE
fix(cmake): Use Release as build type in its preset

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -102,6 +102,7 @@
             "name": "release",
             "binaryDir": "${sourceDir}/build/saunafs/release",
             "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release",
                 "CMAKE_INSTALL_PREFIX": "/",
                 "ENABLE_TESTS": "OFF",
                 "ENABLE_WERROR": "OFF",


### PR DESCRIPTION
Previously, the `release` configure preset inherited `RelWithDebInfo` as its build type. This commit changes it to `Release`.

Co-authored-by: Urmas Rist <urmas@leil.io>

Signed-off-by: guillex <guillex@leil.io>