### PR TITLE
feat(chunkserver): Add PLUGINS_DIR variable

### DIFF
--- a/doc/sfschunkserver.cfg.5.adoc
+++ b/doc/sfschunkserver.cfg.5.adoc
@@ -173,6 +173,12 @@ the operation is considered failed and is immediately aborted (default: 1000)
 replication. After this timeout, next wave of read requests is sent to other
 chunkservers (default: 500)
 
+*PLUGINS_DIR*:: directory to search for Chunkserver plugins (absolute path).
+When set, the plugin manager will search this directory first. If not set, then
+it will search in usual plugin locations, like /usr/local/lib/saunafs/plugins/chunkserver,
+PLUGINS_PATH/chunkserver (PLUGINS_PATH is defined at build time), and
+/usr/lib/saunafs/plugins/chunkserver (default is empty string, i.e. disabled)
+
 *CHUNK_TRASH_ENABLED (EXPERIMENTAL)*:: enables or disables the chunk trash
 feature. When enabled, deleted chunks are moved to a trash directory instead of
 being immediately removed. (Default: 0)

--- a/src/admin/dump_config_command.cc
+++ b/src/admin/dump_config_command.cc
@@ -174,6 +174,7 @@ const static std::unordered_map<std::string, std::string> defaultOptionsCS = {
     {"REPLICATION_TOTAL_TIMEOUT_MS", "60000"},
     {"REPLICATION_CONNECTION_TIMEOUT_MS", "1000"},
     {"REPLICATION_WAVE_TIMEOUT_MS", "500"},
+    {"PLUGINS_DIR", ""},
     {"CHUNK_TRASH_ENABLED", "0"},
     {"CHUNK_TRASH_EXPIRATION_SECONDS", "259200"},
     {"CHUNK_TRASH_FREE_SPACE_THRESHOLD_GB", "0"},

--- a/src/chunkserver/hddspacemgr.cc
+++ b/src/chunkserver/hddspacemgr.cc
@@ -2720,21 +2720,23 @@ int initDiskManager() {
 }
 
 int loadPlugins() {
-	std::string pluginsInstallDirPath = PLUGINS_PATH "/chunkserver";
-	std::string pluginsBuildDirPath = BUILD_PATH "/plugins/chunkserver";
+	const std::array<std::string, 5> pluginPaths = {
+	    cfg_getstring("PLUGINS_DIR", ""),              // Higher priority (user-defined)
+	    "/usr/local/lib/saunafs/plugins/chunkserver",  // Local install
+	    PLUGINS_PATH "/chunkserver",                   // Build-time defined path
+	    "/usr/lib/saunafs/plugins/chunkserver",        // Standard install
+	    BUILD_PATH "/plugins/chunkserver"              // Build tree (for development)
+	};
 
-	// Try to load plugins first from the installation directory
-	if (!pluginManager.loadPlugins(pluginsInstallDirPath)) {
-		safs_pretty_syslog(LOG_NOTICE,
-		                   "PluginManager: No plugins loaded from: %s",
-		                   pluginsInstallDirPath.c_str());
+	for (const auto &path : pluginPaths) {
+		if (path.empty()) { continue; }
 
-		// If no plugins were loaded from the installation directory,
-		// try to load them from the build directory (useful for development)
-		if (!pluginManager.loadPlugins(pluginsBuildDirPath)) {
-			safs_pretty_syslog(LOG_NOTICE,
-			                   "PluginManager: No plugins loaded from: %s",
-			                   pluginsBuildDirPath.c_str());
+		if (!pluginManager.loadPlugins(path)) {
+			safs::log_debug("PluginManager: No plugins loaded from: {}", path);
+		} else {
+			safs::log_info("PluginManager: Plugins loaded from: {}", path);
+			// stop after the first successful load, we don't want to load from multiple dirs
+			break;
 		}
 	}
 

--- a/src/data/sfschunkserver.cfg.in
+++ b/src/data/sfschunkserver.cfg.in
@@ -221,6 +221,15 @@
 ## 'off'
 # LOG_LEVEL = info
 
+## Directory to search for Chunkserver plugins (absolute path).
+## When set, the plugin manager will search this directory first.
+## If not set, then it will search in usual plugin locations, like:
+## /usr/local/lib/saunafs/plugins/chunkserver
+## @PLUGINS_PATH@/chunkserver (defined at build time)
+## /usr/lib/saunafs/plugins/chunkserver
+## (Default: empty string - disabled)
+# PLUGINS_DIR = ""
+
 ##### EXPERIMENTAL:
 
 ## Enables or disables the chunk trash feature. When enabled, deleted chunks are


### PR DESCRIPTION
feat(chunkserver): Add PLUGINS_DIR config variable
This commit allows to specify a directory (absolute path) to
search for available plugins. For instance:

PLUGINS_DIR = /opt/saunafs/plugins/chunkserver

The Plugin Manager will search in this order:
1. PLUGINS_DIR: defined by the user, takes higher precedence.
2. /usr/local/lib/saunafs/plugins/chunkserver
3. PLUGINS_PATH/chunkserver: defined at configuration time (cmake),
   depends on the build settings (Debug, Release, installDir,
   CMAKE_INSTALL_PREFIX).
4. /usr/lib/saunafs/plugins/chunkserver
5. BUILD_PATH: Useful for development, points to the build directory.

The scan stops after finding plugins in one of the directories, in
order to not mix plugins from different directories.

Co-authored-by: Urmas Rist <urmas@leil.io>

Signed-off-by: guillex <guillex@leil.io>