### PR TITLE
refactor(master): relocate more FS operations

### DIFF
--- a/src/data/sfsmaster.cfg.in
+++ b/src/data/sfsmaster.cfg.in
@@ -176,10 +176,6 @@
 ## (Default: 0)
 # CHUNKS_REBALANCING_BETWEEN_LABELS = 0
 
-## Interval of freeing inodes being unused for longer than 24 hours in seconds.
-## (Default: 60)
-# FREE_INODES_PERIOD = 60
-
 ## Whether to update inode access time on every access,
 ## boolean value (0 or 1)
 ## (Default: 0)

--- a/src/master/filesystem.h
+++ b/src/master/filesystem.h
@@ -30,13 +30,9 @@
 #include "master/fs_context.h"
 #include "protocol/quota.h"
 
-struct JobInfo;
-
 SAUNAFS_CREATE_EXCEPTION_CLASS_MSG(NoMetadataException, Exception, "no metadata");
 
 inline std::string gClusterId;  ///< Unique cluster identifier
-
-uint8_t fs_cancel_job(uint32_t job_id);
 
 uint8_t fs_apply_freeinodes(uint32_t timestamp, inode_t freeinodes);
 
@@ -82,9 +78,6 @@ void fs_disable_checksum_verification(bool value);
 #else
 
 void fs_cs_disconnected(void);
-
-/// Return info about currently executed tasks
-std::vector<JobInfo> fs_get_current_tasks_info();
 
 // Disable saving metadata on exit
 void fs_disable_metadata_dump_on_exit();

--- a/src/master/filesystem.h
+++ b/src/master/filesystem.h
@@ -34,8 +34,6 @@ SAUNAFS_CREATE_EXCEPTION_CLASS_MSG(NoMetadataException, Exception, "no metadata"
 
 inline std::string gClusterId;  ///< Unique cluster identifier
 
-uint8_t fs_apply_freeinodes(uint32_t timestamp, inode_t freeinodes);
-
 uint8_t fs_quota_get_all(const FsContext &context, std::vector<QuotaEntry> &results);
 uint8_t fs_quota_get(const FsContext &context, const std::vector<QuotaOwner> &owners,
                      std::vector<QuotaEntry> &results);

--- a/src/master/filesystem_freenode.cc
+++ b/src/master/filesystem_freenode.cc
@@ -38,9 +38,3 @@ inode_t IdGeneratorWithDetainer::getNextId(uint32_t timeStamp, inode_t requested
 
 	return requestedId;
 }
-
-uint8_t fs_apply_freeinodes(uint32_t /*ts*/, inode_t /*freeinodes*/) {
-	// left for compatibility when reading from old metadata change log
-	gMetadata->metadataVersion++;
-	return 0;
-}

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -3038,11 +3038,11 @@ const Goal &FilesystemOperationsBase::fs_get_goal_definition(uint8_t goalId) con
 	return gGoalDefinitions[goalId];
 }
 
