### PR TITLE
refactor(master): make FS quota functions extensible

### DIFF
--- a/src/master/filesystem.h
+++ b/src/master/filesystem.h
@@ -34,16 +34,6 @@ SAUNAFS_CREATE_EXCEPTION_CLASS_MSG(NoMetadataException, Exception, "no metadata"
 
 inline std::string gClusterId;  ///< Unique cluster identifier
 
-uint8_t fs_quota_get_all(const FsContext &context, std::vector<QuotaEntry> &results);
-uint8_t fs_quota_get(const FsContext &context, const std::vector<QuotaOwner> &owners,
-                     std::vector<QuotaEntry> &results);
-uint8_t fs_quota_set(const FsContext &context, const std::vector<QuotaEntry> &entries);
-uint8_t fs_quota_get_info(const FsContext &context, const std::vector<QuotaEntry> &entries,
-                          std::vector<std::string> &result);
-
-uint8_t fs_apply_setquota(char rigor, char resource, char ownerType, inode_t ownerId,
-                          uint64_t limit);
-
 /// Returns checksum of the loaded metadata.
 uint64_t fs_checksum(ChecksumMode mode);
 

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -3056,6 +3056,11 @@ uint64_t FilesystemOperationsBase::fs_getversion() {
 	return gMetadata->metadataVersion;
 }
 
+uint8_t FilesystemOperationsBase::fs_apply_setquota(char rigor, char resource, char ownerType,
+                                                    inode_t ownerId, uint64_t limit) {
+	return quotas::fs_apply_setquota(rigor, resource, ownerType, ownerId, limit);
+}
+
 #ifndef METARESTORE
 const std::map<int, Goal> &FilesystemOperationsBase::fs_get_goal_definitions() const {
 	return gGoalDefinitions;
@@ -3133,4 +3138,25 @@ uint8_t FilesystemOperationsBase::fs_getchunksinfo(const FsContext &context, uin
 	return SAUNAFS_STATUS_OK;
 }
 
+uint8_t FilesystemOperationsBase::fs_quota_get_all(const FsContext &context,
+                                                   std::vector<QuotaEntry> &results) {
+	return quotas::fs_quota_get_all(context, results);
+}
+
+uint8_t FilesystemOperationsBase::fs_quota_get(const FsContext &context,
+                                               const std::vector<QuotaOwner> &owners,
+                                               std::vector<QuotaEntry> &results) {
+	return quotas::fs_quota_get(context, owners, results);
+}
+
+uint8_t FilesystemOperationsBase::fs_quota_set(const FsContext &context,
+                                               const std::vector<QuotaEntry> &entries) {
+	return quotas::fs_quota_set(context, entries);
+}
+
+uint8_t FilesystemOperationsBase::fs_quota_get_info(const FsContext &context,
+                                                    const std::vector<QuotaEntry> &entries,
+                                                    std::vector<std::string> &result) {
+	return quotas::fs_quota_get_info(context, entries, result);
+}
 #endif

--- a/src/master/filesystem_operations.h
+++ b/src/master/filesystem_operations.h
@@ -223,6 +223,15 @@ public:
 	                              std::string &fullPath) override;
 	std::string fs_full_path_by_inode(inode_t initial_inode) override;
 
+	// QUOTAS
+
+	uint8_t fs_quota_get_all(const FsContext &context, std::vector<QuotaEntry> &results) override;
+	uint8_t fs_quota_get(const FsContext &context, const std::vector<QuotaOwner> &owners,
+	                     std::vector<QuotaEntry> &results) override;
+	uint8_t fs_quota_set(const FsContext &context, const std::vector<QuotaEntry> &entries) override;
+	uint8_t fs_quota_get_info(const FsContext &context, const std::vector<QuotaEntry> &entries,
+	                          std::vector<std::string> &result) override;
+
 #endif
 	void fs_add_files_to_chunks(bool isMetadataLoading = true) override;
 
@@ -252,6 +261,9 @@ public:
 	uint8_t fs_apply_unlock(uint64_t chunkid) override;
 	uint8_t fs_apply_trunc(uint32_t timestamp, inode_t inode, uint32_t indx, uint64_t chunkid,
 	                       uint32_t lockid) override;
+
+	uint8_t fs_apply_setquota(char rigor, char resource, char ownerType, inode_t ownerId,
+	                          uint64_t limit) override;
 
 	// Locks
 

--- a/src/master/filesystem_operations_interface.h
+++ b/src/master/filesystem_operations_interface.h
@@ -244,6 +244,17 @@ public:
 	                                      std::string &fullPath) = 0;
 	virtual std::string fs_full_path_by_inode(inode_t initial_inode) = 0;
 
