### PR TITLE
refactor(master): Move matoclserv serializers to own files

### DIFF
--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -21,6 +21,7 @@
 #include "common/platform.h"
 
 #include "master/matoclserv.h"
+#include "master/matoclserv_serializer.h"
 #include "master/matoclserv_sessions.h"
 
 #include <errno.h>
@@ -101,21 +102,12 @@ enum class ClientConnectionMode : std::uint8_t {
 	DATA			/// Read data packet
 };
 
-// chunkDelayedOperation types
-enum DelayedChunkOperationType : std::uint32_t {
-	FUSE_WRITE,          /// Reply to FUSE_WRITE_CHUNK is delayed
-	FUSE_TRUNCATE,       /// Reply to FUSE_TRUNCATE which does not require writing is delayed
-	FUSE_TRUNCATE_BEGIN, /// Reply to FUSE_TRUNCATE which does require writing is delayed
-	FUSE_TRUNCATE_END    /// Reply to FUSE_TRUNCATE_END is delayed
-};
-
 const uint32_t kMaxNumberOfChunkCopies = 100U;
 constexpr uint8_t kClientInactivityTimeout = 10;
 
 struct matoclserventry;
 
 // locked chunks
-class PacketSerializer;
 
 struct DelayedChunkOperation {
 	uint64_t chunkId;       ///< Chunk ID
@@ -210,276 +202,6 @@ static uint32_t statsPacketsReceived = 0;
 static uint32_t statsPacketsSent = 0;
 static uint64_t statsBytesReceived = 0;
 static uint64_t statsBytesSent = 0;
-
-static void getStandardChunkCopies(const std::vector<ChunkTypeWithAddress>& allCopies,
-		std::vector<NetworkAddress>& standardCopies);
-
-class PacketSerializer {
-public:
-	static const PacketSerializer* getSerializer(PacketHeader::Type type, uint32_t version);
-	virtual ~PacketSerializer() {}
-
-	virtual bool isSaunaFsPacketSerializer() const = 0;
-
-	virtual void serializeFuseReadChunk(std::vector<uint8_t>& packetBuffer,
-			uint32_t messageId, uint8_t status) const = 0;
-	virtual void serializeFuseReadChunk(std::vector<uint8_t>& packetBuffer,
-			uint32_t messageId, uint64_t fileLength, uint64_t chunkId, uint32_t chunkVersion,
-			const std::vector<ChunkTypeWithAddress>& chunkCopies) const = 0;
-	virtual void deserializeFuseReadChunk(const std::vector<uint8_t>& packetBuffer,
-			uint32_t& messageId, inode_t& inode, uint32_t& chunkIndex) const = 0;
-
-	virtual void serializeFuseWriteChunk(std::vector<uint8_t>& packetBuffer,
-			uint32_t messageId, uint8_t status) const = 0;
-	virtual void serializeFuseWriteChunk(std::vector<uint8_t>& packetBuffer,
-			uint32_t messageId, uint64_t fileLength,
-			uint64_t chunkId, uint32_t chunkVersion, uint32_t lockId,
-			const std::vector<ChunkTypeWithAddress>& chunkCopies) const = 0;
-	virtual void deserializeFuseWriteChunk(const std::vector<uint8_t>& packetBuffer,
-			uint32_t& messageId, inode_t& inode, uint32_t& chunkIndex, uint32_t& lockId) const = 0;
-
-	virtual void serializeFuseWriteChunkEnd(std::vector<uint8_t>& packetBuffer,
-			uint32_t messageId, uint8_t status) const = 0;
-	virtual void deserializeFuseWriteChunkEnd(const std::vector<uint8_t>& packetBuffer,
-			uint32_t& messageId, uint64_t& chunkId, uint32_t& lockId,
-			inode_t& inode, uint64_t& fileLength) const = 0;
-
-	virtual void serializeFuseTruncate(std::vector<uint8_t>& packetBuffer,
-			uint32_t type /* FUSE_TRUNCATE | FUSE_TRUNCATE_END*/,
-			uint32_t messageId, uint8_t status) const = 0;
-	virtual void serializeFuseTruncate(std::vector<uint8_t>& packetBuffer,
-			uint32_t type /* FUSE_TRUNCATE | FUSE_TRUNCATE_END*/,
-			uint32_t messageId, const Attributes& attributes) const = 0;
-	virtual void deserializeFuseTruncate(std::vector<uint8_t>& packetBuffer,
-			uint32_t& messageId, inode_t& inode, bool& isOpened,
-			uint32_t& uid, uint32_t& gid, uint64_t& length) const = 0;
-};
-
-class LegacyPacketSerializer : public PacketSerializer {
-public:
-	virtual bool isSaunaFsPacketSerializer() const {
-		return false;
-	}
-
-	virtual void serializeFuseReadChunk(std::vector<uint8_t>& packetBuffer,
-			uint32_t messageId, uint8_t status) const {
-		serializeLegacyPacket(packetBuffer, MATOCL_FUSE_READ_CHUNK, messageId, status);
-	}
-
-	virtual void serializeFuseReadChunk(std::vector<uint8_t>& packetBuffer,
-			uint32_t messageId, uint64_t fileLength, uint64_t chunkId, uint32_t chunkVersion,
-			const std::vector<ChunkTypeWithAddress>& chunkCopies) const {
-		LegacyVector<NetworkAddress> standardChunkCopies;
-		getStandardChunkCopies(chunkCopies, standardChunkCopies);
-		serializeLegacyPacket(packetBuffer, MATOCL_FUSE_READ_CHUNK, messageId, fileLength,
-				chunkId, chunkVersion, standardChunkCopies);
-	}
-
-	virtual void deserializeFuseReadChunk(const std::vector<uint8_t>& packetBuffer,
-			uint32_t& messageId, inode_t& inode, uint32_t& chunkIndex) const {
-		deserializeAllLegacyPacketDataNoHeader(packetBuffer, messageId, inode, chunkIndex);
-	}
-
-	virtual void serializeFuseWriteChunk(std::vector<uint8_t>& packetBuffer,
-			uint32_t messageId, uint8_t status) const {
-		serializeLegacyPacket(packetBuffer, MATOCL_FUSE_WRITE_CHUNK, messageId, status);
-	}
-
-	virtual void serializeFuseWriteChunk(std::vector<uint8_t>& packetBuffer,
-			uint32_t messageId, uint64_t fileLength,
-			uint64_t chunkId, uint32_t chunkVersion, uint32_t lockId,
-			const std::vector<ChunkTypeWithAddress>& chunkCopies) const {
-		sassert(lockId == 1);
-		LegacyVector<NetworkAddress> standardChunkCopies;
-		getStandardChunkCopies(chunkCopies, standardChunkCopies);
-		serializeLegacyPacket(packetBuffer, MATOCL_FUSE_WRITE_CHUNK, messageId, fileLength,
-						chunkId, chunkVersion, standardChunkCopies);
-	}
-
-	virtual void deserializeFuseWriteChunk(const std::vector<uint8_t>& packetBuffer,
-			uint32_t& messageId, inode_t& inode, uint32_t& chunkIndex, uint32_t& lockId) const {
-		deserializeAllLegacyPacketDataNoHeader(packetBuffer, messageId, inode, chunkIndex);
-		lockId = 1;
-	}
-
-	virtual void serializeFuseWriteChunkEnd(std::vector<uint8_t>& packetBuffer,
-			uint32_t messageId, uint8_t status) const {
-		serializeLegacyPacket(packetBuffer, MATOCL_FUSE_WRITE_CHUNK_END, messageId, status);
-	}
-
-	virtual void deserializeFuseWriteChunkEnd(const std::vector<uint8_t>& packetBuffer,
-			uint32_t& messageId, uint64_t& chunkId, uint32_t& lockId,
-			inode_t& inode, uint64_t& fileLength) const {
-		deserializeAllLegacyPacketDataNoHeader(packetBuffer,
-				messageId, chunkId, inode, fileLength);
-		lockId = 1;
-	}
-
-	virtual void serializeFuseTruncate(std::vector<uint8_t>& packetBuffer,
-			uint32_t type, uint32_t messageId, uint8_t status) const {
-		sassert(type == FUSE_TRUNCATE || type == FUSE_TRUNCATE_END);
-		if (type == FUSE_TRUNCATE) {
-			serializeLegacyPacket(packetBuffer, MATOCL_FUSE_TRUNCATE, messageId, status);
-		} else {
-			// this should never happen, so do anything
-			serializeLegacyPacket(packetBuffer, MATOCL_FUSE_TRUNCATE,
-					messageId, uint8_t(SAUNAFS_ERROR_ENOTSUP));
-		}
-	}
-
-	virtual void serializeFuseTruncate(std::vector<uint8_t>& packetBuffer,
-			uint32_t type, uint32_t messageId, const Attributes& attributes) const {
-		sassert(type == FUSE_TRUNCATE || type == FUSE_TRUNCATE_END);
-		if (type == FUSE_TRUNCATE) {
-			serializeLegacyPacket(packetBuffer, MATOCL_FUSE_TRUNCATE, messageId, attributes);
-		} else {
-			// this should never happen, so do anything
-			serializeLegacyPacket(packetBuffer, MATOCL_FUSE_TRUNCATE,
-					messageId, uint8_t(SAUNAFS_ERROR_ENOTSUP));
-		}
-
-	}
-
-	virtual void deserializeFuseTruncate(std::vector<uint8_t>& packetBuffer,
-			uint32_t& messageId, inode_t& inode, bool& isOpened,
-			uint32_t& uid, uint32_t& gid, uint64_t& length) const {
-		deserializeAllLegacyPacketDataNoHeader(packetBuffer,
-				messageId, inode, isOpened, uid, gid, length);
-
-	}
-};
-
-class SaunaFsPacketSerializer : public PacketSerializer {
-public:
-	virtual bool isSaunaFsPacketSerializer() const {
-		return true;
-	}
-
-	virtual void serializeFuseReadChunk(std::vector<uint8_t>& packetBuffer,
-			uint32_t messageId, uint8_t status) const {
-		matocl::fuseReadChunk::serialize(packetBuffer, messageId, status);
-	}
-
-	virtual void serializeFuseReadChunk(std::vector<uint8_t>& packetBuffer,
-			uint32_t messageId, uint64_t fileLength, uint64_t chunkId, uint32_t chunkVersion,
-			const std::vector<ChunkTypeWithAddress>& chunkCopies) const {
-		matocl::fuseReadChunk::serialize(packetBuffer, messageId, fileLength, chunkId, chunkVersion,
-				chunkCopies);
-	}
-
-	virtual void deserializeFuseReadChunk(const std::vector<uint8_t>& packetBuffer,
-			uint32_t& messageId, inode_t& inode, uint32_t& chunkIndex) const {
-		cltoma::fuseReadChunk::deserialize(packetBuffer, messageId, inode, chunkIndex);
-	}
-
-	virtual void serializeFuseWriteChunk(std::vector<uint8_t>& packetBuffer,
-			uint32_t messageId, uint8_t status) const {
-		matocl::fuseWriteChunk::serialize(packetBuffer, messageId, status);
-	}
-
-	virtual void serializeFuseWriteChunk(std::vector<uint8_t>& packetBuffer,
-			uint32_t messageId, uint64_t fileLength,
-			uint64_t chunkId, uint32_t chunkVersion, uint32_t lockId,
-			const std::vector<ChunkTypeWithAddress>& chunkCopies) const {
-		matocl::fuseWriteChunk::serialize(packetBuffer, messageId,
-				fileLength, chunkId, chunkVersion, lockId, chunkCopies);
-	}
-
-	virtual void deserializeFuseWriteChunk(const std::vector<uint8_t>& packetBuffer,
-			uint32_t& messageId, inode_t& inode, uint32_t& chunkIndex, uint32_t& lockId) const {
-		cltoma::fuseWriteChunk::deserialize(packetBuffer, messageId, inode, chunkIndex, lockId);
-	}
-
-	virtual void serializeFuseWriteChunkEnd(std::vector<uint8_t>& packetBuffer,
-			uint32_t messageId, uint8_t status) const {
-		matocl::fuseWriteChunkEnd::serialize(packetBuffer, messageId, status);
-	}
-
-	virtual void deserializeFuseWriteChunkEnd(const std::vector<uint8_t>& packetBuffer,
-			uint32_t& messageId, uint64_t& chunkId, uint32_t& lockId,
-			inode_t& inode, uint64_t& fileLength) const {
-		cltoma::fuseWriteChunkEnd::deserialize(packetBuffer,
-				messageId, chunkId, lockId, inode, fileLength);
-	}
-
-	virtual void serializeFuseTruncate(std::vector<uint8_t>& packetBuffer,
-			uint32_t type, uint32_t messageId, uint8_t status) const {
-		sassert(type == FUSE_TRUNCATE || type == FUSE_TRUNCATE_END);
-		if (type == FUSE_TRUNCATE) {
-			matocl::fuseTruncate::serialize(packetBuffer, messageId, status);
-		} else {
-			matocl::fuseTruncateEnd::serialize(packetBuffer, messageId, status);
-		}
-	}
-
-	virtual void serializeFuseTruncate(std::vector<uint8_t>& packetBuffer,
-			uint32_t type, uint32_t messageId, const Attributes& attributes) const {
-		sassert(type == FUSE_TRUNCATE || type == FUSE_TRUNCATE_END);
-		if (type == FUSE_TRUNCATE) {
-			matocl::fuseTruncate::serialize(packetBuffer, messageId, attributes);
-		} else {
-			matocl::fuseTruncateEnd::serialize(packetBuffer, messageId, attributes);
-		}
-
-	}
-
-	virtual void deserializeFuseTruncate(std::vector<uint8_t>& packetBuffer,
-			uint32_t& messageId, inode_t& inode, bool& isOpened,
-			uint32_t& uid, uint32_t& gid, uint64_t& length) const {
-		cltoma::fuseTruncate::deserialize(packetBuffer,
-				messageId, inode, isOpened, uid, gid, length);
-	}
-};
-
-class SaunaFsStdXorPacketSerializer : public SaunaFsPacketSerializer {
-public:
-	virtual void serializeFuseReadChunk(std::vector<uint8_t>& packetBuffer,
-			uint32_t messageId, uint64_t fileLength, uint64_t chunkId, uint32_t chunkVersion,
-			const std::vector<ChunkTypeWithAddress>& chunkCopies) const {
-		std::vector<legacy::ChunkTypeWithAddress> chunk_copies;
-		for (const auto &part : chunkCopies) {
-			if ((int)part.chunk_type.getSliceType() >= Goal::Slice::Type::kECFirst) {
-				continue;
-			}
-			chunk_copies.push_back(legacy::ChunkTypeWithAddress(part.address, (legacy::ChunkPartType)part.chunk_type));
-		}
-		matocl::fuseReadChunk::serialize(packetBuffer, messageId, fileLength, chunkId, chunkVersion,
-				chunk_copies);
-	}
-
-	virtual void serializeFuseWriteChunk(std::vector<uint8_t>& packetBuffer,
-			uint32_t messageId, uint64_t fileLength,
-			uint64_t chunkId, uint32_t chunkVersion, uint32_t lockId,
-			const std::vector<ChunkTypeWithAddress>& chunkCopies) const {
-		std::vector<legacy::ChunkTypeWithAddress> chunk_copies;
-		for (const auto &part : chunkCopies) {
-			if ((int)part.chunk_type.getSliceType() >= Goal::Slice::Type::kECFirst) {
-				continue;
-			}
-			chunk_copies.push_back(legacy::ChunkTypeWithAddress(part.address, (legacy::ChunkPartType)part.chunk_type));
-		}
-		matocl::fuseWriteChunk::serialize(packetBuffer, messageId,
-				fileLength, chunkId, chunkVersion, lockId, chunk_copies);
-	}
-};
-
-
-const PacketSerializer* PacketSerializer::getSerializer(PacketHeader::Type type, uint32_t version) {
-	sassert((type >= PacketHeader::kMinSauPacketType && type <= PacketHeader::kMaxSauPacketType)
-			|| type <= PacketHeader::kMaxOldPacketType);
-	if (type <= PacketHeader::kMaxOldPacketType) {
-		static LegacyPacketSerializer singleton;
-		return &singleton;
-	}
-
-	static SaunaFsPacketSerializer singleton;
-	if (version < kFirstECVersion) {
-		static SaunaFsStdXorPacketSerializer singletonStdXor;
-		return &singletonStdXor;
-	}
-
-	return &singleton;
-}
 
 void matoclserv_stats(uint64_t stats[5]) {
 	stats[0] = statsPacketsReceived;
@@ -643,19 +365,6 @@ static inline FsContext matoclserv_get_context(matoclserventry *eptr, uint32_t u
 	matoclserv_ugid_remap(eptr, &uid, &gid);
 	return FsContext::getForMasterWithSession(eventloop_time(), eptr->sessionData->rootInode,
 	                                          eptr->sessionData->flags, uid, gid, auid, agid);
-}
-
-/// Extracts network addresses of standard chunk copies from a list of all chunk copies.
-/// @param allCopies List of all chunk copies with their addresses
-/// @param standardCopies Output vector to store the addresses of standard chunk copies
-static void getStandardChunkCopies(const std::vector<ChunkTypeWithAddress>& allCopies,
-		std::vector<NetworkAddress>& standardCopies) {
-	sassert(standardCopies.empty());
-	for (auto& chunkCopy : allCopies) {
-		if (slice_traits::isStandard(chunkCopy.chunk_type)) {
-			standardCopies.push_back(chunkCopy.address);
-		}
-	}
 }
 
 /// Removes unsupported EC parts from a given list of chunk parts.

--- a/src/master/matoclserv_serializer.cc
+++ b/src/master/matoclserv_serializer.cc
@@ -1,0 +1,257 @@
+/*
+   Copyright 2005-2017 Jakub Kruszona-Zawadzki, Gemius SA
+   Copyright 2013-2014 EditShare
+   Copyright 2013-2017 Skytechnology sp. z o.o.
+   Copyright 2023      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "common/platform.h"
+
+#include "master/matoclserv_serializer.h"
+
+#include "common/legacy_vector.h"
+#include "common/saunafs_version.h"
+#include "protocol/cltoma.h"
+#include "protocol/matocl.h"
+
+const PacketSerializer *PacketSerializer::getSerializer(PacketHeader::Type type, uint32_t version) {
+	sassert((type >= PacketHeader::kMinSauPacketType && type <= PacketHeader::kMaxSauPacketType) ||
+	        type <= PacketHeader::kMaxOldPacketType);
+	if (type <= PacketHeader::kMaxOldPacketType) {
+		static LegacyPacketSerializer singleton;
+		return &singleton;
+	}
+
+	static SaunaFsPacketSerializer singleton;
+	if (version < kFirstECVersion) {
+		static SaunaFsStdXorPacketSerializer singletonStdXor;
+		return &singletonStdXor;
+	}
+
+	return &singleton;
+}
+
+// LegacyPacketSerializer implementations
+void LegacyPacketSerializer::serializeFuseReadChunk(std::vector<uint8_t> &packetBuffer,
+                                                    uint32_t messageId, uint8_t status) const {
+	serializeLegacyPacket(packetBuffer, MATOCL_FUSE_READ_CHUNK, messageId, status);
+}
+
+void LegacyPacketSerializer::serializeFuseReadChunk(
+    std::vector<uint8_t> &packetBuffer, uint32_t messageId, uint64_t fileLength, uint64_t chunkId,
+    uint32_t chunkVersion, const std::vector<ChunkTypeWithAddress> &chunkCopies) const {
+	LegacyVector<NetworkAddress> standardChunkCopies;
+	getStandardChunkCopies(chunkCopies, standardChunkCopies);
+	serializeLegacyPacket(packetBuffer, MATOCL_FUSE_READ_CHUNK, messageId, fileLength, chunkId,
+	                      chunkVersion, standardChunkCopies);
+}
+
+void LegacyPacketSerializer::deserializeFuseReadChunk(const std::vector<uint8_t> &packetBuffer,
+                                                      uint32_t &messageId, inode_t &inode,
+                                                      uint32_t &chunkIndex) const {
+	deserializeAllLegacyPacketDataNoHeader(packetBuffer, messageId, inode, chunkIndex);
+}
+
+void LegacyPacketSerializer::serializeFuseWriteChunk(std::vector<uint8_t> &packetBuffer,
+                                                     uint32_t messageId, uint8_t status) const {
+	serializeLegacyPacket(packetBuffer, MATOCL_FUSE_WRITE_CHUNK, messageId, status);
+}
+
+void LegacyPacketSerializer::serializeFuseWriteChunk(
+    std::vector<uint8_t> &packetBuffer, uint32_t messageId, uint64_t fileLength, uint64_t chunkId,
+    uint32_t chunkVersion, uint32_t lockId,
+    const std::vector<ChunkTypeWithAddress> &chunkCopies) const {
+	sassert(lockId == 1);
+	LegacyVector<NetworkAddress> standardChunkCopies;
+	getStandardChunkCopies(chunkCopies, standardChunkCopies);
+	serializeLegacyPacket(packetBuffer, MATOCL_FUSE_WRITE_CHUNK, messageId, fileLength, chunkId,
+	                      chunkVersion, standardChunkCopies);
+}
+
+void LegacyPacketSerializer::deserializeFuseWriteChunk(const std::vector<uint8_t> &packetBuffer,
+                                                       uint32_t &messageId, inode_t &inode,
+                                                       uint32_t &chunkIndex,
+                                                       uint32_t &lockId) const {
+	deserializeAllLegacyPacketDataNoHeader(packetBuffer, messageId, inode, chunkIndex);
+	lockId = 1;
+}
+
+void LegacyPacketSerializer::serializeFuseWriteChunkEnd(std::vector<uint8_t> &packetBuffer,
+                                                        uint32_t messageId, uint8_t status) const {
+	serializeLegacyPacket(packetBuffer, MATOCL_FUSE_WRITE_CHUNK_END, messageId, status);
+}
+
+void LegacyPacketSerializer::deserializeFuseWriteChunkEnd(const std::vector<uint8_t> &packetBuffer,
+                                                          uint32_t &messageId, uint64_t &chunkId,
+                                                          uint32_t &lockId, inode_t &inode,
+                                                          uint64_t &fileLength) const {
+	deserializeAllLegacyPacketDataNoHeader(packetBuffer, messageId, chunkId, inode, fileLength);
+	lockId = 1;
+}
+
+void LegacyPacketSerializer::serializeFuseTruncate(std::vector<uint8_t> &packetBuffer,
+                                                   uint32_t type, uint32_t messageId,
+                                                   uint8_t status) const {
+	sassert(type == FUSE_TRUNCATE || type == FUSE_TRUNCATE_END);
+	if (type == FUSE_TRUNCATE) {
+		serializeLegacyPacket(packetBuffer, MATOCL_FUSE_TRUNCATE, messageId, status);
+	} else {
+		// this should never happen, so do anything
+		serializeLegacyPacket(packetBuffer, MATOCL_FUSE_TRUNCATE, messageId,
+		                      uint8_t(SAUNAFS_ERROR_ENOTSUP));
+	}
+}
+
+void LegacyPacketSerializer::serializeFuseTruncate(std::vector<uint8_t> &packetBuffer,
+                                                   uint32_t type, uint32_t messageId,
+                                                   const Attributes &attributes) const {
+	sassert(type == FUSE_TRUNCATE || type == FUSE_TRUNCATE_END);
+	if (type == FUSE_TRUNCATE) {
+		serializeLegacyPacket(packetBuffer, MATOCL_FUSE_TRUNCATE, messageId, attributes);
+	} else {
+		// this should never happen, so do anything
+		serializeLegacyPacket(packetBuffer, MATOCL_FUSE_TRUNCATE, messageId,
+		                      uint8_t(SAUNAFS_ERROR_ENOTSUP));
+	}
+}
+
+void LegacyPacketSerializer::deserializeFuseTruncate(std::vector<uint8_t> &packetBuffer,
+                                                     uint32_t &messageId, inode_t &inode,
+                                                     bool &isOpened, uint32_t &uid, uint32_t &gid,
+                                                     uint64_t &length) const {
+	deserializeAllLegacyPacketDataNoHeader(packetBuffer, messageId, inode, isOpened, uid, gid,
+	                                       length);
+}
+
+// SaunaFsStdXorPacketSerializer overrides for chunk filtering
+void SaunaFsStdXorPacketSerializer::serializeFuseReadChunk(
+    std::vector<uint8_t> &packetBuffer, uint32_t messageId, uint64_t fileLength, uint64_t chunkId,
+    uint32_t chunkVersion, const std::vector<ChunkTypeWithAddress> &chunkCopies) const {
+	std::vector<legacy::ChunkTypeWithAddress> chunk_copies;
+	for (const auto &part : chunkCopies) {
+		if ((int)part.chunk_type.getSliceType() >= Goal::Slice::Type::kECFirst) { continue; }
+		chunk_copies.emplace_back(part.address, (legacy::ChunkPartType)part.chunk_type);
+	}
+	matocl::fuseReadChunk::serialize(packetBuffer, messageId, fileLength, chunkId, chunkVersion,
+	                                 chunk_copies);
+}
+
+// SaunaFsPacketSerializer implementations
+void SaunaFsPacketSerializer::serializeFuseReadChunk(std::vector<uint8_t> &packetBuffer,
+                                                     uint32_t messageId, uint8_t status) const {
+	matocl::fuseReadChunk::serialize(packetBuffer, messageId, status);
+}
+
+void SaunaFsPacketSerializer::serializeFuseReadChunk(
+    std::vector<uint8_t> &packetBuffer, uint32_t messageId, uint64_t fileLength, uint64_t chunkId,
+    uint32_t chunkVersion, const std::vector<ChunkTypeWithAddress> &chunkCopies) const {
+	matocl::fuseReadChunk::serialize(packetBuffer, messageId, fileLength, chunkId, chunkVersion,
+	                                 chunkCopies);
+}
+
+void SaunaFsPacketSerializer::deserializeFuseReadChunk(const std::vector<uint8_t> &packetBuffer,
+                                                       uint32_t &messageId, inode_t &inode,
+                                                       uint32_t &chunkIndex) const {
+	cltoma::fuseReadChunk::deserialize(packetBuffer, messageId, inode, chunkIndex);
+}
+
+void SaunaFsPacketSerializer::serializeFuseWriteChunk(std::vector<uint8_t> &packetBuffer,
+                                                      uint32_t messageId, uint8_t status) const {
+	matocl::fuseWriteChunk::serialize(packetBuffer, messageId, status);
+}
+
+void SaunaFsPacketSerializer::serializeFuseWriteChunk(
+    std::vector<uint8_t> &packetBuffer, uint32_t messageId, uint64_t fileLength, uint64_t chunkId,
+    uint32_t chunkVersion, uint32_t lockId,
+    const std::vector<ChunkTypeWithAddress> &chunkCopies) const {
+	matocl::fuseWriteChunk::serialize(packetBuffer, messageId, fileLength, chunkId, chunkVersion,
+	                                  lockId, chunkCopies);
+}
+
+void SaunaFsPacketSerializer::deserializeFuseWriteChunk(const std::vector<uint8_t> &packetBuffer,
+                                                        uint32_t &messageId, inode_t &inode,
+                                                        uint32_t &chunkIndex,
+                                                        uint32_t &lockId) const {
+	cltoma::fuseWriteChunk::deserialize(packetBuffer, messageId, inode, chunkIndex, lockId);
+}
+
+void SaunaFsPacketSerializer::serializeFuseWriteChunkEnd(std::vector<uint8_t> &packetBuffer,
+                                                         uint32_t messageId, uint8_t status) const {
+	matocl::fuseWriteChunkEnd::serialize(packetBuffer, messageId, status);
+}
+
+void SaunaFsPacketSerializer::deserializeFuseWriteChunkEnd(const std::vector<uint8_t> &packetBuffer,
+                                                           uint32_t &messageId, uint64_t &chunkId,
+                                                           uint32_t &lockId, inode_t &inode,
+                                                           uint64_t &fileLength) const {
+	cltoma::fuseWriteChunkEnd::deserialize(packetBuffer, messageId, chunkId, lockId, inode,
+	                                       fileLength);
+}
+
+void SaunaFsPacketSerializer::serializeFuseTruncate(std::vector<uint8_t> &packetBuffer,
+                                                    uint32_t type, uint32_t messageId,
+                                                    uint8_t status) const {
+	sassert(type == FUSE_TRUNCATE || type == FUSE_TRUNCATE_END);
+	if (type == FUSE_TRUNCATE) {
+		matocl::fuseTruncate::serialize(packetBuffer, messageId, status);
+	} else {
+		matocl::fuseTruncateEnd::serialize(packetBuffer, messageId, status);
+	}
+}
+
+void SaunaFsPacketSerializer::serializeFuseTruncate(std::vector<uint8_t> &packetBuffer,
+                                                    uint32_t type, uint32_t messageId,
+                                                    const Attributes &attributes) const {
+	sassert(type == FUSE_TRUNCATE || type == FUSE_TRUNCATE_END);
+	if (type == FUSE_TRUNCATE) {
+		matocl::fuseTruncate::serialize(packetBuffer, messageId, attributes);
+	} else {
+		matocl::fuseTruncateEnd::serialize(packetBuffer, messageId, attributes);
+	}
+}
+
+void SaunaFsPacketSerializer::deserializeFuseTruncate(std::vector<uint8_t> &packetBuffer,
+                                                      uint32_t &messageId, inode_t &inode,
+                                                      bool &isOpened, uint32_t &uid, uint32_t &gid,
+                                                      uint64_t &length) const {
+	cltoma::fuseTruncate::deserialize(packetBuffer, messageId, inode, isOpened, uid, gid, length);
+}
+
+void SaunaFsStdXorPacketSerializer::serializeFuseWriteChunk(
+    std::vector<uint8_t> &packetBuffer, uint32_t messageId, uint64_t fileLength, uint64_t chunkId,
+    uint32_t chunkVersion, uint32_t lockId,
+    const std::vector<ChunkTypeWithAddress> &chunkCopies) const {
+	std::vector<legacy::ChunkTypeWithAddress> chunk_copies;
+	for (const auto &part : chunkCopies) {
+		if ((int)part.chunk_type.getSliceType() >= Goal::Slice::Type::kECFirst) { continue; }
+		chunk_copies.emplace_back(part.address, (legacy::ChunkPartType)part.chunk_type);
+	}
+	matocl::fuseWriteChunk::serialize(packetBuffer, messageId, fileLength, chunkId, chunkVersion,
+	                                  lockId, chunk_copies);
+}
+
+void LegacyPacketSerializer::getStandardChunkCopies(
+    const std::vector<ChunkTypeWithAddress> &allCopies,
+    std::vector<NetworkAddress> &standardCopies) {
+	sassert(standardCopies.empty());
+
+	for (const auto &chunkCopy : allCopies) {
+		if (slice_traits::isStandard(chunkCopy.chunk_type)) {
+			standardCopies.push_back(chunkCopy.address);
+		}
+	}
+}

--- a/src/master/matoclserv_serializer.h
+++ b/src/master/matoclserv_serializer.h
@@ -1,0 +1,209 @@
+/*
+   Copyright 2005-2010 Jakub Kruszona-Zawadzki, Gemius SA
+   Copyright 2013-2014 EditShare
+   Copyright 2013-2015 Skytechnology sp. z o.o.
+   Copyright 2023      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "common/platform.h"
+
+#include <cstdint>
+#include <vector>
+
+#include "common/attributes.h"
+#include "common/chunk_type_with_address.h"
+#include "common/type_defs.h"
+#include "protocol/packet.h"
+
+// chunkDelayedOperation types
+enum DelayedChunkOperationType : std::uint32_t {
+	FUSE_WRITE,           /// Reply to FUSE_WRITE_CHUNK is delayed
+	FUSE_TRUNCATE,        /// Reply to FUSE_TRUNCATE which does not require writing is delayed
+	FUSE_TRUNCATE_BEGIN,  /// Reply to FUSE_TRUNCATE which does require writing is delayed
+	FUSE_TRUNCATE_END     /// Reply to FUSE_TRUNCATE_END is delayed
+};
+
+class PacketSerializer {
+public:
+	/// Factory method to get a serializer instance for a given packet type and client version.
+	/// @param type Packet type
+	/// @param version Client version
+	static const PacketSerializer *getSerializer(PacketHeader::Type type, uint32_t version);
+
+	/// Default constructor
+	PacketSerializer() = default;
+
+	/// Unneeded copy and move constructors and assignment operators
+	PacketSerializer(const PacketSerializer &) = delete;
+	PacketSerializer &operator=(const PacketSerializer &) = delete;
+	PacketSerializer(PacketSerializer &&) = delete;
+	PacketSerializer &operator=(PacketSerializer &&) = delete;
+
+	/// Virtual destructor for polymorphic base class
+	virtual ~PacketSerializer() = default;
+
+	virtual bool isSaunaFsPacketSerializer() const = 0;
+
+	virtual void serializeFuseReadChunk(std::vector<uint8_t> &packetBuffer, uint32_t messageId,
+	                                    uint8_t status) const = 0;
+	virtual void serializeFuseReadChunk(
+	    std::vector<uint8_t> &packetBuffer, uint32_t messageId, uint64_t fileLength,
+	    uint64_t chunkId, uint32_t chunkVersion,
+	    const std::vector<ChunkTypeWithAddress> &chunkCopies) const = 0;
+	virtual void deserializeFuseReadChunk(const std::vector<uint8_t> &packetBuffer,
+	                                      uint32_t &messageId, inode_t &inode,
+	                                      uint32_t &chunkIndex) const = 0;
+
+	virtual void serializeFuseWriteChunk(std::vector<uint8_t> &packetBuffer, uint32_t messageId,
+	                                     uint8_t status) const = 0;
+	virtual void serializeFuseWriteChunk(
+	    std::vector<uint8_t> &packetBuffer, uint32_t messageId, uint64_t fileLength,
+	    uint64_t chunkId, uint32_t chunkVersion, uint32_t lockId,
+	    const std::vector<ChunkTypeWithAddress> &chunkCopies) const = 0;
+	virtual void deserializeFuseWriteChunk(const std::vector<uint8_t> &packetBuffer,
+	                                       uint32_t &messageId, inode_t &inode,
+	                                       uint32_t &chunkIndex, uint32_t &lockId) const = 0;
+
+	virtual void serializeFuseWriteChunkEnd(std::vector<uint8_t> &packetBuffer, uint32_t messageId,
+	                                        uint8_t status) const = 0;
+	virtual void deserializeFuseWriteChunkEnd(const std::vector<uint8_t> &packetBuffer,
+	                                          uint32_t &messageId, uint64_t &chunkId,
+	                                          uint32_t &lockId, inode_t &inode,
+	                                          uint64_t &fileLength) const = 0;
+
+	virtual void serializeFuseTruncate(std::vector<uint8_t> &packetBuffer,
+	                                   uint32_t type /* FUSE_TRUNCATE | FUSE_TRUNCATE_END*/,
+	                                   uint32_t messageId, uint8_t status) const = 0;
+	virtual void serializeFuseTruncate(std::vector<uint8_t> &packetBuffer,
+	                                   uint32_t type /* FUSE_TRUNCATE | FUSE_TRUNCATE_END*/,
+	                                   uint32_t messageId, const Attributes &attributes) const = 0;
+	virtual void deserializeFuseTruncate(std::vector<uint8_t> &packetBuffer, uint32_t &messageId,
+	                                     inode_t &inode, bool &isOpened, uint32_t &uid,
+	                                     uint32_t &gid, uint64_t &length) const = 0;
+};
+
+class LegacyPacketSerializer : public PacketSerializer {
+public:
+	bool isSaunaFsPacketSerializer() const override { return false; }
+
+	void serializeFuseReadChunk(std::vector<uint8_t> &packetBuffer, uint32_t messageId,
+	                            uint8_t status) const override;
+
+	void serializeFuseReadChunk(
+	    std::vector<uint8_t> &packetBuffer, uint32_t messageId, uint64_t fileLength,
+	    uint64_t chunkId, uint32_t chunkVersion,
+	    const std::vector<ChunkTypeWithAddress> &chunkCopies) const override;
+
+	void deserializeFuseReadChunk(const std::vector<uint8_t> &packetBuffer, uint32_t &messageId,
+	                              inode_t &inode, uint32_t &chunkIndex) const override;
+
+	void serializeFuseWriteChunk(std::vector<uint8_t> &packetBuffer, uint32_t messageId,
+	                             uint8_t status) const override;
+
+	void serializeFuseWriteChunk(
+	    std::vector<uint8_t> &packetBuffer, uint32_t messageId, uint64_t fileLength,
+	    uint64_t chunkId, uint32_t chunkVersion, uint32_t lockId,
+	    const std::vector<ChunkTypeWithAddress> &chunkCopies) const override;
+
+	void deserializeFuseWriteChunk(const std::vector<uint8_t> &packetBuffer, uint32_t &messageId,
+	                               inode_t &inode, uint32_t &chunkIndex,
+	                               uint32_t &lockId) const override;
+
+	void serializeFuseWriteChunkEnd(std::vector<uint8_t> &packetBuffer, uint32_t messageId,
+	                                uint8_t status) const override;
+
+	void deserializeFuseWriteChunkEnd(const std::vector<uint8_t> &packetBuffer, uint32_t &messageId,
+	                                  uint64_t &chunkId, uint32_t &lockId, inode_t &inode,
+	                                  uint64_t &fileLength) const override;
+
+	void serializeFuseTruncate(std::vector<uint8_t> &packetBuffer, uint32_t type,
+	                           uint32_t messageId, uint8_t status) const override;
+
+	void serializeFuseTruncate(std::vector<uint8_t> &packetBuffer, uint32_t type,
+	                           uint32_t messageId, const Attributes &attributes) const override;
+
+	void deserializeFuseTruncate(std::vector<uint8_t> &packetBuffer, uint32_t &messageId,
+	                             inode_t &inode, bool &isOpened, uint32_t &uid, uint32_t &gid,
+	                             uint64_t &length) const override;
+
+private:
+	/// Extracts network addresses of standard chunk copies from a list of all chunk copies.
+	/// @param allCopies List of all chunk copies with their addresses
+	/// @param standardCopies Output vector to store the addresses of standard chunk copies
+	static void getStandardChunkCopies(const std::vector<ChunkTypeWithAddress> &allCopies,
+	                                   std::vector<NetworkAddress> &standardCopies);
+};
+
+class SaunaFsPacketSerializer : public PacketSerializer {
+public:
+	bool isSaunaFsPacketSerializer() const override { return true; }
+
+	void serializeFuseReadChunk(std::vector<uint8_t> &packetBuffer, uint32_t messageId,
+	                            uint8_t status) const override;
+
+	void serializeFuseReadChunk(
+	    std::vector<uint8_t> &packetBuffer, uint32_t messageId, uint64_t fileLength,
+	    uint64_t chunkId, uint32_t chunkVersion,
+	    const std::vector<ChunkTypeWithAddress> &chunkCopies) const override;
+
+	void deserializeFuseReadChunk(const std::vector<uint8_t> &packetBuffer, uint32_t &messageId,
+	                              inode_t &inode, uint32_t &chunkIndex) const override;
+
+	void serializeFuseWriteChunk(std::vector<uint8_t> &packetBuffer, uint32_t messageId,
+	                             uint8_t status) const override;
+
+	void serializeFuseWriteChunk(
+	    std::vector<uint8_t> &packetBuffer, uint32_t messageId, uint64_t fileLength,
+	    uint64_t chunkId, uint32_t chunkVersion, uint32_t lockId,
+	    const std::vector<ChunkTypeWithAddress> &chunkCopies) const override;
+
+	void deserializeFuseWriteChunk(const std::vector<uint8_t> &packetBuffer, uint32_t &messageId,
+	                               inode_t &inode, uint32_t &chunkIndex,
+	                               uint32_t &lockId) const override;
+
+	void serializeFuseWriteChunkEnd(std::vector<uint8_t> &packetBuffer, uint32_t messageId,
+	                                uint8_t status) const override;
+
+	void deserializeFuseWriteChunkEnd(const std::vector<uint8_t> &packetBuffer, uint32_t &messageId,
+	                                  uint64_t &chunkId, uint32_t &lockId, inode_t &inode,
+	                                  uint64_t &fileLength) const override;
+
+	void serializeFuseTruncate(std::vector<uint8_t> &packetBuffer, uint32_t type,
+	                           uint32_t messageId, uint8_t status) const override;
+
+	void serializeFuseTruncate(std::vector<uint8_t> &packetBuffer, uint32_t type,
+	                           uint32_t messageId, const Attributes &attributes) const override;
+
+	void deserializeFuseTruncate(std::vector<uint8_t> &packetBuffer, uint32_t &messageId,
+	                             inode_t &inode, bool &isOpened, uint32_t &uid, uint32_t &gid,
+	                             uint64_t &length) const override;
+};
+
+class SaunaFsStdXorPacketSerializer : public SaunaFsPacketSerializer {
+public:
+	void serializeFuseReadChunk(
+	    std::vector<uint8_t> &packetBuffer, uint32_t messageId, uint64_t fileLength,
+	    uint64_t chunkId, uint32_t chunkVersion,
+	    const std::vector<ChunkTypeWithAddress> &chunkCopies) const override;
+
+	void serializeFuseWriteChunk(
+	    std::vector<uint8_t> &packetBuffer, uint32_t messageId, uint64_t fileLength,
+	    uint64_t chunkId, uint32_t chunkVersion, uint32_t lockId,
+	    const std::vector<ChunkTypeWithAddress> &chunkCopies) const override;
+};


### PR DESCRIPTION
Removes secondary implementation details from matoclserv to own files, improving modularity and cleaning a bit the interface to the clients.

The commit just moves the code with minimal changes to ease the review, no deep refactor was applied yet.