### PR TITLE
perf(cs): Configure buffers pool size

### DIFF
--- a/doc/sfschunkserver.cfg.5.adoc
+++ b/doc/sfschunkserver.cfg.5.adoc
@@ -142,6 +142,11 @@ in a single read job. If possible, will try to make a single pread call
 *MAX_PARALLEL_HDD_READ_JOBS_PER_CS_ENTRY*:: maximum number of read jobs processed
 in parallel per client connection (default is 1)
 
+*MAX_BUFFERS_POOL_SIZE_MB*:: maximum size of the buffers pool used for read, write
+and replicate operations, in megabytes. Consider decreasing it if the system is
+running out of memory, or increasing it to improve performance if there is enough
+memory available. Unused buffers are regularly freed (default is 512)
+
 *READ_AHEAD_KB*:: additional number of kilobytes which should be passed to
 posix_fadvise(POSIX_FADV_WILLNEED) before reading data from a chunk (default is
 0, i.e. use posix_fadvise only with the amount of data that is really needed;

--- a/src/admin/dump_config_command.cc
+++ b/src/admin/dump_config_command.cc
@@ -168,6 +168,7 @@ const static std::unordered_map<std::string, std::string> defaultOptionsCS = {
     {"MAX_BLOCKS_PER_HDD_WRITE_JOB", "16"},
     {"MAX_BLOCKS_PER_HDD_READ_JOB", "16"},
     {"MAX_PARALLEL_HDD_READ_JOBS_PER_CS_ENTRY", "1"},
+    {"MAX_BUFFERS_POOL_SIZE_MB", "512"},
     {"MAX_READ_BEHIND_KB", "0"},
     {"PERFORM_FSYNC", "1"},
     {"STAT_CHUNKS_AT_DISK_SCAN", "1"},

--- a/src/chunkserver/buffers_pool.h
+++ b/src/chunkserver/buffers_pool.h
@@ -58,8 +58,8 @@ public:
 
 		if (operationsSinceLastLog_ == kLogAfterEveryXTimes) {
 			safs::log_trace(
-			    "BuffersPool::get {} blocks, currentNumberOfBlocks_ = {}, kMaxNumberOfBlocks = {}",
-			    numBlocks, currentNumberOfBlocks_, kMaxNumberOfBlocks);
+			    "BuffersPool::get {} blocks, currentNumberOfBlocks_ = {}, maxNumberOfBlocks_ = {}",
+			    numBlocks, currentNumberOfBlocks_, maxNumberOfBlocks_);
 			operationsSinceLastLog_ = 0;
 		}
 		operationsSinceLastLog_++;
@@ -93,13 +93,13 @@ public:
 
 		if (operationsSinceLastLog_ == kLogAfterEveryXTimes) {
 			safs::log_trace(
-			    "BuffersPool::put {} blocks, currentNumberOfBlocks_ = {}, kMaxNumberOfBlocks = {}",
-			    numBlocks, currentNumberOfBlocks_, kMaxNumberOfBlocks);
+			    "BuffersPool::put {} blocks, currentNumberOfBlocks_ = {}, maxNumberOfBlocks_ = {}",
+			    numBlocks, currentNumberOfBlocks_, maxNumberOfBlocks_);
 			operationsSinceLastLog_ = 0;
 		}
 		operationsSinceLastLog_++;
 
