### PR TITLE
chore: Ignore FDBTests suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,8 +83,9 @@ compile_commands.json
 src/chunkserver/plugins/zonefs_disk
 src/chunkserver/plugins/ice_disk_energy_manager
 tests/ci_build/run-smr-tests.sh
-tests/test_suites/SMRTests
+tests/test_suites/FDBTests
 tests/test_suites/ICETests
+tests/test_suites/SMRTests
 tests/test_suites/WindowsClientTests
 
 # Windows #


### PR DESCRIPTION
It is now provided from an external submodule.

Note: Should be merged after: #584