### PR TITLE
refactor: Simplify csentry network IO functions

### DIFF
--- a/src/chunkserver/chunkserver_entry.cc
+++ b/src/chunkserver/chunkserver_entry.cc
@@ -1113,7 +1113,8 @@ bool ChunkserverEntry::processRWBytes(int bytesRW, PacketStruct &packet, bool sh
 
 	if (bytesRW < 0) {
 		if (errno != EAGAIN) {
-			safs::log_error_code(errno, "({}) {} error", callerName, isRead ? "read" : "write");
+			safs::log_info_with_error_code(errno, "({}) {} error", callerName,
+			                               isRead ? "read" : "write");
 
 			if (shouldForwardError) {
 				fwdError();
@@ -1132,6 +1133,74 @@ bool ChunkserverEntry::processRWBytes(int bytesRW, PacketStruct &packet, bool sh
 	packet.startPtr += bytesRW;
 	packet.bytesLeft -= bytesRW;
 
+	return true;
+}
+
+bool ChunkserverEntry::readHeader(int socket, PacketStruct &packet, uint8_t *headerBuf,
+                                  Mode &targetMode) {
+	// At this point, packet.startPtr points to the current position in the header buffer,
+	// and packet.bytesLeft is the number of bytes remaining to read to complete the header.
+	// Therefore, packet.startPtr + packet.bytesLeft should equal headerBuf + PacketHeader::kSize,
+	// ensuring that the header buffer will be fully filled after reading the remaining bytes.
+	sassert(packet.startPtr + packet.bytesLeft == headerBuf + PacketHeader::kSize);
+
+	bool fromForward = (socket == fwdSocket);
+	bool mustForward = (state == State::WriteForward && !fromForward);
+	sassert(targetMode == Mode::Header);
+
+	auto bytesRead = ::read(socket, packet.startPtr, packet.bytesLeft);
+
+	if (!processRWBytes(bytesRead, packet, fromForward, __func__, true)) { return false; }
+
+	if (packet.bytesLeft > 0) { return false; }
+
+	auto [type, length] = getTypeAndLengthFromHeader(headerBuf);
+
+	if (length > kMaxPacketSize) {
+		safs::log_warn("({}) packet too long ({}/{})", __func__, length, kMaxPacketSize);
+
+		if (fromForward) {
+			fwdError();
+		} else {
+			state = State::Close;
+		}
+		return false;
+	}
+
+	if (type == SAU_CLTOCS_WRITE_DATA) {
+		prepareInputBufferForWrite(mustForward);
+
+		if (mustForward) {
+			inputBuffer->copyIntoBuffer(InputBuffer::BufferType::Header, headerBuffer,
+			                            PacketHeader::kSize);
+		}
+		// Setting up packet.startPtr is not needed, inputBuffer will be used for reading data
+	} else {
+		if (mustForward) {
+			packet.packet.resize(PacketHeader::kSize + length);
+			passert(packet.packet.data());
+			std::copy(headerBuffer, headerBuffer + PacketHeader::kSize, packet.packet.begin());
+			packet.startPtr = packet.packet.data() + PacketHeader::kSize;
+		} else if (length > 0) {  // asserts might fail if length is 0
+			packet.packet.resize(length);
+			passert(packet.packet.data());
+			packet.startPtr = packet.packet.data();
+		}
+	}
+	packet.bytesLeft = length;
+
+	if (mustForward && (type == SAU_CLTOCS_WRITE_DATA || type == SAU_CLTOCS_WRITE_END)) {
+		fwdOutputPacket.bytesLeft = PacketHeader::kSize;
+		// Use the correct buffer for forwarding
+		if (type == SAU_CLTOCS_WRITE_DATA) {
+			fwdOutputPacket.startPtr =
+			    const_cast<uint8_t *>(inputBuffer->getStartLastWriteOperationHeader());
+		} else {
+			fwdOutputPacket.startPtr = packet.packet.data();
+		}
+	}
+
+	targetMode = Mode::Data;
 	return true;
 }
 
@@ -1154,43 +1223,9 @@ void ChunkserverEntry::fwdRead() {
 	uint32_t opSize;
 	const uint8_t *ptr;
 
-	if (fwdMode == Mode::Header) {
-		bytesRead = read(fwdSocket, fwdInputPacket.startPtr, fwdInputPacket.bytesLeft);
-		if (bytesRead == 0) {
-			fwdError();
-			return;
-		}
-		if (bytesRead < 0) {
-			if (errno != EAGAIN) {
-				safs::log_info_with_error_code(errno, "({}) read error", __func__);
-				fwdError();
-			}
-			return;
-		}
-		stats_bytesin += bytesRead;
-		fwdInputPacket.startPtr += bytesRead;
-		fwdInputPacket.bytesLeft -= bytesRead;
-		if (fwdInputPacket.bytesLeft > 0) {
-			return;
-		}
-
-		ptr = fwdHeaderBuffer;
-		get32bit(&ptr, type);
-		get32bit(&ptr, opSize);
-
-		if (opSize > kMaxPacketSize) {
-			safs::log_warn("({}) packet too long ({}/{})", __func__, opSize, kMaxPacketSize);
-			fwdError();
-			return;
-		}
-
-		if (opSize > 0) {
-			fwdInputPacket.packet.resize(opSize);
-			passert(fwdInputPacket.packet.data());
-			fwdInputPacket.startPtr = fwdInputPacket.packet.data();
-		}
-		fwdInputPacket.bytesLeft = opSize;
-		fwdMode = Mode::Data;
+	if (fwdMode == Mode::Header &&
+	    !readHeader(fwdSocket, fwdInputPacket, fwdHeaderBuffer, fwdMode)) {
+		return;
 	}
 
 	if (fwdMode == Mode::Data) {
@@ -1264,78 +1299,7 @@ void ChunkserverEntry::forward() {
 	TRACETHIS();
 	ssize_t bytesReadOrWritten{0};
 
-	if (mode == Mode::Header) {
-		bytesReadOrWritten = ::read(sock, inputPacket.startPtr, inputPacket.bytesLeft);
-
-		if (bytesReadOrWritten == 0) {
-			state = State::Close;
-			return;
-		}
-
-		if (bytesReadOrWritten < 0) {
-			if (errno != EAGAIN) {
-				safs::log_info_with_error_code(errno, "({}) read error", __func__);
-				state = State::Close;
-			}
-			return;
-		}
-
-		stats_bytesin += bytesReadOrWritten;
-		inputPacket.startPtr += bytesReadOrWritten;
-		inputPacket.bytesLeft -= bytesReadOrWritten;
-
-		if (inputPacket.bytesLeft > 0) {
-			return;
-		}
-
-		PacketHeader header;
-
-		try {
-			deserializePacketHeader(headerBuffer, sizeof(headerBuffer), header);
-		} catch (IncorrectDeserializationException &) {
-			safs::log_warn("({}) Received malformed network packet", __func__);
-			state = State::Close;
-			return;
-		}
-
-		if (header.length > kMaxPacketSize) {
-			safs::log_warn("({}) packet too long ({}/{})", __func__, header.length, kMaxPacketSize);
-			state = State::Close;
-			return;
-		}
-
-		uint32_t totalPacketLength = PacketHeader::kSize + header.length;
-
-		// Check if we can use aligned memory directly
-		if (header.type == SAU_CLTOCS_WRITE_DATA) {
-			prepareInputBufferForWrite(true);
-			inputBuffer->copyIntoBuffer(InputBuffer::BufferType::Header, headerBuffer,
-			                            PacketHeader::kSize);
-			inputPacket.startPtr = const_cast<uint8_t *>(
-			    inputBuffer->getStartLastWriteOperationHeader() + PacketHeader::kSize);
-
-			inputPacket.bytesLeft = header.length;
-		} else {
-			inputPacket.packet.resize(totalPacketLength);
-			passert(inputPacket.packet.data());
-			std::copy(headerBuffer, headerBuffer + PacketHeader::kSize, inputPacket.packet.begin());
-			inputPacket.startPtr = inputPacket.packet.data() + PacketHeader::kSize;
-			inputPacket.bytesLeft = header.length;
-		}
-
-		if (header.type == SAU_CLTOCS_WRITE_DATA || header.type == SAU_CLTOCS_WRITE_END) {
-			fwdOutputPacket.bytesLeft = PacketHeader::kSize;
-			// Use the correct buffer for forwarding
-			if (header.type == SAU_CLTOCS_WRITE_DATA) {
-				fwdOutputPacket.startPtr =
-				    const_cast<uint8_t *>(inputBuffer->getStartLastWriteOperationHeader());
-			} else {
-				fwdOutputPacket.startPtr = inputPacket.packet.data();
-			}
-		}
-
-		mode = Mode::Data;
-	}
+	if (mode == Mode::Header && !readHeader(sock, inputPacket, headerBuffer, mode)) { return; }
 
 	if (inputPacket.bytesLeft > 0) {
 		if (isLastHeaderTypeWriteData()) {
@@ -1423,52 +1387,7 @@ void ChunkserverEntry::readFromSocket() {
 	uint32_t opSize;
 	const uint8_t *ptr;
 
-	if (mode == Mode::Header) {
-		sassert(inputPacket.startPtr + inputPacket.bytesLeft == headerBuffer + PacketHeader::kSize);
-		bytesRead = ::read(sock, inputPacket.startPtr, inputPacket.bytesLeft);
-		if (bytesRead == 0) {
-			state = State::Close;
-			return;
-		}
-		if (bytesRead < 0) {
-			if (errno != EAGAIN) {
-				safs::log_info_with_error_code(errno, "({}) read error", __func__);
-				state = State::Close;
-			}
-			return;
-		}
-		stats_bytesin += bytesRead;
-		inputPacket.startPtr += bytesRead;
-		inputPacket.bytesLeft -= bytesRead;
-
-		if (inputPacket.bytesLeft > 0) {
-			return;
-		}
-
-		ptr = headerBuffer;
-		get32bit(&ptr, type);
-		get32bit(&ptr, opSize);
-
-		if (opSize > 0) {
-			if (opSize > kMaxPacketSize) {
-				safs::log_warn("({}) packet too long ({}/{})", __func__, opSize, kMaxPacketSize);
-				state = State::Close;
-				return;
-			}
-
-			if (type == SAU_CLTOCS_WRITE_DATA) {
-				prepareInputBufferForWrite(false);
-				inputPacket.startPtr =
-				    const_cast<uint8_t *>(inputBuffer->getStartLastWriteOperationHeader());
-			} else {
-				inputPacket.packet.resize(opSize);
-				passert(inputPacket.packet.data());
-				inputPacket.startPtr = inputPacket.packet.data();
-			}
-		}
-		inputPacket.bytesLeft = opSize;
-		mode = Mode::Data;
-	}
+	if (mode == Mode::Header && !readHeader(sock, inputPacket, headerBuffer, mode)) { return; }
 
 	if (mode == Mode::Data) {
 		if (inputPacket.bytesLeft > 0) {

--- a/src/chunkserver/chunkserver_entry.cc
+++ b/src/chunkserver/chunkserver_entry.cc
@@ -1204,6 +1204,30 @@ bool ChunkserverEntry::readHeader(int socket, PacketStruct &packet, uint8_t *hea
 	return true;
 }
 
+bool ChunkserverEntry::readData(int socket, PacketStruct &packet) {
+	bool fromForward = (socket == fwdSocket);
+	bool mustForward = (state == State::WriteForward && !fromForward);
+	sassert((mode == Mode::Data && !fromForward) || (fwdMode == Mode::Data && fromForward));
+
+	if (packet.bytesLeft == 0) { return true; }
+
+	int bytesRead{0};
+	if (!fromForward && isLastHeaderTypeWriteData()) {
+		bytesRead = inputBuffer->readFromSocket(socket, packet.bytesLeft);
+	} else {
+		bytesRead = ::read(socket, packet.startPtr, packet.bytesLeft);
+	}
+
+	if (!processRWBytes(bytesRead, packet, fromForward, __func__, true)) { return false; }
+
+	if (mustForward && fwdOutputPacket.startPtr != nullptr) {
+		fwdOutputPacket.bytesLeft += bytesRead;
+	}
+	if (!mustForward && packet.bytesLeft > 0) { return false; }
+
+	return true;
+}
+
 void ChunkserverEntry::fwdConnected() {
 	TRACETHIS();
 	int status = tcpgetstatus(fwdSocket);
@@ -1218,7 +1242,6 @@ void ChunkserverEntry::fwdConnected() {
 
 void ChunkserverEntry::fwdRead() {
 	TRACETHIS();
-	int32_t bytesRead;
 	uint32_t type;
 	uint32_t opSize;
 	const uint8_t *ptr;
@@ -1229,26 +1252,8 @@ void ChunkserverEntry::fwdRead() {
 	}
 
 	if (fwdMode == Mode::Data) {
-		if (fwdInputPacket.bytesLeft > 0) {
-			bytesRead = read(fwdSocket, fwdInputPacket.startPtr, fwdInputPacket.bytesLeft);
-			if (bytesRead == 0) {
-				fwdError();
-				return;
-			}
-			if (bytesRead < 0) {
-				if (errno != EAGAIN) {
-					safs::log_info_with_error_code(errno, "({}) read error", __func__);
-					fwdError();
-				}
-				return;
-			}
-			stats_bytesin += bytesRead;
-			fwdInputPacket.startPtr += bytesRead;
-			fwdInputPacket.bytesLeft -= bytesRead;
-			if (fwdInputPacket.bytesLeft > 0) {
-				return;
-			}
-		}
+		if (!readData(fwdSocket, fwdInputPacket)) { return; }
+
 		ptr = fwdHeaderBuffer;
 		get32bit(&ptr, type);
 		get32bit(&ptr, opSize);
@@ -1301,33 +1306,7 @@ void ChunkserverEntry::forward() {
 
 	if (mode == Mode::Header && !readHeader(sock, inputPacket, headerBuffer, mode)) { return; }
 
-	if (inputPacket.bytesLeft > 0) {
-		if (isLastHeaderTypeWriteData()) {
-			bytesReadOrWritten = inputBuffer->readFromSocket(sock, inputPacket.bytesLeft);
-		} else {
-			bytesReadOrWritten = ::read(sock, inputPacket.startPtr, inputPacket.bytesLeft);
-		}
-
-		if (bytesReadOrWritten == 0) {
-			state = State::Close;
-			return;
-		}
-		if (bytesReadOrWritten < 0) {
-			if (errno != EAGAIN) {
-				safs::log_info_with_error_code(errno, "({}) read error", __func__);
-				state = State::Close;
-			}
-			return;
-		}
-
-		stats_bytesin += bytesReadOrWritten;
-		// Note startPtr could point to anywhere in some cases
-		inputPacket.startPtr += bytesReadOrWritten;
-		inputPacket.bytesLeft -= bytesReadOrWritten;
-		if (fwdOutputPacket.startPtr != nullptr) {
-			fwdOutputPacket.bytesLeft += bytesReadOrWritten;
-		}
-	}
+	if (!readData(sock, inputPacket)) { return; }
 
 	if (fwdOutputPacket.bytesLeft > 0) {
 		sassert(fwdOutputPacket.startPtr != nullptr);
@@ -1382,7 +1361,6 @@ void ChunkserverEntry::forward() {
 
 void ChunkserverEntry::readFromSocket() {
 	TRACETHIS();
-	int32_t bytesRead;
 	uint32_t type;
 	uint32_t opSize;
 	const uint8_t *ptr;
@@ -1390,31 +1368,7 @@ void ChunkserverEntry::readFromSocket() {
 	if (mode == Mode::Header && !readHeader(sock, inputPacket, headerBuffer, mode)) { return; }
 
 	if (mode == Mode::Data) {
-		if (inputPacket.bytesLeft > 0) {
-			if (isLastHeaderTypeWriteData()) {
-				bytesRead = inputBuffer->readFromSocket(sock, inputPacket.bytesLeft);
-			} else {
-				bytesRead = ::read(sock, inputPacket.startPtr, inputPacket.bytesLeft);
-			}
-
-			if (bytesRead == 0) {
-				state = State::Close;
-				return;
-			}
-			if (bytesRead < 0) {
-				if (errno != EAGAIN) {
-					safs::log_info_with_error_code(errno, "({}) read error", __func__);
-					state = State::Close;
-				}
-				return;
-			}
-			stats_bytesin += bytesRead;
-			// Note startPtr could point to anywhere in some cases
-			inputPacket.startPtr += bytesRead;
-			inputPacket.bytesLeft -= bytesRead;
-
-			if (inputPacket.bytesLeft > 0) { return; }
-		}
+		if (!readData(sock, inputPacket)) { return; }
 
 		ptr = headerBuffer;
 		get32bit(&ptr, type);

--- a/src/chunkserver/chunkserver_entry.cc
+++ b/src/chunkserver/chunkserver_entry.cc
@@ -502,11 +502,19 @@ void ChunkserverEntry::prefetch(const uint8_t *data, PacketHeader::Type type,
 
 // Write helpers
 
-bool ChunkserverEntry::isLastHeaderTypeWriteData() {
+/// @brief Returns a pair of type and length obtained from a header pointer.
+/// @param headerPtr The pointer to the header (must point to at least 8 bytes).
+/// @return A pair where the first element is the type and the second is the length.
+static std::pair<uint32_t, uint32_t> getTypeAndLengthFromHeader(const uint8_t *headerPtr) {
 	uint32_t type;
-	const uint8_t *ptr = headerBuffer;
-	get32bit(&ptr, type);
-	return type == SAU_CLTOCS_WRITE_DATA;
+	uint32_t length;
+	get32bit(&headerPtr, type);
+	get32bit(&headerPtr, length);
+	return {type, length};
+}
+
+bool ChunkserverEntry::isLastHeaderTypeWriteData() {
+	return getTypeAndLengthFromHeader(headerBuffer).first == SAU_CLTOCS_WRITE_DATA;
 }
 
 void ChunkserverEntry::updateUsingWriteStatusAndReply(uint8_t status, uint32_t writeId) {
@@ -688,8 +696,8 @@ void ChunkserverEntry::writeInit(const uint8_t *data, PacketHeader::Type type,
 		fwdServer = chain[0].address;
 		chain.erase(chain.begin());
 		serializeCltocsWriteInit(fwdInitPacket, chunkId, chunkVersion, chunkType, chain);
-		fwdStartPtr = fwdInitPacket.data();
-		fwdBytesLeft = fwdInitPacket.size();
+		fwdOutputPacket.startPtr = fwdInitPacket.data();
+		fwdOutputPacket.bytesLeft = fwdInitPacket.size();
 		connectRetryCounter = 0;
 
 		if (initConnection() < kInitConnectionOK) {
@@ -1091,6 +1099,42 @@ void ChunkserverEntry::gotPacket(uint32_t type, const uint8_t *data,
 	}
 }
 
+bool ChunkserverEntry::processRWBytes(int bytesRW, PacketStruct &packet, bool shouldForwardError,
+                                      const char *callerName, bool isRead) {
+	if (bytesRW == 0) {
+		if (shouldForwardError) {
+			fwdError();
+		} else {
+			state = State::Close;
+		}
+
+		return false;
+	}
+
+	if (bytesRW < 0) {
+		if (errno != EAGAIN) {
+			safs::log_error_code(errno, "({}) {} error", callerName, isRead ? "read" : "write");
+
+			if (shouldForwardError) {
+				fwdError();
+			} else {
+				state = State::Close;
+			}
+		}
+		return false;
+	}
+
+	if (isRead) {
+		stats_bytesin += bytesRW;
+	} else {
+		stats_bytesout += bytesRW;
+	}
+	packet.startPtr += bytesRW;
+	packet.bytesLeft -= bytesRW;
+
+	return true;
+}
+
 void ChunkserverEntry::fwdConnected() {
 	TRACETHIS();
 	int status = tcpgetstatus(fwdSocket);
@@ -1186,8 +1230,8 @@ void ChunkserverEntry::fwdWrite() {
 	TRACETHIS();
 	int32_t bytesWritten;
 
-	if (fwdBytesLeft > 0) {
-		bytesWritten = ::write(fwdSocket, fwdStartPtr, fwdBytesLeft);
+	if (fwdOutputPacket.bytesLeft > 0) {
+		bytesWritten = ::write(fwdSocket, fwdOutputPacket.startPtr, fwdOutputPacket.bytesLeft);
 		if (bytesWritten == 0) {
 			fwdError();
 			return;
@@ -1202,13 +1246,13 @@ void ChunkserverEntry::fwdWrite() {
 		}
 
 		stats_bytesout += bytesWritten;
-		fwdStartPtr += bytesWritten;
-		fwdBytesLeft -= bytesWritten;
+		fwdOutputPacket.startPtr += bytesWritten;
+		fwdOutputPacket.bytesLeft -= bytesWritten;
 	}
 
-	if (fwdBytesLeft == 0) {
+	if (fwdOutputPacket.bytesLeft == 0) {
 		fwdInitPacket.clear();
-		fwdStartPtr = nullptr;
+		fwdOutputPacket.startPtr = nullptr;
 		fwdMode = Mode::Header;
 		fwdInputPacket.bytesLeft = PacketHeader::kSize;
 		fwdInputPacket.startPtr = fwdHeaderBuffer;
@@ -1280,13 +1324,13 @@ void ChunkserverEntry::forward() {
 		}
 
 		if (header.type == SAU_CLTOCS_WRITE_DATA || header.type == SAU_CLTOCS_WRITE_END) {
-			fwdBytesLeft = PacketHeader::kSize;
+			fwdOutputPacket.bytesLeft = PacketHeader::kSize;
 			// Use the correct buffer for forwarding
 			if (header.type == SAU_CLTOCS_WRITE_DATA) {
-				fwdStartPtr =
+				fwdOutputPacket.startPtr =
 				    const_cast<uint8_t *>(inputBuffer->getStartLastWriteOperationHeader());
 			} else {
-				fwdStartPtr = inputPacket.packet.data();
+				fwdOutputPacket.startPtr = inputPacket.packet.data();
 			}
 		}
 
@@ -1316,17 +1360,18 @@ void ChunkserverEntry::forward() {
 		// Note startPtr could point to anywhere in some cases
 		inputPacket.startPtr += bytesReadOrWritten;
 		inputPacket.bytesLeft -= bytesReadOrWritten;
-		if (fwdStartPtr != nullptr) {
-			fwdBytesLeft += bytesReadOrWritten;
+		if (fwdOutputPacket.startPtr != nullptr) {
+			fwdOutputPacket.bytesLeft += bytesReadOrWritten;
 		}
 	}
 
-	if (fwdBytesLeft > 0) {
-		sassert(fwdStartPtr != nullptr);
+	if (fwdOutputPacket.bytesLeft > 0) {
+		sassert(fwdOutputPacket.startPtr != nullptr);
 		if (isLastHeaderTypeWriteData()) {
-			bytesReadOrWritten = inputBuffer->writeToSocket(fwdSocket, fwdBytesLeft);
+			bytesReadOrWritten = inputBuffer->writeToSocket(fwdSocket, fwdOutputPacket.bytesLeft);
 		} else {
-			bytesReadOrWritten = ::write(fwdSocket, fwdStartPtr, fwdBytesLeft);
+			bytesReadOrWritten =
+			    ::write(fwdSocket, fwdOutputPacket.startPtr, fwdOutputPacket.bytesLeft);
 		}
 
 		if (bytesReadOrWritten == 0) {
@@ -1341,12 +1386,12 @@ void ChunkserverEntry::forward() {
 			return;
 		}
 		stats_bytesout += bytesReadOrWritten;
-		// Note fwdStartPtr could point to anywhere in some cases
-		fwdStartPtr += bytesReadOrWritten;
-		fwdBytesLeft -= bytesReadOrWritten;
+		// Note fwdOutputPacket.startPtr could point to anywhere in some cases
+		fwdOutputPacket.startPtr += bytesReadOrWritten;
+		fwdOutputPacket.bytesLeft -= bytesReadOrWritten;
 	}
 
-	if (inputPacket.bytesLeft == 0 && fwdBytesLeft == 0) {
+	if (inputPacket.bytesLeft == 0 && fwdOutputPacket.bytesLeft == 0) {
 		PacketHeader header;
 		try {
 			deserializePacketHeader(headerBuffer, sizeof(headerBuffer), header);
@@ -1367,7 +1412,7 @@ void ChunkserverEntry::forward() {
 			packetData = inputPacket.packet.data() + PacketHeader::kSize;
 		}
 		gotPacket(header.type, packetData, header.length);
-		fwdStartPtr = nullptr;
+		fwdOutputPacket.startPtr = nullptr;
 	}
 }
 

--- a/src/chunkserver/chunkserver_entry.cc
+++ b/src/chunkserver/chunkserver_entry.cc
@@ -1228,6 +1228,29 @@ bool ChunkserverEntry::readData(int socket, PacketStruct &packet) {
 	return true;
 }
 
+void ChunkserverEntry::processPacket(PacketStruct &packet, uint8_t *headerBuf, Mode &targetMode,
+                                     bool fromForward) {
+	sassert(targetMode == Mode::Data);
+	bool mustForward = (state == State::WriteForward && !fromForward);
+
+	auto [type, length] = getTypeAndLengthFromHeader(headerBuf);
+
+	targetMode = Mode::Header;
+	packet.bytesLeft = PacketHeader::kSize;
+	packet.startPtr = headerBuf;
+
+	uint32_t offsetFromSkipHeaderInForward = mustForward ? PacketHeader::kSize : 0;
+	const uint8_t *packetData{nullptr};
+	if (!fromForward && isLastHeaderTypeWriteData()) {
+		packetData =
+		    inputBuffer->getStartLastWriteOperationHeader() + offsetFromSkipHeaderInForward;
+	} else {
+		packetData = packet.packet.data() + offsetFromSkipHeaderInForward;
+	}
+
+	gotPacket(type, packetData, length);
+}
+
 void ChunkserverEntry::fwdConnected() {
 	TRACETHIS();
 	int status = tcpgetstatus(fwdSocket);
@@ -1242,9 +1265,6 @@ void ChunkserverEntry::fwdConnected() {
 
 void ChunkserverEntry::fwdRead() {
 	TRACETHIS();
-	uint32_t type;
-	uint32_t opSize;
-	const uint8_t *ptr;
 
 	if (fwdMode == Mode::Header &&
 	    !readHeader(fwdSocket, fwdInputPacket, fwdHeaderBuffer, fwdMode)) {
@@ -1254,15 +1274,7 @@ void ChunkserverEntry::fwdRead() {
 	if (fwdMode == Mode::Data) {
 		if (!readData(fwdSocket, fwdInputPacket)) { return; }
 
-		ptr = fwdHeaderBuffer;
-		get32bit(&ptr, type);
-		get32bit(&ptr, opSize);
-
-		fwdMode = Mode::Header;
-		fwdInputPacket.bytesLeft = PacketHeader::kSize;
-		fwdInputPacket.startPtr = fwdHeaderBuffer;
-
-		gotPacket(type, fwdInputPacket.packet.data(), opSize);
+		processPacket(fwdInputPacket, fwdHeaderBuffer, fwdMode, true);
 	}
 }
 
@@ -1335,54 +1347,20 @@ void ChunkserverEntry::forward() {
 	}
 
 	if (inputPacket.bytesLeft == 0 && fwdOutputPacket.bytesLeft == 0) {
-		PacketHeader header;
-		try {
-			deserializePacketHeader(headerBuffer, sizeof(headerBuffer), header);
-		} catch (IncorrectDeserializationException &) {
-			safs::log_warn("({}) Received malformed network packet", __func__);
-			state = State::Close;
-			return;
-		}
-		mode = Mode::Header;
-		inputPacket.bytesLeft = PacketHeader::kSize;
-		inputPacket.startPtr = headerBuffer;
-
-		uint8_t *packetData{nullptr};
-		if (isLastHeaderTypeWriteData()) {
-			packetData = const_cast<uint8_t *>(inputBuffer->getStartLastWriteOperationHeader() +
-			                                   PacketHeader::kSize);
-		} else {
-			packetData = inputPacket.packet.data() + PacketHeader::kSize;
-		}
-		gotPacket(header.type, packetData, header.length);
+		processPacket(inputPacket, headerBuffer, mode, false);
 		fwdOutputPacket.startPtr = nullptr;
 	}
 }
 
 void ChunkserverEntry::readFromSocket() {
 	TRACETHIS();
-	uint32_t type;
-	uint32_t opSize;
-	const uint8_t *ptr;
 
 	if (mode == Mode::Header && !readHeader(sock, inputPacket, headerBuffer, mode)) { return; }
 
 	if (mode == Mode::Data) {
 		if (!readData(sock, inputPacket)) { return; }
 
-		ptr = headerBuffer;
-		get32bit(&ptr, type);
-		get32bit(&ptr, opSize);
-
-		mode = Mode::Header;
-		inputPacket.bytesLeft = PacketHeader::kSize;
-		inputPacket.startPtr = headerBuffer;
-
-		if (isLastHeaderTypeWriteData()) {
-			gotPacket(type, inputBuffer->getStartLastWriteOperationHeader(), opSize);
-		} else {
-			gotPacket(type, inputPacket.packet.data(), opSize);
-		}
+		processPacket(inputPacket, headerBuffer, mode, false);
 	}
 }
 

--- a/src/chunkserver/chunkserver_entry.cc
+++ b/src/chunkserver/chunkserver_entry.cc
@@ -1228,6 +1228,27 @@ bool ChunkserverEntry::readData(int socket, PacketStruct &packet) {
 	return true;
 }
 
+bool ChunkserverEntry::writePacket(int socket, PacketStruct &packet) {
+	bool toForward = (socket == fwdSocket);
+	bool isWriteInit = (state == State::WriteInit);
+
+	if (packet.bytesLeft == 0) { return true; }
+
+	int bytesWritten{0};
+	if (!isWriteInit && toForward && isLastHeaderTypeWriteData()) {
+		bytesWritten = inputBuffer->writeToSocket(socket, packet.bytesLeft);
+	} else {
+		sassert(packet.startPtr != nullptr);
+		bytesWritten = ::write(socket, packet.startPtr, packet.bytesLeft);
+	}
+
+	if (!processRWBytes(bytesWritten, packet, toForward, __func__, false)) { return false; }
+
+	if (packet.bytesLeft > 0) { return false; }
+
+	return true;
+}
+
 void ChunkserverEntry::processPacket(PacketStruct &packet, uint8_t *headerBuf, Mode &targetMode,
                                      bool fromForward) {
 	sassert(targetMode == Mode::Data);
@@ -1280,27 +1301,8 @@ void ChunkserverEntry::fwdRead() {
 
 void ChunkserverEntry::fwdWrite() {
 	TRACETHIS();
-	int32_t bytesWritten;
 
-	if (fwdOutputPacket.bytesLeft > 0) {
-		bytesWritten = ::write(fwdSocket, fwdOutputPacket.startPtr, fwdOutputPacket.bytesLeft);
-		if (bytesWritten == 0) {
-			fwdError();
-			return;
-		}
-
-		if (bytesWritten < 0) {
-			if (errno != EAGAIN) {
-				safs::log_info_with_error_code(errno, "({}) write error", __func__);
-				fwdError();
-			}
-			return;
-		}
-
-		stats_bytesout += bytesWritten;
-		fwdOutputPacket.startPtr += bytesWritten;
-		fwdOutputPacket.bytesLeft -= bytesWritten;
-	}
+	if (!writePacket(fwdSocket, fwdOutputPacket)) { return; }
 
 	if (fwdOutputPacket.bytesLeft == 0) {
 		fwdInitPacket.clear();
@@ -1314,37 +1316,12 @@ void ChunkserverEntry::fwdWrite() {
 
 void ChunkserverEntry::forward() {
 	TRACETHIS();
-	ssize_t bytesReadOrWritten{0};
 
 	if (mode == Mode::Header && !readHeader(sock, inputPacket, headerBuffer, mode)) { return; }
 
 	if (!readData(sock, inputPacket)) { return; }
 
-	if (fwdOutputPacket.bytesLeft > 0) {
-		sassert(fwdOutputPacket.startPtr != nullptr);
-		if (isLastHeaderTypeWriteData()) {
-			bytesReadOrWritten = inputBuffer->writeToSocket(fwdSocket, fwdOutputPacket.bytesLeft);
-		} else {
-			bytesReadOrWritten =
-			    ::write(fwdSocket, fwdOutputPacket.startPtr, fwdOutputPacket.bytesLeft);
-		}
-
-		if (bytesReadOrWritten == 0) {
-			fwdError();
-			return;
-		}
-		if (bytesReadOrWritten < 0) {
-			if (errno != EAGAIN) {
-				safs::log_info_with_error_code(errno, "({}) write error", __func__);
-				fwdError();
-			}
-			return;
-		}
-		stats_bytesout += bytesReadOrWritten;
-		// Note fwdOutputPacket.startPtr could point to anywhere in some cases
-		fwdOutputPacket.startPtr += bytesReadOrWritten;
-		fwdOutputPacket.bytesLeft -= bytesReadOrWritten;
-	}
+	if (!writePacket(fwdSocket, fwdOutputPacket)) { return; }
 
 	if (inputPacket.bytesLeft == 0 && fwdOutputPacket.bytesLeft == 0) {
 		processPacket(inputPacket, headerBuffer, mode, false);
@@ -1367,7 +1344,6 @@ void ChunkserverEntry::readFromSocket() {
 void ChunkserverEntry::writeToSocket() {
 	TRACETHIS();
 	PacketStruct *pack = nullptr;
-	int32_t bytesWritten;
 
 	for (;;) {
 		if (outputPackets.empty()) { return; }
@@ -1389,25 +1365,8 @@ void ChunkserverEntry::writeToSocket() {
 			} else if (ret == OutputBuffer::WriteStatus::Again) {
 				return;
 			}
-		} else {
-			bytesWritten = ::write(sock, pack->startPtr, pack->bytesLeft);
-			if (bytesWritten == 0) {
-				state = State::Close;
-				return;
-			}
-			if (bytesWritten < 0) {
-				if (errno != EAGAIN) {
-					safs::log_info_with_error_code(errno, "({}) write error", __func__);
-					state = State::Close;
-				}
-				return;
-			}
-			stats_bytesout += bytesWritten;
-			pack->startPtr += bytesWritten;
-			pack->bytesLeft -= bytesWritten;
-			if (pack->bytesLeft > 0) {
-				return;
-			}
+		} else if (!writePacket(sock, *pack)) {
+			return;
 		}
 		// packet has been sent
 		if (pack->outputBuffer) {

--- a/src/chunkserver/chunkserver_entry.h
+++ b/src/chunkserver/chunkserver_entry.h
@@ -270,6 +270,12 @@ struct ChunkserverEntry {
 	/// @return True if the data was read successfully, false otherwise.
 	bool readData(int socket, PacketStruct &packet);
 
+	/// Writes the packet data to the socket.
+	/// @param socket The socket to write to.
+	/// @param packet The packet structure containing the data to write.
+	/// @return True if the data was written successfully, false otherwise.
+	bool writePacket(int socket, PacketStruct &packet);
+
 	/// Processes a packet based on its type and the current mode.
 	/// @param packet The packet structure to process.
 	/// @param headerBuf The buffer containing the packet header.

--- a/src/chunkserver/chunkserver_entry.h
+++ b/src/chunkserver/chunkserver_entry.h
@@ -127,8 +127,7 @@ struct ChunkserverEntry {
 	uint8_t fwdHeaderBuffer[PacketHeader::kSize]{};  ///< fwd packet header buff
 	/// Stores the data of the incoming packet for processing
 	PacketStruct inputPacket;
-	uint8_t *fwdStartPtr = nullptr; ///< used for forwarding inputpacket data
-	uint32_t fwdBytesLeft = 0; ///< used for forwarding inputpacket data
+	PacketStruct fwdOutputPacket; ///< used for forwarding inputpacket data
 	PacketStruct fwdInputPacket; ///< used for receiving status from fwdSocket
 	std::vector<uint8_t> fwdInitPacket; ///< used only for write initialization
 
@@ -246,6 +245,16 @@ struct ChunkserverEntry {
 	/// @param operationSize The size of the operation.
 	/// @return Pointer to the created packet data.
 	uint8_t *createAttachedPacket(uint32_t type, uint32_t operationSize);
+
+	/// Processes read or write bytes from the socket.
+	/// @param bytesRW The number of bytes read or written.
+	/// @param packet The packet structure being processed.
+	/// @param shouldForwardError Indicates if the error should be forwarded.
+	/// @param callerName The name of the calling function for logging purposes.
+	/// @param isRead Indicates if the operation is a read (true) or write (false).
+	/// @return True if the operation was successful, false otherwise.
+	bool processRWBytes(int bytesRW, PacketStruct &packet, bool shouldForwardError,
+	                    const char *callerName, bool isRead);
 
 	/// Handles forwarding errors by setting the appropriate error status and
 	/// transitioning the connection state to `WriteFinish`.

--- a/src/chunkserver/chunkserver_entry.h
+++ b/src/chunkserver/chunkserver_entry.h
@@ -264,6 +264,12 @@ struct ChunkserverEntry {
 	/// @return True if the header was read successfully, false otherwise.
 	bool readHeader(int socket, PacketStruct &packet, uint8_t *headerBuf, Mode &targetMode);
 
+	/// Reads data from the socket into the packet structure.
+	/// @param socket The socket to read from.
+	/// @param packet The packet structure to fill.
+	/// @return True if the data was read successfully, false otherwise.
+	bool readData(int socket, PacketStruct &packet);
+
 	/// Handles forwarding errors by setting the appropriate error status and
 	/// transitioning the connection state to `WriteFinish`.
 	///

--- a/src/chunkserver/chunkserver_entry.h
+++ b/src/chunkserver/chunkserver_entry.h
@@ -270,6 +270,14 @@ struct ChunkserverEntry {
 	/// @return True if the data was read successfully, false otherwise.
 	bool readData(int socket, PacketStruct &packet);
 
+	/// Processes a packet based on its type and the current mode.
+	/// @param packet The packet structure to process.
+	/// @param headerBuf The buffer containing the packet header.
+	/// @param targetMode The mode to set after processing the packet.
+	/// @param fromForward Indicates if the packet is being processed from a forward operation.
+	void processPacket(PacketStruct &packet, uint8_t *headerBuf, Mode &targetMode,
+	                   bool fromForward);
+
 	/// Handles forwarding errors by setting the appropriate error status and
 	/// transitioning the connection state to `WriteFinish`.
 	///

--- a/src/chunkserver/chunkserver_entry.h
+++ b/src/chunkserver/chunkserver_entry.h
@@ -256,6 +256,14 @@ struct ChunkserverEntry {
 	bool processRWBytes(int bytesRW, PacketStruct &packet, bool shouldForwardError,
 	                    const char *callerName, bool isRead);
 
+	/// Reads the packet header from the socket.
+	/// @param socket The socket to read from.
+	/// @param packet The packet structure to fill.
+	/// @param headerBuf The buffer to store the header.
+	/// @param targetMode The mode to set after reading the header.
+	/// @return True if the header was read successfully, false otherwise.
+	bool readHeader(int socket, PacketStruct &packet, uint8_t *headerBuf, Mode &targetMode);
+
 	/// Handles forwarding errors by setting the appropriate error status and
 	/// transitioning the connection state to `WriteFinish`.
 	///

--- a/src/chunkserver/network_worker_thread.cc
+++ b/src/chunkserver/network_worker_thread.cc
@@ -157,7 +157,7 @@ void NetworkWorkerThread::preparePollFds() {
 				entry.fwdPDescPos = pdesc.size() - 1;
 				break;
 			case ChunkserverEntry::State::WriteInit:
-				if (entry.fwdBytesLeft > 0) {
+				if (entry.fwdOutputPacket.bytesLeft > 0) {
 					pdesc.emplace_back(pollfd(entry.fwdSocket, POLLOUT, 0));
 					entry.fwdPDescPos = pdesc.size() - 1;
 				}
@@ -165,7 +165,7 @@ void NetworkWorkerThread::preparePollFds() {
 			case ChunkserverEntry::State::WriteForward:
 				pdesc.emplace_back(pollfd(entry.fwdSocket, POLLIN, 0));
 				entry.fwdPDescPos = pdesc.size() - 1;
-				if (entry.fwdBytesLeft > 0) {
+				if (entry.fwdOutputPacket.bytesLeft > 0) {
 					pdesc.back().events |= POLLOUT;
 				}
 


### PR DESCRIPTION
This PR targets simplifying most of the ChunkserverEntry network IO
functions by reducing much of the nearly duplicated duplicated code by
some more general functions (readHeader, readData, processPacket,
writePacket).

It also implements some other helper functions
(getTypeAndLengthFromHeader and processRWBytes) to help with the code
duplication and substitutes the fwdStartPtr and fwdBytesLeft variables
by a proper fwdOutputPacket structure inside the ChunkserverEntry.

Signed-off-by: Dave <dave@leil.io>