+	// QUOTAS
+
+	virtual uint8_t fs_quota_get_all(const FsContext &context,
+	                                 std::vector<QuotaEntry> &results) = 0;
+	virtual uint8_t fs_quota_get(const FsContext &context, const std::vector<QuotaOwner> &owners,
+	                             std::vector<QuotaEntry> &results) = 0;
+	virtual uint8_t fs_quota_set(const FsContext &context,
+	                             const std::vector<QuotaEntry> &entries) = 0;
+	virtual uint8_t fs_quota_get_info(const FsContext &context,
+	                                  const std::vector<QuotaEntry> &entries,
+	                                  std::vector<std::string> &result) = 0;
 #endif
 	virtual void fs_add_files_to_chunks(bool isMetadataLoading = true) = 0;
 
@@ -273,6 +284,9 @@ public:
 	virtual uint8_t fs_apply_unlock(uint64_t chunkid) = 0;
 	virtual uint8_t fs_apply_trunc(uint32_t timestamp, inode_t inode, uint32_t indx,
 	                               uint64_t chunkid, uint32_t lockid) = 0;
+
+	virtual uint8_t fs_apply_setquota(char rigor, char resource, char ownerType, inode_t ownerId,
+	                                  uint64_t limit) = 0;
 
 	// Lock operations
 

--- a/src/master/filesystem_quota.cc
+++ b/src/master/filesystem_quota.cc
@@ -69,93 +69,6 @@ static void fs_remove_invisible_quota_entries(inode_t root_inode, std::vector<Qu
 	results.erase(it, results.end());
 }
 
-uint8_t fs_quota_get_all(const FsContext &context, std::vector<QuotaEntry> &results) {
-	if (context.uid() != 0 && !(context.sesflags() & SESFLAG_ALLCANCHANGEQUOTA)) {
-		return SAUNAFS_ERROR_EPERM;
-	}
-	results = gMetadata->quotaDatabase.getEntriesWithStats();
-
-	for (auto &entry : results) {
-		if (entry.entryKey.owner.ownerType != QuotaOwnerType::kInode ||
-		    entry.entryKey.rigor != QuotaRigor::kUsed) {
-			continue;
-		}
-
-		FSNodeDirectory *node = fsnodes_id_to_node<FSNodeDirectory>(entry.entryKey.owner.ownerId);
-		if (!node || node->type != FSNodeType::kDirectory) {
-			continue;
-		}
-
-		switch (entry.entryKey.resource) {
-		case QuotaResource::kSize:
-			entry.limit = node->stats.size;
-			break;
-		case QuotaResource::kInodes:
-			entry.limit = node->stats.inodes;
-			break;
-		}
-	}
-
-	fs_remove_invisible_quota_entries(context.rootinode(), results);
-
-	return SAUNAFS_STATUS_OK;
-}
-
-uint8_t fs_quota_get(const FsContext &context,
-		const std::vector<QuotaOwner> &owners, std::vector<QuotaEntry> &results) {
-	std::vector<QuotaEntry> tmp;
-	FSNodeDirectory *node;
-	for (const QuotaOwner &owner : owners) {
-		if (context.uid() != 0 && !(context.sesflags() & SESFLAG_ALLCANCHANGEQUOTA)) {
-			switch (owner.ownerType) {
-			case QuotaOwnerType::kUser:
-				if (context.uid() != owner.ownerId) {
-					return SAUNAFS_ERROR_EPERM;
-				}
-				break;
-			case QuotaOwnerType::kGroup:
-				if (context.gid() != owner.ownerId && !(context.sesflags() & SESFLAG_IGNOREGID)) {
-					return SAUNAFS_ERROR_EPERM;
-				}
-				break;
-			case QuotaOwnerType::kInode:
-				node = fsnodes_id_to_node<FSNodeDirectory>(owner.ownerId);
-				if (!node || node->type != FSNodeType::kDirectory) {
-					return SAUNAFS_ERROR_EINVAL;
-				}
-				if (node->uid != context.uid() || (node->gid != context.gid() && !(context.sesflags() & SESFLAG_IGNOREGID))) {
-					return SAUNAFS_ERROR_EPERM;
-				}
-				break;
-			default:
-				return SAUNAFS_ERROR_EINVAL;
-			}
-		}
-		auto result = gMetadata->quotaDatabase.get(owner.ownerType, owner.ownerId);
-		if (result) {
-			for (auto rigor : {QuotaRigor::kSoft, QuotaRigor::kHard, QuotaRigor::kUsed}) {
-				if (owner.ownerType == QuotaOwnerType::kInode && rigor == QuotaRigor::kUsed) {
-					node = fsnodes_id_to_node<FSNodeDirectory>(owner.ownerId);
-					assert(node);
-					tmp.push_back({{owner, rigor, QuotaResource::kInodes},
-					               (uint64_t)node->stats.inodes});
-					tmp.push_back({{owner, rigor, QuotaResource::kSize},
-					               (uint64_t)node->stats.size});
-					continue;
-				}
-				for (auto resource : {QuotaResource::kInodes, QuotaResource::kSize}) {
-					tmp.push_back({{owner, rigor, resource}, (*result)[(int)rigor][(int)resource]});
-				}
-			}
-		}
-	}
-
-	fs_remove_invisible_quota_entries(context.rootinode(), tmp);
-	results = std::move(tmp);
-
-	return SAUNAFS_STATUS_OK;
-}
-
 static void fsnodes_getpath(inode_t root_inode, FSNode *node, std::string &ret) {
 	std::string::size_type size;
 	FSNode *p;
@@ -198,6 +111,89 @@ static void fsnodes_getpath(inode_t root_inode, FSNode *node, std::string &ret) 
 		}
 		p = parent;
 	}
