### PR TITLE
fix: Extend support for alarm and profiling signals

### DIFF
--- a/src/chunkserver/chartsdata.cc
+++ b/src/chunkserver/chartsdata.cc
@@ -139,13 +139,6 @@ static const estatdef estatdefs[]=ESTATDEFS
 
 static struct itimerval it_set;
 
-// Signal handler that prevents process termination from timer signals
-static void timerSignalHandler(int /*signal*/) {
-	// Reset both timers to prevent future signals from killing the process
-	setitimer(ITIMER_PROF, &it_set, nullptr);
-	setitimer(ITIMER_VIRTUAL, &it_set, nullptr);
-}
-
 inline uint32_t toMicroSeconds(struct itimerval &itimer) {
     return itimer.it_value.tv_sec * 1000000 + itimer.it_value.tv_usec;
 }
@@ -276,7 +269,7 @@ void chartsdata_store(void) {
 	charts_store();
 }
 
-int chartsdata_init(void) {
+int chartsdata_init() {
 	struct itimerval userTime, procTime;
 
 	it_set.it_interval.tv_sec = 0;
@@ -284,19 +277,11 @@ int chartsdata_init(void) {
 	it_set.it_value.tv_sec = 999;
 	it_set.it_value.tv_usec = 999999;
 
-	// Install timer signal handlers for SIGVTALRM and SIGPROF
-	if (initializeTimerSignalHandlers(timerSignalHandler) != 0) {
-		safs::log_err("{} failed to initialize timer signal handlers", __func__);
-		return -1;
-	}
-
 	setitimer(ITIMER_VIRTUAL, &it_set, &userTime); // user time
 	setitimer(ITIMER_PROF, &it_set, &procTime);    // user time + system time
 
-	eventloop_timeregister(TIMEMODE_RUN_LATE, SECONDS_IN_ONE_MINUTE, 0,
-	                       chartsdata_refresh);
-	eventloop_timeregister(TIMEMODE_RUN_LATE, SECONDS_IN_ONE_HOUR, 0,
-	                       chartsdata_store);
+	eventloop_timeregister(TIMEMODE_RUN_LATE, SECONDS_IN_ONE_MINUTE, 0, chartsdata_refresh);
+	eventloop_timeregister(TIMEMODE_RUN_LATE, SECONDS_IN_ONE_HOUR, 0, chartsdata_store);
 	eventloop_destructregister(chartsdata_term);
 	return charts_init(calcdefs, statdefs, estatdefs, CHARTS_FILENAME);
 }

--- a/src/chunkserver/chartsdata.h
+++ b/src/chunkserver/chartsdata.h
@@ -25,4 +25,4 @@
 #define SECONDS_IN_ONE_MINUTE 60
 #define SECONDS_IN_ONE_HOUR   3600
 
-int chartsdata_init(void);
+int chartsdata_init();

--- a/src/common/charts.cc
+++ b/src/common/charts.cc
@@ -2000,28 +2000,3 @@ void charts_get_png(uint8_t *buff) {
 	}
 	compsize=0;
 }
-
-#ifndef _WIN32
-int initializeTimerSignalHandlers(void (*handler)(int)) {
-	struct sigaction signalAction{};
-	sigemptyset(&signalAction.sa_mask);
-	signalAction.sa_handler = handler;
-	signalAction.sa_flags = SA_RESTART;  // Automatically restart interrupted system calls
-
-	// Handle SIGPROF (ITIMER_PROF - signal 27)
-	if (sigaction(SIGPROF, &signalAction, nullptr) == -1) {
-		safs::log_err("{}: failed to install SIGPROF handler using sigaction with error {}",
-		              __func__, strerror(errno));
-		return -1;
-	}
-
-	// Handle SIGVTALRM (ITIMER_VIRTUAL - signal 26)
-	if (sigaction(SIGVTALRM, &signalAction, nullptr) == -1) {
-		safs::log_err("{}: failed to install SIGVTALRM handler using sigaction with error {}",
-		              __func__, strerror(errno));
-		return -1;
-	}
-
-	return 0;
-}
-#endif

--- a/src/common/charts.h
+++ b/src/common/charts.h
@@ -143,12 +143,3 @@ void charts_add (uint64_t *data,uint32_t datats);
 void charts_store (void);
 int charts_init (const uint32_t *calcs,const statdef *stats,const estatdef *estats,const char *filename);
 void charts_term (void);
-
-#ifndef _WIN32
-/**
- * @brief Initializes timer signal handlers for SIGPROF and SIGVTALRM
- * @param handler Signal handler function to install
- * @return 0 on success, -1 on error
- */
-int initializeTimerSignalHandlers(void (*handler)(int));
-#endif

--- a/src/main/main.cc
+++ b/src/main/main.cc
@@ -132,6 +132,13 @@ static void signal_pipe_serv(const std::vector<pollfd> &pdesc) {
 			} else if (sigid=='\003') {
 				safs_pretty_syslog(LOG_NOTICE, "Received SIGUSR1, killing gently...");
 				exit(SAUNAFS_EXIT_STATUS_GENTLY_KILL);
+			} else if (sigid == '\004') {
+				safs_pretty_syslog(LOG_NOTICE, "Received SIGPROF signal");
+			} else if (sigid == '\005') {
+				safs_pretty_syslog(LOG_NOTICE, "Received SIGVTALRM signal");
+			} else if (sigid == '\006') {
+				// Disabling logging for SIGALRM to avoid bunch of logs triggered by
+				// SignalLoopWatchdog class
 			}
 		}
 	}
