### PR TITLE
refactor(master): Make more FS operations extensible

### DIFF
--- a/src/master/changelog.cc
+++ b/src/master/changelog.cc
@@ -42,8 +42,8 @@
 
 #include "common/setup.h"
 #include "master/exceptions.h"
-#include "master/filesystem.h"
 #include "master/filesystem_metadata.h"
+#include "master/filesystem_operations_interface.h"
 #include "master/restore.h"
 #endif  // #if !defined(METARESTORE) && !defined(METALOGGER)
 
@@ -313,16 +313,14 @@ void load_changelogs() {
 				uint64_t first = changelogGetFirstLogVersion(s);
 				uint64_t last = changelogGetLastLogVersion(s);
 				if (last >= first) {
-					if (last >= fs_getversion()) {
-						load_changelog(s);
-					}
+					if (last >= gFilesystemOperations->fs_getversion()) { load_changelog(s); }
 				} else {
 					throw InitializeException(
 					    "changelog " + fullFileName +
 					    " inconsistent, "
 					    "use sfsmetarestore to recover the filesystem; "
 					    "current fs version: " +
-					    std::to_string(fs_getversion()) +
+					    std::to_string(gFilesystemOperations->fs_getversion()) +
 					    ", first change in the file: " + std::to_string(first));
 				}
 			} else if (oldExists && s != kChangelogFilename) {
@@ -348,7 +346,7 @@ void load_changelog(const std::string &path) {
 	uint64_t appliedEntries = 0;
 	while (std::getline(changelog, line).good()) {
 		id = std::stoull(line, &end);
-		if (id < fs_getversion()) {
+		if (id < gFilesystemOperations->fs_getversion()) {
 			++skippedEntries;
 			continue;
 		} else if (!first) {

--- a/src/master/chunks.cc
+++ b/src/master/chunks.cc
@@ -823,7 +823,7 @@ void chunk_emergency_increase_version(Chunk *c) {
 	c->operation = Chunk::SET_VERSION;
 	c->version++;
 	chunk_update_checksum(c);
-	fs_incversion(c->chunkid);
+	gFilesystemOperations->fs_incversion(c->chunkid);
 	emit_chunk_changed(c);
 }
 
@@ -1570,7 +1570,8 @@ void chunk_server_has_chunk(matocsserventry *ptr, uint64_t chunkid, uint32_t ver
 		// chunkserver has nonexistent chunk, so create it for future deletion
 		if (chunkid >= ChunksMetadata::getNextChunkId() &&
 		    gChunkIdGenerator->isStrictlyMonotonic()) {
-			fs_set_nextchunkid(FsContext::getForMaster(eventloop_time()), chunkid + 1);
+			gFilesystemOperations->fs_set_nextchunkid(FsContext::getForMaster(eventloop_time()),
+			                                          chunkid + 1);
 		}
 		c = chunk_new(chunkid, new_version);
 		c->lockedto = (uint32_t)eventloop_time()+UNUSED_DELETE_TIMEOUT;

--- a/src/master/filesystem.cc
+++ b/src/master/filesystem.cc
@@ -437,7 +437,8 @@ void fs_reload(void) {
 }
 
 void fs_unload() {
-	safs_pretty_syslog(LOG_WARNING, "unloading filesystem at %" PRIu64, fs_getversion());
+	safs_pretty_syslog(LOG_WARNING, "unloading filesystem at %" PRIu64,
+	                   gFilesystemOperations->fs_getversion());
 	restore_reset();
 	matoclserv_session_unload();
 	chunk_unload();

--- a/src/master/filesystem.h
+++ b/src/master/filesystem.h
@@ -23,35 +23,32 @@
 #include "common/platform.h"
 
 #include <cstdint>
-#include <map>
 
-#include "common/access_control_list.h"
-#include "common/acl_type.h"
-#include "common/attributes.h"
-#include "common/chunk_with_address_and_label.h"
 #include "common/exception.h"
-#include "common/goal.h"
-#include "common/richacl.h"
 #include "common/type_defs.h"
 #include "master/checksum.h"
 #include "master/fs_context.h"
-#include "master/hstring.h"
-#include "master/setgoal_task.h"
-#include "master/settrashtime_task.h"
-#include "protocol/directory_entry.h"
-#include "protocol/handle_inode_entry.h"
-#include "protocol/named_inode_entry.h"
 #include "protocol/quota.h"
+
+struct JobInfo;
 
 SAUNAFS_CREATE_EXCEPTION_CLASS_MSG(NoMetadataException, Exception, "no metadata");
 
 inline std::string gClusterId;  ///< Unique cluster identifier
 
 uint8_t fs_cancel_job(uint32_t job_id);
-uint32_t fs_reserve_job_id();
 
-/// Returns version of the loaded metadata.
-uint64_t fs_getversion();
+uint8_t fs_apply_freeinodes(uint32_t timestamp, inode_t freeinodes);
+
+uint8_t fs_quota_get_all(const FsContext &context, std::vector<QuotaEntry> &results);
+uint8_t fs_quota_get(const FsContext &context, const std::vector<QuotaOwner> &owners,
+                     std::vector<QuotaEntry> &results);
+uint8_t fs_quota_set(const FsContext &context, const std::vector<QuotaEntry> &entries);
+uint8_t fs_quota_get_info(const FsContext &context, const std::vector<QuotaEntry> &entries,
+                          std::vector<std::string> &result);
+
+uint8_t fs_apply_setquota(char rigor, char resource, char ownerType, inode_t ownerId,
+                          uint64_t limit);
 
 /// Returns checksum of the loaded metadata.
 uint64_t fs_checksum(ChecksumMode mode);
@@ -60,132 +57,8 @@ uint64_t fs_checksum(ChecksumMode mode);
 /// \return SAUNAFS_STATUS_OK iff dump started successfully, otherwise cause of the failure.
 uint8_t fs_start_checksum_recalculation();
 
-/// Load and apply changelogs.
-void fs_load_changelogs();
-
 /// Load whole filesystem information.
 int fs_loadall(bool isFromInit);
-
-// Functions which create/apply (depending on the given context) changes to the metadata.
-// Common for metarestore and master server (both personalities)
-uint8_t fs_acquire(const FsContext &context, inode_t inode, uint32_t sessionid);
-uint8_t fs_append(const FsContext &context, inode_t inode, inode_t inode_src);
-uint8_t fs_deleteacl(const FsContext &context, inode_t inode, AclType type);
-uint8_t fs_link(const FsContext &context, inode_t inode_src, inode_t parent_dst,
-                const HString &name_dst, inode_t *inode, Attributes *attr);
-uint8_t fs_purge(const FsContext &context, inode_t inode);
-uint8_t fs_rename(const FsContext &context, inode_t parent_src, const HString &name_src,
-                  inode_t parent_dst, const HString &name_dst, inode_t *inode, Attributes *attr);
-uint8_t fs_release(const FsContext &context, inode_t inode, uint32_t sessionid);
-uint8_t fs_setacl(const FsContext &context, inode_t inode, AclType type,
-                  const AccessControlList &acl);
-uint8_t fs_setacl(const FsContext &context, inode_t inode, const RichACL &acl);
-uint8_t fs_seteattr(const FsContext &context, inode_t inode, uint8_t eattr, uint8_t smode,
-                    inode_t *sinodes, inode_t *ncinodes, inode_t *nsinodes);
-uint8_t fs_setgoal(const FsContext &context, inode_t inode, uint8_t goal, uint8_t smode,
-                   std::shared_ptr<SetGoalTask::StatsArray> setgoal_stats,
-                   const std::function<void(int)> &callback);
-uint8_t fs_apply_setgoal(const FsContext &context, inode_t inode, uint8_t goal, uint8_t smode,
-                         uint32_t master_result);
-uint8_t fs_deprecated_setgoal(const FsContext &context, inode_t inode, uint8_t goal, uint8_t smode,
-                              inode_t *sinodes, inode_t *ncinodes, inode_t *nsinodes);
-uint8_t fs_settrashpath(const FsContext &context, inode_t inode, const std::string &path);
-uint8_t fs_settrashtime(const FsContext &context, inode_t inode, uint32_t trashtime, uint8_t smode,
-                        std::shared_ptr<SetTrashtimeTask::StatsArray> settrashtime_stats,
-                        const std::function<void(int)> &callback);
-uint8_t fs_apply_settrashtime(const FsContext &context, inode_t inode, uint32_t trashtime,
-                              uint8_t smode, uint32_t master_result);
-uint8_t fs_deprecated_settrashtime(const FsContext &context, inode_t inode, uint32_t trashtime,
-                                   uint8_t smode, inode_t *sinodes, inode_t *ncinodes, inode_t *nsinodes);
-uint8_t fs_symlink(const FsContext &context, inode_t parent, const HString &name,
-                   const std::string &path, inode_t *inode, Attributes *attr);
-uint8_t fs_undel(const FsContext &context, inode_t inode);
-uint8_t fs_writechunk(const FsContext &context, inode_t inode, uint32_t indx, bool usedummylockid,
-                      /* inout */ uint32_t *lockid, uint64_t *chunkid, uint8_t *opflag,
-                      uint64_t *length, uint32_t min_server_version = 0);
-uint8_t fs_set_nextchunkid(const FsContext &context, uint64_t nextChunkId);
-uint8_t fs_access(const FsContext &context, inode_t inode, int modemask);
-uint8_t fs_lookup(const FsContext &context, inode_t parent, const HString &name, inode_t *inode,
-                  Attributes &attr);
-uint8_t fs_whole_path_lookup(const FsContext &context, inode_t parent, const std::string &path,
-                             inode_t *found_inode, Attributes &attr);
-uint8_t fs_getattr(const FsContext &context, inode_t inode, Attributes &attr);
-uint8_t fs_try_setlength(const FsContext &context, inode_t inode, uint8_t opened, uint64_t length,
-                         bool denyTruncatingParity, uint32_t lockid, Attributes &attr,
-                         uint64_t *chunkid);
-uint8_t fs_do_setlength(const FsContext &context, inode_t inode, uint64_t length, Attributes &attr);
-uint8_t fs_setattr(const FsContext &context, inode_t inode, uint8_t setmask, uint16_t attrmode,
-                   uint32_t attruid, uint32_t attrgid, uint32_t attratime, uint32_t attrmtime,
-                   SugidClearMode sugidclearmode, Attributes &attr);
-uint8_t fs_readlink(const FsContext &context, inode_t inode, std::string &path);
-void fs_statfs(const FsContext &context, uint64_t *totalspace, uint64_t *availspace,
-               uint64_t *trashspace, uint64_t *reservedspace, inode_t *inodes);
-uint8_t fs_mknod(const FsContext &context, inode_t parent, const HString &name, FSNodeType type,
-                 uint16_t mode, uint16_t umask, uint32_t rdev, inode_t *inode, Attributes &attr);
-uint8_t fs_mkdir(const FsContext &context, inode_t parent, const HString &name, uint16_t mode,
-                 uint16_t umask, uint8_t copysgid, inode_t *inode, Attributes &attr);
-uint8_t fs_remove_chunk_from_file(const FsContext &context, inode_t inode, uint64_t chunkId);
-uint8_t fs_repair(const FsContext &context, inode_t inode, uint8_t correct_only,
-                  uint32_t *notchanged, uint32_t *erased, uint32_t *repaired);
-uint8_t fs_rmdir(const FsContext &context, inode_t parent, const HString &name);
-uint8_t fs_recursive_remove(const FsContext &context, inode_t parent, const HString &name,
-                            const std::function<void(int)> &callback,
-                            uint32_t job_id = fs_reserve_job_id());
-uint8_t fs_readdir_size(const FsContext &context, inode_t inode, uint8_t flags, void **dnode,
-                        uint32_t *dbuffsize);
-void fs_readdir_data(const FsContext &context, uint8_t flags, void *dnode, uint8_t *dbuff);
-
-uint8_t fs_readdir(const FsContext &context, inode_t inode, uint64_t first_entry,
-                   uint64_t number_of_entries, std::vector<DirectoryEntry> &dir_entries);
-
-uint8_t fs_checkfile(const FsContext &context, inode_t inode, uint32_t chunkcount[CHUNK_MATRIX_SIZE]);
-uint8_t fs_opencheck(const FsContext &context, inode_t inode, uint8_t flags, Attributes &attr);
-uint8_t fs_getgoal(const FsContext &context, inode_t inode, uint8_t gmode, GoalStatistics &fgtab,
-                   GoalStatistics &dgtab);
-uint8_t fs_gettrashtime_prepare(const FsContext &context, inode_t inode, uint8_t gmode,
-                                TrashtimeMap &fileTrashtimes, TrashtimeMap &dirTrashtimes);
-uint8_t fs_geteattr(const FsContext &context, inode_t inode, uint8_t gmode, uint32_t feattrtab[16],
-                    uint32_t deattrtab[16]);
-uint8_t fs_listxattr_leng(const FsContext &context, inode_t inode, uint8_t opened, void **xanode,
-                          uint32_t *xasize);
-uint8_t fs_getxattr(const FsContext &context, inode_t inode, uint8_t opened, uint8_t anleng,
-                    const uint8_t *attrname, uint32_t *avleng, uint8_t **attrvalue);
-uint8_t fs_setxattr(const FsContext &context, inode_t inode, uint8_t opened, uint8_t anleng,
-                    const uint8_t *attrname, uint32_t avleng, const uint8_t *attrvalue,
-                    uint8_t mode);
-uint8_t fs_quota_get_all(const FsContext &context, std::vector<QuotaEntry> &results);
-uint8_t fs_quota_get(const FsContext &context, const std::vector<QuotaOwner> &owners,
-                     std::vector<QuotaEntry> &results);
-uint8_t fs_unlink(const FsContext &context, inode_t parent, const HString &name);
-uint8_t fs_getacl(const FsContext &context, inode_t inode, RichACL &acl);
-uint8_t fs_quota_set(const FsContext &context, const std::vector<QuotaEntry> &entries);
-uint8_t fs_quota_get_info(const FsContext &context, const std::vector<QuotaEntry> &entries,
-                          std::vector<std::string> &result);
-uint8_t fs_getchunksinfo(const FsContext &context, uint32_t current_ip, inode_t inode,
-                         uint32_t chunk_index, uint32_t chunk_count,
-                         std::vector<ChunkWithAddressAndLabel> &chunks);
-
-// Functions which apply changes from changelog, only for shadow master and metarestore
-uint8_t fs_apply_checksum(const std::string &version, uint64_t checksum);
-uint8_t fs_apply_create(uint32_t ts, inode_t parent, const HString &name, FSNodeType type,
-                        uint32_t mode, uint32_t uid, uint32_t gid, uint32_t rdev, inode_t inode);
-uint8_t fs_apply_access(uint32_t ts, inode_t inode);
-uint8_t fs_apply_attr(uint32_t ts, inode_t inode, uint32_t mode, uint32_t uid, uint32_t gid,
-                      uint32_t atime, uint32_t mtime);
-uint8_t fs_apply_session(uint32_t sessionid);
-uint8_t fs_apply_freeinodes(uint32_t ts, inode_t freeinodes);
-uint8_t fs_apply_incversion(uint64_t chunkid);
-uint8_t fs_apply_length(uint32_t ts, inode_t inode, uint64_t length, bool eraseFurtherChunks);
-uint8_t fs_apply_repair(uint32_t ts, inode_t inode, uint32_t indx, uint32_t nversion);
-uint8_t fs_apply_setxattr(uint32_t ts, inode_t inode, uint32_t anleng, const uint8_t *attrname,
-                          uint32_t avleng, const uint8_t *attrvalue, uint32_t mode);
-uint8_t fs_apply_setacl(uint32_t ts, inode_t inode, char aclType, const char *aclString);
-uint8_t fs_apply_setrichacl(uint32_t ts, inode_t inode, const std::string &acl_string);
-uint8_t fs_apply_setquota(char rigor, char resource, char ownerType, inode_t ownerId,
-                          uint64_t limit);
-uint8_t fs_apply_unlink(uint32_t ts, inode_t parent, const HString &name, inode_t inode);
-uint8_t fs_apply_unlock(uint64_t chunkid);
-uint8_t fs_apply_trunc(uint32_t ts, inode_t inode, uint32_t indx, uint64_t chunkid, uint32_t lockid);
 
 /// Unloads metadata.
 /// This should be called in the shadow master each time it needs to download
@@ -208,55 +81,11 @@ void fs_disable_checksum_verification(bool value);
 
 #else
 
-// Functions which modify metadata or return some information.
-// To be used by the master server with personality == kMaster
-void fs_info(uint64_t *totalSpace, uint64_t *availableSpace, uint64_t *trashSpace,
-             inode_t *trashNodes, uint64_t *reservedSpace, inode_t *reservedNodes, inode_t *inodes,
-             inode_t *directoryNodes, inode_t *fileNodes, inode_t *linkNodes);
-uint32_t fs_getdirpath_size(inode_t inode);
-void fs_getdirpath_data(inode_t inode, uint8_t *buff, uint32_t size);
-uint8_t fs_getrootinode(inode_t *rootinode, const uint8_t *path);
-uint8_t fs_end_setlength(uint64_t chunkid);
-uint8_t fs_readchunk(inode_t inode, uint32_t indx, uint64_t *chunkid, uint64_t *length);
-uint8_t fs_writeend(inode_t inode, uint64_t length, uint64_t chunkid, uint32_t lockid);
-void fs_gettrashtime_store(TrashtimeMap &fileTrashtimes, TrashtimeMap &dirTrashtimes,
-                           uint8_t *buff);
-void fs_listxattr_data(void *xanode, uint8_t *xabuff);
-
-uint32_t fs_newsessionid(void);
-
-// RESERVED
-uint8_t fs_readreserved_size(inode_t rootinode, uint8_t sesflags, uint32_t *dbuffsize);
-void fs_readreserved_data(inode_t rootinode, uint8_t sesflags, uint8_t *dbuff);
-void fs_readreserved(uint32_t off, uint32_t max_entries, std::vector<NamedInodeEntry> &entries);
-void fs_readreserved(uint64_t handleOffset, uint32_t maxEntries,
-                     std::vector<HandleInodeEntry> &entries);
-
-// TRASH
-uint8_t fs_readtrash_size(inode_t rootinode, uint8_t sesflags, uint32_t *dbuffsize);
-void fs_readtrash_data(inode_t rootinode, uint8_t sesflags, uint8_t *dbuff);
-void fs_readtrash(uint32_t off, uint32_t max_entries, std::vector<NamedInodeEntry> &entries);
-void fs_readtrash(uint64_t handleOffset, uint32_t maxEntries,
-                  std::vector<HandleInodeEntry> &entries);
-uint8_t fs_gettrashpath(inode_t rootinode, uint8_t sesflags, inode_t inode, std::string &path);
-
-// RESERVED+TRASH
-uint8_t fs_getdetachedattr(inode_t rootinode, uint8_t sesflags, inode_t inode, Attributes &attr,
-                           uint8_t dtype);
-
-// EXTRA
-uint8_t fs_get_dir_stats(const FsContext &context, inode_t inode, inode_t *inodes, inode_t *dirs,
-                         inode_t *files, inode_t *links, uint32_t *chunks, uint64_t *length,
-                         uint64_t *size, uint64_t *rsize);
-uint8_t fs_get_chunkid(const FsContext &context, inode_t inode, uint32_t index, uint64_t *chunkid);
-
-// SPECIAL - LOG EMERGENCY INCREASE VERSION FROM CHUNKS-MODULE
-void fs_incversion(uint64_t chunkid);
-
 void fs_cs_disconnected(void);
 
 /// Return info about currently executed tasks
 std::vector<JobInfo> fs_get_current_tasks_info();
+
 // Disable saving metadata on exit
 void fs_disable_metadata_dump_on_exit();
 
@@ -267,4 +96,5 @@ void fs_erase_message_from_lockfile();
 
 int fs_init(void);
 int fs_init(bool force);
+
 #endif

--- a/src/master/filesystem_checksum_updater.h
+++ b/src/master/filesystem_checksum_updater.h
@@ -26,7 +26,7 @@
 #include "master/filesystem_checksum.h"
 #include "master/filesystem_checksum_background_updater.h"
 #include "master/filesystem_metadata.h"
-#include "master/filesystem_operations.h"
+#include "master/filesystem_operations_interface.h"
 
 #ifndef METARESTORE
 
@@ -55,7 +55,8 @@ protected:
 		if (metadataserver::isMaster() && !gChecksumBackgroundUpdater.inProgress()) {
 			std::string versionString = saunafsVersionToString(SAUNAFS_VERSHEX);
 			uint64_t checksum = fs_checksum(ChecksumMode::kGetCurrent);
-			fs_changelog(ts, "CHECKSUM(%s):%" PRIu64, versionString.c_str(), checksum);
+			gFilesystemOperations->fs_changelog(ts, "CHECKSUM(%s):%" PRIu64, versionString.c_str(),
+			                                    checksum);
 		}
 	}
 

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -1484,12 +1484,12 @@ uint8_t fsnodes_undel(uint32_t ts, FSNodeFile *node) {
 				assert(metadataserver::isMaster());
 #endif
 
-				fs_changelog(ts,
-				             "CREATE(%" PRIiNode ",%s,%c,%d,%" PRIu32 ",%" PRIu32 ",%" PRIu32
-				             "):%" PRIiNode,
-				             p->id, fsnodes_escape_name(name).c_str(),
-				             static_cast<char>(FSNodeType::kDirectory), n->mode & 07777,
-				             (uint32_t)0, (uint32_t)0, (uint32_t)0, n->id);
+				gFilesystemOperations->fs_changelog(
+				    ts,
+				    "CREATE(%" PRIiNode ",%s,%c,%d,%" PRIu32 ",%" PRIu32 ",%" PRIu32 "):%" PRIiNode,
+				    p->id, fsnodes_escape_name(name).c_str(),
+				    static_cast<char>(FSNodeType::kDirectory), n->mode & 07777, (uint32_t)0,
+				    (uint32_t)0, (uint32_t)0, n->id);
 			}
 			p = static_cast<FSNodeDirectory*>(n);
 			assert(n->type == FSNodeType::kDirectory);

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -76,7 +76,7 @@ bool decodeChar(const char *keys, const std::vector<T> values, char key, T &valu
 	return false;
 }
 
-void fs_changelog(uint32_t ts, const char *format, ...) {
+void FilesystemOperationsBase::fs_changelog(uint32_t ts, const char *format, ...) {
 #ifdef METARESTORE
 	(void)ts;
 	(void)format;
@@ -110,7 +110,8 @@ void fs_changelog(uint32_t ts, const char *format, ...) {
 }
 
 #ifndef METARESTORE
-uint8_t fs_readreserved_size(inode_t rootinode, uint8_t sesflags, uint32_t *dbuffsize) {
+uint8_t FilesystemOperationsBase::fs_readreserved_size(inode_t rootinode, uint8_t sesflags,
+                                                       uint32_t *dbuffsize) {
 	if (rootinode != 0) {
 		return SAUNAFS_ERROR_EPERM;
 	}
@@ -119,22 +120,25 @@ uint8_t fs_readreserved_size(inode_t rootinode, uint8_t sesflags, uint32_t *dbuf
 	return SAUNAFS_STATUS_OK;
 }
 
-void fs_readreserved_data(inode_t rootinode, uint8_t sesflags, uint8_t *dbuff) {
+void FilesystemOperationsBase::fs_readreserved_data(inode_t rootinode, uint8_t sesflags,
+                                                    uint8_t *dbuff) {
 	(void)rootinode;
 	(void)sesflags;
 	fsnodes_getdetacheddata(gMetadata->reserved, dbuff);
 }
 
-void fs_readreserved(uint32_t off, uint32_t max_entries, std::vector<NamedInodeEntry> &entries) {
+void FilesystemOperationsBase::fs_readreserved(uint32_t off, uint32_t max_entries,
+                                               std::vector<NamedInodeEntry> &entries) {
 	fsnodes_getdetacheddata(gMetadata->reserved, off, max_entries, entries);
 }
 
-void fs_readreserved(uint64_t handleOffset, uint32_t maxEntries,
+void FilesystemOperationsBase::fs_readreserved(uint64_t handleOffset, uint32_t maxEntries,
                      std::vector<HandleInodeEntry> &entries) {
 	fsnodes_getdetacheddata(gMetadata->reservedHandlesIndex, handleOffset, maxEntries, entries, false);
 }
 
-uint8_t fs_readtrash_size(inode_t rootinode, uint8_t sesflags, uint32_t *dbuffsize) {
+uint8_t FilesystemOperationsBase::fs_readtrash_size(inode_t rootinode, uint8_t sesflags,
+                                                    uint32_t *dbuffsize) {
 	if (rootinode != 0) {
 		return SAUNAFS_ERROR_EPERM;
 	}
@@ -143,24 +147,27 @@ uint8_t fs_readtrash_size(inode_t rootinode, uint8_t sesflags, uint32_t *dbuffsi
 	return SAUNAFS_STATUS_OK;
 }
 
-void fs_readtrash_data(inode_t rootinode, uint8_t sesflags, uint8_t *dbuff) {
+void FilesystemOperationsBase::fs_readtrash_data(inode_t rootinode, uint8_t sesflags,
+                                                 uint8_t *dbuff) {
 	(void)rootinode;
 	(void)sesflags;
 	fsnodes_getdetacheddata(gMetadata->trash, dbuff);
 }
 
-void fs_readtrash(uint32_t off, uint32_t max_entries, std::vector<NamedInodeEntry> &entries) {
+void FilesystemOperationsBase::fs_readtrash(uint32_t off, uint32_t max_entries,
+                                            std::vector<NamedInodeEntry> &entries) {
 	fsnodes_getdetacheddata(gMetadata->trash, off, max_entries, entries);
 }
 
-void fs_readtrash(uint64_t handleOffset, uint32_t maxEntries,
-                  std::vector<HandleInodeEntry> &entries) {
+void FilesystemOperationsBase::fs_readtrash(uint64_t handleOffset, uint32_t maxEntries,
+                                            std::vector<HandleInodeEntry> &entries) {
 	fsnodes_getdetacheddata(gMetadata->trashHandlesIndex, handleOffset, maxEntries, entries, true);
 }
 
 /* common procedure for trash and reserved files */
-uint8_t fs_getdetachedattr(inode_t rootinode, uint8_t sesflags, inode_t inode, Attributes &attr,
-				uint8_t dtype) {
+uint8_t FilesystemOperationsBase::fs_getdetachedattr(inode_t rootinode, uint8_t sesflags,
+                                                     inode_t inode, Attributes &attr,
+                                                     uint8_t dtype) {
 	FSNode *p;
 	attr.fill(0);
 	if (rootinode != 0) {
@@ -187,7 +194,8 @@ uint8_t fs_getdetachedattr(inode_t rootinode, uint8_t sesflags, inode_t inode, A
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t fs_gettrashpath(inode_t rootinode, uint8_t sesflags, inode_t inode, std::string &path) {
+uint8_t FilesystemOperationsBase::fs_gettrashpath(inode_t rootinode, uint8_t sesflags,
+                                                  inode_t inode, std::string &path) {
 	FSNode *p;
 	if (rootinode != 0) {
 		return SAUNAFS_ERROR_EPERM;
@@ -205,7 +213,8 @@ uint8_t fs_gettrashpath(inode_t rootinode, uint8_t sesflags, inode_t inode, std:
 }
 #endif
 
-uint8_t fs_settrashpath(const FsContext &context, inode_t inode, const std::string &path) {
+uint8_t FilesystemOperationsBase::fs_settrashpath(const FsContext &context, inode_t inode,
+                                                  const std::string &path) {
 	ChecksumUpdater cu(context.ts());
 	FSNode *p;
 	uint8_t status = verify_session(context, OperationMode::kReadWrite, SessionType::kOnlyMeta);
@@ -239,7 +248,7 @@ uint8_t fs_settrashpath(const FsContext &context, inode_t inode, const std::stri
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t fs_undel(const FsContext &context, inode_t inode) {
+uint8_t FilesystemOperationsBase::fs_undel(const FsContext &context, inode_t inode) {
 	ChecksumUpdater cu(context.ts());
 	FSNode *p;
 	uint8_t status = verify_session(context, OperationMode::kReadWrite, SessionType::kOnlyMeta);
@@ -265,7 +274,7 @@ uint8_t fs_undel(const FsContext &context, inode_t inode) {
 	return status;
 }
 
-uint8_t fs_purge(const FsContext &context, inode_t inode) {
+uint8_t FilesystemOperationsBase::fs_purge(const FsContext &context, inode_t inode) {
 	ChecksumUpdater cu(context.ts());
 	FSNode *p;
 	uint8_t status = verify_session(context, OperationMode::kReadWrite, SessionType::kOnlyMeta);
@@ -292,10 +301,11 @@ uint8_t fs_purge(const FsContext &context, inode_t inode) {
 }
 
 #ifndef METARESTORE
-void fs_info(uint64_t *totalSpace, uint64_t *availableSpace, uint64_t *trashSpace,
-             inode_t *trashNodes, uint64_t *reservedSpace, inode_t *reservedNodes,
-             inode_t *inodes, inode_t *directoryNodes, inode_t *fileNodes,
-             inode_t *linkNodes) {
+void FilesystemOperationsBase::fs_info(uint64_t *totalSpace, uint64_t *availableSpace,
+                                       uint64_t *trashSpace, inode_t *trashNodes,
+                                       uint64_t *reservedSpace, inode_t *reservedNodes,
+                                       inode_t *inodes, inode_t *directoryNodes, inode_t *fileNodes,
+                                       inode_t *linkNodes) {
 	matocsserv_getspace(totalSpace, availableSpace);
 	*trashSpace = gMetadata->trashSpace;
 	*trashNodes = gMetadata->trashNodes;
@@ -307,7 +317,7 @@ void fs_info(uint64_t *totalSpace, uint64_t *availableSpace, uint64_t *trashSpac
 	*linkNodes = gMetadata->linkNodes;
 }
 
-uint8_t fs_getrootinode(inode_t *rootinode, const uint8_t *path) {
+uint8_t FilesystemOperationsBase::fs_getrootinode(inode_t *rootinode, const uint8_t *path) {
 	HString hname;
 	uint32_t nleng;
 	const uint8_t *name;
@@ -343,8 +353,9 @@ uint8_t fs_getrootinode(inode_t *rootinode, const uint8_t *path) {
 	}
 }
 
-void fs_statfs(const FsContext &context, uint64_t *totalspace, uint64_t *availspace,
-               uint64_t *trspace, uint64_t *respace, inode_t *inodes) {
+void FilesystemOperationsBase::fs_statfs(const FsContext &context, uint64_t *totalspace,
+                                         uint64_t *availspace, uint64_t *trspace, uint64_t *respace,
+                                         inode_t *inodes) {
 	FSNode *rn;
 	StatsRecord sr;
 	if (context.rootinode() == SPECIAL_INODE_ROOT) {
@@ -371,7 +382,7 @@ void fs_statfs(const FsContext &context, uint64_t *totalspace, uint64_t *availsp
 }
 #endif /* #ifndef METARESTORE */
 
-uint8_t fs_apply_checksum(const std::string &version, uint64_t checksum) {
+uint8_t FilesystemOperationsBase::fs_apply_checksum(const std::string &version, uint64_t checksum) {
 	std::string versionString = saunafsVersionToString(SAUNAFS_VERSHEX);
 	uint64_t computedChecksum = fs_checksum(ChecksumMode::kGetCurrent);
 	gMetadata->metadataVersion++;
@@ -383,20 +394,20 @@ uint8_t fs_apply_checksum(const std::string &version, uint64_t checksum) {
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t fs_apply_access(uint32_t ts, inode_t inode) {
+uint8_t FilesystemOperationsBase::fs_apply_access(uint32_t timestamp, inode_t inode) {
 	FSNode *p;
 	p = fsnodes_id_to_node(inode);
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
-	p->atime = ts;
+	p->atime = timestamp;
 	fsnodes_update_checksum(p);
 	gMetadata->metadataVersion++;
 	return SAUNAFS_STATUS_OK;
 }
 
 #ifndef METARESTORE
-uint8_t fs_access(const FsContext &context, inode_t inode, int modemask) {
+uint8_t FilesystemOperationsBase::fs_access(const FsContext &context, inode_t inode, int modemask) {
 	FSNode *p;
 
 	uint8_t status = verify_session(context, (modemask & MODE_MASK_W) ? OperationMode::kReadWrite : OperationMode::kReadOnly, SessionType::kNotMeta);
@@ -405,10 +416,11 @@ uint8_t fs_access(const FsContext &context, inode_t inode, int modemask) {
 	}
 
 	return fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny, modemask,
-	                                      inode, &p);
+									  inode, &p);
 }
 
-uint8_t fs_lookup(const FsContext &context, inode_t parent, const HString &name, inode_t *inode, Attributes &attr) {
+uint8_t FilesystemOperationsBase::fs_lookup(const FsContext &context, inode_t parent,
+                                            const HString &name, inode_t *inode, Attributes &attr) {
 	FSNode *wd;
 	FSNodeDirectory *rn;
 
@@ -478,7 +490,9 @@ uint8_t fs_lookup(const FsContext &context, inode_t parent, const HString &name,
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t fs_whole_path_lookup(const FsContext &context, inode_t parent, const std::string &path, inode_t *found_inode, Attributes &attr) {
+uint8_t FilesystemOperationsBase::fs_whole_path_lookup(const FsContext &context, inode_t parent,
+                                                       const std::string &path,
+                                                       inode_t *found_inode, Attributes &attr) {
 	uint8_t status;
 	inode_t tmp_inode = context.rootinode();
 
@@ -506,8 +520,9 @@ uint8_t fs_whole_path_lookup(const FsContext &context, inode_t parent, const std
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t fs_full_path_by_inode(const FsContext &context, inode_t initial_inode,
-                              std::string &fullPath) {
+uint8_t FilesystemOperationsBase::fs_full_path_by_inode(const FsContext &context,
+                                                        inode_t initial_inode,
+                                                        std::string &fullPath) {
 	inode_t current_inode = initial_inode;
 	FSNode *parent_node;
 	FSNode *current_node;
@@ -554,7 +569,8 @@ uint8_t fs_full_path_by_inode(const FsContext &context, inode_t initial_inode,
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t fs_getattr(const FsContext &context, inode_t inode, Attributes &attr) {
+uint8_t FilesystemOperationsBase::fs_getattr(const FsContext &context, inode_t inode,
+                                             Attributes &attr) {
 	FSNode *p;
 
 	attr.fill(0);
@@ -576,9 +592,10 @@ uint8_t fs_getattr(const FsContext &context, inode_t inode, Attributes &attr) {
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t fs_try_setlength(const FsContext &context, inode_t inode, uint8_t opened,
-			uint64_t length, bool denyTruncatingParity, uint32_t lockId, Attributes &attr,
-			uint64_t *chunkid) {
+uint8_t FilesystemOperationsBase::fs_try_setlength(const FsContext &context, inode_t inode,
+                                                   uint8_t opened, uint64_t length,
+                                                   bool denyTruncatingParity, uint32_t lockId,
+                                                   Attributes &attr, uint64_t *chunkid) {
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
 	FSNode *p;
@@ -629,8 +646,8 @@ uint8_t fs_try_setlength(const FsContext &context, inode_t inode, uint8_t opened
 }
 #endif
 
-uint8_t fs_apply_trunc(uint32_t ts, inode_t inode, uint32_t indx, uint64_t chunkid,
-			uint32_t lockid) {
+uint8_t FilesystemOperationsBase::fs_apply_trunc(uint32_t timestamp, inode_t inode, uint32_t indx,
+                                                 uint64_t chunkid, uint32_t lockid) {
 	uint64_t ochunkid, nchunkid;
 	uint8_t status;
 	FSNodeFile *p = fsnodes_id_to_node<FSNodeFile>(inode);
@@ -652,7 +669,7 @@ uint8_t fs_apply_trunc(uint32_t ts, inode_t inode, uint32_t indx, uint64_t chunk
 		safs::log_err("fs_apply_trunc: node does not have a chunk at index {} chunks, inode {}", indx, inode);
 		return SAUNAFS_ERROR_NOCHUNK;
 	}
-	status = chunk_apply_modification(ts, ochunkid, lockid, p->goal, true, &nchunkid);
+	status = chunk_apply_modification(timestamp, ochunkid, lockid, p->goal, true, &nchunkid);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
@@ -665,7 +682,8 @@ uint8_t fs_apply_trunc(uint32_t ts, inode_t inode, uint32_t indx, uint64_t chunk
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t fs_set_nextchunkid(const FsContext &context, uint64_t nextChunkId) {
+uint8_t FilesystemOperationsBase::fs_set_nextchunkid(const FsContext &context,
+                                                     uint64_t nextChunkId) {
 	ChecksumUpdater cu(context.ts());
 	uint8_t status = chunk_set_next_chunkid(nextChunkId);
 	if (context.isPersonalityMaster()) {
@@ -679,7 +697,7 @@ uint8_t fs_set_nextchunkid(const FsContext &context, uint64_t nextChunkId) {
 }
 
 #ifndef METARESTORE
-uint8_t fs_end_setlength(uint64_t chunkid) {
+uint8_t FilesystemOperationsBase::fs_end_setlength(uint64_t chunkid) {
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
 	fs_changelog(ts, "UNLOCK(%" PRIu64 ")", chunkid);
@@ -687,14 +705,14 @@ uint8_t fs_end_setlength(uint64_t chunkid) {
 }
 #endif
 
-uint8_t fs_apply_unlock(uint64_t chunkid) {
+uint8_t FilesystemOperationsBase::fs_apply_unlock(uint64_t chunkid) {
 	gMetadata->metadataVersion++;
 	return chunk_unlock(chunkid);
 }
 
 #ifndef METARESTORE
-uint8_t fs_do_setlength(const FsContext &context, inode_t inode, uint64_t length,
-			Attributes &attr) {
+uint8_t FilesystemOperationsBase::fs_do_setlength(const FsContext &context, inode_t inode,
+                                                  uint64_t length, Attributes &attr) {
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
 	FSNode *p = NULL;
@@ -729,9 +747,11 @@ uint8_t fs_do_setlength(const FsContext &context, inode_t inode, uint64_t length
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t fs_setattr(const FsContext &context, inode_t inode, uint8_t setmask, uint16_t attrmode,
-		uint32_t attruid, uint32_t attrgid, uint32_t attratime, uint32_t attrmtime,
-		SugidClearMode sugidclearmode, Attributes &attr) {
+uint8_t FilesystemOperationsBase::fs_setattr(const FsContext &context, inode_t inode,
+                                             uint8_t setmask, uint16_t attrmode, uint32_t attruid,
+                                             uint32_t attrgid, uint32_t attratime,
+                                             uint32_t attrmtime, SugidClearMode sugidclearmode,
+                                             Attributes &attr) {
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
 	FSNode *p = NULL;
@@ -864,8 +884,9 @@ uint8_t fs_setattr(const FsContext &context, inode_t inode, uint8_t setmask, uin
 }
 #endif
 
-uint8_t fs_apply_attr(uint32_t ts, inode_t inode, uint32_t mode, uint32_t uid, uint32_t gid,
-			uint32_t atime, uint32_t mtime) {
+uint8_t FilesystemOperationsBase::fs_apply_attr(uint32_t timestamp, inode_t inode, uint32_t mode,
+                                                uint32_t uid, uint32_t gid, uint32_t atime,
+                                                uint32_t mtime) {
 	FSNode *p = fsnodes_id_to_node(inode);
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
@@ -880,13 +901,14 @@ uint8_t fs_apply_attr(uint32_t ts, inode_t inode, uint32_t mode, uint32_t uid, u
 	}
 	p->atime = atime;
 	p->mtime = mtime;
-	fsnodes_update_ctime(p, ts);
+	fsnodes_update_ctime(p, timestamp);
 	fsnodes_update_checksum(p);
 	gMetadata->metadataVersion++;
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t fs_apply_length(uint32_t ts, inode_t inode, uint64_t length, bool eraseFurtherChunks) {
+uint8_t FilesystemOperationsBase::fs_apply_length(uint32_t timestamp, inode_t inode,
+                                                  uint64_t length, bool eraseFurtherChunks) {
 	FSNode *p = fsnodes_id_to_node(inode);
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
@@ -896,8 +918,8 @@ uint8_t fs_apply_length(uint32_t ts, inode_t inode, uint64_t length, bool eraseF
 		return SAUNAFS_ERROR_EINVAL;
 	}
 	fsnodes_setlength(static_cast<FSNodeFile *>(p), length, eraseFurtherChunks);
-	p->mtime = ts;
-	fsnodes_update_ctime(p, ts);
+	p->mtime = timestamp;
+	fsnodes_update_ctime(p, timestamp);
 	fsnodes_update_checksum(p);
 	gMetadata->metadataVersion++;
 	return SAUNAFS_STATUS_OK;
@@ -911,11 +933,12 @@ static inline void fs_update_atime(FSNode *p, uint32_t ts) {
 	if (!gAtimeDisabled && p->atime != ts) {
 		p->atime = ts;
 		fsnodes_update_checksum(p);
-		fs_changelog(ts, "ACCESS(%" PRIiNode ")", p->id);
+		gFilesystemOperations->fs_changelog(ts, "ACCESS(%" PRIiNode ")", p->id);
 	}
 }
 
-uint8_t fs_readlink(const FsContext &context, inode_t inode, std::string &path) {
+uint8_t FilesystemOperationsBase::fs_readlink(const FsContext &context, inode_t inode,
+                                              std::string &path) {
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
 	FSNode *p = NULL;
@@ -942,8 +965,9 @@ uint8_t fs_readlink(const FsContext &context, inode_t inode, std::string &path) 
 }
 #endif
 
-uint8_t fs_symlink(const FsContext &context, inode_t parent, const HString &name,
-		const std::string &path, inode_t *inode, Attributes *attr) {
+uint8_t FilesystemOperationsBase::fs_symlink(const FsContext &context, inode_t parent,
+                                             const HString &name, const std::string &path,
+                                             inode_t *inode, Attributes *attr) {
 	ChecksumUpdater cu(context.ts());
 	FSNode *wd;
 	uint8_t status = verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
@@ -1007,9 +1031,10 @@ uint8_t fs_symlink(const FsContext &context, inode_t parent, const HString &name
 }
 
 #ifndef METARESTORE
-uint8_t fs_mknod(const FsContext &context, inode_t parent, const HString &name,
-		FSNodeType type, uint16_t mode, uint16_t umask, uint32_t rdev, inode_t *inode,
-		Attributes &attr) {
+uint8_t FilesystemOperationsBase::fs_mknod(const FsContext &context, inode_t parent,
+                                           const HString &name, FSNodeType type, uint16_t mode,
+                                           uint16_t umask, uint32_t rdev, inode_t *inode,
+                                           Attributes &attr) {
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
 	FSNode *wd, *p;
@@ -1062,8 +1087,9 @@ uint8_t fs_mknod(const FsContext &context, inode_t parent, const HString &name,
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t fs_mkdir(const FsContext &context, inode_t parent, const HString &name, uint16_t mode,
-				 uint16_t umask, uint8_t copysgid, inode_t *inode, Attributes &attr) {
+uint8_t FilesystemOperationsBase::fs_mkdir(const FsContext &context, inode_t parent,
+                                           const HString &name, uint16_t mode, uint16_t umask,
+                                           uint8_t copysgid, inode_t *inode, Attributes &attr) {
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
 	FSNode *wd, *p;
@@ -1117,8 +1143,10 @@ uint8_t fs_mkdir(const FsContext &context, inode_t parent, const HString &name, 
 }
 #endif
 
-uint8_t fs_apply_create(uint32_t ts, inode_t parent, const HString &name, FSNodeType type,
-                        uint32_t mode, uint32_t uid, uint32_t gid, uint32_t rdev, inode_t inode) {
+uint8_t FilesystemOperationsBase::fs_apply_create(uint32_t timestamp, inode_t parent,
+                                                  const HString &name, FSNodeType type,
+                                                  uint32_t mode, uint32_t uid, uint32_t gid,
+                                                  uint32_t rdev, inode_t inode) {
 	FSNode *wd, *p;
 	if (type != FSNodeType::kFile && type != FSNodeType::kSocket && type != FSNodeType::kFifo &&
 	    type != FSNodeType::kBlockDev && type != FSNodeType::kCharDev &&
@@ -1136,8 +1164,8 @@ uint8_t fs_apply_create(uint32_t ts, inode_t parent, const HString &name, FSNode
 		return SAUNAFS_ERROR_EEXIST;
 	}
 	// we pass requested inode number here
-	p = fsnodes_create_node(ts, static_cast<FSNodeDirectory*>(wd), name, type, mode, 0, uid, gid, 0,
-	                        AclInheritance::kInheritAcl, inode);
+	p = fsnodes_create_node(timestamp, static_cast<FSNodeDirectory *>(wd), name, type, mode, 0, uid,
+	                        gid, 0, AclInheritance::kInheritAcl, inode);
 	if (type == FSNodeType::kBlockDev || type == FSNodeType::kCharDev) {
 		static_cast<FSNodeDevice*>(p)->rdev = rdev;
 		fsnodes_update_checksum(p);
@@ -1151,7 +1179,8 @@ uint8_t fs_apply_create(uint32_t ts, inode_t parent, const HString &name, FSNode
 }
 
 #ifndef METARESTORE
-uint8_t fs_unlink(const FsContext &context, inode_t parent, const HString &name) {
+uint8_t FilesystemOperationsBase::fs_unlink(const FsContext &context, inode_t parent,
+                                            const HString &name) {
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
 	FSNode *wd;
@@ -1188,9 +1217,10 @@ uint8_t fs_unlink(const FsContext &context, inode_t parent, const HString &name)
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t fs_recursive_remove(const FsContext &context, inode_t parent,
-			    const HString &name, const std::function<void(int)> &callback,
-			    uint32_t job_id) {
+uint8_t FilesystemOperationsBase::fs_recursive_remove(const FsContext &context, inode_t parent,
+                                                      const HString &name,
+                                                      const std::function<void(int)> &callback,
+                                                      uint32_t job_id) {
 	ChecksumUpdater cu(context.ts());
 	FSNode *wd_tmp;
 
@@ -1220,7 +1250,8 @@ uint8_t fs_recursive_remove(const FsContext &context, inode_t parent,
 	                                          callback);
 }
 
-uint8_t fs_rmdir(const FsContext &context, inode_t parent, const HString &name) {
+uint8_t FilesystemOperationsBase::fs_rmdir(const FsContext &context, inode_t parent,
+                                           const HString &name) {
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
 	FSNode *wd;
@@ -1261,8 +1292,8 @@ uint8_t fs_rmdir(const FsContext &context, inode_t parent, const HString &name) 
 }
 #endif
 
-uint8_t fs_apply_unlink(uint32_t ts, inode_t parent, const HString &name,
-		inode_t inode) {
+uint8_t FilesystemOperationsBase::fs_apply_unlink(uint32_t timestamp, inode_t parent,
+                                                  const HString &name, inode_t inode) {
 	FSNode *wd;
 	wd = fsnodes_id_to_node(parent);
 	if (!wd) {
@@ -1282,13 +1313,15 @@ uint8_t fs_apply_unlink(uint32_t ts, inode_t parent, const HString &name,
 	    !static_cast<FSNodeDirectory *>(child)->entries.empty()) {
 		return SAUNAFS_ERROR_ENOTEMPTY;
 	}
-	fsnodes_unlink(ts, static_cast<FSNodeDirectory*>(wd), name, child);
+	fsnodes_unlink(timestamp, static_cast<FSNodeDirectory*>(wd), name, child);
 	gMetadata->metadataVersion++;
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t fs_rename(const FsContext &context, inode_t parent_src, const HString &name_src,
-		inode_t parent_dst, const HString &name_dst, inode_t *inode, Attributes *attr) {
+uint8_t FilesystemOperationsBase::fs_rename(const FsContext &context, inode_t parent_src,
+                                            const HString &name_src, inode_t parent_dst,
+                                            const HString &name_dst, inode_t *inode,
+                                            Attributes *attr) {
 	ChecksumUpdater cu(context.ts());
 	FSNode *swd;
 	FSNode *dwd;
@@ -1392,8 +1425,9 @@ uint8_t fs_rename(const FsContext &context, inode_t parent_src, const HString &n
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t fs_link(const FsContext &context, inode_t inode_src, inode_t parent_dst,
-		const HString &name_dst, inode_t *inode, Attributes *attr) {
+uint8_t FilesystemOperationsBase::fs_link(const FsContext &context, inode_t inode_src,
+                                          inode_t parent_dst, const HString &name_dst,
+                                          inode_t *inode, Attributes *attr) {
 	ChecksumUpdater cu(context.ts());
 	FSNode *sp;
 	FSNode *dwd;
@@ -1440,7 +1474,8 @@ uint8_t fs_link(const FsContext &context, inode_t inode_src, inode_t parent_dst,
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t fs_append(const FsContext &context, inode_t inode, inode_t inode_src) {
+uint8_t FilesystemOperationsBase::fs_append(const FsContext &context, inode_t inode,
+                                            inode_t inode_src) {
 	ChecksumUpdater cu(context.ts());
 	FSNode *p, *sp;
 	if (inode == inode_src) {
@@ -1770,7 +1805,9 @@ int FilesystemOperationsBase::fs_locks_remove_pending(const FsContext &context, 
 
 #ifndef METARESTORE
 
-uint8_t fs_readdir_size(const FsContext &context, inode_t inode, uint8_t flags, void **dnode, uint32_t *dbuffsize) {
+uint8_t FilesystemOperationsBase::fs_readdir_size(const FsContext &context, inode_t inode,
+                                                  uint8_t flags, void **dnode,
+                                                  uint32_t *dbuffsize) {
 	FSNode *p;
 	*dnode = NULL;
 	*dbuffsize = 0;
@@ -1791,7 +1828,8 @@ uint8_t fs_readdir_size(const FsContext &context, inode_t inode, uint8_t flags, 
 	return SAUNAFS_STATUS_OK;
 }
 
-void fs_readdir_data(const FsContext &context, uint8_t flags, void *dnode, uint8_t *dbuff) {
+void FilesystemOperationsBase::fs_readdir_data(const FsContext &context, uint8_t flags, void *dnode,
+                                               uint8_t *dbuff) {
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
 	FSNode *p = (FSNode *)dnode;
@@ -1803,8 +1841,9 @@ void fs_readdir_data(const FsContext &context, uint8_t flags, void *dnode, uint8
 	metrics::Counter::increment(metrics::Counter::Master::FS_READDIR);
 }
 
-uint8_t fs_readdir(const FsContext &context, inode_t inode, uint64_t first_entry,
-                   uint64_t number_of_entries, std::vector<DirectoryEntry> &dir_entries) {
+uint8_t FilesystemOperationsBase::fs_readdir(const FsContext &context, inode_t inode,
+                                             uint64_t first_entry, uint64_t number_of_entries,
+                                             std::vector<DirectoryEntry> &dir_entries) {
 	uint8_t status = verify_session(context, OperationMode::kReadOnly, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
@@ -1833,8 +1872,8 @@ uint8_t fs_readdir(const FsContext &context, inode_t inode, uint64_t first_entry
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t fs_checkfile(const FsContext &context, inode_t inode,
-                     uint32_t chunkcount[CHUNK_MATRIX_SIZE]) {
+uint8_t FilesystemOperationsBase::fs_checkfile(const FsContext &context, inode_t inode,
+                                               uint32_t chunkcount[CHUNK_MATRIX_SIZE]) {
 	FSNode *p;
 
 	uint8_t status = verify_session(context, OperationMode::kReadOnly, SessionType::kAny);
@@ -1852,9 +1891,9 @@ uint8_t fs_checkfile(const FsContext &context, inode_t inode,
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t fs_opencheck(const FsContext &context, inode_t inode, uint8_t flags, Attributes &attr) {
+uint8_t FilesystemOperationsBase::fs_opencheck(const FsContext &context, inode_t inode,
+                                               uint8_t flags, Attributes &attr) {
 	FSNode *p;
-
 
 	uint8_t status = verify_session(context, (flags & WANT_WRITE) ? OperationMode::kReadWrite : OperationMode::kReadOnly, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
@@ -1886,7 +1925,8 @@ uint8_t fs_opencheck(const FsContext &context, inode_t inode, uint8_t flags, Att
 }
 #endif
 
-uint8_t fs_acquire(const FsContext &context, inode_t inode, uint32_t sessionid) {
+uint8_t FilesystemOperationsBase::fs_acquire(const FsContext &context, inode_t inode,
+                                             uint32_t sessionid) {
 	ChecksumUpdater cu(context.ts());
 #ifndef METARESTORE
 	if (context.isPersonalityShadow()) {
@@ -1914,7 +1954,8 @@ uint8_t fs_acquire(const FsContext &context, inode_t inode, uint32_t sessionid) 
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t fs_release(const FsContext &context, inode_t inode, uint32_t sessionid) {
+uint8_t FilesystemOperationsBase::fs_release(const FsContext &context, inode_t inode,
+                                             uint32_t sessionid) {
 	ChecksumUpdater cu(context.ts());
 	FSNodeFile *p = fsnodes_id_to_node<FSNodeFile>(inode);
 	if (!p) {
@@ -1951,7 +1992,7 @@ uint8_t fs_release(const FsContext &context, inode_t inode, uint32_t sessionid) 
 }
 
 #ifndef METARESTORE
-uint32_t fs_newsessionid(void) {
+uint32_t FilesystemOperationsBase::fs_newsessionid(void) {
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
 	const uint32_t current = gMetadata->nextSessionId().getValue();
@@ -1960,7 +2001,7 @@ uint32_t fs_newsessionid(void) {
 	return current;
 }
 #endif
-uint8_t fs_apply_session(uint32_t sessionid) {
+uint8_t FilesystemOperationsBase::fs_apply_session(uint32_t sessionid) {
 	if (sessionid != gMetadata->nextSessionId().getValue()) {
 		return SAUNAFS_ERROR_MISMATCH;
 	}
@@ -1976,7 +2017,7 @@ uint8_t fs_auto_repair_if_needed(FSNodeFile *p, uint32_t chunkIndex) {
 	if (chunkId != 0 && chunk_has_only_invalid_copies(chunkId)) {
 		uint32_t notchanged, erased, repaired;
 		FsContext context = FsContext::getForMasterWithSession(0, SPECIAL_INODE_ROOT, 0, 0, 0, 0, 0);
-		fs_repair(context, p->id, 0, &notchanged, &erased, &repaired);
+		gFilesystemOperations->fs_repair(context, p->id, 0, &notchanged, &erased, &repaired);
 		safs_pretty_syslog(LOG_NOTICE,
 		       "auto repair inode %" PRIiNode ", chunk %016" PRIX64
 		       ": "
@@ -1987,7 +2028,8 @@ uint8_t fs_auto_repair_if_needed(FSNodeFile *p, uint32_t chunkIndex) {
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t fs_readchunk(inode_t inode, uint32_t indx, uint64_t *chunkid, uint64_t *length) {
+uint8_t FilesystemOperationsBase::fs_readchunk(inode_t inode, uint32_t indx, uint64_t *chunkid,
+                                               uint64_t *length) {
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
 	FSNodeFile *p;
@@ -2021,9 +2063,11 @@ uint8_t fs_readchunk(inode_t inode, uint32_t indx, uint64_t *chunkid, uint64_t *
 }
 #endif
 
-uint8_t fs_writechunk(const FsContext &context, inode_t inode, uint32_t indx, bool usedummylockid,
-		/* inout */ uint32_t *lockid, uint64_t *chunkid, uint8_t *opflag,
-		uint64_t *length, uint32_t min_server_version) {
+uint8_t FilesystemOperationsBase::fs_writechunk(const FsContext &context, inode_t inode,
+                                                uint32_t indx, bool usedummylockid,
+                                                /* inout */ uint32_t *lockid, uint64_t *chunkid,
+                                                uint8_t *opflag, uint64_t *length,
+                                                uint32_t min_server_version) {
 	ChecksumUpdater cu(context.ts());
 	uint64_t ochunkid, nchunkid;
 	FSNode *node;
@@ -2123,7 +2167,8 @@ uint8_t fs_writechunk(const FsContext &context, inode_t inode, uint32_t indx, bo
 }
 
 #ifndef METARESTORE
-uint8_t fs_writeend(inode_t inode, uint64_t length, uint64_t chunkid, uint32_t lockid) {
+uint8_t FilesystemOperationsBase::fs_writeend(inode_t inode, uint64_t length, uint64_t chunkid,
+                                              uint32_t lockid) {
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
 	uint8_t status = chunk_can_unlock(chunkid, lockid);
@@ -2157,20 +2202,21 @@ uint8_t fs_writeend(inode_t inode, uint64_t length, uint64_t chunkid, uint32_t l
 	return chunk_unlock(chunkid);
 }
 
-void fs_incversion(uint64_t chunkid) {
+void FilesystemOperationsBase::fs_incversion(uint64_t chunkid) {
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
 	fs_changelog(ts, "INCVERSION(%" PRIu64 ")", chunkid);
 }
 #endif
 
-uint8_t fs_apply_incversion(uint64_t chunkid) {
+uint8_t FilesystemOperationsBase::fs_apply_incversion(uint64_t chunkid) {
 	gMetadata->metadataVersion++;
 	return chunk_increase_version(chunkid);
 }
 
 #ifndef METARESTORE
-uint8_t fs_remove_chunk_from_file(const FsContext &context, inode_t inode, uint64_t chunkId) {
+uint8_t FilesystemOperationsBase::fs_remove_chunk_from_file(const FsContext &context, inode_t inode,
+                                                            uint64_t chunkId) {
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
 	StatsRecord psr, nsr;
@@ -2217,8 +2263,9 @@ uint8_t fs_remove_chunk_from_file(const FsContext &context, inode_t inode, uint6
 #endif /* #ifndef METARESTORE */
 
 #ifndef METARESTORE
-uint8_t fs_repair(const FsContext &context, inode_t inode,
-		uint8_t correct_only, uint32_t *notchanged, uint32_t *erased, uint32_t *repaired) {
+uint8_t FilesystemOperationsBase::fs_repair(const FsContext &context, inode_t inode,
+                                            uint8_t correct_only, uint32_t *notchanged,
+                                            uint32_t *erased, uint32_t *repaired) {
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
 	uint32_t nversion, indx;
@@ -2270,7 +2317,8 @@ uint8_t fs_repair(const FsContext &context, inode_t inode,
 }
 #endif /* #ifndef METARESTORE */
 
-uint8_t fs_apply_repair(uint32_t ts, inode_t inode, uint32_t indx, uint32_t nversion) {
+uint8_t FilesystemOperationsBase::fs_apply_repair(uint32_t timestamp, inode_t inode, uint32_t indx,
+                                                  uint32_t nversion) {
 	FSNodeFile *p;
 	uint8_t status;
 	StatsRecord psr, nsr;
@@ -2308,15 +2356,15 @@ uint8_t fs_apply_repair(uint32_t ts, inode_t inode, uint32_t indx, uint32_t nver
 	}
 	fsnodes_quota_update(p, {{QuotaResource::kSize, nsr.size - psr.size}});
 	gMetadata->metadataVersion++;
-	p->mtime = ts;
-	fsnodes_update_ctime(p, ts);
+	p->mtime = timestamp;
+	fsnodes_update_ctime(p, timestamp);
 	fsnodes_update_checksum(p);
 	return status;
 }
 
 #ifndef METARESTORE
-uint8_t fs_getgoal(const FsContext &context, inode_t inode, uint8_t gmode,
-		GoalStatistics &fgtab, GoalStatistics &dgtab) {
+uint8_t FilesystemOperationsBase::fs_getgoal(const FsContext &context, inode_t inode, uint8_t gmode,
+                                             GoalStatistics &fgtab, GoalStatistics &dgtab) {
 	FSNode *p;
 
 	if (!GMODE_ISVALID(gmode)) {
@@ -2337,8 +2385,10 @@ uint8_t fs_getgoal(const FsContext &context, inode_t inode, uint8_t gmode,
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t fs_gettrashtime_prepare(const FsContext &context, inode_t inode, uint8_t gmode,
-	TrashtimeMap &fileTrashtimes, TrashtimeMap &dirTrashtimes) {
+uint8_t FilesystemOperationsBase::fs_gettrashtime_prepare(const FsContext &context, inode_t inode,
+                                                          uint8_t gmode,
+                                                          TrashtimeMap &fileTrashtimes,
+                                                          TrashtimeMap &dirTrashtimes) {
 	FSNode *p;
 
 	if (!GMODE_ISVALID(gmode)) {
@@ -2360,7 +2410,8 @@ uint8_t fs_gettrashtime_prepare(const FsContext &context, inode_t inode, uint8_t
 	return SAUNAFS_STATUS_OK;
 }
 
-void fs_gettrashtime_store(TrashtimeMap &fileTrashtimes,TrashtimeMap &dirTrashtimes,uint8_t *buff) {
+void FilesystemOperationsBase::fs_gettrashtime_store(TrashtimeMap &fileTrashtimes,
+                                                     TrashtimeMap &dirTrashtimes, uint8_t *buff) {
 	for (auto i : fileTrashtimes) {
 		put32bit(&buff, i.first);
 		put32bit(&buff, i.second);
@@ -2371,8 +2422,9 @@ void fs_gettrashtime_store(TrashtimeMap &fileTrashtimes,TrashtimeMap &dirTrashti
 	}
 }
 
-uint8_t fs_geteattr(const FsContext &context, inode_t inode, uint8_t gmode,
-			uint32_t feattrtab[16], uint32_t deattrtab[16]) {
+uint8_t FilesystemOperationsBase::fs_geteattr(const FsContext &context, inode_t inode,
+                                              uint8_t gmode, uint32_t feattrtab[16],
+                                              uint32_t deattrtab[16]) {
 	FSNode *p;
 
 	memset(feattrtab, 0, 16 * sizeof(uint32_t));
@@ -2397,9 +2449,10 @@ uint8_t fs_geteattr(const FsContext &context, inode_t inode, uint8_t gmode,
 
 #endif
 
-uint8_t fs_setgoal(const FsContext &context, inode_t inode, uint8_t goal, uint8_t smode,
-		std::shared_ptr<SetGoalTask::StatsArray> setgoal_stats,
-		const std::function<void(int)> &callback) {
+uint8_t FilesystemOperationsBase::fs_setgoal(const FsContext &context, inode_t inode, uint8_t goal,
+                                             uint8_t smode,
+                                             std::shared_ptr<SetGoalTask::StatsArray> setgoal_stats,
+                                             const std::function<void(int)> &callback) {
 	ChecksumUpdater cu(context.ts());
 	if (!SMODE_ISVALID(smode) || !GoalId::isValid(goal) ||
 	    (smode & (SMODE_INCREASE | SMODE_DECREASE))) {
@@ -2442,9 +2495,9 @@ uint8_t fs_setgoal(const FsContext &context, inode_t inode, uint8_t goal, uint8_
 }
 
 //This function is only used by Shadow
-uint8_t fs_apply_setgoal(const FsContext &context, inode_t inode, uint8_t goal, uint8_t smode,
-		uint32_t master_result) {
-
+uint8_t FilesystemOperationsBase::fs_apply_setgoal(const FsContext &context, inode_t inode,
+                                                   uint8_t goal, uint8_t smode,
+                                                   uint32_t master_result) {
 	assert(context.isPersonalityShadow());
 	ChecksumUpdater cu(context.ts());
 	if (!SMODE_ISVALID(smode) || !GoalId::isValid(goal) ||
@@ -2478,9 +2531,10 @@ uint8_t fs_apply_setgoal(const FsContext &context, inode_t inode, uint8_t goal, 
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t fs_settrashtime(const FsContext &context, inode_t inode, uint32_t trashtime, uint8_t smode,
-			std::shared_ptr<SetTrashtimeTask::StatsArray> settrashtime_stats,
-			const std::function<void(int)> &callback) {
+uint8_t FilesystemOperationsBase::fs_settrashtime(
+    const FsContext &context, inode_t inode, uint32_t trashtime, uint8_t smode,
+    std::shared_ptr<SetTrashtimeTask::StatsArray> settrashtime_stats,
+    const std::function<void(int)> &callback) {
 	ChecksumUpdater cu(context.ts());
 	if (!SMODE_ISVALID(smode)) {
 		return SAUNAFS_ERROR_EINVAL;
@@ -2514,9 +2568,9 @@ uint8_t fs_settrashtime(const FsContext &context, inode_t inode, uint32_t trasht
 	                                          callback);
 }
 
-uint8_t fs_apply_settrashtime(const FsContext &context, inode_t inode, uint32_t trashtime,
-			      uint8_t smode, uint32_t master_result) {
-
+uint8_t FilesystemOperationsBase::fs_apply_settrashtime(const FsContext &context, inode_t inode,
+                                                        uint32_t trashtime, uint8_t smode,
+                                                        uint32_t master_result) {
 	assert(context.isPersonalityShadow());
 	ChecksumUpdater cu(context.ts());
 	if (!SMODE_ISVALID(smode)) {
@@ -2549,8 +2603,9 @@ uint8_t fs_apply_settrashtime(const FsContext &context, inode_t inode, uint32_t 
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t fs_seteattr(const FsContext &context, inode_t inode, uint8_t eattr, uint8_t smode,
-			inode_t *sinodes, inode_t *ncinodes, inode_t *nsinodes) {
+uint8_t FilesystemOperationsBase::fs_seteattr(const FsContext &context, inode_t inode,
+                                              uint8_t eattr, uint8_t smode, inode_t *sinodes,
+                                              inode_t *ncinodes, inode_t *nsinodes) {
 	ChecksumUpdater cu(context.ts());
 	if (!SMODE_ISVALID(smode) ||
 	    (eattr & (~(EATTR_NOOWNER | EATTR_NOACACHE | EATTR_NOECACHE | EATTR_NODATACACHE)))) {
@@ -2593,8 +2648,9 @@ uint8_t fs_seteattr(const FsContext &context, inode_t inode, uint8_t eattr, uint
 
 #ifndef METARESTORE
 
-uint8_t fs_listxattr_leng(const FsContext &context, inode_t inode, uint8_t opened,
-			void **xanode, uint32_t *xasize) {
+uint8_t FilesystemOperationsBase::fs_listxattr_leng(const FsContext &context, inode_t inode,
+                                                    uint8_t opened, void **xanode,
+                                                    uint32_t *xasize) {
 	FSNode *p;
 
 	uint8_t status = verify_session(context, OperationMode::kReadOnly, SessionType::kNotMeta);
@@ -2612,14 +2668,15 @@ uint8_t fs_listxattr_leng(const FsContext &context, inode_t inode, uint8_t opene
 	return get_xattrs_length_for_inode(p->id, xanode, xasize);
 }
 
-void fs_listxattr_data(void *xanode, uint8_t *xabuff) {
+void FilesystemOperationsBase::fs_listxattr_data(void *xanode, uint8_t *xabuff) {
 	memcpy(xabuff, kAclXattrs, sizeof(kAclXattrs));
 	xattr_listattr_data(xanode, xabuff + sizeof(kAclXattrs));
 }
 
-uint8_t fs_setxattr(const FsContext &context, inode_t inode, uint8_t opened,
-		uint8_t anleng, const uint8_t *attrname,
-		uint32_t avleng, const uint8_t *attrvalue, uint8_t mode) {
+uint8_t FilesystemOperationsBase::fs_setxattr(const FsContext &context, inode_t inode,
+                                              uint8_t opened, uint8_t anleng,
+                                              const uint8_t *attrname, uint32_t avleng,
+                                              const uint8_t *attrvalue, uint8_t mode) {
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
 	FSNode *p;
@@ -2655,9 +2712,10 @@ uint8_t fs_setxattr(const FsContext &context, inode_t inode, uint8_t opened,
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t fs_getxattr(const FsContext &context, inode_t inode, uint8_t opened,
-		uint8_t anleng, const uint8_t *attrname,
-		uint32_t *avleng, uint8_t **attrvalue) {
+uint8_t FilesystemOperationsBase::fs_getxattr(const FsContext &context, inode_t inode,
+                                              uint8_t opened, uint8_t anleng,
+                                              const uint8_t *attrname, uint32_t *avleng,
+                                              uint8_t **attrvalue) {
 	FSNode *p;
 
 	uint8_t status = verify_session(context, OperationMode::kReadOnly, SessionType::kNotMeta);
@@ -2679,8 +2737,10 @@ uint8_t fs_getxattr(const FsContext &context, inode_t inode, uint8_t opened,
 
 #endif /* #ifndef METARESTORE */
 
-uint8_t fs_apply_setxattr(uint32_t ts, inode_t inode, uint32_t anleng, const uint8_t *attrname,
-			uint32_t avleng, const uint8_t *attrvalue, uint32_t mode) {
+uint8_t FilesystemOperationsBase::fs_apply_setxattr(uint32_t timestamp, inode_t inode,
+                                                    uint32_t anleng, const uint8_t *attrname,
+                                                    uint32_t avleng, const uint8_t *attrvalue,
+                                                    uint32_t mode) {
 	FSNode *p;
 	uint8_t status;
 	if (anleng == 0 || anleng > SFS_XATTR_NAME_MAX || avleng > SFS_XATTR_SIZE_MAX ||
@@ -2696,13 +2756,14 @@ uint8_t fs_apply_setxattr(uint32_t ts, inode_t inode, uint32_t anleng, const uin
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	fsnodes_update_ctime(p, ts);
+	fsnodes_update_ctime(p, timestamp);
 	gMetadata->metadataVersion++;
 	fsnodes_update_checksum(p);
 	return status;
 }
 
-uint8_t fs_deleteacl(const FsContext &context, inode_t inode, AclType type) {
+uint8_t FilesystemOperationsBase::fs_deleteacl(const FsContext &context, inode_t inode,
+                                               AclType type) {
 	ChecksumUpdater cu(context.ts());
 	FSNode *p;
 	uint8_t status = verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
@@ -2733,7 +2794,8 @@ uint8_t fs_deleteacl(const FsContext &context, inode_t inode, AclType type) {
 
 #ifndef METARESTORE
 
-uint8_t fs_setacl(const FsContext &context, inode_t inode, const RichACL &acl) {
+uint8_t FilesystemOperationsBase::fs_setacl(const FsContext &context, inode_t inode,
+                                            const RichACL &acl) {
 	ChecksumUpdater cu(context.ts());
 	FSNode *p;
 	uint8_t status = verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
@@ -2757,7 +2819,8 @@ uint8_t fs_setacl(const FsContext &context, inode_t inode, const RichACL &acl) {
 	return status;
 }
 
-uint8_t fs_setacl(const FsContext &context, inode_t inode, AclType type, const AccessControlList &acl) {
+uint8_t FilesystemOperationsBase::fs_setacl(const FsContext &context, inode_t inode, AclType type,
+                                            const AccessControlList &acl) {
 	ChecksumUpdater cu(context.ts());
 	FSNode *p;
 	uint8_t status = verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
@@ -2784,7 +2847,7 @@ uint8_t fs_setacl(const FsContext &context, inode_t inode, AclType type, const A
 	return SAUNAFS_ERROR_EINVAL;
 }
 
-uint8_t fs_getacl(const FsContext &context, inode_t inode, RichACL &acl) {
+uint8_t FilesystemOperationsBase::fs_getacl(const FsContext &context, inode_t inode, RichACL &acl) {
 	FSNode *p;
 	uint8_t status = verify_session(context, OperationMode::kReadOnly, SessionType::kAny);
 	if (status != SAUNAFS_STATUS_OK) {
@@ -2800,7 +2863,8 @@ uint8_t fs_getacl(const FsContext &context, inode_t inode, RichACL &acl) {
 
 #endif /* #ifndef METARESTORE */
 
-uint8_t fs_apply_setacl(uint32_t ts, inode_t inode, char aclType, const char *aclString) {
+uint8_t FilesystemOperationsBase::fs_apply_setacl(uint32_t timestamp, inode_t inode, char aclType,
+                                                  const char *aclString) {
 	AccessControlList acl;
 	try {
 		acl = AccessControlList::fromString(aclString);
@@ -2815,14 +2879,15 @@ uint8_t fs_apply_setacl(uint32_t ts, inode_t inode, char aclType, const char *ac
 	if (!decodeChar("da", {AclType::kDefault, AclType::kAccess}, aclType, aclTypeEnum)) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
-	uint8_t status = fsnodes_setacl(p, aclTypeEnum, std::move(acl), ts);
+	uint8_t status = fsnodes_setacl(p, aclTypeEnum, std::move(acl), timestamp);
 	if (status == SAUNAFS_STATUS_OK) {
 		gMetadata->metadataVersion++;
 	}
 	return status;
 }
 
-uint8_t fs_apply_setrichacl(uint32_t ts, inode_t inode, const std::string &acl_string) {
+uint8_t FilesystemOperationsBase::fs_apply_setrichacl(uint32_t timestamp, inode_t inode,
+                                                      const std::string &acl_string) {
 	RichACL acl;
 	try {
 		acl = RichACL::fromString(acl_string);
@@ -2833,7 +2898,7 @@ uint8_t fs_apply_setrichacl(uint32_t ts, inode_t inode, const std::string &acl_s
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
-	uint8_t status = fsnodes_setacl(p, std::move(acl), ts);
+	uint8_t status = fsnodes_setacl(p, std::move(acl), timestamp);
 	if (status == SAUNAFS_STATUS_OK) {
 		gMetadata->metadataVersion++;
 	}
@@ -2841,7 +2906,7 @@ uint8_t fs_apply_setrichacl(uint32_t ts, inode_t inode, const std::string &acl_s
 }
 
 #ifndef METARESTORE
-uint32_t fs_getdirpath_size(inode_t inode) {
+uint32_t FilesystemOperationsBase::fs_getdirpath_size(inode_t inode) {
 	FSNode *node;
 	node = fsnodes_id_to_node(inode);
 	if (node) {
@@ -2860,7 +2925,7 @@ uint32_t fs_getdirpath_size(inode_t inode) {
 	return 0;  // unreachable
 }
 
-void fs_getdirpath_data(inode_t inode, uint8_t *buff, uint32_t size) {
+void FilesystemOperationsBase::fs_getdirpath_data(inode_t inode, uint8_t *buff, uint32_t size) {
 	FSNode *node;
 	node = fsnodes_id_to_node(inode);
 	if (node) {
@@ -2889,10 +2954,11 @@ void fs_getdirpath_data(inode_t inode, uint8_t *buff, uint32_t size) {
 	}
 }
 
-uint8_t fs_get_dir_stats(const FsContext &context, inode_t inode,
-                         inode_t *inodes, inode_t *dirs, inode_t *files,
-                         inode_t *links, uint32_t *chunks, uint64_t *length,
-                         uint64_t *size, uint64_t *rsize) {
+uint8_t FilesystemOperationsBase::fs_get_dir_stats(const FsContext &context, inode_t inode,
+                                                   inode_t *inodes, inode_t *dirs, inode_t *files,
+                                                   inode_t *links, uint32_t *chunks,
+                                                   uint64_t *length, uint64_t *size,
+                                                   uint64_t *rsize) {
 	FSNode *p;
 	StatsRecord sr;
 
@@ -2920,8 +2986,8 @@ uint8_t fs_get_dir_stats(const FsContext &context, inode_t inode,
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t fs_get_chunkid(const FsContext &context, inode_t inode, uint32_t index,
-			uint64_t *chunkid) {
+uint8_t FilesystemOperationsBase::fs_get_chunkid(const FsContext &context, inode_t inode,
+                                                 uint32_t index, uint64_t *chunkid) {
 	FSNode *p;
 	uint8_t status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kFile,
 	                                                MODE_MASK_EMPTY, inode, &p);
@@ -2941,7 +3007,7 @@ uint8_t fs_get_chunkid(const FsContext &context, inode_t inode, uint32_t index,
 }
 #endif
 
-void fs_add_files_to_chunks(bool isMetadataLoading) {
+void FilesystemOperationsBase::fs_add_files_to_chunks(bool isMetadataLoading) {
 	for (uint32_t i = 0; i < NODEHASHSIZE; i++) {
 		for (const auto &node : gMetadata->nodeHash[i]) {
 			if (node->type == FSNodeType::kFile || node->type == FSNodeType::kTrash ||
@@ -2956,7 +3022,7 @@ void fs_add_files_to_chunks(bool isMetadataLoading) {
 	}
 }
 
-uint64_t fs_getversion() {
+uint64_t FilesystemOperationsBase::fs_getversion() {
 	if (!gMetadata) {
 		throw NoMetadataException();
 	}
@@ -2984,12 +3050,14 @@ uint8_t fs_cancel_job(uint32_t job_id) {
 	}
 }
 
-uint32_t fs_reserve_job_id() {
+uint32_t FilesystemOperationsBase::fs_reserve_job_id() {
 	return gMetadata->taskManager.reserveJobId();
 }
 
-uint8_t fs_getchunksinfo(const FsContext& context, uint32_t current_ip, inode_t inode,
-		uint32_t chunk_index, uint32_t chunk_count, std::vector<ChunkWithAddressAndLabel> &chunks) {
+uint8_t FilesystemOperationsBase::fs_getchunksinfo(const FsContext &context, uint32_t current_ip,
+                                                   inode_t inode, uint32_t chunk_index,
+                                                   uint32_t chunk_count,
+                                                   std::vector<ChunkWithAddressAndLabel> &chunks) {
 	static constexpr int kMaxNumberOfChunkCopies = 100;
 
 	FSNode *p;

--- a/src/master/filesystem_operations.h
+++ b/src/master/filesystem_operations.h
@@ -48,15 +48,207 @@ constexpr uint32_t kDefaultTrashTime = 94620;
 /// FilesystemOperationsKV.
 class FilesystemOperationsBase : public IFilesystemOperations {
 public:
-#ifndef METARESTORE
-	// Goals
+	/// Returns version of the loaded metadata.
+	uint64_t fs_getversion() override;
 
+	/// @see IFilesystemOperations::fs_changelog
+	void fs_changelog(uint32_t ts, const char *format, ...) override
+	    __attribute__((__format__(__printf__, 3, 4)));
+
+	// Functions which create/apply (depending on the given context) changes to the metadata.
+	// Common for metarestore and master server (both personalities)
+
+	uint8_t fs_acquire(const FsContext &context, inode_t inode, uint32_t sessionid) override;
+	uint8_t fs_append(const FsContext &context, inode_t inode, inode_t inode_src) override;
+	uint8_t fs_deleteacl(const FsContext &context, inode_t inode, AclType type) override;
+	uint8_t fs_link(const FsContext &context, inode_t inode_src, inode_t parent_dst,
+	                const HString &name_dst, inode_t *inode, Attributes *attr) override;
+	uint8_t fs_purge(const FsContext &context, inode_t inode) override;
+	uint8_t fs_rename(const FsContext &context, inode_t parent_src, const HString &name_src,
+	                  inode_t parent_dst, const HString &name_dst, inode_t *inode,
+	                  Attributes *attr) override;
+	uint8_t fs_release(const FsContext &context, inode_t inode, uint32_t sessionid) override;
+	uint8_t fs_seteattr(const FsContext &context, inode_t inode, uint8_t eattr, uint8_t smode,
+	                    inode_t *sinodes, inode_t *ncinodes, inode_t *nsinodes) override;
+	uint8_t fs_setgoal(const FsContext &context, inode_t inode, uint8_t goal, uint8_t smode,
+	                   std::shared_ptr<SetGoalTask::StatsArray> setgoal_stats,
+	                   const std::function<void(int)> &callback) override;
+	uint8_t fs_apply_setgoal(const FsContext &context, inode_t inode, uint8_t goal, uint8_t smode,
+	                         uint32_t master_result) override;
+	uint8_t fs_settrashpath(const FsContext &context, inode_t inode,
+	                        const std::string &path) override;
+	uint8_t fs_settrashtime(const FsContext &context, inode_t inode, uint32_t trashtime,
+	                        uint8_t smode,
+	                        std::shared_ptr<SetTrashtimeTask::StatsArray> settrashtime_stats,
+	                        const std::function<void(int)> &callback) override;
+	uint8_t fs_apply_settrashtime(const FsContext &context, inode_t inode, uint32_t trashtime,
+	                              uint8_t smode, uint32_t master_result) override;
+	uint8_t fs_symlink(const FsContext &context, inode_t parent, const HString &name,
+	                   const std::string &path, inode_t *inode, Attributes *attr) override;
+	uint8_t fs_undel(const FsContext &context, inode_t inode) override;
+	uint8_t fs_writechunk(const FsContext &context, inode_t inode, uint32_t indx,
+	                      bool usedummylockid,
+	                      /* inout */ uint32_t *lockid, uint64_t *chunkid, uint8_t *opflag,
+	                      uint64_t *length, uint32_t min_server_version = 0) override;
+	uint8_t fs_set_nextchunkid(const FsContext &context, uint64_t nextChunkId) override;
+
+#ifndef METARESTORE
 	/// Returns a map with all defined goals.
 	const std::map<int, Goal> &fs_get_goal_definitions() const override;
 
 	/// Returns goal definition for given goal id.
 	const Goal &fs_get_goal_definition(uint8_t goalId) const override;
+
+	uint32_t fs_reserve_job_id() override;
+
+	uint8_t fs_access(const FsContext &context, inode_t inode, int modemask) override;
+	uint8_t fs_lookup(const FsContext &context, inode_t parent, const HString &name, inode_t *inode,
+	                  Attributes &attr) override;
+	uint8_t fs_whole_path_lookup(const FsContext &context, inode_t parent, const std::string &path,
+	                             inode_t *found_inode, Attributes &attr) override;
+	uint8_t fs_getattr(const FsContext &context, inode_t inode, Attributes &attr) override;
+	uint8_t fs_try_setlength(const FsContext &context, inode_t inode, uint8_t opened,
+	                         uint64_t length, bool denyTruncatingParity, uint32_t lockid,
+	                         Attributes &attr, uint64_t *chunkid) override;
+	uint8_t fs_do_setlength(const FsContext &context, inode_t inode, uint64_t length,
+	                        Attributes &attr) override;
+	uint8_t fs_setattr(const FsContext &context, inode_t inode, uint8_t setmask, uint16_t attrmode,
+	                   uint32_t attruid, uint32_t attrgid, uint32_t attratime, uint32_t attrmtime,
+	                   SugidClearMode sugidclearmode, Attributes &attr) override;
+	uint8_t fs_readlink(const FsContext &context, inode_t inode, std::string &path) override;
+	void fs_statfs(const FsContext &context, uint64_t *totalspace, uint64_t *availspace,
+	               uint64_t *trashspace, uint64_t *reservedspace, inode_t *inodes) override;
+	uint8_t fs_mknod(const FsContext &context, inode_t parent, const HString &name, FSNodeType type,
+	                 uint16_t mode, uint16_t umask, uint32_t rdev, inode_t *inode,
+	                 Attributes &attr) override;
+	uint8_t fs_mkdir(const FsContext &context, inode_t parent, const HString &name, uint16_t mode,
+	                 uint16_t umask, uint8_t copysgid, inode_t *inode, Attributes &attr) override;
+	uint8_t fs_remove_chunk_from_file(const FsContext &context, inode_t inode,
+	                                  uint64_t chunkId) override;
+	uint8_t fs_repair(const FsContext &context, inode_t inode, uint8_t correct_only,
+	                  uint32_t *notchanged, uint32_t *erased, uint32_t *repaired) override;
+	uint8_t fs_rmdir(const FsContext &context, inode_t parent, const HString &name) override;
+	uint8_t fs_recursive_remove(const FsContext &context, inode_t parent, const HString &name,
+	                            const std::function<void(int)> &callback, uint32_t job_id) override;
+	uint8_t fs_readdir_size(const FsContext &context, inode_t inode, uint8_t flags, void **dnode,
+	                        uint32_t *dbuffsize) override;
+	void fs_readdir_data(const FsContext &context, uint8_t flags, void *dnode,
+	                     uint8_t *dbuff) override;
+
+	uint8_t fs_readdir(const FsContext &context, inode_t inode, uint64_t first_entry,
+	                   uint64_t number_of_entries,
+	                   std::vector<DirectoryEntry> &dir_entries) override;
+
+	uint8_t fs_checkfile(const FsContext &context, inode_t inode,
+	                     uint32_t chunkcount[CHUNK_MATRIX_SIZE]) override;
+	uint8_t fs_opencheck(const FsContext &context, inode_t inode, uint8_t flags,
+	                     Attributes &attr) override;
+	uint8_t fs_getgoal(const FsContext &context, inode_t inode, uint8_t gmode,
+	                   GoalStatistics &fgtab, GoalStatistics &dgtab) override;
+	uint8_t fs_getxattr(const FsContext &context, inode_t inode, uint8_t opened, uint8_t anleng,
+	                    const uint8_t *attrname, uint32_t *avleng, uint8_t **attrvalue) override;
+	uint8_t fs_geteattr(const FsContext &context, inode_t inode, uint8_t gmode,
+	                    uint32_t feattrtab[16], uint32_t deattrtab[16]) override;
+	uint8_t fs_listxattr_leng(const FsContext &context, inode_t inode, uint8_t opened,
+	                          void **xanode, uint32_t *xasize) override;
+	uint8_t fs_setxattr(const FsContext &context, inode_t inode, uint8_t opened, uint8_t anleng,
+	                    const uint8_t *attrname, uint32_t avleng, const uint8_t *attrvalue,
+	                    uint8_t mode) override;
+	uint8_t fs_unlink(const FsContext &context, inode_t parent, const HString &name) override;
+	uint8_t fs_getchunksinfo(const FsContext &context, uint32_t current_ip, inode_t inode,
+	                         uint32_t chunk_index, uint32_t chunk_count,
+	                         std::vector<ChunkWithAddressAndLabel> &chunks) override;
+	uint8_t fs_gettrashtime_prepare(const FsContext &context, inode_t inode, uint8_t gmode,
+	                                TrashtimeMap &fileTrashtimes,
+	                                TrashtimeMap &dirTrashtimes) override;
+	uint8_t fs_setacl(const FsContext &context, inode_t inode, AclType type,
+	                  const AccessControlList &acl) override;
+	uint8_t fs_setacl(const FsContext &context, inode_t inode, const RichACL &acl) override;
+	uint8_t fs_getacl(const FsContext &context, inode_t inode, RichACL &acl) override;
+
+	// Functions which modify metadata or return some information.
+	// To be used by the master server with personality == kMaster
+	void fs_info(uint64_t *totalSpace, uint64_t *availableSpace, uint64_t *trashSpace,
+	             inode_t *trashNodes, uint64_t *reservedSpace, inode_t *reservedNodes,
+	             inode_t *inodes, inode_t *directoryNodes, inode_t *fileNodes,
+	             inode_t *linkNodes) override;
+	uint32_t fs_getdirpath_size(inode_t inode) override;
+	void fs_getdirpath_data(inode_t inode, uint8_t *buff, uint32_t size) override;
+	uint8_t fs_getrootinode(inode_t *rootinode, const uint8_t *path) override;
+	uint8_t fs_end_setlength(uint64_t chunkid) override;
+	uint8_t fs_readchunk(inode_t inode, uint32_t indx, uint64_t *chunkid,
+	                     uint64_t *length) override;
+	uint8_t fs_writeend(inode_t inode, uint64_t length, uint64_t chunkid, uint32_t lockid) override;
+	void fs_gettrashtime_store(TrashtimeMap &fileTrashtimes, TrashtimeMap &dirTrashtimes,
+	                           uint8_t *buff) override;
+	void fs_listxattr_data(void *xanode, uint8_t *xabuff) override;
+
+	uint32_t fs_newsessionid(void) override;
+
+	// RESERVED
+	uint8_t fs_readreserved_size(inode_t rootinode, uint8_t sesflags, uint32_t *dbuffsize) override;
+	void fs_readreserved_data(inode_t rootinode, uint8_t sesflags, uint8_t *dbuff) override;
+	void fs_readreserved(uint32_t off, uint32_t max_entries,
+	                     std::vector<NamedInodeEntry> &entries) override;
+	void fs_readreserved(uint64_t handleOffset, uint32_t maxEntries,
+	                     std::vector<HandleInodeEntry> &entries) override;
+
+	// TRASH
+	uint8_t fs_readtrash_size(inode_t rootinode, uint8_t sesflags, uint32_t *dbuffsize) override;
+	void fs_readtrash_data(inode_t rootinode, uint8_t sesflags, uint8_t *dbuff) override;
+	void fs_readtrash(uint32_t off, uint32_t max_entries,
+	                  std::vector<NamedInodeEntry> &entries) override;
+	void fs_readtrash(uint64_t handleOffset, uint32_t maxEntries,
+	                  std::vector<HandleInodeEntry> &entries) override;
+	uint8_t fs_gettrashpath(inode_t rootinode, uint8_t sesflags, inode_t inode,
+	                        std::string &path) override;
+
+	// RESERVED+TRASH
+	uint8_t fs_getdetachedattr(inode_t rootinode, uint8_t sesflags, inode_t inode, Attributes &attr,
+	                           uint8_t dtype) override;
+
+	// EXTRA
+	uint8_t fs_get_dir_stats(const FsContext &context, inode_t inode, inode_t *inodes,
+	                         inode_t *dirs, inode_t *files, inode_t *links, uint32_t *chunks,
+	                         uint64_t *length, uint64_t *size, uint64_t *rsize) override;
+	uint8_t fs_get_chunkid(const FsContext &context, inode_t inode, uint32_t index,
+	                       uint64_t *chunkid) override;
+
+	// SPECIAL - LOG EMERGENCY INCREASE VERSION FROM CHUNKS-MODULE
+	void fs_incversion(uint64_t chunkid) override;
+
+	uint8_t fs_full_path_by_inode(const FsContext &context, inode_t inode,
+	                              std::string &fullPath) override;
+
 #endif
+	void fs_add_files_to_chunks(bool isMetadataLoading = true) override;
+
+	// Functions which apply changes from changelog, only for shadow master and metarestore
+	uint8_t fs_apply_checksum(const std::string &version, uint64_t checksum) override;
+	uint8_t fs_apply_create(uint32_t timestamp, inode_t parent, const HString &name,
+	                        FSNodeType type, uint32_t mode, uint32_t uid, uint32_t gid,
+	                        uint32_t rdev, inode_t inode) override;
+	uint8_t fs_apply_access(uint32_t timestamp, inode_t inode) override;
+	uint8_t fs_apply_attr(uint32_t timestamp, inode_t inode, uint32_t mode, uint32_t uid,
+	                      uint32_t gid, uint32_t atime, uint32_t mtime) override;
+	uint8_t fs_apply_session(uint32_t sessionid) override;
+	uint8_t fs_apply_incversion(uint64_t chunkid) override;
+	uint8_t fs_apply_length(uint32_t timestamp, inode_t inode, uint64_t length,
+	                        bool eraseFurtherChunks) override;
+	uint8_t fs_apply_repair(uint32_t timestamp, inode_t inode, uint32_t indx,
+	                        uint32_t nversion) override;
+	uint8_t fs_apply_setxattr(uint32_t timestamp, inode_t inode, uint32_t anleng,
+	                          const uint8_t *attrname, uint32_t avleng, const uint8_t *attrvalue,
+	                          uint32_t mode) override;
+	uint8_t fs_apply_setacl(uint32_t timestamp, inode_t inode, char aclType,
+	                        const char *aclString) override;
+	uint8_t fs_apply_setrichacl(uint32_t timestamp, inode_t inode,
+	                            const std::string &acl_string) override;
+	uint8_t fs_apply_unlink(uint32_t timestamp, inode_t parent, const HString &name,
+	                        inode_t inode) override;
+	uint8_t fs_apply_unlock(uint64_t chunkid) override;
+	uint8_t fs_apply_trunc(uint32_t timestamp, inode_t inode, uint32_t indx, uint64_t chunkid,
+	                       uint32_t lockid) override;
 
 	// Locks
 
@@ -117,13 +309,3 @@ private:
 	                                            uint64_t end,
 	                                            std::vector<FileLocks::Owner> &applied);
 };
-
-// Adds an entry to a changelog, updates filesystem.cc internal structures, prepends a
-// proper timestamp to changelog entry and broadcasts it to metaloggers and shadow masters
-void fs_changelog(uint32_t ts, const char *format, ...)
-    __attribute__((__format__(__printf__, 2, 3)));
-void fs_add_files_to_chunks(bool isMetadataLoading = true);
-
-uint64_t fs_getversion();
-
-uint8_t fs_full_path_by_inode(const FsContext &context, inode_t inode, std::string &fullPath);

--- a/src/master/filesystem_operations_interface.h
+++ b/src/master/filesystem_operations_interface.h
@@ -23,9 +23,26 @@
 #include <map>
 #include <memory>
 
+#include "common/attributes.h"
 #include "common/goal.h"
+#include "master/filesystem_node_types.h"
 #include "master/fs_context.h"
 #include "master/locks.h"
+#include "master/setgoal_task.h"
+#include "master/settrashtime_task.h"
+
+class HString;
+class AccessControlList;
+class RichACL;
+
+struct DirectoryEntry;
+struct ChunkWithAddressAndLabel;
+
+struct QuotaEntry;
+struct QuotaOwner;
+
+struct NamedInodeEntry;
+struct HandleInodeEntry;
 
 /// Interface for filesystem operations extensibility.
 /// Classes implementing this interface can be used to override default filesystem behavior.
@@ -43,15 +60,216 @@ public:
 	/// Virtual destructor
 	virtual ~IFilesystemOperations() = default;
 
-#ifndef METARESTORE
-	// Goals
+	/// Returns version of the loaded metadata.
+	virtual uint64_t fs_getversion() = 0;
 
+	/// Adds an entry to a changelog, updates filesystem.cc internal structures, prepends a
+	/// proper timestamp to changelog entry and broadcasts it to metaloggers and shadow masters.
+	/// The attribute is used to ensure printf-like format string checking by the compiler.
+	virtual void fs_changelog(uint32_t ts, const char *format, ...)
+	    __attribute__((__format__(__printf__, 3, 4))) = 0;
+
+	// Functions which create/apply (depending on the given context) changes to the metadata.
+	// Common for metarestore and master server (both personalities)
+
+	virtual uint8_t fs_acquire(const FsContext &context, inode_t inode, uint32_t sessionid) = 0;
+	virtual uint8_t fs_append(const FsContext &context, inode_t inode, inode_t inode_src) = 0;
+	virtual uint8_t fs_deleteacl(const FsContext &context, inode_t inode, AclType type) = 0;
+	virtual uint8_t fs_link(const FsContext &context, inode_t inode_src, inode_t parent_dst,
+	                        const HString &name_dst, inode_t *inode, Attributes *attr) = 0;
+	virtual uint8_t fs_purge(const FsContext &context, inode_t inode) = 0;
+	virtual uint8_t fs_rename(const FsContext &context, inode_t parent_src, const HString &name_src,
+	                          inode_t parent_dst, const HString &name_dst, inode_t *inode,
+	                          Attributes *attr) = 0;
+	virtual uint8_t fs_release(const FsContext &context, inode_t inode, uint32_t sessionid) = 0;
+	virtual uint8_t fs_seteattr(const FsContext &context, inode_t inode, uint8_t eattr,
+	                            uint8_t smode, inode_t *sinodes, inode_t *ncinodes,
+	                            inode_t *nsinodes) = 0;
+	virtual uint8_t fs_setgoal(const FsContext &context, inode_t inode, uint8_t goal, uint8_t smode,
+	                           std::shared_ptr<SetGoalTask::StatsArray> setgoal_stats,
+	                           const std::function<void(int)> &callback) = 0;
+	virtual uint8_t fs_apply_setgoal(const FsContext &context, inode_t inode, uint8_t goal,
+	                                 uint8_t smode, uint32_t master_result) = 0;
+	virtual uint8_t fs_settrashpath(const FsContext &context, inode_t inode,
+	                                const std::string &path) = 0;
+	virtual uint8_t fs_settrashtime(
+	    const FsContext &context, inode_t inode, uint32_t trashtime, uint8_t smode,
+	    std::shared_ptr<SetTrashtimeTask::StatsArray> settrashtime_stats,
+	    const std::function<void(int)> &callback) = 0;
+	virtual uint8_t fs_apply_settrashtime(const FsContext &context, inode_t inode,
+	                                      uint32_t trashtime, uint8_t smode,
+	                                      uint32_t master_result) = 0;
+	virtual uint8_t fs_symlink(const FsContext &context, inode_t parent, const HString &name,
+	                           const std::string &path, inode_t *inode, Attributes *attr) = 0;
+	virtual uint8_t fs_undel(const FsContext &context, inode_t inode) = 0;
+	virtual uint8_t fs_writechunk(const FsContext &context, inode_t inode, uint32_t indx,
+	                              bool usedummylockid,
+	                              /* inout */ uint32_t *lockid, uint64_t *chunkid, uint8_t *opflag,
+	                              uint64_t *length, uint32_t min_server_version = 0) = 0;
+	virtual uint8_t fs_set_nextchunkid(const FsContext &context, uint64_t nextChunkId) = 0;
+
+#ifndef METARESTORE
 	/// Returns a map with all defined goals.
 	virtual const std::map<int, Goal> &fs_get_goal_definitions() const = 0;
 
 	/// Returns goal definition for given goal id.
 	virtual const Goal &fs_get_goal_definition(uint8_t goalId) const = 0;
+
+	virtual uint32_t fs_reserve_job_id() = 0;
+
+	virtual uint8_t fs_access(const FsContext &context, inode_t inode, int modemask) = 0;
+	virtual uint8_t fs_lookup(const FsContext &context, inode_t parent, const HString &name,
+	                          inode_t *inode, Attributes &attr) = 0;
+	virtual uint8_t fs_whole_path_lookup(const FsContext &context, inode_t parent,
+	                                     const std::string &path, inode_t *found_inode,
+	                                     Attributes &attr) = 0;
+	virtual uint8_t fs_getattr(const FsContext &context, inode_t inode, Attributes &attr) = 0;
+	virtual uint8_t fs_try_setlength(const FsContext &context, inode_t inode, uint8_t opened,
+	                                 uint64_t length, bool denyTruncatingParity, uint32_t lockid,
+	                                 Attributes &attr, uint64_t *chunkid) = 0;
+	virtual uint8_t fs_do_setlength(const FsContext &context, inode_t inode, uint64_t length,
+	                                Attributes &attr) = 0;
+	virtual uint8_t fs_setattr(const FsContext &context, inode_t inode, uint8_t setmask,
+	                           uint16_t attrmode, uint32_t attruid, uint32_t attrgid,
+	                           uint32_t attratime, uint32_t attrmtime,
+	                           SugidClearMode sugidclearmode, Attributes &attr) = 0;
+	virtual uint8_t fs_readlink(const FsContext &context, inode_t inode, std::string &path) = 0;
+	virtual void fs_statfs(const FsContext &context, uint64_t *totalspace, uint64_t *availspace,
+	                       uint64_t *trashspace, uint64_t *reservedspace, inode_t *inodes) = 0;
+	virtual uint8_t fs_mknod(const FsContext &context, inode_t parent, const HString &name,
+	                         FSNodeType type, uint16_t mode, uint16_t umask, uint32_t rdev,
+	                         inode_t *inode, Attributes &attr) = 0;
+	virtual uint8_t fs_mkdir(const FsContext &context, inode_t parent, const HString &name,
+	                         uint16_t mode, uint16_t umask, uint8_t copysgid, inode_t *inode,
+	                         Attributes &attr) = 0;
+	virtual uint8_t fs_remove_chunk_from_file(const FsContext &context, inode_t inode,
+	                                          uint64_t chunkId) = 0;
+	virtual uint8_t fs_repair(const FsContext &context, inode_t inode, uint8_t correct_only,
+	                          uint32_t *notchanged, uint32_t *erased, uint32_t *repaired) = 0;
+	virtual uint8_t fs_rmdir(const FsContext &context, inode_t parent, const HString &name) = 0;
+	virtual uint8_t fs_recursive_remove(const FsContext &context, inode_t parent,
+	                                    const HString &name,
+	                                    const std::function<void(int)> &callback,
+	                                    uint32_t job_id) = 0;
+	virtual uint8_t fs_readdir_size(const FsContext &context, inode_t inode, uint8_t flags,
+	                                void **dnode, uint32_t *dbuffsize) = 0;
+	virtual void fs_readdir_data(const FsContext &context, uint8_t flags, void *dnode,
+	                             uint8_t *dbuff) = 0;
+
+	virtual uint8_t fs_readdir(const FsContext &context, inode_t inode, uint64_t first_entry,
+	                           uint64_t number_of_entries,
+	                           std::vector<DirectoryEntry> &dir_entries) = 0;
+
+	virtual uint8_t fs_checkfile(const FsContext &context, inode_t inode,
+	                             uint32_t chunkcount[CHUNK_MATRIX_SIZE]) = 0;
+	virtual uint8_t fs_opencheck(const FsContext &context, inode_t inode, uint8_t flags,
+	                             Attributes &attr) = 0;
+	virtual uint8_t fs_getgoal(const FsContext &context, inode_t inode, uint8_t gmode,
+	                           GoalStatistics &fgtab, GoalStatistics &dgtab) = 0;
+	virtual uint8_t fs_geteattr(const FsContext &context, inode_t inode, uint8_t gmode,
+	                            uint32_t feattrtab[16], uint32_t deattrtab[16]) = 0;
+	virtual uint8_t fs_listxattr_leng(const FsContext &context, inode_t inode, uint8_t opened,
+	                                  void **xanode, uint32_t *xasize) = 0;
+	virtual uint8_t fs_getxattr(const FsContext &context, inode_t inode, uint8_t opened,
+	                            uint8_t anleng, const uint8_t *attrname, uint32_t *avleng,
+	                            uint8_t **attrvalue) = 0;
+	virtual uint8_t fs_setxattr(const FsContext &context, inode_t inode, uint8_t opened,
+	                            uint8_t anleng, const uint8_t *attrname, uint32_t avleng,
+	                            const uint8_t *attrvalue, uint8_t mode) = 0;
+	virtual uint8_t fs_unlink(const FsContext &context, inode_t parent, const HString &name) = 0;
+	virtual uint8_t fs_getchunksinfo(const FsContext &context, uint32_t current_ip, inode_t inode,
+	                                 uint32_t chunk_index, uint32_t chunk_count,
+	                                 std::vector<ChunkWithAddressAndLabel> &chunks) = 0;
+	virtual uint8_t fs_gettrashtime_prepare(const FsContext &context, inode_t inode, uint8_t gmode,
+	                                        TrashtimeMap &fileTrashtimes,
+	                                        TrashtimeMap &dirTrashtimes) = 0;
+	virtual uint8_t fs_setacl(const FsContext &context, inode_t inode, AclType type,
+	                          const AccessControlList &acl) = 0;
+	virtual uint8_t fs_setacl(const FsContext &context, inode_t inode, const RichACL &acl) = 0;
+	virtual uint8_t fs_getacl(const FsContext &context, inode_t inode, RichACL &acl) = 0;
+
+	// Functions which modify metadata or return some information.
+	// To be used by the master server with personality == kMaster
+	virtual void fs_info(uint64_t *totalSpace, uint64_t *availableSpace, uint64_t *trashSpace,
+	             inode_t *trashNodes, uint64_t *reservedSpace, inode_t *reservedNodes,
+	             inode_t *inodes, inode_t *directoryNodes, inode_t *fileNodes, inode_t *linkNodes) = 0;
+	virtual uint32_t fs_getdirpath_size(inode_t inode) = 0;
+	virtual void fs_getdirpath_data(inode_t inode, uint8_t *buff, uint32_t size) = 0;
+	virtual uint8_t fs_getrootinode(inode_t *rootinode, const uint8_t *path) = 0;
+	virtual uint8_t fs_end_setlength(uint64_t chunkid) = 0;
+	virtual uint8_t fs_readchunk(inode_t inode, uint32_t indx, uint64_t *chunkid, uint64_t *length) = 0;
+	virtual uint8_t fs_writeend(inode_t inode, uint64_t length, uint64_t chunkid, uint32_t lockid) = 0;
+	virtual void fs_gettrashtime_store(TrashtimeMap &fileTrashtimes, TrashtimeMap &dirTrashtimes,
+	                                   uint8_t *buff) = 0;
+	virtual void fs_listxattr_data(void *xanode, uint8_t *xabuff) = 0;
+
+	virtual uint32_t fs_newsessionid(void) = 0;
+
+	// RESERVED
+	virtual uint8_t fs_readreserved_size(inode_t rootinode, uint8_t sesflags, uint32_t *dbuffsize) = 0;
+	virtual void fs_readreserved_data(inode_t rootinode, uint8_t sesflags, uint8_t *dbuff) = 0;
+	virtual void fs_readreserved(uint32_t off, uint32_t max_entries,
+	                             std::vector<NamedInodeEntry> &entries) = 0;
+	virtual void fs_readreserved(uint64_t handleOffset, uint32_t maxEntries,
+	                             std::vector<HandleInodeEntry> &entries) = 0;
+
+	// TRASH
+	virtual uint8_t fs_readtrash_size(inode_t rootinode, uint8_t sesflags, uint32_t *dbuffsize) = 0;
+	virtual void fs_readtrash_data(inode_t rootinode, uint8_t sesflags, uint8_t *dbuff) = 0;
+	virtual void fs_readtrash(uint32_t off, uint32_t max_entries,
+	                          std::vector<NamedInodeEntry> &entries) = 0;
+	virtual void fs_readtrash(uint64_t handleOffset, uint32_t maxEntries,
+	                          std::vector<HandleInodeEntry> &entries) = 0;
+	virtual uint8_t fs_gettrashpath(inode_t rootinode, uint8_t sesflags, inode_t inode, std::string &path) = 0;
+
+	// RESERVED+TRASH
+	virtual uint8_t fs_getdetachedattr(inode_t rootinode, uint8_t sesflags, inode_t inode,
+	                                   Attributes &attr, uint8_t dtype) = 0;
+
+	// EXTRA
+	virtual uint8_t fs_get_dir_stats(const FsContext &context, inode_t inode, inode_t *inodes,
+	                                 inode_t *dirs, inode_t *files, inode_t *links,
+	                                 uint32_t *chunks, uint64_t *length, uint64_t *size,
+	                                 uint64_t *rsize) = 0;
+	virtual uint8_t fs_get_chunkid(const FsContext &context, inode_t inode, uint32_t index,
+	                               uint64_t *chunkid) = 0;
+
+	// SPECIAL - LOG EMERGENCY INCREASE VERSION FROM CHUNKS-MODULE
+	virtual void fs_incversion(uint64_t chunkid) = 0;
+
+	virtual uint8_t fs_full_path_by_inode(const FsContext &context, inode_t inode,
+	                                      std::string &fullPath) = 0;
+
 #endif
+	virtual void fs_add_files_to_chunks(bool isMetadataLoading = true) = 0;
+
+	// Functions which apply changes from changelog, only for shadow master and metarestore
+	virtual uint8_t fs_apply_checksum(const std::string &version, uint64_t checksum) = 0;
+	virtual uint8_t fs_apply_create(uint32_t timestamp, inode_t parent, const HString &name,
+	                                FSNodeType type, uint32_t mode, uint32_t uid, uint32_t gid,
+	                                uint32_t rdev, inode_t inode) = 0;
+	virtual uint8_t fs_apply_access(uint32_t timestamp, inode_t inode) = 0;
+	virtual uint8_t fs_apply_attr(uint32_t timestamp, inode_t inode, uint32_t mode, uint32_t uid,
+	                              uint32_t gid, uint32_t atime, uint32_t mtime) = 0;
+	virtual uint8_t fs_apply_session(uint32_t sessionid) = 0;
+	// virtual uint8_t fs_apply_freeinodes(uint32_t timestamp, inode_t freeinodes) = 0;
+	virtual uint8_t fs_apply_incversion(uint64_t chunkid) = 0;
+	virtual uint8_t fs_apply_length(uint32_t timestamp, inode_t inode, uint64_t length,
+	                                bool eraseFurtherChunks) = 0;
+	virtual uint8_t fs_apply_repair(uint32_t timestamp, inode_t inode, uint32_t indx,
+	                                uint32_t nversion) = 0;
+	virtual uint8_t fs_apply_setxattr(uint32_t timestamp, inode_t inode, uint32_t anleng,
+	                                  const uint8_t *attrname, uint32_t avleng,
+	                                  const uint8_t *attrvalue, uint32_t mode) = 0;
+	virtual uint8_t fs_apply_setacl(uint32_t timestamp, inode_t inode, char aclType,
+	                                const char *aclString) = 0;
+	virtual uint8_t fs_apply_setrichacl(uint32_t timestamp, inode_t inode,
+	                                    const std::string &acl_string) = 0;
+	virtual uint8_t fs_apply_unlink(uint32_t timestamp, inode_t parent, const HString &name,
+	                                inode_t inode) = 0;
+	virtual uint8_t fs_apply_unlock(uint64_t chunkid) = 0;
+	virtual uint8_t fs_apply_trunc(uint32_t timestamp, inode_t inode, uint32_t indx,
+	                               uint64_t chunkid, uint32_t lockid) = 0;
 
 	// Lock operations
 

--- a/src/master/filesystem_periodic.cc
+++ b/src/master/filesystem_periodic.cc
@@ -37,7 +37,7 @@
 #include "master/filesystem_checksum_updater.h"
 #include "master/filesystem_metadata.h"
 #include "master/filesystem_node.h"
-#include "master/filesystem_operations.h"
+#include "master/filesystem_operations_interface.h"
 #include "master/matoclserv.h"
 
 #define MSGBUFFSIZE 1000000
@@ -550,7 +550,7 @@ static void fs_do_emptytrash(uint32_t ts) {
 		fsnodes_purge(ts, node);
 
 		// Purge operation should be performed anyway - if it fails, inode will be reserved
-		fs_changelog(ts, "PURGE(%" PRIiNode ")", node_id);
+		gFilesystemOperations->fs_changelog(ts, "PURGE(%" PRIiNode ")", node_id);
 
 		it = gMetadata->trash.begin();
 
@@ -586,7 +586,7 @@ static void fs_do_emptyreserved(uint32_t ts) {
 		fsnodes_purge(ts, node);
 
 		// Purge operation should be performed anyway
-		fs_changelog(ts, "PURGE(%" PRIiNode ")", node_id);
+		gFilesystemOperations->fs_changelog(ts, "PURGE(%" PRIiNode ")", node_id);
 
 		it = gMetadata->reserved.begin();
 

--- a/src/master/filesystem_quota.cc
+++ b/src/master/filesystem_quota.cc
@@ -29,6 +29,7 @@
 #include "master/filesystem_checksum_updater.h"
 #include "master/filesystem_metadata.h"
 #include "master/filesystem_node.h"
+#include "master/filesystem_operations_interface.h"
 
 template <class T>
 bool decodeChar(const char *keys, const std::vector<T> values, char key, T &value) {
@@ -246,10 +247,10 @@ uint8_t fs_quota_set(const FsContext &context, const std::vector<QuotaEntry> &en
 		                              entry.entryKey.resource, entry.limit);
 		gMetadata->quotaDatabase.removeEmpty(owner.ownerType, owner.ownerId);
 		gMetadata->quotaChecksum = gMetadata->quotaDatabase.checksum();
-		fs_changelog(ts, "SETQUOTA(%c,%c,%c,%" PRIiNode ",%" PRIu64 ")",
-		             rigor_name[(int)entry.entryKey.rigor],
-		             resource_name[(int)entry.entryKey.resource], owner_name[(int)owner.ownerType],
-		             inode_t{owner.ownerId}, uint64_t{entry.limit});
+		gFilesystemOperations->fs_changelog(
+		    ts, "SETQUOTA(%c,%c,%c,%" PRIiNode ",%" PRIu64 ")",
+		    rigor_name[(int)entry.entryKey.rigor], resource_name[(int)entry.entryKey.resource],
+		    owner_name[(int)owner.ownerType], inode_t{owner.ownerId}, uint64_t{entry.limit});
 	}
 	return SAUNAFS_STATUS_OK;
 }

--- a/src/master/masterconn.cc
+++ b/src/master/masterconn.cc
@@ -52,6 +52,7 @@
 #include "config/cfg.h"
 #include "errors/saunafs_error_codes.h"
 #include "master/changelog.h"
+#include "master/filesystem_operations_interface.h"
 #include "master/metadata_backend_common.h"
 #include "master/metadata_backend_interface.h"
 #include "protocol/SFSCommunication.h"
@@ -334,7 +335,7 @@ void MasterConn::sendRegister() {
 #ifndef METALOGGER
 	// shadow master registration
 	uint64_t metadataVersion = 0;
-	if (state == State::kSynchronized) { metadataVersion = fs_getversion(); }
+	if (state == State::kSynchronized) { metadataVersion = gFilesystemOperations->fs_getversion(); }
 	auto request = mltoma::registerShadow::build(
 	    SAUNAFS_VERSHEX, cfgMasterTimeout * kMillisecondsInSecond, metadataVersion);
 	createPacket(std::move(request));
@@ -431,7 +432,8 @@ void MasterConn::onRegistered(const uint8_t *data, uint32_t length) {
 		                                    masterMetadataVersion);
 		masterVersion = incommingMasterVersion;
 		sendMatoClPort();
-		if ((state == State::kSynchronized) && (fs_getversion() != masterMetadataVersion)) {
+		if ((state == State::kSynchronized) &&
+		    (gFilesystemOperations->fs_getversion() != masterMetadataVersion)) {
 			forceMetadataDownload();
 		}
 	} else {
@@ -610,7 +612,7 @@ void MasterConn::downloadNext() {
 				if (state == State::kDownloading) {
 					try {
 						fs_loadall(false);
-						lastLogVersion = fs_getversion() - 1;
+						lastLogVersion = gFilesystemOperations->fs_getversion() - 1;
 						safs::log_info("synced at version = {}", lastLogVersion);
 						state = State::kSynchronized;
 					} catch (Exception &ex) {

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -454,7 +454,7 @@ void matoclserv_chunk_status(uint64_t chunkId, uint8_t status, bool isFailedCrea
 	case FUSE_WRITE:
 		if (status != SAUNAFS_STATUS_OK) {
 			if (isFailedCreateOperation) {
-				fs_remove_chunk_from_file(context, inode, chunkId);
+				gFilesystemOperations->fs_remove_chunk_from_file(context, inode, chunkId);
 			}
 			serializer->serializeFuseWriteChunk(reply, messageId, status);
 			matoclserv_createpacket(eptr, std::move(reply));
@@ -463,7 +463,7 @@ void matoclserv_chunk_status(uint64_t chunkId, uint8_t status, bool isFailedCrea
 					chunkId, messageId, fileLength, lockId);
 		}
 		if (status != SAUNAFS_STATUS_OK) {
-			fs_writeend(0, 0, chunkId, 0); // ignore status - just do it.
+			gFilesystemOperations->fs_writeend(0, 0, chunkId, 0);  // ignore status - just do it.
 		}
 		return;
 	case FUSE_TRUNCATE_BEGIN:
@@ -476,12 +476,12 @@ void matoclserv_chunk_status(uint64_t chunkId, uint8_t status, bool isFailedCrea
 		return;
 	case FUSE_TRUNCATE:
 	case FUSE_TRUNCATE_END:
-		fs_end_setlength(chunkId);
+		gFilesystemOperations->fs_end_setlength(chunkId);
 		if (status != SAUNAFS_STATUS_OK) {
 			serializer->serializeFuseTruncate(reply, operationType, messageId, status);
 		} else {
 			Attributes attr;
-			fs_do_setlength(context, inode, fileLength, attr);
+			gFilesystemOperations->fs_do_setlength(context, inode, fileLength, attr);
 			serializer->serializeFuseTruncate(reply, operationType, messageId, attr);
 		}
 		matoclserv_createpacket(eptr, std::move(reply));
@@ -611,7 +611,7 @@ void matoclserv_metadataserver_status(matoclserventry* eptr, const uint8_t* data
 
 	uint64_t metadataVersion = 0;
 	try {
-		metadataVersion = fs_getversion();
+		metadataVersion = gFilesystemOperations->fs_getversion();
 	} catch (NoMetadataException &) {}
 
 	uint8_t status =
@@ -714,7 +714,7 @@ void matoclserv_session_list(matoclserventry *eptr, const uint8_t *data, uint32_
 				size += 1;  // for '.'
 			} else {
 				size += sizeof(pathLength);
-				size += fs_getdirpath_size(eaptr->sessionData->rootInode);
+				size += gFilesystemOperations->fs_getdirpath_size(eaptr->sessionData->rootInode);
 			}
 		}
 	}
@@ -743,10 +743,12 @@ void matoclserv_session_list(matoclserventry *eptr, const uint8_t *data, uint32_
 				putINode(&ptr, static_cast<inode_t>(1));
 				put8bit(&ptr, '.');
 			} else {
-				pathLength = fs_getdirpath_size(eaptr->sessionData->rootInode);
+				pathLength =
+				    gFilesystemOperations->fs_getdirpath_size(eaptr->sessionData->rootInode);
 				put32bit(&ptr, pathLength);
 				if (pathLength > 0) {
-					fs_getdirpath_data(eaptr->sessionData->rootInode, ptr, pathLength);
+					gFilesystemOperations->fs_getdirpath_data(eaptr->sessionData->rootInode, ptr,
+					                                          pathLength);
 					ptr += pathLength;
 				}
 			}
@@ -884,11 +886,11 @@ void matoclserv_info(matoclserventry *eptr, const uint8_t *data, uint32_t length
 	statistics.version = saunafsVersion(SAUNAFS_PACKAGE_VERSION_MAJOR,
 			SAUNAFS_PACKAGE_VERSION_MINOR, SAUNAFS_PACKAGE_VERSION_MICRO);
 
-	fs_info(&statistics.totalSpace, &statistics.availableSpace,
-	        &statistics.trashSpace, &statistics.trashNodes,
-	        &statistics.reservedSpace, &statistics.reservedNodes,
-	        &statistics.allNodes, &statistics.dirNodes, &statistics.fileNodes,
-	        &statistics.symlinkNodes);
+	gFilesystemOperations->fs_info(&statistics.totalSpace, &statistics.availableSpace,
+	                               &statistics.trashSpace, &statistics.trashNodes,
+	                               &statistics.reservedSpace, &statistics.reservedNodes,
+	                               &statistics.allNodes, &statistics.dirNodes,
+	                               &statistics.fileNodes, &statistics.symlinkNodes);
 
 	chunk_info(&statistics.chunks, &statistics.chunkCopies, &statistics.regularCopies);
 
@@ -1204,7 +1206,7 @@ void matoclserv_fuse_register(matoclserventry *eptr, const uint8_t *data, uint32
 			}
 
 			if (status == SAUNAFS_STATUS_OK) {
-				status = fs_getrootinode(&rootInode, path);
+				status = gFilesystemOperations->fs_getrootinode(&rootInode, path);
 			}
 
 			if (status == SAUNAFS_STATUS_OK) {
@@ -1486,7 +1488,7 @@ void matoclserv_fuse_reserved_inodes(matoclserventry *eptr, const uint8_t *data,
 		inode_t openFileIno = *it;
 		if (!inodes_to_reserve.contains(openFileIno)) {
 			// erase files not belonging to the reserve inodes list provided
-			fs_release(context, openFileIno, eptr->sessionData->sessionId);
+			gFilesystemOperations->fs_release(context, openFileIno, eptr->sessionData->sessionId);
 			it = eptr->sessionData->openFilesSet.erase(it);
 		} else {
 			// skip files already in session
@@ -1497,8 +1499,8 @@ void matoclserv_fuse_reserved_inodes(matoclserventry *eptr, const uint8_t *data,
 	}
 
 	for (const auto &inode_to_reserve : inodes_to_reserve) {
-		if (fs_acquire(context, inode_to_reserve, eptr->sessionData->sessionId) ==
-		    SAUNAFS_STATUS_OK) {
+		if (gFilesystemOperations->fs_acquire(context, inode_to_reserve,
+		                                      eptr->sessionData->sessionId) == SAUNAFS_STATUS_OK) {
 			// Insert reserved inodes into the opened files set
 			eptr->sessionData->openFilesSet.insert(inode_to_reserve);
 		}
@@ -1523,7 +1525,8 @@ void matoclserv_fuse_statfs(matoclserventry *eptr, const uint8_t *data, uint32_t
 
 	get32bit(&data, msgid);
 	FsContext context = matoclserv_get_context(eptr);
-	fs_statfs(context, &totalspace, &availspace, &trashspace, &reservedspace, &inodes);
+	gFilesystemOperations->fs_statfs(context, &totalspace, &availspace, &trashspace, &reservedspace,
+	                                 &inodes);
 
 	constexpr uint32_t kPacketSize = sizeof(msgid) + sizeof(totalspace) + sizeof(availspace) +
 	                                 sizeof(trashspace) + sizeof(reservedspace) + sizeof(inodes);
@@ -1565,7 +1568,7 @@ void matoclserv_fuse_access(matoclserventry *eptr, const uint8_t *data, uint32_t
 	if (status == SAUNAFS_STATUS_OK && inode != SPECIAL_INODE_PATH_BY_INODE &&
 	    inode != SPECIAL_INODE_FILE_BY_INODE) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = fs_access(context, inode, modemask);
+		status = gFilesystemOperations->fs_access(context, inode, modemask);
 	}
 
 	constexpr uint8_t kAnswerSize = sizeof(msgid) + sizeof(status);
@@ -1588,7 +1591,8 @@ void matoclserv_sau_whole_path_lookup(matoclserventry *eptr, const uint8_t *data
 	status = matoclserv_check_group_cache(eptr, gid);
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = fs_whole_path_lookup(context, inode, path, &found_inode, attr);
+		status =
+		    gFilesystemOperations->fs_whole_path_lookup(context, inode, path, &found_inode, attr);
 	}
 
 	if (status != SAUNAFS_STATUS_OK) {
@@ -1611,7 +1615,7 @@ void matoclserv_sau_full_path_by_inode(matoclserventry *eptr, const uint8_t *dat
 	status = matoclserv_check_group_cache(eptr, gid);
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = fs_full_path_by_inode(context, inode, fullPath);
+		status = gFilesystemOperations->fs_full_path_by_inode(context, inode, fullPath);
 	}
 
 	if (status != SAUNAFS_STATUS_OK) {
@@ -1702,7 +1706,7 @@ void matoclserv_fuse_getattr(matoclserventry *eptr, const uint8_t *data, uint32_
 	status = matoclserv_check_group_cache(eptr, gid);
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = fs_getattr(context,inode,attr);
+		status = gFilesystemOperations->fs_getattr(context, inode, attr);
 	}
 
 	constexpr uint32_t kFailedAnswerSize = sizeof(msgid) + sizeof(status);
@@ -1768,8 +1772,9 @@ void matoclserv_fuse_setattr(matoclserventry *eptr, const uint8_t *data, uint32_
 
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = fs_setattr(context, inode, setmask, attrmode, attruid, attrgid,
-							attratime, attrmtime, sugidclearmode, attr);
+		status =
+		    gFilesystemOperations->fs_setattr(context, inode, setmask, attrmode, attruid, attrgid,
+		                                      attratime, attrmtime, sugidclearmode, attr);
 	}
 
 	constexpr uint32_t kFailedAnswerSize = sizeof(msgid) + sizeof(status);
@@ -1818,11 +1823,12 @@ void matoclserv_fuse_truncate(matoclserventry *eptr, PacketHeader header, const 
 				status = SAUNAFS_ERROR_WRONGLOCKID;
 			} else {
 				// let's check if chunk is still locked by us
-				status = fs_get_chunkid(context, inode, length / SFSCHUNKSIZE, &chunkId);
+				status = gFilesystemOperations->fs_get_chunkid(context, inode,
+				                                               length / SFSCHUNKSIZE, &chunkId);
 				if (status == SAUNAFS_STATUS_OK) {
 					status = chunk_can_unlock(chunkId, lockId);
 				}
-				fs_end_setlength(chunkId);
+				gFilesystemOperations->fs_end_setlength(chunkId);
 			}
 		}
 	} else {
@@ -1837,8 +1843,8 @@ void matoclserv_fuse_truncate(matoclserventry *eptr, PacketHeader header, const 
 	// Try to do the truncate
 	Attributes attr;
 	if (status == SAUNAFS_STATUS_OK) {
-		status = fs_try_setlength(context, inode, opened, length,
-								  (type != FUSE_TRUNCATE_END), lockId, attr, &chunkId);
+		status = gFilesystemOperations->fs_try_setlength(
+		    context, inode, opened, length, (type != FUSE_TRUNCATE_END), lockId, attr, &chunkId);
 	}
 
 	// In case of SAUNAFS_ERROR_NOTPOSSIBLE we have to tell the client to write the chunk before truncating
@@ -1846,8 +1852,8 @@ void matoclserv_fuse_truncate(matoclserventry *eptr, PacketHeader header, const 
 		// New client requested to truncate xor chunk. He has to do it himself.
 		uint64_t fileLength;
 		uint8_t opflag;
-		fs_writechunk(context, inode, length / SFSCHUNKSIZE, false,
-				&lockId, &chunkId, &opflag, &fileLength);
+		gFilesystemOperations->fs_writechunk(context, inode, length / SFSCHUNKSIZE, false, &lockId,
+		                                     &chunkId, &opflag, &fileLength);
 		if (opflag) {
 			// But first we have to duplicate chunk :)
 			type = FUSE_TRUNCATE_BEGIN;
@@ -1887,7 +1893,7 @@ void matoclserv_fuse_truncate(matoclserventry *eptr, PacketHeader header, const 
 		return;
 	}
 	if (status == SAUNAFS_STATUS_OK) {
-		status = fs_do_setlength(context, inode, length, attr);
+		status = gFilesystemOperations->fs_do_setlength(context, inode, length, attr);
 	}
 	if (status == SAUNAFS_STATUS_OK) {
 		dcm_modify(inode, eptr->sessionData->sessionId);
@@ -1927,7 +1933,7 @@ void matoclserv_fuse_readlink(matoclserventry *eptr, const uint8_t *data, uint32
 	getINode(&data, inode);
 
 	FsContext context = matoclserv_get_context(eptr);
-	status = fs_readlink(context, inode, path);
+	status = gFilesystemOperations->fs_readlink(context, inode, path);
 
 	constexpr uint32_t kFailedAnswerSize = sizeof(msgid) + sizeof(status);
 	constexpr uint32_t kSuccessAnswerSize = sizeof(msgid) + sizeof(uint32_t);
@@ -2010,8 +2016,9 @@ void matoclserv_fuse_symlink(matoclserventry *eptr, const uint8_t *data, uint32_
 	status = matoclserv_check_group_cache(eptr, gid);
 	if (status == SAUNAFS_STATUS_OK) {
 		auto context = matoclserv_get_context(eptr, uid, gid);
-		status = fs_symlink(context, inode, HString((char *)name, nleng),
-	                    std::string((char *)path, pleng), &newinode, &attr);
+		status =
+		    gFilesystemOperations->fs_symlink(context, inode, HString((char *)name, nleng),
+		                                      std::string((char *)path, pleng), &newinode, &attr);
 	}
 
 	constexpr uint32_t kFailedAnswerSize = sizeof(msgid) + sizeof(status);
@@ -2055,8 +2062,9 @@ void matoclserv_fuse_mknod(matoclserventry *eptr, PacketHeader header, const uin
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
 
-		status = fs_mknod(context, inode, HString(std::move(name)), static_cast<FSNodeType>(type),
-		                  mode, umask, rdev, &newinode, attr);
+		status = gFilesystemOperations->fs_mknod(context, inode, HString(std::move(name)),
+		                                         static_cast<FSNodeType>(type), mode, umask, rdev,
+		                                         &newinode, attr);
 	}
 
 	MessageBuffer reply;
@@ -2092,8 +2100,8 @@ void matoclserv_fuse_mkdir(matoclserventry *eptr, PacketHeader header, const uin
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
 
-		status = fs_mkdir(context, inode, HString(std::move(name)), mode, umask,
-						copysgid, &newinode, attr);
+		status = gFilesystemOperations->fs_mkdir(context, inode, HString(std::move(name)), mode,
+		                                         umask, copysgid, &newinode, attr);
 	}
 
 	MessageBuffer reply;
@@ -2147,7 +2155,7 @@ void matoclserv_fuse_unlink(matoclserventry *eptr, const uint8_t *data, uint32_t
 
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = fs_unlink(context,inode, HString((char*)name, nleng));
+		status = gFilesystemOperations->fs_unlink(context, inode, HString((char *)name, nleng));
 	}
 
 	ptr = matoclserv_createpacket(eptr, MATOCL_FUSE_UNLINK, sizeof(msgid) + sizeof(status));
@@ -2180,9 +2188,11 @@ void matoclserv_fuse_recursive_remove(matoclserventry *eptr, const uint8_t *data
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
 
-		status = fs_recursive_remove(context, parent_inode, HString(name),
-					    std::bind(matoclserv_fuse_recursive_remove_wake_up,
-				      eptr->sessionData->sessionId, msgid, std::placeholders::_1), job_id);
+		status = gFilesystemOperations->fs_recursive_remove(
+		    context, parent_inode, HString(name),
+		    std::bind(matoclserv_fuse_recursive_remove_wake_up, eptr->sessionData->sessionId, msgid,
+		              std::placeholders::_1),
+		    job_id);
 	}
 	if (status != SAUNAFS_ERROR_WAITING) {
 		matoclserv_createpacket(eptr, matocl::recursiveRemove::build(msgid, status));
@@ -2228,7 +2238,7 @@ void matoclserv_fuse_rmdir(matoclserventry *eptr, const uint8_t *data, uint32_t 
 
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = fs_rmdir(context,inode,HString((char*)name, nleng));
+		status = gFilesystemOperations->fs_rmdir(context, inode, HString((char *)name, nleng));
 	}
 
 	ptr = matoclserv_createpacket(eptr, MATOCL_FUSE_RMDIR, sizeof(msgid) + sizeof(status));
@@ -2298,8 +2308,9 @@ void matoclserv_fuse_rename(matoclserventry *eptr, const uint8_t *data, uint32_t
 
 	if (status == SAUNAFS_STATUS_OK) {
 		auto context = matoclserv_get_context(eptr, uid, gid);
-		status = fs_rename(context, inode_src, HString((char*)name_src, nleng_src),
-		                   inode_dst, HString((char*)name_dst, nleng_dst), &inode, &attr);
+		status = gFilesystemOperations->fs_rename(
+		    context, inode_src, HString((char *)name_src, nleng_src), inode_dst,
+		    HString((char *)name_dst, nleng_dst), &inode, &attr);
 	}
 
 	if (eptr->version >= 0x010615 && status == SAUNAFS_STATUS_OK) {
@@ -2367,7 +2378,8 @@ void matoclserv_fuse_link(matoclserventry *eptr, const uint8_t *data, uint32_t l
 
 	if (status == SAUNAFS_STATUS_OK) {
 		auto context = matoclserv_get_context(eptr, uid, gid);
-		status = fs_link(context, inode, inode_dst, HString((char*)name_dst, nleng_dst), &newinode, &attr);
+		status = gFilesystemOperations->fs_link(
+		    context, inode, inode_dst, HString((char *)name_dst, nleng_dst), &newinode, &attr);
 	}
 
 	constexpr uint32_t kFailedAnswerSize = sizeof(msgid) + sizeof(status);
@@ -2414,7 +2426,8 @@ void matoclserv_fuse_getdir(matoclserventry *eptr,const PacketHeader &header, co
 
 		if (packet_version == cltoma::fuseGetDir::kClientAbleToProcessDirentIndex) {
 			std::vector<DirectoryEntry> dir_entries;
-			status = fs_readdir(context, inode, first_entry, number_of_entries, dir_entries); //<DirectoryEntry>
+			status = gFilesystemOperations->fs_readdir(
+			    context, inode, first_entry, number_of_entries, dir_entries);  //<DirectoryEntry>
 
 			if (status != SAUNAFS_STATUS_OK) {
 				matocl::fuseGetDir::serialize(buffer, message_id, status);
@@ -2475,7 +2488,7 @@ void matoclserv_fuse_getdir(matoclserventry *eptr, const uint8_t *data, uint32_t
 	}
 
 	FsContext context = matoclserv_get_context(eptr, uid, gid);
-	status = fs_readdir_size(context, inode, flags, &custom, &dleng);
+	status = gFilesystemOperations->fs_readdir_size(context, inode, flags, &custom, &dleng);
 
 	constexpr uint32_t kFailedAnswerSize = sizeof(msgid) + sizeof(status);
 	const uint32_t kSuccessAnswerSize = sizeof(msgid) + dleng;  // Can't be constexpr
@@ -2488,7 +2501,7 @@ void matoclserv_fuse_getdir(matoclserventry *eptr, const uint8_t *data, uint32_t
 	if (status != SAUNAFS_STATUS_OK) {
 		put8bit(&ptr, status);
 	} else {
-		fs_readdir_data(context, flags, custom, ptr);
+		gFilesystemOperations->fs_readdir_data(context, flags, custom, ptr);
 	}
 
 	eptr->sessionData->currHourOperationsStats[12]++;
@@ -2525,7 +2538,9 @@ void matoclserv_fuse_open(matoclserventry *eptr, const uint8_t *data, uint32_t l
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
 		status = matoclserv_insert_open_file(eptr->sessionData, inode);
-		if (status == SAUNAFS_STATUS_OK) { status = fs_opencheck(context, inode, flags, attr); }
+		if (status == SAUNAFS_STATUS_OK) {
+			status = gFilesystemOperations->fs_opencheck(context, inode, flags, attr);
+		}
 	}
 
 	if (eptr->version >= 0x010609 && status == SAUNAFS_STATUS_OK) {
@@ -2566,7 +2581,7 @@ void matoclserv_fuse_read_chunk(matoclserventry *eptr, PacketHeader header, cons
 	std::vector<uint8_t> receivedData(data, data + header.length);
 	serializer->deserializeFuseReadChunk(receivedData, messageId, inode, index);
 
-	status = fs_readchunk(inode, index, &chunkid, &fleng);
+	status = gFilesystemOperations->fs_readchunk(inode, index, &chunkid, &fleng);
 	std::vector<ChunkTypeWithAddress> allChunkCopies;
 	if (status == SAUNAFS_STATUS_OK) {
 		if (chunkid > 0) {
@@ -2615,8 +2630,8 @@ void matoclserv_chunks_info(matoclserventry *eptr, const uint8_t *data, uint32_t
 	status = matoclserv_check_group_cache(eptr, gid);
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status =
-		    fs_getchunksinfo(context, eptr->peerIpAddress, inode, chunk_index, chunk_count, chunks);
+		status = gFilesystemOperations->fs_getchunksinfo(context, eptr->peerIpAddress, inode,
+		                                                 chunk_index, chunk_count, chunks);
 	}
 
 	if (status != SAUNAFS_STATUS_OK) {
@@ -2648,8 +2663,9 @@ void matoclserv_fuse_write_chunk(matoclserventry *eptr, PacketHeader header, con
 
 	// Original Legacy (1.6.27) does not use lock ID's
 	bool useDummyLockId = false;
-	status = fs_writechunk(matoclserv_get_context(eptr), inode, chunkIndex, useDummyLockId,
-			&lockId, &chunkId, &opflag, &fileLength, min_server_version);
+	status = gFilesystemOperations->fs_writechunk(matoclserv_get_context(eptr), inode, chunkIndex,
+	                                              useDummyLockId, &lockId, &chunkId, &opflag,
+	                                              &fileLength, min_server_version);
 
 	if (status != SAUNAFS_STATUS_OK) {
 		serializer->serializeFuseWriteChunk(outMessage, messageId, status);
@@ -2674,7 +2690,7 @@ void matoclserv_fuse_write_chunk(matoclserventry *eptr, PacketHeader header, con
 		status = matoclserv_fuse_write_chunk_respond(eptr, serializer,
 				chunkId, messageId, fileLength, lockId);
 		if (status != SAUNAFS_STATUS_OK) {
-			fs_writeend(0, 0, chunkId, 0);  // ignore status - just do it.
+			gFilesystemOperations->fs_writeend(0, 0, chunkId, 0);  // ignore status - just do it.
 		}
 	}
 
@@ -2705,7 +2721,7 @@ void matoclserv_fuse_write_chunk_end(matoclserventry *eptr, PacketHeader header,
 	} else if (eptr->sessionData->flags & SESFLAG_READONLY) {
 		status = SAUNAFS_ERROR_EROFS;
 	} else {
-		status = fs_writeend(inode, fileLength, chunkId, lockId);
+		status = gFilesystemOperations->fs_writeend(inode, fileLength, chunkId, lockId);
 	}
 
 	dcm_modify(inode,eptr->sessionData->sessionId);
@@ -2744,8 +2760,8 @@ void matoclserv_fuse_repair(matoclserventry *eptr, const uint8_t *data, uint32_t
 
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = fs_repair(context, inode, correct_only, &chunksnotchanged, &chunkserased,
-		                   &chunksrepaired);
+		status = gFilesystemOperations->fs_repair(context, inode, correct_only, &chunksnotchanged,
+		                                          &chunkserased, &chunksrepaired);
 	}
 
 	constexpr uint32_t kFailedSize = sizeof(msgid) + sizeof(status);
@@ -2785,7 +2801,7 @@ void matoclserv_fuse_check(matoclserventry *eptr, const uint8_t *data, uint32_t 
 	get32bit(&data, msgid);
 	getINode(&data, inode);
 
-	status = fs_checkfile(matoclserv_get_context(eptr), inode, chunkcount);
+	status = gFilesystemOperations->fs_checkfile(matoclserv_get_context(eptr), inode, chunkcount);
 
 	if (status != SAUNAFS_STATUS_OK) {
 		ptr = matoclserv_createpacket(eptr,MATOCL_FUSE_CHECK, sizeof(msgid) + sizeof(status));
@@ -2826,7 +2842,7 @@ void matoclserv_fuse_check(matoclserventry *eptr, const uint8_t *data, uint32_t 
 void matoclserv_fuse_request_task_id(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	uint32_t msgid, taskid;
 	cltoma::requestTaskId::deserialize(data, length, msgid);
-	taskid = fs_reserve_job_id();
+	taskid = gFilesystemOperations->fs_reserve_job_id();
 	MessageBuffer reply;
 	matocl::requestTaskId::serialize(reply, msgid, taskid);
 	matoclserv_createpacket(eptr, reply);
@@ -2855,8 +2871,8 @@ void matoclserv_fuse_gettrashtime(matoclserventry *eptr,const uint8_t *data,uint
 	getINode(&data, inode);
 	gmode = get8bit(&data);
 
-	status = fs_gettrashtime_prepare(matoclserv_get_context(eptr), inode, gmode, fileTrashtimes,
-	                                 dirTrashtimes);
+	status = gFilesystemOperations->fs_gettrashtime_prepare(matoclserv_get_context(eptr), inode,
+	                                                        gmode, fileTrashtimes, dirTrashtimes);
 	fileTrashtimesSize = fileTrashtimes.size();
 	dirTrashtimesSize = dirTrashtimes.size();
 
@@ -2877,7 +2893,7 @@ void matoclserv_fuse_gettrashtime(matoclserventry *eptr,const uint8_t *data,uint
 	} else {
 		put32bit(&ptr, fileTrashtimesSize);
 		put32bit(&ptr, dirTrashtimesSize);
-		fs_gettrashtime_store(fileTrashtimes, dirTrashtimes, ptr);
+		gFilesystemOperations->fs_gettrashtime_store(fileTrashtimes, dirTrashtimes, ptr);
 	}
 }
 
@@ -2935,10 +2951,10 @@ void matoclserv_fuse_settrashtime(matoclserventry *eptr, PacketHeader header, co
 	auto settrashtime_stats = std::make_shared<SetTrashtimeTask::StatsArray>();
 
 	if (status == SAUNAFS_STATUS_OK) {
-		status = fs_settrashtime(matoclserv_get_context(eptr, uid, 0), inode, trashtime,
-					 smode, settrashtime_stats,
-			   std::bind(matoclserv_fuse_settrashtime_wake_up, eptr->sessionData->sessionId,
-				     msgid, settrashtime_stats, std::placeholders::_1));
+		status = gFilesystemOperations->fs_settrashtime(
+		    matoclserv_get_context(eptr, uid, 0), inode, trashtime, smode, settrashtime_stats,
+		    std::bind(matoclserv_fuse_settrashtime_wake_up, eptr->sessionData->sessionId, msgid,
+		              settrashtime_stats, std::placeholders::_1));
 	}
 
 	if (status != SAUNAFS_ERROR_WAITING) {
@@ -2960,7 +2976,8 @@ void matoclserv_fuse_getgoal(matoclserventry *eptr, PacketHeader header, const u
 	}
 
 	GoalStatistics fgtab{{0}}, dgtab{{0}}; // explicit value initialization to clear variables
-	uint8_t status = fs_getgoal(matoclserv_get_context(eptr), inode, gmode, fgtab, dgtab);
+	uint8_t status =
+	    gFilesystemOperations->fs_getgoal(matoclserv_get_context(eptr), inode, gmode, fgtab, dgtab);
 
 	MessageBuffer reply;
 	if (status == SAUNAFS_STATUS_OK) {
@@ -3050,9 +3067,10 @@ void matoclserv_fuse_setgoal(matoclserventry *eptr, PacketHeader header, const u
 
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, 0);
-		status = fs_setgoal(context, inode, goalId, smode, setgoal_stats,
-			   std::bind(matoclserv_fuse_setgoal_wake_up, eptr->sessionData->sessionId,
-				     msgid, header.type, setgoal_stats, std::placeholders::_1));
+		status = gFilesystemOperations->fs_setgoal(
+		    context, inode, goalId, smode, setgoal_stats,
+		    std::bind(matoclserv_fuse_setgoal_wake_up, eptr->sessionData->sessionId, msgid,
+		              header.type, setgoal_stats, std::placeholders::_1));
 	}
 
 	if (status != SAUNAFS_ERROR_WAITING) {
@@ -3085,7 +3103,8 @@ void matoclserv_fuse_geteattr(matoclserventry *eptr, const uint8_t *data, uint32
 	getINode(&data, inode);
 	gmode = get8bit(&data);
 
-	status = fs_geteattr(matoclserv_get_context(eptr), inode, gmode, feattrtab, deattrtab);
+	status = gFilesystemOperations->fs_geteattr(matoclserv_get_context(eptr), inode, gmode,
+	                                            feattrtab, deattrtab);
 	fn = 0;
 	dn = 0;
 
@@ -3151,8 +3170,8 @@ void matoclserv_fuse_seteattr(matoclserventry *eptr, const uint8_t *data, uint32
 	eattr = get8bit(&data);
 	smode = get8bit(&data);
 
-	status = fs_seteattr(matoclserv_get_context(eptr, uid, 0), inode, eattr, smode, &changed,
-	                     &notchanged, &notpermitted);
+	status = gFilesystemOperations->fs_seteattr(matoclserv_get_context(eptr, uid, 0), inode, eattr,
+	                                            smode, &changed, &notchanged, &notpermitted);
 
 	constexpr uint32_t kFailedSize = sizeof(msgid) + sizeof(status);
 	constexpr uint32_t kSuccessSize =
@@ -3233,7 +3252,7 @@ void matoclserv_fuse_getxattr(matoclserventry *eptr, const uint8_t *data, uint32
 	} else if (anleng == 0) {
 		void *xanode;
 		uint32_t xasize;
-		status = fs_listxattr_leng(context, inode, opened, &xanode, &xasize);
+		status = gFilesystemOperations->fs_listxattr_leng(context, inode, opened, &xanode, &xasize);
 		const uint32_t kSuccessSize =
 		    sizeof(msgid) + sizeof(xasize) + ((mode == XATTR_GMODE_GET_DATA) ? xasize : 0);
 		ptr = matoclserv_createpacket(eptr, MATOCL_FUSE_GETXATTR,
@@ -3245,12 +3264,15 @@ void matoclserv_fuse_getxattr(matoclserventry *eptr, const uint8_t *data, uint32
 			put8bit(&ptr, status);
 		} else {
 			put32bit(&ptr, xasize);
-			if (mode == XATTR_GMODE_GET_DATA && xasize > 0) { fs_listxattr_data(xanode, ptr); }
+			if (mode == XATTR_GMODE_GET_DATA && xasize > 0) {
+				gFilesystemOperations->fs_listxattr_data(xanode, ptr);
+			}
 		}
 	} else {
 		uint8_t *attrvalue;
 		uint32_t avleng;
-		status = fs_getxattr(context, inode, opened, anleng, attrname, &avleng, &attrvalue);
+		status = gFilesystemOperations->fs_getxattr(context, inode, opened, anleng, attrname,
+		                                            &avleng, &attrvalue);
 		const uint32_t kSuccessSize =
 		    sizeof(msgid) + sizeof(avleng) + ((mode == XATTR_GMODE_GET_DATA) ? avleng : 0);
 		ptr = matoclserv_createpacket(eptr, MATOCL_FUSE_GETXATTR,
@@ -3327,7 +3349,8 @@ void matoclserv_fuse_setxattr(matoclserventry *eptr, const uint8_t *data, uint32
 
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = fs_setxattr(context, inode, opened, anleng, attrname, avleng, attrvalue, mode);
+		status = gFilesystemOperations->fs_setxattr(context, inode, opened, anleng, attrname,
+		                                            avleng, attrvalue, mode);
 	}
 
 	ptr = matoclserv_createpacket(eptr, MATOCL_FUSE_SETXATTR, sizeof(msgid) + sizeof(status));
@@ -3364,7 +3387,7 @@ void matoclserv_fuse_append(matoclserventry *eptr, const uint8_t *data, uint32_t
 
 	if (status == SAUNAFS_STATUS_OK) {
 		auto context = matoclserv_get_context(eptr, uid, gid);
-		status = fs_append(context, inode, inode_src);
+		status = gFilesystemOperations->fs_append(context, inode, inode_src);
 	}
 
 	ptr = matoclserv_createpacket(eptr, MATOCL_FUSE_APPEND, sizeof(msgid) + sizeof(status));
@@ -3439,8 +3462,9 @@ void matoclserv_fuse_getdirstats_old(matoclserventry *eptr, const uint8_t *data,
 	get32bit(&data, msgid);
 	getINode(&data, inode);
 
-	status = fs_get_dir_stats(matoclserv_get_context(eptr), inode, &inodes, &dirs, &files, &links,
-	                          &chunks, &leng, &size, &rsize);
+	status =
+	    gFilesystemOperations->fs_get_dir_stats(matoclserv_get_context(eptr), inode, &inodes, &dirs,
+	                                            &files, &links, &chunks, &leng, &size, &rsize);
 
 	constexpr uint8_t kDirStatsLegacyFullPayload =
 	    sizeof(msgid) + sizeof(inodes) + sizeof(dirs) + sizeof(files) + sizeof(links) +
@@ -3492,8 +3516,9 @@ void matoclserv_fuse_getdirstats(matoclserventry *eptr, const uint8_t *data, uin
 	get32bit(&data, msgid);
 	getINode(&data, inode);
 
-	status = fs_get_dir_stats(matoclserv_get_context(eptr), inode, &inodes, &dirs, &files, &links,
-	                          &chunks, &leng, &size, &rsize);
+	status =
+	    gFilesystemOperations->fs_get_dir_stats(matoclserv_get_context(eptr), inode, &inodes, &dirs,
+	                                            &files, &links, &chunks, &leng, &size, &rsize);
 
 	constexpr uint8_t kFailedSize = sizeof(msgid) + sizeof(status);
 	constexpr uint8_t kSuccessSize = sizeof(msgid) + sizeof(inodes) + sizeof(dirs) + sizeof(files) +
@@ -3534,7 +3559,8 @@ void matoclserv_fuse_gettrash(matoclserventry *eptr, const uint8_t *data, uint32
 
 	get32bit(&data, msgid);
 
-	status = fs_readtrash_size(eptr->sessionData->rootInode,eptr->sessionData->flags,&dleng);
+	status = gFilesystemOperations->fs_readtrash_size(eptr->sessionData->rootInode,
+	                                                  eptr->sessionData->flags, &dleng);
 
 	ptr = matoclserv_createpacket(
 	    eptr, MATOCL_FUSE_GETTRASH,
@@ -3545,7 +3571,8 @@ void matoclserv_fuse_gettrash(matoclserventry *eptr, const uint8_t *data, uint32
 	if (status != SAUNAFS_STATUS_OK) {
 		put8bit(&ptr, status);
 	} else {
-		fs_readtrash_data(eptr->sessionData->rootInode, eptr->sessionData->flags, ptr);
+		gFilesystemOperations->fs_readtrash_data(eptr->sessionData->rootInode,
+		                                         eptr->sessionData->flags, ptr);
 	}
 }
 
@@ -3559,7 +3586,7 @@ void matoclserv_fuse_gettrash(matoclserventry *eptr, const PacketHeader &header,
 		uint32_t off;
 		cltoma::fuseGetTrash::deserialize(data, header.length, msgId, off, maxEntries);
 		std::vector<NamedInodeEntry> entries;
-		fs_readtrash(
+		gFilesystemOperations->fs_readtrash(
 		    off, std::min<uint32_t>(maxEntries, matocl::fuseGetDir::kMaxNumberOfDirectoryEntries),
 		    entries);
 		matoclserv_createpacket(eptr, matocl::fuseGetTrash::build(msgId, entries));
@@ -3567,7 +3594,7 @@ void matoclserv_fuse_gettrash(matoclserventry *eptr, const PacketHeader &header,
 		uint64_t off;
 		cltoma::fuseGetTrash::deserialize(data, header.length, msgId, off, maxEntries);
 		std::vector<HandleInodeEntry> entries;
-		fs_readtrash(
+		gFilesystemOperations->fs_readtrash(
 		    off, std::min<uint32_t>(maxEntries, matocl::fuseGetDir::kMaxNumberOfDirectoryEntries),
 		    entries);
 		matoclserv_createpacket(eptr, matocl::fuseGetTrash::build(msgId, entries));
@@ -3603,8 +3630,8 @@ void matoclserv_fuse_getdetachedattr(matoclserventry *eptr, const uint8_t *data,
 		dtype = DTYPE_UNKNOWN;
 	}
 
-	status = fs_getdetachedattr(eptr->sessionData->rootInode, eptr->sessionData->flags, inode, attr,
-	                            dtype);
+	status = gFilesystemOperations->fs_getdetachedattr(
+	    eptr->sessionData->rootInode, eptr->sessionData->flags, inode, attr, dtype);
 
 	constexpr uint32_t kFailedSize = sizeof(msgid) + sizeof(status);
 	constexpr uint32_t kSuccessSize = sizeof(msgid) + attr.size();
@@ -3641,7 +3668,8 @@ void matoclserv_fuse_gettrashpath(matoclserventry *eptr, const uint8_t *data, ui
 	get32bit(&data, msgid);
 	getINode(&data, inode);
 
-	status = fs_gettrashpath(eptr->sessionData->rootInode, eptr->sessionData->flags, inode, path);
+	status = gFilesystemOperations->fs_gettrashpath(eptr->sessionData->rootInode,
+	                                                eptr->sessionData->flags, inode, path);
 
 	constexpr uint32_t kFailedSize = sizeof(msgid) + sizeof(status);
 	const uint32_t kSuccessSize = sizeof(msgid) + sizeof(uint32_t) + path.length() + 1;
@@ -3697,7 +3725,8 @@ void matoclserv_fuse_settrashpath(matoclserventry *eptr, const uint8_t *data, ui
 	data += pleng;
 	while (pleng > 0 && path[pleng - 1] == 0) { pleng--; }
 
-	status = fs_settrashpath(matoclserv_get_context(eptr), inode, std::string((char*)path, pleng));
+	status = gFilesystemOperations->fs_settrashpath(matoclserv_get_context(eptr), inode,
+	                                                std::string((char *)path, pleng));
 
 	ptr = matoclserv_createpacket(eptr, MATOCL_FUSE_SETTRASHPATH, sizeof(msgid) + sizeof(status));
 
@@ -3723,7 +3752,7 @@ void matoclserv_fuse_undel(matoclserventry *eptr, const uint8_t *data, uint32_t 
 	get32bit(&data, msgid);
 	getINode(&data, inode);
 
-	status = fs_undel(matoclserv_get_context(eptr), inode);
+	status = gFilesystemOperations->fs_undel(matoclserv_get_context(eptr), inode);
 
 	ptr = matoclserv_createpacket(eptr, MATOCL_FUSE_UNDEL, sizeof(msgid) + sizeof(status));
 
@@ -3749,7 +3778,7 @@ void matoclserv_fuse_purge(matoclserventry *eptr, const uint8_t *data, uint32_t 
 	get32bit(&data, msgid);
 	getINode(&data, inode);
 
-	status = fs_purge(matoclserv_get_context(eptr), inode);
+	status = gFilesystemOperations->fs_purge(matoclserv_get_context(eptr), inode);
 
 	ptr = matoclserv_createpacket(eptr, MATOCL_FUSE_PURGE, sizeof(msgid) + sizeof(status));
 	put32bit(&ptr, msgid);
@@ -3774,7 +3803,8 @@ void matoclserv_fuse_getreserved(matoclserventry *eptr, const uint8_t *data, uin
 
 	get32bit(&data, msgid);
 
-	status = fs_readreserved_size(eptr->sessionData->rootInode, eptr->sessionData->flags, &dleng);
+	status = gFilesystemOperations->fs_readreserved_size(eptr->sessionData->rootInode,
+	                                                     eptr->sessionData->flags, &dleng);
 
 	constexpr uint32_t kFailedSize = sizeof(msgid) + sizeof(status);
 	const uint32_t kSuccessSize = sizeof(msgid) + dleng;
@@ -3787,7 +3817,8 @@ void matoclserv_fuse_getreserved(matoclserventry *eptr, const uint8_t *data, uin
 	if (status!=SAUNAFS_STATUS_OK) {
 		put8bit(&ptr,status);
 	} else {
-		fs_readreserved_data(eptr->sessionData->rootInode, eptr->sessionData->flags, ptr);
+		gFilesystemOperations->fs_readreserved_data(eptr->sessionData->rootInode,
+		                                            eptr->sessionData->flags, ptr);
 	}
 }
 
@@ -3801,7 +3832,7 @@ void matoclserv_fuse_getreserved(matoclserventry *eptr, const PacketHeader &head
 		uint32_t off;
 		cltoma::fuseGetReserved::deserialize(data, header.length, msgId, off, maxEntries);
 		std::vector<NamedInodeEntry> entries;
-		fs_readreserved(
+		gFilesystemOperations->fs_readreserved(
 		    off, std::min<uint32_t>(maxEntries, matocl::fuseGetDir::kMaxNumberOfDirectoryEntries),
 		    entries);
 		matoclserv_createpacket(eptr, matocl::fuseGetReserved::build(msgId, entries));
@@ -3809,7 +3840,7 @@ void matoclserv_fuse_getreserved(matoclserventry *eptr, const PacketHeader &head
 		uint64_t off;
 		cltoma::fuseGetReserved::deserialize(data, header.length, msgId, off, maxEntries);
 		std::vector<HandleInodeEntry> entries;
-		fs_readreserved(
+		gFilesystemOperations->fs_readreserved(
 		    off, std::min<uint32_t>(maxEntries, matocl::fuseGetDir::kMaxNumberOfDirectoryEntries),
 		    entries);
 		matoclserv_createpacket(eptr, matocl::fuseGetReserved::build(msgId, entries));
@@ -3828,7 +3859,7 @@ void matoclserv_fuse_deleteacl(matoclserventry *eptr, const uint8_t *data, uint3
 	uint8_t status = matoclserv_check_group_cache(eptr, gid);
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = fs_deleteacl(context, inode, type);
+		status = gFilesystemOperations->fs_deleteacl(context, inode, type);
 	}
 	matoclserv_createpacket(eptr, matocl::fuseDeleteAcl::build(messageId, status));
 }
@@ -3847,7 +3878,7 @@ void matoclserv_fuse_getacl(matoclserventry *eptr, const uint8_t *data, uint32_t
 
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = fs_getacl(context, inode, acl);
+		status = gFilesystemOperations->fs_getacl(context, inode, acl);
 	}
 
 	if (status == SAUNAFS_STATUS_OK) {
@@ -4264,9 +4295,9 @@ void matoclserv_fuse_setacl(matoclserventry *eptr, const uint8_t *data, uint32_t
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
 		if (use_posix) {
-			status = fs_setacl(context, inode, type, posix_acl);
+			status = gFilesystemOperations->fs_setacl(context, inode, type, posix_acl);
 		} else {
-			status = fs_setacl(context, inode, rich_acl);
+			status = gFilesystemOperations->fs_setacl(context, inode, rich_acl);
 		}
 	}
 	matoclserv_createpacket(eptr, matocl::fuseSetAcl::build(messageId, status));
@@ -4597,7 +4628,7 @@ void matocl_close_files(Session *currentSession) {
 	FsContext context = FsContext::getForMaster(eventloop_time());
 
 	for (const auto &openFileInode : currentSession->openFilesSet) {
-		fs_release(context, openFileInode, currentSession->sessionId);
+		gFilesystemOperations->fs_release(context, openFileInode, currentSession->sessionId);
 		matocl_locks_release(context, openFileInode, currentSession->sessionId);
 	}
 
@@ -4687,7 +4718,7 @@ void matocl_before_disconnect(matoclserventry *eptr) {
 	// unlock locked chunks
 	for (const auto &operation : eptr->delayedChunkOperations) {
 		if (operation->type == FUSE_TRUNCATE) {
-			fs_end_setlength(operation->chunkId);
+			gFilesystemOperations->fs_end_setlength(operation->chunkId);
 		}
 	}
 

--- a/src/master/matoclserv_sessions.cc
+++ b/src/master/matoclserv_sessions.cc
@@ -28,7 +28,7 @@
 #include "common/massert.h"
 #include "common/type_defs.h"
 #include "config/cfg.h"
-#include "master/filesystem.h"
+#include "master/filesystem_operations_interface.h"
 #include "master/metadata_backend_common.h"
 #include "protocol/SFSCommunication.h"
 #include "slogger/slogger.h"
@@ -38,7 +38,7 @@ Session *matoclserv_new_session(uint8_t newSession, uint8_t noNewId) {
 	passert(sessionPtr.get());
 
 	auto newSessionIdNotNeeded = (newSession == 0 && noNewId);
-	sessionPtr->sessionId = (newSessionIdNotNeeded) ? 0 : fs_newsessionid();
+	sessionPtr->sessionId = (newSessionIdNotNeeded) ? 0 : gFilesystemOperations->fs_newsessionid();
 	sessionPtr->newSession = newSession;
 	sessionPtr->connections = 1;
 	gSessionsVector.push_back(std::move(sessionPtr));
@@ -332,8 +332,8 @@ int matoclserv_insert_open_file(Session *currentSession, inode_t inode) {
 		return SAUNAFS_STATUS_OK;  // file already acquired - nothing to do
 	}
 
-	int status = fs_acquire(FsContext::getForMaster(eventloop_time()), inode,
-	                        currentSession->sessionId);
+	int status = gFilesystemOperations->fs_acquire(FsContext::getForMaster(eventloop_time()), inode,
+	                                               currentSession->sessionId);
 
 	if (status == SAUNAFS_STATUS_OK) { currentSession->openFilesSet.insert(inode); }
 

--- a/src/master/matomlserv.cc
+++ b/src/master/matomlserv.cc
@@ -46,10 +46,10 @@
 #include "common/sockets.h"
 #include "config/cfg.h"
 #include "master/filesystem.h"
+#include "master/filesystem_operations_interface.h"
 #include "master/metadata_backend_common.h"
-#include <master/metadata_backend_interface.h>
+#include "master/metadata_backend_interface.h"
 #include "master/personality.h"
-#include "metadata_backend_interface.h"
 #include "protocol/SFSCommunication.h"
 #include "protocol/matoml.h"
 #include "protocol/mltoma.h"
@@ -448,7 +448,7 @@ void matomlserv_register_shadow(matomlserventry *eptr, const uint8_t *data, uint
 		return;
 	}
 
-	uint64_t myMedatataVersion = fs_getversion();
+	uint64_t myMedatataVersion = gFilesystemOperations->fs_getversion();
 	uint64_t replyVersion;
 	if (myMedatataVersion > shadowMetadataVersion
 			&& old_changes_head != nullptr
@@ -1086,4 +1086,3 @@ int matomlserv_init(void) {
 	}
 	return 0;
 }
-

--- a/src/master/metadata_backend_file.cc
+++ b/src/master/metadata_backend_file.cc
@@ -45,6 +45,7 @@
 #include <master/filesystem_node.h>
 #include <master/filesystem_node_types.h>
 #include <master/filesystem_operations.h>
+#include <master/filesystem_operations_interface.h>
 #include <master/filesystem_quota.h>
 #include <master/filesystem_store_acl.h>
 #include <master/matoclserv.h>
@@ -53,8 +54,8 @@
 #include <master/metadata_backend_common.h>
 #include <master/metadata_dumper_file.h>
 #include <master/restore.h>
+#include <protocol/SFSCommunication.h>
 #include <slogger/slogger.h>
-#include "protocol/SFSCommunication.h"
 
 MetadataBackendFile::MetadataBackendFile()
 #if !defined(METARESTORE) && !defined(METALOGGER)
@@ -976,7 +977,7 @@ void MetadataBackendFile::loadall(int ignoreflag) {
 	safs::log_info("connecting files and chunks");
 	{
 		util::ScopedTimer timer("connecting files and chunks took");
-		fs_add_files_to_chunks();
+		gFilesystemOperations->fs_add_files_to_chunks();
 	}
 	unlink(kMetadataTmpFilename);
 	safs::log_info("calculating checksum of the metadata");

--- a/src/master/recursive_remove_task.cc
+++ b/src/master/recursive_remove_task.cc
@@ -22,7 +22,7 @@
 #include "master/recursive_remove_task.h"
 
 #include "master/filesystem_node.h"
-#include "master/filesystem_operations.h"
+#include "master/filesystem_operations_interface.h"
 #include "master/filesystem_stats.h"
 
 bool RemoveTask::isFinished() const {
@@ -49,8 +49,8 @@ int RemoveTask::retrieveNodes(FSNodeDirectory *&wd, FSNode *&child) {
 }
 
 void RemoveTask::doUnlink(uint32_t ts, FSNodeDirectory *wd, FSNode *child) {
-	fs_changelog(ts, "UNLINK(%" PRIiNode ",%s):%" PRIiNode, parent_,
-		    fsnodes_escape_name(*current_subtask_).c_str(), child->id);
+	gFilesystemOperations->fs_changelog(ts, "UNLINK(%" PRIiNode ",%s):%" PRIiNode, parent_,
+	                                    fsnodes_escape_name(*current_subtask_).c_str(), child->id);
 	fsnodes_unlink(ts, wd, *current_subtask_, child);
 }
 

--- a/src/master/restore.cc
+++ b/src/master/restore.cc
@@ -208,7 +208,7 @@ int do_access(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
 	EAT(ptr,filename,lv,'(');
 	GETINODE(inode,ptr);
 	EAT(ptr,filename,lv,')');
-	return fs_apply_access(ts,inode);
+	return gFilesystemOperations->fs_apply_access(ts,inode);
 }
 
 int do_append(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -219,7 +219,7 @@ int do_append(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
 	EAT(ptr,filename,lv,',');
 	GETINODE(inode_src,ptr);
 	EAT(ptr,filename,lv,')');
-	return fs_append(FsContext::getForRestore(ts), inode, inode_src);
+	return gFilesystemOperations->fs_append(FsContext::getForRestore(ts), inode, inode_src);
 }
 
 int do_acquire(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -230,7 +230,7 @@ int do_acquire(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) 
 	EAT(ptr,filename,lv,',');
 	GETU32(cuid,ptr);
 	EAT(ptr,filename,lv,')');
-	return fs_acquire(FsContext::getForRestore(ts), inode, cuid);
+	return gFilesystemOperations->fs_acquire(FsContext::getForRestore(ts), inode, cuid);
 }
 
 int do_attr(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -249,7 +249,7 @@ int do_attr(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
 	EAT(ptr,filename,lv,',');
 	GETU32(mtime,ptr);
 	EAT(ptr,filename,lv,')');
-	return fs_apply_attr(ts,inode,mode,uid,gid,atime,mtime);
+	return gFilesystemOperations->fs_apply_attr(ts, inode, mode, uid, gid, atime, mtime);
 }
 
 int do_checksum(const char *filename, uint64_t lv, uint32_t, const char *ptr) {
@@ -260,7 +260,7 @@ int do_checksum(const char *filename, uint64_t lv, uint32_t, const char *ptr) {
 	EAT(ptr,filename,lv,')');
 	EAT(ptr,filename,lv,':');
 	GETU64(checksum,ptr);
-	return fs_apply_checksum((char*)&version, checksum);
+	return gFilesystemOperations->fs_apply_checksum((char *)&version, checksum);
 }
 
 int do_create(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -286,8 +286,9 @@ int do_create(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
 	EAT(ptr,filename,lv,')');
 	EAT(ptr,filename,lv,':');
 	GETINODE(inode,ptr);
-	return fs_apply_create(ts, parent, HString((const char *)name), static_cast<FSNodeType>(type),
-	                       mode, uid, gid, rdev, inode);
+	return gFilesystemOperations->fs_apply_create(ts, parent, HString((const char *)name),
+	                                              static_cast<FSNodeType>(type), mode, uid, gid,
+	                                              rdev, inode);
 }
 
 int do_session(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -297,7 +298,7 @@ int do_session(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) 
 	EAT(ptr,filename,lv,')');
 	EAT(ptr,filename,lv,':');
 	GETU32(cuid,ptr);
-	return fs_apply_session(cuid);
+	return gFilesystemOperations->fs_apply_session(cuid);
 }
 
 int do_freeinodes(const char *filename, uint64_t lv, uint32_t ts, const char* ptr) {
@@ -315,7 +316,7 @@ int do_incversion(const char *filename, uint64_t lv, uint32_t ts, const char *pt
 	EAT(ptr,filename,lv,'(');
 	GETU64(chunkid,ptr);
 	EAT(ptr,filename,lv,')');
-	return fs_apply_incversion(chunkid);
+	return gFilesystemOperations->fs_apply_incversion(chunkid);
 }
 
 int do_link(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -329,8 +330,8 @@ int do_link(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
 	EAT(ptr,filename,lv,',');
 	GETNAME(name,ptr,filename,lv,')');
 	EAT(ptr,filename,lv,')');
-	return fs_link(FsContext::getForRestore(ts), inode, parent, HString((const char*)name),
-			nullptr, nullptr);
+	return gFilesystemOperations->fs_link(FsContext::getForRestore(ts), inode, parent,
+	                                      HString((const char *)name), nullptr, nullptr);
 }
 
 int do_length(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -350,7 +351,7 @@ int do_length(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
 		GETU32(eraseFurtherChunks, ptr);
 	}
 	EAT(ptr, filename, lv, ')');
-	return fs_apply_length(ts, inode, length, eraseFurtherChunks != 0);
+	return gFilesystemOperations->fs_apply_length(ts, inode, length, eraseFurtherChunks != 0);
 }
 
 int do_move(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
@@ -369,10 +370,9 @@ int do_move(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
 	EAT(ptr,filename,lv,')');
 	EAT(ptr,filename,lv,':');
 	GETINODE(inode,ptr);
-	return fs_rename(FsContext::getForRestore(ts),
-			parent_src, HString((const char*)name_src),
-			parent_dst, HString((const char*)name_dst),
-			&inode, nullptr);
+	return gFilesystemOperations->fs_rename(FsContext::getForRestore(ts), parent_src,
+	                                        HString((const char *)name_src), parent_dst,
+	                                        HString((const char *)name_dst), &inode, nullptr);
 }
 
 int do_lock_op(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -483,7 +483,7 @@ int do_purge(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
 	EAT(ptr,filename,lv,'(');
 	GETINODE(inode,ptr);
 	EAT(ptr,filename,lv,')');
-	return fs_purge(FsContext::getForRestore(ts), inode);
+	return gFilesystemOperations->fs_purge(FsContext::getForRestore(ts), inode);
 }
 
 int do_release(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
@@ -494,7 +494,7 @@ int do_release(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) 
 	EAT(ptr,filename,lv,',');
 	GETU32(cuid,ptr);
 	EAT(ptr,filename,lv,')');
-	return fs_release(FsContext::getForRestore(ts), inode, cuid);
+	return gFilesystemOperations->fs_release(FsContext::getForRestore(ts), inode, cuid);
 }
 
 int do_repair(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
@@ -508,7 +508,7 @@ int do_repair(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
 	EAT(ptr,filename,lv,')');
 	EAT(ptr,filename,lv,':');
 	GETU32(version,ptr);
-	return fs_apply_repair(ts,inode,indx,version);
+	return gFilesystemOperations->fs_apply_repair(ts, inode, indx, version);
 }
 
 int do_seteattr(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
@@ -533,7 +533,8 @@ int do_seteattr(const char* filename, uint64_t lv, uint32_t ts, const char* ptr)
 	GETINODE(nci,ptr);
 	EAT(ptr,filename,lv,',');
 	GETINODE(npi,ptr);
-	return fs_seteattr(FsContext::getForRestoreWithUidGid(ts, uid, 0), inode, eattr, smode, &ci, &nci, &npi);
+	return gFilesystemOperations->fs_seteattr(FsContext::getForRestoreWithUidGid(ts, uid, 0), inode,
+	                                          eattr, smode, &ci, &nci, &npi);
 }
 
 int do_setgoal(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -553,11 +554,12 @@ int do_setgoal(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) 
 	if (*(ptr) == ':') {
 		EAT(ptr, filename, lv, ':');
 		GETINODE(ci, ptr);
-		return fs_apply_setgoal(FsContext::getForRestoreWithUidGid(ts, uid, 0),
-			                        inode, goal, smode, ci);
+		return gFilesystemOperations->fs_apply_setgoal(
+		    FsContext::getForRestoreWithUidGid(ts, uid, 0), inode, goal, smode, ci);
 	} else {
-		return fs_apply_setgoal(FsContext::getForRestoreWithUidGid(ts, uid, 0), inode, goal,
-		                        smode, SetGoalTask::kChanged);
+		return gFilesystemOperations->fs_apply_setgoal(
+		    FsContext::getForRestoreWithUidGid(ts, uid, 0), inode, goal, smode,
+		    SetGoalTask::kChanged);
 	}
 }
 
@@ -570,7 +572,8 @@ int do_setpath(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) 
 	EAT(ptr,filename,lv,',');
 	GETPATH(path,pathsize,ptr,filename,lv,')');
 	EAT(ptr,filename,lv,')');
-	return fs_settrashpath(FsContext::getForRestore(ts), inode, std::string((const char*)path));
+	return gFilesystemOperations->fs_settrashpath(FsContext::getForRestore(ts), inode,
+	                                              std::string((const char *)path));
 }
 
 int do_settrashtime(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -591,11 +594,12 @@ int do_settrashtime(const char *filename, uint64_t lv, uint32_t ts, const char *
 	if ((*ptr) == ':') {
 		EAT(ptr, filename, lv, ':');
 		GETINODE(ci, ptr);
-		return fs_apply_settrashtime(FsContext::getForRestoreWithUidGid(ts, uid, 0),
-			                         inode, trashtime, smode, ci);
+		return gFilesystemOperations->fs_apply_settrashtime(
+		    FsContext::getForRestoreWithUidGid(ts, uid, 0), inode, trashtime, smode, ci);
 	} else {
-		return fs_apply_settrashtime(FsContext::getForRestoreWithUidGid(ts, uid, 0), inode,
-		                             trashtime, smode, SetTrashtimeTask::kChanged);
+		return gFilesystemOperations->fs_apply_settrashtime(
+		    FsContext::getForRestoreWithUidGid(ts, uid, 0), inode, trashtime, smode,
+		    SetTrashtimeTask::kChanged);
 	}
 }
 
@@ -614,7 +618,8 @@ int do_setxattr(const char* filename, uint64_t lv, uint32_t ts, const char* ptr)
 	EAT(ptr,filename,lv,',');
 	GETU32(mode,ptr);
 	EAT(ptr,filename,lv,')');
-	return fs_apply_setxattr(ts,inode,strlen((char*)name),name,valueleng,value,mode);
+	return gFilesystemOperations->fs_apply_setxattr(ts, inode, strlen((char *)name), name,
+	                                                valueleng, value, mode);
 }
 
 int do_deleteacl(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -637,7 +642,7 @@ int do_deleteacl(const char *filename, uint64_t lv, uint32_t ts, const char *ptr
 		safs_pretty_syslog(LOG_ERR, "%s:%" PRIu64 ": corrupted ACL type", filename, lv);
 		return -1;
 	}
-	return fs_deleteacl(FsContext::getForRestore(ts), inode, aclType);
+	return gFilesystemOperations->fs_deleteacl(FsContext::getForRestore(ts), inode, aclType);
 }
 
 int do_setacl(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -654,7 +659,8 @@ int do_setacl(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
 	GETPATH(aclString, aclSize, ptr, filename, lv, ')');
 	EAT(ptr, filename, lv, ')');
 
-	return fs_apply_setacl(ts, inode, aclType, reinterpret_cast<const char*>(aclString));
+	return gFilesystemOperations->fs_apply_setacl(ts, inode, aclType,
+	                                              reinterpret_cast<const char *>(aclString));
 }
 
 int do_setrichacl(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -668,7 +674,8 @@ int do_setrichacl(const char *filename, uint64_t lv, uint32_t ts, const char *pt
 	GETPATH(acl_string, acl_size, ptr, filename, lv, ')');
 	EAT(ptr, filename, lv, ')');
 
-	return fs_apply_setrichacl(ts, inode, reinterpret_cast<const char*>(acl_string));
+	return gFilesystemOperations->fs_apply_setrichacl(ts, inode,
+	                                                  reinterpret_cast<const char *>(acl_string));
 }
 
 int do_setquota(const char *filename, uint64_t lv, uint32_t, const char *ptr) {
@@ -735,8 +742,9 @@ int do_symlink(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) 
 	EAT(ptr,filename,lv,')');
 	EAT(ptr,filename,lv,':');
 	GETINODE(inode,ptr);
-	return fs_symlink(FsContext::getForRestoreWithUidGid(ts, uid, gid),
-			parent, HString((char*)name), std::string((char*)path), &inode, nullptr);
+	return gFilesystemOperations->fs_symlink(FsContext::getForRestoreWithUidGid(ts, uid, gid),
+	                                         parent, HString((char *)name),
+	                                         std::string((char *)path), &inode, nullptr);
 }
 
 int do_undel(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
@@ -744,7 +752,7 @@ int do_undel(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
 	EAT(ptr,filename,lv,'(');
 	GETINODE(inode,ptr);
 	EAT(ptr,filename,lv,')');
-	return fs_undel(FsContext::getForRestore(ts), inode);
+	return gFilesystemOperations->fs_undel(FsContext::getForRestore(ts), inode);
 }
 
 int do_unlink(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
@@ -758,7 +766,7 @@ int do_unlink(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
 	EAT(ptr,filename,lv,')');
 	EAT(ptr,filename,lv,':');
 	GETINODE(inode,ptr);
-	return fs_apply_unlink(ts, parent, HString((char*)name), inode);
+	return gFilesystemOperations->fs_apply_unlink(ts, parent, HString((char *)name), inode);
 }
 
 int do_unlock(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
@@ -767,7 +775,7 @@ int do_unlock(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
 	EAT(ptr,filename,lv,'(');
 	GETU64(chunkid,ptr);
 	EAT(ptr,filename,lv,')');
-	return fs_apply_unlock(chunkid);
+	return gFilesystemOperations->fs_apply_unlock(chunkid);
 }
 
 int do_nextchunkid(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
@@ -775,7 +783,7 @@ int do_nextchunkid(const char* filename, uint64_t lv, uint32_t ts, const char* p
 	EAT(ptr, filename, lv, '(');
 	GETU64(nextChunkId, ptr);
 	EAT(ptr, filename, lv, ')');
-	return fs_set_nextchunkid(FsContext::getForRestore(ts), nextChunkId);
+	return gFilesystemOperations->fs_set_nextchunkid(FsContext::getForRestore(ts), nextChunkId);
 }
 
 
@@ -797,7 +805,7 @@ int do_trunc(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
 	EAT(ptr,filename,lv,')');
 	EAT(ptr,filename,lv,':');
 	GETU64(chunkid,ptr);
-	return fs_apply_trunc(ts,inode,indx,chunkid,lockid);
+	return gFilesystemOperations->fs_apply_trunc(ts, inode, indx, chunkid, lockid);
 }
 
 int do_write(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
@@ -825,7 +833,8 @@ int do_write(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
 	EAT(ptr,filename,lv,')');
 	EAT(ptr,filename,lv,':');
 	GETU64(chunkid,ptr);
-	return fs_writechunk(FsContext::getForRestore(ts), inode, indx, false, &lockid, &chunkid, &opflag, nullptr);
+	return gFilesystemOperations->fs_writechunk(FsContext::getForRestore(ts), inode, indx, false,
+	                                            &lockid, &chunkid, &opflag, nullptr);
 }
 
 int restore_line(const char* filename, uint64_t lv, const char* line) {
@@ -1017,7 +1026,7 @@ uint8_t restore(const char* filename, uint64_t newLogVersion, const char *ptr, R
 		/*
 		 * This is first call to restore().
 		 */
-		nextFsVersion = fs_getversion();
+		nextFsVersion = gFilesystemOperations->fs_getversion();
 		currentFsVersion = nextFsVersion - 1;
 		lastfn = "(no file)";
 	}
@@ -1053,7 +1062,7 @@ uint8_t restore(const char* filename, uint64_t newLogVersion, const char *ptr, R
 			if (status != SAUNAFS_STATUS_OK) { // other errors - stop processing data
 				return status;
 			}
-			nextFsVersion = fs_getversion();
+			nextFsVersion = gFilesystemOperations->fs_getversion();
 			if ((newLogVersion + 1) != nextFsVersion) {
 				/*
 				 * restore_line() should bump nextFsVersion by exactly 1, but it didn't.

--- a/src/master/setgoal_task.cc
+++ b/src/master/setgoal_task.cc
@@ -24,7 +24,7 @@
 
 #include "master/filesystem_checksum.h"
 #include "master/filesystem_node.h"
-#include "master/filesystem_operations.h"
+#include "master/filesystem_operations_interface.h"
 
 int SetGoalTask::execute(uint32_t ts, intrusive_list<Task> &work_queue) {
 	assert(current_inode_ != inode_list_.end());
@@ -55,8 +55,9 @@ int SetGoalTask::execute(uint32_t ts, intrusive_list<Task> &work_queue) {
 		}
 		(*stats_)[result] += 1;
 		if (result == kChanged) {
-			fs_changelog(ts, "SETGOAL(%" PRIiNode ",%" PRIu32 ",%" PRIu8 ",%" PRIu8 ")",
-			             inode, uid_, goal_, smode_);
+			gFilesystemOperations->fs_changelog(
+			    ts, "SETGOAL(%" PRIiNode ",%" PRIu32 ",%" PRIu8 ",%" PRIu8 ")", inode, uid_, goal_,
+			    smode_);
 		}
 	}
 

--- a/src/master/settrashtime_task.cc
+++ b/src/master/settrashtime_task.cc
@@ -24,7 +24,7 @@
 
 #include "master/filesystem_checksum.h"
 #include "master/filesystem_node.h"
-#include "master/filesystem_operations.h"
+#include "master/filesystem_operations_interface.h"
 
 int SetTrashtimeTask::execute(uint32_t ts, intrusive_list<Task> &work_queue) {
 	assert(current_inode_ != inode_list_.end());
@@ -56,9 +56,9 @@ int SetTrashtimeTask::execute(uint32_t ts, intrusive_list<Task> &work_queue) {
 		}
 		(*stats_)[result] += 1;
 		if (result == kChanged) {
-			fs_changelog(ts,
-			             "SETTRASHTIME(%" PRIiNode ",%" PRIu32 ",%" PRIu32 ",%" PRIu8 ")",
-			             inode, uid_, trashtime_, smode_);
+			gFilesystemOperations->fs_changelog(
+			    ts, "SETTRASHTIME(%" PRIiNode ",%" PRIu32 ",%" PRIu32 ",%" PRIu8 ")", inode, uid_,
+			    trashtime_, smode_);
 		}
 	}
 	return SAUNAFS_STATUS_OK;

--- a/src/master/snapshot_task.cc
+++ b/src/master/snapshot_task.cc
@@ -25,7 +25,7 @@
 #include "master/filesystem_checksum.h"
 #include "master/filesystem_metadata.h"
 #include "master/filesystem_node.h"
-#include "master/filesystem_operations.h"
+#include "master/filesystem_operations_interface.h"
 #include "master/filesystem_quota.h"
 
 int SnapshotTask::cloneNodeTest(FSNode *src_node, FSNode *dst_node, FSNodeDirectory *dst_parent) {
@@ -207,9 +207,10 @@ void SnapshotTask::emitChangelog(uint32_t ts, inode_t dst_inode) {
 		return;
 	}
 
-	fs_changelog(ts, "CLONE(%" PRIiNode ",%" PRIiNode ",%" PRIiNode ",%s,%" PRIu8 ")",
-	             current_subtask_->first, dst_parent_inode_, dst_inode,
-	             fsnodes_escape_name(current_subtask_->second).c_str(), can_overwrite_);
+	gFilesystemOperations->fs_changelog(
+	    ts, "CLONE(%" PRIiNode ",%" PRIiNode ",%" PRIiNode ",%s,%" PRIu8 ")",
+	    current_subtask_->first, dst_parent_inode_, dst_inode,
+	    fsnodes_escape_name(current_subtask_->second).c_str(), can_overwrite_);
 }
 
 int SnapshotTask::cloneNode(uint32_t ts) {

--- a/src/metarestore/main.cc
+++ b/src/metarestore/main.cc
@@ -40,6 +40,7 @@
 #include "master/changelog.h"
 #include "master/chunks.h"
 #include "master/filesystem.h"
+#include "master/filesystem_operations_interface.h"
 #include "master/hstring_memstorage.h"
 #include "master/hstring_storage.h"
 #include "master/metadata_backend_common.h"
@@ -351,12 +352,13 @@ int main(int argc,char **argv) {
 		safs_pretty_syslog(LOG_ERR, "error: can't read metadata from file: %s, %s", metadata.c_str(), e.what());
 		return 1;
 	}
-	if (fs_getversion() == 0) {
+	if (gFilesystemOperations->fs_getversion() == 0) {
 		safs_pretty_syslog(LOG_ERR, "invalid metadata version (0)");
 		return 1;
 	}
 	if (vl > 0) {
-		safs_pretty_syslog(LOG_NOTICE, "loaded metadata with version %" PRIu64 "", fs_getversion());
+		safs_pretty_syslog(LOG_NOTICE, "loaded metadata with version %" PRIu64 "",
+		                   gFilesystemOperations->fs_getversion());
 	}
 
 	if (autorestore) {
@@ -378,7 +380,12 @@ int main(int argc,char **argv) {
 					safs_pretty_syslog(LOG_WARNING, "%s", ex.what());
 					lastlv = 0;
 				}
-				skip = ((lastlv<fs_getversion() || firstlv==0) && forcealllogs==0)?1:0;
+
+				skip = ((lastlv < gFilesystemOperations->fs_getversion() || firstlv == 0) &&
+				        forcealllogs == 0)
+				           ? 1
+				           : 0;
+
 				if (vl>0) {
 					std::ostringstream oss;
 					if (skip) {
@@ -427,7 +434,12 @@ int main(int argc,char **argv) {
 				safs_pretty_syslog(LOG_WARNING, "%s", ex.what());
 				lastlv = 0;
 			}
-			skip = ((lastlv<fs_getversion() || firstlv==0) && forcealllogs==0)?1:0;
+
+			skip = ((lastlv < gFilesystemOperations->fs_getversion() || firstlv == 0) &&
+			        forcealllogs == 0)
+			           ? 1
+			           : 0;
+
 			if (vl>0) {
 				std::ostringstream oss;
 				if (skip) {


### PR DESCRIPTION
Move function declarations from filesystem.h to
filesystem_operations_interface.h and their implementations to filesystem_operations.{h,cc}. This enables extending filesystem operations in concrete implementations (e.g., FDB backend).

Key changes:
- Add more functions to the IFilesystemOperations interface and FilesystemOperationsBase class.
- Replace direct fs_* function calls with gFilesystemOperations-> indirection.
- Update all call sites across the codebase.
- Rename short parameter names (ts → timestamp) to comply with coding standards (names too short).
- Update header dependencies to point to interface, potentially reducing compilation time.

This refactoring maintains backward compatibility while providing a foundation for alternative filesystem storage backends.

Reviewers, I am cutting here not to make the PR too long:
- Next steps:
  - Rename the functions (maybe removing the fs_ prefix and making the camel case).
  - Probably renaming gFilesystemOperations to something shorter, like: gFS, gFSOpertations or gFSOps, just to make the lines shorter.
  - Decide how to move the Quota related functions that were implemented in other place.