### PR TITLE
fix: Fix `removeReservedEntry` function usage

### DIFF
--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -1442,7 +1442,7 @@ int fsnodes_purge(uint32_t ts, FSNode *p) {
 		gMetadata->reservedNodes--;
 
 		removeReservedEntry(gMetadata->reserved, gMetadata->reservedHandlesIndex,
-		                    gMetadata->trashReservedToId, p);
+		                    gMetadata->trashReservedToId, p->id);
 
 		file_node->ctime = ts;
 		fsnodes_update_checksum(file_node);
@@ -1528,7 +1528,7 @@ uint8_t fsnodes_undel(uint32_t ts, FSNodeFile *node) {
 				                 gMetadata->trashReservedToId, node);
 			} else {
 				removeReservedEntry(gMetadata->reserved, gMetadata->reservedHandlesIndex,
-				                    gMetadata->trashReservedToId, node);
+				                    gMetadata->trashReservedToId, node->id);
 			}
 
 			node->type = FSNodeType::kFile;

--- a/src/master/filesystem_periodic.cc
+++ b/src/master/filesystem_periodic.cc
@@ -575,7 +575,7 @@ static void fs_do_emptyreserved(uint32_t ts) {
 
 		if (!node) {
 			removeReservedEntry(gMetadata->reserved, gMetadata->reservedHandlesIndex,
-			                    gMetadata->trashReservedToId, node);
+			                    gMetadata->trashReservedToId, (*it).first);
 			it = gMetadata->reserved.begin();
 			continue;
 		}

