### PR TITLE
feat(master): Emit signals on metadata changes

### DIFF
--- a/src/master/chunks.cc
+++ b/src/master/chunks.cc
@@ -730,6 +730,10 @@ static void chunk_recalculate_checksum() {
 	}
 }
 
+static inline void emit_chunk_changed(const Chunk *c) {
+	gChunkChangedSignal.emit(c->chunkid, c->version, c->lockedto, c->lockid);
+}
+
 uint64_t chunk_checksum(ChecksumMode mode) {
 	uint64_t checksum = 46586918175221;
 	addToChecksum(checksum, gChunksMetadata->nextchunkid);
@@ -801,6 +805,7 @@ void chunk_emergency_increase_version(Chunk *c) {
 	c->version++;
 	chunk_update_checksum(c);
 	fs_incversion(c->chunkid);
+	emit_chunk_changed(c);
 }
 
 void chunk_finalize_failed_operation(Chunk *c) {
@@ -1008,6 +1013,7 @@ int chunk_unlock(uint64_t chunkid) {
 	// Don't remove lockid to safely accept retransmission of FUSE_CHUNK_UNLOCK message
 	c->lockedto = 0;
 	chunk_update_checksum(c);
+	emit_chunk_changed(c);
 	return SAUNAFS_STATUS_OK;
 }
 
@@ -1192,6 +1198,7 @@ uint8_t chunk_multi_modify(uint64_t ochunkid, uint32_t *lockid, uint8_t goal,
 	}
 	c->lockid = *lockid;
 	chunk_update_checksum(c);
+	emit_chunk_changed(c);
 	return SAUNAFS_STATUS_OK;
 }
 
@@ -1270,6 +1277,7 @@ uint8_t chunk_multi_truncate(uint64_t ochunkid, uint32_t lockid, uint32_t length
 	c->lockedto=(uint32_t)eventloop_time()+LOCKTIMEOUT;
 	c->lockid = lockid;
 	chunk_update_checksum(c);
+	emit_chunk_changed(c);
 	return SAUNAFS_STATUS_OK;
 }
 #endif // ! METARESTORE
@@ -1304,6 +1312,7 @@ uint8_t chunk_apply_modification(uint32_t ts, uint64_t oldChunkId, uint32_t lock
 	c->lockedto = ts + LOCKTIMEOUT;
 	c->lockid = lockid;
 	chunk_update_checksum(c);
+	emit_chunk_changed(c);
 	*newChunkId = c->chunkid;
 	return SAUNAFS_STATUS_OK;
 }
@@ -1376,6 +1385,7 @@ int chunk_repair(uint8_t goal, uint64_t ochunkid, uint32_t *nversion, uint8_t co
 	c->needverincrease=1;
 	c->updateStats();
 	chunk_update_checksum(c);
+	emit_chunk_changed(c);
 	return 1;
 }
 #endif
@@ -1389,6 +1399,7 @@ int chunk_set_version(uint64_t chunkid,uint32_t version) {
 	}
 	c->version = version;
 	chunk_update_checksum(c);
+	emit_chunk_changed(c);
 	return SAUNAFS_STATUS_OK;
 }
 
@@ -1401,6 +1412,7 @@ int chunk_increase_version(uint64_t chunkid) {
 	}
 	c->version++;
 	chunk_update_checksum(c);
+	emit_chunk_changed(c);
 	return SAUNAFS_STATUS_OK;
 }
 