+}
+
+namespace quotas {
+uint8_t fs_quota_get_all(const FsContext &context, std::vector<QuotaEntry> &results) {
+	if (context.uid() != 0 && !(context.sesflags() & SESFLAG_ALLCANCHANGEQUOTA)) {
+		return SAUNAFS_ERROR_EPERM;
+	}
+	results = gMetadata->quotaDatabase.getEntriesWithStats();
+
+	for (auto &entry : results) {
+		if (entry.entryKey.owner.ownerType != QuotaOwnerType::kInode ||
+		    entry.entryKey.rigor != QuotaRigor::kUsed) {
+			continue;
+		}
+
+		FSNodeDirectory *node = fsnodes_id_to_node<FSNodeDirectory>(entry.entryKey.owner.ownerId);
+		if (!node || node->type != FSNodeType::kDirectory) { continue; }
+
+		switch (entry.entryKey.resource) {
+		case QuotaResource::kSize:
+			entry.limit = node->stats.size;
+			break;
+		case QuotaResource::kInodes:
+			entry.limit = node->stats.inodes;
+			break;
+		}
+	}
+
+	fs_remove_invisible_quota_entries(context.rootinode(), results);
+
+	return SAUNAFS_STATUS_OK;
+}
+
+uint8_t fs_quota_get(const FsContext &context, const std::vector<QuotaOwner> &owners,
+                     std::vector<QuotaEntry> &results) {
+	std::vector<QuotaEntry> tmp;
+	FSNodeDirectory *node;
+	for (const QuotaOwner &owner : owners) {
+		if (context.uid() != 0 && !(context.sesflags() & SESFLAG_ALLCANCHANGEQUOTA)) {
+			switch (owner.ownerType) {
+			case QuotaOwnerType::kUser:
+				if (context.uid() != owner.ownerId) { return SAUNAFS_ERROR_EPERM; }
+				break;
+			case QuotaOwnerType::kGroup:
+				if (context.gid() != owner.ownerId && !(context.sesflags() & SESFLAG_IGNOREGID)) {
+					return SAUNAFS_ERROR_EPERM;
+				}
+				break;
+			case QuotaOwnerType::kInode:
+				node = fsnodes_id_to_node<FSNodeDirectory>(owner.ownerId);
+				if (!node || node->type != FSNodeType::kDirectory) { return SAUNAFS_ERROR_EINVAL; }
+				if (node->uid != context.uid() ||
+				    (node->gid != context.gid() && !(context.sesflags() & SESFLAG_IGNOREGID))) {
+					return SAUNAFS_ERROR_EPERM;
+				}
+				break;
+			default:
+				return SAUNAFS_ERROR_EINVAL;
+			}
+		}
+		auto result = gMetadata->quotaDatabase.get(owner.ownerType, owner.ownerId);
+		if (result) {
+			for (auto rigor : {QuotaRigor::kSoft, QuotaRigor::kHard, QuotaRigor::kUsed}) {
+				if (owner.ownerType == QuotaOwnerType::kInode && rigor == QuotaRigor::kUsed) {
+					node = fsnodes_id_to_node<FSNodeDirectory>(owner.ownerId);
+					assert(node);
+					tmp.push_back(
+					    {{owner, rigor, QuotaResource::kInodes}, (uint64_t)node->stats.inodes});
+					tmp.push_back(
+					    {{owner, rigor, QuotaResource::kSize}, (uint64_t)node->stats.size});
+					continue;
+				}
+				for (auto resource : {QuotaResource::kInodes, QuotaResource::kSize}) {
+					tmp.push_back({{owner, rigor, resource}, (*result)[(int)rigor][(int)resource]});
+				}
+			}
+		}
+	}
+
+	fs_remove_invisible_quota_entries(context.rootinode(), tmp);
+	results = std::move(tmp);
+
+	return SAUNAFS_STATUS_OK;
 }
 
 uint8_t fs_quota_get_info(const FsContext &context, const std::vector<QuotaEntry> &entries,
@@ -254,8 +250,11 @@ uint8_t fs_quota_set(const FsContext &context, const std::vector<QuotaEntry> &en
 	}
 	return SAUNAFS_STATUS_OK;
 }
-#endif
+}  // namespace quotas
 
