### PR TITLE
refactor: Drop support legacy packets

### DIFF
--- a/doc/sfsmaster.cfg.5.adoc
+++ b/doc/sfsmaster.cfg.5.adoc
@@ -169,9 +169,6 @@ chunkservers that doesn't trigger chunk rebalancing (default is 0.1, i.e. 10%).
 chunks between servers with different labels (default is 0, i.e. chunks will be
 moved only between servers with the same label).
 
-*REJECT_OLD_CLIENTS*:: Reject **sfsmount**s older than 1.6.0 (0 or 1, default
-is 0). Note that *sfsexports* access control is NOT used for those old clients.
-
 *GLOBALIOLIMITS_FILENAME*:: Configuration of global I/O limits (default is no
 I/O limiting)
 

--- a/src/admin/dump_config_command.cc
+++ b/src/admin/dump_config_command.cc
@@ -111,7 +111,6 @@ const static std::unordered_map<std::string, std::string> defaultOptionsMaster =
     {"ENDANGERED_CHUNKS_MAX_CAPACITY", "1048576"},
     {"ACCEPTABLE_DIFFERENCE", "0.1"},
     {"CHUNKS_REBALANCING_BETWEEN_LABELS", "0"},
-    {"REJECT_OLD_CLIENTS", "0"},
     {"GLOBALIOLIMITS_FILENAME", ""},
     {"GLOBALIOLIMITS_RENEGOTIATION_PERIOD_SECONDS", "0.1"},
     {"GLOBALIOLIMITS_ACCUMULATE_MS", "250"},

