### PR TITLE
Handle promotion failures, deadlocks, and state transitions

### DIFF
--- a/src/uraft/saunafs-uraft-helper.in
+++ b/src/uraft/saunafs-uraft-helper.in
@@ -331,7 +331,7 @@ saunafs_drop_ip() {
 		else
 			log "Successfully dropped floating IP: ${ipaddr}"
 		fi
-	else
+	elif [[ "$ipaddr" != "" ]]; then
 		log "Floating IP ${ipaddr} not present - nothing to drop"
 	fi
 
@@ -342,7 +342,7 @@ saunafs_drop_ip() {
 		else
 			log "Successfully dropped floating IP: ${ipaddr2}"
 		fi
-	else
+	elif [[ "$ipaddr2" != "" ]]; then
 		log "Floating IP ${ipaddr2} not present - nothing to drop"
 	fi
 }

--- a/src/uraft/saunafs-uraft-helper.in
+++ b/src/uraft/saunafs-uraft-helper.in
@@ -196,6 +196,36 @@ saunafs_demote() {
 	saunafs_master -o initial-personality=shadow restart
 }
 
+saunafs_cleanup_dirty_state() {
+	load_config
+
+	log "Attempting to clean up dirty metadata state"
+
+	# Remove temporary metadata file
+	if [[ -f "${SAUNAFS_DATA_DIR}/metadata.sfs.tmp" ]]; then
+		log "Removing ${SAUNAFS_DATA_DIR}/metadata.sfs.tmp"
+		rm -f "${SAUNAFS_DATA_DIR}/metadata.sfs.tmp" || {
+			log "Failed to remove metadata.sfs.tmp"
+			return $SAUNAFS_URAFT_ERROR
+		}
+	fi
+
+	# Release stale metadata lock
+	if [[ -f "${SAUNAFS_DATA_DIR}/.sfsmaster.lock" ]]; then
+		# Check if lock is stale (no process holding it)
+		if ! fuser "${SAUNAFS_DATA_DIR}/.sfsmaster.lock" &>/dev/null; then
+			log "Removing ${SAUNAFS_DATA_DIR}/.sfsmaster.lock file"
+			rm -f "${SAUNAFS_DATA_DIR}/.sfsmaster.lock" || {
+				log "Failed to remove stale lock file"
+				return $SAUNAFS_URAFT_ERROR
+			}
+		fi
+	fi
+
+	log "Cleanup dirty metadata completed successfully"
+	return $SAUNAFS_URAFT_OK
+}
+
 saunafs_quick_stop() {
 	echo -n "${ADMIN_PASSWORD}" | \
 			saunafs_admin stop-master-without-saving-metadata "${matocl_host}" ${matocl_port}
@@ -292,9 +322,28 @@ saunafs_assign_ip() {
 
 saunafs_drop_ip() {
 	load_config
-	sudo ip -f inet addr delete $ipaddr/$netmask dev $iface
-	if [[ "$ipaddr2" != "" ]]; then
-		sudo ip -f inet addr delete $ipaddr2/$netmask2 dev $iface2
+
+	# Check if floating IP exists before trying to drop it
+	if is_ip_present "${ipaddr}" "${iface}"; then
+		log "Dropping floating IP: ${ipaddr} from interface: ${iface}"
+		if ! sudo ip -f inet addr delete $ipaddr/$netmask dev $iface; then
+			log "Warning: Failed to drop floating IP: ${ipaddr}"
+		else
+			log "Successfully dropped floating IP: ${ipaddr}"
+		fi
+	else
+		log "Floating IP ${ipaddr} not present - nothing to drop"
+	fi
+
+	if [[ "$ipaddr2" != "" ]] && is_ip_present "$ipaddr2" "$iface2"; then
+		log "Dropping floating IP: ${ipaddr2} from interface: ${iface2}"
+		if ! sudo ip -f inet addr delete $ipaddr2/$netmask2 dev $iface2; then
+			log "Warning: Failed to drop floating IP: ${ipaddr2}"
+		else
+			log "Successfully dropped floating IP: ${ipaddr2}"
+		fi
+	else
+		log "Floating IP ${ipaddr2} not present - nothing to drop"
 	fi
 }
 
@@ -310,6 +359,7 @@ print_help() {
 	echo "quick-stop"
 	echo "promote"
 	echo "demote"
+	echo "cleanup"
 	echo "assign-ip"
 	echo "drop-ip"
 	echo "dead"
@@ -325,6 +375,7 @@ case "$1" in
 	quick-stop)        saunafs_quick_stop;;
 	promote)           saunafs_promote;;
 	demote)            saunafs_demote;;
+	cleanup)           saunafs_cleanup_dirty_state;;
 	assign-ip)         saunafs_assign_ip;;
 	drop-ip)           saunafs_drop_ip;;
 	dead)              saunafs_dead;;

