### PR TITLE
chore(master): add keys for FS level statistics

### DIFF
--- a/src/master/filesystem_metadata.h
+++ b/src/master/filesystem_metadata.h
@@ -70,8 +70,10 @@ public:
 	FileLocks flockLocks;
 	FileLocks posixLocks;
 
-	inode_t nodes{};
 	uint64_t metadataVersion{};
+
+	// FS level statistics
+	inode_t nodes{};
 	uint64_t trashSpace{};
 	uint64_t reservedSpace{};
 	inode_t trashNodes{};

--- a/src/master/kv_common_keys.h
+++ b/src/master/kv_common_keys.h
@@ -30,6 +30,16 @@ inline constexpr std::string_view kMetaNextSessionKey = "META_NEXT_SESSION";
 inline constexpr std::string_view kInodeRangeStartKey = "META_NEXT_INODE_RANGE";
 inline constexpr std::string_view kChunkRangeStartKey = "META_NEXT_CHUNK_RANGE";
 
+// Keys for filesystem statistics
+inline constexpr std::string_view kMetaNodesKey = "META_NODES";
+inline constexpr std::string_view kMetaTrashSpaceKey = "META_TRASH_SPACE";
+inline constexpr std::string_view kMetaReservedSpaceKey = "META_RESERVED_SPACE";
+inline constexpr std::string_view kMetaTrashNodesKey = "META_TRASH_NODES";
+inline constexpr std::string_view kMetaReservedNodesKey = "META_RESERVED_NODES";
+inline constexpr std::string_view kMetaFileNodesKey = "META_FILE_NODES";
+inline constexpr std::string_view kMetaDirNodesKey = "META_DIR_NODES";
+inline constexpr std::string_view kMetaLinkNodesKey = "META_LINK_NODES";
+
 // Metadata sections prefixes
 inline constexpr std::string_view kNodeKeyPrefix = "NODE_";    // Section NODE 1.0
 inline constexpr std::string_view kEdgeKeyPrefix = "EDGE_";    // Section EDGE 1.0


### PR DESCRIPTION
Adds the keys related to FS level statistics, for:
- Total number of inodes.
- Trash space.
- Reserved files used space.
- Number of nodes in trash.
- Number of reserved nodes.
- Number of nodes of type File.
- Number of directories.
- Number of link nodes.

The keys are intended to be used by any metadata backend implementation based on a KV store (FDB or others).

filesystem_metadata.h was touched to separate the logical stats group.