### PR TITLE
fix(tools): Restore console code pages on Windows

### DIFF
--- a/src/common/args_stat_encoding.h
+++ b/src/common/args_stat_encoding.h
@@ -30,6 +30,32 @@
 
 using saunafs_stat_t = struct _stat64;
 
+// This class is a RAII guard to restore console code pages on destruction on
+// Windows.
+// Used to temporarily set console code pages to UTF-8 and restore them later
+// to their original values.
+class ConsoleCodePageGuard {
+public:
+	explicit ConsoleCodePageGuard(uint32_t newCodePage) {
+		oldOutputCP_ = GetConsoleOutputCP();
+		oldInputCP_ = GetConsoleCP();
+		SetConsoleOutputCP(newCodePage);
+		SetConsoleCP(newCodePage);
+	}
+
+	~ConsoleCodePageGuard() {
+		SetConsoleOutputCP(oldOutputCP_);
+		SetConsoleCP(oldInputCP_);
+	}
+
+	ConsoleCodePageGuard(const ConsoleCodePageGuard &) = delete;
+	ConsoleCodePageGuard &operator=(const ConsoleCodePageGuard &) = delete;
+
+private:
+	uint32_t oldOutputCP_;
+	uint32_t oldInputCP_;
+};
+
 // Represents UTF-8 command-line arguments for Windows.
 // Keeps argvPtrs alive for the lifetime of the object.
 class Utf8CmdArguments {

--- a/src/tools/main.cc
+++ b/src/tools/main.cc
@@ -69,8 +69,7 @@ int main(int argc, char **argv) {
 	// Enable UTF-8 encoding for console I/O on Windows. This is necessary to properly
 	// handle Unicode characters in file paths and other strings on Windows systems,
 	// as the default console code page may not support UTF-8.
-	SetConsoleCP(CP_UTF8);
-	SetConsoleOutputCP(CP_UTF8);
+	ConsoleCodePageGuard codePageGuard(CP_UTF8);
 
 	Utf8CmdArguments args;
 	argc = args.getArgc();


### PR DESCRIPTION
Changes from commit 1ffe9bd8 were making the changes made to the console code pages permanent on the current PowerShell session on Windows where the command was executed. This could lead to other applications misbehaving due to unexpected code page settings if executed on the same console. This commit ensures that the original code pages are restored after the necessary operations from saunafs command are completed.