### PR TITLE
refactor(master): Add IFilesystemOperations interface

### DIFF
--- a/src/master/chunks.cc
+++ b/src/master/chunks.cc
@@ -60,6 +60,7 @@
 #include "master/chunk_goal_counters.h"
 #include "master/chunkserver_db.h"
 #include "master/filesystem.h"
+#include "master/filesystem_operations_interface.h"
 #include "master/get_servers_for_new_chunk.h"
 #include "master/goal_cache.h"
 #include "master/id_generator_incremental.h"
@@ -356,7 +357,7 @@ public:
 		Goal result;
 		int prev_goal = -1;
 		for (auto counter : goalCounters_) {
-			const Goal &goal = fs_get_goal_definition(counter.goal);
+			const Goal &goal = gFilesystemOperations->fs_get_goal_definition(counter.goal);
 			if (prev_goal != (int)counter.goal) {
 				result.mergeIn(goal);
 				prev_goal = counter.goal;
@@ -1104,7 +1105,7 @@ uint8_t chunk_multi_modify(uint64_t ochunkid, uint32_t *lockid, uint8_t goal,
 				return SAUNAFS_ERROR_NOCHUNKSERVERS;
 			}
 		}
-		ChunkCopiesCalculator calculator(fs_get_goal_definition(goal));
+		ChunkCopiesCalculator calculator(gFilesystemOperations->fs_get_goal_definition(goal));
 		for (const auto &server_with_type : serversWithChunkTypes) {
 			calculator.addPart(server_with_type.second, MediaLabel::kWildcard);
 		}

--- a/src/master/filesystem.cc
+++ b/src/master/filesystem.cc
@@ -227,6 +227,12 @@ static void ensureChunkIdGenerator() {
 	}
 }
 
+static void initFSOperations() {
+	if (!gFilesystemOperations) {
+		gFilesystemOperations = std::make_unique<FilesystemOperationsBase>();
+	}
+}
+
 /* executed in master mode */
 #ifndef METARESTORE
 
@@ -448,6 +454,9 @@ int fs_init(bool doLoad) {
 		throw;
 	}
 
+	// Initialize the concrete filesystem operations before any FS call
+	initFSOperations();
+
 	if (!gMetadataLockfile) {
 		gMetadataLockfile = std::make_unique<Lockfile>(kMetadataFilename + std::string(".lock"));
 	}