@@ -250,6 +257,21 @@ static int ignoresignal[]={
 	-1
 };
 
+static int timerSignalCodes[]={
+#ifndef GPERFTOOLS
+#ifdef SIGALRM
+	SIGALRM,
+#endif
+#ifdef SIGVTALRM
+	SIGVTALRM,
+#endif
+#ifdef SIGPROF
+	SIGPROF,
+#endif
+#endif
+	-1
+};
+
 static int exitsignal[]={
 #if defined(SIGUSR1) && defined(ENABLE_EXIT_ON_USR1)
 	SIGUSR1,
@@ -275,6 +297,29 @@ void reloadhandle(int signo) {
 void exithandle(int signo) {
 	signo = write(signalpipe[1],"\003",1); // see above
 	(void)signo;
+}
+
+void alarmSignalsHandler(int signo) {
+#ifndef GPERFTOOLS
+	ssize_t bytesWritten = 0;
+#ifdef SIGPROF
+	if (signo == SIGPROF) {
+		bytesWritten = write(signalpipe[1], "\004", 1);  // see above
+	}
+#endif
+#ifdef SIGVTALRM
+	if (signo == SIGVTALRM) {
+		bytesWritten = write(signalpipe[1], "\005", 1);  // see above
+	}
+#endif
+#ifdef SIGALRM
+	if (signo == SIGALRM) {
+		bytesWritten = write(signalpipe[1], "\006", 1);  // see above
+	}
+#endif
+	(void)bytesWritten;  // Prevent compiler warning
+#endif
+	(void)signo;  // Prevent compiler warning
 }
 
 void set_signal_handlers(int daemonflag) {
@@ -305,6 +350,10 @@ void set_signal_handlers(int daemonflag) {
 	sa.sa_handler = SIG_IGN;
 	for (i=0 ; ignoresignal[i]>0 ; i++) {
 		sigaction(ignoresignal[i],&sa,(struct sigaction *)0);
+	}
+	sa.sa_handler = alarmSignalsHandler;
+	for (i = 0; timerSignalCodes[i] > 0; i++) {
+		sigaction(timerSignalCodes[i], &sa, (struct sigaction *)0);
 	}
 	sa.sa_handler = daemonflag?SIG_IGN:termhandle;
 	for (i=0 ; daemonignoresignal[i]>0 ; i++) {

--- a/src/master/chartsdata.cc
+++ b/src/master/chartsdata.cc
@@ -144,14 +144,6 @@ static const estatdef estatdefs[]=ESTATDEFS
 
 #ifdef CPU_USAGE
 static struct itimerval it_set;
-
-// Signal handler that prevents process termination from timer signals
-static void timerSignalHandler(int /*signal*/) {
-	// Reset both timers to prevent future signals from killing the process
-	setitimer(ITIMER_PROF, &it_set, nullptr);
-	setitimer(ITIMER_VIRTUAL, &it_set, nullptr);
-}
-
 #endif
 
 #ifdef MEMORY_USAGE
@@ -263,9 +255,9 @@ void chartsdata_store(void) {
 	charts_store();
 }
 
-int chartsdata_init (void) {
+int chartsdata_init() {
 #ifdef CPU_USAGE
-	struct itimerval uc,pc;
+	struct itimerval uc, pc;
 #endif
 #ifdef MEMORY_USAGE
 	struct rusage ru;
@@ -277,17 +269,11 @@ int chartsdata_init (void) {
 	it_set.it_value.tv_sec = 999;
 	it_set.it_value.tv_usec = 999999;
 
-	// Install timer signal handlers for SIGVTALRM and SIGPROF
-	if (initializeTimerSignalHandlers(timerSignalHandler) != 0) {
-		safs::log_err("{} failed to initialize timer signal handlers", __func__);
-		return -1;
-	}
-
-	setitimer(ITIMER_VIRTUAL,&it_set,&uc);             // user time
-	setitimer(ITIMER_PROF,&it_set,&pc);                // user time + system time
+	setitimer(ITIMER_VIRTUAL, &it_set, &uc);  // user time
+	setitimer(ITIMER_PROF, &it_set, &pc);     // user time + system time
 #endif
 #ifdef MEMORY_USAGE
-	getrusage(RUSAGE_SELF,&ru);
+	getrusage(RUSAGE_SELF, &ru);
 #  ifdef __APPLE__
 	memusage = ru.ru_maxrss;
 #  else
@@ -295,8 +281,8 @@ int chartsdata_init (void) {
 #  endif
 #endif
 
-	eventloop_timeregister(TIMEMODE_RUN_LATE,60,0,chartsdata_refresh);
-	eventloop_timeregister(TIMEMODE_RUN_LATE,3600,0,chartsdata_store);
+	eventloop_timeregister(TIMEMODE_RUN_LATE, 60, 0, chartsdata_refresh);
+	eventloop_timeregister(TIMEMODE_RUN_LATE, 3600, 0, chartsdata_store);
 	eventloop_destructregister(chartsdata_term);
-	return charts_init(calcdefs,statdefs,estatdefs,CHARTS_FILENAME);
+	return charts_init(calcdefs, statdefs, estatdefs, CHARTS_FILENAME);
 }

--- a/src/master/chartsdata.h
+++ b/src/master/chartsdata.h
@@ -25,4 +25,4 @@
 #include <cstdint>
 
 uint64_t chartsdata_memusage(void);
-int chartsdata_init (void);
+int chartsdata_init ();

--- a/tests/test_suites/SanityChecks/test_handle_sigprof_sigalrm_and_sigvtalrm.sh
+++ b/tests/test_suites/SanityChecks/test_handle_sigprof_sigalrm_and_sigvtalrm.sh
@@ -35,13 +35,17 @@ assert_eventually "saunafs_shadow_synchronized 1"
 touch "${info[mount0]}"/test_file_before_signals
 assert_eventually "saunafs_shadow_synchronized 1"
 
-# Test SIGPROF and SIGVTALRM on shadow master
+# Add a metalogger
+saunafs_metalogger_daemon start
+
+# Test SIGPROF, SIGVTALRM and SIGALRM on shadow master
 shadow_pid=$(saunafs_master_n 1 test | sed 's/.*: //')
 assert_matches "^[0-9]+$" "$shadow_pid"
 
 echo "Testing shadow master signal handling (PID: ${shadow_pid})"
 validate_signal_handling "shadow_master" "${shadow_pid}" "SIGPROF"
 validate_signal_handling "shadow_master" "${shadow_pid}" "SIGVTALRM"
+validate_signal_handling "shadow_master" "${shadow_pid}" "SIGALRM"
 
 # Test signals on primary master
 master_pid=$(saunafs_master_daemon test | sed 's/.*: //')
@@ -50,6 +54,7 @@ assert_matches "^[0-9]+$" "$master_pid"
 echo "Testing primary master signal handling (PID: ${master_pid})"
 validate_signal_handling "primary_master" "${master_pid}" "SIGPROF"
 validate_signal_handling "primary_master" "${master_pid}" "SIGVTALRM"
+validate_signal_handling "primary_master" "${master_pid}" "SIGALRM"
 
 # Test signals on chunkserver
 chunkserver_pid=$(saunafs_chunkserver_daemon 0 test | sed 's/.*pid: //')
@@ -58,6 +63,16 @@ assert_matches "^[0-9]+$" "$chunkserver_pid"
 echo "Testing chunkserver signal handling (PID: ${chunkserver_pid})"
 validate_signal_handling "chunkserver" "${chunkserver_pid}" "SIGPROF"
 validate_signal_handling "chunkserver" "${chunkserver_pid}" "SIGVTALRM"
+validate_signal_handling "chunkserver" "${chunkserver_pid}" "SIGALRM"
+
+# Test signals on metalogger
+metalogger_pid=$(saunafs_metalogger_daemon test | sed 's/.*: //')
+assert_matches "^[0-9]+$" "$metalogger_pid"
+
+echo "Testing metalogger signal handling (PID: ${metalogger_pid})"
+validate_signal_handling "metalogger" "${metalogger_pid}" "SIGPROF"
+validate_signal_handling "metalogger" "${metalogger_pid}" "SIGVTALRM"
+validate_signal_handling "metalogger" "${metalogger_pid}" "SIGALRM"
 
 # Verify all components are still functional after signal testing
 echo "Verifying system functionality after signal testing..."


### PR DESCRIPTION
Previously, SaunaFS handled alarm and profiling signals inconsistently across modules. The master supported SIGPROF, SIGALRM, and SIGVTALRM, but chunkserver only handled SIGPROF and SIGVTALRM, while metalogger only handled SIGALRM.

This commit unifies and improves signal handling by:
- Introducing global handlers for alarm and profiling signals.
- Adding SIGALRM support in all modules (previously missing in chunkserver).
- Extending tests to cover SIGALRM and validate handling in metalogger.