-		if (currentNumberOfBlocks_ + numBlocks <= kMaxNumberOfBlocks) {
+		if (currentNumberOfBlocks_ + numBlocks <= maxNumberOfBlocks_) {
 			buffer->clear();
 			buffers.emplace(std::move(buffer));
 			currentNumberOfBlocks_ += numBlocks;
@@ -131,6 +131,15 @@ public:
 		// Destructor of the vector should release the last copy of the buffers
 	}
 
+	/**
+	 * Sets the maximum number of blocks allowed in the pool.
+	 * @param maxBlocks The new maximum number of blocks.
+	 */
+	void setMaxNumberOfBlocks(size_t maxBlocks) {
+		std::lock_guard lock(mutex_);
+		maxNumberOfBlocks_ = maxBlocks;
+	}
+
 private:
 	struct BufferPoolEntry {
 		std::shared_ptr<T> entry_;
@@ -150,7 +159,7 @@ private:
 	/// Number of operations since last log message.
 	size_t operationsSinceLastLog_ = 0;
 	/// Maximum number of buffers in the pool.
-	static constexpr size_t kMaxNumberOfBlocks = 8192;
+	size_t maxNumberOfBlocks_ = 8192;
 	/// Current number of buffers in the pool.
 	size_t currentNumberOfBlocks_ = 0;
 	/// Buffers pool map: a queue of buffers for each type of buffer.

--- a/src/chunkserver/io_buffers.cc
+++ b/src/chunkserver/io_buffers.cc
@@ -397,3 +397,17 @@ void releaseOldIoBuffers(uint32_t expirationTime_ms) {
 	    __func__, gCurrentTotalOutputBufferBlocks.load(), gCurrentTotalInputBufferBlocks.load(),
 	    gCurrentTotalReplicatorBufferBlocks.load());
 }
+
+void setNewMaxIoBuffersPoolSize(size_t maxBuffersPoolSize_mb) {
+	if (maxBuffersPoolSize_mb > (1 << 20)) {
+		safs::log_warn(
+		    "({}) Given maxBuffersPoolSize_mb {} is too large, capping to 1 TB.",
+		    __func__, maxBuffersPoolSize_mb);
+		maxBuffersPoolSize_mb = (1 << 20);
+	}
+
+	size_t maxBuffersPoolSize_blocks = (maxBuffersPoolSize_mb * 1024 * 1024) / SFSBLOCKSIZE;
+	getReadOutputBufferPool().setMaxNumberOfBlocks(maxBuffersPoolSize_blocks);
+	getWriteInputBufferPool().setMaxNumberOfBlocks(maxBuffersPoolSize_blocks);
+	getReplicateBuffersPool().setMaxNumberOfBlocks(maxBuffersPoolSize_blocks);
+}

--- a/src/chunkserver/io_buffers.h
+++ b/src/chunkserver/io_buffers.h
@@ -554,3 +554,4 @@ inline ReplicatorBufferPool &getReplicateBuffersPool() {
 }
 
 void releaseOldIoBuffers(uint32_t expirationTime_ms);
+void setNewMaxIoBuffersPoolSize(size_t maxBuffersPoolSize_mb);

--- a/src/chunkserver/network_main_thread.cc
+++ b/src/chunkserver/network_main_thread.cc
@@ -116,6 +116,9 @@ void mainNetworkThreadReload(void) {
 	    "MAX_PARALLEL_HDD_READ_JOBS_PER_CS_ENTRY",
 	    NetworkWorkerThread::kDefaultMaxParallelHddReadJobsPerCsEntry, 1);
 
+	size_t maxBuffersPoolSize_mb = cfg_get_minvalue<size_t>("MAX_BUFFERS_POOL_SIZE_MB", 512, 0);
+	setNewMaxIoBuffersPoolSize(maxBuffersPoolSize_mb);
+
 	gHDDReadAhead.setReadAhead_kB(
 			cfg_get_maxvalue<uint32_t>("READ_AHEAD_KB", 0, SFSCHUNKSIZE / 1024));
 	gHDDReadAhead.setMaxReadBehind_kB(
@@ -246,6 +249,9 @@ int mainNetworkThreadInit(void) {
 	gMaxParallelHddReadJobsPerCsEntry = cfg_get_minvalue<uint16_t>(
 	    "MAX_PARALLEL_HDD_READ_JOBS_PER_CS_ENTRY",
 	    NetworkWorkerThread::kDefaultMaxParallelHddReadJobsPerCsEntry, 1);
+
+	size_t maxBuffersPoolSize_mb = cfg_get_minvalue<size_t>("MAX_BUFFERS_POOL_SIZE_MB", 512, 0);
+	setNewMaxIoBuffersPoolSize(maxBuffersPoolSize_mb);
 
 	gHDDReadAhead.setReadAhead_kB(
 			cfg_get_maxvalue<uint32_t>("READ_AHEAD_KB", 0, SFSCHUNKSIZE / 1024));

--- a/src/data/sfschunkserver.cfg.in
+++ b/src/data/sfschunkserver.cfg.in
@@ -163,6 +163,13 @@
 ## (Default: 1)
 # MAX_PARALLEL_HDD_READ_JOBS_PER_CS_ENTRY = 1
 
+## Maximum size of the buffers pool used for read, write and replicate operations,
+## in megabytes. Consider decreasing it if the system is running out of memory, or
+## increasing it to improve performance if there is enough memory available. Unused
+## buffers are regularly freed.
+## (Default: 512)
+# MAX_BUFFERS_POOL_SIZE_MB = 512
+
 ## additional number of kilobytes which should be passed to
 ## posix_fadvise(POSIX_FADV_WILLNEED) before reading data from a chunk
 ## (Default: 0), i.e. use posix_fadvise only with the amount of data that is

--- a/tests/test_suites/ShortSystemTests/test_cs_max_buffers_pool_size.sh
+++ b/tests/test_suites/ShortSystemTests/test_cs_max_buffers_pool_size.sh
@@ -1,0 +1,52 @@
+timeout_set 30 seconds
+
+CHUNKSERVERS=6 \
+	USE_RAMDISK=YES \
+	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER" \
+	CHUNKSERVER_EXTRA_CONFIG="MAX_BUFFERS_POOL_SIZE_MB = 0`
+		`|MAX_BLOCKS_PER_HDD_WRITE_JOB = 1`
+		`|MAX_BLOCKS_PER_HDD_READ_JOB = 1`
+		`|MAX_PARALLEL_HDD_READ_JOBS_PER_CS_ENTRY = 1`
+		`|LOG_LEVEL = trace|LOG_FLUSH_ON = TRACE|MAGIC_DEBUG_LOG = ${TEMP_DIR}/log" \
+	MASTER_CUSTOM_GOALS="8 ec42: \$ec(4,2)"
+	setup_local_empty_saunafs info
+
+apply_chunkserver_config() {
+	local parameter=$1
+	local value=$2
+	for i in $(seq 0 $(( ${info[chunkserver_count]} - 1 ))); do
+		sed -i -re "s/^$parameter = .*/$parameter = $value/" "${info[chunkserver${i}_cfg]}"
+	done
+}
+
+file_size=$(( 4 * SAUNAFS_CHUNK_SIZE ))
+
+mkdir -p "${info[mount0]}/data"
+saunafs setgoal -r ec42 "${info[mount0]}/data"
+saunafs settrashtime 0 "${info[mount0]}/data"
+cd "${info[mount0]}/data"
+
+current_iteration=0
+for maxBuffersPoolSize_mb in 0 64 512 4096; do
+	apply_chunkserver_config MAX_BUFFERS_POOL_SIZE_MB ${maxBuffersPoolSize_mb}
+	# To apply the new configuration, we just need to reload the chunkservers.
+	for i in $(seq 0 $(( ${info[chunkserver_count]} - 1 ))); do
+		saunafs_chunkserver_daemon $i reload
+	done
+	saunafs_wait_for_all_ready_chunkservers
+
+	echo "Testing with MAX_BUFFERS_POOL_SIZE_MB=${maxBuffersPoolSize_mb}..."
+	FILE_SIZE=${file_size} BLOCK_SIZE=65536 file-generate file_${maxBuffersPoolSize_mb}
+	if ! file-validate file_${maxBuffersPoolSize_mb}; then
+		test_add_failure "File validation failed for MAX_BUFFERS_POOL_SIZE_MB=${maxBuffersPoolSize_mb}"
+	fi
+
+	echo "File validation succeeded for MAX_BUFFERS_POOL_SIZE_MB=${maxBuffersPoolSize_mb}"
+	rm -f file_${maxBuffersPoolSize_mb}
+	sleep 1
+
+	expectedNumberOfBlocks=$((maxBuffersPoolSize_mb * 1024 * 1024 / SAUNAFS_BLOCK_SIZE))
+	if ! grep "maxNumberOfBlocks_ = ${expectedNumberOfBlocks}" "${TEMP_DIR}/log"; then
+		test_add_failure "Log does not contain expected buffer pool size: maxNumberOfBlocks_ = ${expectedNumberOfBlocks}"
+	fi
+done


### PR DESCRIPTION
This change targets improving the tuning of the chunkserver by setting
the max size of the buffers pool. It allows to reduce the memory used
by the chunkserver if performance is the desired one and to have some
extra buffering space if the memory is not an issue.

The commit also adds a new test to check the new parameter does not
affect the chunkserver behavior.

Signed-off-by: Dave <dave@leil.io>