### PR TITLE
fix(master): Make IIdGenerator generic

### DIFF
--- a/src/master/filesystem_freenode.h
+++ b/src/master/filesystem_freenode.h
@@ -30,7 +30,7 @@
 /// Inode id generator using the inode pool from gMetadata.
 /// Provides the usual behavior but now implements the IIdGenerator interface to allow custom
 /// polymorphic generators.
-class IdGeneratorWithDetainer : public IIdGenerator {
+class IdGeneratorWithDetainer : public IIdGenerator<inode_t> {
 public:
 	IdGeneratorWithDetainer() = default;
 

--- a/src/master/filesystem_metadata.h
+++ b/src/master/filesystem_metadata.h
@@ -155,7 +155,7 @@ extern bool gDisableChecksumVerification;
 extern uint32_t gTestStartTime;
 extern bool gDisableEmptyFoldersMetadataOnFullDisk;
 
-inline std::unique_ptr<IIdGenerator> gInodeIdGenerator = nullptr;
+inline std::unique_ptr<IIdGenerator<inode_t>> gInodeIdGenerator = nullptr;
 
 #ifndef METARESTORE
 extern std::map<int, Goal> gGoalDefinitions;

--- a/src/master/id_generator_interface.h
+++ b/src/master/id_generator_interface.h
@@ -20,11 +20,11 @@
 
 #include "common/platform.h"
 
+#include <concepts>
 #include <cstdint>
 
-#include "common/type_defs.h"
-
-/// Interface for id generators
+/// Generic interface for id generators
+template<std::unsigned_integral T>
 class IIdGenerator {
 public:
 	/// Default constructor
@@ -48,5 +48,5 @@ public:
 	/// @param requestedId  Requested id: >0 - specific id, 0 - get any free id
 	///
 	/// @return 0 - no more free ids, >0 - allocated id (may differ from requested if already taken)
-	virtual inode_t getNextId(uint32_t timeStamp, inode_t requestedId) = 0;
+	virtual T getNextId(uint32_t timeStamp, T requestedId) = 0;
 };


### PR DESCRIPTION
There will be generators at least for types:
- uint32_t: so far for current inodes.
- uint64_t: inodes at some point and current chunk ids.