### PR TITLE
chore(build): Bump some vcpkg ports versions

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -290,11 +290,11 @@
     },
     {
       "name": "fmt",
-      "version": "11.0.2"
+      "version": "12.0.0"
     },
     {
       "name": "gtest",
-      "version": "1.15.2"
+      "version": "1.17.0"
     },
     {
       "name": "liblzma",
@@ -306,7 +306,7 @@
     },
     {
       "name": "spdlog",
-      "version": "1.15.0"
+      "version": "1.15.3"
     },
     {
       "name": "vcpkg-boost",


### PR DESCRIPTION
Upgrades fmt, spdlog and gtest versions for better compatibility with current compiler versions like clang21.