### PR TITLE
refactor(master): make FS checksum functions extensible

### DIFF
--- a/src/master/filesystem.cc
+++ b/src/master/filesystem.cc
@@ -38,19 +38,20 @@
 #include "master/filesystem_checksum_updater.h"
 #include "master/filesystem_metadata.h"
 #include "master/filesystem_operations.h"
+#include "master/filesystem_operations_interface.h"
 #include "master/filesystem_periodic.h"
 #include "master/filesystem_snapshot.h"
 #include "master/goal_config_loader.h"
 #include "master/id_generator_incremental.h"
 #include "master/matoclserv_sessions.h"
 #include "master/metadata_backend_common.h"
-#include "master/metadata_backend_file.h"
 #include "master/metadata_backend_interface.h"
 #include "master/restore.h"
 #include "slogger/slogger.h"
 
 #ifdef METARESTORE
 #include "master/filesystem_freenode.h"
+#include "master/metadata_backend_file.h"
 #endif
 
 FilesystemMetadata* gMetadata = nullptr;
@@ -116,7 +117,7 @@ static void metadataPollServe(const std::vector<pollfd> &pdesc) {
 			if (dumper->useMetarestore()) {
 				// master should recalculate its checksum
 				safs_pretty_syslog(LOG_WARNING, "dumping metadata failed, recalculating checksum");
-				fs_start_checksum_recalculation();
+				gFilesystemOperations->fs_start_checksum_recalculation();
 			}
 			unlink(kMetadataTmpFilename);
 		}

--- a/src/master/filesystem.h
+++ b/src/master/filesystem.h
@@ -25,21 +25,10 @@
 #include <cstdint>
 
 #include "common/exception.h"
-#include "common/type_defs.h"
-#include "master/checksum.h"
-#include "master/fs_context.h"
-#include "protocol/quota.h"
 
 SAUNAFS_CREATE_EXCEPTION_CLASS_MSG(NoMetadataException, Exception, "no metadata");
 
 inline std::string gClusterId;  ///< Unique cluster identifier
-
-/// Returns checksum of the loaded metadata.
-uint64_t fs_checksum(ChecksumMode mode);
-
-/// Starts recalculating metadata checksum in background.
-/// \return SAUNAFS_STATUS_OK iff dump started successfully, otherwise cause of the failure.
-uint8_t fs_start_checksum_recalculation();
 
 /// Load whole filesystem information.
 int fs_loadall(bool isFromInit);

--- a/src/master/filesystem_checksum.cc
+++ b/src/master/filesystem_checksum.cc
@@ -132,6 +132,7 @@ static void fsnodes_recalculate_checksum() {
 	}
 }
 
+namespace checksum {
 uint64_t fs_checksum(ChecksumMode mode) {
 	uint64_t checksum = 0x1251;
 	hashCombine(checksum, gMetadata->maxInodeId().getValue());
@@ -159,3 +160,4 @@ uint8_t fs_start_checksum_recalculation() {
 	}
 }
 #endif
+}  // namespace checksum

--- a/src/master/filesystem_checksum.h
+++ b/src/master/filesystem_checksum.h
@@ -28,5 +28,10 @@
 void fsnodes_checksum_add_to_background(FSNode *node);
 void fsnodes_update_checksum(FSNode *node);
 
+// Namespace for in-memory checksum related functions
+namespace checksum {
 uint64_t fs_checksum(ChecksumMode mode);
+#ifndef METARESTORE
 uint8_t fs_start_checksum_recalculation();
+#endif
+}  // namespace checksum

