### PR TITLE
fix: Prevent path by inode unneeded waits

### DIFF
--- a/src/mount/path_by_inode.h
+++ b/src/mount/path_by_inode.h
@@ -19,16 +19,20 @@
 
 #include "common/platform.h"
 
-#include <condition_variable>
+#include "common/type_defs.h"
+
 #include <mutex>
 #include <string>
 
+struct PidPathEntry {
+	pid_t pid;
+	std::string path;
+	bool operator<(const PidPathEntry &other) const { return pid < other.pid; }
+};
+
 struct InodePathInfo {
-    std::string pathByInode;
-    inode_t inode = 0; 
-    std::mutex mtx;
-    std::condition_variable cv;
-    bool locked = false;
+	std::set<PidPathEntry> contextPidToPath;
+	std::mutex mtx;
 };
 
 inline InodePathInfo gInodePathInfo;

--- a/src/mount/sauna_client.cc
+++ b/src/mount/sauna_client.cc
@@ -938,12 +938,6 @@ EntryParam lookup(Context &ctx, inode_t parent, const char *name) {
 			throw RequestException(SAUNAFS_ERROR_EINVAL);
 		}
 		std::unique_lock<std::mutex> lock(gInodePathInfo.mtx);
-		gInodePathInfo.cv.wait(lock, [inode] {
-			return !gInodePathInfo.locked ||
-			       gInodePathInfo.inode == inode;
-		});
-		gInodePathInfo.locked = true;
-		gInodePathInfo.inode = inode;
 		std::string fullPath = "";
 		int lookupStatus = SAUNAFS_STATUS_OK;
 		int getattrStatus = SAUNAFS_STATUS_OK;
@@ -953,13 +947,12 @@ EntryParam lookup(Context &ctx, inode_t parent, const char *name) {
 			fs_getattr(inode, ctx.uid, ctx.gid, attr));
 		if (lookupStatus != SAUNAFS_STATUS_OK || getattrStatus != SAUNAFS_STATUS_OK) {
 			status = lookupStatus != SAUNAFS_STATUS_OK ? lookupStatus : getattrStatus;
-			gInodePathInfo.locked = false;
-			gInodePathInfo.cv.notify_one();
 			lock.unlock();
 			throw RequestException(status);
 		}
 		status = SAUNAFS_STATUS_OK;
-		gInodePathInfo.pathByInode = fullPath;
+		PidPathEntry entry{ctx.pid, fullPath};
+		gInodePathInfo.contextPidToPath.insert(entry);
 		attr[0] = TYPE_FILE;
 		inode = parent;
 		icacheflag = 0;

--- a/src/mount/special_open.cc
+++ b/src/mount/special_open.cc
@@ -116,7 +116,15 @@ static void open(const Context &ctx, FileInfo *fi) {
 		            saunafs_error_string(SAUNAFS_ERROR_EACCES));
 		throw RequestException(SAUNAFS_ERROR_EACCES);
 	}
-	fi->fh = reinterpret_cast<uintptr_t>(gInodePathInfo.pathByInode.c_str());
+
+	PidPathEntry searchEntry{ctx.pid, ""};
+	auto it = gInodePathInfo.contextPidToPath.find(searchEntry);
+	if (it != gInodePathInfo.contextPidToPath.end()) {
+		fi->fh = reinterpret_cast<uintptr_t>(&(*it));
+	} else {
+		fi->fh = 0;
+	}
+
 	fi->direct_io = 1;
 	fi->keep_cache = 0;
 	oplog_printf(ctx, "open (%" PRIiNode ") (internal node: PATH_BY_INODE_FILE): OK (1,0)",

--- a/src/mount/special_read.cc
+++ b/src/mount/special_read.cc
@@ -214,8 +214,10 @@ static std::vector<uint8_t> read(const Context &ctx,
 	if (debug_mode) {
 		printDebugReadInfo(ctx, SPECIAL_INODE_PATH_BY_INODE, size, off);
 	}
-	uint32_t ssize = gInodePathInfo.pathByInode.size();
-	uint8_t *buff = reinterpret_cast<uint8_t*>(fi->fh);
+
+	auto entry = reinterpret_cast<PidPathEntry *>(fi->fh);
+	uint32_t ssize = entry ? entry->path.size() : 0;
+	const uint8_t *buff = entry ? reinterpret_cast<const uint8_t *>(entry->path.data()) : nullptr;
 	if (off >= static_cast<off_t>(ssize)) {
 		printReadOplogNoData(ctx,
 		                    SPECIAL_INODE_PATH_BY_INODE,

--- a/src/mount/special_release.cc
+++ b/src/mount/special_release.cc
@@ -97,11 +97,9 @@ static void release(FileInfo *fi) {
 namespace InodePathByInode {
 static void release(FileInfo *fi) {
 	std::unique_lock<std::mutex> lock(gInodePathInfo.mtx);
+	auto entry = reinterpret_cast<PidPathEntry *>(fi->fh);
+	if (entry) { gInodePathInfo.contextPidToPath.erase(*entry); }
 	fi->fh = 0;
-	if (gInodePathInfo.locked) {
-		gInodePathInfo.locked = false;
-		gInodePathInfo.cv.notify_one();
-	}
 	oplog_printf("release (%" PRIiNode ") (internal node: PATH_BY_INODE_FILE): OK", inode_);
 }
 } // InodePathByInode


### PR DESCRIPTION
Previously, the design of the .saunafs_path_by_inode special file used a condition variable to isolate each request, forcing requests to execute one at a time. This approach introduced unnecessary delays, as each call had to wait for the previous one to complete. The issue arose because the buffer used to store responses was shared across all requests to this special inode.

This commit ensures that each path-by-inode request has its own dedicated buffer for storing the response. As a result, unnecessary waits are eliminated and potential deadlocks are prevented when multiple path-by-inode requests are triggered concurrently.