### PR TITLE
chore(master): improve FS operations code style

### DIFF
--- a/src/master/changelog.cc
+++ b/src/master/changelog.cc
@@ -313,14 +313,14 @@ void load_changelogs() {
 				uint64_t first = changelogGetFirstLogVersion(s);
 				uint64_t last = changelogGetLastLogVersion(s);
 				if (last >= first) {
-					if (last >= gFSOperations->fs_getversion()) { load_changelog(s); }
+					if (last >= gFSOperations->getMetadataVersion()) { load_changelog(s); }
 				} else {
 					throw InitializeException(
 					    "changelog " + fullFileName +
 					    " inconsistent, "
 					    "use sfsmetarestore to recover the filesystem; "
 					    "current fs version: " +
-					    std::to_string(gFSOperations->fs_getversion()) +
+					    std::to_string(gFSOperations->getMetadataVersion()) +
 					    ", first change in the file: " + std::to_string(first));
 				}
 			} else if (oldExists && s != kChangelogFilename) {
@@ -346,7 +346,7 @@ void load_changelog(const std::string &path) {
 	uint64_t appliedEntries = 0;
 	while (std::getline(changelog, line).good()) {
 		id = std::stoull(line, &end);
-		if (id < gFSOperations->fs_getversion()) {
+		if (id < gFSOperations->getMetadataVersion()) {
 			++skippedEntries;
 			continue;
 		} else if (!first) {

--- a/src/master/changelog.cc
+++ b/src/master/changelog.cc
@@ -313,14 +313,14 @@ void load_changelogs() {
 				uint64_t first = changelogGetFirstLogVersion(s);
 				uint64_t last = changelogGetLastLogVersion(s);
 				if (last >= first) {
-					if (last >= gFilesystemOperations->fs_getversion()) { load_changelog(s); }
+					if (last >= gFSOperations->fs_getversion()) { load_changelog(s); }
 				} else {
 					throw InitializeException(
 					    "changelog " + fullFileName +
 					    " inconsistent, "
 					    "use sfsmetarestore to recover the filesystem; "
 					    "current fs version: " +
-					    std::to_string(gFilesystemOperations->fs_getversion()) +
+					    std::to_string(gFSOperations->fs_getversion()) +
 					    ", first change in the file: " + std::to_string(first));
 				}
 			} else if (oldExists && s != kChangelogFilename) {
@@ -346,7 +346,7 @@ void load_changelog(const std::string &path) {
 	uint64_t appliedEntries = 0;
 	while (std::getline(changelog, line).good()) {
 		id = std::stoull(line, &end);
-		if (id < gFilesystemOperations->fs_getversion()) {
+		if (id < gFSOperations->fs_getversion()) {
 			++skippedEntries;
 			continue;
 		} else if (!first) {

--- a/src/master/chunks.cc
+++ b/src/master/chunks.cc
@@ -357,7 +357,7 @@ public:
 		Goal result;
 		int prev_goal = -1;
 		for (auto counter : goalCounters_) {
-			const Goal &goal = gFilesystemOperations->fs_get_goal_definition(counter.goal);
+			const Goal &goal = gFSOperations->fs_get_goal_definition(counter.goal);
 			if (prev_goal != (int)counter.goal) {
 				result.mergeIn(goal);
 				prev_goal = counter.goal;
@@ -823,7 +823,7 @@ void chunk_emergency_increase_version(Chunk *c) {
 	c->operation = Chunk::SET_VERSION;
 	c->version++;
 	chunk_update_checksum(c);
-	gFilesystemOperations->fs_incversion(c->chunkid);
+	gFSOperations->fs_incversion(c->chunkid);
 	emit_chunk_changed(c);
 }
 
@@ -1105,7 +1105,7 @@ uint8_t chunk_multi_modify(uint64_t ochunkid, uint32_t *lockid, uint8_t goal,
 				return SAUNAFS_ERROR_NOCHUNKSERVERS;
 			}
 		}
-		ChunkCopiesCalculator calculator(gFilesystemOperations->fs_get_goal_definition(goal));
+		ChunkCopiesCalculator calculator(gFSOperations->fs_get_goal_definition(goal));
 		for (const auto &server_with_type : serversWithChunkTypes) {
 			calculator.addPart(server_with_type.second, MediaLabel::kWildcard);
 		}
@@ -1570,8 +1570,8 @@ void chunk_server_has_chunk(matocsserventry *ptr, uint64_t chunkid, uint32_t ver
 		// chunkserver has nonexistent chunk, so create it for future deletion
 		if (chunkid >= ChunksMetadata::getNextChunkId() &&
 		    gChunkIdGenerator->isStrictlyMonotonic()) {
-			gFilesystemOperations->fs_set_nextchunkid(FsContext::getForMaster(eventloop_time()),
-			                                          chunkid + 1);
+			gFSOperations->fs_set_nextchunkid(FsContext::getForMaster(eventloop_time()),
+			                                  chunkid + 1);
 		}
 		c = chunk_new(chunkid, new_version);
 		c->lockedto = (uint32_t)eventloop_time()+UNUSED_DELETE_TIMEOUT;

--- a/src/master/chunks.cc
+++ b/src/master/chunks.cc
@@ -357,7 +357,7 @@ public:
 		Goal result;
 		int prev_goal = -1;
 		for (auto counter : goalCounters_) {
-			const Goal &goal = gFSOperations->fs_get_goal_definition(counter.goal);
+			const Goal &goal = gFSOperations->getGoalDefinition(counter.goal);
 			if (prev_goal != (int)counter.goal) {
 				result.mergeIn(goal);
 				prev_goal = counter.goal;
@@ -823,7 +823,7 @@ void chunk_emergency_increase_version(Chunk *c) {
 	c->operation = Chunk::SET_VERSION;
 	c->version++;
 	chunk_update_checksum(c);
-	gFSOperations->fs_incversion(c->chunkid);
+	gFSOperations->increaseChunkVersion(c->chunkid);
 	emit_chunk_changed(c);
 }
 
@@ -1105,7 +1105,7 @@ uint8_t chunk_multi_modify(uint64_t ochunkid, uint32_t *lockid, uint8_t goal,
 				return SAUNAFS_ERROR_NOCHUNKSERVERS;
 			}
 		}
-		ChunkCopiesCalculator calculator(gFSOperations->fs_get_goal_definition(goal));
+		ChunkCopiesCalculator calculator(gFSOperations->getGoalDefinition(goal));
 		for (const auto &server_with_type : serversWithChunkTypes) {
 			calculator.addPart(server_with_type.second, MediaLabel::kWildcard);
 		}
@@ -1570,8 +1570,7 @@ void chunk_server_has_chunk(matocsserventry *ptr, uint64_t chunkid, uint32_t ver
 		// chunkserver has nonexistent chunk, so create it for future deletion
 		if (chunkid >= ChunksMetadata::getNextChunkId() &&
 		    gChunkIdGenerator->isStrictlyMonotonic()) {
-			gFSOperations->fs_set_nextchunkid(FsContext::getForMaster(eventloop_time()),
-			                                  chunkid + 1);
+			gFSOperations->setNextChunkId(FsContext::getForMaster(eventloop_time()), chunkid + 1);
 		}
 		c = chunk_new(chunkid, new_version);
 		c->lockedto = (uint32_t)eventloop_time()+UNUSED_DELETE_TIMEOUT;

--- a/src/master/filesystem.cc
+++ b/src/master/filesystem.cc
@@ -117,7 +117,7 @@ static void metadataPollServe(const std::vector<pollfd> &pdesc) {
 			if (dumper->useMetarestore()) {
 				// master should recalculate its checksum
 				safs_pretty_syslog(LOG_WARNING, "dumping metadata failed, recalculating checksum");
-				gFSOperations->fs_start_checksum_recalculation();
+				gFSOperations->startChecksumRecalculation();
 			}
 			unlink(kMetadataTmpFilename);
 		}
@@ -437,7 +437,7 @@ void fs_reload(void) {
 
 void fs_unload() {
 	safs_pretty_syslog(LOG_WARNING, "unloading filesystem at %" PRIu64,
-	                   gFSOperations->fs_getversion());
+	                   gFSOperations->getMetadataVersion());
 	restore_reset();
 	matoclserv_session_unload();
 	chunk_unload();

--- a/src/master/filesystem.cc
+++ b/src/master/filesystem.cc
@@ -117,7 +117,7 @@ static void metadataPollServe(const std::vector<pollfd> &pdesc) {
 			if (dumper->useMetarestore()) {
 				// master should recalculate its checksum
 				safs_pretty_syslog(LOG_WARNING, "dumping metadata failed, recalculating checksum");
-				gFilesystemOperations->fs_start_checksum_recalculation();
+				gFSOperations->fs_start_checksum_recalculation();
 			}
 			unlink(kMetadataTmpFilename);
 		}
@@ -229,9 +229,7 @@ static void ensureChunkIdGenerator() {
 }
 
 static void initFSOperations() {
-	if (!gFilesystemOperations) {
-		gFilesystemOperations = std::make_unique<FilesystemOperationsBase>();
-	}
+	if (!gFSOperations) { gFSOperations = std::make_unique<FilesystemOperationsBase>(); }
 }
 
 /* executed in master mode */
@@ -439,7 +437,7 @@ void fs_reload(void) {
 
 void fs_unload() {
 	safs_pretty_syslog(LOG_WARNING, "unloading filesystem at %" PRIu64,
-	                   gFilesystemOperations->fs_getversion());
+	                   gFSOperations->fs_getversion());
 	restore_reset();
 	matoclserv_session_unload();
 	chunk_unload();

--- a/src/master/filesystem_checksum_updater.h
+++ b/src/master/filesystem_checksum_updater.h
@@ -54,9 +54,9 @@ protected:
 		lastEntry_ = gMetadata->metadataVersion;
 		if (metadataserver::isMaster() && !gChecksumBackgroundUpdater.inProgress()) {
 			std::string versionString = saunafsVersionToString(SAUNAFS_VERSHEX);
-			uint64_t checksum = gFilesystemOperations->fs_checksum(ChecksumMode::kGetCurrent);
-			gFilesystemOperations->fs_changelog(ts, "CHECKSUM(%s):%" PRIu64, versionString.c_str(),
-			                                    checksum);
+			uint64_t checksum = gFSOperations->fs_checksum(ChecksumMode::kGetCurrent);
+			gFSOperations->fs_changelog(ts, "CHECKSUM(%s):%" PRIu64, versionString.c_str(),
+			                            checksum);
 		}
 	}
 

--- a/src/master/filesystem_checksum_updater.h
+++ b/src/master/filesystem_checksum_updater.h
@@ -54,9 +54,8 @@ protected:
 		lastEntry_ = gMetadata->metadataVersion;
 		if (metadataserver::isMaster() && !gChecksumBackgroundUpdater.inProgress()) {
 			std::string versionString = saunafsVersionToString(SAUNAFS_VERSHEX);
-			uint64_t checksum = gFSOperations->fs_checksum(ChecksumMode::kGetCurrent);
-			gFSOperations->fs_changelog(ts, "CHECKSUM(%s):%" PRIu64, versionString.c_str(),
-			                            checksum);
+			uint64_t checksum = gFSOperations->metadataChecksum(ChecksumMode::kGetCurrent);
+			gFSOperations->changeLog(ts, "CHECKSUM(%s):%" PRIu64, versionString.c_str(), checksum);
 		}
 	}
 

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -148,7 +148,7 @@ static uint64_t file_realsize(FSNodeFile *node, uint32_t nonzero_chunks, uint64_
 	(void)file_size;
 	return 0; // Doesn't really matter. Metarestore doesn't need this value
 #else
-	const Goal &goal = gFSOperations->fs_get_goal_definition(node->goal);
+	const Goal &goal = gFSOperations->getGoalDefinition(node->goal);
 
 	uint64_t full_size = 0;
 	for (const auto &slice : goal) {
@@ -1484,12 +1484,12 @@ uint8_t fsnodes_undel(uint32_t ts, FSNodeFile *node) {
 				assert(metadataserver::isMaster());
 #endif
 
-				gFSOperations->fs_changelog(
-				    ts,
-				    "CREATE(%" PRIiNode ",%s,%c,%d,%" PRIu32 ",%" PRIu32 ",%" PRIu32 "):%" PRIiNode,
-				    p->id, fsnodes_escape_name(name).c_str(),
-				    static_cast<char>(FSNodeType::kDirectory), n->mode & 07777, (uint32_t)0,
-				    (uint32_t)0, (uint32_t)0, n->id);
+				gFSOperations->changeLog(ts,
+				                         "CREATE(%" PRIiNode ",%s,%c,%d,%" PRIu32 ",%" PRIu32
+				                         ",%" PRIu32 "):%" PRIiNode,
+				                         p->id, fsnodes_escape_name(name).c_str(),
+				                         static_cast<char>(FSNodeType::kDirectory), n->mode & 07777,
+				                         (uint32_t)0, (uint32_t)0, (uint32_t)0, n->id);
 			}
 			p = static_cast<FSNodeDirectory*>(n);
 			assert(n->type == FSNodeType::kDirectory);

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -148,7 +148,7 @@ static uint64_t file_realsize(FSNodeFile *node, uint32_t nonzero_chunks, uint64_
 	(void)file_size;
 	return 0; // Doesn't really matter. Metarestore doesn't need this value
 #else
-	const Goal &goal = gFilesystemOperations->fs_get_goal_definition(node->goal);
+	const Goal &goal = gFSOperations->fs_get_goal_definition(node->goal);
 
 	uint64_t full_size = 0;
 	for (const auto &slice : goal) {
@@ -1484,7 +1484,7 @@ uint8_t fsnodes_undel(uint32_t ts, FSNodeFile *node) {
 				assert(metadataserver::isMaster());
 #endif
 
-				gFilesystemOperations->fs_changelog(
+				gFSOperations->fs_changelog(
 				    ts,
 				    "CREATE(%" PRIiNode ",%s,%c,%d,%" PRIu32 ",%" PRIu32 ",%" PRIu32 "):%" PRIiNode,
 				    p->id, fsnodes_escape_name(name).c_str(),

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -960,7 +960,7 @@ static inline void fs_update_atime(FSNode *p, uint32_t ts) {
 	if (!gAtimeDisabled && p->atime != ts) {
 		p->atime = ts;
 		fsnodes_update_checksum(p);
-		gFilesystemOperations->fs_changelog(ts, "ACCESS(%" PRIiNode ")", p->id);
+		gFSOperations->fs_changelog(ts, "ACCESS(%" PRIiNode ")", p->id);
 	}
 }
 
@@ -2044,7 +2044,7 @@ uint8_t fs_auto_repair_if_needed(FSNodeFile *p, uint32_t chunkIndex) {
 	if (chunkId != 0 && chunk_has_only_invalid_copies(chunkId)) {
 		uint32_t notchanged, erased, repaired;
 		FsContext context = FsContext::getForMasterWithSession(0, SPECIAL_INODE_ROOT, 0, 0, 0, 0, 0);
-		gFilesystemOperations->fs_repair(context, p->id, 0, &notchanged, &erased, &repaired);
+		gFSOperations->fs_repair(context, p->id, 0, &notchanged, &erased, &repaired);
 		safs_pretty_syslog(LOG_NOTICE,
 		       "auto repair inode %" PRIiNode ", chunk %016" PRIX64
 		       ": "

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -77,7 +77,7 @@ bool decodeChar(const char *keys, const std::vector<T> values, char key, T &valu
 	return false;
 }
 
-void FilesystemOperationsBase::fs_changelog(uint32_t ts, const char *format, ...) {
+void FilesystemOperationsBase::changeLog(uint32_t ts, const char *format, ...) {
 #ifdef METARESTORE
 	(void)ts;
 	(void)format;
@@ -112,8 +112,8 @@ void FilesystemOperationsBase::fs_changelog(uint32_t ts, const char *format, ...
 }
 
 #ifndef METARESTORE
-uint8_t FilesystemOperationsBase::fs_readreserved_size(inode_t rootinode, uint8_t sesflags,
-                                                       uint32_t *dbuffsize) {
+uint8_t FilesystemOperationsBase::readReservedSize(inode_t rootinode, uint8_t sesflags,
+                                                   uint32_t *dbuffsize) {
 	if (rootinode != 0) {
 		return SAUNAFS_ERROR_EPERM;
 	}
@@ -122,25 +122,25 @@ uint8_t FilesystemOperationsBase::fs_readreserved_size(inode_t rootinode, uint8_
 	return SAUNAFS_STATUS_OK;
 }
 
-void FilesystemOperationsBase::fs_readreserved_data(inode_t rootinode, uint8_t sesflags,
-                                                    uint8_t *dbuff) {
+void FilesystemOperationsBase::readReservedData(inode_t rootinode, uint8_t sesflags,
+                                                uint8_t *dbuff) {
 	(void)rootinode;
 	(void)sesflags;
 	fsnodes_getdetacheddata(gMetadata->reserved, dbuff);
 }
 
-void FilesystemOperationsBase::fs_readreserved(uint32_t off, uint32_t max_entries,
-                                               std::vector<NamedInodeEntry> &entries) {
+void FilesystemOperationsBase::readReserved(uint32_t off, uint32_t max_entries,
+                                            std::vector<NamedInodeEntry> &entries) {
 	fsnodes_getdetacheddata(gMetadata->reserved, off, max_entries, entries);
 }
 
-void FilesystemOperationsBase::fs_readreserved(uint64_t handleOffset, uint32_t maxEntries,
-                     std::vector<HandleInodeEntry> &entries) {
+void FilesystemOperationsBase::readReserved(uint64_t handleOffset, uint32_t maxEntries,
+                                            std::vector<HandleInodeEntry> &entries) {
 	fsnodes_getdetacheddata(gMetadata->reservedHandlesIndex, handleOffset, maxEntries, entries, false);
 }
 
-uint8_t FilesystemOperationsBase::fs_readtrash_size(inode_t rootinode, uint8_t sesflags,
-                                                    uint32_t *dbuffsize) {
+uint8_t FilesystemOperationsBase::readTrashSize(inode_t rootinode, uint8_t sesflags,
+                                                uint32_t *dbuffsize) {
 	if (rootinode != 0) {
 		return SAUNAFS_ERROR_EPERM;
 	}
@@ -149,27 +149,25 @@ uint8_t FilesystemOperationsBase::fs_readtrash_size(inode_t rootinode, uint8_t s
 	return SAUNAFS_STATUS_OK;
 }
 
-void FilesystemOperationsBase::fs_readtrash_data(inode_t rootinode, uint8_t sesflags,
-                                                 uint8_t *dbuff) {
+void FilesystemOperationsBase::readTrashData(inode_t rootinode, uint8_t sesflags, uint8_t *dbuff) {
 	(void)rootinode;
 	(void)sesflags;
 	fsnodes_getdetacheddata(gMetadata->trash, dbuff);
 }
 
-void FilesystemOperationsBase::fs_readtrash(uint32_t off, uint32_t max_entries,
-                                            std::vector<NamedInodeEntry> &entries) {
+void FilesystemOperationsBase::readTrash(uint32_t off, uint32_t max_entries,
+                                         std::vector<NamedInodeEntry> &entries) {
 	fsnodes_getdetacheddata(gMetadata->trash, off, max_entries, entries);
 }
 
-void FilesystemOperationsBase::fs_readtrash(uint64_t handleOffset, uint32_t maxEntries,
-                                            std::vector<HandleInodeEntry> &entries) {
+void FilesystemOperationsBase::readTrash(uint64_t handleOffset, uint32_t maxEntries,
+                                         std::vector<HandleInodeEntry> &entries) {
 	fsnodes_getdetacheddata(gMetadata->trashHandlesIndex, handleOffset, maxEntries, entries, true);
 }
 
 /* common procedure for trash and reserved files */
-uint8_t FilesystemOperationsBase::fs_getdetachedattr(inode_t rootinode, uint8_t sesflags,
-                                                     inode_t inode, Attributes &attr,
-                                                     uint8_t dtype) {
+uint8_t FilesystemOperationsBase::getDetachedAttr(inode_t rootinode, uint8_t sesflags,
+                                                  inode_t inode, Attributes &attr, uint8_t dtype) {
 	FSNode *p;
 	attr.fill(0);
 	if (rootinode != 0) {
@@ -196,8 +194,8 @@ uint8_t FilesystemOperationsBase::fs_getdetachedattr(inode_t rootinode, uint8_t 
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t FilesystemOperationsBase::fs_gettrashpath(inode_t rootinode, uint8_t sesflags,
-                                                  inode_t inode, std::string &path) {
+uint8_t FilesystemOperationsBase::getTrashPath(inode_t rootinode, uint8_t sesflags, inode_t inode,
+                                               std::string &path) {
 	FSNode *p;
 	if (rootinode != 0) {
 		return SAUNAFS_ERROR_EPERM;
@@ -215,8 +213,8 @@ uint8_t FilesystemOperationsBase::fs_gettrashpath(inode_t rootinode, uint8_t ses
 }
 #endif
 
-uint8_t FilesystemOperationsBase::fs_settrashpath(const FsContext &context, inode_t inode,
-                                                  const std::string &path) {
+uint8_t FilesystemOperationsBase::setTrashPath(const FsContext &context, inode_t inode,
+                                               const std::string &path) {
 	ChecksumUpdater cu(context.ts());
 	FSNode *p;
 	uint8_t status = verify_session(context, OperationMode::kReadWrite, SessionType::kOnlyMeta);
@@ -242,15 +240,15 @@ uint8_t FilesystemOperationsBase::fs_settrashpath(const FsContext &context, inod
 	                     gMetadata->trashReservedToId, p, path);
 
 	if (context.isPersonalityMaster()) {
-		fs_changelog(context.ts(), "SETPATH(%" PRIiNode ",%s)", p->id,
-		             fsnodes_escape_name(path).c_str());
+		changeLog(context.ts(), "SETPATH(%" PRIiNode ",%s)", p->id,
+		          fsnodes_escape_name(path).c_str());
 	} else {
 		gMetadata->metadataVersion++;
 	}
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t FilesystemOperationsBase::fs_undel(const FsContext &context, inode_t inode) {
+uint8_t FilesystemOperationsBase::undel(const FsContext &context, inode_t inode) {
 	ChecksumUpdater cu(context.ts());
 	FSNode *p;
 	uint8_t status = verify_session(context, OperationMode::kReadWrite, SessionType::kOnlyMeta);
@@ -267,16 +265,14 @@ uint8_t FilesystemOperationsBase::fs_undel(const FsContext &context, inode_t ino
 
 	status = fsnodes_undel(context.ts(), static_cast<FSNodeFile*>(p));
 	if (context.isPersonalityMaster()) {
-		if (status == SAUNAFS_STATUS_OK) {
-			fs_changelog(context.ts(), "UNDEL(%" PRIiNode ")", p->id);
-		}
+		if (status == SAUNAFS_STATUS_OK) { changeLog(context.ts(), "UNDEL(%" PRIiNode ")", p->id); }
 	} else {
 		gMetadata->metadataVersion++;
 	}
 	return status;
 }
 
-uint8_t FilesystemOperationsBase::fs_purge(const FsContext &context, inode_t inode) {
+uint8_t FilesystemOperationsBase::purge(const FsContext &context, inode_t inode) {
 	ChecksumUpdater cu(context.ts());
 	FSNode *p;
 	uint8_t status = verify_session(context, OperationMode::kReadWrite, SessionType::kOnlyMeta);
@@ -295,7 +291,7 @@ uint8_t FilesystemOperationsBase::fs_purge(const FsContext &context, inode_t ino
 	fsnodes_purge(context.ts(), p);
 
 	if (context.isPersonalityMaster()) {
-		fs_changelog(context.ts(), "PURGE(%" PRIiNode ")", purged_inode);
+		changeLog(context.ts(), "PURGE(%" PRIiNode ")", purged_inode);
 	} else {
 		gMetadata->metadataVersion++;
 	}
@@ -303,11 +299,11 @@ uint8_t FilesystemOperationsBase::fs_purge(const FsContext &context, inode_t ino
 }
 
 #ifndef METARESTORE
-void FilesystemOperationsBase::fs_info(uint64_t *totalSpace, uint64_t *availableSpace,
-                                       uint64_t *trashSpace, inode_t *trashNodes,
-                                       uint64_t *reservedSpace, inode_t *reservedNodes,
-                                       inode_t *inodes, inode_t *directoryNodes, inode_t *fileNodes,
-                                       inode_t *linkNodes) {
+void FilesystemOperationsBase::getFSStats(uint64_t *totalSpace, uint64_t *availableSpace,
+                                          uint64_t *trashSpace, inode_t *trashNodes,
+                                          uint64_t *reservedSpace, inode_t *reservedNodes,
+                                          inode_t *inodes, inode_t *directoryNodes,
+                                          inode_t *fileNodes, inode_t *linkNodes) {
 	matocsserv_getspace(totalSpace, availableSpace);
 	*trashSpace = gMetadata->trashSpace;
 	*trashNodes = gMetadata->trashNodes;
@@ -319,7 +315,7 @@ void FilesystemOperationsBase::fs_info(uint64_t *totalSpace, uint64_t *available
 	*linkNodes = gMetadata->linkNodes;
 }
 
-uint8_t FilesystemOperationsBase::fs_getrootinode(inode_t *rootinode, const uint8_t *path) {
+uint8_t FilesystemOperationsBase::getRootInode(inode_t *rootinode, const uint8_t *path) {
 	HString hname;
 	uint32_t nleng;
 	const uint8_t *name;
@@ -355,9 +351,9 @@ uint8_t FilesystemOperationsBase::fs_getrootinode(inode_t *rootinode, const uint
 	}
 }
 
-void FilesystemOperationsBase::fs_statfs(const FsContext &context, uint64_t *totalspace,
-                                         uint64_t *availspace, uint64_t *trspace, uint64_t *respace,
-                                         inode_t *inodes) {
+void FilesystemOperationsBase::statfs(const FsContext &context, uint64_t *totalspace,
+                                      uint64_t *availspace, uint64_t *trspace, uint64_t *respace,
+                                      inode_t *inodes) {
 	FSNode *rn;
 	StatsRecord sr;
 	if (context.rootinode() == SPECIAL_INODE_ROOT) {
@@ -384,9 +380,9 @@ void FilesystemOperationsBase::fs_statfs(const FsContext &context, uint64_t *tot
 }
 #endif /* #ifndef METARESTORE */
 
-uint8_t FilesystemOperationsBase::fs_apply_checksum(const std::string &version, uint64_t checksum) {
+uint8_t FilesystemOperationsBase::applyChecksum(const std::string &version, uint64_t checksum) {
 	std::string versionString = saunafsVersionToString(SAUNAFS_VERSHEX);
-	uint64_t computedChecksum = fs_checksum(ChecksumMode::kGetCurrent);
+	uint64_t computedChecksum = metadataChecksum(ChecksumMode::kGetCurrent);
 	gMetadata->metadataVersion++;
 	if (!gDisableChecksumVerification && (version == versionString)) {
 		if (checksum != computedChecksum) {
@@ -396,7 +392,7 @@ uint8_t FilesystemOperationsBase::fs_apply_checksum(const std::string &version, 
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t FilesystemOperationsBase::fs_apply_access(uint32_t timestamp, inode_t inode) {
+uint8_t FilesystemOperationsBase::applyAccess(uint32_t timestamp, inode_t inode) {
 	FSNode *p;
 	p = fsnodes_id_to_node(inode);
 	if (!p) {
@@ -409,7 +405,7 @@ uint8_t FilesystemOperationsBase::fs_apply_access(uint32_t timestamp, inode_t in
 }
 
 #ifndef METARESTORE
-uint8_t FilesystemOperationsBase::fs_access(const FsContext &context, inode_t inode, int modemask) {
+uint8_t FilesystemOperationsBase::access(const FsContext &context, inode_t inode, int modemask) {
 	FSNode *p;
 
 	uint8_t status = verify_session(context, (modemask & MODE_MASK_W) ? OperationMode::kReadWrite : OperationMode::kReadOnly, SessionType::kNotMeta);
@@ -421,8 +417,8 @@ uint8_t FilesystemOperationsBase::fs_access(const FsContext &context, inode_t in
 									  inode, &p);
 }
 
-uint8_t FilesystemOperationsBase::fs_lookup(const FsContext &context, inode_t parent,
-                                            const HString &name, inode_t *inode, Attributes &attr) {
+uint8_t FilesystemOperationsBase::lookup(const FsContext &context, inode_t parent,
+                                         const HString &name, inode_t *inode, Attributes &attr) {
 	FSNode *wd;
 	FSNodeDirectory *rn;
 
@@ -492,9 +488,9 @@ uint8_t FilesystemOperationsBase::fs_lookup(const FsContext &context, inode_t pa
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t FilesystemOperationsBase::fs_whole_path_lookup(const FsContext &context, inode_t parent,
-                                                       const std::string &path,
-                                                       inode_t *found_inode, Attributes &attr) {
+uint8_t FilesystemOperationsBase::wholePathLookup(const FsContext &context, inode_t parent,
+                                                  const std::string &path, inode_t *found_inode,
+                                                  Attributes &attr) {
 	uint8_t status;
 	inode_t tmp_inode = context.rootinode();
 
@@ -503,7 +499,7 @@ uint8_t FilesystemOperationsBase::fs_whole_path_lookup(const FsContext &context,
 		auto delim_it = std::find(current_it, path.end(), '/');
 		if (current_it != delim_it) {
 			HString hstr(current_it, delim_it);
-			status = fs_lookup(context, parent, hstr, &tmp_inode, attr);
+			status = lookup(context, parent, hstr, &tmp_inode, attr);
 			if (status != SAUNAFS_STATUS_OK) {
 				return status;
 			}
@@ -516,15 +512,12 @@ uint8_t FilesystemOperationsBase::fs_whole_path_lookup(const FsContext &context,
 	}
 
 	*found_inode = tmp_inode;
-	if (tmp_inode == context.rootinode()) {
-		return fs_getattr(context, SPECIAL_INODE_ROOT, attr);
-	}
+	if (tmp_inode == context.rootinode()) { return getAttr(context, SPECIAL_INODE_ROOT, attr); }
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t FilesystemOperationsBase::fs_full_path_by_inode(const FsContext &context,
-                                                        inode_t initial_inode,
-                                                        std::string &fullPath) {
+uint8_t FilesystemOperationsBase::fullPathByInode(const FsContext &context, inode_t initial_inode,
+                                                  std::string &fullPath) {
 	inode_t current_inode = initial_inode;
 	FSNode *parent_node;
 	FSNode *current_node;
@@ -571,7 +564,7 @@ uint8_t FilesystemOperationsBase::fs_full_path_by_inode(const FsContext &context
 	return SAUNAFS_STATUS_OK;
 }
 
-std::string FilesystemOperationsBase::fs_full_path_by_inode(inode_t initial_inode) {
+std::string FilesystemOperationsBase::fullPathByInode(inode_t initial_inode) {
 	std::string fullPath = "";
 	inode_t current_inode = initial_inode;
 	FSNode *current_node = fsnodes_id_to_node(current_inode);
@@ -596,8 +589,8 @@ std::string FilesystemOperationsBase::fs_full_path_by_inode(inode_t initial_inod
 	return fullPath;
 }
 
-uint8_t FilesystemOperationsBase::fs_getattr(const FsContext &context, inode_t inode,
-                                             Attributes &attr) {
+uint8_t FilesystemOperationsBase::getAttr(const FsContext &context, inode_t inode,
+                                          Attributes &attr) {
 	FSNode *p;
 
 	attr.fill(0);
@@ -619,10 +612,10 @@ uint8_t FilesystemOperationsBase::fs_getattr(const FsContext &context, inode_t i
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t FilesystemOperationsBase::fs_try_setlength(const FsContext &context, inode_t inode,
-                                                   uint8_t opened, uint64_t length,
-                                                   bool denyTruncatingParity, uint32_t lockId,
-                                                   Attributes &attr, uint64_t *chunkid) {
+uint8_t FilesystemOperationsBase::trySetLength(const FsContext &context, inode_t inode,
+                                               uint8_t opened, uint64_t length,
+                                               bool denyTruncatingParity, uint32_t lockId,
+                                               Attributes &attr, uint64_t *chunkid) {
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
 	FSNode *p;
@@ -659,8 +652,8 @@ uint8_t FilesystemOperationsBase::fs_try_setlength(const FsContext &context, ino
 				}
 				node_file->chunks[indx] = nchunkid;
 				*chunkid = nchunkid;
-				fs_changelog(ts, "TRUNC(%" PRIiNode ",%" PRIu32 ",%" PRIu32 "):%" PRIu64, p->id, indx,
-				             lockId, nchunkid);
+				changeLog(ts, "TRUNC(%" PRIiNode ",%" PRIu32 ",%" PRIu32 "):%" PRIu64, p->id, indx,
+				          lockId, nchunkid);
 				fsnodes_update_checksum(p);
 				return SAUNAFS_ERROR_DELAYED;
 			}
@@ -673,8 +666,8 @@ uint8_t FilesystemOperationsBase::fs_try_setlength(const FsContext &context, ino
 }
 #endif
 
-uint8_t FilesystemOperationsBase::fs_apply_trunc(uint32_t timestamp, inode_t inode, uint32_t indx,
-                                                 uint64_t chunkid, uint32_t lockid) {
+uint8_t FilesystemOperationsBase::applyTrunc(uint32_t timestamp, inode_t inode, uint32_t indx,
+                                             uint64_t chunkid, uint32_t lockid) {
 	uint64_t ochunkid, nchunkid;
 	uint8_t status;
 	FSNodeFile *p = fsnodes_id_to_node<FSNodeFile>(inode);
@@ -709,13 +702,12 @@ uint8_t FilesystemOperationsBase::fs_apply_trunc(uint32_t timestamp, inode_t ino
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t FilesystemOperationsBase::fs_set_nextchunkid(const FsContext &context,
-                                                     uint64_t nextChunkId) {
+uint8_t FilesystemOperationsBase::setNextChunkId(const FsContext &context, uint64_t nextChunkId) {
 	ChecksumUpdater cu(context.ts());
 	uint8_t status = chunk_set_next_chunkid(nextChunkId);
 	if (context.isPersonalityMaster()) {
 		if (status == SAUNAFS_STATUS_OK) {
-			fs_changelog(context.ts(), "NEXTCHUNKID(%" PRIu64 ")", nextChunkId);
+			changeLog(context.ts(), "NEXTCHUNKID(%" PRIu64 ")", nextChunkId);
 		}
 	} else {
 		gMetadata->metadataVersion++;
@@ -724,22 +716,22 @@ uint8_t FilesystemOperationsBase::fs_set_nextchunkid(const FsContext &context,
 }
 
 #ifndef METARESTORE
-uint8_t FilesystemOperationsBase::fs_end_setlength(uint64_t chunkid) {
+uint8_t FilesystemOperationsBase::endSetLength(uint64_t chunkid) {
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
-	fs_changelog(ts, "UNLOCK(%" PRIu64 ")", chunkid);
+	changeLog(ts, "UNLOCK(%" PRIu64 ")", chunkid);
 	return chunk_unlock(chunkid);
 }
 #endif
 
-uint8_t FilesystemOperationsBase::fs_apply_unlock(uint64_t chunkid) {
+uint8_t FilesystemOperationsBase::applyUnlock(uint64_t chunkid) {
 	gMetadata->metadataVersion++;
 	return chunk_unlock(chunkid);
 }
 
 #ifndef METARESTORE
-uint8_t FilesystemOperationsBase::fs_do_setlength(const FsContext &context, inode_t inode,
-                                                  uint64_t length, Attributes &attr) {
+uint8_t FilesystemOperationsBase::doSetLength(const FsContext &context, inode_t inode,
+                                              uint64_t length, Attributes &attr) {
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
 	FSNode *p = NULL;
@@ -763,8 +755,8 @@ uint8_t FilesystemOperationsBase::fs_do_setlength(const FsContext &context, inod
 	// length of the file and we should erase further chunks.
 	bool eraseFurtherChunks = true;
 	fsnodes_setlength(static_cast<FSNodeFile *>(p), length, eraseFurtherChunks);
-	fs_changelog(ts, "LENGTH(%" PRIiNode ",%" PRIu64 ",%" PRIu32 ")", inode,
-	             static_cast<FSNodeFile *>(p)->length, static_cast<uint32_t>(eraseFurtherChunks));
+	changeLog(ts, "LENGTH(%" PRIiNode ",%" PRIu64 ",%" PRIu32 ")", inode,
+	          static_cast<FSNodeFile *>(p)->length, static_cast<uint32_t>(eraseFurtherChunks));
 	p->mtime = ts;
 	fsnodes_update_ctime(p, ts);
 	fsnodes_update_checksum(p);
@@ -774,11 +766,10 @@ uint8_t FilesystemOperationsBase::fs_do_setlength(const FsContext &context, inod
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t FilesystemOperationsBase::fs_setattr(const FsContext &context, inode_t inode,
-                                             uint8_t setmask, uint16_t attrmode, uint32_t attruid,
-                                             uint32_t attrgid, uint32_t attratime,
-                                             uint32_t attrmtime, SugidClearMode sugidclearmode,
-                                             Attributes &attr) {
+uint8_t FilesystemOperationsBase::setAttr(const FsContext &context, inode_t inode, uint8_t setmask,
+                                          uint16_t attrmode, uint32_t attruid, uint32_t attrgid,
+                                          uint32_t attratime, uint32_t attrmtime,
+                                          SugidClearMode sugidclearmode, Attributes &attr) {
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
 	FSNode *p = NULL;
@@ -900,8 +891,8 @@ uint8_t FilesystemOperationsBase::fs_setattr(const FsContext &context, inode_t i
 	} else if (setmask & SET_MTIME_FLAG) {
 		p->mtime = attrmtime;
 	}
-	fs_changelog(ts, "ATTR(%" PRIiNode ",%d,%" PRIu32 ",%" PRIu32 ",%" PRIu32 ",%" PRIu32 ")",
-	             p->id, p->mode & 07777, p->uid, p->gid, p->atime, p->mtime);
+	changeLog(ts, "ATTR(%" PRIiNode ",%d,%" PRIu32 ",%" PRIu32 ",%" PRIu32 ",%" PRIu32 ")", p->id,
+	          p->mode & 07777, p->uid, p->gid, p->atime, p->mtime);
 	fsnodes_update_ctime(p, ts);
 	fsnodes_fill_attr(p, NULL, context.uid(), context.gid(), context.auid(), context.agid(), context.sesflags(), attr);
 	fsnodes_update_checksum(p);
@@ -911,9 +902,9 @@ uint8_t FilesystemOperationsBase::fs_setattr(const FsContext &context, inode_t i
 }
 #endif
 
-uint8_t FilesystemOperationsBase::fs_apply_attr(uint32_t timestamp, inode_t inode, uint32_t mode,
-                                                uint32_t uid, uint32_t gid, uint32_t atime,
-                                                uint32_t mtime) {
+uint8_t FilesystemOperationsBase::applyAttr(uint32_t timestamp, inode_t inode, uint32_t mode,
+                                            uint32_t uid, uint32_t gid, uint32_t atime,
+                                            uint32_t mtime) {
 	FSNode *p = fsnodes_id_to_node(inode);
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
@@ -934,8 +925,8 @@ uint8_t FilesystemOperationsBase::fs_apply_attr(uint32_t timestamp, inode_t inod
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t FilesystemOperationsBase::fs_apply_length(uint32_t timestamp, inode_t inode,
-                                                  uint64_t length, bool eraseFurtherChunks) {
+uint8_t FilesystemOperationsBase::applyLength(uint32_t timestamp, inode_t inode, uint64_t length,
+                                              bool eraseFurtherChunks) {
 	FSNode *p = fsnodes_id_to_node(inode);
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
@@ -960,12 +951,12 @@ static inline void fs_update_atime(FSNode *p, uint32_t ts) {
 	if (!gAtimeDisabled && p->atime != ts) {
 		p->atime = ts;
 		fsnodes_update_checksum(p);
-		gFSOperations->fs_changelog(ts, "ACCESS(%" PRIiNode ")", p->id);
+		gFSOperations->changeLog(ts, "ACCESS(%" PRIiNode ")", p->id);
 	}
 }
 
-uint8_t FilesystemOperationsBase::fs_readlink(const FsContext &context, inode_t inode,
-                                              std::string &path) {
+uint8_t FilesystemOperationsBase::readlink(const FsContext &context, inode_t inode,
+                                           std::string &path) {
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
 	FSNode *p = NULL;
@@ -992,9 +983,9 @@ uint8_t FilesystemOperationsBase::fs_readlink(const FsContext &context, inode_t 
 }
 #endif
 
-uint8_t FilesystemOperationsBase::fs_symlink(const FsContext &context, inode_t parent,
-                                             const HString &name, const std::string &path,
-                                             inode_t *inode, Attributes *attr) {
+uint8_t FilesystemOperationsBase::symlink(const FsContext &context, inode_t parent,
+                                          const HString &name, const std::string &path,
+                                          inode_t *inode, Attributes *attr) {
 	ChecksumUpdater cu(context.ts());
 	FSNode *wd;
 	uint8_t status = verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
@@ -1041,9 +1032,9 @@ uint8_t FilesystemOperationsBase::fs_symlink(const FsContext &context, inode_t p
 	if (context.isPersonalityMaster()) {
 		assert(*inode == 0);
 		*inode = p->id;
-		fs_changelog(context.ts(), "SYMLINK(%" PRIiNode ",%s,%s,%" PRIu32 ",%" PRIu32 "):%" PRIiNode,
-		             wd->id, fsnodes_escape_name(name).c_str(), fsnodes_escape_name(path).c_str(),
-		             context.uid(), context.gid(), p->id);
+		changeLog(context.ts(), "SYMLINK(%" PRIiNode ",%s,%s,%" PRIu32 ",%" PRIu32 "):%" PRIiNode,
+		          wd->id, fsnodes_escape_name(name).c_str(), fsnodes_escape_name(path).c_str(),
+		          context.uid(), context.gid(), p->id);
 	} else {
 		if (*inode != p->id) {
 			return SAUNAFS_ERROR_MISMATCH;
@@ -1058,10 +1049,10 @@ uint8_t FilesystemOperationsBase::fs_symlink(const FsContext &context, inode_t p
 }
 
 #ifndef METARESTORE
-uint8_t FilesystemOperationsBase::fs_mknod(const FsContext &context, inode_t parent,
-                                           const HString &name, FSNodeType type, uint16_t mode,
-                                           uint16_t umask, uint32_t rdev, inode_t *inode,
-                                           Attributes &attr) {
+uint8_t FilesystemOperationsBase::mknod(const FsContext &context, inode_t parent,
+                                        const HString &name, FSNodeType type, uint16_t mode,
+                                        uint16_t umask, uint32_t rdev, inode_t *inode,
+                                        Attributes &attr) {
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
 	FSNode *wd, *p;
@@ -1104,19 +1095,18 @@ uint8_t FilesystemOperationsBase::fs_mknod(const FsContext &context, inode_t par
 	}
 	*inode = p->id;
 	fsnodes_fill_attr(p, wd, context.uid(), context.gid(), context.auid(), context.agid(), context.sesflags(), attr);
-	fs_changelog(ts,
-	             "CREATE(%" PRIiNode ",%s,%c,%d,%" PRIu32 ",%" PRIu32 ",%" PRIu32 "):%" PRIiNode,
-	             wd->id, fsnodes_escape_name(name).c_str(), static_cast<char>(type),
-	             p->mode & 07777, context.uid(), context.gid(), rdev, p->id);
+	changeLog(ts, "CREATE(%" PRIiNode ",%s,%c,%d,%" PRIu32 ",%" PRIu32 ",%" PRIu32 "):%" PRIiNode,
+	          wd->id, fsnodes_escape_name(name).c_str(), static_cast<char>(type), p->mode & 07777,
+	          context.uid(), context.gid(), rdev, p->id);
 	incrementFSStat(FsStats::Mknod);
 	metrics::Counter::increment(metrics::Counter::Master::FS_MKNOD);
 	fsnodes_update_checksum(p);
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t FilesystemOperationsBase::fs_mkdir(const FsContext &context, inode_t parent,
-                                           const HString &name, uint16_t mode, uint16_t umask,
-                                           uint8_t copysgid, inode_t *inode, Attributes &attr) {
+uint8_t FilesystemOperationsBase::mkdir(const FsContext &context, inode_t parent,
+                                        const HString &name, uint16_t mode, uint16_t umask,
+                                        uint8_t copysgid, inode_t *inode, Attributes &attr) {
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
 	FSNode *wd, *p;
@@ -1160,20 +1150,19 @@ uint8_t FilesystemOperationsBase::fs_mkdir(const FsContext &context, inode_t par
 	*inode = p->id;
 	fsnodes_fill_attr(p, wd, context.uid(), context.gid(), context.auid(), context.agid(),
 	                  context.sesflags(), attr);
-	fs_changelog(
-	    ts, "CREATE(%" PRIiNode ",%s,%c,%d,%" PRIu32 ",%" PRIu32 ",%" PRIu32 "):%" PRIiNode, wd->id,
-	    fsnodes_escape_name(name).c_str(), static_cast<char>(FSNodeType::kDirectory),
-	    p->mode & 07777, context.uid(), context.gid(), 0, p->id);
+	changeLog(ts, "CREATE(%" PRIiNode ",%s,%c,%d,%" PRIu32 ",%" PRIu32 ",%" PRIu32 "):%" PRIiNode,
+	          wd->id, fsnodes_escape_name(name).c_str(), static_cast<char>(FSNodeType::kDirectory),
+	          p->mode & 07777, context.uid(), context.gid(), 0, p->id);
 	incrementFSStat(FsStats::Mkdir);
 	metrics::Counter::increment(metrics::Counter::Master::FS_MKDIR);
 	return SAUNAFS_STATUS_OK;
 }
 #endif
 
-uint8_t FilesystemOperationsBase::fs_apply_create(uint32_t timestamp, inode_t parent,
-                                                  const HString &name, FSNodeType type,
-                                                  uint32_t mode, uint32_t uid, uint32_t gid,
-                                                  uint32_t rdev, inode_t inode) {
+uint8_t FilesystemOperationsBase::applyCreate(uint32_t timestamp, inode_t parent,
+                                              const HString &name, FSNodeType type, uint32_t mode,
+                                              uint32_t uid, uint32_t gid, uint32_t rdev,
+                                              inode_t inode) {
 	FSNode *wd, *p;
 	if (type != FSNodeType::kFile && type != FSNodeType::kSocket && type != FSNodeType::kFifo &&
 	    type != FSNodeType::kBlockDev && type != FSNodeType::kCharDev &&
@@ -1206,8 +1195,8 @@ uint8_t FilesystemOperationsBase::fs_apply_create(uint32_t timestamp, inode_t pa
 }
 
 #ifndef METARESTORE
-uint8_t FilesystemOperationsBase::fs_unlink(const FsContext &context, inode_t parent,
-                                            const HString &name) {
+uint8_t FilesystemOperationsBase::unlink(const FsContext &context, inode_t parent,
+                                         const HString &name) {
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
 	FSNode *wd;
@@ -1236,18 +1225,18 @@ uint8_t FilesystemOperationsBase::fs_unlink(const FsContext &context, inode_t pa
 	if (child->type == FSNodeType::kDirectory) {
 		return SAUNAFS_ERROR_EPERM;
 	}
-	fs_changelog(ts, "UNLINK(%" PRIiNode ",%s):%" PRIiNode, wd->id,
-	             fsnodes_escape_name(name).c_str(), child->id);
+	changeLog(ts, "UNLINK(%" PRIiNode ",%s):%" PRIiNode, wd->id, fsnodes_escape_name(name).c_str(),
+	          child->id);
 	fsnodes_unlink(ts, static_cast<FSNodeDirectory*>(wd), name, child);
 	incrementFSStat(FsStats::Unlink);
 	metrics::Counter::increment(metrics::Counter::Master::FS_UNLINK);
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t FilesystemOperationsBase::fs_recursive_remove(const FsContext &context, inode_t parent,
-                                                      const HString &name,
-                                                      const std::function<void(int)> &callback,
-                                                      uint32_t job_id) {
+uint8_t FilesystemOperationsBase::recursiveRemove(const FsContext &context, inode_t parent,
+                                                  const HString &name,
+                                                  const std::function<void(int)> &callback,
+                                                  uint32_t job_id) {
 	ChecksumUpdater cu(context.ts());
 	FSNode *wd_tmp;
 
@@ -1277,8 +1266,8 @@ uint8_t FilesystemOperationsBase::fs_recursive_remove(const FsContext &context, 
 	                                          callback);
 }
 
-uint8_t FilesystemOperationsBase::fs_rmdir(const FsContext &context, inode_t parent,
-                                           const HString &name) {
+uint8_t FilesystemOperationsBase::rmdir(const FsContext &context, inode_t parent,
+                                        const HString &name) {
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
 	FSNode *wd;
@@ -1310,8 +1299,8 @@ uint8_t FilesystemOperationsBase::fs_rmdir(const FsContext &context, inode_t par
 	if (!static_cast<FSNodeDirectory*>(child)->entries.empty()) {
 		return SAUNAFS_ERROR_ENOTEMPTY;
 	}
-	fs_changelog(ts, "UNLINK(%" PRIiNode ",%s):%" PRIiNode, wd->id,
-	             fsnodes_escape_name(name).c_str(), child->id);
+	changeLog(ts, "UNLINK(%" PRIiNode ",%s):%" PRIiNode, wd->id, fsnodes_escape_name(name).c_str(),
+	          child->id);
 	fsnodes_unlink(ts, static_cast<FSNodeDirectory*>(wd), name, child);
 	incrementFSStat(FsStats::Rmdir);
 	metrics::Counter::increment(metrics::Counter::Master::FS_RMDIR);
@@ -1319,8 +1308,8 @@ uint8_t FilesystemOperationsBase::fs_rmdir(const FsContext &context, inode_t par
 }
 #endif
 
-uint8_t FilesystemOperationsBase::fs_apply_unlink(uint32_t timestamp, inode_t parent,
-                                                  const HString &name, inode_t inode) {
+uint8_t FilesystemOperationsBase::applyUnlink(uint32_t timestamp, inode_t parent,
+                                              const HString &name, inode_t inode) {
 	FSNode *wd;
 	wd = fsnodes_id_to_node(parent);
 	if (!wd) {
@@ -1345,10 +1334,10 @@ uint8_t FilesystemOperationsBase::fs_apply_unlink(uint32_t timestamp, inode_t pa
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t FilesystemOperationsBase::fs_rename(const FsContext &context, inode_t parent_src,
-                                            const HString &name_src, inode_t parent_dst,
-                                            const HString &name_dst, inode_t *inode,
-                                            Attributes *attr) {
+uint8_t FilesystemOperationsBase::rename(const FsContext &context, inode_t parent_src,
+                                         const HString &name_src, inode_t parent_dst,
+                                         const HString &name_dst, inode_t *inode,
+                                         Attributes *attr) {
 	ChecksumUpdater cu(context.ts());
 	FSNode *swd;
 	FSNode *dwd;
@@ -1439,9 +1428,9 @@ uint8_t FilesystemOperationsBase::fs_rename(const FsContext &context, inode_t pa
 		fsnodes_fill_attr(context, se_child, dwd, *attr);
 	}
 	if (context.isPersonalityMaster()) {
-		fs_changelog(context.ts(), "MOVE(%" PRIiNode ",%s,%" PRIiNode ",%s):%" PRIiNode, swd->id,
-		             fsnodes_escape_name(name_src).c_str(), dwd->id,
-		             fsnodes_escape_name(name_dst).c_str(), se_child->id);
+		changeLog(context.ts(), "MOVE(%" PRIiNode ",%s,%" PRIiNode ",%s):%" PRIiNode, swd->id,
+		          fsnodes_escape_name(name_src).c_str(), dwd->id,
+		          fsnodes_escape_name(name_dst).c_str(), se_child->id);
 	} else {
 		gMetadata->metadataVersion++;
 	}
@@ -1452,9 +1441,9 @@ uint8_t FilesystemOperationsBase::fs_rename(const FsContext &context, inode_t pa
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t FilesystemOperationsBase::fs_link(const FsContext &context, inode_t inode_src,
-                                          inode_t parent_dst, const HString &name_dst,
-                                          inode_t *inode, Attributes *attr) {
+uint8_t FilesystemOperationsBase::link(const FsContext &context, inode_t inode_src,
+                                       inode_t parent_dst, const HString &name_dst, inode_t *inode,
+                                       Attributes *attr) {
 	ChecksumUpdater cu(context.ts());
 	FSNode *sp;
 	FSNode *dwd;
@@ -1489,8 +1478,8 @@ uint8_t FilesystemOperationsBase::fs_link(const FsContext &context, inode_t inod
 		fsnodes_fill_attr(context, sp, dwd, *attr);
 	}
 	if (context.isPersonalityMaster()) {
-		fs_changelog(context.ts(), "LINK(%" PRIiNode ",%" PRIiNode ",%s)", sp->id, dwd->id,
-		             fsnodes_escape_name(name_dst).c_str());
+		changeLog(context.ts(), "LINK(%" PRIiNode ",%" PRIiNode ",%s)", sp->id, dwd->id,
+		          fsnodes_escape_name(name_dst).c_str());
 	} else {
 		gMetadata->metadataVersion++;
 	}
@@ -1501,8 +1490,8 @@ uint8_t FilesystemOperationsBase::fs_link(const FsContext &context, inode_t inod
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t FilesystemOperationsBase::fs_append(const FsContext &context, inode_t inode,
-                                            inode_t inode_src) {
+uint8_t FilesystemOperationsBase::append(const FsContext &context, inode_t inode,
+                                         inode_t inode_src) {
 	ChecksumUpdater cu(context.ts());
 	FSNode *p, *sp;
 	if (inode == inode_src) {
@@ -1530,7 +1519,7 @@ uint8_t FilesystemOperationsBase::fs_append(const FsContext &context, inode_t in
 		return status;
 	}
 	if (context.isPersonalityMaster()) {
-		fs_changelog(context.ts(), "APPEND(%" PRIiNode ",%" PRIiNode ")", p->id, sp->id);
+		changeLog(context.ts(), "APPEND(%" PRIiNode ",%" PRIiNode ")", p->id, sp->id);
 	} else {
 		gMetadata->metadataVersion++;
 	}
@@ -1550,10 +1539,10 @@ static int fsnodes_check_lock_permissions(const FsContext &context, inode_t inod
 	return fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny, modemask, inode, &dummy);
 }
 
-int FilesystemOperationsBase::fs_posixlock_probe(const FsContext &context, inode_t inode,
-                                                 uint64_t start, uint64_t end, uint64_t owner,
-                                                 uint32_t sessionid, uint32_t reqid, uint32_t msgid,
-                                                 uint16_t oper, safs_locks::FlockWrapper &info) {
+int FilesystemOperationsBase::posixLockProbe(const FsContext &context, inode_t inode,
+                                             uint64_t start, uint64_t end, uint64_t owner,
+                                             uint32_t sessionid, uint32_t reqid, uint32_t msgid,
+                                             uint16_t oper, safs_locks::FlockWrapper &info) {
 	uint8_t status;
 
 	if (oper != safs_locks::kShared && oper != safs_locks::kExclusive &&
@@ -1583,11 +1572,11 @@ int FilesystemOperationsBase::fs_posixlock_probe(const FsContext &context, inode
 	}
 }
 
-int FilesystemOperationsBase::fs_lock_op(const FsContext &context, FileLocks &locks, inode_t inode,
-                                         uint64_t start, uint64_t end, uint64_t owner,
-                                         uint32_t sessionid, uint32_t reqid, uint32_t msgid,
-                                         uint16_t oper, bool nonblocking,
-                                         std::vector<FileLocks::Owner> &applied) {
+int FilesystemOperationsBase::lockOperation(const FsContext &context, FileLocks &locks,
+                                            inode_t inode, uint64_t start, uint64_t end,
+                                            uint64_t owner, uint32_t sessionid, uint32_t reqid,
+                                            uint32_t msgid, uint16_t oper, bool nonblocking,
+                                            std::vector<FileLocks::Owner> &applied) {
 	uint8_t status;
 
 	if ((status = fsnodes_check_lock_permissions(context, inode, oper)) != SAUNAFS_STATUS_OK) {
@@ -1642,17 +1631,17 @@ int FilesystemOperationsBase::fs_lock_op(const FsContext &context, FileLocks &lo
 	return status;
 }
 
-int FilesystemOperationsBase::fs_flock_op(const FsContext &context, inode_t inode, uint64_t owner,
-                                          uint32_t sessionid, uint32_t reqid, uint32_t msgid,
-                                          uint16_t oper, bool nonblocking,
-                                          std::vector<FileLocks::Owner> &applied) {
+int FilesystemOperationsBase::flockOperation(const FsContext &context, inode_t inode,
+                                             uint64_t owner, uint32_t sessionid, uint32_t reqid,
+                                             uint32_t msgid, uint16_t oper, bool nonblocking,
+                                             std::vector<FileLocks::Owner> &applied) {
 	ChecksumUpdater cu(context.ts());
-	int ret = fs_lock_op(context, gMetadata->flockLocks, inode, 0, 1, owner, sessionid, reqid,
-	                     msgid, oper, nonblocking, applied);
+	int ret = lockOperation(context, gMetadata->flockLocks, inode, 0, 1, owner, sessionid, reqid,
+	                        msgid, oper, nonblocking, applied);
 	if (context.isPersonalityMaster()) {
-		fs_changelog(context.ts(),
-		             "FLCK(%" PRIu8 ",%" PRIiNode ",0,1,%" PRIu64 ",%" PRIu32 ",%" PRIu16 ")",
-		             (uint8_t)safs_locks::Type::kFlock, inode, owner, sessionid, oper);
+		changeLog(context.ts(),
+		          "FLCK(%" PRIu8 ",%" PRIiNode ",0,1,%" PRIu64 ",%" PRIu32 ",%" PRIu16 ")",
+		          (uint8_t)safs_locks::Type::kFlock, inode, owner, sessionid, oper);
 	} else {
 		gMetadata->metadataVersion++;
 	}
@@ -1660,28 +1649,28 @@ int FilesystemOperationsBase::fs_flock_op(const FsContext &context, inode_t inod
 	return ret;
 }
 
-int FilesystemOperationsBase::fs_posixlock_op(const FsContext &context, inode_t inode,
-                                              uint64_t start, uint64_t end, uint64_t owner,
-                                              uint32_t sessionid, uint32_t reqid, uint32_t msgid,
-                                              uint16_t oper, bool nonblocking,
-                                              std::vector<FileLocks::Owner> &applied) {
+int FilesystemOperationsBase::posixLockOperation(const FsContext &context, inode_t inode,
+                                                 uint64_t start, uint64_t end, uint64_t owner,
+                                                 uint32_t sessionid, uint32_t reqid, uint32_t msgid,
+                                                 uint16_t oper, bool nonblocking,
+                                                 std::vector<FileLocks::Owner> &applied) {
 	ChecksumUpdater cu(context.ts());
-	int ret = fs_lock_op(context, gMetadata->posixLocks, inode, start, end, owner, sessionid, reqid,
-	                     msgid, oper, nonblocking, applied);
+	int ret = lockOperation(context, gMetadata->posixLocks, inode, start, end, owner, sessionid,
+	                        reqid, msgid, oper, nonblocking, applied);
 	if (context.isPersonalityMaster()) {
-		fs_changelog(context.ts(),
-		             "FLCK(%" PRIu8 ",%" PRIiNode ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu32
-		             ",%" PRIu16 ")",
-		             (uint8_t)safs_locks::Type::kPosix, inode, start, end, owner, sessionid, oper);
+		changeLog(context.ts(),
+		          "FLCK(%" PRIu8 ",%" PRIiNode ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu32
+		          ",%" PRIu16 ")",
+		          (uint8_t)safs_locks::Type::kPosix, inode, start, end, owner, sessionid, oper);
 	} else {
 		gMetadata->metadataVersion++;
 	}
 	return ret;
 }
 
-int FilesystemOperationsBase::fs_locks_clear_session(const FsContext &context, uint8_t type,
-                                                     inode_t inode, uint32_t sessionid,
-                                                     std::vector<FileLocks::Owner> &applied) {
+int FilesystemOperationsBase::locksClearSession(const FsContext &context, uint8_t type,
+                                                inode_t inode, uint32_t sessionid,
+                                                std::vector<FileLocks::Owner> &applied) {
 	if (type != (uint8_t)safs_locks::Type::kFlock && type != (uint8_t)safs_locks::Type::kPosix) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
@@ -1707,8 +1696,8 @@ int FilesystemOperationsBase::fs_locks_clear_session(const FsContext &context, u
 		}
 	}
 	if (context.isPersonalityMaster()) {
-		fs_changelog(context.ts(), "CLRLCK(%" PRIu8 ",%" PRIiNode ",%" PRIu32 ")", type, inode,
-		             sessionid);
+		changeLog(context.ts(), "CLRLCK(%" PRIu8 ",%" PRIiNode ",%" PRIu32 ")", type, inode,
+		          sessionid);
 	} else {
 		gMetadata->metadataVersion++;
 	}
@@ -1716,9 +1705,9 @@ int FilesystemOperationsBase::fs_locks_clear_session(const FsContext &context, u
 	return SAUNAFS_STATUS_OK;
 }
 
-int FilesystemOperationsBase::fs_locks_list_all(const FsContext &context, uint8_t type,
-                                                bool pending, uint64_t start, uint64_t max,
-                                                std::vector<safs_locks::Info> &outLocks) {
+int FilesystemOperationsBase::locksListAll(const FsContext &context, uint8_t type, bool pending,
+                                           uint64_t start, uint64_t max,
+                                           std::vector<safs_locks::Info> &outLocks) {
 	(void)context;
 	FileLocks *locks;
 	if (type == (uint8_t)safs_locks::Type::kFlock) {
@@ -1738,10 +1727,9 @@ int FilesystemOperationsBase::fs_locks_list_all(const FsContext &context, uint8_
 	return SAUNAFS_STATUS_OK;
 }
 
-int FilesystemOperationsBase::fs_locks_list_inode(const FsContext &context, uint8_t type,
-                                                  bool pending, inode_t inode, uint64_t start,
-                                                  uint64_t max,
-                                                  std::vector<safs_locks::Info> &outLocks) {
+int FilesystemOperationsBase::locksListInode(const FsContext &context, uint8_t type, bool pending,
+                                             inode_t inode, uint64_t start, uint64_t max,
+                                             std::vector<safs_locks::Info> &outLocks) {
 	(void)context;
 	FileLocks *locks;
 
@@ -1762,9 +1750,9 @@ int FilesystemOperationsBase::fs_locks_list_inode(const FsContext &context, uint
 	return SAUNAFS_STATUS_OK;
 }
 
-void FilesystemOperationsBase::fs_manage_lock_try_lock_pending(
-    FileLocks &locks, inode_t inode, uint64_t start, uint64_t end,
-    std::vector<FileLocks::Owner> &applied) {
+void FilesystemOperationsBase::manageLockTryLockPending(FileLocks &locks, inode_t inode,
+                                                        uint64_t start, uint64_t end,
+                                                        std::vector<FileLocks::Owner> &applied) {
 	FileLocks::LockQueue queue;
 	locks.gatherCandidates(inode, start, end, queue);
 	for (auto &candidate : queue) {
@@ -1774,24 +1762,24 @@ void FilesystemOperationsBase::fs_manage_lock_try_lock_pending(
 	}
 }
 
-int FilesystemOperationsBase::fs_locks_unlock_inode(const FsContext &context, uint8_t type,
-                                                    inode_t inode,
-                                                    std::vector<FileLocks::Owner> &applied) {
+int FilesystemOperationsBase::locksUnlockInode(const FsContext &context, uint8_t type,
+                                               inode_t inode,
+                                               std::vector<FileLocks::Owner> &applied) {
 	ChecksumUpdater cu(context.ts());
 
 	if (type == (uint8_t)safs_locks::Type::kFlock) {
 		gMetadata->flockLocks.unlock(inode);
-		fs_manage_lock_try_lock_pending(gMetadata->flockLocks, inode, 0, 1, applied);
+		manageLockTryLockPending(gMetadata->flockLocks, inode, 0, 1, applied);
 	} else if (type == (uint8_t)safs_locks::Type::kPosix) {
 		gMetadata->posixLocks.unlock(inode);
-		fs_manage_lock_try_lock_pending(gMetadata->posixLocks, inode, 0,
-		                                std::numeric_limits<uint64_t>::max(), applied);
+		manageLockTryLockPending(gMetadata->posixLocks, inode, 0,
+		                         std::numeric_limits<uint64_t>::max(), applied);
 	} else {
 		return SAUNAFS_ERROR_EINVAL;
 	}
 
 	if (context.isPersonalityMaster()) {
-		fs_changelog(context.ts(), "FLCKINODE(%" PRIu8 ",%" PRIiNode ")", type, inode);
+		changeLog(context.ts(), "FLCKINODE(%" PRIu8 ",%" PRIiNode ")", type, inode);
 	} else {
 		gMetadata->metadataVersion++;
 	}
@@ -1799,9 +1787,9 @@ int FilesystemOperationsBase::fs_locks_unlock_inode(const FsContext &context, ui
 	return SAUNAFS_STATUS_OK;
 }
 
-int FilesystemOperationsBase::fs_locks_remove_pending(const FsContext &context, uint8_t type,
-                                                      uint64_t ownerid, uint32_t sessionid,
-                                                      inode_t inode, uint64_t reqid) {
+int FilesystemOperationsBase::locksRemovePending(const FsContext &context, uint8_t type,
+                                                 uint64_t ownerid, uint32_t sessionid,
+                                                 inode_t inode, uint64_t reqid) {
 	ChecksumUpdater cu(context.ts());
 
 	FileLocks *locks;
@@ -1820,9 +1808,9 @@ int FilesystemOperationsBase::fs_locks_remove_pending(const FsContext &context, 
 	});
 
 	if (context.isPersonalityMaster()) {
-		fs_changelog(context.ts(),
-			     "RMPLOCK(%" PRIu8 ",%" PRIu64",%" PRIu32 ",%" PRIiNode ",%" PRIu64")",
-			     type, ownerid, sessionid, inode, reqid);
+		changeLog(context.ts(),
+		          "RMPLOCK(%" PRIu8 ",%" PRIu64 ",%" PRIu32 ",%" PRIiNode ",%" PRIu64 ")", type,
+		          ownerid, sessionid, inode, reqid);
 	} else {
 		gMetadata->metadataVersion++;
 	}
@@ -1832,9 +1820,8 @@ int FilesystemOperationsBase::fs_locks_remove_pending(const FsContext &context, 
 
 #ifndef METARESTORE
 
-uint8_t FilesystemOperationsBase::fs_readdir_size(const FsContext &context, inode_t inode,
-                                                  uint8_t flags, void **dnode,
-                                                  uint32_t *dbuffsize) {
+uint8_t FilesystemOperationsBase::readdirSize(const FsContext &context, inode_t inode,
+                                              uint8_t flags, void **dnode, uint32_t *dbuffsize) {
 	FSNode *p;
 	*dnode = NULL;
 	*dbuffsize = 0;
@@ -1855,8 +1842,8 @@ uint8_t FilesystemOperationsBase::fs_readdir_size(const FsContext &context, inod
 	return SAUNAFS_STATUS_OK;
 }
 
-void FilesystemOperationsBase::fs_readdir_data(const FsContext &context, uint8_t flags, void *dnode,
-                                               uint8_t *dbuff) {
+void FilesystemOperationsBase::readdirData(const FsContext &context, uint8_t flags, void *dnode,
+                                           uint8_t *dbuff) {
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
 	FSNode *p = (FSNode *)dnode;
@@ -1868,9 +1855,9 @@ void FilesystemOperationsBase::fs_readdir_data(const FsContext &context, uint8_t
 	metrics::Counter::increment(metrics::Counter::Master::FS_READDIR);
 }
 
-uint8_t FilesystemOperationsBase::fs_readdir(const FsContext &context, inode_t inode,
-                                             uint64_t first_entry, uint64_t number_of_entries,
-                                             std::vector<DirectoryEntry> &dir_entries) {
+uint8_t FilesystemOperationsBase::readdir(const FsContext &context, inode_t inode,
+                                          uint64_t first_entry, uint64_t number_of_entries,
+                                          std::vector<DirectoryEntry> &dir_entries) {
 	uint8_t status = verify_session(context, OperationMode::kReadOnly, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
@@ -1899,8 +1886,8 @@ uint8_t FilesystemOperationsBase::fs_readdir(const FsContext &context, inode_t i
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t FilesystemOperationsBase::fs_checkfile(const FsContext &context, inode_t inode,
-                                               uint32_t chunkcount[CHUNK_MATRIX_SIZE]) {
+uint8_t FilesystemOperationsBase::checkFile(const FsContext &context, inode_t inode,
+                                            uint32_t chunkcount[CHUNK_MATRIX_SIZE]) {
 	FSNode *p;
 
 	uint8_t status = verify_session(context, OperationMode::kReadOnly, SessionType::kAny);
@@ -1918,8 +1905,8 @@ uint8_t FilesystemOperationsBase::fs_checkfile(const FsContext &context, inode_t
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t FilesystemOperationsBase::fs_opencheck(const FsContext &context, inode_t inode,
-                                               uint8_t flags, Attributes &attr) {
+uint8_t FilesystemOperationsBase::openCheck(const FsContext &context, inode_t inode, uint8_t flags,
+                                            Attributes &attr) {
 	FSNode *p;
 
 	uint8_t status = verify_session(context, (flags & WANT_WRITE) ? OperationMode::kReadWrite : OperationMode::kReadOnly, SessionType::kNotMeta);
@@ -1952,8 +1939,8 @@ uint8_t FilesystemOperationsBase::fs_opencheck(const FsContext &context, inode_t
 }
 #endif
 
-uint8_t FilesystemOperationsBase::fs_acquire(const FsContext &context, inode_t inode,
-                                             uint32_t sessionid) {
+uint8_t FilesystemOperationsBase::acquire(const FsContext &context, inode_t inode,
+                                          uint32_t sessionid) {
 	ChecksumUpdater cu(context.ts());
 #ifndef METARESTORE
 	if (context.isPersonalityShadow()) {
@@ -1974,15 +1961,15 @@ uint8_t FilesystemOperationsBase::fs_acquire(const FsContext &context, inode_t i
 	p->sessionIds.push_back(sessionid);
 	fsnodes_update_checksum(p);
 	if (context.isPersonalityMaster()) {
-		fs_changelog(context.ts(), "ACQUIRE(%" PRIiNode ",%" PRIu32 ")", inode, sessionid);
+		changeLog(context.ts(), "ACQUIRE(%" PRIiNode ",%" PRIu32 ")", inode, sessionid);
 	} else {
 		gMetadata->metadataVersion++;
 	}
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t FilesystemOperationsBase::fs_release(const FsContext &context, inode_t inode,
-                                             uint32_t sessionid) {
+uint8_t FilesystemOperationsBase::release(const FsContext &context, inode_t inode,
+                                          uint32_t sessionid) {
 	ChecksumUpdater cu(context.ts());
 	FSNodeFile *p = fsnodes_id_to_node<FSNodeFile>(inode);
 	if (!p) {
@@ -2006,7 +1993,7 @@ uint8_t FilesystemOperationsBase::fs_release(const FsContext &context, inode_t i
 		}
 #endif /* #ifndef METARESTORE */
 		if (context.isPersonalityMaster()) {
-			fs_changelog(context.ts(), "RELEASE(%" PRIiNode ",%" PRIu32 ")", inode, sessionid);
+			changeLog(context.ts(), "RELEASE(%" PRIiNode ",%" PRIu32 ")", inode, sessionid);
 		} else {
 			gMetadata->metadataVersion++;
 		}
@@ -2019,16 +2006,16 @@ uint8_t FilesystemOperationsBase::fs_release(const FsContext &context, inode_t i
 }
 
 #ifndef METARESTORE
-uint32_t FilesystemOperationsBase::fs_newsessionid(void) {
+uint32_t FilesystemOperationsBase::newSessionId() {
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
 	const uint32_t current = gMetadata->nextSessionId().getValue();
-	fs_changelog(ts, "SESSION():%" PRIu32, current);
+	changeLog(ts, "SESSION():%" PRIu32, current);
 	gMetadata->nextSessionId().increment();
 	return current;
 }
 #endif
-uint8_t FilesystemOperationsBase::fs_apply_session(uint32_t sessionid) {
+uint8_t FilesystemOperationsBase::applySession(uint32_t sessionid) {
 	if (sessionid != gMetadata->nextSessionId().getValue()) {
 		return SAUNAFS_ERROR_MISMATCH;
 	}
@@ -2044,7 +2031,7 @@ uint8_t fs_auto_repair_if_needed(FSNodeFile *p, uint32_t chunkIndex) {
 	if (chunkId != 0 && chunk_has_only_invalid_copies(chunkId)) {
 		uint32_t notchanged, erased, repaired;
 		FsContext context = FsContext::getForMasterWithSession(0, SPECIAL_INODE_ROOT, 0, 0, 0, 0, 0);
-		gFSOperations->fs_repair(context, p->id, 0, &notchanged, &erased, &repaired);
+		gFSOperations->repair(context, p->id, 0, &notchanged, &erased, &repaired);
 		safs_pretty_syslog(LOG_NOTICE,
 		       "auto repair inode %" PRIiNode ", chunk %016" PRIX64
 		       ": "
@@ -2055,8 +2042,8 @@ uint8_t fs_auto_repair_if_needed(FSNodeFile *p, uint32_t chunkIndex) {
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t FilesystemOperationsBase::fs_readchunk(inode_t inode, uint32_t indx, uint64_t *chunkid,
-                                               uint64_t *length) {
+uint8_t FilesystemOperationsBase::readChunk(inode_t inode, uint32_t indx, uint64_t *chunkid,
+                                            uint64_t *length) {
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
 	FSNodeFile *p;
@@ -2090,11 +2077,11 @@ uint8_t FilesystemOperationsBase::fs_readchunk(inode_t inode, uint32_t indx, uin
 }
 #endif
 
-uint8_t FilesystemOperationsBase::fs_writechunk(const FsContext &context, inode_t inode,
-                                                uint32_t indx, bool usedummylockid,
-                                                /* inout */ uint32_t *lockid, uint64_t *chunkid,
-                                                uint8_t *opflag, uint64_t *length,
-                                                uint32_t min_server_version) {
+uint8_t FilesystemOperationsBase::writeChunk(const FsContext &context, inode_t inode,
+                                             uint32_t index, bool usedummylockid,
+                                             /* inout */ uint32_t *lockid, uint64_t *chunkid,
+                                             uint8_t *opflag, uint64_t *length,
+                                             uint32_t min_server_version) {
 	ChecksumUpdater cu(context.ts());
 	uint64_t ochunkid, nchunkid;
 	FSNode *node;
@@ -2110,12 +2097,12 @@ uint8_t FilesystemOperationsBase::fs_writechunk(const FsContext &context, inode_
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	if (indx > MAX_INDEX) {
+	if (index > MAX_INDEX) {
 		return SAUNAFS_ERROR_INDEXTOOBIG;
 	}
 #ifndef METARESTORE
 	if (gMagicAutoFileRepair && context.isPersonalityMaster()) {
-		fs_auto_repair_if_needed(p, indx);
+		fs_auto_repair_if_needed(p, index);
 	}
 #endif
 
@@ -2124,23 +2111,23 @@ uint8_t FilesystemOperationsBase::fs_writechunk(const FsContext &context, inode_
 	fsnodes_get_stats(p, &psr);
 
 	/* resize chunks structure */
-	if (indx >= p->chunks.size()) {
+	if (index >= p->chunks.size()) {
 		if (context.isPersonalityMaster() && quota_exceeded) {
 			return SAUNAFS_ERROR_QUOTA;
 		}
 		uint32_t new_size;
-		if (indx < 8) {
-			new_size = indx + 1;
-		} else if (indx < 64) {
-			new_size = (indx & 0xFFFFFFF8) + 8;
+		if (index < 8) {
+			new_size = index + 1;
+		} else if (index < 64) {
+			new_size = (index & 0xFFFFFFF8) + 8;
 		} else {
-			new_size = (indx & 0xFFFFFFC0) + 64;
+			new_size = (index & 0xFFFFFFC0) + 64;
 		}
-		assert(new_size > indx);
+		assert(new_size > index);
 		p->chunks.resize(new_size, 0);
 	}
 
-	ochunkid = p->chunks[indx];
+	ochunkid = p->chunks[index];
 	if (context.isPersonalityMaster()) {
 #ifndef METARESTORE
 		status = chunk_multi_modify(ochunkid, lockid, p->goal, usedummylockid,
@@ -2164,7 +2151,7 @@ uint8_t FilesystemOperationsBase::fs_writechunk(const FsContext &context, inode_
 		fsnodes_update_checksum(p);
 		return SAUNAFS_ERROR_MISMATCH;
 	}
-	p->chunks[indx] = nchunkid;
+	p->chunks[index] = nchunkid;
 	*chunkid = nchunkid;
 	StatsRecord nsr;
 	fsnodes_get_stats(p, &nsr);
@@ -2177,9 +2164,8 @@ uint8_t FilesystemOperationsBase::fs_writechunk(const FsContext &context, inode_
 		*length = p->length;
 	}
 	if (context.isPersonalityMaster()) {
-		fs_changelog(context.ts(),
-		             "WRITE(%" PRIiNode ",%" PRIu32 ",%" PRIu8 ",%" PRIu32 "):%" PRIu64,
-		             inode, indx, *opflag, *lockid, nchunkid);
+		changeLog(context.ts(), "WRITE(%" PRIiNode ",%" PRIu32 ",%" PRIu8 ",%" PRIu32 "):%" PRIu64,
+		          inode, index, *opflag, *lockid, nchunkid);
 	} else {
 		gMetadata->metadataVersion++;
 	}
@@ -2194,8 +2180,8 @@ uint8_t FilesystemOperationsBase::fs_writechunk(const FsContext &context, inode_
 }
 
 #ifndef METARESTORE
-uint8_t FilesystemOperationsBase::fs_writeend(inode_t inode, uint64_t length, uint64_t chunkid,
-                                              uint32_t lockid) {
+uint8_t FilesystemOperationsBase::writeEnd(inode_t inode, uint64_t length, uint64_t chunkid,
+                                           uint32_t lockid) {
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
 	uint8_t status = chunk_can_unlock(chunkid, lockid);
@@ -2221,29 +2207,29 @@ uint8_t FilesystemOperationsBase::fs_writeend(inode_t inode, uint64_t length, ui
 			p->mtime = ts;
 			fsnodes_update_ctime(p, ts);
 			fsnodes_update_checksum(p);
-			fs_changelog(ts, "LENGTH(%" PRIiNode ",%" PRIu64 ",%" PRIu32 ")", inode, length,
-			             static_cast<uint32_t>(eraseFurtherChunks));
+			changeLog(ts, "LENGTH(%" PRIiNode ",%" PRIu64 ",%" PRIu32 ")", inode, length,
+			          static_cast<uint32_t>(eraseFurtherChunks));
 		}
 	}
-	fs_changelog(ts, "UNLOCK(%" PRIu64 ")", chunkid);
+	changeLog(ts, "UNLOCK(%" PRIu64 ")", chunkid);
 	return chunk_unlock(chunkid);
 }
 
-void FilesystemOperationsBase::fs_incversion(uint64_t chunkid) {
+void FilesystemOperationsBase::increaseChunkVersion(uint64_t chunkid) {
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
-	fs_changelog(ts, "INCVERSION(%" PRIu64 ")", chunkid);
+	changeLog(ts, "INCVERSION(%" PRIu64 ")", chunkid);
 }
 #endif
 
-uint8_t FilesystemOperationsBase::fs_apply_incversion(uint64_t chunkid) {
+uint8_t FilesystemOperationsBase::applyIncreaseChunkVersion(uint64_t chunkid) {
 	gMetadata->metadataVersion++;
 	return chunk_increase_version(chunkid);
 }
 
 #ifndef METARESTORE
-uint8_t FilesystemOperationsBase::fs_remove_chunk_from_file(const FsContext &context, inode_t inode,
-                                                            uint64_t chunkId) {
+uint8_t FilesystemOperationsBase::removeChunkFromFile(const FsContext &context, inode_t inode,
+                                                      uint64_t chunkId) {
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
 	StatsRecord psr, nsr;
@@ -2276,7 +2262,7 @@ uint8_t FilesystemOperationsBase::fs_remove_chunk_from_file(const FsContext &con
 
 	// Log the repair operation with new version 0 (indicating deletion)
 	uint32_t nversion = 0;
-	fs_changelog(ts, "REPAIR(%" PRIiNode ",%" PRIu32 "):%" PRIu32, inode, indx, nversion);
+	changeLog(ts, "REPAIR(%" PRIiNode ",%" PRIu32 "):%" PRIu32, inode, indx, nversion);
 
 	fsnodes_get_stats(p, &nsr);
 	for (const auto &[parentId, _] : p->parents) {
@@ -2290,9 +2276,9 @@ uint8_t FilesystemOperationsBase::fs_remove_chunk_from_file(const FsContext &con
 #endif /* #ifndef METARESTORE */
 
 #ifndef METARESTORE
-uint8_t FilesystemOperationsBase::fs_repair(const FsContext &context, inode_t inode,
-                                            uint8_t correct_only, uint32_t *notchanged,
-                                            uint32_t *erased, uint32_t *repaired) {
+uint8_t FilesystemOperationsBase::repair(const FsContext &context, inode_t inode,
+                                         uint8_t correct_only, uint32_t *notchanged,
+                                         uint32_t *erased, uint32_t *repaired) {
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
 	uint32_t nversion, indx;
@@ -2318,8 +2304,7 @@ uint8_t FilesystemOperationsBase::fs_repair(const FsContext &context, inode_t in
 	fsnodes_get_stats(p, &psr);
 	for (indx = 0; indx < node_file->chunks.size(); indx++) {
 		if (chunk_repair(p->goal, node_file->chunks[indx], &nversion, correct_only)) {
-			fs_changelog(ts, "REPAIR(%" PRIiNode ",%" PRIu32 "):%" PRIu32, inode, indx,
-			             nversion);
+			changeLog(ts, "REPAIR(%" PRIiNode ",%" PRIu32 "):%" PRIu32, inode, indx, nversion);
 			p->mtime = ts;
 			fsnodes_update_ctime(p, ts);
 			if (nversion > 0) {
@@ -2344,8 +2329,8 @@ uint8_t FilesystemOperationsBase::fs_repair(const FsContext &context, inode_t in
 }
 #endif /* #ifndef METARESTORE */
 
-uint8_t FilesystemOperationsBase::fs_apply_repair(uint32_t timestamp, inode_t inode, uint32_t indx,
-                                                  uint32_t nversion) {
+uint8_t FilesystemOperationsBase::applyRepair(uint32_t timestamp, inode_t inode, uint32_t indx,
+                                              uint32_t nversion) {
 	FSNodeFile *p;
 	uint8_t status;
 	StatsRecord psr, nsr;
@@ -2390,8 +2375,8 @@ uint8_t FilesystemOperationsBase::fs_apply_repair(uint32_t timestamp, inode_t in
 }
 
 #ifndef METARESTORE
-uint8_t FilesystemOperationsBase::fs_getgoal(const FsContext &context, inode_t inode, uint8_t gmode,
-                                             GoalStatistics &fgtab, GoalStatistics &dgtab) {
+uint8_t FilesystemOperationsBase::getGoal(const FsContext &context, inode_t inode, uint8_t gmode,
+                                          GoalStatistics &fgtab, GoalStatistics &dgtab) {
 	FSNode *p;
 
 	if (!GMODE_ISVALID(gmode)) {
@@ -2412,10 +2397,9 @@ uint8_t FilesystemOperationsBase::fs_getgoal(const FsContext &context, inode_t i
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t FilesystemOperationsBase::fs_gettrashtime_prepare(const FsContext &context, inode_t inode,
-                                                          uint8_t gmode,
-                                                          TrashtimeMap &fileTrashtimes,
-                                                          TrashtimeMap &dirTrashtimes) {
+uint8_t FilesystemOperationsBase::getTrashTimePrepare(const FsContext &context, inode_t inode,
+                                                      uint8_t gmode, TrashtimeMap &fileTrashtimes,
+                                                      TrashtimeMap &dirTrashtimes) {
 	FSNode *p;
 
 	if (!GMODE_ISVALID(gmode)) {
@@ -2437,8 +2421,8 @@ uint8_t FilesystemOperationsBase::fs_gettrashtime_prepare(const FsContext &conte
 	return SAUNAFS_STATUS_OK;
 }
 
-void FilesystemOperationsBase::fs_gettrashtime_store(TrashtimeMap &fileTrashtimes,
-                                                     TrashtimeMap &dirTrashtimes, uint8_t *buff) {
+void FilesystemOperationsBase::getTrashTimeStore(TrashtimeMap &fileTrashtimes,
+                                                 TrashtimeMap &dirTrashtimes, uint8_t *buff) {
 	for (auto i : fileTrashtimes) {
 		put32bit(&buff, i.first);
 		put32bit(&buff, i.second);
@@ -2449,9 +2433,8 @@ void FilesystemOperationsBase::fs_gettrashtime_store(TrashtimeMap &fileTrashtime
 	}
 }
 
-uint8_t FilesystemOperationsBase::fs_geteattr(const FsContext &context, inode_t inode,
-                                              uint8_t gmode, uint32_t feattrtab[16],
-                                              uint32_t deattrtab[16]) {
+uint8_t FilesystemOperationsBase::getEAttr(const FsContext &context, inode_t inode, uint8_t gmode,
+                                           uint32_t feattrtab[16], uint32_t deattrtab[16]) {
 	FSNode *p;
 
 	memset(feattrtab, 0, 16 * sizeof(uint32_t));
@@ -2476,10 +2459,10 @@ uint8_t FilesystemOperationsBase::fs_geteattr(const FsContext &context, inode_t 
 
 #endif
 
-uint8_t FilesystemOperationsBase::fs_setgoal(const FsContext &context, inode_t inode, uint8_t goal,
-                                             uint8_t smode,
-                                             std::shared_ptr<SetGoalTask::StatsArray> setgoal_stats,
-                                             const std::function<void(int)> &callback) {
+uint8_t FilesystemOperationsBase::setGoal(const FsContext &context, inode_t inode, uint8_t goal,
+                                          uint8_t smode,
+                                          std::shared_ptr<SetGoalTask::StatsArray> setgoal_stats,
+                                          const std::function<void(int)> &callback) {
 	ChecksumUpdater cu(context.ts());
 	if (!SMODE_ISVALID(smode) || !GoalId::isValid(goal) ||
 	    (smode & (SMODE_INCREASE | SMODE_DECREASE))) {
@@ -2522,9 +2505,9 @@ uint8_t FilesystemOperationsBase::fs_setgoal(const FsContext &context, inode_t i
 }
 
 //This function is only used by Shadow
-uint8_t FilesystemOperationsBase::fs_apply_setgoal(const FsContext &context, inode_t inode,
-                                                   uint8_t goal, uint8_t smode,
-                                                   uint32_t master_result) {
+uint8_t FilesystemOperationsBase::applySetGoal(const FsContext &context, inode_t inode,
+                                               uint8_t goal, uint8_t smode,
+                                               uint32_t master_result) {
 	assert(context.isPersonalityShadow());
 	ChecksumUpdater cu(context.ts());
 	if (!SMODE_ISVALID(smode) || !GoalId::isValid(goal) ||
@@ -2558,7 +2541,7 @@ uint8_t FilesystemOperationsBase::fs_apply_setgoal(const FsContext &context, ino
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t FilesystemOperationsBase::fs_settrashtime(
+uint8_t FilesystemOperationsBase::setTrashTime(
     const FsContext &context, inode_t inode, uint32_t trashtime, uint8_t smode,
     std::shared_ptr<SetTrashtimeTask::StatsArray> settrashtime_stats,
     const std::function<void(int)> &callback) {
@@ -2595,9 +2578,9 @@ uint8_t FilesystemOperationsBase::fs_settrashtime(
 	                                          callback);
 }
 
-uint8_t FilesystemOperationsBase::fs_apply_settrashtime(const FsContext &context, inode_t inode,
-                                                        uint32_t trashtime, uint8_t smode,
-                                                        uint32_t master_result) {
+uint8_t FilesystemOperationsBase::applySetTrashTime(const FsContext &context, inode_t inode,
+                                                    uint32_t trashtime, uint8_t smode,
+                                                    uint32_t master_result) {
 	assert(context.isPersonalityShadow());
 	ChecksumUpdater cu(context.ts());
 	if (!SMODE_ISVALID(smode)) {
@@ -2630,9 +2613,9 @@ uint8_t FilesystemOperationsBase::fs_apply_settrashtime(const FsContext &context
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t FilesystemOperationsBase::fs_seteattr(const FsContext &context, inode_t inode,
-                                              uint8_t eattr, uint8_t smode, inode_t *sinodes,
-                                              inode_t *ncinodes, inode_t *nsinodes) {
+uint8_t FilesystemOperationsBase::setEAttr(const FsContext &context, inode_t inode, uint8_t eattr,
+                                           uint8_t smode, inode_t *sinodes, inode_t *ncinodes,
+                                           inode_t *nsinodes) {
 	ChecksumUpdater cu(context.ts());
 	if (!SMODE_ISVALID(smode) ||
 	    (eattr & (~(EATTR_NOOWNER | EATTR_NOACACHE | EATTR_NOECACHE | EATTR_NODATACACHE)))) {
@@ -2661,9 +2644,10 @@ uint8_t FilesystemOperationsBase::fs_seteattr(const FsContext &context, inode_t 
 		*sinodes = si;
 		*ncinodes = nci;
 		*nsinodes = nsi;
-		fs_changelog(context.ts(), "SETEATTR(%" PRIiNode ",%" PRIu32 ",%" PRIu8 ",%" PRIu8
-		                           "):%" PRIiNode ",%" PRIiNode ",%" PRIiNode,
-		             p->id, context.uid(), eattr, smode, si, nci, nsi);
+		changeLog(context.ts(),
+		          "SETEATTR(%" PRIiNode ",%" PRIu32 ",%" PRIu8 ",%" PRIu8 "):%" PRIiNode
+		          ",%" PRIiNode ",%" PRIiNode,
+		          p->id, context.uid(), eattr, smode, si, nci, nsi);
 	} else {
 		gMetadata->metadataVersion++;
 		if ((*sinodes != si) || (*ncinodes != nci) || (*nsinodes != nsi)) {
@@ -2675,9 +2659,8 @@ uint8_t FilesystemOperationsBase::fs_seteattr(const FsContext &context, inode_t 
 
 #ifndef METARESTORE
 
-uint8_t FilesystemOperationsBase::fs_listxattr_leng(const FsContext &context, inode_t inode,
-                                                    uint8_t opened, void **xanode,
-                                                    uint32_t *xasize) {
+uint8_t FilesystemOperationsBase::listXAttrLeng(const FsContext &context, inode_t inode,
+                                                uint8_t opened, void **xanode, uint32_t *xasize) {
 	FSNode *p;
 
 	uint8_t status = verify_session(context, OperationMode::kReadOnly, SessionType::kNotMeta);
@@ -2695,15 +2678,14 @@ uint8_t FilesystemOperationsBase::fs_listxattr_leng(const FsContext &context, in
 	return get_xattrs_length_for_inode(p->id, xanode, xasize);
 }
 
-void FilesystemOperationsBase::fs_listxattr_data(void *xanode, uint8_t *xabuff) {
+void FilesystemOperationsBase::listXAttrData(void *xanode, uint8_t *xabuff) {
 	memcpy(xabuff, kAclXattrs, sizeof(kAclXattrs));
 	xattr_listattr_data(xanode, xabuff + sizeof(kAclXattrs));
 }
 
-uint8_t FilesystemOperationsBase::fs_setxattr(const FsContext &context, inode_t inode,
-                                              uint8_t opened, uint8_t anleng,
-                                              const uint8_t *attrname, uint32_t avleng,
-                                              const uint8_t *attrvalue, uint8_t mode) {
+uint8_t FilesystemOperationsBase::setXAttr(const FsContext &context, inode_t inode, uint8_t opened,
+                                           uint8_t anleng, const uint8_t *attrname, uint32_t avleng,
+                                           const uint8_t *attrvalue, uint8_t mode) {
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
 	FSNode *p;
@@ -2732,17 +2714,15 @@ uint8_t FilesystemOperationsBase::fs_setxattr(const FsContext &context, inode_t 
 	}
 	fsnodes_update_ctime(p, ts);
 	fsnodes_update_checksum(p);
-	fs_changelog(ts, "SETXATTR(%" PRIiNode ",%s,%s,%" PRIu8 ")", p->id,
-	             fsnodes_escape_name(std::string((const char*)attrname, anleng)).c_str(),
-	             fsnodes_escape_name(std::string((const char*)attrvalue, avleng)).c_str(),
-	             mode);
+	changeLog(ts, "SETXATTR(%" PRIiNode ",%s,%s,%" PRIu8 ")", p->id,
+	          fsnodes_escape_name(std::string((const char *)attrname, anleng)).c_str(),
+	          fsnodes_escape_name(std::string((const char *)attrvalue, avleng)).c_str(), mode);
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t FilesystemOperationsBase::fs_getxattr(const FsContext &context, inode_t inode,
-                                              uint8_t opened, uint8_t anleng,
-                                              const uint8_t *attrname, uint32_t *avleng,
-                                              uint8_t **attrvalue) {
+uint8_t FilesystemOperationsBase::getXAttr(const FsContext &context, inode_t inode, uint8_t opened,
+                                           uint8_t anleng, const uint8_t *attrname,
+                                           uint32_t *avleng, uint8_t **attrvalue) {
 	FSNode *p;
 
 	uint8_t status = verify_session(context, OperationMode::kReadOnly, SessionType::kNotMeta);
@@ -2764,10 +2744,9 @@ uint8_t FilesystemOperationsBase::fs_getxattr(const FsContext &context, inode_t 
 
 #endif /* #ifndef METARESTORE */
 
-uint8_t FilesystemOperationsBase::fs_apply_setxattr(uint32_t timestamp, inode_t inode,
-                                                    uint32_t anleng, const uint8_t *attrname,
-                                                    uint32_t avleng, const uint8_t *attrvalue,
-                                                    uint32_t mode) {
+uint8_t FilesystemOperationsBase::applySetXAttr(uint32_t timestamp, inode_t inode, uint32_t anleng,
+                                                const uint8_t *attrname, uint32_t avleng,
+                                                const uint8_t *attrvalue, uint32_t mode) {
 	FSNode *p;
 	uint8_t status;
 	if (anleng == 0 || anleng > SFS_XATTR_NAME_MAX || avleng > SFS_XATTR_SIZE_MAX ||
@@ -2789,8 +2768,7 @@ uint8_t FilesystemOperationsBase::fs_apply_setxattr(uint32_t timestamp, inode_t 
 	return status;
 }
 
-uint8_t FilesystemOperationsBase::fs_deleteacl(const FsContext &context, inode_t inode,
-                                               AclType type) {
+uint8_t FilesystemOperationsBase::deleteAcl(const FsContext &context, inode_t inode, AclType type) {
 	ChecksumUpdater cu(context.ts());
 	FSNode *p;
 	uint8_t status = verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
@@ -2811,7 +2789,8 @@ uint8_t FilesystemOperationsBase::fs_deleteacl(const FsContext &context, inode_t
 			static_assert((int)AclType::kDefault == 1, "fix acl_type table");
 			static_assert((int)AclType::kRichACL == 2, "fix acl_type table");
 
-			fs_changelog(context.ts(), "DELETEACL(%" PRIiNode ",%c)", p->id, acl_type[std::min(3, (int)type)]);
+			changeLog(context.ts(), "DELETEACL(%" PRIiNode ",%c)", p->id,
+			          acl_type[std::min(3, (int)type)]);
 		}
 	} else {
 		gMetadata->metadataVersion++;
@@ -2821,8 +2800,8 @@ uint8_t FilesystemOperationsBase::fs_deleteacl(const FsContext &context, inode_t
 
 #ifndef METARESTORE
 
-uint8_t FilesystemOperationsBase::fs_setacl(const FsContext &context, inode_t inode,
-                                            const RichACL &acl) {
+uint8_t FilesystemOperationsBase::setAcl(const FsContext &context, inode_t inode,
+                                         const RichACL &acl) {
 	ChecksumUpdater cu(context.ts());
 	FSNode *p;
 	uint8_t status = verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
@@ -2838,7 +2817,7 @@ uint8_t FilesystemOperationsBase::fs_setacl(const FsContext &context, inode_t in
 	status = fsnodes_setacl(p, acl, context.ts());
 	if (context.isPersonalityMaster()) {
 		if (status == SAUNAFS_STATUS_OK) {
-			fs_changelog(context.ts(), "SETRICHACL(%" PRIiNode ",%s)", p->id, acl_string.c_str());
+			changeLog(context.ts(), "SETRICHACL(%" PRIiNode ",%s)", p->id, acl_string.c_str());
 		}
 	} else {
 		gMetadata->metadataVersion++;
@@ -2846,8 +2825,8 @@ uint8_t FilesystemOperationsBase::fs_setacl(const FsContext &context, inode_t in
 	return status;
 }
 
-uint8_t FilesystemOperationsBase::fs_setacl(const FsContext &context, inode_t inode, AclType type,
-                                            const AccessControlList &acl) {
+uint8_t FilesystemOperationsBase::setAcl(const FsContext &context, inode_t inode, AclType type,
+                                         const AccessControlList &acl) {
 	ChecksumUpdater cu(context.ts());
 	FSNode *p;
 	uint8_t status = verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
@@ -2863,8 +2842,8 @@ uint8_t FilesystemOperationsBase::fs_setacl(const FsContext &context, inode_t in
 	status = fsnodes_setacl(p, type, acl, context.ts());
 	if (context.isPersonalityMaster()) {
 		if (status == SAUNAFS_STATUS_OK) {
-			fs_changelog(context.ts(), "SETACL(%" PRIiNode ",%c,%s)", p->id,
-						 (type == AclType::kAccess ? 'a' : 'd'), acl_string.c_str());
+			changeLog(context.ts(), "SETACL(%" PRIiNode ",%c,%s)", p->id,
+			          (type == AclType::kAccess ? 'a' : 'd'), acl_string.c_str());
 		}
 	} else {
 		gMetadata->metadataVersion++;
@@ -2874,7 +2853,7 @@ uint8_t FilesystemOperationsBase::fs_setacl(const FsContext &context, inode_t in
 	return SAUNAFS_ERROR_EINVAL;
 }
 
-uint8_t FilesystemOperationsBase::fs_getacl(const FsContext &context, inode_t inode, RichACL &acl) {
+uint8_t FilesystemOperationsBase::getAcl(const FsContext &context, inode_t inode, RichACL &acl) {
 	FSNode *p;
 	uint8_t status = verify_session(context, OperationMode::kReadOnly, SessionType::kAny);
 	if (status != SAUNAFS_STATUS_OK) {
@@ -2890,8 +2869,8 @@ uint8_t FilesystemOperationsBase::fs_getacl(const FsContext &context, inode_t in
 
 #endif /* #ifndef METARESTORE */
 
-uint8_t FilesystemOperationsBase::fs_apply_setacl(uint32_t timestamp, inode_t inode, char aclType,
-                                                  const char *aclString) {
+uint8_t FilesystemOperationsBase::applySetAcl(uint32_t timestamp, inode_t inode, char aclType,
+                                              const char *aclString) {
 	AccessControlList acl;
 	try {
 		acl = AccessControlList::fromString(aclString);
@@ -2913,8 +2892,8 @@ uint8_t FilesystemOperationsBase::fs_apply_setacl(uint32_t timestamp, inode_t in
 	return status;
 }
 
-uint8_t FilesystemOperationsBase::fs_apply_setrichacl(uint32_t timestamp, inode_t inode,
-                                                      const std::string &acl_string) {
+uint8_t FilesystemOperationsBase::applySetRichAcl(uint32_t timestamp, inode_t inode,
+                                                  const std::string &acl_string) {
 	RichACL acl;
 	try {
 		acl = RichACL::fromString(acl_string);
@@ -2933,7 +2912,7 @@ uint8_t FilesystemOperationsBase::fs_apply_setrichacl(uint32_t timestamp, inode_
 }
 
 #ifndef METARESTORE
-uint32_t FilesystemOperationsBase::fs_getdirpath_size(inode_t inode) {
+uint32_t FilesystemOperationsBase::getDirPathSize(inode_t inode) {
 	FSNode *node;
 	node = fsnodes_id_to_node(inode);
 	if (node) {
@@ -2952,7 +2931,7 @@ uint32_t FilesystemOperationsBase::fs_getdirpath_size(inode_t inode) {
 	return 0;  // unreachable
 }
 
-void FilesystemOperationsBase::fs_getdirpath_data(inode_t inode, uint8_t *buff, uint32_t size) {
+void FilesystemOperationsBase::getDirPathData(inode_t inode, uint8_t *buff, uint32_t size) {
 	FSNode *node;
 	node = fsnodes_id_to_node(inode);
 	if (node) {
@@ -2981,11 +2960,10 @@ void FilesystemOperationsBase::fs_getdirpath_data(inode_t inode, uint8_t *buff, 
 	}
 }
 
-uint8_t FilesystemOperationsBase::fs_get_dir_stats(const FsContext &context, inode_t inode,
-                                                   inode_t *inodes, inode_t *dirs, inode_t *files,
-                                                   inode_t *links, uint32_t *chunks,
-                                                   uint64_t *length, uint64_t *size,
-                                                   uint64_t *rsize) {
+uint8_t FilesystemOperationsBase::getDirStats(const FsContext &context, inode_t inode,
+                                              inode_t *inodes, inode_t *dirs, inode_t *files,
+                                              inode_t *links, uint32_t *chunks, uint64_t *length,
+                                              uint64_t *size, uint64_t *rsize) {
 	FSNode *p;
 	StatsRecord sr;
 
@@ -3013,8 +2991,8 @@ uint8_t FilesystemOperationsBase::fs_get_dir_stats(const FsContext &context, ino
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t FilesystemOperationsBase::fs_get_chunkid(const FsContext &context, inode_t inode,
-                                                 uint32_t index, uint64_t *chunkid) {
+uint8_t FilesystemOperationsBase::getChunkId(const FsContext &context, inode_t inode,
+                                             uint32_t index, uint64_t *chunkid) {
 	FSNode *p;
 	uint8_t status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kFile,
 	                                                MODE_MASK_EMPTY, inode, &p);
@@ -3034,7 +3012,7 @@ uint8_t FilesystemOperationsBase::fs_get_chunkid(const FsContext &context, inode
 }
 #endif
 
-void FilesystemOperationsBase::fs_add_files_to_chunks(bool isMetadataLoading) {
+void FilesystemOperationsBase::addFilesToChunks(bool isMetadataLoading) {
 	for (uint32_t i = 0; i < NODEHASHSIZE; i++) {
 		for (const auto &node : gMetadata->nodeHash[i]) {
 			if (node->type == FSNodeType::kFile || node->type == FSNodeType::kTrash ||
@@ -3049,36 +3027,36 @@ void FilesystemOperationsBase::fs_add_files_to_chunks(bool isMetadataLoading) {
 	}
 }
 
-uint64_t FilesystemOperationsBase::fs_getversion() {
+uint64_t FilesystemOperationsBase::getMetadataVersion() {
 	if (!gMetadata) {
 		throw NoMetadataException();
 	}
 	return gMetadata->metadataVersion;
 }
 
-uint8_t FilesystemOperationsBase::fs_apply_setquota(char rigor, char resource, char ownerType,
-                                                    inode_t ownerId, uint64_t limit) {
+uint8_t FilesystemOperationsBase::applySetQuota(char rigor, char resource, char ownerType,
+                                                inode_t ownerId, uint64_t limit) {
 	return quotas::fs_apply_setquota(rigor, resource, ownerType, ownerId, limit);
 }
 
-uint64_t FilesystemOperationsBase::fs_checksum(ChecksumMode mode) {
+uint64_t FilesystemOperationsBase::metadataChecksum(ChecksumMode mode) {
 	return checksum::fs_checksum(mode);
 }
 
 #ifndef METARESTORE
-const std::map<int, Goal> &FilesystemOperationsBase::fs_get_goal_definitions() const {
+const std::map<int, Goal> &FilesystemOperationsBase::getAllGoalDefinitions() const {
 	return gGoalDefinitions;
 }
 
-const Goal &FilesystemOperationsBase::fs_get_goal_definition(uint8_t goalId) const {
+const Goal &FilesystemOperationsBase::getGoalDefinition(uint8_t goalId) const {
 	return gGoalDefinitions[goalId];
 }
 
-std::vector<JobInfo> FilesystemOperationsBase::fs_get_current_tasks_info() {
+std::vector<JobInfo> FilesystemOperationsBase::getCurrentTasksInfo() {
 	return gMetadata->taskManager.getCurrentJobsInfo();
 }
 
-uint8_t FilesystemOperationsBase::fs_cancel_job(uint32_t job_id) {
+uint8_t FilesystemOperationsBase::cancelJob(uint32_t job_id) {
 	if (gMetadata->taskManager.cancelJob(job_id)) {
 		return SAUNAFS_STATUS_OK;
 	} else {
@@ -3086,14 +3064,12 @@ uint8_t FilesystemOperationsBase::fs_cancel_job(uint32_t job_id) {
 	}
 }
 
-uint32_t FilesystemOperationsBase::fs_reserve_job_id() {
-	return gMetadata->taskManager.reserveJobId();
-}
+uint32_t FilesystemOperationsBase::reserveJobId() { return gMetadata->taskManager.reserveJobId(); }
 
-uint8_t FilesystemOperationsBase::fs_getchunksinfo(const FsContext &context, uint32_t current_ip,
-                                                   inode_t inode, uint32_t chunk_index,
-                                                   uint32_t chunk_count,
-                                                   std::vector<ChunkWithAddressAndLabel> &chunks) {
+uint8_t FilesystemOperationsBase::getChunksInfo(const FsContext &context, uint32_t current_ip,
+                                                inode_t inode, uint32_t chunk_index,
+                                                uint32_t chunk_count,
+                                                std::vector<ChunkWithAddressAndLabel> &chunks) {
 	static constexpr int kMaxNumberOfChunkCopies = 100;
 
 	FSNode *p;
@@ -3142,29 +3118,29 @@ uint8_t FilesystemOperationsBase::fs_getchunksinfo(const FsContext &context, uin
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t FilesystemOperationsBase::fs_quota_get_all(const FsContext &context,
-                                                   std::vector<QuotaEntry> &results) {
+uint8_t FilesystemOperationsBase::quotaGetAll(const FsContext &context,
+                                              std::vector<QuotaEntry> &results) {
 	return quotas::fs_quota_get_all(context, results);
 }
 
-uint8_t FilesystemOperationsBase::fs_quota_get(const FsContext &context,
-                                               const std::vector<QuotaOwner> &owners,
-                                               std::vector<QuotaEntry> &results) {
+uint8_t FilesystemOperationsBase::quotaGet(const FsContext &context,
+                                           const std::vector<QuotaOwner> &owners,
+                                           std::vector<QuotaEntry> &results) {
 	return quotas::fs_quota_get(context, owners, results);
 }
 
-uint8_t FilesystemOperationsBase::fs_quota_set(const FsContext &context,
-                                               const std::vector<QuotaEntry> &entries) {
+uint8_t FilesystemOperationsBase::quotaSet(const FsContext &context,
+                                           const std::vector<QuotaEntry> &entries) {
 	return quotas::fs_quota_set(context, entries);
 }
 
-uint8_t FilesystemOperationsBase::fs_quota_get_info(const FsContext &context,
-                                                    const std::vector<QuotaEntry> &entries,
-                                                    std::vector<std::string> &result) {
+uint8_t FilesystemOperationsBase::quotaGetInfo(const FsContext &context,
+                                               const std::vector<QuotaEntry> &entries,
+                                               std::vector<std::string> &result) {
 	return quotas::fs_quota_get_info(context, entries, result);
 }
 
-uint8_t FilesystemOperationsBase::fs_start_checksum_recalculation() {
+uint8_t FilesystemOperationsBase::startChecksumRecalculation() {
 	return checksum::fs_start_checksum_recalculation();
 }
 #endif

--- a/src/master/filesystem_operations.h
+++ b/src/master/filesystem_operations.h
@@ -49,289 +49,281 @@ constexpr uint32_t kDefaultTrashTime = 94620;
 class FilesystemOperationsBase : public IFilesystemOperations {
 public:
 	/// Returns version of the loaded metadata.
-	uint64_t fs_getversion() override;
+	uint64_t getMetadataVersion() override;
 
 	/// @see IFilesystemOperations::fs_changelog
-	void fs_changelog(uint32_t ts, const char *format, ...) override
+	void changeLog(uint32_t ts, const char *format, ...) override
 	    __attribute__((__format__(__printf__, 3, 4)));
 
 	// Functions which create/apply (depending on the given context) changes to the metadata.
 	// Common for metarestore and master server (both personalities)
 
-	uint8_t fs_acquire(const FsContext &context, inode_t inode, uint32_t sessionid) override;
-	uint8_t fs_append(const FsContext &context, inode_t inode, inode_t inode_src) override;
-	uint8_t fs_deleteacl(const FsContext &context, inode_t inode, AclType type) override;
-	uint8_t fs_link(const FsContext &context, inode_t inode_src, inode_t parent_dst,
-	                const HString &name_dst, inode_t *inode, Attributes *attr) override;
-	uint8_t fs_purge(const FsContext &context, inode_t inode) override;
-	uint8_t fs_rename(const FsContext &context, inode_t parent_src, const HString &name_src,
-	                  inode_t parent_dst, const HString &name_dst, inode_t *inode,
-	                  Attributes *attr) override;
-	uint8_t fs_release(const FsContext &context, inode_t inode, uint32_t sessionid) override;
-	uint8_t fs_seteattr(const FsContext &context, inode_t inode, uint8_t eattr, uint8_t smode,
-	                    inode_t *sinodes, inode_t *ncinodes, inode_t *nsinodes) override;
-	uint8_t fs_setgoal(const FsContext &context, inode_t inode, uint8_t goal, uint8_t smode,
-	                   std::shared_ptr<SetGoalTask::StatsArray> setgoal_stats,
-	                   const std::function<void(int)> &callback) override;
-	uint8_t fs_apply_setgoal(const FsContext &context, inode_t inode, uint8_t goal, uint8_t smode,
-	                         uint32_t master_result) override;
-	uint8_t fs_settrashpath(const FsContext &context, inode_t inode,
-	                        const std::string &path) override;
-	uint8_t fs_settrashtime(const FsContext &context, inode_t inode, uint32_t trashtime,
-	                        uint8_t smode,
-	                        std::shared_ptr<SetTrashtimeTask::StatsArray> settrashtime_stats,
-	                        const std::function<void(int)> &callback) override;
-	uint8_t fs_apply_settrashtime(const FsContext &context, inode_t inode, uint32_t trashtime,
-	                              uint8_t smode, uint32_t master_result) override;
-	uint8_t fs_symlink(const FsContext &context, inode_t parent, const HString &name,
-	                   const std::string &path, inode_t *inode, Attributes *attr) override;
-	uint8_t fs_undel(const FsContext &context, inode_t inode) override;
-	uint8_t fs_writechunk(const FsContext &context, inode_t inode, uint32_t indx,
-	                      bool usedummylockid,
-	                      /* inout */ uint32_t *lockid, uint64_t *chunkid, uint8_t *opflag,
-	                      uint64_t *length, uint32_t min_server_version = 0) override;
-	uint8_t fs_set_nextchunkid(const FsContext &context, uint64_t nextChunkId) override;
+	uint8_t acquire(const FsContext &context, inode_t inode, uint32_t sessionid) override;
+	uint8_t append(const FsContext &context, inode_t inode, inode_t inode_src) override;
+	uint8_t deleteAcl(const FsContext &context, inode_t inode, AclType type) override;
+	uint8_t link(const FsContext &context, inode_t inode_src, inode_t parent_dst,
+	             const HString &name_dst, inode_t *inode, Attributes *attr) override;
+	uint8_t purge(const FsContext &context, inode_t inode) override;
+	uint8_t rename(const FsContext &context, inode_t parent_src, const HString &name_src,
+	               inode_t parent_dst, const HString &name_dst, inode_t *inode,
+	               Attributes *attr) override;
+	uint8_t release(const FsContext &context, inode_t inode, uint32_t sessionid) override;
+	uint8_t setEAttr(const FsContext &context, inode_t inode, uint8_t eattr, uint8_t smode,
+	                 inode_t *sinodes, inode_t *ncinodes, inode_t *nsinodes) override;
+	uint8_t setGoal(const FsContext &context, inode_t inode, uint8_t goal, uint8_t smode,
+	                std::shared_ptr<SetGoalTask::StatsArray> setgoal_stats,
+	                const std::function<void(int)> &callback) override;
+	uint8_t applySetGoal(const FsContext &context, inode_t inode, uint8_t goal, uint8_t smode,
+	                     uint32_t master_result) override;
+	uint8_t setTrashPath(const FsContext &context, inode_t inode, const std::string &path) override;
+	uint8_t setTrashTime(const FsContext &context, inode_t inode, uint32_t trashtime, uint8_t smode,
+	                     std::shared_ptr<SetTrashtimeTask::StatsArray> settrashtime_stats,
+	                     const std::function<void(int)> &callback) override;
+	uint8_t applySetTrashTime(const FsContext &context, inode_t inode, uint32_t trashtime,
+	                          uint8_t smode, uint32_t master_result) override;
+	uint8_t symlink(const FsContext &context, inode_t parent, const HString &name,
+	                const std::string &path, inode_t *inode, Attributes *attr) override;
+	uint8_t undel(const FsContext &context, inode_t inode) override;
+	uint8_t writeChunk(const FsContext &context, inode_t inode, uint32_t index, bool usedummylockid,
+	                   /* inout */ uint32_t *lockid, uint64_t *chunkid, uint8_t *opflag,
+	                   uint64_t *length, uint32_t min_server_version = 0) override;
+	uint8_t setNextChunkId(const FsContext &context, uint64_t nextChunkId) override;
 
 #ifndef METARESTORE
 	/// Returns a map with all defined goals.
-	const std::map<int, Goal> &fs_get_goal_definitions() const override;
+	const std::map<int, Goal> &getAllGoalDefinitions() const override;
 
 	/// Returns goal definition for given goal id.
-	const Goal &fs_get_goal_definition(uint8_t goalId) const override;
+	const Goal &getGoalDefinition(uint8_t goalId) const override;
 
-	uint32_t fs_reserve_job_id() override;
-	uint8_t fs_cancel_job(uint32_t job_id) override;
-	std::vector<JobInfo> fs_get_current_tasks_info() override;
+	uint32_t reserveJobId() override;
+	uint8_t cancelJob(uint32_t job_id) override;
+	std::vector<JobInfo> getCurrentTasksInfo() override;
 
-	uint8_t fs_access(const FsContext &context, inode_t inode, int modemask) override;
-	uint8_t fs_lookup(const FsContext &context, inode_t parent, const HString &name, inode_t *inode,
+	uint8_t access(const FsContext &context, inode_t inode, int modemask) override;
+	uint8_t lookup(const FsContext &context, inode_t parent, const HString &name, inode_t *inode,
+	               Attributes &attr) override;
+	uint8_t wholePathLookup(const FsContext &context, inode_t parent, const std::string &path,
+	                        inode_t *found_inode, Attributes &attr) override;
+	uint8_t getAttr(const FsContext &context, inode_t inode, Attributes &attr) override;
+	uint8_t trySetLength(const FsContext &context, inode_t inode, uint8_t opened, uint64_t length,
+	                     bool denyTruncatingParity, uint32_t lockid, Attributes &attr,
+	                     uint64_t *chunkid) override;
+	uint8_t doSetLength(const FsContext &context, inode_t inode, uint64_t length,
+	                    Attributes &attr) override;
+	uint8_t setAttr(const FsContext &context, inode_t inode, uint8_t setmask, uint16_t attrmode,
+	                uint32_t attruid, uint32_t attrgid, uint32_t attratime, uint32_t attrmtime,
+	                SugidClearMode sugidclearmode, Attributes &attr) override;
+	uint8_t readlink(const FsContext &context, inode_t inode, std::string &path) override;
+	void statfs(const FsContext &context, uint64_t *totalspace, uint64_t *availspace,
+	            uint64_t *trashspace, uint64_t *reservedspace, inode_t *inodes) override;
+	uint8_t mknod(const FsContext &context, inode_t parent, const HString &name, FSNodeType type,
+	              uint16_t mode, uint16_t umask, uint32_t rdev, inode_t *inode,
+	              Attributes &attr) override;
+	uint8_t mkdir(const FsContext &context, inode_t parent, const HString &name, uint16_t mode,
+	              uint16_t umask, uint8_t copysgid, inode_t *inode, Attributes &attr) override;
+	uint8_t removeChunkFromFile(const FsContext &context, inode_t inode, uint64_t chunkId) override;
+	uint8_t repair(const FsContext &context, inode_t inode, uint8_t correct_only,
+	               uint32_t *notchanged, uint32_t *erased, uint32_t *repaired) override;
+	uint8_t rmdir(const FsContext &context, inode_t parent, const HString &name) override;
+	uint8_t recursiveRemove(const FsContext &context, inode_t parent, const HString &name,
+	                        const std::function<void(int)> &callback, uint32_t job_id) override;
+	uint8_t readdirSize(const FsContext &context, inode_t inode, uint8_t flags, void **dnode,
+	                    uint32_t *dbuffsize) override;
+	void readdirData(const FsContext &context, uint8_t flags, void *dnode, uint8_t *dbuff) override;
+
+	uint8_t readdir(const FsContext &context, inode_t inode, uint64_t first_entry,
+	                uint64_t number_of_entries, std::vector<DirectoryEntry> &dir_entries) override;
+
+	uint8_t checkFile(const FsContext &context, inode_t inode,
+	                  uint32_t chunkcount[CHUNK_MATRIX_SIZE]) override;
+	uint8_t openCheck(const FsContext &context, inode_t inode, uint8_t flags,
 	                  Attributes &attr) override;
-	uint8_t fs_whole_path_lookup(const FsContext &context, inode_t parent, const std::string &path,
-	                             inode_t *found_inode, Attributes &attr) override;
-	uint8_t fs_getattr(const FsContext &context, inode_t inode, Attributes &attr) override;
-	uint8_t fs_try_setlength(const FsContext &context, inode_t inode, uint8_t opened,
-	                         uint64_t length, bool denyTruncatingParity, uint32_t lockid,
-	                         Attributes &attr, uint64_t *chunkid) override;
-	uint8_t fs_do_setlength(const FsContext &context, inode_t inode, uint64_t length,
-	                        Attributes &attr) override;
-	uint8_t fs_setattr(const FsContext &context, inode_t inode, uint8_t setmask, uint16_t attrmode,
-	                   uint32_t attruid, uint32_t attrgid, uint32_t attratime, uint32_t attrmtime,
-	                   SugidClearMode sugidclearmode, Attributes &attr) override;
-	uint8_t fs_readlink(const FsContext &context, inode_t inode, std::string &path) override;
-	void fs_statfs(const FsContext &context, uint64_t *totalspace, uint64_t *availspace,
-	               uint64_t *trashspace, uint64_t *reservedspace, inode_t *inodes) override;
-	uint8_t fs_mknod(const FsContext &context, inode_t parent, const HString &name, FSNodeType type,
-	                 uint16_t mode, uint16_t umask, uint32_t rdev, inode_t *inode,
-	                 Attributes &attr) override;
-	uint8_t fs_mkdir(const FsContext &context, inode_t parent, const HString &name, uint16_t mode,
-	                 uint16_t umask, uint8_t copysgid, inode_t *inode, Attributes &attr) override;
-	uint8_t fs_remove_chunk_from_file(const FsContext &context, inode_t inode,
-	                                  uint64_t chunkId) override;
-	uint8_t fs_repair(const FsContext &context, inode_t inode, uint8_t correct_only,
-	                  uint32_t *notchanged, uint32_t *erased, uint32_t *repaired) override;
-	uint8_t fs_rmdir(const FsContext &context, inode_t parent, const HString &name) override;
-	uint8_t fs_recursive_remove(const FsContext &context, inode_t parent, const HString &name,
-	                            const std::function<void(int)> &callback, uint32_t job_id) override;
-	uint8_t fs_readdir_size(const FsContext &context, inode_t inode, uint8_t flags, void **dnode,
-	                        uint32_t *dbuffsize) override;
-	void fs_readdir_data(const FsContext &context, uint8_t flags, void *dnode,
-	                     uint8_t *dbuff) override;
-
-	uint8_t fs_readdir(const FsContext &context, inode_t inode, uint64_t first_entry,
-	                   uint64_t number_of_entries,
-	                   std::vector<DirectoryEntry> &dir_entries) override;
-
-	uint8_t fs_checkfile(const FsContext &context, inode_t inode,
-	                     uint32_t chunkcount[CHUNK_MATRIX_SIZE]) override;
-	uint8_t fs_opencheck(const FsContext &context, inode_t inode, uint8_t flags,
-	                     Attributes &attr) override;
-	uint8_t fs_getgoal(const FsContext &context, inode_t inode, uint8_t gmode,
-	                   GoalStatistics &fgtab, GoalStatistics &dgtab) override;
-	uint8_t fs_getxattr(const FsContext &context, inode_t inode, uint8_t opened, uint8_t anleng,
-	                    const uint8_t *attrname, uint32_t *avleng, uint8_t **attrvalue) override;
-	uint8_t fs_geteattr(const FsContext &context, inode_t inode, uint8_t gmode,
-	                    uint32_t feattrtab[16], uint32_t deattrtab[16]) override;
-	uint8_t fs_listxattr_leng(const FsContext &context, inode_t inode, uint8_t opened,
-	                          void **xanode, uint32_t *xasize) override;
-	uint8_t fs_setxattr(const FsContext &context, inode_t inode, uint8_t opened, uint8_t anleng,
-	                    const uint8_t *attrname, uint32_t avleng, const uint8_t *attrvalue,
-	                    uint8_t mode) override;
-	uint8_t fs_unlink(const FsContext &context, inode_t parent, const HString &name) override;
-	uint8_t fs_getchunksinfo(const FsContext &context, uint32_t current_ip, inode_t inode,
-	                         uint32_t chunk_index, uint32_t chunk_count,
-	                         std::vector<ChunkWithAddressAndLabel> &chunks) override;
-	uint8_t fs_gettrashtime_prepare(const FsContext &context, inode_t inode, uint8_t gmode,
-	                                TrashtimeMap &fileTrashtimes,
-	                                TrashtimeMap &dirTrashtimes) override;
-	uint8_t fs_setacl(const FsContext &context, inode_t inode, AclType type,
-	                  const AccessControlList &acl) override;
-	uint8_t fs_setacl(const FsContext &context, inode_t inode, const RichACL &acl) override;
-	uint8_t fs_getacl(const FsContext &context, inode_t inode, RichACL &acl) override;
+	uint8_t getGoal(const FsContext &context, inode_t inode, uint8_t gmode, GoalStatistics &fgtab,
+	                GoalStatistics &dgtab) override;
+	uint8_t getXAttr(const FsContext &context, inode_t inode, uint8_t opened, uint8_t anleng,
+	                 const uint8_t *attrname, uint32_t *avleng, uint8_t **attrvalue) override;
+	uint8_t getEAttr(const FsContext &context, inode_t inode, uint8_t gmode, uint32_t feattrtab[16],
+	                 uint32_t deattrtab[16]) override;
+	uint8_t listXAttrLeng(const FsContext &context, inode_t inode, uint8_t opened, void **xanode,
+	                      uint32_t *xasize) override;
+	uint8_t setXAttr(const FsContext &context, inode_t inode, uint8_t opened, uint8_t anleng,
+	                 const uint8_t *attrname, uint32_t avleng, const uint8_t *attrvalue,
+	                 uint8_t mode) override;
+	uint8_t unlink(const FsContext &context, inode_t parent, const HString &name) override;
+	uint8_t getChunksInfo(const FsContext &context, uint32_t current_ip, inode_t inode,
+	                      uint32_t chunk_index, uint32_t chunk_count,
+	                      std::vector<ChunkWithAddressAndLabel> &chunks) override;
+	uint8_t getTrashTimePrepare(const FsContext &context, inode_t inode, uint8_t gmode,
+	                            TrashtimeMap &fileTrashtimes, TrashtimeMap &dirTrashtimes) override;
+	uint8_t setAcl(const FsContext &context, inode_t inode, AclType type,
+	               const AccessControlList &acl) override;
+	uint8_t setAcl(const FsContext &context, inode_t inode, const RichACL &acl) override;
+	uint8_t getAcl(const FsContext &context, inode_t inode, RichACL &acl) override;
 
 	// Functions which modify metadata or return some information.
 	// To be used by the master server with personality == kMaster
-	void fs_info(uint64_t *totalSpace, uint64_t *availableSpace, uint64_t *trashSpace,
-	             inode_t *trashNodes, uint64_t *reservedSpace, inode_t *reservedNodes,
-	             inode_t *inodes, inode_t *directoryNodes, inode_t *fileNodes,
-	             inode_t *linkNodes) override;
-	uint32_t fs_getdirpath_size(inode_t inode) override;
-	void fs_getdirpath_data(inode_t inode, uint8_t *buff, uint32_t size) override;
-	uint8_t fs_getrootinode(inode_t *rootinode, const uint8_t *path) override;
-	uint8_t fs_end_setlength(uint64_t chunkid) override;
-	uint8_t fs_readchunk(inode_t inode, uint32_t indx, uint64_t *chunkid,
-	                     uint64_t *length) override;
-	uint8_t fs_writeend(inode_t inode, uint64_t length, uint64_t chunkid, uint32_t lockid) override;
-	void fs_gettrashtime_store(TrashtimeMap &fileTrashtimes, TrashtimeMap &dirTrashtimes,
-	                           uint8_t *buff) override;
-	void fs_listxattr_data(void *xanode, uint8_t *xabuff) override;
 
-	uint32_t fs_newsessionid(void) override;
+	void getFSStats(uint64_t *totalSpace, uint64_t *availableSpace, uint64_t *trashSpace,
+	                inode_t *trashNodes, uint64_t *reservedSpace, inode_t *reservedNodes,
+	                inode_t *inodes, inode_t *directoryNodes, inode_t *fileNodes,
+	                inode_t *linkNodes) override;
+	uint32_t getDirPathSize(inode_t inode) override;
+	void getDirPathData(inode_t inode, uint8_t *buff, uint32_t size) override;
+	uint8_t getRootInode(inode_t *rootinode, const uint8_t *path) override;
+	uint8_t endSetLength(uint64_t chunkid) override;
+	uint8_t readChunk(inode_t inode, uint32_t indx, uint64_t *chunkid, uint64_t *length) override;
+	uint8_t writeEnd(inode_t inode, uint64_t length, uint64_t chunkid, uint32_t lockid) override;
+	void getTrashTimeStore(TrashtimeMap &fileTrashtimes, TrashtimeMap &dirTrashtimes,
+	                       uint8_t *buff) override;
+	void listXAttrData(void *xanode, uint8_t *xabuff) override;
+
+	uint32_t newSessionId() override;
 
 	// RESERVED
-	uint8_t fs_readreserved_size(inode_t rootinode, uint8_t sesflags, uint32_t *dbuffsize) override;
-	void fs_readreserved_data(inode_t rootinode, uint8_t sesflags, uint8_t *dbuff) override;
-	void fs_readreserved(uint32_t off, uint32_t max_entries,
-	                     std::vector<NamedInodeEntry> &entries) override;
-	void fs_readreserved(uint64_t handleOffset, uint32_t maxEntries,
-	                     std::vector<HandleInodeEntry> &entries) override;
+	uint8_t readReservedSize(inode_t rootinode, uint8_t sesflags, uint32_t *dbuffsize) override;
+	void readReservedData(inode_t rootinode, uint8_t sesflags, uint8_t *dbuff) override;
+	void readReserved(uint32_t off, uint32_t max_entries,
+	                  std::vector<NamedInodeEntry> &entries) override;
+	void readReserved(uint64_t handleOffset, uint32_t maxEntries,
+	                  std::vector<HandleInodeEntry> &entries) override;
 
 	// TRASH
-	uint8_t fs_readtrash_size(inode_t rootinode, uint8_t sesflags, uint32_t *dbuffsize) override;
-	void fs_readtrash_data(inode_t rootinode, uint8_t sesflags, uint8_t *dbuff) override;
-	void fs_readtrash(uint32_t off, uint32_t max_entries,
-	                  std::vector<NamedInodeEntry> &entries) override;
-	void fs_readtrash(uint64_t handleOffset, uint32_t maxEntries,
-	                  std::vector<HandleInodeEntry> &entries) override;
-	uint8_t fs_gettrashpath(inode_t rootinode, uint8_t sesflags, inode_t inode,
-	                        std::string &path) override;
+	uint8_t readTrashSize(inode_t rootinode, uint8_t sesflags, uint32_t *dbuffsize) override;
+	void readTrashData(inode_t rootinode, uint8_t sesflags, uint8_t *dbuff) override;
+	void readTrash(uint32_t off, uint32_t max_entries,
+	               std::vector<NamedInodeEntry> &entries) override;
+	void readTrash(uint64_t handleOffset, uint32_t maxEntries,
+	               std::vector<HandleInodeEntry> &entries) override;
+	uint8_t getTrashPath(inode_t rootinode, uint8_t sesflags, inode_t inode,
+	                     std::string &path) override;
 
 	// RESERVED+TRASH
-	uint8_t fs_getdetachedattr(inode_t rootinode, uint8_t sesflags, inode_t inode, Attributes &attr,
-	                           uint8_t dtype) override;
+	uint8_t getDetachedAttr(inode_t rootinode, uint8_t sesflags, inode_t inode, Attributes &attr,
+	                        uint8_t dtype) override;
 
 	// EXTRA
-	uint8_t fs_get_dir_stats(const FsContext &context, inode_t inode, inode_t *inodes,
-	                         inode_t *dirs, inode_t *files, inode_t *links, uint32_t *chunks,
-	                         uint64_t *length, uint64_t *size, uint64_t *rsize) override;
-	uint8_t fs_get_chunkid(const FsContext &context, inode_t inode, uint32_t index,
-	                       uint64_t *chunkid) override;
+	uint8_t getDirStats(const FsContext &context, inode_t inode, inode_t *inodes, inode_t *dirs,
+	                    inode_t *files, inode_t *links, uint32_t *chunks, uint64_t *length,
+	                    uint64_t *size, uint64_t *rsize) override;
+	uint8_t getChunkId(const FsContext &context, inode_t inode, uint32_t index,
+	                   uint64_t *chunkid) override;
 
 	// SPECIAL - LOG EMERGENCY INCREASE VERSION FROM CHUNKS-MODULE
-	void fs_incversion(uint64_t chunkid) override;
+	void increaseChunkVersion(uint64_t chunkid) override;
 
-	uint8_t fs_full_path_by_inode(const FsContext &context, inode_t inode,
-	                              std::string &fullPath) override;
-	std::string fs_full_path_by_inode(inode_t initial_inode) override;
+	uint8_t fullPathByInode(const FsContext &context, inode_t inode,
+	                        std::string &fullPath) override;
+	std::string fullPathByInode(inode_t initial_inode) override;
 
 	// QUOTAS
 
-	uint8_t fs_quota_get_all(const FsContext &context, std::vector<QuotaEntry> &results) override;
-	uint8_t fs_quota_get(const FsContext &context, const std::vector<QuotaOwner> &owners,
-	                     std::vector<QuotaEntry> &results) override;
-	uint8_t fs_quota_set(const FsContext &context, const std::vector<QuotaEntry> &entries) override;
-	uint8_t fs_quota_get_info(const FsContext &context, const std::vector<QuotaEntry> &entries,
-	                          std::vector<std::string> &result) override;
+	uint8_t quotaGetAll(const FsContext &context, std::vector<QuotaEntry> &results) override;
+	uint8_t quotaGet(const FsContext &context, const std::vector<QuotaOwner> &owners,
+	                 std::vector<QuotaEntry> &results) override;
+	uint8_t quotaSet(const FsContext &context, const std::vector<QuotaEntry> &entries) override;
+	uint8_t quotaGetInfo(const FsContext &context, const std::vector<QuotaEntry> &entries,
+	                     std::vector<std::string> &result) override;
 
 	// CHECKSUM
 
 	/// Starts recalculating metadata checksum in background.
 	/// @see IFilesystemOperations::fs_start_checksum_recalculation.
-	uint8_t fs_start_checksum_recalculation() override;
+	uint8_t startChecksumRecalculation() override;
 
 #endif
-	void fs_add_files_to_chunks(bool isMetadataLoading = true) override;
+	void addFilesToChunks(bool isMetadataLoading = true) override;
 
 	// Functions which apply changes from changelog, only for shadow master and metarestore
-	uint8_t fs_apply_checksum(const std::string &version, uint64_t checksum) override;
-	uint8_t fs_apply_create(uint32_t timestamp, inode_t parent, const HString &name,
-	                        FSNodeType type, uint32_t mode, uint32_t uid, uint32_t gid,
-	                        uint32_t rdev, inode_t inode) override;
-	uint8_t fs_apply_access(uint32_t timestamp, inode_t inode) override;
-	uint8_t fs_apply_attr(uint32_t timestamp, inode_t inode, uint32_t mode, uint32_t uid,
-	                      uint32_t gid, uint32_t atime, uint32_t mtime) override;
-	uint8_t fs_apply_session(uint32_t sessionid) override;
-	uint8_t fs_apply_incversion(uint64_t chunkid) override;
-	uint8_t fs_apply_length(uint32_t timestamp, inode_t inode, uint64_t length,
-	                        bool eraseFurtherChunks) override;
-	uint8_t fs_apply_repair(uint32_t timestamp, inode_t inode, uint32_t indx,
-	                        uint32_t nversion) override;
-	uint8_t fs_apply_setxattr(uint32_t timestamp, inode_t inode, uint32_t anleng,
-	                          const uint8_t *attrname, uint32_t avleng, const uint8_t *attrvalue,
-	                          uint32_t mode) override;
-	uint8_t fs_apply_setacl(uint32_t timestamp, inode_t inode, char aclType,
-	                        const char *aclString) override;
-	uint8_t fs_apply_setrichacl(uint32_t timestamp, inode_t inode,
-	                            const std::string &acl_string) override;
-	uint8_t fs_apply_unlink(uint32_t timestamp, inode_t parent, const HString &name,
-	                        inode_t inode) override;
-	uint8_t fs_apply_unlock(uint64_t chunkid) override;
-	uint8_t fs_apply_trunc(uint32_t timestamp, inode_t inode, uint32_t indx, uint64_t chunkid,
-	                       uint32_t lockid) override;
+	uint8_t applyChecksum(const std::string &version, uint64_t checksum) override;
+	uint8_t applyCreate(uint32_t timestamp, inode_t parent, const HString &name, FSNodeType type,
+	                    uint32_t mode, uint32_t uid, uint32_t gid, uint32_t rdev,
+	                    inode_t inode) override;
+	uint8_t applyAccess(uint32_t timestamp, inode_t inode) override;
+	uint8_t applyAttr(uint32_t timestamp, inode_t inode, uint32_t mode, uint32_t uid, uint32_t gid,
+	                  uint32_t atime, uint32_t mtime) override;
+	uint8_t applySession(uint32_t sessionid) override;
+	uint8_t applyIncreaseChunkVersion(uint64_t chunkid) override;
+	uint8_t applyLength(uint32_t timestamp, inode_t inode, uint64_t length,
+	                    bool eraseFurtherChunks) override;
+	uint8_t applyRepair(uint32_t timestamp, inode_t inode, uint32_t indx,
+	                    uint32_t nversion) override;
+	uint8_t applySetXAttr(uint32_t timestamp, inode_t inode, uint32_t anleng,
+	                      const uint8_t *attrname, uint32_t avleng, const uint8_t *attrvalue,
+	                      uint32_t mode) override;
+	uint8_t applySetAcl(uint32_t timestamp, inode_t inode, char aclType,
+	                    const char *aclString) override;
+	uint8_t applySetRichAcl(uint32_t timestamp, inode_t inode,
+	                        const std::string &acl_string) override;
+	uint8_t applyUnlink(uint32_t timestamp, inode_t parent, const HString &name,
+	                    inode_t inode) override;
+	uint8_t applyUnlock(uint64_t chunkid) override;
+	uint8_t applyTrunc(uint32_t timestamp, inode_t inode, uint32_t indx, uint64_t chunkid,
+	                   uint32_t lockid) override;
 
-	uint8_t fs_apply_setquota(char rigor, char resource, char ownerType, inode_t ownerId,
-	                          uint64_t limit) override;
+	uint8_t applySetQuota(char rigor, char resource, char ownerType, inode_t ownerId,
+	                      uint64_t limit) override;
 
 	// CHECKSUM
 
 	/// Returns checksum of the loaded metadata.
-	uint64_t fs_checksum(ChecksumMode mode) override;
+	uint64_t metadataChecksum(ChecksumMode mode) override;
 
 	// Locks
 
 	/// Perform a flock operation on filesystem.
 	/// @see IFilesystemOperations::fs_flock_op.
-	int fs_flock_op(const FsContext &context, inode_t inode, uint64_t owner, uint32_t sessionid,
-	                uint32_t reqid, uint32_t msgid, uint16_t oper, bool nonblocking,
-	                std::vector<FileLocks::Owner> &applied) override;
+	int flockOperation(const FsContext &context, inode_t inode, uint64_t owner, uint32_t sessionid,
+	                   uint32_t reqid, uint32_t msgid, uint16_t oper, bool nonblocking,
+	                   std::vector<FileLocks::Owner> &applied) override;
 
 	/// Perform a posix lock operation on filesystem.
 	/// @see IFilesystemOperations::fs_posixlock_op.
-	int fs_posixlock_op(const FsContext &context, inode_t inode, uint64_t start, uint64_t end,
-	                    uint64_t owner, uint32_t sessionid, uint32_t reqid, uint32_t msgid,
-	                    uint16_t oper, bool nonblocking,
-	                    std::vector<FileLocks::Owner> &applied) override;
+	int posixLockOperation(const FsContext &context, inode_t inode, uint64_t start, uint64_t end,
+	                       uint64_t owner, uint32_t sessionid, uint32_t reqid, uint32_t msgid,
+	                       uint16_t oper, bool nonblocking,
+	                       std::vector<FileLocks::Owner> &applied) override;
 
 	/// Perform a POSIX lock probe on filesystem.
 	/// @see IFilesystemOperations::fs_posixlock_probe.
-	int fs_posixlock_probe(const FsContext &context, inode_t inode, uint64_t start, uint64_t end,
-	                       uint64_t owner, uint32_t sessionid, uint32_t reqid, uint32_t msgid,
-	                       uint16_t oper, safs_locks::FlockWrapper &info) override;
+	int posixLockProbe(const FsContext &context, inode_t inode, uint64_t start, uint64_t end,
+	                   uint64_t owner, uint32_t sessionid, uint32_t reqid, uint32_t msgid,
+	                   uint16_t oper, safs_locks::FlockWrapper &info) override;
 
 	/// Release (unlock + unqueue) all locks from a given session.
 	/// @see IFilesystemOperations::fs_locks_clear_session.
-	int fs_locks_clear_session(const FsContext &context, uint8_t type, inode_t inode,
-	                           uint32_t sessionid, std::vector<FileLocks::Owner> &applied) override;
+	int locksClearSession(const FsContext &context, uint8_t type, inode_t inode, uint32_t sessionid,
+	                      std::vector<FileLocks::Owner> &applied) override;
 
 	/// List locks in the filesystem.
 	/// @see IFilesystemOperations::fs_locks_list_all.
-	int fs_locks_list_all(const FsContext &context, uint8_t type, bool pending, uint64_t start,
-	                      uint64_t max, std::vector<safs_locks::Info> &outLocks) override;
+	int locksListAll(const FsContext &context, uint8_t type, bool pending, uint64_t start,
+	                 uint64_t max, std::vector<safs_locks::Info> &outLocks) override;
 
 	/// List locks for a specific inode.
 	/// @see IFilesystemOperations::fs_locks_list_inode.
-	int fs_locks_list_inode(const FsContext &context, uint8_t type, bool pending, inode_t inode,
-	                        uint64_t start, uint64_t max,
-	                        std::vector<safs_locks::Info> &outLocks) override;
+	int locksListInode(const FsContext &context, uint8_t type, bool pending, inode_t inode,
+	                   uint64_t start, uint64_t max,
+	                   std::vector<safs_locks::Info> &outLocks) override;
 
 	/// Unlocks the matching locks on the specified inode and tries to apply pending locks.
 	/// @see IFilesystemOperations::fs_locks_unlock_inode.
-	int fs_locks_unlock_inode(const FsContext &context, uint8_t type, inode_t inode,
-	                          std::vector<FileLocks::Owner> &applied) override;
+	int locksUnlockInode(const FsContext &context, uint8_t type, inode_t inode,
+	                     std::vector<FileLocks::Owner> &applied) override;
 
 	/// Removes a pending lock matching the provided parameters.
 	/// @see IFilesystemOperations::fs_locks_remove_pending.
-	int fs_locks_remove_pending(const FsContext &context, uint8_t type, uint64_t ownerid,
-	                            uint32_t sessionid, inode_t inode, uint64_t reqid) override;
+	int locksRemovePending(const FsContext &context, uint8_t type, uint64_t ownerid,
+	                       uint32_t sessionid, inode_t inode, uint64_t reqid) override;
 
 private:
 	/// Helper function used internally by `fs_flock_op` and `fs_posixlock_op`.
-	static int fs_lock_op(const FsContext &context, FileLocks &locks, inode_t inode, uint64_t start,
-	                      uint64_t end, uint64_t owner, uint32_t sessionid, uint32_t reqid,
-	                      uint32_t msgid, uint16_t oper, bool nonblocking,
-	                      std::vector<FileLocks::Owner> &applied);
+	static int lockOperation(const FsContext &context, FileLocks &locks, inode_t inode,
+	                         uint64_t start, uint64_t end, uint64_t owner, uint32_t sessionid,
+	                         uint32_t reqid, uint32_t msgid, uint16_t oper, bool nonblocking,
+	                         std::vector<FileLocks::Owner> &applied);
 
 	/// Helper function used internally by `fs_locks_unlock_inode`.
-	static void fs_manage_lock_try_lock_pending(FileLocks &locks, inode_t inode, uint64_t start,
-	                                            uint64_t end,
-	                                            std::vector<FileLocks::Owner> &applied);
+	static void manageLockTryLockPending(FileLocks &locks, inode_t inode, uint64_t start,
+	                                     uint64_t end, std::vector<FileLocks::Owner> &applied);
 };

--- a/src/master/filesystem_operations_interface.h
+++ b/src/master/filesystem_operations_interface.h
@@ -62,243 +62,239 @@ public:
 	virtual ~IFilesystemOperations() = default;
 
 	/// Returns version of the loaded metadata.
-	virtual uint64_t fs_getversion() = 0;
+	virtual uint64_t getMetadataVersion() = 0;
 
 	/// Adds an entry to a changelog, updates filesystem.cc internal structures, prepends a
 	/// proper timestamp to changelog entry and broadcasts it to metaloggers and shadow masters.
 	/// The attribute is used to ensure printf-like format string checking by the compiler.
-	virtual void fs_changelog(uint32_t ts, const char *format, ...)
+	virtual void changeLog(uint32_t ts, const char *format, ...)
 	    __attribute__((__format__(__printf__, 3, 4))) = 0;
 
 	// Functions which create/apply (depending on the given context) changes to the metadata.
 	// Common for metarestore and master server (both personalities)
 
-	virtual uint8_t fs_acquire(const FsContext &context, inode_t inode, uint32_t sessionid) = 0;
-	virtual uint8_t fs_append(const FsContext &context, inode_t inode, inode_t inode_src) = 0;
-	virtual uint8_t fs_deleteacl(const FsContext &context, inode_t inode, AclType type) = 0;
-	virtual uint8_t fs_link(const FsContext &context, inode_t inode_src, inode_t parent_dst,
-	                        const HString &name_dst, inode_t *inode, Attributes *attr) = 0;
-	virtual uint8_t fs_purge(const FsContext &context, inode_t inode) = 0;
-	virtual uint8_t fs_rename(const FsContext &context, inode_t parent_src, const HString &name_src,
-	                          inode_t parent_dst, const HString &name_dst, inode_t *inode,
-	                          Attributes *attr) = 0;
-	virtual uint8_t fs_release(const FsContext &context, inode_t inode, uint32_t sessionid) = 0;
-	virtual uint8_t fs_seteattr(const FsContext &context, inode_t inode, uint8_t eattr,
-	                            uint8_t smode, inode_t *sinodes, inode_t *ncinodes,
-	                            inode_t *nsinodes) = 0;
-	virtual uint8_t fs_setgoal(const FsContext &context, inode_t inode, uint8_t goal, uint8_t smode,
-	                           std::shared_ptr<SetGoalTask::StatsArray> setgoal_stats,
-	                           const std::function<void(int)> &callback) = 0;
-	virtual uint8_t fs_apply_setgoal(const FsContext &context, inode_t inode, uint8_t goal,
-	                                 uint8_t smode, uint32_t master_result) = 0;
-	virtual uint8_t fs_settrashpath(const FsContext &context, inode_t inode,
-	                                const std::string &path) = 0;
-	virtual uint8_t fs_settrashtime(
-	    const FsContext &context, inode_t inode, uint32_t trashtime, uint8_t smode,
-	    std::shared_ptr<SetTrashtimeTask::StatsArray> settrashtime_stats,
-	    const std::function<void(int)> &callback) = 0;
-	virtual uint8_t fs_apply_settrashtime(const FsContext &context, inode_t inode,
-	                                      uint32_t trashtime, uint8_t smode,
-	                                      uint32_t master_result) = 0;
-	virtual uint8_t fs_symlink(const FsContext &context, inode_t parent, const HString &name,
-	                           const std::string &path, inode_t *inode, Attributes *attr) = 0;
-	virtual uint8_t fs_undel(const FsContext &context, inode_t inode) = 0;
-	virtual uint8_t fs_writechunk(const FsContext &context, inode_t inode, uint32_t indx,
-	                              bool usedummylockid,
-	                              /* inout */ uint32_t *lockid, uint64_t *chunkid, uint8_t *opflag,
-	                              uint64_t *length, uint32_t min_server_version = 0) = 0;
-	virtual uint8_t fs_set_nextchunkid(const FsContext &context, uint64_t nextChunkId) = 0;
+	virtual uint8_t acquire(const FsContext &context, inode_t inode, uint32_t sessionid) = 0;
+	virtual uint8_t append(const FsContext &context, inode_t inode, inode_t inode_src) = 0;
+	virtual uint8_t deleteAcl(const FsContext &context, inode_t inode, AclType type) = 0;
+	virtual uint8_t link(const FsContext &context, inode_t inode_src, inode_t parent_dst,
+	                     const HString &name_dst, inode_t *inode, Attributes *attr) = 0;
+	virtual uint8_t purge(const FsContext &context, inode_t inode) = 0;
+	virtual uint8_t rename(const FsContext &context, inode_t parent_src, const HString &name_src,
+	                       inode_t parent_dst, const HString &name_dst, inode_t *inode,
+	                       Attributes *attr) = 0;
+	virtual uint8_t release(const FsContext &context, inode_t inode, uint32_t sessionid) = 0;
+	virtual uint8_t setEAttr(const FsContext &context, inode_t inode, uint8_t eattr, uint8_t smode,
+	                         inode_t *sinodes, inode_t *ncinodes, inode_t *nsinodes) = 0;
+	virtual uint8_t setGoal(const FsContext &context, inode_t inode, uint8_t goal, uint8_t smode,
+	                        std::shared_ptr<SetGoalTask::StatsArray> setgoal_stats,
+	                        const std::function<void(int)> &callback) = 0;
+	virtual uint8_t applySetGoal(const FsContext &context, inode_t inode, uint8_t goal,
+	                             uint8_t smode, uint32_t master_result) = 0;
+	virtual uint8_t setTrashPath(const FsContext &context, inode_t inode,
+	                             const std::string &path) = 0;
+	virtual uint8_t setTrashTime(const FsContext &context, inode_t inode, uint32_t trashtime,
+	                             uint8_t smode,
+	                             std::shared_ptr<SetTrashtimeTask::StatsArray> settrashtime_stats,
+	                             const std::function<void(int)> &callback) = 0;
+	virtual uint8_t applySetTrashTime(const FsContext &context, inode_t inode, uint32_t trashtime,
+	                                  uint8_t smode, uint32_t master_result) = 0;
+	virtual uint8_t symlink(const FsContext &context, inode_t parent, const HString &name,
+	                        const std::string &path, inode_t *inode, Attributes *attr) = 0;
+	virtual uint8_t undel(const FsContext &context, inode_t inode) = 0;
+	virtual uint8_t writeChunk(const FsContext &context, inode_t inode, uint32_t index,
+	                           bool usedummylockid,
+	                           /* inout */ uint32_t *lockid, uint64_t *chunkid, uint8_t *opflag,
+	                           uint64_t *length, uint32_t min_server_version = 0) = 0;
+	virtual uint8_t setNextChunkId(const FsContext &context, uint64_t nextChunkId) = 0;
 
 #ifndef METARESTORE
 	/// Returns a map with all defined goals.
-	virtual const std::map<int, Goal> &fs_get_goal_definitions() const = 0;
+	virtual const std::map<int, Goal> &getAllGoalDefinitions() const = 0;
 
 	/// Returns goal definition for given goal id.
-	virtual const Goal &fs_get_goal_definition(uint8_t goalId) const = 0;
+	virtual const Goal &getGoalDefinition(uint8_t goalId) const = 0;
 
-	virtual uint32_t fs_reserve_job_id() = 0;
-	virtual uint8_t fs_cancel_job(uint32_t job_id) = 0;
+	virtual uint32_t reserveJobId() = 0;
+	virtual uint8_t cancelJob(uint32_t job_id) = 0;
 	/// Return info about currently executed tasks
-	virtual std::vector<JobInfo> fs_get_current_tasks_info() = 0;
+	virtual std::vector<JobInfo> getCurrentTasksInfo() = 0;
 
-	virtual uint8_t fs_access(const FsContext &context, inode_t inode, int modemask) = 0;
-	virtual uint8_t fs_lookup(const FsContext &context, inode_t parent, const HString &name,
-	                          inode_t *inode, Attributes &attr) = 0;
-	virtual uint8_t fs_whole_path_lookup(const FsContext &context, inode_t parent,
-	                                     const std::string &path, inode_t *found_inode,
-	                                     Attributes &attr) = 0;
-	virtual uint8_t fs_getattr(const FsContext &context, inode_t inode, Attributes &attr) = 0;
-	virtual uint8_t fs_try_setlength(const FsContext &context, inode_t inode, uint8_t opened,
-	                                 uint64_t length, bool denyTruncatingParity, uint32_t lockid,
-	                                 Attributes &attr, uint64_t *chunkid) = 0;
-	virtual uint8_t fs_do_setlength(const FsContext &context, inode_t inode, uint64_t length,
+	virtual uint8_t access(const FsContext &context, inode_t inode, int modemask) = 0;
+	virtual uint8_t lookup(const FsContext &context, inode_t parent, const HString &name,
+	                       inode_t *inode, Attributes &attr) = 0;
+	virtual uint8_t wholePathLookup(const FsContext &context, inode_t parent,
+	                                const std::string &path, inode_t *found_inode,
 	                                Attributes &attr) = 0;
-	virtual uint8_t fs_setattr(const FsContext &context, inode_t inode, uint8_t setmask,
-	                           uint16_t attrmode, uint32_t attruid, uint32_t attrgid,
-	                           uint32_t attratime, uint32_t attrmtime,
-	                           SugidClearMode sugidclearmode, Attributes &attr) = 0;
-	virtual uint8_t fs_readlink(const FsContext &context, inode_t inode, std::string &path) = 0;
-	virtual void fs_statfs(const FsContext &context, uint64_t *totalspace, uint64_t *availspace,
-	                       uint64_t *trashspace, uint64_t *reservedspace, inode_t *inodes) = 0;
-	virtual uint8_t fs_mknod(const FsContext &context, inode_t parent, const HString &name,
-	                         FSNodeType type, uint16_t mode, uint16_t umask, uint32_t rdev,
-	                         inode_t *inode, Attributes &attr) = 0;
-	virtual uint8_t fs_mkdir(const FsContext &context, inode_t parent, const HString &name,
-	                         uint16_t mode, uint16_t umask, uint8_t copysgid, inode_t *inode,
-	                         Attributes &attr) = 0;
-	virtual uint8_t fs_remove_chunk_from_file(const FsContext &context, inode_t inode,
-	                                          uint64_t chunkId) = 0;
-	virtual uint8_t fs_repair(const FsContext &context, inode_t inode, uint8_t correct_only,
-	                          uint32_t *notchanged, uint32_t *erased, uint32_t *repaired) = 0;
-	virtual uint8_t fs_rmdir(const FsContext &context, inode_t parent, const HString &name) = 0;
-	virtual uint8_t fs_recursive_remove(const FsContext &context, inode_t parent,
-	                                    const HString &name,
-	                                    const std::function<void(int)> &callback,
-	                                    uint32_t job_id) = 0;
-	virtual uint8_t fs_readdir_size(const FsContext &context, inode_t inode, uint8_t flags,
-	                                void **dnode, uint32_t *dbuffsize) = 0;
-	virtual void fs_readdir_data(const FsContext &context, uint8_t flags, void *dnode,
-	                             uint8_t *dbuff) = 0;
+	virtual uint8_t getAttr(const FsContext &context, inode_t inode, Attributes &attr) = 0;
+	virtual uint8_t trySetLength(const FsContext &context, inode_t inode, uint8_t opened,
+	                             uint64_t length, bool denyTruncatingParity, uint32_t lockid,
+	                             Attributes &attr, uint64_t *chunkid) = 0;
+	virtual uint8_t doSetLength(const FsContext &context, inode_t inode, uint64_t length,
+	                            Attributes &attr) = 0;
+	virtual uint8_t setAttr(const FsContext &context, inode_t inode, uint8_t setmask,
+	                        uint16_t attrmode, uint32_t attruid, uint32_t attrgid,
+	                        uint32_t attratime, uint32_t attrmtime, SugidClearMode sugidclearmode,
+	                        Attributes &attr) = 0;
+	virtual uint8_t readlink(const FsContext &context, inode_t inode, std::string &path) = 0;
+	virtual void statfs(const FsContext &context, uint64_t *totalspace, uint64_t *availspace,
+	                    uint64_t *trashspace, uint64_t *reservedspace, inode_t *inodes) = 0;
+	virtual uint8_t mknod(const FsContext &context, inode_t parent, const HString &name,
+	                      FSNodeType type, uint16_t mode, uint16_t umask, uint32_t rdev,
+	                      inode_t *inode, Attributes &attr) = 0;
+	virtual uint8_t mkdir(const FsContext &context, inode_t parent, const HString &name,
+	                      uint16_t mode, uint16_t umask, uint8_t copysgid, inode_t *inode,
+	                      Attributes &attr) = 0;
+	virtual uint8_t removeChunkFromFile(const FsContext &context, inode_t inode,
+	                                    uint64_t chunkId) = 0;
+	virtual uint8_t repair(const FsContext &context, inode_t inode, uint8_t correct_only,
+	                       uint32_t *notchanged, uint32_t *erased, uint32_t *repaired) = 0;
+	virtual uint8_t rmdir(const FsContext &context, inode_t parent, const HString &name) = 0;
+	virtual uint8_t recursiveRemove(const FsContext &context, inode_t parent, const HString &name,
+	                                const std::function<void(int)> &callback, uint32_t job_id) = 0;
+	virtual uint8_t readdirSize(const FsContext &context, inode_t inode, uint8_t flags,
+	                            void **dnode, uint32_t *dbuffsize) = 0;
+	virtual void readdirData(const FsContext &context, uint8_t flags, void *dnode,
+	                         uint8_t *dbuff) = 0;
 
-	virtual uint8_t fs_readdir(const FsContext &context, inode_t inode, uint64_t first_entry,
-	                           uint64_t number_of_entries,
-	                           std::vector<DirectoryEntry> &dir_entries) = 0;
+	virtual uint8_t readdir(const FsContext &context, inode_t inode, uint64_t first_entry,
+	                        uint64_t number_of_entries,
+	                        std::vector<DirectoryEntry> &dir_entries) = 0;
 
-	virtual uint8_t fs_checkfile(const FsContext &context, inode_t inode,
-	                             uint32_t chunkcount[CHUNK_MATRIX_SIZE]) = 0;
-	virtual uint8_t fs_opencheck(const FsContext &context, inode_t inode, uint8_t flags,
-	                             Attributes &attr) = 0;
-	virtual uint8_t fs_getgoal(const FsContext &context, inode_t inode, uint8_t gmode,
-	                           GoalStatistics &fgtab, GoalStatistics &dgtab) = 0;
-	virtual uint8_t fs_geteattr(const FsContext &context, inode_t inode, uint8_t gmode,
-	                            uint32_t feattrtab[16], uint32_t deattrtab[16]) = 0;
-	virtual uint8_t fs_listxattr_leng(const FsContext &context, inode_t inode, uint8_t opened,
-	                                  void **xanode, uint32_t *xasize) = 0;
-	virtual uint8_t fs_getxattr(const FsContext &context, inode_t inode, uint8_t opened,
-	                            uint8_t anleng, const uint8_t *attrname, uint32_t *avleng,
-	                            uint8_t **attrvalue) = 0;
-	virtual uint8_t fs_setxattr(const FsContext &context, inode_t inode, uint8_t opened,
-	                            uint8_t anleng, const uint8_t *attrname, uint32_t avleng,
-	                            const uint8_t *attrvalue, uint8_t mode) = 0;
-	virtual uint8_t fs_unlink(const FsContext &context, inode_t parent, const HString &name) = 0;
-	virtual uint8_t fs_getchunksinfo(const FsContext &context, uint32_t current_ip, inode_t inode,
-	                                 uint32_t chunk_index, uint32_t chunk_count,
-	                                 std::vector<ChunkWithAddressAndLabel> &chunks) = 0;
-	virtual uint8_t fs_gettrashtime_prepare(const FsContext &context, inode_t inode, uint8_t gmode,
-	                                        TrashtimeMap &fileTrashtimes,
-	                                        TrashtimeMap &dirTrashtimes) = 0;
-	virtual uint8_t fs_setacl(const FsContext &context, inode_t inode, AclType type,
-	                          const AccessControlList &acl) = 0;
-	virtual uint8_t fs_setacl(const FsContext &context, inode_t inode, const RichACL &acl) = 0;
-	virtual uint8_t fs_getacl(const FsContext &context, inode_t inode, RichACL &acl) = 0;
+	virtual uint8_t checkFile(const FsContext &context, inode_t inode,
+	                          uint32_t chunkcount[CHUNK_MATRIX_SIZE]) = 0;
+	virtual uint8_t openCheck(const FsContext &context, inode_t inode, uint8_t flags,
+	                          Attributes &attr) = 0;
+	virtual uint8_t getGoal(const FsContext &context, inode_t inode, uint8_t gmode,
+	                        GoalStatistics &fgtab, GoalStatistics &dgtab) = 0;
+	virtual uint8_t getEAttr(const FsContext &context, inode_t inode, uint8_t gmode,
+	                         uint32_t feattrtab[16], uint32_t deattrtab[16]) = 0;
+	virtual uint8_t listXAttrLeng(const FsContext &context, inode_t inode, uint8_t opened,
+	                              void **xanode, uint32_t *xasize) = 0;
+	virtual uint8_t getXAttr(const FsContext &context, inode_t inode, uint8_t opened,
+	                         uint8_t anleng, const uint8_t *attrname, uint32_t *avleng,
+	                         uint8_t **attrvalue) = 0;
+	virtual uint8_t setXAttr(const FsContext &context, inode_t inode, uint8_t opened,
+	                         uint8_t anleng, const uint8_t *attrname, uint32_t avleng,
+	                         const uint8_t *attrvalue, uint8_t mode) = 0;
+	virtual uint8_t unlink(const FsContext &context, inode_t parent, const HString &name) = 0;
+	virtual uint8_t getChunksInfo(const FsContext &context, uint32_t current_ip, inode_t inode,
+	                              uint32_t chunk_index, uint32_t chunk_count,
+	                              std::vector<ChunkWithAddressAndLabel> &chunks) = 0;
+	virtual uint8_t getTrashTimePrepare(const FsContext &context, inode_t inode, uint8_t gmode,
+	                                    TrashtimeMap &fileTrashtimes,
+	                                    TrashtimeMap &dirTrashtimes) = 0;
+	virtual uint8_t setAcl(const FsContext &context, inode_t inode, AclType type,
+	                       const AccessControlList &acl) = 0;
+	virtual uint8_t setAcl(const FsContext &context, inode_t inode, const RichACL &acl) = 0;
+	virtual uint8_t getAcl(const FsContext &context, inode_t inode, RichACL &acl) = 0;
 
 	// Functions which modify metadata or return some information.
 	// To be used by the master server with personality == kMaster
-	virtual void fs_info(uint64_t *totalSpace, uint64_t *availableSpace, uint64_t *trashSpace,
-	             inode_t *trashNodes, uint64_t *reservedSpace, inode_t *reservedNodes,
-	             inode_t *inodes, inode_t *directoryNodes, inode_t *fileNodes, inode_t *linkNodes) = 0;
-	virtual uint32_t fs_getdirpath_size(inode_t inode) = 0;
-	virtual void fs_getdirpath_data(inode_t inode, uint8_t *buff, uint32_t size) = 0;
-	virtual uint8_t fs_getrootinode(inode_t *rootinode, const uint8_t *path) = 0;
-	virtual uint8_t fs_end_setlength(uint64_t chunkid) = 0;
-	virtual uint8_t fs_readchunk(inode_t inode, uint32_t indx, uint64_t *chunkid, uint64_t *length) = 0;
-	virtual uint8_t fs_writeend(inode_t inode, uint64_t length, uint64_t chunkid, uint32_t lockid) = 0;
-	virtual void fs_gettrashtime_store(TrashtimeMap &fileTrashtimes, TrashtimeMap &dirTrashtimes,
-	                                   uint8_t *buff) = 0;
-	virtual void fs_listxattr_data(void *xanode, uint8_t *xabuff) = 0;
 
-	virtual uint32_t fs_newsessionid(void) = 0;
+	virtual void getFSStats(uint64_t *totalSpace, uint64_t *availableSpace, uint64_t *trashSpace,
+	                        inode_t *trashNodes, uint64_t *reservedSpace, inode_t *reservedNodes,
+	                        inode_t *inodes, inode_t *directoryNodes, inode_t *fileNodes,
+	                        inode_t *linkNodes) = 0;
+	virtual uint32_t getDirPathSize(inode_t inode) = 0;
+	virtual void getDirPathData(inode_t inode, uint8_t *buff, uint32_t size) = 0;
+	virtual uint8_t getRootInode(inode_t *rootinode, const uint8_t *path) = 0;
+	virtual uint8_t endSetLength(uint64_t chunkid) = 0;
+	virtual uint8_t readChunk(inode_t inode, uint32_t indx, uint64_t *chunkid,
+	                          uint64_t *length) = 0;
+	virtual uint8_t writeEnd(inode_t inode, uint64_t length, uint64_t chunkid, uint32_t lockid) = 0;
+	virtual void getTrashTimeStore(TrashtimeMap &fileTrashtimes, TrashtimeMap &dirTrashtimes,
+	                               uint8_t *buff) = 0;
+	virtual void listXAttrData(void *xanode, uint8_t *xabuff) = 0;
+
+	virtual uint32_t newSessionId() = 0;
 
 	// RESERVED
-	virtual uint8_t fs_readreserved_size(inode_t rootinode, uint8_t sesflags, uint32_t *dbuffsize) = 0;
-	virtual void fs_readreserved_data(inode_t rootinode, uint8_t sesflags, uint8_t *dbuff) = 0;
-	virtual void fs_readreserved(uint32_t off, uint32_t max_entries,
-	                             std::vector<NamedInodeEntry> &entries) = 0;
-	virtual void fs_readreserved(uint64_t handleOffset, uint32_t maxEntries,
-	                             std::vector<HandleInodeEntry> &entries) = 0;
+	virtual uint8_t readReservedSize(inode_t rootinode, uint8_t sesflags, uint32_t *dbuffsize) = 0;
+	virtual void readReservedData(inode_t rootinode, uint8_t sesflags, uint8_t *dbuff) = 0;
+	virtual void readReserved(uint32_t off, uint32_t max_entries,
+	                          std::vector<NamedInodeEntry> &entries) = 0;
+	virtual void readReserved(uint64_t handleOffset, uint32_t maxEntries,
+	                          std::vector<HandleInodeEntry> &entries) = 0;
 
 	// TRASH
-	virtual uint8_t fs_readtrash_size(inode_t rootinode, uint8_t sesflags, uint32_t *dbuffsize) = 0;
-	virtual void fs_readtrash_data(inode_t rootinode, uint8_t sesflags, uint8_t *dbuff) = 0;
-	virtual void fs_readtrash(uint32_t off, uint32_t max_entries,
-	                          std::vector<NamedInodeEntry> &entries) = 0;
-	virtual void fs_readtrash(uint64_t handleOffset, uint32_t maxEntries,
-	                          std::vector<HandleInodeEntry> &entries) = 0;
-	virtual uint8_t fs_gettrashpath(inode_t rootinode, uint8_t sesflags, inode_t inode, std::string &path) = 0;
+	virtual uint8_t readTrashSize(inode_t rootinode, uint8_t sesflags, uint32_t *dbuffsize) = 0;
+	virtual void readTrashData(inode_t rootinode, uint8_t sesflags, uint8_t *dbuff) = 0;
+	virtual void readTrash(uint32_t off, uint32_t max_entries,
+	                       std::vector<NamedInodeEntry> &entries) = 0;
+	virtual void readTrash(uint64_t handleOffset, uint32_t maxEntries,
+	                       std::vector<HandleInodeEntry> &entries) = 0;
+	virtual uint8_t getTrashPath(inode_t rootinode, uint8_t sesflags, inode_t inode,
+	                             std::string &path) = 0;
 
 	// RESERVED+TRASH
-	virtual uint8_t fs_getdetachedattr(inode_t rootinode, uint8_t sesflags, inode_t inode,
-	                                   Attributes &attr, uint8_t dtype) = 0;
+	virtual uint8_t getDetachedAttr(inode_t rootinode, uint8_t sesflags, inode_t inode,
+	                                Attributes &attr, uint8_t dtype) = 0;
 
 	// EXTRA
-	virtual uint8_t fs_get_dir_stats(const FsContext &context, inode_t inode, inode_t *inodes,
-	                                 inode_t *dirs, inode_t *files, inode_t *links,
-	                                 uint32_t *chunks, uint64_t *length, uint64_t *size,
-	                                 uint64_t *rsize) = 0;
-	virtual uint8_t fs_get_chunkid(const FsContext &context, inode_t inode, uint32_t index,
-	                               uint64_t *chunkid) = 0;
+	virtual uint8_t getDirStats(const FsContext &context, inode_t inode, inode_t *inodes,
+	                            inode_t *dirs, inode_t *files, inode_t *links, uint32_t *chunks,
+	                            uint64_t *length, uint64_t *size, uint64_t *rsize) = 0;
+	virtual uint8_t getChunkId(const FsContext &context, inode_t inode, uint32_t index,
+	                           uint64_t *chunkid) = 0;
 
 	// SPECIAL - LOG EMERGENCY INCREASE VERSION FROM CHUNKS-MODULE
-	virtual void fs_incversion(uint64_t chunkid) = 0;
+	virtual void increaseChunkVersion(uint64_t chunkid) = 0;
 
-	virtual uint8_t fs_full_path_by_inode(const FsContext &context, inode_t inode,
-	                                      std::string &fullPath) = 0;
-	virtual std::string fs_full_path_by_inode(inode_t initial_inode) = 0;
+	virtual uint8_t fullPathByInode(const FsContext &context, inode_t inode,
+	                                std::string &fullPath) = 0;
+	virtual std::string fullPathByInode(inode_t initial_inode) = 0;
 
 	// QUOTAS
 
-	virtual uint8_t fs_quota_get_all(const FsContext &context,
-	                                 std::vector<QuotaEntry> &results) = 0;
-	virtual uint8_t fs_quota_get(const FsContext &context, const std::vector<QuotaOwner> &owners,
-	                             std::vector<QuotaEntry> &results) = 0;
-	virtual uint8_t fs_quota_set(const FsContext &context,
-	                             const std::vector<QuotaEntry> &entries) = 0;
-	virtual uint8_t fs_quota_get_info(const FsContext &context,
-	                                  const std::vector<QuotaEntry> &entries,
-	                                  std::vector<std::string> &result) = 0;
+	virtual uint8_t quotaGetAll(const FsContext &context, std::vector<QuotaEntry> &results) = 0;
+	virtual uint8_t quotaGet(const FsContext &context, const std::vector<QuotaOwner> &owners,
+	                         std::vector<QuotaEntry> &results) = 0;
+	virtual uint8_t quotaSet(const FsContext &context, const std::vector<QuotaEntry> &entries) = 0;
+	virtual uint8_t quotaGetInfo(const FsContext &context, const std::vector<QuotaEntry> &entries,
+	                             std::vector<std::string> &result) = 0;
 
 	// CHECKSUM
 
 	/// Starts recalculating metadata checksum in background.
 	/// @return SAUNAFS_STATUS_OK if dump started successfully, otherwise cause of the failure.
-	virtual uint8_t fs_start_checksum_recalculation() = 0;
+	virtual uint8_t startChecksumRecalculation() = 0;
 #endif
-	virtual void fs_add_files_to_chunks(bool isMetadataLoading = true) = 0;
+	virtual void addFilesToChunks(bool isMetadataLoading = true) = 0;
 
 	// Functions which apply changes from changelog, only for shadow master and metarestore
-	virtual uint8_t fs_apply_checksum(const std::string &version, uint64_t checksum) = 0;
-	virtual uint8_t fs_apply_create(uint32_t timestamp, inode_t parent, const HString &name,
-	                                FSNodeType type, uint32_t mode, uint32_t uid, uint32_t gid,
-	                                uint32_t rdev, inode_t inode) = 0;
-	virtual uint8_t fs_apply_access(uint32_t timestamp, inode_t inode) = 0;
-	virtual uint8_t fs_apply_attr(uint32_t timestamp, inode_t inode, uint32_t mode, uint32_t uid,
-	                              uint32_t gid, uint32_t atime, uint32_t mtime) = 0;
-	virtual uint8_t fs_apply_session(uint32_t sessionid) = 0;
-	virtual uint8_t fs_apply_incversion(uint64_t chunkid) = 0;
-	virtual uint8_t fs_apply_length(uint32_t timestamp, inode_t inode, uint64_t length,
-	                                bool eraseFurtherChunks) = 0;
-	virtual uint8_t fs_apply_repair(uint32_t timestamp, inode_t inode, uint32_t indx,
-	                                uint32_t nversion) = 0;
-	virtual uint8_t fs_apply_setxattr(uint32_t timestamp, inode_t inode, uint32_t anleng,
-	                                  const uint8_t *attrname, uint32_t avleng,
-	                                  const uint8_t *attrvalue, uint32_t mode) = 0;
-	virtual uint8_t fs_apply_setacl(uint32_t timestamp, inode_t inode, char aclType,
-	                                const char *aclString) = 0;
-	virtual uint8_t fs_apply_setrichacl(uint32_t timestamp, inode_t inode,
-	                                    const std::string &acl_string) = 0;
-	virtual uint8_t fs_apply_unlink(uint32_t timestamp, inode_t parent, const HString &name,
-	                                inode_t inode) = 0;
-	virtual uint8_t fs_apply_unlock(uint64_t chunkid) = 0;
-	virtual uint8_t fs_apply_trunc(uint32_t timestamp, inode_t inode, uint32_t indx,
-	                               uint64_t chunkid, uint32_t lockid) = 0;
+	virtual uint8_t applyChecksum(const std::string &version, uint64_t checksum) = 0;
+	virtual uint8_t applyCreate(uint32_t timestamp, inode_t parent, const HString &name,
+	                            FSNodeType type, uint32_t mode, uint32_t uid, uint32_t gid,
+	                            uint32_t rdev, inode_t inode) = 0;
+	virtual uint8_t applyAccess(uint32_t timestamp, inode_t inode) = 0;
+	virtual uint8_t applyAttr(uint32_t timestamp, inode_t inode, uint32_t mode, uint32_t uid,
+	                          uint32_t gid, uint32_t atime, uint32_t mtime) = 0;
+	virtual uint8_t applySession(uint32_t sessionid) = 0;
+	virtual uint8_t applyIncreaseChunkVersion(uint64_t chunkid) = 0;
+	virtual uint8_t applyLength(uint32_t timestamp, inode_t inode, uint64_t length,
+	                            bool eraseFurtherChunks) = 0;
+	virtual uint8_t applyRepair(uint32_t timestamp, inode_t inode, uint32_t indx,
+	                            uint32_t nversion) = 0;
+	virtual uint8_t applySetXAttr(uint32_t timestamp, inode_t inode, uint32_t anleng,
+	                              const uint8_t *attrname, uint32_t avleng,
+	                              const uint8_t *attrvalue, uint32_t mode) = 0;
+	virtual uint8_t applySetAcl(uint32_t timestamp, inode_t inode, char aclType,
+	                            const char *aclString) = 0;
+	virtual uint8_t applySetRichAcl(uint32_t timestamp, inode_t inode,
+	                                const std::string &acl_string) = 0;
+	virtual uint8_t applyUnlink(uint32_t timestamp, inode_t parent, const HString &name,
+	                            inode_t inode) = 0;
+	virtual uint8_t applyUnlock(uint64_t chunkid) = 0;
+	virtual uint8_t applyTrunc(uint32_t timestamp, inode_t inode, uint32_t indx, uint64_t chunkid,
+	                           uint32_t lockid) = 0;
 
-	virtual uint8_t fs_apply_setquota(char rigor, char resource, char ownerType, inode_t ownerId,
-	                                  uint64_t limit) = 0;
+	virtual uint8_t applySetQuota(char rigor, char resource, char ownerType, inode_t ownerId,
+	                              uint64_t limit) = 0;
 
 	// CHECKSUM
 
 	/// Returns checksum of the loaded metadata.
-	virtual uint64_t fs_checksum(ChecksumMode mode) = 0;
+	virtual uint64_t metadataChecksum(ChecksumMode mode) = 0;
 
 	// Lock operations
 
@@ -320,9 +316,9 @@ public:
 	/// @return `SAUNAFS_STATUS_OK` on success, `SAUNAFS_ERROR_WAITING` if the request
 	///         cannot be granted immediately, `SAUNAFS_ERROR_EINVAL` for invalid args,
 	///         or other filesystem-specific error codes (permission, quota, etc.).
-	virtual int fs_flock_op(const FsContext &context, inode_t inode, uint64_t owner,
-	                        uint32_t sessionid, uint32_t reqid, uint32_t msgid, uint16_t oper,
-	                        bool nonblocking, std::vector<FileLocks::Owner> &applied) = 0;
+	virtual int flockOperation(const FsContext &context, inode_t inode, uint64_t owner,
+	                           uint32_t sessionid, uint32_t reqid, uint32_t msgid, uint16_t oper,
+	                           bool nonblocking, std::vector<FileLocks::Owner> &applied) = 0;
 
 	/// Perform a POSIX byte-range (fcntl) lock operation on the filesystem.
 	///
@@ -344,10 +340,10 @@ public:
 	/// @return `SAUNAFS_STATUS_OK` on success, `SAUNAFS_ERROR_WAITING` if the request
 	///         cannot be granted immediately, `SAUNAFS_ERROR_EINVAL` for invalid args,
 	///         or other filesystem-specific error codes (permission, quota, etc.).
-	virtual int fs_posixlock_op(const FsContext &context, inode_t inode, uint64_t start,
-	                            uint64_t end, uint64_t owner, uint32_t sessionid, uint32_t reqid,
-	                            uint32_t msgid, uint16_t oper, bool nonblocking,
-	                            std::vector<FileLocks::Owner> &applied) = 0;
+	virtual int posixLockOperation(const FsContext &context, inode_t inode, uint64_t start,
+	                               uint64_t end, uint64_t owner, uint32_t sessionid, uint32_t reqid,
+	                               uint32_t msgid, uint16_t oper, bool nonblocking,
+	                               std::vector<FileLocks::Owner> &applied) = 0;
 
 	/// Perform a POSIX lock probe on filesystem.
 	/// A POSIX probe checks whether a lock request (shared/exclusive) would be blocked
@@ -367,10 +363,9 @@ public:
 	/// @return SAUNAFS_STATUS_OK if no conflicting lock was found (info.l_type set to kUnlock),
 	///         SAUNAFS_ERROR_WAITING if a conflicting lock was found (info filled),
 	///         SAUNAFS_ERROR_EINVAL for invalid parameters.
-	virtual int fs_posixlock_probe(const FsContext &context, inode_t inode, uint64_t start,
-	                               uint64_t end, uint64_t owner, uint32_t sessionid, uint32_t reqid,
-	                               uint32_t msgid, uint16_t oper,
-	                               safs_locks::FlockWrapper &info) = 0;
+	virtual int posixLockProbe(const FsContext &context, inode_t inode, uint64_t start,
+	                           uint64_t end, uint64_t owner, uint32_t sessionid, uint32_t reqid,
+	                           uint32_t msgid, uint16_t oper, safs_locks::FlockWrapper &info) = 0;
 
 	/// Release (unlock + unqueue) all locks from a given session.
 	/// @param context Filesystem context.
@@ -378,9 +373,8 @@ public:
 	/// @param inode inode number on which to clear locks.
 	/// @param sessionid Session id whose locks are to be cleared.
 	/// @param applied Vector to be filled with the owners of the cleared locks.
-	virtual int fs_locks_clear_session(const FsContext &context, uint8_t type, inode_t inode,
-	                                   uint32_t sessionid,
-	                                   std::vector<FileLocks::Owner> &applied) = 0;
+	virtual int locksClearSession(const FsContext &context, uint8_t type, inode_t inode,
+	                              uint32_t sessionid, std::vector<FileLocks::Owner> &applied) = 0;
 
 	/// List locks in the filesystem.
 	/// Fills outLocks with locks matching the type and pending parameters.
@@ -390,9 +384,8 @@ public:
 	/// @param start Start index for listing.
 	/// @param max Maximum number of locks to list.
 	/// @param outLocks Vector to be filled with the listed locks.
-	virtual int fs_locks_list_all(const FsContext &context, uint8_t type, bool pending,
-	                              uint64_t start, uint64_t max,
-	                              std::vector<safs_locks::Info> &outLocks) = 0;
+	virtual int locksListAll(const FsContext &context, uint8_t type, bool pending, uint64_t start,
+	                         uint64_t max, std::vector<safs_locks::Info> &outLocks) = 0;
 
 	/// List locks for a specific inode.
 	/// @param context Filesystem context (could be ignored in some implementations).
@@ -402,17 +395,17 @@ public:
 	/// @param start Start index for listing.
 	/// @param max Maximum number of locks to list.
 	/// @param outLocks Vector to be filled with the listed locks.
-	virtual int fs_locks_list_inode(const FsContext &context, uint8_t type, bool pending,
-	                                inode_t inode, uint64_t start, uint64_t max,
-	                                std::vector<safs_locks::Info> &outLocks) = 0;
+	virtual int locksListInode(const FsContext &context, uint8_t type, bool pending, inode_t inode,
+	                           uint64_t start, uint64_t max,
+	                           std::vector<safs_locks::Info> &outLocks) = 0;
 
 	/// Unlocks the matching locks on the specified inode and tries to apply pending locks.
 	/// @param context Filesystem context.
 	/// @param type Type of locks to unlock (kFlock, kPosix).
 	/// @param inode inode number on which to unlock locks.
 	/// @param applied Vector to be filled with the owners of the unlocked locks.
-	virtual int fs_locks_unlock_inode(const FsContext &context, uint8_t type, inode_t inode,
-	                                  std::vector<FileLocks::Owner> &applied) = 0;
+	virtual int locksUnlockInode(const FsContext &context, uint8_t type, inode_t inode,
+	                             std::vector<FileLocks::Owner> &applied) = 0;
 
 	/// Removes a pending lock matching the provided parameters.
 	/// @param context Filesystem context.
@@ -421,8 +414,8 @@ public:
 	/// @param sessionid Session id of the client that enqueued the lock.
 	/// @param inode Inode number on which the pending lock was queued.
 	/// @param reqid Request id (used to identify interruptible requests).
-	virtual int fs_locks_remove_pending(const FsContext &context, uint8_t type, uint64_t ownerid,
-	                                    uint32_t sessionid, inode_t inode, uint64_t reqid) = 0;
+	virtual int locksRemovePending(const FsContext &context, uint8_t type, uint64_t ownerid,
+	                               uint32_t sessionid, inode_t inode, uint64_t reqid) = 0;
 };
 
 // Global filesystem operations instance.

--- a/src/master/filesystem_operations_interface.h
+++ b/src/master/filesystem_operations_interface.h
@@ -429,4 +429,4 @@ public:
 // This global unique_ptr is initialized once at startup (before any FS calls) and set to a single
 // concrete implementation for the process lifetime. It must not be reassigned and its dynamic type
 // remains stable, so callers may assume one immutable implementation.
-inline std::unique_ptr<IFilesystemOperations> gFilesystemOperations = nullptr;
+inline std::unique_ptr<IFilesystemOperations> gFSOperations = nullptr;

--- a/src/master/filesystem_periodic.cc
+++ b/src/master/filesystem_periodic.cc
@@ -550,7 +550,7 @@ static void fs_do_emptytrash(uint32_t ts) {
 		fsnodes_purge(ts, node);
 
 		// Purge operation should be performed anyway - if it fails, inode will be reserved
-		gFilesystemOperations->fs_changelog(ts, "PURGE(%" PRIiNode ")", node_id);
+		gFSOperations->fs_changelog(ts, "PURGE(%" PRIiNode ")", node_id);
 
 		it = gMetadata->trash.begin();
 
@@ -586,7 +586,7 @@ static void fs_do_emptyreserved(uint32_t ts) {
 		fsnodes_purge(ts, node);
 
 		// Purge operation should be performed anyway
-		gFilesystemOperations->fs_changelog(ts, "PURGE(%" PRIiNode ")", node_id);
+		gFSOperations->fs_changelog(ts, "PURGE(%" PRIiNode ")", node_id);
 
 		it = gMetadata->reserved.begin();
 

--- a/src/master/filesystem_periodic.cc
+++ b/src/master/filesystem_periodic.cc
@@ -550,7 +550,7 @@ static void fs_do_emptytrash(uint32_t ts) {
 		fsnodes_purge(ts, node);
 
 		// Purge operation should be performed anyway - if it fails, inode will be reserved
-		gFSOperations->fs_changelog(ts, "PURGE(%" PRIiNode ")", node_id);
+		gFSOperations->changeLog(ts, "PURGE(%" PRIiNode ")", node_id);
 
 		it = gMetadata->trash.begin();
 
@@ -586,7 +586,7 @@ static void fs_do_emptyreserved(uint32_t ts) {
 		fsnodes_purge(ts, node);
 
 		// Purge operation should be performed anyway
-		gFSOperations->fs_changelog(ts, "PURGE(%" PRIiNode ")", node_id);
+		gFSOperations->changeLog(ts, "PURGE(%" PRIiNode ")", node_id);
 
 		it = gMetadata->reserved.begin();
 

--- a/src/master/filesystem_quota.cc
+++ b/src/master/filesystem_quota.cc
@@ -243,7 +243,7 @@ uint8_t fs_quota_set(const FsContext &context, const std::vector<QuotaEntry> &en
 		                              entry.entryKey.resource, entry.limit);
 		gMetadata->quotaDatabase.removeEmpty(owner.ownerType, owner.ownerId);
 		gMetadata->quotaChecksum = gMetadata->quotaDatabase.checksum();
-		gFilesystemOperations->fs_changelog(
+		gFSOperations->fs_changelog(
 		    ts, "SETQUOTA(%c,%c,%c,%" PRIiNode ",%" PRIu64 ")",
 		    rigor_name[(int)entry.entryKey.rigor], resource_name[(int)entry.entryKey.resource],
 		    owner_name[(int)owner.ownerType], inode_t{owner.ownerId}, uint64_t{entry.limit});

--- a/src/master/filesystem_quota.cc
+++ b/src/master/filesystem_quota.cc
@@ -243,7 +243,7 @@ uint8_t fs_quota_set(const FsContext &context, const std::vector<QuotaEntry> &en
 		                              entry.entryKey.resource, entry.limit);
 		gMetadata->quotaDatabase.removeEmpty(owner.ownerType, owner.ownerId);
 		gMetadata->quotaChecksum = gMetadata->quotaDatabase.checksum();
-		gFSOperations->fs_changelog(
+		gFSOperations->changeLog(
 		    ts, "SETQUOTA(%c,%c,%c,%" PRIiNode ",%" PRIu64 ")",
 		    rigor_name[(int)entry.entryKey.rigor], resource_name[(int)entry.entryKey.resource],
 		    owner_name[(int)owner.ownerType], inode_t{owner.ownerId}, uint64_t{entry.limit});

--- a/src/master/masterconn.cc
+++ b/src/master/masterconn.cc
@@ -335,7 +335,7 @@ void MasterConn::sendRegister() {
 #ifndef METALOGGER
 	// shadow master registration
 	uint64_t metadataVersion = 0;
-	if (state == State::kSynchronized) { metadataVersion = gFSOperations->fs_getversion(); }
+	if (state == State::kSynchronized) { metadataVersion = gFSOperations->getMetadataVersion(); }
 	auto request = mltoma::registerShadow::build(
 	    SAUNAFS_VERSHEX, cfgMasterTimeout * kMillisecondsInSecond, metadataVersion);
 	createPacket(std::move(request));
@@ -433,7 +433,7 @@ void MasterConn::onRegistered(const uint8_t *data, uint32_t length) {
 		masterVersion = incommingMasterVersion;
 		sendMatoClPort();
 		if ((state == State::kSynchronized) &&
-		    (gFSOperations->fs_getversion() != masterMetadataVersion)) {
+		    (gFSOperations->getMetadataVersion() != masterMetadataVersion)) {
 			forceMetadataDownload();
 		}
 	} else {
@@ -612,7 +612,7 @@ void MasterConn::downloadNext() {
 				if (state == State::kDownloading) {
 					try {
 						fs_loadall(false);
-						lastLogVersion = gFSOperations->fs_getversion() - 1;
+						lastLogVersion = gFSOperations->getMetadataVersion() - 1;
 						safs::log_info("synced at version = {}", lastLogVersion);
 						state = State::kSynchronized;
 					} catch (Exception &ex) {

--- a/src/master/masterconn.cc
+++ b/src/master/masterconn.cc
@@ -335,7 +335,7 @@ void MasterConn::sendRegister() {
 #ifndef METALOGGER
 	// shadow master registration
 	uint64_t metadataVersion = 0;
-	if (state == State::kSynchronized) { metadataVersion = gFilesystemOperations->fs_getversion(); }
+	if (state == State::kSynchronized) { metadataVersion = gFSOperations->fs_getversion(); }
 	auto request = mltoma::registerShadow::build(
 	    SAUNAFS_VERSHEX, cfgMasterTimeout * kMillisecondsInSecond, metadataVersion);
 	createPacket(std::move(request));
@@ -433,7 +433,7 @@ void MasterConn::onRegistered(const uint8_t *data, uint32_t length) {
 		masterVersion = incommingMasterVersion;
 		sendMatoClPort();
 		if ((state == State::kSynchronized) &&
-		    (gFilesystemOperations->fs_getversion() != masterMetadataVersion)) {
+		    (gFSOperations->fs_getversion() != masterMetadataVersion)) {
 			forceMetadataDownload();
 		}
 	} else {
@@ -612,7 +612,7 @@ void MasterConn::downloadNext() {
 				if (state == State::kDownloading) {
 					try {
 						fs_loadall(false);
-						lastLogVersion = gFilesystemOperations->fs_getversion() - 1;
+						lastLogVersion = gFSOperations->fs_getversion() - 1;
 						safs::log_info("synced at version = {}", lastLogVersion);
 						state = State::kSynchronized;
 					} catch (Exception &ex) {

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -455,7 +455,7 @@ void matoclserv_chunk_status(uint64_t chunkId, uint8_t status, bool isFailedCrea
 	case FUSE_WRITE:
 		if (status != SAUNAFS_STATUS_OK) {
 			if (isFailedCreateOperation) {
-				gFSOperations->fs_remove_chunk_from_file(context, inode, chunkId);
+				gFSOperations->removeChunkFromFile(context, inode, chunkId);
 			}
 			serializer->serializeFuseWriteChunk(reply, messageId, status);
 			matoclserv_createpacket(eptr, std::move(reply));
@@ -464,7 +464,7 @@ void matoclserv_chunk_status(uint64_t chunkId, uint8_t status, bool isFailedCrea
 					chunkId, messageId, fileLength, lockId);
 		}
 		if (status != SAUNAFS_STATUS_OK) {
-			gFSOperations->fs_writeend(0, 0, chunkId, 0);  // ignore status - just do it.
+			gFSOperations->writeEnd(0, 0, chunkId, 0);  // ignore status - just do it.
 		}
 		return;
 	case FUSE_TRUNCATE_BEGIN:
@@ -477,12 +477,12 @@ void matoclserv_chunk_status(uint64_t chunkId, uint8_t status, bool isFailedCrea
 		return;
 	case FUSE_TRUNCATE:
 	case FUSE_TRUNCATE_END:
-		gFSOperations->fs_end_setlength(chunkId);
+		gFSOperations->endSetLength(chunkId);
 		if (status != SAUNAFS_STATUS_OK) {
 			serializer->serializeFuseTruncate(reply, operationType, messageId, status);
 		} else {
 			Attributes attr;
-			gFSOperations->fs_do_setlength(context, inode, fileLength, attr);
+			gFSOperations->doSetLength(context, inode, fileLength, attr);
 			serializer->serializeFuseTruncate(reply, operationType, messageId, attr);
 		}
 		matoclserv_createpacket(eptr, std::move(reply));
@@ -612,7 +612,7 @@ void matoclserv_metadataserver_status(matoclserventry* eptr, const uint8_t* data
 
 	uint64_t metadataVersion = 0;
 	try {
-		metadataVersion = gFSOperations->fs_getversion();
+		metadataVersion = gFSOperations->getMetadataVersion();
 	} catch (NoMetadataException &) {}
 
 	uint8_t status =
@@ -633,7 +633,7 @@ void matoclserv_metadataserver_status(matoclserventry* eptr, const uint8_t* data
 /// response packet.
 void matoclserv_list_goals(matoclserventry* eptr) {
 	std::vector<SerializedGoal> serializedGoals;
-	const std::map<int, Goal> &goalsMap = gFSOperations->fs_get_goal_definitions();
+	const std::map<int, Goal> &goalsMap = gFSOperations->getAllGoalDefinitions();
 
 	for (const auto& goal : goalsMap) {
 		serializedGoals.emplace_back(goal.first, goal.second.getName(), to_string(goal.second));
@@ -715,7 +715,7 @@ void matoclserv_session_list(matoclserventry *eptr, const uint8_t *data, uint32_
 				size += 1;  // for '.'
 			} else {
 				size += sizeof(pathLength);
-				size += gFSOperations->fs_getdirpath_size(eaptr->sessionData->rootInode);
+				size += gFSOperations->getDirPathSize(eaptr->sessionData->rootInode);
 			}
 		}
 	}
@@ -744,11 +744,10 @@ void matoclserv_session_list(matoclserventry *eptr, const uint8_t *data, uint32_
 				putINode(&ptr, static_cast<inode_t>(1));
 				put8bit(&ptr, '.');
 			} else {
-				pathLength = gFSOperations->fs_getdirpath_size(eaptr->sessionData->rootInode);
+				pathLength = gFSOperations->getDirPathSize(eaptr->sessionData->rootInode);
 				put32bit(&ptr, pathLength);
 				if (pathLength > 0) {
-					gFSOperations->fs_getdirpath_data(eaptr->sessionData->rootInode, ptr,
-					                                  pathLength);
+					gFSOperations->getDirPathData(eaptr->sessionData->rootInode, ptr, pathLength);
 					ptr += pathLength;
 				}
 			}
@@ -886,11 +885,11 @@ void matoclserv_info(matoclserventry *eptr, const uint8_t *data, uint32_t length
 	statistics.version = saunafsVersion(SAUNAFS_PACKAGE_VERSION_MAJOR,
 			SAUNAFS_PACKAGE_VERSION_MINOR, SAUNAFS_PACKAGE_VERSION_MICRO);
 
-	gFSOperations->fs_info(&statistics.totalSpace, &statistics.availableSpace,
-	                       &statistics.trashSpace, &statistics.trashNodes,
-	                       &statistics.reservedSpace, &statistics.reservedNodes,
-	                       &statistics.allNodes, &statistics.dirNodes, &statistics.fileNodes,
-	                       &statistics.symlinkNodes);
+	gFSOperations->getFSStats(&statistics.totalSpace, &statistics.availableSpace,
+	                          &statistics.trashSpace, &statistics.trashNodes,
+	                          &statistics.reservedSpace, &statistics.reservedNodes,
+	                          &statistics.allNodes, &statistics.dirNodes, &statistics.fileNodes,
+	                          &statistics.symlinkNodes);
 
 	chunk_info(&statistics.chunks, &statistics.chunkCopies, &statistics.regularCopies);
 
@@ -1211,7 +1210,7 @@ void matoclserv_fuse_register(matoclserventry *eptr, const uint8_t *data, uint32
 			}
 
 			if (status == SAUNAFS_STATUS_OK) {
-				status = gFSOperations->fs_getrootinode(&rootInode, path);
+				status = gFSOperations->getRootInode(&rootInode, path);
 			}
 
 			if (status == SAUNAFS_STATUS_OK) {
@@ -1493,7 +1492,7 @@ void matoclserv_fuse_reserved_inodes(matoclserventry *eptr, const uint8_t *data,
 		inode_t openFileIno = *it;
 		if (!inodes_to_reserve.contains(openFileIno)) {
 			// erase files not belonging to the reserve inodes list provided
-			gFSOperations->fs_release(context, openFileIno, eptr->sessionData->sessionId);
+			gFSOperations->release(context, openFileIno, eptr->sessionData->sessionId);
 			it = eptr->sessionData->openFilesSet.erase(it);
 		} else {
 			// skip files already in session
@@ -1504,7 +1503,7 @@ void matoclserv_fuse_reserved_inodes(matoclserventry *eptr, const uint8_t *data,
 	}
 
 	for (const auto &inode_to_reserve : inodes_to_reserve) {
-		if (gFSOperations->fs_acquire(context, inode_to_reserve, eptr->sessionData->sessionId) ==
+		if (gFSOperations->acquire(context, inode_to_reserve, eptr->sessionData->sessionId) ==
 		    SAUNAFS_STATUS_OK) {
 			// Insert reserved inodes into the opened files set
 			eptr->sessionData->openFilesSet.insert(inode_to_reserve);
@@ -1530,8 +1529,7 @@ void matoclserv_fuse_statfs(matoclserventry *eptr, const uint8_t *data, uint32_t
 
 	get32bit(&data, msgid);
 	FsContext context = matoclserv_get_context(eptr);
-	gFSOperations->fs_statfs(context, &totalspace, &availspace, &trashspace, &reservedspace,
-	                         &inodes);
+	gFSOperations->statfs(context, &totalspace, &availspace, &trashspace, &reservedspace, &inodes);
 
 	constexpr uint32_t kPacketSize = sizeof(msgid) + sizeof(totalspace) + sizeof(availspace) +
 	                                 sizeof(trashspace) + sizeof(reservedspace) + sizeof(inodes);
@@ -1573,7 +1571,7 @@ void matoclserv_fuse_access(matoclserventry *eptr, const uint8_t *data, uint32_t
 	if (status == SAUNAFS_STATUS_OK && inode != SPECIAL_INODE_PATH_BY_INODE &&
 	    inode != SPECIAL_INODE_FILE_BY_INODE) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = gFSOperations->fs_access(context, inode, modemask);
+		status = gFSOperations->access(context, inode, modemask);
 	}
 
 	constexpr uint8_t kAnswerSize = sizeof(msgid) + sizeof(status);
@@ -1596,7 +1594,7 @@ void matoclserv_sau_whole_path_lookup(matoclserventry *eptr, const uint8_t *data
 	status = matoclserv_check_group_cache(eptr, gid);
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = gFSOperations->fs_whole_path_lookup(context, inode, path, &found_inode, attr);
+		status = gFSOperations->wholePathLookup(context, inode, path, &found_inode, attr);
 	}
 
 	if (status != SAUNAFS_STATUS_OK) {
@@ -1619,7 +1617,7 @@ void matoclserv_sau_full_path_by_inode(matoclserventry *eptr, const uint8_t *dat
 	status = matoclserv_check_group_cache(eptr, gid);
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = gFSOperations->fs_full_path_by_inode(context, inode, fullPath);
+		status = gFSOperations->fullPathByInode(context, inode, fullPath);
 	}
 
 	if (status != SAUNAFS_STATUS_OK) {
@@ -1664,7 +1662,7 @@ void matoclserv_sau_get_self_quota(matoclserventry *eptr, const uint8_t *data, u
 		owners.emplace_back(QuotaOwnerType::kUser, uid);
 		owners.emplace_back(QuotaOwnerType::kGroup, gid);
 		owners.emplace_back(QuotaOwnerType::kInode, inode);
-		status = gFSOperations->fs_quota_get(context, owners, results);
+		status = gFSOperations->quotaGet(context, owners, results);
 
 		if (inode == context.rootinode() && !foundContextRootInodeResult(inode)) {
 			auto ino = fsnodes_id_to_node(inode);
@@ -1678,7 +1676,7 @@ void matoclserv_sau_get_self_quota(matoclserventry *eptr, const uint8_t *data, u
 
 	MessageBuffer reply;
 	if (status == SAUNAFS_STATUS_OK) {
-		status = gFSOperations->fs_quota_get_info(matoclserv_get_context(eptr), results, info);
+		status = gFSOperations->quotaGetInfo(matoclserv_get_context(eptr), results, info);
 	}
 	if (status == SAUNAFS_STATUS_OK) {
 		matocl::fuseGetSelfQuota::serialize(reply, messageId, results);
@@ -1710,7 +1708,7 @@ void matoclserv_fuse_getattr(matoclserventry *eptr, const uint8_t *data, uint32_
 	status = matoclserv_check_group_cache(eptr, gid);
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = gFSOperations->fs_getattr(context, inode, attr);
+		status = gFSOperations->getAttr(context, inode, attr);
 	}
 
 	constexpr uint32_t kFailedAnswerSize = sizeof(msgid) + sizeof(status);
@@ -1776,8 +1774,8 @@ void matoclserv_fuse_setattr(matoclserventry *eptr, const uint8_t *data, uint32_
 
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = gFSOperations->fs_setattr(context, inode, setmask, attrmode, attruid, attrgid,
-		                                   attratime, attrmtime, sugidclearmode, attr);
+		status = gFSOperations->setAttr(context, inode, setmask, attrmode, attruid, attrgid,
+		                                attratime, attrmtime, sugidclearmode, attr);
 	}
 
 	constexpr uint32_t kFailedAnswerSize = sizeof(msgid) + sizeof(status);
@@ -1826,12 +1824,11 @@ void matoclserv_fuse_truncate(matoclserventry *eptr, PacketHeader header, const 
 				status = SAUNAFS_ERROR_WRONGLOCKID;
 			} else {
 				// let's check if chunk is still locked by us
-				status =
-				    gFSOperations->fs_get_chunkid(context, inode, length / SFSCHUNKSIZE, &chunkId);
+				status = gFSOperations->getChunkId(context, inode, length / SFSCHUNKSIZE, &chunkId);
 				if (status == SAUNAFS_STATUS_OK) {
 					status = chunk_can_unlock(chunkId, lockId);
 				}
-				gFSOperations->fs_end_setlength(chunkId);
+				gFSOperations->endSetLength(chunkId);
 			}
 		}
 	} else {
@@ -1846,8 +1843,8 @@ void matoclserv_fuse_truncate(matoclserventry *eptr, PacketHeader header, const 
 	// Try to do the truncate
 	Attributes attr;
 	if (status == SAUNAFS_STATUS_OK) {
-		status = gFSOperations->fs_try_setlength(
-		    context, inode, opened, length, (type != FUSE_TRUNCATE_END), lockId, attr, &chunkId);
+		status = gFSOperations->trySetLength(context, inode, opened, length,
+		                                     (type != FUSE_TRUNCATE_END), lockId, attr, &chunkId);
 	}
 
 	// In case of SAUNAFS_ERROR_NOTPOSSIBLE we have to tell the client to write the chunk before truncating
@@ -1855,8 +1852,8 @@ void matoclserv_fuse_truncate(matoclserventry *eptr, PacketHeader header, const 
 		// New client requested to truncate xor chunk. He has to do it himself.
 		uint64_t fileLength;
 		uint8_t opflag;
-		gFSOperations->fs_writechunk(context, inode, length / SFSCHUNKSIZE, false, &lockId,
-		                             &chunkId, &opflag, &fileLength);
+		gFSOperations->writeChunk(context, inode, length / SFSCHUNKSIZE, false, &lockId, &chunkId,
+		                          &opflag, &fileLength);
 		if (opflag) {
 			// But first we have to duplicate chunk :)
 			type = FUSE_TRUNCATE_BEGIN;
@@ -1896,7 +1893,7 @@ void matoclserv_fuse_truncate(matoclserventry *eptr, PacketHeader header, const 
 		return;
 	}
 	if (status == SAUNAFS_STATUS_OK) {
-		status = gFSOperations->fs_do_setlength(context, inode, length, attr);
+		status = gFSOperations->doSetLength(context, inode, length, attr);
 	}
 	if (status == SAUNAFS_STATUS_OK) {
 		dcm_modify(inode, eptr->sessionData->sessionId);
@@ -1936,7 +1933,7 @@ void matoclserv_fuse_readlink(matoclserventry *eptr, const uint8_t *data, uint32
 	getINode(&data, inode);
 
 	FsContext context = matoclserv_get_context(eptr);
-	status = gFSOperations->fs_readlink(context, inode, path);
+	status = gFSOperations->readlink(context, inode, path);
 
 	constexpr uint32_t kFailedAnswerSize = sizeof(msgid) + sizeof(status);
 	constexpr uint32_t kSuccessAnswerSize = sizeof(msgid) + sizeof(uint32_t);
@@ -2019,8 +2016,8 @@ void matoclserv_fuse_symlink(matoclserventry *eptr, const uint8_t *data, uint32_
 	status = matoclserv_check_group_cache(eptr, gid);
 	if (status == SAUNAFS_STATUS_OK) {
 		auto context = matoclserv_get_context(eptr, uid, gid);
-		status = gFSOperations->fs_symlink(context, inode, HString((char *)name, nleng),
-		                                   std::string((char *)path, pleng), &newinode, &attr);
+		status = gFSOperations->symlink(context, inode, HString((char *)name, nleng),
+		                                std::string((char *)path, pleng), &newinode, &attr);
 	}
 
 	constexpr uint32_t kFailedAnswerSize = sizeof(msgid) + sizeof(status);
@@ -2064,9 +2061,9 @@ void matoclserv_fuse_mknod(matoclserventry *eptr, PacketHeader header, const uin
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
 
-		status = gFSOperations->fs_mknod(context, inode, HString(std::move(name)),
-		                                 static_cast<FSNodeType>(type), mode, umask, rdev,
-		                                 &newinode, attr);
+		status =
+		    gFSOperations->mknod(context, inode, HString(std::move(name)),
+		                         static_cast<FSNodeType>(type), mode, umask, rdev, &newinode, attr);
 	}
 
 	MessageBuffer reply;
@@ -2102,8 +2099,8 @@ void matoclserv_fuse_mkdir(matoclserventry *eptr, PacketHeader header, const uin
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
 
-		status = gFSOperations->fs_mkdir(context, inode, HString(std::move(name)), mode, umask,
-		                                 copysgid, &newinode, attr);
+		status = gFSOperations->mkdir(context, inode, HString(std::move(name)), mode, umask,
+		                              copysgid, &newinode, attr);
 	}
 
 	MessageBuffer reply;
@@ -2157,7 +2154,7 @@ void matoclserv_fuse_unlink(matoclserventry *eptr, const uint8_t *data, uint32_t
 
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = gFSOperations->fs_unlink(context, inode, HString((char *)name, nleng));
+		status = gFSOperations->unlink(context, inode, HString((char *)name, nleng));
 	}
 
 	ptr = matoclserv_createpacket(eptr, MATOCL_FUSE_UNLINK, sizeof(msgid) + sizeof(status));
@@ -2190,7 +2187,7 @@ void matoclserv_fuse_recursive_remove(matoclserventry *eptr, const uint8_t *data
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
 
-		status = gFSOperations->fs_recursive_remove(
+		status = gFSOperations->recursiveRemove(
 		    context, parent_inode, HString(name),
 		    std::bind(matoclserv_fuse_recursive_remove_wake_up, eptr->sessionData->sessionId, msgid,
 		              std::placeholders::_1),
@@ -2240,7 +2237,7 @@ void matoclserv_fuse_rmdir(matoclserventry *eptr, const uint8_t *data, uint32_t 
 
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = gFSOperations->fs_rmdir(context, inode, HString((char *)name, nleng));
+		status = gFSOperations->rmdir(context, inode, HString((char *)name, nleng));
 	}
 
 	ptr = matoclserv_createpacket(eptr, MATOCL_FUSE_RMDIR, sizeof(msgid) + sizeof(status));
@@ -2310,9 +2307,9 @@ void matoclserv_fuse_rename(matoclserventry *eptr, const uint8_t *data, uint32_t
 
 	if (status == SAUNAFS_STATUS_OK) {
 		auto context = matoclserv_get_context(eptr, uid, gid);
-		status = gFSOperations->fs_rename(context, inode_src, HString((char *)name_src, nleng_src),
-		                                  inode_dst, HString((char *)name_dst, nleng_dst), &inode,
-		                                  &attr);
+		status =
+		    gFSOperations->rename(context, inode_src, HString((char *)name_src, nleng_src),
+		                          inode_dst, HString((char *)name_dst, nleng_dst), &inode, &attr);
 	}
 
 	if (status == SAUNAFS_STATUS_OK) {
@@ -2380,8 +2377,8 @@ void matoclserv_fuse_link(matoclserventry *eptr, const uint8_t *data, uint32_t l
 
 	if (status == SAUNAFS_STATUS_OK) {
 		auto context = matoclserv_get_context(eptr, uid, gid);
-		status = gFSOperations->fs_link(context, inode, inode_dst,
-		                                HString((char *)name_dst, nleng_dst), &newinode, &attr);
+		status = gFSOperations->link(context, inode, inode_dst,
+		                             HString((char *)name_dst, nleng_dst), &newinode, &attr);
 	}
 
 	constexpr uint32_t kFailedAnswerSize = sizeof(msgid) + sizeof(status);
@@ -2428,8 +2425,8 @@ void matoclserv_fuse_getdir(matoclserventry *eptr,const PacketHeader &header, co
 
 		if (packet_version == cltoma::fuseGetDir::kClientAbleToProcessDirentIndex) {
 			std::vector<DirectoryEntry> dir_entries;
-			status = gFSOperations->fs_readdir(context, inode, first_entry, number_of_entries,
-			                                   dir_entries);  //<DirectoryEntry>
+			status = gFSOperations->readdir(context, inode, first_entry, number_of_entries,
+			                                dir_entries);  //<DirectoryEntry>
 
 			if (status != SAUNAFS_STATUS_OK) {
 				matocl::fuseGetDir::serialize(buffer, message_id, status);
@@ -2490,7 +2487,7 @@ void matoclserv_fuse_getdir(matoclserventry *eptr, const uint8_t *data, uint32_t
 	}
 
 	FsContext context = matoclserv_get_context(eptr, uid, gid);
-	status = gFSOperations->fs_readdir_size(context, inode, flags, &custom, &dleng);
+	status = gFSOperations->readdirSize(context, inode, flags, &custom, &dleng);
 
 	constexpr uint32_t kFailedAnswerSize = sizeof(msgid) + sizeof(status);
 	const uint32_t kSuccessAnswerSize = sizeof(msgid) + dleng;  // Can't be constexpr
@@ -2503,7 +2500,7 @@ void matoclserv_fuse_getdir(matoclserventry *eptr, const uint8_t *data, uint32_t
 	if (status != SAUNAFS_STATUS_OK) {
 		put8bit(&ptr, status);
 	} else {
-		gFSOperations->fs_readdir_data(context, flags, custom, ptr);
+		gFSOperations->readdirData(context, flags, custom, ptr);
 	}
 
 	eptr->sessionData->currHourOperationsStats[12]++;
@@ -2541,7 +2538,7 @@ void matoclserv_fuse_open(matoclserventry *eptr, const uint8_t *data, uint32_t l
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
 		status = matoclserv_insert_open_file(eptr->sessionData, inode);
 		if (status == SAUNAFS_STATUS_OK) {
-			status = gFSOperations->fs_opencheck(context, inode, flags, attr);
+			status = gFSOperations->openCheck(context, inode, flags, attr);
 		}
 	}
 
@@ -2583,7 +2580,7 @@ void matoclserv_fuse_read_chunk(matoclserventry *eptr, PacketHeader header, cons
 	std::vector<uint8_t> receivedData(data, data + header.length);
 	serializer->deserializeFuseReadChunk(receivedData, messageId, inode, index);
 
-	status = gFSOperations->fs_readchunk(inode, index, &chunkid, &fleng);
+	status = gFSOperations->readChunk(inode, index, &chunkid, &fleng);
 	std::vector<ChunkTypeWithAddress> allChunkCopies;
 	if (status == SAUNAFS_STATUS_OK) {
 		if (chunkid > 0) {
@@ -2632,8 +2629,8 @@ void matoclserv_chunks_info(matoclserventry *eptr, const uint8_t *data, uint32_t
 	status = matoclserv_check_group_cache(eptr, gid);
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = gFSOperations->fs_getchunksinfo(context, eptr->peerIpAddress, inode, chunk_index,
-		                                         chunk_count, chunks);
+		status = gFSOperations->getChunksInfo(context, eptr->peerIpAddress, inode, chunk_index,
+		                                      chunk_count, chunks);
 	}
 
 	if (status != SAUNAFS_STATUS_OK) {
@@ -2665,9 +2662,9 @@ void matoclserv_fuse_write_chunk(matoclserventry *eptr, PacketHeader header, con
 
 	// Original Legacy (1.6.27) does not use lock ID's
 	bool useDummyLockId = false;
-	status = gFSOperations->fs_writechunk(matoclserv_get_context(eptr), inode, chunkIndex,
-	                                      useDummyLockId, &lockId, &chunkId, &opflag, &fileLength,
-	                                      min_server_version);
+	status =
+	    gFSOperations->writeChunk(matoclserv_get_context(eptr), inode, chunkIndex, useDummyLockId,
+	                              &lockId, &chunkId, &opflag, &fileLength, min_server_version);
 
 	if (status != SAUNAFS_STATUS_OK) {
 		serializer->serializeFuseWriteChunk(outMessage, messageId, status);
@@ -2692,7 +2689,7 @@ void matoclserv_fuse_write_chunk(matoclserventry *eptr, PacketHeader header, con
 		status = matoclserv_fuse_write_chunk_respond(eptr, serializer,
 				chunkId, messageId, fileLength, lockId);
 		if (status != SAUNAFS_STATUS_OK) {
-			gFSOperations->fs_writeend(0, 0, chunkId, 0);  // ignore status - just do it.
+			gFSOperations->writeEnd(0, 0, chunkId, 0);  // ignore status - just do it.
 		}
 	}
 
@@ -2723,7 +2720,7 @@ void matoclserv_fuse_write_chunk_end(matoclserventry *eptr, PacketHeader header,
 	} else if (eptr->sessionData->flags & SESFLAG_READONLY) {
 		status = SAUNAFS_ERROR_EROFS;
 	} else {
-		status = gFSOperations->fs_writeend(inode, fileLength, chunkId, lockId);
+		status = gFSOperations->writeEnd(inode, fileLength, chunkId, lockId);
 	}
 
 	dcm_modify(inode,eptr->sessionData->sessionId);
@@ -2762,8 +2759,8 @@ void matoclserv_fuse_repair(matoclserventry *eptr, const uint8_t *data, uint32_t
 
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = gFSOperations->fs_repair(context, inode, correct_only, &chunksnotchanged,
-		                                  &chunkserased, &chunksrepaired);
+		status = gFSOperations->repair(context, inode, correct_only, &chunksnotchanged,
+		                               &chunkserased, &chunksrepaired);
 	}
 
 	constexpr uint32_t kFailedSize = sizeof(msgid) + sizeof(status);
@@ -2803,7 +2800,7 @@ void matoclserv_fuse_check(matoclserventry *eptr, const uint8_t *data, uint32_t 
 	get32bit(&data, msgid);
 	getINode(&data, inode);
 
-	status = gFSOperations->fs_checkfile(matoclserv_get_context(eptr), inode, chunkcount);
+	status = gFSOperations->checkFile(matoclserv_get_context(eptr), inode, chunkcount);
 
 	if (status != SAUNAFS_STATUS_OK) {
 		ptr = matoclserv_createpacket(eptr,MATOCL_FUSE_CHECK, sizeof(msgid) + sizeof(status));
@@ -2820,7 +2817,7 @@ void matoclserv_fuse_check(matoclserventry *eptr, const uint8_t *data, uint32_t 
 void matoclserv_fuse_request_task_id(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	uint32_t msgid, taskid;
 	cltoma::requestTaskId::deserialize(data, length, msgid);
-	taskid = gFSOperations->fs_reserve_job_id();
+	taskid = gFSOperations->reserveJobId();
 	MessageBuffer reply;
 	matocl::requestTaskId::serialize(reply, msgid, taskid);
 	matoclserv_createpacket(eptr, reply);
@@ -2849,8 +2846,8 @@ void matoclserv_fuse_gettrashtime(matoclserventry *eptr,const uint8_t *data,uint
 	getINode(&data, inode);
 	gmode = get8bit(&data);
 
-	status = gFSOperations->fs_gettrashtime_prepare(matoclserv_get_context(eptr), inode, gmode,
-	                                                fileTrashtimes, dirTrashtimes);
+	status = gFSOperations->getTrashTimePrepare(matoclserv_get_context(eptr), inode, gmode,
+	                                            fileTrashtimes, dirTrashtimes);
 	fileTrashtimesSize = fileTrashtimes.size();
 	dirTrashtimesSize = dirTrashtimes.size();
 
@@ -2871,7 +2868,7 @@ void matoclserv_fuse_gettrashtime(matoclserventry *eptr,const uint8_t *data,uint
 	} else {
 		put32bit(&ptr, fileTrashtimesSize);
 		put32bit(&ptr, dirTrashtimesSize);
-		gFSOperations->fs_gettrashtime_store(fileTrashtimes, dirTrashtimes, ptr);
+		gFSOperations->getTrashTimeStore(fileTrashtimes, dirTrashtimes, ptr);
 	}
 }
 
@@ -2929,7 +2926,7 @@ void matoclserv_fuse_settrashtime(matoclserventry *eptr, PacketHeader header, co
 	auto settrashtime_stats = std::make_shared<SetTrashtimeTask::StatsArray>();
 
 	if (status == SAUNAFS_STATUS_OK) {
-		status = gFSOperations->fs_settrashtime(
+		status = gFSOperations->setTrashTime(
 		    matoclserv_get_context(eptr, uid, 0), inode, trashtime, smode, settrashtime_stats,
 		    std::bind(matoclserv_fuse_settrashtime_wake_up, eptr->sessionData->sessionId, msgid,
 		              settrashtime_stats, std::placeholders::_1));
@@ -2955,11 +2952,11 @@ void matoclserv_fuse_getgoal(matoclserventry *eptr, PacketHeader header, const u
 
 	GoalStatistics fgtab{{0}}, dgtab{{0}}; // explicit value initialization to clear variables
 	uint8_t status =
-	    gFSOperations->fs_getgoal(matoclserv_get_context(eptr), inode, gmode, fgtab, dgtab);
+	    gFSOperations->getGoal(matoclserv_get_context(eptr), inode, gmode, fgtab, dgtab);
 
 	MessageBuffer reply;
 	if (status == SAUNAFS_STATUS_OK) {
-		const std::map<int, Goal> &goalDefinitions = gFSOperations->fs_get_goal_definitions();
+		const std::map<int, Goal> &goalDefinitions = gFSOperations->getAllGoalDefinitions();
 		std::vector<FuseGetGoalStats> sauReply;
 		for (const auto &goal : goalDefinitions) {
 			if (fgtab[goal.first] || dgtab[goal.first]) {
@@ -3008,7 +3005,7 @@ void matoclserv_fuse_setgoal(matoclserventry *eptr, PacketHeader header, const u
 		cltoma::fuseSetGoal::deserialize(data, header.length,
 				msgid, inode, uid, goalName, smode);
 		// find a proper goalId,
-		const std::map<int, Goal> &goalDefinitions = gFSOperations->fs_get_goal_definitions();
+		const std::map<int, Goal> &goalDefinitions = gFSOperations->getAllGoalDefinitions();
 		bool goalFound = false;
 		for (const auto &goal : goalDefinitions) {
 			if (goal.second.getName() == goalName) {
@@ -3043,7 +3040,7 @@ void matoclserv_fuse_setgoal(matoclserventry *eptr, PacketHeader header, const u
 
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, 0);
-		status = gFSOperations->fs_setgoal(
+		status = gFSOperations->setGoal(
 		    context, inode, goalId, smode, setgoal_stats,
 		    std::bind(matoclserv_fuse_setgoal_wake_up, eptr->sessionData->sessionId, msgid,
 		              header.type, setgoal_stats, std::placeholders::_1));
@@ -3079,8 +3076,8 @@ void matoclserv_fuse_geteattr(matoclserventry *eptr, const uint8_t *data, uint32
 	getINode(&data, inode);
 	gmode = get8bit(&data);
 
-	status = gFSOperations->fs_geteattr(matoclserv_get_context(eptr), inode, gmode, feattrtab,
-	                                    deattrtab);
+	status =
+	    gFSOperations->getEAttr(matoclserv_get_context(eptr), inode, gmode, feattrtab, deattrtab);
 	fn = 0;
 	dn = 0;
 
@@ -3146,8 +3143,8 @@ void matoclserv_fuse_seteattr(matoclserventry *eptr, const uint8_t *data, uint32
 	eattr = get8bit(&data);
 	smode = get8bit(&data);
 
-	status = gFSOperations->fs_seteattr(matoclserv_get_context(eptr, uid, 0), inode, eattr, smode,
-	                                    &changed, &notchanged, &notpermitted);
+	status = gFSOperations->setEAttr(matoclserv_get_context(eptr, uid, 0), inode, eattr, smode,
+	                                 &changed, &notchanged, &notpermitted);
 
 	constexpr uint32_t kFailedSize = sizeof(msgid) + sizeof(status);
 	constexpr uint32_t kSuccessSize =
@@ -3228,7 +3225,7 @@ void matoclserv_fuse_getxattr(matoclserventry *eptr, const uint8_t *data, uint32
 	} else if (anleng == 0) {
 		void *xanode;
 		uint32_t xasize;
-		status = gFSOperations->fs_listxattr_leng(context, inode, opened, &xanode, &xasize);
+		status = gFSOperations->listXAttrLeng(context, inode, opened, &xanode, &xasize);
 		const uint32_t kSuccessSize =
 		    sizeof(msgid) + sizeof(xasize) + ((mode == XATTR_GMODE_GET_DATA) ? xasize : 0);
 		ptr = matoclserv_createpacket(eptr, MATOCL_FUSE_GETXATTR,
@@ -3241,14 +3238,14 @@ void matoclserv_fuse_getxattr(matoclserventry *eptr, const uint8_t *data, uint32
 		} else {
 			put32bit(&ptr, xasize);
 			if (mode == XATTR_GMODE_GET_DATA && xasize > 0) {
-				gFSOperations->fs_listxattr_data(xanode, ptr);
+				gFSOperations->listXAttrData(xanode, ptr);
 			}
 		}
 	} else {
 		uint8_t *attrvalue;
 		uint32_t avleng;
-		status = gFSOperations->fs_getxattr(context, inode, opened, anleng, attrname, &avleng,
-		                                    &attrvalue);
+		status =
+		    gFSOperations->getXAttr(context, inode, opened, anleng, attrname, &avleng, &attrvalue);
 		const uint32_t kSuccessSize =
 		    sizeof(msgid) + sizeof(avleng) + ((mode == XATTR_GMODE_GET_DATA) ? avleng : 0);
 		ptr = matoclserv_createpacket(eptr, MATOCL_FUSE_GETXATTR,
@@ -3325,8 +3322,8 @@ void matoclserv_fuse_setxattr(matoclserventry *eptr, const uint8_t *data, uint32
 
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = gFSOperations->fs_setxattr(context, inode, opened, anleng, attrname, avleng,
-		                                    attrvalue, mode);
+		status = gFSOperations->setXAttr(context, inode, opened, anleng, attrname, avleng,
+		                                 attrvalue, mode);
 	}
 
 	ptr = matoclserv_createpacket(eptr, MATOCL_FUSE_SETXATTR, sizeof(msgid) + sizeof(status));
@@ -3363,7 +3360,7 @@ void matoclserv_fuse_append(matoclserventry *eptr, const uint8_t *data, uint32_t
 
 	if (status == SAUNAFS_STATUS_OK) {
 		auto context = matoclserv_get_context(eptr, uid, gid);
-		status = gFSOperations->fs_append(context, inode, inode_src);
+		status = gFSOperations->append(context, inode, inode_src);
 	}
 
 	ptr = matoclserv_createpacket(eptr, MATOCL_FUSE_APPEND, sizeof(msgid) + sizeof(status));
@@ -3438,8 +3435,8 @@ void matoclserv_fuse_getdirstats_old(matoclserventry *eptr, const uint8_t *data,
 	get32bit(&data, msgid);
 	getINode(&data, inode);
 
-	status = gFSOperations->fs_get_dir_stats(matoclserv_get_context(eptr), inode, &inodes, &dirs,
-	                                         &files, &links, &chunks, &leng, &size, &rsize);
+	status = gFSOperations->getDirStats(matoclserv_get_context(eptr), inode, &inodes, &dirs, &files,
+	                                    &links, &chunks, &leng, &size, &rsize);
 
 	constexpr uint8_t kDirStatsLegacyFullPayload =
 	    sizeof(msgid) + sizeof(inodes) + sizeof(dirs) + sizeof(files) + sizeof(links) +
@@ -3491,8 +3488,8 @@ void matoclserv_fuse_getdirstats(matoclserventry *eptr, const uint8_t *data, uin
 	get32bit(&data, msgid);
 	getINode(&data, inode);
 
-	status = gFSOperations->fs_get_dir_stats(matoclserv_get_context(eptr), inode, &inodes, &dirs,
-	                                         &files, &links, &chunks, &leng, &size, &rsize);
+	status = gFSOperations->getDirStats(matoclserv_get_context(eptr), inode, &inodes, &dirs, &files,
+	                                    &links, &chunks, &leng, &size, &rsize);
 
 	constexpr uint8_t kFailedSize = sizeof(msgid) + sizeof(status);
 	constexpr uint8_t kSuccessSize = sizeof(msgid) + sizeof(inodes) + sizeof(dirs) + sizeof(files) +
@@ -3533,8 +3530,8 @@ void matoclserv_fuse_gettrash(matoclserventry *eptr, const uint8_t *data, uint32
 
 	get32bit(&data, msgid);
 
-	status = gFSOperations->fs_readtrash_size(eptr->sessionData->rootInode,
-	                                          eptr->sessionData->flags, &dleng);
+	status = gFSOperations->readTrashSize(eptr->sessionData->rootInode, eptr->sessionData->flags,
+	                                      &dleng);
 
 	ptr = matoclserv_createpacket(
 	    eptr, MATOCL_FUSE_GETTRASH,
@@ -3545,8 +3542,7 @@ void matoclserv_fuse_gettrash(matoclserventry *eptr, const uint8_t *data, uint32
 	if (status != SAUNAFS_STATUS_OK) {
 		put8bit(&ptr, status);
 	} else {
-		gFSOperations->fs_readtrash_data(eptr->sessionData->rootInode, eptr->sessionData->flags,
-		                                 ptr);
+		gFSOperations->readTrashData(eptr->sessionData->rootInode, eptr->sessionData->flags, ptr);
 	}
 }
 
@@ -3560,7 +3556,7 @@ void matoclserv_fuse_gettrash(matoclserventry *eptr, const PacketHeader &header,
 		uint32_t off;
 		cltoma::fuseGetTrash::deserialize(data, header.length, msgId, off, maxEntries);
 		std::vector<NamedInodeEntry> entries;
-		gFSOperations->fs_readtrash(
+		gFSOperations->readTrash(
 		    off, std::min<uint32_t>(maxEntries, matocl::fuseGetDir::kMaxNumberOfDirectoryEntries),
 		    entries);
 		matoclserv_createpacket(eptr, matocl::fuseGetTrash::build(msgId, entries));
@@ -3568,7 +3564,7 @@ void matoclserv_fuse_gettrash(matoclserventry *eptr, const PacketHeader &header,
 		uint64_t off;
 		cltoma::fuseGetTrash::deserialize(data, header.length, msgId, off, maxEntries);
 		std::vector<HandleInodeEntry> entries;
-		gFSOperations->fs_readtrash(
+		gFSOperations->readTrash(
 		    off, std::min<uint32_t>(maxEntries, matocl::fuseGetDir::kMaxNumberOfDirectoryEntries),
 		    entries);
 		matoclserv_createpacket(eptr, matocl::fuseGetTrash::build(msgId, entries));
@@ -3604,8 +3600,8 @@ void matoclserv_fuse_getdetachedattr(matoclserventry *eptr, const uint8_t *data,
 		dtype = DTYPE_UNKNOWN;
 	}
 
-	status = gFSOperations->fs_getdetachedattr(eptr->sessionData->rootInode,
-	                                           eptr->sessionData->flags, inode, attr, dtype);
+	status = gFSOperations->getDetachedAttr(eptr->sessionData->rootInode, eptr->sessionData->flags,
+	                                        inode, attr, dtype);
 
 	constexpr uint32_t kFailedSize = sizeof(msgid) + sizeof(status);
 	constexpr uint32_t kSuccessSize = sizeof(msgid) + attr.size();
@@ -3642,8 +3638,8 @@ void matoclserv_fuse_gettrashpath(matoclserventry *eptr, const uint8_t *data, ui
 	get32bit(&data, msgid);
 	getINode(&data, inode);
 
-	status = gFSOperations->fs_gettrashpath(eptr->sessionData->rootInode, eptr->sessionData->flags,
-	                                        inode, path);
+	status = gFSOperations->getTrashPath(eptr->sessionData->rootInode, eptr->sessionData->flags,
+	                                     inode, path);
 
 	constexpr uint32_t kFailedSize = sizeof(msgid) + sizeof(status);
 	const uint32_t kSuccessSize = sizeof(msgid) + sizeof(uint32_t) + path.length() + 1;
@@ -3699,8 +3695,8 @@ void matoclserv_fuse_settrashpath(matoclserventry *eptr, const uint8_t *data, ui
 	data += pleng;
 	while (pleng > 0 && path[pleng - 1] == 0) { pleng--; }
 
-	status = gFSOperations->fs_settrashpath(matoclserv_get_context(eptr), inode,
-	                                        std::string((char *)path, pleng));
+	status = gFSOperations->setTrashPath(matoclserv_get_context(eptr), inode,
+	                                     std::string((char *)path, pleng));
 
 	ptr = matoclserv_createpacket(eptr, MATOCL_FUSE_SETTRASHPATH, sizeof(msgid) + sizeof(status));
 
@@ -3726,7 +3722,7 @@ void matoclserv_fuse_undel(matoclserventry *eptr, const uint8_t *data, uint32_t 
 	get32bit(&data, msgid);
 	getINode(&data, inode);
 
-	status = gFSOperations->fs_undel(matoclserv_get_context(eptr), inode);
+	status = gFSOperations->undel(matoclserv_get_context(eptr), inode);
 
 	ptr = matoclserv_createpacket(eptr, MATOCL_FUSE_UNDEL, sizeof(msgid) + sizeof(status));
 
@@ -3752,7 +3748,7 @@ void matoclserv_fuse_purge(matoclserventry *eptr, const uint8_t *data, uint32_t 
 	get32bit(&data, msgid);
 	getINode(&data, inode);
 
-	status = gFSOperations->fs_purge(matoclserv_get_context(eptr), inode);
+	status = gFSOperations->purge(matoclserv_get_context(eptr), inode);
 
 	ptr = matoclserv_createpacket(eptr, MATOCL_FUSE_PURGE, sizeof(msgid) + sizeof(status));
 	put32bit(&ptr, msgid);
@@ -3777,8 +3773,8 @@ void matoclserv_fuse_getreserved(matoclserventry *eptr, const uint8_t *data, uin
 
 	get32bit(&data, msgid);
 
-	status = gFSOperations->fs_readreserved_size(eptr->sessionData->rootInode,
-	                                             eptr->sessionData->flags, &dleng);
+	status = gFSOperations->readReservedSize(eptr->sessionData->rootInode, eptr->sessionData->flags,
+	                                         &dleng);
 
 	constexpr uint32_t kFailedSize = sizeof(msgid) + sizeof(status);
 	const uint32_t kSuccessSize = sizeof(msgid) + dleng;
@@ -3791,8 +3787,8 @@ void matoclserv_fuse_getreserved(matoclserventry *eptr, const uint8_t *data, uin
 	if (status!=SAUNAFS_STATUS_OK) {
 		put8bit(&ptr,status);
 	} else {
-		gFSOperations->fs_readreserved_data(eptr->sessionData->rootInode, eptr->sessionData->flags,
-		                                    ptr);
+		gFSOperations->readReservedData(eptr->sessionData->rootInode, eptr->sessionData->flags,
+		                                ptr);
 	}
 }
 
@@ -3806,7 +3802,7 @@ void matoclserv_fuse_getreserved(matoclserventry *eptr, const PacketHeader &head
 		uint32_t off;
 		cltoma::fuseGetReserved::deserialize(data, header.length, msgId, off, maxEntries);
 		std::vector<NamedInodeEntry> entries;
-		gFSOperations->fs_readreserved(
+		gFSOperations->readReserved(
 		    off, std::min<uint32_t>(maxEntries, matocl::fuseGetDir::kMaxNumberOfDirectoryEntries),
 		    entries);
 		matoclserv_createpacket(eptr, matocl::fuseGetReserved::build(msgId, entries));
@@ -3814,7 +3810,7 @@ void matoclserv_fuse_getreserved(matoclserventry *eptr, const PacketHeader &head
 		uint64_t off;
 		cltoma::fuseGetReserved::deserialize(data, header.length, msgId, off, maxEntries);
 		std::vector<HandleInodeEntry> entries;
-		gFSOperations->fs_readreserved(
+		gFSOperations->readReserved(
 		    off, std::min<uint32_t>(maxEntries, matocl::fuseGetDir::kMaxNumberOfDirectoryEntries),
 		    entries);
 		matoclserv_createpacket(eptr, matocl::fuseGetReserved::build(msgId, entries));
@@ -3833,7 +3829,7 @@ void matoclserv_fuse_deleteacl(matoclserventry *eptr, const uint8_t *data, uint3
 	uint8_t status = matoclserv_check_group_cache(eptr, gid);
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = gFSOperations->fs_deleteacl(context, inode, type);
+		status = gFSOperations->deleteAcl(context, inode, type);
 	}
 	matoclserv_createpacket(eptr, matocl::fuseDeleteAcl::build(messageId, status));
 }
@@ -3852,7 +3848,7 @@ void matoclserv_fuse_getacl(matoclserventry *eptr, const uint8_t *data, uint32_t
 
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = gFSOperations->fs_getacl(context, inode, acl);
+		status = gFSOperations->getAcl(context, inode, acl);
 	}
 
 	if (status == SAUNAFS_STATUS_OK) {
@@ -3948,8 +3944,8 @@ void matoclserv_fuse_flock(matoclserventry *eptr, const uint8_t *data, uint32_t 
 	}
 
 	std::vector<FileLocks::Owner> applied;
-	status = gFSOperations->fs_flock_op(context, inode, owner, eptr->sessionData->sessionId,
-	                                    requestId, messageId, op, nonblocking, applied);
+	status = gFSOperations->flockOperation(context, inode, owner, eptr->sessionData->sessionId,
+	                                       requestId, messageId, op, nonblocking, applied);
 
 	matoclserv_lock_wake_up(applied, safs_locks::Type::kFlock);
 
@@ -3989,9 +3985,9 @@ void matoclserv_fuse_getlk(matoclserventry *eptr, const uint8_t *data, uint32_t 
 		lock_end = (uint64_t)lock_info.l_start + (uint64_t)lock_info.l_len;
 	}
 
-	status = gFSOperations->fs_posixlock_probe(context, inode, lock_info.l_start, lock_end, owner,
-	                                           eptr->sessionData->sessionId, 0, message_id,
-	                                           lock_info.l_type, lock_info);
+	status = gFSOperations->posixLockProbe(context, inode, lock_info.l_start, lock_end, owner,
+	                                       eptr->sessionData->sessionId, 0, message_id,
+	                                       lock_info.l_type, lock_info);
 
 	// Standard states that lock of length 0 is a lock till EOF
 	if (lock_info.l_len == std::numeric_limits<int64_t>::max()) {
@@ -4043,9 +4039,9 @@ void matoclserv_fuse_setlk(matoclserventry *eptr, const uint8_t *data, uint32_t 
 	}
 
 	std::vector<FileLocks::Owner> applied;
-	status = gFSOperations->fs_posixlock_op(context, inode, lock_info.l_start, lock_end, owner,
-	                                        eptr->sessionData->sessionId, request_id, message_id,
-	                                        op, nonblocking, applied);
+	status = gFSOperations->posixLockOperation(context, inode, lock_info.l_start, lock_end, owner,
+	                                           eptr->sessionData->sessionId, request_id, message_id,
+	                                           op, nonblocking, applied);
 
 	matoclserv_lock_wake_up(applied, safs_locks::Type::kPosix);
 
@@ -4093,13 +4089,12 @@ void matoclserv_manage_locks_list(matoclserventry *eptr, const uint8_t *data, ui
 	if (version == cltoma::manageLocksList::kAll) {
 		cltoma::manageLocksList::deserialize(data, length, type, pending, start, max);
 		max = std::min(max, SAU_CLTOMA_MANAGE_LOCKS_LIST_LIMIT);
-		status =
-		    gFSOperations->fs_locks_list_all(context, (uint8_t)type, pending, start, max, locks);
+		status = gFSOperations->locksListAll(context, (uint8_t)type, pending, start, max, locks);
 	} else if (version == cltoma::manageLocksList::kInode) {
 		cltoma::manageLocksList::deserialize(data, length, inode, type, pending, start, max);
 		max = std::min(max, SAU_CLTOMA_MANAGE_LOCKS_LIST_LIMIT);
-		status = gFSOperations->fs_locks_list_inode(context, (uint8_t)type, pending, inode, start,
-		                                            max, locks);
+		status = gFSOperations->locksListInode(context, (uint8_t)type, pending, inode, start, max,
+		                                       locks);
 	} else {
 		throw IncorrectDeserializationException(
 				"Unknown SAU_CLTOMA_MANAGE_LOCKS_LIST version: " + std::to_string(version));
@@ -4144,24 +4139,25 @@ void matoclserv_manage_locks_unlock(matoclserventry *eptr, const uint8_t *data, 
 			end = std::numeric_limits<decltype(end)>::max();
 		}
 		if (type == safs_locks::Type::kAll || type == safs_locks::Type::kFlock) {
-			status = gFSOperations->fs_flock_op(context, inode, owner, sessionid, 0, 0,
-			                                    safs_locks::kUnlock, true, flocks_applied);
+			status = gFSOperations->flockOperation(context, inode, owner, sessionid, 0, 0,
+			                                       safs_locks::kUnlock, true, flocks_applied);
 		}
 		if (status == SAUNAFS_STATUS_OK &&
 		    (type == safs_locks::Type::kAll || type == safs_locks::Type::kPosix)) {
-			status = gFSOperations->fs_posixlock_op(context, inode, start, end, owner, sessionid, 0,
-			                                        0, safs_locks::kUnlock, true, posix_applied);
+			status =
+			    gFSOperations->posixLockOperation(context, inode, start, end, owner, sessionid, 0,
+			                                      0, safs_locks::kUnlock, true, posix_applied);
 		}
 	} else if (version == cltoma::manageLocksUnlock::kInode) {
 		cltoma::manageLocksUnlock::deserialize(data, length, type, inode);
 		if (type == safs_locks::Type::kAll || type == safs_locks::Type::kFlock) {
-			status = gFSOperations->fs_locks_unlock_inode(
-			    context, (uint8_t)safs_locks::Type::kFlock, inode, flocks_applied);
+			status = gFSOperations->locksUnlockInode(context, (uint8_t)safs_locks::Type::kFlock,
+			                                         inode, flocks_applied);
 		}
 		if (status == SAUNAFS_STATUS_OK &&
 		    (type == safs_locks::Type::kAll || type == safs_locks::Type::kPosix)) {
-			status = gFSOperations->fs_locks_unlock_inode(
-			    context, (uint8_t)safs_locks::Type::kPosix, inode, posix_applied);
+			status = gFSOperations->locksUnlockInode(context, (uint8_t)safs_locks::Type::kPosix,
+			                                         inode, posix_applied);
 		}
 	} else {
 		throw IncorrectDeserializationException("Unknown SAU_CLTOMA_MANAGE_LOCKS_UNLOCK version: " +
@@ -4183,7 +4179,7 @@ void matoclserv_manage_locks_unlock(matoclserventry *eptr, const uint8_t *data, 
 }
 
 void matoclserv_list_tasks(matoclserventry *eptr) {
-	std::vector<JobInfo> jobs_info = gFSOperations->fs_get_current_tasks_info();
+	std::vector<JobInfo> jobs_info = gFSOperations->getCurrentTasksInfo();
 	matoclserv_createpacket(eptr, matocl::listTasks::build(jobs_info));
 }
 
@@ -4191,7 +4187,7 @@ void matoclserv_stop_task(matoclserventry *eptr, const uint8_t *data, uint32_t l
 	uint32_t job_id, msgid;
 	uint8_t status;
 	cltoma::stopTask::deserialize(data, length, msgid, job_id);
-	status = gFSOperations->fs_cancel_job(job_id);
+	status = gFSOperations->cancelJob(job_id);
 	matoclserv_createpacket(eptr, matocl::stopTask::build(msgid, status));
 }
 
@@ -4212,9 +4208,9 @@ void matoclserv_fuse_locks_interrupt(matoclserventry *eptr, const uint8_t *data,
 	cltoma::fuseFlock::deserialize(data, length, messageId, interruptData);
 
 	// we do not reply, so there is not need for checking status of this fs_operation
-	gFSOperations->fs_locks_remove_pending(context, type, interruptData.owner,
-	                                       eptr->sessionData->sessionId, interruptData.ino,
-	                                       interruptData.reqid);
+	gFSOperations->locksRemovePending(context, type, interruptData.owner,
+	                                  eptr->sessionData->sessionId, interruptData.ino,
+	                                  interruptData.reqid);
 }
 
 void matoclserv_update_credentials(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
@@ -4268,9 +4264,9 @@ void matoclserv_fuse_setacl(matoclserventry *eptr, const uint8_t *data, uint32_t
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
 		if (use_posix) {
-			status = gFSOperations->fs_setacl(context, inode, type, posix_acl);
+			status = gFSOperations->setAcl(context, inode, type, posix_acl);
 		} else {
-			status = gFSOperations->fs_setacl(context, inode, rich_acl);
+			status = gFSOperations->setAcl(context, inode, rich_acl);
 		}
 	}
 	matoclserv_createpacket(eptr, matocl::fuseSetAcl::build(messageId, status));
@@ -4284,7 +4280,7 @@ void matoclserv_fuse_setquota(matoclserventry *eptr, const uint8_t *data, uint32
 	uint8_t status = matoclserv_check_group_cache(eptr, gid);
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = gFSOperations->fs_quota_set(context, entries);
+		status = gFSOperations->quotaSet(context, entries);
 	}
 
 	MessageBuffer reply;
@@ -4305,7 +4301,7 @@ void matoclserv_fuse_getquota(matoclserventry *eptr, const uint8_t *data, uint32
 		status = matoclserv_check_group_cache(eptr, gid);
 		if (status == SAUNAFS_STATUS_OK) {
 			FsContext context = matoclserv_get_context(eptr, uid, gid);
-			status = gFSOperations->fs_quota_get_all(context, results);
+			status = gFSOperations->quotaGetAll(context, results);
 		}
 	} else if (version == cltoma::fuseGetQuota::kSelectedLimits) {
 		std::vector<QuotaOwner> owners;
@@ -4313,7 +4309,7 @@ void matoclserv_fuse_getquota(matoclserventry *eptr, const uint8_t *data, uint32
 		status = matoclserv_check_group_cache(eptr, gid);
 		if (status == SAUNAFS_STATUS_OK) {
 			FsContext context = matoclserv_get_context(eptr, uid, gid);
-			status = gFSOperations->fs_quota_get(context, owners, results);
+			status = gFSOperations->quotaGet(context, owners, results);
 		}
 	} else {
 		throw IncorrectDeserializationException(
@@ -4322,7 +4318,7 @@ void matoclserv_fuse_getquota(matoclserventry *eptr, const uint8_t *data, uint32
 
 	MessageBuffer reply;
 	if (status == SAUNAFS_STATUS_OK) {
-		status = gFSOperations->fs_quota_get_info(matoclserv_get_context(eptr), results, info);
+		status = gFSOperations->quotaGetInfo(matoclserv_get_context(eptr), results, info);
 	}
 
 	if (status == SAUNAFS_STATUS_OK) {
@@ -4549,7 +4545,7 @@ void matoclserv_admin_recalculate_metadata_checksum(matoclserventry *eptr, const
 	if (eptr->registered == ClientState::kAdmin) {
 		safs::log_info("metadata checksum recalculation requested using saunafs-admin by {}",
 		               ipToString(eptr->peerIpAddress));
-		uint8_t status = gFSOperations->fs_start_checksum_recalculation();
+		uint8_t status = gFSOperations->startChecksumRecalculation();
 
 		if (status != SAUNAFS_STATUS_OK || asynchronous) {
 			matoclserv_createpacket(eptr, matocl::adminRecalculateMetadataChecksum::build(status));
@@ -4581,16 +4577,16 @@ void matoclserv_broadcast_metadata_checksum_recalculated(uint8_t status) {
 void matocl_locks_release(const FsContext &context, inode_t inode, uint32_t sessionId) {
 	std::vector<FileLocks::Owner> applied;
 
-	gFSOperations->fs_locks_clear_session(context, (uint8_t)safs_locks::Type::kFlock, inode,
-	                                      sessionId, applied);
+	gFSOperations->locksClearSession(context, (uint8_t)safs_locks::Type::kFlock, inode, sessionId,
+	                                 applied);
 
 	for (auto candidate : applied) {
 		matoclserv_lock_wake_up(candidate.sessionid, candidate.msgid, safs_locks::Type::kFlock);
 	}
 
 	applied.clear();
-	gFSOperations->fs_locks_clear_session(context, (uint8_t)safs_locks::Type::kPosix, inode,
-	                                      sessionId, applied);
+	gFSOperations->locksClearSession(context, (uint8_t)safs_locks::Type::kPosix, inode, sessionId,
+	                                 applied);
 
 	for (auto candidate : applied) {
 		matoclserv_lock_wake_up(candidate.sessionid, candidate.msgid, safs_locks::Type::kPosix);
@@ -4601,7 +4597,7 @@ void matocl_close_files(Session *currentSession) {
 	FsContext context = FsContext::getForMaster(eventloop_time());
 
 	for (const auto &openFileInode : currentSession->openFilesSet) {
-		gFSOperations->fs_release(context, openFileInode, currentSession->sessionId);
+		gFSOperations->release(context, openFileInode, currentSession->sessionId);
 		matocl_locks_release(context, openFileInode, currentSession->sessionId);
 	}
 
@@ -4690,9 +4686,7 @@ void matocl_session_check() {
 void matocl_before_disconnect(matoclserventry *eptr) {
 	// unlock locked chunks
 	for (const auto &operation : eptr->delayedChunkOperations) {
-		if (operation->type == FUSE_TRUNCATE) {
-			gFSOperations->fs_end_setlength(operation->chunkId);
-		}
+		if (operation->type == FUSE_TRUNCATE) { gFSOperations->endSetLength(operation->chunkId); }
 	}
 
 	eptr->delayedChunkOperations.clear();

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -455,7 +455,7 @@ void matoclserv_chunk_status(uint64_t chunkId, uint8_t status, bool isFailedCrea
 	case FUSE_WRITE:
 		if (status != SAUNAFS_STATUS_OK) {
 			if (isFailedCreateOperation) {
-				gFilesystemOperations->fs_remove_chunk_from_file(context, inode, chunkId);
+				gFSOperations->fs_remove_chunk_from_file(context, inode, chunkId);
 			}
 			serializer->serializeFuseWriteChunk(reply, messageId, status);
 			matoclserv_createpacket(eptr, std::move(reply));
@@ -464,7 +464,7 @@ void matoclserv_chunk_status(uint64_t chunkId, uint8_t status, bool isFailedCrea
 					chunkId, messageId, fileLength, lockId);
 		}
 		if (status != SAUNAFS_STATUS_OK) {
-			gFilesystemOperations->fs_writeend(0, 0, chunkId, 0);  // ignore status - just do it.
+			gFSOperations->fs_writeend(0, 0, chunkId, 0);  // ignore status - just do it.
 		}
 		return;
 	case FUSE_TRUNCATE_BEGIN:
@@ -477,12 +477,12 @@ void matoclserv_chunk_status(uint64_t chunkId, uint8_t status, bool isFailedCrea
 		return;
 	case FUSE_TRUNCATE:
 	case FUSE_TRUNCATE_END:
-		gFilesystemOperations->fs_end_setlength(chunkId);
+		gFSOperations->fs_end_setlength(chunkId);
 		if (status != SAUNAFS_STATUS_OK) {
 			serializer->serializeFuseTruncate(reply, operationType, messageId, status);
 		} else {
 			Attributes attr;
-			gFilesystemOperations->fs_do_setlength(context, inode, fileLength, attr);
+			gFSOperations->fs_do_setlength(context, inode, fileLength, attr);
 			serializer->serializeFuseTruncate(reply, operationType, messageId, attr);
 		}
 		matoclserv_createpacket(eptr, std::move(reply));
@@ -612,7 +612,7 @@ void matoclserv_metadataserver_status(matoclserventry* eptr, const uint8_t* data
 
 	uint64_t metadataVersion = 0;
 	try {
-		metadataVersion = gFilesystemOperations->fs_getversion();
+		metadataVersion = gFSOperations->fs_getversion();
 	} catch (NoMetadataException &) {}
 
 	uint8_t status =
@@ -633,7 +633,7 @@ void matoclserv_metadataserver_status(matoclserventry* eptr, const uint8_t* data
 /// response packet.
 void matoclserv_list_goals(matoclserventry* eptr) {
 	std::vector<SerializedGoal> serializedGoals;
-	const std::map<int, Goal>& goalsMap = gFilesystemOperations->fs_get_goal_definitions();
+	const std::map<int, Goal> &goalsMap = gFSOperations->fs_get_goal_definitions();
 
 	for (const auto& goal : goalsMap) {
 		serializedGoals.emplace_back(goal.first, goal.second.getName(), to_string(goal.second));
@@ -715,7 +715,7 @@ void matoclserv_session_list(matoclserventry *eptr, const uint8_t *data, uint32_
 				size += 1;  // for '.'
 			} else {
 				size += sizeof(pathLength);
-				size += gFilesystemOperations->fs_getdirpath_size(eaptr->sessionData->rootInode);
+				size += gFSOperations->fs_getdirpath_size(eaptr->sessionData->rootInode);
 			}
 		}
 	}
@@ -744,12 +744,11 @@ void matoclserv_session_list(matoclserventry *eptr, const uint8_t *data, uint32_
 				putINode(&ptr, static_cast<inode_t>(1));
 				put8bit(&ptr, '.');
 			} else {
-				pathLength =
-				    gFilesystemOperations->fs_getdirpath_size(eaptr->sessionData->rootInode);
+				pathLength = gFSOperations->fs_getdirpath_size(eaptr->sessionData->rootInode);
 				put32bit(&ptr, pathLength);
 				if (pathLength > 0) {
-					gFilesystemOperations->fs_getdirpath_data(eaptr->sessionData->rootInode, ptr,
-					                                          pathLength);
+					gFSOperations->fs_getdirpath_data(eaptr->sessionData->rootInode, ptr,
+					                                  pathLength);
 					ptr += pathLength;
 				}
 			}
@@ -887,11 +886,11 @@ void matoclserv_info(matoclserventry *eptr, const uint8_t *data, uint32_t length
 	statistics.version = saunafsVersion(SAUNAFS_PACKAGE_VERSION_MAJOR,
 			SAUNAFS_PACKAGE_VERSION_MINOR, SAUNAFS_PACKAGE_VERSION_MICRO);
 
-	gFilesystemOperations->fs_info(&statistics.totalSpace, &statistics.availableSpace,
-	                               &statistics.trashSpace, &statistics.trashNodes,
-	                               &statistics.reservedSpace, &statistics.reservedNodes,
-	                               &statistics.allNodes, &statistics.dirNodes,
-	                               &statistics.fileNodes, &statistics.symlinkNodes);
+	gFSOperations->fs_info(&statistics.totalSpace, &statistics.availableSpace,
+	                       &statistics.trashSpace, &statistics.trashNodes,
+	                       &statistics.reservedSpace, &statistics.reservedNodes,
+	                       &statistics.allNodes, &statistics.dirNodes, &statistics.fileNodes,
+	                       &statistics.symlinkNodes);
 
 	chunk_info(&statistics.chunks, &statistics.chunkCopies, &statistics.regularCopies);
 
@@ -1212,7 +1211,7 @@ void matoclserv_fuse_register(matoclserventry *eptr, const uint8_t *data, uint32
 			}
 
 			if (status == SAUNAFS_STATUS_OK) {
-				status = gFilesystemOperations->fs_getrootinode(&rootInode, path);
+				status = gFSOperations->fs_getrootinode(&rootInode, path);
 			}
 
 			if (status == SAUNAFS_STATUS_OK) {
@@ -1494,7 +1493,7 @@ void matoclserv_fuse_reserved_inodes(matoclserventry *eptr, const uint8_t *data,
 		inode_t openFileIno = *it;
 		if (!inodes_to_reserve.contains(openFileIno)) {
 			// erase files not belonging to the reserve inodes list provided
-			gFilesystemOperations->fs_release(context, openFileIno, eptr->sessionData->sessionId);
+			gFSOperations->fs_release(context, openFileIno, eptr->sessionData->sessionId);
 			it = eptr->sessionData->openFilesSet.erase(it);
 		} else {
 			// skip files already in session
@@ -1505,8 +1504,8 @@ void matoclserv_fuse_reserved_inodes(matoclserventry *eptr, const uint8_t *data,
 	}
 
 	for (const auto &inode_to_reserve : inodes_to_reserve) {
-		if (gFilesystemOperations->fs_acquire(context, inode_to_reserve,
-		                                      eptr->sessionData->sessionId) == SAUNAFS_STATUS_OK) {
+		if (gFSOperations->fs_acquire(context, inode_to_reserve, eptr->sessionData->sessionId) ==
+		    SAUNAFS_STATUS_OK) {
 			// Insert reserved inodes into the opened files set
 			eptr->sessionData->openFilesSet.insert(inode_to_reserve);
 		}
@@ -1531,8 +1530,8 @@ void matoclserv_fuse_statfs(matoclserventry *eptr, const uint8_t *data, uint32_t
 
 	get32bit(&data, msgid);
 	FsContext context = matoclserv_get_context(eptr);
-	gFilesystemOperations->fs_statfs(context, &totalspace, &availspace, &trashspace, &reservedspace,
-	                                 &inodes);
+	gFSOperations->fs_statfs(context, &totalspace, &availspace, &trashspace, &reservedspace,
+	                         &inodes);
 
 	constexpr uint32_t kPacketSize = sizeof(msgid) + sizeof(totalspace) + sizeof(availspace) +
 	                                 sizeof(trashspace) + sizeof(reservedspace) + sizeof(inodes);
@@ -1574,7 +1573,7 @@ void matoclserv_fuse_access(matoclserventry *eptr, const uint8_t *data, uint32_t
 	if (status == SAUNAFS_STATUS_OK && inode != SPECIAL_INODE_PATH_BY_INODE &&
 	    inode != SPECIAL_INODE_FILE_BY_INODE) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = gFilesystemOperations->fs_access(context, inode, modemask);
+		status = gFSOperations->fs_access(context, inode, modemask);
 	}
 
 	constexpr uint8_t kAnswerSize = sizeof(msgid) + sizeof(status);
@@ -1597,8 +1596,7 @@ void matoclserv_sau_whole_path_lookup(matoclserventry *eptr, const uint8_t *data
 	status = matoclserv_check_group_cache(eptr, gid);
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status =
-		    gFilesystemOperations->fs_whole_path_lookup(context, inode, path, &found_inode, attr);
+		status = gFSOperations->fs_whole_path_lookup(context, inode, path, &found_inode, attr);
 	}
 
 	if (status != SAUNAFS_STATUS_OK) {
@@ -1621,7 +1619,7 @@ void matoclserv_sau_full_path_by_inode(matoclserventry *eptr, const uint8_t *dat
 	status = matoclserv_check_group_cache(eptr, gid);
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = gFilesystemOperations->fs_full_path_by_inode(context, inode, fullPath);
+		status = gFSOperations->fs_full_path_by_inode(context, inode, fullPath);
 	}
 
 	if (status != SAUNAFS_STATUS_OK) {
@@ -1666,7 +1664,7 @@ void matoclserv_sau_get_self_quota(matoclserventry *eptr, const uint8_t *data, u
 		owners.emplace_back(QuotaOwnerType::kUser, uid);
 		owners.emplace_back(QuotaOwnerType::kGroup, gid);
 		owners.emplace_back(QuotaOwnerType::kInode, inode);
-		status = gFilesystemOperations->fs_quota_get(context, owners, results);
+		status = gFSOperations->fs_quota_get(context, owners, results);
 
 		if (inode == context.rootinode() && !foundContextRootInodeResult(inode)) {
 			auto ino = fsnodes_id_to_node(inode);
@@ -1680,8 +1678,7 @@ void matoclserv_sau_get_self_quota(matoclserventry *eptr, const uint8_t *data, u
 
 	MessageBuffer reply;
 	if (status == SAUNAFS_STATUS_OK) {
-		status =
-		    gFilesystemOperations->fs_quota_get_info(matoclserv_get_context(eptr), results, info);
+		status = gFSOperations->fs_quota_get_info(matoclserv_get_context(eptr), results, info);
 	}
 	if (status == SAUNAFS_STATUS_OK) {
 		matocl::fuseGetSelfQuota::serialize(reply, messageId, results);
@@ -1713,7 +1710,7 @@ void matoclserv_fuse_getattr(matoclserventry *eptr, const uint8_t *data, uint32_
 	status = matoclserv_check_group_cache(eptr, gid);
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = gFilesystemOperations->fs_getattr(context, inode, attr);
+		status = gFSOperations->fs_getattr(context, inode, attr);
 	}
 
 	constexpr uint32_t kFailedAnswerSize = sizeof(msgid) + sizeof(status);
@@ -1779,9 +1776,8 @@ void matoclserv_fuse_setattr(matoclserventry *eptr, const uint8_t *data, uint32_
 
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status =
-		    gFilesystemOperations->fs_setattr(context, inode, setmask, attrmode, attruid, attrgid,
-		                                      attratime, attrmtime, sugidclearmode, attr);
+		status = gFSOperations->fs_setattr(context, inode, setmask, attrmode, attruid, attrgid,
+		                                   attratime, attrmtime, sugidclearmode, attr);
 	}
 
 	constexpr uint32_t kFailedAnswerSize = sizeof(msgid) + sizeof(status);
@@ -1830,12 +1826,12 @@ void matoclserv_fuse_truncate(matoclserventry *eptr, PacketHeader header, const 
 				status = SAUNAFS_ERROR_WRONGLOCKID;
 			} else {
 				// let's check if chunk is still locked by us
-				status = gFilesystemOperations->fs_get_chunkid(context, inode,
-				                                               length / SFSCHUNKSIZE, &chunkId);
+				status =
+				    gFSOperations->fs_get_chunkid(context, inode, length / SFSCHUNKSIZE, &chunkId);
 				if (status == SAUNAFS_STATUS_OK) {
 					status = chunk_can_unlock(chunkId, lockId);
 				}
-				gFilesystemOperations->fs_end_setlength(chunkId);
+				gFSOperations->fs_end_setlength(chunkId);
 			}
 		}
 	} else {
@@ -1850,7 +1846,7 @@ void matoclserv_fuse_truncate(matoclserventry *eptr, PacketHeader header, const 
 	// Try to do the truncate
 	Attributes attr;
 	if (status == SAUNAFS_STATUS_OK) {
-		status = gFilesystemOperations->fs_try_setlength(
+		status = gFSOperations->fs_try_setlength(
 		    context, inode, opened, length, (type != FUSE_TRUNCATE_END), lockId, attr, &chunkId);
 	}
 
@@ -1859,8 +1855,8 @@ void matoclserv_fuse_truncate(matoclserventry *eptr, PacketHeader header, const 
 		// New client requested to truncate xor chunk. He has to do it himself.
 		uint64_t fileLength;
 		uint8_t opflag;
-		gFilesystemOperations->fs_writechunk(context, inode, length / SFSCHUNKSIZE, false, &lockId,
-		                                     &chunkId, &opflag, &fileLength);
+		gFSOperations->fs_writechunk(context, inode, length / SFSCHUNKSIZE, false, &lockId,
+		                             &chunkId, &opflag, &fileLength);
 		if (opflag) {
 			// But first we have to duplicate chunk :)
 			type = FUSE_TRUNCATE_BEGIN;
@@ -1900,7 +1896,7 @@ void matoclserv_fuse_truncate(matoclserventry *eptr, PacketHeader header, const 
 		return;
 	}
 	if (status == SAUNAFS_STATUS_OK) {
-		status = gFilesystemOperations->fs_do_setlength(context, inode, length, attr);
+		status = gFSOperations->fs_do_setlength(context, inode, length, attr);
 	}
 	if (status == SAUNAFS_STATUS_OK) {
 		dcm_modify(inode, eptr->sessionData->sessionId);
@@ -1940,7 +1936,7 @@ void matoclserv_fuse_readlink(matoclserventry *eptr, const uint8_t *data, uint32
 	getINode(&data, inode);
 
 	FsContext context = matoclserv_get_context(eptr);
-	status = gFilesystemOperations->fs_readlink(context, inode, path);
+	status = gFSOperations->fs_readlink(context, inode, path);
 
 	constexpr uint32_t kFailedAnswerSize = sizeof(msgid) + sizeof(status);
 	constexpr uint32_t kSuccessAnswerSize = sizeof(msgid) + sizeof(uint32_t);
@@ -2023,9 +2019,8 @@ void matoclserv_fuse_symlink(matoclserventry *eptr, const uint8_t *data, uint32_
 	status = matoclserv_check_group_cache(eptr, gid);
 	if (status == SAUNAFS_STATUS_OK) {
 		auto context = matoclserv_get_context(eptr, uid, gid);
-		status =
-		    gFilesystemOperations->fs_symlink(context, inode, HString((char *)name, nleng),
-		                                      std::string((char *)path, pleng), &newinode, &attr);
+		status = gFSOperations->fs_symlink(context, inode, HString((char *)name, nleng),
+		                                   std::string((char *)path, pleng), &newinode, &attr);
 	}
 
 	constexpr uint32_t kFailedAnswerSize = sizeof(msgid) + sizeof(status);
@@ -2069,9 +2064,9 @@ void matoclserv_fuse_mknod(matoclserventry *eptr, PacketHeader header, const uin
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
 
-		status = gFilesystemOperations->fs_mknod(context, inode, HString(std::move(name)),
-		                                         static_cast<FSNodeType>(type), mode, umask, rdev,
-		                                         &newinode, attr);
+		status = gFSOperations->fs_mknod(context, inode, HString(std::move(name)),
+		                                 static_cast<FSNodeType>(type), mode, umask, rdev,
+		                                 &newinode, attr);
 	}
 
 	MessageBuffer reply;
@@ -2107,8 +2102,8 @@ void matoclserv_fuse_mkdir(matoclserventry *eptr, PacketHeader header, const uin
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
 
-		status = gFilesystemOperations->fs_mkdir(context, inode, HString(std::move(name)), mode,
-		                                         umask, copysgid, &newinode, attr);
+		status = gFSOperations->fs_mkdir(context, inode, HString(std::move(name)), mode, umask,
+		                                 copysgid, &newinode, attr);
 	}
 
 	MessageBuffer reply;
@@ -2162,7 +2157,7 @@ void matoclserv_fuse_unlink(matoclserventry *eptr, const uint8_t *data, uint32_t
 
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = gFilesystemOperations->fs_unlink(context, inode, HString((char *)name, nleng));
+		status = gFSOperations->fs_unlink(context, inode, HString((char *)name, nleng));
 	}
 
 	ptr = matoclserv_createpacket(eptr, MATOCL_FUSE_UNLINK, sizeof(msgid) + sizeof(status));
@@ -2195,7 +2190,7 @@ void matoclserv_fuse_recursive_remove(matoclserventry *eptr, const uint8_t *data
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
 
-		status = gFilesystemOperations->fs_recursive_remove(
+		status = gFSOperations->fs_recursive_remove(
 		    context, parent_inode, HString(name),
 		    std::bind(matoclserv_fuse_recursive_remove_wake_up, eptr->sessionData->sessionId, msgid,
 		              std::placeholders::_1),
@@ -2245,7 +2240,7 @@ void matoclserv_fuse_rmdir(matoclserventry *eptr, const uint8_t *data, uint32_t 
 
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = gFilesystemOperations->fs_rmdir(context, inode, HString((char *)name, nleng));
+		status = gFSOperations->fs_rmdir(context, inode, HString((char *)name, nleng));
 	}
 
 	ptr = matoclserv_createpacket(eptr, MATOCL_FUSE_RMDIR, sizeof(msgid) + sizeof(status));
@@ -2315,9 +2310,9 @@ void matoclserv_fuse_rename(matoclserventry *eptr, const uint8_t *data, uint32_t
 
 	if (status == SAUNAFS_STATUS_OK) {
 		auto context = matoclserv_get_context(eptr, uid, gid);
-		status = gFilesystemOperations->fs_rename(
-		    context, inode_src, HString((char *)name_src, nleng_src), inode_dst,
-		    HString((char *)name_dst, nleng_dst), &inode, &attr);
+		status = gFSOperations->fs_rename(context, inode_src, HString((char *)name_src, nleng_src),
+		                                  inode_dst, HString((char *)name_dst, nleng_dst), &inode,
+		                                  &attr);
 	}
 
 	if (status == SAUNAFS_STATUS_OK) {
@@ -2385,8 +2380,8 @@ void matoclserv_fuse_link(matoclserventry *eptr, const uint8_t *data, uint32_t l
 
 	if (status == SAUNAFS_STATUS_OK) {
 		auto context = matoclserv_get_context(eptr, uid, gid);
-		status = gFilesystemOperations->fs_link(
-		    context, inode, inode_dst, HString((char *)name_dst, nleng_dst), &newinode, &attr);
+		status = gFSOperations->fs_link(context, inode, inode_dst,
+		                                HString((char *)name_dst, nleng_dst), &newinode, &attr);
 	}
 
 	constexpr uint32_t kFailedAnswerSize = sizeof(msgid) + sizeof(status);
@@ -2433,8 +2428,8 @@ void matoclserv_fuse_getdir(matoclserventry *eptr,const PacketHeader &header, co
 
 		if (packet_version == cltoma::fuseGetDir::kClientAbleToProcessDirentIndex) {
 			std::vector<DirectoryEntry> dir_entries;
-			status = gFilesystemOperations->fs_readdir(
-			    context, inode, first_entry, number_of_entries, dir_entries);  //<DirectoryEntry>
+			status = gFSOperations->fs_readdir(context, inode, first_entry, number_of_entries,
+			                                   dir_entries);  //<DirectoryEntry>
 
 			if (status != SAUNAFS_STATUS_OK) {
 				matocl::fuseGetDir::serialize(buffer, message_id, status);
@@ -2495,7 +2490,7 @@ void matoclserv_fuse_getdir(matoclserventry *eptr, const uint8_t *data, uint32_t
 	}
 
 	FsContext context = matoclserv_get_context(eptr, uid, gid);
-	status = gFilesystemOperations->fs_readdir_size(context, inode, flags, &custom, &dleng);
+	status = gFSOperations->fs_readdir_size(context, inode, flags, &custom, &dleng);
 
 	constexpr uint32_t kFailedAnswerSize = sizeof(msgid) + sizeof(status);
 	const uint32_t kSuccessAnswerSize = sizeof(msgid) + dleng;  // Can't be constexpr
@@ -2508,7 +2503,7 @@ void matoclserv_fuse_getdir(matoclserventry *eptr, const uint8_t *data, uint32_t
 	if (status != SAUNAFS_STATUS_OK) {
 		put8bit(&ptr, status);
 	} else {
-		gFilesystemOperations->fs_readdir_data(context, flags, custom, ptr);
+		gFSOperations->fs_readdir_data(context, flags, custom, ptr);
 	}
 
 	eptr->sessionData->currHourOperationsStats[12]++;
@@ -2546,7 +2541,7 @@ void matoclserv_fuse_open(matoclserventry *eptr, const uint8_t *data, uint32_t l
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
 		status = matoclserv_insert_open_file(eptr->sessionData, inode);
 		if (status == SAUNAFS_STATUS_OK) {
-			status = gFilesystemOperations->fs_opencheck(context, inode, flags, attr);
+			status = gFSOperations->fs_opencheck(context, inode, flags, attr);
 		}
 	}
 
@@ -2588,7 +2583,7 @@ void matoclserv_fuse_read_chunk(matoclserventry *eptr, PacketHeader header, cons
 	std::vector<uint8_t> receivedData(data, data + header.length);
 	serializer->deserializeFuseReadChunk(receivedData, messageId, inode, index);
 
-	status = gFilesystemOperations->fs_readchunk(inode, index, &chunkid, &fleng);
+	status = gFSOperations->fs_readchunk(inode, index, &chunkid, &fleng);
 	std::vector<ChunkTypeWithAddress> allChunkCopies;
 	if (status == SAUNAFS_STATUS_OK) {
 		if (chunkid > 0) {
@@ -2637,8 +2632,8 @@ void matoclserv_chunks_info(matoclserventry *eptr, const uint8_t *data, uint32_t
 	status = matoclserv_check_group_cache(eptr, gid);
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = gFilesystemOperations->fs_getchunksinfo(context, eptr->peerIpAddress, inode,
-		                                                 chunk_index, chunk_count, chunks);
+		status = gFSOperations->fs_getchunksinfo(context, eptr->peerIpAddress, inode, chunk_index,
+		                                         chunk_count, chunks);
 	}
 
 	if (status != SAUNAFS_STATUS_OK) {
@@ -2670,9 +2665,9 @@ void matoclserv_fuse_write_chunk(matoclserventry *eptr, PacketHeader header, con
 
 	// Original Legacy (1.6.27) does not use lock ID's
 	bool useDummyLockId = false;
-	status = gFilesystemOperations->fs_writechunk(matoclserv_get_context(eptr), inode, chunkIndex,
-	                                              useDummyLockId, &lockId, &chunkId, &opflag,
-	                                              &fileLength, min_server_version);
+	status = gFSOperations->fs_writechunk(matoclserv_get_context(eptr), inode, chunkIndex,
+	                                      useDummyLockId, &lockId, &chunkId, &opflag, &fileLength,
+	                                      min_server_version);
 
 	if (status != SAUNAFS_STATUS_OK) {
 		serializer->serializeFuseWriteChunk(outMessage, messageId, status);
@@ -2697,7 +2692,7 @@ void matoclserv_fuse_write_chunk(matoclserventry *eptr, PacketHeader header, con
 		status = matoclserv_fuse_write_chunk_respond(eptr, serializer,
 				chunkId, messageId, fileLength, lockId);
 		if (status != SAUNAFS_STATUS_OK) {
-			gFilesystemOperations->fs_writeend(0, 0, chunkId, 0);  // ignore status - just do it.
+			gFSOperations->fs_writeend(0, 0, chunkId, 0);  // ignore status - just do it.
 		}
 	}
 
@@ -2728,7 +2723,7 @@ void matoclserv_fuse_write_chunk_end(matoclserventry *eptr, PacketHeader header,
 	} else if (eptr->sessionData->flags & SESFLAG_READONLY) {
 		status = SAUNAFS_ERROR_EROFS;
 	} else {
-		status = gFilesystemOperations->fs_writeend(inode, fileLength, chunkId, lockId);
+		status = gFSOperations->fs_writeend(inode, fileLength, chunkId, lockId);
 	}
 
 	dcm_modify(inode,eptr->sessionData->sessionId);
@@ -2767,8 +2762,8 @@ void matoclserv_fuse_repair(matoclserventry *eptr, const uint8_t *data, uint32_t
 
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = gFilesystemOperations->fs_repair(context, inode, correct_only, &chunksnotchanged,
-		                                          &chunkserased, &chunksrepaired);
+		status = gFSOperations->fs_repair(context, inode, correct_only, &chunksnotchanged,
+		                                  &chunkserased, &chunksrepaired);
 	}
 
 	constexpr uint32_t kFailedSize = sizeof(msgid) + sizeof(status);
@@ -2808,7 +2803,7 @@ void matoclserv_fuse_check(matoclserventry *eptr, const uint8_t *data, uint32_t 
 	get32bit(&data, msgid);
 	getINode(&data, inode);
 
-	status = gFilesystemOperations->fs_checkfile(matoclserv_get_context(eptr), inode, chunkcount);
+	status = gFSOperations->fs_checkfile(matoclserv_get_context(eptr), inode, chunkcount);
 
 	if (status != SAUNAFS_STATUS_OK) {
 		ptr = matoclserv_createpacket(eptr,MATOCL_FUSE_CHECK, sizeof(msgid) + sizeof(status));
@@ -2825,7 +2820,7 @@ void matoclserv_fuse_check(matoclserventry *eptr, const uint8_t *data, uint32_t 
 void matoclserv_fuse_request_task_id(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	uint32_t msgid, taskid;
 	cltoma::requestTaskId::deserialize(data, length, msgid);
-	taskid = gFilesystemOperations->fs_reserve_job_id();
+	taskid = gFSOperations->fs_reserve_job_id();
 	MessageBuffer reply;
 	matocl::requestTaskId::serialize(reply, msgid, taskid);
 	matoclserv_createpacket(eptr, reply);
@@ -2854,8 +2849,8 @@ void matoclserv_fuse_gettrashtime(matoclserventry *eptr,const uint8_t *data,uint
 	getINode(&data, inode);
 	gmode = get8bit(&data);
 
-	status = gFilesystemOperations->fs_gettrashtime_prepare(matoclserv_get_context(eptr), inode,
-	                                                        gmode, fileTrashtimes, dirTrashtimes);
+	status = gFSOperations->fs_gettrashtime_prepare(matoclserv_get_context(eptr), inode, gmode,
+	                                                fileTrashtimes, dirTrashtimes);
 	fileTrashtimesSize = fileTrashtimes.size();
 	dirTrashtimesSize = dirTrashtimes.size();
 
@@ -2876,7 +2871,7 @@ void matoclserv_fuse_gettrashtime(matoclserventry *eptr,const uint8_t *data,uint
 	} else {
 		put32bit(&ptr, fileTrashtimesSize);
 		put32bit(&ptr, dirTrashtimesSize);
-		gFilesystemOperations->fs_gettrashtime_store(fileTrashtimes, dirTrashtimes, ptr);
+		gFSOperations->fs_gettrashtime_store(fileTrashtimes, dirTrashtimes, ptr);
 	}
 }
 
@@ -2934,7 +2929,7 @@ void matoclserv_fuse_settrashtime(matoclserventry *eptr, PacketHeader header, co
 	auto settrashtime_stats = std::make_shared<SetTrashtimeTask::StatsArray>();
 
 	if (status == SAUNAFS_STATUS_OK) {
-		status = gFilesystemOperations->fs_settrashtime(
+		status = gFSOperations->fs_settrashtime(
 		    matoclserv_get_context(eptr, uid, 0), inode, trashtime, smode, settrashtime_stats,
 		    std::bind(matoclserv_fuse_settrashtime_wake_up, eptr->sessionData->sessionId, msgid,
 		              settrashtime_stats, std::placeholders::_1));
@@ -2960,12 +2955,11 @@ void matoclserv_fuse_getgoal(matoclserventry *eptr, PacketHeader header, const u
 
 	GoalStatistics fgtab{{0}}, dgtab{{0}}; // explicit value initialization to clear variables
 	uint8_t status =
-	    gFilesystemOperations->fs_getgoal(matoclserv_get_context(eptr), inode, gmode, fgtab, dgtab);
+	    gFSOperations->fs_getgoal(matoclserv_get_context(eptr), inode, gmode, fgtab, dgtab);
 
 	MessageBuffer reply;
 	if (status == SAUNAFS_STATUS_OK) {
-		const std::map<int, Goal> &goalDefinitions =
-		    gFilesystemOperations->fs_get_goal_definitions();
+		const std::map<int, Goal> &goalDefinitions = gFSOperations->fs_get_goal_definitions();
 		std::vector<FuseGetGoalStats> sauReply;
 		for (const auto &goal : goalDefinitions) {
 			if (fgtab[goal.first] || dgtab[goal.first]) {
@@ -3014,8 +3008,7 @@ void matoclserv_fuse_setgoal(matoclserventry *eptr, PacketHeader header, const u
 		cltoma::fuseSetGoal::deserialize(data, header.length,
 				msgid, inode, uid, goalName, smode);
 		// find a proper goalId,
-		const std::map<int, Goal> &goalDefinitions =
-		    gFilesystemOperations->fs_get_goal_definitions();
+		const std::map<int, Goal> &goalDefinitions = gFSOperations->fs_get_goal_definitions();
 		bool goalFound = false;
 		for (const auto &goal : goalDefinitions) {
 			if (goal.second.getName() == goalName) {
@@ -3050,7 +3043,7 @@ void matoclserv_fuse_setgoal(matoclserventry *eptr, PacketHeader header, const u
 
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, 0);
-		status = gFilesystemOperations->fs_setgoal(
+		status = gFSOperations->fs_setgoal(
 		    context, inode, goalId, smode, setgoal_stats,
 		    std::bind(matoclserv_fuse_setgoal_wake_up, eptr->sessionData->sessionId, msgid,
 		              header.type, setgoal_stats, std::placeholders::_1));
@@ -3086,8 +3079,8 @@ void matoclserv_fuse_geteattr(matoclserventry *eptr, const uint8_t *data, uint32
 	getINode(&data, inode);
 	gmode = get8bit(&data);
 
-	status = gFilesystemOperations->fs_geteattr(matoclserv_get_context(eptr), inode, gmode,
-	                                            feattrtab, deattrtab);
+	status = gFSOperations->fs_geteattr(matoclserv_get_context(eptr), inode, gmode, feattrtab,
+	                                    deattrtab);
 	fn = 0;
 	dn = 0;
 
@@ -3153,8 +3146,8 @@ void matoclserv_fuse_seteattr(matoclserventry *eptr, const uint8_t *data, uint32
 	eattr = get8bit(&data);
 	smode = get8bit(&data);
 
-	status = gFilesystemOperations->fs_seteattr(matoclserv_get_context(eptr, uid, 0), inode, eattr,
-	                                            smode, &changed, &notchanged, &notpermitted);
+	status = gFSOperations->fs_seteattr(matoclserv_get_context(eptr, uid, 0), inode, eattr, smode,
+	                                    &changed, &notchanged, &notpermitted);
 
 	constexpr uint32_t kFailedSize = sizeof(msgid) + sizeof(status);
 	constexpr uint32_t kSuccessSize =
@@ -3235,7 +3228,7 @@ void matoclserv_fuse_getxattr(matoclserventry *eptr, const uint8_t *data, uint32
 	} else if (anleng == 0) {
 		void *xanode;
 		uint32_t xasize;
-		status = gFilesystemOperations->fs_listxattr_leng(context, inode, opened, &xanode, &xasize);
+		status = gFSOperations->fs_listxattr_leng(context, inode, opened, &xanode, &xasize);
 		const uint32_t kSuccessSize =
 		    sizeof(msgid) + sizeof(xasize) + ((mode == XATTR_GMODE_GET_DATA) ? xasize : 0);
 		ptr = matoclserv_createpacket(eptr, MATOCL_FUSE_GETXATTR,
@@ -3248,14 +3241,14 @@ void matoclserv_fuse_getxattr(matoclserventry *eptr, const uint8_t *data, uint32
 		} else {
 			put32bit(&ptr, xasize);
 			if (mode == XATTR_GMODE_GET_DATA && xasize > 0) {
-				gFilesystemOperations->fs_listxattr_data(xanode, ptr);
+				gFSOperations->fs_listxattr_data(xanode, ptr);
 			}
 		}
 	} else {
 		uint8_t *attrvalue;
 		uint32_t avleng;
-		status = gFilesystemOperations->fs_getxattr(context, inode, opened, anleng, attrname,
-		                                            &avleng, &attrvalue);
+		status = gFSOperations->fs_getxattr(context, inode, opened, anleng, attrname, &avleng,
+		                                    &attrvalue);
 		const uint32_t kSuccessSize =
 		    sizeof(msgid) + sizeof(avleng) + ((mode == XATTR_GMODE_GET_DATA) ? avleng : 0);
 		ptr = matoclserv_createpacket(eptr, MATOCL_FUSE_GETXATTR,
@@ -3332,8 +3325,8 @@ void matoclserv_fuse_setxattr(matoclserventry *eptr, const uint8_t *data, uint32
 
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = gFilesystemOperations->fs_setxattr(context, inode, opened, anleng, attrname,
-		                                            avleng, attrvalue, mode);
+		status = gFSOperations->fs_setxattr(context, inode, opened, anleng, attrname, avleng,
+		                                    attrvalue, mode);
 	}
 
 	ptr = matoclserv_createpacket(eptr, MATOCL_FUSE_SETXATTR, sizeof(msgid) + sizeof(status));
@@ -3370,7 +3363,7 @@ void matoclserv_fuse_append(matoclserventry *eptr, const uint8_t *data, uint32_t
 
 	if (status == SAUNAFS_STATUS_OK) {
 		auto context = matoclserv_get_context(eptr, uid, gid);
-		status = gFilesystemOperations->fs_append(context, inode, inode_src);
+		status = gFSOperations->fs_append(context, inode, inode_src);
 	}
 
 	ptr = matoclserv_createpacket(eptr, MATOCL_FUSE_APPEND, sizeof(msgid) + sizeof(status));
@@ -3445,9 +3438,8 @@ void matoclserv_fuse_getdirstats_old(matoclserventry *eptr, const uint8_t *data,
 	get32bit(&data, msgid);
 	getINode(&data, inode);
 
-	status =
-	    gFilesystemOperations->fs_get_dir_stats(matoclserv_get_context(eptr), inode, &inodes, &dirs,
-	                                            &files, &links, &chunks, &leng, &size, &rsize);
+	status = gFSOperations->fs_get_dir_stats(matoclserv_get_context(eptr), inode, &inodes, &dirs,
+	                                         &files, &links, &chunks, &leng, &size, &rsize);
 
 	constexpr uint8_t kDirStatsLegacyFullPayload =
 	    sizeof(msgid) + sizeof(inodes) + sizeof(dirs) + sizeof(files) + sizeof(links) +
@@ -3499,9 +3491,8 @@ void matoclserv_fuse_getdirstats(matoclserventry *eptr, const uint8_t *data, uin
 	get32bit(&data, msgid);
 	getINode(&data, inode);
 
-	status =
-	    gFilesystemOperations->fs_get_dir_stats(matoclserv_get_context(eptr), inode, &inodes, &dirs,
-	                                            &files, &links, &chunks, &leng, &size, &rsize);
+	status = gFSOperations->fs_get_dir_stats(matoclserv_get_context(eptr), inode, &inodes, &dirs,
+	                                         &files, &links, &chunks, &leng, &size, &rsize);
 
 	constexpr uint8_t kFailedSize = sizeof(msgid) + sizeof(status);
 	constexpr uint8_t kSuccessSize = sizeof(msgid) + sizeof(inodes) + sizeof(dirs) + sizeof(files) +
@@ -3542,8 +3533,8 @@ void matoclserv_fuse_gettrash(matoclserventry *eptr, const uint8_t *data, uint32
 
 	get32bit(&data, msgid);
 
-	status = gFilesystemOperations->fs_readtrash_size(eptr->sessionData->rootInode,
-	                                                  eptr->sessionData->flags, &dleng);
+	status = gFSOperations->fs_readtrash_size(eptr->sessionData->rootInode,
+	                                          eptr->sessionData->flags, &dleng);
 
 	ptr = matoclserv_createpacket(
 	    eptr, MATOCL_FUSE_GETTRASH,
@@ -3554,8 +3545,8 @@ void matoclserv_fuse_gettrash(matoclserventry *eptr, const uint8_t *data, uint32
 	if (status != SAUNAFS_STATUS_OK) {
 		put8bit(&ptr, status);
 	} else {
-		gFilesystemOperations->fs_readtrash_data(eptr->sessionData->rootInode,
-		                                         eptr->sessionData->flags, ptr);
+		gFSOperations->fs_readtrash_data(eptr->sessionData->rootInode, eptr->sessionData->flags,
+		                                 ptr);
 	}
 }
 
@@ -3569,7 +3560,7 @@ void matoclserv_fuse_gettrash(matoclserventry *eptr, const PacketHeader &header,
 		uint32_t off;
 		cltoma::fuseGetTrash::deserialize(data, header.length, msgId, off, maxEntries);
 		std::vector<NamedInodeEntry> entries;
-		gFilesystemOperations->fs_readtrash(
+		gFSOperations->fs_readtrash(
 		    off, std::min<uint32_t>(maxEntries, matocl::fuseGetDir::kMaxNumberOfDirectoryEntries),
 		    entries);
 		matoclserv_createpacket(eptr, matocl::fuseGetTrash::build(msgId, entries));
@@ -3577,7 +3568,7 @@ void matoclserv_fuse_gettrash(matoclserventry *eptr, const PacketHeader &header,
 		uint64_t off;
 		cltoma::fuseGetTrash::deserialize(data, header.length, msgId, off, maxEntries);
 		std::vector<HandleInodeEntry> entries;
-		gFilesystemOperations->fs_readtrash(
+		gFSOperations->fs_readtrash(
 		    off, std::min<uint32_t>(maxEntries, matocl::fuseGetDir::kMaxNumberOfDirectoryEntries),
 		    entries);
 		matoclserv_createpacket(eptr, matocl::fuseGetTrash::build(msgId, entries));
@@ -3613,8 +3604,8 @@ void matoclserv_fuse_getdetachedattr(matoclserventry *eptr, const uint8_t *data,
 		dtype = DTYPE_UNKNOWN;
 	}
 
-	status = gFilesystemOperations->fs_getdetachedattr(
-	    eptr->sessionData->rootInode, eptr->sessionData->flags, inode, attr, dtype);
+	status = gFSOperations->fs_getdetachedattr(eptr->sessionData->rootInode,
+	                                           eptr->sessionData->flags, inode, attr, dtype);
 
 	constexpr uint32_t kFailedSize = sizeof(msgid) + sizeof(status);
 	constexpr uint32_t kSuccessSize = sizeof(msgid) + attr.size();
@@ -3651,8 +3642,8 @@ void matoclserv_fuse_gettrashpath(matoclserventry *eptr, const uint8_t *data, ui
 	get32bit(&data, msgid);
 	getINode(&data, inode);
 
-	status = gFilesystemOperations->fs_gettrashpath(eptr->sessionData->rootInode,
-	                                                eptr->sessionData->flags, inode, path);
+	status = gFSOperations->fs_gettrashpath(eptr->sessionData->rootInode, eptr->sessionData->flags,
+	                                        inode, path);
 
 	constexpr uint32_t kFailedSize = sizeof(msgid) + sizeof(status);
 	const uint32_t kSuccessSize = sizeof(msgid) + sizeof(uint32_t) + path.length() + 1;
@@ -3708,8 +3699,8 @@ void matoclserv_fuse_settrashpath(matoclserventry *eptr, const uint8_t *data, ui
 	data += pleng;
 	while (pleng > 0 && path[pleng - 1] == 0) { pleng--; }
 
-	status = gFilesystemOperations->fs_settrashpath(matoclserv_get_context(eptr), inode,
-	                                                std::string((char *)path, pleng));
+	status = gFSOperations->fs_settrashpath(matoclserv_get_context(eptr), inode,
+	                                        std::string((char *)path, pleng));
 
 	ptr = matoclserv_createpacket(eptr, MATOCL_FUSE_SETTRASHPATH, sizeof(msgid) + sizeof(status));
 
@@ -3735,7 +3726,7 @@ void matoclserv_fuse_undel(matoclserventry *eptr, const uint8_t *data, uint32_t 
 	get32bit(&data, msgid);
 	getINode(&data, inode);
 
-	status = gFilesystemOperations->fs_undel(matoclserv_get_context(eptr), inode);
+	status = gFSOperations->fs_undel(matoclserv_get_context(eptr), inode);
 
 	ptr = matoclserv_createpacket(eptr, MATOCL_FUSE_UNDEL, sizeof(msgid) + sizeof(status));
 
@@ -3761,7 +3752,7 @@ void matoclserv_fuse_purge(matoclserventry *eptr, const uint8_t *data, uint32_t 
 	get32bit(&data, msgid);
 	getINode(&data, inode);
 
-	status = gFilesystemOperations->fs_purge(matoclserv_get_context(eptr), inode);
+	status = gFSOperations->fs_purge(matoclserv_get_context(eptr), inode);
 
 	ptr = matoclserv_createpacket(eptr, MATOCL_FUSE_PURGE, sizeof(msgid) + sizeof(status));
 	put32bit(&ptr, msgid);
@@ -3786,8 +3777,8 @@ void matoclserv_fuse_getreserved(matoclserventry *eptr, const uint8_t *data, uin
 
 	get32bit(&data, msgid);
 
-	status = gFilesystemOperations->fs_readreserved_size(eptr->sessionData->rootInode,
-	                                                     eptr->sessionData->flags, &dleng);
+	status = gFSOperations->fs_readreserved_size(eptr->sessionData->rootInode,
+	                                             eptr->sessionData->flags, &dleng);
 
 	constexpr uint32_t kFailedSize = sizeof(msgid) + sizeof(status);
 	const uint32_t kSuccessSize = sizeof(msgid) + dleng;
@@ -3800,8 +3791,8 @@ void matoclserv_fuse_getreserved(matoclserventry *eptr, const uint8_t *data, uin
 	if (status!=SAUNAFS_STATUS_OK) {
 		put8bit(&ptr,status);
 	} else {
-		gFilesystemOperations->fs_readreserved_data(eptr->sessionData->rootInode,
-		                                            eptr->sessionData->flags, ptr);
+		gFSOperations->fs_readreserved_data(eptr->sessionData->rootInode, eptr->sessionData->flags,
+		                                    ptr);
 	}
 }
 
@@ -3815,7 +3806,7 @@ void matoclserv_fuse_getreserved(matoclserventry *eptr, const PacketHeader &head
 		uint32_t off;
 		cltoma::fuseGetReserved::deserialize(data, header.length, msgId, off, maxEntries);
 		std::vector<NamedInodeEntry> entries;
-		gFilesystemOperations->fs_readreserved(
+		gFSOperations->fs_readreserved(
 		    off, std::min<uint32_t>(maxEntries, matocl::fuseGetDir::kMaxNumberOfDirectoryEntries),
 		    entries);
 		matoclserv_createpacket(eptr, matocl::fuseGetReserved::build(msgId, entries));
@@ -3823,7 +3814,7 @@ void matoclserv_fuse_getreserved(matoclserventry *eptr, const PacketHeader &head
 		uint64_t off;
 		cltoma::fuseGetReserved::deserialize(data, header.length, msgId, off, maxEntries);
 		std::vector<HandleInodeEntry> entries;
-		gFilesystemOperations->fs_readreserved(
+		gFSOperations->fs_readreserved(
 		    off, std::min<uint32_t>(maxEntries, matocl::fuseGetDir::kMaxNumberOfDirectoryEntries),
 		    entries);
 		matoclserv_createpacket(eptr, matocl::fuseGetReserved::build(msgId, entries));
@@ -3842,7 +3833,7 @@ void matoclserv_fuse_deleteacl(matoclserventry *eptr, const uint8_t *data, uint3
 	uint8_t status = matoclserv_check_group_cache(eptr, gid);
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = gFilesystemOperations->fs_deleteacl(context, inode, type);
+		status = gFSOperations->fs_deleteacl(context, inode, type);
 	}
 	matoclserv_createpacket(eptr, matocl::fuseDeleteAcl::build(messageId, status));
 }
@@ -3861,7 +3852,7 @@ void matoclserv_fuse_getacl(matoclserventry *eptr, const uint8_t *data, uint32_t
 
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = gFilesystemOperations->fs_getacl(context, inode, acl);
+		status = gFSOperations->fs_getacl(context, inode, acl);
 	}
 
 	if (status == SAUNAFS_STATUS_OK) {
@@ -3957,8 +3948,8 @@ void matoclserv_fuse_flock(matoclserventry *eptr, const uint8_t *data, uint32_t 
 	}
 
 	std::vector<FileLocks::Owner> applied;
-	status = gFilesystemOperations->fs_flock_op(context, inode, owner, eptr->sessionData->sessionId,
-	                                            requestId, messageId, op, nonblocking, applied);
+	status = gFSOperations->fs_flock_op(context, inode, owner, eptr->sessionData->sessionId,
+	                                    requestId, messageId, op, nonblocking, applied);
 
 	matoclserv_lock_wake_up(applied, safs_locks::Type::kFlock);
 
@@ -3998,9 +3989,9 @@ void matoclserv_fuse_getlk(matoclserventry *eptr, const uint8_t *data, uint32_t 
 		lock_end = (uint64_t)lock_info.l_start + (uint64_t)lock_info.l_len;
 	}
 
-	status = gFilesystemOperations->fs_posixlock_probe(context, inode, lock_info.l_start, lock_end,
-	                                                   owner, eptr->sessionData->sessionId, 0,
-	                                                   message_id, lock_info.l_type, lock_info);
+	status = gFSOperations->fs_posixlock_probe(context, inode, lock_info.l_start, lock_end, owner,
+	                                           eptr->sessionData->sessionId, 0, message_id,
+	                                           lock_info.l_type, lock_info);
 
 	// Standard states that lock of length 0 is a lock till EOF
 	if (lock_info.l_len == std::numeric_limits<int64_t>::max()) {
@@ -4052,9 +4043,9 @@ void matoclserv_fuse_setlk(matoclserventry *eptr, const uint8_t *data, uint32_t 
 	}
 
 	std::vector<FileLocks::Owner> applied;
-	status = gFilesystemOperations->fs_posixlock_op(context, inode, lock_info.l_start, lock_end,
-	                                                owner, eptr->sessionData->sessionId, request_id,
-	                                                message_id, op, nonblocking, applied);
+	status = gFSOperations->fs_posixlock_op(context, inode, lock_info.l_start, lock_end, owner,
+	                                        eptr->sessionData->sessionId, request_id, message_id,
+	                                        op, nonblocking, applied);
 
 	matoclserv_lock_wake_up(applied, safs_locks::Type::kPosix);
 
@@ -4102,13 +4093,13 @@ void matoclserv_manage_locks_list(matoclserventry *eptr, const uint8_t *data, ui
 	if (version == cltoma::manageLocksList::kAll) {
 		cltoma::manageLocksList::deserialize(data, length, type, pending, start, max);
 		max = std::min(max, SAU_CLTOMA_MANAGE_LOCKS_LIST_LIMIT);
-		status = gFilesystemOperations->fs_locks_list_all(context, (uint8_t)type, pending, start,
-		                                                  max, locks);
+		status =
+		    gFSOperations->fs_locks_list_all(context, (uint8_t)type, pending, start, max, locks);
 	} else if (version == cltoma::manageLocksList::kInode) {
 		cltoma::manageLocksList::deserialize(data, length, inode, type, pending, start, max);
 		max = std::min(max, SAU_CLTOMA_MANAGE_LOCKS_LIST_LIMIT);
-		status = gFilesystemOperations->fs_locks_list_inode(context, (uint8_t)type, pending, inode,
-		                                                    start, max, locks);
+		status = gFSOperations->fs_locks_list_inode(context, (uint8_t)type, pending, inode, start,
+		                                            max, locks);
 	} else {
 		throw IncorrectDeserializationException(
 				"Unknown SAU_CLTOMA_MANAGE_LOCKS_LIST version: " + std::to_string(version));
@@ -4153,24 +4144,23 @@ void matoclserv_manage_locks_unlock(matoclserventry *eptr, const uint8_t *data, 
 			end = std::numeric_limits<decltype(end)>::max();
 		}
 		if (type == safs_locks::Type::kAll || type == safs_locks::Type::kFlock) {
-			status = gFilesystemOperations->fs_flock_op(context, inode, owner, sessionid, 0, 0,
-			                                            safs_locks::kUnlock, true, flocks_applied);
+			status = gFSOperations->fs_flock_op(context, inode, owner, sessionid, 0, 0,
+			                                    safs_locks::kUnlock, true, flocks_applied);
 		}
 		if (status == SAUNAFS_STATUS_OK &&
 		    (type == safs_locks::Type::kAll || type == safs_locks::Type::kPosix)) {
-			status = gFilesystemOperations->fs_posixlock_op(context, inode, start, end, owner,
-			                                                sessionid, 0, 0, safs_locks::kUnlock,
-			                                                true, posix_applied);
+			status = gFSOperations->fs_posixlock_op(context, inode, start, end, owner, sessionid, 0,
+			                                        0, safs_locks::kUnlock, true, posix_applied);
 		}
 	} else if (version == cltoma::manageLocksUnlock::kInode) {
 		cltoma::manageLocksUnlock::deserialize(data, length, type, inode);
 		if (type == safs_locks::Type::kAll || type == safs_locks::Type::kFlock) {
-			status = gFilesystemOperations->fs_locks_unlock_inode(
+			status = gFSOperations->fs_locks_unlock_inode(
 			    context, (uint8_t)safs_locks::Type::kFlock, inode, flocks_applied);
 		}
 		if (status == SAUNAFS_STATUS_OK &&
 		    (type == safs_locks::Type::kAll || type == safs_locks::Type::kPosix)) {
-			status = gFilesystemOperations->fs_locks_unlock_inode(
+			status = gFSOperations->fs_locks_unlock_inode(
 			    context, (uint8_t)safs_locks::Type::kPosix, inode, posix_applied);
 		}
 	} else {
@@ -4193,7 +4183,7 @@ void matoclserv_manage_locks_unlock(matoclserventry *eptr, const uint8_t *data, 
 }
 
 void matoclserv_list_tasks(matoclserventry *eptr) {
-	std::vector<JobInfo> jobs_info = gFilesystemOperations->fs_get_current_tasks_info();
+	std::vector<JobInfo> jobs_info = gFSOperations->fs_get_current_tasks_info();
 	matoclserv_createpacket(eptr, matocl::listTasks::build(jobs_info));
 }
 
@@ -4201,7 +4191,7 @@ void matoclserv_stop_task(matoclserventry *eptr, const uint8_t *data, uint32_t l
 	uint32_t job_id, msgid;
 	uint8_t status;
 	cltoma::stopTask::deserialize(data, length, msgid, job_id);
-	status = gFilesystemOperations->fs_cancel_job(job_id);
+	status = gFSOperations->fs_cancel_job(job_id);
 	matoclserv_createpacket(eptr, matocl::stopTask::build(msgid, status));
 }
 
@@ -4222,9 +4212,9 @@ void matoclserv_fuse_locks_interrupt(matoclserventry *eptr, const uint8_t *data,
 	cltoma::fuseFlock::deserialize(data, length, messageId, interruptData);
 
 	// we do not reply, so there is not need for checking status of this fs_operation
-	gFilesystemOperations->fs_locks_remove_pending(context, type, interruptData.owner,
-	                                               eptr->sessionData->sessionId, interruptData.ino,
-	                                               interruptData.reqid);
+	gFSOperations->fs_locks_remove_pending(context, type, interruptData.owner,
+	                                       eptr->sessionData->sessionId, interruptData.ino,
+	                                       interruptData.reqid);
 }
 
 void matoclserv_update_credentials(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
@@ -4278,9 +4268,9 @@ void matoclserv_fuse_setacl(matoclserventry *eptr, const uint8_t *data, uint32_t
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
 		if (use_posix) {
-			status = gFilesystemOperations->fs_setacl(context, inode, type, posix_acl);
+			status = gFSOperations->fs_setacl(context, inode, type, posix_acl);
 		} else {
-			status = gFilesystemOperations->fs_setacl(context, inode, rich_acl);
+			status = gFSOperations->fs_setacl(context, inode, rich_acl);
 		}
 	}
 	matoclserv_createpacket(eptr, matocl::fuseSetAcl::build(messageId, status));
@@ -4294,7 +4284,7 @@ void matoclserv_fuse_setquota(matoclserventry *eptr, const uint8_t *data, uint32
 	uint8_t status = matoclserv_check_group_cache(eptr, gid);
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = gFilesystemOperations->fs_quota_set(context, entries);
+		status = gFSOperations->fs_quota_set(context, entries);
 	}
 
 	MessageBuffer reply;
@@ -4315,7 +4305,7 @@ void matoclserv_fuse_getquota(matoclserventry *eptr, const uint8_t *data, uint32
 		status = matoclserv_check_group_cache(eptr, gid);
 		if (status == SAUNAFS_STATUS_OK) {
 			FsContext context = matoclserv_get_context(eptr, uid, gid);
-			status = gFilesystemOperations->fs_quota_get_all(context, results);
+			status = gFSOperations->fs_quota_get_all(context, results);
 		}
 	} else if (version == cltoma::fuseGetQuota::kSelectedLimits) {
 		std::vector<QuotaOwner> owners;
@@ -4323,7 +4313,7 @@ void matoclserv_fuse_getquota(matoclserventry *eptr, const uint8_t *data, uint32
 		status = matoclserv_check_group_cache(eptr, gid);
 		if (status == SAUNAFS_STATUS_OK) {
 			FsContext context = matoclserv_get_context(eptr, uid, gid);
-			status = gFilesystemOperations->fs_quota_get(context, owners, results);
+			status = gFSOperations->fs_quota_get(context, owners, results);
 		}
 	} else {
 		throw IncorrectDeserializationException(
@@ -4332,8 +4322,7 @@ void matoclserv_fuse_getquota(matoclserventry *eptr, const uint8_t *data, uint32
 
 	MessageBuffer reply;
 	if (status == SAUNAFS_STATUS_OK) {
-		status =
-		    gFilesystemOperations->fs_quota_get_info(matoclserv_get_context(eptr), results, info);
+		status = gFSOperations->fs_quota_get_info(matoclserv_get_context(eptr), results, info);
 	}
 
 	if (status == SAUNAFS_STATUS_OK) {
@@ -4560,7 +4549,7 @@ void matoclserv_admin_recalculate_metadata_checksum(matoclserventry *eptr, const
 	if (eptr->registered == ClientState::kAdmin) {
 		safs::log_info("metadata checksum recalculation requested using saunafs-admin by {}",
 		               ipToString(eptr->peerIpAddress));
-		uint8_t status = gFilesystemOperations->fs_start_checksum_recalculation();
+		uint8_t status = gFSOperations->fs_start_checksum_recalculation();
 
 		if (status != SAUNAFS_STATUS_OK || asynchronous) {
 			matoclserv_createpacket(eptr, matocl::adminRecalculateMetadataChecksum::build(status));
@@ -4592,16 +4581,16 @@ void matoclserv_broadcast_metadata_checksum_recalculated(uint8_t status) {
 void matocl_locks_release(const FsContext &context, inode_t inode, uint32_t sessionId) {
 	std::vector<FileLocks::Owner> applied;
 
-	gFilesystemOperations->fs_locks_clear_session(context, (uint8_t)safs_locks::Type::kFlock, inode,
-	                                              sessionId, applied);
+	gFSOperations->fs_locks_clear_session(context, (uint8_t)safs_locks::Type::kFlock, inode,
+	                                      sessionId, applied);
 
 	for (auto candidate : applied) {
 		matoclserv_lock_wake_up(candidate.sessionid, candidate.msgid, safs_locks::Type::kFlock);
 	}
 
 	applied.clear();
-	gFilesystemOperations->fs_locks_clear_session(context, (uint8_t)safs_locks::Type::kPosix, inode,
-	                                              sessionId, applied);
+	gFSOperations->fs_locks_clear_session(context, (uint8_t)safs_locks::Type::kPosix, inode,
+	                                      sessionId, applied);
 
 	for (auto candidate : applied) {
 		matoclserv_lock_wake_up(candidate.sessionid, candidate.msgid, safs_locks::Type::kPosix);
@@ -4612,7 +4601,7 @@ void matocl_close_files(Session *currentSession) {
 	FsContext context = FsContext::getForMaster(eventloop_time());
 
 	for (const auto &openFileInode : currentSession->openFilesSet) {
-		gFilesystemOperations->fs_release(context, openFileInode, currentSession->sessionId);
+		gFSOperations->fs_release(context, openFileInode, currentSession->sessionId);
 		matocl_locks_release(context, openFileInode, currentSession->sessionId);
 	}
 
@@ -4702,7 +4691,7 @@ void matocl_before_disconnect(matoclserventry *eptr) {
 	// unlock locked chunks
 	for (const auto &operation : eptr->delayedChunkOperations) {
 		if (operation->type == FUSE_TRUNCATE) {
-			gFilesystemOperations->fs_end_setlength(operation->chunkId);
+			gFSOperations->fs_end_setlength(operation->chunkId);
 		}
 	}
 

--- a/src/master/matoclserv_sessions.cc
+++ b/src/master/matoclserv_sessions.cc
@@ -38,7 +38,7 @@ Session *matoclserv_new_session(uint8_t newSession, uint8_t noNewId) {
 	passert(sessionPtr.get());
 
 	auto newSessionIdNotNeeded = (newSession == 0 && noNewId);
-	sessionPtr->sessionId = (newSessionIdNotNeeded) ? 0 : gFilesystemOperations->fs_newsessionid();
+	sessionPtr->sessionId = (newSessionIdNotNeeded) ? 0 : gFSOperations->fs_newsessionid();
 	sessionPtr->newSession = newSession;
 	sessionPtr->connections = 1;
 	gSessionsVector.push_back(std::move(sessionPtr));
@@ -332,8 +332,8 @@ int matoclserv_insert_open_file(Session *currentSession, inode_t inode) {
 		return SAUNAFS_STATUS_OK;  // file already acquired - nothing to do
 	}
 
-	int status = gFilesystemOperations->fs_acquire(FsContext::getForMaster(eventloop_time()), inode,
-	                                               currentSession->sessionId);
+	int status = gFSOperations->fs_acquire(FsContext::getForMaster(eventloop_time()), inode,
+	                                       currentSession->sessionId);
 
 	if (status == SAUNAFS_STATUS_OK) { currentSession->openFilesSet.insert(inode); }
 

--- a/src/master/matoclserv_sessions.cc
+++ b/src/master/matoclserv_sessions.cc
@@ -38,7 +38,7 @@ Session *matoclserv_new_session(uint8_t newSession, uint8_t noNewId) {
 	passert(sessionPtr.get());
 
 	auto newSessionIdNotNeeded = (newSession == 0 && noNewId);
-	sessionPtr->sessionId = (newSessionIdNotNeeded) ? 0 : gFSOperations->fs_newsessionid();
+	sessionPtr->sessionId = (newSessionIdNotNeeded) ? 0 : gFSOperations->newSessionId();
 	sessionPtr->newSession = newSession;
 	sessionPtr->connections = 1;
 	gSessionsVector.push_back(std::move(sessionPtr));
@@ -332,8 +332,8 @@ int matoclserv_insert_open_file(Session *currentSession, inode_t inode) {
 		return SAUNAFS_STATUS_OK;  // file already acquired - nothing to do
 	}
 
-	int status = gFSOperations->fs_acquire(FsContext::getForMaster(eventloop_time()), inode,
-	                                       currentSession->sessionId);
+	int status = gFSOperations->acquire(FsContext::getForMaster(eventloop_time()), inode,
+	                                    currentSession->sessionId);
 
 	if (status == SAUNAFS_STATUS_OK) { currentSession->openFilesSet.insert(inode); }
 

--- a/src/master/matocsserv.cc
+++ b/src/master/matocsserv.cc
@@ -320,7 +320,7 @@ std::vector<std::pair<matocsserventry *, ChunkPartType>> matocsserv_getservers_f
 		uint8_t goal_id, uint32_t min_server_version) {
 	static std::array<ChunkCreationHistory, GoalId::kMax + 1> history;
 	GetServersForNewChunk getter;
-	const Goal &goal(gFilesystemOperations->fs_get_goal_definition(goal_id));
+	const Goal &goal(gFSOperations->fs_get_goal_definition(goal_id));
 
 	for (const auto &eptr : matocsservList) {
 		if (eptr->mode != KILL && eptr->totalspace > 0 &&

--- a/src/master/matocsserv.cc
+++ b/src/master/matocsserv.cc
@@ -320,7 +320,7 @@ std::vector<std::pair<matocsserventry *, ChunkPartType>> matocsserv_getservers_f
 		uint8_t goal_id, uint32_t min_server_version) {
 	static std::array<ChunkCreationHistory, GoalId::kMax + 1> history;
 	GetServersForNewChunk getter;
-	const Goal &goal(gFSOperations->fs_get_goal_definition(goal_id));
+	const Goal &goal(gFSOperations->getGoalDefinition(goal_id));
 
 	for (const auto &eptr : matocsservList) {
 		if (eptr->mode != KILL && eptr->totalspace > 0 &&

--- a/src/master/matomlserv.cc
+++ b/src/master/matomlserv.cc
@@ -448,7 +448,7 @@ void matomlserv_register_shadow(matomlserventry *eptr, const uint8_t *data, uint
 		return;
 	}
 
-	uint64_t myMedatataVersion = gFSOperations->fs_getversion();
+	uint64_t myMedatataVersion = gFSOperations->getMetadataVersion();
 	uint64_t replyVersion;
 	if (myMedatataVersion > shadowMetadataVersion
 			&& old_changes_head != nullptr
@@ -610,7 +610,7 @@ void matomlserv_changelog_apply_error(matomlserventry *eptr, const uint8_t *data
 		gShadowQueue.addRequest(eptr);
 		gMetadataBackend->fs_storeall(DumpType::kBackgroundDump);
 		if (recvStatus == SAUNAFS_ERROR_BADMETADATACHECKSUM) {
-			gFSOperations->fs_start_checksum_recalculation();
+			gFSOperations->startChecksumRecalculation();
 		}
 	} else {
 		safs_silent_syslog(LOG_DEBUG, "master.mltoma_changelog_apply_error: delay");

--- a/src/master/matomlserv.cc
+++ b/src/master/matomlserv.cc
@@ -448,7 +448,7 @@ void matomlserv_register_shadow(matomlserventry *eptr, const uint8_t *data, uint
 		return;
 	}
 
-	uint64_t myMedatataVersion = gFilesystemOperations->fs_getversion();
+	uint64_t myMedatataVersion = gFSOperations->fs_getversion();
 	uint64_t replyVersion;
 	if (myMedatataVersion > shadowMetadataVersion
 			&& old_changes_head != nullptr
@@ -610,7 +610,7 @@ void matomlserv_changelog_apply_error(matomlserventry *eptr, const uint8_t *data
 		gShadowQueue.addRequest(eptr);
 		gMetadataBackend->fs_storeall(DumpType::kBackgroundDump);
 		if (recvStatus == SAUNAFS_ERROR_BADMETADATACHECKSUM) {
-			gFilesystemOperations->fs_start_checksum_recalculation();
+			gFSOperations->fs_start_checksum_recalculation();
 		}
 	} else {
 		safs_silent_syslog(LOG_DEBUG, "master.mltoma_changelog_apply_error: delay");

--- a/src/master/matontserv.cc
+++ b/src/master/matontserv.cc
@@ -262,7 +262,7 @@ void matontserv_get_path_type_inode(MatontservEntry *eptr, const uint8_t *data, 
 		return;
 	}
 
-	pathByInode = gFilesystemOperations->fs_full_path_by_inode(inode);
+	pathByInode = gFSOperations->fs_full_path_by_inode(inode);
 	responseData =
 	    matontserv_addpacket(eptr, MATONT_GET_PATH_TYPE_INODE,
 	                         sizeof(responseInode) + sizeof(node->type) + pathByInode.size() + 1);

--- a/src/master/matontserv.cc
+++ b/src/master/matontserv.cc
@@ -262,7 +262,7 @@ void matontserv_get_path_type_inode(MatontservEntry *eptr, const uint8_t *data, 
 		return;
 	}
 
-	pathByInode = gFSOperations->fs_full_path_by_inode(inode);
+	pathByInode = gFSOperations->fullPathByInode(inode);
 	responseData =
 	    matontserv_addpacket(eptr, MATONT_GET_PATH_TYPE_INODE,
 	                         sizeof(responseInode) + sizeof(node->type) + pathByInode.size() + 1);

--- a/src/master/metadata_backend_file.cc
+++ b/src/master/metadata_backend_file.cc
@@ -186,8 +186,7 @@ uint8_t MetadataBackendFile::fs_storeall(DumpType dumpType) {
 	matomlserv_broadcast_logrotate();
 	// child == true says that we forked
 	// bg may be changed to dump in foreground in case of a fork error
-	bool child =
-	    dumper()->start(dumpType, gFilesystemOperations->fs_checksum(ChecksumMode::kGetCurrent));
+	bool child = dumper()->start(dumpType, gFSOperations->fs_checksum(ChecksumMode::kGetCurrent));
 	uint8_t status = SAUNAFS_STATUS_OK;
 
 	if (dumpType == DumpType::kForegroundDump) {
@@ -916,7 +915,7 @@ void fs_new(void) {
 	gMetadata->dirNodes = 1;
 	gMetadata->fileNodes = 0;
 
-	gFilesystemOperations->fs_checksum(ChecksumMode::kForceRecalculate);
+	gFSOperations->fs_checksum(ChecksumMode::kForceRecalculate);
 	fsnodes_quota_update(gMetadata->root, {{QuotaResource::kInodes, +1}});
 }
 
@@ -978,13 +977,13 @@ void MetadataBackendFile::loadall(int ignoreflag) {
 	safs::log_info("connecting files and chunks");
 	{
 		util::ScopedTimer timer("connecting files and chunks took");
-		gFilesystemOperations->fs_add_files_to_chunks();
+		gFSOperations->fs_add_files_to_chunks();
 	}
 	unlink(kMetadataTmpFilename);
 	safs::log_info("calculating checksum of the metadata");
 	{
 		util::ScopedTimer timer("calculating checksum of the metadata took");
-		gFilesystemOperations->fs_checksum(ChecksumMode::kForceRecalculate);
+		gFSOperations->fs_checksum(ChecksumMode::kForceRecalculate);
 	}
 
 #ifndef METARESTORE

--- a/src/master/metadata_backend_file.cc
+++ b/src/master/metadata_backend_file.cc
@@ -186,7 +186,8 @@ uint8_t MetadataBackendFile::fs_storeall(DumpType dumpType) {
 	matomlserv_broadcast_logrotate();
 	// child == true says that we forked
 	// bg may be changed to dump in foreground in case of a fork error
-	bool child = dumper()->start(dumpType, gFSOperations->fs_checksum(ChecksumMode::kGetCurrent));
+	bool child =
+	    dumper()->start(dumpType, gFSOperations->metadataChecksum(ChecksumMode::kGetCurrent));
 	uint8_t status = SAUNAFS_STATUS_OK;
 
 	if (dumpType == DumpType::kForegroundDump) {
@@ -915,7 +916,7 @@ void fs_new(void) {
 	gMetadata->dirNodes = 1;
 	gMetadata->fileNodes = 0;
 
-	gFSOperations->fs_checksum(ChecksumMode::kForceRecalculate);
+	gFSOperations->metadataChecksum(ChecksumMode::kForceRecalculate);
 	fsnodes_quota_update(gMetadata->root, {{QuotaResource::kInodes, +1}});
 }
 
@@ -977,13 +978,13 @@ void MetadataBackendFile::loadall(int ignoreflag) {
 	safs::log_info("connecting files and chunks");
 	{
 		util::ScopedTimer timer("connecting files and chunks took");
-		gFSOperations->fs_add_files_to_chunks();
+		gFSOperations->addFilesToChunks();
 	}
 	unlink(kMetadataTmpFilename);
 	safs::log_info("calculating checksum of the metadata");
 	{
 		util::ScopedTimer timer("calculating checksum of the metadata took");
-		gFSOperations->fs_checksum(ChecksumMode::kForceRecalculate);
+		gFSOperations->metadataChecksum(ChecksumMode::kForceRecalculate);
 	}
 
 #ifndef METARESTORE

--- a/src/master/recursive_remove_task.cc
+++ b/src/master/recursive_remove_task.cc
@@ -49,8 +49,8 @@ int RemoveTask::retrieveNodes(FSNodeDirectory *&wd, FSNode *&child) {
 }
 
 void RemoveTask::doUnlink(uint32_t ts, FSNodeDirectory *wd, FSNode *child) {
-	gFilesystemOperations->fs_changelog(ts, "UNLINK(%" PRIiNode ",%s):%" PRIiNode, parent_,
-	                                    fsnodes_escape_name(*current_subtask_).c_str(), child->id);
+	gFSOperations->fs_changelog(ts, "UNLINK(%" PRIiNode ",%s):%" PRIiNode, parent_,
+	                            fsnodes_escape_name(*current_subtask_).c_str(), child->id);
 	fsnodes_unlink(ts, wd, *current_subtask_, child);
 }
 

--- a/src/master/recursive_remove_task.cc
+++ b/src/master/recursive_remove_task.cc
@@ -49,8 +49,8 @@ int RemoveTask::retrieveNodes(FSNodeDirectory *&wd, FSNode *&child) {
 }
 
 void RemoveTask::doUnlink(uint32_t ts, FSNodeDirectory *wd, FSNode *child) {
-	gFSOperations->fs_changelog(ts, "UNLINK(%" PRIiNode ",%s):%" PRIiNode, parent_,
-	                            fsnodes_escape_name(*current_subtask_).c_str(), child->id);
+	gFSOperations->changeLog(ts, "UNLINK(%" PRIiNode ",%s):%" PRIiNode, parent_,
+	                         fsnodes_escape_name(*current_subtask_).c_str(), child->id);
 	fsnodes_unlink(ts, wd, *current_subtask_, child);
 }
 

--- a/src/master/restore.cc
+++ b/src/master/restore.cc
@@ -208,7 +208,7 @@ int do_access(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
 	EAT(ptr,filename,lv,'(');
 	GETINODE(inode,ptr);
 	EAT(ptr,filename,lv,')');
-	return gFSOperations->fs_apply_access(ts, inode);
+	return gFSOperations->applyAccess(ts, inode);
 }
 
 int do_append(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -219,7 +219,7 @@ int do_append(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
 	EAT(ptr,filename,lv,',');
 	GETINODE(inode_src,ptr);
 	EAT(ptr,filename,lv,')');
-	return gFSOperations->fs_append(FsContext::getForRestore(ts), inode, inode_src);
+	return gFSOperations->append(FsContext::getForRestore(ts), inode, inode_src);
 }
 
 int do_acquire(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -230,7 +230,7 @@ int do_acquire(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) 
 	EAT(ptr,filename,lv,',');
 	GETU32(cuid,ptr);
 	EAT(ptr,filename,lv,')');
-	return gFSOperations->fs_acquire(FsContext::getForRestore(ts), inode, cuid);
+	return gFSOperations->acquire(FsContext::getForRestore(ts), inode, cuid);
 }
 
 int do_attr(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -249,7 +249,7 @@ int do_attr(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
 	EAT(ptr,filename,lv,',');
 	GETU32(mtime,ptr);
 	EAT(ptr,filename,lv,')');
-	return gFSOperations->fs_apply_attr(ts, inode, mode, uid, gid, atime, mtime);
+	return gFSOperations->applyAttr(ts, inode, mode, uid, gid, atime, mtime);
 }
 
 int do_checksum(const char *filename, uint64_t lv, uint32_t, const char *ptr) {
@@ -260,7 +260,7 @@ int do_checksum(const char *filename, uint64_t lv, uint32_t, const char *ptr) {
 	EAT(ptr,filename,lv,')');
 	EAT(ptr,filename,lv,':');
 	GETU64(checksum,ptr);
-	return gFSOperations->fs_apply_checksum((char *)&version, checksum);
+	return gFSOperations->applyChecksum((char *)&version, checksum);
 }
 
 int do_create(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -286,9 +286,8 @@ int do_create(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
 	EAT(ptr,filename,lv,')');
 	EAT(ptr,filename,lv,':');
 	GETINODE(inode,ptr);
-	return gFSOperations->fs_apply_create(ts, parent, HString((const char *)name),
-	                                      static_cast<FSNodeType>(type), mode, uid, gid, rdev,
-	                                      inode);
+	return gFSOperations->applyCreate(ts, parent, HString((const char *)name),
+	                                  static_cast<FSNodeType>(type), mode, uid, gid, rdev, inode);
 }
 
 int do_session(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -298,7 +297,7 @@ int do_session(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) 
 	EAT(ptr,filename,lv,')');
 	EAT(ptr,filename,lv,':');
 	GETU32(cuid,ptr);
-	return gFSOperations->fs_apply_session(cuid);
+	return gFSOperations->applySession(cuid);
 }
 
 int do_incversion(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -307,7 +306,7 @@ int do_incversion(const char *filename, uint64_t lv, uint32_t ts, const char *pt
 	EAT(ptr,filename,lv,'(');
 	GETU64(chunkid,ptr);
 	EAT(ptr,filename,lv,')');
-	return gFSOperations->fs_apply_incversion(chunkid);
+	return gFSOperations->applyIncreaseChunkVersion(chunkid);
 }
 
 int do_link(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -321,8 +320,8 @@ int do_link(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
 	EAT(ptr,filename,lv,',');
 	GETNAME(name,ptr,filename,lv,')');
 	EAT(ptr,filename,lv,')');
-	return gFSOperations->fs_link(FsContext::getForRestore(ts), inode, parent,
-	                              HString((const char *)name), nullptr, nullptr);
+	return gFSOperations->link(FsContext::getForRestore(ts), inode, parent,
+	                           HString((const char *)name), nullptr, nullptr);
 }
 
 int do_length(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -342,7 +341,7 @@ int do_length(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
 		GETU32(eraseFurtherChunks, ptr);
 	}
 	EAT(ptr, filename, lv, ')');
-	return gFSOperations->fs_apply_length(ts, inode, length, eraseFurtherChunks != 0);
+	return gFSOperations->applyLength(ts, inode, length, eraseFurtherChunks != 0);
 }
 
 int do_move(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
@@ -361,9 +360,9 @@ int do_move(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
 	EAT(ptr,filename,lv,')');
 	EAT(ptr,filename,lv,':');
 	GETINODE(inode,ptr);
-	return gFSOperations->fs_rename(FsContext::getForRestore(ts), parent_src,
-	                                HString((const char *)name_src), parent_dst,
-	                                HString((const char *)name_dst), &inode, nullptr);
+	return gFSOperations->rename(FsContext::getForRestore(ts), parent_src,
+	                             HString((const char *)name_src), parent_dst,
+	                             HString((const char *)name_dst), &inode, nullptr);
 }
 
 int do_lock_op(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -394,13 +393,13 @@ int do_lock_op(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) 
 
 	switch (static_cast<safs_locks::Type>(lock_type)) {
 	case safs_locks::Type::kFlock:
-		status = gFSOperations->fs_flock_op(FsContext::getForRestore(ts), inode, owner, sessionid,
-		                                    0, 0, op, nonblocking, dummy_applied);
+		status = gFSOperations->flockOperation(FsContext::getForRestore(ts), inode, owner,
+		                                       sessionid, 0, 0, op, nonblocking, dummy_applied);
 		break;
 	case safs_locks::Type::kPosix:
-		status =
-		    gFSOperations->fs_posixlock_op(FsContext::getForRestore(ts), inode, start, end, owner,
-		                                   sessionid, 0, 0, op, nonblocking, dummy_applied);
+		status = gFSOperations->posixLockOperation(FsContext::getForRestore(ts), inode, start, end,
+		                                           owner, sessionid, 0, 0, op, nonblocking,
+		                                           dummy_applied);
 		break;
 	default:
 		safs_pretty_syslog(LOG_ERR, "Invalid lock type passed to restore: %u", lock_type);
@@ -432,8 +431,8 @@ int do_remove_pending_op(const char *filename, uint64_t lv, uint32_t ts, const c
 	GETU64(reqid, ptr);
 	EAT(ptr,filename,lv,')');
 
-	return gFSOperations->fs_locks_remove_pending(FsContext::getForRestore(ts), lock_type, ownerid,
-	                                              sessionid, inode, reqid);
+	return gFSOperations->locksRemovePending(FsContext::getForRestore(ts), lock_type, ownerid,
+	                                         sessionid, inode, reqid);
 }
 
 int do_lock_clear_session(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -449,8 +448,8 @@ int do_lock_clear_session(const char *filename, uint64_t lv, uint32_t ts, const 
 	GETU32(sessionid, ptr);
 	EAT(ptr, filename, lv, ')');
 
-	return gFSOperations->fs_locks_clear_session(FsContext::getForRestore(ts), lock_type, inode,
-	                                             sessionid, applied);
+	return gFSOperations->locksClearSession(FsContext::getForRestore(ts), lock_type, inode,
+	                                        sessionid, applied);
 }
 
 int do_lock_unlock_inode(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -464,8 +463,7 @@ int do_lock_unlock_inode(const char *filename, uint64_t lv, uint32_t ts, const c
 	GETINODE(inode, ptr);
 	EAT(ptr, filename, lv, ')');
 
-	return gFSOperations->fs_locks_unlock_inode(FsContext::getForRestore(ts), lock_type, inode,
-	                                            applied);
+	return gFSOperations->locksUnlockInode(FsContext::getForRestore(ts), lock_type, inode, applied);
 }
 
 int do_purge(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
@@ -473,7 +471,7 @@ int do_purge(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
 	EAT(ptr,filename,lv,'(');
 	GETINODE(inode,ptr);
 	EAT(ptr,filename,lv,')');
-	return gFSOperations->fs_purge(FsContext::getForRestore(ts), inode);
+	return gFSOperations->purge(FsContext::getForRestore(ts), inode);
 }
 
 int do_release(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
@@ -484,7 +482,7 @@ int do_release(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) 
 	EAT(ptr,filename,lv,',');
 	GETU32(cuid,ptr);
 	EAT(ptr,filename,lv,')');
-	return gFSOperations->fs_release(FsContext::getForRestore(ts), inode, cuid);
+	return gFSOperations->release(FsContext::getForRestore(ts), inode, cuid);
 }
 
 int do_repair(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
@@ -498,7 +496,7 @@ int do_repair(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
 	EAT(ptr,filename,lv,')');
 	EAT(ptr,filename,lv,':');
 	GETU32(version,ptr);
-	return gFSOperations->fs_apply_repair(ts, inode, indx, version);
+	return gFSOperations->applyRepair(ts, inode, indx, version);
 }
 
 int do_seteattr(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
@@ -523,8 +521,8 @@ int do_seteattr(const char* filename, uint64_t lv, uint32_t ts, const char* ptr)
 	GETINODE(nci,ptr);
 	EAT(ptr,filename,lv,',');
 	GETINODE(npi,ptr);
-	return gFSOperations->fs_seteattr(FsContext::getForRestoreWithUidGid(ts, uid, 0), inode, eattr,
-	                                  smode, &ci, &nci, &npi);
+	return gFSOperations->setEAttr(FsContext::getForRestoreWithUidGid(ts, uid, 0), inode, eattr,
+	                               smode, &ci, &nci, &npi);
 }
 
 int do_setgoal(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -544,11 +542,11 @@ int do_setgoal(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) 
 	if (*(ptr) == ':') {
 		EAT(ptr, filename, lv, ':');
 		GETINODE(ci, ptr);
-		return gFSOperations->fs_apply_setgoal(FsContext::getForRestoreWithUidGid(ts, uid, 0),
-		                                       inode, goal, smode, ci);
+		return gFSOperations->applySetGoal(FsContext::getForRestoreWithUidGid(ts, uid, 0), inode,
+		                                   goal, smode, ci);
 	} else {
-		return gFSOperations->fs_apply_setgoal(FsContext::getForRestoreWithUidGid(ts, uid, 0),
-		                                       inode, goal, smode, SetGoalTask::kChanged);
+		return gFSOperations->applySetGoal(FsContext::getForRestoreWithUidGid(ts, uid, 0), inode,
+		                                   goal, smode, SetGoalTask::kChanged);
 	}
 }
 
@@ -561,8 +559,8 @@ int do_setpath(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) 
 	EAT(ptr,filename,lv,',');
 	GETPATH(path,pathsize,ptr,filename,lv,')');
 	EAT(ptr,filename,lv,')');
-	return gFSOperations->fs_settrashpath(FsContext::getForRestore(ts), inode,
-	                                      std::string((const char *)path));
+	return gFSOperations->setTrashPath(FsContext::getForRestore(ts), inode,
+	                                   std::string((const char *)path));
 }
 
 int do_settrashtime(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -583,12 +581,12 @@ int do_settrashtime(const char *filename, uint64_t lv, uint32_t ts, const char *
 	if ((*ptr) == ':') {
 		EAT(ptr, filename, lv, ':');
 		GETINODE(ci, ptr);
-		return gFSOperations->fs_apply_settrashtime(FsContext::getForRestoreWithUidGid(ts, uid, 0),
-		                                            inode, trashtime, smode, ci);
+		return gFSOperations->applySetTrashTime(FsContext::getForRestoreWithUidGid(ts, uid, 0),
+		                                        inode, trashtime, smode, ci);
 	} else {
-		return gFSOperations->fs_apply_settrashtime(FsContext::getForRestoreWithUidGid(ts, uid, 0),
-		                                            inode, trashtime, smode,
-		                                            SetTrashtimeTask::kChanged);
+		return gFSOperations->applySetTrashTime(FsContext::getForRestoreWithUidGid(ts, uid, 0),
+		                                        inode, trashtime, smode,
+		                                        SetTrashtimeTask::kChanged);
 	}
 }
 
@@ -607,8 +605,8 @@ int do_setxattr(const char* filename, uint64_t lv, uint32_t ts, const char* ptr)
 	EAT(ptr,filename,lv,',');
 	GETU32(mode,ptr);
 	EAT(ptr,filename,lv,')');
-	return gFSOperations->fs_apply_setxattr(ts, inode, strlen((char *)name), name, valueleng, value,
-	                                        mode);
+	return gFSOperations->applySetXAttr(ts, inode, strlen((char *)name), name, valueleng, value,
+	                                    mode);
 }
 
 int do_deleteacl(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -631,7 +629,7 @@ int do_deleteacl(const char *filename, uint64_t lv, uint32_t ts, const char *ptr
 		safs_pretty_syslog(LOG_ERR, "%s:%" PRIu64 ": corrupted ACL type", filename, lv);
 		return -1;
 	}
-	return gFSOperations->fs_deleteacl(FsContext::getForRestore(ts), inode, aclType);
+	return gFSOperations->deleteAcl(FsContext::getForRestore(ts), inode, aclType);
 }
 
 int do_setacl(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -648,8 +646,8 @@ int do_setacl(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
 	GETPATH(aclString, aclSize, ptr, filename, lv, ')');
 	EAT(ptr, filename, lv, ')');
 
-	return gFSOperations->fs_apply_setacl(ts, inode, aclType,
-	                                      reinterpret_cast<const char *>(aclString));
+	return gFSOperations->applySetAcl(ts, inode, aclType,
+	                                  reinterpret_cast<const char *>(aclString));
 }
 
 int do_setrichacl(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -663,8 +661,7 @@ int do_setrichacl(const char *filename, uint64_t lv, uint32_t ts, const char *pt
 	GETPATH(acl_string, acl_size, ptr, filename, lv, ')');
 	EAT(ptr, filename, lv, ')');
 
-	return gFSOperations->fs_apply_setrichacl(ts, inode,
-	                                          reinterpret_cast<const char *>(acl_string));
+	return gFSOperations->applySetRichAcl(ts, inode, reinterpret_cast<const char *>(acl_string));
 }
 
 int do_setquota(const char *filename, uint64_t lv, uint32_t, const char *ptr) {
@@ -684,7 +681,7 @@ int do_setquota(const char *filename, uint64_t lv, uint32_t, const char *ptr) {
 	GETU64(limit, ptr);
 	EAT(ptr, filename, lv, ')');
 
-	return gFSOperations->fs_apply_setquota(rigor, resource, ownerType, ownerId, limit);
+	return gFSOperations->applySetQuota(rigor, resource, ownerType, ownerId, limit);
 }
 
 int do_snapshot(const char* /*filename*/, uint64_t /*lv*/, uint32_t /*ts*/, const char* /*ptr*/) {
@@ -731,9 +728,9 @@ int do_symlink(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) 
 	EAT(ptr,filename,lv,')');
 	EAT(ptr,filename,lv,':');
 	GETINODE(inode,ptr);
-	return gFSOperations->fs_symlink(FsContext::getForRestoreWithUidGid(ts, uid, gid), parent,
-	                                 HString((char *)name), std::string((char *)path), &inode,
-	                                 nullptr);
+	return gFSOperations->symlink(FsContext::getForRestoreWithUidGid(ts, uid, gid), parent,
+	                              HString((char *)name), std::string((char *)path), &inode,
+	                              nullptr);
 }
 
 int do_undel(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
@@ -741,7 +738,7 @@ int do_undel(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
 	EAT(ptr,filename,lv,'(');
 	GETINODE(inode,ptr);
 	EAT(ptr,filename,lv,')');
-	return gFSOperations->fs_undel(FsContext::getForRestore(ts), inode);
+	return gFSOperations->undel(FsContext::getForRestore(ts), inode);
 }
 
 int do_unlink(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
@@ -755,7 +752,7 @@ int do_unlink(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
 	EAT(ptr,filename,lv,')');
 	EAT(ptr,filename,lv,':');
 	GETINODE(inode,ptr);
-	return gFSOperations->fs_apply_unlink(ts, parent, HString((char *)name), inode);
+	return gFSOperations->applyUnlink(ts, parent, HString((char *)name), inode);
 }
 
 int do_unlock(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
@@ -764,7 +761,7 @@ int do_unlock(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
 	EAT(ptr,filename,lv,'(');
 	GETU64(chunkid,ptr);
 	EAT(ptr,filename,lv,')');
-	return gFSOperations->fs_apply_unlock(chunkid);
+	return gFSOperations->applyUnlock(chunkid);
 }
 
 int do_nextchunkid(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
@@ -772,7 +769,7 @@ int do_nextchunkid(const char* filename, uint64_t lv, uint32_t ts, const char* p
 	EAT(ptr, filename, lv, '(');
 	GETU64(nextChunkId, ptr);
 	EAT(ptr, filename, lv, ')');
-	return gFSOperations->fs_set_nextchunkid(FsContext::getForRestore(ts), nextChunkId);
+	return gFSOperations->setNextChunkId(FsContext::getForRestore(ts), nextChunkId);
 }
 
 
@@ -794,7 +791,7 @@ int do_trunc(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
 	EAT(ptr,filename,lv,')');
 	EAT(ptr,filename,lv,':');
 	GETU64(chunkid,ptr);
-	return gFSOperations->fs_apply_trunc(ts, inode, indx, chunkid, lockid);
+	return gFSOperations->applyTrunc(ts, inode, indx, chunkid, lockid);
 }
 
 int do_write(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
@@ -822,8 +819,8 @@ int do_write(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
 	EAT(ptr,filename,lv,')');
 	EAT(ptr,filename,lv,':');
 	GETU64(chunkid,ptr);
-	return gFSOperations->fs_writechunk(FsContext::getForRestore(ts), inode, indx, false, &lockid,
-	                                    &chunkid, &opflag, nullptr);
+	return gFSOperations->writeChunk(FsContext::getForRestore(ts), inode, indx, false, &lockid,
+	                                 &chunkid, &opflag, nullptr);
 }
 
 int restore_line(const char* filename, uint64_t lv, const char* line) {
@@ -1013,7 +1010,7 @@ uint8_t restore(const char* filename, uint64_t newLogVersion, const char *ptr, R
 		/*
 		 * This is first call to restore().
 		 */
-		nextFsVersion = gFSOperations->fs_getversion();
+		nextFsVersion = gFSOperations->getMetadataVersion();
 		currentFsVersion = nextFsVersion - 1;
 		lastfn = "(no file)";
 	}
@@ -1049,7 +1046,7 @@ uint8_t restore(const char* filename, uint64_t newLogVersion, const char *ptr, R
 			if (status != SAUNAFS_STATUS_OK) { // other errors - stop processing data
 				return status;
 			}
-			nextFsVersion = gFSOperations->fs_getversion();
+			nextFsVersion = gFSOperations->getMetadataVersion();
 			if ((newLogVersion + 1) != nextFsVersion) {
 				/*
 				 * restore_line() should bump nextFsVersion by exactly 1, but it didn't.

--- a/src/master/restore.cc
+++ b/src/master/restore.cc
@@ -208,7 +208,7 @@ int do_access(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
 	EAT(ptr,filename,lv,'(');
 	GETINODE(inode,ptr);
 	EAT(ptr,filename,lv,')');
-	return gFilesystemOperations->fs_apply_access(ts,inode);
+	return gFSOperations->fs_apply_access(ts, inode);
 }
 
 int do_append(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -219,7 +219,7 @@ int do_append(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
 	EAT(ptr,filename,lv,',');
 	GETINODE(inode_src,ptr);
 	EAT(ptr,filename,lv,')');
-	return gFilesystemOperations->fs_append(FsContext::getForRestore(ts), inode, inode_src);
+	return gFSOperations->fs_append(FsContext::getForRestore(ts), inode, inode_src);
 }
 
 int do_acquire(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -230,7 +230,7 @@ int do_acquire(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) 
 	EAT(ptr,filename,lv,',');
 	GETU32(cuid,ptr);
 	EAT(ptr,filename,lv,')');
-	return gFilesystemOperations->fs_acquire(FsContext::getForRestore(ts), inode, cuid);
+	return gFSOperations->fs_acquire(FsContext::getForRestore(ts), inode, cuid);
 }
 
 int do_attr(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -249,7 +249,7 @@ int do_attr(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
 	EAT(ptr,filename,lv,',');
 	GETU32(mtime,ptr);
 	EAT(ptr,filename,lv,')');
-	return gFilesystemOperations->fs_apply_attr(ts, inode, mode, uid, gid, atime, mtime);
+	return gFSOperations->fs_apply_attr(ts, inode, mode, uid, gid, atime, mtime);
 }
 
 int do_checksum(const char *filename, uint64_t lv, uint32_t, const char *ptr) {
@@ -260,7 +260,7 @@ int do_checksum(const char *filename, uint64_t lv, uint32_t, const char *ptr) {
 	EAT(ptr,filename,lv,')');
 	EAT(ptr,filename,lv,':');
 	GETU64(checksum,ptr);
-	return gFilesystemOperations->fs_apply_checksum((char *)&version, checksum);
+	return gFSOperations->fs_apply_checksum((char *)&version, checksum);
 }
 
 int do_create(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -286,9 +286,9 @@ int do_create(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
 	EAT(ptr,filename,lv,')');
 	EAT(ptr,filename,lv,':');
 	GETINODE(inode,ptr);
-	return gFilesystemOperations->fs_apply_create(ts, parent, HString((const char *)name),
-	                                              static_cast<FSNodeType>(type), mode, uid, gid,
-	                                              rdev, inode);
+	return gFSOperations->fs_apply_create(ts, parent, HString((const char *)name),
+	                                      static_cast<FSNodeType>(type), mode, uid, gid, rdev,
+	                                      inode);
 }
 
 int do_session(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -298,7 +298,7 @@ int do_session(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) 
 	EAT(ptr,filename,lv,')');
 	EAT(ptr,filename,lv,':');
 	GETU32(cuid,ptr);
-	return gFilesystemOperations->fs_apply_session(cuid);
+	return gFSOperations->fs_apply_session(cuid);
 }
 
 int do_incversion(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -307,7 +307,7 @@ int do_incversion(const char *filename, uint64_t lv, uint32_t ts, const char *pt
 	EAT(ptr,filename,lv,'(');
 	GETU64(chunkid,ptr);
 	EAT(ptr,filename,lv,')');
-	return gFilesystemOperations->fs_apply_incversion(chunkid);
+	return gFSOperations->fs_apply_incversion(chunkid);
 }
 
 int do_link(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -321,8 +321,8 @@ int do_link(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
 	EAT(ptr,filename,lv,',');
 	GETNAME(name,ptr,filename,lv,')');
 	EAT(ptr,filename,lv,')');
-	return gFilesystemOperations->fs_link(FsContext::getForRestore(ts), inode, parent,
-	                                      HString((const char *)name), nullptr, nullptr);
+	return gFSOperations->fs_link(FsContext::getForRestore(ts), inode, parent,
+	                              HString((const char *)name), nullptr, nullptr);
 }
 
 int do_length(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -342,7 +342,7 @@ int do_length(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
 		GETU32(eraseFurtherChunks, ptr);
 	}
 	EAT(ptr, filename, lv, ')');
-	return gFilesystemOperations->fs_apply_length(ts, inode, length, eraseFurtherChunks != 0);
+	return gFSOperations->fs_apply_length(ts, inode, length, eraseFurtherChunks != 0);
 }
 
 int do_move(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
@@ -361,9 +361,9 @@ int do_move(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
 	EAT(ptr,filename,lv,')');
 	EAT(ptr,filename,lv,':');
 	GETINODE(inode,ptr);
-	return gFilesystemOperations->fs_rename(FsContext::getForRestore(ts), parent_src,
-	                                        HString((const char *)name_src), parent_dst,
-	                                        HString((const char *)name_dst), &inode, nullptr);
+	return gFSOperations->fs_rename(FsContext::getForRestore(ts), parent_src,
+	                                HString((const char *)name_src), parent_dst,
+	                                HString((const char *)name_dst), &inode, nullptr);
 }
 
 int do_lock_op(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -394,14 +394,13 @@ int do_lock_op(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) 
 
 	switch (static_cast<safs_locks::Type>(lock_type)) {
 	case safs_locks::Type::kFlock:
-		status =
-		    gFilesystemOperations->fs_flock_op(FsContext::getForRestore(ts), inode, owner,
-		                                       sessionid, 0, 0, op, nonblocking, dummy_applied);
+		status = gFSOperations->fs_flock_op(FsContext::getForRestore(ts), inode, owner, sessionid,
+		                                    0, 0, op, nonblocking, dummy_applied);
 		break;
 	case safs_locks::Type::kPosix:
-		status = gFilesystemOperations->fs_posixlock_op(FsContext::getForRestore(ts), inode, start,
-		                                                end, owner, sessionid, 0, 0, op,
-		                                                nonblocking, dummy_applied);
+		status =
+		    gFSOperations->fs_posixlock_op(FsContext::getForRestore(ts), inode, start, end, owner,
+		                                   sessionid, 0, 0, op, nonblocking, dummy_applied);
 		break;
 	default:
 		safs_pretty_syslog(LOG_ERR, "Invalid lock type passed to restore: %u", lock_type);
@@ -433,8 +432,8 @@ int do_remove_pending_op(const char *filename, uint64_t lv, uint32_t ts, const c
 	GETU64(reqid, ptr);
 	EAT(ptr,filename,lv,')');
 
-	return gFilesystemOperations->fs_locks_remove_pending(FsContext::getForRestore(ts), lock_type,
-	                                                      ownerid, sessionid, inode, reqid);
+	return gFSOperations->fs_locks_remove_pending(FsContext::getForRestore(ts), lock_type, ownerid,
+	                                              sessionid, inode, reqid);
 }
 
 int do_lock_clear_session(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -450,8 +449,8 @@ int do_lock_clear_session(const char *filename, uint64_t lv, uint32_t ts, const 
 	GETU32(sessionid, ptr);
 	EAT(ptr, filename, lv, ')');
 
-	return gFilesystemOperations->fs_locks_clear_session(FsContext::getForRestore(ts), lock_type,
-	                                                     inode, sessionid, applied);
+	return gFSOperations->fs_locks_clear_session(FsContext::getForRestore(ts), lock_type, inode,
+	                                             sessionid, applied);
 }
 
 int do_lock_unlock_inode(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -465,8 +464,8 @@ int do_lock_unlock_inode(const char *filename, uint64_t lv, uint32_t ts, const c
 	GETINODE(inode, ptr);
 	EAT(ptr, filename, lv, ')');
 
-	return gFilesystemOperations->fs_locks_unlock_inode(FsContext::getForRestore(ts), lock_type,
-	                                                    inode, applied);
+	return gFSOperations->fs_locks_unlock_inode(FsContext::getForRestore(ts), lock_type, inode,
+	                                            applied);
 }
 
 int do_purge(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
@@ -474,7 +473,7 @@ int do_purge(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
 	EAT(ptr,filename,lv,'(');
 	GETINODE(inode,ptr);
 	EAT(ptr,filename,lv,')');
-	return gFilesystemOperations->fs_purge(FsContext::getForRestore(ts), inode);
+	return gFSOperations->fs_purge(FsContext::getForRestore(ts), inode);
 }
 
 int do_release(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
@@ -485,7 +484,7 @@ int do_release(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) 
 	EAT(ptr,filename,lv,',');
 	GETU32(cuid,ptr);
 	EAT(ptr,filename,lv,')');
-	return gFilesystemOperations->fs_release(FsContext::getForRestore(ts), inode, cuid);
+	return gFSOperations->fs_release(FsContext::getForRestore(ts), inode, cuid);
 }
 
 int do_repair(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
@@ -499,7 +498,7 @@ int do_repair(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
 	EAT(ptr,filename,lv,')');
 	EAT(ptr,filename,lv,':');
 	GETU32(version,ptr);
-	return gFilesystemOperations->fs_apply_repair(ts, inode, indx, version);
+	return gFSOperations->fs_apply_repair(ts, inode, indx, version);
 }
 
 int do_seteattr(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
@@ -524,8 +523,8 @@ int do_seteattr(const char* filename, uint64_t lv, uint32_t ts, const char* ptr)
 	GETINODE(nci,ptr);
 	EAT(ptr,filename,lv,',');
 	GETINODE(npi,ptr);
-	return gFilesystemOperations->fs_seteattr(FsContext::getForRestoreWithUidGid(ts, uid, 0), inode,
-	                                          eattr, smode, &ci, &nci, &npi);
+	return gFSOperations->fs_seteattr(FsContext::getForRestoreWithUidGid(ts, uid, 0), inode, eattr,
+	                                  smode, &ci, &nci, &npi);
 }
 
 int do_setgoal(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -545,12 +544,11 @@ int do_setgoal(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) 
 	if (*(ptr) == ':') {
 		EAT(ptr, filename, lv, ':');
 		GETINODE(ci, ptr);
-		return gFilesystemOperations->fs_apply_setgoal(
-		    FsContext::getForRestoreWithUidGid(ts, uid, 0), inode, goal, smode, ci);
+		return gFSOperations->fs_apply_setgoal(FsContext::getForRestoreWithUidGid(ts, uid, 0),
+		                                       inode, goal, smode, ci);
 	} else {
-		return gFilesystemOperations->fs_apply_setgoal(
-		    FsContext::getForRestoreWithUidGid(ts, uid, 0), inode, goal, smode,
-		    SetGoalTask::kChanged);
+		return gFSOperations->fs_apply_setgoal(FsContext::getForRestoreWithUidGid(ts, uid, 0),
+		                                       inode, goal, smode, SetGoalTask::kChanged);
 	}
 }
 
@@ -563,8 +561,8 @@ int do_setpath(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) 
 	EAT(ptr,filename,lv,',');
 	GETPATH(path,pathsize,ptr,filename,lv,')');
 	EAT(ptr,filename,lv,')');
-	return gFilesystemOperations->fs_settrashpath(FsContext::getForRestore(ts), inode,
-	                                              std::string((const char *)path));
+	return gFSOperations->fs_settrashpath(FsContext::getForRestore(ts), inode,
+	                                      std::string((const char *)path));
 }
 
 int do_settrashtime(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -585,12 +583,12 @@ int do_settrashtime(const char *filename, uint64_t lv, uint32_t ts, const char *
 	if ((*ptr) == ':') {
 		EAT(ptr, filename, lv, ':');
 		GETINODE(ci, ptr);
-		return gFilesystemOperations->fs_apply_settrashtime(
-		    FsContext::getForRestoreWithUidGid(ts, uid, 0), inode, trashtime, smode, ci);
+		return gFSOperations->fs_apply_settrashtime(FsContext::getForRestoreWithUidGid(ts, uid, 0),
+		                                            inode, trashtime, smode, ci);
 	} else {
-		return gFilesystemOperations->fs_apply_settrashtime(
-		    FsContext::getForRestoreWithUidGid(ts, uid, 0), inode, trashtime, smode,
-		    SetTrashtimeTask::kChanged);
+		return gFSOperations->fs_apply_settrashtime(FsContext::getForRestoreWithUidGid(ts, uid, 0),
+		                                            inode, trashtime, smode,
+		                                            SetTrashtimeTask::kChanged);
 	}
 }
 
@@ -609,8 +607,8 @@ int do_setxattr(const char* filename, uint64_t lv, uint32_t ts, const char* ptr)
 	EAT(ptr,filename,lv,',');
 	GETU32(mode,ptr);
 	EAT(ptr,filename,lv,')');
-	return gFilesystemOperations->fs_apply_setxattr(ts, inode, strlen((char *)name), name,
-	                                                valueleng, value, mode);
+	return gFSOperations->fs_apply_setxattr(ts, inode, strlen((char *)name), name, valueleng, value,
+	                                        mode);
 }
 
 int do_deleteacl(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -633,7 +631,7 @@ int do_deleteacl(const char *filename, uint64_t lv, uint32_t ts, const char *ptr
 		safs_pretty_syslog(LOG_ERR, "%s:%" PRIu64 ": corrupted ACL type", filename, lv);
 		return -1;
 	}
-	return gFilesystemOperations->fs_deleteacl(FsContext::getForRestore(ts), inode, aclType);
+	return gFSOperations->fs_deleteacl(FsContext::getForRestore(ts), inode, aclType);
 }
 
 int do_setacl(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -650,8 +648,8 @@ int do_setacl(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
 	GETPATH(aclString, aclSize, ptr, filename, lv, ')');
 	EAT(ptr, filename, lv, ')');
 
-	return gFilesystemOperations->fs_apply_setacl(ts, inode, aclType,
-	                                              reinterpret_cast<const char *>(aclString));
+	return gFSOperations->fs_apply_setacl(ts, inode, aclType,
+	                                      reinterpret_cast<const char *>(aclString));
 }
 
 int do_setrichacl(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -665,8 +663,8 @@ int do_setrichacl(const char *filename, uint64_t lv, uint32_t ts, const char *pt
 	GETPATH(acl_string, acl_size, ptr, filename, lv, ')');
 	EAT(ptr, filename, lv, ')');
 
-	return gFilesystemOperations->fs_apply_setrichacl(ts, inode,
-	                                                  reinterpret_cast<const char *>(acl_string));
+	return gFSOperations->fs_apply_setrichacl(ts, inode,
+	                                          reinterpret_cast<const char *>(acl_string));
 }
 
 int do_setquota(const char *filename, uint64_t lv, uint32_t, const char *ptr) {
@@ -686,7 +684,7 @@ int do_setquota(const char *filename, uint64_t lv, uint32_t, const char *ptr) {
 	GETU64(limit, ptr);
 	EAT(ptr, filename, lv, ')');
 
-	return gFilesystemOperations->fs_apply_setquota(rigor, resource, ownerType, ownerId, limit);
+	return gFSOperations->fs_apply_setquota(rigor, resource, ownerType, ownerId, limit);
 }
 
 int do_snapshot(const char* /*filename*/, uint64_t /*lv*/, uint32_t /*ts*/, const char* /*ptr*/) {
@@ -733,9 +731,9 @@ int do_symlink(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) 
 	EAT(ptr,filename,lv,')');
 	EAT(ptr,filename,lv,':');
 	GETINODE(inode,ptr);
-	return gFilesystemOperations->fs_symlink(FsContext::getForRestoreWithUidGid(ts, uid, gid),
-	                                         parent, HString((char *)name),
-	                                         std::string((char *)path), &inode, nullptr);
+	return gFSOperations->fs_symlink(FsContext::getForRestoreWithUidGid(ts, uid, gid), parent,
+	                                 HString((char *)name), std::string((char *)path), &inode,
+	                                 nullptr);
 }
 
 int do_undel(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
@@ -743,7 +741,7 @@ int do_undel(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
 	EAT(ptr,filename,lv,'(');
 	GETINODE(inode,ptr);
 	EAT(ptr,filename,lv,')');
-	return gFilesystemOperations->fs_undel(FsContext::getForRestore(ts), inode);
+	return gFSOperations->fs_undel(FsContext::getForRestore(ts), inode);
 }
 
 int do_unlink(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
@@ -757,7 +755,7 @@ int do_unlink(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
 	EAT(ptr,filename,lv,')');
 	EAT(ptr,filename,lv,':');
 	GETINODE(inode,ptr);
-	return gFilesystemOperations->fs_apply_unlink(ts, parent, HString((char *)name), inode);
+	return gFSOperations->fs_apply_unlink(ts, parent, HString((char *)name), inode);
 }
 
 int do_unlock(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
@@ -766,7 +764,7 @@ int do_unlock(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
 	EAT(ptr,filename,lv,'(');
 	GETU64(chunkid,ptr);
 	EAT(ptr,filename,lv,')');
-	return gFilesystemOperations->fs_apply_unlock(chunkid);
+	return gFSOperations->fs_apply_unlock(chunkid);
 }
 
 int do_nextchunkid(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
@@ -774,7 +772,7 @@ int do_nextchunkid(const char* filename, uint64_t lv, uint32_t ts, const char* p
 	EAT(ptr, filename, lv, '(');
 	GETU64(nextChunkId, ptr);
 	EAT(ptr, filename, lv, ')');
-	return gFilesystemOperations->fs_set_nextchunkid(FsContext::getForRestore(ts), nextChunkId);
+	return gFSOperations->fs_set_nextchunkid(FsContext::getForRestore(ts), nextChunkId);
 }
 
 
@@ -796,7 +794,7 @@ int do_trunc(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
 	EAT(ptr,filename,lv,')');
 	EAT(ptr,filename,lv,':');
 	GETU64(chunkid,ptr);
-	return gFilesystemOperations->fs_apply_trunc(ts, inode, indx, chunkid, lockid);
+	return gFSOperations->fs_apply_trunc(ts, inode, indx, chunkid, lockid);
 }
 
 int do_write(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
@@ -824,8 +822,8 @@ int do_write(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
 	EAT(ptr,filename,lv,')');
 	EAT(ptr,filename,lv,':');
 	GETU64(chunkid,ptr);
-	return gFilesystemOperations->fs_writechunk(FsContext::getForRestore(ts), inode, indx, false,
-	                                            &lockid, &chunkid, &opflag, nullptr);
+	return gFSOperations->fs_writechunk(FsContext::getForRestore(ts), inode, indx, false, &lockid,
+	                                    &chunkid, &opflag, nullptr);
 }
 
 int restore_line(const char* filename, uint64_t lv, const char* line) {
@@ -1015,7 +1013,7 @@ uint8_t restore(const char* filename, uint64_t newLogVersion, const char *ptr, R
 		/*
 		 * This is first call to restore().
 		 */
-		nextFsVersion = gFilesystemOperations->fs_getversion();
+		nextFsVersion = gFSOperations->fs_getversion();
 		currentFsVersion = nextFsVersion - 1;
 		lastfn = "(no file)";
 	}
@@ -1051,7 +1049,7 @@ uint8_t restore(const char* filename, uint64_t newLogVersion, const char *ptr, R
 			if (status != SAUNAFS_STATUS_OK) { // other errors - stop processing data
 				return status;
 			}
-			nextFsVersion = gFilesystemOperations->fs_getversion();
+			nextFsVersion = gFSOperations->fs_getversion();
 			if ((newLogVersion + 1) != nextFsVersion) {
 				/*
 				 * restore_line() should bump nextFsVersion by exactly 1, but it didn't.

--- a/src/master/setgoal_task.cc
+++ b/src/master/setgoal_task.cc
@@ -55,9 +55,9 @@ int SetGoalTask::execute(uint32_t ts, intrusive_list<Task> &work_queue) {
 		}
 		(*stats_)[result] += 1;
 		if (result == kChanged) {
-			gFilesystemOperations->fs_changelog(
-			    ts, "SETGOAL(%" PRIiNode ",%" PRIu32 ",%" PRIu8 ",%" PRIu8 ")", inode, uid_, goal_,
-			    smode_);
+			gFSOperations->fs_changelog(ts,
+			                            "SETGOAL(%" PRIiNode ",%" PRIu32 ",%" PRIu8 ",%" PRIu8 ")",
+			                            inode, uid_, goal_, smode_);
 		}
 	}
 

--- a/src/master/setgoal_task.cc
+++ b/src/master/setgoal_task.cc
@@ -55,9 +55,8 @@ int SetGoalTask::execute(uint32_t ts, intrusive_list<Task> &work_queue) {
 		}
 		(*stats_)[result] += 1;
 		if (result == kChanged) {
-			gFSOperations->fs_changelog(ts,
-			                            "SETGOAL(%" PRIiNode ",%" PRIu32 ",%" PRIu8 ",%" PRIu8 ")",
-			                            inode, uid_, goal_, smode_);
+			gFSOperations->changeLog(ts, "SETGOAL(%" PRIiNode ",%" PRIu32 ",%" PRIu8 ",%" PRIu8 ")",
+			                         inode, uid_, goal_, smode_);
 		}
 	}
 

--- a/src/master/settrashtime_task.cc
+++ b/src/master/settrashtime_task.cc
@@ -56,7 +56,7 @@ int SetTrashtimeTask::execute(uint32_t ts, intrusive_list<Task> &work_queue) {
 		}
 		(*stats_)[result] += 1;
 		if (result == kChanged) {
-			gFSOperations->fs_changelog(
+			gFSOperations->changeLog(
 			    ts, "SETTRASHTIME(%" PRIiNode ",%" PRIu32 ",%" PRIu32 ",%" PRIu8 ")", inode, uid_,
 			    trashtime_, smode_);
 		}

--- a/src/master/settrashtime_task.cc
+++ b/src/master/settrashtime_task.cc
@@ -56,7 +56,7 @@ int SetTrashtimeTask::execute(uint32_t ts, intrusive_list<Task> &work_queue) {
 		}
 		(*stats_)[result] += 1;
 		if (result == kChanged) {
-			gFilesystemOperations->fs_changelog(
+			gFSOperations->fs_changelog(
 			    ts, "SETTRASHTIME(%" PRIiNode ",%" PRIu32 ",%" PRIu32 ",%" PRIu8 ")", inode, uid_,
 			    trashtime_, smode_);
 		}

--- a/src/master/snapshot_task.cc
+++ b/src/master/snapshot_task.cc
@@ -207,7 +207,7 @@ void SnapshotTask::emitChangelog(uint32_t ts, inode_t dst_inode) {
 		return;
 	}
 
-	gFilesystemOperations->fs_changelog(
+	gFSOperations->fs_changelog(
 	    ts, "CLONE(%" PRIiNode ",%" PRIiNode ",%" PRIiNode ",%s,%" PRIu8 ")",
 	    current_subtask_->first, dst_parent_inode_, dst_inode,
 	    fsnodes_escape_name(current_subtask_->second).c_str(), can_overwrite_);

--- a/src/master/snapshot_task.cc
+++ b/src/master/snapshot_task.cc
@@ -207,10 +207,9 @@ void SnapshotTask::emitChangelog(uint32_t ts, inode_t dst_inode) {
 		return;
 	}
 
-	gFSOperations->fs_changelog(
-	    ts, "CLONE(%" PRIiNode ",%" PRIiNode ",%" PRIiNode ",%s,%" PRIu8 ")",
-	    current_subtask_->first, dst_parent_inode_, dst_inode,
-	    fsnodes_escape_name(current_subtask_->second).c_str(), can_overwrite_);
+	gFSOperations->changeLog(ts, "CLONE(%" PRIiNode ",%" PRIiNode ",%" PRIiNode ",%s,%" PRIu8 ")",
+	                         current_subtask_->first, dst_parent_inode_, dst_inode,
+	                         fsnodes_escape_name(current_subtask_->second).c_str(), can_overwrite_);
 }
 
 int SnapshotTask::cloneNode(uint32_t ts) {

--- a/src/metarestore/main.cc
+++ b/src/metarestore/main.cc
@@ -352,13 +352,13 @@ int main(int argc,char **argv) {
 		safs_pretty_syslog(LOG_ERR, "error: can't read metadata from file: %s, %s", metadata.c_str(), e.what());
 		return 1;
 	}
-	if (gFilesystemOperations->fs_getversion() == 0) {
+	if (gFSOperations->fs_getversion() == 0) {
 		safs_pretty_syslog(LOG_ERR, "invalid metadata version (0)");
 		return 1;
 	}
 	if (vl > 0) {
 		safs_pretty_syslog(LOG_NOTICE, "loaded metadata with version %" PRIu64 "",
-		                   gFilesystemOperations->fs_getversion());
+		                   gFSOperations->fs_getversion());
 	}
 
 	if (autorestore) {
@@ -381,10 +381,10 @@ int main(int argc,char **argv) {
 					lastlv = 0;
 				}
 
-				skip = ((lastlv < gFilesystemOperations->fs_getversion() || firstlv == 0) &&
-				        forcealllogs == 0)
-				           ? 1
-				           : 0;
+				skip =
+				    ((lastlv < gFSOperations->fs_getversion() || firstlv == 0) && forcealllogs == 0)
+				        ? 1
+				        : 0;
 
 				if (vl>0) {
 					std::ostringstream oss;
@@ -435,8 +435,7 @@ int main(int argc,char **argv) {
 				lastlv = 0;
 			}
 
-			skip = ((lastlv < gFilesystemOperations->fs_getversion() || firstlv == 0) &&
-			        forcealllogs == 0)
+			skip = ((lastlv < gFSOperations->fs_getversion() || firstlv == 0) && forcealllogs == 0)
 			           ? 1
 			           : 0;
 
@@ -476,7 +475,7 @@ int main(int argc,char **argv) {
 	}
 
 	int returnStatus = 0;
-	uint64_t checksum = gFilesystemOperations->fs_checksum(ChecksumMode::kForceRecalculate);
+	uint64_t checksum = gFSOperations->fs_checksum(ChecksumMode::kForceRecalculate);
 	if (printhash) {
 		printf("%" PRIu64 "\n", checksum);
 	}

--- a/src/metarestore/main.cc
+++ b/src/metarestore/main.cc
@@ -352,13 +352,13 @@ int main(int argc,char **argv) {
 		safs_pretty_syslog(LOG_ERR, "error: can't read metadata from file: %s, %s", metadata.c_str(), e.what());
 		return 1;
 	}
-	if (gFSOperations->fs_getversion() == 0) {
+	if (gFSOperations->getMetadataVersion() == 0) {
 		safs_pretty_syslog(LOG_ERR, "invalid metadata version (0)");
 		return 1;
 	}
 	if (vl > 0) {
 		safs_pretty_syslog(LOG_NOTICE, "loaded metadata with version %" PRIu64 "",
-		                   gFSOperations->fs_getversion());
+		                   gFSOperations->getMetadataVersion());
 	}
 
 	if (autorestore) {
@@ -381,10 +381,10 @@ int main(int argc,char **argv) {
 					lastlv = 0;
 				}
 
-				skip =
-				    ((lastlv < gFSOperations->fs_getversion() || firstlv == 0) && forcealllogs == 0)
-				        ? 1
-				        : 0;
+				skip = ((lastlv < gFSOperations->getMetadataVersion() || firstlv == 0) &&
+				        forcealllogs == 0)
+				           ? 1
+				           : 0;
 
 				if (vl>0) {
 					std::ostringstream oss;
@@ -435,7 +435,8 @@ int main(int argc,char **argv) {
 				lastlv = 0;
 			}
 
-			skip = ((lastlv < gFSOperations->fs_getversion() || firstlv == 0) && forcealllogs == 0)
+			skip = ((lastlv < gFSOperations->getMetadataVersion() || firstlv == 0) &&
+			        forcealllogs == 0)
 			           ? 1
 			           : 0;
 
@@ -475,7 +476,7 @@ int main(int argc,char **argv) {
 	}
 
 	int returnStatus = 0;
-	uint64_t checksum = gFSOperations->fs_checksum(ChecksumMode::kForceRecalculate);
+	uint64_t checksum = gFSOperations->metadataChecksum(ChecksumMode::kForceRecalculate);
 	if (printhash) {
 		printf("%" PRIu64 "\n", checksum);
 	}


### PR DESCRIPTION
Main changes:
- Rename gFilesystemOperations to gFSOperations, which is shorter and maintains the context.
- Rename the functions in IFilesystemOperation interface to match better our code style.