--- a/src/master/filesystem_checksum_updater.h
+++ b/src/master/filesystem_checksum_updater.h
@@ -54,7 +54,7 @@ protected:
 		lastEntry_ = gMetadata->metadataVersion;
 		if (metadataserver::isMaster() && !gChecksumBackgroundUpdater.inProgress()) {
 			std::string versionString = saunafsVersionToString(SAUNAFS_VERSHEX);
-			uint64_t checksum = fs_checksum(ChecksumMode::kGetCurrent);
+			uint64_t checksum = gFilesystemOperations->fs_checksum(ChecksumMode::kGetCurrent);
 			gFilesystemOperations->fs_changelog(ts, "CHECKSUM(%s):%" PRIu64, versionString.c_str(),
 			                                    checksum);
 		}

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -3061,6 +3061,10 @@ uint8_t FilesystemOperationsBase::fs_apply_setquota(char rigor, char resource, c
 	return quotas::fs_apply_setquota(rigor, resource, ownerType, ownerId, limit);
 }
 
+uint64_t FilesystemOperationsBase::fs_checksum(ChecksumMode mode) {
+	return checksum::fs_checksum(mode);
+}
+
 #ifndef METARESTORE
 const std::map<int, Goal> &FilesystemOperationsBase::fs_get_goal_definitions() const {
 	return gGoalDefinitions;
@@ -3158,5 +3162,9 @@ uint8_t FilesystemOperationsBase::fs_quota_get_info(const FsContext &context,
                                                     const std::vector<QuotaEntry> &entries,
                                                     std::vector<std::string> &result) {
 	return quotas::fs_quota_get_info(context, entries, result);
+}
+
+uint8_t FilesystemOperationsBase::fs_start_checksum_recalculation() {
+	return checksum::fs_start_checksum_recalculation();
 }
 #endif

--- a/src/master/filesystem_operations.h
+++ b/src/master/filesystem_operations.h
@@ -232,6 +232,12 @@ public:
 	uint8_t fs_quota_get_info(const FsContext &context, const std::vector<QuotaEntry> &entries,
 	                          std::vector<std::string> &result) override;
 
+	// CHECKSUM
+
+	/// Starts recalculating metadata checksum in background.
+	/// @see IFilesystemOperations::fs_start_checksum_recalculation.
+	uint8_t fs_start_checksum_recalculation() override;
+
 #endif
 	void fs_add_files_to_chunks(bool isMetadataLoading = true) override;
 
@@ -264,6 +270,11 @@ public:
 
 	uint8_t fs_apply_setquota(char rigor, char resource, char ownerType, inode_t ownerId,
 	                          uint64_t limit) override;
+
+	// CHECKSUM
+
+	/// Returns checksum of the loaded metadata.
+	uint64_t fs_checksum(ChecksumMode mode) override;
 
 	// Locks
 

--- a/src/master/filesystem_operations_interface.h
+++ b/src/master/filesystem_operations_interface.h
@@ -25,6 +25,7 @@
 
 #include "common/attributes.h"
 #include "common/goal.h"
+#include "master/checksum.h"
 #include "master/filesystem_node_types.h"
 #include "master/fs_context.h"
 #include "master/locks.h"
@@ -255,6 +256,12 @@ public:
 	virtual uint8_t fs_quota_get_info(const FsContext &context,
 	                                  const std::vector<QuotaEntry> &entries,
 	                                  std::vector<std::string> &result) = 0;
+
+	// CHECKSUM
+
+	/// Starts recalculating metadata checksum in background.
+	/// @return SAUNAFS_STATUS_OK if dump started successfully, otherwise cause of the failure.
+	virtual uint8_t fs_start_checksum_recalculation() = 0;
 #endif
 	virtual void fs_add_files_to_chunks(bool isMetadataLoading = true) = 0;
 
@@ -287,6 +294,11 @@ public:
 
 	virtual uint8_t fs_apply_setquota(char rigor, char resource, char ownerType, inode_t ownerId,
 	                                  uint64_t limit) = 0;
+
+	// CHECKSUM
+
+	/// Returns checksum of the loaded metadata.
+	virtual uint64_t fs_checksum(ChecksumMode mode) = 0;
 
 	// Lock operations
 

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -4584,7 +4584,7 @@ void matoclserv_admin_recalculate_metadata_checksum(matoclserventry *eptr, const
 	if (eptr->registered == ClientState::kAdmin) {
 		safs::log_info("metadata checksum recalculation requested using saunafs-admin by {}",
 		               ipToString(eptr->peerIpAddress));
-		uint8_t status = fs_start_checksum_recalculation();
+		uint8_t status = gFilesystemOperations->fs_start_checksum_recalculation();
 
 		if (status != SAUNAFS_STATUS_OK || asynchronous) {
 			matoclserv_createpacket(eptr, matocl::adminRecalculateMetadataChecksum::build(status));

--- a/src/master/matomlserv.cc
+++ b/src/master/matomlserv.cc
@@ -610,7 +610,7 @@ void matomlserv_changelog_apply_error(matomlserventry *eptr, const uint8_t *data
 		gShadowQueue.addRequest(eptr);
 		gMetadataBackend->fs_storeall(DumpType::kBackgroundDump);
 		if (recvStatus == SAUNAFS_ERROR_BADMETADATACHECKSUM) {
-			fs_start_checksum_recalculation();
+			gFilesystemOperations->fs_start_checksum_recalculation();
 		}
 	} else {
 		safs_silent_syslog(LOG_DEBUG, "master.mltoma_changelog_apply_error: delay");

--- a/src/master/metadata_backend_file.cc
+++ b/src/master/metadata_backend_file.cc
@@ -186,7 +186,8 @@ uint8_t MetadataBackendFile::fs_storeall(DumpType dumpType) {
 	matomlserv_broadcast_logrotate();
 	// child == true says that we forked
 	// bg may be changed to dump in foreground in case of a fork error
-	bool child = dumper()->start(dumpType, fs_checksum(ChecksumMode::kGetCurrent));
+	bool child =
+	    dumper()->start(dumpType, gFilesystemOperations->fs_checksum(ChecksumMode::kGetCurrent));
 	uint8_t status = SAUNAFS_STATUS_OK;
 
 	if (dumpType == DumpType::kForegroundDump) {
@@ -915,7 +916,7 @@ void fs_new(void) {
 	gMetadata->dirNodes = 1;
 	gMetadata->fileNodes = 0;
 
-	fs_checksum(ChecksumMode::kForceRecalculate);
+	gFilesystemOperations->fs_checksum(ChecksumMode::kForceRecalculate);
 	fsnodes_quota_update(gMetadata->root, {{QuotaResource::kInodes, +1}});
 }
 
@@ -983,7 +984,7 @@ void MetadataBackendFile::loadall(int ignoreflag) {
 	safs::log_info("calculating checksum of the metadata");
 	{
 		util::ScopedTimer timer("calculating checksum of the metadata took");
-		fs_checksum(ChecksumMode::kForceRecalculate);
+		gFilesystemOperations->fs_checksum(ChecksumMode::kForceRecalculate);
 	}
 
 #ifndef METARESTORE

--- a/src/metarestore/main.cc
+++ b/src/metarestore/main.cc
@@ -476,7 +476,7 @@ int main(int argc,char **argv) {
 	}
 
 	int returnStatus = 0;
-	uint64_t checksum = fs_checksum(ChecksumMode::kForceRecalculate);
+	uint64_t checksum = gFilesystemOperations->fs_checksum(ChecksumMode::kForceRecalculate);
 	if (printhash) {
 		printf("%" PRIu64 "\n", checksum);
 	}


### PR DESCRIPTION
IFilesystemOperations interface now provides the functions `fs_checksum` and `fs_start_checksum_recalculation`, making them extensible through inheritance. To be more explicit, the functions with the same name in filesystem_checksum.h were placed in the new `checksum` namespace.

The references to these functions were updated to use the polymorphic gFilesystemOperations. Custom operations just need to provide their own implementation.