### PR TITLE
fix: Fix test for client retry tuning

### DIFF
--- a/tests/test_suites/ShortSystemTests/test_wait_retry_time_and_sleep_time_divisor.sh
+++ b/tests/test_suites/ShortSystemTests/test_wait_retry_time_and_sleep_time_divisor.sh
@@ -1,13 +1,41 @@
-timeout_set "5 minutes"
+timeout_set "4 minutes"
 
 run_ls_background() {
-    local suffix="$1"
+	local suffix="$1"
 
-    # start the ls command in the background and redirect
-    # its output to a file named ls_output_<suffix>.txt
-    (
-      ls -l "${info[mount0]}" > "/tmp/ls_output_${suffix}.txt" 2>&1
-    ) &
+	# start the ls command in the background and redirect
+	# its output to a file named ls_output_<suffix>.txt
+	(
+		ls -l "${info[mount0]}" > "$TEMP_DIR/ls_output_${suffix}.txt" 2>&1
+	) &
+}
+
+# This function tests client retry behavior when the master server is temporarily unavailable.
+# It works as follows:
+# 1. Stops the master server.
+# 2. Starts an 'ls' command in the background on the client, which will try to access the mount point.
+# 3. Waits for a specified sleep time, allowing the client to enter retry mode.
+# 4. Restarts the master server and waits for chunkservers to be ready.
+# 5. Checks the result:
+#	- If 'expected' is "success", the master was restarted before the client's retry limit expired,
+#	so the 'ls' command should succeed.
+#	- If 'expected' is "failure", the master was not restarted in time, so the 'ls' command should fail.
+validate_ls_background() {
+	local suffix="$1"
+	local sleep_time="$2"
+	local expected="$3"
+
+	saunafs_master_daemon stop
+	run_ls_background "$suffix"
+	sleep "$sleep_time"
+	saunafs_master_daemon start
+	saunafs_wait_for_ready_chunkservers 1
+
+	if [ "$expected" = "success" ]; then
+		assert_success grep -q "total" "$TEMP_DIR/ls_output_${suffix}.txt"
+	else
+		assert_failure grep -q "total" "$TEMP_DIR/ls_output_${suffix}.txt"
+	fi
 }
 
 USE_RAMDISK=YES \
@@ -15,13 +43,7 @@ USE_RAMDISK=YES \
 	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER,sfsioretries=10,maxwaitretrytime=3,mastercommsleeptimedivisor=2" \
 	setup_local_empty_saunafs info
 
-# stop master server daemon
-saunafs_master_daemon stop
-
-# start the ls command in the background with suffix "1"
-run_ls_background "1"
-
-# wait for a duration longer than the maximum time the 
+# Wait for a duration longer than the maximum time the 
 # client will wait for the master server to return.
 # The calculation is as follows:
 # The client performs up to 10 retries, waiting a period
@@ -35,41 +57,22 @@ run_ls_background "1"
 # Then we will wait for 50 seconds to reconnect the master server
 # and check that client could not successfully finish the ls command
 # before the master server is back online.
-sleep 50
-saunafs_master_daemon start
-saunafs_wait_for_ready_chunkservers 1
+validate_ls_background "1" "50" "failure"
 
-# at this time, the ls command should have failed
-assert_success grep -q "Input/output error" "/tmp/ls_output_1.txt"
-
-# now check the case when the master server is back online
+# Now check the case when the master server is back online
 # on a time less than the maximum time the client will wait
-# for the master server to return
-
-# stop master server daemon
-saunafs_master_daemon stop
-
-# start the ls command in the background with suffix "2"
-run_ls_background "2"
-
-# wait for a duration shorter than the maximum time the
-# client will wait for the master server to return a response
-# for the first operation during the ls command, which is
+# for the master server to return. In this case, client will 
+# wait for the master server to return a response for the 
+# first operation during the ls command, which is
 # SAU_MATOCL_UPDATE_CREDENTIALS. Then if we reconnect the
 # master server before first 24 seconds, the ls command should
 # be able to finish successfully.
-sleep 12
-saunafs_master_daemon start
-saunafs_wait_for_ready_chunkservers 1
-
-# at this time, the ls command should have succeeded
-# and created the file ls_output_2.txt as expected
-assert_failure grep -q "Input/output error" "/tmp/ls_output_2.txt"
+validate_ls_background "2" "15" "success"
 
 # Add a delay of 5 seconds to ensure that cluster is stable
 sleep 5
 
-# now check changing the values of sfsioretries, maxwaitretrytime
+# Now check changing the values of sfsioretries, maxwaitretrytime
 # and mastercommsleeptimedivisor using the tweaks file
 echo "MaxRetriesMasterComm=5" | sudo tee "${info[mount0]}/.saunafs_tweaks"
 echo "MaxWaitRetryTimeMasterComm=5" | sudo tee "${info[mount0]}/.saunafs_tweaks"
@@ -80,45 +83,23 @@ assert_equals "5" $(cat "${info[mount0]}/.saunafs_tweaks" | egrep MaxRetriesMast
 assert_equals "5" $(cat "${info[mount0]}/.saunafs_tweaks" | egrep MaxWaitRetryTimeMasterComm | awk '{print $2}')
 assert_equals "1" $(cat "${info[mount0]}/.saunafs_tweaks" | egrep MasterCommSleepTimeDivisor | awk '{print $2}')
 
-# stop master server daemon
-saunafs_master_daemon stop
-
-# start the ls command in the background with suffix "3"
-run_ls_background "3"
-
-# wait for a duration longer than the maximum time the
+# Wait for a duration longer than the maximum time the
 # client will wait for the master server to return.
 # The calculation is as follows:
 # The client performs up to 1 + 2 + 3 + 4 + 5 = 15 seconds for
 # each failing operation. Then, for this case, we need to wait
 # for more than 30 seconds to check that the ls command
 # could not finish before the master server is back online.
-sleep 32
-saunafs_master_daemon start
-saunafs_wait_for_ready_chunkservers 1
+validate_ls_background "3" "35" "failure"
 
-# at this time, the ls command should have failed
-assert_success grep -q "Input/output error" "/tmp/ls_output_3.txt"
-
-# now check the case when the master server is back online
+# Now check another case when the master server is back online
 # on a time less than the maximum time the client will wait
-# for the master server to return
-saunafs_master_daemon stop
-
-# start the ls command in the background with suffix "4"
-run_ls_background "4"
-
-# wait for a duration shorter than the maximum time the
-# client will wait for the master server to return a response
-# for the first operation during the ls command, which is
+# for the master server to return.
+# In this case, client will wait for the master server to return
+# a response for the first operation during the ls command, which is
 # SAU_MATOCL_UPDATE_CREDENTIALS.
-sleep 15
-saunafs_master_daemon start
-saunafs_wait_for_ready_chunkservers 1
-
-# if options maxwaitretrytime and mastercommsleeptimedivisor would
+# If options maxwaitretrytime and mastercommsleeptimedivisor would
 # have default values (10 and 3 respectively), the ls command would have
-# failed.
-# but since we set them to 5 and 1 respectively, the ls command
+# failed. But since we set them to 5 and 1 respectively, the ls command
 # should have succeeded as expected.
-assert_failure grep -q "Input/output error" "/tmp/ls_output_4.txt"
+validate_ls_background "4" "15" "success"


### PR DESCRIPTION
Previous version of test for retry time and sleep time divisor parametized options was flaky due to no catching correct output from ls -l command and not waiting as much as expected to make the command output the expected value. This commit fixes those issues.