### PR TITLE
fix(vcpkg): Make baseline update optional

### DIFF
--- a/utils/vcpkg_install.sh
+++ b/utils/vcpkg_install.sh
@@ -1,18 +1,66 @@
 #!/usr/bin/env bash
 set -xeu -o pipefail
 
-# Set the baseline for the verioning
-vcpkg x-update-baseline --add-initial-baseline
+## This script installs the dependencies specified in vcpkg.json
+## and pins the versions of those dependencies.
+## Usually, you should run `vcpkg install` on a daily basis,
+## and this script should be run after updating the dependencies in vcpkg.json
+
+usage() {
+  cat <<EOF
+Usage: $0 [-u|--update-baseline]
+
+Options:
+  -u, --update-baseline  Update the baseline for versioning
+
+Examples:
+  $0
+  $0 -u
+EOF
+}
+
+: "${UPDATE_BASELINE:=false}"
+
+die() {	echo "Error: $@" >&2; exit 1; }
+
+if ! command -v jq >/dev/null 2>&1; then
+  die "jq is not found. Please install jq."
+fi
+
+if [ ! -f "vcpkg.json" ]; then
+	die "vcpkg.json not found"
+fi
+
+while [ -n "${1:-}" ]; do
+	case "${1}" in
+	-u|--update-baseline)
+		UPDATE_BASELINE=true
+		shift
+		;;
+	-h|--help)
+		usage
+		exit 0
+		;;
+	*)
+		usage
+		exit 1
+		;;
+	esac
+done
+
+if [ "${UPDATE_BASELINE}" = "true" ]; then
+	# Set the baseline for the versioning
+	vcpkg x-update-baseline --add-initial-baseline
+fi
 
 # Install dependencies specified in vcpkg.json
-# vcpkg install
 vcpkg install --x-asset-sources=clear --binarysource=clear --x-install-root=./vcpkg_installed
 
 # Pin the dependencies versions
 # Get the versions from the current list of installed packages
 overrides_attribute="$(vcpkg list --x-json | jq -c '[.[] | {name:.package_name,version}]')"
 if [ "${overrides_attribute}" == "[]" ]; then
-	exit 0
+	die "No dependencies found"
 fi
 # Remove the overrides attribute from the vcpkg.json file
 mv vcpkg.json vcpkg.json.bak

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -8,8 +8,8 @@
     "boost-system",
     "fmt",
     "gtest",
-    "spdlog",
-    "prometheus-cpp"
+    "prometheus-cpp",
+    "spdlog"
   ],
   "overrides": [
     {
@@ -285,6 +285,10 @@
       "version": "1.0.8"
     },
     {
+      "name": "civetweb",
+      "version": "1.16"
+    },
+    {
       "name": "fmt",
       "version": "11.0.2"
     },
@@ -295,6 +299,10 @@
     {
       "name": "liblzma",
       "version": "5.6.3"
+    },
+    {
+      "name": "prometheus-cpp",
+      "version": "1.3.0"
     },
     {
       "name": "spdlog",
@@ -319,10 +327,6 @@
     {
       "name": "zstd",
       "version": "1.5.6"
-    },
-    {
-      "name": "prometheus-cpp",
-      "version": "1.3.0"
     }
   ]
 }


### PR DESCRIPTION
The vcpkg_install.sh script is intended to pin the package versions for achieving reproducible environments. It also sets the version baseline for packaging. However, updating the baseline each time could potentially break builds.

This commit allows safer execution of the script by making baseline updates optional and disabled by default.