@@ -1543,6 +1555,7 @@ void chunk_server_has_chunk(matocsserventry *ptr, uint64_t chunkid, uint32_t ver
 		c->lockedto = (uint32_t)eventloop_time()+UNUSED_DELETE_TIMEOUT;
 		c->lockid = 0;
 		chunk_update_checksum(c);
+		emit_chunk_changed(c);
 	}
 	auto server_csid = matocsserv_get_csdb(ptr)->csid;
 	for (auto &part : c->parts) {
@@ -2709,6 +2722,13 @@ void chunk_dump(void) {
 }
 
 #endif
+
+void chunk_add_from_initial_metadata_load(uint64_t chunkId, uint32_t chunkVersion,
+                                          uint32_t lockedTo, uint32_t lockId) {
+	Chunk *chunk = chunk_new(chunkId, chunkVersion);
+	chunk->lockedto = lockedTo;
+	chunk->lockid = lockId;
+}
 
 bool chunksLoadFromFile(MetadataLoader::Options options) {
 	const uint8_t *ptr = options.metadataFile->seek(options.offset);

--- a/src/master/chunks.h
+++ b/src/master/chunks.h
@@ -22,12 +22,14 @@
 
 #include "common/platform.h"
 
+#include <cstdint>
 #include <cstdio>
 
 #include "common/chunk_part_type.h"
 #include "common/chunk_type_with_address.h"
 #include "common/chunk_with_address_and_label.h"
 #include "common/chunks_availability_state.h"
+#include "common/observable_property.h"
 #include "common/time_utils.h"
 #include "master/checksum.h"
 #include "master/metadata_loader.h"
@@ -38,6 +40,10 @@ extern bool gAvoidSameIpChunkservers;
 
 extern Timeout gTimeoutSinceLastChunkRegistration;
 
+inline Signal<uint64_t, uint32_t, uint32_t, uint32_t> gChunkChangedSignal;
+
+void chunk_add_from_initial_metadata_load(uint64_t chunkId, uint32_t chunkVersion,
+                                          uint32_t lockedTo, uint32_t lockId);
 int chunk_increase_version(uint64_t chunkid);
 int chunk_set_version(uint64_t chunkid,uint32_t version);
 int chunk_change_file(uint64_t chunkid,uint8_t prevgoal,uint8_t newgoal);

--- a/src/master/filesystem_metadata.h
+++ b/src/master/filesystem_metadata.h
@@ -33,6 +33,7 @@
 #include "master/filesystem_checksum_background_updater.h"
 #include "master/filesystem_node_types.h"
 #include "master/filesystem_xattr.h"
+#include "master/hstring_storage.h"
 #include "master/id_pool_detainer.h"
 #include "master/locks.h"
 #include "master/task_manager.h"
@@ -59,7 +60,6 @@ public:
 	ReservedPathContainer reserved;
 	FSNodeDirectory *root{};
 	std::array<FSNodePointerVector, NODEHASHSIZE> nodeHash;
-	Signal<FSNode *> nodeChangedSignal;  ///< Signal emitted when a node changes
 	TaskManager taskManager;
 	FileLocks flockLocks;
 	FileLocks posixLocks;
@@ -79,6 +79,17 @@ public:
 	uint64_t fsNodesChecksum{};
 	uint64_t xattrChecksum{};
 	uint64_t quotaChecksum{quotaDatabase.checksum()};
+
+	// Signals
+
+	/// Signal emitted when a node changes (added, modified, but not removed)
+	Signal<FSNode *> nodeChangedSignal;
+
+	/// Signal emitted when an edge changes (added, modified, but not removed)
+	Signal<FSNodeDirectory *, FSNode *, hstorage::Handle *> edgeChangedSignal;
+
+	/// Signal emitted when an edge is removed
+	Signal<inode_t, inode_t> edgeRemovedSignal;
 
 	FilesystemMetadata()
 	    : inodePool{SFS_INODE_REUSE_DELAY,

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -523,24 +523,26 @@ void fsnodes_remove_edge(uint32_t ts, FSNodeDirectory *parent, const HString &na
 	assert(node->type != FSNodeType::kTrash);
 	node->ctime = ts;
 	fsnodes_update_checksum(node);
+
+	gMetadata->edgeRemovedSignal.emit(parent->id, node->id);
 }
 
 void fsnodes_link(uint32_t ts, FSNodeDirectory *parent, FSNode *child, const HString &name) {
 	// Needs to be freed in fsnodes_remove_edge
-	hstorage::Handle *handlePtr = new hstorage::Handle(name);
+	auto *handlePtr = new hstorage::Handle(name);
 	parent->entries.insert({handlePtr, child});
 	parent->entries_hash ^= name.hash();
 
 	if (parent->case_insensitive) {
 		HString lowerCaseName = HString::hstringToLowerCase(name);
 		// Needs to be freed in fsnodes_remove_edge
-		auto lowercaseHandlePtr =
-		    new hstorage::Handle(std::string(lowerCaseName.c_str()));
+		auto *lowercaseHandlePtr = new hstorage::Handle(std::string(lowerCaseName.c_str()));
 		parent->lowerCaseEntries.insert({lowercaseHandlePtr, child});
 		parent->lowerCaseEntriesHash ^= lowerCaseName.hash();
 	}
 
 	child->parents.push_back({parent->id, handlePtr});
+	gMetadata->edgeChangedSignal.emit(parent, child, handlePtr);
 
 	if (child->type == FSNodeType::kDirectory) {
 		parent->nlink++;

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -1254,6 +1254,7 @@ void fsnodes_setlength(FSNodeFile *obj, uint64_t length, bool eraseFurtherChunks
 		fsnodes_add_sub_stats(parent_node, &nsr, &psr);
 	}
 	fsnodes_update_checksum(obj);
+	gMetadata->nodeChangedSignal.emit(obj);
 }
 
 void fsnodes_change_uid_gid(FSNode *p, uint32_t uid, uint32_t gid) {

--- a/src/master/id_pool_detainer.h
+++ b/src/master/id_pool_detainer.h
@@ -3,6 +3,7 @@
 #include "common/platform.h"
 
 #include "common/id_pool.h"
+#include "common/observable_property.h"
 
 #if defined(SAUNAFS_HAVE_JUDY) && defined(SAUNAFS_HAVE_WORKING_JUDY1)
 #include <Judy.h>
@@ -374,6 +375,7 @@ public:
 			std::size_t nid = *bucket.data.begin();
 			if (bucket.data.unset(nid)) {
 				--detained_count_;
+				detainedRemovedSignal.emit(IdType(nid));
 			}
 
 			if (bucket.data.empty()) {
@@ -459,6 +461,7 @@ public:
 		for(auto it = detention_.begin(); it != detention_.end(); ++it) {
 			if (it->data.unset(nid)) {
 				--detained_count_;
+				detainedRemovedSignal.emit(IdType(nid));
 				if (it->data.empty()) {
 					detention_.erase(it);
 				}
@@ -545,6 +548,7 @@ public:
 
 			++count;
 			--detained_count_;
+			detainedRemovedSignal.emit(IdType(nid));
 			base::release(IdType(nid));
 
 			if (bucket.data.empty()) {
@@ -583,6 +587,11 @@ public:
 
 	using base::maxSize;
 
+	/// Notifies external observers about new detained id
+	Signal<IdType, TimeType> detainedAddedSignal;
+	/// Notifies external observers about released detained id
+	Signal<IdType> detainedRemovedSignal;
+
 protected:
 	void insert(const IdType &id, const TimeType &ts) {
 		if (detention_.empty() || (detention_.back().ts + bucket_time_) < ts) {
@@ -592,6 +601,7 @@ protected:
 
 		if (detention_.back().data.set(id)) {
 			detained_count_++;
+			detainedAddedSignal.emit(id, ts);
 		}
 	}
 
@@ -608,6 +618,7 @@ protected:
 
 			--count;
 			--detained_count_;
+			detainedRemovedSignal.emit(IdType(nid));
 			base::release(IdType(nid));
 
 			if (bucket.data.empty()) {


### PR DESCRIPTION
This change informs possible observers about metadata changes.
Observers could be custom metadata backends or other components that need to react on metadata changes.

Note: merge after PR #586