### PR TITLE
test: Stabilize metadata notifier test

### DIFF
--- a/tests/test_suites/ShortSystemTests/test_metadata_notifier.sh
+++ b/tests/test_suites/ShortSystemTests/test_metadata_notifier.sh
@@ -2,18 +2,20 @@ CHUNKSERVERS=1 \
 	USE_RAMDISK=YES \
 	setup_local_empty_saunafs info
 
+# Start the metadata notifier which will log all the messages to a file
+metadata-notifier localhost "${info[matont]}" > "${TEMP_DIR}/notifier.log" 2>&1 &
+NOTIFIER_PID=$!
+echo "Notifier started with PID $NOTIFIER_PID"
+
+# Verify that the notifier process is running
+assert_eventually "ps -p $NOTIFIER_PID -o cmd= | grep -q metadata-notifier"
+
 cd "${info[mount0]}"
 
 mkdir folder1
 mkdir folder2
 mkdir folder1/subfolder1
 mkdir folder1/subfolder2
-
-# Start the metadata notifier which will log all the messages to a file
-metadata-notifier localhost "${info[matont]}" > "${info[mount0]}/notifier.log" 2>&1 &
-NOTIFIER_PID=$!
-echo "Notifier started with PID $NOTIFIER_PID"
-echo "Pgrep notifier PID $(pgrep -fa metadata-notifier)"
 
 # Now perform some operations to generate metadata change notifications
 folders=("." "folder1" "folder2" "folder1/subfolder1" "folder1/subfolder2")
@@ -24,7 +26,7 @@ done
 
 # Stop the notifier and print the log file
 kill -s SIGKILL $NOTIFIER_PID
-cat "${info[mount0]}/notifier.log"
+cat "${TEMP_DIR}/notifier.log"
 
 # Assert expected substrings
 expected=(
@@ -40,5 +42,5 @@ expected=(
     "inode 5: type=d path=/folder1/subfolder2"
 )
 for e in "${expected[@]}"; do
-    assert_success grep -q "$e" "${info[mount0]}/notifier.log"
+    assert_success grep -q "$e" "${TEMP_DIR}/notifier.log"
 done


### PR DESCRIPTION
Previous version of test for metadata notifier behavior was flaky due to outputing the content generated from the given notifier binary to log files located on the mountpoint, which could potenciall create extra uneeded noise when expected the operations related with folder access as checked on the test. This commit fixes that potencial issue.