### PR TITLE
fix(master): Avoid possible reinit of gMetadata

### DIFF
--- a/src/master/filesystem.cc
+++ b/src/master/filesystem.cc
@@ -207,8 +207,13 @@ void fs_term(const char *fname, bool noLock) {
 }
 #endif
 
-void fs_strinit(void) {
-	gMetadata = new FilesystemMetadata;
+void fs_strinit(bool isFromInit) {
+	if (isFromInit) {
+		if (gMetadata == nullptr) { gMetadata = new FilesystemMetadata; }
+	} else {
+		// Could be called from masterconn in Shadow mode
+		gMetadata = new FilesystemMetadata;
+	}
 }
 
 /* executed in master mode */
@@ -262,8 +267,8 @@ void executeMetadataDump() {
 	}
 }
 
-int fs_loadall(void) {
-	fs_strinit();
+int fs_loadall(bool isFromInit = true) {
+	fs_strinit(isFromInit);
 	chunk_strinit();
 
 	{
@@ -450,7 +455,7 @@ int fs_init(bool doLoad) {
 	changelog_init(kChangelogFilename, 0, 50);
 
 	if (doLoad || (metadataserver::isMaster())) {
-		fs_loadall();
+		fs_loadall(true);
 	}
 
 	eventloop_reloadregister(fs_reload);
@@ -488,7 +493,7 @@ int fs_init(const char *fname, int ignoreflag, bool noLock) {
 		gMetadataLockfile.reset(new Lockfile(fs::dirname(fname) + "/" + kMetadataFilename + ".lock"));
 		gMetadataLockfile->lock(Lockfile::StaleLock::kSwallow);
 	}
-	fs_strinit();
+	fs_strinit(true);
 	chunk_strinit();
 	gMetadataBackend->loadall(ignoreflag);
 	return 0;

--- a/src/master/filesystem.h
+++ b/src/master/filesystem.h
@@ -63,7 +63,7 @@ uint8_t fs_start_checksum_recalculation();
 void fs_load_changelogs();
 
 /// Load whole filesystem information.
-int fs_loadall();
+int fs_loadall(bool isFromInit);
 
 // Functions which create/apply (depending on the given context) changes to the metadata.
 // Common for metarestore and master server (both personalities)

--- a/src/master/masterconn.cc
+++ b/src/master/masterconn.cc
@@ -609,7 +609,7 @@ void MasterConn::downloadNext() {
 				 */
 				if (state == State::kDownloading) {
 					try {
-						fs_loadall();
+						fs_loadall(false);
 						lastLogVersion = fs_getversion() - 1;
 						safs::log_info("synced at version = {}", lastLogVersion);
 						state = State::kSynchronized;


### PR DESCRIPTION
During initialization, some backends could create the gMetadata instance earlier. This commit adds a partial protection but still allows the old behavior (for compatibility) if called from other places, like from masterconn in Shadow mode (as before).