### PR TITLE
chore: Ignore MDS resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,10 +83,15 @@ compile_commands.json
 src/chunkserver/plugins/zonefs_disk
 src/chunkserver/plugins/ice_disk_energy_manager
 tests/ci_build/run-smr-tests.sh
-tests/test_suites/FDBTests
 tests/test_suites/ICETests
 tests/test_suites/SMRTests
 tests/test_suites/WindowsClientTests
+
+# MDS #
+###########
+src/mds
+src/data/sfsmds*
+tests/test_suites/FDBTests
 
 # Windows #
 ###########


### PR DESCRIPTION
MDS resources come from a submodule, so no need to track them in this repository.