### PR TITLE
fix: Corrected Windows specific error messages

### DIFF
--- a/src/common/server_connection.cc
+++ b/src/common/server_connection.cc
@@ -140,18 +140,20 @@ MessageBuffer ServerConnection::sendAndReceive(
 	return receiveRequestGeneric(fd, expectedType, receiveMode, timeout);
 }
 
-void ServerConnection::connect(const NetworkAddress& server) {
+void ServerConnection::connect(const NetworkAddress &server) {
 	fd_ = tcpsocket();
+	int tcpLastError = 0;
 	if (fd_ < 0) {
-		throw ConnectionException(
-				"Can't create socket: " + std::string(strerr(tcpgetlasterror())));
+		tcpLastError = tcpgetlasterror();
+		throw ConnectionException("Can't create socket: " + std::string(strerr(tcpLastError)));
 	}
 	tcpnonblock(fd_);
 	if (tcpnumtoconnect(fd_, server.ip, server.port, timeout_) != 0) {
+		tcpLastError = tcpgetlasterror();
 		tcpclose(fd_);
 		fd_ = -1;
-		throw ConnectionException(
-				"Can't connect to " + server.toString() + ": " + strerr(tcpgetlasterror()));
+		throw ConnectionException("Can't connect to " + server.toString() + ": " +
+		                          strerr(tcpLastError));
 	}
 }
 

--- a/src/errors/sfserr.cc
+++ b/src/errors/sfserr.cc
@@ -29,6 +29,10 @@
 
 #include "saunafs_error_codes.h"
 
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
 #ifndef EDQUOT
 # define EDQUOT ENOSPC
 #endif
@@ -89,6 +93,24 @@ int saunafs_error_conv(uint8_t status) {
 	}
 }
 
+#ifdef _WIN32
+static std::string windows_error_to_string(int error_code) {
+	char buffer[256];
+	DWORD length = FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+	                              nullptr, error_code, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+	                              buffer, sizeof(buffer), nullptr);
+
+	if (length > 0) {
+		while (length > 0 && (buffer[length - 1] == '\r' || buffer[length - 1] == '\n')) {
+			buffer[--length] = '\0';
+		}
+		return buffer;
+	}
+
+	return "Error code: " + std::to_string(error_code);
+}
+#endif
+
 const char *strerr(int error_code) {
 	static std::unordered_map<int, std::string> error_description;
 	static std::mutex error_description_mutex;
@@ -99,7 +121,14 @@ const char *strerr(int error_code) {
 		return it->second.c_str();
 	}
 
-	const char *error_string = strerror(error_code);
+	std::string error_string;
+
+#ifdef _WIN32
+	error_string = windows_error_to_string(error_code);
+#else
+	error_string = std::strerror(error_code);
+#endif
+
 	auto insert_it = error_description.insert({error_code, std::string(error_string)}).first;
 	return insert_it->second.c_str();
 }


### PR DESCRIPTION
This commit resolves two issues:
- Error codes returned by Windows libraries (e.g., winsock2.h) could have identifiers not present in the Linux error number set, resulting in incorrect error messages when handling Windows-only errors. The error message handling has been updated to properly display Windows-specific error codes.

- Fixed an issue in ServerConnection::connect where the last TCP error was requested after the socket was closed, causing incorrect error messages to be shown. The error retrieval now occurs before socket closure to ensure accurate reporting. This fixed problem was specially present when catching Windows socket library errors.