### PR TITLE
refactor(master): Make node operations extensible

### DIFF
--- a/src/master/filesystem.cc
+++ b/src/master/filesystem.cc
@@ -37,6 +37,7 @@
 #include "master/deferred_metadata_dump_task.h"
 #include "master/filesystem_checksum_updater.h"
 #include "master/filesystem_metadata.h"
+#include "master/filesystem_node.h"
 #include "master/filesystem_operations.h"
 #include "master/filesystem_operations_interface.h"
 #include "master/filesystem_periodic.h"
@@ -229,7 +230,10 @@ static void ensureChunkIdGenerator() {
 }
 
 static void initFSOperations() {
-	if (!gFSOperations) { gFSOperations = std::make_unique<FilesystemOperationsBase>(); }
+	if (!gFSOperations) {
+		auto nodeOps = std::make_unique<FilesystemNodeOperationsBase>();
+		gFSOperations = std::make_unique<FilesystemOperationsBase>(std::move(nodeOps));
+	}
 }
 
 /* executed in master mode */

--- a/src/master/filesystem_dump.cc
+++ b/src/master/filesystem_dump.cc
@@ -25,22 +25,23 @@
 #include "master/filesystem_freenode.h"
 #include "master/filesystem_metadata.h"
 #include "master/filesystem_node.h"
+#include "master/filesystem_operations_interface.h"
 
 void fs_dumpedge(FSNodeDirectory *parent, FSNode *child, const std::string &name) {
 	if (parent == NULL) {
 		if (child->type == FSNodeType::kTrash) {
 			printf("E|p:     TRASH|c:%10" PRIiNode "|n:%s\n", child->id,
-			       fsnodes_escape_name(name).c_str());
+			       gFSOperations->nodeOperations()->fsnodes_escape_name(name).c_str());
 		} else if (child->type == FSNodeType::kReserved) {
 			printf("E|p:  RESERVED|c:%10" PRIiNode "|n:%s\n", child->id,
-			       fsnodes_escape_name(name).c_str());
+			       gFSOperations->nodeOperations()->fsnodes_escape_name(name).c_str());
 		} else {
 			printf("E|p:      NULL|c:%10" PRIiNode "|n:%s\n", child->id,
-			       fsnodes_escape_name(name).c_str());
+			       gFSOperations->nodeOperations()->fsnodes_escape_name(name).c_str());
 		}
 	} else {
 		printf("E|p:%10" PRIiNode "|c:%10" PRIiNode "|n:%s\n", parent->id, child->id,
-		       fsnodes_escape_name(name).c_str());
+		       gFSOperations->nodeOperations()->fsnodes_escape_name(name).c_str());
 	}
 }
 
