### PR TITLE
feat(kv,fdb): add async get operation support

### DIFF
--- a/src/fdb/fdb.cc
+++ b/src/fdb/fdb.cc
@@ -24,6 +24,7 @@
 
 #include <foundationdb/fdb_c_types.h>
 
+#include "fdb/fdb_future.h"
 #include "slogger/slogger.h"
 
 namespace fdb {
@@ -106,6 +107,15 @@ std::optional<kv::Value> Transaction::get(const kv::Key &key, bool snapshot) {
 	}
 
 	return value;
+}
+
+std::unique_ptr<kv::IFuture> Transaction::getAsync(const kv::Key &key, bool snapshot) {
+	if (!tr_) { return nullptr; }
+
+	FDBFuture *future = fdb_transaction_get(tr_.get(), key.data(), static_cast<int>(key.size()),
+	                                         static_cast<fdb_bool_t>(snapshot));
+
+	return std::make_unique<FDBFutureValue>(future);
 }
 
 kv::GetRangeResult Transaction::getRange(

--- a/src/fdb/fdb.h
+++ b/src/fdb/fdb.h
@@ -24,8 +24,7 @@
 #include <memory>
 #include <string>
 
-#define FDB_API_VERSION 730
-
+#include <fdb/fdb_api_version.h>  // Needs to be included before foundationdb/fdb_c.h
 #include <foundationdb/fdb_c.h>
 #include <foundationdb/fdb_c_types.h>
 
@@ -143,6 +142,13 @@ public:
 	/// Gets a value for a given key.
 	/// @param key The key to retrieve the value for.
 	std::optional<kv::Value> get(const kv::Key &key, bool snapshot = false);
+
+	/// Gets a value for a given key asynchronously.
+	/// @param key The key to retrieve the value for.
+	/// @param snapshot Whether to use a snapshot for the transaction.
+	/// @return A future that will contain the value when ready.
+	/// @note The transaction must remain alive until the future's get() method is called.
+	std::unique_ptr<kv::IFuture> getAsync(const kv::Key &key, bool snapshot = false);
 
 	/// Gets a range of keys and values.
 	/// @param begin The starting key for the range.

--- a/src/fdb/fdb_api_version.h
+++ b/src/fdb/fdb_api_version.h
@@ -1,0 +1,23 @@
+/*
+   Copyright 2023      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+/// Define the FoundationDB API version before including fdb_c.h
+/// This must be included before any foundationdb headers.
+#define FDB_API_VERSION 730

--- a/src/fdb/fdb_future.cc
+++ b/src/fdb/fdb_future.cc
@@ -1,0 +1,86 @@
+/*
+   Copyright 2023      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "common/platform.h"
+
+#include "fdb/fdb_future.h"
+
+#include "slogger/slogger.h"
+
+namespace fdb {
+
+FDBFutureValue::FDBFutureValue(FDBFuture *future) : future_(future) {}
+
+FDBFutureValue::~FDBFutureValue() {
+	if (future_ != nullptr) { fdb_future_destroy(future_); }
+}
+
+bool FDBFutureValue::isReady() {
+	if (future_ == nullptr) { return false; }
+
+	return fdb_future_is_ready(future_) != 0;
+}
+
+std::optional<kv::Value> FDBFutureValue::get(int *error) {
+	// Return nullopt if already consumed or invalid
+	if (consumed_ || future_ == nullptr) {
+		if (error != nullptr) { *error = 1; }
+		return std::nullopt;
+	}
+
+	// Mark as consumed
+	consumed_ = true;
+
+	// Block until the future is ready
+	fdb_error_t fdbError = fdb_future_block_until_ready(future_);
+
+	if (fdbError != 0) {
+		safs::log_err("FDBFutureValue::get: fdb_future_block_until_ready: error: {}",
+		              fdb_get_error(fdbError));
+		if (error != nullptr) { *error = static_cast<int>(fdbError); }
+		return std::nullopt;
+	}
+
+	// Extract the value from the future
+	fdb_bool_t valuePresent{};
+	const uint8_t *valueRead{};
+	int valueLength{};
+
+	fdbError = fdb_future_get_value(future_, &valuePresent, &valueRead, &valueLength);
+
+	if (fdbError != 0) {
+		safs::log_err("FDBFutureValue::get: fdb_future_get_value: error: {}",
+		              fdb_get_error(fdbError));
+		if (error != nullptr) { *error = static_cast<int>(fdbError); }
+		return std::nullopt;
+	}
+
+	// Set error to success
+	if (error != nullptr) { *error = 0; }
+
+	// Return the value if present
+	if (valuePresent != 0) {
+		kv::Value value(valueRead, std::next(valueRead, valueLength));
+		return value;
+	}
+
+	// Key not found
+	return std::nullopt;
+}
+
+}  // namespace fdb

--- a/src/fdb/fdb_future.h
+++ b/src/fdb/fdb_future.h
@@ -1,0 +1,67 @@
+/*
+   Copyright 2023      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "common/platform.h"
+
+// Needs to be included before foundationdb/fdb_c.h
+#include <fdb/fdb_api_version.h>
+
+#include <foundationdb/fdb_c.h>
+
+#include "kv/ifuture.h"
+
+namespace fdb {
+
+/// Wraps a FoundationDB future (FDBFuture*) with RAII semantics.
+/// Implements the kv::IFuture interface for asynchronous get operations.
+///
+/// @note The transaction that created this future must remain alive until get() is called.
+/// @note This future is single-use: get() can only be called once successfully.
+class FDBFutureValue final : public kv::IFuture {
+public:
+	/// Constructs a FDBFutureValue wrapping the given FDBFuture*.
+	/// @param future The FDB future to wrap. Takes ownership.
+	explicit FDBFutureValue(FDBFuture *future);
+
+	/// Destructor. Destroys the wrapped FDB future.
+	~FDBFutureValue() override;
+
+	// Non-copyable, non-movable
+	FDBFutureValue(const FDBFutureValue &) = delete;
+	FDBFutureValue &operator=(const FDBFutureValue &) = delete;
+	FDBFutureValue(FDBFutureValue &&) = delete;
+	FDBFutureValue &operator=(FDBFutureValue &&) = delete;
+
+	/// Checks if the future result is ready without blocking.
+	/// @return True if the result is ready, false otherwise.
+	bool isReady() override;
+
+	/// Blocks until the result is ready and retrieves the value.
+	/// @param error Optional pointer to store error code (0 on success, non-zero on error).
+	/// @return The value if successful and present, std::nullopt on error or if key not found.
+	/// @note This method can only be called once. Subsequent calls return std::nullopt.
+	std::optional<kv::Value> get(int *error = nullptr) override;
+
+private:
+	FDBFuture *future_;
+	bool consumed_ = false;
+};
+
+}  // namespace fdb

--- a/src/fdb/fdb_transaction.cc
+++ b/src/fdb/fdb_transaction.cc
@@ -18,12 +18,20 @@
 
 #include "fdb/fdb_transaction.h"
 
+#include "kv/ifuture.h"
+
 namespace fdb {
 
 std::optional<kv::Value> FDBTransaction::get(const kv::Key &key) {
 	if (!tr_) { return std::nullopt; }
 
 	return tr_.get(key);
+}
+
+std::unique_ptr<kv::IFuture> FDBTransaction::getAsync(const kv::Key &key) {
+	if (!tr_) { return nullptr; }
+
+	return tr_.getAsync(key);
 }
 
 kv::GetRangeResult FDBTransaction::getRange(const kv::KeySelector &start,

--- a/src/fdb/fdb_transaction.h
+++ b/src/fdb/fdb_transaction.h
@@ -33,13 +33,11 @@ public:
 	/// @param tr The fdb::Transaction to wrap.
 	FDBTransaction(fdb::Transaction &&_tr) : tr_(std::move(_tr)), error_(0) {}
 
-	// Non-copyable, but movable (maybe to a queue of transactions).
+	// Non-copyable, non-movable (base class is non-movable)
 	FDBTransaction(const FDBTransaction &) = delete;
 	FDBTransaction &operator=(const FDBTransaction &) = delete;
-
-	/// Move constructor/assignment operator.
-	FDBTransaction(FDBTransaction &&) = default;
-	FDBTransaction &operator=(FDBTransaction &&) = default;
+	FDBTransaction(FDBTransaction &&) = delete;
+	FDBTransaction &operator=(FDBTransaction &&) = delete;
 
 	/// Default destructor. The members are RAII or simple.
 	~FDBTransaction() = default;
@@ -47,6 +45,12 @@ public:
 	/// Retrieves the value for a given key.
 	/// @param key The key to retrieve the value for.
 	std::optional<kv::Value> get(const kv::Key &key) override;
+
+	/// Retrieves the value for a given key asynchronously.
+	/// @param key The key to retrieve the value for.
+	/// @return A future that will contain the value when ready.
+	/// @note The transaction must remain alive until the future's get() method is called.
+	std::unique_ptr<kv::IFuture> getAsync(const kv::Key &key) override;
 
 	/// Retrieves a range of keys and values
 	/// @param start The starting key for the range.

--- a/src/fdb/fdb_unittest.cc
+++ b/src/fdb/fdb_unittest.cc
@@ -21,6 +21,7 @@
 #include "fdb/fdb.h"
 #include "fdb/fdb_context.h"
 #include "fdb/fdb_kv_engine.h"
+#include "kv/ifuture.h"
 #include "kv/itransaction.h"
 
 #include <gtest/gtest.h>
@@ -172,4 +173,53 @@ TEST_F(FDBKVEngineTest, AtomicAdd) {
 	    << "Final value does not match expected value after atomicAdd.";
 
 	safs::log_info("Atomic add successful: final value for 'count' is {}", finalValue);
+}
+
+TEST_F(FDBKVEngineTest, GetAsync) {
+	std::string_view keyStr = "async_key";
+	std::string_view valueStr = "async_value";
+	auto key = kv::toBytes(keyStr);
+	auto value = kv::toBytes(valueStr);
+
+	// First, set the value using a synchronous transaction
+	{
+		auto transaction = kvEngine->createReadWriteTransaction();
+		transaction->set(key, value);
+		ASSERT_TRUE(transaction->commit()) << "Failed to commit transaction for async test.";
+	}
+
+	// Now retrieve it asynchronously
+	auto transaction = kvEngine->createReadWriteTransaction();
+	auto future = transaction->getAsync(key);
+
+	ASSERT_TRUE(future != nullptr) << "Failed to create async future.";
+
+	// Retrieve the value from the future
+	int error = 0;
+	auto retrievedValue = future->get(&error);
+
+	ASSERT_EQ(error, 0) << "Error occurred while getting async value: " << error;
+	ASSERT_TRUE(retrievedValue.has_value()) << "Value for key '" << keyStr << "' not found.";
+	ASSERT_EQ(retrievedValue.value(), value)
+	    << "Retrieved async value does not match expected value.";
+
+	safs::log_info("Async value retrieved successfully: {} = {}", keyStr, valueStr);
+
+	// Test retrieving a non-existing key
+	std::string_view nonExistentKeyStr = "non_existent_key";
+	auto nonExistentKey = kv::toBytes(nonExistentKeyStr);
+
+	auto transaction2 = kvEngine->createReadWriteTransaction();
+	auto futureMissing = transaction2->getAsync(nonExistentKey);
+
+	ASSERT_TRUE(futureMissing != nullptr) << "Failed to create async future for non-existent key.";
+
+	int error2 = 0;
+	auto retrievedMissing = futureMissing->get(&error2);
+
+	ASSERT_EQ(error2, 0) << "Error occurred while getting non-existent key: " << error2;
+	ASSERT_FALSE(retrievedMissing.has_value()) << "Non-existent key should not have a value.";
+
+	safs::log_info("Non-existent key test passed: key '{}' correctly returned no value",
+	               nonExistentKeyStr);
 }

--- a/src/kv/ifuture.h
+++ b/src/kv/ifuture.h
@@ -1,0 +1,57 @@
+/*
+   Copyright 2023      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <optional>
+
+#include "kv/kv_utils.h"
+
+namespace kv {
+
+/// Interface for asynchronous future results from key-value operations.
+/// Provides methods to check readiness and retrieve values from pending operations.
+///
+/// @note This future is single-use: get() can only be called once successfully.
+/// @note The transaction that created this future must remain alive until get() is called.
+class IFuture {
+public:
+	virtual ~IFuture() = default;
+
+	// Non-copyable, non-movable
+	IFuture(const IFuture &) = delete;
+	IFuture &operator=(const IFuture &) = delete;
+	IFuture(IFuture &&) = delete;
+	IFuture &operator=(IFuture &&) = delete;
+
+	/// Checks if the future result is ready without blocking.
+	/// @return True if the result is ready, false otherwise.
+	virtual bool isReady() = 0;
+
+	/// Blocks until the result is ready and retrieves the value.
+	/// @param error Optional pointer to store error code (0 on success, non-zero on error).
+	/// @return The value if successful and present, std::nullopt on error or if key not found.
+	/// @note This method can only be called once. Subsequent calls return std::nullopt.
+	/// @note The caller must keep the transaction alive until this method returns.
+	virtual std::optional<Value> get(int *error = nullptr) = 0;
+
+protected:
+	IFuture() = default;
+};
+
+}  // namespace kv

--- a/src/kv/itransaction.h
+++ b/src/kv/itransaction.h
@@ -20,12 +20,15 @@
 
 #include <cstdint>
 #include <cstring>
+#include <memory>
 #include <optional>
 #include <vector>
 
 #include "kv/kv_utils.h"
 
 namespace kv {
+
+class IFuture;
 
 /// Represents a key-value pair in the key-value store.
 /// Keys and values are stored as vectors of bytes.
@@ -80,9 +83,21 @@ class IReadOnlyTransaction {
 public:
 	virtual ~IReadOnlyTransaction() = default;
 
+	// Non-copyable, non-movable
+	IReadOnlyTransaction(const IReadOnlyTransaction &) = delete;
+	IReadOnlyTransaction &operator=(const IReadOnlyTransaction &) = delete;
+	IReadOnlyTransaction(IReadOnlyTransaction &&) = delete;
+	IReadOnlyTransaction &operator=(IReadOnlyTransaction &&) = delete;
+
 	/// Retrieves the value for a given key.
 	/// @param key The key to retrieve the value for.
 	virtual std::optional<Value> get(const Key &key) = 0;
+
+	/// Retrieves the value for a given key asynchronously.
+	/// @param key The key to retrieve the value for.
+	/// @return A future that will contain the value when ready.
+	/// @note The transaction must remain alive until the future's get() method is called.
+	virtual std::unique_ptr<IFuture> getAsync(const Key &key) = 0;
 
 	/// Retrieves a range of keys and values
 	/// @param start The starting key for the range.
@@ -90,6 +105,9 @@ public:
 	/// @param limit The maximum number of key-value pairs to retrieve.
 	virtual GetRangeResult getRange(const KeySelector &start, const KeySelector &end,
 	                                int limit = kDefaultGetRangeLimit) = 0;
+
+protected:
+	IReadOnlyTransaction() = default;
 };
 
 /// Interface for read-write transactions in the key-value store.
@@ -97,6 +115,12 @@ public:
 class IReadWriteTransaction : public IReadOnlyTransaction {
 public:
 	virtual ~IReadWriteTransaction() override = default;
+
+	// Non-copyable, non-movable (also removes the clang-tidy warning)
+	IReadWriteTransaction(const IReadWriteTransaction &) = delete;
+	IReadWriteTransaction &operator=(const IReadWriteTransaction &) = delete;
+	IReadWriteTransaction(IReadWriteTransaction &&) = delete;
+	IReadWriteTransaction &operator=(IReadWriteTransaction &&) = delete;
 
 	/// Sets a value for a given key.
 	/// @param key The key to set the value for.
@@ -117,6 +141,9 @@ public:
 
 	/// Returns the committed version of the transaction, if available.
 	virtual std::optional<int64_t> getCommittedVersion() const = 0;
+
+protected:
+	IReadWriteTransaction() = default;
 };
 
 }  // namespace kv


### PR DESCRIPTION
Implement asynchronous value retrieval for FoundationDB transactions to enable non-blocking operations. This introduces the IFuture interface and FDBFutureValue implementation for handling async results.

Changes include:
- Add IFuture interface for async operation results.
- Implement FDBFutureValue wrapping FDB futures with RAII.
- Add getAsync() methods to ITransaction and implementations.
- Extract FDB_API_VERSION to separate header file.
- Make transaction interfaces non-copyable and non-movable.
- Add unit tests for async operations.

The async interface allows multiple concurrent reads without blocking, improving performance for workloads with multiple independent key lookups.

Reviewers: I am already using it in the MDS.