### PR TITLE
perf(cs): Streamline blocker operations

### DIFF
--- a/src/chunkserver/bgjobs.cc
+++ b/src/chunkserver/bgjobs.cc
@@ -71,7 +71,7 @@ JobPool::JobPool(const std::string &name, uint8_t workers, uint32_t maxJobs, uin
 		listenerInfos_[i].nextJobId = 1;
 	}
 
-	jobsQueue = std::make_unique<ProducerConsumerQueue>(maxJobs);
+	jobsQueue = std::make_unique<ProducerConsumerQueue>(1, maxJobs);
 
 	for (uint8_t i = 0; i < workers; ++i) {
 		workerThreads.emplace_back(&JobPool::workerThread, this, name_, i);

--- a/src/chunkserver/bgjobs.cc
+++ b/src/chunkserver/bgjobs.cc
@@ -71,7 +71,8 @@ JobPool::JobPool(const std::string &name, uint8_t workers, uint32_t maxJobs, uin
 		listenerInfos_[i].nextJobId = 1;
 	}
 
-	jobsQueue = std::make_unique<ProducerConsumerQueue>(1, maxJobs);
+	// Initialize the job queue with a maximum size and two priority levels
+	jobsQueue = std::make_unique<ProducerConsumerQueue>(2, maxJobs);
 
 	for (uint8_t i = 0; i < workers; ++i) {
 		workerThreads.emplace_back(&JobPool::workerThread, this, name_, i);
@@ -80,7 +81,8 @@ JobPool::JobPool(const std::string &name, uint8_t workers, uint32_t maxJobs, uin
 
 JobPool::~JobPool() {
 	for (uint8_t i = 0; i < workers; ++i) {
-		jobsQueue->put(0, JobPool::ChunkOperation::Exit, nullptr, 1);
+		// Use priority 1 to ensure exit jobs are processed after all other jobs
+		jobsQueue->put(0, JobPool::ChunkOperation::Exit, nullptr, 1, 1);
 	}
 
 	for (auto &thread : workerThreads) {
@@ -118,8 +120,10 @@ uint32_t JobPool::addJob(ChunkOperation operation, JobCallback callback, void *e
 	job->state = JobPool::State::Enabled;
 	job->listenerId = listenerId;
 	listenerInfo.jobHash[jobId] = std::move(job);
-	jobsQueue->put(jobId, operation, reinterpret_cast<uint8_t *>(listenerInfo.jobHash[jobId].get()),
-	               1);
+	// Use higher priority (0) for Open and GetBlocks operations
+	jobsQueue->put(
+	    jobId, operation, reinterpret_cast<uint8_t *>(listenerInfo.jobHash[jobId].get()), 1,
+	    (operation == ChunkOperation::Open || operation == ChunkOperation::GetBlocks) ? 0 : 1);
 	return jobId;
 }
 

--- a/src/chunkserver/bgjobs.cc
+++ b/src/chunkserver/bgjobs.cc
@@ -68,7 +68,6 @@ JobPool::JobPool(const std::string &name, uint8_t workers, uint32_t maxJobs, uin
 		}
 		wakeupFDs[i] = listenerInfos_[i].notifierFD;
 
-		listenerInfos_[i].statusQueue = std::make_unique<ProducerConsumerQueue>();
 		listenerInfos_[i].nextJobId = 1;
 	}
 
@@ -89,11 +88,10 @@ JobPool::~JobPool() {
 	}
 
 	for (size_t i = 0; i < listenerInfos_.size(); ++i) {
-		if (!listenerInfos_[i].statusQueue->isEmpty()) { processCompletedJobs(i); }
+		if (!listenerInfos_[i].statusQueue.empty()) { processCompletedJobs(i); }
 	}
 
 	jobsQueue.reset();
-	for (auto &listenerInfo : listenerInfos_) { listenerInfo.statusQueue.reset(); }
 
 	workerThreads.clear();
 
@@ -307,12 +305,12 @@ void JobPool::sendStatus(uint32_t jobId, uint8_t status, uint32_t listenerId) {
 	auto &listenerInfo = listenerInfos_[listenerId];
 	std::lock_guard statusLock(listenerInfo.notifierMutex);
 
-	if (listenerInfo.statusQueue->isEmpty()) {
+	if (listenerInfo.statusQueue.empty()) {
 		static constexpr eventfd_t dummyValue = 1;  // Dummy value to wake up the eventfd
 		eassert(::eventfd_write(listenerInfo.notifierFD, dummyValue) == 0 &&
 		        "JobPool: SendStatus: Failed to write to eventfd");
 	}
-	listenerInfo.statusQueue->put(jobId, status, nullptr, 1);
+	listenerInfo.statusQueue.emplace(jobId, status);
 }
 
 bool JobPool::receiveStatus(uint32_t &jobId, uint8_t &status, uint32_t listenerId) {
@@ -324,12 +322,11 @@ bool JobPool::receiveStatus(uint32_t &jobId, uint8_t &status, uint32_t listenerI
 	}
 
 	auto &listenerInfo = listenerInfos_[listenerId];
-	uint32_t qstatus = 0;
 	std::lock_guard statusLock(listenerInfo.notifierMutex);
 
-	listenerInfo.statusQueue->get(&jobId, &qstatus, nullptr, nullptr);
-	status = qstatus;
-	if (listenerInfo.statusQueue->isEmpty()) {
+	std::tie(jobId, status) = listenerInfo.statusQueue.front();
+	listenerInfo.statusQueue.pop();
+	if (listenerInfo.statusQueue.empty()) {
 		eventfd_t dummyEvent;  // Only to clear the eventfd
 		eassert(::eventfd_read(listenerInfo.notifierFD, &dummyEvent) == 0 &&
 		        "JobPool: ReceiveStatus: Failed to read from eventfd");

--- a/src/chunkserver/bgjobs.h
+++ b/src/chunkserver/bgjobs.h
@@ -189,10 +189,10 @@ private:
 
 	/// @brief Structure to hold information about a listener.
 	struct ListenerInfo {
-		int notifierFD;                                      /// File descriptor for notifications.
-		std::mutex notifierMutex;                            /// Mutex for event notifications.
-		std::mutex jobsMutex;                                /// Mutex for job operations.
-		std::unique_ptr<ProducerConsumerQueue> statusQueue;  /// Queue for job statuses.
+		int notifierFD;            /// File descriptor for notifications.
+		std::mutex notifierMutex;  /// Mutex for event notifications.
+		std::mutex jobsMutex;      /// Mutex for job operations.
+		std::queue<std::pair<uint32_t, uint8_t>> statusQueue;        /// Queue for job statuses.
 		std::unordered_map<uint32_t, std::unique_ptr<Job>> jobHash;  /// Hash map of job.
 		uint32_t nextJobId;                                          /// Next job ID to be assigned.
 	};

--- a/src/common/pcqueue.cc
+++ b/src/common/pcqueue.cc
@@ -23,28 +23,38 @@
 
 #include <cerrno>
 #include <cstdlib>
-#include "devtools/TracePrinter.h"
 #include <pthread.h>
+#include "devtools/TracePrinter.h"
+#include "slogger/slogger.h"
 
-ProducerConsumerQueue::ProducerConsumerQueue(uint32_t maxSize, Deleter deleter)
-    : maxSize_(maxSize), currentSize_(0), deleter_(deleter) {
+ProducerConsumerQueue::ProducerConsumerQueue(uint8_t priorityLevels, uint32_t maxSize,
+                                             Deleter deleter)
+    : maxSize_(maxSize), currentElements_(0), currentSize_(0), deleter_(deleter) {
+	if (priorityLevels == 0) {
+		safs::log_info("ProducerConsumerQueue::{}: Given priorityLevels is 0, using 1 instead",
+		               __func__);
+		priorityLevels = 1;
+	}
+	queuesByPriority_.reserve(priorityLevels);
+	queuesByPriority_.resize(priorityLevels);
 	TRACETHIS();
 }
 
 ProducerConsumerQueue::~ProducerConsumerQueue() {
 	TRACETHIS();
 	std::lock_guard<std::mutex> lock(mutex_);
-	while (!queue_.empty()) {
-		auto &entry = queue_.front();
-		deleter_(entry.data);
-		queue_.pop();
+	for (auto &queue : queuesByPriority_) {
+		while (!queue.empty()) {
+			deleter_(queue.front().data);
+			queue.pop();
+		}
 	}
 }
 
 bool ProducerConsumerQueue::isEmpty() const {
 	TRACETHIS();
 	std::lock_guard<std::mutex> lock(mutex_);
-	return queue_.empty();
+	return currentSize_ == 0;
 }
 
 bool ProducerConsumerQueue::isFull() const {
@@ -62,11 +72,11 @@ uint32_t ProducerConsumerQueue::sizeLeft() const {
 uint32_t ProducerConsumerQueue::elements() const {
 	TRACETHIS();
 	std::lock_guard<std::mutex> lock(mutex_);
-	return queue_.size();
+	return currentElements_;
 }
 
-bool ProducerConsumerQueue::put(uint32_t jobId, uint32_t jobType, uint8_t *data,
-                                uint32_t length) {
+bool ProducerConsumerQueue::put(uint32_t jobId, uint32_t jobType, uint8_t *data, uint32_t length,
+                                uint8_t priority) {
 	TRACETHIS();
 	std::unique_lock<std::mutex> lock(mutex_);
 	notFull_.wait(lock, [this, length] {
@@ -78,15 +88,14 @@ bool ProducerConsumerQueue::put(uint32_t jobId, uint32_t jobType, uint8_t *data,
 		return false;
 	}
 
-	queue_.emplace(jobId, jobType, data, length);
-	currentSize_ += length;
+	put_(jobId, jobType, data, length, priority);
 
 	notEmpty_.notify_one();
 	return true;
 }
 
-bool ProducerConsumerQueue::tryPut(uint32_t jobId, uint32_t jobType,
-                                   uint8_t *data, uint32_t length) {
+bool ProducerConsumerQueue::tryPut(uint32_t jobId, uint32_t jobType, uint8_t *data, uint32_t length,
+                                   uint8_t priority) {
 	TRACETHIS();
 	std::lock_guard<std::mutex> lock(mutex_);
 	if (maxSize_ > 0) {
@@ -101,8 +110,7 @@ bool ProducerConsumerQueue::tryPut(uint32_t jobId, uint32_t jobType,
 		}
 	}
 
-	queue_.emplace(jobId, jobType, data, length);
-	currentSize_ += length;
+	put_(jobId, jobType, data, length, priority);
 
 	notEmpty_.notify_one();
 	return true;
@@ -112,18 +120,9 @@ bool ProducerConsumerQueue::get(uint32_t *jobId, uint32_t *jobType,
                                 uint8_t **data, uint32_t *length) {
 	TRACETHIS();
 	std::unique_lock<std::mutex> lock(mutex_);
-	notEmpty_.wait(lock, [this] { return !queue_.empty(); });
+	notEmpty_.wait(lock, [this] { return currentSize_ > 0; });
 
-	auto &entry = queue_.front();
-	currentSize_ -= entry.length;
-
-	if (jobId) { *jobId = entry.jobId; }
-	if (jobType) { *jobType = entry.jobType; }
-	if (data) { *data = entry.data; }
-	if (length) { *length = entry.length; }
-
-	queue_.pop();
-
+	get_(jobId, jobType, data, length);
 	notFull_.notify_one();
 	return true;
 }
@@ -132,7 +131,7 @@ bool ProducerConsumerQueue::tryGet(uint32_t *jobId, uint32_t *jobType,
                                    uint8_t **data, uint32_t *length) {
 	TRACETHIS();
 	std::lock_guard<std::mutex> lock(mutex_);
-	if (queue_.empty()) {
+	if (currentSize_ == 0) {
 		if (jobId) { *jobId = 0; }
 		if (jobType) { *jobType = 0; }
 		if (data) { *data = nullptr; }
@@ -141,15 +140,55 @@ bool ProducerConsumerQueue::tryGet(uint32_t *jobId, uint32_t *jobType,
 		return false;
 	}
 
-	auto &entry = queue_.front();
+	get_(jobId, jobType, data, length);
+	notFull_.notify_one();
+	return true;
+}
+
+void ProducerConsumerQueue::put_(uint32_t jobId, uint32_t jobType, uint8_t *data, uint32_t length,
+                                 uint8_t priority) {
+	assert(queuesByPriority_.size() > 0);
+	if (priority >= queuesByPriority_.size()) {
+		safs::log_info(
+		    "ProducerConsumerQueue::{}: Given priority {} exceeds max priority {}, using lowest priority instead",
+		    __func__, priority, queuesByPriority_.size() - 1);
+		priority = queuesByPriority_.size() - 1;  // lowest priority
+	}
+
+	queuesByPriority_[priority].emplace(jobId, jobType, data, length);
+	currentSize_ += length;
+	currentElements_++;
+}
+
+void ProducerConsumerQueue::get_(uint32_t *jobId, uint32_t *jobType, uint8_t **data,
+                                 uint32_t *length) {
+	std::queue<QueueEntry> *notEmptyQueue = nullptr;
+	for (auto &queue : queuesByPriority_) {
+		if (!queue.empty()) {
+			notEmptyQueue = &queue;
+			break;
+		}
+	}
+
+	if (notEmptyQueue == nullptr) {
+		safs::log_warn(
+		    "ProducerConsumerQueue::{}: No non-empty queue found (this should not happen)",
+		    __func__);
+		if (jobId) { *jobId = 0; }
+		if (jobType) { *jobType = 0; }
+		if (data) { *data = nullptr; }
+		if (length) { *length = 0; }
+		return;
+	}
+
+	auto &entry = notEmptyQueue->front();
 	currentSize_ -= entry.length;
+	currentElements_--;
 
 	if (jobId) { *jobId = entry.jobId; }
 	if (jobType) { *jobType = entry.jobType; }
 	if (data) { *data = entry.data; }
 	if (length) { *length = entry.length; }
 
-	queue_.pop();
-	notFull_.notify_one();
-	return true;
+	notEmptyQueue->pop();
 }

--- a/src/common/pcqueue.h
+++ b/src/common/pcqueue.h
@@ -38,6 +38,9 @@ inline void deleterDummy(uint8_t * /*unused*/) {}
 /// @class ProducerConsumerQueue
 /// @brief A thread-safe queue for producer-consumer scenarios.
 ///
+/// Can be configured to support several priority levels. Final interface is queue-like,
+/// but preferring higher priority items and preserving order within each priority level.
+///
 /// This class provides a thread-safe queue implementation that allows multiple
 /// producers and consumers to add and remove items concurrently. It uses a
 /// mutex and condition variables to ensure thread safety and to manage the
@@ -83,11 +86,12 @@ public:
 	/// @brief Constructs a ProducerConsumerQueue with a specified maximum size
 	/// and deleter.
 	///
+	/// @param priorityLevels The number of priority levels. Default is 1 (no priorities).
 	/// @param maxSize The maximum number of elements the queue can hold.
 	/// Default is 0 (unlimited).
 	/// @param deleter A callable type that defines how to delete the data
 	/// stored in the queue. Default is deleterDummy.
-	explicit ProducerConsumerQueue(uint32_t maxSize = 0,
+	explicit ProducerConsumerQueue(uint8_t priorityLevels = 1, uint32_t maxSize = 0,
 	                               Deleter deleter = deleterDummy);
 
 	/// @brief Destructor for the ProducerConsumerQueue.
@@ -120,8 +124,11 @@ public:
 	/// @param jobType The job type associated with the element.
 	/// @param data A pointer to the data to be added.
 	/// @param length The length of the data to be added.
+	/// @param priority The priority level of the element (0 is the highest
+	/// priority). Default is 0.
 	/// @return true if the element was added successfully, false otherwise.
-	bool put(uint32_t jobId, uint32_t jobType, uint8_t *data, uint32_t length);
+	bool put(uint32_t jobId, uint32_t jobType, uint8_t *data, uint32_t length,
+	         uint8_t priority = 0);
 
 	/// @brief Tries to add an element to the queue without blocking.
 	///
@@ -129,9 +136,11 @@ public:
 	/// @param jobType The job type associated with the element.
 	/// @param data A pointer to the data to be added.
 	/// @param length The length of the data to be added.
+	/// @param priority The priority level of the element (0 is the highest
+	/// priority). Default is 0.
 	/// @return true if the element was added successfully, false otherwise.
-	bool tryPut(uint32_t jobId, uint32_t jobType, uint8_t *data,
-	            uint32_t length);
+	bool tryPut(uint32_t jobId, uint32_t jobType, uint8_t *data, uint32_t length,
+	            uint8_t priority = 0);
 
 	/// @brief Removes an element from the queue.
 	///
@@ -156,6 +165,15 @@ public:
 	            uint32_t *length);
 
 private:
+	/// @brief Adds an element to the queue assuming non-fullness.
+	/// mutex_: LOCKED
+	inline void put_(uint32_t jobId, uint32_t jobType, uint8_t *data, uint32_t length,
+	                 uint8_t priority);
+
+	/// @brief Removes an element from the queue assuming non-emptiness.
+	/// mutex_: LOCKED
+	inline void get_(uint32_t *jobId, uint32_t *jobType, uint8_t **data, uint32_t *length);
+
 	/// @brief Represents an entry in the queue.
 	struct QueueEntry {
 		uint32_t jobId;    ///< The job ID associated with the entry.
@@ -173,22 +191,27 @@ private:
 		           uint32_t length)
 		    : jobId(jobId), jobType(jobType), data(data), length(length) {}
 
-		// Remove unneeded constructors and assignment operators to avoid misuse
+		// Remove default constructor to avoid uninitialized entries.
 		QueueEntry() = delete;
-		QueueEntry(const QueueEntry &) = delete;
-		QueueEntry &operator=(const QueueEntry &) = delete;
-		QueueEntry(QueueEntry &&) = delete;
-		QueueEntry &operator=(QueueEntry &&) = delete;
+
+		// Allowing copy and move semantics for QueueEntry is not desirable, but required
+		// for queuesByPriority_ vector of std::queue.
+		QueueEntry(const QueueEntry &) = default;
+		QueueEntry(QueueEntry &&) = default;
+		QueueEntry &operator=(const QueueEntry &) = default;
+		QueueEntry &operator=(QueueEntry &&) = default;
 
 		/// @brief Destructor for the QueueEntry.
 		~QueueEntry() = default;
 	};
 
-	///< The underlying queue storing the entries.
-	std::queue<QueueEntry> queue_;
+	///< The underlying queues storing the entries.
+	std::vector<std::queue<QueueEntry>> queuesByPriority_;
 	///< The maximum number of elements the queue can hold.
 	uint32_t maxSize_;
 	///< The current number of elements in the queue.
+	uint32_t currentElements_;
+	///< The current amount of data in the queue.
 	uint32_t currentSize_;
 	///< Mutex for synchronizing access to the queue.
 	mutable std::mutex mutex_;

--- a/src/common/pcqueue_unittest.cc
+++ b/src/common/pcqueue_unittest.cc
@@ -31,7 +31,7 @@ const uint32_t kMaxQueueSize = 100;
 
 // Test adding and removing a single element
 TEST(ProducerConsumerQueueTests, SingleElement) {
-	ProducerConsumerQueue queue(kMaxSize, customDeleter);
+	ProducerConsumerQueue queue(1, kMaxSize, customDeleter);
 	auto *data = new uint8_t[kMaxLength];
 	EXPECT_TRUE(queue.put(1, 1, data, kMaxLength));
 
@@ -49,7 +49,7 @@ TEST(ProducerConsumerQueueTests, SingleElement) {
 
 // Test adding and removing multiple elements
 TEST(ProducerConsumerQueueTests, MultipleElements) {
-	ProducerConsumerQueue queue(kMaxQueueSize, customDeleter);
+	ProducerConsumerQueue queue(1, kMaxQueueSize, customDeleter);
 	for (int i = 0; i < kMaxSize; ++i) {
 		auto *data = new uint8_t[kMaxLength];
 		EXPECT_TRUE(queue.put(i, i, data, kMaxLength));
@@ -70,7 +70,7 @@ TEST(ProducerConsumerQueueTests, MultipleElements) {
 
 // Test behavior when the queue is full
 TEST(ProducerConsumerQueueTests, QueueFull) {
-	ProducerConsumerQueue queue(2, customDeleter);
+	ProducerConsumerQueue queue(1, 2, customDeleter);
 	auto *data1 = new uint8_t[kMaxLength];
 	auto *data2 = new uint8_t[kMaxLength];
 	auto *data3 = new uint8_t[kMaxLength];
@@ -82,7 +82,7 @@ TEST(ProducerConsumerQueueTests, QueueFull) {
 
 // Test behavior when the queue is empty
 TEST(ProducerConsumerQueueTests, QueueEmpty) {
-	ProducerConsumerQueue queue(kMaxSize, customDeleter);
+	ProducerConsumerQueue queue(1, kMaxSize, customDeleter);
 	uint32_t jobId = 0;
 	uint32_t jobType = 0;
 	uint32_t length = 0;
@@ -95,7 +95,7 @@ TEST(ProducerConsumerQueueTests, MultipleProducers) {
 	const int kMaxProducersSize = 10;
 	const int kMaxInsertionsPerThread = 10;
 
-	ProducerConsumerQueue queue(kMaxQueueSize, customDeleter);
+	ProducerConsumerQueue queue(1, kMaxQueueSize, customDeleter);
 	std::vector<std::thread> producers;
 	producers.reserve(kMaxProducersSize);
 
@@ -117,7 +117,7 @@ TEST(ProducerConsumerQueueTests, MultipleConsumers) {
 	const int kMaxConsumersSize = 10;
 	const int kMaxRemovalsPerThread = 10;
 
-	ProducerConsumerQueue queue(kMaxQueueSize, customDeleter);
+	ProducerConsumerQueue queue(1, kMaxQueueSize, customDeleter);
 	for (uint32_t i = 0; i < kMaxQueueSize; ++i) {
 		auto *data = new uint8_t[kMaxLength];
 		queue.put(i, i, data, 1);
@@ -149,7 +149,7 @@ TEST(ProducerConsumerQueueTests, ProducersAndConsumers) {
 	const int kMaxInsertionsPerThread = 10;
 	const int kMaxRemovalsPerThread = 10;
 
-	ProducerConsumerQueue queue(kMaxQueueSize, customDeleter);
+	ProducerConsumerQueue queue(1, kMaxQueueSize, customDeleter);
 	std::vector<std::thread> producers;
 	producers.reserve(kMaxProducersSize);
 
@@ -192,10 +192,119 @@ TEST(ProducerConsumerQueueTests, CustomDeleter) {
 	};
 
 	{
-		ProducerConsumerQueue queue(kMaxSize, customDeleter);
+		ProducerConsumerQueue queue(1, kMaxSize, customDeleter);
 		auto *data = new uint8_t[kMaxLength];
 		queue.put(1, 1, data, kMaxLength);
 	}
 
 	EXPECT_TRUE(deleterCalled);
+}
+
+// Test expected ordering with multiple priorities
+TEST(ProducerConsumerQueueTests, MultiplePrioritiesBasic) {
+	const int kPriorityLevels = 3;
+	const int kInsertionsPerPriority = 10;
+	const int kNumberOfInsertions = kPriorityLevels * kInsertionsPerPriority;
+	const int kBiggerMaxQueueSize = 100000;
+
+	ProducerConsumerQueue queue(kPriorityLevels, kBiggerMaxQueueSize, customDeleter);
+	for (int i = 0; i < kNumberOfInsertions; ++i) {
+		auto *data = new uint8_t[kMaxLength];
+		queue.put(i, i, data, kMaxLength, i % kPriorityLevels);
+	}
+
+	for (int i = 0; i < kNumberOfInsertions; ++i) {
+		uint32_t jobId = 0;
+		uint32_t jobType = 0;
+		uint32_t length = 0;
+		uint8_t *retrievedData = nullptr;
+
+		EXPECT_TRUE(queue.get(&jobId, &jobType, &retrievedData, &length));
+		EXPECT_EQ(jobId, jobType);
+		/// order should be: 0, 3, 6, 9, ... 1, 4, 7, 10, ... 2, 5, 8, 11, ...
+		/// sorted by priority first (remainder), then by insertion order
+		EXPECT_EQ(jobId, static_cast<uint32_t>(i / kInsertionsPerPriority +
+		                                       (i % kInsertionsPerPriority) * kPriorityLevels));
+		EXPECT_EQ(length, kMaxLength);
+	}
+
+	EXPECT_TRUE(queue.isEmpty());
+}
+
+// Test expected ordering with multiple priorities with concurrent put/get operations
+TEST(ProducerConsumerQueueTests, MultiplePrioritiesConcurrent) {
+	const int kPriorityLevels = 3;
+	const int kInsertionsPerTick = 10;
+	const int kTicks = 50;
+	const int kNumberOfThreads = 10;
+	const int kBiggerMaxQueueSize = 100000;
+
+	ProducerConsumerQueue queue(kPriorityLevels, kBiggerMaxQueueSize, customDeleter);
+	std::mutex frequencyMutex;
+	std::vector<int> frequency(kPriorityLevels, 0);
+
+	std::vector<std::thread> producers;
+	producers.reserve(kNumberOfThreads);
+	for (int i = 0; i < kNumberOfThreads; ++i) {
+		producers.emplace_back([&queue, &frequency, &frequencyMutex]() {
+			// Seed the random number generator with a combination of time and thread ID
+			srand(static_cast<unsigned int>(time(nullptr)) ^
+			      std::hash<std::thread::id>()(std::this_thread::get_id()));
+
+			for (int j = 0; j < kTicks; ++j) {
+				for (int k = 0; k < kInsertionsPerTick; ++k) {
+					std::lock_guard<std::mutex> lock(frequencyMutex);
+					int basePriority = rand();
+					int priority = basePriority % kPriorityLevels;
+					uint8_t *data = nullptr;
+					if (queue.tryPut(basePriority, priority, data, kMaxLength, priority)) {
+						frequency[priority]++;
+					}
+				}
+				std::this_thread::sleep_for(std::chrono::milliseconds(1));
+			}
+		});
+	}
+
+	std::vector<std::thread> consumers;
+	consumers.reserve(kNumberOfThreads);
+	for (int i = 0; i < kNumberOfThreads; ++i) {
+		consumers.emplace_back([&queue, &frequency, &frequencyMutex]() {
+			// Let some puts work before starting the gets
+			std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+			for (int j = 0; j < kTicks; ++j) {
+				int k = 0;
+				while (k < kInsertionsPerTick) {
+					uint32_t jobId = 0;
+					uint32_t jobType = 0;
+					uint32_t length = 0;
+					uint8_t *retrievedData = nullptr;
+
+					std::lock_guard<std::mutex> lock(frequencyMutex);
+					if (queue.tryGet(&jobId, &jobType, &retrievedData, &length)) {
+						EXPECT_EQ(length, kMaxLength);
+						EXPECT_EQ(retrievedData, nullptr);
+	
+						auto basePriority = jobId;
+						auto priority = jobType;
+						EXPECT_EQ(priority, basePriority % kPriorityLevels);
+	
+						// All higher priorities should have been consumed already
+						for (uint32_t p = 0; p < priority; ++p) { EXPECT_EQ(frequency[p], 0); }
+						EXPECT_GT(frequency[priority], 0);
+						frequency[priority]--;
+	
+						k++; // one more successful get
+					}
+				}
+				std::this_thread::sleep_for(std::chrono::milliseconds(1));
+			}
+		});
+	}
+
+	for (auto &producer : producers) { producer.join(); }
+	for (auto &consumer : consumers) { consumer.join(); }
+
+	EXPECT_TRUE(queue.isEmpty());
 }

--- a/src/mount/writedata.cc
+++ b/src/mount/writedata.cc
@@ -369,7 +369,7 @@ void *delayed_queue_worker(void *) {
 		while (it != delayedQueue.end()) {
 			if (it->inodeData == NULL) { return NULL; }
 			if (--it->ticksLeft <= 0) {
-				jobsQueue->put(0, 0, reinterpret_cast<uint8_t *>(it->inodeData), 0);
+				jobsQueue->put(0, 0, reinterpret_cast<uint8_t *>(it->inodeData), 1);
 				it = delayedQueue.erase(it);
 			} else {
 				++it;
@@ -391,12 +391,12 @@ void write_delayed_enqueue(inodedata *id, uint32_t seconds, Glock &lock) {
 	if (seconds > 0) {
 		delayed_queue_put(id, seconds, lock);
 	} else {
-		jobsQueue->put(0, 0, reinterpret_cast<uint8_t *>(id), 0);
+		jobsQueue->put(0, 0, reinterpret_cast<uint8_t *>(id), 1);
 	}
 }
 
 void write_enqueue(inodedata *id, Glock &) {
-	jobsQueue->put(0, 0, reinterpret_cast<uint8_t *>(id), 0);
+	jobsQueue->put(0, 0, reinterpret_cast<uint8_t *>(id), 1);
 }
 
 void write_job_delayed_end(inodedata *id, int status, int seconds, Glock &lock) {
@@ -768,7 +768,7 @@ void write_data_init(uint32_t cachesize, uint32_t retries, uint32_t workers,
 
 	writeStatsInit();
 
-	jobsQueue = std::make_unique<ProducerConsumerQueue>(0, deleterByType<inodedata>);
+	jobsQueue = std::make_unique<ProducerConsumerQueue>(1, 0, deleterByType<inodedata>);
 
 	pthread_attr_init(&thattr);
 	pthread_attr_setstacksize(&thattr, 0x100000);
@@ -791,7 +791,7 @@ void write_data_term(void) {
 		Glock lock(gMutex);
 		delayed_queue_put(nullptr, 0, lock);
 	}
-	for (i = 0; i < write_worker_th.size(); i++) { jobsQueue->put(0, 0, NULL, 0); }
+	for (i = 0; i < write_worker_th.size(); i++) { jobsQueue->put(0, 0, nullptr, 1); }
 	for (i = 0; i < write_worker_th.size(); i++) { pthread_join(write_worker_th[i], NULL); }
 	pthread_join(delayed_queue_worker_th, NULL);
 	jobsQueue.reset();
@@ -1427,7 +1427,7 @@ void *delayed_queue_worker(void *) {
 			if (it->chunkData == NO_CHUNKDATA) { return NULL; }
 			if (--it->ticksLeft <= 0) {
 				auto *data = reinterpret_cast<uint8_t *>(it->chunkData);
-				jobsQueue->put(0, 0, data, 0);
+				jobsQueue->put(0, 0, data, 1);
 				it = delayedQueue.erase(it);
 			} else {
 				++it;
@@ -1450,17 +1450,17 @@ void write_delayed_enqueue(ChunkData *chunkData, uint32_t seconds, Lock &globalL
 	if (seconds > 0) {
 		delayed_queue_put(chunkData, seconds, globalLock);
 	} else {
-		jobsQueue->put(0, 0, reinterpret_cast<uint8_t *>(chunkData), 0);
+		jobsQueue->put(0, 0, reinterpret_cast<uint8_t *>(chunkData), 1);
 	}
 }
 
 void write_enqueue(ChunkData *chunkData, Lock &) {
-	jobsQueue->put(0, 0, reinterpret_cast<uint8_t *>(chunkData), 0);
+	jobsQueue->put(0, 0, reinterpret_cast<uint8_t *>(chunkData), 1);
 }
 
 /* globalLock: LOCKED*/
 void write_enqueue(std::vector<ChunkData *> &chunks, Lock &) {
-	for (auto chunk : chunks) { jobsQueue->put(0, 0, reinterpret_cast<uint8_t *>(chunk), 0); }
+	for (auto chunk : chunks) { jobsQueue->put(0, 0, reinterpret_cast<uint8_t *>(chunk), 1); }
 }
 
 /* globalLock: LOCKED*/
@@ -1841,7 +1841,7 @@ void write_data_init(uint32_t cachesize, uint32_t retries, uint32_t workers,
 
 	writeStatsInit();
 
-	jobsQueue = std::make_unique<ProducerConsumerQueue>(0, deleterByType<ChunkData>);
+	jobsQueue = std::make_unique<ProducerConsumerQueue>(1, 0, deleterByType<ChunkData>);
 
 	pthread_attr_init(&thattr);
 	pthread_attr_setstacksize(&thattr, 0x100000);
@@ -1863,7 +1863,7 @@ void write_data_term(void) {
 		Lock globalLock(gMutex);
 		delayed_queue_put(NO_CHUNKDATA, 0, globalLock);
 	}
-	for (i = 0; i < write_worker_th.size(); i++) { jobsQueue->put(0, 0, NO_CHUNKDATA, 0); }
+	for (i = 0; i < write_worker_th.size(); i++) { jobsQueue->put(0, 0, NO_CHUNKDATA, 1); }
 	for (i = 0; i < write_worker_th.size(); i++) { pthread_join(write_worker_th[i], NULL); }
 	pthread_join(delayed_queue_worker_th, NULL);
 	jobsQueue.reset();


### PR DESCRIPTION
This PR extends the ProducerConsumerQueue by adding the support to
add discrete priorities to the put/tryPut functions in such a way that
the jobs with higher priority are got first and the ordering per
priority is the input one.

Side changes:
- update and create new unittests.
- make the jobsQueue in our write algorithm to add length = 1 jobs to
comply with the new ProducerConsumerQueue assumptions (length > 0).
- simplify statusQueue: the ProducerConsumerQueue is not necessary
since the operations are synced by the notifierMutex and structure can
be replaced by a queue.

This change also takes advantage of the new capabilities of the
ProducerConsumerQueue to prioritize the open and get_blocks operations
over the remaining operation types. Those operations needs to be
replied in order to continue sending data in the case of writes (open
case) and to start requesting data for replications (get_blocks case).
This is why those are kind of blocker operations and needs to be
processed faster.

Signed-off-by: Dave <dave@leil.io>