@@ -90,7 +91,10 @@ void fs_dumpnode(FSNode *f) {
 		printf("|d:%5" PRIu32 ",%5" PRIu32 "\n", static_cast<FSNodeDevice*>(f)->rdev >> 16,
 		       static_cast<FSNodeDevice*>(f)->rdev & 0xFFFF);
 	} else if (f->type == FSNodeType::kSymlink) {
-		printf("|p:%s\n", fsnodes_escape_name((std::string)static_cast<FSNodeSymlink*>(f)->path).c_str());
+		printf("|p:%s\n",
+		       gFSOperations->nodeOperations()
+		           ->fsnodes_escape_name((std::string) static_cast<FSNodeSymlink *>(f)->path)
+		           .c_str());
 	} else if (f->type == FSNodeType::kFile || f->type == FSNodeType::kTrash ||
 	           f->type == FSNodeType::kReserved) {
 		FSNodeFile *node_file = static_cast<FSNodeFile*>(f);
@@ -142,14 +146,14 @@ void fs_dumpedgelist(FSNodeDirectory *parent) {
 
 void fs_dumpedgelist(const TrashPathContainer &data) {
 	for (const auto &entry : data) {
-		FSNode *child = fsnodes_id_to_node(entry.first.id);
+		FSNode *child = gFSOperations->nodeOperations()->fsnodes_id_to_node(entry.first.id);
 		fs_dumpedge(nullptr, child, (std::string)entry.second);
 	}
 }
 
 void fs_dumpedgelist(const ReservedPathContainer &data) {
 	for (const auto &entry : data) {
-		FSNode *child = fsnodes_id_to_node(entry.first);
+		FSNode *child = gFSOperations->nodeOperations()->fsnodes_id_to_node(entry.first);
 		fs_dumpedge(nullptr, child, (std::string)entry.second);
 	}
 }
@@ -181,14 +185,17 @@ void fs_dumpfree() {
 void xattr_dump() {
 	for (auto i = 0; i < XATTR_DATA_HASH_SIZE; i++) {
 		for (const auto &xattrDataEntry : gMetadata->xattrDataHash[i]) {
-			printf(
-			    "X|i:%10" PRIiNode "|n:%s|v:%s\n", xattrDataEntry.get()->inode,
-			    fsnodes_escape_name(std::string((char *)xattrDataEntry.get()->attributeName.data(),
-			                                    xattrDataEntry.get()->attributeName.size()))
-			        .c_str(),
-			    fsnodes_escape_name(std::string((char *)xattrDataEntry.get()->attributeValue.data(),
-			                                    xattrDataEntry.get()->attributeValue.size()))
-			        .c_str());
+			printf("X|i:%10" PRIiNode "|n:%s|v:%s\n", xattrDataEntry.get()->inode,
+			       gFSOperations->nodeOperations()
+			           ->fsnodes_escape_name(
+			               std::string((char *)xattrDataEntry.get()->attributeName.data(),
+			                           xattrDataEntry.get()->attributeName.size()))
+			           .c_str(),
+			       gFSOperations->nodeOperations()
+			           ->fsnodes_escape_name(
+			               std::string((char *)xattrDataEntry.get()->attributeValue.data(),
+			                           xattrDataEntry.get()->attributeValue.size()))
+			           .c_str());
 		}
 	}
 }

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -35,7 +35,6 @@
 #include "master/chunks.h"
 #include "master/datacachemgr.h"
 #include "master/filesystem_checksum.h"
-#include "master/filesystem_freenode.h"
 #include "master/filesystem_metadata.h"
 #include "master/filesystem_node_types.h"
 #include "master/filesystem_operations.h"
@@ -84,8 +83,12 @@ void FSNode::destroy(FSNode *node) {
 	delete node;
 }
 
+// ============================================================================
+// FilesystemNodeOperationsBase - Private helper methods
+// ============================================================================
+
 // number of blocks in the last chunk before EOF
-static uint32_t last_chunk_blocks(FSNodeFile *node) {
+uint32_t FilesystemNodeOperationsBase::last_chunk_blocks(FSNodeFile *node) {
 	const uint64_t last_byte = node->length - 1;
 	const uint32_t last_byte_offset = last_byte % SFSCHUNKSIZE;
 	const uint32_t last_block = last_byte_offset / SFSBLOCKSIZE;
@@ -94,7 +97,7 @@ static uint32_t last_chunk_blocks(FSNodeFile *node) {
 }
 
 // does the last chunk exist and contain non-zero data?
-static bool last_chunk_nonempty(FSNodeFile *node) {
+bool FilesystemNodeOperationsBase::last_chunk_nonempty(FSNodeFile *node) {
 	std::size_t chunks = node->chunks.size();
 	if (chunks == 0) {
 		// no non-zero chunks, return now
@@ -113,13 +116,13 @@ static bool last_chunk_nonempty(FSNodeFile *node) {
 }
 
 // count chunks in a file, disregard sparse file holes
-static uint32_t file_chunks(FSNodeFile *node) {
+uint32_t FilesystemNodeOperationsBase::file_chunks(FSNodeFile *node) {
 	return std::accumulate(node->chunks.begin(), node->chunks.end(), (uint32_t)0,
 	                       [](uint32_t sum, uint64_t v) { return sum + (v != 0); });
 }
 
 // compute the "size" statistic for a file node
-static uint64_t file_size(FSNodeFile *node, uint32_t nonzero_chunks) {
+uint64_t FilesystemNodeOperationsBase::file_size(FSNodeFile *node, uint32_t nonzero_chunks) {
 	uint64_t size = (uint64_t)nonzero_chunks * (SFSCHUNKSIZE + SFSHDRSIZE);
 	if (last_chunk_nonempty(node)) {
 		size -= SFSCHUNKSIZE;
@@ -130,7 +133,8 @@ static uint64_t file_size(FSNodeFile *node, uint32_t nonzero_chunks) {
 
 #ifndef METARESTORE
 // compute the disk space cost of all parts of a xor/ec chunk of given size
-static uint32_t ec_chunk_realsize(uint32_t blocks, uint32_t data_part_count, uint32_t parity_part_count) {
+uint32_t FilesystemNodeOperationsBase::ec_chunk_realsize(uint32_t blocks, uint32_t data_part_count,
+                                                         uint32_t parity_part_count) {
 	const uint32_t stripes = (blocks + data_part_count - 1) / data_part_count;
 	uint32_t size = blocks * SFSBLOCKSIZE;                 // file data
 	size += parity_part_count * stripes * SFSBLOCKSIZE;     // parity data
@@ -141,7 +145,8 @@ static uint32_t ec_chunk_realsize(uint32_t blocks, uint32_t data_part_count, uin
 
 // compute the "realsize" statistic for a file node
 // NOTICE: file_size takes into account chunk headers and doesn't takes nonzero_chunks
-static uint64_t file_realsize(FSNodeFile *node, uint32_t nonzero_chunks, uint64_t file_size) {
+uint64_t FilesystemNodeOperationsBase::file_realsize(FSNodeFile *node, uint32_t nonzero_chunks,
+                                                     uint64_t file_size) {
 #ifdef METARESTORE
 	(void)node;
 	(void)nonzero_chunks;
@@ -178,7 +183,43 @@ static uint64_t file_realsize(FSNodeFile *node, uint32_t nonzero_chunks, uint64_
 #endif
 }
 
-std::string fsnodes_escape_name(const std::string &name) {
+// Protected methods
+
+FSNode *FilesystemNodeOperationsBase::fsnodes_id_to_node_internal(inode_t id) {
+	// Find the node with the given id
+	uint32_t nodeHashIndex = NODEHASHPOS(id);
+
+	for (const auto &node : gMetadata->nodeHash[nodeHashIndex]) {
+		if (node->id == id) { return node; }
+	}
+
+	return nullptr;
+}
+
+// Public methods
+
+FSNode *FilesystemNodeOperationsBase::fsnodes_lookup(FSNodeDirectory *node,
+                                                     const HString &name) const {
+	auto it = node->find(name);
+	if (it != node->end()) { return (*it).second; }
+
+	return nullptr;
+}
+
+void FilesystemNodeOperationsBase::fsnodes_update_ctime(FSNode *node, uint32_t ctime) {
+	if (node->type == FSNodeType::kTrash && node->ctime != ctime) {
+		auto old_key = TrashPathKey(node);
+		node->ctime = ctime;
+		auto it = gMetadata->trash.find(old_key);
+		if (it != gMetadata->trash.end()) {
+			updateTrashFromOldEntry(gMetadata->trash, node, old_key);
+		}
+	} else {
+		node->ctime = ctime;
+	}
+}
+
+std::string FilesystemNodeOperationsBase::fsnodes_escape_name(const std::string &name) {
 	constexpr std::array<char, 16> hex_digit = {{'0', '1', '2', '3', '4', '5', '6', '7',
 	                                             '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'}};
 	std::string result;
@@ -206,12 +247,12 @@ std::string fsnodes_escape_name(const std::string &name) {
 	return result;
 }
 
-int fsnodes_nameisused(FSNodeDirectory *node, const HString &name) {
+int FilesystemNodeOperationsBase::fsnodes_nameisused(FSNodeDirectory *node, const HString &name) {
 	return fsnodes_lookup(node, name) != nullptr;
 }
 
 /*! \brief Returns true iff \param ancestor is ancestor of \param node. */
-bool fsnodes_isancestor(FSNodeDirectory *ancestor, FSNode *node) {
+bool FilesystemNodeOperationsBase::fsnodes_isancestor(FSNodeDirectory *ancestor, FSNode *node) {
 	for (const auto &[parentId, _] : node->parents) {
 		auto *dir_node = fsnodes_id_to_node_verify<FSNodeDirectory>(parentId);
 
@@ -236,7 +277,8 @@ bool fsnodes_isancestor(FSNodeDirectory *ancestor, FSNode *node) {
 /*! \brief Returns true iff \param node is reserved or in trash
  * or \param ancestor is ancestor of \param node.
  */
-bool fsnodes_isancestor_or_node_reserved_or_trash(FSNodeDirectory *ancestor, FSNode *node) {
+bool FilesystemNodeOperationsBase::fsnodes_isancestor_or_node_reserved_or_trash(
+    FSNodeDirectory *ancestor, FSNode *node) {
 	// Return true if file is reserved:
 	if (node && (node->type == FSNodeType::kReserved || node->type == FSNodeType::kTrash)) {
 		return true;
@@ -247,7 +289,7 @@ bool fsnodes_isancestor_or_node_reserved_or_trash(FSNodeDirectory *ancestor, FSN
 
 // stats
 
-void fsnodes_get_stats(FSNode *node, StatsRecord *sr) {
+void FilesystemNodeOperationsBase::fsnodes_get_stats(FSNode *node, StatsRecord *sr) {
 	switch (node->type) {
 	case FSNodeType::kDirectory:
 		*sr = static_cast<FSNodeDirectory*>(node)->stats;
@@ -288,13 +330,13 @@ void fsnodes_get_stats(FSNode *node, StatsRecord *sr) {
 	}
 }
 
-int64_t fsnodes_get_size(FSNode *node) {
+int64_t FilesystemNodeOperationsBase::fsnodes_get_size(FSNode *node) {
 	StatsRecord sr;
 	fsnodes_get_stats(node, &sr);
 	return sr.size;
 }
 
-FSNodeDirectory *fsnodes_get_first_parent(FSNode *node) {
+FSNodeDirectory *FilesystemNodeOperationsBase::fsnodes_get_first_parent(FSNode *node) {
 	assert(node);
 	FSNodeDirectory *parent;
 	if (!node->parents.empty()) {
@@ -305,7 +347,7 @@ FSNodeDirectory *fsnodes_get_first_parent(FSNode *node) {
 	return parent;
 }
 
-static inline void fsnodes_sub_stats(FSNodeDirectory *parent, StatsRecord *sr) {
+void FilesystemNodeOperationsBase::fsnodes_sub_stats(FSNodeDirectory *parent, StatsRecord *sr) {
 	StatsRecord *psr;
 	if (parent) {
 		psr = &parent->stats;
@@ -326,7 +368,7 @@ static inline void fsnodes_sub_stats(FSNodeDirectory *parent, StatsRecord *sr) {
 	}
 }
 
-void fsnodes_add_stats(FSNodeDirectory *parent, StatsRecord *sr) {
+void FilesystemNodeOperationsBase::fsnodes_add_stats(FSNodeDirectory *parent, StatsRecord *sr) {
 	StatsRecord *psr;
 	if (parent) {
 		psr = &parent->stats;
@@ -347,7 +389,8 @@ void fsnodes_add_stats(FSNodeDirectory *parent, StatsRecord *sr) {
 	}
 }
 
-void fsnodes_add_sub_stats(FSNodeDirectory *parent, StatsRecord *newsr, StatsRecord *prevsr) {
+void FilesystemNodeOperationsBase::fsnodes_add_sub_stats(FSNodeDirectory *parent,
+                                                         StatsRecord *newsr, StatsRecord *prevsr) {
 	StatsRecord sr;
 	sr.inodes = newsr->inodes - prevsr->inodes;
 	sr.dirs = newsr->dirs - prevsr->dirs;
@@ -360,8 +403,9 @@ void fsnodes_add_sub_stats(FSNodeDirectory *parent, StatsRecord *newsr, StatsRec
 	fsnodes_add_stats(parent, &sr);
 }
 
-void fsnodes_fill_attr(FSNode *node, FSNode *parent, uint32_t uid, uint32_t gid, uint32_t auid,
-			uint32_t agid, uint8_t sesflags, Attributes &attr) {
+void FilesystemNodeOperationsBase::fsnodes_fill_attr(FSNode *node, FSNode *parent, uint32_t uid,
+                                                     uint32_t gid, uint32_t auid, uint32_t agid,
+                                                     uint8_t sesflags, Attributes &attr) {
 #ifdef METARESTORE
 	mabort("Bad code path - fsnodes_fill_attr() shall not be executed in metarestore context.");
 #endif /* METARESTORE */
@@ -460,16 +504,18 @@ void fsnodes_fill_attr(FSNode *node, FSNode *parent, uint32_t uid, uint32_t gid,
 	}
 }
 
-void fsnodes_fill_attr(const FsContext &context, FSNode *node, FSNode *parent, Attributes &attr) {
+void FilesystemNodeOperationsBase::fsnodes_fill_attr(const FsContext &context, FSNode *node,
+                                                     FSNode *parent, Attributes &attr) {
 #ifdef METARESTORE
 	mabort("Bad code path - fsnodes_fill_attr() shall not be executed in metarestore context.");
 #endif /* METARESTORE */
 	sassert(context.hasSessionData() && context.hasUidGidData());
-	fsnodes_fill_attr(node, parent, context.uid(), context.gid(), context.auid(),
-	                  context.agid(), context.sesflags(), attr);
+	fsnodes_fill_attr(node, parent, context.uid(), context.gid(), context.auid(), context.agid(),
+	                  context.sesflags(), attr);
 }
 
-void fsnodes_remove_edge(uint32_t ts, FSNodeDirectory *parent, const HString &name, FSNode *node) {
+void FilesystemNodeOperationsBase::fsnodes_remove_edge(uint32_t ts, FSNodeDirectory *parent,
+                                                       const HString &name, FSNode *node) {
 	assert(parent);
 
 	auto dir_it = parent->find(name);
@@ -516,8 +562,7 @@ void fsnodes_remove_edge(uint32_t ts, FSNodeDirectory *parent, const HString &na
 		node->parents.erase(it);
 	}
 
-	// Delete the handle after the check in the parent vector in the son is
-	// done.
+	// Delete the handle after the check in the parent vector in the son is done.
 	delete handlePtrToErase;
 
 	assert(node->type != FSNodeType::kTrash);
@@ -527,7 +572,8 @@ void fsnodes_remove_edge(uint32_t ts, FSNodeDirectory *parent, const HString &na
 	gMetadata->edgeRemovedSignal.emit(parent->id, node->id);
 }
 
-void fsnodes_link(uint32_t ts, FSNodeDirectory *parent, FSNode *child, const HString &name) {
+void FilesystemNodeOperationsBase::fsnodes_link(uint32_t ts, FSNodeDirectory *parent, FSNode *child,
+                                                const HString &name) {
 	// Needs to be freed in fsnodes_remove_edge
 	auto *handlePtr = new hstorage::Handle(name);
 	parent->entries.insert({handlePtr, child});
@@ -560,10 +606,10 @@ void fsnodes_link(uint32_t ts, FSNodeDirectory *parent, FSNode *child, const HSt
 	}
 }
 
-FSNode *fsnodes_create_node(uint32_t ts, FSNodeDirectory *parent, const HString &name,
-                            FSNodeType type, uint16_t mode, uint16_t umask, uint32_t uid,
-                            uint32_t gid, uint8_t copysgid, AclInheritance inheritacl,
-                            inode_t req_inode) {
+FSNode *FilesystemNodeOperationsBase::fsnodes_create_node(
+    uint32_t ts, FSNodeDirectory *parent, const HString &name, FSNodeType type, uint16_t mode,
+    uint16_t umask, uint32_t uid, uint32_t gid, uint8_t copysgid, AclInheritance inheritacl,
+    inode_t req_inode) {
 	assert(type != FSNodeType::kTrash);
 
 	FSNode *node = FSNode::create(type);
@@ -631,7 +677,8 @@ FSNode *fsnodes_create_node(uint32_t ts, FSNodeDirectory *parent, const HString 
 	return node;
 }
 
-uint32_t fsnodes_getpath_size(FSNodeDirectory *parent, FSNode *child) {
+uint32_t FilesystemNodeOperationsBase::fsnodes_getpath_size(FSNodeDirectory *parent,
+                                                            FSNode *child) {
 	std::string name;
 	uint32_t size;
 
@@ -653,7 +700,8 @@ uint32_t fsnodes_getpath_size(FSNodeDirectory *parent, FSNode *child) {
 	return size;
 }
 
-void fsnodes_getpath_data(FSNodeDirectory *parent, FSNode *child, uint8_t *path, uint32_t size) {
+void FilesystemNodeOperationsBase::fsnodes_getpath_data(FSNodeDirectory *parent, FSNode *child,
+                                                        uint8_t *path, uint32_t size) {
 	std::string name;
 
 	if (parent == nullptr || child == nullptr) {
@@ -690,7 +738,8 @@ void fsnodes_getpath_data(FSNodeDirectory *parent, FSNode *child, uint8_t *path,
 	}
 }
 
-void fsnodes_getpath(FSNodeDirectory *parent, FSNode *child, std::string &path) {
+void FilesystemNodeOperationsBase::fsnodes_getpath(FSNodeDirectory *parent, FSNode *child,
+                                                   std::string &path) {
 	uint32_t size = fsnodes_getpath_size(parent, child);
 
 	if (size > 65535) {
@@ -700,9 +749,8 @@ void fsnodes_getpath(FSNodeDirectory *parent, FSNode *child, std::string &path) 
 
 	path.resize(size);
 
-	fsnodes_getpath_data(parent, child, (uint8_t*)path.data(), size);
+	fsnodes_getpath_data(parent, child, (uint8_t *)path.data(), size);
 }
-
 
 #ifndef METARESTORE
 constexpr uint32_t kOldPathContainerLimit = 1000000;
@@ -795,17 +843,18 @@ static inline void getdetacheddata(const T &data, uint8_t *dbuff) {
 	}
 }
 
-uint32_t fsnodes_getdetachedsize(const TrashPathContainer &data)
-{
+uint32_t FilesystemNodeOperationsBase::fsnodes_getdetachedsize(const TrashPathContainer &data) {
 	return getdetachedsize(data);
 }
 
-void fsnodes_getdetacheddata(const TrashPathContainer &data, uint8_t *dbuff)
-{
+void FilesystemNodeOperationsBase::fsnodes_getdetacheddata(const TrashPathContainer &data,
+                                                           uint8_t *dbuff) {
 	getdetacheddata(data, dbuff);
 }
 
-void fsnodes_getdetacheddata(const TrashPathContainer &data, uint32_t off, uint32_t max_entries, std::vector<NamedInodeEntry> &entries) {
+void FilesystemNodeOperationsBase::fsnodes_getdetacheddata(const TrashPathContainer &data,
+                                                           uint32_t off, uint32_t max_entries,
+                                                           std::vector<NamedInodeEntry> &entries) {
 #if defined(SAUNAFS_HAVE_64BIT_JUDY) && !defined(DISABLE_JUDY_FOR_TRASHPATHCONTAINER)
 	auto it = data.find_nth(off);
 #else
@@ -820,9 +869,11 @@ void fsnodes_getdetacheddata(const TrashPathContainer &data, uint32_t off, uint3
 // The offset provided by the client (e.g., FUSE readdir) is always non-negative (sign bit 0).
 // Internally, the server may store offsets with the sign bit set (bit 63 = 1).
 // All lookups are enforced to be done ignoring the sign bit by setting it to 0.
-void fsnodes_getdetacheddata(const HandleIndexContainer &data, uint64_t handleOffset,
-                             uint32_t maxEntries, std::vector<HandleInodeEntry> &entries,
-                             bool fromTrash) {
+void FilesystemNodeOperationsBase::fsnodes_getdetacheddata(const HandleIndexContainer &data,
+                                                           uint64_t handleOffset,
+                                                           uint32_t maxEntries,
+                                                           std::vector<HandleInodeEntry> &entries,
+                                                           bool fromTrash) {
 	uint64_t start = (handleOffset & ~k64SignBitMask);
 	auto it = data.lower_bound(HandleIndexKey(start));
 
@@ -842,15 +893,18 @@ void fsnodes_getdetacheddata(const HandleIndexContainer &data, uint64_t handleOf
 	}
 }
 
-uint32_t fsnodes_getdetachedsize(const ReservedPathContainer &data) {
+uint32_t FilesystemNodeOperationsBase::fsnodes_getdetachedsize(const ReservedPathContainer &data) {
 	return getdetachedsize(data);
 }
 
-void fsnodes_getdetacheddata(const ReservedPathContainer &data, uint8_t *dbuff) {
+void FilesystemNodeOperationsBase::fsnodes_getdetacheddata(const ReservedPathContainer &data,
+                                                           uint8_t *dbuff) {
 	getdetacheddata(data, dbuff);
 }
 
-void fsnodes_getdetacheddata(const ReservedPathContainer &data, uint32_t off, uint32_t max_entries, std::vector<NamedInodeEntry> &entries) {
+void FilesystemNodeOperationsBase::fsnodes_getdetacheddata(const ReservedPathContainer &data,
+                                                           uint32_t off, uint32_t max_entries,
+                                                           std::vector<NamedInodeEntry> &entries) {
 #if defined(SAUNAFS_HAVE_64BIT_JUDY) && !defined(DISABLE_JUDY_FOR_RESERVEDPATHCONTAINER)
 	auto it = data.find_nth(off);
 #else
@@ -861,7 +915,8 @@ void fsnodes_getdetacheddata(const ReservedPathContainer &data, uint32_t off, ui
 	}
 }
 
-uint32_t fsnodes_getdirsize(const FSNodeDirectory *p, uint8_t withattr) {
+uint32_t FilesystemNodeOperationsBase::fsnodes_getdirsize(const FSNodeDirectory *p,
+                                                          uint8_t withattr) {
 	uint32_t result = ((withattr) ? 40 : 6) * 2 + 3;  // for '.' and '..'
 	std::string name;
 	for (const auto &entry : p->entries) {
@@ -871,8 +926,10 @@ uint32_t fsnodes_getdirsize(const FSNodeDirectory *p, uint8_t withattr) {
 	return result;
 }
 
-void fsnodes_getdirdata(inode_t rootinode, uint32_t uid, uint32_t gid, uint32_t auid, uint32_t agid,
-                        uint8_t sesflags, FSNodeDirectory *p, uint8_t *dbuff, uint8_t withattr) {
+void FilesystemNodeOperationsBase::fsnodes_getdirdata(inode_t rootinode, uint32_t uid, uint32_t gid,
+                                                      uint32_t auid, uint32_t agid,
+                                                      uint8_t sesflags, FSNodeDirectory *p,
+                                                      uint8_t *dbuff, uint8_t withattr) {
 	// '.' - self
 	dbuff[0] = 1;
 	dbuff[1] = '.';
@@ -913,21 +970,18 @@ void fsnodes_getdirdata(inode_t rootinode, uint32_t uid, uint32_t gid, uint32_t 
 		if (withattr) {
 			if (!p->parents.empty()) {
 				auto *parent = fsnodes_id_to_node_verify<FSNode>(p->parents[0].first);
-				fsnodes_fill_attr(parent, p, uid, gid, auid, agid,
-				                  sesflags, attr);
+				fsnodes_fill_attr(parent, p, uid, gid, auid, agid, sesflags, attr);
 				::memcpy(dbuff, attr.data(), attr.size());
 			} else {
 				if (rootinode == SPECIAL_INODE_ROOT) {
-					fsnodes_fill_attr(gMetadata->root, p, uid, gid, auid, agid,
-					                  sesflags, attr);
+					fsnodes_fill_attr(gMetadata->root, p, uid, gid, auid, agid, sesflags, attr);
 					::memcpy(dbuff, attr.data(), attr.size());
 				} else {
 					FSNode *rn = fsnodes_id_to_node(rootinode);
 					if (rn) {  // it should be always true because it's checked
 						   // before, but better check than sorry
-						fsnodes_fill_attr(rn, p, uid, gid, auid, agid,
-						                  sesflags, attr);
-						::memcpy(dbuff, attr.data(), attr.size());
+						   fsnodes_fill_attr(rn, p, uid, gid, auid, agid, sesflags, attr);
+						   ::memcpy(dbuff, attr.data(), attr.size());
 					} else {
 						memset(dbuff, 0, attr.size());
 					}
@@ -968,9 +1022,11 @@ void fsnodes_getdirdata(inode_t rootinode, uint32_t uid, uint32_t gid, uint32_t 
  * \param number_of_entries number of dirents to get
  * \param[out] container into which dirents are inserted
  */
-void fsnodes_getdir(inode_t rootinode, uint32_t uid, uint32_t gid, uint32_t auid, uint32_t agid,
-                    uint8_t sesflags, FSNodeDirectory *p, uint64_t first_entry,
-                    uint64_t number_of_entries, std::vector<DirectoryEntry> &dir_entries) {
+void FilesystemNodeOperationsBase::fsnodes_getdir(inode_t rootinode, uint32_t uid, uint32_t gid,
+                                                  uint32_t auid, uint32_t agid, uint8_t sesflags,
+                                                  FSNodeDirectory *p, uint64_t first_entry,
+                                                  uint64_t number_of_entries,
+                                                  std::vector<DirectoryEntry> &dir_entries) {
 	uint64_t const SIGN_BIT_64(1ULL << 63ULL);
 	sassert(!(first_entry & SIGN_BIT_64));
 	// special entryIndex values
@@ -1011,8 +1067,7 @@ void fsnodes_getdir(inode_t rootinode, uint32_t uid, uint32_t gid, uint32_t auid
 			    p->parents.empty() ? SPECIAL_INODE_ROOT : p->parents[0].first);
 			grandparent = fsnodes_id_to_node_verify<FSNodeDirectory>(
 			    parent->parents.empty() ? SPECIAL_INODE_ROOT : parent->parents[0].first);
-			fsnodes_fill_attr(parent, grandparent, uid, gid, auid, agid, sesflags,
-			                  attr);
+			fsnodes_fill_attr(parent, grandparent, uid, gid, auid, agid, sesflags, attr);
 		}
 
 		uint64_t next_index = kUnusedEntryIndex;
@@ -1072,7 +1127,8 @@ void fsnodes_getdir(inode_t rootinode, uint32_t uid, uint32_t gid, uint32_t auid
 	}
 }
 
-void fsnodes_checkfile(FSNodeFile *p, uint32_t chunk_count[CHUNK_MATRIX_SIZE]) {
+void FilesystemNodeOperationsBase::fsnodes_checkfile(FSNodeFile *p,
+                                                     uint32_t chunk_count[CHUNK_MATRIX_SIZE]) {
 	uint8_t count;
 
 	for(int i = 0; i < CHUNK_MATRIX_SIZE; ++i) {
@@ -1089,7 +1145,8 @@ void fsnodes_checkfile(FSNodeFile *p, uint32_t chunk_count[CHUNK_MATRIX_SIZE]) {
 }
 #endif
 
-uint8_t fsnodes_appendchunks(uint32_t ts, FSNodeFile *dst, FSNodeFile *src) {
+uint8_t FilesystemNodeOperationsBase::fsnodes_appendchunks(uint32_t ts, FSNodeFile *dst,
+                                                           FSNodeFile *src) {
 	if (src->chunks.empty()) {
 		return SAUNAFS_STATUS_OK;
 	}
@@ -1144,7 +1201,7 @@ uint8_t fsnodes_appendchunks(uint32_t ts, FSNodeFile *dst, FSNodeFile *src) {
 	return SAUNAFS_STATUS_OK;
 }
 
-void fsnodes_changefilegoal(FSNodeFile *obj, uint8_t goal) {
+void FilesystemNodeOperationsBase::fsnodes_changefilegoal(FSNodeFile *obj, uint8_t goal) {
 	uint8_t old_goal = obj->goal;
 	StatsRecord psr, nsr;
 
@@ -1165,7 +1222,8 @@ void fsnodes_changefilegoal(FSNodeFile *obj, uint8_t goal) {
 	gMetadata->nodeChangedSignal.emit(obj);
 }
 
-void fsnodes_setlength(FSNodeFile *obj, uint64_t length, bool eraseFurtherChunks) {
+void FilesystemNodeOperationsBase::fsnodes_setlength(FSNodeFile *obj, uint64_t length,
+                                                     bool eraseFurtherChunks) {
 	uint32_t chunks;
 	StatsRecord psr, nsr;
 	fsnodes_get_stats(obj, &psr);
@@ -1210,7 +1268,7 @@ void fsnodes_setlength(FSNodeFile *obj, uint64_t length, bool eraseFurtherChunks
 	gMetadata->nodeChangedSignal.emit(obj);
 }
 
-void fsnodes_change_uid_gid(FSNode *p, uint32_t uid, uint32_t gid) {
+void FilesystemNodeOperationsBase::fsnodes_change_uid_gid(FSNode *p, uint32_t uid, uint32_t gid) {
 	int64_t size = 0;
 	fsnodes_quota_update(p, {{QuotaResource::kInodes, -1}});
 	if (p->type == FSNodeType::kFile || p->type == FSNodeType::kTrash ||
@@ -1227,7 +1285,7 @@ void fsnodes_change_uid_gid(FSNode *p, uint32_t uid, uint32_t gid) {
 	}
 }
 
-static inline void fsnodes_remove_node(uint32_t ts, FSNode *node) {
+void FilesystemNodeOperationsBase::fsnodes_remove_node(uint32_t ts, FSNode *node) {
 	if (!node->parents.empty()) {
 		return;
 	}
@@ -1289,7 +1347,8 @@ static inline void fsnodes_remove_node(uint32_t ts, FSNode *node) {
 	}
 }
 
-void fsnodes_unlink(uint32_t ts, FSNodeDirectory *parent, const HString &child_name, FSNode *child) {
+void FilesystemNodeOperationsBase::fsnodes_unlink(uint32_t ts, FSNodeDirectory *parent,
+                                                  const HString &child_name, FSNode *child) {
 	std::string path;
 
 	if (child->parents.size() == 1) {  // last link
@@ -1335,7 +1394,7 @@ void fsnodes_unlink(uint32_t ts, FSNodeDirectory *parent, const HString &child_n
 	}
 }
 
-int fsnodes_purge(uint32_t ts, FSNode *p) {
+int FilesystemNodeOperationsBase::fsnodes_purge(uint32_t ts, FSNode *p) {
 	if (p->type == FSNodeType::kTrash) {
 		FSNodeFile *file_node = static_cast<FSNodeFile*>(p);
 		gMetadata->trashSpace -= file_node->length;
@@ -1378,7 +1437,7 @@ int fsnodes_purge(uint32_t ts, FSNode *p) {
 	return -1;
 }
 
-uint8_t fsnodes_undel(uint32_t ts, FSNodeFile *node) {
+uint8_t FilesystemNodeOperationsBase::fsnodes_undel(uint32_t ts, FSNodeFile *node) {
 	uint8_t is_new;
 	uint32_t i, partleng, dots;
 	/* check path */
@@ -1476,8 +1535,7 @@ uint8_t fsnodes_undel(uint32_t ts, FSNodeFile *node) {
 				}
 			}
 			if (is_new == 1) {
-				n = fsnodes_create_node(ts, p, name, FSNodeType::kDirectory, 0755,
-				                        0, 0, 0, 0,
+				n = fsnodes_create_node(ts, p, name, FSNodeType::kDirectory, 0755, 0, 0, 0, 0,
 				                        AclInheritance::kDontInheritAcl);
 
 #ifndef METARESTORE
@@ -1501,14 +1559,15 @@ uint8_t fsnodes_undel(uint32_t ts, FSNodeFile *node) {
 
 #ifndef METARESTORE
 
-void fsnodes_getgoal_recursive(FSNode *node, uint8_t gmode, GoalStatistics &fgtab,
-                               GoalStatistics &dgtab) {
+void FilesystemNodeOperationsBase::fsnodes_getgoal_recursive(FSNode *node, uint8_t gmode,
+                                                             GoalStatistics &fgtab,
+                                                             GoalStatistics &dgtab) {
 	if (node->type == FSNodeType::kFile || node->type == FSNodeType::kTrash ||
 	    node->type == FSNodeType::kReserved) {
 		if (!GoalId::isValid(node->goal)) {
 			safs_pretty_syslog(LOG_WARNING, "file inode %" PRIiNode ": unknown goal !!! - fixing",
 			       node->id);
-			fsnodes_changefilegoal(static_cast<FSNodeFile*>(node), DEFAULT_GOAL);
+			fsnodes_changefilegoal(static_cast<FSNodeFile *>(node), DEFAULT_GOAL);
 		}
 		fgtab[node->goal]++;
 	} else if (node->type == FSNodeType::kDirectory) {
@@ -1527,8 +1586,9 @@ void fsnodes_getgoal_recursive(FSNode *node, uint8_t gmode, GoalStatistics &fgta
 	}
 }
 
-void fsnodes_gettrashtime_recursive(FSNode *node, uint8_t gmode,
-	TrashtimeMap &fileTrashtimes, TrashtimeMap &dirTrashtimes) {
+void FilesystemNodeOperationsBase::fsnodes_gettrashtime_recursive(FSNode *node, uint8_t gmode,
+                                                                  TrashtimeMap &fileTrashtimes,
+                                                                  TrashtimeMap &dirTrashtimes) {
 	if (node->type == FSNodeType::kFile || node->type == FSNodeType::kTrash ||
 	    node->type == FSNodeType::kReserved) {
 		fileTrashtimes[node->trashtime] += 1;
@@ -1543,9 +1603,9 @@ void fsnodes_gettrashtime_recursive(FSNode *node, uint8_t gmode,
 	}
 }
 
-void fsnodes_geteattr_recursive(FSNode *node, uint8_t gmode, uint32_t feattrtab[16],
-				uint32_t deattrtab[16]) {
-
+void FilesystemNodeOperationsBase::fsnodes_geteattr_recursive(FSNode *node, uint8_t gmode,
+                                                              uint32_t feattrtab[16],
+                                                              uint32_t deattrtab[16]) {
 	if (node->type != FSNodeType::kDirectory) {
 		feattrtab[(node->mode >> 12) &
 		          (EATTR_NOOWNER | EATTR_NOACACHE | EATTR_NODATACACHE)]++;
@@ -1559,10 +1619,13 @@ void fsnodes_geteattr_recursive(FSNode *node, uint8_t gmode, uint32_t feattrtab[
 		}
 	}
 }
-#endif
 
-void fsnodes_setgoal_recursive(FSNode *node, uint32_t ts, uint32_t uid, uint8_t goal, uint8_t smode,
-                               inode_t *sinodes, inode_t *ncinodes, inode_t *nsinodes) {
+#endif  // METARESTORE
+
+void FilesystemNodeOperationsBase::fsnodes_setgoal_recursive(FSNode *node, uint32_t ts,
+                                                             uint32_t uid, uint8_t goal,
+                                                             uint8_t smode, inode_t *sinodes,
+                                                             inode_t *ncinodes, inode_t *nsinodes) {
 	if (node->type == FSNodeType::kFile || node->type == FSNodeType::kDirectory ||
 	    node->type == FSNodeType::kTrash || node->type == FSNodeType::kReserved) {
 		if ((node->mode & (EATTR_NOOWNER << 12)) == 0 && uid != 0 && node->uid != uid) {
@@ -1570,7 +1633,7 @@ void fsnodes_setgoal_recursive(FSNode *node, uint32_t ts, uint32_t uid, uint8_t 
 		} else {
 			if ((smode & SMODE_TMASK) == SMODE_SET && node->goal != goal) {
 				if (node->type != FSNodeType::kDirectory) {
-					fsnodes_changefilegoal(static_cast<FSNodeFile*>(node), goal);
+					fsnodes_changefilegoal(static_cast<FSNodeFile *>(node), goal);
 					(*sinodes)++;
 				} else {
 					node->goal = goal;
@@ -1585,16 +1648,18 @@ void fsnodes_setgoal_recursive(FSNode *node, uint32_t ts, uint32_t uid, uint8_t 
 		}
 		if (node->type == FSNodeType::kDirectory && (smode & SMODE_RMASK)) {
 			for (const auto &entry : static_cast<const FSNodeDirectory*>(node)->entries) {
-				fsnodes_setgoal_recursive(entry.second, ts, uid, goal, smode, sinodes,
-				                          ncinodes, nsinodes);
+				fsnodes_setgoal_recursive(entry.second, ts, uid, goal, smode, sinodes, ncinodes,
+				                          nsinodes);
 			}
 		}
 	}
 }
 
-void fsnodes_settrashtime_recursive(FSNode *node, uint32_t ts, uint32_t uid, uint32_t trashtime,
-                                    uint8_t smode, inode_t *sinodes, inode_t *ncinodes,
-                                    inode_t *nsinodes) {
+void FilesystemNodeOperationsBase::fsnodes_settrashtime_recursive(FSNode *node, uint32_t ts,
+                                                                  uint32_t uid, uint32_t trashtime,
+                                                                  uint8_t smode, inode_t *sinodes,
+                                                                  inode_t *ncinodes,
+                                                                  inode_t *nsinodes) {
 	uint8_t set;
 
 	if (node->type == FSNodeType::kFile || node->type == FSNodeType::kDirectory ||
@@ -1637,16 +1702,18 @@ void fsnodes_settrashtime_recursive(FSNode *node, uint32_t ts, uint32_t uid, uin
 		}
 		if (node->type == FSNodeType::kDirectory && (smode & SMODE_RMASK)) {
 			for(const auto &entry : static_cast<const FSNodeDirectory*>(node)->entries) {
-				fsnodes_settrashtime_recursive(entry.second, ts, uid, trashtime, smode,
-				                               sinodes, ncinodes, nsinodes);
+				fsnodes_settrashtime_recursive(entry.second, ts, uid, trashtime, smode, sinodes,
+				                               ncinodes, nsinodes);
 			}
 		}
 	}
 }
 
-void fsnodes_seteattr_recursive(FSNode *node, uint32_t ts, uint32_t uid, uint8_t eattr,
-                                uint8_t smode, inode_t *sinodes, inode_t *ncinodes,
-                                inode_t *nsinodes) {
+void FilesystemNodeOperationsBase::fsnodes_seteattr_recursive(FSNode *node, uint32_t ts,
+                                                              uint32_t uid, uint8_t eattr,
+                                                              uint8_t smode, inode_t *sinodes,
+                                                              inode_t *ncinodes,
+                                                              inode_t *nsinodes) {
 	uint8_t neweattr, seattr;
 
 	if ((node->mode & (EATTR_NOOWNER << 12)) == 0 && uid != 0 && node->uid != uid) {
@@ -1685,14 +1752,14 @@ void fsnodes_seteattr_recursive(FSNode *node, uint32_t ts, uint32_t uid, uint8_t
 	if (node->type == FSNodeType::kDirectory && (smode & SMODE_RMASK)) {
 		const FSNodeDirectory *dir_node = static_cast<const FSNodeDirectory*>(node);
 		for (const auto &entry : dir_node->entries) {
-			fsnodes_seteattr_recursive(entry.second, ts, uid, eattr, smode, sinodes,
-			                           ncinodes, nsinodes);
+			fsnodes_seteattr_recursive(entry.second, ts, uid, eattr, smode, sinodes, ncinodes,
+			                           nsinodes);
 		}
 	}
 	fsnodes_update_checksum(node);
 }
 
-uint8_t fsnodes_deleteacl(FSNode *p, AclType type, uint32_t ts) {
+uint8_t FilesystemNodeOperationsBase::fsnodes_deleteacl(FSNode *p, AclType type, uint32_t ts) {
 	if (type == AclType::kRichACL) {
 		gMetadata->aclStorage.erase(p->id);
 	} else if (type == AclType::kDefault) {
@@ -1731,7 +1798,7 @@ uint8_t fsnodes_deleteacl(FSNode *p, AclType type, uint32_t ts) {
 }
 
 #ifndef METARESTORE
-uint8_t fsnodes_getacl(FSNode *p, RichACL &acl) {
+uint8_t FilesystemNodeOperationsBase::fsnodes_getacl(FSNode *p, RichACL &acl) {
 	const RichACL *richacl = gMetadata->aclStorage.get(p->id);
 	if (!richacl) {
 		return SAUNAFS_ERROR_ENOATTR;
@@ -1742,7 +1809,7 @@ uint8_t fsnodes_getacl(FSNode *p, RichACL &acl) {
 }
 #endif
 
-uint8_t fsnodes_setacl(FSNode *p, const RichACL &acl, uint32_t ts) {
+uint8_t FilesystemNodeOperationsBase::fsnodes_setacl(FSNode *p, const RichACL &acl, uint32_t ts) {
 	if (!acl.checkInheritFlags(p->type == FSNodeType::kDirectory)) {
 		return SAUNAFS_ERROR_ENOTSUP;
 	}
@@ -1768,7 +1835,8 @@ uint8_t fsnodes_setacl(FSNode *p, const RichACL &acl, uint32_t ts) {
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t fsnodes_setacl(FSNode *p, AclType type, const AccessControlList &acl, uint32_t ts) {
+uint8_t FilesystemNodeOperationsBase::fsnodes_setacl(FSNode *p, AclType type,
+                                                     const AccessControlList &acl, uint32_t ts) {
 	if (type != AclType::kDefault && type != AclType::kAccess) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
@@ -1800,7 +1868,7 @@ uint8_t fsnodes_setacl(FSNode *p, AclType type, const AccessControlList &acl, ui
 	return SAUNAFS_STATUS_OK;
 }
 
-int fsnodes_namecheck(const std::string &name) {
+int FilesystemNodeOperationsBase::fsnodes_namecheck(const std::string &name) {
 	uint32_t i;
 	if (name.length() == 0 || name.length() > MAXFNAMELENG) {
 		return -1;
@@ -1821,7 +1889,8 @@ int fsnodes_namecheck(const std::string &name) {
 	return 0;
 }
 
-int fsnodes_access(const FsContext &context, FSNode *node, uint8_t modemask) {
+int FilesystemNodeOperationsBase::fsnodes_access(const FsContext &context, FSNode *node,
+                                                 uint8_t modemask) {
 	uint8_t nodemode;
 	if ((context.sesflags() & SESFLAG_NOMASTERPERMCHECK) || context.uid() == 0) {
 		return 1;
@@ -1852,7 +1921,8 @@ int fsnodes_access(const FsContext &context, FSNode *node, uint8_t modemask) {
 	return 0;
 }
 
-int fsnodes_sticky_access(FSNode *parent, FSNode *node, uint32_t uid) {
+int FilesystemNodeOperationsBase::fsnodes_sticky_access(FSNode *parent, FSNode *node,
+                                                        uint32_t uid) {
 	if (uid == 0 || (parent->mode & 01000) == 0) {  // super user or sticky bit is not set
 		return 1;
 	}
@@ -1863,8 +1933,9 @@ int fsnodes_sticky_access(FSNode *parent, FSNode *node, uint32_t uid) {
 	return 0;
 }
 
-uint8_t verify_session(const FsContext &context, OperationMode operationMode,
-			SessionType sessionType) {
+uint8_t FilesystemNodeOperationsBase::verify_session(const FsContext &context,
+                                                     OperationMode operationMode,
+                                                     SessionType sessionType) {
 	if (context.hasSessionData() && (context.sesflags() & SESFLAG_READONLY) &&
 	    (operationMode == OperationMode::kReadWrite)) {
 		return SAUNAFS_ERROR_EROFS;
@@ -1888,9 +1959,9 @@ uint8_t verify_session(const FsContext &context, OperationMode operationMode,
  * Checks for permissions needed to perform the operation (defined by modemask)
  * Can return a reserved node or a node from trash
  */
-uint8_t fsnodes_get_node_for_operation(const FsContext &context, ExpectedNodeType expectedNodeType,
-                                       uint8_t modemask, inode_t inode, FSNode **ret,
-                                       FSNodeDirectory **ret_rn) {
+uint8_t FilesystemNodeOperationsBase::fsnodes_get_node_for_operation(
+    const FsContext &context, ExpectedNodeType expectedNodeType, uint8_t modemask, inode_t inode,
+    FSNode **ret, FSNodeDirectory **ret_rn) {
 	FSNode *p;
 	FSNodeDirectory *rn;
 	if (!context.hasSessionData()) {

--- a/src/master/filesystem_node.h
+++ b/src/master/filesystem_node.h
@@ -22,178 +22,149 @@
 
 #include "common/platform.h"
 
-#include "master/filesystem_metadata.h"
+#include "master/filesystem_node_operations_interface.h"
 #include "master/filesystem_node_types.h"
 #include "master/fs_context.h"
-#include "protocol/handle_inode_entry.h"
 #include "protocol/directory_entry.h"
+#include "protocol/handle_inode_entry.h"
 #include "protocol/named_inode_entry.h"
 
-namespace detail {
+/// Base class for filesystem node operations extensibility.
+///
+/// Provides default implementations for all methods of IFilesystemNodeOperations interface,
+/// assuming an in-memory metadata representation.
+class FilesystemNodeOperationsBase : public IFilesystemNodeOperations {
+public:
+	FSNode *fsnodes_lookup(FSNodeDirectory *node, const HString &name) const override;
 
-inline FSNode *fsnodes_id_to_node_internal(inode_t id) {
-	// Find the node with the given id
-	uint32_t nodeHashIndex = NODEHASHPOS(id);
+	FSNode *fsnodes_create_node(uint32_t ts, FSNodeDirectory *parent, const HString &name,
+	                            FSNodeType type, uint16_t mode, uint16_t umask, uint32_t uid,
+	                            uint32_t gid, uint8_t copysgid, AclInheritance inheritacl,
+	                            inode_t req_inode = 0) override;
+	void fsnodes_link(uint32_t ts, FSNodeDirectory *parent, FSNode *child,
+	                  const HString &name) override;
+	void fsnodes_unlink(uint32_t ts, FSNodeDirectory *parent, const HString &node_name,
+	                    FSNode *node) override;
+	void fsnodes_remove_edge(uint32_t ts, FSNodeDirectory *parent, const HString &node_name,
+	                         FSNode *node) override;
 
-	for (const auto &node : gMetadata->nodeHash[nodeHashIndex]) {
-		if (node->id == id) {
-			return node;
-		}
-	}
+	void fsnodes_update_ctime(FSNode *node, uint32_t ctime) override;
+	void fsnodes_fill_attr(FSNode *node, FSNode *parent, uint32_t uid, uint32_t gid, uint32_t auid,
+	                       uint32_t agid, uint8_t sesflags, Attributes &attr) override;
+	void fsnodes_fill_attr(const FsContext &context, FSNode *node, FSNode *parent,
+	                       Attributes &attr) override;
+	void fsnodes_get_stats(FSNode *node, StatsRecord *sr) override;
+	void fsnodes_add_stats(FSNodeDirectory *parent, StatsRecord *sr) override;
+	void fsnodes_add_sub_stats(FSNodeDirectory *parent, StatsRecord *newsr,
+	                           StatsRecord *prevsr) override;
+	void fsnodes_change_uid_gid(FSNode *p, uint32_t uid, uint32_t gid) override;
 
-	return nullptr;
-}
+	void fsnodes_setlength(FSNodeFile *obj, uint64_t length, bool eraseFurtherChunks) override;
+	uint8_t fsnodes_appendchunks(uint32_t ts, FSNodeFile *dstobj, FSNodeFile *srcobj) override;
+	void fsnodes_changefilegoal(FSNodeFile *obj, uint8_t goal) override;
+#ifndef METARESTORE
+	void fsnodes_checkfile(FSNodeFile *p, uint32_t chunkcount[CHUNK_MATRIX_SIZE]) override;
+#endif
+	int64_t fsnodes_get_size(FSNode *node) override;
 
-template<class NodeType>
-inline void fsnodes_check_node_type(const NodeType *node) {
-	assert(node);
-	(void)node;
-}
+#ifndef METARESTORE
+	uint32_t fsnodes_getdirsize(const FSNodeDirectory *p, uint8_t withattr) override;
+	void fsnodes_getdirdata(inode_t rootinode, uint32_t uid, uint32_t gid, uint32_t auid,
+	                        uint32_t agid, uint8_t sesflags, FSNodeDirectory *p, uint8_t *dbuff,
+	                        uint8_t withattr) override;
+	void fsnodes_getdir(inode_t rootinode, uint32_t uid, uint32_t gid, uint32_t auid, uint32_t agid,
+	                    uint8_t sesflags, FSNodeDirectory *p, uint64_t first_entry,
+	                    uint64_t number_of_entries,
+	                    std::vector<DirectoryEntry> &dir_entries) override;
+#endif
+	int fsnodes_nameisused(FSNodeDirectory *node, const HString &name) override;
 
-template<>
-inline void fsnodes_check_node_type(const FSNodeFile *node) {
-	assert(node && (node->type == FSNodeType::kFile || node->type == FSNodeType::kTrash ||
-	                node->type == FSNodeType::kReserved));
-	(void)node;
-}
+	// Trash/Reserved operations
+	int fsnodes_purge(uint32_t ts, FSNode *p) override;
+	uint8_t fsnodes_undel(uint32_t ts, FSNodeFile *node) override;
+#ifndef METARESTORE
+	uint32_t fsnodes_getdetachedsize(const TrashPathContainer &data) override;
+	void fsnodes_getdetacheddata(const TrashPathContainer &data, uint8_t *dbuff) override;
+	void fsnodes_getdetacheddata(const TrashPathContainer &data, uint32_t off, uint32_t max_entries,
+	                             std::vector<NamedInodeEntry> &entries) override;
+	uint32_t fsnodes_getdetachedsize(const ReservedPathContainer &data) override;
+	void fsnodes_getdetacheddata(const ReservedPathContainer &data, uint8_t *dbuff) override;
+	void fsnodes_getdetacheddata(const ReservedPathContainer &data, uint32_t off,
+	                             uint32_t max_entries,
+	                             std::vector<NamedInodeEntry> &entries) override;
+	void fsnodes_getdetacheddata(const HandleIndexContainer &data, uint64_t handleOffset,
+	                             uint32_t maxEntries, std::vector<HandleInodeEntry> &entries,
+	                             bool fromTrash) override;
+#endif
 
-template<>
-inline void fsnodes_check_node_type(const FSNodeDirectory *node) {
-	assert(node && node->type == FSNodeType::kDirectory);
-	(void)node;
-}
+	// Path operations
+	void fsnodes_getpath(FSNodeDirectory *parent, FSNode *child, std::string &path) override;
+	uint32_t fsnodes_getpath_size(FSNodeDirectory *parent, FSNode *child) override;
+	void fsnodes_getpath_data(FSNodeDirectory *parent, FSNode *child, uint8_t *path,
+	                          uint32_t size) override;
+	std::string fsnodes_escape_name(const std::string &name) override;
 
-template<>
-inline void fsnodes_check_node_type(const FSNodeSymlink *node) {
-	assert(node && node->type == FSNodeType::kSymlink);
-	(void)node;
-}
+	// ACL operations
+	uint8_t fsnodes_setacl(FSNode *p, const RichACL &acl, uint32_t ts) override;
+	uint8_t fsnodes_setacl(FSNode *p, AclType type, const AccessControlList &acl,
+	                       uint32_t ts) override;
+#ifndef METARESTORE
+	uint8_t fsnodes_getacl(FSNode *p, RichACL &acl) override;
+#endif  // METARESTORE
+	uint8_t fsnodes_deleteacl(FSNode *p, AclType type, uint32_t ts) override;
 
-template<>
-inline void fsnodes_check_node_type(const FSNodeDevice *node) {
-	assert(node && (node->type == FSNodeType::kBlockDev || node->type == FSNodeType::kCharDev));
-	(void)node;
-}
+	// Recursive operations
+#ifndef METARESTORE
+	void fsnodes_getgoal_recursive(FSNode *node, uint8_t gmode, GoalStatistics &fgtab,
+	                               GoalStatistics &dgtab) override;
+	void fsnodes_gettrashtime_recursive(FSNode *node, uint8_t gmode, TrashtimeMap &fileTrashtimes,
+	                                    TrashtimeMap &dirTrashtimes) override;
+	void fsnodes_geteattr_recursive(FSNode *node, uint8_t gmode, uint32_t feattrtab[16],
+	                                uint32_t deattrtab[16]) override;
+#endif  // METARESTORE
+	void fsnodes_setgoal_recursive(FSNode *node, uint32_t ts, uint32_t uid, uint8_t goal,
+	                               uint8_t smode, inode_t *sinodes, inode_t *ncinodes,
+	                               inode_t *nsinodes) override;
 
-} // detail
+	void fsnodes_settrashtime_recursive(FSNode *node, uint32_t ts, uint32_t uid, uint32_t trashtime,
+	                                    uint8_t smode, inode_t *sinodes, inode_t *ncinodes,
+	                                    inode_t *nsinodes) override;
+	void fsnodes_seteattr_recursive(FSNode *node, uint32_t ts, uint32_t uid, uint8_t eattr,
+	                                uint8_t smode, inode_t *sinodes, inode_t *ncinodes,
+	                                inode_t *nsinodes) override;
 
-/// searches for an edge with given name (`name`) in given directory (`node`)
-inline FSNode *fsnodes_lookup(FSNodeDirectory *node, const HString &name) {
-	auto it = node->find(name);
-	if (it != node->end()) {
-		return (*it).second;
-	}
+	// Access control operations
+	int fsnodes_access(const FsContext &context, FSNode *node, uint8_t modemask) override;
+	int fsnodes_sticky_access(FSNode *parent, FSNode *node, uint32_t uid) override;
+	int fsnodes_namecheck(const std::string &name) override;
+	uint8_t verify_session(const FsContext &context, OperationMode operationMode,
+	                       SessionType sessionType) override;
+	uint8_t fsnodes_get_node_for_operation(const FsContext &context,
+	                                       ExpectedNodeType expectedNodeType, uint8_t modemask,
+	                                       inode_t inode, FSNode **ret,
+	                                       FSNodeDirectory **ret_rn = nullptr) override;
 
-	return nullptr;
-}
+	// Ancestry operations
+	bool fsnodes_isancestor(FSNodeDirectory *f, FSNode *p) override;
+	bool fsnodes_isancestor_or_node_reserved_or_trash(FSNodeDirectory *f, FSNode *p) override;
+	FSNodeDirectory *fsnodes_get_first_parent(FSNode *node) override;
 
-template<class NodeType>
-inline NodeType *fsnodes_id_to_node_verify(inode_t id) {
-	auto *node = static_cast<NodeType *>(detail::fsnodes_id_to_node_internal(id));
-	detail::fsnodes_check_node_type(node);
-	return node;
-}
+protected:
+	/// Internal node lookup operation - override in subclasses for custom storage
+	FSNode *fsnodes_id_to_node_internal(inode_t id) override;
 
-template<class NodeType = FSNode>
-inline NodeType *fsnodes_id_to_node(inode_t id) {
-	return static_cast<NodeType*>(detail::fsnodes_id_to_node_internal(id));
-}
+private:
+	// Private helpers
+	void fsnodes_sub_stats(FSNodeDirectory *parent, StatsRecord *sr);
+	void fsnodes_remove_node(uint32_t ts, FSNode *node);
 
-inline void fsnodes_update_ctime(FSNode *node, uint32_t ctime) {
-	if (node->type == FSNodeType::kTrash && node->ctime != ctime) {
-		auto old_key = TrashPathKey(node);
-		node->ctime = ctime;
-		auto it = gMetadata->trash.find(old_key);
-		if (it != gMetadata->trash.end()) {
-			updateTrashFromOldEntry(gMetadata->trash, node, old_key);
-		}
-	} else {
-		node->ctime = ctime;
-	}
-}
-
-std::string fsnodes_escape_name(const std::string &name);
-int fsnodes_purge(uint32_t ts, FSNode *p);
-uint32_t fsnodes_getdetachedsize(const TrashPathContainer &data);
-void fsnodes_getdetacheddata(const TrashPathContainer &data, uint8_t *dbuff);
-void fsnodes_getdetacheddata(const TrashPathContainer &data, uint32_t off, uint32_t max_entries, std::vector<NamedInodeEntry> &entries);
-uint32_t fsnodes_getdetachedsize(const ReservedPathContainer &data);
-void fsnodes_getdetacheddata(const ReservedPathContainer &data, uint8_t *dbuff);
-void fsnodes_getdetacheddata(const ReservedPathContainer &data, uint32_t off, uint32_t max_entries, std::vector<NamedInodeEntry> &entries);
-void fsnodes_getdetacheddata(const HandleIndexContainer &data, uint64_t handleOffset,
-                             uint32_t maxEntries, std::vector<HandleInodeEntry> &entries,
-                             bool fromTrash);
-void fsnodes_getpath(FSNodeDirectory *parent, FSNode *child, std::string &path);
-void fsnodes_fill_attr(FSNode *node, FSNode *parent, uint32_t uid, uint32_t gid, uint32_t auid,
-	uint32_t agid, uint8_t sesflags, Attributes &attr);
-void fsnodes_fill_attr(const FsContext &context, FSNode *node, FSNode *parent, Attributes &attr);
-
-uint8_t verify_session(const FsContext &context, OperationMode operationMode,
-	SessionType sessionType);
-
-uint8_t fsnodes_get_node_for_operation(const FsContext &context, ExpectedNodeType expectedNodeType,
-                                       uint8_t modemask, inode_t inode, FSNode **ret,
-                                       FSNodeDirectory **ret_rn = nullptr);
-uint8_t fsnodes_undel(uint32_t ts, FSNodeFile *node);
-
-int fsnodes_namecheck(const std::string &name);
-void fsnodes_get_stats(FSNode *node, StatsRecord *sr);
-bool fsnodes_isancestor_or_node_reserved_or_trash(FSNodeDirectory *f, FSNode *p);
-int fsnodes_access(const FsContext &context, FSNode *node, uint8_t modemask);
-
-void fsnodes_setlength(FSNodeFile *obj, uint64_t length, bool eraseFurtherChunks);
-void fsnodes_change_uid_gid(FSNode *p, uint32_t uid, uint32_t gid);
-int fsnodes_nameisused(FSNodeDirectory *node, const HString &name);
-bool fsnodes_inode_quota_exceeded(uint32_t uid, uint32_t gid);
-
-FSNode *fsnodes_create_node(uint32_t ts, FSNodeDirectory *node, const HString &name,
-                            FSNodeType type, uint16_t mode, uint16_t umask, uint32_t uid,
-                            uint32_t gid, uint8_t copysgid, AclInheritance inheritacl,
-                            inode_t req_inode = 0);
-
-void fsnodes_add_stats(FSNodeDirectory *parent, StatsRecord *sr);
-int fsnodes_sticky_access(FSNode *parent, FSNode *node, uint32_t uid);
-void fsnodes_unlink(uint32_t ts, FSNodeDirectory *parent, const HString &node_name, FSNode *node);
-bool fsnodes_isancestor(FSNodeDirectory *f, FSNode *p);
-void fsnodes_remove_edge(uint32_t ts, FSNodeDirectory *parent, const HString &node_name, FSNode *node);
-void fsnodes_link(uint32_t ts, FSNodeDirectory *parent, FSNode *child, const HString &name);
-
-uint8_t fsnodes_appendchunks(uint32_t ts, FSNodeFile *dstobj, FSNodeFile *srcobj);
-void fsnodes_changefilegoal(FSNodeFile *obj, uint8_t goal);
-uint32_t fsnodes_getdirsize(const FSNodeDirectory *p, uint8_t withattr);
-void fsnodes_getdirdata(inode_t rootinode, uint32_t uid, uint32_t gid, uint32_t auid, uint32_t agid,
-                        uint8_t sesflags, FSNodeDirectory *p, uint8_t *dbuff, uint8_t withattr);
-void fsnodes_getdir(inode_t rootinode, uint32_t uid, uint32_t gid, uint32_t auid, uint32_t agid,
-                    uint8_t sesflags, FSNodeDirectory *p, uint64_t first_entry,
-                    uint64_t number_of_entries, std::vector<DirectoryEntry> &dir_entries);
-void fsnodes_checkfile(FSNodeFile *p, uint32_t chunkcount[CHUNK_MATRIX_SIZE]);
-
-bool fsnodes_has_tape_goal(FSNode *node);
-void fsnodes_add_sub_stats(FSNodeDirectory *parent, StatsRecord *newsr, StatsRecord *prevsr);
-
-void fsnodes_getgoal_recursive(FSNode *node, uint8_t gmode, GoalStatistics &fgtab,
-                               GoalStatistics &dgtab);
-
-void fsnodes_gettrashtime_recursive(FSNode *node, uint8_t gmode, TrashtimeMap &fileTrashtimes,
-                                    TrashtimeMap &dirTrashtimes);
-void fsnodes_geteattr_recursive(FSNode *node, uint8_t gmode, uint32_t feattrtab[16],
-                                uint32_t deattrtab[16]);
-void fsnodes_setgoal_recursive(FSNode *node, uint32_t ts, uint32_t uid, uint8_t goal, uint8_t smode,
-                               inode_t *sinodes, inode_t *ncinodes, inode_t *nsinodes);
-void fsnodes_settrashtime_recursive(FSNode *node, uint32_t ts, uint32_t uid, uint32_t trashtime,
-                                    uint8_t smode, inode_t *sinodes, inode_t *ncinodes,
-                                    inode_t *nsinodes);
-void fsnodes_seteattr_recursive(FSNode *node, uint32_t ts, uint32_t uid, uint8_t eattr,
-                                uint8_t smode, inode_t *sinodes, inode_t *ncinodes,
-                                inode_t *nsinodes);
-uint8_t fsnodes_deleteacl(FSNode *p, AclType type, uint32_t ts);
-
-uint8_t fsnodes_setacl(FSNode *p, const RichACL &acl, uint32_t ts);
-uint8_t fsnodes_setacl(FSNode *p, AclType type, const AccessControlList &acl, uint32_t ts);
-uint8_t fsnodes_getacl(FSNode *p, RichACL &acl);
-
-uint32_t fsnodes_getpath_size(FSNodeDirectory *parent, FSNode *child);
-void fsnodes_getpath_data(FSNodeDirectory *parent, FSNode *child, uint8_t *path, uint32_t size);
-
-int64_t fsnodes_get_size(FSNode *node);
-FSNodeDirectory *fsnodes_get_first_parent(FSNode *node);
+	uint32_t last_chunk_blocks(FSNodeFile *node);
+	bool last_chunk_nonempty(FSNodeFile *node);
+	uint32_t file_chunks(FSNodeFile *node);
+	uint64_t file_size(FSNodeFile *node, uint32_t nonzero_chunks);
+	uint64_t file_realsize(FSNodeFile *node, uint32_t nonzero_chunks, uint64_t file_size);
+#ifndef METARESTORE
+	uint32_t ec_chunk_realsize(uint32_t blocks, uint32_t data_part_count,
+	                           uint32_t parity_part_count);
+#endif
+};

--- a/src/master/filesystem_node_operations_interface.h
+++ b/src/master/filesystem_node_operations_interface.h
@@ -1,0 +1,232 @@
+/*
+   Copyright 2023      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "common/platform.h"
+
+#include <string>
+#include <vector>
+
+#include "common/attributes.h"
+#include "master/filesystem_node_types.h"
+#include "master/filesystem_trash_reserved_files.h"
+#include "master/fs_context.h"
+#include "protocol/directory_entry.h"
+#include "protocol/handle_inode_entry.h"
+#include "protocol/named_inode_entry.h"
+
+class HString;
+class RichACL;
+class AccessControlList;
+class FsContext;
+struct StatsRecord;
+struct DirectoryEntry;
+struct HandleInodeEntry;
+struct NamedInodeEntry;
+
+/// Interface for filesystem node operations extensibility.
+///
+/// Classes implementing this interface can be used to override default filesystem node behavior.
+class IFilesystemNodeOperations {
+public:
+	/// Default constructor
+	IFilesystemNodeOperations() = default;
+
+	/// Virtual destructor
+	virtual ~IFilesystemNodeOperations() = default;
+
+	/// Non-copyable and non-movable
+	IFilesystemNodeOperations(const IFilesystemNodeOperations &) = delete;
+	IFilesystemNodeOperations &operator=(const IFilesystemNodeOperations &) = delete;
+	IFilesystemNodeOperations(IFilesystemNodeOperations &&) = delete;
+	IFilesystemNodeOperations &operator=(IFilesystemNodeOperations &&) = delete;
+
+	// Type-safe node lookup operations
+
+	template <class NodeType>
+	NodeType *fsnodes_id_to_node_verify(inode_t id) {
+		auto *node = static_cast<NodeType *>(this->fsnodes_id_to_node_internal(id));
+		this->fsnodes_check_node_type(node);
+		return node;
+	}
+
+	template <class NodeType = FSNode>
+	NodeType *fsnodes_id_to_node(inode_t id) {
+		return static_cast<NodeType *>(this->fsnodes_id_to_node_internal(id));
+	}
+
+	// Main node operations
+
+	virtual FSNode *fsnodes_lookup(FSNodeDirectory *node, const HString &name) const = 0;
+
+	virtual FSNode *fsnodes_create_node(uint32_t ts, FSNodeDirectory *parent, const HString &name,
+	                                    FSNodeType type, uint16_t mode, uint16_t umask,
+	                                    uint32_t uid, uint32_t gid, uint8_t copysgid,
+	                                    AclInheritance inheritacl, inode_t req_inode = 0) = 0;
+	virtual void fsnodes_link(uint32_t ts, FSNodeDirectory *parent, FSNode *child,
+	                          const HString &name) = 0;
+	virtual void fsnodes_unlink(uint32_t ts, FSNodeDirectory *parent, const HString &node_name,
+	                            FSNode *node) = 0;
+	virtual void fsnodes_remove_edge(uint32_t ts, FSNodeDirectory *parent, const HString &node_name,
+	                                 FSNode *node) = 0;
+
+	virtual void fsnodes_update_ctime(FSNode *node, uint32_t ctime) = 0;
+	virtual void fsnodes_fill_attr(FSNode *node, FSNode *parent, uint32_t uid, uint32_t gid,
+	                               uint32_t auid, uint32_t agid, uint8_t sesflags,
+	                               Attributes &attr) = 0;
+	virtual void fsnodes_fill_attr(const FsContext &context, FSNode *node, FSNode *parent,
+	                               Attributes &attr) = 0;
+	virtual void fsnodes_get_stats(FSNode *node, StatsRecord *sr) = 0;
+	virtual void fsnodes_add_stats(FSNodeDirectory *parent, StatsRecord *sr) = 0;
+	virtual void fsnodes_add_sub_stats(FSNodeDirectory *parent, StatsRecord *newsr,
+	                                   StatsRecord *prevsr) = 0;
+	virtual void fsnodes_change_uid_gid(FSNode *p, uint32_t uid, uint32_t gid) = 0;
+
+	virtual void fsnodes_setlength(FSNodeFile *obj, uint64_t length, bool eraseFurtherChunks) = 0;
+	virtual uint8_t fsnodes_appendchunks(uint32_t ts, FSNodeFile *dstobj, FSNodeFile *srcobj) = 0;
+	virtual void fsnodes_changefilegoal(FSNodeFile *obj, uint8_t goal) = 0;
+#ifndef METARESTORE
+	virtual void fsnodes_checkfile(FSNodeFile *p, uint32_t chunkcount[CHUNK_MATRIX_SIZE]) = 0;
+#endif
+	virtual int64_t fsnodes_get_size(FSNode *node) = 0;
+
+#ifndef METARESTORE
+	virtual uint32_t fsnodes_getdirsize(const FSNodeDirectory *p, uint8_t withattr) = 0;
+	virtual void fsnodes_getdirdata(inode_t rootinode, uint32_t uid, uint32_t gid, uint32_t auid,
+	                                uint32_t agid, uint8_t sesflags, FSNodeDirectory *p,
+	                                uint8_t *dbuff, uint8_t withattr) = 0;
+	virtual void fsnodes_getdir(inode_t rootinode, uint32_t uid, uint32_t gid, uint32_t auid,
+	                            uint32_t agid, uint8_t sesflags, FSNodeDirectory *p,
+	                            uint64_t first_entry, uint64_t number_of_entries,
+	                            std::vector<DirectoryEntry> &dir_entries) = 0;
+#endif
+	virtual int fsnodes_nameisused(FSNodeDirectory *node, const HString &name) = 0;
+
+	// Trash/Reserved operations
+
+	virtual int fsnodes_purge(uint32_t ts, FSNode *p) = 0;
+	virtual uint8_t fsnodes_undel(uint32_t ts, FSNodeFile *node) = 0;
+#ifndef METARESTORE
+	virtual uint32_t fsnodes_getdetachedsize(const TrashPathContainer &data) = 0;
+	virtual void fsnodes_getdetacheddata(const TrashPathContainer &data, uint8_t *dbuff) = 0;
+	virtual void fsnodes_getdetacheddata(const TrashPathContainer &data, uint32_t off,
+	                                     uint32_t max_entries,
+	                                     std::vector<NamedInodeEntry> &entries) = 0;
+	virtual uint32_t fsnodes_getdetachedsize(const ReservedPathContainer &data) = 0;
+	virtual void fsnodes_getdetacheddata(const ReservedPathContainer &data, uint8_t *dbuff) = 0;
+	virtual void fsnodes_getdetacheddata(const ReservedPathContainer &data, uint32_t off,
+	                                     uint32_t max_entries,
+	                                     std::vector<NamedInodeEntry> &entries) = 0;
+	virtual void fsnodes_getdetacheddata(const HandleIndexContainer &data, uint64_t handleOffset,
+	                                     uint32_t maxEntries,
+	                                     std::vector<HandleInodeEntry> &entries,
+	                                     bool fromTrash) = 0;
+#endif
+
+	// Path operations
+	virtual void fsnodes_getpath(FSNodeDirectory *parent, FSNode *child, std::string &path) = 0;
+	virtual uint32_t fsnodes_getpath_size(FSNodeDirectory *parent, FSNode *child) = 0;
+	virtual void fsnodes_getpath_data(FSNodeDirectory *parent, FSNode *child, uint8_t *path,
+	                                  uint32_t size) = 0;
+	virtual std::string fsnodes_escape_name(const std::string &name) = 0;
+
+	// ACL operations
+	virtual uint8_t fsnodes_setacl(FSNode *p, const RichACL &acl, uint32_t ts) = 0;
+	virtual uint8_t fsnodes_setacl(FSNode *p, AclType type, const AccessControlList &acl,
+	                               uint32_t ts) = 0;
+#ifndef METARESTORE
+	virtual uint8_t fsnodes_getacl(FSNode *p, RichACL &acl) = 0;
+#endif  // METARESTORE
+	virtual uint8_t fsnodes_deleteacl(FSNode *p, AclType type, uint32_t ts) = 0;
+
+	// Recursive operations
+#ifndef METARESTORE
+	virtual void fsnodes_getgoal_recursive(FSNode *node, uint8_t gmode, GoalStatistics &fgtab,
+	                                       GoalStatistics &dgtab) = 0;
+	virtual void fsnodes_gettrashtime_recursive(FSNode *node, uint8_t gmode,
+	                                            TrashtimeMap &fileTrashtimes,
+	                                            TrashtimeMap &dirTrashtimes) = 0;
+	virtual void fsnodes_geteattr_recursive(FSNode *node, uint8_t gmode, uint32_t feattrtab[16],
+	                                        uint32_t deattrtab[16]) = 0;
+#endif
+	virtual void fsnodes_setgoal_recursive(FSNode *node, uint32_t ts, uint32_t uid, uint8_t goal,
+	                                       uint8_t smode, inode_t *sinodes, inode_t *ncinodes,
+	                                       inode_t *nsinodes) = 0;
+
+	virtual void fsnodes_settrashtime_recursive(FSNode *node, uint32_t ts, uint32_t uid,
+	                                            uint32_t trashtime, uint8_t smode, inode_t *sinodes,
+	                                            inode_t *ncinodes, inode_t *nsinodes) = 0;
+
+	virtual void fsnodes_seteattr_recursive(FSNode *node, uint32_t ts, uint32_t uid, uint8_t eattr,
+	                                        uint8_t smode, inode_t *sinodes, inode_t *ncinodes,
+	                                        inode_t *nsinodes) = 0;
+
+	// Access control operations
+	virtual int fsnodes_access(const FsContext &context, FSNode *node, uint8_t modemask) = 0;
+	virtual int fsnodes_sticky_access(FSNode *parent, FSNode *node, uint32_t uid) = 0;
+	virtual int fsnodes_namecheck(const std::string &name) = 0;
+	virtual uint8_t verify_session(const FsContext &context, OperationMode operationMode,
+	                               SessionType sessionType) = 0;
+	virtual uint8_t fsnodes_get_node_for_operation(const FsContext &context,
+	                                               ExpectedNodeType expectedNodeType,
+	                                               uint8_t modemask, inode_t inode, FSNode **ret,
+	                                               FSNodeDirectory **ret_rn = nullptr) = 0;
+
+	// Ancestry operations
+	virtual bool fsnodes_isancestor(FSNodeDirectory *f, FSNode *p) = 0;
+	virtual bool fsnodes_isancestor_or_node_reserved_or_trash(FSNodeDirectory *f, FSNode *p) = 0;
+	virtual FSNodeDirectory *fsnodes_get_first_parent(FSNode *node) = 0;
+
+protected:
+	// Core node lookup operation - override in subclasses for custom storage
+	virtual FSNode *fsnodes_id_to_node_internal(inode_t id) = 0;
+
+	// Type checking helper - base case
+	template <class NodeType>
+	void fsnodes_check_node_type(const NodeType *node) {
+		assert(node);
+		(void)node;
+	}
+};
+
+// Template specializations for type checking
+template <>
+inline void IFilesystemNodeOperations::fsnodes_check_node_type(const FSNodeFile *node) {
+	assert(node && (node->type == FSNodeType::kFile || node->type == FSNodeType::kTrash ||
+	                node->type == FSNodeType::kReserved));
+	(void)node;
+}
+
+template <>
+inline void IFilesystemNodeOperations::fsnodes_check_node_type(const FSNodeDirectory *node) {
+	assert(node && node->type == FSNodeType::kDirectory);
+	(void)node;
+}
+
+template <>
+inline void IFilesystemNodeOperations::fsnodes_check_node_type(const FSNodeSymlink *node) {
+	assert(node && node->type == FSNodeType::kSymlink);
+	(void)node;
+}
+
+template <>
+inline void IFilesystemNodeOperations::fsnodes_check_node_type(const FSNodeDevice *node) {
+	assert(node && (node->type == FSNodeType::kBlockDev || node->type == FSNodeType::kCharDev));
+	(void)node;
+};

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -38,6 +38,7 @@
 #include "master/filesystem_metadata.h"
 #include "master/filesystem_node.h"
 #include "master/filesystem_node_types.h"
+#include "master/filesystem_operations_interface.h"
 #include "master/filesystem_quota.h"
 #include "master/filesystem_stats.h"
 #include "master/fs_context.h"
@@ -76,6 +77,10 @@ bool decodeChar(const char *keys, const std::vector<T> values, char key, T &valu
 	}
 	return false;
 }
+
+FilesystemOperationsBase::FilesystemOperationsBase(
+    std::unique_ptr<IFilesystemNodeOperations> _nodeOps)
+    : nodeOperations_(std::move(_nodeOps)) {}
 
 void FilesystemOperationsBase::changeLog(uint32_t ts, const char *format, ...) {
 #ifdef METARESTORE
@@ -118,7 +123,7 @@ uint8_t FilesystemOperationsBase::readReservedSize(inode_t rootinode, uint8_t se
 		return SAUNAFS_ERROR_EPERM;
 	}
 	(void)sesflags;
-	*dbuffsize = fsnodes_getdetachedsize(gMetadata->reserved);
+	*dbuffsize = nodeOperations_->fsnodes_getdetachedsize(gMetadata->reserved);
 	return SAUNAFS_STATUS_OK;
 }
 
@@ -126,17 +131,18 @@ void FilesystemOperationsBase::readReservedData(inode_t rootinode, uint8_t sesfl
                                                 uint8_t *dbuff) {
 	(void)rootinode;
 	(void)sesflags;
-	fsnodes_getdetacheddata(gMetadata->reserved, dbuff);
+	nodeOperations_->fsnodes_getdetacheddata(gMetadata->reserved, dbuff);
 }
 
 void FilesystemOperationsBase::readReserved(uint32_t off, uint32_t max_entries,
                                             std::vector<NamedInodeEntry> &entries) {
-	fsnodes_getdetacheddata(gMetadata->reserved, off, max_entries, entries);
+	nodeOperations_->fsnodes_getdetacheddata(gMetadata->reserved, off, max_entries, entries);
 }
 
 void FilesystemOperationsBase::readReserved(uint64_t handleOffset, uint32_t maxEntries,
                                             std::vector<HandleInodeEntry> &entries) {
-	fsnodes_getdetacheddata(gMetadata->reservedHandlesIndex, handleOffset, maxEntries, entries, false);
+	nodeOperations_->fsnodes_getdetacheddata(gMetadata->reservedHandlesIndex, handleOffset,
+	                                         maxEntries, entries, false);
 }
 
 uint8_t FilesystemOperationsBase::readTrashSize(inode_t rootinode, uint8_t sesflags,
@@ -145,24 +151,25 @@ uint8_t FilesystemOperationsBase::readTrashSize(inode_t rootinode, uint8_t sesfl
 		return SAUNAFS_ERROR_EPERM;
 	}
 	(void)sesflags;
-	*dbuffsize = fsnodes_getdetachedsize(gMetadata->trash);
+	*dbuffsize = nodeOperations_->fsnodes_getdetachedsize(gMetadata->trash);
 	return SAUNAFS_STATUS_OK;
 }
 
 void FilesystemOperationsBase::readTrashData(inode_t rootinode, uint8_t sesflags, uint8_t *dbuff) {
 	(void)rootinode;
 	(void)sesflags;
-	fsnodes_getdetacheddata(gMetadata->trash, dbuff);
+	nodeOperations_->fsnodes_getdetacheddata(gMetadata->trash, dbuff);
 }
 
 void FilesystemOperationsBase::readTrash(uint32_t off, uint32_t max_entries,
                                          std::vector<NamedInodeEntry> &entries) {
-	fsnodes_getdetacheddata(gMetadata->trash, off, max_entries, entries);
+	nodeOperations_->fsnodes_getdetacheddata(gMetadata->trash, off, max_entries, entries);
 }
 
 void FilesystemOperationsBase::readTrash(uint64_t handleOffset, uint32_t maxEntries,
                                          std::vector<HandleInodeEntry> &entries) {
-	fsnodes_getdetacheddata(gMetadata->trashHandlesIndex, handleOffset, maxEntries, entries, true);
+	nodeOperations_->fsnodes_getdetacheddata(gMetadata->trashHandlesIndex, handleOffset, maxEntries,
+	                                         entries, true);
 }
 
 /* common procedure for trash and reserved files */
@@ -177,7 +184,7 @@ uint8_t FilesystemOperationsBase::getDetachedAttr(inode_t rootinode, uint8_t ses
 	if (!DTYPE_ISVALID(dtype)) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
-	p = fsnodes_id_to_node(inode);
+	p = nodeOperations_->fsnodes_id_to_node(inode);
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
@@ -190,7 +197,7 @@ uint8_t FilesystemOperationsBase::getDetachedAttr(inode_t rootinode, uint8_t ses
 	if (dtype == DTYPE_RESERVED && p->type == FSNodeType::kTrash) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
-	fsnodes_fill_attr(p, NULL, p->uid, p->gid, p->uid, p->gid, sesflags, attr);
+	nodeOperations_->fsnodes_fill_attr(p, NULL, p->uid, p->gid, p->uid, p->gid, sesflags, attr);
 	return SAUNAFS_STATUS_OK;
 }
 
@@ -201,7 +208,7 @@ uint8_t FilesystemOperationsBase::getTrashPath(inode_t rootinode, uint8_t sesfla
 		return SAUNAFS_ERROR_EPERM;
 	}
 	(void)sesflags;
-	p = fsnodes_id_to_node(inode);
+	p = nodeOperations_->fsnodes_id_to_node(inode);
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
@@ -217,12 +224,13 @@ uint8_t FilesystemOperationsBase::setTrashPath(const FsContext &context, inode_t
                                                const std::string &path) {
 	ChecksumUpdater cu(context.ts());
 	FSNode *p;
-	uint8_t status = verify_session(context, OperationMode::kReadWrite, SessionType::kOnlyMeta);
+	uint8_t status =
+	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kOnlyMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny, MODE_MASK_EMPTY,
-	                                        inode, &p);
+	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny,
+	                                                         MODE_MASK_EMPTY, inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	} else if (p->type != FSNodeType::kTrash) {
@@ -241,7 +249,7 @@ uint8_t FilesystemOperationsBase::setTrashPath(const FsContext &context, inode_t
 
 	if (context.isPersonalityMaster()) {
 		changeLog(context.ts(), "SETPATH(%" PRIiNode ",%s)", p->id,
-		          fsnodes_escape_name(path).c_str());
+		          nodeOperations_->fsnodes_escape_name(path).c_str());
 	} else {
 		gMetadata->metadataVersion++;
 	}
@@ -251,19 +259,20 @@ uint8_t FilesystemOperationsBase::setTrashPath(const FsContext &context, inode_t
 uint8_t FilesystemOperationsBase::undel(const FsContext &context, inode_t inode) {
 	ChecksumUpdater cu(context.ts());
 	FSNode *p;
-	uint8_t status = verify_session(context, OperationMode::kReadWrite, SessionType::kOnlyMeta);
+	uint8_t status =
+	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kOnlyMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny, MODE_MASK_EMPTY,
-	                                        inode, &p);
+	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny,
+	                                                         MODE_MASK_EMPTY, inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	} else if (p->type != FSNodeType::kTrash) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
 
-	status = fsnodes_undel(context.ts(), static_cast<FSNodeFile*>(p));
+	status = nodeOperations_->fsnodes_undel(context.ts(), static_cast<FSNodeFile *>(p));
 	if (context.isPersonalityMaster()) {
 		if (status == SAUNAFS_STATUS_OK) { changeLog(context.ts(), "UNDEL(%" PRIiNode ")", p->id); }
 	} else {
@@ -275,12 +284,13 @@ uint8_t FilesystemOperationsBase::undel(const FsContext &context, inode_t inode)
 uint8_t FilesystemOperationsBase::purge(const FsContext &context, inode_t inode) {
 	ChecksumUpdater cu(context.ts());
 	FSNode *p;
-	uint8_t status = verify_session(context, OperationMode::kReadWrite, SessionType::kOnlyMeta);
+	uint8_t status =
+	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kOnlyMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny, MODE_MASK_EMPTY,
-	                                        inode, &p);
+	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny,
+	                                                         MODE_MASK_EMPTY, inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	} else if (p->type != FSNodeType::kTrash) {
@@ -288,7 +298,7 @@ uint8_t FilesystemOperationsBase::purge(const FsContext &context, inode_t inode)
 	}
 	// This should be equal to inode, because p is not a directory
 	inode_t purged_inode = p->id;
-	fsnodes_purge(context.ts(), p);
+	nodeOperations_->fsnodes_purge(context.ts(), p);
 
 	if (context.isPersonalityMaster()) {
 		changeLog(context.ts(), "PURGE(%" PRIiNode ")", purged_inode);
@@ -336,10 +346,8 @@ uint8_t FilesystemOperationsBase::getRootInode(inode_t *rootinode, const uint8_t
 			nleng++;
 		}
 		hname = HString((const char*)name, nleng);
-		if (fsnodes_namecheck(hname) < 0) {
-			return SAUNAFS_ERROR_EINVAL;
-		}
-		FSNode *child = fsnodes_lookup(parent, hname);
+		if (nodeOperations_->fsnodes_namecheck(hname) < 0) { return SAUNAFS_ERROR_EINVAL; }
+		FSNode *child = nodeOperations_->fsnodes_lookup(parent, hname);
 		if (!child) {
 			return SAUNAFS_ERROR_ENOENT;
 		}
@@ -363,7 +371,7 @@ void FilesystemOperationsBase::statfs(const FsContext &context, uint64_t *totals
 	} else {
 		*trspace = 0;
 		*respace = 0;
-		rn = fsnodes_id_to_node(context.rootinode());
+		rn = nodeOperations_->fsnodes_id_to_node(context.rootinode());
 	}
 	if (!rn || rn->type != FSNodeType::kDirectory) {
 		*totalspace = 0;
@@ -372,7 +380,7 @@ void FilesystemOperationsBase::statfs(const FsContext &context, uint64_t *totals
 	} else {
 		matocsserv_getspace(totalspace, availspace);
 		fsnodes_quota_adjust_space(rn, *totalspace, *availspace);
-		fsnodes_get_stats(rn, &sr);
+		nodeOperations_->fsnodes_get_stats(rn, &sr);
 		*inodes = sr.inodes;
 	}
 	incrementFSStat(FsStats::Statfs);
@@ -394,7 +402,7 @@ uint8_t FilesystemOperationsBase::applyChecksum(const std::string &version, uint
 
 uint8_t FilesystemOperationsBase::applyAccess(uint32_t timestamp, inode_t inode) {
 	FSNode *p;
-	p = fsnodes_id_to_node(inode);
+	p = nodeOperations_->fsnodes_id_to_node(inode);
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
@@ -408,13 +416,15 @@ uint8_t FilesystemOperationsBase::applyAccess(uint32_t timestamp, inode_t inode)
 uint8_t FilesystemOperationsBase::access(const FsContext &context, inode_t inode, int modemask) {
 	FSNode *p;
 
-	uint8_t status = verify_session(context, (modemask & MODE_MASK_W) ? OperationMode::kReadWrite : OperationMode::kReadOnly, SessionType::kNotMeta);
+	uint8_t status = nodeOperations_->verify_session(
+	    context, (modemask & MODE_MASK_W) ? OperationMode::kReadWrite : OperationMode::kReadOnly,
+	    SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	return fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny, modemask,
-									  inode, &p);
+	return nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny,
+	                                                       modemask, inode, &p);
 }
 
 uint8_t FilesystemOperationsBase::lookup(const FsContext &context, inode_t parent,
@@ -425,13 +435,14 @@ uint8_t FilesystemOperationsBase::lookup(const FsContext &context, inode_t paren
 	*inode = 0;
 	attr.fill(0);
 
-	uint8_t status = verify_session(context, OperationMode::kReadOnly, SessionType::kNotMeta);
+	uint8_t status =
+	    nodeOperations_->verify_session(context, OperationMode::kReadOnly, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kDirectory, MODE_MASK_X,
-	                                        parent, &wd, &rn);
+	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kDirectory,
+	                                                         MODE_MASK_X, parent, &wd, &rn);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
@@ -443,7 +454,8 @@ uint8_t FilesystemOperationsBase::lookup(const FsContext &context, inode_t paren
 			} else {
 				*inode = wd->id;
 			}
-			fsnodes_fill_attr(wd, wd, context.uid(), context.gid(), context.auid(), context.agid(), context.sesflags(), attr);
+			nodeOperations_->fsnodes_fill_attr(wd, wd, context.uid(), context.gid(), context.auid(),
+			                                   context.agid(), context.sesflags(), attr);
 			incrementFSStat(FsStats::Lookup);
 			metrics::Counter::increment(metrics::Counter::Master::FS_LOOKUP);
 			return SAUNAFS_STATUS_OK;
@@ -451,7 +463,9 @@ uint8_t FilesystemOperationsBase::lookup(const FsContext &context, inode_t paren
 		if (name.length() == 2 && name[1] == '.') {  // parent
 			if (wd->id == context.rootinode()) {
 				*inode = SPECIAL_INODE_ROOT;
-				fsnodes_fill_attr(wd, wd, context.uid(), context.gid(), context.auid(), context.agid(), context.sesflags(), attr);
+				nodeOperations_->fsnodes_fill_attr(wd, wd, context.uid(), context.gid(),
+				                                   context.auid(), context.agid(),
+				                                   context.sesflags(), attr);
 			} else {
 				if (!wd->parents.empty()) {
 					if (wd->parents[0].first == context.rootinode()) {
@@ -459,13 +473,15 @@ uint8_t FilesystemOperationsBase::lookup(const FsContext &context, inode_t paren
 					} else {
 						*inode = wd->parents[0].first;
 					}
-					FSNode *pp = fsnodes_id_to_node(wd->parents[0].first);
-					fsnodes_fill_attr(pp, wd, context.uid(), context.gid(), context.auid(),
-					                  context.agid(), context.sesflags(), attr);
+					FSNode *pp = nodeOperations_->fsnodes_id_to_node(wd->parents[0].first);
+					nodeOperations_->fsnodes_fill_attr(pp, wd, context.uid(), context.gid(),
+					                                   context.auid(), context.agid(),
+					                                   context.sesflags(), attr);
 				} else {
 					*inode = SPECIAL_INODE_ROOT;  // rn->id;
-					fsnodes_fill_attr(rn, wd, context.uid(), context.gid(), context.auid(), context.agid(), context.sesflags(),
-					                  attr);
+					nodeOperations_->fsnodes_fill_attr(rn, wd, context.uid(), context.gid(),
+					                                   context.auid(), context.agid(),
+					                                   context.sesflags(), attr);
 				}
 			}
 			incrementFSStat(FsStats::Lookup);
@@ -473,16 +489,15 @@ uint8_t FilesystemOperationsBase::lookup(const FsContext &context, inode_t paren
 			return SAUNAFS_STATUS_OK;
 		}
 	}
-	if (fsnodes_namecheck(name) < 0) {
-		return SAUNAFS_ERROR_EINVAL;
-	}
+	if (nodeOperations_->fsnodes_namecheck(name) < 0) { return SAUNAFS_ERROR_EINVAL; }
 
-	FSNode *child = fsnodes_lookup(static_cast<FSNodeDirectory*>(wd), name);
+	FSNode *child = nodeOperations_->fsnodes_lookup(static_cast<FSNodeDirectory *>(wd), name);
 	if (!child) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
 	*inode = child->id;
-	fsnodes_fill_attr(child, wd, context.uid(), context.gid(), context.auid(), context.agid(), context.sesflags(), attr);
+	nodeOperations_->fsnodes_fill_attr(child, wd, context.uid(), context.gid(), context.auid(),
+	                                   context.agid(), context.sesflags(), attr);
 	incrementFSStat(FsStats::Lookup);
 	metrics::Counter::increment(metrics::Counter::Master::FS_LOOKUP);
 	return SAUNAFS_STATUS_OK;
@@ -523,11 +538,12 @@ uint8_t FilesystemOperationsBase::fullPathByInode(const FsContext &context, inod
 	FSNode *current_node;
 	std::string current_name = "";
 
-	uint8_t status = verify_session(context, OperationMode::kReadOnly, SessionType::kNotMeta);
+	uint8_t status =
+	    nodeOperations_->verify_session(context, OperationMode::kReadOnly, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) { return status; }
 
-	status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny, MODE_MASK_R,
-	                                        initial_inode, &current_node);
+	status = nodeOperations_->fsnodes_get_node_for_operation(
+	    context, ExpectedNodeType::kAny, MODE_MASK_R, initial_inode, &current_node);
 	if (status != SAUNAFS_STATUS_OK) { return status; }
 
 	if (current_inode == SPECIAL_INODE_ROOT) {
@@ -550,8 +566,8 @@ uint8_t FilesystemOperationsBase::fullPathByInode(const FsContext &context, inod
 		}
 		auto [parentId, nameHandle] = current_node->parents[0];
 		if (!nameHandle) { return SAUNAFS_ERROR_ENOENT; }
-		status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny, MODE_MASK_R,
-		                                        parentId, &parent_node);
+		status = nodeOperations_->fsnodes_get_node_for_operation(
+		    context, ExpectedNodeType::kAny, MODE_MASK_R, parentId, &parent_node);
 		if (status != SAUNAFS_STATUS_OK) { return status; }
 		current_name = nameHandle->get();
 		fullPath = current_inode == initial_inode
@@ -567,7 +583,7 @@ uint8_t FilesystemOperationsBase::fullPathByInode(const FsContext &context, inod
 std::string FilesystemOperationsBase::fullPathByInode(inode_t initial_inode) {
 	std::string fullPath = "";
 	inode_t current_inode = initial_inode;
-	FSNode *current_node = fsnodes_id_to_node(current_inode);
+	FSNode *current_node = nodeOperations_->fsnodes_id_to_node(current_inode);
 	std::string current_name = "";
 
 	while (current_inode != SPECIAL_INODE_ROOT) {
@@ -577,7 +593,7 @@ std::string FilesystemOperationsBase::fullPathByInode(inode_t initial_inode) {
 			break;
 		}
 		auto parent = current_node->parents[0].first;
-		auto parent_node = fsnodes_id_to_node<FSNodeDirectory>(parent);
+		auto parent_node = nodeOperations_->fsnodes_id_to_node<FSNodeDirectory>(parent);
 		if (!parent_node) { return ""; }
 		current_name = parent_node->getChildName(current_node);
 		fullPath = current_inode == initial_inode ? current_name : current_name + "/" + fullPath;
@@ -595,18 +611,20 @@ uint8_t FilesystemOperationsBase::getAttr(const FsContext &context, inode_t inod
 
 	attr.fill(0);
 
-	uint8_t status = verify_session(context, OperationMode::kReadOnly, SessionType::kNotMeta);
+	uint8_t status =
+	    nodeOperations_->verify_session(context, OperationMode::kReadOnly, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny, MODE_MASK_EMPTY,
-	                                        inode, &p);
+	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny,
+	                                                         MODE_MASK_EMPTY, inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	fsnodes_fill_attr(p, NULL, context.uid(), context.gid(), context.auid(), context.agid(), context.sesflags(), attr);
+	nodeOperations_->fsnodes_fill_attr(p, NULL, context.uid(), context.gid(), context.auid(),
+	                                   context.agid(), context.sesflags(), attr);
 	incrementFSStat(FsStats::Getattr);
 	metrics::Counter::increment(metrics::Counter::Master::FS_GETATTR);
 	return SAUNAFS_STATUS_OK;
@@ -621,14 +639,14 @@ uint8_t FilesystemOperationsBase::trySetLength(const FsContext &context, inode_t
 	FSNode *p;
 	attr.fill(0);
 
-	uint8_t status = verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
+	uint8_t status =
+	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kFile,
-	                                        opened == 0 ? MODE_MASK_W : MODE_MASK_EMPTY,
-	                                        inode, &p);
+	status = nodeOperations_->fsnodes_get_node_for_operation(
+	    context, ExpectedNodeType::kFile, opened == 0 ? MODE_MASK_W : MODE_MASK_EMPTY, inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
@@ -659,7 +677,8 @@ uint8_t FilesystemOperationsBase::trySetLength(const FsContext &context, inode_t
 			}
 		}
 	}
-	fsnodes_fill_attr(p, NULL, context.uid(), context.gid(), context.auid(), context.agid(), context.sesflags(), attr);
+	nodeOperations_->fsnodes_fill_attr(p, NULL, context.uid(), context.gid(), context.auid(),
+	                                   context.agid(), context.sesflags(), attr);
 	incrementFSStat(FsStats::Setattr);
 	metrics::Counter::increment(metrics::Counter::Master::FS_SETATTR);
 	return SAUNAFS_STATUS_OK;
@@ -670,7 +689,7 @@ uint8_t FilesystemOperationsBase::applyTrunc(uint32_t timestamp, inode_t inode, 
                                              uint64_t chunkid, uint32_t lockid) {
 	uint64_t ochunkid, nchunkid;
 	uint8_t status;
-	FSNodeFile *p = fsnodes_id_to_node<FSNodeFile>(inode);
+	FSNodeFile *p = nodeOperations_->fsnodes_id_to_node<FSNodeFile>(inode);
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
@@ -738,13 +757,14 @@ uint8_t FilesystemOperationsBase::doSetLength(const FsContext &context, inode_t 
 
 	attr.fill(0);
 
-	uint8_t status = verify_session(context, OperationMode::kReadWrite, SessionType::kAny);
+	uint8_t status =
+	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kAny);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kFile, MODE_MASK_EMPTY,
-	                                        inode, &p);
+	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kFile,
+	                                                         MODE_MASK_EMPTY, inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
@@ -754,13 +774,14 @@ uint8_t FilesystemOperationsBase::doSetLength(const FsContext &context, inode_t 
 	// eraseFurtherChunks should be set to true because we are setting the
 	// length of the file and we should erase further chunks.
 	bool eraseFurtherChunks = true;
-	fsnodes_setlength(static_cast<FSNodeFile *>(p), length, eraseFurtherChunks);
+	nodeOperations_->fsnodes_setlength(static_cast<FSNodeFile *>(p), length, eraseFurtherChunks);
 	changeLog(ts, "LENGTH(%" PRIiNode ",%" PRIu64 ",%" PRIu32 ")", inode,
 	          static_cast<FSNodeFile *>(p)->length, static_cast<uint32_t>(eraseFurtherChunks));
 	p->mtime = ts;
-	fsnodes_update_ctime(p, ts);
+	nodeOperations_->fsnodes_update_ctime(p, ts);
 	fsnodes_update_checksum(p);
-	fsnodes_fill_attr(p, NULL, context.uid(), context.gid(), context.auid(), context.agid(), context.sesflags(), attr);
+	nodeOperations_->fsnodes_fill_attr(p, NULL, context.uid(), context.gid(), context.auid(),
+	                                   context.agid(), context.sesflags(), attr);
 	incrementFSStat(FsStats::Setattr);
 	metrics::Counter::increment(metrics::Counter::Master::FS_SETATTR);
 	return SAUNAFS_STATUS_OK;
@@ -776,13 +797,14 @@ uint8_t FilesystemOperationsBase::setAttr(const FsContext &context, inode_t inod
 
 	attr.fill(0);
 
-	auto status = verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
+	auto status =
+	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny, MODE_MASK_EMPTY,
-	                                        inode, &p);
+	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny,
+	                                                         MODE_MASK_EMPTY, inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
@@ -801,7 +823,7 @@ uint8_t FilesystemOperationsBase::setAttr(const FsContext &context, inode_t inod
 			return SAUNAFS_ERROR_EPERM;
 		}
 		if ((setmask & (SET_ATIME_NOW_FLAG | SET_MTIME_NOW_FLAG)) &&
-		    !fsnodes_access(context, p, MODE_MASK_W)) {
+		    !nodeOperations_->fsnodes_access(context, p, MODE_MASK_W)) {
 			return SAUNAFS_ERROR_EACCES;
 		}
 	}
@@ -878,8 +900,8 @@ uint8_t FilesystemOperationsBase::setAttr(const FsContext &context, inode_t inod
 		gMetadata->aclStorage.setMode(p->id, p->mode, p->type == FSNodeType::kDirectory);
 	}
 	if (setmask & (SET_UID_FLAG | SET_GID_FLAG)) {
-		fsnodes_change_uid_gid(p, ((setmask & SET_UID_FLAG) ? attruid : p->uid),
-		                       ((setmask & SET_GID_FLAG) ? attrgid : p->gid));
+		nodeOperations_->fsnodes_change_uid_gid(p, ((setmask & SET_UID_FLAG) ? attruid : p->uid),
+		                                        ((setmask & SET_GID_FLAG) ? attrgid : p->gid));
 	}
 	if (setmask & SET_ATIME_NOW_FLAG) {
 		p->atime = ts;
@@ -893,8 +915,9 @@ uint8_t FilesystemOperationsBase::setAttr(const FsContext &context, inode_t inod
 	}
 	changeLog(ts, "ATTR(%" PRIiNode ",%d,%" PRIu32 ",%" PRIu32 ",%" PRIu32 ",%" PRIu32 ")", p->id,
 	          p->mode & 07777, p->uid, p->gid, p->atime, p->mtime);
-	fsnodes_update_ctime(p, ts);
-	fsnodes_fill_attr(p, NULL, context.uid(), context.gid(), context.auid(), context.agid(), context.sesflags(), attr);
+	nodeOperations_->fsnodes_update_ctime(p, ts);
+	nodeOperations_->fsnodes_fill_attr(p, NULL, context.uid(), context.gid(), context.auid(),
+	                                   context.agid(), context.sesflags(), attr);
 	fsnodes_update_checksum(p);
 	incrementFSStat(FsStats::Setattr);
 	metrics::Counter::increment(metrics::Counter::Master::FS_SETATTR);
@@ -905,7 +928,7 @@ uint8_t FilesystemOperationsBase::setAttr(const FsContext &context, inode_t inod
 uint8_t FilesystemOperationsBase::applyAttr(uint32_t timestamp, inode_t inode, uint32_t mode,
                                             uint32_t uid, uint32_t gid, uint32_t atime,
                                             uint32_t mtime) {
-	FSNode *p = fsnodes_id_to_node(inode);
+	FSNode *p = nodeOperations_->fsnodes_id_to_node(inode);
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
@@ -914,12 +937,10 @@ uint8_t FilesystemOperationsBase::applyAttr(uint32_t timestamp, inode_t inode, u
 	}
 	p->mode = mode | (p->mode & 0xF000);
 	gMetadata->aclStorage.setMode(p->id, p->mode, p->type == FSNodeType::kDirectory);
-	if (p->uid != uid || p->gid != gid) {
-		fsnodes_change_uid_gid(p, uid, gid);
-	}
+	if (p->uid != uid || p->gid != gid) { nodeOperations_->fsnodes_change_uid_gid(p, uid, gid); }
 	p->atime = atime;
 	p->mtime = mtime;
-	fsnodes_update_ctime(p, timestamp);
+	nodeOperations_->fsnodes_update_ctime(p, timestamp);
 	fsnodes_update_checksum(p);
 	gMetadata->metadataVersion++;
 	return SAUNAFS_STATUS_OK;
@@ -927,7 +948,7 @@ uint8_t FilesystemOperationsBase::applyAttr(uint32_t timestamp, inode_t inode, u
 
 uint8_t FilesystemOperationsBase::applyLength(uint32_t timestamp, inode_t inode, uint64_t length,
                                               bool eraseFurtherChunks) {
-	FSNode *p = fsnodes_id_to_node(inode);
+	FSNode *p = nodeOperations_->fsnodes_id_to_node(inode);
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
@@ -935,9 +956,9 @@ uint8_t FilesystemOperationsBase::applyLength(uint32_t timestamp, inode_t inode,
 	    p->type != FSNodeType::kReserved) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
-	fsnodes_setlength(static_cast<FSNodeFile *>(p), length, eraseFurtherChunks);
+	nodeOperations_->fsnodes_setlength(static_cast<FSNodeFile *>(p), length, eraseFurtherChunks);
 	p->mtime = timestamp;
-	fsnodes_update_ctime(p, timestamp);
+	nodeOperations_->fsnodes_update_ctime(p, timestamp);
 	fsnodes_update_checksum(p);
 	gMetadata->metadataVersion++;
 	return SAUNAFS_STATUS_OK;
@@ -961,13 +982,14 @@ uint8_t FilesystemOperationsBase::readlink(const FsContext &context, inode_t ino
 	ChecksumUpdater cu(ts);
 	FSNode *p = NULL;
 
-	uint8_t status = verify_session(context, OperationMode::kReadOnly, SessionType::kNotMeta);
+	uint8_t status =
+	    nodeOperations_->verify_session(context, OperationMode::kReadOnly, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny, MODE_MASK_EMPTY,
-	                                        inode, &p);
+	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny,
+	                                                         MODE_MASK_EMPTY, inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
@@ -988,12 +1010,13 @@ uint8_t FilesystemOperationsBase::symlink(const FsContext &context, inode_t pare
                                           inode_t *inode, Attributes *attr) {
 	ChecksumUpdater cu(context.ts());
 	FSNode *wd;
-	uint8_t status = verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
+	uint8_t status =
+	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kDirectory, MODE_MASK_W,
-	                                        parent, &wd);
+	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kDirectory,
+	                                                         MODE_MASK_W, parent, &wd);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
@@ -1005,10 +1028,8 @@ uint8_t FilesystemOperationsBase::symlink(const FsContext &context, inode_t pare
 			return SAUNAFS_ERROR_EINVAL;
 		}
 	}
-	if (fsnodes_namecheck(name) < 0) {
-		return SAUNAFS_ERROR_EINVAL;
-	}
-	if (fsnodes_nameisused(static_cast<FSNodeDirectory*>(wd), name)) {
+	if (nodeOperations_->fsnodes_namecheck(name) < 0) { return SAUNAFS_ERROR_EINVAL; }
+	if (nodeOperations_->fsnodes_nameisused(static_cast<FSNodeDirectory *>(wd), name)) {
 		return SAUNAFS_ERROR_EEXIST;
 	}
 	if (context.isPersonalityMaster() &&
@@ -1016,7 +1037,7 @@ uint8_t FilesystemOperationsBase::symlink(const FsContext &context, inode_t pare
 	     fsnodes_quota_exceeded_dir(wd, {{QuotaResource::kInodes, 1}}))) {
 		return SAUNAFS_ERROR_QUOTA;
 	}
-	FSNodeSymlink *p = static_cast<FSNodeSymlink *>(fsnodes_create_node(
+	FSNodeSymlink *p = static_cast<FSNodeSymlink *>(nodeOperations_->fsnodes_create_node(
 	    context.ts(), static_cast<FSNodeDirectory *>(wd), name, FSNodeType::kSymlink, 0777, 0,
 	    context.uid(), context.gid(), 0, AclInheritance::kDontInheritAcl, *inode));
 	p->path = HString(path);
@@ -1025,16 +1046,15 @@ uint8_t FilesystemOperationsBase::symlink(const FsContext &context, inode_t pare
 	StatsRecord sr;
 	memset(&sr, 0, sizeof(StatsRecord));
 	sr.length = path.length();
-	fsnodes_add_stats(static_cast<FSNodeDirectory *>(wd), &sr);
-	if (attr != NULL) {
-		fsnodes_fill_attr(context, p, wd, *attr);
-	}
+	nodeOperations_->fsnodes_add_stats(static_cast<FSNodeDirectory *>(wd), &sr);
+	if (attr != NULL) { nodeOperations_->fsnodes_fill_attr(context, p, wd, *attr); }
 	if (context.isPersonalityMaster()) {
 		assert(*inode == 0);
 		*inode = p->id;
 		changeLog(context.ts(), "SYMLINK(%" PRIiNode ",%s,%s,%" PRIu32 ",%" PRIu32 "):%" PRIiNode,
-		          wd->id, fsnodes_escape_name(name).c_str(), fsnodes_escape_name(path).c_str(),
-		          context.uid(), context.gid(), p->id);
+		          wd->id, nodeOperations_->fsnodes_escape_name(name).c_str(),
+		          nodeOperations_->fsnodes_escape_name(path).c_str(), context.uid(), context.gid(),
+		          p->id);
 	} else {
 		if (*inode != p->id) {
 			return SAUNAFS_ERROR_MISMATCH;
@@ -1059,7 +1079,8 @@ uint8_t FilesystemOperationsBase::mknod(const FsContext &context, inode_t parent
 	*inode = 0;
 	attr.fill(0);
 
-	uint8_t status = verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
+	uint8_t status =
+	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
@@ -1069,16 +1090,14 @@ uint8_t FilesystemOperationsBase::mknod(const FsContext &context, inode_t parent
 		return SAUNAFS_ERROR_EINVAL;
 	}
 
-	status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kDirectory, MODE_MASK_W,
-	                                        parent, &wd);
+	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kDirectory,
+	                                                         MODE_MASK_W, parent, &wd);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	if (fsnodes_namecheck(name) < 0) {
-		return SAUNAFS_ERROR_EINVAL;
-	}
-	if (fsnodes_nameisused(static_cast<FSNodeDirectory*>(wd), name)) {
+	if (nodeOperations_->fsnodes_namecheck(name) < 0) { return SAUNAFS_ERROR_EINVAL; }
+	if (nodeOperations_->fsnodes_nameisused(static_cast<FSNodeDirectory *>(wd), name)) {
 		return SAUNAFS_ERROR_EEXIST;
 	}
 	if (fsnodes_quota_exceeded_ug(context.uid(), context.gid(), {{QuotaResource::kInodes, 1}}) ||
@@ -1088,16 +1107,18 @@ uint8_t FilesystemOperationsBase::mknod(const FsContext &context, inode_t parent
 
 	static_cast<FSNodeDirectory *>(wd)->case_insensitive =
 	    context.sesflags() & SESFLAG_CASEINSENSITIVE;
-	p = fsnodes_create_node(ts, static_cast<FSNodeDirectory*>(wd), name, type, mode, umask, context.uid(), context.gid(), 0,
-	                        AclInheritance::kInheritAcl);
+	p = nodeOperations_->fsnodes_create_node(ts, static_cast<FSNodeDirectory *>(wd), name, type,
+	                                         mode, umask, context.uid(), context.gid(), 0,
+	                                         AclInheritance::kInheritAcl);
 	if (type == FSNodeType::kBlockDev || type == FSNodeType::kCharDev) {
 		static_cast<FSNodeDevice*>(p)->rdev = rdev;
 	}
 	*inode = p->id;
-	fsnodes_fill_attr(p, wd, context.uid(), context.gid(), context.auid(), context.agid(), context.sesflags(), attr);
+	nodeOperations_->fsnodes_fill_attr(p, wd, context.uid(), context.gid(), context.auid(),
+	                                   context.agid(), context.sesflags(), attr);
 	changeLog(ts, "CREATE(%" PRIiNode ",%s,%c,%d,%" PRIu32 ",%" PRIu32 ",%" PRIu32 "):%" PRIiNode,
-	          wd->id, fsnodes_escape_name(name).c_str(), static_cast<char>(type), p->mode & 07777,
-	          context.uid(), context.gid(), rdev, p->id);
+	          wd->id, nodeOperations_->fsnodes_escape_name(name).c_str(), static_cast<char>(type),
+	          p->mode & 07777, context.uid(), context.gid(), rdev, p->id);
 	incrementFSStat(FsStats::Mknod);
 	metrics::Counter::increment(metrics::Counter::Master::FS_MKNOD);
 	fsnodes_update_checksum(p);
@@ -1113,21 +1134,20 @@ uint8_t FilesystemOperationsBase::mkdir(const FsContext &context, inode_t parent
 	*inode = 0;
 	attr.fill(0);
 
-	uint8_t status = verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
+	uint8_t status =
+	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kDirectory, MODE_MASK_W,
-	                                        parent, &wd);
+	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kDirectory,
+	                                                         MODE_MASK_W, parent, &wd);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	if (fsnodes_namecheck(name) < 0) {
-		return SAUNAFS_ERROR_EINVAL;
-	}
-	if (fsnodes_nameisused(static_cast<FSNodeDirectory*>(wd), name)) {
+	if (nodeOperations_->fsnodes_namecheck(name) < 0) { return SAUNAFS_ERROR_EINVAL; }
+	if (nodeOperations_->fsnodes_nameisused(static_cast<FSNodeDirectory *>(wd), name)) {
 		return SAUNAFS_ERROR_EEXIST;
 	}
 	if (fsnodes_quota_exceeded_ug(context.uid(), context.gid(), {{QuotaResource::kInodes, 1}}) ||
@@ -1144,15 +1164,16 @@ uint8_t FilesystemOperationsBase::mkdir(const FsContext &context, inode_t parent
 
 	static_cast<FSNodeDirectory *>(wd)->case_insensitive =
 	    context.sesflags() & SESFLAG_CASEINSENSITIVE;
-	p = fsnodes_create_node(ts, static_cast<FSNodeDirectory *>(wd), name, FSNodeType::kDirectory,
-	                        mode, umask, context.uid(), context.gid(), copysgid,
-	                        AclInheritance::kInheritAcl);
+	p = nodeOperations_->fsnodes_create_node(ts, static_cast<FSNodeDirectory *>(wd), name,
+	                                         FSNodeType::kDirectory, mode, umask, context.uid(),
+	                                         context.gid(), copysgid, AclInheritance::kInheritAcl);
 	*inode = p->id;
-	fsnodes_fill_attr(p, wd, context.uid(), context.gid(), context.auid(), context.agid(),
-	                  context.sesflags(), attr);
+	nodeOperations_->fsnodes_fill_attr(p, wd, context.uid(), context.gid(), context.auid(),
+	                                   context.agid(), context.sesflags(), attr);
 	changeLog(ts, "CREATE(%" PRIiNode ",%s,%c,%d,%" PRIu32 ",%" PRIu32 ",%" PRIu32 "):%" PRIiNode,
-	          wd->id, fsnodes_escape_name(name).c_str(), static_cast<char>(FSNodeType::kDirectory),
-	          p->mode & 07777, context.uid(), context.gid(), 0, p->id);
+	          wd->id, nodeOperations_->fsnodes_escape_name(name).c_str(),
+	          static_cast<char>(FSNodeType::kDirectory), p->mode & 07777, context.uid(),
+	          context.gid(), 0, p->id);
 	incrementFSStat(FsStats::Mkdir);
 	metrics::Counter::increment(metrics::Counter::Master::FS_MKDIR);
 	return SAUNAFS_STATUS_OK;
@@ -1169,19 +1190,20 @@ uint8_t FilesystemOperationsBase::applyCreate(uint32_t timestamp, inode_t parent
 	    type != FSNodeType::kDirectory) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
-	wd = fsnodes_id_to_node(parent);
+	wd = nodeOperations_->fsnodes_id_to_node(parent);
 	if (!wd) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
 	if (wd->type != FSNodeType::kDirectory) {
 		return SAUNAFS_ERROR_ENOTDIR;
 	}
-	if (fsnodes_nameisused(static_cast<FSNodeDirectory*>(wd), name)) {
+	if (nodeOperations_->fsnodes_nameisused(static_cast<FSNodeDirectory *>(wd), name)) {
 		return SAUNAFS_ERROR_EEXIST;
 	}
 	// we pass requested inode number here
-	p = fsnodes_create_node(timestamp, static_cast<FSNodeDirectory *>(wd), name, type, mode, 0, uid,
-	                        gid, 0, AclInheritance::kInheritAcl, inode);
+	p = nodeOperations_->fsnodes_create_node(timestamp, static_cast<FSNodeDirectory *>(wd), name,
+	                                         type, mode, 0, uid, gid, 0,
+	                                         AclInheritance::kInheritAcl, inode);
 	if (type == FSNodeType::kBlockDev || type == FSNodeType::kCharDev) {
 		static_cast<FSNodeDevice*>(p)->rdev = rdev;
 		fsnodes_update_checksum(p);
@@ -1201,33 +1223,32 @@ uint8_t FilesystemOperationsBase::unlink(const FsContext &context, inode_t paren
 	ChecksumUpdater cu(ts);
 	FSNode *wd;
 
-	uint8_t status = verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
+	uint8_t status =
+	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kDirectory, MODE_MASK_W,
-	                                        parent, &wd);
+	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kDirectory,
+	                                                         MODE_MASK_W, parent, &wd);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	if (fsnodes_namecheck(name) < 0) {
-		return SAUNAFS_ERROR_EINVAL;
-	}
-	FSNode *child = fsnodes_lookup(static_cast<FSNodeDirectory*>(wd), name);
+	if (nodeOperations_->fsnodes_namecheck(name) < 0) { return SAUNAFS_ERROR_EINVAL; }
+	FSNode *child = nodeOperations_->fsnodes_lookup(static_cast<FSNodeDirectory *>(wd), name);
 	if (!child) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
-	if (!fsnodes_sticky_access(wd, child, context.uid())) {
+	if (!nodeOperations_->fsnodes_sticky_access(wd, child, context.uid())) {
 		return SAUNAFS_ERROR_EPERM;
 	}
 	if (child->type == FSNodeType::kDirectory) {
 		return SAUNAFS_ERROR_EPERM;
 	}
-	changeLog(ts, "UNLINK(%" PRIiNode ",%s):%" PRIiNode, wd->id, fsnodes_escape_name(name).c_str(),
-	          child->id);
-	fsnodes_unlink(ts, static_cast<FSNodeDirectory*>(wd), name, child);
+	changeLog(ts, "UNLINK(%" PRIiNode ",%s):%" PRIiNode, wd->id,
+	          nodeOperations_->fsnodes_escape_name(name).c_str(), child->id);
+	nodeOperations_->fsnodes_unlink(ts, static_cast<FSNodeDirectory *>(wd), name, child);
 	incrementFSStat(FsStats::Unlink);
 	metrics::Counter::increment(metrics::Counter::Master::FS_UNLINK);
 	return SAUNAFS_STATUS_OK;
@@ -1240,17 +1261,18 @@ uint8_t FilesystemOperationsBase::recursiveRemove(const FsContext &context, inod
 	ChecksumUpdater cu(context.ts());
 	FSNode *wd_tmp;
 
-	uint8_t status = verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
+	uint8_t status =
+	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kDirectory, MODE_MASK_W,
-	                                        parent, &wd_tmp);
+	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kDirectory,
+	                                                         MODE_MASK_W, parent, &wd_tmp);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	FSNode *child = fsnodes_lookup(static_cast<FSNodeDirectory*>(wd_tmp), name);
+	FSNode *child = nodeOperations_->fsnodes_lookup(static_cast<FSNodeDirectory *>(wd_tmp), name);
 	if (!child) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
@@ -1260,7 +1282,7 @@ uint8_t FilesystemOperationsBase::recursiveRemove(const FsContext &context, inod
 
 	std::string node_name;
 
-	fsnodes_getpath(static_cast<FSNodeDirectory*>(wd_tmp), child, node_name);
+	nodeOperations_->fsnodes_getpath(static_cast<FSNodeDirectory *>(wd_tmp), child, node_name);
 	return gMetadata->taskManager.submitTask(job_id, context.ts(), kInitialTaskBatchSize,
 	                                          task, RemoveTask::generateDescription(node_name),
 	                                          callback);
@@ -1272,25 +1294,24 @@ uint8_t FilesystemOperationsBase::rmdir(const FsContext &context, inode_t parent
 	ChecksumUpdater cu(ts);
 	FSNode *wd;
 
-	uint8_t status = verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
+	uint8_t status =
+	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kDirectory, MODE_MASK_W,
-	                                        parent, &wd);
+	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kDirectory,
+	                                                         MODE_MASK_W, parent, &wd);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	if (fsnodes_namecheck(name) < 0) {
-		return SAUNAFS_ERROR_EINVAL;
-	}
-	FSNode *child = fsnodes_lookup(static_cast<FSNodeDirectory*>(wd), name);
+	if (nodeOperations_->fsnodes_namecheck(name) < 0) { return SAUNAFS_ERROR_EINVAL; }
+	FSNode *child = nodeOperations_->fsnodes_lookup(static_cast<FSNodeDirectory *>(wd), name);
 	if (!child) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
-	if (!fsnodes_sticky_access(wd, child, context.uid())) {
+	if (!nodeOperations_->fsnodes_sticky_access(wd, child, context.uid())) {
 		return SAUNAFS_ERROR_EPERM;
 	}
 	if (child->type != FSNodeType::kDirectory) {
@@ -1299,9 +1320,9 @@ uint8_t FilesystemOperationsBase::rmdir(const FsContext &context, inode_t parent
 	if (!static_cast<FSNodeDirectory*>(child)->entries.empty()) {
 		return SAUNAFS_ERROR_ENOTEMPTY;
 	}
-	changeLog(ts, "UNLINK(%" PRIiNode ",%s):%" PRIiNode, wd->id, fsnodes_escape_name(name).c_str(),
-	          child->id);
-	fsnodes_unlink(ts, static_cast<FSNodeDirectory*>(wd), name, child);
+	changeLog(ts, "UNLINK(%" PRIiNode ",%s):%" PRIiNode, wd->id,
+	          nodeOperations_->fsnodes_escape_name(name).c_str(), child->id);
+	nodeOperations_->fsnodes_unlink(ts, static_cast<FSNodeDirectory *>(wd), name, child);
 	incrementFSStat(FsStats::Rmdir);
 	metrics::Counter::increment(metrics::Counter::Master::FS_RMDIR);
 	return SAUNAFS_STATUS_OK;
@@ -1311,14 +1332,14 @@ uint8_t FilesystemOperationsBase::rmdir(const FsContext &context, inode_t parent
 uint8_t FilesystemOperationsBase::applyUnlink(uint32_t timestamp, inode_t parent,
                                               const HString &name, inode_t inode) {
 	FSNode *wd;
-	wd = fsnodes_id_to_node(parent);
+	wd = nodeOperations_->fsnodes_id_to_node(parent);
 	if (!wd) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
 	if (wd->type != FSNodeType::kDirectory) {
 		return SAUNAFS_ERROR_ENOTDIR;
 	}
-	FSNode *child = fsnodes_lookup(static_cast<FSNodeDirectory*>(wd), name);
+	FSNode *child = nodeOperations_->fsnodes_lookup(static_cast<FSNodeDirectory *>(wd), name);
 	if (!child) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
@@ -1329,7 +1350,7 @@ uint8_t FilesystemOperationsBase::applyUnlink(uint32_t timestamp, inode_t parent
 	    !static_cast<FSNodeDirectory *>(child)->entries.empty()) {
 		return SAUNAFS_ERROR_ENOTEMPTY;
 	}
-	fsnodes_unlink(timestamp, static_cast<FSNodeDirectory*>(wd), name, child);
+	nodeOperations_->fsnodes_unlink(timestamp, static_cast<FSNodeDirectory *>(wd), name, child);
 	gMetadata->metadataVersion++;
 	return SAUNAFS_STATUS_OK;
 }
@@ -1341,28 +1362,29 @@ uint8_t FilesystemOperationsBase::rename(const FsContext &context, inode_t paren
 	ChecksumUpdater cu(context.ts());
 	FSNode *swd;
 	FSNode *dwd;
-	uint8_t status = verify_session(context, OperationMode::kReadWrite, SessionType::kAny);
+	uint8_t status =
+	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kAny);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kDirectory, MODE_MASK_W,
-	                                        parent_dst, &dwd);
+	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kDirectory,
+	                                                         MODE_MASK_W, parent_dst, &dwd);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kDirectory, MODE_MASK_W,
-	                                        parent_src, &swd);
+	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kDirectory,
+	                                                         MODE_MASK_W, parent_src, &swd);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	if (fsnodes_namecheck(name_src) < 0) {
-		return SAUNAFS_ERROR_EINVAL;
-	}
-	FSNode *se_child = fsnodes_lookup(static_cast<FSNodeDirectory*>(swd), name_src);
+	if (nodeOperations_->fsnodes_namecheck(name_src) < 0) { return SAUNAFS_ERROR_EINVAL; }
+	FSNode *se_child =
+	    nodeOperations_->fsnodes_lookup(static_cast<FSNodeDirectory *>(swd), name_src);
 	if (!se_child) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
-	if (context.canCheckPermissions() && !fsnodes_sticky_access(swd, se_child, context.uid())) {
+	if (context.canCheckPermissions() &&
+	    !nodeOperations_->fsnodes_sticky_access(swd, se_child, context.uid())) {
 		return SAUNAFS_ERROR_EPERM;
 	}
 	if ((context.personality() != metadataserver::Personality::kMaster) &&
@@ -1373,18 +1395,17 @@ uint8_t FilesystemOperationsBase::rename(const FsContext &context, inode_t paren
 	}
 	std::array<int64_t, 2> quota_delta = {{1, 1}};
 	if (se_child->type == FSNodeType::kDirectory) {
-		if (fsnodes_isancestor(static_cast<FSNodeDirectory*>(se_child), dwd)) {
+		if (nodeOperations_->fsnodes_isancestor(static_cast<FSNodeDirectory *>(se_child), dwd)) {
 			return SAUNAFS_ERROR_EINVAL;
 		}
 		const StatsRecord &stats = static_cast<FSNodeDirectory*>(se_child)->stats;
 		quota_delta = {{(int64_t)stats.inodes, (int64_t)stats.size}};
 	} else if (se_child->type == FSNodeType::kFile) {
-		quota_delta[(int)QuotaResource::kSize] = fsnodes_get_size(se_child);
+		quota_delta[(int)QuotaResource::kSize] = nodeOperations_->fsnodes_get_size(se_child);
 	}
-	if (fsnodes_namecheck(name_dst) < 0) {
-		return SAUNAFS_ERROR_EINVAL;
-	}
-	FSNode *de_child = fsnodes_lookup(static_cast<FSNodeDirectory*>(dwd), name_dst);
+	if (nodeOperations_->fsnodes_namecheck(name_dst) < 0) { return SAUNAFS_ERROR_EINVAL; }
+	FSNode *de_child =
+	    nodeOperations_->fsnodes_lookup(static_cast<FSNodeDirectory *>(dwd), name_dst);
 
 	if (de_child == se_child) {
 		return SAUNAFS_STATUS_OK;
@@ -1396,7 +1417,7 @@ uint8_t FilesystemOperationsBase::rename(const FsContext &context, inode_t paren
 			return SAUNAFS_ERROR_ENOTEMPTY;
 		}
 		if (context.canCheckPermissions() &&
-		    !fsnodes_sticky_access(dwd, de_child, context.uid())) {
+		    !nodeOperations_->fsnodes_sticky_access(dwd, de_child, context.uid())) {
 			return SAUNAFS_ERROR_EPERM;
 		}
 		if (de_child->type == FSNodeType::kDirectory) {
@@ -1405,7 +1426,8 @@ uint8_t FilesystemOperationsBase::rename(const FsContext &context, inode_t paren
 			quota_delta[(int)QuotaResource::kSize] -= stats.size;
 		} else if (de_child->type == FSNodeType::kFile) {
 			quota_delta[(int)QuotaResource::kInodes] -= 1;
-			quota_delta[(int)QuotaResource::kSize] -= fsnodes_get_size(static_cast<FSNodeFile*>(de_child));
+			quota_delta[(int)QuotaResource::kSize] -=
+			    nodeOperations_->fsnodes_get_size(static_cast<FSNodeFile *>(de_child));
 		} else {
 			quota_delta[(int)QuotaResource::kInodes] -= 1;
 			quota_delta[(int)QuotaResource::kSize] -= 1;
@@ -1420,17 +1442,18 @@ uint8_t FilesystemOperationsBase::rename(const FsContext &context, inode_t paren
 	}
 
 	if (de_child) {
-		fsnodes_unlink(context.ts(), static_cast<FSNodeDirectory*>(dwd), name_dst, de_child);
+		nodeOperations_->fsnodes_unlink(context.ts(), static_cast<FSNodeDirectory *>(dwd), name_dst,
+		                                de_child);
 	}
-	fsnodes_remove_edge(context.ts(), static_cast<FSNodeDirectory*>(swd), name_src, se_child);
-	fsnodes_link(context.ts(), static_cast<FSNodeDirectory*>(dwd), se_child, name_dst);
-	if (attr) {
-		fsnodes_fill_attr(context, se_child, dwd, *attr);
-	}
+	nodeOperations_->fsnodes_remove_edge(context.ts(), static_cast<FSNodeDirectory *>(swd),
+	                                     name_src, se_child);
+	nodeOperations_->fsnodes_link(context.ts(), static_cast<FSNodeDirectory *>(dwd), se_child,
+	                              name_dst);
+	if (attr) { nodeOperations_->fsnodes_fill_attr(context, se_child, dwd, *attr); }
 	if (context.isPersonalityMaster()) {
 		changeLog(context.ts(), "MOVE(%" PRIiNode ",%s,%" PRIiNode ",%s):%" PRIiNode, swd->id,
-		          fsnodes_escape_name(name_src).c_str(), dwd->id,
-		          fsnodes_escape_name(name_dst).c_str(), se_child->id);
+		          nodeOperations_->fsnodes_escape_name(name_src).c_str(), dwd->id,
+		          nodeOperations_->fsnodes_escape_name(name_dst).c_str(), se_child->id);
 	} else {
 		gMetadata->metadataVersion++;
 	}
@@ -1447,39 +1470,36 @@ uint8_t FilesystemOperationsBase::link(const FsContext &context, inode_t inode_s
 	ChecksumUpdater cu(context.ts());
 	FSNode *sp;
 	FSNode *dwd;
-	uint8_t status = verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
+	uint8_t status =
+	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kDirectory, MODE_MASK_W,
-	                                        parent_dst, &dwd);
+	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kDirectory,
+	                                                         MODE_MASK_W, parent_dst, &dwd);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kNotDirectory,
-	                                        MODE_MASK_EMPTY, inode_src, &sp);
+	status = nodeOperations_->fsnodes_get_node_for_operation(
+	    context, ExpectedNodeType::kNotDirectory, MODE_MASK_EMPTY, inode_src, &sp);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 	if (sp->type == FSNodeType::kTrash || sp->type == FSNodeType::kReserved) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
-	if (fsnodes_namecheck(name_dst) < 0) {
-		return SAUNAFS_ERROR_EINVAL;
-	}
-	if (fsnodes_nameisused(static_cast<FSNodeDirectory*>(dwd), name_dst)) {
+	if (nodeOperations_->fsnodes_namecheck(name_dst) < 0) { return SAUNAFS_ERROR_EINVAL; }
+	if (nodeOperations_->fsnodes_nameisused(static_cast<FSNodeDirectory *>(dwd), name_dst)) {
 		return SAUNAFS_ERROR_EEXIST;
 	}
-	fsnodes_link(context.ts(), static_cast<FSNodeDirectory*>(dwd), sp, name_dst);
+	nodeOperations_->fsnodes_link(context.ts(), static_cast<FSNodeDirectory *>(dwd), sp, name_dst);
 	if (inode) {
 		*inode = inode_src;
 	}
-	if (attr) {
-		fsnodes_fill_attr(context, sp, dwd, *attr);
-	}
+	if (attr) { nodeOperations_->fsnodes_fill_attr(context, sp, dwd, *attr); }
 	if (context.isPersonalityMaster()) {
 		changeLog(context.ts(), "LINK(%" PRIiNode ",%" PRIiNode ",%s)", sp->id, dwd->id,
-		          fsnodes_escape_name(name_dst).c_str());
+		          nodeOperations_->fsnodes_escape_name(name_dst).c_str());
 	} else {
 		gMetadata->metadataVersion++;
 	}
@@ -1497,24 +1517,26 @@ uint8_t FilesystemOperationsBase::append(const FsContext &context, inode_t inode
 	if (inode == inode_src) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
-	uint8_t status = verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
+	uint8_t status =
+	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kFile, MODE_MASK_W,
-	                                        inode, &p);
+	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kFile,
+	                                                         MODE_MASK_W, inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kFile, MODE_MASK_R,
-	                                        inode_src, &sp);
+	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kFile,
+	                                                         MODE_MASK_R, inode_src, &sp);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 	if (context.isPersonalityMaster() && fsnodes_quota_exceeded(p, {{QuotaResource::kSize, 1}})) {
 		return SAUNAFS_ERROR_QUOTA;
 	}
-	status = fsnodes_appendchunks(context.ts(), static_cast<FSNodeFile*>(p), static_cast<FSNodeFile*>(sp));
+	status = nodeOperations_->fsnodes_appendchunks(context.ts(), static_cast<FSNodeFile *>(p),
+	                                               static_cast<FSNodeFile *>(sp));
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
@@ -1536,7 +1558,8 @@ static int fsnodes_check_lock_permissions(const FsContext &context, inode_t inod
 		modemask = MODE_MASK_R;
 	}
 
-	return fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny, modemask, inode, &dummy);
+	return gFSOperations->nodeOperations()->fsnodes_get_node_for_operation(
+	    context, ExpectedNodeType::kAny, modemask, inode, &dummy);
 }
 
 int FilesystemOperationsBase::posixLockProbe(const FsContext &context, inode_t inode,
@@ -1826,19 +1849,21 @@ uint8_t FilesystemOperationsBase::readdirSize(const FsContext &context, inode_t 
 	*dnode = NULL;
 	*dbuffsize = 0;
 
-	uint8_t status = verify_session(context, OperationMode::kReadOnly, SessionType::kNotMeta);
+	uint8_t status =
+	    nodeOperations_->verify_session(context, OperationMode::kReadOnly, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kDirectory, MODE_MASK_R,
-	                                        inode, &p);
+	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kDirectory,
+	                                                         MODE_MASK_R, inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
 	*dnode = p;
-	*dbuffsize = fsnodes_getdirsize(static_cast<FSNodeDirectory*>(p), flags & GETDIR_FLAG_WITHATTR);
+	*dbuffsize = nodeOperations_->fsnodes_getdirsize(static_cast<FSNodeDirectory *>(p),
+	                                                 flags & GETDIR_FLAG_WITHATTR);
 	return SAUNAFS_STATUS_OK;
 }
 
@@ -1848,9 +1873,9 @@ void FilesystemOperationsBase::readdirData(const FsContext &context, uint8_t fla
 	ChecksumUpdater cu(ts);
 	FSNode *p = (FSNode *)dnode;
 	fs_update_atime(p, ts);
-	fsnodes_getdirdata(context.rootinode(), context.uid(), context.gid(), context.auid(), context.agid(),
-					   context.sesflags(), static_cast<FSNodeDirectory*>(p), dbuff,
-	                   flags & GETDIR_FLAG_WITHATTR);
+	nodeOperations_->fsnodes_getdirdata(
+	    context.rootinode(), context.uid(), context.gid(), context.auid(), context.agid(),
+	    context.sesflags(), static_cast<FSNodeDirectory *>(p), dbuff, flags & GETDIR_FLAG_WITHATTR);
 	incrementFSStat(FsStats::Readdir);
 	metrics::Counter::increment(metrics::Counter::Master::FS_READDIR);
 }
@@ -1858,14 +1883,15 @@ void FilesystemOperationsBase::readdirData(const FsContext &context, uint8_t fla
 uint8_t FilesystemOperationsBase::readdir(const FsContext &context, inode_t inode,
                                           uint64_t first_entry, uint64_t number_of_entries,
                                           std::vector<DirectoryEntry> &dir_entries) {
-	uint8_t status = verify_session(context, OperationMode::kReadOnly, SessionType::kNotMeta);
+	uint8_t status =
+	    nodeOperations_->verify_session(context, OperationMode::kReadOnly, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
 	FSNode *dir;
-	status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kDirectory, MODE_MASK_R,
-	                                        inode, &dir);
+	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kDirectory,
+	                                                         MODE_MASK_R, inode, &dir);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
@@ -1875,10 +1901,10 @@ uint8_t FilesystemOperationsBase::readdir(const FsContext &context, inode_t inod
 
 	fs_update_atime(dir, ts);
 
-	fsnodes_getdir(context.rootinode(),
-		       context.uid(), context.gid(), context.auid(), context.agid(), context.sesflags(),
-		       static_cast<FSNodeDirectory*>(dir),
-		       first_entry, number_of_entries, dir_entries);
+	nodeOperations_->fsnodes_getdir(context.rootinode(), context.uid(), context.gid(),
+	                                context.auid(), context.agid(), context.sesflags(),
+	                                static_cast<FSNodeDirectory *>(dir), first_entry,
+	                                number_of_entries, dir_entries);
 
 	incrementFSStat(FsStats::Readdir);
 	metrics::Counter::increment(metrics::Counter::Master::FS_READDIR);
@@ -1890,18 +1916,19 @@ uint8_t FilesystemOperationsBase::checkFile(const FsContext &context, inode_t in
                                             uint32_t chunkcount[CHUNK_MATRIX_SIZE]) {
 	FSNode *p;
 
-	uint8_t status = verify_session(context, OperationMode::kReadOnly, SessionType::kAny);
+	uint8_t status =
+	    nodeOperations_->verify_session(context, OperationMode::kReadOnly, SessionType::kAny);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kFile, MODE_MASK_EMPTY,
-	                                        inode, &p);
+	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kFile,
+	                                                         MODE_MASK_EMPTY, inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	fsnodes_checkfile(static_cast<FSNodeFile*>(p), chunkcount);
+	nodeOperations_->fsnodes_checkfile(static_cast<FSNodeFile *>(p), chunkcount);
 	return SAUNAFS_STATUS_OK;
 }
 
@@ -1909,13 +1936,15 @@ uint8_t FilesystemOperationsBase::openCheck(const FsContext &context, inode_t in
                                             Attributes &attr) {
 	FSNode *p;
 
-	uint8_t status = verify_session(context, (flags & WANT_WRITE) ? OperationMode::kReadWrite : OperationMode::kReadOnly, SessionType::kNotMeta);
+	uint8_t status = nodeOperations_->verify_session(
+	    context, (flags & WANT_WRITE) ? OperationMode::kReadWrite : OperationMode::kReadOnly,
+	    SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kFile, MODE_MASK_EMPTY,
-	                                        inode, &p);
+	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kFile,
+	                                                         MODE_MASK_EMPTY, inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
@@ -1928,11 +1957,10 @@ uint8_t FilesystemOperationsBase::openCheck(const FsContext &context, inode_t in
 		if (flags & WANT_WRITE) {
 			modemask |= MODE_MASK_W;
 		}
-		if (!fsnodes_access(context, p, modemask)) {
-			return SAUNAFS_ERROR_EACCES;
-		}
+		if (!nodeOperations_->fsnodes_access(context, p, modemask)) { return SAUNAFS_ERROR_EACCES; }
 	}
-	fsnodes_fill_attr(p, NULL, context.uid(), context.gid(), context.auid(), context.agid(), context.sesflags(), attr);
+	nodeOperations_->fsnodes_fill_attr(p, NULL, context.uid(), context.gid(), context.auid(),
+	                                   context.agid(), context.sesflags(), attr);
 	incrementFSStat(FsStats::Open);
 	metrics::Counter::increment(metrics::Counter::Master::FS_OPEN);
 	return SAUNAFS_STATUS_OK;
@@ -1947,7 +1975,7 @@ uint8_t FilesystemOperationsBase::acquire(const FsContext &context, inode_t inod
 		matoclserv_add_open_file(sessionid, inode);
 	}
 #endif /* #ifndef METARESTORE */
-	FSNodeFile *p = fsnodes_id_to_node<FSNodeFile>(inode);
+	FSNodeFile *p = nodeOperations_->fsnodes_id_to_node<FSNodeFile>(inode);
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
@@ -1971,7 +1999,7 @@ uint8_t FilesystemOperationsBase::acquire(const FsContext &context, inode_t inod
 uint8_t FilesystemOperationsBase::release(const FsContext &context, inode_t inode,
                                           uint32_t sessionid) {
 	ChecksumUpdater cu(context.ts());
-	FSNodeFile *p = fsnodes_id_to_node<FSNodeFile>(inode);
+	FSNodeFile *p = nodeOperations_->fsnodes_id_to_node<FSNodeFile>(inode);
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
@@ -1983,7 +2011,7 @@ uint8_t FilesystemOperationsBase::release(const FsContext &context, inode_t inod
 	if (it != p->sessionIds.end()) {
 		p->sessionIds.erase(it);
 		if (p->type == FSNodeType::kReserved && p->sessionIds.empty()) {
-			fsnodes_purge(context.ts(), p);
+			nodeOperations_->fsnodes_purge(context.ts(), p);
 		} else {
 			fsnodes_update_checksum(p);
 		}
@@ -2050,7 +2078,7 @@ uint8_t FilesystemOperationsBase::readChunk(inode_t inode, uint32_t indx, uint64
 
 	*chunkid = 0;
 	*length = 0;
-	p = fsnodes_id_to_node<FSNodeFile>(inode);
+	p = nodeOperations_->fsnodes_id_to_node<FSNodeFile>(inode);
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
@@ -2087,12 +2115,13 @@ uint8_t FilesystemOperationsBase::writeChunk(const FsContext &context, inode_t i
 	FSNode *node;
 	FSNodeFile *p;
 
-	uint8_t status = verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
+	uint8_t status =
+	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kFile, MODE_MASK_EMPTY,
-	                                        inode, &node);
+	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kFile,
+	                                                         MODE_MASK_EMPTY, inode, &node);
 	p = static_cast<FSNodeFile*>(node);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
@@ -2108,7 +2137,7 @@ uint8_t FilesystemOperationsBase::writeChunk(const FsContext &context, inode_t i
 
 	const bool quota_exceeded = fsnodes_quota_exceeded(p, {{QuotaResource::kSize, 1}});
 	StatsRecord psr;
-	fsnodes_get_stats(p, &psr);
+	nodeOperations_->fsnodes_get_stats(p, &psr);
 
 	/* resize chunks structure */
 	if (index >= p->chunks.size()) {
@@ -2154,10 +2183,10 @@ uint8_t FilesystemOperationsBase::writeChunk(const FsContext &context, inode_t i
 	p->chunks[index] = nchunkid;
 	*chunkid = nchunkid;
 	StatsRecord nsr;
-	fsnodes_get_stats(p, &nsr);
+	nodeOperations_->fsnodes_get_stats(p, &nsr);
 	for (const auto &[parentId, _] : p->parents) {
-		auto *parent = fsnodes_id_to_node_verify<FSNodeDirectory>(parentId);
-		fsnodes_add_sub_stats(parent, &nsr, &psr);
+		auto *parent = nodeOperations_->fsnodes_id_to_node_verify<FSNodeDirectory>(parentId);
+		nodeOperations_->fsnodes_add_sub_stats(parent, &nsr, &psr);
 	}
 	fsnodes_quota_update(p, {{QuotaResource::kSize, nsr.size - psr.size}});
 	if (length) {
@@ -2170,7 +2199,7 @@ uint8_t FilesystemOperationsBase::writeChunk(const FsContext &context, inode_t i
 		gMetadata->metadataVersion++;
 	}
 	p->mtime = context.ts();
-	fsnodes_update_ctime(p, context.ts());
+	nodeOperations_->fsnodes_update_ctime(p, context.ts());
 	fsnodes_update_checksum(p);
 #ifndef METARESTORE
 	incrementFSStat(FsStats::Write);
@@ -2189,7 +2218,7 @@ uint8_t FilesystemOperationsBase::writeEnd(inode_t inode, uint64_t length, uint6
 		return status;
 	}
 	if (length > 0) {
-		FSNodeFile *p = fsnodes_id_to_node<FSNodeFile>(inode);
+		FSNodeFile *p = nodeOperations_->fsnodes_id_to_node<FSNodeFile>(inode);
 		if (!p) {
 			return SAUNAFS_ERROR_ENOENT;
 		}
@@ -2203,9 +2232,9 @@ uint8_t FilesystemOperationsBase::writeEnd(inode_t inode, uint64_t length, uint6
 			// reason is that those might be done by other clients and we don't
 			// want to erase the chunks other clients are writing.
 			bool eraseFurtherChunks = false;
-			fsnodes_setlength(p, length, eraseFurtherChunks);
+			nodeOperations_->fsnodes_setlength(p, length, eraseFurtherChunks);
 			p->mtime = ts;
-			fsnodes_update_ctime(p, ts);
+			nodeOperations_->fsnodes_update_ctime(p, ts);
 			fsnodes_update_checksum(p);
 			changeLog(ts, "LENGTH(%" PRIiNode ",%" PRIu64 ",%" PRIu32 ")", inode, length,
 			          static_cast<uint32_t>(eraseFurtherChunks));
@@ -2237,15 +2266,16 @@ uint8_t FilesystemOperationsBase::removeChunkFromFile(const FsContext &context, 
 
 	if (chunkId == 0) { return SAUNAFS_ERROR_NOCHUNK; }
 
-	uint8_t status = verify_session(context, OperationMode::kReadWrite, SessionType::kAny);
+	uint8_t status =
+	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kAny);
 	if (status != SAUNAFS_STATUS_OK) { return status; }
 
-	status =
-	    fsnodes_get_node_for_operation(context, ExpectedNodeType::kFile, MODE_MASK_W, inode, &p);
+	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kFile,
+	                                                         MODE_MASK_W, inode, &p);
 	if (status != SAUNAFS_STATUS_OK) { return status; }
 
 	auto *node_file = dynamic_cast<FSNodeFile *>(p);
-	fsnodes_get_stats(p, &psr);
+	nodeOperations_->fsnodes_get_stats(p, &psr);
 	auto it = std::ranges::find(node_file->chunks, chunkId);
 	uint32_t indx = (it == node_file->chunks.end()) ? node_file->chunks.size()
 	                                                : std::distance(node_file->chunks.begin(), it);
@@ -2258,16 +2288,16 @@ uint8_t FilesystemOperationsBase::removeChunkFromFile(const FsContext &context, 
 
 	node_file->chunks[indx] = 0;
 	p->mtime = ts;
-	fsnodes_update_ctime(p, ts);
+	nodeOperations_->fsnodes_update_ctime(p, ts);
 
 	// Log the repair operation with new version 0 (indicating deletion)
 	uint32_t nversion = 0;
 	changeLog(ts, "REPAIR(%" PRIiNode ",%" PRIu32 "):%" PRIu32, inode, indx, nversion);
 
-	fsnodes_get_stats(p, &nsr);
+	nodeOperations_->fsnodes_get_stats(p, &nsr);
 	for (const auto &[parentId, _] : p->parents) {
-		auto *parent = fsnodes_id_to_node_verify<FSNodeDirectory>(parentId);
-		fsnodes_add_sub_stats(parent, &nsr, &psr);
+		auto *parent = nodeOperations_->fsnodes_id_to_node_verify<FSNodeDirectory>(parentId);
+		nodeOperations_->fsnodes_add_sub_stats(parent, &nsr, &psr);
 	}
 	fsnodes_quota_update(p, {{QuotaResource::kSize, nsr.size - psr.size}});
 	fsnodes_update_checksum(p);
@@ -2289,24 +2319,25 @@ uint8_t FilesystemOperationsBase::repair(const FsContext &context, inode_t inode
 	*erased = 0;
 	*repaired = 0;
 
-	uint8_t status = verify_session(context, OperationMode::kReadWrite, SessionType::kAny);
+	uint8_t status =
+	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kAny);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kFile, MODE_MASK_W,
-	                                        inode, &p);
+	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kFile,
+	                                                         MODE_MASK_W, inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
 	FSNodeFile *node_file = static_cast<FSNodeFile*>(p);
-	fsnodes_get_stats(p, &psr);
+	nodeOperations_->fsnodes_get_stats(p, &psr);
 	for (indx = 0; indx < node_file->chunks.size(); indx++) {
 		if (chunk_repair(p->goal, node_file->chunks[indx], &nversion, correct_only)) {
 			changeLog(ts, "REPAIR(%" PRIiNode ",%" PRIu32 "):%" PRIu32, inode, indx, nversion);
 			p->mtime = ts;
-			fsnodes_update_ctime(p, ts);
+			nodeOperations_->fsnodes_update_ctime(p, ts);
 			if (nversion > 0) {
 				(*repaired)++;
 			} else {
@@ -2317,11 +2348,11 @@ uint8_t FilesystemOperationsBase::repair(const FsContext &context, inode_t inode
 			(*notchanged)++;
 		}
 	}
-	fsnodes_get_stats(p, &nsr);
+	nodeOperations_->fsnodes_get_stats(p, &nsr);
 	for (const auto &[parentId, _] : p->parents) {
 		FSNodeDirectory *parent =
-		    fsnodes_id_to_node_verify<FSNodeDirectory>(parentId);
-		fsnodes_add_sub_stats(parent, &nsr, &psr);
+		    nodeOperations_->fsnodes_id_to_node_verify<FSNodeDirectory>(parentId);
+		nodeOperations_->fsnodes_add_sub_stats(parent, &nsr, &psr);
 	}
 	fsnodes_quota_update(p, {{QuotaResource::kSize, nsr.size - psr.size}});
 	fsnodes_update_checksum(p);
@@ -2335,7 +2366,7 @@ uint8_t FilesystemOperationsBase::applyRepair(uint32_t timestamp, inode_t inode,
 	uint8_t status;
 	StatsRecord psr, nsr;
 
-	p = fsnodes_id_to_node<FSNodeFile>(inode);
+	p = nodeOperations_->fsnodes_id_to_node<FSNodeFile>(inode);
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
@@ -2354,22 +2385,22 @@ uint8_t FilesystemOperationsBase::applyRepair(uint32_t timestamp, inode_t inode,
 		safs::log_err("fs_apply_repair: node chunks at index {} has no chunks, inode {}", indx, inode);
 		return SAUNAFS_ERROR_NOCHUNK;
 	}
-	fsnodes_get_stats(p, &psr);
+	nodeOperations_->fsnodes_get_stats(p, &psr);
 	if (nversion == 0) {
 		status = chunk_delete_file(p->chunks[indx], p->goal);
 		p->chunks[indx] = 0;
 	} else {
 		status = chunk_set_version(p->chunks[indx], nversion);
 	}
-	fsnodes_get_stats(p, &nsr);
+	nodeOperations_->fsnodes_get_stats(p, &nsr);
 	for (const auto &[parentId, _] : p->parents) {
-		auto *parent = fsnodes_id_to_node_verify<FSNodeDirectory>(parentId);
-		fsnodes_add_sub_stats(parent, &nsr, &psr);
+		auto *parent = nodeOperations_->fsnodes_id_to_node_verify<FSNodeDirectory>(parentId);
+		nodeOperations_->fsnodes_add_sub_stats(parent, &nsr, &psr);
 	}
 	fsnodes_quota_update(p, {{QuotaResource::kSize, nsr.size - psr.size}});
 	gMetadata->metadataVersion++;
 	p->mtime = timestamp;
-	fsnodes_update_ctime(p, timestamp);
+	nodeOperations_->fsnodes_update_ctime(p, timestamp);
 	fsnodes_update_checksum(p);
 	return status;
 }
@@ -2383,17 +2414,19 @@ uint8_t FilesystemOperationsBase::getGoal(const FsContext &context, inode_t inod
 		return SAUNAFS_ERROR_EINVAL;
 	}
 
-	uint8_t status = verify_session(context, OperationMode::kReadOnly, SessionType::kAny);
+	uint8_t status =
+	    nodeOperations_->verify_session(context, OperationMode::kReadOnly, SessionType::kAny);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kFileOrDirectory, 0, inode, &p);
+	status = nodeOperations_->fsnodes_get_node_for_operation(
+	    context, ExpectedNodeType::kFileOrDirectory, 0, inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	fsnodes_getgoal_recursive(p, gmode, fgtab, dgtab);
+	nodeOperations_->fsnodes_getgoal_recursive(p, gmode, fgtab, dgtab);
 	return SAUNAFS_STATUS_OK;
 }
 
@@ -2406,17 +2439,19 @@ uint8_t FilesystemOperationsBase::getTrashTimePrepare(const FsContext &context, 
 		return SAUNAFS_ERROR_EINVAL;
 	}
 
-	uint8_t status = verify_session(context, OperationMode::kReadOnly, SessionType::kAny);
+	uint8_t status =
+	    nodeOperations_->verify_session(context, OperationMode::kReadOnly, SessionType::kAny);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kFileOrDirectory, 0, inode, &p);
+	status = nodeOperations_->fsnodes_get_node_for_operation(
+	    context, ExpectedNodeType::kFileOrDirectory, 0, inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	fsnodes_gettrashtime_recursive(p, gmode, fileTrashtimes, dirTrashtimes);
+	nodeOperations_->fsnodes_gettrashtime_recursive(p, gmode, fileTrashtimes, dirTrashtimes);
 
 	return SAUNAFS_STATUS_OK;
 }
@@ -2443,17 +2478,19 @@ uint8_t FilesystemOperationsBase::getEAttr(const FsContext &context, inode_t ino
 		return SAUNAFS_ERROR_EINVAL;
 	}
 
-	uint8_t status = verify_session(context, OperationMode::kReadOnly, SessionType::kAny);
+	uint8_t status =
+	    nodeOperations_->verify_session(context, OperationMode::kReadOnly, SessionType::kAny);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny, 0, inode, &p);
+	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny, 0,
+	                                                         inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	fsnodes_geteattr_recursive(p, gmode, feattrtab, deattrtab);
+	nodeOperations_->fsnodes_geteattr_recursive(p, gmode, feattrtab, deattrtab);
 	return SAUNAFS_STATUS_OK;
 }
 
@@ -2468,13 +2505,14 @@ uint8_t FilesystemOperationsBase::setGoal(const FsContext &context, inode_t inod
 	    (smode & (SMODE_INCREASE | SMODE_DECREASE))) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
-	uint8_t status = verify_session(context, OperationMode::kReadWrite, SessionType::kAny);
+	uint8_t status =
+	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kAny);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 	FSNode *p;
-	status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny, MODE_MASK_EMPTY,
-	                                        inode, &p);
+	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny,
+	                                                         MODE_MASK_EMPTY, inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
@@ -2490,8 +2528,8 @@ uint8_t FilesystemOperationsBase::setGoal(const FsContext &context, inode_t inod
 	auto task = new SetGoalTask({p->id}, context.uid(), goal,
 							  smode, setgoal_stats);
 	std::string node_name;
-	FSNodeDirectory *parent = fsnodes_get_first_parent(p);
-	fsnodes_getpath(parent, p, node_name);
+	FSNodeDirectory *parent = nodeOperations_->fsnodes_get_first_parent(p);
+	nodeOperations_->fsnodes_getpath(parent, p, node_name);
 
 	std::string goal_name;
 #ifndef METARESTORE
@@ -2514,13 +2552,14 @@ uint8_t FilesystemOperationsBase::applySetGoal(const FsContext &context, inode_t
 	    (smode & (SMODE_INCREASE | SMODE_DECREASE))) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
-	uint8_t status = verify_session(context, OperationMode::kReadWrite, SessionType::kAny);
+	uint8_t status =
+	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kAny);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 	FSNode *p;
-	status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny, MODE_MASK_EMPTY,
-	                                        inode, &p);
+	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny,
+	                                                         MODE_MASK_EMPTY, inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
@@ -2549,13 +2588,14 @@ uint8_t FilesystemOperationsBase::setTrashTime(
 	if (!SMODE_ISVALID(smode)) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
-	uint8_t status = verify_session(context, OperationMode::kReadWrite, SessionType::kAny);
+	uint8_t status =
+	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kAny);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 	FSNode *p;
-	status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny, MODE_MASK_EMPTY,
-	                                        inode, &p);
+	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny,
+	                                                         MODE_MASK_EMPTY, inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
@@ -2571,8 +2611,8 @@ uint8_t FilesystemOperationsBase::setTrashTime(
 	auto task = new SetTrashtimeTask({p->id}, context.uid(), trashtime,
 							  smode, settrashtime_stats);
 	std::string node_name;
-	FSNodeDirectory *parent = fsnodes_get_first_parent(p);
-	fsnodes_getpath(parent, p, node_name);
+	FSNodeDirectory *parent = nodeOperations_->fsnodes_get_first_parent(p);
+	nodeOperations_->fsnodes_getpath(parent, p, node_name);
 	return gMetadata->taskManager.submitTask(context.ts(), kInitialTaskBatchSize,
 	                                          task, SetTrashtimeTask::generateDescription(node_name, trashtime),
 	                                          callback);
@@ -2586,13 +2626,14 @@ uint8_t FilesystemOperationsBase::applySetTrashTime(const FsContext &context, in
 	if (!SMODE_ISVALID(smode)) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
-	uint8_t status = verify_session(context, OperationMode::kReadWrite, SessionType::kAny);
+	uint8_t status =
+	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kAny);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 	FSNode *p;
-	status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny, MODE_MASK_EMPTY,
-	                                        inode, &p);
+	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny,
+	                                                         MODE_MASK_EMPTY, inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
@@ -2621,13 +2662,14 @@ uint8_t FilesystemOperationsBase::setEAttr(const FsContext &context, inode_t ino
 	    (eattr & (~(EATTR_NOOWNER | EATTR_NOACACHE | EATTR_NOECACHE | EATTR_NODATACACHE)))) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
-	uint8_t status = verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
+	uint8_t status =
+	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 	FSNode *p;
-	status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny, MODE_MASK_EMPTY,
-	                                        inode, &p);
+	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny,
+	                                                         MODE_MASK_EMPTY, inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
@@ -2636,7 +2678,8 @@ uint8_t FilesystemOperationsBase::setEAttr(const FsContext &context, inode_t ino
 	inode_t nci = 0;
 	inode_t nsi = 0;
 	sassert(context.hasUidGidData());
-	fsnodes_seteattr_recursive(p, context.ts(), context.uid(), eattr, smode, &si, &nci, &nsi);
+	nodeOperations_->fsnodes_seteattr_recursive(p, context.ts(), context.uid(), eattr, smode, &si,
+	                                            &nci, &nsi);
 	if (context.isPersonalityMaster()) {
 		if ((smode & SMODE_RMASK) == 0 && nsi > 0 && si == 0 && nci == 0) {
 			return SAUNAFS_ERROR_EPERM;
@@ -2663,13 +2706,14 @@ uint8_t FilesystemOperationsBase::listXAttrLeng(const FsContext &context, inode_
                                                 uint8_t opened, void **xanode, uint32_t *xasize) {
 	FSNode *p;
 
-	uint8_t status = verify_session(context, OperationMode::kReadOnly, SessionType::kNotMeta);
+	uint8_t status =
+	    nodeOperations_->verify_session(context, OperationMode::kReadOnly, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny,
-	                                        opened == 0 ? MODE_MASK_R : MODE_MASK_EMPTY, inode, &p);
+	status = nodeOperations_->fsnodes_get_node_for_operation(
+	    context, ExpectedNodeType::kAny, opened == 0 ? MODE_MASK_R : MODE_MASK_EMPTY, inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
@@ -2691,13 +2735,14 @@ uint8_t FilesystemOperationsBase::setXAttr(const FsContext &context, inode_t ino
 	FSNode *p;
 	uint8_t status;
 
-	status = verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
+	status =
+	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny,
-	                                        opened == 0 ? MODE_MASK_W : MODE_MASK_EMPTY, inode, &p);
+	status = nodeOperations_->fsnodes_get_node_for_operation(
+	    context, ExpectedNodeType::kAny, opened == 0 ? MODE_MASK_W : MODE_MASK_EMPTY, inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
@@ -2712,11 +2757,13 @@ uint8_t FilesystemOperationsBase::setXAttr(const FsContext &context, inode_t ino
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	fsnodes_update_ctime(p, ts);
+	nodeOperations_->fsnodes_update_ctime(p, ts);
 	fsnodes_update_checksum(p);
-	changeLog(ts, "SETXATTR(%" PRIiNode ",%s,%s,%" PRIu8 ")", p->id,
-	          fsnodes_escape_name(std::string((const char *)attrname, anleng)).c_str(),
-	          fsnodes_escape_name(std::string((const char *)attrvalue, avleng)).c_str(), mode);
+	changeLog(
+	    ts, "SETXATTR(%" PRIiNode ",%s,%s,%" PRIu8 ")", p->id,
+	    nodeOperations_->fsnodes_escape_name(std::string((const char *)attrname, anleng)).c_str(),
+	    nodeOperations_->fsnodes_escape_name(std::string((const char *)attrvalue, avleng)).c_str(),
+	    mode);
 	return SAUNAFS_STATUS_OK;
 }
 
@@ -2725,13 +2772,14 @@ uint8_t FilesystemOperationsBase::getXAttr(const FsContext &context, inode_t ino
                                            uint32_t *avleng, uint8_t **attrvalue) {
 	FSNode *p;
 
-	uint8_t status = verify_session(context, OperationMode::kReadOnly, SessionType::kNotMeta);
+	uint8_t status =
+	    nodeOperations_->verify_session(context, OperationMode::kReadOnly, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny,
-	                                        opened == 0 ? MODE_MASK_R : MODE_MASK_EMPTY, inode, &p);
+	status = nodeOperations_->fsnodes_get_node_for_operation(
+	    context, ExpectedNodeType::kAny, opened == 0 ? MODE_MASK_R : MODE_MASK_EMPTY, inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
@@ -2753,7 +2801,7 @@ uint8_t FilesystemOperationsBase::applySetXAttr(uint32_t timestamp, inode_t inod
 	    mode > XATTR_SMODE_REMOVE) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
-	p = fsnodes_id_to_node(inode);
+	p = nodeOperations_->fsnodes_id_to_node(inode);
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
@@ -2762,7 +2810,7 @@ uint8_t FilesystemOperationsBase::applySetXAttr(uint32_t timestamp, inode_t inod
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	fsnodes_update_ctime(p, timestamp);
+	nodeOperations_->fsnodes_update_ctime(p, timestamp);
 	gMetadata->metadataVersion++;
 	fsnodes_update_checksum(p);
 	return status;
@@ -2771,16 +2819,17 @@ uint8_t FilesystemOperationsBase::applySetXAttr(uint32_t timestamp, inode_t inod
 uint8_t FilesystemOperationsBase::deleteAcl(const FsContext &context, inode_t inode, AclType type) {
 	ChecksumUpdater cu(context.ts());
 	FSNode *p;
-	uint8_t status = verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
+	uint8_t status =
+	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny, MODE_MASK_EMPTY,
-	                                        inode, &p);
+	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny,
+	                                                         MODE_MASK_EMPTY, inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	status = fsnodes_deleteacl(p, type, context.ts());
+	status = nodeOperations_->fsnodes_deleteacl(p, type, context.ts());
 	if (context.isPersonalityMaster()) {
 		if (status == SAUNAFS_STATUS_OK) {
 			static char acl_type[3] = {'a', 'd', 'r'};
@@ -2804,17 +2853,18 @@ uint8_t FilesystemOperationsBase::setAcl(const FsContext &context, inode_t inode
                                          const RichACL &acl) {
 	ChecksumUpdater cu(context.ts());
 	FSNode *p;
-	uint8_t status = verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
+	uint8_t status =
+	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny, MODE_MASK_EMPTY,
-	                                        inode, &p);
+	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny,
+	                                                         MODE_MASK_EMPTY, inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 	std::string acl_string = acl.toString();
-	status = fsnodes_setacl(p, acl, context.ts());
+	status = nodeOperations_->fsnodes_setacl(p, acl, context.ts());
 	if (context.isPersonalityMaster()) {
 		if (status == SAUNAFS_STATUS_OK) {
 			changeLog(context.ts(), "SETRICHACL(%" PRIiNode ",%s)", p->id, acl_string.c_str());
@@ -2829,17 +2879,18 @@ uint8_t FilesystemOperationsBase::setAcl(const FsContext &context, inode_t inode
                                          const AccessControlList &acl) {
 	ChecksumUpdater cu(context.ts());
 	FSNode *p;
-	uint8_t status = verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
+	uint8_t status =
+	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny, MODE_MASK_EMPTY,
-	                                        inode, &p);
+	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny,
+	                                                         MODE_MASK_EMPTY, inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 	std::string acl_string = acl.toString();
-	status = fsnodes_setacl(p, type, acl, context.ts());
+	status = nodeOperations_->fsnodes_setacl(p, type, acl, context.ts());
 	if (context.isPersonalityMaster()) {
 		if (status == SAUNAFS_STATUS_OK) {
 			changeLog(context.ts(), "SETACL(%" PRIiNode ",%c,%s)", p->id,
@@ -2855,16 +2906,17 @@ uint8_t FilesystemOperationsBase::setAcl(const FsContext &context, inode_t inode
 
 uint8_t FilesystemOperationsBase::getAcl(const FsContext &context, inode_t inode, RichACL &acl) {
 	FSNode *p;
-	uint8_t status = verify_session(context, OperationMode::kReadOnly, SessionType::kAny);
+	uint8_t status =
+	    nodeOperations_->verify_session(context, OperationMode::kReadOnly, SessionType::kAny);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny, MODE_MASK_EMPTY,
-	                                        inode, &p);
+	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny,
+	                                                         MODE_MASK_EMPTY, inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	return fsnodes_getacl(p, acl);
+	return nodeOperations_->fsnodes_getacl(p, acl);
 }
 
 #endif /* #ifndef METARESTORE */
@@ -2877,7 +2929,7 @@ uint8_t FilesystemOperationsBase::applySetAcl(uint32_t timestamp, inode_t inode,
 	} catch (Exception &) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
-	FSNode *p = fsnodes_id_to_node(inode);
+	FSNode *p = nodeOperations_->fsnodes_id_to_node(inode);
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
@@ -2885,7 +2937,7 @@ uint8_t FilesystemOperationsBase::applySetAcl(uint32_t timestamp, inode_t inode,
 	if (!decodeChar("da", {AclType::kDefault, AclType::kAccess}, aclType, aclTypeEnum)) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
-	uint8_t status = fsnodes_setacl(p, aclTypeEnum, std::move(acl), timestamp);
+	uint8_t status = nodeOperations_->fsnodes_setacl(p, aclTypeEnum, std::move(acl), timestamp);
 	if (status == SAUNAFS_STATUS_OK) {
 		gMetadata->metadataVersion++;
 	}
@@ -2900,11 +2952,11 @@ uint8_t FilesystemOperationsBase::applySetRichAcl(uint32_t timestamp, inode_t in
 	} catch (Exception &) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
-	FSNode *p = fsnodes_id_to_node(inode);
+	FSNode *p = nodeOperations_->fsnodes_id_to_node(inode);
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
-	uint8_t status = fsnodes_setacl(p, std::move(acl), timestamp);
+	uint8_t status = nodeOperations_->fsnodes_setacl(p, std::move(acl), timestamp);
 	if (status == SAUNAFS_STATUS_OK) {
 		gMetadata->metadataVersion++;
 	}
@@ -2914,16 +2966,17 @@ uint8_t FilesystemOperationsBase::applySetRichAcl(uint32_t timestamp, inode_t in
 #ifndef METARESTORE
 uint32_t FilesystemOperationsBase::getDirPathSize(inode_t inode) {
 	FSNode *node;
-	node = fsnodes_id_to_node(inode);
+	node = nodeOperations_->fsnodes_id_to_node(inode);
 	if (node) {
 		if (node->type != FSNodeType::kDirectory) {
 			return 15;  // "(not directory)"
 		} else {
 			FSNodeDirectory *parent = nullptr;
 			if (!node->parents.empty()) {
-				parent = fsnodes_id_to_node_verify<FSNodeDirectory>(node->parents[0].first);
+				parent = nodeOperations_->fsnodes_id_to_node_verify<FSNodeDirectory>(
+				    node->parents[0].first);
 			}
-			return 1 + fsnodes_getpath_size(parent, node);
+			return 1 + nodeOperations_->fsnodes_getpath_size(parent, node);
 		}
 	} else {
 		return 11;  // "(not found)"
@@ -2933,7 +2986,7 @@ uint32_t FilesystemOperationsBase::getDirPathSize(inode_t inode) {
 
 void FilesystemOperationsBase::getDirPathData(inode_t inode, uint8_t *buff, uint32_t size) {
 	FSNode *node;
-	node = fsnodes_id_to_node(inode);
+	node = nodeOperations_->fsnodes_id_to_node(inode);
 	if (node) {
 		if (node->type != FSNodeType::kDirectory) {
 			if (size >= 15) {
@@ -2944,11 +2997,12 @@ void FilesystemOperationsBase::getDirPathData(inode_t inode, uint8_t *buff, uint
 			if (size > 0) {
 				FSNodeDirectory *parent = nullptr;
 				if (!node->parents.empty()) {
-					parent = fsnodes_id_to_node_verify<FSNodeDirectory>(node->parents[0].first);
+					parent = nodeOperations_->fsnodes_id_to_node_verify<FSNodeDirectory>(
+					    node->parents[0].first);
 				}
 
 				buff[0] = '/';
-				fsnodes_getpath_data(parent, node, buff + 1, size - 1);
+				nodeOperations_->fsnodes_getpath_data(parent, node, buff + 1, size - 1);
 				return;
 			}
 		}
@@ -2967,18 +3021,19 @@ uint8_t FilesystemOperationsBase::getDirStats(const FsContext &context, inode_t 
 	FSNode *p;
 	StatsRecord sr;
 
-	uint8_t status = verify_session(context, OperationMode::kReadOnly, SessionType::kAny);
+	uint8_t status =
+	    nodeOperations_->verify_session(context, OperationMode::kReadOnly, SessionType::kAny);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kFileOrDirectory, MODE_MASK_EMPTY,
-	                                        inode, &p);
+	status = nodeOperations_->fsnodes_get_node_for_operation(
+	    context, ExpectedNodeType::kFileOrDirectory, MODE_MASK_EMPTY, inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	fsnodes_get_stats(p, &sr);
+	nodeOperations_->fsnodes_get_stats(p, &sr);
 	*inodes = sr.inodes;
 	*dirs = sr.dirs;
 	*files = sr.files;
@@ -2994,8 +3049,8 @@ uint8_t FilesystemOperationsBase::getDirStats(const FsContext &context, inode_t 
 uint8_t FilesystemOperationsBase::getChunkId(const FsContext &context, inode_t inode,
                                              uint32_t index, uint64_t *chunkid) {
 	FSNode *p;
-	uint8_t status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kFile,
-	                                                MODE_MASK_EMPTY, inode, &p);
+	uint8_t status = nodeOperations_->fsnodes_get_node_for_operation(
+	    context, ExpectedNodeType::kFile, MODE_MASK_EMPTY, inode, &p);
 	FSNodeFile *node_file = static_cast<FSNodeFile*>(p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
@@ -3074,13 +3129,14 @@ uint8_t FilesystemOperationsBase::getChunksInfo(const FsContext &context, uint32
 
 	FSNode *p;
 
-	uint8_t status = verify_session(context, OperationMode::kReadOnly, SessionType::kAny);
+	uint8_t status =
+	    nodeOperations_->verify_session(context, OperationMode::kReadOnly, SessionType::kAny);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kFile, MODE_MASK_R,
-	                                        inode, &p);
+	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kFile,
+	                                                         MODE_MASK_R, inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}

--- a/src/master/filesystem_operations.h
+++ b/src/master/filesystem_operations.h
@@ -48,6 +48,13 @@ constexpr uint32_t kDefaultTrashTime = 94620;
 /// FilesystemOperationsKV.
 class FilesystemOperationsBase : public IFilesystemOperations {
 public:
+	/// Constructor
+	/// @param _nodeOps Concrete node operations implementation.
+	FilesystemOperationsBase(std::unique_ptr<IFilesystemNodeOperations> _nodeOps);
+
+	/// Returns the concrete node operations implementation.
+	IFilesystemNodeOperations *nodeOperations() override { return nodeOperations_.get(); }
+
 	/// Returns version of the loaded metadata.
 	uint64_t getMetadataVersion() override;
 
@@ -326,4 +333,7 @@ private:
 	/// Helper function used internally by `fs_locks_unlock_inode`.
 	static void manageLockTryLockPending(FileLocks &locks, inode_t inode, uint64_t start,
 	                                     uint64_t end, std::vector<FileLocks::Owner> &applied);
+
+	/// Node operations object
+	std::unique_ptr<IFilesystemNodeOperations> nodeOperations_;
 };

--- a/src/master/filesystem_operations_interface.h
+++ b/src/master/filesystem_operations_interface.h
@@ -26,6 +26,7 @@
 #include "common/attributes.h"
 #include "common/goal.h"
 #include "master/checksum.h"
+#include "master/filesystem_node_operations_interface.h"
 #include "master/filesystem_node_types.h"
 #include "master/fs_context.h"
 #include "master/locks.h"
@@ -60,6 +61,9 @@ public:
 
 	/// Virtual destructor
 	virtual ~IFilesystemOperations() = default;
+
+	/// Returns the concrete node operations implementation.
+	virtual IFilesystemNodeOperations *nodeOperations() = 0;
 
 	/// Returns version of the loaded metadata.
 	virtual uint64_t getMetadataVersion() = 0;

--- a/src/master/filesystem_periodic.cc
+++ b/src/master/filesystem_periodic.cc
@@ -36,7 +36,6 @@
 #include "master/filesystem_checksum.h"
 #include "master/filesystem_checksum_updater.h"
 #include "master/filesystem_metadata.h"
-#include "master/filesystem_node.h"
 #include "master/filesystem_operations_interface.h"
 #include "master/matoclserv.h"
 
@@ -110,8 +109,10 @@ static std::string get_node_info(FSNode *node) {
 		bool first = true;
 		for (const auto &[parentId, _] : node->parents) {
 			std::string path;
-			auto *parent = fsnodes_id_to_node_verify<FSNodeDirectory>(parentId);
-			fsnodes_getpath(parent, node, path);
+			auto *parent =
+			    gFSOperations->nodeOperations()->fsnodes_id_to_node_verify<FSNodeDirectory>(
+			        parentId);
+			gFSOperations->nodeOperations()->fsnodes_getpath(parent, node, path);
 			if (!first) {
 				name += "|" + path;
 			} else {
@@ -124,13 +125,14 @@ static std::string get_node_info(FSNode *node) {
 		std::string path;
 		FSNodeDirectory *parent = nullptr;
 		if (!node->parents.empty()) {
-			parent = fsnodes_id_to_node_verify<FSNodeDirectory>(node->parents.front().first);
+			parent = gFSOperations->nodeOperations()->fsnodes_id_to_node_verify<FSNodeDirectory>(
+			    node->parents.front().first);
 		}
-		fsnodes_getpath(parent, node, path);
+		gFSOperations->nodeOperations()->fsnodes_getpath(parent, node, path);
 		name += path;
 	}
 
-	return fsnodes_escape_name(name);
+	return gFSOperations->nodeOperations()->fsnodes_escape_name(name);
 }
 
 std::vector<DefectiveFileInfo> fs_get_defective_nodes_info(uint8_t requested_flags, uint64_t max_entries,
@@ -143,7 +145,7 @@ std::vector<DefectiveFileInfo> fs_get_defective_nodes_info(uint8_t requested_fla
 	watchdog.start();
 	for (uint64_t i = 0; i < max_entries && it != gDefectiveNodes.end(); ++it) {
 		if (((*it).second & requested_flags) != 0) {
-			node = fsnodes_id_to_node<FSNode>((*it).first);
+			node = gFSOperations->nodeOperations()->fsnodes_id_to_node<FSNode>((*it).first);
 			std::string info = get_node_info(node);
 			defective_nodes_info.emplace_back(std::move(info), (*it).second);
 			++i;
@@ -168,7 +170,7 @@ void fs_test_getdata(uint32_t &loopstart, uint32_t &loopend, inode_t &files, ino
 			break;
 		}
 
-		FSNode *node = fsnodes_id_to_node<FSNode>(entry.first);
+		FSNode *node = gFSOperations->nodeOperations()->fsnodes_id_to_node<FSNode>(entry.first);
 		if (!node) {
 			report << "Structure error in defective list, entry " << std::to_string(entry.first) << "\n";
 			errors++;
@@ -534,7 +536,8 @@ static void fs_do_emptytrash(uint32_t ts) {
 	auto it = gMetadata->trash.begin();
 	watchdog.start();
 	while (it != gMetadata->trash.end() && ((*it).first.timestamp < ts)) {
-		FSNodeFile *node = fsnodes_id_to_node_verify<FSNodeFile>((*it).first.id);
+		FSNodeFile *node =
+		    gFSOperations->nodeOperations()->fsnodes_id_to_node_verify<FSNodeFile>((*it).first.id);
 
 		if (!node) {
 			std::string pathName = (*it).second.get();
@@ -547,7 +550,7 @@ static void fs_do_emptytrash(uint32_t ts) {
 		assert(node->type == FSNodeType::kTrash);
 
 		auto node_id = node->id;
-		fsnodes_purge(ts, node);
+		gFSOperations->nodeOperations()->fsnodes_purge(ts, node);
 
 		// Purge operation should be performed anyway - if it fails, inode will be reserved
 		gFSOperations->changeLog(ts, "PURGE(%" PRIiNode ")", node_id);
@@ -571,7 +574,8 @@ static void fs_do_emptyreserved(uint32_t ts) {
 	auto it = gMetadata->reserved.begin();
 	watchdog.start();
 	while (it != gMetadata->reserved.end()) {
-		FSNodeFile *node = fsnodes_id_to_node_verify<FSNodeFile>((*it).first);
+		FSNodeFile *node =
+		    gFSOperations->nodeOperations()->fsnodes_id_to_node_verify<FSNodeFile>((*it).first);
 
 		if (!node) {
 			removeReservedEntry(gMetadata->reserved, gMetadata->reservedHandlesIndex,
@@ -583,7 +587,7 @@ static void fs_do_emptyreserved(uint32_t ts) {
 		assert(node->type == FSNodeType::kReserved);
 
 		auto node_id = node->id;
-		fsnodes_purge(ts, node);
+		gFSOperations->nodeOperations()->fsnodes_purge(ts, node);
 
 		// Purge operation should be performed anyway
 		gFSOperations->changeLog(ts, "PURGE(%" PRIiNode ")", node_id);

--- a/src/master/filesystem_quota.cc
+++ b/src/master/filesystem_quota.cc
@@ -25,10 +25,8 @@
 
 #include "common/event_loop.h"
 #include "common/quota_database.h"
-#include "common/small_vector.h"
 #include "master/filesystem_checksum_updater.h"
 #include "master/filesystem_metadata.h"
-#include "master/filesystem_node.h"
 #include "master/filesystem_operations_interface.h"
 
 template <class T>
@@ -51,18 +49,20 @@ static void fs_remove_invisible_quota_entries(inode_t root_inode, std::vector<Qu
 		return;
 	}
 
-	FSNodeDirectory *root_node = fsnodes_id_to_node_verify<FSNodeDirectory>(root_inode);
+	FSNodeDirectory *root_node =
+	    gFSOperations->nodeOperations()->fsnodes_id_to_node_verify<FSNodeDirectory>(root_inode);
 
 	auto it = std::remove_if(results.begin(), results.end(), [root_node](const QuotaEntry &entry) {
 		if (entry.entryKey.owner.ownerType == QuotaOwnerType::kInode) {
-			FSNode *node = fsnodes_id_to_node(entry.entryKey.owner.ownerId);
+			FSNode *node =
+			    gFSOperations->nodeOperations()->fsnodes_id_to_node(entry.entryKey.owner.ownerId);
 			if (!node) {
 				return true;
 			}
 			if (root_node->id == entry.entryKey.owner.ownerId) {
 				return false;
 			}
-			return !fsnodes_isancestor(root_node, node);
+			return !gFSOperations->nodeOperations()->fsnodes_isancestor(root_node, node);
 		}
 		return false;
 	});
@@ -82,7 +82,8 @@ static void fsnodes_getpath(inode_t root_inode, FSNode *node, std::string &ret) 
 	size = 0;
 	while (p != gMetadata->root && !p->parents.empty() && p->id != root_inode) {
 		// get first parent
-		auto *parent = fsnodes_id_to_node_verify<FSNodeDirectory>(p->parents[0].first);
+		auto *parent = gFSOperations->nodeOperations()->fsnodes_id_to_node_verify<FSNodeDirectory>(
+		    p->parents[0].first);
 		size += parent->getChildName(p).length() + 1;
 		p = parent;
 	}
@@ -95,7 +96,8 @@ static void fsnodes_getpath(inode_t root_inode, FSNode *node, std::string &ret) 
 
 	p = node;
 	while (p != gMetadata->root && !p->parents.empty()) {
-		auto *parent = fsnodes_id_to_node_verify<FSNodeDirectory>(p->parents[0].first);
+		auto *parent = gFSOperations->nodeOperations()->fsnodes_id_to_node_verify<FSNodeDirectory>(
+		    p->parents[0].first);
 		std::string name = parent->getChildName(p);
 		if (size >= name.length()) {
 			size -= name.length();
@@ -126,7 +128,9 @@ uint8_t fs_quota_get_all(const FsContext &context, std::vector<QuotaEntry> &resu
 			continue;
 		}
 
-		FSNodeDirectory *node = fsnodes_id_to_node<FSNodeDirectory>(entry.entryKey.owner.ownerId);
+		FSNodeDirectory *node =
+		    gFSOperations->nodeOperations()->fsnodes_id_to_node<FSNodeDirectory>(
+		        entry.entryKey.owner.ownerId);
 		if (!node || node->type != FSNodeType::kDirectory) { continue; }
 
 		switch (entry.entryKey.resource) {
@@ -160,7 +164,8 @@ uint8_t fs_quota_get(const FsContext &context, const std::vector<QuotaOwner> &ow
 				}
 				break;
 			case QuotaOwnerType::kInode:
-				node = fsnodes_id_to_node<FSNodeDirectory>(owner.ownerId);
+				node = gFSOperations->nodeOperations()->fsnodes_id_to_node<FSNodeDirectory>(
+				    owner.ownerId);
 				if (!node || node->type != FSNodeType::kDirectory) { return SAUNAFS_ERROR_EINVAL; }
 				if (node->uid != context.uid() ||
 				    (node->gid != context.gid() && !(context.sesflags() & SESFLAG_IGNOREGID))) {
@@ -175,7 +180,8 @@ uint8_t fs_quota_get(const FsContext &context, const std::vector<QuotaOwner> &ow
 		if (result) {
 			for (auto rigor : {QuotaRigor::kSoft, QuotaRigor::kHard, QuotaRigor::kUsed}) {
 				if (owner.ownerType == QuotaOwnerType::kInode && rigor == QuotaRigor::kUsed) {
-					node = fsnodes_id_to_node<FSNodeDirectory>(owner.ownerId);
+					node = gFSOperations->nodeOperations()->fsnodes_id_to_node<FSNodeDirectory>(
+					    owner.ownerId);
 					assert(node);
 					tmp.push_back(
 					    {{owner, rigor, QuotaResource::kInodes}, (uint64_t)node->stats.inodes});
@@ -204,7 +210,8 @@ uint8_t fs_quota_get_info(const FsContext &context, const std::vector<QuotaEntry
 	for (const auto &entry : entries) {
 		info.clear();
 		if (entry.entryKey.owner.ownerType == QuotaOwnerType::kInode) {
-			FSNode *node = fsnodes_id_to_node(entry.entryKey.owner.ownerId);
+			FSNode *node =
+			    gFSOperations->nodeOperations()->fsnodes_id_to_node(entry.entryKey.owner.ownerId);
 			if (node) {
 				fsnodes_getpath(context.rootinode(), node, info);
 			}
@@ -231,7 +238,8 @@ uint8_t fs_quota_set(const FsContext &context, const std::vector<QuotaEntry> &en
 		if(entry.entryKey.owner.ownerType != QuotaOwnerType::kInode) {
 			continue;
 		}
-		FSNode *node = fsnodes_id_to_node(entry.entryKey.owner.ownerId);
+		FSNode *node =
+		    gFSOperations->nodeOperations()->fsnodes_id_to_node(entry.entryKey.owner.ownerId);
 		if(!node) {
 			return SAUNAFS_ERROR_EINVAL;
 		}
@@ -282,7 +290,8 @@ static int fsnodes_find_depth(FSNodeDirectory *a) {
 	assert(a);
 	int depth = 1;
 	while (!a->parents.empty()) {
-		a = fsnodes_id_to_node_verify<FSNodeDirectory>(a->parents[0].first);
+		a = gFSOperations->nodeOperations()->fsnodes_id_to_node_verify<FSNodeDirectory>(
+		    a->parents[0].first);
 		++depth;
 	}
 
@@ -309,12 +318,14 @@ static FSNode *fsnodes_find_common_ancestor(FSNodeDirectory *a, FSNodeDirectory 
 	if (depth_a > depth_b) {
 		for(;depth_a > depth_b;--depth_a) {
 			assert(a && !a->parents.empty());
-			a = fsnodes_id_to_node_verify<FSNodeDirectory>(a->parents[0].first);
+			a = gFSOperations->nodeOperations()->fsnodes_id_to_node_verify<FSNodeDirectory>(
+			    a->parents[0].first);
 		}
 	} else if (depth_b > depth_a) {
 		for(;depth_b > depth_a;--depth_b) {
 			assert(b && !b->parents.empty());
-			b = fsnodes_id_to_node_verify<FSNodeDirectory>(b->parents[0].first);
+			b = gFSOperations->nodeOperations()->fsnodes_id_to_node_verify<FSNodeDirectory>(
+			    b->parents[0].first);
 		}
 	}
 
@@ -325,8 +336,10 @@ static FSNode *fsnodes_find_common_ancestor(FSNodeDirectory *a, FSNodeDirectory 
 	while(!a->parents.empty()) {
 		assert(!b->parents.empty());
 
-		a = fsnodes_id_to_node_verify<FSNodeDirectory>(a->parents[0].first);
-		b = fsnodes_id_to_node_verify<FSNodeDirectory>(b->parents[0].first);
+		a = gFSOperations->nodeOperations()->fsnodes_id_to_node_verify<FSNodeDirectory>(
+		    a->parents[0].first);
+		b = gFSOperations->nodeOperations()->fsnodes_id_to_node_verify<FSNodeDirectory>(
+		    b->parents[0].first);
 
 		if (a == b) {
 			return a;
@@ -402,7 +415,9 @@ bool fsnodes_quota_exceeded_dir(FSNode *node,
 	if (node->type == FSNodeType::kDirectory) {
 		// Directory can have only one parent, so we get rid of recursion.
 		while(!node->parents.empty()) {
-			auto *parent = fsnodes_id_to_node_verify<FSNodeDirectory>(node->parents[0].first);
+			auto *parent =
+			    gFSOperations->nodeOperations()->fsnodes_id_to_node_verify<FSNodeDirectory>(
+			        node->parents[0].first);
 			if (fsnodes_test_dir_quota_noparents(parent, resource_list)) {
 				return true;
 			}
@@ -410,7 +425,9 @@ bool fsnodes_quota_exceeded_dir(FSNode *node,
 		}
 	} else {
 		for (const auto &[parentId, _] : node->parents) {
-			auto *parent = fsnodes_id_to_node_verify<FSNodeDirectory>(parentId);
+			auto *parent =
+			    gFSOperations->nodeOperations()->fsnodes_id_to_node_verify<FSNodeDirectory>(
+			        parentId);
 			if (fsnodes_quota_exceeded_dir(parent, resource_list)) {
 				return true;
 			}
@@ -435,7 +452,8 @@ bool fsnodes_quota_exceeded_dir(FSNodeDirectory *node, FSNodeDirectory* prev_nod
 
 	// node is directory so it has only one parent.
 	while(!node->parents.empty()) {
-		auto *parent = fsnodes_id_to_node<FSNodeDirectory>(node->parents[0].first);
+		auto *parent = gFSOperations->nodeOperations()->fsnodes_id_to_node<FSNodeDirectory>(
+		    node->parents[0].first);
 
 		if (parent == common) {
 			return false;

--- a/src/master/filesystem_snapshot.cc
+++ b/src/master/filesystem_snapshot.cc
@@ -22,7 +22,7 @@
 #include "config/cfg.h"
 #include "master/filesystem_checksum_updater.h"
 #include "master/filesystem_metadata.h"
-#include "master/filesystem_node.h"
+#include "master/filesystem_operations_interface.h"
 #include "master/snapshot_task.h"
 #include "master/task_manager.h"
 
@@ -40,23 +40,25 @@ uint8_t fs_snapshot(const FsContext &context, inode_t inode_src, inode_t parent_
 	ChecksumUpdater cu(context.ts());
 	FSNode *src_node = nullptr;
 	FSNode *dst_parent_node = nullptr;
-	uint8_t status = verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
+	uint8_t status = gFSOperations->nodeOperations()->verify_session(
+	    context, OperationMode::kReadWrite, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kDirectory, MODE_MASK_W,
-	                                        parent_dst, &dst_parent_node);
+	status = gFSOperations->nodeOperations()->fsnodes_get_node_for_operation(
+	    context, ExpectedNodeType::kDirectory, MODE_MASK_W, parent_dst, &dst_parent_node);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	status = fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny, MODE_MASK_R, inode_src,
-	                                        &src_node);
+	status = gFSOperations->nodeOperations()->fsnodes_get_node_for_operation(
+	    context, ExpectedNodeType::kAny, MODE_MASK_R, inode_src, &src_node);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 	if (src_node->type == FSNodeType::kDirectory) {
 		if (src_node == dst_parent_node ||
-		    fsnodes_isancestor(static_cast<FSNodeDirectory *>(src_node), dst_parent_node)) {
+		    gFSOperations->nodeOperations()->fsnodes_isancestor(
+		        static_cast<FSNodeDirectory *>(src_node), dst_parent_node)) {
 			return SAUNAFS_ERROR_EINVAL;
 		}
 	}
@@ -67,12 +69,13 @@ uint8_t fs_snapshot(const FsContext &context, inode_t inode_src, inode_t parent_
 	                                   static_cast<FSNodeDirectory *>(dst_parent_node)->id,
 	                                   0, can_overwrite, ignore_missing_src, true, true);
 	std::string src_path;
-	FSNodeDirectory *parent = fsnodes_get_first_parent(src_node);
-	fsnodes_getpath(parent, src_node, src_path);
+	FSNodeDirectory *parent = gFSOperations->nodeOperations()->fsnodes_get_first_parent(src_node);
+	gFSOperations->nodeOperations()->fsnodes_getpath(parent, src_node, src_path);
 
 	std::string dst_path;
-	FSNodeDirectory *grandparent = fsnodes_get_first_parent(dst_parent_node);
-	fsnodes_getpath(grandparent, dst_parent_node, dst_path);
+	FSNodeDirectory *grandparent =
+	    gFSOperations->nodeOperations()->fsnodes_get_first_parent(dst_parent_node);
+	gFSOperations->nodeOperations()->fsnodes_getpath(grandparent, dst_parent_node, dst_path);
 	if (dst_path.size() > 1) {
 		dst_path += "/";
 	}

--- a/src/master/filesystem_store_acl.cc
+++ b/src/master/filesystem_store_acl.cc
@@ -26,7 +26,7 @@
 #include <vector>
 
 #include "master/filesystem_metadata.h"
-#include "master/filesystem_node.h"
+#include "master/filesystem_operations_interface.h"
 
 static void fs_store_marker(FILE *fd) {
 	static std::vector<uint8_t> buffer;
@@ -106,7 +106,7 @@ static int fs_load_posix_acl(const std::shared_ptr<MemoryMappedFile> &metadataFi
 		AccessControlList posix_acl;
 		deserialize(ptr, size, inode, posix_acl);
 		offsetBegin += size;
-		FSNode *p = fsnodes_id_to_node(inode);
+		FSNode *p = gFSOperations->nodeOperations()->fsnodes_id_to_node(inode);
 		if (!p) {
 			throw Exception("unknown inode: " + std::to_string(inode));
 		}
@@ -176,7 +176,7 @@ static int fs_load_legacy_acl(const std::shared_ptr<MemoryMappedFile> &metadataF
 		std::unique_ptr<legacy::AccessControlList> default_acl;
 		deserialize(ptr, size, inode, extended_acl, default_acl);
 		offsetBegin += size;
-		FSNode *p = fsnodes_id_to_node(inode);
+		FSNode *p = gFSOperations->nodeOperations()->fsnodes_id_to_node(inode);
 		if (!p) {
 			throw Exception("unknown inode: " + std::to_string(inode));
 		}
@@ -275,7 +275,7 @@ int fs_load_acl(const std::shared_ptr<MemoryMappedFile> &metadataFile, size_t &o
 		RichACL acl;
 		deserialize(ptr, size, inode, acl);
 		offsetBegin += size;
-		FSNode *p = fsnodes_id_to_node(inode);
+		FSNode *p = gFSOperations->nodeOperations()->fsnodes_id_to_node(inode);
 		if (!p) {
 			throw Exception("unknown inode: " + std::to_string(inode));
 		}

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -1665,9 +1665,9 @@ void matoclserv_sau_get_self_quota(matoclserventry *eptr, const uint8_t *data, u
 		status = gFSOperations->quotaGet(context, owners, results);
 
 		if (inode == context.rootinode() && !foundContextRootInodeResult(inode)) {
-			auto ino = fsnodes_id_to_node(inode);
+			auto ino = gFSOperations->nodeOperations()->fsnodes_id_to_node(inode);
 			StatsRecord rootInodeStatRec;
-			fsnodes_get_stats(ino, &rootInodeStatRec);
+			gFSOperations->nodeOperations()->fsnodes_get_stats(ino, &rootInodeStatRec);
 			results.emplace_back(QuotaEntry{QuotaEntryKey{QuotaOwner{QuotaOwnerType::kInode, inode},
 			                                              QuotaRigor::kUsed, QuotaResource::kSize},
 			                                rootInodeStatRec.size});
@@ -3853,7 +3853,7 @@ void matoclserv_fuse_getacl(matoclserventry *eptr, const uint8_t *data, uint32_t
 
 	if (status == SAUNAFS_STATUS_OK) {
 		if (eptr->version >= kRichACLVersion) {
-			FSNode *node = fsnodes_id_to_node(inode);
+			FSNode *node = gFSOperations->nodeOperations()->fsnodes_id_to_node(inode);
 			uint32_t owner_id = node ? node->uid : RichACL::Ace::kInvalidId;
 			matocl::fuseGetAcl::serialize(reply, messageId, owner_id, acl);
 		} else {

--- a/src/master/matontserv.cc
+++ b/src/master/matontserv.cc
@@ -250,7 +250,8 @@ void matontserv_get_path_type_inode(MatontservEntry *eptr, const uint8_t *data, 
 
 	inode_t inode = static_cast<inode_t>(responseInode);
 	std::string pathByInode;
-	FSNode *node = invalidInode ? nullptr : fsnodes_id_to_node(inode);
+	FSNode *node =
+	    invalidInode ? nullptr : gFSOperations->nodeOperations()->fsnodes_id_to_node(inode);
 	if (node == nullptr) {
 		safs::log_info("NTTOMA_GET_PATH_TYPE_INODE - inode {} not found", responseInode);
 		// Send back an empty path

--- a/src/master/metadata_backend_file.cc
+++ b/src/master/metadata_backend_file.cc
@@ -412,12 +412,11 @@ static int8_t fs_parseEdge(const std::shared_ptr<MemoryMappedFile> &metadataFile
 
 	std::string name(pSrc, pSrc + edgeNameSize);
 	sectionOffset += edgeNameSize;
-	FSNode *child = fsnodes_id_to_node(childId);
+	FSNode *child = gFSOperations->nodeOperations()->fsnodes_id_to_node(childId);
 	if (!child) {
 		safs_pretty_syslog(
-		    LOG_ERR,
-		    "loading edge: %" PRIiNode ",%s->%" PRIiNode " error: child not found",
-		    parentId, fsnodes_escape_name(name).c_str(), childId);
+		    LOG_ERR, "loading edge: %" PRIiNode ",%s->%" PRIiNode " error: child not found",
+		    parentId, gFSOperations->nodeOperations()->fsnodes_escape_name(name).c_str(), childId);
 		if (ignoreFlag) {
 			return kSuccess;
 		}
@@ -436,39 +435,40 @@ static int8_t fs_parseEdge(const std::shared_ptr<MemoryMappedFile> &metadataFile
 			gMetadata->reservedNodes++;
 		} else {
 			safs::log_err("loading edge: {}, {}->{} error: bad child type ({})", parentId,
-			              fsnodes_escape_name(name), childId, static_cast<char>(child->type));
+			              gFSOperations->nodeOperations()->fsnodes_escape_name(name), childId,
+			              static_cast<char>(child->type));
 			return kError;
 		}
 	} else {
 		FSNodeDirectory *parent;
 		if (currentParentId != parentId){
-			parent = fsnodes_id_to_node<FSNodeDirectory>(parentId);
+			parent = gFSOperations->nodeOperations()->fsnodes_id_to_node<FSNodeDirectory>(parentId);
 			currentParentNode = parent;
 		} else {
 			parent = currentParentNode;
 		}
 		if (!parent) {
-			safs_pretty_syslog(LOG_ERR,
-			                   "loading edge: %" PRIiNode ",%s->%" PRIiNode
-			                   " error: parent not found",
-			                   parentId, fsnodes_escape_name(name).c_str(),
-			                   childId);
+			safs_pretty_syslog(
+			    LOG_ERR, "loading edge: %" PRIiNode ",%s->%" PRIiNode " error: parent not found",
+			    parentId, gFSOperations->nodeOperations()->fsnodes_escape_name(name).c_str(),
+			    childId);
 			if (ignoreFlag) {
-				parent =
-				    fsnodes_id_to_node<FSNodeDirectory>(SPECIAL_INODE_ROOT);
+				parent = gFSOperations->nodeOperations()->fsnodes_id_to_node<FSNodeDirectory>(
+				    SPECIAL_INODE_ROOT);
 				if (!parent || parent->type != FSNodeType::kDirectory) {
 					safs_pretty_syslog(
 					    LOG_ERR,
-					    "loading edge: %" PRIiNode ",%s->%" PRIiNode
-					    " root dir not found !!!",
-					    parentId, fsnodes_escape_name(name).c_str(), childId);
+					    "loading edge: %" PRIiNode ",%s->%" PRIiNode " root dir not found !!!",
+					    parentId,
+					    gFSOperations->nodeOperations()->fsnodes_escape_name(name).c_str(),
+					    childId);
 					return kError;
 				}
-				safs_pretty_syslog(LOG_ERR,
-				                   "loading edge: %" PRIiNode ",%s->%" PRIiNode
-				                   " attaching node to root dir",
-				                   parentId, fsnodes_escape_name(name).c_str(),
-				                   childId);
+				safs_pretty_syslog(
+				    LOG_ERR,
+				    "loading edge: %" PRIiNode ",%s->%" PRIiNode " attaching node to root dir",
+				    parentId, gFSOperations->nodeOperations()->fsnodes_escape_name(name).c_str(),
+				    childId);
 				parentId = SPECIAL_INODE_ROOT;
 			} else {
 				safs_pretty_syslog(
@@ -480,23 +480,25 @@ static int8_t fs_parseEdge(const std::shared_ptr<MemoryMappedFile> &metadataFile
 		}
 		if (parent->type != FSNodeType::kDirectory) {
 			safs::log_err("loading edge: {}, {}->{} error: bad parent type ({})", parentId,
-			              fsnodes_escape_name(name), childId, static_cast<char>(parent->type));
+			              gFSOperations->nodeOperations()->fsnodes_escape_name(name), childId,
+			              static_cast<char>(parent->type));
 			if (ignoreFlag) {
-				parent =
-				    fsnodes_id_to_node<FSNodeDirectory>(SPECIAL_INODE_ROOT);
+				parent = gFSOperations->nodeOperations()->fsnodes_id_to_node<FSNodeDirectory>(
+				    SPECIAL_INODE_ROOT);
 				if (!parent || parent->type != FSNodeType::kDirectory) {
 					safs_pretty_syslog(
 					    LOG_ERR,
-					    "loading edge: %" PRIiNode ",%s->%" PRIiNode
-					    " root dir not found !!!",
-					    parentId, fsnodes_escape_name(name).c_str(), childId);
+					    "loading edge: %" PRIiNode ",%s->%" PRIiNode " root dir not found !!!",
+					    parentId,
+					    gFSOperations->nodeOperations()->fsnodes_escape_name(name).c_str(),
+					    childId);
 					return kError;
 				}
-				safs_pretty_syslog(LOG_ERR,
-				                   "loading edge: %" PRIiNode ",%s->%" PRIiNode
-				                   " attaching node to root dir",
-				                   parentId, fsnodes_escape_name(name).c_str(),
-				                   childId);
+				safs_pretty_syslog(
+				    LOG_ERR,
+				    "loading edge: %" PRIiNode ",%s->%" PRIiNode " attaching node to root dir",
+				    parentId, gFSOperations->nodeOperations()->fsnodes_escape_name(name).c_str(),
+				    childId);
 				parentId = SPECIAL_INODE_ROOT;
 			} else {
 				safs_pretty_syslog(
@@ -508,11 +510,12 @@ static int8_t fs_parseEdge(const std::shared_ptr<MemoryMappedFile> &metadataFile
 		}
 		if (currentParentId != parentId) {
 			if (parent->entries.size() > 0) {
-				safs_pretty_syslog(LOG_ERR,
-				                   "loading edge: %" PRIiNode ",%s->%" PRIiNode
-				                   " error: parent node sequence error",
-				                   parentId, fsnodes_escape_name(name).c_str(),
-				                   childId);
+				safs_pretty_syslog(
+				    LOG_ERR,
+				    "loading edge: %" PRIiNode ",%s->%" PRIiNode
+				    " error: parent node sequence error",
+				    parentId, gFSOperations->nodeOperations()->fsnodes_escape_name(name).c_str(),
+				    childId);
 				return kError;
 			}
 			currentParentId = parentId;
@@ -547,8 +550,8 @@ static int8_t fs_parseEdge(const std::shared_ptr<MemoryMappedFile> &metadataFile
 		}
 
 		StatsRecord sr;
-		fsnodes_get_stats(child, &sr);
-		fsnodes_add_stats(parent, &sr);
+		gFSOperations->nodeOperations()->fsnodes_get_stats(child, &sr);
+		gFSOperations->nodeOperations()->fsnodes_add_stats(parent, &sr);
 	}
 	return kSuccess;
 }
@@ -611,7 +614,8 @@ static int8_t fs_parseNode(const std::shared_ptr<MemoryMappedFile> &metadataFile
 			matoclserv_add_open_file(sessionId, node->id);
 		}
 #endif
-		fsnodes_quota_update(node, {{QuotaResource::kSize, +fsnodes_get_size(node)}});
+		fsnodes_quota_update(node, {{QuotaResource::kSize,
+		                             +gFSOperations->nodeOperations()->fsnodes_get_size(node)}});
 		gMetadata->fileNodes++;
 		break;
 	default:
@@ -643,8 +647,8 @@ static int fs_lostnode(FSNode *p) {
 			             p->id, i);
 		}
 		HString name((const char *)artname, l);
-		if (!fsnodes_nameisused(gMetadata->root, name)) {
-			fsnodes_link(0, gMetadata->root, p, name);
+		if (!gFSOperations->nodeOperations()->fsnodes_nameisused(gMetadata->root, name)) {
+			gFSOperations->nodeOperations()->fsnodes_link(0, gMetadata->root, p, name);
 			return 1;
 		}
 		i++;
@@ -872,7 +876,8 @@ static int fs_load(const std::shared_ptr<MemoryMappedFile> &metadataFile, int ig
 
 	util::ScopedTimer timer("checking filesystem consistency of the metadata file took");
 
-	gMetadata->root = fsnodes_id_to_node<FSNodeDirectory>(SPECIAL_INODE_ROOT);
+	gMetadata->root =
+	    gFSOperations->nodeOperations()->fsnodes_id_to_node<FSNodeDirectory>(SPECIAL_INODE_ROOT);
 	if (gMetadata->root == nullptr) {
 		safs::log_err("error reading metadata (root node not found)");
 		return kOpFailure;
@@ -1135,14 +1140,14 @@ void MetadataBackendFile::storeedgelist(FSNodeDirectory *parent, FILE *fd) {
 
 void MetadataBackendFile::storeedgelist(const TrashPathContainer &data, FILE *fd) {
 	for (const auto &entry : data) {
-		FSNode *child = fsnodes_id_to_node(entry.first.id);
+		FSNode *child = gFSOperations->nodeOperations()->fsnodes_id_to_node(entry.first.id);
 		storeedge(nullptr, child, (std::string)entry.second, fd);
 	}
 }
 
 void MetadataBackendFile::storeedgelist(const ReservedPathContainer &data, FILE *fd) {
 	for (const auto &entry : data) {
-		FSNode *child = fsnodes_id_to_node(entry.first);
+		FSNode *child = gFSOperations->nodeOperations()->fsnodes_id_to_node(entry.first);
 		storeedge(nullptr, child, (std::string)entry.second, fd);
 	}
 }

--- a/src/master/recursive_remove_task.cc
+++ b/src/master/recursive_remove_task.cc
@@ -21,7 +21,6 @@
 
 #include "master/recursive_remove_task.h"
 
-#include "master/filesystem_node.h"
 #include "master/filesystem_operations_interface.h"
 #include "master/filesystem_stats.h"
 
@@ -30,28 +29,29 @@ bool RemoveTask::isFinished() const {
 }
 
 int RemoveTask::retrieveNodes(FSNodeDirectory *&wd, FSNode *&child) {
-	FSNode *wd_tmp = fsnodes_id_to_node(parent_);
+	FSNode *wd_tmp = gFSOperations->nodeOperations()->fsnodes_id_to_node(parent_);
 	if (!wd_tmp) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
-	if (!fsnodes_access(*context_, wd_tmp, MODE_MASK_W)) {
+	if (!gFSOperations->nodeOperations()->fsnodes_access(*context_, wd_tmp, MODE_MASK_W)) {
 		return SAUNAFS_ERROR_EACCES;
 	}
 	wd = static_cast<FSNodeDirectory*>(wd_tmp);
-	child = fsnodes_lookup(wd, *current_subtask_);
+	child = gFSOperations->nodeOperations()->fsnodes_lookup(wd, *current_subtask_);
 	if (!child) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
-	if (!fsnodes_sticky_access(wd, child, context_->uid())) {
+	if (!gFSOperations->nodeOperations()->fsnodes_sticky_access(wd, child, context_->uid())) {
 		return SAUNAFS_ERROR_EPERM;
 	}
 	return SAUNAFS_STATUS_OK;
 }
 
 void RemoveTask::doUnlink(uint32_t ts, FSNodeDirectory *wd, FSNode *child) {
-	gFSOperations->changeLog(ts, "UNLINK(%" PRIiNode ",%s):%" PRIiNode, parent_,
-	                         fsnodes_escape_name(*current_subtask_).c_str(), child->id);
-	fsnodes_unlink(ts, wd, *current_subtask_, child);
+	gFSOperations->changeLog(
+	    ts, "UNLINK(%" PRIiNode ",%s):%" PRIiNode, parent_,
+	    gFSOperations->nodeOperations()->fsnodes_escape_name(*current_subtask_).c_str(), child->id);
+	gFSOperations->nodeOperations()->fsnodes_unlink(ts, wd, *current_subtask_, child);
 }
 
 int RemoveTask::execute(uint32_t ts, intrusive_list<Task> &work_queue) {

--- a/src/master/setgoal_task.cc
+++ b/src/master/setgoal_task.cc
@@ -23,7 +23,7 @@
 #include "master/setgoal_task.h"
 
 #include "master/filesystem_checksum.h"
-#include "master/filesystem_node.h"
+#include "master/filesystem_metadata.h"
 #include "master/filesystem_operations_interface.h"
 
 int SetGoalTask::execute(uint32_t ts, intrusive_list<Task> &work_queue) {
@@ -31,7 +31,7 @@ int SetGoalTask::execute(uint32_t ts, intrusive_list<Task> &work_queue) {
 
 	inode_t inode = *current_inode_;
 	++current_inode_;
-	FSNode *node = fsnodes_id_to_node(inode);
+	FSNode *node = gFSOperations->nodeOperations()->fsnodes_id_to_node(inode);
 	if (!node) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
@@ -75,12 +75,13 @@ uint8_t SetGoalTask::setGoal(FSNode *node, uint32_t ts) {
 		} else {
 			if ((smode_ & SMODE_TMASK) == SMODE_SET && node->goal != goal_) {
 				if (node->type != FSNodeType::kDirectory) {
-					fsnodes_changefilegoal(static_cast<FSNodeFile *>(node), goal_);
+					gFSOperations->nodeOperations()->fsnodes_changefilegoal(
+					    static_cast<FSNodeFile *>(node), goal_);
 				} else {
 					node->goal = goal_;
 					gMetadata->nodeChangedSignal.emit(node);
 				}
-				fsnodes_update_ctime(node, ts);
+				gFSOperations->nodeOperations()->fsnodes_update_ctime(node, ts);
 				fsnodes_update_checksum(node);
 				return SetGoalTask::kChanged;
 			} else {

--- a/src/master/settrashtime_task.cc
+++ b/src/master/settrashtime_task.cc
@@ -23,7 +23,7 @@
 #include "master/settrashtime_task.h"
 
 #include "master/filesystem_checksum.h"
-#include "master/filesystem_node.h"
+#include "master/filesystem_metadata.h"
 #include "master/filesystem_operations_interface.h"
 
 int SetTrashtimeTask::execute(uint32_t ts, intrusive_list<Task> &work_queue) {
@@ -31,7 +31,7 @@ int SetTrashtimeTask::execute(uint32_t ts, intrusive_list<Task> &work_queue) {
 
 	inode_t inode = *current_inode_;
 	++current_inode_;
-	FSNode *node = fsnodes_id_to_node(inode);
+	FSNode *node = gFSOperations->nodeOperations()->fsnodes_id_to_node(inode);
 	if (!node) {
 		return SAUNAFS_ERROR_EINVAL;
 	}

--- a/src/master/snapshot_task.cc
+++ b/src/master/snapshot_task.cc
@@ -24,7 +24,6 @@
 #include "master/chunks.h"
 #include "master/filesystem_checksum.h"
 #include "master/filesystem_metadata.h"
-#include "master/filesystem_node.h"
 #include "master/filesystem_operations_interface.h"
 #include "master/filesystem_quota.h"
 
@@ -89,9 +88,9 @@ FSNode *SnapshotTask::cloneToExistingNode(uint32_t ts, FSNode *src_node,
 }
 
 FSNode *SnapshotTask::cloneToNewNode(uint32_t ts, FSNode *src_node, FSNodeDirectory *dst_parent) {
-	FSNode *dst_node = fsnodes_create_node(
-	        ts, dst_parent, current_subtask_->second, src_node->type, src_node->mode, 0,
-	        src_node->uid, src_node->gid, 0, AclInheritance::kDontInheritAcl, dst_inode_);
+	FSNode *dst_node = gFSOperations->nodeOperations()->fsnodes_create_node(
+	    ts, dst_parent, current_subtask_->second, src_node->type, src_node->mode, 0, src_node->uid,
+	    src_node->gid, 0, AclInheritance::kDontInheritAcl, dst_inode_);
 
 	dst_node->goal = src_node->goal;
 	dst_node->trashtime = src_node->trashtime;
@@ -132,10 +131,11 @@ FSNodeFile *SnapshotTask::cloneToExistingFileNode(uint32_t ts, FSNodeFile *src_n
 		return dst_node;
 	}
 
-	fsnodes_unlink(ts, dst_parent, current_subtask_->second, dst_node);
-	dst_node = static_cast<FSNodeFile *>(fsnodes_create_node(
-	        ts, dst_parent, current_subtask_->second, FSNodeType::kFile, src_node->mode, 0,
-	        src_node->uid, src_node->gid, 0, AclInheritance::kDontInheritAcl, dst_inode_));
+	gFSOperations->nodeOperations()->fsnodes_unlink(ts, dst_parent, current_subtask_->second,
+	                                                dst_node);
+	dst_node = static_cast<FSNodeFile *>(gFSOperations->nodeOperations()->fsnodes_create_node(
+	    ts, dst_parent, current_subtask_->second, FSNodeType::kFile, src_node->mode, 0,
+	    src_node->uid, src_node->gid, 0, AclInheritance::kDontInheritAcl, dst_inode_));
 
 	cloneChunkData(src_node, dst_node, dst_parent);
 
@@ -146,7 +146,7 @@ void SnapshotTask::cloneChunkData(const FSNodeFile *src_node, FSNodeFile *dst_no
 		FSNodeDirectory *dst_parent) {
 	StatsRecord psr, nsr;
 
-	fsnodes_get_stats(dst_node, &psr);
+	gFSOperations->nodeOperations()->fsnodes_get_stats(dst_node, &psr);
 
 	dst_node->goal = src_node->goal;
 	dst_node->trashtime = src_node->trashtime;
@@ -164,8 +164,8 @@ void SnapshotTask::cloneChunkData(const FSNodeFile *src_node, FSNodeFile *dst_no
 		}
 	}
 
-	fsnodes_get_stats(dst_node, &nsr);
-	fsnodes_add_sub_stats(dst_parent, &nsr, &psr);
+	gFSOperations->nodeOperations()->fsnodes_get_stats(dst_node, &nsr);
+	gFSOperations->nodeOperations()->fsnodes_add_sub_stats(dst_parent, &nsr, &psr);
 	fsnodes_quota_update(dst_node, {{QuotaResource::kSize, nsr.size - psr.size}});
 }
 
@@ -180,10 +180,8 @@ void SnapshotTask::cloneDirectoryData(const FSNodeDirectory *src_node, FSNodeDir
 		data.emplace_back(std::move(local_id), (HString)(*entry.first));
 	}
 	if (!data.empty()) {
-		auto task = new SnapshotTask(std::move(data), orig_inode_,
-		                                           dst_node->id, 0, can_overwrite_,
-		                                           ignore_missing_src_,
-		                                           emit_changelog_, enqueue_work_);
+		auto task = new SnapshotTask(std::move(data), orig_inode_, dst_node->id, 0, can_overwrite_,
+		                             ignore_missing_src_, emit_changelog_, enqueue_work_);
 		local_tasks_.push_back(*task);
 	}
 }
@@ -192,13 +190,13 @@ void SnapshotTask::cloneSymlinkData(FSNodeSymlink *src_node, FSNodeSymlink *dst_
 		FSNodeDirectory *dst_parent) {
 	StatsRecord psr, nsr;
 
-	fsnodes_get_stats(dst_node, &psr);
+	gFSOperations->nodeOperations()->fsnodes_get_stats(dst_node, &psr);
 
 	dst_node->path = src_node->path;
 	dst_node->path_length = src_node->path_length;
 
-	fsnodes_get_stats(dst_node, &nsr);
-	fsnodes_add_sub_stats(dst_parent, &nsr, &psr);
+	gFSOperations->nodeOperations()->fsnodes_get_stats(dst_node, &nsr);
+	gFSOperations->nodeOperations()->fsnodes_add_sub_stats(dst_parent, &nsr, &psr);
 }
 
 void SnapshotTask::emitChangelog(uint32_t ts, inode_t dst_inode) {
@@ -207,14 +205,17 @@ void SnapshotTask::emitChangelog(uint32_t ts, inode_t dst_inode) {
 		return;
 	}
 
-	gFSOperations->changeLog(ts, "CLONE(%" PRIiNode ",%" PRIiNode ",%" PRIiNode ",%s,%" PRIu8 ")",
-	                         current_subtask_->first, dst_parent_inode_, dst_inode,
-	                         fsnodes_escape_name(current_subtask_->second).c_str(), can_overwrite_);
+	gFSOperations->changeLog(
+	    ts, "CLONE(%" PRIiNode ",%" PRIiNode ",%" PRIiNode ",%s,%" PRIu8 ")",
+	    current_subtask_->first, dst_parent_inode_, dst_inode,
+	    gFSOperations->nodeOperations()->fsnodes_escape_name(current_subtask_->second).c_str(),
+	    can_overwrite_);
 }
 
 int SnapshotTask::cloneNode(uint32_t ts) {
-	FSNode *src_node = fsnodes_id_to_node(current_subtask_->first);
-	FSNodeDirectory *dst_parent = fsnodes_id_to_node<FSNodeDirectory>(dst_parent_inode_);
+	FSNode *src_node = gFSOperations->nodeOperations()->fsnodes_id_to_node(current_subtask_->first);
+	FSNodeDirectory *dst_parent =
+	    gFSOperations->nodeOperations()->fsnodes_id_to_node<FSNodeDirectory>(dst_parent_inode_);
 
 	if (!src_node || src_node->type == FSNodeType::kTrash ||
 	    src_node->type == FSNodeType::kReserved) {
@@ -224,7 +225,8 @@ int SnapshotTask::cloneNode(uint32_t ts) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
 
-	FSNode *dst_node = fsnodes_lookup(dst_parent, current_subtask_->second);
+	FSNode *dst_node =
+	    gFSOperations->nodeOperations()->fsnodes_lookup(dst_parent, current_subtask_->second);
 
 	int status = cloneNodeTest(src_node, dst_node, dst_parent);
 	if (status != SAUNAFS_STATUS_OK) {


### PR DESCRIPTION
This change introduces the IFilesystemNodeOperations interface, which allows to override the default behavior (in-memory) for operations on top of filesystem nodes.

The free functions in filesystem_node.h and filesystem_node.cc now belongs to the implementation FilesystemNodeOperationsBase, which provides the usual behavior. As new implementations appear, the common functions will remain in FilesystemNodeOperationsBase and a new FilesystemNodeOperationsInMemory will handle the current approach.

The operations on top of nodes, as a design decision, are now accessed through gFSOperations->nodeOperations().

All places where the free functions were called, were updated accordingly and formated automatically (clang-format).

This change keeps the original function names to ease the review process, but further commits will rename them. So a call like:

gFSOperations->nodeOperations()->fsnodes_getpath(parent, node, path);

Could become:

gFSOperations->nodeOperations()->getPath(parent, node, path);

Reviewers: I tried to avoid non-related refactors to keep the initial review easy, but I plan to do it in further commits.