### PR TITLE
refactor(cs): Improve plugin dir selection

### DIFF
--- a/doc/sfschunkserver.cfg.5.adoc
+++ b/doc/sfschunkserver.cfg.5.adoc
@@ -180,8 +180,8 @@ chunkservers (default: 500)
 
 *PLUGINS_DIR*:: directory to search for Chunkserver plugins (absolute path).
 When set, the plugin manager will search this directory first. If not set, then
-it will search in usual plugin locations, like /usr/local/lib/saunafs/plugins/chunkserver,
-PLUGINS_PATH/chunkserver (PLUGINS_PATH is defined at build time), and
+it will search in usual plugin locations, like PLUGINS_PATH/chunkserver (PLUGINS_PATH is 
+defined at build time), /usr/local/lib/saunafs/plugins/chunkserver, and
 /usr/lib/saunafs/plugins/chunkserver (default is empty string, i.e. disabled)
 
 *CHUNK_TRASH_ENABLED (EXPERIMENTAL)*:: enables or disables the chunk trash

--- a/src/chunkserver/hddspacemgr.cc
+++ b/src/chunkserver/hddspacemgr.cc
@@ -2722,10 +2722,10 @@ int initDiskManager() {
 int loadPlugins() {
 	const std::array<std::string, 5> pluginPaths = {
 	    cfg_getstring("PLUGINS_DIR", ""),              // Higher priority (user-defined)
-	    "/usr/local/lib/saunafs/plugins/chunkserver",  // Local install
 	    PLUGINS_PATH "/chunkserver",                   // Build-time defined path
-	    "/usr/lib/saunafs/plugins/chunkserver",        // Standard install
-	    BUILD_PATH "/plugins/chunkserver"              // Build tree (for development)
+	    BUILD_PATH "/plugins/chunkserver",             // Build tree (for development)
+	    "/usr/local/lib/saunafs/plugins/chunkserver",  // Local install
+	    "/usr/lib/saunafs/plugins/chunkserver"         // Standard install
 	};
 
 	for (const auto &path : pluginPaths) {


### PR DESCRIPTION
This change fixes the selection of the plugin directory to load from,
ensuring that those in build directories take higher precedence. It
should not affect the actual deployments because plugins should not be
built over there.

Signed-off-by: Dave <dave@leil.io>