--- a/src/master/filesystem_trash_reserved_files.h
+++ b/src/master/filesystem_trash_reserved_files.h
@@ -147,8 +147,14 @@ inline void addTrashEntry(TrashPathContainer &trash, HandleIndexContainer &trash
 inline void removeTrashEntry(TrashPathContainer &trash, HandleIndexContainer &trashHandlesIndex,
                              TrashReservedToIdContainer &trashReservedToId, FSNode *node) {
 	TrashPathKey key(node);
-	uint64_t handleHash = trash.at(key).data();
-	uint64_t pathId = trashReservedToId.getOrAdd(handleHash);
+	auto handleHashIt = trash.find(key);
+	if (handleHashIt == trash.end()) { return; }
+
+	uint64_t handleHash = (*handleHashIt).second.data();
+	auto pathIdIt = trashReservedToId.nameToId.find(handleHash);
+	if (pathIdIt == trashReservedToId.nameToId.end()) { return; }
+
+	uint64_t pathId = pathIdIt->second;
 	trashHandlesIndex.erase(HandleIndexKey(pathId));
 	trashReservedToId.erase(handleHash);
 	trash.erase(key);
@@ -167,8 +173,14 @@ inline void addReservedEntry(ReservedPathContainer &reserved,
 inline void removeReservedEntry(ReservedPathContainer &reserved,
                                 HandleIndexContainer &reservedHandlesIndex,
                                 TrashReservedToIdContainer &trashReservedToId, inode_t inode) {
-	uint64_t handleHash = reserved.at(inode).data();
-	uint64_t pathId = trashReservedToId.getOrAdd(handleHash);
+	auto handleHashIt = reserved.find(inode);
+	if (handleHashIt == reserved.end()) { return; }
+
+	uint64_t handleHash = (*handleHashIt).second.data();
+	auto pathIdIt = trashReservedToId.nameToId.find(handleHash);
+	if (pathIdIt == trashReservedToId.nameToId.end()) { return; }
+
+	uint64_t pathId = pathIdIt->second;
 	reservedHandlesIndex.erase(HandleIndexKey(pathId));
 	trashReservedToId.erase(handleHash);
 	reserved.erase(inode);
@@ -180,8 +192,14 @@ inline void moveTrashToReservedEntry(TrashPathContainer &trash,
                                      HandleIndexContainer &reservedHandlesIndex,
                                      TrashReservedToIdContainer &trashReservedToId, FSNode *node) {
 	TrashPathKey key(node);
-	uint64_t handleHash = trash.at(key).data();
-	uint64_t idFromName = trashReservedToId.getOrAdd(handleHash);
+	auto handleHashIt = trash.find(key);
+	if (handleHashIt == trash.end()) { return; }
+
+	uint64_t handleHash = (*handleHashIt).second.data();
+	auto pathIdIt = trashReservedToId.nameToId.find(handleHash);
+	if (pathIdIt == trashReservedToId.nameToId.end()) { return; }
+
+	uint64_t idFromName = pathIdIt->second;
 
 	trashHandlesIndex.erase(HandleIndexKey(idFromName));
 	hstorage::Handle nameHandle = std::move(trash.at(key));
@@ -194,18 +212,29 @@ inline void moveTrashToReservedEntry(TrashPathContainer &trash,
 inline void updateTrashNameEntry(TrashPathContainer &trash, HandleIndexContainer &trashHandlesIndex,
                                  TrashReservedToIdContainer &trashReservedToId, FSNode *node,
                                  const std::string &newPath) {
-	uint64_t oldHash = trash[TrashPathKey(node)].data();
-	trashHandlesIndex.erase(HandleIndexKey(trashReservedToId.getOrAdd(oldHash)));
+	TrashPathKey key(node);
+	auto handleHashIt = trash.find(key);
+	if (handleHashIt == trash.end()) { return; }
+
+	uint64_t oldHash = (*handleHashIt).second.data();
+	auto oldPathIdIt = trashReservedToId.nameToId.find(oldHash);
+	if (oldPathIdIt == trashReservedToId.nameToId.end()) { return; }
+
+	uint64_t oldPathId = oldPathIdIt->second;
+	trashHandlesIndex.erase(HandleIndexKey(oldPathId));
 	trashReservedToId.erase(oldHash);
 
-	trash[TrashPathKey(node)] = HString(newPath);
-	uint64_t newHash = trash[TrashPathKey(node)].data();
+	trash[key] = HString(newPath);
+	uint64_t newHash = trash[key].data();
 	trashHandlesIndex.insert({HandleIndexKey(trashReservedToId.getOrAdd(newHash)), node->id});
 }
 
 inline void updateTrashFromOldEntry(TrashPathContainer &trash, FSNode *node,
                                     const TrashPathKey &oldKey) {
-	hstorage::Handle path = std::move(trash.at(oldKey));
+	auto handleHashIt = trash.find(oldKey);
+	if (handleHashIt == trash.end()) { return; }
+
+	hstorage::Handle path = std::move((*handleHashIt).second);
 	trash.erase(oldKey);
 	trash.insert({TrashPathKey(node), std::move(path)});
 }

--- a/src/master/filesystem_trash_reserved_files.h
+++ b/src/master/filesystem_trash_reserved_files.h
@@ -166,12 +166,12 @@ inline void addReservedEntry(ReservedPathContainer &reserved,
 
 inline void removeReservedEntry(ReservedPathContainer &reserved,
                                 HandleIndexContainer &reservedHandlesIndex,
-                                TrashReservedToIdContainer &trashReservedToId, FSNode *node) {
-	uint64_t handleHash = reserved.at(node->id).data();
+                                TrashReservedToIdContainer &trashReservedToId, inode_t inode) {
+	uint64_t handleHash = reserved.at(inode).data();
 	uint64_t pathId = trashReservedToId.getOrAdd(handleHash);
 	reservedHandlesIndex.erase(HandleIndexKey(pathId));
 	trashReservedToId.erase(handleHash);
-	reserved.erase(node->id);
+	reserved.erase(inode);
 }
 
 inline void moveTrashToReservedEntry(TrashPathContainer &trash,

--- a/src/master/filesystem_trash_reserved_files_unittest.cc
+++ b/src/master/filesystem_trash_reserved_files_unittest.cc
@@ -97,7 +97,7 @@ TEST_F(FilesystemTrashReservedTests, AddAndRemoveReservedEntryFromContainers) {
 	ASSERT_EQ(reservedReservedToId.counter, 1U);
 
 	// Remove from reserved
-	removeReservedEntry(reserved, reservedHandlesIndex, reservedReservedToId, node);
+	removeReservedEntry(reserved, reservedHandlesIndex, reservedReservedToId, node->id);
 
 	ASSERT_EQ(reserved.size(), 0U);
 	ASSERT_EQ(reservedHandlesIndex.size(), 0U);


### PR DESCRIPTION
Since commit 4386f2dd, the usage of the `removeReservedEntry` function in the master code was unsafe when called from `fs_do_emptyreserved`. The execution path could lead to `removeReservedEntry` being called with a null `FSNodeFile` instance, resulting in a dereference error when accessing its `id` field. This commit fixes the issue by improving `removeReservedEntry` to accept only the required parameters, avoiding null reference passing on id value. The problem was detected when compiling the project using the `release-vcpkg` preset.