### PR TITLE
fix(cs): Fix chunkserver while timing out reads

### DIFF
--- a/src/chunkserver/bgjobs.cc
+++ b/src/chunkserver/bgjobs.cc
@@ -166,9 +166,9 @@ void JobPool::disableJob(uint32_t jobId, uint32_t listenerId) {
 	}
 }
 
-std::queue<uint32_t> JobPool::disableJobs(std::list<uint32_t> &jobIds, uint32_t listenerId) {
+std::list<uint32_t> JobPool::disableJobs(const std::list<uint32_t> &jobIds, uint32_t listenerId) {
 	// Check if the listenerId is valid
-	std::queue<uint32_t> disabledJobIds;
+	std::list<uint32_t> disabledJobIds;
 	if (listenerId >= listenerInfos_.size()) {
 		safs::log_warn("JobPool: disableJobs: Invalid listenerId {}, returning",
 		               listenerId);
@@ -183,7 +183,7 @@ std::queue<uint32_t> JobPool::disableJobs(std::list<uint32_t> &jobIds, uint32_t 
 		if (jobIterator != listenerInfo.jobHash.end()) {
 			if (jobIterator->second->state == JobPool::State::Enabled) {
 				jobIterator->second->state = JobPool::State::Disabled;
-				disabledJobIds.push(jobId);
+				disabledJobIds.push_back(jobId);
 			}
 		}
 	}

--- a/src/chunkserver/bgjobs.h
+++ b/src/chunkserver/bgjobs.h
@@ -131,8 +131,8 @@ public:
 	///
 	/// @param jobIds The list of jobs by IDs to be disabled.
 	/// @param listenerId The ID of the listener associated with the jobs.
-	/// @return A queue of job IDs that were successfully disabled.
-	std::queue<uint32_t> disableJobs(std::list<uint32_t> &jobIds, uint32_t listenerId = 0);
+	/// @return A list of job IDs that were successfully disabled.
+	std::list<uint32_t> disableJobs(const std::list<uint32_t> &jobIds, uint32_t listenerId = 0);
 
 	/// @brief Checks the status of jobs in the JobPool and calls their callbacks.
 	///

--- a/src/chunkserver/chunkserver-common/hdd_utils.cc
+++ b/src/chunkserver/chunkserver-common/hdd_utils.cc
@@ -200,9 +200,8 @@ int hddIOEnd(IChunk *chunk) {
 	}
 
 	if (chunk->refCount() <= 0) {
-		safs_silent_syslog(LOG_WARNING,
-		                   "hddIOEnd: refcount = 0 - "
-		                   "This should never happen!");
+		safs::log_warn("({}) refcount = 0 - This should never happen! (chunkId: {})", __func__,
+		               chunk->id());
 		errno = 0;
 
 		return SAUNAFS_STATUS_OK;

--- a/src/chunkserver/chunkserver_entry.cc
+++ b/src/chunkserver/chunkserver_entry.cc
@@ -187,10 +187,15 @@ void ChunkserverEntry::retryConnect() {
 // common - delayed close
 
 void ChunkserverEntry::checkAndApplyClosed() {
-	if (pendingDelayedJobs == 0 && toDiscardReadJobIds.empty()) {
+	if (pendingDelayedJobs == 0) {
 		while (!writeDataBuffers.empty()) {
 			getWriteInputBufferPool().put(std::move(writeDataBuffers.back()));
 			writeDataBuffers.pop_back();
+		}
+
+		if (isChunkOpen) {
+			job_close(*workerJobPool, kEmptyCallback, kEmptyExtra, chunkId, chunkType);
+			isChunkOpen = 0;
 		}
 		state = State::Closed;
 	}
@@ -199,6 +204,7 @@ void ChunkserverEntry::checkAndApplyClosed() {
 void ChunkserverEntry::delayedCloseCallback(uint8_t status, void *entry) {
 	TRACETHIS();
 	auto *eptr = static_cast<ChunkserverEntry*>(entry);
+	assert(eptr->state == State::CloseWait);
 
 	if (eptr->isOpenWriteJobBeingProcessed() && status == SAUNAFS_STATUS_OK) {
 		// this was job_open (write)
@@ -206,12 +212,7 @@ void ChunkserverEntry::delayedCloseCallback(uint8_t status, void *entry) {
 		eptr->setNoWriteJobBeingProcessed();
 	}
 
-	if (eptr->isChunkOpen) {
-		job_close(*eptr->workerJobPool, kEmptyCallback, kEmptyExtra, eptr->chunkId,
-		          eptr->chunkType);
-		eptr->isChunkOpen = 0;
-	}
-
+	assert(eptr->pendingDelayedJobs > 0);
 	eptr->pendingDelayedJobs--;
 	eptr->checkAndApplyClosed();
 }
@@ -220,6 +221,11 @@ void ChunkserverEntry::delayedDiscardCallback(uint8_t status, void *entry) {
 	TRACETHIS();
 	(void)status;
 	auto *eptr = static_cast<ChunkserverEntry *>(entry);
+	assert(eptr->state == State::CloseWait);
+
+	if (status == SAUNAFS_STATUS_OK) {
+		eptr->isChunkOpen = 1;
+	}
 
 	while (!eptr->toDiscardReadDataBuffers.empty() &&
 	       eptr->toDiscardReadDataBuffers.front()->getStatus() != kNotSaunafsStatus) {
@@ -228,6 +234,8 @@ void ChunkserverEntry::delayedDiscardCallback(uint8_t status, void *entry) {
 		eptr->toDiscardReadJobIds.pop_front();
 	}
 
+	assert(eptr->pendingDelayedJobs > 0);
+	eptr->pendingDelayedJobs--;
 	eptr->checkAndApplyClosed();
 }
 
@@ -264,6 +272,7 @@ void ChunkserverEntry::prepareDiscardReadJobs() {
 	// The jobs which are not going to be processed: all but the ones in progress
 	auto disabledJobIds = workerJobPool->disableJobs(pendingReadJobIds);
 	workerJobPool->changeCallback(pendingReadJobIds, readDiscardCallback, this);
+	workerJobPool->changeCallback(disabledJobIds, kEmptyCallback, kEmptyExtra);
 	while (!pendingReadJobIds.empty()) {
 		// pendingReadJobIds and pendingReadDataBuffers should have the related elements in the
 		// correct order
@@ -275,7 +284,7 @@ void ChunkserverEntry::prepareDiscardReadJobs() {
 			// Already processed packets, can be moved to the pool
 			getReadOutputBufferPool().put(std::move(pendingReadDataBuffers.front()));
 			if (!disabledJobIds.empty() && disabledJobIds.front() == pendingReadJobIds.front()) {
-				disabledJobIds.pop();
+				disabledJobIds.pop_front();
 			}
 		}
 
@@ -957,12 +966,12 @@ void ChunkserverEntry::closeJobs() {
 	TRACETHIS();
 
 	if (!pendingReadJobIds.empty()) {
-		isChunkOpen = 1;
 		prepareDiscardReadJobs();
 	}
 	if (!toDiscardReadJobIds.empty()) {
 		// Already disabled jobs
 		workerJobPool->changeCallback(toDiscardReadJobIds, delayedDiscardCallback, this);
+		pendingDelayedJobs += toDiscardReadJobIds.size();
 		state = State::CloseWait;
 	}
 
@@ -983,11 +992,7 @@ void ChunkserverEntry::closeJobs() {
 		pendingDelayedJobs++;
 		state = State::CloseWait;
 	} else {
-		if (isChunkOpen) {
-			job_close(*workerJobPool, kEmptyCallback, kEmptyExtra, chunkId, chunkType);
-			isChunkOpen = 0;
-		}
-
+		// Not necessary to close chunk - checkAndApplyClosed will do it
 		checkAndApplyClosed();
 	}
 }

--- a/tests/test_suites/ShortSystemTests/test_chunkserver_force_timeout_reads.sh
+++ b/tests/test_suites/ShortSystemTests/test_chunkserver_force_timeout_reads.sh
@@ -1,0 +1,39 @@
+timeout_set 90 seconds
+
+# Use goal 2 to increase the chance of overwhelming the chunkserver read queues
+# Lots of readahead requests should be sent to chunkservers with very low timeout, and we want
+# to make sure that the chunkserver read scheme can handle this without serious issues.
+
+CHUNKSERVERS=2 \
+	USE_RAMDISK=YES \
+	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER|maxreadaheadrequests=10|readaheadmaxwindowsize=65536|` \
+		`sfschunkserverwavereadto=30|sfschunkserverconnectreadto=30|sfschunkservertotalreadto=30" \
+	CHUNKSERVER_EXTRA_CONFIG="MAX_PARALLEL_HDD_READ_JOBS_PER_CS_ENTRY=8|`
+		`MAGIC_DEBUG_LOG=${TEMP_DIR}/log" \
+	setup_local_empty_saunafs info
+
+cd ${info[mount0]}
+
+mkdir dir_rep2
+saunafs setgoal -r 2 dir_rep2
+
+# Create a big file that will be read in many chunks
+FILE_SIZE=$((900 * 1024 * 1024)) BLOCK_SIZE=12345 file-generate dir_rep2/file
+
+for i in $(seq 1 20); do
+	if ! file-validate dir_rep2/file; then
+		test_add_failure "File validation failed, retrying (iter: ${i})"
+	fi
+	echo "File validation succeeded (iter: ${i})"
+done
+
+if grep -q "refcount = 0 - This should never happen!" "${TEMP_DIR}/log"; then
+	test_add_failure "Fatal: refcount = 0 - This should never happen! found in chunkserver logs"
+fi
+
+# Search for "[error]" in the chunkserver logs
+if grep -F '[error]' "${TEMP_DIR}/log"; then
+	test_add_failure "Fatal: Found errors in the chunkserver logs!"
+fi
+
+sfschunkserver_check_no_buffer_in_use


### PR DESCRIPTION
This PR fixes a couple of concerning issues appearing in
chunkserver while handling a high load of read requests that caused
some of them to time out:
- possible crash of the chunkserver: the already disabled jobs in
prepareDiscardReadJobs were having assigned the readDiscardCallback as
callback, which in cases of fast destruction of the ChunkserverEntry
instance may have caused those callbacks to try using unassigned memory
and therefore SEGFAULT. The fix consists in changing those disabled
jobs callback into not doing anything.
- extra closing chunks ("refcount = 0" messages): this surplus of
job_close relates to assuming some job_read previously scheduled as
successful when they weren't or they were not processed at all. The fix
consists in setting the isChunkOpen member as true when some of those
job_read ends successfully and closing only a single time at the end
if the chunk is said to be open.

Side changes:
- improved the "refcount = 0 - This should never happen!" to include the
troubling chunk.
- assert that ChunkserverEntry state in delayedCloseCallback and
delayedDiscardCallback is State::CloseWait.

A test has been added to check the expected behavior in the scenario of
reads timing out.

Signed-off-by: Dave <dave@leil.io>