### PR TITLE
perf: Defer metadata dumping during failover

### DIFF
--- a/src/master/deferred_metadata_dump_task.cc
+++ b/src/master/deferred_metadata_dump_task.cc
@@ -51,5 +51,13 @@ int DeferredMetadataDumpTask::execute(uint32_t /*timeStamp*/, intrusive_list<Tas
 }
 
 bool DeferredMetadataDumpTask::isFinished() const {
+	// This task is executed only once and triggers a background dump that relies on fork.
+	// Unlike other tasks (e.g., SetGoalTask, SetTrashtimeTask) that iterate through collections
+	// and track progress via iterators, this task's responsibility ends immediately after
+	// calling fs_storeall(DumpType::kBackgroundDump).
+	//
+	// The actual metadata dumping happens asynchronously in a forked child process,
+	// which is monitored separately through the metadata dumper's polling mechanism.
+	// Therefore, the task is considered finished as soon as fs_storeall() returns.
 	return true;  // Single execution task
 }

--- a/src/master/deferred_metadata_dump_task.cc
+++ b/src/master/deferred_metadata_dump_task.cc
@@ -1,0 +1,58 @@
+/*
+   Copyright 2025      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "master/deferred_metadata_dump_task.h"
+
+#include "errors/saunafs_error_codes.h"
+#include "master/metadata_dumper_interface.h"
+#include "slogger/slogger.h"
+
+DeferredMetadataDumpTask::DeferredMetadataDumpTask(IMetadataBackend *backend) : backend_(backend) {}
+
+int DeferredMetadataDumpTask::execute(uint32_t timeStamp, intrusive_list<Task> &work_queue) {
+	(void)timeStamp;   // Suppress unused parameter warning
+	(void)work_queue;  // Task doesn't create subtasks
+
+	safs::log_info("Executing deferred metadata dump");
+
+	try {
+		uint8_t result = backend_->fs_storeall(DumpType::kBackgroundDump);
+
+		if (result == SAUNAFS_ERROR_TEMP_NOTPOSSIBLE) {
+			safs::log_info(
+			    "Deferred metadata dump skipped due to periodic dump in progress - "
+			    "metadata will be captured in next periodic dump");
+			return SAUNAFS_STATUS_OK;  // Treat as success
+		}
+
+		if (result == SAUNAFS_STATUS_OK) {
+			safs::log_info("Deferred metadata dump completed successfully");
+			return SAUNAFS_STATUS_OK;
+		}
+
+		safs::log_err("Deferred metadata dump failed with result: {}", result);
+		return result;
+	} catch (const std::exception &e) {
+		safs::log_err("Deferred metadata dump failed with exception: {}", e.what());
+		return SAUNAFS_ERROR_IO;
+	}
+}
+
+bool DeferredMetadataDumpTask::isFinished() const {
+	return true;  // Single execution task
+}

--- a/src/master/deferred_metadata_dump_task.cc
+++ b/src/master/deferred_metadata_dump_task.cc
@@ -24,10 +24,7 @@
 
 DeferredMetadataDumpTask::DeferredMetadataDumpTask(IMetadataBackend *backend) : backend_(backend) {}
 
-int DeferredMetadataDumpTask::execute(uint32_t timeStamp, intrusive_list<Task> &work_queue) {
-	(void)timeStamp;   // Suppress unused parameter warning
-	(void)work_queue;  // Task doesn't create subtasks
-
+int DeferredMetadataDumpTask::execute(uint32_t /*timeStamp*/, intrusive_list<Task> & /*subTasks*/) {
 	safs::log_info("Executing deferred metadata dump");
 
 	try {

--- a/src/master/deferred_metadata_dump_task.h
+++ b/src/master/deferred_metadata_dump_task.h
@@ -27,7 +27,7 @@ class DeferredMetadataDumpTask : public TaskManager::Task {
 public:
 	DeferredMetadataDumpTask(IMetadataBackend *backend);
 
-	int execute(uint32_t timeStamp, intrusive_list<Task> &work_queue) override;
+	int execute(uint32_t /*timeStamp*/, intrusive_list<Task> &/*subTasks*/) override;
 	bool isFinished() const override;
 
 	static std::string generateDescription() { return "Deferred metadata dump (post-failover)"; }

--- a/src/master/deferred_metadata_dump_task.h
+++ b/src/master/deferred_metadata_dump_task.h
@@ -1,0 +1,37 @@
+/*
+   Copyright 2025      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "master/metadata_backend_interface.h"
+#include "master/task_manager.h"
+
+/// Task for deferred metadata dumping after failover
+/// This allows chunkservers to connect immediately while metadata dump happens in background
+class DeferredMetadataDumpTask : public TaskManager::Task {
+public:
+	DeferredMetadataDumpTask(IMetadataBackend *backend);
+
+	int execute(uint32_t timeStamp, intrusive_list<Task> &work_queue) override;
+	bool isFinished() const override;
+
+	static std::string generateDescription() { return "Deferred metadata dump (post-failover)"; }
+
+private:
+	IMetadataBackend *backend_ = nullptr;
+};

--- a/src/master/filesystem.cc
+++ b/src/master/filesystem.cc
@@ -225,6 +225,43 @@ void fs_erase_message_from_lockfile() {
 	}
 }
 
+/// @brief Executes a metadata dump operation, either immediately or deferred.
+///
+/// This function checks for the "defer-metadata-dump" option. If present, it schedules
+/// a deferred metadata dump task using the TaskManager, logging the outcome upon completion.
+/// Otherwise, it performs an immediate metadata dump after applying changelogs.
+///
+/// The deferred dump uses the global metadata backend and submits a one-time task.
+/// The immediate dump invokes the metadata backend's fs_storeall() function with a foreground dump
+/// type.
+///
+/// Logging is performed to indicate the success or failure of the operation.
+void executeMetadataDump() {
+	bool deferDump = main_has_extra_argument("defer-metadata-dump", CaseSensitivity::kIgnore);
+
+	if (deferDump) {
+		safs::log_info("Deferring metadata dump option detected");
+
+		auto *metadataBackendPtr = gMetadataBackend.get();
+		auto metadataDumpTask = std::make_unique<DeferredMetadataDumpTask>(metadataBackendPtr);
+
+		// Schedule one-time deferred metadata dump task using TaskManager
+		gMetadata->taskManager.submitTask(
+		    0, 1, metadataDumpTask.release(), DeferredMetadataDumpTask::generateDescription(),
+		    [](int status) {
+			    if (status == SAUNAFS_STATUS_OK) {
+				    safs::log_info("Deferred metadata dump completed successfully");
+			    } else {
+				    safs::log_err("Deferred metadata dump failed with status: {}", status);
+			    }
+		    });
+	} else {
+		// Original behavior: dump the new metadata immediately
+		gMetadataBackend->fs_storeall(DumpType::kForegroundDump);
+		safs::log_info("Metadata dumped successfully after applying changelogs");
+	}
+}
+
 int fs_loadall(void) {
 	fs_strinit();
 	chunk_strinit();
@@ -235,7 +272,6 @@ int fs_loadall(void) {
 	}
 
 	bool autoRecovery = fs_can_do_auto_recovery();
-	bool deferDump = main_has_extra_argument("defer-metadata-dump", CaseSensitivity::kIgnore);
 
 	if (autoRecovery || (metadataserver::getPersonality() == metadataserver::Personality::kShadow)) {
 		safs::log_info("{} - applying changelogs from {}",
@@ -251,27 +287,8 @@ int fs_loadall(void) {
 		load_changelogs();
 		safs::log_info("all needed changelogs applied successfully");
 
-		if (deferDump) {
-			safs::log_info("Deferring metadata dump option detected");
-
-			auto *metadataBackendPtr = gMetadataBackend.get();
-			auto metadataDumpTask = std::make_unique<DeferredMetadataDumpTask>(metadataBackendPtr);
-
-			// Schedule one-time deferred metadata dump task using TaskManager
-			gMetadata->taskManager.submitTask(
-			    0, 1, metadataDumpTask.release(), DeferredMetadataDumpTask::generateDescription(),
-			    [](int status) {
-				    if (status == SAUNAFS_STATUS_OK) {
-					    safs::log_info("Deferred metadata dump completed successfully");
-				    } else {
-					    safs::log_err("Deferred metadata dump failed with status: {}", status);
-				    }
-			    });
-		} else {
-			// Original behavior: dump the new metadata immediately
-			gMetadataBackend->fs_storeall(DumpType::kForegroundDump);
-			safs::log_info("Metadata dumped successfully after applying changelogs");
-		}
+		// Dump the new metadata
+		executeMetadataDump();
 
 		// Restore the original personality
 		metadataserver::setPersonality(personality);

--- a/src/master/filesystem.cc
+++ b/src/master/filesystem.cc
@@ -34,6 +34,7 @@
 #include "master/changelog.h"
 #include "master/chunks.h"
 #include "master/datacachemgr.h"
+#include "master/deferred_metadata_dump_task.h"
 #include "master/filesystem_checksum_updater.h"
 #include "master/filesystem_metadata.h"
 #include "master/filesystem_operations.h"
@@ -234,6 +235,7 @@ int fs_loadall(void) {
 	}
 
 	bool autoRecovery = fs_can_do_auto_recovery();
+	bool deferDump = main_has_extra_argument("defer-metadata-dump", CaseSensitivity::kIgnore);
 
 	if (autoRecovery || (metadataserver::getPersonality() == metadataserver::Personality::kShadow)) {
 		safs::log_info("{} - applying changelogs from {}",
@@ -249,9 +251,29 @@ int fs_loadall(void) {
 		load_changelogs();
 		safs::log_info("all needed changelogs applied successfully");
 
-		// Dump the new metadata
-		gMetadataBackend->fs_storeall(DumpType::kForegroundDump);
-		safs::log_info("Metadata dumped successfully after applying changelogs");
+		if (deferDump) {
+			safs::log_info("Deferring metadata dump option detected");
+
+			// Schedule one-time deferred metadata dump task using TaskManager
+			uint32_t delayedTime = eventloop_time() + 30;  // 30 seconds delay
+
+			auto *metadataBackendPtr = gMetadataBackend.get();
+			auto metadataDumpTask = std::make_unique<DeferredMetadataDumpTask>(metadataBackendPtr);
+
+			gMetadata->taskManager.submitTask(delayedTime, 1, metadataDumpTask.release(),
+				DeferredMetadataDumpTask::generateDescription(),
+				[](int status) {
+					if (status == SAUNAFS_STATUS_OK) {
+						safs::log_info("Deferred metadata dump completed successfully");
+					} else {
+						safs::log_err("Deferred metadata dump failed with status: {}", status);
+					}
+				});
+		} else {
+			// Original behavior: dump the new metadata immediately
+			gMetadataBackend->fs_storeall(DumpType::kForegroundDump);
+			safs::log_info("Metadata dumped successfully after applying changelogs");
+		}
 
 		// Restore the original personality
 		metadataserver::setPersonality(personality);

--- a/src/master/filesystem.cc
+++ b/src/master/filesystem.cc
@@ -254,21 +254,19 @@ int fs_loadall(void) {
 		if (deferDump) {
 			safs::log_info("Deferring metadata dump option detected");
 
-			// Schedule one-time deferred metadata dump task using TaskManager
-			uint32_t delayedTime = eventloop_time() + 30;  // 30 seconds delay
-
 			auto *metadataBackendPtr = gMetadataBackend.get();
 			auto metadataDumpTask = std::make_unique<DeferredMetadataDumpTask>(metadataBackendPtr);
 
-			gMetadata->taskManager.submitTask(delayedTime, 1, metadataDumpTask.release(),
-				DeferredMetadataDumpTask::generateDescription(),
-				[](int status) {
-					if (status == SAUNAFS_STATUS_OK) {
-						safs::log_info("Deferred metadata dump completed successfully");
-					} else {
-						safs::log_err("Deferred metadata dump failed with status: {}", status);
-					}
-				});
+			// Schedule one-time deferred metadata dump task using TaskManager
+			gMetadata->taskManager.submitTask(
+			    0, 1, metadataDumpTask.release(), DeferredMetadataDumpTask::generateDescription(),
+			    [](int status) {
+				    if (status == SAUNAFS_STATUS_OK) {
+					    safs::log_info("Deferred metadata dump completed successfully");
+				    } else {
+					    safs::log_err("Deferred metadata dump failed with status: {}", status);
+				    }
+			    });
 		} else {
 			// Original behavior: dump the new metadata immediately
 			gMetadataBackend->fs_storeall(DumpType::kForegroundDump);

--- a/src/uraft/saunafs-uraft-helper.in
+++ b/src/uraft/saunafs-uraft-helper.in
@@ -174,7 +174,10 @@ saunafs_promote() {
 		log "metadata is on disk instead of ram"
 		saunafs_master stop
 		unlink "${METADATA_LOCK}"
-		saunafs_master -o initial-personality=master -o auto-recovery restart
+		saunafs_master -o initial-personality=master \
+					-o auto-recovery \
+					-o defer-metadata-dump \
+					restart
 		if [[ $? != 0 ]]; then
 			log "promotion to master failed"
 			exit $SAUNAFS_URAFT_ERROR

--- a/tests/test_suites/ShortSystemTests/test_deferred_metadata_dump.sh
+++ b/tests/test_suites/ShortSystemTests/test_deferred_metadata_dump.sh
@@ -1,0 +1,82 @@
+timeout_set 45 seconds
+
+master_log_file="${TEMP_DIR}/log"
+
+master_cfg="PERSONALITY=ha-cluster-managed"
+master_cfg+="|MAGIC_DEBUG_LOG = ${master_log_file}|LOG_FLUSH_ON=DEBUG"
+
+CHUNKSERVERS=3 \
+    USE_RAMDISK="YES" \
+	MASTER_EXTRA_CONFIG="${master_cfg}" \
+	MASTER_START_PARAM="-o ha-cluster-managed -o initial-personality=master" \
+	SHADOW_START_PARAM="-o ha-cluster-managed -o initial-personality=shadow" \
+    setup_local_empty_saunafs info
+
+saunafs_master_daemon_ha () {
+	local command=$1
+	shift
+	saunafs_master_daemon ${command} -o ha-cluster-managed $@
+}
+
+cd "${info[mount0]}"
+
+# Create some test data to ensure metadata changes exist
+mkdir test_dir
+saunafs setgoal 2 test_dir
+echo "test_data" > test_dir/test_file.txt
+
+echo "Starting test with deferred metadata dump..."
+
+echo "Stopping primary master to simulate failover..."
+assert_success saunafs_master_daemon_ha stop
+
+# Verify that starting sfsmaster with default values does not trigger a deferred metadata dump
+log=$(cat "${master_log_file}")
+assert_awk_finds_no '/Executing deferred metadata dump/' "${log}"
+
+# Restart the master server, this time using `-o defer-metadata-dump` option
+assert_success saunafs_master_daemon_ha start -o initial-personality=master \
+	-o auto-recovery -o defer-metadata-dump
+
+echo "Testing filesystem functionality during metadata dump..."
+echo "additional_data_during_dump" > test_dir/during_dump_file.txt
+
+assert_equals "test_data" "$(cat test_dir/test_file.txt)"
+assert_equals "additional_data_during_dump" "$(cat test_dir/during_dump_file.txt)"
+
+echo "Verifying deferred metadata dump was scheduled..."
+log=$(cat "${master_log_file}")
+assert_awk_finds '/Deferring metadata dump option detected/' "${log}"
+
+echo "Waiting for deferred metadata dump to execute..."
+log=$(cat "${master_log_file}")
+assert_awk_finds '/Executing deferred metadata dump/' "${log}"
+
+echo "Testing filesystem remains functional during background metadata dump..."
+
+echo "data_during_background_dump" > test_dir/background_dump_file.txt
+assert_equals "additional_data_during_dump" "$(cat test_dir/during_dump_file.txt)"
+assert_equals "data_during_background_dump" "$(cat test_dir/background_dump_file.txt)"
+
+echo "Waiting for deferred metadata dump to complete..."
+log=$(cat "${master_log_file}")
+assert_awk_finds '/Deferred metadata dump completed successfully/' "${log}"
+
+echo "Verifying data integrity after deferred dump completion..."
+
+assert_equals "test_data" "$(cat test_dir/test_file.txt)"
+assert_equals "additional_data_during_dump" "$(cat test_dir/during_dump_file.txt)"
+assert_equals "data_during_background_dump" "$(cat test_dir/background_dump_file.txt)"
+
+echo "Verifying no metadata corruption by checking filesystem consistency..."
+saunafs-admin metadataserver-status localhost "${info[matocl]}"
+
+echo "Checking for error messages in master logs..."
+log=$(cat "${master_log_file}")
+assert_awk_finds_no '/Deferred metadata dump failed/' "${log}"
+
+mkdir test_dir/final_test
+echo "final_test_data" > test_dir/final_test/final_file.txt
+assert_equals "final_test_data" "$(cat test_dir/final_test/final_file.txt)"
+
+echo "Test handling deferred metadata dump completed successfully!"

--- a/tests/test_suites/ShortSystemTests/test_deferred_metadata_dump.sh
+++ b/tests/test_suites/ShortSystemTests/test_deferred_metadata_dump.sh
@@ -6,16 +6,27 @@ master_cfg="PERSONALITY=ha-cluster-managed"
 master_cfg+="|MAGIC_DEBUG_LOG = ${master_log_file}|LOG_FLUSH_ON=DEBUG"
 
 CHUNKSERVERS=3 \
-    USE_RAMDISK="YES" \
+	USE_RAMDISK="YES" \
 	MASTER_EXTRA_CONFIG="${master_cfg}" \
 	MASTER_START_PARAM="-o ha-cluster-managed -o initial-personality=master" \
 	SHADOW_START_PARAM="-o ha-cluster-managed -o initial-personality=shadow" \
-    setup_local_empty_saunafs info
+	setup_local_empty_saunafs info
 
 saunafs_master_daemon_ha () {
 	local command=$1
 	shift
 	saunafs_master_daemon ${command} -o ha-cluster-managed $@
+}
+
+# Function to get birth time with nanosecond precision
+get_birth_time_timestamp() {
+	local file_path="$1"
+	local stat_info=$(stat "${file_path}")
+	# Generate birth timestamp with the format "HH:MM:SS.nnnnnnnnn"
+	local birth_time=$(echo "${stat_info}" | grep 'Birth' | awk '{print $3}')
+	# Format the birth timestamp to an integer with the format "HHMMSSnnnnnnnnn"
+	local timestamp=$(echo "${birth_time}" | sed 's/[^0-9]*//g')
+	echo "${timestamp}"
 }
 
 cd "${info[mount0]}"
@@ -33,6 +44,12 @@ assert_success saunafs_master_daemon_ha stop
 # Verify that starting sfsmaster with default values does not trigger a deferred metadata dump
 log=$(cat "${master_log_file}")
 assert_awk_finds_no '/Executing deferred metadata dump/' "${log}"
+
+# Message for the usual metadata dump
+assert_awk_finds '/Metadata dumped successfully after applying changelogs/' "${log}"
+
+# Save birth timestamp of metadata.sfs after stopping the initial master
+birth_timestamp_after_stop=$(get_birth_time_timestamp "${info[master_data_path]}/metadata.sfs")
 
 # Restart the master server, this time using `-o defer-metadata-dump` option
 assert_success saunafs_master_daemon_ha start -o initial-personality=master \
@@ -61,6 +78,16 @@ assert_equals "data_during_background_dump" "$(cat test_dir/background_dump_file
 echo "Waiting for deferred metadata dump to complete..."
 log=$(cat "${master_log_file}")
 assert_awk_finds '/Deferred metadata dump completed successfully/' "${log}"
+
+# Save birth timestamp of metadata.sfs after starting the master
+birth_timestamp_after_start=$(get_birth_time_timestamp "${info[master_data_path]}/metadata.sfs")
+
+# Validate the file was actually updated
+assert_less_than "${birth_timestamp_after_stop}" "${birth_timestamp_after_start}"
+echo "Verified: metadata.sfs was updated by deferred dump"
+echo "  Birthtime after stop: ${birth_timestamp_after_stop}"
+echo "  Birthtime after start:  ${birth_timestamp_after_start}"
+echo "  Difference: $((birth_timestamp_after_start - birth_timestamp_after_stop))"
 
 echo "Verifying data integrity after deferred dump completion..."
 


### PR DESCRIPTION
This PR introduces deferred metadata dumping in SaunaFS master to improve failover recovery time and cluster availability.

Previously, when a shadow was promoted to master, it had to perform a full metadata dump before accepting connections from chunkservers. This introduced unnecessary delays, as the cluster could not serve I/O until the dump completed.

**Summary of changes:**

- **DeferredMetadataDumpTask**
  - A new task class that runs the metadata dump in the background.
  - Logs detailed outcomes and gracefully handles cases where a periodic dump is already in progress.

- **Master failover behavior**
  - Added -o defer-metadata-dump option to master startup.
  - When enabled, metadata dump is scheduled asynchronously via TaskManager (with a 30s delay) instead of being performed immediately.
  - This allows chunkservers to reconnect and I/O operations to resume sooner.

- **uraft helper update**
  - Failover path (saunafs-uraft-helper) now uses `-o defer-metadata-dump` by default when promoting a shadow to master.

- **New integration test** (test_deferred_metadata_dump.sh)
  - Validates cluster behavior during a deferred metadata dump.
  - Ensures logs reflect scheduling and successful completion.

Signed-off-by: Crash <<crash@leil.io>>