### PR TITLE
refactor(master): Modernize master-metalogger comm

### DIFF
--- a/src/master/matomlserv.cc
+++ b/src/master/matomlserv.cc
@@ -35,13 +35,16 @@
 #include <syslog.h>
 #include <time.h>
 #include <unistd.h>
+#include <queue>
 #include <set>
 
 #include "common/crc.h"
 #include "common/datapack.h"
 #include "common/event_loop.h"
+#include "common/input_packet.h"
 #include "common/loop_watchdog.h"
 #include "common/massert.h"
+#include "common/output_packet.h"
 #include "common/saunafs_version.h"
 #include "common/sockets.h"
 #include "config/cfg.h"
@@ -55,47 +58,47 @@
 #include "protocol/mltoma.h"
 #include "slogger/slogger.h"
 
-#define MaxPacketSize 1500000
-#define OLD_CHANGES_BLOCK_SIZE 5000
+constexpr uint32_t kMaxPacketSize = 1500000;
+constexpr uint16_t kOldChangesBlockSize = 5000;
 
-// matomlserventry.mode
-enum{KILL,HEADER,DATA};
-
-struct packetstruct {
-	struct packetstruct *next;
-	uint8_t *startptr;
-	uint32_t bytesleft;
-	uint8_t *packet;
+enum class MetaloggerConnectionMode : uint8_t {
+	KILL,
+	HEADER,
+	DATA
 };
 
-using matomlserventry = struct matomlserventry {
-	uint8_t mode;
+struct MatomlservEntry {
+	MetaloggerConnectionMode mode = MetaloggerConnectionMode::HEADER;
 	int sock;
-	int32_t pdescpos;
-	uint32_t lastread,lastwrite;
-	uint8_t hdrbuff[8];
-	packetstruct inputpacket;
-	packetstruct *outputhead,**outputtail;
+	int32_t pollFdIndex{-1};
+	uint32_t lastRead{0};
+	uint32_t lastWrite{0};
+	std::array<uint8_t, PacketHeader::kSize> headerBuff{0};
+	InputPacket inputPacket{kMaxPacketSize};
+	std::queue<OutputPacket> outputPackets;
+	uint16_t timeout{10};
+	std::string serviceStrIp;
+	uint32_t version{};
+	uint32_t serviceIp{};
+	uint16_t servicePort{};
+	std::string config;
+	bool shadow{false};
+	int metaFD{-1};
+	int chain1FD{-1};
+	int chain2FD{-1};
 
-	uint16_t timeout;
-
-	char *servstrip;                // human readable version of servip
-	uint32_t version;
-	uint32_t servip;
-	uint16_t servport;
-	bool shadow;
-
-	int metafd,chain1fd,chain2fd;
-
-	char* config;
-
-	struct matomlserventry *next;
+	MatomlservEntry(int sock_, uint32_t now) : sock(sock_), lastRead(now), lastWrite(now) {}
 };
 
-static matomlserventry *matomlservhead=NULL;
-static int lsock;
-static int32_t lsockpdescpos;
+static std::deque<MatomlservEntry> matomlservList;
+static int listenSocket;
+static int32_t listenSocketPollFdIndex;
 static bool gExiting = false;
+
+// from config
+static std::string gListenHost;
+static std::string gListenPort;
+static uint16_t gChangelogSecondsToRemember;
 
 /// Minimal period (in seconds) between two metadata save processes requested by shadow masters
 static uint32_t gMinMetadataSaveRequestPeriod_s;
@@ -103,21 +106,20 @@ static uint32_t gMinMetadataSaveRequestPeriod_s;
 /// Timestamp of the last metadata save request
 static uint32_t gLastMetadataSaveRequestTimestamp = 0;
 
-struct old_changes_entry {
-	uint64_t version;
-	uint32_t length;
-	uint8_t *data;
+struct OldChangesEntry {
+	uint64_t version{};
+	std::vector<uint8_t> data;
 };
 
-struct old_changes_block {
-	old_changes_entry old_changes_block [OLD_CHANGES_BLOCK_SIZE];
-	uint32_t entries;
-	uint32_t mintimestamp;
-	uint64_t minversion;
-	struct old_changes_block *next;
+struct OldChangesBlock {
+	std::vector<OldChangesEntry> oldChangesBlock;
+	uint32_t minTimestamp{};
+	uint64_t minVersion{};
 };
 
-void matomlserv_createpacket(matomlserventry *eptr, std::vector<uint8_t> data);
+std::deque<OldChangesBlock> oldChangesBlocks;
+
+void matomlserv_createpacket(MatomlservEntry *eptr, const std::vector<uint8_t> &data);
 
 /*! \brief Keep queue of Shadows interested in receiving information
  * regarding status of requested metadata dump.
@@ -128,17 +130,13 @@ public:
 	 *
 	 * \param eptr - connection handler to be queued.
 	 */
-	void addRequest(matomlserventry* eptr) {
-		shadowRequests_.insert(eptr);
-	}
+	void addRequest(MatomlservEntry *eptr) { shadowRequests_.insert(eptr); }
 
 	/*! \brief Remove given connection handler from queue.
 	 *
 	 * \param eptr - connection handler to be removed from queue.
 	 */
-	void removeRequest(matomlserventry* eptr) {
-		shadowRequests_.erase(eptr);
-	}
+	void removeRequest(MatomlservEntry *eptr) { shadowRequests_.erase(eptr); }
 
 	/*! \brief Handle all awaiting Shadows in queue.
 	 *
@@ -147,285 +145,208 @@ public:
 	 * \param status - status of recently finished metadata dump.
 	 */
 	void handleRequests(uint8_t status) {
-		for (matomlserventry* eptr : shadowRequests_) {
+		for (const auto &eptr : shadowRequests_) {
 			matomlserv_createpacket(eptr, matoml::changelogApplyError::build(status));
 		}
 		shadowRequests_.clear();
 	}
+
 private:
-	using ShadowRequests = std::set<matomlserventry *>;
+	using ShadowRequests = std::set<MatomlservEntry *>;
 	ShadowRequests shadowRequests_;
-} gShadowQueue;
+};
+
+static ShadowQueue gShadowQueue;
 
 /*! \brief Forward metadata dump status to Shadow queue.
  *
  * \param status - status to be forwarded.
  */
-void matomlserv_broadcast_metadata_saved(uint8_t status) {
-	gShadowQueue.handleRequests(status);
-}
+void matomlserv_broadcast_metadata_saved(uint8_t status) { gShadowQueue.handleRequests(status); }
 
-static old_changes_block *old_changes_head=NULL;
-static old_changes_block *old_changes_current=NULL;
-
-// from config
-static char *ListenHost;
-static char *ListenPort;
-static uint16_t ChangelogSecondsToRemember;
-
-void matomlserv_old_changes_free_block(old_changes_block *oc) {
-	uint32_t i;
-	for (i=0 ; i<oc->entries ; i++) {
-		free(oc->old_changes_block[i].data);
-	}
-	free(oc);
-}
-
-void matomlserv_store_logstring(uint64_t version,uint8_t *logstr,uint32_t logstrsize) {\
-	old_changes_block *oc;
-	old_changes_entry *oce;
-	uint32_t ts;
-	if (ChangelogSecondsToRemember==0) {
-		while (old_changes_head) {
-			oc = old_changes_head->next;
-			matomlserv_old_changes_free_block(old_changes_head);
-			old_changes_head = oc;
-		}
+void matomlserv_store_logstring(uint64_t version, uint8_t *logstr, uint32_t logstrsize) {
+	if (gChangelogSecondsToRemember == 0) {
+		oldChangesBlocks.clear();
 		return;
 	}
-	if (old_changes_current==NULL || old_changes_head==NULL || old_changes_current->entries>=OLD_CHANGES_BLOCK_SIZE) {
-		oc = (old_changes_block*) malloc(sizeof(old_changes_block));
-		passert(oc);
-		ts = eventloop_time();
-		oc->entries = 0;
-		oc->minversion = version;
-		oc->mintimestamp = ts;
-		oc->next = NULL;
-		if (old_changes_current==NULL || old_changes_head==NULL) {
-			old_changes_head = old_changes_current = oc;
-		} else {
-			old_changes_current->next = oc;
-			old_changes_current = oc;
-		}
-		while (old_changes_head && old_changes_head->next && old_changes_head->next->mintimestamp+ChangelogSecondsToRemember<ts) {
-			oc = old_changes_head->next;
-			matomlserv_old_changes_free_block(old_changes_head);
-			old_changes_head = oc;
+
+	uint32_t ts = eventloop_time();
+
+	// Create new block if needed
+	if (oldChangesBlocks.empty() ||
+	    oldChangesBlocks.back().oldChangesBlock.size() >= kOldChangesBlockSize) {
+		OldChangesBlock newBlock;
+		newBlock.minVersion = version;
+		newBlock.minTimestamp = ts;
+		oldChangesBlocks.push_back(std::move(newBlock));
+
+		while (oldChangesBlocks.size() > 1 &&
+		       oldChangesBlocks[1].minTimestamp + gChangelogSecondsToRemember < ts) {
+			oldChangesBlocks.pop_front();
 		}
 	}
-	oc = old_changes_current;
-	oce = oc->old_changes_block + oc->entries;
-	oce->version = version;
-	oce->length = logstrsize;
-	oce->data = (uint8_t*) malloc(logstrsize);
-	passert(oce->data);
-	memcpy(oce->data,logstr,logstrsize);
-	oc->entries++;
+
+	// Add new entry to the current block
+	OldChangesBlock &block = oldChangesBlocks.back();
+	block.oldChangesBlock.emplace_back(OldChangesEntry{
+	    .version = version, .data = std::vector<uint8_t>(logstr, logstr + logstrsize)});
 }
 
 uint32_t matomlserv_mloglist_size(void) {
-	matomlserventry *eptr;
 	uint32_t i = 0;
 
-	for (eptr = matomlservhead ; eptr ; eptr=eptr->next) {
-		if (!eptr->shadow && eptr->mode!=KILL) {
-			i++;
-		}
+	for (const auto &eptr : matomlservList) {
+		if (!eptr.shadow && eptr.mode != MetaloggerConnectionMode::KILL) { i++; }
 	}
 
-	return i * (sizeof(matomlserventry::version) + sizeof(matomlserventry::servip));
+	return i * (sizeof(MatomlservEntry::version) + sizeof(MatomlservEntry::serviceIp));
 }
 
 void matomlserv_mloglist_data(uint8_t *ptr) {
-	matomlserventry *eptr;
-	for (eptr = matomlservhead ; eptr ; eptr=eptr->next) {
-		if (!eptr->shadow && eptr->mode!=KILL) {
-			put32bit(&ptr,eptr->version);
-			put32bit(&ptr,eptr->servip);
+	for (const auto &eptr : matomlservList) {
+		if (!eptr.shadow && eptr.mode != MetaloggerConnectionMode::KILL) {
+			put32bit(&ptr, eptr.version);
+			put32bit(&ptr, eptr.serviceIp);
 		}
 	}
 }
 
 std::vector<MetadataserverListEntry> matomlserv_shadows() {
 	std::vector<MetadataserverListEntry> ret;
-	for (matomlserventry* eptr = matomlservhead; eptr; eptr=eptr->next) {
-		if (eptr->shadow) {
-			ret.emplace_back(eptr->servip, eptr->servport, eptr->version);
-		}
+	for (const auto &eptr : matomlservList) {
+		if (eptr.shadow) { ret.emplace_back(eptr.serviceIp, eptr.servicePort, eptr.version); }
 	}
 	return ret;
 }
 
 std::string get_metaloggers_config() {
 	std::map<std::string, std::string> configs;
-	for (matomlserventry *eptr = matomlservhead; eptr != nullptr; eptr = eptr->next) {
-		if (eptr->shadow) { continue; }
-		NetworkAddress addr(eptr->servip, eptr->servport);
-		configs[addr.toString()] = eptr->config;
+	for (const auto &eptr : matomlservList) {
+		if (eptr.shadow) { continue; }
+		NetworkAddress addr(eptr.serviceIp, eptr.servicePort);
+		configs[addr.toString()] = eptr.config;
 	}
 	return cfg_yaml_list("metaloggers", configs);
 }
 
 uint32_t matomlserv_shadows_count() {
 	uint32_t count = 0;
-	for (matomlserventry* eptr = matomlservhead; eptr; eptr=eptr->next) {
-		if (eptr->shadow) {
-			count++;
-		}
+	for (const auto &eptr : matomlservList) {
+		if (eptr.shadow) { count++; }
 	}
 	return count;
 }
 
 void matomlserv_status(void) {
-	matomlserventry *eptr;
-	for (eptr = matomlservhead ; eptr ; eptr=eptr->next) {
-		if (eptr->mode==HEADER || eptr->mode==DATA) {
+	for (const auto &eptr : matomlservList) {
+		if (eptr.mode == MetaloggerConnectionMode::HEADER ||
+		    eptr.mode == MetaloggerConnectionMode::DATA) {
 			return;
 		}
 	}
-	safs_pretty_syslog(LOG_WARNING,"no meta loggers connected !!!");
+	safs::log_warn("no meta loggers connected !!!");
 }
 
-char* matomlserv_makestrip(uint32_t ip) {
-	uint8_t *ptr,pt[4];
-	uint32_t l,i;
-	char *optr;
-	ptr = pt;
-	put32bit(&ptr,ip);
-	l=0;
-	for (i=0 ; i<4 ; i++) {
-		if (pt[i]>=100) {
-			l+=3;
-		} else if (pt[i]>=10) {
-			l+=2;
-		} else {
-			l+=1;
-		}
-	}
-	l+=4;
-	optr = (char*) malloc(l);
-	passert(optr);
-	snprintf(optr,l,"%" PRIu8 ".%" PRIu8 ".%" PRIu8 ".%" PRIu8,pt[0],pt[1],pt[2],pt[3]);
-	optr[l-1]=0;
-	return optr;
+uint8_t *matomlserv_createpacket(MatomlservEntry *eptr, uint32_t type, uint32_t size) {
+	eptr->outputPackets.emplace(PacketHeader(type, size));
+	return eptr->outputPackets.back().packet.data() + PacketHeader::kSize;
 }
 
-uint8_t* matomlserv_createpacket(matomlserventry *eptr,uint32_t type,uint32_t size) {
-	packetstruct *outpacket;
-	uint8_t *ptr;
-	uint32_t psize;
-
-	outpacket=(packetstruct*)malloc(sizeof(packetstruct));
-	passert(outpacket);
-	psize = size+8;
-	outpacket->packet= (uint8_t*) malloc(psize);
-	passert(outpacket->packet);
-	outpacket->bytesleft = psize;
-	ptr = outpacket->packet;
-	put32bit(&ptr,type);
-	put32bit(&ptr,size);
-	outpacket->startptr = (uint8_t*)(outpacket->packet);
-	outpacket->next = NULL;
-	*(eptr->outputtail) = outpacket;
-	eptr->outputtail = &(outpacket->next);
-	return ptr;
+void matomlserv_createpacket(MatomlservEntry *eptr, const std::vector<uint8_t> &data) {
+	eptr->outputPackets.emplace(data);
 }
 
-void matomlserv_createpacket(matomlserventry *eptr, std::vector<uint8_t> data) {
-	packetstruct *outpacket = (packetstruct*) malloc(sizeof(packetstruct));
-	passert(outpacket);
-	outpacket->packet = (uint8_t*) malloc(data.size());
-	passert(outpacket->packet);
-	memcpy(outpacket->packet, data.data(), data.size());
-	outpacket->bytesleft = data.size();
-	outpacket->startptr = outpacket->packet;
-	outpacket->next = nullptr;
-	*(eptr->outputtail) = outpacket;
-	eptr->outputtail = &(outpacket->next);
-}
+void matomlserv_send_old_changes(MatomlservEntry *eptr, uint64_t version) {
+	if (oldChangesBlocks.empty()) { return; }
 
-void matomlserv_send_old_changes(matomlserventry *eptr,uint64_t version) {
-	old_changes_block *oc;
-	old_changes_entry *oce;
-	uint8_t *data;
-	uint8_t start=0;
-	uint32_t i;
-	if (old_changes_head==NULL) {
-		return;
-	}
-	if (old_changes_head->minversion>version) {
-		safs_pretty_syslog(LOG_WARNING,"meta logger wants changes since version: %" PRIu64 ", but minimal version in storage is: %" PRIu64,version,old_changes_head->minversion);
+	if (oldChangesBlocks.front().minVersion > version) {
+		safs::log_warn(
+		    "meta logger wants changes since version: {}, but minimal version in storage is: {}",
+		    version, oldChangesBlocks.front().minVersion);
 		// TODO(msulikowski) send a special message which will cause the shadow master to unload fs
 	}
-	for (oc=old_changes_head ; oc ; oc=oc->next) {
-		if (oc->minversion>=version) {
-			start=1;
-		} else if (oc->minversion<=version && (oc->next==NULL || oc->next->minversion>version)) {
-			start=1;
+
+	bool start = false;
+	for (std::size_t idx = 0; idx < oldChangesBlocks.size(); ++idx) {
+		const auto &block = oldChangesBlocks[idx];
+
+		if (block.minVersion >= version) {
+			start = true;
+		} else if (block.minVersion <= version) {
+			if (idx + 1 >= oldChangesBlocks.size() ||
+			    oldChangesBlocks[idx + 1].minVersion > version) {
+				start = true;
+			}
 		}
+
 		if (start) {
-			for (i=0 ; i<oc->entries ; i++) {
-				oce = oc->old_changes_block + i;
-				if (version < oce->version) {
-					data = matomlserv_createpacket(eptr,MATOML_METACHANGES_LOG,9+oce->length);
-					put8bit(&data,0xFF);
-					put64bit(&data,oce->version);
-					memcpy(data,oce->data,oce->length);
+			for (std::size_t i = 0; i < block.oldChangesBlock.size(); ++i) {
+				const auto &entry = block.oldChangesBlock[i];
+				if (version < entry.version) {
+					uint8_t *data = matomlserv_createpacket(eptr, MATOML_METACHANGES_LOG,
+					                                        9 + entry.data.size());
+					put8bit(&data, 0xFF);
+					put64bit(&data, entry.version);
+					std::memcpy(data, entry.data.data(), entry.data.size());
 				}
 			}
 		}
 	}
 }
 
-void matomlserv_register(matomlserventry *eptr,const uint8_t *data,uint32_t length) {
-	if (eptr->version>0) {
-		safs_pretty_syslog(LOG_WARNING,"got register message from registered metalogger !!!");
-		eptr->mode=KILL;
+void matomlserv_register(MatomlservEntry *eptr, const uint8_t *data, uint32_t length) {
+	if (eptr->version > 0) {
+		safs::log_warn("got register message from registered metalogger !!!");
+		eptr->mode = MetaloggerConnectionMode::KILL;
 		return;
 	}
-	if (length<1) {
-		safs_pretty_syslog(LOG_NOTICE,"MLTOMA_REGISTER - wrong size (%" PRIu32 ")",length);
-		eptr->mode=KILL;
+
+	if (length < 1) {
+		safs::log_info("MLTOMA_REGISTER - wrong size ({})", length);
+		eptr->mode = MetaloggerConnectionMode::KILL;
 		return;
 	} else {
 		uint8_t rversion = get8bit(&data);
 		if (rversion < 1 || rversion > 4) {
-			safs_pretty_syslog(LOG_NOTICE,"MLTOMA_REGISTER - wrong version (%" PRIu8 ")",rversion);
-			eptr->mode=KILL;
+			safs::log_info("MLTOMA_REGISTER - wrong version ({})", rversion);
+			eptr->mode = MetaloggerConnectionMode::KILL;
 			return;
 		}
-		static const uint32_t expected_length[] = {0, 7, 7+8, 7, 7+8};
+
+		static const uint32_t expected_length[] = {0, 7, 7 + 8, 7, 7 + 8};
 		if (length != expected_length[rversion]) {
-			safs_pretty_syslog(LOG_NOTICE,"MLTOMA_REGISTER (ver %" PRIu8 ") - wrong size (%" PRIu32
-					"/%" PRIu32 ")", rversion, length, expected_length[rversion]);
-			eptr->mode=KILL;
+			safs::log_info("MLTOMA_REGISTER (ver {}) - wrong size ({}/{})", rversion, length,
+			               expected_length[rversion]);
+			eptr->mode = MetaloggerConnectionMode::KILL;
 			return;
 		}
+
 		get32bit(&data, eptr->version);
 		eptr->timeout = get16bit(&data);
 		eptr->shadow = (rversion == 3 || rversion == 4);
 		if (eptr->shadow) {
-		// supported shadow master servers register using SAU_MLTOMA_REGISTER_SHADOW packet
-			safs_pretty_syslog(LOG_NOTICE,
-					"MLTOMA_REGISTER (ver %" PRIu8 ") - rejected old shadow master (v%s) from %s",
-					rversion, saunafsVersionToString(eptr->version).c_str(), eptr->servstrip);
-			eptr->mode=KILL;
+			// supported shadow master servers register using SAU_MLTOMA_REGISTER_SHADOW packet
+			safs::log_info("MLTOMA_REGISTER (ver {}) - rejected old shadow master (v{}) from {}",
+			               rversion, saunafsVersionToString(eptr->version), eptr->serviceStrIp);
+			eptr->mode = MetaloggerConnectionMode::KILL;
 			return;
 		}
+
 		if (rversion == 2 || rversion == 4) {
 			uint64_t minversion = get64bit(&data);
-			matomlserv_send_old_changes(eptr,minversion);
+			matomlserv_send_old_changes(eptr, minversion);
 		}
-		if (eptr->timeout<10) {
-			safs_pretty_syslog(LOG_NOTICE,"MLTOMA_REGISTER communication timeout too small (%" PRIu16 " seconds - should be at least 10 seconds)",eptr->timeout);
-			if (eptr->timeout<3) {
-				eptr->timeout=3;
-			}
+
+		if (eptr->timeout < 10) {
+			safs::log_info(
+			    "MLTOMA_REGISTER communication timeout too small ({} seconds - should be at least 10 seconds)",
+			    eptr->timeout);
+			if (eptr->timeout < 3) { eptr->timeout = 3; }
 		}
 	}
 }
 
-void matomlserv_register_shadow(matomlserventry *eptr, const uint8_t *data, uint32_t length) {
+void matomlserv_register_shadow(MatomlservEntry *eptr, const uint8_t *data, uint32_t length) {
 	uint32_t version, timeout_ms;
 	uint64_t shadowMetadataVersion;
 	mltoma::registerShadow::deserialize(data, length, version, timeout_ms, shadowMetadataVersion);
@@ -433,26 +354,25 @@ void matomlserv_register_shadow(matomlserventry *eptr, const uint8_t *data, uint
 	eptr->version = version;
 	eptr->shadow = true;
 	if (eptr->timeout < 10) {
-		safs_pretty_syslog(LOG_NOTICE,
-				"MLTOMA_REGISTER_SHADOW communication timeout too small (%" PRIu32 " milliseconds)"
-				" - should be at least 10 seconds; increasing to 10 seconds", timeout_ms);
-		if (eptr->timeout < 10) {
-			eptr->timeout = 10;
-		}
+		safs::log_info(
+		    "MLTOMA_REGISTER_SHADOW communication timeout too small ({} milliseconds)"
+		    " - should be at least 10 seconds; increasing to 10 seconds",
+		    timeout_ms);
+		if (eptr->timeout < 10) { eptr->timeout = 10; }
 	}
+
 	if (eptr->version < SAUNAFS_VERSHEX) {
-		safs_pretty_syslog(LOG_NOTICE,
-				"MLTOMA_REGISTER_SHADOW - rejected old client (v%s) from %s",
-				saunafsVersionToString(eptr->version).c_str(), eptr->servstrip);
-		matomlserv_createpacket(eptr, matoml::registerShadow::build(uint8_t(SAUNAFS_ERROR_REGISTER)));
+		safs::log_info("MLTOMA_REGISTER_SHADOW - rejected old client (v{}) from {}",
+		               saunafsVersionToString(eptr->version), eptr->serviceStrIp);
+		matomlserv_createpacket(eptr,
+		                        matoml::registerShadow::build(uint8_t(SAUNAFS_ERROR_REGISTER)));
 		return;
 	}
 
 	uint64_t myMedatataVersion = gFSOperations->getMetadataVersion();
 	uint64_t replyVersion;
-	if (myMedatataVersion > shadowMetadataVersion
-			&& old_changes_head != nullptr
-			&& old_changes_head->minversion <= shadowMetadataVersion) {
+	if (myMedatataVersion > shadowMetadataVersion && !oldChangesBlocks.empty() &&
+	    oldChangesBlocks.front().minVersion <= shadowMetadataVersion) {
 		// Our version is newer than shadow's, but we can cheat a bit by sending old changes
 		replyVersion = shadowMetadataVersion;
 	} else {
@@ -462,515 +382,403 @@ void matomlserv_register_shadow(matomlserventry *eptr, const uint8_t *data, uint
 	}
 
 	matomlserv_createpacket(eptr, matoml::registerShadow::build(SAUNAFS_VERSHEX, replyVersion));
-	matomlserv_send_old_changes(eptr, replyVersion - 1); // this function expects lastlogversion
+	matomlserv_send_old_changes(eptr, replyVersion - 1);  // this function expects lastlogversion
 }
 
-void matomlserv_register_config(matomlserventry *eptr, const uint8_t *data, uint32_t length) {
-	std::string config;
-	mltoma::dumpConfiguration::deserialize(data, length, config);
-	if(eptr->config) {
-		free(eptr->config);
-	}
-	eptr->config = strdup(config.c_str());
+void matomlserv_register_config(MatomlservEntry *eptr, const uint8_t *data, uint32_t length) {
+	mltoma::dumpConfiguration::deserialize(data, length, eptr->config);
 }
 
-void matomlserv_matoclport(matomlserventry *eptr, const uint8_t *data, uint32_t length) {
-	mltoma::matoclport::deserialize(data, length, eptr->servport);
+void matomlserv_matoclport(MatomlservEntry *eptr, const uint8_t *data, uint32_t length) {
+	mltoma::matoclport::deserialize(data, length, eptr->servicePort);
 }
 
-void matomlserv_download_start(matomlserventry *eptr,const uint8_t *data,uint32_t length) {
-	if (length!=1) {
-		safs_pretty_syslog(LOG_NOTICE,"MLTOMA_DOWNLOAD_START - wrong size (%" PRIu32 "/1)",length);
-		eptr->mode=KILL;
+void matomlserv_download_start(MatomlservEntry *eptr, const uint8_t *data, uint32_t length) {
+	if (length != 1) {
+		safs::log_info("MLTOMA_DOWNLOAD_START - wrong size ({}/1)", length);
+		eptr->mode = MetaloggerConnectionMode::KILL;
 		return;
 	}
 	if (gExiting) {
-		safs_pretty_syslog(LOG_NOTICE,"MLTOMA_DOWNLOAD_START - ignoring in the exit phase");
+		safs::log_info("MLTOMA_DOWNLOAD_START - ignoring in the exit phase");
 		return;
 	}
 	uint8_t filenum = get8bit(&data);
 
 	if ((filenum == DOWNLOAD_METADATA_SFS) || (filenum == DOWNLOAD_SESSIONS_SFS)) {
-		if (eptr->metafd>=0) {
-			close(eptr->metafd);
-			eptr->metafd=-1;
+		if (eptr->metaFD >= 0) {
+			close(eptr->metaFD);
+			eptr->metaFD = -1;
 		}
-		if (eptr->chain1fd>=0) {
-			close(eptr->chain1fd);
-			eptr->chain1fd=-1;
+		if (eptr->chain1FD >= 0) {
+			close(eptr->chain1FD);
+			eptr->chain1FD = -1;
 		}
-		if (eptr->chain2fd>=0) {
-			close(eptr->chain2fd);
-			eptr->chain2fd=-1;
+		if (eptr->chain2FD >= 0) {
+			close(eptr->chain2FD);
+			eptr->chain2FD = -1;
 		}
 	}
 	if (filenum == DOWNLOAD_METADATA_SFS) {
-		eptr->metafd = open(kMetadataFilename, O_RDONLY);
-		eptr->chain1fd = open(kChangelogFilename, O_RDONLY);
-		eptr->chain2fd = open((std::string(kChangelogFilename) + ".1").c_str(), O_RDONLY);
+		eptr->metaFD = open(kMetadataFilename, O_RDONLY);
+		eptr->chain1FD = open(kChangelogFilename, O_RDONLY);
+		eptr->chain2FD = open((std::string(kChangelogFilename) + ".1").c_str(), O_RDONLY);
 	} else if (filenum == DOWNLOAD_SESSIONS_SFS) {
-		eptr->metafd = open(kSessionsFilename, O_RDONLY);
+		eptr->metaFD = open(kSessionsFilename, O_RDONLY);
 	} else if (filenum == DOWNLOAD_CHANGELOG_SFS) {
-		if (eptr->metafd>=0) {
-			close(eptr->metafd);
-		}
-		eptr->metafd = eptr->chain1fd;
-		eptr->chain1fd = -1;
+		if (eptr->metaFD >= 0) { close(eptr->metaFD); }
+		eptr->metaFD = eptr->chain1FD;
+		eptr->chain1FD = -1;
 	} else if (filenum == DOWNLOAD_CHANGELOG_SFS_1) {
-		if (eptr->metafd>=0) {
-			close(eptr->metafd);
-		}
-		eptr->metafd = eptr->chain2fd;
-		eptr->chain2fd = -1;
+		if (eptr->metaFD >= 0) { close(eptr->metaFD); }
+		eptr->metaFD = eptr->chain2FD;
+		eptr->chain2FD = -1;
 	} else {
-		eptr->mode=KILL;
+		eptr->mode = MetaloggerConnectionMode::KILL;
 		return;
 	}
 	uint8_t *ptr;
-	if (eptr->metafd<0) {
-		if (filenum==11 || filenum==12) {
-			ptr = matomlserv_createpacket(eptr,MATOML_DOWNLOAD_START,8);
-			put64bit(&ptr,0);
+	if (eptr->metaFD < 0) {
+		if (filenum == 11 || filenum == 12) {
+			ptr = matomlserv_createpacket(eptr, MATOML_DOWNLOAD_START, 8);
+			put64bit(&ptr, 0);
 			return;
 		} else {
-			ptr = matomlserv_createpacket(eptr,MATOML_DOWNLOAD_START,1);
-			put8bit(&ptr,0xff);     // error
+			ptr = matomlserv_createpacket(eptr, MATOML_DOWNLOAD_START, 1);
+			put8bit(&ptr, 0xff);  // error
 			return;
 		}
 	}
-	uint64_t size = lseek(eptr->metafd,0,SEEK_END);
-	ptr = matomlserv_createpacket(eptr,MATOML_DOWNLOAD_START,8);
-	put64bit(&ptr,size);    // ok
+	uint64_t size = lseek(eptr->metaFD, 0, SEEK_END);
+	ptr = matomlserv_createpacket(eptr, MATOML_DOWNLOAD_START, 8);
+	put64bit(&ptr, size);  // ok
 }
 
-void matomlserv_download_data(matomlserventry *eptr,const uint8_t *data,uint32_t length) {
+void matomlserv_download_data(MatomlservEntry *eptr, const uint8_t *data, uint32_t length) {
 	uint8_t *ptr;
 	uint64_t offset;
 	uint32_t leng;
 	uint32_t crc;
 	ssize_t ret;
 
-	if (length!=12) {
-		safs_pretty_syslog(LOG_NOTICE,"MLTOMA_DOWNLOAD_DATA - wrong size (%" PRIu32 "/12)",length);
-		eptr->mode=KILL;
+	if (length != 12) {
+		safs::log_info("MLTOMA_DOWNLOAD_DATA - wrong size ({}/12)", length);
+		eptr->mode = MetaloggerConnectionMode::KILL;
 		return;
 	}
 	if (gExiting) {
-		safs_pretty_syslog(LOG_NOTICE,"MLTOMA_DOWNLOAD_DATA - ignoring in the exit phase");
+		safs::log_info("MLTOMA_DOWNLOAD_DATA - ignoring in the exit phase");
 		return;
 	}
-	if (eptr->metafd<0) {
-		safs_pretty_syslog(LOG_NOTICE,"MLTOMA_DOWNLOAD_DATA - file not opened");
-		eptr->mode=KILL;
+	if (eptr->metaFD < 0) {
+		safs::log_info("MLTOMA_DOWNLOAD_DATA - file not opened");
+		eptr->mode = MetaloggerConnectionMode::KILL;
 		return;
 	}
 	offset = get64bit(&data);
 	get32bit(&data, leng);
-	ptr = matomlserv_createpacket(eptr,MATOML_DOWNLOAD_DATA,16+leng);
-	put64bit(&ptr,offset);
-	put32bit(&ptr,leng);
-	ret = pread(eptr->metafd,ptr+4,leng,offset);
-	if (ret!=(ssize_t)leng) {
-		safs_silent_errlog(LOG_NOTICE,"error reading metafile");
-		eptr->mode=KILL;
+	ptr = matomlserv_createpacket(eptr, MATOML_DOWNLOAD_DATA, 16 + leng);
+	put64bit(&ptr, offset);
+	put32bit(&ptr, leng);
+	ret = pread(eptr->metaFD, ptr + 4, leng, offset);
+	if (ret != (ssize_t)leng) {
+		safs::log_err("error reading metafile");
+		eptr->mode = MetaloggerConnectionMode::KILL;
 		return;
 	}
-	crc = mycrc32(0,ptr+4,leng);
-	put32bit(&ptr,crc);
+	crc = mycrc32(0, ptr + 4, leng);
+	put32bit(&ptr, crc);
 }
 
-void matomlserv_download_end(matomlserventry *eptr,const uint8_t *data,uint32_t length) {
+void matomlserv_download_end(MatomlservEntry *eptr, const uint8_t *data, uint32_t length) {
 	(void)data;
-	if (length!=0) {
-		safs_pretty_syslog(LOG_NOTICE,"MLTOMA_DOWNLOAD_END - wrong size (%" PRIu32 "/0)",length);
-		eptr->mode=KILL;
+	if (length != 0) {
+		safs::log_info("MLTOMA_DOWNLOAD_END - wrong size ({}/0)", length);
+		eptr->mode = MetaloggerConnectionMode::KILL;
 		return;
 	}
-	if (eptr->metafd>=0) {
-		close(eptr->metafd);
-		eptr->metafd=-1;
+	if (eptr->metaFD >= 0) {
+		close(eptr->metaFD);
+		eptr->metaFD = -1;
 	}
 }
 
-void matomlserv_changelog_apply_error(matomlserventry *eptr, const uint8_t *data, uint32_t length) {
+void matomlserv_changelog_apply_error(MatomlservEntry *eptr, const uint8_t *data, uint32_t length) {
 	uint8_t recvStatus;
 	mltoma::changelogApplyError::deserialize(data, length, recvStatus);
 	if (gExiting) {
-		safs_pretty_syslog(LOG_NOTICE,"SAU_MLTOMA_CHANGELOG_APPLY_ERROR - ignoring in the exit phase");
+		safs::log_info("SAU_MLTOMA_CHANGELOG_APPLY_ERROR - ignoring in the exit phase");
 		return;
 	}
 
 	int32_t secondsSinceLastRequest = eventloop_time() - gLastMetadataSaveRequestTimestamp;
 	if (secondsSinceLastRequest >= int32_t(gMinMetadataSaveRequestPeriod_s)) {
 		gLastMetadataSaveRequestTimestamp = eventloop_time();
-		safs_silent_syslog(LOG_DEBUG, "master.mltoma_changelog_apply_error: do");
-		safs_pretty_syslog(LOG_INFO,
-				"SAU_MLTOMA_CHANGELOG_APPLY_ERROR, status: %s - storing metadata",
-				saunafs_error_string(recvStatus));
+		safs::log_debug("master.mltoma_changelog_apply_error: do");
+		safs::log_info("SAU_MLTOMA_CHANGELOG_APPLY_ERROR, status: {} - storing metadata",
+		               saunafs_error_string(recvStatus));
 		gShadowQueue.addRequest(eptr);
 		gMetadataBackend->fs_storeall(DumpType::kBackgroundDump);
 		if (recvStatus == SAUNAFS_ERROR_BADMETADATACHECKSUM) {
 			gFSOperations->startChecksumRecalculation();
 		}
 	} else {
-		safs_silent_syslog(LOG_DEBUG, "master.mltoma_changelog_apply_error: delay");
-		safs_pretty_syslog(LOG_INFO,
-				"SAU_MLTOMA_CHANGELOG_APPLY_ERROR, status: %s - "
-				"refusing to store metadata because only %" PRIi32 " seconds elapsed since the "
-				"previous request and METADATA_SAVE_REQUEST_MIN_PERIOD=%" PRIu32,
-				saunafs_error_string(recvStatus), secondsSinceLastRequest, gMinMetadataSaveRequestPeriod_s);
+		safs::log_debug("master.mltoma_changelog_apply_error: delay");
+		safs::log_info(
+		    "SAU_MLTOMA_CHANGELOG_APPLY_ERROR, status: {} - "
+		    "refusing to store metadata because only {} seconds elapsed since the "
+		    "previous request and METADATA_SAVE_REQUEST_MIN_PERIOD={}",
+		    saunafs_error_string(recvStatus), secondsSinceLastRequest,
+		    gMinMetadataSaveRequestPeriod_s);
 		matomlserv_createpacket(eptr, matoml::changelogApplyError::build(SAUNAFS_ERROR_DELAYED));
 	}
 }
 
-void matomlserv_broadcast_logstring(uint64_t version,uint8_t *logstr,uint32_t logstrsize) {
-	matomlserventry *eptr;
+void matomlserv_broadcast_logstring(uint64_t version, uint8_t *logstr, uint32_t logstrsize) {
 	uint8_t *data;
 
-	matomlserv_store_logstring(version,logstr,logstrsize);
+	matomlserv_store_logstring(version, logstr, logstrsize);
 
-	for (eptr = matomlservhead ; eptr ; eptr=eptr->next) {
-		if (eptr->version>0) {
-			data = matomlserv_createpacket(eptr,MATOML_METACHANGES_LOG,9+logstrsize);
-			put8bit(&data,0xFF);
-			put64bit(&data,version);
-			memcpy(data,logstr,logstrsize);
+	for (auto &eptr : matomlservList) {
+		if (eptr.version > 0) {
+			data = matomlserv_createpacket(&eptr, MATOML_METACHANGES_LOG, 9 + logstrsize);
+			put8bit(&data, 0xFF);
+			put64bit(&data, version);
+			memcpy(data, logstr, logstrsize);
 		}
 	}
 }
 
 void matomlserv_broadcast_logrotate() {
-	matomlserventry *eptr;
 	uint8_t *data;
 
-	for (eptr = matomlservhead ; eptr ; eptr=eptr->next) {
-		if (eptr->version>0) {
-			data = matomlserv_createpacket(eptr,MATOML_METACHANGES_LOG,1);
+	for (auto &eptr : matomlservList) {
+		if (eptr.version > 0) {
+			data = matomlserv_createpacket(&eptr, MATOML_METACHANGES_LOG, 1);
 			put8bit(&data, FORCE_LOG_ROTATE);
 		}
 	}
 }
 
-void matomlserv_beforeclose(matomlserventry *eptr) {
-	if (eptr->metafd>=0) {
-		close(eptr->metafd);
-		eptr->metafd=-1;
+void matomlserv_beforeclose(MatomlservEntry *eptr) {
+	if (eptr->metaFD >= 0) {
+		close(eptr->metaFD);
+		eptr->metaFD = -1;
 	}
-	if (eptr->chain1fd>=0) {
-		close(eptr->chain1fd);
-		eptr->chain1fd=-1;
+	if (eptr->chain1FD >= 0) {
+		close(eptr->chain1FD);
+		eptr->chain1FD = -1;
 	}
-	if (eptr->chain2fd>=0) {
-		close(eptr->chain2fd);
-		eptr->chain2fd=-1;
+	if (eptr->chain2FD >= 0) {
+		close(eptr->chain2FD);
+		eptr->chain2FD = -1;
 	}
 	gShadowQueue.removeRequest(eptr);
 }
 
-void matomlserv_gotpacket(matomlserventry *eptr,uint32_t type,const uint8_t *data,uint32_t length) {
+void matomlserv_gotpacket(MatomlservEntry *eptr, uint32_t type, const uint8_t *data,
+                          uint32_t length) {
 	try {
 		switch (type) {
-			case ANTOAN_NOP:
-				break;
-			case ANTOAN_UNKNOWN_COMMAND: // for future use
-				break;
-			case ANTOAN_BAD_COMMAND_SIZE: // for future use
-				break;
-			case MLTOMA_REGISTER:
-				matomlserv_register(eptr,data,length);
-				break;
-			case SAU_MLTOMA_REGISTER_SHADOW:
-				matomlserv_register_shadow(eptr,data,length);
-				break;
-			case SAU_MLTOMA_DUMP_CONFIG:
-				matomlserv_register_config(eptr,data,length);
-				break;
-			case MLTOMA_DOWNLOAD_START:
-				matomlserv_download_start(eptr,data,length);
-				break;
-			case MLTOMA_DOWNLOAD_DATA:
-				matomlserv_download_data(eptr,data,length);
-				break;
-			case MLTOMA_DOWNLOAD_END:
-				matomlserv_download_end(eptr,data,length);
-				break;
-			case SAU_MLTOMA_CHANGELOG_APPLY_ERROR:
-				matomlserv_changelog_apply_error(eptr, data, length);
-				break;
-			case SAU_MLTOMA_CLTOMA_PORT:
-				matomlserv_matoclport(eptr, data, length);
-				break;
-			default:
-				safs_pretty_syslog(LOG_NOTICE,"master <-> metaloggers module: got unknown message (type:%" PRIu32 ")",type);
-				eptr->mode=KILL;
-		}
-	} catch (IncorrectDeserializationException& ex) {
-		safs_pretty_syslog(LOG_NOTICE, "Packet 0x%" PRIX32 " - can't deserialize: %s", type, ex.what());
-		eptr->mode = KILL;
-	}
-}
-
-void matomlserv_term(void) {
-	matomlserventry *eptr,*eaptr;
-	packetstruct *pptr,*paptr;
-	safs_pretty_syslog(LOG_INFO,"master <-> metaloggers module: closing %s:%s",ListenHost,ListenPort);
-	tcpclose(lsock);
-
-	eptr = matomlservhead;
-	while (eptr) {
-		if (eptr->inputpacket.packet) {
-			free(eptr->inputpacket.packet);
-		}
-		if (eptr->servstrip) {
-			free(eptr->servstrip);
-		}
-		pptr = eptr->outputhead;
-		while (pptr) {
-			if (pptr->packet) {
-				free(pptr->packet);
-			}
-			paptr = pptr;
-			pptr = pptr->next;
-			free(paptr);
-		}
-		eaptr = eptr;
-		eptr = eptr->next;
-		gShadowQueue.removeRequest(eaptr);
-		free(eaptr);
-	}
-	matomlservhead=NULL;
-
-	free(ListenHost);
-	free(ListenPort);
-}
-
-void matomlserv_read(matomlserventry *eptr) {
-	SignalLoopWatchdog watchdog;
-	int32_t i;
-	uint32_t type,size;
-	const uint8_t *ptr;
-
-	watchdog.start();
-	while (eptr->mode != KILL) {
-		i=read(eptr->sock,eptr->inputpacket.startptr,eptr->inputpacket.bytesleft);
-		if (i==0) {
-			safs_pretty_syslog(LOG_NOTICE,"connection with ML(%s) has been closed by peer",eptr->servstrip);
-			eptr->mode = KILL;
-			return;
-		}
-		if (i<0) {
-			if (errno!=EAGAIN) {
-				safs_silent_errlog(LOG_NOTICE,"read from ML(%s) error",eptr->servstrip);
-				eptr->mode = KILL;
-			}
-			return;
-		}
-		eptr->inputpacket.startptr+=i;
-		eptr->inputpacket.bytesleft-=i;
-
-		if (eptr->inputpacket.bytesleft>0) {
-			return;
-		}
-
-		if (eptr->mode==HEADER) {
-			ptr = eptr->hdrbuff+4;
-			get32bit(&ptr, size);
-
-			if (size>0) {
-				if (size>MaxPacketSize) {
-					safs_pretty_syslog(LOG_WARNING,"ML(%s) packet too long (%" PRIu32 "/%u)",eptr->servstrip,size,MaxPacketSize);
-					eptr->mode = KILL;
-					return;
-				}
-				eptr->inputpacket.packet = (uint8_t*) malloc(size);
-				passert(eptr->inputpacket.packet);
-				eptr->inputpacket.bytesleft = size;
-				eptr->inputpacket.startptr = eptr->inputpacket.packet;
-				eptr->mode = DATA;
-				continue;
-			}
-			eptr->mode = DATA;
-		}
-
-		if (eptr->mode==DATA) {
-			ptr = eptr->hdrbuff;
-			get32bit(&ptr, type);
-			get32bit(&ptr, size);
-
-			eptr->mode=HEADER;
-			eptr->inputpacket.bytesleft = 8;
-			eptr->inputpacket.startptr = eptr->hdrbuff;
-
-			matomlserv_gotpacket(eptr,type,eptr->inputpacket.packet,size);
-
-			if (eptr->inputpacket.packet) {
-				free(eptr->inputpacket.packet);
-			}
-			eptr->inputpacket.packet=NULL;
+		case ANTOAN_NOP:
 			break;
-		}
-
-		if (watchdog.expired()) {
+		case ANTOAN_UNKNOWN_COMMAND:  // for future use
 			break;
+		case ANTOAN_BAD_COMMAND_SIZE:  // for future use
+			break;
+		case MLTOMA_REGISTER:
+			matomlserv_register(eptr, data, length);
+			break;
+		case SAU_MLTOMA_REGISTER_SHADOW:
+			matomlserv_register_shadow(eptr, data, length);
+			break;
+		case SAU_MLTOMA_DUMP_CONFIG:
+			matomlserv_register_config(eptr, data, length);
+			break;
+		case MLTOMA_DOWNLOAD_START:
+			matomlserv_download_start(eptr, data, length);
+			break;
+		case MLTOMA_DOWNLOAD_DATA:
+			matomlserv_download_data(eptr, data, length);
+			break;
+		case MLTOMA_DOWNLOAD_END:
+			matomlserv_download_end(eptr, data, length);
+			break;
+		case SAU_MLTOMA_CHANGELOG_APPLY_ERROR:
+			matomlserv_changelog_apply_error(eptr, data, length);
+			break;
+		case SAU_MLTOMA_CLTOMA_PORT:
+			matomlserv_matoclport(eptr, data, length);
+			break;
+		default:
+			safs::log_info("master <-> metaloggers module: got unknown message (type:{})", type);
+			eptr->mode = MetaloggerConnectionMode::KILL;
 		}
+	} catch (IncorrectDeserializationException &ex) {
+		safs::log_info("Packet 0x{} - can't deserialize: {}", type, ex.what());
+		eptr->mode = MetaloggerConnectionMode::KILL;
 	}
 }
 
-void matomlserv_write(matomlserventry *eptr) {
+void matomlserv_term() {
+	safs::log_info("master <-> metaloggers module: closing {}:{}", gListenHost, gListenPort);
+	tcpclose(listenSocket);
+
+	for (auto &eptr : matomlservList) {
+		// Remove from shadow queue
+		gShadowQueue.removeRequest(&eptr);
+	}
+	matomlservList.clear();
+}
+
+void matomlserv_read(MatomlservEntry *eptr) {
 	SignalLoopWatchdog watchdog;
-	packetstruct *pack;
 	int32_t i;
 
 	watchdog.start();
-	for (;;) {
-		pack = eptr->outputhead;
-		if (pack==NULL) {
+	while (eptr->mode != MetaloggerConnectionMode::KILL) {
+		uint32_t bytesToRead = eptr->inputPacket.bytesToBeRead();
+		i = read(eptr->sock, eptr->inputPacket.pointerToBeReadInto(), bytesToRead);
+		if (i == 0) {
+			safs::log_info("connection with ML({}) has been closed by peer", eptr->serviceStrIp);
+			eptr->mode = MetaloggerConnectionMode::KILL;
 			return;
 		}
-		i=write(eptr->sock,pack->startptr,pack->bytesleft);
-		if (i<0) {
-			if (errno!=EAGAIN) {
-				safs_silent_errlog(LOG_NOTICE,"write to ML(%s) error",eptr->servstrip);
-				eptr->mode = KILL;
+
+		if (i < 0) {
+			if (errno != EAGAIN) {
+				safs::log_err("read from ML({}) error", eptr->serviceStrIp);
+				eptr->mode = MetaloggerConnectionMode::KILL;
 			}
 			return;
 		}
-		pack->startptr+=i;
-		pack->bytesleft-=i;
-		if (pack->bytesleft>0) {
+
+		try {
+			eptr->inputPacket.increaseBytesRead(i);
+		} catch (InputPacketTooLongException &ex) {
+			safs::log_warn("reading from ML({}): {}", eptr->serviceStrIp, ex.what());
+			eptr->mode = MetaloggerConnectionMode::KILL;
 			return;
 		}
-		free(pack->packet);
-		eptr->outputhead = pack->next;
-		if (eptr->outputhead==NULL) {
-			eptr->outputtail = &(eptr->outputhead);
-		}
-		free(pack);
 
-		if (watchdog.expired()) {
-			break;
+		if (eptr->inputPacket.hasData()) {
+			auto header = eptr->inputPacket.getHeader();
+			const auto data = eptr->inputPacket.getData();
+			matomlserv_gotpacket(eptr, header.type, data.data(), data.size());
+			eptr->inputPacket.reset();
 		}
+
+		if (watchdog.expired()) { break; }
+	}
+}
+
+void matomlserv_write(MatomlservEntry *eptr) {
+	SignalLoopWatchdog watchdog;
+	int32_t bytesWritten;
+
+	watchdog.start();
+	while (!eptr->outputPackets.empty()) {
+		OutputPacket &outputPacket = eptr->outputPackets.front();
+		bytesWritten = write(eptr->sock, outputPacket.packet.data() + outputPacket.bytesSent,
+		                     outputPacket.packet.size() - outputPacket.bytesSent);
+		if (bytesWritten < 0) {
+			if (errno != EAGAIN) {
+				safs::log_err("main master server module: (ip:{}) write error", eptr->serviceStrIp);
+				eptr->mode = MetaloggerConnectionMode::KILL;
+			}
+			return;
+		}
+		outputPacket.bytesSent += bytesWritten;
+
+		if (outputPacket.bytesSent >= outputPacket.packet.size()) {
+			eptr->outputPackets.pop();
+		} else {
+			return;
+		}
+
+		if (watchdog.expired()) { break; }
 	}
 }
 
 void matomlserv_desc(std::vector<pollfd> &pdesc) {
-	matomlserventry *eptr;
 	if (!gExiting) {
-		pdesc.push_back({lsock,POLLIN,0});
-		lsockpdescpos = pdesc.size() - 1;
+		pdesc.push_back({listenSocket, POLLIN, 0});
+		listenSocketPollFdIndex = pdesc.size() - 1;
 	} else {
-		lsockpdescpos = -1;
+		listenSocketPollFdIndex = -1;
 	}
-	for (eptr=matomlservhead ; eptr ; eptr=eptr->next) {
-		pdesc.push_back({eptr->sock,POLLIN,0});
-		eptr->pdescpos = pdesc.size() - 1;
-		if (eptr->outputhead!=NULL) {
-			pdesc.back().events |= POLLOUT;
-		}
+	for (auto &eptr : matomlservList) {
+		pdesc.push_back({eptr.sock, POLLIN, 0});
+		eptr.pollFdIndex = pdesc.size() - 1;
+		if (!eptr.outputPackets.empty()) { pdesc.back().events |= POLLOUT; }
 	}
 }
 
 void matomlserv_serve(const std::vector<pollfd> &pdesc) {
-	uint32_t now=eventloop_time();
-	matomlserventry *eptr,**kptr;
-	packetstruct *pptr,*paptr;
+	uint32_t now = eventloop_time();
 	int ns;
 
-	if (lsockpdescpos>=0 && (pdesc[lsockpdescpos].revents & POLLIN)) {
-		ns=tcpaccept(lsock);
-		if (ns<0) {
-			safs_silent_errlog(LOG_NOTICE,"master<->ML socket: accept error");
+	if (listenSocketPollFdIndex >= 0 && (pdesc[listenSocketPollFdIndex].revents & POLLIN)) {
+		ns = tcpaccept(listenSocket);
+		if (ns < 0) {
+			safs_silent_errlog(LOG_NOTICE, "master<->ML socket: accept error");
 		} else if (metadataserver::isMaster()) {
 			tcpnonblock(ns);
 			tcpnodelay(ns);
-			eptr = (matomlserventry*) malloc(sizeof(matomlserventry));
-			passert(eptr);
-			eptr->next = matomlservhead;
-			matomlservhead = eptr;
-			eptr->sock = ns;
-			eptr->pdescpos = -1;
-			eptr->mode = HEADER;
-			eptr->lastread = now;
-			eptr->lastwrite = now;
-			eptr->inputpacket.next = NULL;
-			eptr->inputpacket.bytesleft = 8;
-			eptr->inputpacket.startptr = eptr->hdrbuff;
-			eptr->inputpacket.packet = NULL;
-			eptr->outputhead = NULL;
-			eptr->outputtail = &(eptr->outputhead);
-			eptr->timeout = 10;
-			eptr->servport = 0;// For shadow masters this will be changed to their MATOCL_SERV_PORT
-			eptr->shadow = false;
-
-			tcpgetpeer(eptr->sock,&(eptr->servip),NULL);
-			eptr->servstrip = matomlserv_makestrip(eptr->servip);
-			eptr->version=0;
-			eptr->metafd=-1;
-			eptr->chain1fd=-1;
-			eptr->chain2fd=-1;
-			eptr->config=nullptr;
+			matomlservList.emplace_front(ns, now);
+			MatomlservEntry &eptr = matomlservList.front();
+			tcpgetpeer(eptr.sock, &(eptr.serviceIp), nullptr);
+			eptr.serviceStrIp = ipToString(eptr.serviceIp);
+			eptr.config.clear();
 		} else {
 			tcpclose(ns);
 		}
 	}
-	for (eptr=matomlservhead ; eptr ; eptr=eptr->next) {
-		if (eptr->pdescpos>=0) {
-			if (pdesc[eptr->pdescpos].revents & (POLLERR|POLLHUP)) {
-				eptr->mode = KILL;
+
+	for (auto &eptr : matomlservList) {
+		if (eptr.pollFdIndex >= 0) {
+			if (pdesc[eptr.pollFdIndex].revents & (POLLERR | POLLHUP)) {
+				eptr.mode = MetaloggerConnectionMode::KILL;
 			}
-			if ((pdesc[eptr->pdescpos].revents & POLLIN) && eptr->mode!=KILL) {
-				eptr->lastread = now;
-				matomlserv_read(eptr);
+
+			if ((pdesc[eptr.pollFdIndex].revents & POLLIN) &&
+			    eptr.mode != MetaloggerConnectionMode::KILL) {
+				eptr.lastRead = now;
+				matomlserv_read(&eptr);
 			}
-			if ((pdesc[eptr->pdescpos].revents & POLLOUT) && eptr->mode!=KILL) {
-				eptr->lastwrite = now;
-				matomlserv_write(eptr);
+
+			if ((pdesc[eptr.pollFdIndex].revents & POLLOUT) &&
+			    eptr.mode != MetaloggerConnectionMode::KILL) {
+				eptr.lastWrite = now;
+				matomlserv_write(&eptr);
 			}
 		}
-		if ((uint32_t)(eptr->lastread+eptr->timeout)<(uint32_t)now) {
-			eptr->mode = KILL;
+
+		if ((uint32_t)(eptr.lastRead + eptr.timeout) < (uint32_t)now) {
+			eptr.mode = MetaloggerConnectionMode::KILL;
 		}
-		if ((uint32_t)(eptr->lastwrite+(eptr->timeout/3))<(uint32_t)now
-				&& eptr->outputhead==NULL
-				&& !gExiting) {
-			matomlserv_createpacket(eptr,ANTOAN_NOP,0);
+
+		if ((uint32_t)(eptr.lastWrite + (eptr.timeout / 3)) < (uint32_t)now &&
+		    eptr.outputPackets.empty() && !gExiting) {
+			matomlserv_createpacket(&eptr, ANTOAN_NOP, 0);
 		}
 	}
-	kptr = &matomlservhead;
-	while ((eptr=*kptr)) {
-		if (eptr->mode == KILL) {
-			matomlserv_beforeclose(eptr);
-			tcpclose(eptr->sock);
-			if (eptr->inputpacket.packet) {
-				free(eptr->inputpacket.packet);
-			}
-			pptr = eptr->outputhead;
-			while (pptr) {
-				if (pptr->packet) {
-					free(pptr->packet);
-				}
-				paptr = pptr;
-				pptr = pptr->next;
-				free(paptr);
-			}
-			if (eptr->servstrip) {
-				free(eptr->servstrip);
-			}
-			if (eptr->config) {
-				free(eptr->config);
-			}
-			*kptr = eptr->next;
-			free(eptr);
+
+	for (auto it = matomlservList.begin(); it != matomlservList.end();) {
+		if (it->mode == MetaloggerConnectionMode::KILL) {
+			matomlserv_beforeclose(&(*it));
+			tcpclose(it->sock);
+			it = matomlservList.erase(it);
 		} else {
-			kptr = &(eptr->next);
+			++it;
 		}
 	}
 }
 
 void matomlserv_wantexit(void) {
 	gExiting = true;
-	for (matomlserventry *eptr = matomlservhead; eptr != nullptr; eptr = eptr->next) {
-		matomlserv_createpacket(eptr, matoml::endSession::build());
+	for (auto &eptr : matomlservList) {
+		matomlserv_createpacket(&eptr, matoml::endSession::build());
 	}
 	// Now we won't create any new packets, but we will wait for all existing packets to be
 	// transmitted to shadow masters and metaloggers
@@ -978,11 +786,11 @@ void matomlserv_wantexit(void) {
 
 int matomlserv_canexit(void) {
 	// Exit when all connections are closed
-	return (matomlservhead == nullptr);
+	return matomlservList.empty();
 }
 
 void matomlserv_become_master() {
-	eventloop_timeregister(TIMEMODE_SKIP_LATE,3600,0,matomlserv_status);
+	eventloop_timeregister(TIMEMODE_SKIP_LATE, 3600, 0, matomlserv_status);
 	return;
 }
 
@@ -993,96 +801,101 @@ void matomlserv_read_config_file() {
 }
 
 void matomlserv_reload(void) {
-	char *oldListenHost,*oldListenPort;
-	int newlsock;
+	std::string oldListenHost;
+	std::string oldListenPort;
+	int newListenSock;
 
 	matomlserv_read_config_file();
 
-	oldListenHost = ListenHost;
-	oldListenPort = ListenPort;
-	ListenHost = cfg_getstr("MATOML_LISTEN_HOST","*");
-	ListenPort = cfg_getstr("MATOML_LISTEN_PORT","9419");
-	if (strcmp(oldListenHost,ListenHost)==0 && strcmp(oldListenPort,ListenPort)==0) {
-		free(oldListenHost);
-		free(oldListenPort);
-		safs_pretty_syslog(LOG_NOTICE,"master <-> metaloggers module: socket address hasn't changed (%s:%s)",ListenHost,ListenPort);
+	oldListenHost = gListenHost;
+	oldListenPort = gListenPort;
+	gListenHost = cfg_getstring("MATOML_LISTEN_HOST", "*");
+	gListenPort = cfg_getstring("MATOML_LISTEN_PORT", "9419");
+	if (oldListenHost == gListenHost && oldListenPort == gListenPort) {
+		safs::log_info("master <-> metaloggers module: socket address hasn't changed ({}:{})",
+		               gListenHost, gListenPort);
 		return;
 	}
 
-	newlsock = tcpsocket();
-	if (newlsock<0) {
-		safs_pretty_errlog(LOG_WARNING,"master <-> metaloggers module: socket address has changed, but can't create new socket");
-		free(ListenHost);
-		free(ListenPort);
-		ListenHost = oldListenHost;
-		ListenPort = oldListenPort;
+	newListenSock = tcpsocket();
+	if (newListenSock < 0) {
+		safs::log_warn(
+		    "master <-> metaloggers module: socket address has changed, but can't create new socket");
+		gListenHost = oldListenHost;
+		gListenPort = oldListenPort;
 		return;
 	}
-	tcpnonblock(newlsock);
-	tcpnodelay(newlsock);
-	tcpreuseaddr(newlsock);
-	if (tcpsetacceptfilter(newlsock)<0 && errno!=ENOTSUP) {
-		safs_silent_errlog(LOG_NOTICE,"master <-> metaloggers module: can't set accept filter");
-	}
-	if (tcpstrlisten(newlsock,ListenHost,ListenPort,100)<0) {
-		safs_pretty_errlog(LOG_ERR,"master <-> metaloggers module: socket address has changed, but can't listen on socket (%s:%s)",ListenHost,ListenPort);
-		free(ListenHost);
-		free(ListenPort);
-		ListenHost = oldListenHost;
-		ListenPort = oldListenPort;
-		tcpclose(newlsock);
-		return;
-	}
-	safs_pretty_syslog(LOG_NOTICE,"master <-> metaloggers module: socket address has changed, now listen on %s:%s",ListenHost,ListenPort);
-	free(oldListenHost);
-	free(oldListenPort);
-	tcpclose(lsock);
-	lsock = newlsock;
 
-	ChangelogSecondsToRemember = cfg_getuint16("MATOML_LOG_PRESERVE_SECONDS",600);
-	if (ChangelogSecondsToRemember>3600) {
-		safs_pretty_syslog(LOG_WARNING,"Number of seconds of change logs to be preserved in master is too big (%" PRIu16 ") - decreasing to 3600 seconds",ChangelogSecondsToRemember);
-		ChangelogSecondsToRemember=3600;
+	tcpnonblock(newListenSock);
+	tcpnodelay(newListenSock);
+	tcpreuseaddr(newListenSock);
+	if (tcpsetacceptfilter(newListenSock) < 0 && errno != ENOTSUP) {
+		safs_silent_errlog(LOG_NOTICE, "master <-> metaloggers module: can't set accept filter");
+	}
+
+	if (tcpstrlisten(newListenSock, gListenHost.c_str(), gListenPort.c_str(), 100) < 0) {
+		safs::log_err(
+		    "master <-> metaloggers module: socket address has changed, but can't listen on socket ({}:{})",
+		    gListenHost, gListenPort);
+		gListenHost = oldListenHost;
+		gListenPort = oldListenPort;
+		tcpclose(newListenSock);
+		return;
+	}
+
+	safs::log_info("master <-> metaloggers module: socket address has changed, now listen on {}:{}",
+	               gListenHost, gListenPort);
+	tcpclose(listenSocket);
+	listenSocket = newListenSock;
+
+	gChangelogSecondsToRemember = cfg_getuint16("MATOML_LOG_PRESERVE_SECONDS", 600);
+	if (gChangelogSecondsToRemember > 3600) {
+		safs::log_warn(
+		    "Number of seconds of change logs to be preserved in master is too big ({}) - decreasing to 3600 seconds",
+		    gChangelogSecondsToRemember);
+		gChangelogSecondsToRemember = 3600;
 	}
 }
 
 int matomlserv_init(void) {
 	matomlserv_read_config_file();
-	ListenHost = cfg_getstr("MATOML_LISTEN_HOST","*");
-	ListenPort = cfg_getstr("MATOML_LISTEN_PORT","9419");
+	gListenHost = cfg_getstring("MATOML_LISTEN_HOST", "*");
+	gListenPort = cfg_getstring("MATOML_LISTEN_PORT", "9419");
 
-	lsock = tcpsocket();
-	if (lsock<0) {
-		safs_pretty_errlog(LOG_ERR,"master <-> metaloggers module: can't create socket");
+	listenSocket = tcpsocket();
+	if (listenSocket < 0) {
+		safs::log_err("master <-> metaloggers module: can't create socket");
 		return -1;
 	}
-	tcpnonblock(lsock);
-	tcpnodelay(lsock);
-	tcpreuseaddr(lsock);
-	if (tcpsetacceptfilter(lsock)<0 && errno!=ENOTSUP) {
-		safs_silent_errlog(LOG_NOTICE,"master <-> metaloggers module: can't set accept filter");
+	tcpnonblock(listenSocket);
+	tcpnodelay(listenSocket);
+	tcpreuseaddr(listenSocket);
+	if (tcpsetacceptfilter(listenSocket) < 0 && errno != ENOTSUP) {
+		safs::log_err("master <-> metaloggers module: can't set accept filter");
 	}
 
-	if (tcpstrlisten(lsock,ListenHost,ListenPort,100)<0) {
-		safs_pretty_errlog(LOG_ERR,"master <-> metaloggers module: can't listen on %s:%s",ListenHost,ListenPort);
+	if (tcpstrlisten(listenSocket, gListenHost.c_str(), gListenPort.c_str(), 100) < 0) {
+		safs::log_err("master <-> metaloggers module: can't listen on {}:{}", gListenHost,
+		              gListenPort);
 		return -1;
 	}
-	safs_pretty_syslog(LOG_NOTICE,"master <-> metaloggers module: listen on %s:%s",ListenHost,ListenPort);
+	safs::log_info("master <-> metaloggers module: listen on {}:{}", gListenHost, gListenPort);
 
-	matomlservhead = NULL;
-	ChangelogSecondsToRemember = cfg_getuint16("MATOML_LOG_PRESERVE_SECONDS",600);
-	if (ChangelogSecondsToRemember>3600) {
-		safs_pretty_syslog(LOG_WARNING,"Number of seconds of change logs to be preserved in master is too big (%" PRIu16 ") - decreasing to 3600 seconds",ChangelogSecondsToRemember);
-		ChangelogSecondsToRemember=3600;
+	matomlservList.clear();
+	gChangelogSecondsToRemember = cfg_getuint16("MATOML_LOG_PRESERVE_SECONDS", 600);
+	if (gChangelogSecondsToRemember > 3600) {
+		safs::log_warn(
+		    "Number of seconds of change logs to be preserved in master is too big ({}) - decreasing to 3600 seconds",
+		    gChangelogSecondsToRemember);
+		gChangelogSecondsToRemember = 3600;
 	}
+
 	eventloop_wantexitregister(matomlserv_wantexit);
 	eventloop_canexitregister(matomlserv_canexit);
 	eventloop_reloadregister(matomlserv_reload);
 	metadataserver::registerFunctionCalledOnPromotion(matomlserv_become_master);
 	eventloop_destructregister(matomlserv_term);
-	eventloop_pollregister(matomlserv_desc,matomlserv_serve);
-	if (metadataserver::isMaster()) {
-		matomlserv_become_master();
-	}
+	eventloop_pollregister(matomlserv_desc, matomlserv_serve);
+	if (metadataserver::isMaster()) { matomlserv_become_master(); }
 	return 0;
 }


### PR DESCRIPTION
Previous version of the master to metalogger service communication was using an old C-styled code, which made this implementation hard to maintain and understand. Also, previous manual memory assigment and free was performed manually, which is an error-prone approach. This commit modernizes the master to metaloggers service by moving to a C++-style based code.