### PR TITLE
chore(dev): update include path in CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -387,7 +387,7 @@ set(MAIN_SRC ${CMAKE_SOURCE_DIR}/src/main/main.cc)
 if(ZLIB_FOUND)
   include_directories(${ZLIB_INCLUDE_DIRS})
 endif()
-include_directories(src) # Allow paths relative to src, eg. #include common/crc.h
+include_directories(${CMAKE_SOURCE_DIR}/src) # Allow paths relative to src, eg. #include common/crc.h
 link_directories(${LINK_DIRECTORIES} ${FUSE_LIBRARY_DIR})
 
 set(ICON_RESOURCE_FILE "")


### PR DESCRIPTION
The include path in CMakeLists.txt has been updated to use absolute paths derived from `CMAKE_SOURCE_DIR`. This change ensures that the configuration is robust and works correctly across all environments and build directories, avoiding potential issues with relative paths.

It FIXES issues in some IDEs finding include symbols.
