### PR TITLE
Improve path by inode consistency

### DIFF
--- a/src/mount/path_by_inode.h
+++ b/src/mount/path_by_inode.h
@@ -31,7 +31,9 @@ struct PidPathEntry {
 };
 
 struct InodePathInfo {
-	std::set<PidPathEntry> contextPidToPath;
+	// This will store for each PID for a path by inode request, how many times that path was
+	// requested This helps to manage multiple requests triggered from same PID
+	std::map<PidPathEntry, uint64_t> contextPidToPath;
 	std::mutex mtx;
 };
 

--- a/src/mount/sauna_client.cc
+++ b/src/mount/sauna_client.cc
@@ -951,8 +951,10 @@ EntryParam lookup(Context &ctx, inode_t parent, const char *name) {
 			throw RequestException(status);
 		}
 		status = SAUNAFS_STATUS_OK;
-		PidPathEntry entry{ctx.pid, fullPath};
-		gInodePathInfo.contextPidToPath.insert(entry);
+		if (ctx.pid > 0) {
+			PidPathEntry entry{ctx.pid, fullPath};
+			gInodePathInfo.contextPidToPath.insert(entry);
+		}
 		attr[0] = TYPE_FILE;
 		inode = parent;
 		icacheflag = 0;

--- a/src/mount/sauna_client.cc
+++ b/src/mount/sauna_client.cc
@@ -953,7 +953,7 @@ EntryParam lookup(Context &ctx, inode_t parent, const char *name) {
 		status = SAUNAFS_STATUS_OK;
 		if (ctx.pid > 0) {
 			PidPathEntry entry{ctx.pid, fullPath};
-			gInodePathInfo.contextPidToPath.insert(entry);
+			gInodePathInfo.contextPidToPath[entry]++;
 		}
 		attr[0] = TYPE_FILE;
 		inode = parent;

--- a/src/mount/special_open.cc
+++ b/src/mount/special_open.cc
@@ -120,7 +120,7 @@ static void open(const Context &ctx, FileInfo *fi) {
 	PidPathEntry searchEntry{ctx.pid, ""};
 	auto it = gInodePathInfo.contextPidToPath.find(searchEntry);
 	if (it != gInodePathInfo.contextPidToPath.end()) {
-		fi->fh = reinterpret_cast<uintptr_t>(&(*it));
+		fi->fh = reinterpret_cast<uintptr_t>(&(it->first));
 	} else {
 		fi->fh = 0;
 	}

--- a/src/mount/special_release.cc
+++ b/src/mount/special_release.cc
@@ -98,7 +98,12 @@ namespace InodePathByInode {
 static void release(FileInfo *fi) {
 	std::unique_lock<std::mutex> lock(gInodePathInfo.mtx);
 	auto entry = reinterpret_cast<PidPathEntry *>(fi->fh);
-	if (entry) { gInodePathInfo.contextPidToPath.erase(*entry); }
+	if (entry) {
+		auto it = gInodePathInfo.contextPidToPath.find(*entry);
+		if (it != gInodePathInfo.contextPidToPath.end() && --(it->second) <= 0) {
+			gInodePathInfo.contextPidToPath.erase(it);
+		}
+	}
 	fi->fh = 0;
 	oplog_printf("release (%" PRIiNode ") (internal node: PATH_BY_INODE_FILE): OK", inode_);
 }

--- a/tests/test_suites/ShortSystemTests/test_path_by_inode.sh
+++ b/tests/test_suites/ShortSystemTests/test_path_by_inode.sh
@@ -16,3 +16,24 @@ chmod 200 folder
 assert_failure cat .saunafs_path_by_inode/3
 assert_failure cat .saunafs_path_by_inode/5
 assert_failure cat .saunafs_path_by_inode/6
+
+# test path by inode for softlinks and hardlinks
+touch file5
+echo "data_file5" > file5
+
+ln -s file5 softlink_to_file
+ln file5 hardlink_to_file
+
+assert_equals "file5" "$(cat .saunafs_path_by_inode/8)"
+assert_equals "data_file5" "$(cat $(cat .saunafs_path_by_inode/8))"
+
+# check that inode of softlink is a new one
+file5_inode=$(stat -c %i file5)
+softlink_inode=$(stat -c %i softlink_to_file)
+assert_not_equal "$softlink_inode" "$file5_inode"
+assert_equals "softlink_to_file" "$(cat .saunafs_path_by_inode/9)"
+assert_equals "data_file5" "$(cat $(cat .saunafs_path_by_inode/9))"
+
+# check that inode of hardlink is the same as the original file
+file5_hardlink_inode=$(stat -c %i hardlink_to_file)
+assert_equals "$file5_inode" "$file5_hardlink_inode"


### PR DESCRIPTION
This pull request includes two changes:

- fix: Avoid non-positive PIDs in path by inode (6213a29f)
Ensures that only positive PIDs are used when managing the mapping for pending path-by-inode requests. This prevents invalid entries and potential inconsistencies that could occur if special files were opened by contexts with non-positive PIDs (such as PID 0).

- test: Add soft and hard links for path by inode (558f1a47)
Expands the path-by-inode test suite to include checks for both soft (symbolic) and hard links. This improves test coverage and verifies that the feature works correctly for these additional cases.