--- a/src/chunkserver/chunk_replicator.cc
+++ b/src/chunkserver/chunk_replicator.cc
@@ -59,22 +59,14 @@ uint32_t ChunkReplicator::getChunkBlocks(uint64_t chunk_id, uint32_t chunk_versi
 	sassert(fd >= 0);
 
 	std::vector<uint8_t> output_buffer;
-	if (type_with_address.chunkserver_version >= kFirstECVersion) {
-		cstocs::getChunkBlocks::serialize(output_buffer, chunk_id, chunk_version, chunk_type);
-	} else if (type_with_address.chunkserver_version >= kFirstXorVersion) {
-		assert((int)chunk_type.getSliceType() < Goal::Slice::Type::kECFirst);
-		cstocs::getChunkBlocks::serialize(output_buffer, chunk_id, chunk_version, (legacy::ChunkPartType)chunk_type);
-	} else {
-		assert(slice_traits::isStandard(chunk_type));
-		serializeLegacyPacket(output_buffer, CSTOCS_GET_CHUNK_BLOCKS, chunk_id, chunk_version);
-	}
+	sassert(type_with_address.chunkserver_version >= kFirstECVersion);
+	cstocs::getChunkBlocks::serialize(output_buffer, chunk_id, chunk_version, chunk_type);
 	tcptowrite(fd, output_buffer.data(), output_buffer.size(), 1000);
 
 	std::vector<uint8_t> input_buffer;
 	PacketHeader header;
 	receivePacket(header, input_buffer, fd, 1000);
-	if (header.type != SAU_CSTOCS_GET_CHUNK_BLOCKS_STATUS
-			&& header.type != CSTOCS_GET_CHUNK_BLOCKS_STATUS) {
+	if (header.type != SAU_CSTOCS_GET_CHUNK_BLOCKS_STATUS) {
 		close(fd);
 		throw Exception("Unexpected response for chunk get blocks request");
 	}

--- a/src/chunkserver/chunkserver_entry.cc
+++ b/src/chunkserver/chunkserver_entry.cc
@@ -68,13 +68,6 @@ constexpr uint8_t kSauWriteDataPreffixSize = cltocs::writeData::kPrefixSize;
 constexpr uint8_t kSauWriteDataPreffixSizeForward =
     cltocs::writeData::kPrefixSize + PacketHeader::kSize;
 
-// opChunkId (uint64_t), writeId (uint32_t), blocknum (uint16_t), offset16 (uint16_t), opSize
-// (uint32_t), crc (uint32_t)
-constexpr uint8_t kWriteDataPreffixSize = sizeof(uint64_t) + sizeof(uint32_t) + sizeof(uint16_t) +
-                                          sizeof(uint16_t) + sizeof(uint32_t) + sizeof(uint32_t);
-// For forwarding: size of SAU_CLTOCS_WRITE_DATA prefix plus the packet header.
-constexpr uint8_t kWriteDataPreffixSizeForward = kWriteDataPreffixSize + PacketHeader::kSize;
-
 class MessageSerializer {
 public:
 	static MessageSerializer *getSerializer(PacketHeader::Type type);
@@ -90,31 +83,6 @@ public:
 	                                        uint64_t chunkId, uint32_t writeId,
 	                                        uint8_t status) = 0;
 	virtual ~MessageSerializer() {}
-};
-
-class LegacyMessageSerializer : public MessageSerializer {
-public:
-	void serializePrefixOfCstoclReadData(std::vector<uint8_t> &buffer,
-	                                     uint64_t chunkId, uint32_t offset,
-	                                     uint32_t size) override {
-		// This prefix requires CRC (uint32_t) and data (size * uint8_t) to be
-		// appended
-		uint32_t extraSpace = sizeof(uint32_t) + size;
-		serializeLegacyPacketPrefix(buffer, extraSpace, CSTOCL_READ_DATA,
-		                            chunkId, offset, size);
-	}
-
-	void serializeCstoclReadStatus(std::vector<uint8_t> &buffer,
-	                               uint64_t chunkId, uint8_t status) override {
-		serializeLegacyPacket(buffer, CSTOCL_READ_STATUS, chunkId, status);
-	}
-
-	void serializeCstoclWriteStatus(std::vector<uint8_t> &buffer,
-	                                uint64_t chunkId, uint32_t writeId,
-	                                uint8_t status) override {
-		serializeLegacyPacket(buffer, CSTOCL_WRITE_STATUS, chunkId, writeId,
-		                      status);
-	}
 };
 
 class SaunaFsMessageSerializer : public MessageSerializer {
@@ -138,13 +106,8 @@ public:
 };
 
 MessageSerializer *MessageSerializer::getSerializer(PacketHeader::Type type) {
-	sassert((type >= PacketHeader::kMinSauPacketType &&
-	         type <= PacketHeader::kMaxSauPacketType) ||
-	        type <= PacketHeader::kMaxOldPacketType);
-	if (type <= PacketHeader::kMaxOldPacketType) {
-		static LegacyMessageSerializer singleton;
-		return &singleton;
-	}
+	sassert(type >= PacketHeader::kMinSauPacketType &&
+	         type <= PacketHeader::kMaxSauPacketType);
 
 	static SaunaFsMessageSerializer singleton;
 	return &singleton;
@@ -542,27 +505,14 @@ void ChunkserverEntry::readInit(const uint8_t *data, PacketHeader::Type type,
 	TRACETHIS2(type, length);
 
 	// Deserialize request
-	sassert(type == SAU_CLTOCS_READ || type == CLTOCS_READ);
+	sassert(type == SAU_CLTOCS_READ);
 	try {
-		if (type == SAU_CLTOCS_READ) {
-			PacketVersion v;
-			deserializePacketVersionNoHeader(data, length, v);
-			if (v == cltocs::read::kECChunks) {
-				cltocs::read::deserialize(data, length, chunkId, chunkVersion,
-				                          chunkType, offset, size);
-			} else {
-				legacy::ChunkPartType legacy_type;
-				cltocs::read::deserialize(data, length, chunkId, chunkVersion,
-				                          legacy_type, offset, size);
-				chunkType = legacy_type;
-			}
-		} else {
-			deserializeAllLegacyPacketDataNoHeader(data, length, chunkId,
-			                                       chunkVersion, offset, size);
-			chunkType = slice_traits::standard::ChunkPartType();
-		}
+		PacketVersion v;
+		deserializePacketVersionNoHeader(data, length, v);
+		sassert(v == cltocs::read::kECChunks);
+		cltocs::read::deserialize(data, length, chunkId, chunkVersion, chunkType, offset, size);
 		messageSerializer = MessageSerializer::getSerializer(type);
-	} catch (IncorrectDeserializationException&) {
+	} catch (Exception &) {
 		safs_pretty_syslog(
 		    LOG_NOTICE,
 		    "read_init: Cannot deserialize READ message (type:%" PRIX32
@@ -600,16 +550,9 @@ void ChunkserverEntry::prefetch(const uint8_t *data, PacketHeader::Type type,
 	PacketVersion v;
 	try {
 		deserializePacketVersionNoHeader(data, length, v);
-		if (v == cltocs::prefetch::kECChunks) {
-			cltocs::prefetch::deserialize(data, length, chunkId, chunkVersion,
-			                              chunkType, offset, size);
-		} else {
-			legacy::ChunkPartType legacy_type;
-			cltocs::prefetch::deserialize(data, length, chunkId, chunkVersion,
-			                              legacy_type, offset, size);
-			chunkType = legacy_type;
-		}
-	} catch (IncorrectDeserializationException &) {
+		sassert(v == cltocs::prefetch::kECChunks);
+		cltocs::prefetch::deserialize(data, length, chunkId, chunkVersion, chunkType, offset, size);
+	} catch (Exception &) {
 		safs_pretty_syslog(
 		    LOG_NOTICE,
 		    "prefetch: Cannot deserialize PREFETCH message (type:%" PRIX32
@@ -725,16 +668,9 @@ void ChunkserverEntry::prepareInputBufferForWrite(uint32_t type, bool isForward)
 		return;
 	}
 
-	if (type == SAU_CLTOCS_WRITE_DATA) {
-		inputPacket.inputBuffer = getWriteInputBufferPool().get(
-		    isForward ? kSauWriteDataPreffixSizeForward : kSauWriteDataPreffixSize,
-		    maxBlocksPerHddWriteJob);
-	} else {
-		// CLTOCS_WRITE_DATA
-		inputPacket.inputBuffer = getWriteInputBufferPool().get(
-		    isForward ? kWriteDataPreffixSizeForward : kWriteDataPreffixSize,
-		    maxBlocksPerHddWriteJob);
-	}
+	inputPacket.inputBuffer = getWriteInputBufferPool().get(
+	    isForward ? kSauWriteDataPreffixSizeForward : kSauWriteDataPreffixSize,
+	    maxBlocksPerHddWriteJob);
 }
 
 InputBuffer *ChunkserverEntry::getInputBufferForWrite(uint32_t type, bool isForward) {
@@ -750,33 +686,10 @@ InputBuffer *ChunkserverEntry::getInputBufferForWrite(uint32_t type, bool isForw
 	return inputPacket.inputBuffer.get();
 }
 
-void serializeCltocsWriteInit(std::vector<uint8_t> &buffer, uint64_t chunkId,
-                              uint32_t chunkVersion, ChunkPartType chunkType,
-                              const std::vector<ChunkTypeWithAddress> &chain,
-                              uint32_t target_version) {
-	if (target_version >= kFirstECVersion) {
-		cltocs::writeInit::serialize(buffer, chunkId, chunkVersion, chunkType,
-		                             chain);
-	} else if (target_version >= kFirstXorVersion) {
-		assert((int)chunkType.getSliceType() < Goal::Slice::Type::kECFirst);
-		std::vector<NetworkAddress> legacy_chain;
-		legacy_chain.reserve(chain.size());
-		for (const auto &entry : chain) {
-			legacy_chain.push_back(entry.address);
-		}
-		cltocs::writeInit::serialize(buffer, chunkId, chunkVersion,
-		                             (legacy::ChunkPartType)chunkType,
-		                             legacy_chain);
-	} else {
-		assert(slice_traits::isStandard(chunkType));
-		LegacyVector<NetworkAddress> legacy_chain;
-		legacy_chain.reserve(chain.size());
-		for (const auto &entry : chain) {
-			legacy_chain.push_back(entry.address);
-		}
-		serializeLegacyPacket(buffer, CLTOCS_WRITE, chunkId, chunkVersion,
-		                      legacy_chain);
-	}
+void serializeCltocsWriteInit(std::vector<uint8_t> &buffer, uint64_t chunkId, uint32_t chunkVersion,
+                              ChunkPartType chunkType,
+                              const std::vector<ChunkTypeWithAddress> &chain) {
+	cltocs::writeInit::serialize(buffer, chunkId, chunkVersion, chunkType, chain);
 }
 
 void ChunkserverEntry::writeInit(const uint8_t *data, PacketHeader::Type type,
@@ -784,38 +697,14 @@ void ChunkserverEntry::writeInit(const uint8_t *data, PacketHeader::Type type,
 	TRACETHIS();
 	std::vector<ChunkTypeWithAddress> chain;
 
-	sassert(type == SAU_CLTOCS_WRITE_INIT || type == CLTOCS_WRITE);
+	sassert(type == SAU_CLTOCS_WRITE_INIT);
 	try {
-		if (type == SAU_CLTOCS_WRITE_INIT) {
-			PacketVersion v;
-			deserializePacketVersionNoHeader(data, length, v);
-			if (v == cltocs::writeInit::kECChunks) {
-				cltocs::writeInit::deserialize(data, length, chunkId,
-				                               chunkVersion, chunkType, chain);
-			} else {
-				std::vector<NetworkAddress> legacy_chain;
-				legacy::ChunkPartType legacy_type;
-				cltocs::writeInit::deserialize(data, length, chunkId,
-				                               chunkVersion, legacy_type,
-				                               legacy_chain);
-				chunkType = legacy_type;
-				for (const auto &address : legacy_chain) {
-					chain.emplace_back(address, chunkType, kFirstXorVersion);
-				}
-			}
-		} else {
-			LegacyVector<NetworkAddress> legacyChain;
-			deserializeAllLegacyPacketDataNoHeader(data, length, chunkId,
-			                                       chunkVersion, legacyChain);
-			for (const auto &address : legacyChain) {
-				chain.emplace_back(address,
-				                   slice_traits::standard::ChunkPartType(),
-				                   kStdVersion);
-			}
-			chunkType = slice_traits::standard::ChunkPartType();
-		}
+		PacketVersion v;
+		deserializePacketVersionNoHeader(data, length, v);
+		sassert(v == cltocs::writeInit::kECChunks);
+		cltocs::writeInit::deserialize(data, length, chunkId, chunkVersion, chunkType, chain);
 		messageSerializer = MessageSerializer::getSerializer(type);
-	} catch (IncorrectDeserializationException &ex) {
+	} catch (Exception &) {
 		safs_pretty_syslog(
 		    LOG_NOTICE,
 		    "Received malformed WRITE_INIT message (length: %" PRIu32 ")",
@@ -827,10 +716,8 @@ void ChunkserverEntry::writeInit(const uint8_t *data, PacketHeader::Type type,
 	if (!chain.empty()) {
 		// Create a chain -- connect to the next chunkserver
 		fwdServer = chain[0].address;
-		uint32_t target_version = chain[0].chunkserver_version;
 		chain.erase(chain.begin());
-		serializeCltocsWriteInit(fwdInitPacket, chunkId, chunkVersion,
-		                         chunkType, chain, target_version);
+		serializeCltocsWriteInit(fwdInitPacket, chunkId, chunkVersion, chunkType, chain);
 		fwdStartPtr = fwdInitPacket.data();
 		fwdBytesLeft = fwdInitPacket.size();
 		connectRetryCounter = 0;
@@ -861,7 +748,7 @@ void ChunkserverEntry::writeData(const uint8_t *data, PacketHeader::Type type,
 	uint32_t opSize;
 	uint32_t crc;
 
-	sassert(type == SAU_CLTOCS_WRITE_DATA || type == CLTOCS_WRITE_DATA);
+	sassert(type == SAU_CLTOCS_WRITE_DATA);
 	try {
 		const auto *serializer = MessageSerializer::getSerializer(type);
 		if (messageSerializer != serializer) {
@@ -871,18 +758,8 @@ void ChunkserverEntry::writeData(const uint8_t *data, PacketHeader::Type type,
 			state = State::Close;
 			return;
 		}
-		if (type == SAU_CLTOCS_WRITE_DATA) {
-			cltocs::writeData::deserializePrefix(data, kSauWriteDataPreffixSize, opChunkId,
-			                                     writeId, blocknum, opOffset,
-			                                     opSize, crc);
-		} else {
-			uint16_t offset16;
-			deserializeAllLegacyPacketDataNoHeader(data, kWriteDataPreffixSize, opChunkId,
-			                                       writeId, blocknum, offset16,
-			                                       opSize, crc);
-			opOffset = offset16;
-			sassert(chunkType == slice_traits::standard::ChunkPartType());
-		}
+		cltocs::writeData::deserializePrefix(data, kSauWriteDataPreffixSize, opChunkId, writeId,
+		                                     blocknum, opOffset, opSize, crc);
 	} catch (IncorrectDeserializationException &) {
 		safs_pretty_syslog(
 		    LOG_NOTICE,
@@ -927,7 +804,7 @@ void ChunkserverEntry::writeStatus(const uint8_t *data, PacketHeader::Type type,
 	uint32_t writeId;
 	uint8_t status;
 
-	sassert(type == SAU_CSTOCL_WRITE_STATUS || type == CSTOCL_WRITE_STATUS);
+	sassert(type == SAU_CSTOCL_WRITE_STATUS);
 	sassert(messageSerializer != nullptr);
 	try {
 		const auto *serializer = MessageSerializer::getSerializer(type);
@@ -938,15 +815,8 @@ void ChunkserverEntry::writeStatus(const uint8_t *data, PacketHeader::Type type,
 			state = State::Close;
 			return;
 		}
-		if (type == SAU_CSTOCL_WRITE_STATUS) {
-			std::vector<uint8_t> message(data, data + length);
-			cstocl::writeStatus::deserialize(message, opChunkId, writeId,
-			                                 status);
-		} else {
-			deserializeAllLegacyPacketDataNoHeader(data, length, opChunkId,
-			                                       writeId, status);
-			sassert(chunkType == slice_traits::standard::ChunkPartType());
-		}
+		std::vector<uint8_t> message(data, data + length);
+		cstocl::writeStatus::deserialize(message, opChunkId, writeId, status);
 	} catch (IncorrectDeserializationException &) {
 		safs_pretty_syslog(
 		    LOG_NOTICE,
@@ -1035,20 +905,6 @@ void ChunkserverEntry::writeEnd(const uint8_t *data, uint32_t length) {
 	state = State::Idle;
 }
 
-void ChunkserverEntry::sauGetChunkBlocksFinishedLegacyCallback(uint8_t status,
-                                                               void *entry) {
-	TRACETHIS();
-	auto *eptr = static_cast<ChunkserverEntry*>(entry);
-	eptr->getBlocksJobId = 0;
-	std::vector<uint8_t> buffer;
-	cstocs::getChunkBlocksStatus::serialize(
-	    buffer, eptr->chunkId, eptr->chunkVersion,
-	    (legacy::ChunkPartType)eptr->chunkType, eptr->getBlocksJobResult,
-	    status);
-	eptr->createAttachedPacket(buffer);
-	eptr->state = State::Idle;
-}
-
 void ChunkserverEntry::sauGetChunkBlocksFinishedCallback(uint8_t status,
                                                          void *entry) {
 	TRACETHIS();
@@ -1062,46 +918,21 @@ void ChunkserverEntry::sauGetChunkBlocksFinishedCallback(uint8_t status,
 	eptr->state = State::Idle;
 }
 
-void ChunkserverEntry::getChunkBlocksFinishedCallback(uint8_t status,
-                                                      void *entry) {
-	TRACETHIS();
-	auto *eptr = static_cast<ChunkserverEntry *>(entry);
-	eptr->getBlocksJobId = 0;
-	std::vector<uint8_t> buffer;
-	serializeLegacyPacket(buffer, CSTOCS_GET_CHUNK_BLOCKS_STATUS, eptr->chunkId,
-	                      eptr->chunkVersion, eptr->getBlocksJobResult, status);
-	eptr->createAttachedPacket(buffer);
-	eptr->state = State::Idle;
-}
-
 void ChunkserverEntry::sauGetChunkBlocks(const uint8_t *data, uint32_t length) {
-	PacketVersion v;
-	deserializePacketVersionNoHeader(data, length, v);
-	if (v == cstocs::getChunkBlocks::kECChunks) {
-		cstocs::getChunkBlocks::deserialize(data, length, chunkId, chunkVersion,
-		                                    chunkType);
-
-		getBlocksJobId = job_get_blocks(*workerJobPool, sauGetChunkBlocksFinishedCallback, this,
-		                                chunkId, chunkVersion, chunkType, &getBlocksJobResult);
-
-	} else {
-		legacy::ChunkPartType legacy_type;
-		cstocs::getChunkBlocks::deserialize(data, length, chunkId, chunkVersion,
-		                                    legacy_type);
-		chunkType = legacy_type;
-		getBlocksJobId =
-		    job_get_blocks(*workerJobPool, sauGetChunkBlocksFinishedLegacyCallback, this, chunkId,
-		                   chunkVersion, chunkType, &getBlocksJobResult);
+	try {
+		PacketVersion v;
+		deserializePacketVersionNoHeader(data, length, v);
+		sassert(v == cstocs::getChunkBlocks::kECChunks);
+		cstocs::getChunkBlocks::deserialize(data, length, chunkId, chunkVersion, chunkType);
+	} catch (Exception &) {
+		safs::log_info("Received malformed SAU_CSTOCS_GET_CHUNK_BLOCKS message (length: {})",
+		               length);
+		state = State::Close;
+		return;
 	}
-	state = State::GetBlock;
-}
 
-void ChunkserverEntry::getChunkBlocks(const uint8_t *data, uint32_t length) {
-	deserializeAllLegacyPacketDataNoHeader(data, length, chunkId,
-	                                       chunkVersion);
-	chunkType = slice_traits::standard::ChunkPartType();
-	getBlocksJobId = job_get_blocks(*workerJobPool, getChunkBlocksFinishedCallback, this, chunkId,
-	                                chunkVersion, chunkType, &(getBlocksJobResult));
+	getBlocksJobId = job_get_blocks(*workerJobPool, sauGetChunkBlocksFinishedCallback, this,
+	                                chunkId, chunkVersion, chunkType, &getBlocksJobResult);
 	state = State::GetBlock;
 }
 
@@ -1192,17 +1023,10 @@ void ChunkserverEntry::testChunk(const uint8_t *data, uint32_t length) {
 		PacketVersion vers;
 		deserializePacketVersionNoHeader(data, length, vers);
 		ChunkWithVersionAndType chunk;
-		if (vers == cltocs::testChunk::kECChunks) {
-			cltocs::testChunk::deserialize(data, length, chunk.id,
-			                               chunk.version, chunk.type);
-		} else {
-			legacy::ChunkPartType legacy_type;
-			cltocs::testChunk::deserialize(data, length, chunk.id,
-			                               chunk.version, legacy_type);
-			chunk.type = legacy_type;
-		}
+		sassert(vers == cltocs::testChunk::kECChunks);
+		cltocs::testChunk::deserialize(data, length, chunk.id, chunk.version, chunk.type);
 		hddAddChunkToTestQueue(chunk);
-	} catch (IncorrectDeserializationException &e) {
+	} catch (Exception &e) {
 		safs_pretty_syslog(
 		    LOG_NOTICE,
 		    "SAU_CLTOCS_TEST_CHUNK - bad packet: %s (length: %" PRIu32 ")",
@@ -1282,19 +1106,14 @@ void ChunkserverEntry::gotPacket(uint32_t type, const uint8_t *data,
 		case ANTOAN_PING:
 			ping(data, length);
 			break;
-		case CLTOCS_READ:
 		case SAU_CLTOCS_READ:
 			readInit(data, type, length);
 			break;
 		case SAU_CLTOCS_PREFETCH:
 			prefetch(data, type, length);
 			break;
-		case CLTOCS_WRITE:
 		case SAU_CLTOCS_WRITE_INIT:
 			writeInit(data, type, length);
-			break;
-		case CSTOCS_GET_CHUNK_BLOCKS:
-			getChunkBlocks(data, length);
 			break;
 		case SAU_CSTOCS_GET_CHUNK_BLOCKS:
 			sauGetChunkBlocks(data, length);
@@ -1323,7 +1142,6 @@ void ChunkserverEntry::gotPacket(uint32_t type, const uint8_t *data,
 		}
 	} else if (state == State::WriteLast) {
 		switch (type) {
-		case CLTOCS_WRITE_DATA:
 		case SAU_CLTOCS_WRITE_DATA:
 			writeData(data, type, length);
 			break;
@@ -1340,11 +1158,9 @@ void ChunkserverEntry::gotPacket(uint32_t type, const uint8_t *data,
 		}
 	} else if (state == State::WriteForward) {
 		switch (type) {
-		case CLTOCS_WRITE_DATA:
 		case SAU_CLTOCS_WRITE_DATA:
 			writeData(data, type, length);
 			break;
-		case CSTOCL_WRITE_STATUS:
 		case SAU_CSTOCL_WRITE_STATUS:
 			writeStatus(data, type, length);
 			break;
@@ -1361,7 +1177,6 @@ void ChunkserverEntry::gotPacket(uint32_t type, const uint8_t *data,
 		}
 	} else if (state == State::WriteFinish) {
 		switch (type) {
-		case CLTOCS_WRITE_DATA:
 		case SAU_CLTOCS_WRITE_DATA:
 		case SAU_CLTOCS_WRITE_END:
 			return;
@@ -1393,7 +1208,7 @@ void ChunkserverEntry::checkNextPacket() {
 		inputPacket.bytesLeft = PacketHeader::kSize;
 		inputPacket.startPtr = headerBuffer;
 
-		if (type == SAU_CLTOCS_WRITE_DATA || type == CLTOCS_WRITE_DATA) {
+		if (type == SAU_CLTOCS_WRITE_DATA) {
 			if (inputBufferInUse != inputPacket.inputBuffer.get()) {
 				safs::log_warn(
 				    "Inconsistent state in checkNextPacket: inputBufferInUse != inputPacket.inputBuffer");
@@ -1599,7 +1414,7 @@ void ChunkserverEntry::forward() {
 		uint32_t totalPacketLength = PacketHeader::kSize + header.length;
 
 		// Check if we can use aligned memory directly
-		if (header.type == CLTOCS_WRITE_DATA || header.type == SAU_CLTOCS_WRITE_DATA) {
+		if (header.type == SAU_CLTOCS_WRITE_DATA) {
 			inputBufferInUse = getInputBufferForWrite(header.type, true);
 			inputBufferInUse->copyIntoBuffer(InputBuffer::BufferType::Header, headerBuffer,
 			                                 PacketHeader::kSize);
@@ -1616,8 +1431,7 @@ void ChunkserverEntry::forward() {
 			inputBufferInUse = nullptr;
 		}
 
-		if (header.type == CLTOCS_WRITE_DATA || header.type == SAU_CLTOCS_WRITE_DATA ||
-		    header.type == SAU_CLTOCS_WRITE_END) {
+		if (header.type == SAU_CLTOCS_WRITE_DATA || header.type == SAU_CLTOCS_WRITE_END) {
 			fwdBytesLeft = PacketHeader::kSize;
 			// Use the correct buffer for forwarding
 			if (inputBufferInUse != nullptr) {
@@ -1633,7 +1447,7 @@ void ChunkserverEntry::forward() {
 
 	if (inputPacket.bytesLeft > 0) {
 		if (inputBufferInUse != nullptr) {
-			// Case SAU_CLTOCS_WRITE_DATA or CLTOCS_WRITE_DATA
+			// Case SAU_CLTOCS_WRITE_DATA
 			bytesReadOrWritten = inputBufferInUse->readFromSocket(sock, inputPacket.bytesLeft);
 		} else {
 			bytesReadOrWritten = ::read(sock, inputPacket.startPtr, inputPacket.bytesLeft);
@@ -1662,7 +1476,7 @@ void ChunkserverEntry::forward() {
 	if (fwdBytesLeft > 0) {
 		sassert(fwdStartPtr != nullptr);
 		if (inputBufferInUse) {
-			// Case SAU_CLTOCS_WRITE_DATA or CLTOCS_WRITE_DATA
+			// Case SAU_CLTOCS_WRITE_DATA
 			bytesReadOrWritten = inputBufferInUse->writeToSocket(fwdSocket, fwdBytesLeft);
 		} else {
 			bytesReadOrWritten = ::write(fwdSocket, fwdStartPtr, fwdBytesLeft);
@@ -1752,7 +1566,7 @@ void ChunkserverEntry::readFromSocket() {
 				return;
 			}
 
-			if (type == SAU_CLTOCS_WRITE_DATA || type == CLTOCS_WRITE_DATA) {
+			if (type == SAU_CLTOCS_WRITE_DATA) {
 				inputBufferInUse = getInputBufferForWrite(type, false);
 				inputPacket.startPtr =
 				    const_cast<uint8_t *>(inputBufferInUse->getStartLastWriteOperationHeader());
@@ -1770,7 +1584,7 @@ void ChunkserverEntry::readFromSocket() {
 	if (mode == Mode::Data) {
 		if (inputPacket.bytesLeft > 0) {
 			if (inputBufferInUse != nullptr) {
-				// Case SAU_CLTOCS_WRITE_DATA or CLTOCS_WRITE_DATA
+				// Case SAU_CLTOCS_WRITE_DATA
 				bytesRead = inputBufferInUse->readFromSocket(sock, inputPacket.bytesLeft);
 			} else {
 				bytesRead = ::read(sock, inputPacket.startPtr, inputPacket.bytesLeft);

--- a/src/common/read_operation_executor.cc
+++ b/src/common/read_operation_executor.cc
@@ -60,17 +60,9 @@ ReadOperationExecutor::ReadOperationExecutor(
 
 void ReadOperationExecutor::sendReadRequest(const Timeout& timeout) {
 	std::vector<uint8_t> message;
-	if (server_version_ >= kFirstECVersion) {
-		cltocs::read::serialize(message, chunkId_, chunkVersion_, chunkType_,
-			readOperation_.request_offset, readOperation_.request_size);
-	} else if (server_version_ >= kFirstXorVersion) {
-		cltocs::read::serialize(message, chunkId_, chunkVersion_, (legacy::ChunkPartType)chunkType_,
-			readOperation_.request_offset, readOperation_.request_size);
-	} else {
-		serializeLegacyPacket(message, CLTOCS_READ,
-			chunkId_, chunkVersion_, readOperation_.request_offset,
-			readOperation_.request_size);
-	}
+	sassert(server_version_ >= kFirstECVersion);
+	cltocs::read::serialize(message, chunkId_, chunkVersion_, chunkType_,
+	                        readOperation_.request_offset, readOperation_.request_size);
 
 	int32_t ret = tcptowrite(fd_,
 			message.data(),
@@ -167,9 +159,9 @@ void ReadOperationExecutor::processHeaderReceived() {
 		ss << " sent by chunkserver too long (" << packetHeader_.length << " bytes)";
 		throw ChunkserverConnectionException(ss.str(), server_);
 	}
-	if (packetHeader_.type == SAU_CSTOCL_READ_DATA || packetHeader_.type == CSTOCL_READ_DATA) {
+	if (packetHeader_.type == SAU_CSTOCL_READ_DATA) {
 		setState(kReceivingReadDataMessage);
-	} else if (packetHeader_.type == SAU_CSTOCL_READ_STATUS || packetHeader_.type == CSTOCL_READ_STATUS) {
+	} else if (packetHeader_.type == SAU_CSTOCL_READ_STATUS) {
 		setState(kReceivingReadStatusMessage);
 	} else {
 		std::stringstream ss;
@@ -185,13 +177,9 @@ void ReadOperationExecutor::processReadDataMessageReceived() {
 	uint64_t readChunkId;
 	uint32_t readOffset;
 	uint32_t readSize;
-	if (server_version_ >= kFirstXorVersion) {
-		cstocl::readData::deserializePrefix(messageBuffer_, readChunkId, readOffset, readSize,
-			currentlyReadBlockCrc_);
-	} else {
-		deserializeLegacyPacketPrefixNoHeader(messageBuffer_.data(), messageBuffer_.size(),
-			readChunkId, readOffset, readSize, currentlyReadBlockCrc_);
-	}
+	sassert(server_version_ >= kFirstXorVersion);
+	cstocl::readData::deserializePrefix(messageBuffer_, readChunkId, readOffset, readSize,
+	                                    currentlyReadBlockCrc_);
 
 	if (readChunkId != chunkId_) {
 		std::stringstream ss;
@@ -221,12 +209,8 @@ void ReadOperationExecutor::processReadStatusMessageReceived() {
 	uint8_t readStatus;
 	uint64_t readChunkId;
 
-	if (server_version_ >= kFirstXorVersion) {
-		cstocl::readStatus::deserialize(messageBuffer_, readChunkId, readStatus);
-	} else {
-		deserializeAllLegacyPacketDataNoHeader(messageBuffer_.data(), messageBuffer_.size(),
-			readChunkId, readStatus);
-	}
+	sassert(server_version_ >= kFirstXorVersion);
+	cstocl::readStatus::deserialize(messageBuffer_, readChunkId, readStatus);
 
 	if (readChunkId != chunkId_) {
 		std::stringstream ss;
@@ -287,8 +271,8 @@ void ReadOperationExecutor::setState(ReadOperationState newState) {
 		break;
 	case kReceivingReadDataMessage:
 		sassert(state_ == kReceivingHeader);
-		messageBuffer_.resize(server_version_ >= kFirstXorVersion
-			? cstocl::readData::kPrefixSize : cstocl::readData::kLegacyPrefixSize);
+		sassert(server_version_ >= kFirstXorVersion);
+		messageBuffer_.resize(cstocl::readData::kPrefixSize);
 		destination_ = messageBuffer_.data();
 		bytesLeft_ = messageBuffer_.size();
 		break;

--- a/src/common/read_plan_executor.cc
+++ b/src/common/read_plan_executor.cc
@@ -124,15 +124,9 @@ void ReadPlanExecutor::startPrefetchOperation(ExecuteParams &params, ChunkPartTy
 				throw RecoverableReadException("Chunkserver communication timed out");
 			}
 			std::vector<uint8_t> message;
-			if (ctwa.chunkserver_version >= kFirstECVersion) {
-				cltocs::prefetch::serialize(message, chunk_id_, chunk_version_, chunk_type,
-				                            op.request_offset, op.request_size);
-			} else if (ctwa.chunkserver_version >= kFirstXorVersion) {
-				assert((int)chunk_type.getSliceType() < Goal::Slice::Type::kECFirst);
-				cltocs::prefetch::serialize(message, chunk_id_, chunk_version_,
-				                            (legacy::ChunkPartType)chunk_type, op.request_offset,
-				                            op.request_size);
-			}
+			sassert(ctwa.chunkserver_version >= kFirstECVersion);
+			cltocs::prefetch::serialize(message, chunk_id_, chunk_version_, chunk_type,
+			                            op.request_offset, op.request_size);
 			if (message.size() > 0) {
 				int32_t ret =
 				    tcptowrite(fd, message.data(), message.size(), connect_timeout.remaining_ms());

--- a/src/common/write_executor.cc
+++ b/src/common/write_executor.cc
@@ -73,18 +73,11 @@ void WriteExecutor::addInitPacket() {
 		[](const ChunkTypeWithAddress& first, const ChunkTypeWithAddress &second) {
 			return first.chunkserver_version > second.chunkserver_version;
 	});
-	if (!chain_.empty() && chain_.front().chunkserver_version < kFirstECVersion &&
-	    (int)chunkType_.getSliceType() < Goal::Slice::Type::kECFirst) {
-		std::vector<NetworkAddress> legacy_chain;
-		legacy_chain.reserve(chain_.size());
-		for (const auto &link : chain_) {
-			legacy_chain.push_back(link.address);
-		}
-		cltocs::writeInit::serialize(buffer, chunkId_, chunkVersion_,
-		                             static_cast<legacy::ChunkPartType>(chunkType_), legacy_chain);
-	} else {
-		cltocs::writeInit::serialize(buffer, chunkId_, chunkVersion_, chunkType_, chain_);
-	}
+
+	sassert((!chain_.empty() && chain_.front().chunkserver_version >= kFirstECVersion) ||
+	        chunkserver_version_ >= kFirstECVersion);
+	cltocs::writeInit::serialize(buffer, chunkId_, chunkVersion_, chunkType_, chain_);
+
 	increaseUnconfirmedPacketCount();
 	isRunning_ = true;
 }

--- a/src/data/sfsmaster.cfg.in
+++ b/src/data/sfsmaster.cfg.in
@@ -191,11 +191,6 @@
 ## (Default: 86400)
 # SESSION_SUSTAIN_TIME = 86400
 
-## Reject sfsmounts older than 1.6.0 (Boolean, 0 or 1).
-## Note that sfsexports access control is NOT used for those old clients.
-## (Default is 0)
-# REJECT_OLD_CLIENTS = 0
-
 # GLOBALIOLIMITS_FILENAME = @ETC_PATH@/sfsglobaliolimits.cfg
 
 ## How often mountpoints will request bandwidth allocations under constant,

--- a/src/master/chunks.cc
+++ b/src/master/chunks.cc
@@ -1999,6 +1999,7 @@ bool ChunkWorker::tryReplication(Chunk *c, ChunkPartType part_to_recover,
 
 	uint32_t destination_version = matocsserv_get_version(destination_server);
 
+	// Implies destination_version >= kFirstECVersion
 	assert(destination_version >= getMinChunkserverVersion(c, part_to_recover));
 	for (const auto &part : c->parts) {
 		if (!part.is_valid() || part.is_busy() || matocsserv_replication_read_counter(part.server()) >= MaxReadRepl) {
@@ -2007,15 +2008,6 @@ bool ChunkWorker::tryReplication(Chunk *c, ChunkPartType part_to_recover,
 
 		if (slice_traits::isStandard(part.type)) {
 			standard_servers.push_back(part.server());
-		}
-
-		if (destination_version >= kFirstXorVersion && destination_version < kFirstECVersion
-			&& slice_traits::isXor(part_to_recover) && matocsserv_get_version(part.server()) < kFirstXorVersion) {
-			continue;
-		}
-
-		if (destination_version < kFirstXorVersion && !slice_traits::isStandard(part.type)) {
-			continue;
 		}
 
 		all_servers.push_back(part.server());
@@ -2028,18 +2020,12 @@ bool ChunkWorker::tryReplication(Chunk *c, ChunkPartType part_to_recover,
 		return false;
 	}
 
-	if (destination_version >= kFirstECVersion ||
-	    (destination_version >= kFirstXorVersion && slice_traits::isXor(part_to_recover))) {
-		matocsserv_send_sau_replicatechunk(destination_server, c->chunkid, c->version,
-		                                   part_to_recover, all_servers,
-		                                   all_parts);
-		stats_replications++;
-		metrics::Counter::increment(metrics::Counter::Master::CHUNK_REPLICATE);
-		c->needverincrease = 1;
-		return true;
-	}
-
-	return false;
+	matocsserv_send_sau_replicatechunk(destination_server, c->chunkid, c->version, part_to_recover,
+	                                   all_servers, all_parts);
+	stats_replications++;
+	metrics::Counter::increment(metrics::Counter::Master::CHUNK_REPLICATE);
+	c->needverincrease = 1;
+	return true;
 }
 
 void ChunkWorker::deleteInvalidChunkParts(Chunk *c) {

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -257,7 +257,6 @@ static int starting;  ///< Flag indicating whether the server is starting (1) or
 // from config
 static std::string ListenHost;
 static std::string ListenPort;
-static uint32_t RejectOld;
 static uint32_t SessionSustainTime;
 
 static uint32_t gIoLimitsAccumulate_ms;
@@ -1816,9 +1815,6 @@ void matoclserv_fuse_register(matoclserventry *eptr, const uint8_t *data, uint32
 	uint8_t status;
 
 	constexpr uint32_t kBlobSize = REGISTER_BLOB_SIZE;
-	constexpr uint32_t kBlobSizeWithVersion = kBlobSize + sizeof(matoclserventry::version);
-	constexpr uint32_t kBlobSizeWithSessionIdAndVersion =
-	    kBlobSizeWithVersion + sizeof(Session::sessionId);
 
 	if (starting) {
 		eptr->mode = ClientConnectionMode::KILL;
@@ -1837,109 +1833,21 @@ void matoclserv_fuse_register(matoclserventry *eptr, const uint8_t *data, uint32
 
 	// Unregistered no ACL clients and tools
 	if (eptr->registered == ClientState::kUnregistered && (clientsNoACL || toolsNoACL)) {
-		if (RejectOld) {
-			safs::log_info("CLTOMA_FUSE_REGISTER/NOACL - rejected (option REJECT_OLD_CLIENTS is set)");
-			eptr->mode = ClientConnectionMode::KILL;
-			return;
-		}
-		if (toolsNoACL) {
-			if (length != kBlobSize && length != kBlobSizeWithVersion) {
-				safs::log_info("CLTOMA_FUSE_REGISTER/NOACL-TOOLS - wrong size ({}/{}|{})", length,
-				               kBlobSize, kBlobSizeWithVersion);
-				eptr->mode = ClientConnectionMode::KILL;
-				return;
-			}
-		} else {  // clientsNoACL
-			if (length != kBlobSizeWithVersion && length != kBlobSizeWithSessionIdAndVersion) {
-				safs::log_info("CLTOMA_FUSE_REGISTER/NOACL-MOUNT - wrong size ({}/{}|{})", length,
-				               kBlobSizeWithVersion, kBlobSizeWithSessionIdAndVersion);
-				eptr->mode = ClientConnectionMode::KILL;
-				return;
-			}
-		}
-
-		rptr = data + kBlobSize;
-
-		if (toolsNoACL) {
-			sessionId = 0;
-			if (length == kBlobSizeWithVersion) { get32bit(&rptr, eptr->version); }
-		} else {
-			get32bit(&rptr, sessionId);
-			if (length == kBlobSizeWithSessionIdAndVersion) { get32bit(&rptr, eptr->version); }
-		}
-
-		if (eptr->version < 0x010500 && !toolsNoACL) {
-			safs::log_info("got register packet from mount older than 1.5 - rejecting");
-			eptr->mode = ClientConnectionMode::KILL;
-			return;
-		}
-
-		if (sessionId == 0) {           // new session
-			status = SAUNAFS_STATUS_OK; // exports_check(eptr->peerip,(const uint8_t*)"",NULL,NULL,&sesflags);      // check privileges for '/' w/o password
-			eptr->sessionData = matoclserv_new_session(0, toolsNoACL);
-
-			if (eptr->sessionData == nullptr) {
-				safs::log_info("can't allocate session record");
-				eptr->mode = ClientConnectionMode::KILL;
-				return;
-			}
-
-			eptr->sessionData->rootInode = SPECIAL_INODE_ROOT;
-			eptr->sessionData->flags = 0;
-			eptr->sessionData->peerIpAddress = eptr->peerIpAddress;
-			eptr->sessionData->peerPort = eptr->peerPort;
-		} else {  // reconnect or tools
-			eptr->sessionData = matoclserv_find_session(sessionId);
-			if (eptr->sessionData == nullptr) {      // in old model if session doesn't exist then create it
-				eptr->sessionData = matoclserv_new_session(0, 0);
-
-				if (eptr->sessionData == nullptr) {
-					safs::log_info("can't allocate session record");
-					eptr->mode = ClientConnectionMode::KILL;
-					return;
-				}
-
-				eptr->sessionData->rootInode = SPECIAL_INODE_ROOT;
-				eptr->sessionData->flags = 0;
-				eptr->sessionData->peerIpAddress = eptr->peerIpAddress;
-				eptr->sessionData->peerPort = eptr->peerPort;
-				status = SAUNAFS_STATUS_OK;
-			} else if (eptr->sessionData->peerIpAddress == 0) {  // created by "filesystem"
-				eptr->sessionData->peerIpAddress = eptr->peerIpAddress;
-				eptr->sessionData->peerPort = eptr->peerPort;
-				status = SAUNAFS_STATUS_OK;
-			} else if (eptr->sessionData->peerIpAddress == eptr->peerIpAddress) {
-				status = SAUNAFS_STATUS_OK;
-			} else {
-				status = SAUNAFS_ERROR_EACCES;
-			}
-		}
-
-		// answer
-
-		if (toolsNoACL) {
-			wptr = matoclserv_createpacket(eptr, MATOCL_FUSE_REGISTER, sizeof(status));
-		} else {
-			wptr = matoclserv_createpacket(
-			    eptr, MATOCL_FUSE_REGISTER,
-			    (status != SAUNAFS_STATUS_OK) ? sizeof(status) : sizeof(sessionId));
-		}
-
-		if (status != SAUNAFS_STATUS_OK) {
-			put8bit(&wptr, status);
-			return;
-		}
-
-		if (toolsNoACL) {
-			put8bit(&wptr, status);
-		} else {
-			sessionId = eptr->sessionData->sessionId;
-			put32bit(&wptr, sessionId);
-		}
-
-		eptr->registered = (toolsNoACL) ? ClientState::kOldTools : ClientState::kRegistered;
+		safs::log_info("CLTOMA_FUSE_REGISTER/NOACL - rejected");
+		eptr->mode = ClientConnectionMode::KILL;
 		return;
 	}
+
+	auto checkMinimumVersion = [](matoclserventry *eptr) {
+		if (eptr->version < kFirstECVersion) {
+			safs::log_info("Got register packet from client ({}) older than {} - rejecting",
+			               saunafsVersionToString(eptr->version),
+			               saunafsVersionToString(kFirstECVersion));
+			eptr->mode = ClientConnectionMode::KILL;
+			return false;
+		}
+		return true;
+	};
 
 	// clients with ACL support and new tools
 	if (clientsWithACL) {
@@ -2003,6 +1911,11 @@ void matoclserv_fuse_register(matoclserventry *eptr, const uint8_t *data, uint32
 				return;
 			}
 			get32bit(&rptr, eptr->version);
+
+			if (!checkMinimumVersion(eptr)) {
+				return;
+			}
+
 			get32bit(&rptr, infoLength);
 			if (length < kRegisterNewSessionMinSize + infoLength) {
 				safs::log_info("CLTOMA_FUSE_REGISTER/ACL.2 - wrong size ({}/>={} + infoLength({}))",
@@ -2090,43 +2003,30 @@ void matoclserv_fuse_register(matoclserventry *eptr, const uint8_t *data, uint32
 			// answer
 
 			wptr = matoclserv_createpacket(eptr, MATOCL_FUSE_REGISTER,
-			                               (status == SAUNAFS_STATUS_OK)
-			                                   ? ((eptr->version >= saunafsVersion(1, 6, 26))   ? 35
-			                                      : (eptr->version >= saunafsVersion(1, 6, 21)) ? 25
-			                                      : (eptr->version >= saunafsVersion(1, 6, 1))  ? 21
-			                                                                                   : 13)
-			                                   : sizeof(status));
+			                               (status == SAUNAFS_STATUS_OK) ? 35 : sizeof(status));
 
 			if (status != SAUNAFS_STATUS_OK) {
 				put8bit(&wptr, status);
 				return;
 			}
 			sessionId = eptr->sessionData->sessionId;
-			if (eptr->version == saunafsVersion(1, 6, 21)) {
-				put32bit(&wptr, 0);
-			} else if (eptr->version >= saunafsVersion(1, 6, 22)) {
-				put16bit(&wptr, SAUNAFS_PACKAGE_VERSION_MAJOR);
-				put8bit(&wptr, SAUNAFS_PACKAGE_VERSION_MINOR);
-				put8bit(&wptr, SAUNAFS_PACKAGE_VERSION_MICRO);
-			}
+
+			put16bit(&wptr, SAUNAFS_PACKAGE_VERSION_MAJOR);
+			put8bit(&wptr, SAUNAFS_PACKAGE_VERSION_MINOR);
+			put8bit(&wptr, SAUNAFS_PACKAGE_VERSION_MICRO);
 			put32bit(&wptr, sessionId);
 			put8bit(&wptr, sessionFlags);
 			put32bit(&wptr, rootUid);
 			put32bit(&wptr, rootGid);
-			if (eptr->version>=saunafsVersion(1, 6, 1)) {
-				put32bit(&wptr, mapAllUid);
-				put32bit(&wptr, mapAllGid);
-			}
-			if (eptr->version >= saunafsVersion(1, 6, 26)) {
-				put8bit(&wptr, minGoal);
-				put8bit(&wptr, maxGoal);
-				put32bit(&wptr, minTrashTime);
-				put32bit(&wptr, maxTrashTime);
-			}
-			if (eptr->version >= saunafsVersion(1, 6, 30)) {
-				eptr->ioLimitsEnabled = true;
-				matoclserv_send_iolimits_cfg(eptr);
-			}
+			put32bit(&wptr, mapAllUid);
+			put32bit(&wptr, mapAllGid);
+			put8bit(&wptr, minGoal);
+			put8bit(&wptr, maxGoal);
+			put32bit(&wptr, minTrashTime);
+			put32bit(&wptr, maxTrashTime);
+
+			eptr->ioLimitsEnabled = true;
+			matoclserv_send_iolimits_cfg(eptr);
 			eptr->registered = ClientState::kRegistered;
 			return;
 		case REGISTER_NEWMETASESSION:
@@ -2138,6 +2038,11 @@ void matoclserv_fuse_register(matoclserventry *eptr, const uint8_t *data, uint32
 			}
 
 			get32bit(&rptr, eptr->version);
+
+			if (!checkMinimumVersion(eptr)) {
+				return;
+			}
+
 			get32bit(&rptr, infoLength);
 
 			if (length != kRegisterNewMetaSessionMinSize + infoLength &&
@@ -2203,29 +2108,23 @@ void matoclserv_fuse_register(matoclserventry *eptr, const uint8_t *data, uint32
 			// answer
 
 			wptr = matoclserv_createpacket(eptr, MATOCL_FUSE_REGISTER,
-			                               (status == SAUNAFS_STATUS_OK)
-			                                   ? ((eptr->version >= saunafsVersion(1, 6, 26))   ? 19
-			                                      : (eptr->version >= saunafsVersion(1, 6, 21)) ? 9
-			                                                                                    : 5)
-			                                   : sizeof(status));
+			                               (status == SAUNAFS_STATUS_OK) ? 19 : sizeof(status));
 			if (status!=SAUNAFS_STATUS_OK) {
 				put8bit(&wptr,status);
 				return;
 			}
 			sessionId = eptr->sessionData->sessionId;
-			if (eptr->version >= saunafsVersion(1, 6, 21)) {
-				put16bit(&wptr,SAUNAFS_PACKAGE_VERSION_MAJOR);
-				put8bit(&wptr,SAUNAFS_PACKAGE_VERSION_MINOR);
-				put8bit(&wptr,SAUNAFS_PACKAGE_VERSION_MICRO);
-			}
+
+			put16bit(&wptr, SAUNAFS_PACKAGE_VERSION_MAJOR);
+			put8bit(&wptr, SAUNAFS_PACKAGE_VERSION_MINOR);
+			put8bit(&wptr, SAUNAFS_PACKAGE_VERSION_MICRO);
 			put32bit(&wptr, sessionId);
 			put8bit(&wptr, sessionFlags);
-			if (eptr->version >= saunafsVersion(1, 6, 26)) {
-				put8bit(&wptr, minGoal);
-				put8bit(&wptr, maxGoal);
-				put32bit(&wptr, minTrashTime);
-				put32bit(&wptr, maxTrashTime);
-			}
+			put8bit(&wptr, minGoal);
+			put8bit(&wptr, maxGoal);
+			put32bit(&wptr, minTrashTime);
+			put32bit(&wptr, maxTrashTime);
+
 			eptr->registered = ClientState::kRegistered;
 			return;
 		case REGISTER_RECONNECT:
@@ -2238,6 +2137,11 @@ void matoclserv_fuse_register(matoclserventry *eptr, const uint8_t *data, uint32
 			}
 			get32bit(&rptr, sessionId);
 			get32bit(&rptr, eptr->version);
+
+			if (!checkMinimumVersion(eptr)) {
+				return;
+			}
+
 			eptr->sessionData = matoclserv_find_session(sessionId);
 			if (eptr->sessionData == nullptr || eptr->sessionData->peerIpAddress == 0) {
 				status = SAUNAFS_ERROR_BADSESSIONID;
@@ -2259,14 +2163,16 @@ void matoclserv_fuse_register(matoclserventry *eptr, const uint8_t *data, uint32
 			if (status != SAUNAFS_STATUS_OK) { return; }
 
 			if (rcode == REGISTER_RECONNECT) {
-				if (eptr->version >= saunafsVersion(1, 6, 30) &&
-				    eptr->sessionData->rootInode != 0) {
+				if (eptr->sessionData->rootInode != 0) {
 					eptr->ioLimitsEnabled = true;
 					matoclserv_send_iolimits_cfg(eptr);
 				}
 				eptr->registered = ClientState::kRegistered;
 			} else {
 				eptr->registered = ClientState::kOldTools;
+				safs::log_info("Registered old tools from {}:{}, rejecting ...",
+				               ipToString(eptr->peerIpAddress), eptr->peerPort);
+				eptr->mode = ClientConnectionMode::KILL;  // old tools disconnect after register
 			}
 			return;
 		case REGISTER_CLOSESESSION:
@@ -2528,56 +2434,6 @@ void matoclserv_sau_get_self_quota(matoclserventry *eptr, const uint8_t *data, u
 	matoclserv_createpacket(eptr, std::move(reply));
 }
 
-void matoclserv_fuse_lookup(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
-	inode_t inode;
-	uint32_t uid,gid;
-	uint8_t nleng;
-	const uint8_t *name;
-	inode_t newinode;
-	Attributes attr;
-	uint32_t msgid;
-	uint8_t *ptr;
-	uint8_t status;
-	constexpr uint32_t kExpectedPacketSize =
-	    sizeof(msgid) + sizeof(inode) + sizeof(uid) + sizeof(gid) + sizeof(nleng);
-	if (length < kExpectedPacketSize) {
-		safs::log_info("CLTOMA_FUSE_LOOKUP - wrong size ({})", length);
-		eptr->mode = ClientConnectionMode::KILL;
-		return;
-	}
-	get32bit(&data, msgid);
-	getINode(&data, inode);
-	nleng = get8bit(&data);
-	if (length != kExpectedPacketSize + nleng) {
-		safs::log_info("CLTOMA_FUSE_LOOKUP - wrong size ({}:nleng={})", length, nleng);
-		eptr->mode = ClientConnectionMode::KILL;
-		return;
-	}
-	name = data;
-	data += nleng;
-	get32bit(&data, uid);
-	get32bit(&data, gid);
-	status = matoclserv_check_group_cache(eptr, gid);
-	if (status == SAUNAFS_STATUS_OK) {
-		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = fs_lookup(context,inode,HString((char*)name, nleng),&newinode,attr);
-	}
-
-	constexpr uint32_t kFailedAnswerSize = sizeof(msgid) + sizeof(status);
-	constexpr uint32_t kSuccessAnswerSize = sizeof(msgid) + sizeof(newinode) + attr.size();
-	uint8_t answerSize = (status != SAUNAFS_STATUS_OK) ? kFailedAnswerSize : kSuccessAnswerSize;
-
-	ptr = matoclserv_createpacket(eptr, MATOCL_FUSE_LOOKUP, answerSize);
-	put32bit(&ptr,msgid);
-	if (status!=SAUNAFS_STATUS_OK) {
-		put8bit(&ptr,status);
-	} else {
-		putINode(&ptr,newinode);
-		memcpy(ptr, attr.data(), attr.size());
-	}
-	eptr->sessionData->currHourOperationsStats[3]++;
-}
-
 void matoclserv_fuse_getattr(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	inode_t inode;
 	uint32_t uid,gid;
@@ -2690,9 +2546,7 @@ void matoclserv_fuse_setattr(matoclserventry *eptr, const uint8_t *data, uint32_
 }
 
 void matoclserv_fuse_truncate(matoclserventry *eptr, PacketHeader header, const uint8_t *data) {
-	sassert(header.type == CLTOMA_FUSE_TRUNCATE
-			|| header.type == SAU_CLTOMA_FUSE_TRUNCATE
-			|| header.type == SAU_CLTOMA_FUSE_TRUNCATE_END);
+	sassert(header.type == SAU_CLTOMA_FUSE_TRUNCATE || header.type == SAU_CLTOMA_FUSE_TRUNCATE_END);
 
 	// Deserialize the request
 	std::vector<uint8_t> request(data, data + header.length);
@@ -2742,10 +2596,7 @@ void matoclserv_fuse_truncate(matoclserventry *eptr, PacketHeader header, const 
 	}
 
 	// In case of SAUNAFS_ERROR_NOTPOSSIBLE we have to tell the client to write the chunk before truncating
-	if (status == SAUNAFS_ERROR_NOTPOSSIBLE && header.type == CLTOMA_FUSE_TRUNCATE) {
-		// Old client requested to truncate xor chunk. We can't do this!
-		status = SAUNAFS_ERROR_ENOTSUP;
-	} else if (status == SAUNAFS_ERROR_NOTPOSSIBLE && header.type == SAU_CLTOMA_FUSE_TRUNCATE) {
+	if (status == SAUNAFS_ERROR_NOTPOSSIBLE && header.type == SAU_CLTOMA_FUSE_TRUNCATE) {
 		// New client requested to truncate xor chunk. He has to do it himself.
 		uint64_t fileLength;
 		uint8_t opflag;
@@ -2944,11 +2795,7 @@ void matoclserv_fuse_mknod(matoclserventry *eptr, PacketHeader header, const uin
 	uint8_t type;
 	uint16_t mode, umask;
 
-	if (header.type == CLTOMA_FUSE_MKNOD) {
-		deserializeAllLegacyPacketDataNoHeader(data, header.length,
-				messageId, inode, name, type, mode, uid, gid, rdev);
-		umask = 0;
-	} else if (header.type == SAU_CLTOMA_FUSE_MKNOD) {
+	if (header.type == SAU_CLTOMA_FUSE_MKNOD) {
 		cltoma::fuseMknod::deserialize(data, header.length,
 				messageId, inode, name, type, mode, umask, uid, gid, rdev);
 	} else {
@@ -2967,14 +2814,10 @@ void matoclserv_fuse_mknod(matoclserventry *eptr, PacketHeader header, const uin
 	}
 
 	MessageBuffer reply;
-	if (status == SAUNAFS_STATUS_OK && header.type == CLTOMA_FUSE_MKNOD) {
-		serializeLegacyPacket(reply, MATOCL_FUSE_MKNOD, messageId, newinode, attr);
-	} else if (status == SAUNAFS_STATUS_OK && header.type == SAU_CLTOMA_FUSE_MKNOD) {
+	if (status == SAUNAFS_STATUS_OK) {
 		matocl::fuseMknod::serialize(reply, messageId, newinode, attr);
-	} else if (header.type == SAU_CLTOMA_FUSE_MKNOD) {
-		matocl::fuseMknod::serialize(reply, messageId, status);
 	} else {
-		serializeLegacyPacket(reply, MATOCL_FUSE_MKNOD, messageId, status);
+		matocl::fuseMknod::serialize(reply, messageId, status);
 	}
 	matoclserv_createpacket(eptr, std::move(reply));
 	if (eptr->sessionData) {
@@ -2989,17 +2832,7 @@ void matoclserv_fuse_mkdir(matoclserventry *eptr, PacketHeader header, const uin
 	bool copysgid;
 	uint16_t mode, umask;
 
-	if (header.type == CLTOMA_FUSE_MKDIR) {
-		if (eptr->version >= saunafsVersion(1, 6, 25)) {
-			deserializeAllLegacyPacketDataNoHeader(data, header.length,
-					messageId, inode, name, mode, uid, gid, copysgid);
-		} else {
-			deserializeAllLegacyPacketDataNoHeader(data, header.length,
-					messageId, inode, name, mode, uid, gid);
-			copysgid = false;
-		}
-		umask = 0;
-	} else if (header.type == SAU_CLTOMA_FUSE_MKDIR) {
+	if (header.type == SAU_CLTOMA_FUSE_MKDIR) {
 		cltoma::fuseMkdir::deserialize(data, header.length, messageId,
 				inode, name, mode, umask, uid, gid, copysgid);
 	} else {
@@ -3018,14 +2851,10 @@ void matoclserv_fuse_mkdir(matoclserventry *eptr, PacketHeader header, const uin
 	}
 
 	MessageBuffer reply;
-	if (status == SAUNAFS_STATUS_OK && header.type == CLTOMA_FUSE_MKDIR) {
-		serializeLegacyPacket(reply, MATOCL_FUSE_MKDIR, messageId, newinode, attr);
-	} else if (status == SAUNAFS_STATUS_OK && header.type == SAU_CLTOMA_FUSE_MKDIR) {
+	if (status == SAUNAFS_STATUS_OK) {
 		matocl::fuseMkdir::serialize(reply, messageId, newinode, attr);
-	} else if (header.type == SAU_CLTOMA_FUSE_MKDIR) {
-		matocl::fuseMkdir::serialize(reply, messageId, status);
 	} else {
-		serializeLegacyPacket(reply, MATOCL_FUSE_MKDIR, messageId, status);
+		matocl::fuseMkdir::serialize(reply, messageId, status);
 	}
 	matoclserv_createpacket(eptr, std::move(reply));
 	if (eptr->sessionData) {
@@ -3488,7 +3317,7 @@ void matoclserv_fuse_open(matoclserventry *eptr, const uint8_t *data, uint32_t l
 }
 
 void matoclserv_fuse_read_chunk(matoclserventry *eptr, PacketHeader header, const uint8_t *data) {
-	sassert(header.type == CLTOMA_FUSE_READ_CHUNK || header.type == SAU_CLTOMA_FUSE_READ_CHUNK);
+	sassert(header.type == SAU_CLTOMA_FUSE_READ_CHUNK);
 	uint8_t status;
 	uint64_t chunkid;
 	uint64_t fleng;
@@ -3564,7 +3393,7 @@ void matoclserv_chunks_info(matoclserventry *eptr, const uint8_t *data, uint32_t
 }
 
 void matoclserv_fuse_write_chunk(matoclserventry *eptr, PacketHeader header, const uint8_t *data) {
-	sassert(header.type == CLTOMA_FUSE_WRITE_CHUNK || header.type == SAU_CLTOMA_FUSE_WRITE_CHUNK);
+	sassert(header.type == SAU_CLTOMA_FUSE_WRITE_CHUNK);
 	uint8_t status;
 	inode_t inode;
 	uint32_t chunkIndex;
@@ -3580,10 +3409,10 @@ void matoclserv_fuse_write_chunk(matoclserventry *eptr, PacketHeader header, con
 	std::vector<uint8_t> receivedData(data, data + header.length);
 	serializer->deserializeFuseWriteChunk(receivedData, messageId, inode, chunkIndex, lockId);
 
-	uint32_t min_server_version = header.type == SAU_CLTOMA_FUSE_WRITE_CHUNK ? kFirstXorVersion : 0;
+	uint32_t min_server_version = kFirstXorVersion;
 
 	// Original Legacy (1.6.27) does not use lock ID's
-	bool useDummyLockId = (header.type == CLTOMA_FUSE_WRITE_CHUNK);
+	bool useDummyLockId = false;
 	status = fs_writechunk(matoclserv_get_context(eptr), inode, chunkIndex, useDummyLockId,
 			&lockId, &chunkId, &opflag, &fileLength, min_server_version);
 
@@ -3888,9 +3717,7 @@ void matoclserv_fuse_getgoal(matoclserventry *eptr, PacketHeader header, const u
 	uint32_t msgid;
 	uint8_t gmode;
 
-	if (header.type == CLTOMA_FUSE_GETGOAL) {
-		deserializeAllLegacyPacketDataNoHeader(data, header.length, msgid, inode, gmode);
-	} else if (header.type == SAU_CLTOMA_FUSE_GETGOAL) {
+	if (header.type == SAU_CLTOMA_FUSE_GETGOAL) {
 		cltoma::fuseGetGoal::deserialize(data, header.length, msgid, inode, gmode);
 	} else {
 		throw IncorrectDeserializationException(
@@ -3904,34 +3731,14 @@ void matoclserv_fuse_getgoal(matoclserventry *eptr, PacketHeader header, const u
 	if (status == SAUNAFS_STATUS_OK) {
 		const std::map<int, Goal>& goalDefinitions = fs_get_goal_definitions();
 		std::vector<FuseGetGoalStats> sauReply;
-		LegacyVector<std::pair<uint8_t, inode_t>> legacyReplyFiles, legacyReplyDirectories;
 		for (const auto &goal : goalDefinitions) {
 			if (fgtab[goal.first] || dgtab[goal.first]) {
 				sauReply.emplace_back(goal.second.getName(), fgtab[goal.first], dgtab[goal.first]);
 			}
-			if (fgtab[goal.first] > 0) {
-				legacyReplyFiles.emplace_back(goal.first, fgtab[goal.first]);
-			}
-			if (dgtab[goal.first] > 0) {
-				legacyReplyDirectories.emplace_back(goal.first, dgtab[goal.first]);
-			}
 		}
-		if (header.type == SAU_CLTOMA_FUSE_GETGOAL) {
-			matocl::fuseGetGoal::serialize(reply, msgid, sauReply);
-		} else {
-			serializeLegacyPacket(reply, MATOCL_FUSE_GETGOAL,
-					msgid,
-					uint8_t(legacyReplyFiles.size()),
-					uint8_t(legacyReplyDirectories.size()),
-					legacyReplyFiles,
-					legacyReplyDirectories);
-		}
+		matocl::fuseGetGoal::serialize(reply, msgid, sauReply);
 	} else {
-		if (header.type == SAU_CLTOMA_FUSE_GETGOAL) {
-			matocl::fuseGetGoal::serialize(reply, msgid, status);
-		} else {
-			serializeLegacyPacket(reply, MATOCL_FUSE_GETGOAL, msgid, status);
-		}
+		matocl::fuseGetGoal::serialize(reply, msgid, status);
 	}
 	matoclserv_createpacket(eptr, std::move(reply));
 }
@@ -3939,6 +3746,7 @@ void matoclserv_fuse_getgoal(matoclserventry *eptr, PacketHeader header, const u
 void matoclserv_fuse_setgoal_wake_up(uint32_t session_id, uint32_t msgid, uint32_t type,
 				     std::shared_ptr<SetGoalTask::StatsArray> setgoal_stats,
 				     uint32_t status) {
+	sassert(type == SAU_CLTOMA_FUSE_SETGOAL);
 	matoclserventry *eptr = matoclserv_find_connection(session_id);
 	if (!eptr) {
 		return;
@@ -3951,18 +3759,9 @@ void matoclserv_fuse_setgoal_wake_up(uint32_t session_id, uint32_t msgid, uint32
 		notchanged = (*setgoal_stats)[SetGoalTask::kNotChanged];
 		notpermitted = (*setgoal_stats)[SetGoalTask::kNotPermitted];
 
-		if (type == SAU_CLTOMA_FUSE_SETGOAL) {
-			matocl::fuseSetGoal::serialize(reply, msgid, changed, notchanged, notpermitted);
-		} else {
-			serializeLegacyPacket(reply, MATOCL_FUSE_SETGOAL,
-					msgid, changed, notchanged, notpermitted);
-		}
+		matocl::fuseSetGoal::serialize(reply, msgid, changed, notchanged, notpermitted);
 	} else {
-		if (type == SAU_CLTOMA_FUSE_SETGOAL) {
-			matocl::fuseSetGoal::serialize(reply, msgid, status);
-		} else {
-			serializeLegacyPacket(reply, MATOCL_FUSE_SETGOAL, msgid, status);
-		}
+		matocl::fuseSetGoal::serialize(reply, msgid, status);
 	}
 	matoclserv_createpacket(eptr, std::move(reply));
 }
@@ -3974,10 +3773,7 @@ void matoclserv_fuse_setgoal(matoclserventry *eptr, PacketHeader header, const u
 	uint8_t goalId = 0, smode;
 	uint8_t status = SAUNAFS_STATUS_OK;
 
-	if (header.type == CLTOMA_FUSE_SETGOAL) {
-		deserializeAllLegacyPacketDataNoHeader(data, header.length,
-				msgid, inode, uid, goalId, smode);
-	} else if (header.type == SAU_CLTOMA_FUSE_SETGOAL) {
+	if (header.type == SAU_CLTOMA_FUSE_SETGOAL) {
 		std::string goalName;
 		cltoma::fuseSetGoal::deserialize(data, header.length,
 				msgid, inode, uid, goalName, smode);
@@ -4346,11 +4142,8 @@ void matoclserv_fuse_snapshot_wake_up(uint32_t type, uint32_t session_id, uint32
 	}
 
 	MessageBuffer buffer;
-	if (type == SAU_CLTOMA_FUSE_SNAPSHOT) {
-		matocl::snapshot::serialize(buffer, msgid, status);
-	} else {
-		serializeLegacyPacket(buffer, MATOCL_FUSE_SNAPSHOT, msgid, status);
-	}
+	sassert(type == SAU_CLTOMA_FUSE_SNAPSHOT);
+	matocl::snapshot::serialize(buffer, msgid, status);
 	matoclserv_createpacket(eptr, std::move(buffer));
 }
 
@@ -4366,11 +4159,7 @@ void matoclserv_fuse_snapshot(matoclserventry *eptr, PacketHeader header, const 
 	uint32_t initial_batch_size = 0;
 	LegacyString<uint8_t> name_dst;
 
-	if (header.type == CLTOMA_FUSE_SNAPSHOT) {
-		deserializeAllLegacyPacketDataNoHeader(data, header.length,
-				msgid, inode, inode_dst, name_dst, uid, gid, canoverwrite);
-		job_id = fs_reserve_job_id();
-	} else if (header.type == SAU_CLTOMA_FUSE_SNAPSHOT) {
+	if (header.type == SAU_CLTOMA_FUSE_SNAPSHOT) {
 		cltoma::snapshot::deserialize(data, header.length, msgid, job_id, inode,
 		                              inode_dst, name_dst, uid, gid, canoverwrite,
 		                              ignore_missing_src, initial_batch_size);
@@ -5873,9 +5662,6 @@ void matoclserv_gotpacket(matoclserventry *eptr, uint32_t type, const uint8_t *d
 				case CLTOMA_FUSE_ACCESS:
 				    matoclserv_fuse_access(eptr, data, length);
 				    break;
-				case CLTOMA_FUSE_LOOKUP:
-				    matoclserv_fuse_lookup(eptr, data, length);
-				    break;
 				case CLTOMA_FUSE_GETATTR:
 				    matoclserv_fuse_getattr(eptr, data, length);
 				    break;
@@ -5888,11 +5674,9 @@ void matoclserv_gotpacket(matoclserventry *eptr, uint32_t type, const uint8_t *d
 				case CLTOMA_FUSE_SYMLINK:
 				    matoclserv_fuse_symlink(eptr, data, length);
 				    break;
-				case CLTOMA_FUSE_MKNOD:
 				case SAU_CLTOMA_FUSE_MKNOD:
 					matoclserv_fuse_mknod(eptr, PacketHeader(type, length), data);
 					break;
-				case CLTOMA_FUSE_MKDIR:
 				case SAU_CLTOMA_FUSE_MKDIR:
 					matoclserv_fuse_mkdir(eptr, PacketHeader(type, length), data);
 					break;
@@ -5918,14 +5702,12 @@ void matoclserv_gotpacket(matoclserventry *eptr, uint32_t type, const uint8_t *d
 				    matoclserv_fuse_open(eptr, data, length);
 				    break;
 				case SAU_CLTOMA_FUSE_READ_CHUNK:
-				case CLTOMA_FUSE_READ_CHUNK:
 					matoclserv_fuse_read_chunk(eptr, PacketHeader(type, length), data);
 					break;
 				case SAU_CLTOMA_CHUNKS_INFO:
 					matoclserv_chunks_info(eptr, data, length);
 					break;
 				case SAU_CLTOMA_FUSE_WRITE_CHUNK:
-				case CLTOMA_FUSE_WRITE_CHUNK:
 					matoclserv_fuse_write_chunk(eptr, PacketHeader(type, length), data);
 					break;
 				case SAU_CLTOMA_FUSE_WRITE_CHUNK_END:
@@ -5969,11 +5751,9 @@ void matoclserv_gotpacket(matoclserventry *eptr, uint32_t type, const uint8_t *d
 				case CLTOMA_FUSE_SETTRASHTIME:
 					matoclserv_fuse_settrashtime(eptr, PacketHeader(type, length), data);
 					break;
-				case CLTOMA_FUSE_GETGOAL:
 				case SAU_CLTOMA_FUSE_GETGOAL:
 					matoclserv_fuse_getgoal(eptr, PacketHeader(type, length), data);
 					break;
-				case CLTOMA_FUSE_SETGOAL:
 				case SAU_CLTOMA_FUSE_SETGOAL:
 					matoclserv_fuse_setgoal(eptr, PacketHeader(type, length), data);
 					break;
@@ -5985,13 +5765,11 @@ void matoclserv_gotpacket(matoclserventry *eptr, uint32_t type, const uint8_t *d
 				    break;
 				case SAU_CLTOMA_FUSE_TRUNCATE_END:
 				case SAU_CLTOMA_FUSE_TRUNCATE:
-				case CLTOMA_FUSE_TRUNCATE:
 					matoclserv_fuse_truncate(eptr, PacketHeader(type, length), data);
 					break;
 				case CLTOMA_FUSE_REPAIR:
 				    matoclserv_fuse_repair(eptr, data, length);
 				    break;
-				case CLTOMA_FUSE_SNAPSHOT:
 				case SAU_CLTOMA_FUSE_SNAPSHOT:
 					matoclserv_fuse_snapshot(eptr, PacketHeader(type, length), data);
 					break;
@@ -6108,61 +5886,9 @@ void matoclserv_gotpacket(matoclserventry *eptr, uint32_t type, const uint8_t *d
 				    eptr->mode=ClientConnectionMode::KILL;
 			}
 		} else if (eptr->registered == ClientState::kOldTools) {        // old sfstools
-			if (eptr->sessionData == nullptr) {
-				safs::log_err("registered connection (tools) without sesdata !!!");
-				eptr->mode=ClientConnectionMode::KILL;
-				return;
-			}
-			switch (type) {
-				// extra (external tools)
-				case CLTOMA_FUSE_REGISTER:
-				    matoclserv_fuse_register(eptr, data, length);
-				    break;
-				case CLTOMA_FUSE_READ_CHUNK: // used in saunafs fileinfo
-					matoclserv_fuse_read_chunk(eptr, PacketHeader(type, length), data);
-					break;
-				case CLTOMA_FUSE_CHECK:
-					matoclserv_fuse_check(eptr, data, length);
-					break;
-				case CLTOMA_FUSE_GETTRASHTIME:
-					matoclserv_fuse_gettrashtime(eptr, data, length);
-					break;
-				case CLTOMA_FUSE_SETTRASHTIME:
-					matoclserv_fuse_settrashtime(eptr, PacketHeader(type, length), data);
-					break;
-				case CLTOMA_FUSE_GETGOAL:
-					matoclserv_fuse_getgoal(eptr, PacketHeader(type, length), data);
-					break;
-				case CLTOMA_FUSE_SETGOAL:
-					matoclserv_fuse_setgoal(eptr, PacketHeader(type, length), data);
-					break;
-				case CLTOMA_FUSE_APPEND:
-				    matoclserv_fuse_append(eptr, data, length);
-				    break;
-				case CLTOMA_FUSE_GETDIRSTATS:
-				    matoclserv_fuse_getdirstats(eptr, data, length);
-				    break;
-				case CLTOMA_FUSE_TRUNCATE:
-					matoclserv_fuse_truncate(eptr, PacketHeader(type, length), data);
-					break;
-				case CLTOMA_FUSE_REPAIR:
-				    matoclserv_fuse_repair(eptr, data, length);
-				    break;
-				case CLTOMA_FUSE_SNAPSHOT:
-					matoclserv_fuse_snapshot(eptr, PacketHeader(type, length), data);
-					break;
-				case CLTOMA_FUSE_GETEATTR:
-				    matoclserv_fuse_geteattr(eptr, data, length);
-				    break;
-				case CLTOMA_FUSE_SETEATTR:
-				    matoclserv_fuse_seteattr(eptr, data, length);
-				    break;
-				default:
-				    safs::log_info(
-				        "main master server module: got unknown message from saunafs "
-				        "<COMMAND> tools (type:{})", type);
-				    eptr->mode = ClientConnectionMode::KILL;
-			}
+			safs::log_err("registered old tools connection !!!");
+			eptr->mode=ClientConnectionMode::KILL;
+			return;
 		}
 	} catch (IncorrectDeserializationException& e) {
 		safs::log_info(
@@ -6605,7 +6331,6 @@ void matoclserv_reload() {
 		}
 	}
 
-	RejectOld = cfg_getuint32("REJECT_OLD_CLIENTS", 0);
 	SessionSustainTime = cfg_getuint32("SESSION_SUSTAIN_TIME", 86400);
 
 	if (SessionSustainTime > 7 * 86400) {
@@ -6682,8 +6407,6 @@ int matoclserv_network_init() {
 
 	free(host);  // to avoid memory leak allocated by strdup in cfg_getstr() function
 	free(port);  // to avoid memory leak allocated by strdup in cfg_getstr() function
-
-	RejectOld = cfg_getuint32("REJECT_OLD_CLIENTS", 0);
 
 	if (matoclserv_iolimits_reload() != 0) {
 		return -1;

--- a/src/master/matocsserv.cc
+++ b/src/master/matocsserv.cc
@@ -581,19 +581,9 @@ int matocsserv_send_createchunk(matocsserventry *eptr, uint64_t chunkId, ChunkPa
 		uint32_t chunkVersion) {
 	if (eptr->mode != KILL) {
 		eptr->outputPackets.push_back(OutputPacket());
-		if (eptr->version < kFirstXorVersion) {
-			// send old packet when chunkserver doesn't support xor chunks
-			sassert(slice_traits::isStandard(chunkType));
-			serializeLegacyPacket(eptr->outputPackets.back().packet, MATOCS_CREATE, chunkId,
-					chunkVersion);
-		} else if (eptr->version < kFirstECVersion) {
-			sassert((int)chunkType.getSliceType() < Goal::Slice::Type::kECFirst);
-			matocs::createChunk::serialize(eptr->outputPackets.back().packet, chunkId, (legacy::ChunkPartType)chunkType,
-					chunkVersion);
-		} else {
-			matocs::createChunk::serialize(eptr->outputPackets.back().packet, chunkId, chunkType,
-					chunkVersion);
-		}
+		sassert(eptr->version >= kFirstECVersion);
+		matocs::createChunk::serialize(eptr->outputPackets.back().packet, chunkId, chunkType,
+				chunkVersion);
 	}
 	return 0;
 }
@@ -602,21 +592,13 @@ void matocsserv_got_createchunk_status(matocsserventry *eptr, const std::vector<
 	uint64_t chunkId;
 	ChunkPartType chunkType = slice_traits::standard::ChunkPartType();
 	uint8_t status;
-	if (eptr->version < kFirstXorVersion) {
-		// get old packet when chunkserver doesn't support xor chunks
-		deserializeAllLegacyPacketDataNoHeader(data, chunkId, status);
-	}
-	else {
-		PacketVersion v;
-		deserializePacketVersionNoHeader(data, v);
-		if (v == cstoma::createChunk::kECChunks) {
-			cstoma::createChunk::deserialize(data, chunkId, chunkType, status);
-		} else {
-			legacy::ChunkPartType legacy_type;
-			cstoma::createChunk::deserialize(data, chunkId, legacy_type, status);
-			chunkType = legacy_type;
-		}
-	}
+
+	sassert(eptr->version >= kFirstECVersion);
+	PacketVersion v;
+	deserializePacketVersionNoHeader(data, v);
+	sassert(v == cstoma::createChunk::kECChunks);
+	cstoma::createChunk::deserialize(data, chunkId, chunkType, status);
+
 	chunk_got_create_status(eptr, chunkId, chunkType, status);
 	if (status != 0) {
 		safs_pretty_syslog(LOG_NOTICE,"(%s:%" PRIu16 ") chunk: %016" PRIX64 " creation status: %s",
@@ -628,20 +610,9 @@ int matocsserv_send_deletechunk(matocsserventry *eptr, uint64_t chunkId, uint32_
 		ChunkPartType chunkType) {
 	if (eptr->mode != KILL) {
 		eptr->outputPackets.push_back(OutputPacket());
-		if (eptr->version < kFirstXorVersion) {
-			// send old packet when chunkserver doesn't support xor chunks
-			sassert(chunkType == slice_traits::standard::ChunkPartType());
-			serializeLegacyPacket(eptr->outputPackets.back().packet, MATOCS_DELETE,
-					chunkId, chunkVersion);
-		}
-		else if (eptr->version < kFirstECVersion) {
-			sassert((int)chunkType.getSliceType() < Goal::Slice::Type::kECFirst);
-			matocs::deleteChunk::serialize(eptr->outputPackets.back().packet,
-					chunkId, (legacy::ChunkPartType)chunkType, chunkVersion);
-		} else {
-			matocs::deleteChunk::serialize(eptr->outputPackets.back().packet,
-					chunkId, chunkType, chunkVersion);
-		}
+		sassert(eptr->version >= kFirstECVersion);
+		matocs::deleteChunk::serialize(eptr->outputPackets.back().packet,
+				chunkId, chunkType, chunkVersion);
 		eptr->delcounter++;
 	}
 	return 0;
@@ -652,19 +623,11 @@ void matocsserv_got_deletechunk_status(matocsserventry *eptr, const std::vector<
 	ChunkPartType chunkType = slice_traits::standard::ChunkPartType();
 	uint8_t status;
 
-	if (eptr->version < kFirstXorVersion) {
-		deserializeAllLegacyPacketDataNoHeader(data, chunkId, status);
-	} else {
-		PacketVersion v;
-		deserializePacketVersionNoHeader(data, v);
-		if (v == cstoma::deleteChunk::kECChunks) {
-			cstoma::deleteChunk::deserialize(data, chunkId, chunkType, status);
-		} else {
-			legacy::ChunkPartType legacy_type;
-			cstoma::deleteChunk::deserialize(data, chunkId, legacy_type, status);
-			chunkType = legacy_type;
-		}
-	}
+	sassert(eptr->version >= kFirstECVersion);
+	PacketVersion v;
+	deserializePacketVersionNoHeader(data, v);
+	sassert(v == cstoma::deleteChunk::kECChunks);
+	cstoma::deleteChunk::deserialize(data, chunkId, chunkType, status);
 
 	chunk_got_delete_status(eptr, chunkId, chunkType, status);
 	eptr->delcounter--;
@@ -693,29 +656,18 @@ int matocsserv_send_sau_replicatechunk(matocsserventry *eptr, uint64_t chunkid, 
 			return 0;
 		}
 	}
-	if (eptr->version < kFirstECVersion) {
-		std::vector<legacy::ChunkTypeWithAddress> sources;
-		for (size_t i = 0; i < sourcePointers.size(); ++i) {
-			sassert((int)sourceTypes[i].getSliceType() < Goal::Slice::Type::kECFirst);
 
-			matocsserventry *src = sourcePointers[i];
-			sources.emplace_back(NetworkAddress(src->servip, src->servport),
-			                     (legacy::ChunkPartType)sourceTypes[i]);
-		}
-		eptr->outputPackets.emplace_back();
-		matocs::replicateChunk::serialize(eptr->outputPackets.back().packet, chunkid, version,
-		                                  (legacy::ChunkPartType)type, sources);
-	} else {
-		std::vector<ChunkTypeWithAddress> sources;
-		for (size_t i = 0; i < sourcePointers.size(); ++i) {
-			matocsserventry *src = sourcePointers[i];
-			sources.emplace_back(NetworkAddress(src->servip, src->servport), sourceTypes[i],
-			                     src->version);
-		}
-		eptr->outputPackets.emplace_back();
-		matocs::replicateChunk::serialize(eptr->outputPackets.back().packet, chunkid, version, type,
-		                                  sources);
+	sassert(eptr->version >= kFirstECVersion);
+	std::vector<ChunkTypeWithAddress> sources;
+	for (size_t i = 0; i < sourcePointers.size(); ++i) {
+		matocsserventry *src = sourcePointers[i];
+		sources.emplace_back(NetworkAddress(src->servip, src->servport), sourceTypes[i],
+		                     src->version);
 	}
+	eptr->outputPackets.emplace_back();
+	matocs::replicateChunk::serialize(eptr->outputPackets.back().packet, chunkid, version, type,
+	                                  sources);
+
 	matocsserv_replication_begin(chunkid, version, type,
 			eptr, sourcePointers.size(), sourcePointers.data());
 	return 0;
@@ -730,13 +682,8 @@ void matocsserv_got_replicatechunk_status(matocsserventry *eptr, const std::vect
 
 	PacketVersion v;
 	deserializePacketVersionNoHeader(data, v);
-	if (v == cstoma::replicateChunk::kECChunks) {
-		cstoma::replicateChunk::deserialize(data, chunkId, chunkType, status, chunkVersion);
-	} else {
-		legacy::ChunkPartType legacy_type;
-		cstoma::replicateChunk::deserialize(data, chunkId, legacy_type, status, chunkVersion);
-		chunkType = legacy_type;
-	}
+	sassert(v == cstoma::replicateChunk::kECChunks);
+	cstoma::replicateChunk::deserialize(data, chunkId, chunkType, status, chunkVersion);
 
 	matocsserv_replication_end(chunkId, chunkVersion, chunkType, eptr);
 	chunk_got_replicate_status(eptr, chunkId, chunkVersion, chunkType, status);
@@ -750,19 +697,9 @@ int matocsserv_send_setchunkversion(matocsserventry *eptr, uint64_t chunkId, uin
 		uint32_t chunkVersion, ChunkPartType chunkType) {
 	if (eptr->mode != KILL) {
 		eptr->outputPackets.emplace_back();
-		if (eptr->version < kFirstXorVersion) {
-			// send old packet when chunkserver doesn't support xor chunks
-			sassert(chunkType == slice_traits::standard::ChunkPartType());
-			serializeLegacyPacket(eptr->outputPackets.back().packet, MATOCS_SET_VERSION,
-					chunkId, newVersion, chunkVersion);
-		} else if (eptr->version < kFirstECVersion) {
-			sassert((int)chunkType.getSliceType() < Goal::Slice::Type::kECFirst);
-			matocs::setVersion::serialize(eptr->outputPackets.back().packet, chunkId, (legacy::ChunkPartType)chunkType,
-					chunkVersion, newVersion);
-		} else {
-			matocs::setVersion::serialize(eptr->outputPackets.back().packet, chunkId, chunkType,
-					chunkVersion, newVersion);
-		}
+		sassert(eptr->version >= kFirstECVersion);
+		matocs::setVersion::serialize(eptr->outputPackets.back().packet, chunkId, chunkType,
+				chunkVersion, newVersion);
 	}
 	return 0;
 }
@@ -773,19 +710,11 @@ void matocsserv_got_setchunkversion_status(matocsserventry *eptr,
 	ChunkPartType chunkType = slice_traits::standard::ChunkPartType();
 	uint8_t status;
 
-	if (eptr->version < kFirstXorVersion) {
-		deserializeAllLegacyPacketDataNoHeader(data, chunkId, status);
-	} else {
-		PacketVersion v;
-		deserializePacketVersionNoHeader(data, v);
-		if (v == cstoma::setVersion::kECChunks) {
-			cstoma::setVersion::deserialize(data, chunkId, chunkType, status);
-		} else {
-			legacy::ChunkPartType legacy_type;
-			cstoma::setVersion::deserialize(data, chunkId, legacy_type, status);
-			chunkType = legacy_type;
-		}
-	}
+	sassert(eptr->version >= kFirstECVersion);
+	PacketVersion v;
+	deserializePacketVersionNoHeader(data, v);
+	sassert(v == cstoma::setVersion::kECChunks);
+	cstoma::setVersion::deserialize(data, chunkId, chunkType, status);
 
 	chunk_got_setversion_status(eptr, chunkId, chunkType, status);
 	if (status != 0) {
@@ -801,19 +730,9 @@ int matocsserv_send_duplicatechunk(matocsserventry* eptr, uint64_t newChunkId, u
 	}
 
 	OutputPacket outPacket;
-	if (eptr->version < kFirstXorVersion) {
-		sassert(slice_traits::isStandard(chunkType));
-		// Legacy support
-		serializeLegacyPacket(outPacket.packet, MATOCS_DUPLICATE, newChunkId, newChunkVersion,
-				chunkId, chunkVersion);
-	} else if (eptr->version < kFirstECVersion) {
-		sassert((int)chunkType.getSliceType() < Goal::Slice::Type::kECFirst);
-		matocs::duplicateChunk::serialize(outPacket.packet, newChunkId, newChunkVersion,
-				(legacy::ChunkPartType)chunkType, chunkId, chunkVersion);
-	} else {
-		matocs::duplicateChunk::serialize(outPacket.packet, newChunkId, newChunkVersion,
-				chunkType, chunkId, chunkVersion);
-	}
+	sassert(eptr->version >= kFirstECVersion);
+	matocs::duplicateChunk::serialize(outPacket.packet, newChunkId, newChunkVersion, chunkType,
+	                                  chunkId, chunkVersion);
 	eptr->outputPackets.push_back(std::move(outPacket));
 	return 0;
 }
@@ -822,19 +741,12 @@ void matocsserv_got_duplicatechunk_status(matocsserventry* eptr, const std::vect
 	uint64_t chunkId;
 	ChunkPartType chunkType = slice_traits::standard::ChunkPartType();
 	uint8_t status;
-	if (eptr->version < kFirstXorVersion) {
-		deserializeAllLegacyPacketDataNoHeader(data, chunkId, status);
-	} else {
-		PacketVersion v;
-		deserializePacketVersionNoHeader(data, v);
-		if (v == cstoma::duplicateChunk::kECChunks) {
-			cstoma::duplicateChunk::deserialize(data, chunkId, chunkType, status);
-		} else {
-			legacy::ChunkPartType legacy_type;
-			cstoma::duplicateChunk::deserialize(data, chunkId, legacy_type, status);
-			chunkType = legacy_type;
-		}
-	}
+
+	sassert(eptr->version >= kFirstECVersion);
+	PacketVersion v;
+	deserializePacketVersionNoHeader(data, v);
+	sassert(v == cstoma::duplicateChunk::kECChunks);
+	cstoma::duplicateChunk::deserialize(data, chunkId, chunkType, status);
 
 	chunk_got_duplicate_status(eptr, chunkId, chunkType, status);
 	if (status != 0) {
@@ -846,48 +758,14 @@ void matocsserv_got_duplicatechunk_status(matocsserventry* eptr, const std::vect
 
 void matocsserv_send_truncatechunk(matocsserventry* eptr, uint64_t chunkid, ChunkPartType chunkType, uint32_t length,
 		uint32_t newVersion,uint32_t oldVersion) {
-	uint8_t *data;
-
 	if (eptr->mode == KILL) {
 		return;
 	}
-	if (eptr->version < kFirstXorVersion) {
-		sassert(slice_traits::isStandard(chunkType));
-		// Legacy code
-		data = matocsserv_createpacket(eptr,MATOCS_TRUNCATE,8+4+4+4);
-		put64bit(&data,chunkid);
-		put32bit(&data,length);
-		put32bit(&data,newVersion);
-		put32bit(&data,oldVersion);
-	} else if (eptr->version < kFirstECVersion) {
-		sassert((int)chunkType.getSliceType() < (int)kFirstECVersion);
-		eptr->outputPackets.emplace_back();
-		matocs::truncateChunk::serialize(eptr->outputPackets.back().packet,
-				chunkid, (legacy::ChunkPartType)chunkType, length, newVersion, oldVersion);
-	} else {
-		eptr->outputPackets.emplace_back();
-		matocs::truncateChunk::serialize(eptr->outputPackets.back().packet,
-				chunkid, chunkType, length, newVersion, oldVersion);
-	}
-}
 
-void matocsserv_got_truncatechunk_status(matocsserventry *eptr, const uint8_t *data,
-		uint32_t length) {
-	uint64_t chunkid;
-	uint8_t status;
-	if (length!=8+1) {
-		safs_pretty_syslog(LOG_NOTICE,"CSTOMA_TRUNCATE - wrong size (%" PRIu32 "/9)",length);
-		eptr->mode=KILL;
-		return;
-	}
-	passert(data);
-	chunkid = get64bit(&data);
-	status = get8bit(&data);
-	chunk_got_truncate_status(eptr, chunkid, slice_traits::standard::ChunkPartType(), status);
-	if (status!=0) {
-		safs_pretty_syslog(LOG_NOTICE,"(%s:%" PRIu16 ") chunk: %016" PRIX64 " truncate status: %s",
-		       eptr->servstrip, eptr->servport, chunkid, saunafs_error_string(status));
-	}
+	sassert(eptr->version >= kFirstECVersion);
+	eptr->outputPackets.emplace_back();
+	matocs::truncateChunk::serialize(eptr->outputPackets.back().packet, chunkid, chunkType, length,
+	                                 newVersion, oldVersion);
 }
 
 void matocsserv_got_sau_truncatechunk_status(matocsserventry *eptr,
@@ -921,19 +799,10 @@ int matocsserv_send_duptruncchunk(matocsserventry* eptr, uint64_t newChunkId, ui
 	}
 
 	OutputPacket outPacket;
-	if (eptr->version < kFirstXorVersion) {
-		sassert(slice_traits::isStandard(chunkType));
-		// Legacy support
-		serializeLegacyPacket(outPacket.packet, MATOCS_DUPTRUNC, newChunkId, newChunkVersion,
-				chunkId, chunkVersion, newChunkLength);
-	} else if (eptr->version < kFirstECVersion) {
-		sassert((int)chunkType.getSliceType() < Goal::Slice::Type::kECFirst);
-		matocs::duptruncChunk::serialize(outPacket.packet, newChunkId,
-				newChunkVersion, (legacy::ChunkPartType)chunkType, chunkId, chunkVersion, newChunkLength);
-	} else {
-		matocs::duptruncChunk::serialize(outPacket.packet, newChunkId,
-				newChunkVersion, chunkType, chunkId, chunkVersion, newChunkLength);
-	}
+	sassert(eptr->version >= kFirstECVersion);
+	matocs::duptruncChunk::serialize(outPacket.packet, newChunkId, newChunkVersion, chunkType,
+	                                 chunkId, chunkVersion, newChunkLength);
+
 	eptr->outputPackets.push_back(std::move(outPacket));
 	return 0;
 }
@@ -942,19 +811,12 @@ void matocsserv_got_duptruncchunk_status(matocsserventry* eptr, const std::vecto
 	uint64_t chunkId;
 	ChunkPartType chunkType = slice_traits::standard::ChunkPartType();
 	uint8_t status;
-	if (eptr->version < kFirstXorVersion) {
-		deserializeAllLegacyPacketDataNoHeader(data, chunkId, status);
-	} else {
-		PacketVersion v;
-		deserializePacketVersionNoHeader(data, v);
-		if (v == cstoma::duptruncChunk::kECChunks) {
-			cstoma::duptruncChunk::deserialize(data, chunkId, chunkType, status);
-		} else {
-			legacy::ChunkPartType legacy_type;
-			cstoma::duptruncChunk::deserialize(data, chunkId, legacy_type, status);
-			chunkType = legacy_type;
-		}
-	}
+
+	sassert(eptr->version >= kFirstECVersion);
+	PacketVersion v;
+	deserializePacketVersionNoHeader(data, v);
+	sassert(v == cstoma::duptruncChunk::kECChunks);
+	cstoma::duptruncChunk::deserialize(data, chunkId, chunkType, status);
 
 	chunk_got_duptrunc_status(eptr, chunkId, chunkType, status);
 	if (status != 0) {
@@ -970,6 +832,14 @@ void matocsserv_register_host(matocsserventry *eptr, uint32_t version, uint32_t 
 	eptr->servip   = servip;
 	eptr->servport = servport;
 	eptr->timeout  = timeout;
+
+	if (eptr->version < kFirstECVersion) {
+		safs::log_err(
+		    "SAU_CSTOMA_REGISTER_HOST received too old version: {} (minimum supported version is {})",
+		    saunafsVersionToString(eptr->version), saunafsVersionToString(kFirstECVersion));
+		eptr->mode = KILL;
+		return;
+	}
 
 	if (eptr->version >= kFirstVersionWithClusterId) {
 		if (clusterId.empty()) {
@@ -1079,25 +949,14 @@ void matocsserv_sau_register_host(matocsserventry *eptr, const std::vector<uint8
 void matocsserv_sau_register_chunks(matocsserventry *eptr, const std::vector<uint8_t>& data) {
 	PacketVersion v;
 	deserializePacketVersionNoHeader(data, v);
-	if (v == cstoma::registerChunks::kECChunks) {
-		std::vector<ChunkWithVersionAndType> chunks;
-		cstoma::registerChunks::deserialize(data, chunks);
-		for (auto& chunk : chunks) {
-			chunk_server_has_chunk(eptr, chunk.id, chunk.version, chunk.type);
-		}
-	} else if (v == cstoma::registerChunks::kStandardAndXorChunks) {
-		std::vector<legacy::ChunkWithVersionAndType> chunks;
-		cstoma::registerChunks::deserialize(data, chunks);
-		for (auto& chunk : chunks) {
-			chunk_server_has_chunk(eptr, chunk.id, chunk.version, ChunkPartType(chunk.type));
-		}
-	} else {
-		std::vector<ChunkWithVersion> chunks;
-		cstoma::registerChunks::deserialize(data, chunks);
-		for (auto& chunk : chunks) {
-			chunk_server_has_chunk(eptr, chunk.id, chunk.version, slice_traits::standard::ChunkPartType());
-		}
+
+	sassert(v == cstoma::registerChunks::kECChunks);
+	std::vector<ChunkWithVersionAndType> chunks;
+	cstoma::registerChunks::deserialize(data, chunks);
+	for (auto& chunk : chunks) {
+		chunk_server_has_chunk(eptr, chunk.id, chunk.version, chunk.type);
 	}
+
 	// Chunks registration is in progress, so we reset the timeout
 	gTimeoutSinceLastChunkRegistration = Timeout(kTimeoutForChunkRegistration);
 }
@@ -1156,125 +1015,37 @@ void matocsserv_sau_status(matocsserventry *eptr, const std::vector<uint8_t> &da
 	eptr->load_factor = load_factor;
 }
 
-void matocsserv_chunk_damaged(matocsserventry *eptr,const uint8_t *data,uint32_t length) {
-	uint64_t chunkid;
-	uint32_t i;
-
-	if (eptr->version >= kFirstXorVersion) {
-		safs_pretty_syslog(LOG_ERR, "Can't properly mark damaged chunks from chunkserver "
-		"(%s:%" PRIu16 "). Please upgrade it to latest version.", eptr->servstrip, eptr->servport);
-		return;
-	}
-
-	if (length%8!=0) {
-		safs_pretty_syslog(LOG_NOTICE,"CSTOMA_CHUNK_DAMAGED - wrong size (%" PRIu32 "/N*8)",length);
-		eptr->mode=KILL;
-		return;
-	}
-	if (length>0) {
-		passert(data);
-	}
-	for (i=0 ; i<length/8 ; i++) {
-		chunkid = get64bit(&data);
-		chunk_damaged(eptr, chunkid, slice_traits::standard::ChunkPartType());
-	}
-}
-
 void matocsserv_sau_chunk_damaged(matocsserventry *eptr, const std::vector<uint8_t>& data) {
 	PacketVersion v;
 	deserializePacketVersionNoHeader(data, v);
-	if (v == cstoma::chunkDamaged::kECChunks) {
-		std::vector<ChunkWithType> chunks;
-		cstoma::chunkDamaged::deserialize(data, chunks);
-		for (const auto& chunk : chunks) {
-			chunk_damaged(eptr, chunk.id, chunk.type);
-		}
-	} else {
-		std::vector<legacy::ChunkWithType> chunks;
-		cstoma::chunkDamaged::deserialize(data, chunks);
-		for (const auto& chunk : chunks) {
-			chunk_damaged(eptr, chunk.id, ChunkPartType(chunk.type));
-		}
-	}
-}
 
-void matocsserv_chunks_lost(matocsserventry *eptr,const uint8_t *data,uint32_t length) {
-	uint64_t chunkid;
-	uint32_t i;
-
-	if (eptr->version >= kFirstXorVersion) {
-		safs_pretty_syslog(LOG_ERR, "Can't properly mark lost chunks from chunkserver "
-		"(%s:%" PRIu16 "). Please upgrade it to latest version.", eptr->servstrip, eptr->servport);
-		return;
-	}
-
-	if (length%8!=0) {
-		safs_pretty_syslog(LOG_NOTICE,"CSTOMA_CHUNK_LOST - wrong size (%" PRIu32 "/N*8)",length);
-		eptr->mode=KILL;
-		return;
-	}
-	if (length>0) {
-		passert(data);
-	}
-	for (i=0 ; i<length/8 ; i++) {
-		chunkid = get64bit(&data);
-		chunk_lost(eptr, chunkid, slice_traits::standard::ChunkPartType());
+	sassert(v == cstoma::chunkDamaged::kECChunks);
+	std::vector<ChunkWithType> chunks;
+	cstoma::chunkDamaged::deserialize(data, chunks);
+	for (const auto& chunk : chunks) {
+		chunk_damaged(eptr, chunk.id, chunk.type);
 	}
 }
 
 void matocsserv_sau_chunks_lost(matocsserventry *eptr, const std::vector<uint8_t>& data) {
 	PacketVersion v;
 	deserializePacketVersionNoHeader(data, v);
-	if (v == cstoma::chunkLost::kECChunks) {
-		std::vector<ChunkWithType> chunks;
-		cstoma::chunkLost::deserialize(data, chunks);
-		for (const auto& chunk : chunks) {
-			chunk_lost(eptr, chunk.id, chunk.type);
-		}
-	} else {
-		std::vector<legacy::ChunkWithType> chunks;
-		cstoma::chunkLost::deserialize(data, chunks);
-		for (const auto& chunk : chunks) {
-			chunk_lost(eptr, chunk.id, ChunkPartType(chunk.type));
-		}
-	}
-}
 
-void matocsserv_chunks_new(matocsserventry *eptr,const uint8_t *data,uint32_t length) {
-	uint64_t chunkid;
-	uint32_t chunkversion;
-	uint32_t i;
-
-	if (length%12!=0) {
-		safs_pretty_syslog(LOG_NOTICE,"CSTOMA_CHUNK_NEW - wrong size (%" PRIu32 "/N*12)",length);
-		eptr->mode=KILL;
-		return;
-	}
-	if (length>0) {
-		passert(data);
-	}
-	for (i=0 ; i<length/12 ; i++) {
-		chunkid = get64bit(&data);
-		get32bit(&data, chunkversion);
-		chunk_server_has_chunk(eptr, chunkid, chunkversion, slice_traits::standard::ChunkPartType());
-	}
+	sassert(v == cstoma::chunkLost::kECChunks);
+	std::vector<ChunkWithType> chunks;
+	cstoma::chunkLost::deserialize(data, chunks);
+	for (const auto &chunk : chunks) { chunk_lost(eptr, chunk.id, chunk.type); }
 }
 
 void matocsserv_sau_chunk_new(matocsserventry *eptr, const std::vector<uint8_t>& data) {
 	PacketVersion v;
 	deserializePacketVersionNoHeader(data, v);
-	if (v == cstoma::chunkNew::kECChunks) {
-		std::vector<ChunkWithVersionAndType> chunks;
-		cstoma::chunkNew::deserialize(data, chunks);
-		for (auto& chunk : chunks) {
-			chunk_server_has_chunk(eptr, chunk.id, chunk.version, chunk.type);
-		}
-	} else {
-		std::vector<legacy::ChunkWithVersionAndType> chunks;
-		cstoma::chunkNew::deserialize(data, chunks);
-		for (auto& chunk : chunks) {
-			chunk_server_has_chunk(eptr, chunk.id, chunk.version, ChunkPartType(chunk.type));
-		}
+
+	sassert(v == cstoma::chunkNew::kECChunks);
+	std::vector<ChunkWithVersionAndType> chunks;
+	cstoma::chunkNew::deserialize(data, chunks);
+	for (auto &chunk : chunks) {
+		chunk_server_has_chunk(eptr, chunk.id, chunk.version, chunk.type);
 	}
 }
 
@@ -1301,47 +1072,30 @@ void matocsserv_gotpacket(matocsserventry *eptr, PacketHeader header, const Mess
 			case CSTOMA_SPACE:
 				matocsserv_space(eptr, data.data(), length);
 				break;
-			case CSTOMA_CHUNK_DAMAGED:
-				matocsserv_chunk_damaged(eptr, data.data(), length);
-				break;
-			case CSTOMA_CHUNK_LOST:
-				matocsserv_chunks_lost(eptr, data.data(), length);
-				break;
-			case CSTOMA_CHUNK_NEW:
-				matocsserv_chunks_new(eptr, data.data(), length);
-				break;
 			case CSTOMA_ERROR_OCCURRED:
 				matocsserv_error_occurred(eptr, data.data(), length);
 				break;
 			case CSTOAN_CHUNK_CHECKSUM:
 				matocsserv_got_chunk_checksum(eptr, data.data(), length);
 				break;
-			case CSTOMA_CREATE:
 			case SAU_CSTOMA_CREATE_CHUNK:
 				matocsserv_got_createchunk_status(eptr, data);
 				break;
-			case CSTOMA_DELETE:
 			case SAU_CSTOMA_DELETE_CHUNK:
 				matocsserv_got_deletechunk_status(eptr, data);
 				break;
 			case SAU_CSTOMA_REPLICATE_CHUNK:
 				matocsserv_got_replicatechunk_status(eptr, data, header.type);
 				break;
-			case CSTOMA_DUPLICATE:
 			case SAU_CSTOMA_DUPLICATE_CHUNK:
 				matocsserv_got_duplicatechunk_status(eptr, data);
 				break;
-			case CSTOMA_SET_VERSION:
 			case SAU_CSTOMA_SET_VERSION:
 				matocsserv_got_setchunkversion_status(eptr, data);
-				break;
-			case CSTOMA_TRUNCATE:
-				matocsserv_got_truncatechunk_status(eptr, data.data(), length);
 				break;
 			case SAU_CSTOMA_TRUNCATE:
 				matocsserv_got_sau_truncatechunk_status(eptr, data);
 				break;
-			case CSTOMA_DUPTRUNC:
 			case SAU_CSTOMA_DUPTRUNC_CHUNK:
 				matocsserv_got_duptruncchunk_status(eptr, data);
 				break;

--- a/src/protocol/SFSCommunication.h
+++ b/src/protocol/SFSCommunication.h
@@ -390,27 +390,10 @@ enum class SugidClearMode : uint8_t {
 /// usedspace:64 totalspace:64 tdusedspace:64 tdtotalspace:64
 /// usedspace:64 totalspace:64 chunkcount:32 tdusedspace:64 tdtotalspace:64 tdchunkcount:32
 
-// 0x0066
-#define CSTOMA_CHUNK_DAMAGED (PROTO_BASE+102)
-/// chunks:(N * [chunkid:64])
-
 // 0x0450
 #define SAU_CSTOMA_CHUNK_DAMAGED (1000U + 104U)
 /// version==0 chunks:(N * [chunkid:64 chunktype:8])
 /// version==1 chunks:(N * [chunkid:64 chunktype:16])
-
-// 0x0067
-// #define MATOCS_STRUCTURE_LOG (PROTO_BASE+103)
-// version:32 logdata:string (N*[ char:8 ])
-// 0xFF:8 version:64 logdata:string (N*[ char:8 ])
-
-// 0x0068
-// #define MATOCS_STRUCTURE_LOG_ROTATE (PROTO_BASE+104)
-// -
-
-// 0x0069
-#define CSTOMA_CHUNK_LOST (PROTO_BASE+105)
-/// chunks:(N * [chunkid:64])
 
 // 0x0451
 #define SAU_CSTOMA_CHUNK_LOST (1000U + 105U)
@@ -421,81 +404,45 @@ enum class SugidClearMode : uint8_t {
 #define CSTOMA_ERROR_OCCURRED (PROTO_BASE+106)
 /// -
 
-// 0x006B
-#define CSTOMA_CHUNK_NEW (PROTO_BASE+107)
-/// chunks:(N * [chunkid:64 chunkversion:32])
-
 // 0x0453
 #define SAU_CSTOMA_CHUNK_NEW (1000U + 107U)
 /// version==0 chunks:(N * [chunkid:64 chunkversion:32 chunktype:8])
 /// version==1 chunks:(N * [chunkid:64 chunkversion:32 chunktype:16])
-
-// 0x006E
-#define MATOCS_CREATE (PROTO_BASE+110)
-/// chunkid:64 chunkversion:32
 
 // 0x0456
 #define SAU_MATOCS_CREATE_CHUNK (1000U + 110U)
 /// version==0 chunkid:64 chunktype:8 chunkversion:32
 /// version==1 chunkid:64 chunktype:16 chunkversion:32
 
-// 0x006F
-#define CSTOMA_CREATE (PROTO_BASE+111)
-/// chunkid:64 status:8
-
 // 0x0457
 #define SAU_CSTOMA_CREATE_CHUNK (1000U + 111U)
 /// version==0 chunkid:64 chunktype:8 status:8
 /// version==1 chunkid:64 chunktype:16 status:8
-
-// 0x0078
-#define MATOCS_DELETE (PROTO_BASE+120)
-/// chunkid:64 chunkversion:32
 
 // 0x0460
 #define SAU_MATOCS_DELETE_CHUNK (1000U + 120U)
 /// version==0 chunkid:64 chunkversion:32 chunktype:8
 /// version==1 chunkid:64 chunkversion:32 chunktype:16
 
-// 0x0079
-#define CSTOMA_DELETE (PROTO_BASE+121)
-/// chunkid:64 status:8
-
 // 0x0461
 #define SAU_CSTOMA_DELETE_CHUNK (1000U + 121U)
 /// version==0 chunkid:64 chunktype:8 status:8
 /// version==1 chunkid:64 chunktype:16 status:8
-
-// 0x0082
-#define MATOCS_DUPLICATE (PROTO_BASE+130)
-/// chunkid:64 chunkversion:32 oldchunkid:64 oldchunkversion:32
 
 // 0x046A
 #define SAU_MATOCS_DUPLICATE_CHUNK (1000U + 130U)
 /// version==0 chunkid:64 chunkversion:32 chunktype:8 oldchunkid:64 oldchunkversion:32
 /// version==1 chunkid:64 chunkversion:32 chunktype:16 oldchunkid:64 oldchunkversion:32
 
-// 0x0083
-#define CSTOMA_DUPLICATE (PROTO_BASE+131)
-/// chunkid:64 status:8
-
 // 0x046B
 #define SAU_CSTOMA_DUPLICATE_CHUNK (1000U + 131U)
 /// version==0 chunkid:64 chunktype:8 status:8
 /// version==1 chunkid:64 chunktype:16 status:8
 
-// 0x008C
-#define MATOCS_SET_VERSION (PROTO_BASE + 140)
-/// chunkid:64 chunkversion:32 oldchunkversion:32
-
 // 0x0474
 #define SAU_MATOCS_SET_VERSION (1000U + 140U)
 /// version==0 chunkid:64 chunkversion:32 chunktype:8 newchunkversion:32
 /// version==1 chunkid:64 chunkversion:32 chunktype:16 newchunkversion:32
-
-// 0x008D
-#define CSTOMA_SET_VERSION (PROTO_BASE + 141)
-/// chunkid:64 status:8
 
 // 0x0475
 #define SAU_CSTOMA_SET_VERSION (1000U + 141U)
@@ -512,30 +459,6 @@ enum class SugidClearMode : uint8_t {
 /// version==0 chunkid:64 chunktype:8 status:8 chunkversion:32
 /// version==1 chunkid:64 chunktype:16 status:8 chunkversion:32
 
-// 0x0098 (no longer in use)
-#define MATOCS_CHUNKOP (PROTO_BASE+152)
-/// chunkid:64 chunkversion:32 newchunkversion:32 copychunkid:64 copychunkversion:32 chunklength:32
-// all chunk operations
-// newchunkversion>0 && chunklength==0xFFFFFFFF && copychunkid==0              -> change version
-// newchunkversion>0 && chunklength==0xFFFFFFFF && copycnunkid>0               -> duplicate
-// newchunkversion>0 && chunklength>=0 && chunklength<=SFSCHUNKSIZE && copychunkid==0 -> truncate
-// newchunkversion>0 && chunklength>=0 && chunklength<=SFSCHUNKSIZE && copychunkid>0  -> duplicate and truncate
-// newchunkversion==0 && chunklength==0                                        -> delete
-// newchunkversion==0 && chunklength==1                                        -> create
-// newchunkversion==0 && chunklength==2                                        -> test
-
-// 0x0099 (no longer in use)
-#define CSTOMA_CHUNKOP (PROTO_BASE+153)
-/// chunkid:64 chunkversion:32 newchunkversion:32 copychunkid:64 copychunkversion:32 chunklength:32 status:8
-
-// 0x00A0
-#define MATOCS_TRUNCATE (PROTO_BASE+160)
-/// chunkid:64 chunklength:32 chunkversion:32 oldchunkversion:32
-
-// 0x00A1
-#define CSTOMA_TRUNCATE (PROTO_BASE+161)
-/// chunkid:64 status:8
-
 // 0x0488
 #define SAU_MATOCS_TRUNCATE (PROTO_BASE + 1000U + 160U)
 /// version==0 chunkid:64 chunktype:8 chunklength:32 newchunkversion:32 chunkversion:32
@@ -546,18 +469,10 @@ enum class SugidClearMode : uint8_t {
 /// version==0 chunkid:64 chunktype:8 status:8
 /// version==1 chunkid:64 chunktype:16 status:8
 
-// 0x00AA
-#define MATOCS_DUPTRUNC (PROTO_BASE+170)
-/// chunkid:64 chunkversion:32 oldchunkid:64 oldchunkversion:32 chunklength:32
-
 // 0x0492
 #define SAU_MATOCS_DUPTRUNC_CHUNK (1000U + 170U)
 /// version==0 chunkid:64 chunkversion:32 chunktype:8 oldchunkid:64 oldchunkversion:32 chunklength:32
 /// version==1 chunkid:64 chunkversion:32 chunktype:16 oldchunkid:64 oldchunkversion:32 chunklength:32
-
-// 0x00AB
-#define CSTOMA_DUPTRUNC (PROTO_BASE+171)
-/// chunkid:64 status:8
 
 // 0x0493
 #define SAU_CSTOMA_DUPTRUNC_CHUNK (1000U + 171U)

--- a/src/protocol/SFSCommunication.h
+++ b/src/protocol/SFSCommunication.h
@@ -570,18 +570,6 @@ enum class SugidClearMode : uint8_t {
 
 // CHUNKSERVER <-> CLIENT/CHUNKSERVER
 
-// 0x00C8
-#define CLTOCS_READ (PROTO_BASE+200)
-/// chunkid:64 chunkversion:32 offset:32 size:32
-
-// 0x00C9
-#define CSTOCL_READ_STATUS (PROTO_BASE+201)
-/// chunkid:64 status:8
-
-// 0x00CA
-#define CSTOCL_READ_DATA (PROTO_BASE+202)
-/// chunkid:64 offset:32 size:32 crc:32 data:BYTES[size]
-
 // 0x04B0
 #define SAU_CLTOCS_READ (1000U + 200U)
 /// version==0 chunkid:64 chunkversion:32 chunktype:8 offset:32 size:32
@@ -600,34 +588,18 @@ enum class SugidClearMode : uint8_t {
 /// version==0 chunkid:64 chunkversion:32 chunktype:8 offset:32 size:32
 /// version==1 chunkid:64 chunkversion:32 chunktype:16 offset:32 size:32
 
-// 0x00D2
-#define CLTOCS_WRITE (PROTO_BASE+210)
-/// chunkid:64 chunkversion:32 chain:(N * [ip:32 port:16])
-
 // 0x04BA
 #define SAU_CLTOCS_WRITE_INIT (1000U + 210U)
 /// version==0 chunkid:64 chunkversion:32 chunktype:8 chain:(N * [ip:32 port:16])
 /// version==1 chunkid:64 chunkversion:32 chunktype:16 chain:(N * [ip:32 port:16])
 
-// 0x00D3
-#define CSTOCL_WRITE_STATUS (PROTO_BASE+211)
-/// chunkid:64 writeid:32 status:8
-
 // 0x04BB
 #define SAU_CSTOCL_WRITE_STATUS (1000U + 211U)
 /// chunkid:64 writeid:32 status:8
 
-// 0x00D4
-#define CLTOCS_WRITE_DATA (PROTO_BASE+212)
-/// chunkid:64 writeid:32 blocknum:16 offset:16 size:32 crc:32 data:BYTES[size]
-
 // 0x04BC
 #define SAU_CLTOCS_WRITE_DATA (1000U + 212U)
 /// chunkid:64 writeid:32 blocknum:16 offset:32 size:32 crc:32 data:BYTES[size]
-
-// 0x00D5
-#define CLTOCS_WRITE_FINISH (PROTO_BASE+213)
-/// chunkid:64 chunkversion:32
 
 // 0x04BD
 #define SAU_CLTOCS_WRITE_END (1000U + 213U)
@@ -639,14 +611,6 @@ enum class SugidClearMode : uint8_t {
 /// version==1 chunkid:64 chunkversion:32 chunktype:16
 
 //CHUNKSERVER <-> CHUNKSERVER
-
-// 0x00FA
-#define CSTOCS_GET_CHUNK_BLOCKS (PROTO_BASE+250)
-/// chunkid:64 chunkversion:32
-
-// 0x00FB
-#define CSTOCS_GET_CHUNK_BLOCKS_STATUS (PROTO_BASE+251)
-/// chunkid:64 chunkversion:32 blocks:16 status:8
 
 // 0x04E2
 #define SAU_CSTOCS_GET_CHUNK_BLOCKS (1000U + 250U)

--- a/src/protocol/SFSCommunication.h
+++ b/src/protocol/SFSCommunication.h
@@ -687,15 +687,6 @@ enum class SugidClearMode : uint8_t {
 #define MATOCL_FUSE_ACCESS (PROTO_BASE+405)
 /// msgid:32 status:8
 
-// 0x0196
-#define CLTOMA_FUSE_LOOKUP (PROTO_BASE+406)
-/// msgid:32 inode:32 name:NAME uid:32 gid:32
-
-// 0x0197
-#define MATOCL_FUSE_LOOKUP (PROTO_BASE+407)
-/// msgid:32 status:8
-/// msgid:32 inode:32 attr:35B
-
 // 0x0198
 #define CLTOMA_FUSE_GETATTR (PROTO_BASE+408)
 /// msgid:32 inode:32
@@ -736,37 +727,18 @@ enum class SugidClearMode : uint8_t {
 /// msgid:32 status:8
 /// msgid:32 inode:32 attr:35B
 
-// 0x01A0
-#define CLTOMA_FUSE_MKNOD (PROTO_BASE+416)
-/// msgid:32 inode:32 name:NAME nodetype:8 mode:16 uid:32 gid:32 rdev:32
-
 // 0x0588
 #define SAU_CLTOMA_FUSE_MKNOD (1000U + 416U)
 /// msgid:32 inode:32 name:NAME nodetype:8 mode:16 umask:16 uid:32 gid:32 rdev:32
-
-// 0x01A1
-#define MATOCL_FUSE_MKNOD (PROTO_BASE+417)
-/// msgid:32 status:8
-/// msgid:32 inode:32 attr:35B
 
 // 0x0589
 #define SAU_MATOCL_FUSE_MKNOD (1000U + 417U)
 /// version==0 msgid:32 status:8
 /// version==1 msgid:32 inode:32 attr:35B
 
-// 0x01A2
-#define CLTOMA_FUSE_MKDIR (PROTO_BASE+418)
-/// msgid:32 inode:32 name:NAME mode:16 uid:32 gid:32 copysgid:8
-/// msgid:32 inode:32 name:NAME mode:16 uid:32 gid:32 // version < 1.6.25
-
 // 0x058A
 #define SAU_CLTOMA_FUSE_MKDIR (1000U + 418U)
 /// msgid:32 inode:32 name:NAME mode:16 umask:16 uid:32 gid:32 copysgid:8
-
-// 0x01A3
-#define MATOCL_FUSE_MKDIR (PROTO_BASE+419)
-/// msgid:32 status:8
-/// msgid:32 inode:32 attr:35B
 
 // 0x058B
 #define SAU_MATOCL_FUSE_MKDIR (1000U + 419U)
@@ -830,10 +802,6 @@ enum class SugidClearMode : uint8_t {
 // since 1.6.9 if no error:
 /// msgid:32 attr:35B
 
-// 0x01B0
-#define CLTOMA_FUSE_READ_CHUNK (PROTO_BASE+432)
-/// msgid:32 inode:32 chunkindex:32
-
 // 0x01B1
 #define MATOCL_FUSE_READ_CHUNK (PROTO_BASE+433)
 /// msgid:32 status:8
@@ -849,10 +817,6 @@ enum class SugidClearMode : uint8_t {
 /// version==0 msgid:32 status:8
 /// version==1 msgid:32 filelength:64 chunkid:64 chunkversion:32 locations:(N * [ip:32 port:16 chunktype:8])
 /// version==2 msgid:32 filelength:64 chunkid:64 chunkversion:32 locations:(N * [ip:32 port:16 chunktype:16])
-
-// 0x01B2
-#define CLTOMA_FUSE_WRITE_CHUNK (PROTO_BASE+434) /* it creates, duplicates or sets new version of chunk if necessary */
-/// msgid:32 inode:32 chunkindex:32
 
 // 0x01B3
 #define MATOCL_FUSE_WRITE_CHUNK (PROTO_BASE+435)
@@ -924,16 +888,6 @@ enum class SugidClearMode : uint8_t {
 /// msgid:32 status:8
 /// msgid:32 changed:32 notchanged:32 notpermitted:32
 
-
-// 0x01BE
-#define CLTOMA_FUSE_GETGOAL (PROTO_BASE+446)
-/// msgid:32 inode:32 gmode:8
-
-// 0x01BF
-#define MATOCL_FUSE_GETGOAL (PROTO_BASE+447)
-/// msgid:32 status:8
-/// msgid:32 gdirs:8 gfiles:8 data:(gdirs * [goal:8 dirs:32] gfiles * [goal:8 files:32])
-
 // 0x05A6
 #define SAU_CLTOMA_FUSE_GETGOAL (1000U + 446U)
 /// msgid:32 inode:32 gmode:8
@@ -942,15 +896,6 @@ enum class SugidClearMode : uint8_t {
 #define SAU_MATOCL_FUSE_GETGOAL (1000U + 447U)
 /// version==0 msgid:32 status:8
 /// version==1 msgid:32 data:(std::vector<FuseGetGoalStats>)
-
-// 0x01C0
-#define CLTOMA_FUSE_SETGOAL (PROTO_BASE+448)
-/// msgid:32 inode:32 uid:32 goal:8 smode:8
-
-// 0x01C1
-#define MATOCL_FUSE_SETGOAL (PROTO_BASE+449)
-/// msgid:32 status:8
-/// msgid:32 changed:32 notchanged:32 notpermitted:32
 
 // 0x05A8
 #define SAU_CLTOMA_FUSE_SETGOAL (1000U + 448U)
@@ -1021,11 +966,6 @@ enum class SugidClearMode : uint8_t {
 // msgid:32 status:8
 // msgid:32 inodes:32 dirs:32 files:32 ugfiles:32 mfiles:32 chunks:32 ugchunks:32 mchunks:32 length:64 size:64 gsize:64
 
-// 0x01D0
-#define CLTOMA_FUSE_TRUNCATE (PROTO_BASE+464)
-/// msgid:32 inode:32 uid:32 gid:32 filelength:64
-/// msgid:32 inode:32 opened:8 uid:32 gid:32 filelength:64
-
 // 0x05B8
 #define SAU_CLTOMA_FUSE_TRUNCATE (1000U + 464U)
 /// msgid:32 inode:32 opened:8 uid:32 gid:32 filelength:64
@@ -1049,14 +989,6 @@ enum class SugidClearMode : uint8_t {
 #define MATOCL_FUSE_REPAIR (PROTO_BASE+467)
 /// msgid:32 status:8
 /// msgid:32 notchanged:32 erased:32 repaired:32
-
-// 0x01D4
-#define CLTOMA_FUSE_SNAPSHOT (PROTO_BASE+468)
-/// msgid:32 inode:32 inode_dst:32 name_dst:NAME uid:32 gid:32 canoverwrite:8
-
-// 0x01D5
-#define MATOCL_FUSE_SNAPSHOT (PROTO_BASE+469)
-/// msgid:32 status:8
 
 // 0x01D6
 #define CLTOMA_FUSE_GETRESERVED (PROTO_BASE+470)


### PR DESCRIPTION
This PR targets simplying the overall code related to the communication in the system by setting an overall minimum version of the components at kFirstECVersion (v3.9.5). Most of the legacy packet headers were actually removed completely from the code (except some legacy CSTOMA headers) and many version checks were removed/substituted by asserts/enforced when registering to master.

Signed-off-by: Dave <dave@leil.io>