@@ -505,10 +514,14 @@ int fs_init(const char *fname, int ignoreflag, bool noLock) {
 	gMetadataBackend = std::make_unique<MetadataBackendFile>();
 	dynamic_cast<MetadataBackendFile *>(gMetadataBackend.get())->setMetadataFile(fname);
 
+	// Initialize the concrete filesystem operations before any FS call
+	initFSOperations();
+
 	if (!noLock) {
 		gMetadataLockfile.reset(new Lockfile(fs::dirname(fname) + "/" + kMetadataFilename + ".lock"));
 		gMetadataLockfile->lock(Lockfile::StaleLock::kSwallow);
 	}
+
 	fs_strinit(true);
 	ensureChunkIdGenerator();
 	chunk_strinit();

--- a/src/master/filesystem.h
+++ b/src/master/filesystem.h
@@ -262,12 +262,6 @@ void fs_incversion(uint64_t chunkid);
 
 void fs_cs_disconnected(void);
 
-/// Return the current definitions of all goals.
-const std::map<int, Goal> &fs_get_goal_definitions();
-
-/// Return the current definition of the given (by ID) goal.
-const Goal &fs_get_goal_definition(uint8_t goalId);
-
 /// Return info about currently executed tasks
 std::vector<JobInfo> fs_get_current_tasks_info();
 // Disable saving metadata on exit

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -148,7 +148,7 @@ static uint64_t file_realsize(FSNodeFile *node, uint32_t nonzero_chunks, uint64_
 	(void)file_size;
 	return 0; // Doesn't really matter. Metarestore doesn't need this value
 #else
-	const Goal &goal = fs_get_goal_definition(node->goal);
+	const Goal &goal = gFilesystemOperations->fs_get_goal_definition(node->goal);
 
 	uint64_t full_size = 0;
 	for (const auto &slice : goal) {

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -1488,23 +1488,25 @@ static int fsnodes_check_lock_permissions(const FsContext &context, inode_t inod
 	return fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny, modemask, inode, &dummy);
 }
 
-int fs_posixlock_probe(const FsContext &context, inode_t inode, uint64_t start, uint64_t end,
-		uint64_t owner, uint32_t sessionid, uint32_t reqid, uint32_t msgid, uint16_t op,
-		safs_locks::FlockWrapper &info) {
+int FilesystemOperationsBase::fs_posixlock_probe(const FsContext &context, inode_t inode,
+                                                 uint64_t start, uint64_t end, uint64_t owner,
+                                                 uint32_t sessionid, uint32_t reqid, uint32_t msgid,
+                                                 uint16_t oper, safs_locks::FlockWrapper &info) {
 	uint8_t status;
 
-	if (op != safs_locks::kShared && op != safs_locks::kExclusive && op != safs_locks::kUnlock) {
+	if (oper != safs_locks::kShared && oper != safs_locks::kExclusive &&
+	    oper != safs_locks::kUnlock) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
 
-	if ((status = fsnodes_check_lock_permissions(context, inode, op)) != SAUNAFS_STATUS_OK) {
+	if ((status = fsnodes_check_lock_permissions(context, inode, oper)) != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
 	FileLocks &locks = gMetadata->posixLocks;
 	const FileLocks::Lock *collision;
 
-	collision = locks.findCollision(inode, static_cast<FileLocks::Lock::Type>(op), start, end,
+	collision = locks.findCollision(inode, static_cast<FileLocks::Lock::Type>(oper), start, end,
 			FileLocks::Owner{owner, sessionid, reqid, msgid});
 
 	if (collision == nullptr) {
@@ -1513,25 +1515,27 @@ int fs_posixlock_probe(const FsContext &context, inode_t inode, uint64_t start, 
 	} else {
 		info.l_type = static_cast<int>(collision->type);
 		info.l_start = collision->start;
-		info.l_len = std::min<uint64_t>(collision->end - collision->start, std::numeric_limits<int64_t>::max());
+		info.l_len = std::min<uint64_t>(collision->end - collision->start,
+		                                std::numeric_limits<int64_t>::max());
 		return SAUNAFS_ERROR_WAITING;
 	}
 }
 
-int fs_lock_op(const FsContext &context, FileLocks &locks, inode_t inode,
-		uint64_t start, uint64_t end, uint64_t owner, uint32_t sessionid,
-		uint32_t reqid, uint32_t msgid, uint16_t op, bool nonblocking,
-		std::vector<FileLocks::Owner> &applied) {
+int FilesystemOperationsBase::fs_lock_op(const FsContext &context, FileLocks &locks, inode_t inode,
+                                         uint64_t start, uint64_t end, uint64_t owner,
+                                         uint32_t sessionid, uint32_t reqid, uint32_t msgid,
+                                         uint16_t oper, bool nonblocking,
+                                         std::vector<FileLocks::Owner> &applied) {
 	uint8_t status;
 
-	if ((status = fsnodes_check_lock_permissions(context, inode, op)) != SAUNAFS_STATUS_OK) {
+	if ((status = fsnodes_check_lock_permissions(context, inode, oper)) != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
 	FileLocks::LockQueue queue;
 	bool success = false;
 
-	switch (op) {
+	switch (oper) {
 	case safs_locks::kShared:
 		success = locks.sharedLock(inode, start, end,
 				FileLocks::Owner{owner, sessionid, reqid, msgid}, nonblocking);
@@ -1563,7 +1567,7 @@ int fs_lock_op(const FsContext &context, FileLocks &locks, inode_t inode,
 	// and he issued shared lock for this same range. This converts exclusive lock
 	// to shared lock. In the result we may need to apply other shared pending locks
 	// for this range.
-	if (op == safs_locks::kExclusive) {
+	if (oper == safs_locks::kExclusive) {
 		return status;
 	}
 
@@ -1576,39 +1580,46 @@ int fs_lock_op(const FsContext &context, FileLocks &locks, inode_t inode,
 	return status;
 }
 
-int fs_flock_op(const FsContext &context, inode_t inode, uint64_t owner, uint32_t sessionid,
-		uint32_t reqid, uint32_t msgid, uint16_t op, bool nonblocking,
-		std::vector<FileLocks::Owner> &applied) {
+int FilesystemOperationsBase::fs_flock_op(const FsContext &context, inode_t inode, uint64_t owner,
+                                          uint32_t sessionid, uint32_t reqid, uint32_t msgid,
+                                          uint16_t oper, bool nonblocking,
+                                          std::vector<FileLocks::Owner> &applied) {
 	ChecksumUpdater cu(context.ts());
-	int ret = fs_lock_op(context, gMetadata->flockLocks, inode, 0, 1, owner, sessionid,
-			reqid, msgid, op, nonblocking, applied);
+	int ret = fs_lock_op(context, gMetadata->flockLocks, inode, 0, 1, owner, sessionid, reqid,
+	                     msgid, oper, nonblocking, applied);
 	if (context.isPersonalityMaster()) {
-		fs_changelog(context.ts(), "FLCK(%" PRIu8 ",%" PRIiNode ",0,1,%" PRIu64 ",%" PRIu32 ",%" PRIu16 ")",
-				(uint8_t)safs_locks::Type::kFlock, inode, owner, sessionid, op);
+		fs_changelog(context.ts(),
+		             "FLCK(%" PRIu8 ",%" PRIiNode ",0,1,%" PRIu64 ",%" PRIu32 ",%" PRIu16 ")",
+		             (uint8_t)safs_locks::Type::kFlock, inode, owner, sessionid, oper);
+	} else {
+		gMetadata->metadataVersion++;
+	}
+
+	return ret;
+}
+
+int FilesystemOperationsBase::fs_posixlock_op(const FsContext &context, inode_t inode,
+                                              uint64_t start, uint64_t end, uint64_t owner,
+                                              uint32_t sessionid, uint32_t reqid, uint32_t msgid,
+                                              uint16_t oper, bool nonblocking,
+                                              std::vector<FileLocks::Owner> &applied) {
+	ChecksumUpdater cu(context.ts());
+	int ret = fs_lock_op(context, gMetadata->posixLocks, inode, start, end, owner, sessionid, reqid,
+	                     msgid, oper, nonblocking, applied);
+	if (context.isPersonalityMaster()) {
+		fs_changelog(context.ts(),
+		             "FLCK(%" PRIu8 ",%" PRIiNode ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu32
+		             ",%" PRIu16 ")",
+		             (uint8_t)safs_locks::Type::kPosix, inode, start, end, owner, sessionid, oper);
 	} else {
 		gMetadata->metadataVersion++;
 	}
 	return ret;
 }
 
-int fs_posixlock_op(const FsContext &context, inode_t inode, uint64_t start, uint64_t end,
-		uint64_t owner, uint32_t sessionid, uint32_t reqid, uint32_t msgid, uint16_t op,
-		bool nonblocking, std::vector<FileLocks::Owner> &applied) {
-	ChecksumUpdater cu(context.ts());
-	int ret = fs_lock_op(context, gMetadata->posixLocks, inode, start, end, owner, sessionid,
-			reqid, msgid, op, nonblocking, applied);
-	if (context.isPersonalityMaster()) {
-		fs_changelog(context.ts(), "FLCK(%" PRIu8 ",%" PRIiNode ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu32 ",%" PRIu16 ")",
-				(uint8_t)safs_locks::Type::kPosix, inode, start, end, owner, sessionid, op);
-	} else {
-		gMetadata->metadataVersion++;
-	}
-	return ret;
-}
-
-int fs_locks_clear_session(const FsContext &context, uint8_t type, inode_t inode,
-		uint32_t sessionid, std::vector<FileLocks::Owner> &applied) {
-
+int FilesystemOperationsBase::fs_locks_clear_session(const FsContext &context, uint8_t type,
+                                                     inode_t inode, uint32_t sessionid,
+                                                     std::vector<FileLocks::Owner> &applied) {
 	if (type != (uint8_t)safs_locks::Type::kFlock && type != (uint8_t)safs_locks::Type::kPosix) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
@@ -1643,8 +1654,9 @@ int fs_locks_clear_session(const FsContext &context, uint8_t type, inode_t inode
 	return SAUNAFS_STATUS_OK;
 }
 
-int fs_locks_list_all(const FsContext &context, uint8_t type, bool pending, uint64_t start,
-		uint64_t max, std::vector<safs_locks::Info> &result) {
+int FilesystemOperationsBase::fs_locks_list_all(const FsContext &context, uint8_t type,
+                                                bool pending, uint64_t start, uint64_t max,
+                                                std::vector<safs_locks::Info> &outLocks) {
 	(void)context;
 	FileLocks *locks;
 	if (type == (uint8_t)safs_locks::Type::kFlock) {
@@ -1656,16 +1668,18 @@ int fs_locks_list_all(const FsContext &context, uint8_t type, bool pending, uint
 	}
 
 	if (pending) {
-		locks->copyPendingToVector(start, max, result);
+		locks->copyPendingToVector(start, max, outLocks);
 	} else {
-		locks->copyActiveToVector(start, max, result);
+		locks->copyActiveToVector(start, max, outLocks);
 	}
 
 	return SAUNAFS_STATUS_OK;
 }
 
-int fs_locks_list_inode(const FsContext &context, uint8_t type, bool pending, inode_t inode,
-		uint64_t start, uint64_t max, std::vector<safs_locks::Info> &result) {
+int FilesystemOperationsBase::fs_locks_list_inode(const FsContext &context, uint8_t type,
+                                                  bool pending, inode_t inode, uint64_t start,
+                                                  uint64_t max,
+                                                  std::vector<safs_locks::Info> &outLocks) {
 	(void)context;
 	FileLocks *locks;
 
@@ -1678,16 +1692,17 @@ int fs_locks_list_inode(const FsContext &context, uint8_t type, bool pending, in
 	}
 
 	if (pending) {
-		locks->copyPendingToVector(inode, start, max, result);
+		locks->copyPendingToVector(inode, start, max, outLocks);
 	} else {
-		locks->copyActiveToVector(inode, start, max, result);
+		locks->copyActiveToVector(inode, start, max, outLocks);
 	}
 
 	return SAUNAFS_STATUS_OK;
 }
 
-static void fs_manage_lock_try_lock_pending(FileLocks &locks, inode_t inode, uint64_t start,
-		uint64_t end, std::vector<FileLocks::Owner> &applied) {
+void FilesystemOperationsBase::fs_manage_lock_try_lock_pending(
+    FileLocks &locks, inode_t inode, uint64_t start, uint64_t end,
+    std::vector<FileLocks::Owner> &applied) {
 	FileLocks::LockQueue queue;
 	locks.gatherCandidates(inode, start, end, queue);
 	for (auto &candidate : queue) {
@@ -1697,8 +1712,9 @@ static void fs_manage_lock_try_lock_pending(FileLocks &locks, inode_t inode, uin
 	}
 }
 
-int fs_locks_unlock_inode(const FsContext &context, uint8_t type, inode_t inode,
-		std::vector<FileLocks::Owner> &applied) {
+int FilesystemOperationsBase::fs_locks_unlock_inode(const FsContext &context, uint8_t type,
+                                                    inode_t inode,
+                                                    std::vector<FileLocks::Owner> &applied) {
 	ChecksumUpdater cu(context.ts());
 
 	if (type == (uint8_t)safs_locks::Type::kFlock) {
@@ -1721,8 +1737,9 @@ int fs_locks_unlock_inode(const FsContext &context, uint8_t type, inode_t inode,
 	return SAUNAFS_STATUS_OK;
 }
 
-int fs_locks_remove_pending(const FsContext &context, uint8_t type, uint64_t ownerid,
-			uint32_t sessionid, inode_t inode, uint64_t reqid) {
+int FilesystemOperationsBase::fs_locks_remove_pending(const FsContext &context, uint8_t type,
+                                                      uint64_t ownerid, uint32_t sessionid,
+                                                      inode_t inode, uint64_t reqid) {
 	ChecksumUpdater cu(context.ts());
 
 	FileLocks *locks;
@@ -1735,17 +1752,10 @@ int fs_locks_remove_pending(const FsContext &context, uint8_t type, uint64_t own
 		return SAUNAFS_ERROR_EINVAL;
 	}
 
-	locks->removePending(inode,
-			[ownerid, sessionid, reqid](const LockRange &range) {
-				const LockRange::Owner &owner = range.owner();
-				if (owner.owner == ownerid
-					&& owner.sessionid == sessionid
-					&& owner.reqid == reqid) {
-					return true;
-				}
-				return false;
-			}
-		);
+	locks->removePending(inode, [ownerid, sessionid, reqid](const LockRange &range) {
+		const LockRange::Owner &owner = range.owner();
+		return owner.owner == ownerid && owner.sessionid == sessionid && owner.reqid == reqid;
+	});
 
 	if (context.isPersonalityMaster()) {
 		fs_changelog(context.ts(),
@@ -2960,11 +2970,11 @@ uint64_t fs_getversion() {
 }
 
 #ifndef METARESTORE
-const std::map<int, Goal> &fs_get_goal_definitions() {
+const std::map<int, Goal> &FilesystemOperationsBase::fs_get_goal_definitions() const {
 	return gGoalDefinitions;
 }
 
-const Goal &fs_get_goal_definition(uint8_t goalId) {
+const Goal &FilesystemOperationsBase::fs_get_goal_definition(uint8_t goalId) const {
 	return gGoalDefinitions[goalId];
 }
 

--- a/src/master/filesystem_operations.h
+++ b/src/master/filesystem_operations.h
@@ -26,6 +26,7 @@
 
 #include "common/goal.h"
 #include "common/type_defs.h"
+#include "master/filesystem_operations_interface.h"
 #include "master/fs_context.h"
 #include "master/locks.h"
 #include "protocol/lock_info.h"
@@ -39,8 +40,83 @@
 /// 2. Reduce collisions of chunk deletions and metadata dump operations.
 constexpr uint32_t kDefaultTrashTime = 94620;
 
-const std::map<int, Goal> &fs_get_goal_definitions();
-const Goal &fs_get_goal_definition(uint8_t goalId);
+/// Base class for filesystem operations extensibility.
+///
+/// Provides default implementations for all methods of IFilesystemOperations interface.
+/// Will grow with time as new methods are added to the interface. Most likely, will be split
+/// in the future or implemented by specialized classes, like FilesystemOperationsInMemory and/or
+/// FilesystemOperationsKV.
+class FilesystemOperationsBase : public IFilesystemOperations {
+public:
+#ifndef METARESTORE
+	// Goals
+
+	/// Returns a map with all defined goals.
+	const std::map<int, Goal> &fs_get_goal_definitions() const override;
+
+	/// Returns goal definition for given goal id.
+	const Goal &fs_get_goal_definition(uint8_t goalId) const override;
+#endif
+
+	// Locks
+
+	/// Perform a flock operation on filesystem.
+	/// @see IFilesystemOperations::fs_flock_op.
+	int fs_flock_op(const FsContext &context, inode_t inode, uint64_t owner, uint32_t sessionid,
+	                uint32_t reqid, uint32_t msgid, uint16_t oper, bool nonblocking,
+	                std::vector<FileLocks::Owner> &applied) override;
+
+	/// Perform a posix lock operation on filesystem.
+	/// @see IFilesystemOperations::fs_posixlock_op.
+	int fs_posixlock_op(const FsContext &context, inode_t inode, uint64_t start, uint64_t end,
+	                    uint64_t owner, uint32_t sessionid, uint32_t reqid, uint32_t msgid,
+	                    uint16_t oper, bool nonblocking,
+	                    std::vector<FileLocks::Owner> &applied) override;
+
+	/// Perform a POSIX lock probe on filesystem.
+	/// @see IFilesystemOperations::fs_posixlock_probe.
+	int fs_posixlock_probe(const FsContext &context, inode_t inode, uint64_t start, uint64_t end,
+	                       uint64_t owner, uint32_t sessionid, uint32_t reqid, uint32_t msgid,
+	                       uint16_t oper, safs_locks::FlockWrapper &info) override;
+
+	/// Release (unlock + unqueue) all locks from a given session.
+	/// @see IFilesystemOperations::fs_locks_clear_session.
+	int fs_locks_clear_session(const FsContext &context, uint8_t type, inode_t inode,
+	                           uint32_t sessionid, std::vector<FileLocks::Owner> &applied) override;
+
+	/// List locks in the filesystem.
+	/// @see IFilesystemOperations::fs_locks_list_all.
+	int fs_locks_list_all(const FsContext &context, uint8_t type, bool pending, uint64_t start,
+	                      uint64_t max, std::vector<safs_locks::Info> &outLocks) override;
+
+	/// List locks for a specific inode.
+	/// @see IFilesystemOperations::fs_locks_list_inode.
+	int fs_locks_list_inode(const FsContext &context, uint8_t type, bool pending, inode_t inode,
+	                        uint64_t start, uint64_t max,
+	                        std::vector<safs_locks::Info> &outLocks) override;
+
+	/// Unlocks the matching locks on the specified inode and tries to apply pending locks.
+	/// @see IFilesystemOperations::fs_locks_unlock_inode.
+	int fs_locks_unlock_inode(const FsContext &context, uint8_t type, inode_t inode,
+	                          std::vector<FileLocks::Owner> &applied) override;
+
+	/// Removes a pending lock matching the provided parameters.
+	/// @see IFilesystemOperations::fs_locks_remove_pending.
+	int fs_locks_remove_pending(const FsContext &context, uint8_t type, uint64_t ownerid,
+	                            uint32_t sessionid, inode_t inode, uint64_t reqid) override;
+
+private:
+	/// Helper function used internally by `fs_flock_op` and `fs_posixlock_op`.
+	static int fs_lock_op(const FsContext &context, FileLocks &locks, inode_t inode, uint64_t start,
+	                      uint64_t end, uint64_t owner, uint32_t sessionid, uint32_t reqid,
+	                      uint32_t msgid, uint16_t oper, bool nonblocking,
+	                      std::vector<FileLocks::Owner> &applied);
+
+	/// Helper function used internally by `fs_locks_unlock_inode`.
+	static void fs_manage_lock_try_lock_pending(FileLocks &locks, inode_t inode, uint64_t start,
+	                                            uint64_t end,
+	                                            std::vector<FileLocks::Owner> &applied);
+};
 
 // Adds an entry to a changelog, updates filesystem.cc internal structures, prepends a
 // proper timestamp to changelog entry and broadcasts it to metaloggers and shadow masters
@@ -50,45 +126,4 @@ void fs_add_files_to_chunks(bool isMetadataLoading = true);
 
 uint64_t fs_getversion();
 
-/*! \brief Perform a flock operation on filesystem
- * Possible operations:
- * - unlock
- * - shared/exclusive blocking/nonblocking lock
- * - handle interrupt
- */
-int fs_flock_op(const FsContext &context, inode_t inode, uint64_t owner, uint32_t sessionid,
-                uint32_t reqid, uint32_t msgid, uint16_t op, bool nonblocking,
-                std::vector<FileLocks::Owner> &applied);
-
-/*! \brief Perform a posix lock operation on filesystem
- * Possible operations:
- * - unlock
- * - shared/exclusive blocking/nonblocking lock
- * - handle interrupt
- */
-int fs_posixlock_op(const FsContext &context, inode_t inode, uint64_t start, uint64_t end,
-                    uint64_t owner, uint32_t sessionid, uint32_t reqid, uint32_t msgid, uint16_t op,
-                    bool nonblocking, std::vector<FileLocks::Owner> &applied);
-
-/*! \brief Perform a POSIX lock probe on filesystem
- * \param info - wrapper around 'struct flock', filled with data appropriate with getlk standard
- */
-int fs_posixlock_probe(const FsContext &context, inode_t inode, uint64_t start, uint64_t end,
-                       uint64_t owner, uint32_t sessionid, uint32_t reqid, uint32_t msgid,
-                       uint16_t op, safs_locks::FlockWrapper &info);
-
-/*! \brief Release (unlock + unqueue) all locks from a given session
- */
-int fs_locks_clear_session(const FsContext &context, uint8_t type, inode_t inode, uint32_t sessionid,
-                           std::vector<FileLocks::Owner> &applied);
-
-/*! \brief Perform a lock management operation on inode */
-int fs_locks_list_all(const FsContext &context, uint8_t type, bool pending, uint64_t start,
-                      uint64_t max, std::vector<safs_locks::Info> &locks);
-int fs_locks_list_inode(const FsContext &context, uint8_t type, bool pending, inode_t inode,
-                        uint64_t start, uint64_t max, std::vector<safs_locks::Info> &locks);
-int fs_locks_unlock_inode(const FsContext &context, uint8_t type, inode_t inode,
-                          std::vector<FileLocks::Owner> &applied);
-int fs_locks_remove_pending(const FsContext &context, uint8_t type, uint64_t ownerid,
-                            uint32_t sessionid, inode_t inode, uint64_t reqid);
 uint8_t fs_full_path_by_inode(const FsContext &context, inode_t inode, std::string &fullPath);

--- a/src/master/filesystem_operations_interface.h
+++ b/src/master/filesystem_operations_interface.h
@@ -1,0 +1,185 @@
+/*
+   Copyright 2023      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "common/platform.h"
+
+#include <map>
+#include <memory>
+
+#include "common/goal.h"
+#include "master/fs_context.h"
+#include "master/locks.h"
+
+/// Interface for filesystem operations extensibility.
+/// Classes implementing this interface can be used to override default filesystem behavior.
+class IFilesystemOperations {
+public:
+	/// Default constructor
+	IFilesystemOperations() = default;
+
+	/// Unneeded copy/assign constructors/operators
+	IFilesystemOperations(const IFilesystemOperations &) = delete;
+	IFilesystemOperations &operator=(const IFilesystemOperations &) = delete;
+	IFilesystemOperations(IFilesystemOperations &&) = delete;
+	IFilesystemOperations &operator=(IFilesystemOperations &&) = delete;
+
+	/// Virtual destructor
+	virtual ~IFilesystemOperations() = default;
+
+#ifndef METARESTORE
+	// Goals
+
+	/// Returns a map with all defined goals.
+	virtual const std::map<int, Goal> &fs_get_goal_definitions() const = 0;
+
+	/// Returns goal definition for given goal id.
+	virtual const Goal &fs_get_goal_definition(uint8_t goalId) const = 0;
+#endif
+
+	// Lock operations
+
+	/// Perform a flock-style (whole-file) advisory lock operation.
+	///
+	/// Supports placing and removing whole-file shared/exclusive advisory locks, removing pending
+	/// requests and handling interruptible requests.
+	/// @param context Filesystem context.
+	/// @param inode Target inode for the flock operation.
+	/// @param owner Owner identifier provided by the client.
+	/// @param sessionid Session id of the requesting client.
+	/// @param reqid Request id (used to identify interruptible requests).
+	/// @param msgid Message id provided by the client (used for interrupt handling).
+	/// @param oper Operation code: expected values include: safs_locks::{kShared, kExclusive,
+	/// kUnlock, kRelease}.
+	/// @param nonblocking If true, do not block, return immediately if the lock would block.
+	/// @param applied On success (and after unlocking) contains owners of any pending
+	///                locks that were applied as a side-effect.
+	/// @return `SAUNAFS_STATUS_OK` on success, `SAUNAFS_ERROR_WAITING` if the request
+	///         cannot be granted immediately, `SAUNAFS_ERROR_EINVAL` for invalid args,
+	///         or other filesystem-specific error codes (permission, quota, etc.).
+	virtual int fs_flock_op(const FsContext &context, inode_t inode, uint64_t owner,
+	                        uint32_t sessionid, uint32_t reqid, uint32_t msgid, uint16_t oper,
+	                        bool nonblocking, std::vector<FileLocks::Owner> &applied) = 0;
+
+	/// Perform a POSIX byte-range (fcntl) lock operation on the filesystem.
+	///
+	/// Handles POSIX (fcntl) style byte-range locks: place shared/exclusive locks,
+	/// release ranges, enqueue pending requests and handle interruptible requests.
+	/// @param context Filesystem context (permissions, timestamp, personality, ...).
+	/// @param inode Target inode on which the byte-range lock is requested.
+	/// @param start Start offset of the range (inclusive).
+	/// @param end End offset of the range (exclusive).
+	/// @param owner Owner identifier provided by the client (FUSE owner).
+	/// @param sessionid Session id of the requesting client.
+	/// @param reqid Request id (used to identify interruptible requests).
+	/// @param msgid Message id provided by the client (used for interrupt handling).
+	/// @param oper Operation code: expected values include: safs_locks::{kShared, kExclusive,
+	/// kUnlock, kRelease}.
+	/// @param nonblocking If true, do not block, return immediately if the lock would block.
+	/// @param applied When pending locks become applied as a result of this operation,
+	///                their owners are appended to this vector.
+	/// @return `SAUNAFS_STATUS_OK` on success, `SAUNAFS_ERROR_WAITING` if the request
+	///         cannot be granted immediately, `SAUNAFS_ERROR_EINVAL` for invalid args,
+	///         or other filesystem-specific error codes (permission, quota, etc.).
+	virtual int fs_posixlock_op(const FsContext &context, inode_t inode, uint64_t start,
+	                            uint64_t end, uint64_t owner, uint32_t sessionid, uint32_t reqid,
+	                            uint32_t msgid, uint16_t oper, bool nonblocking,
+	                            std::vector<FileLocks::Owner> &applied) = 0;
+
+	/// Perform a POSIX lock probe on filesystem.
+	/// A POSIX probe checks whether a lock request (shared/exclusive) would be blocked
+	/// by existing locks without placing a lock.
+	/// @param context Filesystem context.
+	/// @param inode Inode number on which to probe locks.
+	/// @param start Start of the range to probe.
+	/// @param end End of the range to probe.
+	/// @param owner Owner identifier provided by the client (FUSE owner typically).
+	/// @param sessionid Session id of the client that is probing the lock.
+	/// @param reqid Request id (used to identify interruptible requests).
+	/// @param msgid Message id provided by the client.
+	/// @param oper Operation code: one of safs_locks::kShared, safs_locks::kExclusive or
+	/// safs_locks::kUnlock. The probe checks for conflicts for the requested lock type.
+	/// @param info Wrapper around 'struct flock' (safs_locks::FlockWrapper). If a conflicting lock
+	///             exists, 'info' is filled with the conflicting lock type, start and length.
+	/// @return SAUNAFS_STATUS_OK if no conflicting lock was found (info.l_type set to kUnlock),
+	///         SAUNAFS_ERROR_WAITING if a conflicting lock was found (info filled),
+	///         SAUNAFS_ERROR_EINVAL for invalid parameters.
+	virtual int fs_posixlock_probe(const FsContext &context, inode_t inode, uint64_t start,
+	                               uint64_t end, uint64_t owner, uint32_t sessionid, uint32_t reqid,
+	                               uint32_t msgid, uint16_t oper,
+	                               safs_locks::FlockWrapper &info) = 0;
+
+	/// Release (unlock + unqueue) all locks from a given session.
+	/// @param context Filesystem context.
+	/// @param type Type of locks to clear (kFlock, kPosix).
+	/// @param inode inode number on which to clear locks.
+	/// @param sessionid Session id whose locks are to be cleared.
+	/// @param applied Vector to be filled with the owners of the cleared locks.
+	virtual int fs_locks_clear_session(const FsContext &context, uint8_t type, inode_t inode,
+	                                   uint32_t sessionid,
+	                                   std::vector<FileLocks::Owner> &applied) = 0;
+
+	/// List locks in the filesystem.
+	/// Fills outLocks with locks matching the type and pending parameters.
+	/// @param context Filesystem context (could be ignored in some implementations).
+	/// @param type Type of locks to list (kFlock, kPosix).
+	/// @param pending If true, lists pending locks, otherwise lists active locks.
+	/// @param start Start index for listing.
+	/// @param max Maximum number of locks to list.
+	/// @param outLocks Vector to be filled with the listed locks.
+	virtual int fs_locks_list_all(const FsContext &context, uint8_t type, bool pending,
+	                              uint64_t start, uint64_t max,
+	                              std::vector<safs_locks::Info> &outLocks) = 0;
+
+	/// List locks for a specific inode.
+	/// @param context Filesystem context (could be ignored in some implementations).
+	/// @param type Type of locks to list (kFlock, kPosix).
+	/// @param pending If true, lists pending locks, otherwise lists active locks.
+	/// @param inode inode number on which to list locks.
+	/// @param start Start index for listing.
+	/// @param max Maximum number of locks to list.
+	/// @param outLocks Vector to be filled with the listed locks.
+	virtual int fs_locks_list_inode(const FsContext &context, uint8_t type, bool pending,
+	                                inode_t inode, uint64_t start, uint64_t max,
+	                                std::vector<safs_locks::Info> &outLocks) = 0;
+
+	/// Unlocks the matching locks on the specified inode and tries to apply pending locks.
+	/// @param context Filesystem context.
+	/// @param type Type of locks to unlock (kFlock, kPosix).
+	/// @param inode inode number on which to unlock locks.
+	/// @param applied Vector to be filled with the owners of the unlocked locks.
+	virtual int fs_locks_unlock_inode(const FsContext &context, uint8_t type, inode_t inode,
+	                                  std::vector<FileLocks::Owner> &applied) = 0;
+
+	/// Removes a pending lock matching the provided parameters.
+	/// @param context Filesystem context.
+	/// @param type Type of lock to operate on (kFlock, kPosix).
+	/// @param ownerid Owner identifier provided by the client (FUSE owner typically).
+	/// @param sessionid Session id of the client that enqueued the lock.
+	/// @param inode Inode number on which the pending lock was queued.
+	/// @param reqid Request id (used to identify interruptible requests).
+	virtual int fs_locks_remove_pending(const FsContext &context, uint8_t type, uint64_t ownerid,
+	                                    uint32_t sessionid, inode_t inode, uint64_t reqid) = 0;
+};
+
+// Global filesystem operations instance.
+// This global unique_ptr is initialized once at startup (before any FS calls) and set to a single
+// concrete implementation for the process lifetime. It must not be reassigned and its dynamic type
+// remains stable, so callers may assume one immutable implementation.
+inline std::unique_ptr<IFilesystemOperations> gFilesystemOperations = nullptr;

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -79,6 +79,7 @@
 #include "master/filesystem_node.h"
 #include "master/filesystem_node_types.h"
 #include "master/filesystem_operations.h"
+#include "master/filesystem_operations_interface.h"
 #include "master/filesystem_periodic.h"
 #include "master/filesystem_snapshot.h"
 #include "master/masterconn.h"
@@ -636,7 +637,7 @@ void matoclserv_metadataserver_status(matoclserventry* eptr, const uint8_t* data
 /// response packet.
 void matoclserv_list_goals(matoclserventry* eptr) {
 	std::vector<SerializedGoal> serializedGoals;
-	const std::map<int, Goal>& goalsMap = fs_get_goal_definitions();
+	const std::map<int, Goal>& goalsMap = gFilesystemOperations->fs_get_goal_definitions();
 
 	for (const auto& goal : goalsMap) {
 		serializedGoals.emplace_back(goal.first, goal.second.getName(), to_string(goal.second));
@@ -2979,7 +2980,8 @@ void matoclserv_fuse_getgoal(matoclserventry *eptr, PacketHeader header, const u
 
 	MessageBuffer reply;
 	if (status == SAUNAFS_STATUS_OK) {
-		const std::map<int, Goal>& goalDefinitions = fs_get_goal_definitions();
+		const std::map<int, Goal> &goalDefinitions =
+		    gFilesystemOperations->fs_get_goal_definitions();
 		std::vector<FuseGetGoalStats> sauReply;
 		for (const auto &goal : goalDefinitions) {
 			if (fgtab[goal.first] || dgtab[goal.first]) {
@@ -3028,7 +3030,8 @@ void matoclserv_fuse_setgoal(matoclserventry *eptr, PacketHeader header, const u
 		cltoma::fuseSetGoal::deserialize(data, header.length,
 				msgid, inode, uid, goalName, smode);
 		// find a proper goalId,
-		const std::map<int, Goal> &goalDefinitions = fs_get_goal_definitions();
+		const std::map<int, Goal> &goalDefinitions =
+		    gFilesystemOperations->fs_get_goal_definitions();
 		bool goalFound = false;
 		for (const auto &goal : goalDefinitions) {
 			if (goal.second.getName() == goalName) {
@@ -3956,8 +3959,8 @@ void matoclserv_fuse_flock(matoclserventry *eptr, const uint8_t *data, uint32_t 
 	}
 
 	std::vector<FileLocks::Owner> applied;
-	status = fs_flock_op(context, inode, owner, eptr->sessionData->sessionId, requestId, messageId,
-			op, nonblocking, applied);
+	status = gFilesystemOperations->fs_flock_op(context, inode, owner, eptr->sessionData->sessionId,
+	                                            requestId, messageId, op, nonblocking, applied);
 
 	matoclserv_lock_wake_up(applied, safs_locks::Type::kFlock);
 
@@ -3997,8 +4000,9 @@ void matoclserv_fuse_getlk(matoclserventry *eptr, const uint8_t *data, uint32_t 
 		lock_end = (uint64_t)lock_info.l_start + (uint64_t)lock_info.l_len;
 	}
 
-	status = fs_posixlock_probe(context, inode, lock_info.l_start, lock_end, owner,
-			eptr->sessionData->sessionId, 0, message_id, lock_info.l_type, lock_info);
+	status = gFilesystemOperations->fs_posixlock_probe(context, inode, lock_info.l_start, lock_end,
+	                                                   owner, eptr->sessionData->sessionId, 0,
+	                                                   message_id, lock_info.l_type, lock_info);
 
 	// Standard states that lock of length 0 is a lock till EOF
 	if (lock_info.l_len == std::numeric_limits<int64_t>::max()) {
@@ -4050,8 +4054,9 @@ void matoclserv_fuse_setlk(matoclserventry *eptr, const uint8_t *data, uint32_t 
 	}
 
 	std::vector<FileLocks::Owner> applied;
-	status = fs_posixlock_op(context, inode, lock_info.l_start, lock_end,
-			owner, eptr->sessionData->sessionId, request_id, message_id, op, nonblocking, applied);
+	status = gFilesystemOperations->fs_posixlock_op(context, inode, lock_info.l_start, lock_end,
+	                                                owner, eptr->sessionData->sessionId, request_id,
+	                                                message_id, op, nonblocking, applied);
 
 	matoclserv_lock_wake_up(applied, safs_locks::Type::kPosix);
 
@@ -4099,11 +4104,13 @@ void matoclserv_manage_locks_list(matoclserventry *eptr, const uint8_t *data, ui
 	if (version == cltoma::manageLocksList::kAll) {
 		cltoma::manageLocksList::deserialize(data, length, type, pending, start, max);
 		max = std::min(max, (uint64_t)SAU_CLTOMA_MANAGE_LOCKS_LIST_LIMIT);
-		status = fs_locks_list_all(context, (uint8_t)type, pending, start, max, locks);
+		status = gFilesystemOperations->fs_locks_list_all(context, (uint8_t)type, pending, start,
+		                                                  max, locks);
 	} else if (version == cltoma::manageLocksList::kInode) {
 		cltoma::manageLocksList::deserialize(data, length, inode, type, pending, start, max);
 		max = std::min(max, (uint64_t)SAU_CLTOMA_MANAGE_LOCKS_LIST_LIMIT);
-		status = fs_locks_list_inode(context, (uint8_t)type, pending, inode, start, max, locks);
+		status = gFilesystemOperations->fs_locks_list_inode(context, (uint8_t)type, pending, inode,
+		                                                    start, max, locks);
 	} else {
 		throw IncorrectDeserializationException(
 				"Unknown SAU_CLTOMA_MANAGE_LOCKS_LIST version: " + std::to_string(version));
@@ -4148,24 +4155,25 @@ void matoclserv_manage_locks_unlock(matoclserventry *eptr, const uint8_t *data, 
 			end = std::numeric_limits<decltype(end)>::max();
 		}
 		if (type == safs_locks::Type::kAll || type == safs_locks::Type::kFlock) {
-			status = fs_flock_op(context, inode, owner, sessionid, 0, 0, safs_locks::kUnlock, true,
-			                     flocks_applied);
+			status = gFilesystemOperations->fs_flock_op(context, inode, owner, sessionid, 0, 0,
+			                                            safs_locks::kUnlock, true, flocks_applied);
 		}
 		if (status == SAUNAFS_STATUS_OK &&
 		    (type == safs_locks::Type::kAll || type == safs_locks::Type::kPosix)) {
-			status = fs_posixlock_op(context, inode, start, end, owner, sessionid, 0, 0,
-			                         safs_locks::kUnlock, true, posix_applied);
+			status = gFilesystemOperations->fs_posixlock_op(context, inode, start, end, owner,
+			                                                sessionid, 0, 0, safs_locks::kUnlock,
+			                                                true, posix_applied);
 		}
 	} else if (version == cltoma::manageLocksUnlock::kInode) {
 		cltoma::manageLocksUnlock::deserialize(data, length, type, inode);
 		if (type == safs_locks::Type::kAll || type == safs_locks::Type::kFlock) {
-			status = fs_locks_unlock_inode(context, (uint8_t)safs_locks::Type::kFlock, inode,
-			                               flocks_applied);
+			status = gFilesystemOperations->fs_locks_unlock_inode(
+			    context, (uint8_t)safs_locks::Type::kFlock, inode, flocks_applied);
 		}
 		if (status == SAUNAFS_STATUS_OK &&
 		    (type == safs_locks::Type::kAll || type == safs_locks::Type::kPosix)) {
-			status = fs_locks_unlock_inode(context, (uint8_t)safs_locks::Type::kPosix, inode,
-			                               posix_applied);
+			status = gFilesystemOperations->fs_locks_unlock_inode(
+			    context, (uint8_t)safs_locks::Type::kPosix, inode, posix_applied);
 		}
 	} else {
 		throw IncorrectDeserializationException("Unknown SAU_CLTOMA_MANAGE_LOCKS_UNLOCK version: " +
@@ -4216,8 +4224,9 @@ void matoclserv_fuse_locks_interrupt(matoclserventry *eptr, const uint8_t *data,
 	cltoma::fuseFlock::deserialize(data, length, messageId, interruptData);
 
 	// we do not reply, so there is not need for checking status of this fs_operation
-	fs_locks_remove_pending(context, type, interruptData.owner,
-			   eptr->sessionData->sessionId, interruptData.ino, interruptData.reqid);
+	gFilesystemOperations->fs_locks_remove_pending(context, type, interruptData.owner,
+	                                               eptr->sessionData->sessionId, interruptData.ino,
+	                                               interruptData.reqid);
 }
 
 void matoclserv_update_credentials(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
@@ -4584,14 +4593,16 @@ void matoclserv_broadcast_metadata_checksum_recalculated(uint8_t status) {
 void matocl_locks_release(const FsContext &context, inode_t inode, uint32_t sessionId) {
 	std::vector<FileLocks::Owner> applied;
 
-	fs_locks_clear_session(context, (uint8_t)safs_locks::Type::kFlock, inode, sessionId, applied);
+	gFilesystemOperations->fs_locks_clear_session(context, (uint8_t)safs_locks::Type::kFlock, inode,
+	                                              sessionId, applied);
 
 	for (auto candidate : applied) {
 		matoclserv_lock_wake_up(candidate.sessionid, candidate.msgid, safs_locks::Type::kFlock);
 	}
 
 	applied.clear();
-	fs_locks_clear_session(context, (uint8_t)safs_locks::Type::kPosix, inode, sessionId, applied);
+	gFilesystemOperations->fs_locks_clear_session(context, (uint8_t)safs_locks::Type::kPosix, inode,
+	                                              sessionId, applied);
 
 	for (auto candidate : applied) {
 		matoclserv_lock_wake_up(candidate.sessionid, candidate.msgid, safs_locks::Type::kPosix);

--- a/src/master/matocsserv.cc
+++ b/src/master/matocsserv.cc
@@ -54,6 +54,7 @@
 #include "master/chunks.h"
 #include "master/chunkserver_db.h"
 #include "master/filesystem.h"
+#include "master/filesystem_operations_interface.h"
 #include "master/get_servers_for_new_chunk.h"
 #include "master/personality.h"
 #include "protocol/SFSCommunication.h"
@@ -319,7 +320,7 @@ std::vector<std::pair<matocsserventry *, ChunkPartType>> matocsserv_getservers_f
 		uint8_t goal_id, uint32_t min_server_version) {
 	static std::array<ChunkCreationHistory, GoalId::kMax + 1> history;
 	GetServersForNewChunk getter;
-	const Goal &goal(fs_get_goal_definition(goal_id));
+	const Goal &goal(gFilesystemOperations->fs_get_goal_definition(goal_id));
 
 	for (const auto &eptr : matocsservList) {
 		if (eptr->mode != KILL && eptr->totalspace > 0 &&

--- a/src/master/restore.cc
+++ b/src/master/restore.cc
@@ -32,6 +32,7 @@
 #include "master/filesystem.h"
 #include "master/filesystem_node_types.h"
 #include "master/filesystem_operations.h"
+#include "master/filesystem_operations_interface.h"
 #include "master/filesystem_snapshot.h"
 #include "protocol/SFSCommunication.h"
 #include "slogger/slogger.h"
@@ -402,12 +403,14 @@ int do_lock_op(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) 
 
 	switch (static_cast<safs_locks::Type>(lock_type)) {
 	case safs_locks::Type::kFlock:
-		status = fs_flock_op(FsContext::getForRestore(ts), inode, owner, sessionid, 0, 0,
-				op, nonblocking, dummy_applied);
+		status =
+		    gFilesystemOperations->fs_flock_op(FsContext::getForRestore(ts), inode, owner,
+		                                       sessionid, 0, 0, op, nonblocking, dummy_applied);
 		break;
 	case safs_locks::Type::kPosix:
-		status = fs_posixlock_op(FsContext::getForRestore(ts), inode, start, end, owner, sessionid, 0, 0,
-				op, nonblocking, dummy_applied);
+		status = gFilesystemOperations->fs_posixlock_op(FsContext::getForRestore(ts), inode, start,
+		                                                end, owner, sessionid, 0, 0, op,
+		                                                nonblocking, dummy_applied);
 		break;
 	default:
 		safs_pretty_syslog(LOG_ERR, "Invalid lock type passed to restore: %u", lock_type);
@@ -439,8 +442,8 @@ int do_remove_pending_op(const char *filename, uint64_t lv, uint32_t ts, const c
 	GETU64(reqid, ptr);
 	EAT(ptr,filename,lv,')');
 
-	return fs_locks_remove_pending(FsContext::getForRestore(ts), lock_type, ownerid, sessionid,
-		inode, reqid);
+	return gFilesystemOperations->fs_locks_remove_pending(FsContext::getForRestore(ts), lock_type,
+	                                                      ownerid, sessionid, inode, reqid);
 }
 
 int do_lock_clear_session(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -456,7 +459,8 @@ int do_lock_clear_session(const char *filename, uint64_t lv, uint32_t ts, const 
 	GETU32(sessionid, ptr);
 	EAT(ptr, filename, lv, ')');
 
-	return fs_locks_clear_session(FsContext::getForRestore(ts), lock_type, inode, sessionid, applied);
+	return gFilesystemOperations->fs_locks_clear_session(FsContext::getForRestore(ts), lock_type,
+	                                                     inode, sessionid, applied);
 }
 
 int do_lock_unlock_inode(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -470,7 +474,8 @@ int do_lock_unlock_inode(const char *filename, uint64_t lv, uint32_t ts, const c
 	GETINODE(inode, ptr);
 	EAT(ptr, filename, lv, ')');
 
-	return fs_locks_unlock_inode(FsContext::getForRestore(ts), lock_type, inode, applied);
+	return gFilesystemOperations->fs_locks_unlock_inode(FsContext::getForRestore(ts), lock_type,
+	                                                    inode, applied);
 }
 
 int do_purge(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {


### PR DESCRIPTION
Adds an extensibility layer for filesystem operations. The previous C-style approach for hiding implementation details limited the ability to support new metadata backends and evolve the codebase cleanly.

This commit introduces the IFilesystemOperations interface, allowing custom behavior by implementing the interface. The current default implementation is provided by FilesystemOperationsBase, and most functions from filesystem_operations.h have been migrated to these classes.

This establishes the foundation for further extension as additional operations are incorporated.

Side changes:
- Documented most lock-related functions.
- Renamed a few parameters to satisfy clang-tidy name length rules.
- Updated dependent code to access operations via the global gFilesystemOperations instance.


For reviewers: I did not change the function names to ease the one-to-one review, but I plan to change them later.