--- a/src/uraft/saunafs-uraft-helper.in
+++ b/src/uraft/saunafs-uraft-helper.in
@@ -201,22 +201,14 @@ saunafs_cleanup_dirty_state() {
 
 	log "Attempting to clean up dirty metadata state"
 
-	# Remove temporary metadata file
+	# Remove temporary metadata file created during metadata dump, if it exists
 	if [[ -f "${SAUNAFS_DATA_DIR}/metadata.sfs.tmp" ]]; then
-		log "Removing ${SAUNAFS_DATA_DIR}/metadata.sfs.tmp"
-		rm -f "${SAUNAFS_DATA_DIR}/metadata.sfs.tmp" || {
-			log "Failed to remove metadata.sfs.tmp"
-			return $SAUNAFS_URAFT_ERROR
-		}
-	fi
-
-	# Release stale metadata lock
-	if [[ -f "${SAUNAFS_DATA_DIR}/.sfsmaster.lock" ]]; then
-		# Check if lock is stale (no process holding it)
-		if ! fuser "${SAUNAFS_DATA_DIR}/.sfsmaster.lock" &>/dev/null; then
-			log "Removing ${SAUNAFS_DATA_DIR}/.sfsmaster.lock file"
-			rm -f "${SAUNAFS_DATA_DIR}/.sfsmaster.lock" || {
-				log "Failed to remove stale lock file"
+		# Check if temporary metadata file is stale (no process holding it).
+		# This could represent a leftover from a crashed operation during metadata dump.
+		if ! fuser "${SAUNAFS_DATA_DIR}/metadata.sfs.tmp" &>/dev/null; then
+			log "Removing ${SAUNAFS_DATA_DIR}/metadata.sfs.tmp"
+			rm -f "${SAUNAFS_DATA_DIR}/metadata.sfs.tmp" || {
+				log "Failed to remove metadata.sfs.tmp"
 				return $SAUNAFS_URAFT_ERROR
 			}
 		fi
@@ -324,26 +316,30 @@ saunafs_drop_ip() {
 	load_config
 
 	# Check if floating IP exists before trying to drop it
-	if is_ip_present "${ipaddr}" "${iface}"; then
-		log "Dropping floating IP: ${ipaddr} from interface: ${iface}"
-		if ! sudo ip -f inet addr delete $ipaddr/$netmask dev $iface; then
-			log "Warning: Failed to drop floating IP: ${ipaddr}"
+	if [[ -n "$ipaddr" ]]; then
+		if is_ip_present "${ipaddr}" "${iface}"; then
+			log "Dropping floating IP: ${ipaddr} from interface: ${iface}"
+			if ! sudo ip -f inet addr delete $ipaddr/$netmask dev $iface; then
+				log "Warning: Failed to drop floating IP: ${ipaddr}"
+			else
+				log "Successfully dropped floating IP: ${ipaddr}"
+			fi
 		else
-			log "Successfully dropped floating IP: ${ipaddr}"
+			log "Floating IP ${ipaddr} not present - nothing to drop"
 		fi
-	elif [[ "$ipaddr" != "" ]]; then
-		log "Floating IP ${ipaddr} not present - nothing to drop"
 	fi
 
-	if [[ "$ipaddr2" != "" ]] && is_ip_present "$ipaddr2" "$iface2"; then
-		log "Dropping floating IP: ${ipaddr2} from interface: ${iface2}"
-		if ! sudo ip -f inet addr delete $ipaddr2/$netmask2 dev $iface2; then
-			log "Warning: Failed to drop floating IP: ${ipaddr2}"
+	if [[ -n "$ipaddr2" ]]; then
+		if is_ip_present "$ipaddr2" "$iface2"; then
+			log "Dropping floating IP: ${ipaddr2} from interface: ${iface2}"
+			if ! sudo ip -f inet addr delete $ipaddr2/$netmask2 dev $iface2; then
+				log "Warning: Failed to drop floating IP: ${ipaddr2}"
+			else
+				log "Successfully dropped floating IP: ${ipaddr2}"
+			fi
 		else
-			log "Successfully dropped floating IP: ${ipaddr2}"
+			log "Floating IP ${ipaddr2} not present - nothing to drop"
 		fi
-	elif [[ "$ipaddr2" != "" ]]; then
-		log "Floating IP ${ipaddr2} not present - nothing to drop"
 	fi
 }
 

--- a/src/uraft/uraft.cc
+++ b/src/uraft/uraft.cc
@@ -4,6 +4,8 @@
 
 #include "uraft.h"
 
+#include <syslog.h>
+
 #if defined(SAUNAFS_HAVE_GETIFADDRS)
  #include <sys/types.h>
  #include <ifaddrs.h>
@@ -95,6 +97,8 @@ void uRaft::checkTerm(int /*id*/, const RpcHeader &data) {
 	if (data.term > state_.current_term) {
 		if (state_.president) {
 			assert(state_.type != kFollower);
+			syslog(LOG_NOTICE, "(%s): Higher term detected (%lu): Node %s starting new election",
+			       __func__, data.term, nodeToString(state_.id).c_str());
 			state_.current_term = data.term;
 			electionTimeout(boost::system::error_code());
 			return;
@@ -215,6 +219,8 @@ void uRaft::electionTimeout(const boost::system::error_code &error) {
 		startElectionTimer();
 	} else {
 		state_.type = kLeader;
+		syslog(LOG_NOTICE, "(%s): Election won with quorum: Promoting node %s to Leader", __func__,
+		       nodeToString(state_.id).c_str());
 		nodePromote();
 	}
 }
@@ -240,6 +246,10 @@ void uRaft::heartbeat(const boost::system::error_code &error) {
 				state_.voted_for = -1;
 				startElectionTimer();
 			}
+
+			syslog(LOG_WARNING,
+			       "(%s): Heartbeat quorum lost: Demoting current Leader %s to follower", __func__,
+			       nodeToString(state_.id).c_str());
 			state_.president = false;
 
 			nodeDemote();
@@ -257,6 +267,8 @@ void uRaft::heartbeat(const boost::system::error_code &error) {
 		if (!state_.president) {
 			if (voteCount(true) >= opt_.quorum) {
 				state_.president = true;
+				syslog(LOG_NOTICE, "(%s): Heartbeat quorum confirmed: Node %s is now active Leader",
+				       __func__, nodeToString(state_.id).c_str());
 				nodePromote();
 			}
 		}
@@ -441,6 +453,9 @@ void uRaft::demoteLeader() {
 	if (state_.type == kFollower) {
 		return;
 	}
+
+	syslog(LOG_NOTICE, "(%s): Manual demotion: Stepping down Leader %s to follower", __func__,
+	       nodeToString(state_.id).c_str());
 	state_.type      = kFollower;
 	state_.voted_for = -1;
 	state_.leader_id = -1;
@@ -506,4 +521,19 @@ int uRaft::scanLocalInterfaces() {
 #else
 	return -1;
 #endif
+}
+
+std::string uRaft::nodeToString(int id) {
+	if (id < 0 || id >= (int)opt_.server.size()) {
+		return "Invalid node ID";
+	}
+
+	std::string name = opt_.server[id];
+	std::string::size_type p = name.find(":");
+
+	if (p != std::string::npos) {
+		name = name.substr(0, p);
+	}
+
+	return name;
 }

--- a/src/uraft/uraft.cc
+++ b/src/uraft/uraft.cc
@@ -524,7 +524,7 @@ int uRaft::scanLocalInterfaces() {
 }
 
 std::string uRaft::nodeToString(int id) {
-	if (id < 0 || id >= (int)opt_.server.size()) {
+	if (id < 0 || id >= static_cast<int>(opt_.server.size())) {
 		return "Invalid node ID";
 	}
 

--- a/src/uraft/uraft.h
+++ b/src/uraft/uraft.h
@@ -159,6 +159,8 @@ protected:
 	int findMatchingAddress(const boost::asio::ip::address &addr, int &id);
 	int scanLocalInterfaces();
 
+	std::string nodeToString(int id);
+
 protected:
 	boost::asio::io_context                 &io_service_;
 	boost::asio::ip::udp::socket            socket_;

--- a/src/uraft/uraftcontroller.cc
+++ b/src/uraft/uraftcontroller.cc
@@ -75,7 +75,7 @@ void uRaftController::nodePromote() {
 			return;
 		}
 		// Already promoting
-		syslog(LOG_DEBUG, "Promotion already in progress");
+		syslog(LOG_DEBUG, "Promotion already in progress (PID %d)", command_pid_);
 		return;
 	}
 
@@ -97,17 +97,15 @@ void uRaftController::nodeDemote() {
 			syslog(LOG_WARNING,
 			       "Demotion requested during promotion - will force after completion");
 			force_demote_ = true;
-			set_block_promotion(true);
 			return;
 		}
-		syslog(LOG_DEBUG, "Demotion already in progress");
+		syslog(LOG_DEBUG, "Demotion already in progress (PID %d)", command_pid_);
 		return;
 	}
 
 	setSlowCommandTimeout(opt_.demote_timeout);
 	if (runSlowCommand("saunafs-uraft-helper demote")) {
 		command_type_ = kCmdDemote;
-		set_block_promotion(true);
 	}
 }
 
@@ -174,7 +172,6 @@ void uRaftController::checkCommandStatus(const boost::system::error_code &error)
 			}
 			command_type_ = kCmdNone;
 			command_pid_  = -1;
-			set_block_promotion(false);
 		} else if (command_type_ == kCmdPromote) {
 			if (commandSucceeded) {
 				syslog(LOG_NOTICE, "Metadata server switch to master mode done");
@@ -234,7 +231,6 @@ void uRaftController::checkNodeStatus(const boost::system::error_code &error) {
 				syslog(LOG_NOTICE, "Metadata server is dead");
 				stopFloatingIpManager();
 				demoteLeader();
-				set_block_promotion(true);
 				setSlowCommandTimeout(opt_.dead_handler_timeout);
 				if (runSlowCommand("saunafs-uraft-helper dead")) {
 					command_type_ = kCmdStatusDead;
@@ -462,7 +458,6 @@ void uRaftController::cleanupDirtyPromotion() {
 }
 
 void uRaftController::handlePromotionFailure() {
-	set_block_promotion(true);
 	demoteLeader();
 	cleanupDirtyPromotion();
 }

--- a/src/uraft/uraftcontroller.cc
+++ b/src/uraft/uraftcontroller.cc
@@ -67,34 +67,40 @@ void uRaftController::set_options(const uRaftController::Options &opt) {
 void uRaftController::nodePromote() {
 	syslog(LOG_NOTICE, "Starting metadata server switch to master mode");
 
-	if (command_pid_ >= 0 && command_type_ != kCmdPromote) {
-		syslog(LOG_ERR, "Trying to switch metadata server to master during switch to slave");
-		stopFloatingIpManager();
-		demoteLeader();
-		set_block_promotion(true);
-		return;
-	}
+	// Prevent concurrent transitions
 	if (command_pid_ >= 0) {
+		if (command_type_ == kCmdDemote) {
+			syslog(LOG_WARNING, "Cannot promote during active demotion - ignoring request");
+			force_demote_ = false;
+			return;
+		}
+		// Already promoting
+		syslog(LOG_DEBUG, "Promotion already in progress");
 		return;
 	}
 
 	setSlowCommandTimeout(opt_.promote_timeout);
 	if (runSlowCommand("saunafs-uraft-helper promote")) {
 		command_type_ = kCmdPromote;
-		startFloatingIpManager();
+		// Floating IP Manager will be started after promotion completes successfully
 	}
 }
 
 void uRaftController::nodeDemote() {
 	syslog(LOG_NOTICE, "Starting metadata server switch to slave mode");
 
-	if (command_pid_ >= 0 && command_type_ != kCmdDemote) {
-		syslog(LOG_ERR, "Trying to switch metadata server to slave during switch to master");
-		force_demote_ = true;
-		set_block_promotion(true);
-		return;
-	}
+	// Stop Floating IP Manager immediately when starting demotion
+	stopFloatingIpManager();
+
 	if (command_pid_ >= 0) {
+		if (command_type_ == kCmdPromote) {
+			syslog(LOG_WARNING,
+			       "Demotion requested during promotion - will force after completion");
+			force_demote_ = true;
+			set_block_promotion(true);
+			return;
+		}
+		syslog(LOG_DEBUG, "Demotion already in progress");
 		return;
 	}
 
@@ -102,7 +108,6 @@ void uRaftController::nodeDemote() {
 	if (runSlowCommand("saunafs-uraft-helper demote")) {
 		command_type_ = kCmdDemote;
 		set_block_promotion(true);
-		stopFloatingIpManager();
 	}
 }
 
@@ -157,18 +162,36 @@ void uRaftController::checkCommandStatus(const boost::system::error_code &error)
 	int  status;
 	if (checkSlowCommand(status)) {
 		cmd_timeout_timer_.cancel();
+
+		// Check if command completed successfully
+		bool commandSucceeded = WIFEXITED(status) && WEXITSTATUS(status) == 0;
+
 		if (command_type_ == kCmdDemote) {
-			syslog(LOG_NOTICE, "Metadata server switch to slave mode done");
+			if (commandSucceeded) {
+				syslog(LOG_NOTICE, "Metadata server switch to slave mode succeeded");
+			} else {
+				syslog(LOG_ERR, "Demotion failed with exit code: %d", WEXITSTATUS(status));
+			}
 			command_type_ = kCmdNone;
 			command_pid_  = -1;
 			set_block_promotion(false);
 		} else if (command_type_ == kCmdPromote) {
-			syslog(LOG_NOTICE, "Metadata server switch to master mode done");
-			node_alive_ = true;
+			if (commandSucceeded) {
+				syslog(LOG_NOTICE, "Metadata server switch to master mode done");
+				node_alive_ = true;
+
+				// Start floating IP only after successful promotion
+				startFloatingIpManager();
+			} else {
+				syslog(LOG_ERR, "Promotion failed with exit code: %d", WEXITSTATUS(status));
+				handlePromotionFailure();
+			}
+
 			command_type_ = kCmdNone;
 			command_pid_  = -1;
+
 			if (force_demote_) {
-				syslog(LOG_WARNING, "Staring forced switch to slave mode");
+				syslog(LOG_WARNING, "Starting forced switch to slave mode");
 				nodeDemote();
 				force_demote_ = false;
 			}
@@ -228,9 +251,20 @@ void uRaftController::checkNodeStatus(const boost::system::error_code &error) {
 
 void uRaftController::setSlowCommandTimeout(int timeout) {
 	cmd_timeout_timer_.expires_from_now(boost::posix_time::millisec(timeout));
-	cmd_timeout_timer_.async_wait([this](const boost::system::error_code & error) {
+	cmd_timeout_timer_.async_wait([this, timeout](const boost::system::error_code & error) {
 		if (!error) {
-			syslog(LOG_ERR, "Metadata server mode switching timeout");
+			syslog(LOG_ERR, "Metadata server mode switching timeout after %d ms", timeout);
+
+			// Cleanup based on operation type
+			if (command_type_ == kCmdPromote) {
+				syslog(LOG_WARNING, "Promotion timeout - attempting cleanup");
+				handlePromotionFailure();
+			} else if (command_type_ == kCmdDemote) {
+				syslog(LOG_WARNING, "Demotion timeout - killing stuck command");
+			} else if (command_type_ == kCmdStatusDead) {
+				syslog(LOG_WARNING, "Dead handler timeout - killing stuck command");
+			}
+
 			stopSlowCommand();
 		}
 	});
@@ -416,4 +450,19 @@ void uRaftController::stopFloatingIpManager() {
 		haFloatingIpManager->stop();
 		haFloatingIpManager.reset();
 	}
+}
+
+void uRaftController::cleanupDirtyPromotion() {
+	std::vector<std::string> cleanup = {"saunafs-uraft-helper", "cleanup"};
+	std::string result;
+
+	if (!runCommand(cleanup, result, 5000)) {
+		syslog(LOG_ERR, "Failed to cleanup dirty state: %s", result.c_str());
+	}
+}
+
+void uRaftController::handlePromotionFailure() {
+	set_block_promotion(true);
+	demoteLeader();
+	cleanupDirtyPromotion();
 }

--- a/src/uraft/uraftcontroller.cc
+++ b/src/uraft/uraftcontroller.cc
@@ -26,6 +26,7 @@ uRaftController::uRaftController(boost::asio::io_context &ios)
 	command_pid_  = -1;
 	command_type_ = kCmdNone;
 	force_demote_ = false;
+	force_promote_ = false;
 	node_alive_   = false;
 
 	opt_.check_node_status_period = 250;
@@ -70,8 +71,9 @@ void uRaftController::nodePromote() {
 	// Prevent concurrent transitions
 	if (command_pid_ >= 0) {
 		if (command_type_ == kCmdDemote) {
-			syslog(LOG_WARNING, "Cannot promote during active demotion - ignoring request");
-			force_demote_ = false;
+			syslog(LOG_WARNING,
+			       "Promotion requested during demotion - will force after completion");
+			force_promote_ = true;
 			return;
 		}
 		// Already promoting
@@ -160,8 +162,15 @@ void uRaftController::checkCommandStatus(const boost::system::error_code &error)
 			} else {
 				syslog(LOG_ERR, "Demotion failed with exit code: %d", WEXITSTATUS(status));
 			}
+
 			command_type_ = kCmdNone;
 			command_pid_  = -1;
+
+			if (force_promote_) {
+				syslog(LOG_WARNING, "Starting forced switch to master mode");
+				nodePromote();
+				force_promote_ = false;
+			}
 		} else if (command_type_ == kCmdPromote) {
 			if (commandSucceeded) {
 				syslog(LOG_NOTICE, "Metadata server switch to master mode done");

--- a/src/uraft/uraftcontroller.cc
+++ b/src/uraft/uraftcontroller.cc
@@ -25,8 +25,8 @@ uRaftController::uRaftController(boost::asio::io_context &ios)
 	  cmd_timeout_timer_(ios) {
 	command_pid_  = -1;
 	command_type_ = kCmdNone;
-	force_demote_ = false;
-	force_promote_ = false;
+	is_demote_pending_ = false;
+	is_promote_pending_ = false;
 	node_alive_   = false;
 
 	opt_.check_node_status_period = 250;
@@ -71,9 +71,10 @@ void uRaftController::nodePromote() {
 	// Prevent concurrent transitions
 	if (command_pid_ >= 0) {
 		if (command_type_ == kCmdDemote) {
-			syslog(LOG_WARNING,
-			       "Promotion requested during demotion - will force after completion");
-			force_promote_ = true;
+			syslog(
+			    LOG_WARNING,
+			    "Promotion requested during demotion - will be started after completing demotion");
+			is_promote_pending_ = true;
 			return;
 		}
 		// Already promoting
@@ -96,9 +97,10 @@ void uRaftController::nodeDemote() {
 
 	if (command_pid_ >= 0) {
 		if (command_type_ == kCmdPromote) {
-			syslog(LOG_WARNING,
-			       "Demotion requested during promotion - will force after completion");
-			force_demote_ = true;
+			syslog(
+			    LOG_WARNING,
+			    "Demotion requested during promotion - will be started after completing promotion");
+			is_demote_pending_ = true;
 			return;
 		}
 		syslog(LOG_DEBUG, "Demotion already in progress (PID %d)", command_pid_);
@@ -166,10 +168,10 @@ void uRaftController::checkCommandStatus(const boost::system::error_code &error)
 			command_type_ = kCmdNone;
 			command_pid_  = -1;
 
-			if (force_promote_) {
-				syslog(LOG_WARNING, "Starting forced switch to master mode");
+			if (is_promote_pending_) {
+				syslog(LOG_WARNING, "Starting pending promotion to master mode");
 				nodePromote();
-				force_promote_ = false;
+				is_promote_pending_ = false;
 			}
 		} else if (command_type_ == kCmdPromote) {
 			if (commandSucceeded) {
@@ -186,10 +188,10 @@ void uRaftController::checkCommandStatus(const boost::system::error_code &error)
 			command_type_ = kCmdNone;
 			command_pid_  = -1;
 
-			if (force_demote_) {
-				syslog(LOG_WARNING, "Starting forced switch to slave mode");
+			if (is_demote_pending_) {
+				syslog(LOG_WARNING, "Starting pending demotion to slave mode");
 				nodeDemote();
-				force_demote_ = false;
+				is_demote_pending_ = false;
 			}
 		} else if (command_type_ == kCmdStatusDead) {
 			syslog(LOG_NOTICE, "Waiting for new metadata server instance to be available");
@@ -447,6 +449,13 @@ void uRaftController::stopFloatingIpManager() {
 	}
 }
 
+/// @brief Clean up dirty metadata state after failed promotion.
+///
+/// This prevents subsequent promotion attempts from failing due to leftover files from crashed or
+/// timed-out promotion operations.
+///
+/// \note Uses a 5-second timeout for the cleanup operation.
+/// \note Logs errors if cleanup fails but does not throw exceptions.
 void uRaftController::cleanupDirtyPromotion() {
 	std::vector<std::string> cleanup = {"saunafs-uraft-helper", "cleanup"};
 	std::string result;
@@ -456,6 +465,16 @@ void uRaftController::cleanupDirtyPromotion() {
 	}
 }
 
+/// @brief Handle failed promotion attempts and restore cluster consistency.
+///
+/// This ensures that if a node wins a Raft election but cannot complete the promotion to
+/// SaunaFS master (e.g., due to corrupted metadata, resource exhaustion, or script failures),
+/// the cluster can recover by electing a different node as leader.
+///
+/// Without this recovery mechanism, the cluster could enter a deadlock where:
+/// - The failed node remains Raft leader but cannot serve as master.
+/// - Other nodes cannot win elections due to Raft term constraints.
+/// - Manual intervention becomes necessary to restore cluster operation.
 void uRaftController::handlePromotionFailure() {
 	demoteLeader();
 	cleanupDirtyPromotion();

--- a/src/uraft/uraftcontroller.cc
+++ b/src/uraft/uraftcontroller.cc
@@ -139,18 +139,8 @@ uint64_t uRaftController::nodeGetVersion() {
 }
 
 void uRaftController::nodeLeader(int id) {
-	if (id < 0) {
-		return;
-	}
-
-	std::string name = opt_.server[id];
-	std::string::size_type p = name.find(":");
-
-	if (p != std::string::npos) {
-		name = name.substr(0, p);
-	}
-
-	syslog(LOG_NOTICE, "Node '%s' is now a leader.", name.c_str());
+	auto leaderNode = nodeToString(id);
+	syslog(LOG_NOTICE, "Node '%s' is now a leader.", leaderNode.c_str());
 }
 
 /*! \brief Check promote/demote script status. */

--- a/src/uraft/uraftcontroller.h
+++ b/src/uraft/uraftcontroller.h
@@ -75,6 +75,9 @@ private:
 	void startFloatingIpManager();
 	void stopFloatingIpManager();
 
+	void cleanupDirtyPromotion();
+	void handlePromotionFailure();
+
 protected:
 	boost::asio::deadline_timer check_cmd_status_timer_,check_node_status_timer_;
 	boost::asio::deadline_timer cmd_timeout_timer_;

--- a/src/uraft/uraftcontroller.h
+++ b/src/uraft/uraftcontroller.h
@@ -75,17 +75,53 @@ private:
 	void startFloatingIpManager();
 	void stopFloatingIpManager();
 
+	/// @brief Clean up dirty metadata state after failed promotion.
+	///
+	/// This function is called when a promotion fails or times out, leaving the metadata server in
+	/// an inconsistent state. It invokes the saunafs-uraft-helper 'cleanup' command to remove
+	/// temporary metadata file (metadata.sfs.tmp) if no process is holding it.
+	///
+	/// This is a recovery operation to prevent deadlocks caused by incomplete metadata dumps from
+	/// incomplete promotion attempts.
+	///
+	/// \see handlePromotionFailure()
 	void cleanupDirtyPromotion();
+
+	/// @brief Handle failed promotion attempts and restore cluster consistency.
+	///
+	/// This prevents the cluster from getting stuck when a node wins an election but fails
+	/// to complete the promotion to master, ensuring the cluster can recover by electing
+	/// a different leader.
+	///
+	/// This function is invoked in two scenarios:
+	/// 1. When a promotion command exits with a non-zero status (checkCommandStatus).
+	/// 2. When a promotion times out (setSlowCommandTimeout).
+	///
+	/// It performs the following recovery steps:
+	/// - Demotes the node from Leader state in the Raft algorithm.
+	/// - Cleans up any dirty metadata state left by the failed promotion.
+	///
+	/// \see cleanupDirtyPromotion()
+	/// \see demoteLeader()
 	void handlePromotionFailure();
 
 protected:
-	boost::asio::deadline_timer check_cmd_status_timer_,check_node_status_timer_;
+	boost::asio::deadline_timer check_cmd_status_timer_;
+	boost::asio::deadline_timer check_node_status_timer_;
 	boost::asio::deadline_timer cmd_timeout_timer_;
-	pid_t                       command_pid_;
+	pid_t                       command_pid_;   /// Last run command pid.
 	int                         command_type_;  /// Last run command type.
 	Timer                       command_timer_;
-	bool                        force_demote_;
-	bool                        force_promote_;
+	/// @brief Flag indicating a demotion request is pending.
+	/// Set to true when nodeDemote() is called while a promotion is in progress.
+	/// After the promotion completes, the pending demotion will be executed.
+	/// This prevents concurrent promotion/demotion race conditions.
+	bool                        is_demote_pending_;
+	/// @brief Flag indicating a promotion request is pending.
+	/// Set to true when nodePromote() is called while a demotion is in progress.
+	/// After the demotion completes, the pending promotion will be executed.
+	/// This prevents concurrent promotion/demotion race conditions.
+	bool                        is_promote_pending_;
 	bool                        node_alive_;  /// Last is_alive node status.
 	Options                     opt_;
 	///< Smart pointer to the floating IP manager.

--- a/src/uraft/uraftcontroller.h
+++ b/src/uraft/uraftcontroller.h
@@ -85,6 +85,7 @@ protected:
 	int                         command_type_;  /// Last run command type.
 	Timer                       command_timer_;
 	bool                        force_demote_;
+	bool                        force_promote_;
 	bool                        node_alive_;  /// Last is_alive node status.
 	Options                     opt_;
 	///< Smart pointer to the floating IP manager.


### PR DESCRIPTION
This PR introduces several reliability and observability improvements to uRaft module, addressing multiple edge cases around promotion/demotion handling, deadlock prevention, and cluster recovery.

The main motivation was caused by issue #576 (promotion deadlocks), but there were introduced other improvements in the high-availability mechanism like logging and fixes when handling overlapping transitions or loss of quorum.

**Key Changes**

- **Improved handling of promotion timeouts and failures**
   - Introduces `handlePromotionFailure()` and `cleanupDirtyPromotion()` in `uRaftController`.
   - Automatically triggers cleanup of stale temporary metadata file (`metadata.sfs.tmp`).
   - Ensures the node can rejoin as a shadow after failed or interrupted promotions.
   - Floating IP manager now starts only after a successful promotion.

- **Removed redundant `set_block_promotion()` calls**
   - Prevented unnecessary election blocking in saunafs-uraft-helper and controller logic.
   - Resolved potential promotion deadlocks caused by overlapping state blocking.

- **Logging and Observability**
   - Added structured syslog messages for:
      - Promotion, demotion, and quorum-related transitions.
      - Manual demotions and heartbeat-based state changes.
      - Election victories and higher-term detections.

   - Introduced `nodeToString()` helper for consistent and readable node identifiers in logs.
   - Enhanced logs in `saunafs_drop_ip()` for clarity during IP removal and state cleanup.

- **Deferred promotions during active demotion**
   - Added `force_promote_` flag to defer a promotion request until demotion completes.
   - Ensures that overlapping commands no longer cause promotion loss or inconsistent states.
   - Logs forced transitions for traceability.

**Testing**

The following Molecule scenarios were added and refactored to test the new changes:
- `uraft_kill_sfsmaster:` This scenario was refactored to restart uRaft in the server where the `sfsmaster` process is killed, ensuring the cluster finishes in a stable state.
- `uraft_loss_quorum:` This scenario was modified to simulate a quorum loss and validate that the cluster can continue serving I/O operations once the quorum is restored.
- `uraft_deadlock_multiple_elections:` This is a new scenario introduced to validate that the uRaft cluster remains stable and free of deadlocks during consecutive election cycles.
- `uraft_failed_promotion:` This is a new scenario introduced to verify that the uRaft cluster can gracefully recover when a promotion attempt fails. It also ensures that `handlePromotionFailure()` works as expected in case of failed promotions.

For more details, see `fix-saunafs-issue-576` branch in deployment (Ansible) repository.