+#endif  // METARESTORE
+
+namespace quotas {
 uint8_t fs_apply_setquota(char rigor, char resource, char owner_type, inode_t owner_id,
                           uint64_t limit) {
 	QuotaRigor quotaRigor = QuotaRigor::kSoft;
@@ -277,6 +276,7 @@ uint8_t fs_apply_setquota(char rigor, char resource, char owner_type, inode_t ow
 	gMetadata->quotaChecksum = gMetadata->quotaDatabase.checksum();
 	return SAUNAFS_STATUS_OK;
 }
+}  // namespace quotas
 
 static int fsnodes_find_depth(FSNodeDirectory *a) {
 	assert(a);

--- a/src/master/filesystem_quota.h
+++ b/src/master/filesystem_quota.h
@@ -29,6 +29,8 @@
 #include "master/filesystem_node_types.h"
 #include "protocol/quota.h"
 
+class FsContext;
+
 /*! \brief Test if resource change exceeds quota for users and groups.
  * \param uid User id.
  * \param gid Group id.
@@ -94,3 +96,15 @@ void fsnodes_quota_remove(QuotaOwnerType owner_type, uint32_t owner_id);
  * \param available_space Free space.
  */
 void fsnodes_quota_adjust_space(FSNode *node, uint64_t &total_space, uint64_t &available_space);
+
+namespace quotas {
+uint8_t fs_quota_get_all(const FsContext &context, std::vector<QuotaEntry> &results);
+uint8_t fs_quota_get(const FsContext &context, const std::vector<QuotaOwner> &owners,
+                     std::vector<QuotaEntry> &results);
+uint8_t fs_quota_set(const FsContext &context, const std::vector<QuotaEntry> &entries);
+uint8_t fs_quota_get_info(const FsContext &context, const std::vector<QuotaEntry> &entries,
+                          std::vector<std::string> &result);
+
+uint8_t fs_apply_setquota(char rigor, char resource, char ownerType, inode_t ownerId,
+                          uint64_t limit);
+}  // namespace quotas

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -1666,7 +1666,7 @@ void matoclserv_sau_get_self_quota(matoclserventry *eptr, const uint8_t *data, u
 		owners.emplace_back(QuotaOwnerType::kUser, uid);
 		owners.emplace_back(QuotaOwnerType::kGroup, gid);
 		owners.emplace_back(QuotaOwnerType::kInode, inode);
-		status = fs_quota_get(context, owners, results);
+		status = gFilesystemOperations->fs_quota_get(context, owners, results);
 
 		if (inode == context.rootinode() && !foundContextRootInodeResult(inode)) {
 			auto ino = fsnodes_id_to_node(inode);
@@ -1680,7 +1680,8 @@ void matoclserv_sau_get_self_quota(matoclserventry *eptr, const uint8_t *data, u
 
 	MessageBuffer reply;
 	if (status == SAUNAFS_STATUS_OK) {
-		status = fs_quota_get_info(matoclserv_get_context(eptr), results, info);
+		status =
+		    gFilesystemOperations->fs_quota_get_info(matoclserv_get_context(eptr), results, info);
 	}
 	if (status == SAUNAFS_STATUS_OK) {
 		matocl::fuseGetSelfQuota::serialize(reply, messageId, results);
@@ -4317,7 +4318,7 @@ void matoclserv_fuse_setquota(matoclserventry *eptr, const uint8_t *data, uint32
 	uint8_t status = matoclserv_check_group_cache(eptr, gid);
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = fs_quota_set(context, entries);
+		status = gFilesystemOperations->fs_quota_set(context, entries);
 	}
 
 	MessageBuffer reply;
@@ -4338,7 +4339,7 @@ void matoclserv_fuse_getquota(matoclserventry *eptr, const uint8_t *data, uint32
 		status = matoclserv_check_group_cache(eptr, gid);
 		if (status == SAUNAFS_STATUS_OK) {
 			FsContext context = matoclserv_get_context(eptr, uid, gid);
-			status = fs_quota_get_all(context, results);
+			status = gFilesystemOperations->fs_quota_get_all(context, results);
 		}
 	} else if (version == cltoma::fuseGetQuota::kSelectedLimits) {
 		std::vector<QuotaOwner> owners;
@@ -4346,7 +4347,7 @@ void matoclserv_fuse_getquota(matoclserventry *eptr, const uint8_t *data, uint32
 		status = matoclserv_check_group_cache(eptr, gid);
 		if (status == SAUNAFS_STATUS_OK) {
 			FsContext context = matoclserv_get_context(eptr, uid, gid);
-			status = fs_quota_get(context, owners, results);
+			status = gFilesystemOperations->fs_quota_get(context, owners, results);
 		}
 	} else {
 		throw IncorrectDeserializationException(
@@ -4355,7 +4356,8 @@ void matoclserv_fuse_getquota(matoclserventry *eptr, const uint8_t *data, uint32
 
 	MessageBuffer reply;
 	if (status == SAUNAFS_STATUS_OK) {
-		status = fs_quota_get_info(matoclserv_get_context(eptr), results, info);
+		status =
+		    gFilesystemOperations->fs_quota_get_info(matoclserv_get_context(eptr), results, info);
 	}
 
 	if (status == SAUNAFS_STATUS_OK) {

--- a/src/master/restore.cc
+++ b/src/master/restore.cc
@@ -686,7 +686,7 @@ int do_setquota(const char *filename, uint64_t lv, uint32_t, const char *ptr) {
 	GETU64(limit, ptr);
 	EAT(ptr, filename, lv, ')');
 
-	return fs_apply_setquota(rigor, resource, ownerType, ownerId, limit);
+	return gFilesystemOperations->fs_apply_setquota(rigor, resource, ownerType, ownerId, limit);
 }
 
 int do_snapshot(const char* /*filename*/, uint64_t /*lv*/, uint32_t /*ts*/, const char* /*ptr*/) {


### PR DESCRIPTION
The remaining quota-related function declarations in filesystem.h were previously implemented in filesystem_quota.cc, providing only a concrete implementation assuming that all the metadata related to quotas was in memory.

This change moves the function declarations to the IFilesystemOperations interface and its base implementation, to provide extensibility for the quota-related functions. The current base implementation (for in-memory metadata) just uses the existing functions from the newly introduced namespace `quotas`.