### PR TITLE
fix: Fix trimmed .stats hidden file

### DIFF
--- a/src/mount/special_getattr.cc
+++ b/src/mount/special_getattr.cc
@@ -22,6 +22,7 @@
 
 #include "mount/client_common.h"
 #include "mount/special_inode.h"
+#include "mount/stats.h"
 
 using namespace SaunaClient;
 
@@ -44,6 +45,7 @@ static AttrReply getattr(const Context &ctx, char (&attrstr)[256]) {
 	struct stat o_stbuf;
 	memset(&o_stbuf, 0, sizeof(struct stat));
 	attr_to_stat(inode_, attr, &o_stbuf);
+	o_stbuf.st_size = stats_get_length();
 	stats_inc(OP_GETATTR);
 	makeattrstr(attrstr, 256, &o_stbuf);
 	oplog_printf(ctx, "getattr (%" PRIiNode ") (internal node: STATS): OK (3600,%s)",

--- a/src/mount/special_inode.cc
+++ b/src/mount/special_inode.cc
@@ -36,9 +36,16 @@ const Attributes InodeMasterInfo::attr =
 #endif
 const inode_t InodeMasterInfo::inode_ = SPECIAL_INODE_MASTERINFO;
 
-// 0x01A4 == 0b110100100 == 0644
-const Attributes InodeStats::attr =
-	  {{'f', 0x01,0xA4, 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,1, 0,0,0,0,0,0,0,0}};
+// Win: 0x01B6 == 0b110110110 == 0666
+// Other OSs: 0x01A4 == 0b110100100 == 0644
+const Attributes InodeStats::attr = [] {
+	Attributes attrs{{'f', 0x01, 0xA4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+	                  0,   0,    0,    0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0}};
+#ifdef _WIN32
+	attrs[2] = 0xB6;
+#endif
+	return attrs;
+}();
 const inode_t InodeStats::inode_ = SPECIAL_INODE_STATS;
 
 // Win: 0x0124 == 0b100100100 == 0444

--- a/src/mount/special_lookup.cc
+++ b/src/mount/special_lookup.cc
@@ -22,6 +22,7 @@
 
 #include "mount/client_common.h"
 #include "mount/special_inode.h"
+#include "mount/stats.h"
 
 using namespace SaunaClient;
 
@@ -54,6 +55,7 @@ static EntryParam lookup(const Context &ctx, inode_t parent, const char *name,
 	e.attr_timeout = 3600.0;
 	e.entry_timeout = 3600.0;
 	attr_to_stat(inode_, attr, &e.attr);
+	e.attr.st_size = stats_get_length();
 	stats_inc(OP_LOOKUP_INTERNAL);
 	makeattrstr(attrstr, 256, &e.attr);
 	oplog_printf(ctx, "lookup (%" PRIiNode ",%s) (internal node: STATS): OK (%.1f,%" PRIiNode ",%.1f,%s)",

--- a/src/mount/stats.cc
+++ b/src/mount/stats.cc
@@ -32,6 +32,8 @@ static statsnode *firstnode = NULL;
 static uint32_t allactiveplengs = 0;
 static uint32_t activenodes = 0;
 static std::mutex glock;
+// Overhead for ": %" PRIu64 "\n" (2 for ": " + 20 for uint64_t + 1 for '\n')
+constexpr uint32_t per_line_overhead = 23;
 
 statsnode* stats_get_subnode(statsnode *node, const char *name, uint8_t absolute) {
 	std::lock_guard lock(glock);
@@ -143,9 +145,14 @@ static inline uint32_t stats_print_total(char *buff, uint32_t maxleng) {
 void stats_show_all(char **buff, uint32_t *leng) {
 	std::lock_guard lock(glock);
 
-	uint32_t rl = allactiveplengs + 23 * activenodes + 1;
+	uint32_t rl = allactiveplengs + per_line_overhead * activenodes + 1;
 	*buff = (char*) malloc(rl);
 	*leng = *buff ? stats_print_total(*buff,rl) : 0;
+}
+
+uint64_t stats_get_length() {
+	std::lock_guard lock(glock);
+	return allactiveplengs + per_line_overhead * activenodes + 1;
 }
 
 void stats_free(statsnode *n) {

--- a/src/mount/stats.h
+++ b/src/mount/stats.h
@@ -41,6 +41,7 @@ statsnode* stats_get_subnode(statsnode *node, const char *name, uint8_t absolute
 uint64_t* stats_get_counterptr(statsnode *node);
 void stats_reset_all(void);
 void stats_show_all(char **buff, uint32_t *leng);
+uint64_t stats_get_length();
 void stats_term(void);
 void stats_inc(uint8_t id, std::vector<uint64_t *> &statsptr, uint64_t inc = 1);
 void stats_dec(uint8_t id, std::vector<uint64_t *> &statsptr, uint64_t dec = 1);

--- a/tests/setup_machine.sh
+++ b/tests/setup_machine.sh
@@ -115,6 +115,7 @@ if ! [[ -f /etc/sudoers.d/saunafstest ]] || \
 		ALL ALL = NOPASSWD: /bin/rm -rf /tmp/saunafs_error_dir
 		saunafstest ALL = NOPASSWD: /bin/sh -c echo\ 1\ >\ /proc/sys/vm/drop_caches
 		saunafstest ALL = NOPASSWD: /usr/bin/cat .oplog
+		saunafstest ALL = NOPASSWD: /usr/bin/tee .stats
 	END
 	chmod 0440 /etc/sudoers.d/saunafstest
 fi

--- a/tests/test_suites/SanityChecks/test_write_and_read.sh
+++ b/tests/test_suites/SanityChecks/test_write_and_read.sh
@@ -1,8 +1,11 @@
 timeout_set 70 seconds
 
+WRITE_CACHE_SIZE_mb=128
+ONE_TO_NINE=123456789
+
 CHUNKSERVERS=23 \
 	USE_RAMDISK=YES \
-	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER" \
+	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER,sfswritecachesize=${WRITE_CACHE_SIZE_mb}" \
 	CHUNKSERVER_EXTRA_CONFIG="READ_AHEAD_KB = 1024|MAX_READ_BEHIND_KB = 2048" \
 	MASTER_CUSTOM_GOALS="8 ec_4_17: \$ec(4,17)"
 	setup_local_empty_saunafs info
@@ -10,28 +13,55 @@ CHUNKSERVERS=23 \
 cd ${info[mount0]}
 
 mkdir dir_std
-FILE_SIZE=123456789 BLOCK_SIZE=12345 file-generate dir_std/file
+FILE_SIZE="${ONE_TO_NINE}" BLOCK_SIZE=12345 file-generate dir_std/file
 if ! file-validate dir_std/file; then
 	test_add_failure "Data read from file is different than written"
 fi
 
 mkdir dir_xor
 saunafs setgoal -r xor2 dir_xor
-FILE_SIZE=123456789 BLOCK_SIZE=12345 file-generate dir_xor/file
+FILE_SIZE="${ONE_TO_NINE}" BLOCK_SIZE=12345 file-generate dir_xor/file
 if ! file-validate dir_xor/file; then
 	test_add_failure "Data read from file is different than written"
 fi
 
 mkdir dir_ec
 saunafs setgoal -r ec32 dir_ec
-FILE_SIZE=123456789 BLOCK_SIZE=12345 file-generate dir_ec/file
+FILE_SIZE="${ONE_TO_NINE}" BLOCK_SIZE=12345 file-generate dir_ec/file
 if ! file-validate dir_ec/file; then
 	test_add_failure "Data read from file is different than written"
 fi
 
 mkdir dir_turbo_ec
 saunafs setgoal -r ec_4_17 dir_turbo_ec
-FILE_SIZE=123456789 BLOCK_SIZE=12345 file-generate dir_turbo_ec/file
+FILE_SIZE="${ONE_TO_NINE}" BLOCK_SIZE=12345 file-generate dir_turbo_ec/file
 if ! file-validate dir_turbo_ec/file; then
 	test_add_failure "Data read from file is different than written"
 fi
+
+total_files_size=$((ONE_TO_NINE * 4))
+# Checks some stats
+cat .stats > "${TEMP_DIR}/stats_results"
+
+req_read_bytes=$(grep 'read_details.req_read_bytes' "${TEMP_DIR}/stats_results" | awk '{print $2}')
+assert_less_than "$((total_files_size - 1))" "${req_read_bytes}"
+served_read_bytes=$(grep 'read_details.served_read_bytes' "${TEMP_DIR}/stats_results" \
+	| awk '{print $2}')
+assert_less_than "$((total_files_size - 1))" "${served_read_bytes}"
+read_from_new_req=$(grep 'read_details.read_from_new_req' "${TEMP_DIR}/stats_results" \
+	| awk '{print $2}')
+assert_less_than 3 "${read_from_new_req}"
+free_cache_avg_kb=$(grep 'write_details.free_cache_avg_kb' "${TEMP_DIR}/stats_results" \
+	| awk '{print $2}')
+assert_less_than "${free_cache_avg_kb}" $((WRITE_CACHE_SIZE_mb * 1024 + 1))
+cached_bytes=$(grep 'write_details.cached_bytes' "${TEMP_DIR}/stats_results" | awk '{print $2}')
+assert_equals "${cached_bytes}" "${total_files_size}"
+
+# Check resetting stats
+echo "Something to reset the stats" | sudo tee .stats > /dev/null
+cat .stats > "${TEMP_DIR}/stats_results"
+
+req_read_bytes=$(grep 'read_details.req_read_bytes' "${TEMP_DIR}/stats_results" | awk '{print $2}')
+assert_equals "${req_read_bytes}" 0
+cached_bytes=$(grep 'write_details.cached_bytes' "${TEMP_DIR}/stats_results" | awk '{print $2}')
+assert_equals "${cached_bytes}" 0


### PR DESCRIPTION
This PR encapsulates fixes related to the .stats hidden file. Tries to fix the trimmed output of reading it, performs some consistency check of the IO details in stats and makes sure all Windows users are able to reset the stats.

Signed-off-by: Dave <dave@leil.io>