### PR TITLE
fix(cs): Fix replica writes - DISCONNECTED error

### DIFF
--- a/src/chunkserver/chunkserver_entry.cc
+++ b/src/chunkserver/chunkserver_entry.cc
@@ -175,10 +175,12 @@ void ChunkserverEntry::retryConnect() {
 
 	if (connectRetryCounter < kConnectRetries) {
 		if (initConnection() < kInitConnectionOK) {
+			safs::log_info("({}) Failed initializing connection.", __func__);
 			fwdError();
 			return;
 		}
 	} else {
+		safs::log_info("({}) Connect retry counter reached limit.", __func__);
 		fwdError();
 		return;
 	}
@@ -1103,6 +1105,7 @@ bool ChunkserverEntry::processRWBytes(int bytesRW, PacketStruct &packet, bool sh
                                       const char *callerName, bool isRead) {
 	if (bytesRW == 0) {
 		if (shouldForwardError) {
+			safs::log_info("({}) {} returned 0 bytes", callerName, isRead ? "read" : "write");
 			fwdError();
 		} else {
 			state = State::Close;

--- a/src/chunkserver/io_buffers.cc
+++ b/src/chunkserver/io_buffers.cc
@@ -169,10 +169,12 @@ ssize_t InputBuffer::readFromSocket(int sock, size_t bytesToRead) {
 
 	if (bytesReadInHeaderBuffer < targetBytesInHeaderBuffer) {
 		// If the header buffer is not filled, we read to the header buffer.
-		bytesRead = headerBuffer_.readFromFD(
+		auto headerBytesRead = headerBuffer_.readFromFD(
 		    sock, std::min(targetBytesInHeaderBuffer - bytesReadInHeaderBuffer, bytesToRead));
 
-		if (bytesRead <= 0) { return bytesRead; }
+		if (headerBytesRead <= 0) { return headerBytesRead; }
+
+		bytesRead = headerBytesRead;
 	}
 	bytesReadInHeaderBuffer = headerBuffer_.totalBytesPutInBuffer();
 
@@ -182,7 +184,10 @@ ssize_t InputBuffer::readFromSocket(int sock, size_t bytesToRead) {
 		auto blockBytesRead = blockBuffer_.readFromFD(sock, bytesToRead - bytesRead);
 
 		if (blockBytesRead <= 0) {
-			return bytesRead;  // Return the number of bytes read so far.
+			if (bytesRead > 0) {
+				return bytesRead;  // Return the number of bytes read so far.
+			}
+			return blockBytesRead;  // Return the error code from reading the block buffer.
 		}
 
 		bytesRead += blockBytesRead;
@@ -193,12 +198,15 @@ ssize_t InputBuffer::readFromSocket(int sock, size_t bytesToRead) {
 ssize_t InputBuffer::writeToSocket(int sock, size_t bytesToWrite) {
 	ssize_t bytesWritten = 0;
 	size_t bytesInHeaderBuffer = headerBuffer_.bytesInABuffer();
+
 	if (bytesInHeaderBuffer > 0) {
 		// If the header buffer is not flushed, we write from the header buffer.
 		size_t headerBytesToWrite = std::min(bytesToWrite, bytesInHeaderBuffer);
-		bytesWritten = headerBuffer_.writeToFD(sock, headerBytesToWrite);
+		auto headerBytesWritten = headerBuffer_.writeToFD(sock, headerBytesToWrite);
 
-		if (bytesWritten <= 0) { return bytesWritten; }
+		if (headerBytesWritten <= 0) { return headerBytesWritten; }
+
+		bytesWritten = headerBytesWritten;
 	}
 	bytesInHeaderBuffer = headerBuffer_.bytesInABuffer();
 
@@ -207,7 +215,10 @@ ssize_t InputBuffer::writeToSocket(int sock, size_t bytesToWrite) {
 		auto blockBytesWritten = blockBuffer_.writeToFD(sock, bytesToWrite - bytesWritten);
 
 		if (blockBytesWritten <= 0) {
-			return bytesWritten;  // Return the number of bytes written so far.
+			if (bytesWritten > 0) {
+				return bytesWritten;  // Return the number of bytes written so far.
+			}
+			return blockBytesWritten;  // Return the error code from writing the block buffer.
 		}
 
 		bytesWritten += blockBytesWritten;


### PR DESCRIPTION
It was noticed that in some scenarios the replica writes might fail,
and the error code sent from the chunkservers is DISCONNECTED. This
is caused due to a misshandled case when writing to a socket from the
InputBuffer code. This function was returning 0: causing an immediate
stop in the forward operation and sending through the chain the
previously mentioned error in some cases when it was supposed to return
-1 and use the errno (EAGAIN) to retry the write. The fix consists in
analizing whether the block write had some previous header data written
to the socket and return the expected error when a block write fails
with EAGAIN errno.

A similar fix was applied preemptively to the reads to the InputBuffer.
Also the missing places where the fwdError function was called were
logged for better future debugging.

Signed-off-by: Dave <dave@leil.io>