### PR TITLE
fix: Avoid trying to find asciidoctor on Windows

### DIFF
--- a/cmake/Libraries.cmake
+++ b/cmake/Libraries.cmake
@@ -43,7 +43,9 @@ if(ENABLE_JEMALLOC)
 endif()
 
 # Find extra binaries
-include(FindAsciidoctor)
+if(NOT WIN32)
+  include(FindAsciidoctor)
+endif()
 
 # Find Zlib
 find_package(ZLIB)


### PR DESCRIPTION
This commit fixes a compilation issue for the Windows client project introduced in commit 5d12cc10 where is asciidoctor was being searched for manpage generation. As on Windows client builds we do not generate manpages, we can skip trying to find asciidoctor on Windows.