### PR TITLE
fix: Fix issue with assert version check

### DIFF
--- a/src/master/chunks.cc
+++ b/src/master/chunks.cc
@@ -1997,10 +1997,10 @@ bool ChunkWorker::tryReplication(Chunk *c, ChunkPartType part_to_recover,
 	std::vector<ChunkPartType> all_parts;
 	ChunkCopiesCalculator calc(c->getGoal());
 
-	uint32_t destination_version = matocsserv_get_version(destination_server);
+	// Implies matocsserv_get_version(destination_server) >= kFirstECVersion
+	assert(matocsserv_get_version(destination_server) >=
+	       getMinChunkserverVersion(c, part_to_recover));
 
-	// Implies destination_version >= kFirstECVersion
-	assert(destination_version >= getMinChunkserverVersion(c, part_to_recover));
 	for (const auto &part : c->parts) {
 		if (!part.is_valid() || part.is_busy() || matocsserv_replication_read_counter(part.server()) >= MaxReadRepl) {
 			continue;


### PR DESCRIPTION
After commit 69eecb26, an assert check in the
`ChunkWorker::tryReplication` function caused an unused variable warning when building with the `release-vcpkg` preset. This happened because the variable was only used in an assertion, which is omitted in release
builds, leading to a compilation error in release-ready SaunaFS binaries. This commit resolves the issue.