### PR TITLE
Fix saunafs command display of non-ASCII chars on Windows.

### DIFF
--- a/src/common/args_stat_encoding.h
+++ b/src/common/args_stat_encoding.h
@@ -1,0 +1,98 @@
+/*
+   Copyright 2023      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "common/platform.h"
+
+#include <sys/stat.h>
+
+#ifdef _WIN32
+#include <shellapi.h>
+#include <windows.h>
+#include <string>
+#include <vector>
+
+using saunafs_stat_t = struct _stat64;
+
+// Represents UTF-8 command-line arguments for Windows.
+// Keeps argvPtrs alive for the lifetime of the object.
+class Utf8CmdArguments {
+public:
+	Utf8CmdArguments() {
+		argvUtf8_ = get_utf8_argv();
+		argvPtrs_.reserve(argvUtf8_.size() + 1);
+		for (auto &s : argvUtf8_) { argvPtrs_.push_back(s.data()); }
+		argvPtrs_.push_back(nullptr);
+	}
+
+	char **getArgv() const { return const_cast<char **>(argvPtrs_.data()); }
+	int getArgc() const { return static_cast<int>(argvUtf8_.size()); }
+
+private:
+	static std::vector<std::string> get_utf8_argv() {
+		int argcW = 0;
+		LPWSTR *argvW = CommandLineToArgvW(GetCommandLineW(), &argcW);
+		std::vector<std::string> argvUtf8;
+		if (!argvW || argcW <= 0) { return argvUtf8; }
+		argvUtf8.reserve(argcW);
+
+		for (int i = 0; i < argcW; ++i) {
+			int size = WideCharToMultiByte(CP_UTF8, 0, argvW[i], -1, nullptr, 0, nullptr, nullptr);
+			if (size <= 1) {
+				argvUtf8.emplace_back();
+				continue;
+			}
+			std::string utf8(size, '\0');
+			int written =
+			    WideCharToMultiByte(CP_UTF8, 0, argvW[i], -1, &utf8[0], size, nullptr, nullptr);
+			if (written != size || written == 0) {
+				argvUtf8.emplace_back();
+				continue;
+			}
+			utf8.resize(size - 1);  // Remove the null terminator
+			argvUtf8.push_back(std::move(utf8));
+		}
+		LocalFree(argvW);
+		return argvUtf8;
+	}
+
+	std::vector<std::string> argvUtf8_;
+	std::vector<char *> argvPtrs_;
+};
+
+inline int utf8_stat(const char *path_utf8, saunafs_stat_t *st) {
+	int wlen = MultiByteToWideChar(CP_UTF8, 0, path_utf8, -1, nullptr, 0);
+	if (wlen <= 0) { return -1; }
+
+	std::wstring wpath(wlen, L'\0');  // include null terminator
+	MultiByteToWideChar(CP_UTF8, 0, path_utf8, -1, wpath.data(), wlen);
+
+	return _wstat64(wpath.c_str(), st);
+}
+
+// Unified portable wrapper
+inline int stat_portable(const char *path, saunafs_stat_t *st) {
+	return utf8_stat(path, reinterpret_cast<struct _stat64 *>(st));
+}
+#else
+using saunafs_stat_t = struct stat;
+
+// On POSIX just call stat
+inline int stat_portable(const char *path, saunafs_stat_t *st) { return stat(path, st); }
+#endif

--- a/src/tools/main.cc
+++ b/src/tools/main.cc
@@ -33,6 +33,10 @@
 #include "tools/tools_commands.h"
 #include "tools/tools_common_functions.h"
 
+// This import should be placed after other includes to avoid Windows dependency issues
+// with winsock2.h and windows.h included in tools/tools_common_functions.h
+#include "common/args_stat_encoding.h"
+
 static char path_buf[PATH_MAX];
 
 void split(std::vector<char*> &argv_new, std::vector<char> &line) {
@@ -62,6 +66,16 @@ int main(int argc, char **argv) {
 	set_humode();
 
 #ifdef _WIN32
+	// Enable UTF-8 encoding for console I/O on Windows. This is necessary to properly
+	// handle Unicode characters in file paths and other strings on Windows systems,
+	// as the default console code page may not support UTF-8.
+	SetConsoleCP(CP_UTF8);
+	SetConsoleOutputCP(CP_UTF8);
+
+	Utf8CmdArguments args;
+	argc = args.getArgc();
+	argv = args.getArgv();
+
 	socketinit();
 #endif
 

--- a/src/tools/master_functions.cc
+++ b/src/tools/master_functions.cc
@@ -44,6 +44,10 @@
 #include "protocol/matocl.h"
 #include "tools/tools_common_functions.h"
 
+// This import should be placed after other includes to avoid Windows dependency issues
+// with winsock2.h and windows.h
+#include "common/args_stat_encoding.h"
+
 struct master_info_t {
 	uint32_t ip;
 	uint16_t port;
@@ -126,12 +130,10 @@ static bool contains_master_info_name_end(const char *name) {
 static int read_master_info(const char *name, master_info_t *info) {
 	static constexpr int kMasterInfoSize = 14;
 	uint8_t buffer[kMasterInfoSize];
-	struct stat stb;
+	saunafs_stat_t stb;
 	int sd;
 
-	if (stat(name, &stb) < 0) {
-		return -1;
-	}
+	if (stat_portable(name, &stb) < 0) { return -1; }
 
 	if ((stb.st_ino != SPECIAL_INODE_MASTERINFO &&
 	     !contains_master_info_name_end(name)) ||
@@ -266,7 +268,7 @@ void get_next_path_iteration(std::string &path) {
 
 int open_master_conn(const char *name, inode_t *inode, mode_t *mode, [[maybe_unused]] bool needrwfs) {
 	char rpath[PATH_MAX + 1];
-	struct stat stb;
+	saunafs_stat_t stb;
 	[[maybe_unused]] struct statvfs stvfsb;
 	master_info_t master_info;
 
@@ -297,7 +299,7 @@ int open_master_conn(const char *name, inode_t *inode, mode_t *mode, [[maybe_unu
 #else
 	wsl_to_windows_path(rpath, sizeof(rpath));
 #endif
-	if (stat(rpath, &stb) != 0) {
+	if (stat_portable(rpath, &stb) != 0) {
 		printf("%s: (%s) stat error: %s\n", name, rpath, strerr(errno));
 		return -1;
 	}
@@ -322,8 +324,8 @@ int open_master_conn(const char *name, inode_t *inode, mode_t *mode, [[maybe_unu
 	for (;;) {
 		inode_t rpath_inode;
 
-		if (stat(rpath, &stb) != 0) {
-			printf("%s: (%s) stat error: %s\n", name, rpath, strerr(errno));
+		if (stat_portable(rpath, &stb) != 0) {
+			printf("%s: (%s) stat error: %s\n", name, rpath, strerror(errno));
 			return -1;
 		}
 		rpath_inode = stb.st_ino;
@@ -415,8 +417,8 @@ int open_master_conn(const char *name, inode_t *inode, mode_t *mode, [[maybe_unu
 		}
 #endif
 		dirname_inplace(rpath);
-		if (stat(rpath, &stb) != 0) {
-			printf("%s: (%s) stat error: %s\n", name, rpath, strerr(errno));
+		if (stat_portable(rpath, &stb) != 0) {
+			printf("%s: (%s) stat error: %s\n", name, rpath, strerror(errno));
 			return -1;
 		}
 

--- a/src/tools/snapshot.cc
+++ b/src/tools/snapshot.cc
@@ -38,9 +38,13 @@
 #include "tools/tools_commands.h"
 #include "tools/tools_common_functions.h"
 
+// This import should be placed after other includes to avoid Windows dependency issues
+// with winsock2.h and windows.h included in tools/tools_common_functions.h
+#include "common/args_stat_encoding.h"
+
 static int kInfiniteTimeout = 10 * 24 * 3600 * 1000; // simulate infinite timeout (10 days)
 #ifdef _WIN32
-static struct stat kDefaultEmptyStat = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+static saunafs_stat_t kDefaultEmptyStat = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 #endif
 
 static void snapshot_usage() {
@@ -134,10 +138,10 @@ static int snapshot(const char *dstname, char *const *srcnames, uint32_t srcelem
 	for (uint32_t i = 0; i < srcelements; i++) {
 		lookup_srcnames.push_back(std::string(srcnames[i]));
 	}
-	struct stat sst = kDefaultEmptyStat;
-	struct stat dst = kDefaultEmptyStat;
+	saunafs_stat_t sst = kDefaultEmptyStat;
+	saunafs_stat_t dst = kDefaultEmptyStat;
 #else
-	struct stat sst, dst;
+	saunafs_stat_t sst, dst;
 #endif
 	int status;
 	uint32_t i, l;
@@ -151,8 +155,7 @@ static int snapshot(const char *dstname, char *const *srcnames, uint32_t srcelem
 	}
 #endif
 
-
-	if (stat(lookup_dstname.c_str(), &dst) < 0) {  // dst does not exist
+	if (stat_portable(lookup_dstname.c_str(), &dst) < 0) {  // dst does not exist
 		if (errno != ENOENT) {
 			printf("%s: stat error: %s\n", dstname, strerr(errno));
 			return -1;
@@ -162,7 +165,7 @@ static int snapshot(const char *dstname, char *const *srcnames, uint32_t srcelem
 			return -1;
 		}
 #ifdef _WIN32
-		if (stat(lookup_srcnames[0].c_str(), &sst) < 0) {
+		if (stat_portable(lookup_srcnames[0].c_str(), &sst) < 0) {
 			printf("%s: stat error: %s\n", srcnames[0], strerr(errno));
 			return -1;
 		}
@@ -176,7 +179,7 @@ static int snapshot(const char *dstname, char *const *srcnames, uint32_t srcelem
 			printf("%s: dirname error\n", dstname);
 			return -1;
 		}
-		if (stat(dir, &dst) < 0) {
+		if (stat_portable(dir, &dst) < 0) {
 			printf("%s: stat error: %s\n", dir, strerr(errno));
 			return -1;
 		}
@@ -219,7 +222,7 @@ static int snapshot(const char *dstname, char *const *srcnames, uint32_t srcelem
 				return -1;
 			}
 #ifdef _WIN32
-			if (stat(lookup_srcnames[0].c_str(), &sst) < 0) {
+			if (stat_portable(lookup_srcnames[0].c_str(), &sst) < 0) {
 				printf("%s: stat error: %s\n", srcnames[0], strerr(errno));
 				return -1;
 			}
@@ -251,9 +254,8 @@ static int snapshot(const char *dstname, char *const *srcnames, uint32_t srcelem
 			status = 0;
 			for (i = 0; i < srcelements; i++) {
 #ifdef _WIN32
-				if (stat(lookup_srcnames[i].c_str(), &sst) < 0) {
-					printf("%s: stat error: %lu\n", srcnames[i],
-					       GetLastError());
+				if (stat_portable(lookup_srcnames[i].c_str(), &sst) < 0) {
+					printf("%s: stat error: %lu\n", srcnames[i], GetLastError());
 					status = -1;
 					continue;
 				}

--- a/tests/test_suites/ShortSystemTests/test_saunafs_non_ascii_chars.sh
+++ b/tests/test_suites/ShortSystemTests/test_saunafs_non_ascii_chars.sh
@@ -1,0 +1,34 @@
+USE_RAMDISK="YES" \
+	setup_local_empty_saunafs info
+
+cd "${info[mount0]}"
+
+# Non-ASCII test names
+polish="zażółć"
+chinese="文件夹"
+arabic="ملف"
+
+# Create directories
+mkdir "${polish}" "${chinese}" "${arabic}"
+
+# Create files inside each directory
+touch "${polish}/${polish}_plik"
+touch "${chinese}/${chinese}_file"
+touch "${arabic}/${arabic}_ملف"
+
+# Run saunafs dirinfo on each directory
+for dir in "${polish}" "${chinese}" "${arabic}"; do
+    echo "Testing dirinfo for ${dir}"
+    assert_success saunafs_command dirinfo "${dir}"
+done
+
+# Run saunafs fileinfo on each file
+assert_success saunafs_command fileinfo "${polish}/${polish}_plik"
+assert_success saunafs_command fileinfo "${chinese}/${chinese}_file"
+assert_success saunafs_command fileinfo "${arabic}/${arabic}_ملف"
+
+# Clean up
+rm "${polish}/${polish}_plik"
+rm "${chinese}/${chinese}_file"
+rm "${arabic}/${arabic}_ملف"
+rmdir "${polish}" "${chinese}" "${arabic}"


### PR DESCRIPTION
Previously, special characters in paths (like accented letters or other non-ASCII characters) were not handled correctly on Windows when using
the saunafs tool. This commit ensures that paths are properly converted to UTF-8 before processing, allowing for correct handling of such characters.