-std::vector<JobInfo> fs_get_current_tasks_info() {
+std::vector<JobInfo> FilesystemOperationsBase::fs_get_current_tasks_info() {
 	return gMetadata->taskManager.getCurrentJobsInfo();
 }
 
-uint8_t fs_cancel_job(uint32_t job_id) {
+uint8_t FilesystemOperationsBase::fs_cancel_job(uint32_t job_id) {
 	if (gMetadata->taskManager.cancelJob(job_id)) {
 		return SAUNAFS_STATUS_OK;
 	} else {

--- a/src/master/filesystem_operations.h
+++ b/src/master/filesystem_operations.h
@@ -100,6 +100,8 @@ public:
 	const Goal &fs_get_goal_definition(uint8_t goalId) const override;
 
 	uint32_t fs_reserve_job_id() override;
+	uint8_t fs_cancel_job(uint32_t job_id) override;
+	std::vector<JobInfo> fs_get_current_tasks_info() override;
 
 	uint8_t fs_access(const FsContext &context, inode_t inode, int modemask) override;
 	uint8_t fs_lookup(const FsContext &context, inode_t parent, const HString &name, inode_t *inode,

--- a/src/master/filesystem_operations_interface.h
+++ b/src/master/filesystem_operations_interface.h
@@ -255,7 +255,6 @@ public:
 	virtual uint8_t fs_apply_attr(uint32_t timestamp, inode_t inode, uint32_t mode, uint32_t uid,
 	                              uint32_t gid, uint32_t atime, uint32_t mtime) = 0;
 	virtual uint8_t fs_apply_session(uint32_t sessionid) = 0;
-	// virtual uint8_t fs_apply_freeinodes(uint32_t timestamp, inode_t freeinodes) = 0;
 	virtual uint8_t fs_apply_incversion(uint64_t chunkid) = 0;
 	virtual uint8_t fs_apply_length(uint32_t timestamp, inode_t inode, uint64_t length,
 	                                bool eraseFurtherChunks) = 0;

--- a/src/master/filesystem_operations_interface.h
+++ b/src/master/filesystem_operations_interface.h
@@ -116,6 +116,9 @@ public:
 	virtual const Goal &fs_get_goal_definition(uint8_t goalId) const = 0;
 
 	virtual uint32_t fs_reserve_job_id() = 0;
+	virtual uint8_t fs_cancel_job(uint32_t job_id) = 0;
+	/// Return info about currently executed tasks
+	virtual std::vector<JobInfo> fs_get_current_tasks_info() = 0;
 
 	virtual uint8_t fs_access(const FsContext &context, inode_t inode, int modemask) = 0;
 	virtual uint8_t fs_lookup(const FsContext &context, inode_t parent, const HString &name,

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -4210,7 +4210,7 @@ void matoclserv_manage_locks_unlock(matoclserventry *eptr, const uint8_t *data, 
 }
 
 void matoclserv_list_tasks(matoclserventry *eptr) {
-	std::vector<JobInfo> jobs_info = fs_get_current_tasks_info();
+	std::vector<JobInfo> jobs_info = gFilesystemOperations->fs_get_current_tasks_info();
 	matoclserv_createpacket(eptr, matocl::listTasks::build(jobs_info));
 }
 
@@ -4218,7 +4218,7 @@ void matoclserv_stop_task(matoclserventry *eptr, const uint8_t *data, uint32_t l
 	uint32_t job_id, msgid;
 	uint8_t status;
 	cltoma::stopTask::deserialize(data, length, msgid, job_id);
-	status = fs_cancel_job(job_id);
+	status = gFilesystemOperations->fs_cancel_job(job_id);
 	matoclserv_createpacket(eptr, matocl::stopTask::build(msgid, status));
 }
 

--- a/src/master/restore.cc
+++ b/src/master/restore.cc
@@ -301,15 +301,6 @@ int do_session(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) 
 	return gFilesystemOperations->fs_apply_session(cuid);
 }
 
-int do_freeinodes(const char *filename, uint64_t lv, uint32_t ts, const char* ptr) {
-	inode_t freeinodes;
-	EAT(ptr,filename,lv,'(');
-	EAT(ptr,filename,lv,')');
-	EAT(ptr,filename,lv,':');
-	GETINODE(freeinodes,ptr);
-	return fs_apply_freeinodes(ts,freeinodes);
-}
-
 int do_incversion(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
 	uint64_t chunkid;
 	(void)ts;
@@ -885,8 +876,6 @@ int restore_line(const char* filename, uint64_t lv, const char* line) {
 				status = do_lock_unlock_inode(filename,lv,ts,ptr+9);
 			} else if (strncmp(ptr, "FLCK", 4) == 0) {
 				status = do_lock_op(filename,lv,ts,ptr+4);
-			} else if (strncmp(ptr, "FREEINODES", 10) == 0) {
-				status = do_freeinodes(filename,lv,ts,ptr+10);
 			}
 			break;
 		case 'I':

--- a/tests/test_suites/ShortSystemTests/test_auto_recovery_reuse_freeinodes.sh
+++ b/tests/test_suites/ShortSystemTests/test_auto_recovery_reuse_freeinodes.sh
@@ -2,7 +2,6 @@ timeout_set 1 minute
 
 master_cfg="METADATA_DUMP_PERIOD_SECONDS = 0"
 master_cfg+="|AUTO_RECOVERY = 1"
-master_cfg+="|FREE_INODES_PERIOD = 1"
 master_cfg+="|DISABLE_METADATA_CHECKSUM_VERIFICATION = 1"
 
 CHUNKSERVERS=1 \
@@ -20,7 +19,7 @@ metadata_file="${info[master_data_path]}/metadata.sfs"
 # Remember version of the metadata file. We expect it not to change when generating data.
 metadata_version=$(metadata_get_version "$metadata_file")
 
-# Create and remove inodes, which later will be freed generating FREEINODES entry in changelog
+# Create and remove inodes to test that inode IDs are reused after deletion
 cd ${info[mount0]}
 touch file{00..99}
 assert_eventually '[[ $(grep RELEASE "$changelog_file" | wc -l) == 100 ]]'
@@ -46,7 +45,7 @@ fi
 touch "${info[mount0]}"/file{0000..099}
 assert_awk_finds    '/CREATE.*:20$/' "$(cat "$changelog_file")" # Make sure that inode 20 was reused
 
-# Simulate crash of the master server, auto recover metadata applying FREEINODES and check it
+# Simulate crash in master server, auto recover metadata and verify that there are no changes
 metadata=$(metadata_print "${info[mount0]}")
 saunafs_master_daemon kill
 assert_equals "$new_metadata_version" "$(metadata_get_version "$metadata_file")"


### PR DESCRIPTION
This PR performs minor cleanups in filesystem.h by:

Moving the functions `fs_cancel_job` and
`fs_get_current_tasks_info` from filesystem.h to their
corresponding interface and implementation files.

Removing the deprecated `fs_apply_freeinodes` function and
the unused `FREE_INODES_PERIOD` configuration variable in Master.

Reviewers, please refer to the commits for more details.