### PR TITLE
feat(master): make available kvconnector

### DIFF
--- a/src/config/CMakeLists.txt
+++ b/src/config/CMakeLists.txt
@@ -1,4 +1,4 @@
 collect_sources(CONFIG)
 
 shared_add_library(config ${CONFIG_SOURCES})
-shared_target_link_libraries(config ${YAML_CPP_LIBRARIES})
+shared_target_link_libraries(config STATIC slogger MIXED ${YAML_CPP_LIBRARIES})

--- a/src/config/cfg.h
+++ b/src/config/cfg.h
@@ -22,10 +22,11 @@
 
 #include "common/platform.h"
 
+#include <cstdint>
 #include <map>
 #include <string>
 
-#include "slogger/slogger.h"
+#include "slogger/slogger_interface.h"
 
 #define _CONFIG_MAKE_PROTOTYPE(fname,type) type cfg_get##fname(const char *name,const type def)
 

--- a/src/fdb/fdb_unittest.cc
+++ b/src/fdb/fdb_unittest.cc
@@ -147,14 +147,14 @@ TEST_F(FDBKVEngineTest, AtomicAdd) {
 
 	{
 		auto transaction = kvEngine->createReadWriteTransaction();
-		kv::Value value = kv::toU8VectorLittleEndian(initialValue);
+		kv::Value value = kv::toBytesLE(initialValue);
 		transaction->set(key, value);
 		ASSERT_TRUE(transaction->commit());
 	}
 
 	{
 		auto transaction = kvEngine->createReadWriteTransaction();
-		kv::Value value = kv::toU8VectorLittleEndian(delta);
+		kv::Value value = kv::toBytesLE(delta);
 		transaction->atomicAdd(key, value);
 		ASSERT_TRUE(transaction->commit());
 	}
@@ -167,7 +167,7 @@ TEST_F(FDBKVEngineTest, AtomicAdd) {
 	ASSERT_TRUE(result.value().size() == sizeof(initialValue))
 	    << "Value size mismatch for key 'count'.";
 
-	auto finalValue = kv::fromU8VectorLittleEndianToInt<int64_t>(result.value());
+	auto finalValue = kv::fromBytesLE<int64_t>(result.value());
 	ASSERT_EQ(finalValue, initialValue + delta)
 	    << "Final value does not match expected value after atomicAdd.";
 

--- a/src/kv/CMakeLists.txt
+++ b/src/kv/CMakeLists.txt
@@ -5,5 +5,5 @@ collect_sources(KV)
 add_library(kv ${KV_SOURCES})
 target_link_libraries(kv slogger)
 
-#create_unittest(kv ${KV_TESTS})
-#link_unittest(kv kv)
+create_unittest(kv ${KV_TESTS})
+link_unittest(kv kv sfscommon)

--- a/src/kv/CMakeLists.txt
+++ b/src/kv/CMakeLists.txt
@@ -2,8 +2,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 collect_sources(KV)
 
-add_library(kv ${KV_SOURCES})
-target_link_libraries(kv slogger)
+add_library(kv INTERFACE)
 
 create_unittest(kv ${KV_TESTS})
 link_unittest(kv kv sfscommon)

--- a/src/kv/itransaction.h
+++ b/src/kv/itransaction.h
@@ -21,36 +21,11 @@
 #include <cstdint>
 #include <cstring>
 #include <optional>
-#include <stdexcept>
 #include <vector>
 
+#include "kv/kv_utils.h"
+
 namespace kv {
-
-using Key = std::vector<uint8_t>;
-using Value = std::vector<uint8_t>;
-
-/// Converts string, string_view and const char* to a vector of uint8_t.
-inline std::vector<uint8_t> toU8Vector(std::string_view str) { return {str.begin(), str.end()}; }
-
-/// Converts integral types to a vector of uint8_t.
-template <typename T>
-	requires(std::is_integral_v<T>)
-inline std::vector<uint8_t> toU8VectorLittleEndian(T value) {
-	std::vector<uint8_t> bytes(sizeof(value));
-	for (size_t i = 0; i < sizeof(T); ++i) {
-		bytes[i] = static_cast<uint8_t>((value >> (8 * i)) & 0xFF);
-	}
-	return bytes;
-}
-
-template <typename T>
-    requires(std::is_integral_v<T>)
-T fromU8VectorLittleEndianToInt(const Value &value) {
-	if (value.size() > sizeof(T)) { throw std::invalid_argument("Invalid value size"); }
-	T result = 0;
-	for (size_t i = 0; i < value.size(); ++i) { result |= static_cast<T>(value[i]) << (8 * i); }
-	return result;
-}
 
 /// Represents a key-value pair in the key-value store.
 /// Keys and values are stored as vectors of bytes.

--- a/src/kv/kv_utils.h
+++ b/src/kv/kv_utils.h
@@ -1,0 +1,96 @@
+/*
+   Copyright 2023      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "common/platform.h"
+
+#include <bit>
+#include <cstdint>
+#include <cstring>
+#include <stdexcept>
+#include <vector>
+
+namespace kv {
+
+using Key = std::vector<uint8_t>;
+using Value = std::vector<uint8_t>;
+
+/// Converts string, string_view and const char* to a vector of uint8_t.
+inline std::vector<uint8_t> toU8Vector(std::string_view str) { return {str.begin(), str.end()}; }
+
+/// Converts integral types to a vector of uint8_t encoded in little-endian order.
+template <typename T>
+    requires(std::is_integral_v<T>)
+inline std::vector<uint8_t> toU8VectorLittleEndian(T value) {
+	if constexpr (std::endian::native == std::endian::big) { value = std::byteswap(value); }
+
+	std::vector<uint8_t> result(sizeof(T));
+	std::memcpy(result.data(), &value, sizeof(T));
+	return result;
+}
+
+/// Converts integral types to a vector of uint8_t encoded in big-endian order.
+template <typename T>
+    requires(std::is_integral_v<T>)
+inline std::vector<uint8_t> toU8VectorBigEndian(T value) {
+	if constexpr (std::endian::native == std::endian::little) { value = std::byteswap(value); }
+
+	std::vector<uint8_t> result(sizeof(T));
+	std::memcpy(result.data(), &value, sizeof(T));
+	return result;
+}
+
+template <typename T>
+    requires(std::is_integral_v<T>)
+T fromU8VectorLittleEndianToInt(const Value &value) {
+	if (value.size() > sizeof(T)) { throw std::invalid_argument("Invalid value size"); }
+	T result = 0;
+	for (size_t i = 0; i < value.size(); ++i) { result |= static_cast<T>(value[i]) << (8 * i); }
+	return result;
+}
+
+/// Encodes a key with a prefix followed by one or more integral values in big-endian order.
+/// @param prefix The prefix to prepend to the key.
+/// @param values One or more integral values to encode in big-endian order.
+/// @return A vector of uint8_t representing the encoded key.
+template <typename... Args>
+    requires(std::is_integral_v<Args> && ...)
+Key encodeKeyBE(std::string_view prefix, Args... values) {
+	// Calculate total size needed
+	constexpr size_t totalSize = (sizeof(Args) + ...);
+	Key key(prefix.size() + totalSize);
+
+	// Copy prefix
+	std::memcpy(key.data(), prefix.data(), prefix.size());
+
+	// Helper to encode each value in big-endian and append to key
+	size_t offset = prefix.size();
+	auto encodeValue = [&key, &offset]<typename T>(T value) {
+		if constexpr (std::endian::native == std::endian::little) { value = std::byteswap(value); }
+		std::memcpy(key.data() + offset, &value, sizeof(T));
+		offset += sizeof(T);
+	};
+
+	// Encode all values
+	(encodeValue(values), ...);
+
+	return key;
+}
+
+}  // namespace kv

--- a/src/kv/kv_utils.h
+++ b/src/kv/kv_utils.h
@@ -28,19 +28,20 @@
 
 namespace kv {
 
-using Key = std::vector<uint8_t>;
-using Value = std::vector<uint8_t>;
+using Bytes = std::vector<uint8_t>;
+using Key = Bytes;
+using Value = Bytes;
 
 /// Converts string, string_view and const char* to a vector of uint8_t.
-inline std::vector<uint8_t> toU8Vector(std::string_view str) { return {str.begin(), str.end()}; }
+inline Bytes toBytes(std::string_view str) { return {str.begin(), str.end()}; }
 
 /// Converts integral types to a vector of uint8_t encoded in little-endian order.
 template <typename T>
     requires(std::is_integral_v<T>)
-inline std::vector<uint8_t> toU8VectorLittleEndian(T value) {
+inline Bytes toBytesLE(T value) {
 	if constexpr (std::endian::native == std::endian::big) { value = std::byteswap(value); }
 
-	std::vector<uint8_t> result(sizeof(T));
+	Bytes result(sizeof(T));
 	std::memcpy(result.data(), &value, sizeof(T));
 	return result;
 }
@@ -48,17 +49,17 @@ inline std::vector<uint8_t> toU8VectorLittleEndian(T value) {
 /// Converts integral types to a vector of uint8_t encoded in big-endian order.
 template <typename T>
     requires(std::is_integral_v<T>)
-inline std::vector<uint8_t> toU8VectorBigEndian(T value) {
+inline Bytes toBytesBE(T value) {
 	if constexpr (std::endian::native == std::endian::little) { value = std::byteswap(value); }
 
-	std::vector<uint8_t> result(sizeof(T));
+	Bytes result(sizeof(T));
 	std::memcpy(result.data(), &value, sizeof(T));
 	return result;
 }
 
 template <typename T>
     requires(std::is_integral_v<T>)
-T fromU8VectorLittleEndianToInt(const Value &value) {
+T fromBytesLE(const Value &value) {
 	if (value.size() > sizeof(T)) { throw std::invalid_argument("Invalid value size"); }
 	T result = 0;
 	for (size_t i = 0; i < value.size(); ++i) { result |= static_cast<T>(value[i]) << (8 * i); }

--- a/src/kv/kv_utils_unittest.cc
+++ b/src/kv/kv_utils_unittest.cc
@@ -22,7 +22,7 @@
 
 #include <gtest/gtest.h>
 
-TEST(KVUtilsTest, ToU8Vector) {
+TEST(KVUtilsTest, ToBytes) {
 	const char *text = "Hello, World!";
 	std::string textString{text};
 	std::string_view textStringView{text, strlen(text)};
@@ -32,24 +32,24 @@ TEST(KVUtilsTest, ToU8Vector) {
 	std::memcpy(expected.data(), text, strlen(text));
 
 	// Passing a plain char *
-	auto result = kv::toU8Vector(text);
+	auto result = kv::toBytes(text);
 	EXPECT_EQ(result, expected);
 
 	// Passing a std::string
-	result = kv::toU8Vector(textString);
+	result = kv::toBytes(textString);
 	EXPECT_EQ(result, expected);
 
 	// Passing a std::string_view
-	result = kv::toU8Vector(textStringView);
+	result = kv::toBytes(textStringView);
 	EXPECT_EQ(result, expected);
 }
 
-TEST(KVUtilsTest, ToU8VectorLittleEndian) {
+TEST(KVUtilsTest, ToBytesLE) {
 	// Test uint8_t (single byte - endianness doesn't matter)
 	{
 		constexpr uint8_t kTestValue = 0x42;
 		kv::Value expected = {kTestValue};
-		auto result = kv::toU8VectorLittleEndian(kTestValue);
+		auto result = kv::toBytesLE(kTestValue);
 		EXPECT_EQ(result, expected);
 	}
 
@@ -59,7 +59,7 @@ TEST(KVUtilsTest, ToU8VectorLittleEndian) {
 		constexpr uint8_t kLowByte = 0x34;
 		constexpr uint8_t kHighByte = 0x12;
 		kv::Value expected = {kLowByte, kHighByte};
-		auto result = kv::toU8VectorLittleEndian(kTestValue);
+		auto result = kv::toBytesLE(kTestValue);
 		EXPECT_EQ(result, expected);
 	}
 
@@ -71,7 +71,7 @@ TEST(KVUtilsTest, ToU8VectorLittleEndian) {
 		constexpr uint8_t kByte2 = 0x34;
 		constexpr uint8_t kByte3 = 0x12;
 		kv::Value expected = {kByte0, kByte1, kByte2, kByte3};
-		auto result = kv::toU8VectorLittleEndian(kTestValue);
+		auto result = kv::toBytesLE(kTestValue);
 		EXPECT_EQ(result, expected);
 	}
 
@@ -87,7 +87,7 @@ TEST(KVUtilsTest, ToU8VectorLittleEndian) {
 		constexpr uint8_t kByte6 = 0x34;
 		constexpr uint8_t kByte7 = 0x12;
 		kv::Value expected = {kByte0, kByte1, kByte2, kByte3, kByte4, kByte5, kByte6, kByte7};
-		auto result = kv::toU8VectorLittleEndian(kTestValue);
+		auto result = kv::toBytesLE(kTestValue);
 		EXPECT_EQ(result, expected);
 	}
 
@@ -96,7 +96,7 @@ TEST(KVUtilsTest, ToU8VectorLittleEndian) {
 		constexpr int16_t kTestValue = -1;  // 0xFFFF in two's complement
 		constexpr uint8_t kByte = 0xFF;
 		kv::Value expected = {kByte, kByte};
-		auto result = kv::toU8VectorLittleEndian(kTestValue);
+		auto result = kv::toBytesLE(kTestValue);
 		EXPECT_EQ(result, expected);
 	}
 
@@ -106,7 +106,7 @@ TEST(KVUtilsTest, ToU8VectorLittleEndian) {
 		constexpr uint8_t kLowByte = 0x00;
 		constexpr uint8_t kHighByte = 0xFF;
 		kv::Value expected = {kLowByte, kHighByte, kHighByte, kHighByte};
-		auto result = kv::toU8VectorLittleEndian(kTestValue);
+		auto result = kv::toBytesLE(kTestValue);
 		EXPECT_EQ(result, expected);
 	}
 
@@ -115,7 +115,7 @@ TEST(KVUtilsTest, ToU8VectorLittleEndian) {
 		constexpr uint32_t kTestValue = 0;
 		constexpr uint8_t kZeroByte = 0x00;
 		kv::Value expected = {kZeroByte, kZeroByte, kZeroByte, kZeroByte};
-		auto result = kv::toU8VectorLittleEndian(kTestValue);
+		auto result = kv::toBytesLE(kTestValue);
 		EXPECT_EQ(result, expected);
 	}
 
@@ -124,17 +124,17 @@ TEST(KVUtilsTest, ToU8VectorLittleEndian) {
 		constexpr uint16_t kTestValue = 0xFFFF;
 		constexpr uint8_t kMaxByte = 0xFF;
 		kv::Value expected = {kMaxByte, kMaxByte};
-		auto result = kv::toU8VectorLittleEndian(kTestValue);
+		auto result = kv::toBytesLE(kTestValue);
 		EXPECT_EQ(result, expected);
 	}
 }
 
-TEST(KVUtilsTest, ToU8VectorBigEndian) {
+TEST(KVUtilsTest, ToBytesBE) {
 	// Test uint8_t (single byte - endianness doesn't matter)
 	{
 		constexpr uint8_t kTestValue = 0x42;
 		kv::Value expected = {kTestValue};
-		auto result = kv::toU8VectorBigEndian(kTestValue);
+		auto result = kv::toBytesBE(kTestValue);
 		EXPECT_EQ(result, expected);
 	}
 
@@ -144,7 +144,7 @@ TEST(KVUtilsTest, ToU8VectorBigEndian) {
 		constexpr uint8_t kHighByte = 0x12;
 		constexpr uint8_t kLowByte = 0x34;
 		kv::Value expected = {kHighByte, kLowByte};
-		auto result = kv::toU8VectorBigEndian(kTestValue);
+		auto result = kv::toBytesBE(kTestValue);
 		EXPECT_EQ(result, expected);
 	}
 
@@ -156,7 +156,7 @@ TEST(KVUtilsTest, ToU8VectorBigEndian) {
 		constexpr uint8_t kByte2 = 0x56;
 		constexpr uint8_t kByte3 = 0x78;
 		kv::Value expected = {kByte0, kByte1, kByte2, kByte3};
-		auto result = kv::toU8VectorBigEndian(kTestValue);
+		auto result = kv::toBytesBE(kTestValue);
 		EXPECT_EQ(result, expected);
 	}
 
@@ -172,7 +172,7 @@ TEST(KVUtilsTest, ToU8VectorBigEndian) {
 		constexpr uint8_t kByte6 = 0xDE;
 		constexpr uint8_t kByte7 = 0xF0;
 		kv::Value expected = {kByte0, kByte1, kByte2, kByte3, kByte4, kByte5, kByte6, kByte7};
-		auto result = kv::toU8VectorBigEndian(kTestValue);
+		auto result = kv::toBytesBE(kTestValue);
 		EXPECT_EQ(result, expected);
 	}
 
@@ -181,7 +181,7 @@ TEST(KVUtilsTest, ToU8VectorBigEndian) {
 		constexpr int16_t kTestValue = -1;  // 0xFFFF in two's complement
 		constexpr uint8_t kByte = 0xFF;
 		kv::Value expected = {kByte, kByte};
-		auto result = kv::toU8VectorBigEndian(kTestValue);
+		auto result = kv::toBytesBE(kTestValue);
 		EXPECT_EQ(result, expected);
 	}
 
@@ -191,7 +191,7 @@ TEST(KVUtilsTest, ToU8VectorBigEndian) {
 		constexpr uint8_t kHighByte = 0xFF;
 		constexpr uint8_t kLowByte = 0x00;
 		kv::Value expected = {kHighByte, kHighByte, kHighByte, kLowByte};
-		auto result = kv::toU8VectorBigEndian(kTestValue);
+		auto result = kv::toBytesBE(kTestValue);
 		EXPECT_EQ(result, expected);
 	}
 
@@ -200,7 +200,7 @@ TEST(KVUtilsTest, ToU8VectorBigEndian) {
 		constexpr uint32_t kTestValue = 0;
 		constexpr uint8_t kZeroByte = 0x00;
 		kv::Value expected = {kZeroByte, kZeroByte, kZeroByte, kZeroByte};
-		auto result = kv::toU8VectorBigEndian(kTestValue);
+		auto result = kv::toBytesBE(kTestValue);
 		EXPECT_EQ(result, expected);
 	}
 
@@ -209,17 +209,17 @@ TEST(KVUtilsTest, ToU8VectorBigEndian) {
 		constexpr uint16_t kTestValue = 0xFFFF;
 		constexpr uint8_t kMaxByte = 0xFF;
 		kv::Value expected = {kMaxByte, kMaxByte};
-		auto result = kv::toU8VectorBigEndian(kTestValue);
+		auto result = kv::toBytesBE(kTestValue);
 		EXPECT_EQ(result, expected);
 	}
 }
 
-TEST(KVUtilsTest, FromU8VectorLittleEndianToInt) {
+TEST(KVUtilsTest, FromBytesLE) {
 	// Test uint8_t (single byte)
 	{
 		constexpr uint8_t kExpected = 0x42;
 		kv::Value value = {kExpected};
-		auto result = kv::fromU8VectorLittleEndianToInt<uint8_t>(value);
+		auto result = kv::fromBytesLE<uint8_t>(value);
 		EXPECT_EQ(result, kExpected);
 	}
 
@@ -229,7 +229,7 @@ TEST(KVUtilsTest, FromU8VectorLittleEndianToInt) {
 		constexpr uint8_t kLowByte = 0x34;
 		constexpr uint8_t kHighByte = 0x12;
 		kv::Value value = {kLowByte, kHighByte};
-		auto result = kv::fromU8VectorLittleEndianToInt<uint16_t>(value);
+		auto result = kv::fromBytesLE<uint16_t>(value);
 		EXPECT_EQ(result, kExpected);
 	}
 
@@ -241,7 +241,7 @@ TEST(KVUtilsTest, FromU8VectorLittleEndianToInt) {
 		constexpr uint8_t kByte2 = 0x34;
 		constexpr uint8_t kByte3 = 0x12;
 		kv::Value value = {kByte0, kByte1, kByte2, kByte3};
-		auto result = kv::fromU8VectorLittleEndianToInt<uint32_t>(value);
+		auto result = kv::fromBytesLE<uint32_t>(value);
 		EXPECT_EQ(result, kExpected);
 	}
 
@@ -257,7 +257,7 @@ TEST(KVUtilsTest, FromU8VectorLittleEndianToInt) {
 		constexpr uint8_t kByte6 = 0x34;
 		constexpr uint8_t kByte7 = 0x12;
 		kv::Value value = {kByte0, kByte1, kByte2, kByte3, kByte4, kByte5, kByte6, kByte7};
-		auto result = kv::fromU8VectorLittleEndianToInt<uint64_t>(value);
+		auto result = kv::fromBytesLE<uint64_t>(value);
 		EXPECT_EQ(result, kExpected);
 	}
 
@@ -267,7 +267,7 @@ TEST(KVUtilsTest, FromU8VectorLittleEndianToInt) {
 		constexpr uint8_t kByte0 = 0x34;
 		constexpr uint8_t kByte1 = 0x12;
 		kv::Value value = {kByte0, kByte1};  // Only 2 bytes for uint32_t
-		auto result = kv::fromU8VectorLittleEndianToInt<uint32_t>(value);
+		auto result = kv::fromBytesLE<uint32_t>(value);
 		EXPECT_EQ(result, kExpected);
 	}
 
@@ -276,7 +276,7 @@ TEST(KVUtilsTest, FromU8VectorLittleEndianToInt) {
 		constexpr uint32_t kExpected = 0;
 		constexpr uint8_t kZeroByte = 0x00;
 		kv::Value value = {kZeroByte, kZeroByte, kZeroByte, kZeroByte};
-		auto result = kv::fromU8VectorLittleEndianToInt<uint32_t>(value);
+		auto result = kv::fromBytesLE<uint32_t>(value);
 		EXPECT_EQ(result, kExpected);
 	}
 
@@ -285,7 +285,7 @@ TEST(KVUtilsTest, FromU8VectorLittleEndianToInt) {
 		constexpr uint16_t kExpected = 0xFFFF;
 		constexpr uint8_t kMaxByte = 0xFF;
 		kv::Value value = {kMaxByte, kMaxByte};
-		auto result = kv::fromU8VectorLittleEndianToInt<uint16_t>(value);
+		auto result = kv::fromBytesLE<uint16_t>(value);
 		EXPECT_EQ(result, kExpected);
 	}
 
@@ -293,7 +293,7 @@ TEST(KVUtilsTest, FromU8VectorLittleEndianToInt) {
 	{
 		constexpr uint8_t kByte = 0x12;
 		kv::Value value = {kByte, kByte, kByte};  // 3 bytes for uint16_t (2 bytes)
-		EXPECT_THROW(kv::fromU8VectorLittleEndianToInt<uint16_t>(value), std::invalid_argument);
+		EXPECT_THROW(kv::fromBytesLE<uint16_t>(value), std::invalid_argument);
 	}
 }
 

--- a/src/kv/kv_utils_unittest.cc
+++ b/src/kv/kv_utils_unittest.cc
@@ -1,0 +1,448 @@
+/*
+   Copyright 2023      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "common/platform.h"
+
+#include "kv/kv_utils.h"
+
+#include <gtest/gtest.h>
+
+TEST(KVUtilsTest, ToU8Vector) {
+	const char *text = "Hello, World!";
+	std::string textString{text};
+	std::string_view textStringView{text, strlen(text)};
+
+	// Create expected result as a kv::Value (std::vector<uint8_t>)
+	kv::Value expected(strlen(text));
+	std::memcpy(expected.data(), text, strlen(text));
+
+	// Passing a plain char *
+	auto result = kv::toU8Vector(text);
+	EXPECT_EQ(result, expected);
+
+	// Passing a std::string
+	result = kv::toU8Vector(textString);
+	EXPECT_EQ(result, expected);
+
+	// Passing a std::string_view
+	result = kv::toU8Vector(textStringView);
+	EXPECT_EQ(result, expected);
+}
+
+TEST(KVUtilsTest, ToU8VectorLittleEndian) {
+	// Test uint8_t (single byte - endianness doesn't matter)
+	{
+		constexpr uint8_t kTestValue = 0x42;
+		kv::Value expected = {kTestValue};
+		auto result = kv::toU8VectorLittleEndian(kTestValue);
+		EXPECT_EQ(result, expected);
+	}
+
+	// Test uint16_t - least significant byte first
+	{
+		constexpr uint16_t kTestValue = 0x1234;
+		constexpr uint8_t kLowByte = 0x34;
+		constexpr uint8_t kHighByte = 0x12;
+		kv::Value expected = {kLowByte, kHighByte};
+		auto result = kv::toU8VectorLittleEndian(kTestValue);
+		EXPECT_EQ(result, expected);
+	}
+
+	// Test uint32_t in little-endian byte order
+	{
+		constexpr uint32_t kTestValue = 0x12345678;
+		constexpr uint8_t kByte0 = 0x78;
+		constexpr uint8_t kByte1 = 0x56;
+		constexpr uint8_t kByte2 = 0x34;
+		constexpr uint8_t kByte3 = 0x12;
+		kv::Value expected = {kByte0, kByte1, kByte2, kByte3};
+		auto result = kv::toU8VectorLittleEndian(kTestValue);
+		EXPECT_EQ(result, expected);
+	}
+
+	// Test uint64_t in little-endian byte order
+	{
+		constexpr uint64_t kTestValue = 0x123456789ABCDEF0;
+		constexpr uint8_t kByte0 = 0xF0;
+		constexpr uint8_t kByte1 = 0xDE;
+		constexpr uint8_t kByte2 = 0xBC;
+		constexpr uint8_t kByte3 = 0x9A;
+		constexpr uint8_t kByte4 = 0x78;
+		constexpr uint8_t kByte5 = 0x56;
+		constexpr uint8_t kByte6 = 0x34;
+		constexpr uint8_t kByte7 = 0x12;
+		kv::Value expected = {kByte0, kByte1, kByte2, kByte3, kByte4, kByte5, kByte6, kByte7};
+		auto result = kv::toU8VectorLittleEndian(kTestValue);
+		EXPECT_EQ(result, expected);
+	}
+
+	// Test negative int16_t (two's complement representation)
+	{
+		constexpr int16_t kTestValue = -1;  // 0xFFFF in two's complement
+		constexpr uint8_t kByte = 0xFF;
+		kv::Value expected = {kByte, kByte};
+		auto result = kv::toU8VectorLittleEndian(kTestValue);
+		EXPECT_EQ(result, expected);
+	}
+
+	// Test negative int32_t with specific bit pattern
+	{
+		constexpr int32_t kTestValue = -256;  // 0xFFFFFF00 in two's complement
+		constexpr uint8_t kLowByte = 0x00;
+		constexpr uint8_t kHighByte = 0xFF;
+		kv::Value expected = {kLowByte, kHighByte, kHighByte, kHighByte};
+		auto result = kv::toU8VectorLittleEndian(kTestValue);
+		EXPECT_EQ(result, expected);
+	}
+
+	// Test zero value
+	{
+		constexpr uint32_t kTestValue = 0;
+		constexpr uint8_t kZeroByte = 0x00;
+		kv::Value expected = {kZeroByte, kZeroByte, kZeroByte, kZeroByte};
+		auto result = kv::toU8VectorLittleEndian(kTestValue);
+		EXPECT_EQ(result, expected);
+	}
+
+	// Test maximum uint16_t value
+	{
+		constexpr uint16_t kTestValue = 0xFFFF;
+		constexpr uint8_t kMaxByte = 0xFF;
+		kv::Value expected = {kMaxByte, kMaxByte};
+		auto result = kv::toU8VectorLittleEndian(kTestValue);
+		EXPECT_EQ(result, expected);
+	}
+}
+
+TEST(KVUtilsTest, ToU8VectorBigEndian) {
+	// Test uint8_t (single byte - endianness doesn't matter)
+	{
+		constexpr uint8_t kTestValue = 0x42;
+		kv::Value expected = {kTestValue};
+		auto result = kv::toU8VectorBigEndian(kTestValue);
+		EXPECT_EQ(result, expected);
+	}
+
+	// Test uint16_t - most significant byte first
+	{
+		constexpr uint16_t kTestValue = 0x1234;
+		constexpr uint8_t kHighByte = 0x12;
+		constexpr uint8_t kLowByte = 0x34;
+		kv::Value expected = {kHighByte, kLowByte};
+		auto result = kv::toU8VectorBigEndian(kTestValue);
+		EXPECT_EQ(result, expected);
+	}
+
+	// Test uint32_t in big-endian byte order
+	{
+		constexpr uint32_t kTestValue = 0x12345678;
+		constexpr uint8_t kByte0 = 0x12;
+		constexpr uint8_t kByte1 = 0x34;
+		constexpr uint8_t kByte2 = 0x56;
+		constexpr uint8_t kByte3 = 0x78;
+		kv::Value expected = {kByte0, kByte1, kByte2, kByte3};
+		auto result = kv::toU8VectorBigEndian(kTestValue);
+		EXPECT_EQ(result, expected);
+	}
+
+	// Test uint64_t in big-endian byte order
+	{
+		constexpr uint64_t kTestValue = 0x123456789ABCDEF0;
+		constexpr uint8_t kByte0 = 0x12;
+		constexpr uint8_t kByte1 = 0x34;
+		constexpr uint8_t kByte2 = 0x56;
+		constexpr uint8_t kByte3 = 0x78;
+		constexpr uint8_t kByte4 = 0x9A;
+		constexpr uint8_t kByte5 = 0xBC;
+		constexpr uint8_t kByte6 = 0xDE;
+		constexpr uint8_t kByte7 = 0xF0;
+		kv::Value expected = {kByte0, kByte1, kByte2, kByte3, kByte4, kByte5, kByte6, kByte7};
+		auto result = kv::toU8VectorBigEndian(kTestValue);
+		EXPECT_EQ(result, expected);
+	}
+
+	// Test negative int16_t (two's complement representation)
+	{
+		constexpr int16_t kTestValue = -1;  // 0xFFFF in two's complement
+		constexpr uint8_t kByte = 0xFF;
+		kv::Value expected = {kByte, kByte};
+		auto result = kv::toU8VectorBigEndian(kTestValue);
+		EXPECT_EQ(result, expected);
+	}
+
+	// Test negative int32_t with specific bit pattern
+	{
+		constexpr int32_t kTestValue = -256;  // 0xFFFFFF00 in two's complement
+		constexpr uint8_t kHighByte = 0xFF;
+		constexpr uint8_t kLowByte = 0x00;
+		kv::Value expected = {kHighByte, kHighByte, kHighByte, kLowByte};
+		auto result = kv::toU8VectorBigEndian(kTestValue);
+		EXPECT_EQ(result, expected);
+	}
+
+	// Test zero value
+	{
+		constexpr uint32_t kTestValue = 0;
+		constexpr uint8_t kZeroByte = 0x00;
+		kv::Value expected = {kZeroByte, kZeroByte, kZeroByte, kZeroByte};
+		auto result = kv::toU8VectorBigEndian(kTestValue);
+		EXPECT_EQ(result, expected);
+	}
+
+	// Test maximum uint16_t value
+	{
+		constexpr uint16_t kTestValue = 0xFFFF;
+		constexpr uint8_t kMaxByte = 0xFF;
+		kv::Value expected = {kMaxByte, kMaxByte};
+		auto result = kv::toU8VectorBigEndian(kTestValue);
+		EXPECT_EQ(result, expected);
+	}
+}
+
+TEST(KVUtilsTest, FromU8VectorLittleEndianToInt) {
+	// Test uint8_t (single byte)
+	{
+		constexpr uint8_t kExpected = 0x42;
+		kv::Value value = {kExpected};
+		auto result = kv::fromU8VectorLittleEndianToInt<uint8_t>(value);
+		EXPECT_EQ(result, kExpected);
+	}
+
+	// Test uint16_t from little-endian bytes
+	{
+		constexpr uint16_t kExpected = 0x1234;
+		constexpr uint8_t kLowByte = 0x34;
+		constexpr uint8_t kHighByte = 0x12;
+		kv::Value value = {kLowByte, kHighByte};
+		auto result = kv::fromU8VectorLittleEndianToInt<uint16_t>(value);
+		EXPECT_EQ(result, kExpected);
+	}
+
+	// Test uint32_t from little-endian bytes
+	{
+		constexpr uint32_t kExpected = 0x12345678;
+		constexpr uint8_t kByte0 = 0x78;
+		constexpr uint8_t kByte1 = 0x56;
+		constexpr uint8_t kByte2 = 0x34;
+		constexpr uint8_t kByte3 = 0x12;
+		kv::Value value = {kByte0, kByte1, kByte2, kByte3};
+		auto result = kv::fromU8VectorLittleEndianToInt<uint32_t>(value);
+		EXPECT_EQ(result, kExpected);
+	}
+
+	// Test uint64_t from little-endian bytes
+	{
+		constexpr uint64_t kExpected = 0x123456789ABCDEF0;
+		constexpr uint8_t kByte0 = 0xF0;
+		constexpr uint8_t kByte1 = 0xDE;
+		constexpr uint8_t kByte2 = 0xBC;
+		constexpr uint8_t kByte3 = 0x9A;
+		constexpr uint8_t kByte4 = 0x78;
+		constexpr uint8_t kByte5 = 0x56;
+		constexpr uint8_t kByte6 = 0x34;
+		constexpr uint8_t kByte7 = 0x12;
+		kv::Value value = {kByte0, kByte1, kByte2, kByte3, kByte4, kByte5, kByte6, kByte7};
+		auto result = kv::fromU8VectorLittleEndianToInt<uint64_t>(value);
+		EXPECT_EQ(result, kExpected);
+	}
+
+	// Test partial bytes (smaller vector than type size)
+	{
+		constexpr uint32_t kExpected = 0x1234;
+		constexpr uint8_t kByte0 = 0x34;
+		constexpr uint8_t kByte1 = 0x12;
+		kv::Value value = {kByte0, kByte1};  // Only 2 bytes for uint32_t
+		auto result = kv::fromU8VectorLittleEndianToInt<uint32_t>(value);
+		EXPECT_EQ(result, kExpected);
+	}
+
+	// Test zero value
+	{
+		constexpr uint32_t kExpected = 0;
+		constexpr uint8_t kZeroByte = 0x00;
+		kv::Value value = {kZeroByte, kZeroByte, kZeroByte, kZeroByte};
+		auto result = kv::fromU8VectorLittleEndianToInt<uint32_t>(value);
+		EXPECT_EQ(result, kExpected);
+	}
+
+	// Test maximum uint16_t value
+	{
+		constexpr uint16_t kExpected = 0xFFFF;
+		constexpr uint8_t kMaxByte = 0xFF;
+		kv::Value value = {kMaxByte, kMaxByte};
+		auto result = kv::fromU8VectorLittleEndianToInt<uint16_t>(value);
+		EXPECT_EQ(result, kExpected);
+	}
+
+	// Test exception when value size exceeds type size
+	{
+		constexpr uint8_t kByte = 0x12;
+		kv::Value value = {kByte, kByte, kByte};  // 3 bytes for uint16_t (2 bytes)
+		EXPECT_THROW(kv::fromU8VectorLittleEndianToInt<uint16_t>(value), std::invalid_argument);
+	}
+}
+
+TEST(KVUtilsTest, EncodeKeyBE) {
+	// Test with prefix and single uint32_t value (like NODE_)
+	{
+		constexpr std::string_view kPrefix = "N";
+		constexpr uint32_t kInodeId = 0x12345678;
+		// Create expected manually: prefix + big-endian bytes
+		kv::Key expected;
+		expected.push_back('N');
+		expected.push_back(0x12);
+		expected.push_back(0x34);
+		expected.push_back(0x56);
+		expected.push_back(0x78);
+
+		auto result = kv::encodeKeyBE(kPrefix, kInodeId);
+		EXPECT_EQ(result, expected);
+	}
+
+	// Test with prefix and two uint32_t values (like EDGE_ parent, child)
+	{
+		constexpr std::string_view kPrefix = "E";
+		constexpr uint32_t kParentId = 0x00000001;
+		constexpr uint32_t kChildId = 0x00000002;
+
+		kv::Key expected;
+		expected.push_back('E');
+		// Parent ID in big-endian
+		expected.push_back(0x00);
+		expected.push_back(0x00);
+		expected.push_back(0x00);
+		expected.push_back(0x01);
+		// Child ID in big-endian
+		expected.push_back(0x00);
+		expected.push_back(0x00);
+		expected.push_back(0x00);
+		expected.push_back(0x02);
+
+		auto result = kv::encodeKeyBE(kPrefix, kParentId, kChildId);
+		EXPECT_EQ(result, expected);
+	}
+
+	// Test with uint64_t value
+	{
+		constexpr std::string_view kPrefix = "D";
+		constexpr uint64_t kValue = 0x123456789ABCDEF0;
+
+		kv::Key expected;
+		expected.push_back('D');
+		expected.push_back(0x12);
+		expected.push_back(0x34);
+		expected.push_back(0x56);
+		expected.push_back(0x78);
+		expected.push_back(0x9A);
+		expected.push_back(0xBC);
+		expected.push_back(0xDE);
+		expected.push_back(0xF0);
+
+		auto result = kv::encodeKeyBE(kPrefix, kValue);
+		EXPECT_EQ(result, expected);
+	}
+
+	// Test with mixed types (uint16_t, uint32_t)
+	{
+		constexpr std::string_view kPrefix = "M";
+		constexpr uint16_t kShort = 0xABCD;
+		constexpr uint32_t kInt = 0x12345678;
+
+		kv::Key expected;
+		expected.push_back('M');
+		// uint16_t in big-endian
+		expected.push_back(0xAB);
+		expected.push_back(0xCD);
+		// uint32_t in big-endian
+		expected.push_back(0x12);
+		expected.push_back(0x34);
+		expected.push_back(0x56);
+		expected.push_back(0x78);
+
+		auto result = kv::encodeKeyBE(kPrefix, kShort, kInt);
+		EXPECT_EQ(result, expected);
+	}
+
+	// Test with uint8_t value
+	{
+		constexpr std::string_view kPrefix = "I";
+		constexpr uint8_t kValue = 0x42;
+
+		kv::Key expected;
+		expected.push_back('I');
+		expected.push_back(kValue);
+
+		auto result = kv::encodeKeyBE(kPrefix, kValue);
+		EXPECT_EQ(result, expected);
+	}
+
+	// Test with empty prefix
+	{
+		constexpr std::string_view kPrefix = "";
+		constexpr uint32_t kValue = 0x12345678;
+
+		kv::Key expected;
+		expected.push_back(0x12);
+		expected.push_back(0x34);
+		expected.push_back(0x56);
+		expected.push_back(0x78);
+
+		auto result = kv::encodeKeyBE(kPrefix, kValue);
+		EXPECT_EQ(result, expected);
+	}
+
+	// Test with three values (uint16_t, uint32_t, uint64_t)
+	{
+		constexpr std::string_view kPrefix = "K";
+		constexpr uint16_t kVal1 = 0x0001;
+		constexpr uint32_t kVal2 = 0x00000002;
+		constexpr uint64_t kVal3 = 0x0000000000000003;
+
+		kv::Key expected;
+		expected.push_back('K');
+		// uint16_t
+		expected.push_back(0x00);
+		expected.push_back(0x01);
+		// uint32_t
+		expected.push_back(0x00);
+		expected.push_back(0x00);
+		expected.push_back(0x00);
+		expected.push_back(0x02);
+		// uint64_t
+		expected.push_back(0x00);
+		expected.push_back(0x00);
+		expected.push_back(0x00);
+		expected.push_back(0x00);
+		expected.push_back(0x00);
+		expected.push_back(0x00);
+		expected.push_back(0x00);
+		expected.push_back(0x03);
+
+		auto result = kv::encodeKeyBE(kPrefix, kVal1, kVal2, kVal3);
+		EXPECT_EQ(result, expected);
+	}
+
+	// Test correct size calculation
+	{
+		constexpr std::string_view kPrefix = "TEST_";
+		constexpr uint32_t kValue = 0x12345678;
+
+		auto result = kv::encodeKeyBE(kPrefix, kValue);
+		EXPECT_EQ(result.size(), kPrefix.size() + sizeof(kValue));
+	}
+}

--- a/src/master/kv_connector_fdb.cc
+++ b/src/master/kv_connector_fdb.cc
@@ -65,7 +65,7 @@ bool KVConnectorFDB::init() {
 uint64_t KVConnectorFDB::getPropertyValueUInt64(std::string_view propertyName,
                                                 uint64_t defaultValue) {
 	auto transaction = kvEngine_->createReadWriteTransaction();
-	auto value = transaction->get(kv::toU8Vector(propertyName));
+	auto value = transaction->get(kv::toBytes(propertyName));
 
 	if (value.has_value()) {
 		const uint8_t *data = value.value().data();
@@ -107,7 +107,7 @@ void KVConnectorFDB::onDetainedRemoved(inode_t inodeId) {
 
 void KVConnectorFDB::onNextSessionIdChanged(uint32_t /*oldSessionId*/, uint32_t newSessionId) {
 	auto transaction = kvEngine_->createReadWriteTransaction();
-	kv::Key sessionKey{kv::toU8Vector(gMetadata->nextSessionId().getName())};
+	kv::Key sessionKey{kv::toBytes(gMetadata->nextSessionId().getName())};
 	kv::Value sessionValue;
 	serialize(sessionValue, newSessionId);
 	transaction->set(sessionKey, sessionValue);
@@ -116,7 +116,7 @@ void KVConnectorFDB::onNextSessionIdChanged(uint32_t /*oldSessionId*/, uint32_t 
 }
 
 void KVConnectorFDB::onChangelogEvent(const ChangelogEvent &event) {
-	static kv::Key versionKey{kv::toU8Vector(kMetaVersionKey)};
+	static kv::Key versionKey{kv::toBytes(kMetaVersionKey)};
 	kv::Value serializedVersion;
 	serialize(serializedVersion, event.version);
 	auto transaction = kvEngine_->createReadWriteTransaction();

--- a/src/master/kv_connector_fdb.cc
+++ b/src/master/kv_connector_fdb.cc
@@ -62,14 +62,27 @@ bool KVConnectorFDB::init() {
 	return true;
 }
 
-uint64_t KVConnectorFDB::getPropertyValueUInt64(std::string_view propertyName,
-                                                uint64_t defaultValue) {
+uint64_t KVConnectorFDB::get64bitBE(const kv::Key &key, uint64_t defaultValue) {
 	auto transaction = kvEngine_->createReadWriteTransaction();
-	auto value = transaction->get(kv::toBytes(propertyName));
+	auto value = transaction->get(key);
 
 	if (value.has_value()) {
 		const uint8_t *data = value.value().data();
 		return get64bit(&data);
+	}
+
+	return defaultValue;
+}
+
+uint32_t KVConnectorFDB::get32bitBE(const kv::Key &key, uint32_t defaultValue) {
+	auto transaction = kvEngine_->createReadWriteTransaction();
+	auto value = transaction->get(key);
+
+	if (value.has_value()) {
+		uint32_t result;  // NOLINT(cppcoreguidelines-init-variables)
+		const uint8_t *data = value.value().data();
+		get32bit(&data, result);
+		return result;
 	}
 
 	return defaultValue;

--- a/src/master/kv_connector_fdb.cc
+++ b/src/master/kv_connector_fdb.cc
@@ -1,0 +1,176 @@
+/*
+   Copyright 2023      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "common/platform.h"
+
+#include "master/kv_connector_fdb.h"
+
+#include "common/serialization.h"
+#include "config/cfg.h"
+#include "fdb/fdb_context.h"
+#include "fdb/fdb_kv_engine.h"
+#include "kv/itransaction.h"
+#include "master/changelog.h"
+#include "master/kv_common_keys.h"
+#include "master/kv_connector_interface.h"
+#include "master/filesystem_metadata.h"
+
+bool KVConnectorFDB::init() {
+	std::string clusterFile = cfg_getstring("FDB_CLUSTER_FILE", "");
+
+	if (clusterFile.empty()) {
+		safs::log_err("FDB_CLUSTER_FILE is not set, cannot initialize FoundationDB");
+		return false;
+	}
+
+	fdbContext_ = fdb::FDBContext::create({clusterFile});
+
+	if (!fdbContext_) {
+		safs::log_err("Failed to initialize FoundationDB context");
+		return false;
+	}
+
+	auto fdbDB = fdbContext_->getDB();
+
+	if (!fdbDB) {
+		safs::log_err("Failed to get FoundationDB database instance");
+		return false;
+	}
+
+	kvEngine_ = std::make_shared<fdb::FDBKVEngine>(fdbDB);
+
+	if (!kvEngine_) {
+		safs::log_err("Failed to create FoundationDB KV Engine");
+		return false;
+	}
+
+	return true;
+}
+
+uint64_t KVConnectorFDB::getPropertyValueUInt64(std::string_view propertyName,
+                                                uint64_t defaultValue) {
+	auto transaction = kvEngine_->createReadWriteTransaction();
+	auto value = transaction->get(kv::toU8Vector(propertyName));
+
+	if (value.has_value()) {
+		const uint8_t *data = value.value().data();
+		return get64bit(&data);
+	}
+
+	return defaultValue;
+}
+
+void KVConnectorFDB::onDetainedAdded(inode_t inodeId, uint32_t timestamp) {
+	safs::log_info("Detained added signal: {} -> {}", inodeId, timestamp);
+	auto transaction = kvEngine_->createReadWriteTransaction();
+
+	// Key
+	auto key = kv::encodeKeyBE(kFreeKeyPrefix, inodeId);
+
+	// Value
+	kv::Value value(sizeof(timestamp));
+	auto *ptr = value.data();
+	put32bit(&ptr, timestamp);
+
+	transaction->set(key, value);
+
+	if (!transaction->commit()) {
+		safs::log_err("Failed to store free node: {} -> {}", inodeId, timestamp);
+	}
+}
+
+void KVConnectorFDB::onDetainedRemoved(inode_t inodeId) {
+	safs::log_info("Detained removed signal: {}", inodeId);
+	auto transaction = kvEngine_->createReadWriteTransaction();
+
+	auto key = kv::encodeKeyBE(kFreeKeyPrefix, inodeId);
+
+	transaction->remove(key);
+
+	if (!transaction->commit()) { safs::log_err("Failed to remove free node: {}", inodeId); }
+}
+
+void KVConnectorFDB::onNextSessionIdChanged(uint32_t /*oldSessionId*/, uint32_t newSessionId) {
+	auto transaction = kvEngine_->createReadWriteTransaction();
+	kv::Key sessionKey{kv::toU8Vector(gMetadata->nextSessionId().getName())};
+	kv::Value sessionValue;
+	serialize(sessionValue, newSessionId);
+	transaction->set(sessionKey, sessionValue);
+
+	if (!transaction->commit()) { safs::log_err("Failed to store session ID: {}", newSessionId); }
+}
+
+void KVConnectorFDB::onChangelogEvent(const ChangelogEvent &event) {
+	static kv::Key versionKey{kv::toU8Vector(kMetaVersionKey)};
+	kv::Value serializedVersion;
+	serialize(serializedVersion, event.version);
+	auto transaction = kvEngine_->createReadWriteTransaction();
+	transaction->set(versionKey, serializedVersion);
+
+	if (!transaction->commit()) {
+		safs::log_err("Failed to store changelog entry: {}", event.entry);
+		return;
+	}
+}
+
+void KVConnectorFDB::onNodeChanged(FSNode *node) {
+	auto transaction = kvEngine_->createReadWriteTransaction();
+
+	// Key
+	auto key = kv::encodeKeyBE(kNodeKeyPrefix, node->id);
+
+	// Value
+	kv::Value value;
+	value.resize(node->serializedSize());
+	uint8_t *ptr = value.data();
+	node->serialize(&ptr);
+	transaction->set(key, value);
+
+	if (!transaction->commit()) { safs::log_err("Failed to store node: {}", node->id); }
+}
+
+void KVConnectorFDB::onEdgeChanged(FSNodeDirectory *parent, FSNode *child,
+                                   hstorage::Handle *handlePtr) {
+	auto transaction = kvEngine_->createReadWriteTransaction();
+
+	// Key
+	auto key = kv::encodeKeyBE(kEdgeKeyPrefix, parent->id, child->id);
+
+	// Value
+	auto name = handlePtr->get();
+	kv::Value value(name.size());
+	std::memcpy(value.data(), name.data(), name.size());
+
+	transaction->set(key, value);
+
+	if (!transaction->commit()) {
+		safs::log_err("Failed to store edge: {} -> {} : {}", parent->id, child->id, name);
+	}
+}
+
+void KVConnectorFDB::onEdgeRemoved(inode_t parentId, inode_t childId) {
+	auto transaction = kvEngine_->createReadWriteTransaction();
+
+	auto key = kv::encodeKeyBE(kEdgeKeyPrefix, parentId, childId);
+
+	transaction->remove(key);
+
+	if (!transaction->commit()) {
+		safs::log_err("Failed to remove edge: {} -> {}", parentId, childId);
+	}
+}

--- a/src/master/kv_connector_fdb.h
+++ b/src/master/kv_connector_fdb.h
@@ -35,9 +35,17 @@ public:
 	/// Returns the pointer to the concrete KV engine instance (FDB in this case)
 	kv::IKVEngine *getKVEngine() override { return kvEngine_.get(); }
 
-	/// Concrete implementation on top of FDB
-	/// @see KVConnectorInterface::getPropertyValueUInt64
-	uint64_t getPropertyValueUInt64(std::string_view propertyName, uint64_t defaultValue) override;
+	/// Gets 64 bits integer in Big Endian byte order from the KV store.
+	/// @param key -- the key to get the value for
+	/// @param defaultValue -- the default value to return if the key does not exist
+	/// @return the value associated with the key, or defaultValue if the key does not exist
+	uint64_t get64bitBE(const kv::Key &key, uint64_t defaultValue) override;
+
+	/// Gets 32 bits integer in Big Endian byte order from the KV store.
+	/// @param key -- the key to get the value for
+	/// @param defaultValue -- the default value to return if the key does not exist
+	/// @return the value associated with the key, or defaultValue if the key does not exist
+	uint32_t get32bitBE(const kv::Key &key, uint32_t defaultValue) override;
 
 	// Event handlers for usual metadata operations
 	// The handlers provide the concrete implementation on top of FDB.

--- a/src/master/kv_connector_fdb.h
+++ b/src/master/kv_connector_fdb.h
@@ -1,0 +1,62 @@
+/*
+   Copyright 2023      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "common/platform.h"
+
+#include "fdb/fdb_context.h"
+#include "kv/ikv_engine.h"
+#include "master/kv_connector_interface.h"
+
+/// Implements IKVConnector using FoundationDB as KV store backend
+class KVConnectorFDB : public IKVConnector {
+public:
+	/// Initializes the FDB context and engine using the configuration variable FDB_CLUSTER_FILE.
+	/// @return true on success, false on failure
+	/// @note Must be called after construction, before any other method
+	[[nodiscard]] bool init() override;
+
+	/// Returns the pointer to the concrete KV engine instance (FDB in this case)
+	kv::IKVEngine *getKVEngine() override { return kvEngine_.get(); }
+
+	/// Concrete implementation on top of FDB
+	/// @see KVConnectorInterface::getPropertyValueUInt64
+	uint64_t getPropertyValueUInt64(std::string_view propertyName, uint64_t defaultValue) override;
+
+	// Event handlers for usual metadata operations
+	// The handlers provide the concrete implementation on top of FDB.
+	// @see KVConnectorInterface
+
+	void onDetainedAdded(inode_t inodeId, uint32_t timestamp) override;
+	void onDetainedRemoved(inode_t inodeId) override;
+
+	void onNextSessionIdChanged(uint32_t oldSessionId, uint32_t newSessionId) override;
+
+	void onChangelogEvent(const ChangelogEvent &event) override;
+
+	void onNodeChanged(FSNode *node) override;
+
+	void onEdgeChanged(FSNodeDirectory *parent, FSNode *child,
+	                   hstorage::Handle *handlePtr) override;
+	void onEdgeRemoved(inode_t parentId, inode_t childId) override;
+
+private:
+	std::shared_ptr<fdb::FDBContext> fdbContext_;  ///< FDBContext needed by the engine
+	std::shared_ptr<kv::IKVEngine> kvEngine_;      ///< The concrete KV engine instance (FDB)
+};

--- a/src/master/kv_connector_interface.h
+++ b/src/master/kv_connector_interface.h
@@ -47,12 +47,17 @@ public:
 	/// Returns the KV engine instance
 	virtual kv::IKVEngine *getKVEngine() = 0;
 
-	/// Retrieves a uint64_t property value from the underlying KV store.
-	/// @param propertyName Matches the key in the KV store
-	/// @param defaultValue Returned if the property is not found or on error
-	/// @return The property value or defaultValue
-	virtual uint64_t getPropertyValueUInt64(std::string_view propertyName,
-	                                        uint64_t defaultValue) = 0;
+	/// Gets 64 bits integer in Big Endian byte order from the KV store.
+	/// @param key -- the key to get the value for
+	/// @param defaultValue -- the default value to return if the key does not exist
+	/// @return the value associated with the key, or defaultValue if the key does not exist
+	virtual uint64_t get64bitBE(const kv::Key &key, uint64_t defaultValue) = 0;
+
+	/// Gets 32 bits integer in Big Endian byte order from the KV store.
+	/// @param key -- the key to get the value for
+	/// @param defaultValue -- the default value to return if the key does not exist
+	/// @return the value associated with the key, or defaultValue if the key does not exist
+	virtual uint32_t get32bitBE(const kv::Key &key, uint32_t defaultValue) = 0;
 
 	// Event handlers for usual metadata operations
 

--- a/src/master/kv_connector_interface.h
+++ b/src/master/kv_connector_interface.h
@@ -1,0 +1,92 @@
+/*
+   Copyright 2023      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "common/platform.h"
+
+#include "common/type_defs.h"
+#include "kv/ikv_engine.h"
+#include "master/filesystem_node_types.h"
+
+struct ChangelogEvent;
+
+/// Interface to provide KV store operations in an extensible way
+class IKVConnector {
+public:
+	IKVConnector() = default;
+
+	/// Virtual destructor for proper cleanup of derived classes
+	virtual ~IKVConnector() = default;
+
+	/// Unneeded copy and move operations
+	IKVConnector(const IKVConnector &) = delete;
+	IKVConnector &operator=(const IKVConnector &) = delete;
+	IKVConnector(IKVConnector &&) = delete;
+	IKVConnector &operator=(IKVConnector &&) = delete;
+
+	/// Creates and initializes the concrete resources needed by the implementation
+	/// @return true on success, false on failure
+	[[nodiscard]] virtual bool init() = 0;
+
+	/// Returns the KV engine instance
+	virtual kv::IKVEngine *getKVEngine() = 0;
+
+	/// Retrieves a uint64_t property value from the underlying KV store.
+	/// @param propertyName Matches the key in the KV store
+	/// @param defaultValue Returned if the property is not found or on error
+	/// @return The property value or defaultValue
+	virtual uint64_t getPropertyValueUInt64(std::string_view propertyName,
+	                                        uint64_t defaultValue) = 0;
+
+	// Event handlers for usual metadata operations
+
+	/// Handles the addition of a detained inode id.
+	/// Some implementations need to reuse inode ids, these ids are stored in the FREE section of
+	/// the metadata, including the timestamp of when they were added to the detained list.
+	/// @param inodeId The inode id that was added.
+	/// @param timestamp The timestamp when the inode id was added.
+	virtual void onDetainedAdded(inode_t inodeId, uint32_t timestamp) = 0;
+
+	/// Handles the removal of a detained inode id.
+	/// @param inodeId The inode id that was removed.
+	virtual void onDetainedRemoved(inode_t inodeId) = 0;
+
+	/// Handles the change of the next session id.
+	/// @param oldSessionId The previous session id.
+	/// @param newSessionId The new session id.
+	virtual void onNextSessionIdChanged(uint32_t oldSessionId, uint32_t newSessionId) = 0;
+
+	/// Allows to reacts on changelog events.
+	/// @param event The changelog event that occurred.
+	virtual void onChangelogEvent(const ChangelogEvent &event) = 0;
+
+	/// Reacts on node additions or changes.
+	/// @param node The node that was added or changed.
+	virtual void onNodeChanged(FSNode *node) = 0;
+
+	/// Reacts on edge additions or changes.
+	/// @param parent The parent directory of the edge.
+	/// @param child The child node of the edge.
+	/// @param handlePtr The edge name.
+	virtual void onEdgeChanged(FSNodeDirectory *parent, FSNode *child,
+	                           hstorage::Handle *handlePtr) = 0;
+
+	/// Reacts on edge removals.
+	virtual void onEdgeRemoved(inode_t parentId, inode_t childId) = 0;
+};

--- a/src/slogger/slogger_interface.h
+++ b/src/slogger/slogger_interface.h
@@ -1,0 +1,63 @@
+/*
+   Copyright 2013-2014 EditShare
+   Copyright 2013-2015 Skytechnology sp. z o.o.
+   Copyright 2023      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "common/platform.h"
+
+#include "common/syslog_defs.h"
+
+/**
+ * This header contains only the C-style logging function declarations.
+ * It's designed to be included by modules that need to call logging
+ * functions but shouldn't depend on the full slogger implementation.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * function names may contain following words:
+ *   "pretty" -> write pretty prefix to stderr
+ *   "silent" -> do not write anything to stderr
+ *   "errlog" -> append strerr(errno) to printed message
+ *   "attempt" -> instead of pretty prefix based on priority, write prefix suggesting
+ *      that something is starting
+ */
+
+void safs_pretty_syslog(int priority, const char *format, ...)
+    __attribute__((__format__(__printf__, 2, 3)));
+
+void safs_pretty_syslog_attempt(int priority, const char *format, ...)
+    __attribute__((__format__(__printf__, 2, 3)));
+
+void safs_pretty_errlog(int priority, const char *format, ...)
+    __attribute__((__format__(__printf__, 2, 3)));
+
+void safs_silent_syslog(int priority, const char *format, ...)
+    __attribute__((__format__(__printf__, 2, 3)));
+
+void safs_silent_errlog(int priority, const char *format, ...)
+    __attribute__((__format__(__printf__, 2, 3)));
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif


### PR DESCRIPTION
This change introduces the IKVConnector interface with an implementation based on FDB.
To support the implementation, some utility functions were added/improved in the kv and fdb libraries, including unit testing.