### PR TITLE
refactor: Apply few improvements in metadata load

### DIFF
--- a/src/master/chunks.cc
+++ b/src/master/chunks.cc
@@ -667,7 +667,7 @@ static void chunk_checksum_add_to_background(Chunk *ch) {
 	addToChecksum(gChunksMetadata->chunksChecksum, ch->checksum);
 }
 
-static void chunk_update_checksum(Chunk *ch) {
+static void chunk_update_checksum(Chunk *ch, bool isMetadataLoading = false) {
 	if (!ch) {
 		return;
 	}
@@ -678,9 +678,11 @@ static void chunk_update_checksum(Chunk *ch) {
 	removeFromChecksum(gChunksMetadata->chunksChecksum, ch->checksum);
 	ch->checksum = chunk_checksum(ch);
 	if (chunkHashPos(ch->chunkid) < gChunksMetadata->checksumRecalculationPosition) {
-		safs::log_trace("master.fs.checksum.changing_recalculated_chunk");
+		if (!isMetadataLoading) {
+			safs::log_trace("master.fs.checksum.changing_recalculated_chunk");
+		}
 		addToChecksum(gChunksMetadata->chunksChecksumRecalculated, ch->checksum);
-	} else {
+	} else if (!isMetadataLoading) {
 		safs::log_trace("master.fs.checksum.changing_not_recalculated_chunk");
 	}
 	addToChecksum(gChunksMetadata->chunksChecksum, ch->checksum);
@@ -941,14 +943,14 @@ static inline int chunk_delete_file_int(Chunk *c, uint8_t goal) {
 }
 
 /// updates chunk's goal after a file with goal `goal' has been added
-static inline int chunk_add_file_int(Chunk *c, uint8_t goal) {
+static inline int chunk_add_file_int(Chunk *c, uint8_t goal, bool isMetadataLoading = false) {
 	try {
 		c->addFileWithGoal(goal);
 	} catch (Exception& ex) {
 		safs_pretty_syslog(LOG_WARNING, "chunk_add_file_int: %s", ex.what());
 		return SAUNAFS_ERROR_CHUNKLOST;
 	}
-	chunk_update_checksum(c);
+	chunk_update_checksum(c, isMetadataLoading);
 	return SAUNAFS_STATUS_OK;
 }
 
@@ -962,14 +964,14 @@ int chunk_delete_file(uint64_t chunkid,uint8_t goal) {
 	return chunk_delete_file_int(c,goal);
 }
 
-int chunk_add_file(uint64_t chunkid,uint8_t goal) {
+int chunk_add_file(uint64_t chunkid, uint8_t goal, bool isMetadataLoading) {
 	Chunk *c;
 	c = chunk_find(chunkid);
 	if (c==NULL) {
 		safs::log_err("chunk_add_file: could not find chunkid {}", chunkid);
 		return SAUNAFS_ERROR_NOCHUNK;
 	}
-	return chunk_add_file_int(c,goal);
+	return chunk_add_file_int(c, goal, isMetadataLoading);
 }
 
 int chunk_can_unlock(uint64_t chunkid, uint32_t lockid) {

--- a/src/master/chunks.h
+++ b/src/master/chunks.h
@@ -42,7 +42,7 @@ int chunk_increase_version(uint64_t chunkid);
 int chunk_set_version(uint64_t chunkid,uint32_t version);
 int chunk_change_file(uint64_t chunkid,uint8_t prevgoal,uint8_t newgoal);
 int chunk_delete_file(uint64_t chunkid,uint8_t goal);
-int chunk_add_file(uint64_t chunkid,uint8_t goal);
+int chunk_add_file(uint64_t chunkid, uint8_t goal, bool isMetadataLoading = false);
 int chunk_unlock(uint64_t chunkid);
 uint8_t chunk_apply_modification(uint32_t ts, uint64_t oldChunkId, uint32_t lockid, uint8_t goal,
 		bool doIncreaseVersion, uint64_t *newChunkId);

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -2930,14 +2930,14 @@ uint8_t fs_get_chunkid(const FsContext &context, inode_t inode, uint32_t index,
 }
 #endif
 
-void fs_add_files_to_chunks() {
+void fs_add_files_to_chunks(bool isMetadataLoading) {
 	for (uint32_t i = 0; i < NODEHASHSIZE; i++) {
 		for (const auto &node : gMetadata->nodeHash[i]) {
 			if (node->type == FSNodeType::kFile || node->type == FSNodeType::kTrash ||
 			    node->type == FSNodeType::kReserved) {
 				for (const auto &chunkid : static_cast<FSNodeFile*>(node)->chunks) {
 					if (chunkid > 0) {
-						chunk_add_file(chunkid, node->goal);
+						chunk_add_file(chunkid, node->goal, isMetadataLoading);
 					}
 				}
 			}

--- a/src/master/filesystem_operations.h
+++ b/src/master/filesystem_operations.h
@@ -74,7 +74,7 @@ void fs_broadcast_metadata_saved(uint8_t status);
 // proper timestamp to changelog entry and broadcasts it to metaloggers and shadow masters
 void fs_changelog(uint32_t ts, const char *format, ...)
     __attribute__((__format__(__printf__, 2, 3)));
-void fs_add_files_to_chunks();
+void fs_add_files_to_chunks(bool isMetadataLoading = true);
 
 uint64_t fs_getversion();
 uint8_t fs_repair(inode_t rootinode, uint8_t sesflags, inode_t inode, uint32_t uid, uint32_t gid,

--- a/src/master/metadata_backend_file.cc
+++ b/src/master/metadata_backend_file.cc
@@ -382,8 +382,10 @@ static int8_t fs_parseEdge(const std::shared_ptr<MemoryMappedFile> &metadataFile
 	static const int8_t kSuccess = 0;
 	static const int8_t kLastEdge = 1;
 	static inode_t currentParentId;
+	static FSNodeDirectory* currentParentNode;
 	if (init) {
 		currentParentId = 0;
+		currentParentNode = nullptr;
 		return kSuccess;
 	}
 	const auto* pSrc = metadataFile->seek(sectionOffset);
@@ -434,7 +436,13 @@ static int8_t fs_parseEdge(const std::shared_ptr<MemoryMappedFile> &metadataFile
 			return kError;
 		}
 	} else {
-		FSNodeDirectory *parent = fsnodes_id_to_node<FSNodeDirectory>(parentId);
+		FSNodeDirectory *parent;
+		if (currentParentId != parentId){
+			parent = fsnodes_id_to_node<FSNodeDirectory>(parentId);
+			currentParentNode = parent;
+		} else {
+			parent = currentParentNode;
+		}
 		if (!parent) {
 			safs_pretty_syslog(LOG_ERR,
 			                   "loading edge: %" PRIiNode ",%s->%" PRIiNode
@@ -506,20 +514,30 @@ static int8_t fs_parseEdge(const std::shared_ptr<MemoryMappedFile> &metadataFile
 			currentParentId = parentId;
 		}
 
-		hstorage::Handle *handlePtr = new hstorage::Handle(name);
-		auto it = parent->entries.insert({handlePtr, child}).first;
-		parent->entries_hash ^= (*it).first->hash();
+		auto *handlePtr = new hstorage::Handle(name);
+		if (parent->entries.insert({handlePtr, child}).second) {
+			// On successful insert update the hash
+			parent->entries_hash ^= handlePtr->hash();
+		} else {
+			// insert failed → nobody owns handlePtr → delete it
+			delete handlePtr;
+			return kError;
+		}
 
 		if (parent->case_insensitive) {
 			HString lowerCaseName = HString::hstringToLowerCase(HString(name));
-			auto lowercaseHandlePtr = new hstorage::Handle(lowerCaseName);
-			auto it =
-			    parent->lowerCaseEntries.insert({lowercaseHandlePtr, child})
-			        .first;
-			parent->lowerCaseEntriesHash ^= (*it).first->hash();
+			auto *lowercaseHandlePtr = new hstorage::Handle(lowerCaseName);
+			if (parent->lowerCaseEntries.insert({lowercaseHandlePtr, child}).second) {
+				// On successful insert update the hash
+				parent->lowerCaseEntriesHash ^= lowercaseHandlePtr->hash();
+			} else {
+				// insert failed → nobody owns lowercaseHandlePtr → delete it
+				delete lowercaseHandlePtr;
+				return kError;
+			}
 		}
 
-		child->parents.push_back({parent->id, handlePtr});
+		child->parents.push_back({parentId, handlePtr});
 		if (child->type == FSNodeType::kDirectory) {
 			parent->nlink++;
 		}


### PR DESCRIPTION
This commit encompasses some minor improvements in the metadata load.
The main goal of this changes is to boost the loading time. The changes
can be split into the following:
- do not log trace the recalculation of chunks checksum while loading.
- reuse the already found parent FSNode* structure while parsing edges.
- simplify the accessing to some data (hashes, id).

Signed-off-by: Dave <dave@leil.io>