### PR TITLE
feat(kv,fdb): Add atomicAdd to kv and fdb libs

### DIFF
--- a/src/fdb/fdb.cc
+++ b/src/fdb/fdb.cc
@@ -207,6 +207,13 @@ void Transaction::set(const kv::Key &key, const kv::Value &value) {
 	                    static_cast<int>(value.size()));
 }
 
+void Transaction::atomicAdd(const kv::Key &key, const kv::Value &delta) {
+	if (!tr_) { return; }
+
+	fdb_transaction_atomic_op(tr_.get(), key.data(), static_cast<int>(key.size()), delta.data(),
+	                          static_cast<int>(delta.size()), FDB_MUTATION_TYPE_ADD);
+}
+
 void Transaction::remove(const kv::Key &key) {
 	if (!tr_) { return; }
 

--- a/src/fdb/fdb.h
+++ b/src/fdb/fdb.h
@@ -164,6 +164,11 @@ public:
 	/// @param value The value to set for the key.
 	void set(const kv::Key &key, const kv::Value &value);
 
+	/// Atomically adds a delta value to the existing value for a given key.
+	/// @param key The key to add the delta to.
+	/// @param delta The delta value to add.
+	void atomicAdd(const kv::Key &key, const kv::Value &delta);
+
 	/// Removes a key from the database.
 	/// @param key The key to remove.
 	void remove(const kv::Key &key);

--- a/src/fdb/fdb_transaction.cc
+++ b/src/fdb/fdb_transaction.cc
@@ -39,6 +39,12 @@ void FDBTransaction::set(const kv::Key &key, const kv::Value &value) {
 	tr_.set(key, value);
 }
 
+void FDBTransaction::atomicAdd(const kv::Key &key, const kv::Value &delta) {
+	if (!tr_) { return; }
+
+	tr_.atomicAdd(key, delta);
+}
+
 void FDBTransaction::remove(const kv::Key &key) {
 	if (!tr_) { return; }
 

--- a/src/fdb/fdb_transaction.h
+++ b/src/fdb/fdb_transaction.h
@@ -60,6 +60,11 @@ public:
 	/// @param value The value to set for the key.
 	void set(const kv::Key &key, const kv::Value &value) override;
 
+	/// Atomically adds a delta value to the existing value for a given key.
+	/// @param key The key to add the delta to.
+	/// @param delta The delta value to add (must be little-endian).
+	void atomicAdd(const kv::Key &key, const kv::Value &delta) override;
+
 	/// Removes a key from the database.
 	/// @param key The key to remove.
 	void remove(const kv::Key &key) override;

--- a/src/fdb/fdb_unittest.cc
+++ b/src/fdb/fdb_unittest.cc
@@ -21,6 +21,7 @@
 #include "fdb/fdb.h"
 #include "fdb/fdb_context.h"
 #include "fdb/fdb_kv_engine.h"
+#include "kv/itransaction.h"
 
 #include <gtest/gtest.h>
 
@@ -137,4 +138,38 @@ TEST_F(FDBKVEngineTest, GetRange) {
 	testGetRange(kvEngine.get(), kStart, kEnd, true, false, kNumKeys);
 	testGetRange(kvEngine.get(), kStart, kEnd, false, true, kNumKeys);
 	testGetRange(kvEngine.get(), kStart, kEnd, false, false, kNumKeys);
+}
+
+TEST_F(FDBKVEngineTest, AtomicAdd) {
+	kv::Key key{'c', 'o', 'u', 'n', 't'};
+	constexpr int64_t initialValue = 10;
+	constexpr int64_t delta = 5;
+
+	{
+		auto transaction = kvEngine->createReadWriteTransaction();
+		kv::Value value = kv::toU8VectorLittleEndian(initialValue);
+		transaction->set(key, value);
+		ASSERT_TRUE(transaction->commit());
+	}
+
+	{
+		auto transaction = kvEngine->createReadWriteTransaction();
+		kv::Value value = kv::toU8VectorLittleEndian(delta);
+		transaction->atomicAdd(key, value);
+		ASSERT_TRUE(transaction->commit());
+	}
+
+	auto transaction = kvEngine->createReadWriteTransaction();
+	auto result = transaction->get(key);
+
+	ASSERT_TRUE(result.has_value()) << "Value for key 'count' not found.";
+
+	ASSERT_TRUE(result.value().size() == sizeof(initialValue))
+	    << "Value size mismatch for key 'count'.";
+
+	auto finalValue = kv::fromU8VectorLittleEndianToInt<int64_t>(result.value());
+	ASSERT_EQ(finalValue, initialValue + delta)
+	    << "Final value does not match expected value after atomicAdd.";
+
+	safs::log_info("Atomic add successful: final value for 'count' is {}", finalValue);
 }

--- a/src/kv/itransaction.h
+++ b/src/kv/itransaction.h
@@ -19,8 +19,9 @@
 #pragma once
 
 #include <cstdint>
+#include <cstring>
 #include <optional>
-#include <string>
+#include <stdexcept>
 #include <vector>
 
 namespace kv {
@@ -28,8 +29,27 @@ namespace kv {
 using Key = std::vector<uint8_t>;
 using Value = std::vector<uint8_t>;
 
-inline std::vector<uint8_t> toU8Vector(const std::string &str) {
-	return {str.begin(), str.end()};
+/// Converts string, string_view and const char* to a vector of uint8_t.
+inline std::vector<uint8_t> toU8Vector(std::string_view str) { return {str.begin(), str.end()}; }
+
+/// Converts integral types to a vector of uint8_t.
+template <typename T>
+	requires(std::is_integral_v<T>)
+inline std::vector<uint8_t> toU8VectorLittleEndian(T value) {
+	std::vector<uint8_t> bytes(sizeof(value));
+	for (size_t i = 0; i < sizeof(T); ++i) {
+		bytes[i] = static_cast<uint8_t>((value >> (8 * i)) & 0xFF);
+	}
+	return bytes;
+}
+
+template <typename T>
+    requires(std::is_integral_v<T>)
+T fromU8VectorLittleEndianToInt(const Value &value) {
+	if (value.size() > sizeof(T)) { throw std::invalid_argument("Invalid value size"); }
+	T result = 0;
+	for (size_t i = 0; i < value.size(); ++i) { result |= static_cast<T>(value[i]) << (8 * i); }
+	return result;
 }
 
 /// Represents a key-value pair in the key-value store.
@@ -107,6 +127,11 @@ public:
 	/// @param key The key to set the value for.
 	/// @param value The value to set for the key.
 	virtual void set(const Key &key, const Value &value) = 0;
+
+	/// Atomically adds a delta value to the existing value for a given key.
+	/// @param key The key to add the delta to.
+	/// @param delta The delta value to add (must be little-endian).
+	virtual void atomicAdd(const Key &key, const Value &delta) = 0;
 
 	/// Removes a key from the database.
 	/// @param key The key to remove.


### PR DESCRIPTION
atomicAdd is useful to efficiently implement distributed counters in FoundationDB. It is intended to be used in the distributed id generation.