### PR TITLE
feat(master): Add initial id generator interface

### DIFF
--- a/src/master/filesystem.cc
+++ b/src/master/filesystem.cc
@@ -48,6 +48,10 @@
 #include "master/restore.h"
 #include "slogger/slogger.h"
 
+#ifdef METARESTORE
+#include "master/filesystem_freenode.h"
+#endif
+
 FilesystemMetadata* gMetadata = nullptr;
 std::unique_ptr<Lockfile> gMetadataLockfile;
 
@@ -270,6 +274,8 @@ void executeMetadataDump() {
 int fs_loadall(bool isFromInit = true) {
 	fs_strinit(isFromInit);
 	chunk_strinit();
+
+	gInodeIdGenerator->initialize();
 
 	{
 		auto scopedTimer = util::ScopedTimer("metadata load time");
@@ -495,6 +501,7 @@ int fs_init(const char *fname, int ignoreflag, bool noLock) {
 	}
 	fs_strinit(true);
 	chunk_strinit();
+	gInodeIdGenerator = std::make_unique<IdGeneratorWithDetainer>();
 	gMetadataBackend->loadall(ignoreflag);
 	return 0;
 }

--- a/src/master/filesystem_freenode.cc
+++ b/src/master/filesystem_freenode.cc
@@ -22,20 +22,21 @@
 
 #include "master/filesystem_freenode.h"
 
+#include "common/type_defs.h"
 #include "master/filesystem_metadata.h"
 
-inode_t fsnodes_get_next_id(uint32_t ts, inode_t req_inode) {
-	if(req_inode == 0 || !gMetadata->inodePool.markAsAcquired(req_inode,ts)) {
-		req_inode = gMetadata->inodePool.acquire(ts);
-	}
-	if (req_inode == 0) {
-		mabort("Out of free inode numbers");
-	}
-	if (req_inode > gMetadata->maxInodeId().getValue()) {
-		gMetadata->maxInodeId().setValue(req_inode);
+inode_t IdGeneratorWithDetainer::getNextId(uint32_t timeStamp, inode_t requestedId) {
+	if (requestedId == 0 || !gMetadata->inodePool.markAsAcquired(requestedId, timeStamp)) {
+		requestedId = gMetadata->inodePool.acquire(timeStamp);
 	}
 
-	return req_inode;
+	if (requestedId == 0) { mabort("Out of free inode numbers"); }
+
+	if (requestedId > gMetadata->maxInodeId().getValue()) {
+		gMetadata->maxInodeId().setValue(requestedId);
+	}
+
+	return requestedId;
 }
 
 uint8_t fs_apply_freeinodes(uint32_t /*ts*/, inode_t /*freeinodes*/) {

--- a/src/master/filesystem_metadata.h
+++ b/src/master/filesystem_metadata.h
@@ -24,6 +24,7 @@
 
 #include <cstdint>
 #include <map>
+#include <memory>
 
 #include "common/observable_property.h"
 #include "common/quota_database.h"
@@ -34,6 +35,7 @@
 #include "master/filesystem_node_types.h"
 #include "master/filesystem_xattr.h"
 #include "master/hstring_storage.h"
+#include "master/id_generator_interface.h"
 #include "master/id_pool_detainer.h"
 #include "master/locks.h"
 #include "master/task_manager.h"
@@ -148,6 +150,8 @@ extern ChecksumBackgroundUpdater gChecksumBackgroundUpdater;
 extern bool gDisableChecksumVerification;
 extern uint32_t gTestStartTime;
 extern bool gDisableEmptyFoldersMetadataOnFullDisk;
+
+inline std::unique_ptr<IIdGenerator> gInodeIdGenerator = nullptr;
 
 #ifndef METARESTORE
 extern std::map<int, Goal> gGoalDefinitions;

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -578,7 +578,7 @@ FSNode *fsnodes_create_node(uint32_t ts, FSNodeDirectory *parent, const HString 
 		gMetadata->linkNodes++;
 	}
 	/* create node */
-	node->id = fsnodes_get_next_id(ts, req_inode);
+	node->id = gInodeIdGenerator->getNextId(ts, req_inode);
 
 	node->ctime = node->mtime = node->atime = ts;
 	if (type == FSNodeType::kDirectory || type == FSNodeType::kFile) {

--- a/src/master/id_generator_interface.h
+++ b/src/master/id_generator_interface.h
@@ -1,9 +1,7 @@
 /*
-   Copyright 2005-2010 Jakub Kruszona-Zawadzki, Gemius SA
-   Copyright 2013-2014 EditShare
-   Copyright 2013-2015 Skytechnology sp. z o.o.
    Copyright 2023      Leil Storage OÜ
 
+   This file is part of SaunaFS.
 
    SaunaFS is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -25,18 +23,24 @@
 #include <cstdint>
 
 #include "common/type_defs.h"
-#include "master/id_generator_interface.h"
 
-/// Inode id generator using the inode pool from gMetadata.
-/// Provides the usual behavior but now implements the IIdGenerator interface to allow custom
-/// polymorphic generators.
-class IdGeneratorWithDetainer : public IIdGenerator {
+/// Interface for id generators
+class IIdGenerator {
 public:
-	IdGeneratorWithDetainer() = default;
+	/// Default constructor
+	IIdGenerator() = default;
 
-	bool initialize() override {
-		return true;  // nothing to initialize in this implementation
-	}
+	/// Virtual destructor
+	virtual ~IIdGenerator() = default;
+
+	// Not needed copy/move constructors/assignments
+	IIdGenerator(const IIdGenerator &) = delete;
+	IIdGenerator &operator=(const IIdGenerator &) = delete;
+	IIdGenerator(IIdGenerator &&) = delete;
+	IIdGenerator &operator=(IIdGenerator &&) = delete;
+
+	/// Overload to implement custom initialization if needed for concrete generators
+	virtual bool initialize() = 0;
 
 	/// Get next free inode number.
 	///
@@ -44,6 +48,5 @@ public:
 	/// @param requestedId  Requested id: >0 - specific id, 0 - get any free id
 	///
 	/// @return 0 - no more free ids, >0 - allocated id (may differ from requested if already taken)
-	/// @note This implementation uses the inode pool from gMetadata to provide the usual behavior.
-	inode_t getNextId(uint32_t timeStamp, inode_t requestedId) override;
+	virtual inode_t getNextId(uint32_t timeStamp, inode_t requestedId) = 0;
 };

--- a/src/master/init.h
+++ b/src/master/init.h
@@ -31,6 +31,7 @@
 #include "master/datacachemgr.h"
 #include "master/exports.h"
 #include "master/filesystem.h"
+#include "master/filesystem_freenode.h"
 #include "master/hstorage_init.h"
 #include "master/masterconn.h"
 #include "master/matoclserv.h"
@@ -59,6 +60,7 @@ inline int metadata_backend_init() {
 		try {
 			gMetadataBackend = std::make_unique<MetadataBackendFile>();
 			gMetadataBackend->init();
+			gInodeIdGenerator = std::make_unique<IdGeneratorWithDetainer>();
 		} catch (const std::exception &e) {
 			constexpr auto kErrorMessage = "Failed to initialize metadata backend";
 			safs::log_err("{}: {}", kErrorMessage, e.what());


### PR DESCRIPTION
This commit starts moving the id generation towards a more extensible interface. IIdGenerator provides the interface, compatible with the existing code, while IdGeneratorWithDetainer maintains the current behavior based on an inode pool detainer.

It is expected some custom implementations to arrive soon to provide a distributed id generation for the MDS.