### PR TITLE
chore(setup): Skip FoundationDB install for WSL1

### DIFF
--- a/tests/setup_machine.sh
+++ b/tests/setup_machine.sh
@@ -196,7 +196,11 @@ if [ ! -f /etc/sudoers.d/saunafstest ] || ! grep -q '# FoundationDB' /etc/sudoer
 fi
 
 echo ; echo 'Install FoundationDB'
-"$script_dir/ci_build/install-foundationdb.sh"
+if grep -q Microsoft /proc/version && ! grep -q microsoft-standard /proc/version; then
+	echo "Running on WSL1: skipping FoundationDB installation."
+else
+	"$script_dir/ci_build/install-foundationdb.sh"
+fi
 
 echo ; echo 'Fixing GIDs of users'
 for name in saunafstest saunafstest_{0..9}; do


### PR DESCRIPTION
WSL1 lacks full Linux kernel compatibility, which prevents FoundationDB from running as expected. This caused failures in the testing environment's setup script during Windows client testing environment's configuration. This commit fixes the issue by skipping the FoundationDB installation step when a WSL1 environment is detected.