### PR TITLE
refactor(master): Refactor node operations

### DIFF
--- a/src/master/filesystem_dump.cc
+++ b/src/master/filesystem_dump.cc
@@ -31,17 +31,17 @@ void fs_dumpedge(FSNodeDirectory *parent, FSNode *child, const std::string &name
 	if (parent == NULL) {
 		if (child->type == FSNodeType::kTrash) {
 			printf("E|p:     TRASH|c:%10" PRIiNode "|n:%s\n", child->id,
-			       gFSOperations->nodeOperations()->fsnodes_escape_name(name).c_str());
+			       gFSOperations->nodeOperations()->escapeName(name).c_str());
 		} else if (child->type == FSNodeType::kReserved) {
 			printf("E|p:  RESERVED|c:%10" PRIiNode "|n:%s\n", child->id,
-			       gFSOperations->nodeOperations()->fsnodes_escape_name(name).c_str());
+			       gFSOperations->nodeOperations()->escapeName(name).c_str());
 		} else {
 			printf("E|p:      NULL|c:%10" PRIiNode "|n:%s\n", child->id,
-			       gFSOperations->nodeOperations()->fsnodes_escape_name(name).c_str());
+			       gFSOperations->nodeOperations()->escapeName(name).c_str());
 		}
 	} else {
 		printf("E|p:%10" PRIiNode "|c:%10" PRIiNode "|n:%s\n", parent->id, child->id,
-		       gFSOperations->nodeOperations()->fsnodes_escape_name(name).c_str());
+		       gFSOperations->nodeOperations()->escapeName(name).c_str());
 	}
 }
 
@@ -91,10 +91,9 @@ void fs_dumpnode(FSNode *f) {
 		printf("|d:%5" PRIu32 ",%5" PRIu32 "\n", static_cast<FSNodeDevice*>(f)->rdev >> 16,
 		       static_cast<FSNodeDevice*>(f)->rdev & 0xFFFF);
 	} else if (f->type == FSNodeType::kSymlink) {
-		printf("|p:%s\n",
-		       gFSOperations->nodeOperations()
-		           ->fsnodes_escape_name((std::string) static_cast<FSNodeSymlink *>(f)->path)
-		           .c_str());
+		printf("|p:%s\n", gFSOperations->nodeOperations()
+		                      ->escapeName((std::string) static_cast<FSNodeSymlink *>(f)->path)
+		                      .c_str());
 	} else if (f->type == FSNodeType::kFile || f->type == FSNodeType::kTrash ||
 	           f->type == FSNodeType::kReserved) {
 		FSNodeFile *node_file = static_cast<FSNodeFile*>(f);
@@ -146,14 +145,14 @@ void fs_dumpedgelist(FSNodeDirectory *parent) {
 
 void fs_dumpedgelist(const TrashPathContainer &data) {
 	for (const auto &entry : data) {
-		FSNode *child = gFSOperations->nodeOperations()->fsnodes_id_to_node(entry.first.id);
+		FSNode *child = gFSOperations->nodeOperations()->idToNode(entry.first.id);
 		fs_dumpedge(nullptr, child, (std::string)entry.second);
 	}
 }
 
 void fs_dumpedgelist(const ReservedPathContainer &data) {
 	for (const auto &entry : data) {
-		FSNode *child = gFSOperations->nodeOperations()->fsnodes_id_to_node(entry.first);
+		FSNode *child = gFSOperations->nodeOperations()->idToNode(entry.first);
 		fs_dumpedge(nullptr, child, (std::string)entry.second);
 	}
 }
@@ -187,14 +186,12 @@ void xattr_dump() {
 		for (const auto &xattrDataEntry : gMetadata->xattrDataHash[i]) {
 			printf("X|i:%10" PRIiNode "|n:%s|v:%s\n", xattrDataEntry.get()->inode,
 			       gFSOperations->nodeOperations()
-			           ->fsnodes_escape_name(
-			               std::string((char *)xattrDataEntry.get()->attributeName.data(),
-			                           xattrDataEntry.get()->attributeName.size()))
+			           ->escapeName(std::string((char *)xattrDataEntry.get()->attributeName.data(),
+			                                    xattrDataEntry.get()->attributeName.size()))
 			           .c_str(),
 			       gFSOperations->nodeOperations()
-			           ->fsnodes_escape_name(
-			               std::string((char *)xattrDataEntry.get()->attributeValue.data(),
-			                           xattrDataEntry.get()->attributeValue.size()))
+			           ->escapeName(std::string((char *)xattrDataEntry.get()->attributeValue.data(),
+			                                    xattrDataEntry.get()->attributeValue.size()))
 			           .c_str());
 		}
 	}

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -185,7 +185,7 @@ uint64_t FilesystemNodeOperationsBase::file_realsize(FSNodeFile *node, uint32_t 
 
 // Protected methods
 
-FSNode *FilesystemNodeOperationsBase::fsnodes_id_to_node_internal(inode_t id) {
+FSNode *FilesystemNodeOperationsBase::idToNodeInternal(inode_t id) {
 	// Find the node with the given id
 	uint32_t nodeHashIndex = NODEHASHPOS(id);
 
@@ -198,15 +198,14 @@ FSNode *FilesystemNodeOperationsBase::fsnodes_id_to_node_internal(inode_t id) {
 
 // Public methods
 
-FSNode *FilesystemNodeOperationsBase::fsnodes_lookup(FSNodeDirectory *node,
-                                                     const HString &name) const {
+FSNode *FilesystemNodeOperationsBase::lookup(FSNodeDirectory *node, const HString &name) const {
 	auto it = node->find(name);
 	if (it != node->end()) { return (*it).second; }
 
 	return nullptr;
 }
 
-void FilesystemNodeOperationsBase::fsnodes_update_ctime(FSNode *node, uint32_t ctime) {
+void FilesystemNodeOperationsBase::updateCTime(FSNode *node, uint32_t ctime) {
 	if (node->type == FSNodeType::kTrash && node->ctime != ctime) {
 		auto old_key = TrashPathKey(node);
 		node->ctime = ctime;
@@ -219,7 +218,7 @@ void FilesystemNodeOperationsBase::fsnodes_update_ctime(FSNode *node, uint32_t c
 	}
 }
 
-std::string FilesystemNodeOperationsBase::fsnodes_escape_name(const std::string &name) {
+std::string FilesystemNodeOperationsBase::escapeName(const std::string &name) {
 	constexpr std::array<char, 16> hex_digit = {{'0', '1', '2', '3', '4', '5', '6', '7',
 	                                             '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'}};
 	std::string result;
@@ -247,14 +246,14 @@ std::string FilesystemNodeOperationsBase::fsnodes_escape_name(const std::string 
 	return result;
 }
 
-int FilesystemNodeOperationsBase::fsnodes_nameisused(FSNodeDirectory *node, const HString &name) {
-	return fsnodes_lookup(node, name) != nullptr;
+int FilesystemNodeOperationsBase::isNameUsed(FSNodeDirectory *node, const HString &name) {
+	return lookup(node, name) != nullptr;
 }
 
 /*! \brief Returns true iff \param ancestor is ancestor of \param node. */
-bool FilesystemNodeOperationsBase::fsnodes_isancestor(FSNodeDirectory *ancestor, FSNode *node) {
+bool FilesystemNodeOperationsBase::isAncestor(FSNodeDirectory *ancestor, FSNode *node) {
 	for (const auto &[parentId, _] : node->parents) {
-		auto *dir_node = fsnodes_id_to_node_verify<FSNodeDirectory>(parentId);
+		auto *dir_node = idToNodeVerify<FSNodeDirectory>(parentId);
 
 		while(dir_node) {
 			if (ancestor == dir_node) {
@@ -264,7 +263,7 @@ bool FilesystemNodeOperationsBase::fsnodes_isancestor(FSNodeDirectory *ancestor,
 			assert(dir_node->parents.size() <= 1);
 
 			if (!dir_node->parents.empty()) {
-				dir_node = fsnodes_id_to_node_verify<FSNodeDirectory>(dir_node->parents[0].first);
+				dir_node = idToNodeVerify<FSNodeDirectory>(dir_node->parents[0].first);
 			} else {
 				dir_node = nullptr;
 			}
@@ -277,19 +276,19 @@ bool FilesystemNodeOperationsBase::fsnodes_isancestor(FSNodeDirectory *ancestor,
 /*! \brief Returns true iff \param node is reserved or in trash
  * or \param ancestor is ancestor of \param node.
  */
-bool FilesystemNodeOperationsBase::fsnodes_isancestor_or_node_reserved_or_trash(
-    FSNodeDirectory *ancestor, FSNode *node) {
+bool FilesystemNodeOperationsBase::isAncestorOrNodeReservedOrTrash(FSNodeDirectory *ancestor,
+                                                                   FSNode *node) {
 	// Return true if file is reserved:
 	if (node && (node->type == FSNodeType::kReserved || node->type == FSNodeType::kTrash)) {
 		return true;
 	}
 	// Or if ancestor is ancestor of node
-	return fsnodes_isancestor(ancestor, node);
+	return isAncestor(ancestor, node);
 }
 
 // stats
 
-void FilesystemNodeOperationsBase::fsnodes_get_stats(FSNode *node, StatsRecord *sr) {
+void FilesystemNodeOperationsBase::getStats(FSNode *node, StatsRecord *sr) {
 	switch (node->type) {
 	case FSNodeType::kDirectory:
 		*sr = static_cast<FSNodeDirectory*>(node)->stats;
@@ -330,17 +329,17 @@ void FilesystemNodeOperationsBase::fsnodes_get_stats(FSNode *node, StatsRecord *
 	}
 }
 
-int64_t FilesystemNodeOperationsBase::fsnodes_get_size(FSNode *node) {
+int64_t FilesystemNodeOperationsBase::getSize(FSNode *node) {
 	StatsRecord sr;
-	fsnodes_get_stats(node, &sr);
+	getStats(node, &sr);
 	return sr.size;
 }
 
-FSNodeDirectory *FilesystemNodeOperationsBase::fsnodes_get_first_parent(FSNode *node) {
+FSNodeDirectory *FilesystemNodeOperationsBase::getFirstParent(FSNode *node) {
 	assert(node);
 	FSNodeDirectory *parent;
 	if (!node->parents.empty()) {
-		parent = fsnodes_id_to_node_verify<FSNodeDirectory>(node->parents[0].first);
+		parent = idToNodeVerify<FSNodeDirectory>(node->parents[0].first);
 	} else {
 		parent = gMetadata->root;
 	}
@@ -361,14 +360,14 @@ void FilesystemNodeOperationsBase::fsnodes_sub_stats(FSNodeDirectory *parent, St
 		psr->realsize -= sr->realsize;
 		if (parent != gMetadata->root) {
 			for (auto const &[parentId, _] : parent->parents) {
-				auto *node = fsnodes_id_to_node_verify<FSNodeDirectory>(parentId);
+				auto *node = idToNodeVerify<FSNodeDirectory>(parentId);
 				fsnodes_sub_stats(node, sr);
 			}
 		}
 	}
 }
 
-void FilesystemNodeOperationsBase::fsnodes_add_stats(FSNodeDirectory *parent, StatsRecord *sr) {
+void FilesystemNodeOperationsBase::addStats(FSNodeDirectory *parent, StatsRecord *sr) {
 	StatsRecord *psr;
 	if (parent) {
 		psr = &parent->stats;
@@ -382,15 +381,15 @@ void FilesystemNodeOperationsBase::fsnodes_add_stats(FSNodeDirectory *parent, St
 		psr->realsize += sr->realsize;
 		if (parent != gMetadata->root) {
 			for (auto const &[parentId, _] : parent->parents) {
-				auto *node = fsnodes_id_to_node_verify<FSNodeDirectory>(parentId);
-				fsnodes_add_stats(node, sr);
+				auto *node = idToNodeVerify<FSNodeDirectory>(parentId);
+				addStats(node, sr);
 			}
 		}
 	}
 }
 
-void FilesystemNodeOperationsBase::fsnodes_add_sub_stats(FSNodeDirectory *parent,
-                                                         StatsRecord *newsr, StatsRecord *prevsr) {
+void FilesystemNodeOperationsBase::addSubStats(FSNodeDirectory *parent, StatsRecord *newsr,
+                                               StatsRecord *prevsr) {
 	StatsRecord sr;
 	sr.inodes = newsr->inodes - prevsr->inodes;
 	sr.dirs = newsr->dirs - prevsr->dirs;
@@ -400,12 +399,12 @@ void FilesystemNodeOperationsBase::fsnodes_add_sub_stats(FSNodeDirectory *parent
 	sr.length = newsr->length - prevsr->length;
 	sr.size = newsr->size - prevsr->size;
 	sr.realsize = newsr->realsize - prevsr->realsize;
-	fsnodes_add_stats(parent, &sr);
+	addStats(parent, &sr);
 }
 
-void FilesystemNodeOperationsBase::fsnodes_fill_attr(FSNode *node, FSNode *parent, uint32_t uid,
-                                                     uint32_t gid, uint32_t auid, uint32_t agid,
-                                                     uint8_t sesflags, Attributes &attr) {
+void FilesystemNodeOperationsBase::fillAttr(FSNode *node, FSNode *parent, uint32_t uid,
+                                            uint32_t gid, uint32_t auid, uint32_t agid,
+                                            uint8_t sesflags, Attributes &attr) {
 #ifdef METARESTORE
 	mabort("Bad code path - fsnodes_fill_attr() shall not be executed in metarestore context.");
 #endif /* METARESTORE */
@@ -504,18 +503,18 @@ void FilesystemNodeOperationsBase::fsnodes_fill_attr(FSNode *node, FSNode *paren
 	}
 }
 
-void FilesystemNodeOperationsBase::fsnodes_fill_attr(const FsContext &context, FSNode *node,
-                                                     FSNode *parent, Attributes &attr) {
+void FilesystemNodeOperationsBase::fillAttr(const FsContext &context, FSNode *node, FSNode *parent,
+                                            Attributes &attr) {
 #ifdef METARESTORE
 	mabort("Bad code path - fsnodes_fill_attr() shall not be executed in metarestore context.");
 #endif /* METARESTORE */
 	sassert(context.hasSessionData() && context.hasUidGidData());
-	fsnodes_fill_attr(node, parent, context.uid(), context.gid(), context.auid(), context.agid(),
-	                  context.sesflags(), attr);
+	fillAttr(node, parent, context.uid(), context.gid(), context.auid(), context.agid(),
+	         context.sesflags(), attr);
 }
 
-void FilesystemNodeOperationsBase::fsnodes_remove_edge(uint32_t ts, FSNodeDirectory *parent,
-                                                       const HString &name, FSNode *node) {
+void FilesystemNodeOperationsBase::removeEdge(uint32_t ts, FSNodeDirectory *parent,
+                                              const HString &name, FSNode *node) {
 	assert(parent);
 
 	auto dir_it = parent->find(name);
@@ -537,7 +536,7 @@ void FilesystemNodeOperationsBase::fsnodes_remove_edge(uint32_t ts, FSNodeDirect
 
 	StatsRecord sr;
 
-	fsnodes_get_stats(node, &sr);
+	getStats(node, &sr);
 	fsnodes_sub_stats(parent, &sr);
 	parent->mtime = parent->ctime = ts;
 	if (node->type == FSNodeType::kDirectory) {
@@ -572,8 +571,8 @@ void FilesystemNodeOperationsBase::fsnodes_remove_edge(uint32_t ts, FSNodeDirect
 	gMetadata->edgeRemovedSignal.emit(parent->id, node->id);
 }
 
-void FilesystemNodeOperationsBase::fsnodes_link(uint32_t ts, FSNodeDirectory *parent, FSNode *child,
-                                                const HString &name) {
+void FilesystemNodeOperationsBase::link(uint32_t ts, FSNodeDirectory *parent, FSNode *child,
+                                        const HString &name) {
 	// Needs to be freed in fsnodes_remove_edge
 	auto *handlePtr = new hstorage::Handle(name);
 	parent->entries.insert({handlePtr, child});
@@ -595,8 +594,8 @@ void FilesystemNodeOperationsBase::fsnodes_link(uint32_t ts, FSNodeDirectory *pa
 	}
 
 	StatsRecord sr;
-	fsnodes_get_stats(child, &sr);
-	fsnodes_add_stats(parent, &sr);
+	getStats(child, &sr);
+	addStats(parent, &sr);
 	if (ts > 0) {
 		parent->mtime = parent->ctime = ts;
 		fsnodes_update_checksum(parent);
@@ -606,10 +605,11 @@ void FilesystemNodeOperationsBase::fsnodes_link(uint32_t ts, FSNodeDirectory *pa
 	}
 }
 
-FSNode *FilesystemNodeOperationsBase::fsnodes_create_node(
-    uint32_t ts, FSNodeDirectory *parent, const HString &name, FSNodeType type, uint16_t mode,
-    uint16_t umask, uint32_t uid, uint32_t gid, uint8_t copysgid, AclInheritance inheritacl,
-    inode_t req_inode) {
+FSNode *FilesystemNodeOperationsBase::createNode(uint32_t ts, FSNodeDirectory *parent,
+                                                 const HString &name, FSNodeType type,
+                                                 uint16_t mode, uint16_t umask, uint32_t uid,
+                                                 uint32_t gid, uint8_t copysgid,
+                                                 AclInheritance inheritacl, inode_t req_inode) {
 	assert(type != FSNodeType::kTrash);
 
 	FSNode *node = FSNode::create(type);
@@ -667,18 +667,17 @@ FSNode *FilesystemNodeOperationsBase::fsnodes_create_node(
 	gMetadata->addNode(node);
 
 	fsnodes_update_checksum(node);
-	fsnodes_link(ts, parent, node, name);
+	link(ts, parent, node, name);
 	fsnodes_quota_update(node, {{QuotaResource::kInodes, +1}});
 
 	if (type == FSNodeType::kFile) {
-		fsnodes_quota_update(node, {{QuotaResource::kSize, +fsnodes_get_size(node)}});
+		fsnodes_quota_update(node, {{QuotaResource::kSize, +getSize(node)}});
 	}
 
 	return node;
 }
 
-uint32_t FilesystemNodeOperationsBase::fsnodes_getpath_size(FSNodeDirectory *parent,
-                                                            FSNode *child) {
+uint32_t FilesystemNodeOperationsBase::getPathSize(FSNodeDirectory *parent, FSNode *child) {
 	std::string name;
 	uint32_t size;
 
@@ -692,7 +691,7 @@ uint32_t FilesystemNodeOperationsBase::fsnodes_getpath_size(FSNodeDirectory *par
 	while (parent != gMetadata->root && !parent->parents.empty()) {
 		child = parent;
 		assert(child->parents.size() == 1);
-		parent = fsnodes_id_to_node_verify<FSNodeDirectory>(child->parents[0].first);
+		parent = idToNodeVerify<FSNodeDirectory>(child->parents[0].first);
 		name = parent->getChildName(child);
 		size += name.length() + 1;
 	}
@@ -700,8 +699,8 @@ uint32_t FilesystemNodeOperationsBase::fsnodes_getpath_size(FSNodeDirectory *par
 	return size;
 }
 
-void FilesystemNodeOperationsBase::fsnodes_getpath_data(FSNodeDirectory *parent, FSNode *child,
-                                                        uint8_t *path, uint32_t size) {
+void FilesystemNodeOperationsBase::getPathData(FSNodeDirectory *parent, FSNode *child,
+                                               uint8_t *path, uint32_t size) {
 	std::string name;
 
 	if (parent == nullptr || child == nullptr) {
@@ -723,7 +722,7 @@ void FilesystemNodeOperationsBase::fsnodes_getpath_data(FSNodeDirectory *parent,
 	while (parent != gMetadata->root && !parent->parents.empty()) {
 		child = parent;
 		assert(child->parents.size() == 1);
-		parent = fsnodes_id_to_node_verify<FSNodeDirectory>(child->parents[0].first);
+		parent = idToNodeVerify<FSNodeDirectory>(child->parents[0].first);
 		name = parent->getChildName(child);
 		if (size >= name.length()) {
 			size -= name.length();
@@ -738,9 +737,9 @@ void FilesystemNodeOperationsBase::fsnodes_getpath_data(FSNodeDirectory *parent,
 	}
 }
 
-void FilesystemNodeOperationsBase::fsnodes_getpath(FSNodeDirectory *parent, FSNode *child,
-                                                   std::string &path) {
-	uint32_t size = fsnodes_getpath_size(parent, child);
+void FilesystemNodeOperationsBase::getPath(FSNodeDirectory *parent, FSNode *child,
+                                           std::string &path) {
+	uint32_t size = getPathSize(parent, child);
 
 	if (size > 65535) {
 		safs_pretty_syslog(LOG_WARNING, "path too long !!! - truncate");
@@ -749,7 +748,7 @@ void FilesystemNodeOperationsBase::fsnodes_getpath(FSNodeDirectory *parent, FSNo
 
 	path.resize(size);
 
-	fsnodes_getpath_data(parent, child, (uint8_t *)path.data(), size);
+	getPathData(parent, child, (uint8_t *)path.data(), size);
 }
 
 #ifndef METARESTORE
@@ -843,18 +842,17 @@ static inline void getdetacheddata(const T &data, uint8_t *dbuff) {
 	}
 }
 
-uint32_t FilesystemNodeOperationsBase::fsnodes_getdetachedsize(const TrashPathContainer &data) {
+uint32_t FilesystemNodeOperationsBase::getDetachedSize(const TrashPathContainer &data) {
 	return getdetachedsize(data);
 }
 
-void FilesystemNodeOperationsBase::fsnodes_getdetacheddata(const TrashPathContainer &data,
-                                                           uint8_t *dbuff) {
+void FilesystemNodeOperationsBase::getDetachedData(const TrashPathContainer &data, uint8_t *dbuff) {
 	getdetacheddata(data, dbuff);
 }
 
-void FilesystemNodeOperationsBase::fsnodes_getdetacheddata(const TrashPathContainer &data,
-                                                           uint32_t off, uint32_t max_entries,
-                                                           std::vector<NamedInodeEntry> &entries) {
+void FilesystemNodeOperationsBase::getDetachedData(const TrashPathContainer &data, uint32_t off,
+                                                   uint32_t max_entries,
+                                                   std::vector<NamedInodeEntry> &entries) {
 #if defined(SAUNAFS_HAVE_64BIT_JUDY) && !defined(DISABLE_JUDY_FOR_TRASHPATHCONTAINER)
 	auto it = data.find_nth(off);
 #else
@@ -869,11 +867,10 @@ void FilesystemNodeOperationsBase::fsnodes_getdetacheddata(const TrashPathContai
 // The offset provided by the client (e.g., FUSE readdir) is always non-negative (sign bit 0).
 // Internally, the server may store offsets with the sign bit set (bit 63 = 1).
 // All lookups are enforced to be done ignoring the sign bit by setting it to 0.
-void FilesystemNodeOperationsBase::fsnodes_getdetacheddata(const HandleIndexContainer &data,
-                                                           uint64_t handleOffset,
-                                                           uint32_t maxEntries,
-                                                           std::vector<HandleInodeEntry> &entries,
-                                                           bool fromTrash) {
+void FilesystemNodeOperationsBase::getDetachedData(const HandleIndexContainer &data,
+                                                   uint64_t handleOffset, uint32_t maxEntries,
+                                                   std::vector<HandleInodeEntry> &entries,
+                                                   bool fromTrash) {
 	uint64_t start = (handleOffset & ~k64SignBitMask);
 	auto it = data.lower_bound(HandleIndexKey(start));
 
@@ -884,7 +881,7 @@ void FilesystemNodeOperationsBase::fsnodes_getdetacheddata(const HandleIndexCont
 		uint64_t handleValueForClient = (*it).first.data & ~k64SignBitMask;
 		std::string nameForClient = "";
 		if (fromTrash) {
-			FSNode *node = fsnodes_id_to_node((*it).second);
+			FSNode *node = idToNode((*it).second);
 			nameForClient = gMetadata->trash.at(TrashPathKey(node)).get().c_str();
 		} else {
 			nameForClient = gMetadata->reserved.at((*it).second).get().c_str();
@@ -893,18 +890,18 @@ void FilesystemNodeOperationsBase::fsnodes_getdetacheddata(const HandleIndexCont
 	}
 }
 
-uint32_t FilesystemNodeOperationsBase::fsnodes_getdetachedsize(const ReservedPathContainer &data) {
+uint32_t FilesystemNodeOperationsBase::getDetachedSize(const ReservedPathContainer &data) {
 	return getdetachedsize(data);
 }
 
-void FilesystemNodeOperationsBase::fsnodes_getdetacheddata(const ReservedPathContainer &data,
-                                                           uint8_t *dbuff) {
+void FilesystemNodeOperationsBase::getDetachedData(const ReservedPathContainer &data,
+                                                   uint8_t *dbuff) {
 	getdetacheddata(data, dbuff);
 }
 
-void FilesystemNodeOperationsBase::fsnodes_getdetacheddata(const ReservedPathContainer &data,
-                                                           uint32_t off, uint32_t max_entries,
-                                                           std::vector<NamedInodeEntry> &entries) {
+void FilesystemNodeOperationsBase::getDetachedData(const ReservedPathContainer &data, uint32_t off,
+                                                   uint32_t max_entries,
+                                                   std::vector<NamedInodeEntry> &entries) {
 #if defined(SAUNAFS_HAVE_64BIT_JUDY) && !defined(DISABLE_JUDY_FOR_RESERVEDPATHCONTAINER)
 	auto it = data.find_nth(off);
 #else
@@ -915,8 +912,7 @@ void FilesystemNodeOperationsBase::fsnodes_getdetacheddata(const ReservedPathCon
 	}
 }
 
-uint32_t FilesystemNodeOperationsBase::fsnodes_getdirsize(const FSNodeDirectory *p,
-                                                          uint8_t withattr) {
+uint32_t FilesystemNodeOperationsBase::getDirSize(const FSNodeDirectory *p, uint8_t withattr) {
 	uint32_t result = ((withattr) ? 40 : 6) * 2 + 3;  // for '.' and '..'
 	std::string name;
 	for (const auto &entry : p->entries) {
@@ -926,10 +922,10 @@ uint32_t FilesystemNodeOperationsBase::fsnodes_getdirsize(const FSNodeDirectory 
 	return result;
 }
 
-void FilesystemNodeOperationsBase::fsnodes_getdirdata(inode_t rootinode, uint32_t uid, uint32_t gid,
-                                                      uint32_t auid, uint32_t agid,
-                                                      uint8_t sesflags, FSNodeDirectory *p,
-                                                      uint8_t *dbuff, uint8_t withattr) {
+void FilesystemNodeOperationsBase::getDirData(inode_t rootinode, uint32_t uid, uint32_t gid,
+                                              uint32_t auid, uint32_t agid, uint8_t sesflags,
+                                              FSNodeDirectory *p, uint8_t *dbuff,
+                                              uint8_t withattr) {
 	// '.' - self
 	dbuff[0] = 1;
 	dbuff[1] = '.';
@@ -941,7 +937,7 @@ void FilesystemNodeOperationsBase::fsnodes_getdirdata(inode_t rootinode, uint32_
 	}
 	Attributes attr;
 	if (withattr) {
-		fsnodes_fill_attr(p, p, uid, gid, auid, agid, sesflags, attr);
+		fillAttr(p, p, uid, gid, auid, agid, sesflags, attr);
 		::memcpy(dbuff, attr.data(), attr.size());
 		dbuff += attr.size();
 	} else {
@@ -955,7 +951,7 @@ void FilesystemNodeOperationsBase::fsnodes_getdirdata(inode_t rootinode, uint32_
 	if (p->id == rootinode) {  // root node should returns self as its parent
 		putINode(&dbuff, SPECIAL_INODE_ROOT);
 		if (withattr) {
-			fsnodes_fill_attr(p, p, uid, gid, auid, agid, sesflags, attr);
+			fillAttr(p, p, uid, gid, auid, agid, sesflags, attr);
 			::memcpy(dbuff, attr.data(), attr.size());
 			dbuff += attr.size();
 		} else {
@@ -969,18 +965,18 @@ void FilesystemNodeOperationsBase::fsnodes_getdirdata(inode_t rootinode, uint32_
 		}
 		if (withattr) {
 			if (!p->parents.empty()) {
-				auto *parent = fsnodes_id_to_node_verify<FSNode>(p->parents[0].first);
-				fsnodes_fill_attr(parent, p, uid, gid, auid, agid, sesflags, attr);
+				auto *parent = idToNodeVerify<FSNode>(p->parents[0].first);
+				fillAttr(parent, p, uid, gid, auid, agid, sesflags, attr);
 				::memcpy(dbuff, attr.data(), attr.size());
 			} else {
 				if (rootinode == SPECIAL_INODE_ROOT) {
-					fsnodes_fill_attr(gMetadata->root, p, uid, gid, auid, agid, sesflags, attr);
+					fillAttr(gMetadata->root, p, uid, gid, auid, agid, sesflags, attr);
 					::memcpy(dbuff, attr.data(), attr.size());
 				} else {
-					FSNode *rn = fsnodes_id_to_node(rootinode);
+					FSNode *rn = idToNode(rootinode);
 					if (rn) {  // it should be always true because it's checked
 						   // before, but better check than sorry
-						   fsnodes_fill_attr(rn, p, uid, gid, auid, agid, sesflags, attr);
+						   fillAttr(rn, p, uid, gid, auid, agid, sesflags, attr);
 						   ::memcpy(dbuff, attr.data(), attr.size());
 					} else {
 						memset(dbuff, 0, attr.size());
@@ -1002,7 +998,7 @@ void FilesystemNodeOperationsBase::fsnodes_getdirdata(inode_t rootinode, uint32_
 		dbuff += name.length();
 		putINode(&dbuff, entry.second->id);
 		if (withattr) {
-			fsnodes_fill_attr(entry.second, p, uid, gid, auid, agid, sesflags, attr);
+			fillAttr(entry.second, p, uid, gid, auid, agid, sesflags, attr);
 			::memcpy(dbuff, attr.data(), attr.size());
 			dbuff += attr.size();
 		} else {
@@ -1022,11 +1018,11 @@ void FilesystemNodeOperationsBase::fsnodes_getdirdata(inode_t rootinode, uint32_
  * \param number_of_entries number of dirents to get
  * \param[out] container into which dirents are inserted
  */
-void FilesystemNodeOperationsBase::fsnodes_getdir(inode_t rootinode, uint32_t uid, uint32_t gid,
-                                                  uint32_t auid, uint32_t agid, uint8_t sesflags,
-                                                  FSNodeDirectory *p, uint64_t first_entry,
-                                                  uint64_t number_of_entries,
-                                                  std::vector<DirectoryEntry> &dir_entries) {
+void FilesystemNodeOperationsBase::getDir(inode_t rootinode, uint32_t uid, uint32_t gid,
+                                          uint32_t auid, uint32_t agid, uint8_t sesflags,
+                                          FSNodeDirectory *p, uint64_t first_entry,
+                                          uint64_t number_of_entries,
+                                          std::vector<DirectoryEntry> &dir_entries) {
 	uint64_t const SIGN_BIT_64(1ULL << 63ULL);
 	sassert(!(first_entry & SIGN_BIT_64));
 	// special entryIndex values
@@ -1040,9 +1036,9 @@ void FilesystemNodeOperationsBase::fsnodes_getdir(inode_t rootinode, uint32_t ui
 
 	if (first_entry == kDotEntryIndex && number_of_entries >= 1) {
 		inode = p->id != rootinode ? p->id : SPECIAL_INODE_ROOT;
-		parent = fsnodes_id_to_node_verify<FSNodeDirectory>(
-		    p->parents.empty() ? SPECIAL_INODE_ROOT : p->parents[0].first);
-		fsnodes_fill_attr(p, parent, uid, gid, auid, agid, sesflags, attr);
+		parent = idToNodeVerify<FSNodeDirectory>(p->parents.empty() ? SPECIAL_INODE_ROOT
+		                                                            : p->parents[0].first);
+		fillAttr(p, parent, uid, gid, auid, agid, sesflags, attr);
 		dir_entries.emplace_back(kDotEntryIndex, kDotDotEntryIndex, std::move(inode), std::string("."), std::move(attr));
 
 		first_entry = kDotDotEntryIndex;
@@ -1052,9 +1048,9 @@ void FilesystemNodeOperationsBase::fsnodes_getdir(inode_t rootinode, uint32_t ui
 	if (first_entry == kDotDotEntryIndex && number_of_entries >= 1) {
 		if (p->id == rootinode) {
 			inode = SPECIAL_INODE_ROOT;
-			parent = fsnodes_id_to_node_verify<FSNodeDirectory>(
-			    p->parents.empty() ? SPECIAL_INODE_ROOT : p->parents[0].first);
-			fsnodes_fill_attr(p, parent, uid, gid, auid, agid, sesflags, attr);
+			parent = idToNodeVerify<FSNodeDirectory>(p->parents.empty() ? SPECIAL_INODE_ROOT
+			                                                            : p->parents[0].first);
+			fillAttr(p, parent, uid, gid, auid, agid, sesflags, attr);
 		} else {
 			if (!p->parents.empty() && p->parents[0].first != rootinode) {
 				inode = p->parents[0].first;
@@ -1063,11 +1059,11 @@ void FilesystemNodeOperationsBase::fsnodes_getdir(inode_t rootinode, uint32_t ui
 			}
 
 			FSNodeDirectory *grandparent;
-			parent = fsnodes_id_to_node_verify<FSNodeDirectory>(
-			    p->parents.empty() ? SPECIAL_INODE_ROOT : p->parents[0].first);
-			grandparent = fsnodes_id_to_node_verify<FSNodeDirectory>(
+			parent = idToNodeVerify<FSNodeDirectory>(p->parents.empty() ? SPECIAL_INODE_ROOT
+			                                                            : p->parents[0].first);
+			grandparent = idToNodeVerify<FSNodeDirectory>(
 			    parent->parents.empty() ? SPECIAL_INODE_ROOT : parent->parents[0].first);
-			fsnodes_fill_attr(parent, grandparent, uid, gid, auid, agid, sesflags, attr);
+			fillAttr(parent, grandparent, uid, gid, auid, agid, sesflags, attr);
 		}
 
 		uint64_t next_index = kUnusedEntryIndex;
@@ -1112,7 +1108,7 @@ void FilesystemNodeOperationsBase::fsnodes_getdir(inode_t rootinode, uint32_t ui
 	while (it != p->entries.end() && number_of_entries > 0) {
 		name = static_cast<std::string>(*(*it).first);
 		inode = (*it).second->id;
-		fsnodes_fill_attr((*it).second, p, uid, gid, auid, agid, sesflags, attr);
+		fillAttr((*it).second, p, uid, gid, auid, agid, sesflags, attr);
 
 		first_entry = (*it).first->data() & ~SIGN_BIT_64;
 
@@ -1127,8 +1123,8 @@ void FilesystemNodeOperationsBase::fsnodes_getdir(inode_t rootinode, uint32_t ui
 	}
 }
 
-void FilesystemNodeOperationsBase::fsnodes_checkfile(FSNodeFile *p,
-                                                     uint32_t chunk_count[CHUNK_MATRIX_SIZE]) {
+void FilesystemNodeOperationsBase::checkFile(FSNodeFile *p,
+                                             uint32_t chunk_count[CHUNK_MATRIX_SIZE]) {
 	uint8_t count;
 
 	for(int i = 0; i < CHUNK_MATRIX_SIZE; ++i) {
@@ -1145,8 +1141,7 @@ void FilesystemNodeOperationsBase::fsnodes_checkfile(FSNodeFile *p,
 }
 #endif
 
-uint8_t FilesystemNodeOperationsBase::fsnodes_appendchunks(uint32_t ts, FSNodeFile *dst,
-                                                           FSNodeFile *src) {
+uint8_t FilesystemNodeOperationsBase::appendChunks(uint32_t ts, FSNodeFile *dst, FSNodeFile *src) {
 	if (src->chunks.empty()) {
 		return SAUNAFS_STATUS_OK;
 	}
@@ -1159,7 +1154,7 @@ uint8_t FilesystemNodeOperationsBase::fsnodes_appendchunks(uint32_t ts, FSNodeFi
 	}
 
 	StatsRecord psr, nsr;
-	fsnodes_get_stats(dst, &psr);
+	getStats(dst, &psr);
 
 	uint32_t result_chunks = src_chunks + dst_chunks;
 	dst->chunks.resize(result_chunks, 0);
@@ -1187,11 +1182,11 @@ uint8_t FilesystemNodeOperationsBase::fsnodes_appendchunks(uint32_t ts, FSNodeFi
 		gMetadata->reservedSpace += length;
 	}
 	dst->length = length;
-	fsnodes_get_stats(dst, &nsr);
+	getStats(dst, &nsr);
 	fsnodes_quota_update(dst, {{QuotaResource::kSize, nsr.size - psr.size}});
 	for (const auto &[parentId, _] : dst->parents) {
-		auto *parent_node = fsnodes_id_to_node_verify<FSNodeDirectory>(parentId);
-		fsnodes_add_sub_stats(parent_node, &nsr, &psr);
+		auto *parent_node = idToNodeVerify<FSNodeDirectory>(parentId);
+		addSubStats(parent_node, &nsr, &psr);
 	}
 	dst->mtime = ts;
 	dst->atime = ts;
@@ -1201,17 +1196,17 @@ uint8_t FilesystemNodeOperationsBase::fsnodes_appendchunks(uint32_t ts, FSNodeFi
 	return SAUNAFS_STATUS_OK;
 }
 
-void FilesystemNodeOperationsBase::fsnodes_changefilegoal(FSNodeFile *obj, uint8_t goal) {
+void FilesystemNodeOperationsBase::changeFileGoal(FSNodeFile *obj, uint8_t goal) {
 	uint8_t old_goal = obj->goal;
 	StatsRecord psr, nsr;
 
-	fsnodes_get_stats(obj, &psr);
+	getStats(obj, &psr);
 	obj->goal = goal;
 	nsr = psr;
 	nsr.realsize = file_realsize(obj, nsr.chunks, nsr.size);
 	for (const auto &[parentId, _] : obj->parents) {
-		auto *parent_node = fsnodes_id_to_node_verify<FSNodeDirectory>(parentId);
-		fsnodes_add_sub_stats(parent_node, &nsr, &psr);
+		auto *parent_node = idToNodeVerify<FSNodeDirectory>(parentId);
+		addSubStats(parent_node, &nsr, &psr);
 	}
 	for (const auto &chunkid : obj->chunks) {
 		if (chunkid > 0) {
@@ -1222,11 +1217,11 @@ void FilesystemNodeOperationsBase::fsnodes_changefilegoal(FSNodeFile *obj, uint8
 	gMetadata->nodeChangedSignal.emit(obj);
 }
 
-void FilesystemNodeOperationsBase::fsnodes_setlength(FSNodeFile *obj, uint64_t length,
-                                                     bool eraseFurtherChunks) {
+void FilesystemNodeOperationsBase::setLength(FSNodeFile *obj, uint64_t length,
+                                             bool eraseFurtherChunks) {
 	uint32_t chunks;
 	StatsRecord psr, nsr;
-	fsnodes_get_stats(obj, &psr);
+	getStats(obj, &psr);
 	if (obj->type == FSNodeType::kTrash) {
 		gMetadata->trashSpace -= obj->length;
 		gMetadata->trashSpace += length;
@@ -1258,22 +1253,22 @@ void FilesystemNodeOperationsBase::fsnodes_setlength(FSNodeFile *obj, uint64_t l
 		}
 	}
 
-	fsnodes_get_stats(obj, &nsr);
+	getStats(obj, &nsr);
 	fsnodes_quota_update(obj, {{QuotaResource::kSize, nsr.size - psr.size}});
 	for (const auto &[parentId, _] : obj->parents) {
-		auto *parent_node = fsnodes_id_to_node_verify<FSNodeDirectory>(parentId);
-		fsnodes_add_sub_stats(parent_node, &nsr, &psr);
+		auto *parent_node = idToNodeVerify<FSNodeDirectory>(parentId);
+		addSubStats(parent_node, &nsr, &psr);
 	}
 	fsnodes_update_checksum(obj);
 	gMetadata->nodeChangedSignal.emit(obj);
 }
 
-void FilesystemNodeOperationsBase::fsnodes_change_uid_gid(FSNode *p, uint32_t uid, uint32_t gid) {
+void FilesystemNodeOperationsBase::changeUidGid(FSNode *p, uint32_t uid, uint32_t gid) {
 	int64_t size = 0;
 	fsnodes_quota_update(p, {{QuotaResource::kInodes, -1}});
 	if (p->type == FSNodeType::kFile || p->type == FSNodeType::kTrash ||
 	    p->type == FSNodeType::kReserved) {
-		size = fsnodes_get_size(p);
+		size = getSize(p);
 		fsnodes_quota_update(p, {{QuotaResource::kSize, -size}});
 	}
 	p->uid = uid;
@@ -1306,7 +1301,7 @@ void FilesystemNodeOperationsBase::fsnodes_remove_node(uint32_t ts, FSNode *node
 
 	if (node->type == FSNodeType::kFile || node->type == FSNodeType::kTrash ||
 	    node->type == FSNodeType::kReserved) {
-		fsnodes_quota_update(node, {{QuotaResource::kSize, -fsnodes_get_size(node)}});
+		fsnodes_quota_update(node, {{QuotaResource::kSize, -getSize(node)}});
 		gMetadata->fileNodes--;
 		for (uint32_t i = 0; i < static_cast<FSNodeFile*>(node)->chunks.size(); ++i) {
 			uint64_t chunkid = static_cast<FSNodeFile*>(node)->chunks[i];
@@ -1347,19 +1342,19 @@ void FilesystemNodeOperationsBase::fsnodes_remove_node(uint32_t ts, FSNode *node
 	}
 }
 
-void FilesystemNodeOperationsBase::fsnodes_unlink(uint32_t ts, FSNodeDirectory *parent,
-                                                  const HString &child_name, FSNode *child) {
+void FilesystemNodeOperationsBase::unlink(uint32_t ts, FSNodeDirectory *parent,
+                                          const HString &child_name, FSNode *child) {
 	std::string path;
 
 	if (child->parents.size() == 1) {  // last link
 		if (child->type == FSNodeType::kFile &&
 		    (child->trashtime > 0 ||
 		     !static_cast<FSNodeFile*>(child)->sessionIds.empty())) {  // go to trash or reserved ? - get path
-			fsnodes_getpath(parent, child, path);
+			getPath(parent, child, path);
 		}
 	}
 
-	fsnodes_remove_edge(ts, parent, child_name, child);
+	removeEdge(ts, parent, child_name, child);
 	if (!child->parents.empty()) {
 		return;
 	}
@@ -1394,7 +1389,7 @@ void FilesystemNodeOperationsBase::fsnodes_unlink(uint32_t ts, FSNodeDirectory *
 	}
 }
 
-int FilesystemNodeOperationsBase::fsnodes_purge(uint32_t ts, FSNode *p) {
+int FilesystemNodeOperationsBase::purge(uint32_t ts, FSNode *p) {
 	if (p->type == FSNodeType::kTrash) {
 		FSNodeFile *file_node = static_cast<FSNodeFile*>(p);
 		gMetadata->trashSpace -= file_node->length;
@@ -1437,7 +1432,7 @@ int FilesystemNodeOperationsBase::fsnodes_purge(uint32_t ts, FSNode *p) {
 	return -1;
 }
 
-uint8_t FilesystemNodeOperationsBase::fsnodes_undel(uint32_t ts, FSNodeFile *node) {
+uint8_t FilesystemNodeOperationsBase::undel(uint32_t ts, FSNodeFile *node) {
 	uint8_t is_new;
 	uint32_t i, partleng, dots;
 	/* check path */
@@ -1504,9 +1499,7 @@ uint8_t FilesystemNodeOperationsBase::fsnodes_undel(uint32_t ts, FSNodeFile *nod
 		}
 		HString name(path, partleng);
 		if (partleng == pleng) {  // last name
-			if (fsnodes_nameisused(p, name)) {
-				return SAUNAFS_ERROR_EEXIST;
-			}
+			if (isNameUsed(p, name)) { return SAUNAFS_ERROR_EEXIST; }
 			// remove from trash and link to new parent
 			if (node->type == FSNodeType::kTrash) {
 				removeTrashEntry(gMetadata->trash, gMetadata->trashHandlesIndex,
@@ -1519,13 +1512,13 @@ uint8_t FilesystemNodeOperationsBase::fsnodes_undel(uint32_t ts, FSNodeFile *nod
 			node->type = FSNodeType::kFile;
 			node->ctime = ts;
 			fsnodes_update_checksum(node);
-			fsnodes_link(ts, p, node, name);
+			link(ts, p, node, name);
 			gMetadata->trashSpace -= node->length;
 			gMetadata->trashNodes--;
 			return SAUNAFS_STATUS_OK;
 		} else {
 			if (is_new == 0) {
-				n = fsnodes_lookup(p, name);
+				n = lookup(p, name);
 				if (n == nullptr) {
 					is_new = 1;
 				} else {
@@ -1535,19 +1528,18 @@ uint8_t FilesystemNodeOperationsBase::fsnodes_undel(uint32_t ts, FSNodeFile *nod
 				}
 			}
 			if (is_new == 1) {
-				n = fsnodes_create_node(ts, p, name, FSNodeType::kDirectory, 0755, 0, 0, 0, 0,
-				                        AclInheritance::kDontInheritAcl);
+				n = createNode(ts, p, name, FSNodeType::kDirectory, 0755, 0, 0, 0, 0,
+				               AclInheritance::kDontInheritAcl);
 
 #ifndef METARESTORE
 				assert(metadataserver::isMaster());
 #endif
 
-				gFSOperations->changeLog(ts,
-				                         "CREATE(%" PRIiNode ",%s,%c,%d,%" PRIu32 ",%" PRIu32
-				                         ",%" PRIu32 "):%" PRIiNode,
-				                         p->id, fsnodes_escape_name(name).c_str(),
-				                         static_cast<char>(FSNodeType::kDirectory), n->mode & 07777,
-				                         (uint32_t)0, (uint32_t)0, (uint32_t)0, n->id);
+				gFSOperations->changeLog(
+				    ts,
+				    "CREATE(%" PRIiNode ",%s,%c,%d,%" PRIu32 ",%" PRIu32 ",%" PRIu32 "):%" PRIiNode,
+				    p->id, escapeName(name).c_str(), static_cast<char>(FSNodeType::kDirectory),
+				    n->mode & 07777, (uint32_t)0, (uint32_t)0, (uint32_t)0, n->id);
 			}
 			p = static_cast<FSNodeDirectory*>(n);
 			assert(n->type == FSNodeType::kDirectory);
@@ -1559,15 +1551,14 @@ uint8_t FilesystemNodeOperationsBase::fsnodes_undel(uint32_t ts, FSNodeFile *nod
 
 #ifndef METARESTORE
 
-void FilesystemNodeOperationsBase::fsnodes_getgoal_recursive(FSNode *node, uint8_t gmode,
-                                                             GoalStatistics &fgtab,
-                                                             GoalStatistics &dgtab) {
+void FilesystemNodeOperationsBase::getGoalRecursive(FSNode *node, uint8_t gmode,
+                                                    GoalStatistics &fgtab, GoalStatistics &dgtab) {
 	if (node->type == FSNodeType::kFile || node->type == FSNodeType::kTrash ||
 	    node->type == FSNodeType::kReserved) {
 		if (!GoalId::isValid(node->goal)) {
 			safs_pretty_syslog(LOG_WARNING, "file inode %" PRIiNode ": unknown goal !!! - fixing",
 			       node->id);
-			fsnodes_changefilegoal(static_cast<FSNodeFile *>(node), DEFAULT_GOAL);
+			changeFileGoal(static_cast<FSNodeFile *>(node), DEFAULT_GOAL);
 		}
 		fgtab[node->goal]++;
 	} else if (node->type == FSNodeType::kDirectory) {
@@ -1580,15 +1571,15 @@ void FilesystemNodeOperationsBase::fsnodes_getgoal_recursive(FSNode *node, uint8
 		if (gmode == GMODE_RECURSIVE) {
 			const FSNodeDirectory *dir_node = static_cast<const FSNodeDirectory*>(node);
 			for (const auto &entry : dir_node->entries) {
-				fsnodes_getgoal_recursive(entry.second, gmode, fgtab, dgtab);
+				getGoalRecursive(entry.second, gmode, fgtab, dgtab);
 			}
 		}
 	}
 }
 
-void FilesystemNodeOperationsBase::fsnodes_gettrashtime_recursive(FSNode *node, uint8_t gmode,
-                                                                  TrashtimeMap &fileTrashtimes,
-                                                                  TrashtimeMap &dirTrashtimes) {
+void FilesystemNodeOperationsBase::getTrashTimeRecursive(FSNode *node, uint8_t gmode,
+                                                         TrashtimeMap &fileTrashtimes,
+                                                         TrashtimeMap &dirTrashtimes) {
 	if (node->type == FSNodeType::kFile || node->type == FSNodeType::kTrash ||
 	    node->type == FSNodeType::kReserved) {
 		fileTrashtimes[node->trashtime] += 1;
@@ -1597,15 +1588,15 @@ void FilesystemNodeOperationsBase::fsnodes_gettrashtime_recursive(FSNode *node, 
 		if (gmode == GMODE_RECURSIVE) {
 			const FSNodeDirectory *dir_node = static_cast<const FSNodeDirectory*>(node);
 			for (const auto &entry : dir_node->entries) {
-				fsnodes_gettrashtime_recursive(entry.second, gmode, fileTrashtimes, dirTrashtimes);
+				getTrashTimeRecursive(entry.second, gmode, fileTrashtimes, dirTrashtimes);
 			}
 		}
 	}
 }
 
-void FilesystemNodeOperationsBase::fsnodes_geteattr_recursive(FSNode *node, uint8_t gmode,
-                                                              uint32_t feattrtab[16],
-                                                              uint32_t deattrtab[16]) {
+void FilesystemNodeOperationsBase::getEAttrRecursive(FSNode *node, uint8_t gmode,
+                                                     uint32_t feattrtab[16],
+                                                     uint32_t deattrtab[16]) {
 	if (node->type != FSNodeType::kDirectory) {
 		feattrtab[(node->mode >> 12) &
 		          (EATTR_NOOWNER | EATTR_NOACACHE | EATTR_NODATACACHE)]++;
@@ -1614,7 +1605,7 @@ void FilesystemNodeOperationsBase::fsnodes_geteattr_recursive(FSNode *node, uint
 		if (gmode == GMODE_RECURSIVE) {
 			const FSNodeDirectory *dir_node = static_cast<const FSNodeDirectory*>(node);
 			for (const auto &entry : dir_node->entries) {
-				fsnodes_geteattr_recursive(entry.second, gmode, feattrtab, deattrtab);
+				getEAttrRecursive(entry.second, gmode, feattrtab, deattrtab);
 			}
 		}
 	}
@@ -1622,10 +1613,9 @@ void FilesystemNodeOperationsBase::fsnodes_geteattr_recursive(FSNode *node, uint
 
 #endif  // METARESTORE
 
-void FilesystemNodeOperationsBase::fsnodes_setgoal_recursive(FSNode *node, uint32_t ts,
-                                                             uint32_t uid, uint8_t goal,
-                                                             uint8_t smode, inode_t *sinodes,
-                                                             inode_t *ncinodes, inode_t *nsinodes) {
+void FilesystemNodeOperationsBase::setgoalRecursive(FSNode *node, uint32_t ts, uint32_t uid,
+                                                    uint8_t goal, uint8_t smode, inode_t *sinodes,
+                                                    inode_t *ncinodes, inode_t *nsinodes) {
 	if (node->type == FSNodeType::kFile || node->type == FSNodeType::kDirectory ||
 	    node->type == FSNodeType::kTrash || node->type == FSNodeType::kReserved) {
 		if ((node->mode & (EATTR_NOOWNER << 12)) == 0 && uid != 0 && node->uid != uid) {
@@ -1633,14 +1623,14 @@ void FilesystemNodeOperationsBase::fsnodes_setgoal_recursive(FSNode *node, uint3
 		} else {
 			if ((smode & SMODE_TMASK) == SMODE_SET && node->goal != goal) {
 				if (node->type != FSNodeType::kDirectory) {
-					fsnodes_changefilegoal(static_cast<FSNodeFile *>(node), goal);
+					changeFileGoal(static_cast<FSNodeFile *>(node), goal);
 					(*sinodes)++;
 				} else {
 					node->goal = goal;
 					gMetadata->nodeChangedSignal.emit(node);
 					(*sinodes)++;
 				}
-				fsnodes_update_ctime(node, ts);
+				updateCTime(node, ts);
 				fsnodes_update_checksum(node);
 			} else {
 				(*ncinodes)++;
@@ -1648,18 +1638,16 @@ void FilesystemNodeOperationsBase::fsnodes_setgoal_recursive(FSNode *node, uint3
 		}
 		if (node->type == FSNodeType::kDirectory && (smode & SMODE_RMASK)) {
 			for (const auto &entry : static_cast<const FSNodeDirectory*>(node)->entries) {
-				fsnodes_setgoal_recursive(entry.second, ts, uid, goal, smode, sinodes, ncinodes,
-				                          nsinodes);
+				setgoalRecursive(entry.second, ts, uid, goal, smode, sinodes, ncinodes, nsinodes);
 			}
 		}
 	}
 }
 
-void FilesystemNodeOperationsBase::fsnodes_settrashtime_recursive(FSNode *node, uint32_t ts,
-                                                                  uint32_t uid, uint32_t trashtime,
-                                                                  uint8_t smode, inode_t *sinodes,
-                                                                  inode_t *ncinodes,
-                                                                  inode_t *nsinodes) {
+void FilesystemNodeOperationsBase::setTrashTimeRecursive(FSNode *node, uint32_t ts, uint32_t uid,
+                                                         uint32_t trashtime, uint8_t smode,
+                                                         inode_t *sinodes, inode_t *ncinodes,
+                                                         inode_t *nsinodes) {
 	uint8_t set;
 
 	if (node->type == FSNodeType::kFile || node->type == FSNodeType::kDirectory ||
@@ -1702,18 +1690,16 @@ void FilesystemNodeOperationsBase::fsnodes_settrashtime_recursive(FSNode *node, 
 		}
 		if (node->type == FSNodeType::kDirectory && (smode & SMODE_RMASK)) {
 			for(const auto &entry : static_cast<const FSNodeDirectory*>(node)->entries) {
-				fsnodes_settrashtime_recursive(entry.second, ts, uid, trashtime, smode, sinodes,
-				                               ncinodes, nsinodes);
+				setTrashTimeRecursive(entry.second, ts, uid, trashtime, smode, sinodes, ncinodes,
+				                      nsinodes);
 			}
 		}
 	}
 }
 
-void FilesystemNodeOperationsBase::fsnodes_seteattr_recursive(FSNode *node, uint32_t ts,
-                                                              uint32_t uid, uint8_t eattr,
-                                                              uint8_t smode, inode_t *sinodes,
-                                                              inode_t *ncinodes,
-                                                              inode_t *nsinodes) {
+void FilesystemNodeOperationsBase::setEAttrRecursive(FSNode *node, uint32_t ts, uint32_t uid,
+                                                     uint8_t eattr, uint8_t smode, inode_t *sinodes,
+                                                     inode_t *ncinodes, inode_t *nsinodes) {
 	uint8_t neweattr, seattr;
 
 	if ((node->mode & (EATTR_NOOWNER << 12)) == 0 && uid != 0 && node->uid != uid) {
@@ -1744,7 +1730,7 @@ void FilesystemNodeOperationsBase::fsnodes_seteattr_recursive(FSNode *node, uint
 				                              node->type == FSNodeType::kDirectory);
 			}
 			(*sinodes)++;
-			fsnodes_update_ctime(node, ts);
+			updateCTime(node, ts);
 		} else {
 			(*ncinodes)++;
 		}
@@ -1752,14 +1738,13 @@ void FilesystemNodeOperationsBase::fsnodes_seteattr_recursive(FSNode *node, uint
 	if (node->type == FSNodeType::kDirectory && (smode & SMODE_RMASK)) {
 		const FSNodeDirectory *dir_node = static_cast<const FSNodeDirectory*>(node);
 		for (const auto &entry : dir_node->entries) {
-			fsnodes_seteattr_recursive(entry.second, ts, uid, eattr, smode, sinodes, ncinodes,
-			                           nsinodes);
+			setEAttrRecursive(entry.second, ts, uid, eattr, smode, sinodes, ncinodes, nsinodes);
 		}
 	}
 	fsnodes_update_checksum(node);
 }
 
-uint8_t FilesystemNodeOperationsBase::fsnodes_deleteacl(FSNode *p, AclType type, uint32_t ts) {
+uint8_t FilesystemNodeOperationsBase::deleteAcl(FSNode *p, AclType type, uint32_t ts) {
 	if (type == AclType::kRichACL) {
 		gMetadata->aclStorage.erase(p->id);
 	} else if (type == AclType::kDefault) {
@@ -1792,13 +1777,13 @@ uint8_t FilesystemNodeOperationsBase::fsnodes_deleteacl(FSNode *p, AclType type,
 	} else {
 		return SAUNAFS_ERROR_EINVAL;
 	}
-	fsnodes_update_ctime(p, ts);
+	updateCTime(p, ts);
 	fsnodes_update_checksum(p);
 	return SAUNAFS_STATUS_OK;
 }
 
 #ifndef METARESTORE
-uint8_t FilesystemNodeOperationsBase::fsnodes_getacl(FSNode *p, RichACL &acl) {
+uint8_t FilesystemNodeOperationsBase::getAcl(FSNode *p, RichACL &acl) {
 	const RichACL *richacl = gMetadata->aclStorage.get(p->id);
 	if (!richacl) {
 		return SAUNAFS_ERROR_ENOATTR;
@@ -1809,7 +1794,7 @@ uint8_t FilesystemNodeOperationsBase::fsnodes_getacl(FSNode *p, RichACL &acl) {
 }
 #endif
 
-uint8_t FilesystemNodeOperationsBase::fsnodes_setacl(FSNode *p, const RichACL &acl, uint32_t ts) {
+uint8_t FilesystemNodeOperationsBase::setAcl(FSNode *p, const RichACL &acl, uint32_t ts) {
 	if (!acl.checkInheritFlags(p->type == FSNodeType::kDirectory)) {
 		return SAUNAFS_ERROR_ENOTSUP;
 	}
@@ -1830,13 +1815,13 @@ uint8_t FilesystemNodeOperationsBase::fsnodes_setacl(FSNode *p, const RichACL &a
 		gMetadata->aclStorage.set(p->id, std::move(new_acl));
 	}
 
-	fsnodes_update_ctime(p, ts);
+	updateCTime(p, ts);
 	fsnodes_update_checksum(p);
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t FilesystemNodeOperationsBase::fsnodes_setacl(FSNode *p, AclType type,
-                                                     const AccessControlList &acl, uint32_t ts) {
+uint8_t FilesystemNodeOperationsBase::setAcl(FSNode *p, AclType type, const AccessControlList &acl,
+                                             uint32_t ts) {
 	if (type != AclType::kDefault && type != AclType::kAccess) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
@@ -1863,12 +1848,12 @@ uint8_t FilesystemNodeOperationsBase::fsnodes_setacl(FSNode *p, AclType type,
 	}
 	gMetadata->aclStorage.set(p->id, std::move(new_acl));
 
-	fsnodes_update_ctime(p, ts);
+	updateCTime(p, ts);
 	fsnodes_update_checksum(p);
 	return SAUNAFS_STATUS_OK;
 }
 
-int FilesystemNodeOperationsBase::fsnodes_namecheck(const std::string &name) {
+int FilesystemNodeOperationsBase::nameCheck(const std::string &name) {
 	uint32_t i;
 	if (name.length() == 0 || name.length() > MAXFNAMELENG) {
 		return -1;
@@ -1889,8 +1874,7 @@ int FilesystemNodeOperationsBase::fsnodes_namecheck(const std::string &name) {
 	return 0;
 }
 
-int FilesystemNodeOperationsBase::fsnodes_access(const FsContext &context, FSNode *node,
-                                                 uint8_t modemask) {
+int FilesystemNodeOperationsBase::access(const FsContext &context, FSNode *node, uint8_t modemask) {
 	uint8_t nodemode;
 	if ((context.sesflags() & SESFLAG_NOMASTERPERMCHECK) || context.uid() == 0) {
 		return 1;
@@ -1921,8 +1905,7 @@ int FilesystemNodeOperationsBase::fsnodes_access(const FsContext &context, FSNod
 	return 0;
 }
 
-int FilesystemNodeOperationsBase::fsnodes_sticky_access(FSNode *parent, FSNode *node,
-                                                        uint32_t uid) {
+int FilesystemNodeOperationsBase::stickyAccess(FSNode *parent, FSNode *node, uint32_t uid) {
 	if (uid == 0 || (parent->mode & 01000) == 0) {  // super user or sticky bit is not set
 		return 1;
 	}
@@ -1933,9 +1916,9 @@ int FilesystemNodeOperationsBase::fsnodes_sticky_access(FSNode *parent, FSNode *
 	return 0;
 }
 
-uint8_t FilesystemNodeOperationsBase::verify_session(const FsContext &context,
-                                                     OperationMode operationMode,
-                                                     SessionType sessionType) {
+uint8_t FilesystemNodeOperationsBase::verifySession(const FsContext &context,
+                                                    OperationMode operationMode,
+                                                    SessionType sessionType) {
 	if (context.hasSessionData() && (context.sesflags() & SESFLAG_READONLY) &&
 	    (operationMode == OperationMode::kReadWrite)) {
 		return SAUNAFS_ERROR_EROFS;
@@ -1959,20 +1942,21 @@ uint8_t FilesystemNodeOperationsBase::verify_session(const FsContext &context,
  * Checks for permissions needed to perform the operation (defined by modemask)
  * Can return a reserved node or a node from trash
  */
-uint8_t FilesystemNodeOperationsBase::fsnodes_get_node_for_operation(
-    const FsContext &context, ExpectedNodeType expectedNodeType, uint8_t modemask, inode_t inode,
-    FSNode **ret, FSNodeDirectory **ret_rn) {
+uint8_t FilesystemNodeOperationsBase::getNodeForOperation(const FsContext &context,
+                                                          ExpectedNodeType expectedNodeType,
+                                                          uint8_t modemask, inode_t inode,
+                                                          FSNode **ret, FSNodeDirectory **ret_rn) {
 	FSNode *p;
 	FSNodeDirectory *rn;
 	if (!context.hasSessionData()) {
 		rn = nullptr;
-		p = fsnodes_id_to_node(inode);
+		p = idToNode(inode);
 		if (!p) {
 			return SAUNAFS_ERROR_ENOENT;
 		}
 	} else if (context.rootinode() == SPECIAL_INODE_ROOT || (context.rootinode() == 0)) {
 		rn = gMetadata->root;
-		p = fsnodes_id_to_node(inode);
+		p = idToNode(inode);
 		if (!p) {
 			return SAUNAFS_ERROR_ENOENT;
 		}
@@ -1981,20 +1965,18 @@ uint8_t FilesystemNodeOperationsBase::fsnodes_get_node_for_operation(
 			return SAUNAFS_ERROR_EPERM;
 		}
 	} else {
-		rn = fsnodes_id_to_node<FSNodeDirectory>(context.rootinode());
+		rn = idToNode<FSNodeDirectory>(context.rootinode());
 		if (!rn || rn->type != FSNodeType::kDirectory) {
 			return SAUNAFS_ERROR_ENOENT;
 		}
 		if (inode == SPECIAL_INODE_ROOT || inode == context.rootinode()) {
 			p = rn;
 		} else {
-			p = fsnodes_id_to_node(inode);
+			p = idToNode(inode);
 			if (!p) {
 				return SAUNAFS_ERROR_ENOENT;
 			}
-			if (!fsnodes_isancestor_or_node_reserved_or_trash(rn, p)) {
-				return SAUNAFS_ERROR_EPERM;
-			}
+			if (!isAncestorOrNodeReservedOrTrash(rn, p)) { return SAUNAFS_ERROR_EPERM; }
 		}
 	}
 	if ((expectedNodeType == ExpectedNodeType::kDirectory) && (p->type != FSNodeType::kDirectory)) {
@@ -2013,8 +1995,7 @@ uint8_t FilesystemNodeOperationsBase::fsnodes_get_node_for_operation(
 	    (p->type != FSNodeType::kReserved) && (p->type != FSNodeType::kTrash)) {
 		return SAUNAFS_ERROR_EPERM;
 	}
-	if (context.canCheckPermissions() &&
-	    !fsnodes_access(context, p, modemask)) {
+	if (context.canCheckPermissions() && !access(context, p, modemask)) {
 		return SAUNAFS_ERROR_EACCES;
 	}
 	*ret = p;

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -83,12 +83,9 @@ void FSNode::destroy(FSNode *node) {
 	delete node;
 }
 
-// ============================================================================
-// FilesystemNodeOperationsBase - Private helper methods
-// ============================================================================
+// Private helper methods
 
-// number of blocks in the last chunk before EOF
-uint32_t FilesystemNodeOperationsBase::last_chunk_blocks(FSNodeFile *node) {
+uint32_t FilesystemNodeOperationsBase::lastChunkBlocks(FSNodeFile *node) {
 	const uint64_t last_byte = node->length - 1;
 	const uint32_t last_byte_offset = last_byte % SFSCHUNKSIZE;
 	const uint32_t last_block = last_byte_offset / SFSBLOCKSIZE;
@@ -96,8 +93,7 @@ uint32_t FilesystemNodeOperationsBase::last_chunk_blocks(FSNodeFile *node) {
 	return block_count;
 }
 
-// does the last chunk exist and contain non-zero data?
-bool FilesystemNodeOperationsBase::last_chunk_nonempty(FSNodeFile *node) {
+bool FilesystemNodeOperationsBase::isLastChunkNonEmpty(FSNodeFile *node) {
 	std::size_t chunks = node->chunks.size();
 	if (chunks == 0) {
 		// no non-zero chunks, return now
@@ -115,42 +111,37 @@ bool FilesystemNodeOperationsBase::last_chunk_nonempty(FSNodeFile *node) {
 	return false;
 }
 
-// count chunks in a file, disregard sparse file holes
-uint32_t FilesystemNodeOperationsBase::file_chunks(FSNodeFile *node) {
+uint32_t FilesystemNodeOperationsBase::fileChunksCount(FSNodeFile *node) {
 	return std::accumulate(node->chunks.begin(), node->chunks.end(), (uint32_t)0,
 	                       [](uint32_t sum, uint64_t v) { return sum + (v != 0); });
 }
 
-// compute the "size" statistic for a file node
-uint64_t FilesystemNodeOperationsBase::file_size(FSNodeFile *node, uint32_t nonzero_chunks) {
-	uint64_t size = (uint64_t)nonzero_chunks * (SFSCHUNKSIZE + SFSHDRSIZE);
-	if (last_chunk_nonempty(node)) {
+uint64_t FilesystemNodeOperationsBase::fileSize(FSNodeFile *node, uint32_t nonZeroChunks) {
+	uint64_t size = (uint64_t)nonZeroChunks * (SFSCHUNKSIZE + SFSHDRSIZE);
+	if (isLastChunkNonEmpty(node)) {
 		size -= SFSCHUNKSIZE;
-		size += last_chunk_blocks(node) * SFSBLOCKSIZE;
+		size += lastChunkBlocks(node) * SFSBLOCKSIZE;
 	}
 	return size;
 }
 
 #ifndef METARESTORE
-// compute the disk space cost of all parts of a xor/ec chunk of given size
-uint32_t FilesystemNodeOperationsBase::ec_chunk_realsize(uint32_t blocks, uint32_t data_part_count,
-                                                         uint32_t parity_part_count) {
-	const uint32_t stripes = (blocks + data_part_count - 1) / data_part_count;
-	uint32_t size = blocks * SFSBLOCKSIZE;                 // file data
-	size += parity_part_count * stripes * SFSBLOCKSIZE;     // parity data
-	size += 4096 * (data_part_count + parity_part_count);  // headers of data and parity parts
+uint32_t FilesystemNodeOperationsBase::ecChunkRealSize(uint32_t blocks, uint32_t dataPartCount,
+                                                       uint32_t parityPartCount) {
+	const uint32_t stripes = (blocks + dataPartCount - 1) / dataPartCount;
+	uint32_t size = blocks * SFSBLOCKSIZE;             // file data
+	size += parityPartCount * stripes * SFSBLOCKSIZE;  // parity data
+	size += 4096 * (dataPartCount + parityPartCount);  // headers of data and parity parts
 	return size;
 }
 #endif
 
-// compute the "realsize" statistic for a file node
-// NOTICE: file_size takes into account chunk headers and doesn't takes nonzero_chunks
-uint64_t FilesystemNodeOperationsBase::file_realsize(FSNodeFile *node, uint32_t nonzero_chunks,
-                                                     uint64_t file_size) {
+uint64_t FilesystemNodeOperationsBase::fileRealSize(FSNodeFile *node, uint32_t nonZeroChunks,
+                                                    uint64_t logicalFileSize) {
 #ifdef METARESTORE
 	(void)node;
-	(void)nonzero_chunks;
-	(void)file_size;
+	(void)nonZeroChunks;
+	(void)logicalFileSize;
 	return 0; // Doesn't really matter. Metarestore doesn't need this value
 #else
 	const Goal &goal = gFSOperations->getGoalDefinition(node->goal);
@@ -158,18 +149,17 @@ uint64_t FilesystemNodeOperationsBase::file_realsize(FSNodeFile *node, uint32_t 
 	uint64_t full_size = 0;
 	for (const auto &slice : goal) {
 		if (slice_traits::isStandard(slice) || slice_traits::isTape(slice)) {
-			full_size += file_size * slice.getExpectedCopies();
+			full_size += logicalFileSize * slice.getExpectedCopies();
 		} else if (slice_traits::isXor(slice) || slice_traits::isEC(slice)) {
 			int data_part_count = slice_traits::getNumberOfDataParts(slice);
 			int parity_part_count = slice_traits::getNumberOfParityParts(slice);
 
 			uint32_t full_chunk_realsize =
-			    ec_chunk_realsize(SFSBLOCKSINCHUNK, data_part_count, parity_part_count);
-			uint64_t size = (uint64_t)nonzero_chunks * full_chunk_realsize;
-			if (last_chunk_nonempty(node)) {
+			    ecChunkRealSize(SFSBLOCKSINCHUNK, data_part_count, parity_part_count);
+			uint64_t size = (uint64_t)nonZeroChunks * full_chunk_realsize;
+			if (isLastChunkNonEmpty(node)) {
 				size -= full_chunk_realsize;
-				size +=
-				    ec_chunk_realsize(last_chunk_blocks(node), data_part_count, parity_part_count);
+				size += ecChunkRealSize(lastChunkBlocks(node), data_part_count, parity_part_count);
 			}
 			full_size += size;
 		} else {
@@ -298,11 +288,11 @@ void FilesystemNodeOperationsBase::getStats(FSNode *node, StatsRecord *statsOut)
 		statsOut->dirs = 0;
 		statsOut->files = 1;
 		statsOut->links = 0;
-		statsOut->chunks = file_chunks(static_cast<FSNodeFile *>(node));
+		statsOut->chunks = fileChunksCount(static_cast<FSNodeFile *>(node));
 		statsOut->length = static_cast<FSNodeFile *>(node)->length;
-		statsOut->size = file_size(static_cast<FSNodeFile *>(node), statsOut->chunks);
+		statsOut->size = fileSize(static_cast<FSNodeFile *>(node), statsOut->chunks);
 		statsOut->realsize =
-		    file_realsize(static_cast<FSNodeFile *>(node), statsOut->chunks, statsOut->size);
+		    fileRealSize(static_cast<FSNodeFile *>(node), statsOut->chunks, statsOut->size);
 		break;
 	case FSNodeType::kSymlink:
 		statsOut->inodes = 1;
@@ -343,7 +333,7 @@ FSNodeDirectory *FilesystemNodeOperationsBase::getFirstParent(FSNode *node) {
 	return parent;
 }
 
-void FilesystemNodeOperationsBase::fsnodes_sub_stats(FSNodeDirectory *parent, StatsRecord *stats) {
+void FilesystemNodeOperationsBase::subStats(FSNodeDirectory *parent, StatsRecord *stats) {
 	StatsRecord *psr;
 	if (parent) {
 		psr = &parent->stats;
@@ -358,7 +348,7 @@ void FilesystemNodeOperationsBase::fsnodes_sub_stats(FSNodeDirectory *parent, St
 		if (parent != gMetadata->root) {
 			for (auto const &[parentId, _] : parent->parents) {
 				auto *node = idToNodeVerify<FSNodeDirectory>(parentId);
-				fsnodes_sub_stats(node, stats);
+				subStats(node, stats);
 			}
 		}
 	}
@@ -534,7 +524,7 @@ void FilesystemNodeOperationsBase::removeEdge(uint32_t timeStamp, FSNodeDirector
 	StatsRecord sr;
 
 	getStats(childNode, &sr);
-	fsnodes_sub_stats(parent, &sr);
+	subStats(parent, &sr);
 	parent->mtime = parent->ctime = timeStamp;
 	if (childNode->type == FSNodeType::kDirectory) { parent->nlink--; }
 
@@ -1179,7 +1169,7 @@ void FilesystemNodeOperationsBase::changeFileGoal(FSNodeFile *nodeFile, uint8_t 
 	getStats(nodeFile, &psr);
 	nodeFile->goal = goal;
 	nsr = psr;
-	nsr.realsize = file_realsize(nodeFile, nsr.chunks, nsr.size);
+	nsr.realsize = fileRealSize(nodeFile, nsr.chunks, nsr.size);
 	for (const auto &[parentId, _] : nodeFile->parents) {
 		auto *parent_node = idToNodeVerify<FSNodeDirectory>(parentId);
 		addSubStats(parent_node, &nsr, &psr);
@@ -1256,7 +1246,7 @@ void FilesystemNodeOperationsBase::changeUidGid(FSNode *node, uint32_t uid, uint
 	}
 }
 
-void FilesystemNodeOperationsBase::fsnodes_remove_node(uint32_t timeStamp, FSNode *node) {
+void FilesystemNodeOperationsBase::removeNode(uint32_t timeStamp, FSNode *node) {
 	if (!node->parents.empty()) {
 		return;
 	}
@@ -1357,10 +1347,10 @@ void FilesystemNodeOperationsBase::unlink(uint32_t timeStamp, FSNodeDirectory *p
 			gMetadata->reservedSpace += file_node->length;
 			gMetadata->reservedNodes++;
 		} else {
-			fsnodes_remove_node(timeStamp, childNode);
+			removeNode(timeStamp, childNode);
 		}
 	} else {
-		fsnodes_remove_node(timeStamp, childNode);
+		removeNode(timeStamp, childNode);
 	}
 }
 
@@ -1386,7 +1376,7 @@ int FilesystemNodeOperationsBase::purge(uint32_t timeStamp, FSNode *node) {
 			                 gMetadata->trashReservedToId, node);
 			node->ctime = timeStamp;
 			fsnodes_update_checksum(node);
-			fsnodes_remove_node(timeStamp, node);
+			removeNode(timeStamp, node);
 
 			return 1;
 		}
@@ -1401,7 +1391,7 @@ int FilesystemNodeOperationsBase::purge(uint32_t timeStamp, FSNode *node) {
 
 		file_node->ctime = timeStamp;
 		fsnodes_update_checksum(file_node);
-		fsnodes_remove_node(timeStamp, file_node);
+		removeNode(timeStamp, file_node);
 		return 1;
 	}
 	return -1;

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -1091,11 +1091,10 @@ void FilesystemNodeOperationsBase::getDir(inode_t rootINode, uint32_t uid, uint3
 	}
 }
 
-void FilesystemNodeOperationsBase::checkFile(FSNodeFile *nodeFile,
-                                             uint32_t chunkCount[CHUNK_MATRIX_SIZE]) {
+void FilesystemNodeOperationsBase::checkFile(FSNodeFile *nodeFile, ChunkCountArray &chunkCount) {
 	uint8_t count;
 
-	for (int i = 0; i < CHUNK_MATRIX_SIZE; ++i) { chunkCount[i] = 0; }
+	chunkCount.fill(0);
 
 	for (const auto &chunkid : nodeFile->chunks) {
 		if (chunkid > 0) {

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -1559,17 +1559,16 @@ void FilesystemNodeOperationsBase::getTrashTimeRecursive(FSNode *node, uint8_t g
 }
 
 void FilesystemNodeOperationsBase::getEAttrRecursive(FSNode *node, uint8_t gmode,
-                                                     uint32_t feattrtab[16],
-                                                     uint32_t deattrtab[16]) {
+                                                     ExtendedAttributesArray &fileEAttrTab,
+                                                     ExtendedAttributesArray &dirEAttrTab) {
 	if (node->type != FSNodeType::kDirectory) {
-		feattrtab[(node->mode >> 12) &
-		          (EATTR_NOOWNER | EATTR_NOACACHE | EATTR_NODATACACHE)]++;
+		fileEAttrTab[(node->mode >> 12) & (EATTR_NOOWNER | EATTR_NOACACHE | EATTR_NODATACACHE)]++;
 	} else {
-		deattrtab[(node->mode >> 12)]++;
+		dirEAttrTab[(node->mode >> 12)]++;
 		if (gmode == GMODE_RECURSIVE) {
 			const FSNodeDirectory *dir_node = static_cast<const FSNodeDirectory*>(node);
 			for (const auto &entry : dir_node->entries) {
-				getEAttrRecursive(entry.second, gmode, feattrtab, deattrtab);
+				getEAttrRecursive(entry.second, gmode, fileEAttrTab, dirEAttrTab);
 			}
 		}
 	}

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -1558,9 +1558,9 @@ void FilesystemNodeOperationsBase::getTrashTimeRecursive(FSNode *node, uint8_t g
 	}
 }
 
-void FilesystemNodeOperationsBase::getEAttrRecursive(FSNode *node, uint8_t gmode,
-                                                     ExtendedAttributesArray &fileEAttrTab,
-                                                     ExtendedAttributesArray &dirEAttrTab) {
+void FilesystemNodeOperationsBase::getExtraAttrRecursive(FSNode *node, uint8_t gmode,
+                                                         ExtraAttributesArray &fileEAttrTab,
+                                                         ExtraAttributesArray &dirEAttrTab) {
 	if (node->type != FSNodeType::kDirectory) {
 		fileEAttrTab[(node->mode >> 12) & (EATTR_NOOWNER | EATTR_NOACACHE | EATTR_NODATACACHE)]++;
 	} else {
@@ -1568,7 +1568,7 @@ void FilesystemNodeOperationsBase::getEAttrRecursive(FSNode *node, uint8_t gmode
 		if (gmode == GMODE_RECURSIVE) {
 			const FSNodeDirectory *dir_node = static_cast<const FSNodeDirectory*>(node);
 			for (const auto &entry : dir_node->entries) {
-				getEAttrRecursive(entry.second, gmode, fileEAttrTab, dirEAttrTab);
+				getExtraAttrRecursive(entry.second, gmode, fileEAttrTab, dirEAttrTab);
 			}
 		}
 	}
@@ -1665,7 +1665,7 @@ void FilesystemNodeOperationsBase::setTrashTimeRecursive(FSNode *node, uint32_t 
 	}
 }
 
-void FilesystemNodeOperationsBase::setEAttrRecursive(FSNode *node, uint32_t timeStamp, uint32_t uid,
+void FilesystemNodeOperationsBase::setExtraAttrRecursive(FSNode *node, uint32_t timeStamp, uint32_t uid,
                                                      uint8_t eattr, uint8_t smode,
                                                      inode_t *modifiedINodesOut,
                                                      inode_t *unchangedINodesOut,
@@ -1708,7 +1708,7 @@ void FilesystemNodeOperationsBase::setEAttrRecursive(FSNode *node, uint32_t time
 	if (node->type == FSNodeType::kDirectory && (smode & SMODE_RMASK)) {
 		const FSNodeDirectory *dir_node = static_cast<const FSNodeDirectory*>(node);
 		for (const auto &entry : dir_node->entries) {
-			setEAttrRecursive(entry.second, timeStamp, uid, eattr, smode, modifiedINodesOut,
+			setExtraAttrRecursive(entry.second, timeStamp, uid, eattr, smode, modifiedINodesOut,
 			                  unchangedINodesOut, permissionDeniedINodesOut);
 		}
 	}

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -185,12 +185,12 @@ uint64_t FilesystemNodeOperationsBase::file_realsize(FSNodeFile *node, uint32_t 
 
 // Protected methods
 
-FSNode *FilesystemNodeOperationsBase::idToNodeInternal(inode_t id) {
+FSNode *FilesystemNodeOperationsBase::idToNodeInternal(inode_t inode) {
 	// Find the node with the given id
-	uint32_t nodeHashIndex = NODEHASHPOS(id);
+	uint32_t nodeHashIndex = NODEHASHPOS(inode);
 
 	for (const auto &node : gMetadata->nodeHash[nodeHashIndex]) {
-		if (node->id == id) { return node; }
+		if (node->id == inode) { return node; }
 	}
 
 	return nullptr;
@@ -250,7 +250,6 @@ int FilesystemNodeOperationsBase::isNameUsed(FSNodeDirectory *node, const HStrin
 	return lookup(node, name) != nullptr;
 }
 
-/*! \brief Returns true iff \param ancestor is ancestor of \param node. */
 bool FilesystemNodeOperationsBase::isAncestor(FSNodeDirectory *ancestor, FSNode *node) {
 	for (const auto &[parentId, _] : node->parents) {
 		auto *dir_node = idToNodeVerify<FSNodeDirectory>(parentId);
@@ -273,9 +272,6 @@ bool FilesystemNodeOperationsBase::isAncestor(FSNodeDirectory *ancestor, FSNode 
 	return false;
 }
 
-/*! \brief Returns true iff \param node is reserved or in trash
- * or \param ancestor is ancestor of \param node.
- */
 bool FilesystemNodeOperationsBase::isAncestorOrNodeReservedOrTrash(FSNodeDirectory *ancestor,
                                                                    FSNode *node) {
 	// Return true if file is reserved:
@@ -288,44 +284,45 @@ bool FilesystemNodeOperationsBase::isAncestorOrNodeReservedOrTrash(FSNodeDirecto
 
 // stats
 
-void FilesystemNodeOperationsBase::getStats(FSNode *node, StatsRecord *sr) {
+void FilesystemNodeOperationsBase::getStats(FSNode *node, StatsRecord *statsOut) {
 	switch (node->type) {
 	case FSNodeType::kDirectory:
-		*sr = static_cast<FSNodeDirectory*>(node)->stats;
-		sr->inodes++;
-		sr->dirs++;
+		*statsOut = static_cast<FSNodeDirectory *>(node)->stats;
+		statsOut->inodes++;
+		statsOut->dirs++;
 		break;
 	case FSNodeType::kFile:
 	case FSNodeType::kTrash:
 	case FSNodeType::kReserved:
-		sr->inodes = 1;
-		sr->dirs = 0;
-		sr->files = 1;
-		sr->links = 0;
-		sr->chunks = file_chunks(static_cast<FSNodeFile*>(node));
-		sr->length = static_cast<FSNodeFile*>(node)->length;
-		sr->size = file_size(static_cast<FSNodeFile*>(node), sr->chunks);
-		sr->realsize = file_realsize(static_cast<FSNodeFile*>(node), sr->chunks, sr->size);
+		statsOut->inodes = 1;
+		statsOut->dirs = 0;
+		statsOut->files = 1;
+		statsOut->links = 0;
+		statsOut->chunks = file_chunks(static_cast<FSNodeFile *>(node));
+		statsOut->length = static_cast<FSNodeFile *>(node)->length;
+		statsOut->size = file_size(static_cast<FSNodeFile *>(node), statsOut->chunks);
+		statsOut->realsize =
+		    file_realsize(static_cast<FSNodeFile *>(node), statsOut->chunks, statsOut->size);
 		break;
 	case FSNodeType::kSymlink:
-		sr->inodes = 1;
-		sr->links = 1;
-		sr->files = 0;
-		sr->dirs = 0;
-		sr->chunks = 0;
-		sr->length = static_cast<FSNodeSymlink*>(node)->path_length;
-		sr->size = 0;
-		sr->realsize = 0;
+		statsOut->inodes = 1;
+		statsOut->links = 1;
+		statsOut->files = 0;
+		statsOut->dirs = 0;
+		statsOut->chunks = 0;
+		statsOut->length = static_cast<FSNodeSymlink *>(node)->path_length;
+		statsOut->size = 0;
+		statsOut->realsize = 0;
 		break;
 	default:
-		sr->inodes = 1;
-		sr->files = 0;
-		sr->dirs = 0;
-		sr->links = 0;
-		sr->chunks = 0;
-		sr->length = 0;
-		sr->size = 0;
-		sr->realsize = 0;
+		statsOut->inodes = 1;
+		statsOut->files = 0;
+		statsOut->dirs = 0;
+		statsOut->links = 0;
+		statsOut->chunks = 0;
+		statsOut->length = 0;
+		statsOut->size = 0;
+		statsOut->realsize = 0;
 	}
 }
 
@@ -346,59 +343,59 @@ FSNodeDirectory *FilesystemNodeOperationsBase::getFirstParent(FSNode *node) {
 	return parent;
 }
 
-void FilesystemNodeOperationsBase::fsnodes_sub_stats(FSNodeDirectory *parent, StatsRecord *sr) {
+void FilesystemNodeOperationsBase::fsnodes_sub_stats(FSNodeDirectory *parent, StatsRecord *stats) {
 	StatsRecord *psr;
 	if (parent) {
 		psr = &parent->stats;
-		psr->inodes -= sr->inodes;
-		psr->dirs -= sr->dirs;
-		psr->files -= sr->files;
-		psr->links -= sr->links;
-		psr->chunks -= sr->chunks;
-		psr->length -= sr->length;
-		psr->size -= sr->size;
-		psr->realsize -= sr->realsize;
+		psr->inodes -= stats->inodes;
+		psr->dirs -= stats->dirs;
+		psr->files -= stats->files;
+		psr->links -= stats->links;
+		psr->chunks -= stats->chunks;
+		psr->length -= stats->length;
+		psr->size -= stats->size;
+		psr->realsize -= stats->realsize;
 		if (parent != gMetadata->root) {
 			for (auto const &[parentId, _] : parent->parents) {
 				auto *node = idToNodeVerify<FSNodeDirectory>(parentId);
-				fsnodes_sub_stats(node, sr);
+				fsnodes_sub_stats(node, stats);
 			}
 		}
 	}
 }
 
-void FilesystemNodeOperationsBase::addStats(FSNodeDirectory *parent, StatsRecord *sr) {
+void FilesystemNodeOperationsBase::addStats(FSNodeDirectory *parent, StatsRecord *stats) {
 	StatsRecord *psr;
 	if (parent) {
 		psr = &parent->stats;
-		psr->inodes += sr->inodes;
-		psr->dirs += sr->dirs;
-		psr->files += sr->files;
-		psr->links += sr->links;
-		psr->chunks += sr->chunks;
-		psr->length += sr->length;
-		psr->size += sr->size;
-		psr->realsize += sr->realsize;
+		psr->inodes += stats->inodes;
+		psr->dirs += stats->dirs;
+		psr->files += stats->files;
+		psr->links += stats->links;
+		psr->chunks += stats->chunks;
+		psr->length += stats->length;
+		psr->size += stats->size;
+		psr->realsize += stats->realsize;
 		if (parent != gMetadata->root) {
 			for (auto const &[parentId, _] : parent->parents) {
 				auto *node = idToNodeVerify<FSNodeDirectory>(parentId);
-				addStats(node, sr);
+				addStats(node, stats);
 			}
 		}
 	}
 }
 
-void FilesystemNodeOperationsBase::addSubStats(FSNodeDirectory *parent, StatsRecord *newsr,
-                                               StatsRecord *prevsr) {
+void FilesystemNodeOperationsBase::addSubStats(FSNodeDirectory *parent, StatsRecord *newStats,
+                                               StatsRecord *previousStats) {
 	StatsRecord sr;
-	sr.inodes = newsr->inodes - prevsr->inodes;
-	sr.dirs = newsr->dirs - prevsr->dirs;
-	sr.files = newsr->files - prevsr->files;
-	sr.links = newsr->links - prevsr->links;
-	sr.chunks = newsr->chunks - prevsr->chunks;
-	sr.length = newsr->length - prevsr->length;
-	sr.size = newsr->size - prevsr->size;
-	sr.realsize = newsr->realsize - prevsr->realsize;
+	sr.inodes = newStats->inodes - previousStats->inodes;
+	sr.dirs = newStats->dirs - previousStats->dirs;
+	sr.files = newStats->files - previousStats->files;
+	sr.links = newStats->links - previousStats->links;
+	sr.chunks = newStats->chunks - previousStats->chunks;
+	sr.length = newStats->length - previousStats->length;
+	sr.size = newStats->size - previousStats->size;
+	sr.realsize = newStats->realsize - previousStats->realsize;
 	addStats(parent, &sr);
 }
 
@@ -513,65 +510,59 @@ void FilesystemNodeOperationsBase::fillAttr(const FsContext &context, FSNode *no
 	         context.sesflags(), attr);
 }
 
-void FilesystemNodeOperationsBase::removeEdge(uint32_t ts, FSNodeDirectory *parent,
-                                              const HString &name, FSNode *node) {
+void FilesystemNodeOperationsBase::removeEdge(uint32_t timeStamp, FSNodeDirectory *parent,
+                                              const HString &childName, FSNode *childNode) {
 	assert(parent);
 
-	auto dir_it = parent->find(name);
+	auto dir_it = parent->find(childName);
 	assert(dir_it != parent->end());
-	assert((*dir_it).second == node);
+	assert((*dir_it).second == childNode);
 	auto handlePtrToErase = dir_it->first;
 	if (dir_it != parent->end()) {
 		parent->entries.erase(dir_it);
-		parent->entries_hash ^= name.hash();
+		parent->entries_hash ^= childName.hash();
 
 		if (parent->case_insensitive) {
-			auto lowerCaseIt = parent->find_lowercase_container(name);
+			auto lowerCaseIt = parent->find_lowercase_container(childName);
 			delete lowerCaseIt->first;
 			parent->lowerCaseEntries.erase(lowerCaseIt);
-			HString lowerCaseName = HString::hstringToLowerCase(name);
+			HString lowerCaseName = HString::hstringToLowerCase(childName);
 			parent->lowerCaseEntriesHash ^= lowerCaseName.hash();
 		}
 	}
 
 	StatsRecord sr;
 
-	getStats(node, &sr);
+	getStats(childNode, &sr);
 	fsnodes_sub_stats(parent, &sr);
-	parent->mtime = parent->ctime = ts;
-	if (node->type == FSNodeType::kDirectory) {
-		parent->nlink--;
-	}
+	parent->mtime = parent->ctime = timeStamp;
+	if (childNode->type == FSNodeType::kDirectory) { parent->nlink--; }
 
 	fsnodes_update_checksum(parent);
-	HString currentName = name;
-	if (parent->case_insensitive) {
-		currentName = HString::hstringToLowerCase(name);
-	}
+	HString currentName = childName;
+	if (parent->case_insensitive) { currentName = HString::hstringToLowerCase(childName); }
 
 	auto it = std::find_if(
-	    node->parents.begin(), node->parents.end(),
+	    childNode->parents.begin(), childNode->parents.end(),
 	    [parent, currentName](const std::pair<inode_t, const hstorage::Handle *> &p) {
 		    return p.first == parent->id &&
 		           (parent->case_insensitive ? HString::hstringToLowerCase(p.second->get())
 		                                     : p.second->get()) == currentName;
 	    });
 
-	if (it != node->parents.end()) {
-		node->parents.erase(it);
-	}
+	if (it != childNode->parents.end()) { childNode->parents.erase(it); }
 
 	// Delete the handle after the check in the parent vector in the son is done.
 	delete handlePtrToErase;
 
-	assert(node->type != FSNodeType::kTrash);
-	node->ctime = ts;
-	fsnodes_update_checksum(node);
+	assert(childNode->type != FSNodeType::kTrash);
+	childNode->ctime = timeStamp;
+	fsnodes_update_checksum(childNode);
 
-	gMetadata->edgeRemovedSignal.emit(parent->id, node->id);
+	gMetadata->edgeRemovedSignal.emit(parent->id, childNode->id);
 }
 
-void FilesystemNodeOperationsBase::link(uint32_t ts, FSNodeDirectory *parent, FSNode *child,
+void FilesystemNodeOperationsBase::link(uint32_t timeStamp, FSNodeDirectory *parent, FSNode *child,
                                         const HString &name) {
 	// Needs to be freed in fsnodes_remove_edge
 	auto *handlePtr = new hstorage::Handle(name);
@@ -596,20 +587,21 @@ void FilesystemNodeOperationsBase::link(uint32_t ts, FSNodeDirectory *parent, FS
 	StatsRecord sr;
 	getStats(child, &sr);
 	addStats(parent, &sr);
-	if (ts > 0) {
-		parent->mtime = parent->ctime = ts;
+	if (timeStamp > 0) {
+		parent->mtime = parent->ctime = timeStamp;
 		fsnodes_update_checksum(parent);
 		assert(child->type != FSNodeType::kTrash);
-		child->ctime = ts;
+		child->ctime = timeStamp;
 		fsnodes_update_checksum(child);
 	}
 }
 
-FSNode *FilesystemNodeOperationsBase::createNode(uint32_t ts, FSNodeDirectory *parent,
+FSNode *FilesystemNodeOperationsBase::createNode(uint32_t timeStamp, FSNodeDirectory *parent,
                                                  const HString &name, FSNodeType type,
                                                  uint16_t mode, uint16_t umask, uint32_t uid,
                                                  uint32_t gid, uint8_t copysgid,
-                                                 AclInheritance inheritacl, inode_t req_inode) {
+                                                 AclInheritance inheritAcl,
+                                                 inode_t requestedINode) {
 	assert(type != FSNodeType::kTrash);
 
 	FSNode *node = FSNode::create(type);
@@ -624,9 +616,9 @@ FSNode *FilesystemNodeOperationsBase::createNode(uint32_t ts, FSNodeDirectory *p
 		gMetadata->linkNodes++;
 	}
 	/* create node */
-	node->id = gInodeIdGenerator->getNextId(ts, req_inode);
+	node->id = gInodeIdGenerator->getNextId(timeStamp, requestedINode);
 
-	node->ctime = node->mtime = node->atime = ts;
+	node->ctime = node->mtime = node->atime = timeStamp;
 	if (type == FSNodeType::kDirectory || type == FSNodeType::kFile) {
 		node->goal = parent->goal;
 		node->trashtime = parent->trashtime;
@@ -640,8 +632,9 @@ FSNode *FilesystemNodeOperationsBase::createNode(uint32_t ts, FSNodeDirectory *p
 		node->mode = (mode & 07777) | (parent->mode & (0xF000 & (~(EATTR_NOECACHE << 12))));
 	}
 	// If desired, node inherits permissions from parent's default ACL
-	const RichACL *parent_acl = (inheritacl == AclInheritance::kInheritAcl)
-	                       ? gMetadata->aclStorage.get(parent->id) : nullptr;
+	const RichACL *parent_acl = (inheritAcl == AclInheritance::kInheritAcl)
+	                                ? gMetadata->aclStorage.get(parent->id)
+	                                : nullptr;
 	if (parent_acl) {
 		RichACL acl;
 		uint16_t mode = node->mode;
@@ -667,7 +660,7 @@ FSNode *FilesystemNodeOperationsBase::createNode(uint32_t ts, FSNodeDirectory *p
 	gMetadata->addNode(node);
 
 	fsnodes_update_checksum(node);
-	link(ts, parent, node, name);
+	link(timeStamp, parent, node, name);
 	fsnodes_quota_update(node, {{QuotaResource::kInodes, +1}});
 
 	if (type == FSNodeType::kFile) {
@@ -846,27 +839,24 @@ uint32_t FilesystemNodeOperationsBase::getDetachedSize(const TrashPathContainer 
 	return getdetachedsize(data);
 }
 
-void FilesystemNodeOperationsBase::getDetachedData(const TrashPathContainer &data, uint8_t *dbuff) {
-	getdetacheddata(data, dbuff);
+void FilesystemNodeOperationsBase::getDetachedData(const TrashPathContainer &data,
+                                                   uint8_t *outBuffer) {
+	getdetacheddata(data, outBuffer);
 }
 
-void FilesystemNodeOperationsBase::getDetachedData(const TrashPathContainer &data, uint32_t off,
-                                                   uint32_t max_entries,
+void FilesystemNodeOperationsBase::getDetachedData(const TrashPathContainer &data, uint32_t offset,
+                                                   uint32_t maxEntries,
                                                    std::vector<NamedInodeEntry> &entries) {
 #if defined(SAUNAFS_HAVE_64BIT_JUDY) && !defined(DISABLE_JUDY_FOR_TRASHPATHCONTAINER)
-	auto it = data.find_nth(off);
+	auto it = data.find_nth(offset);
 #else
-	auto it = off < data.size() ? std::next(data.begin(), off) : data.end();
+	auto it = offset < data.size() ? std::next(data.begin(), offset) : data.end();
 #endif
-	for (; max_entries > 0 && it != data.end(); max_entries--, ++it) {
+	for (; maxEntries > 0 && it != data.end(); maxEntries--, ++it) {
 		entries.emplace_back((std::string)(*it).second, (*it).first.id);
 	}
 }
 
-// This function returns entries from a HandleIndexContainer starting at a given handleOffset.
-// The offset provided by the client (e.g., FUSE readdir) is always non-negative (sign bit 0).
-// Internally, the server may store offsets with the sign bit set (bit 63 = 1).
-// All lookups are enforced to be done ignoring the sign bit by setting it to 0.
 void FilesystemNodeOperationsBase::getDetachedData(const HandleIndexContainer &data,
                                                    uint64_t handleOffset, uint32_t maxEntries,
                                                    std::vector<HandleInodeEntry> &entries,
@@ -895,136 +885,126 @@ uint32_t FilesystemNodeOperationsBase::getDetachedSize(const ReservedPathContain
 }
 
 void FilesystemNodeOperationsBase::getDetachedData(const ReservedPathContainer &data,
-                                                   uint8_t *dbuff) {
-	getdetacheddata(data, dbuff);
+                                                   uint8_t *outBuffer) {
+	getdetacheddata(data, outBuffer);
 }
 
-void FilesystemNodeOperationsBase::getDetachedData(const ReservedPathContainer &data, uint32_t off,
-                                                   uint32_t max_entries,
+void FilesystemNodeOperationsBase::getDetachedData(const ReservedPathContainer &data,
+                                                   uint32_t offset, uint32_t maxEntries,
                                                    std::vector<NamedInodeEntry> &entries) {
 #if defined(SAUNAFS_HAVE_64BIT_JUDY) && !defined(DISABLE_JUDY_FOR_RESERVEDPATHCONTAINER)
-	auto it = data.find_nth(off);
+	auto it = data.find_nth(offset);
 #else
-	auto it = off < data.size() ? std::next(data.begin(), off) : data.end();
+	auto it = offset < data.size() ? std::next(data.begin(), offset) : data.end();
 #endif
-	for (; max_entries > 0 && it != data.end(); max_entries--, ++it) {
+	for (; maxEntries > 0 && it != data.end(); maxEntries--, ++it) {
 		entries.emplace_back((std::string)(*it).second, (*it).first);
 	}
 }
 
-uint32_t FilesystemNodeOperationsBase::getDirSize(const FSNodeDirectory *p, uint8_t withattr) {
-	uint32_t result = ((withattr) ? 40 : 6) * 2 + 3;  // for '.' and '..'
+uint32_t FilesystemNodeOperationsBase::getDirSize(const FSNodeDirectory *nodeDir,
+                                                  uint8_t withAttr) {
+	uint32_t result = (((withAttr) ? 40 : 6) * 2) + 3;  // for '.' and '..'
 	std::string name;
-	for (const auto &entry : p->entries) {
+	for (const auto &entry : nodeDir->entries) {
 		name = (std::string)(*entry.first);
-		result += ((withattr) ? 40 : 6) + name.length();
+		result += ((withAttr) ? 40 : 6) + name.length();
 	}
 	return result;
 }
 
-void FilesystemNodeOperationsBase::getDirData(inode_t rootinode, uint32_t uid, uint32_t gid,
+void FilesystemNodeOperationsBase::getDirData(inode_t rootINode, uint32_t uid, uint32_t gid,
                                               uint32_t auid, uint32_t agid, uint8_t sesflags,
-                                              FSNodeDirectory *p, uint8_t *dbuff,
-                                              uint8_t withattr) {
+                                              FSNodeDirectory *nodeDir, uint8_t *outBuffer,
+                                              uint8_t withAttr) {
 	// '.' - self
-	dbuff[0] = 1;
-	dbuff[1] = '.';
-	dbuff += 2;
-	if (p->id != rootinode) {
-		putINode(&dbuff, p->id);
+	outBuffer[0] = 1;
+	outBuffer[1] = '.';
+	outBuffer += 2;
+	if (nodeDir->id != rootINode) {
+		putINode(&outBuffer, nodeDir->id);
 	} else {
-		putINode(&dbuff, SPECIAL_INODE_ROOT);
+		putINode(&outBuffer, SPECIAL_INODE_ROOT);
 	}
 	Attributes attr;
-	if (withattr) {
-		fillAttr(p, p, uid, gid, auid, agid, sesflags, attr);
-		::memcpy(dbuff, attr.data(), attr.size());
-		dbuff += attr.size();
+	if (withAttr) {
+		fillAttr(nodeDir, nodeDir, uid, gid, auid, agid, sesflags, attr);
+		::memcpy(outBuffer, attr.data(), attr.size());
+		outBuffer += attr.size();
 	} else {
-		put8bit(&dbuff, static_cast<uint8_t>(FSNodeType::kDirectory));
+		put8bit(&outBuffer, static_cast<uint8_t>(FSNodeType::kDirectory));
 	}
 	// '..' - parent
-	dbuff[0] = 2;
-	dbuff[1] = '.';
-	dbuff[2] = '.';
-	dbuff += 3;
-	if (p->id == rootinode) {  // root node should returns self as its parent
-		putINode(&dbuff, SPECIAL_INODE_ROOT);
-		if (withattr) {
-			fillAttr(p, p, uid, gid, auid, agid, sesflags, attr);
-			::memcpy(dbuff, attr.data(), attr.size());
-			dbuff += attr.size();
+	outBuffer[0] = 2;
+	outBuffer[1] = '.';
+	outBuffer[2] = '.';
+	outBuffer += 3;
+	if (nodeDir->id == rootINode) {  // root node should returns self as its parent
+		putINode(&outBuffer, SPECIAL_INODE_ROOT);
+		if (withAttr) {
+			fillAttr(nodeDir, nodeDir, uid, gid, auid, agid, sesflags, attr);
+			::memcpy(outBuffer, attr.data(), attr.size());
+			outBuffer += attr.size();
 		} else {
-			put8bit(&dbuff, static_cast<uint8_t>(FSNodeType::kDirectory));
+			put8bit(&outBuffer, static_cast<uint8_t>(FSNodeType::kDirectory));
 		}
 	} else {
-		if (!p->parents.empty() && p->parents[0].first != rootinode) {
-			putINode(&dbuff, p->parents[0].first);
+		if (!nodeDir->parents.empty() && nodeDir->parents[0].first != rootINode) {
+			putINode(&outBuffer, nodeDir->parents[0].first);
 		} else {
-			putINode(&dbuff, SPECIAL_INODE_ROOT);
+			putINode(&outBuffer, SPECIAL_INODE_ROOT);
 		}
-		if (withattr) {
-			if (!p->parents.empty()) {
-				auto *parent = idToNodeVerify<FSNode>(p->parents[0].first);
-				fillAttr(parent, p, uid, gid, auid, agid, sesflags, attr);
-				::memcpy(dbuff, attr.data(), attr.size());
+		if (withAttr) {
+			if (!nodeDir->parents.empty()) {
+				auto *parent = idToNodeVerify<FSNode>(nodeDir->parents[0].first);
+				fillAttr(parent, nodeDir, uid, gid, auid, agid, sesflags, attr);
+				::memcpy(outBuffer, attr.data(), attr.size());
 			} else {
-				if (rootinode == SPECIAL_INODE_ROOT) {
-					fillAttr(gMetadata->root, p, uid, gid, auid, agid, sesflags, attr);
-					::memcpy(dbuff, attr.data(), attr.size());
+				if (rootINode == SPECIAL_INODE_ROOT) {
+					fillAttr(gMetadata->root, nodeDir, uid, gid, auid, agid, sesflags, attr);
+					::memcpy(outBuffer, attr.data(), attr.size());
 				} else {
-					FSNode *rn = idToNode(rootinode);
+					FSNode *rn = idToNode(rootINode);
 					if (rn) {  // it should be always true because it's checked
 						   // before, but better check than sorry
-						   fillAttr(rn, p, uid, gid, auid, agid, sesflags, attr);
-						   ::memcpy(dbuff, attr.data(), attr.size());
+						   fillAttr(rn, nodeDir, uid, gid, auid, agid, sesflags, attr);
+						   ::memcpy(outBuffer, attr.data(), attr.size());
 					} else {
-						memset(dbuff, 0, attr.size());
+						memset(outBuffer, 0, attr.size());
 					}
 				}
 			}
-			dbuff += attr.size();
+			outBuffer += attr.size();
 		} else {
-			put8bit(&dbuff, static_cast<uint8_t>(FSNodeType::kDirectory));
+			put8bit(&outBuffer, static_cast<uint8_t>(FSNodeType::kDirectory));
 		}
 	}
 	// entries
 	std::string name;
-	for (const auto &entry : p->entries) {
+	for (const auto &entry : nodeDir->entries) {
 		name = (std::string)(*entry.first);
-		dbuff[0] = name.size();
-		dbuff++;
-		memcpy(dbuff, name.c_str(), name.length());
-		dbuff += name.length();
-		putINode(&dbuff, entry.second->id);
-		if (withattr) {
-			fillAttr(entry.second, p, uid, gid, auid, agid, sesflags, attr);
-			::memcpy(dbuff, attr.data(), attr.size());
-			dbuff += attr.size();
+		outBuffer[0] = name.size();
+		outBuffer++;
+		memcpy(outBuffer, name.c_str(), name.length());
+		outBuffer += name.length();
+		putINode(&outBuffer, entry.second->id);
+		if (withAttr) {
+			fillAttr(entry.second, nodeDir, uid, gid, auid, agid, sesflags, attr);
+			::memcpy(outBuffer, attr.data(), attr.size());
+			outBuffer += attr.size();
 		} else {
-			put8bit(&dbuff, static_cast<uint8_t>(entry.second->type));
+			put8bit(&outBuffer, static_cast<uint8_t>(entry.second->type));
 		}
 	}
 }
 
-/// Get entries of directory node \a p.
-/**
- * Returns directory entries in \a dir_entries container.
- *
- * \a first_entry == 0 means the very first entry in the directory.
- *
- * \param p directory node to get the entries of
- * \param first_entry index of the first dirent to get
- * \param number_of_entries number of dirents to get
- * \param[out] container into which dirents are inserted
- */
-void FilesystemNodeOperationsBase::getDir(inode_t rootinode, uint32_t uid, uint32_t gid,
+void FilesystemNodeOperationsBase::getDir(inode_t rootINode, uint32_t uid, uint32_t gid,
                                           uint32_t auid, uint32_t agid, uint8_t sesflags,
-                                          FSNodeDirectory *p, uint64_t first_entry,
-                                          uint64_t number_of_entries,
-                                          std::vector<DirectoryEntry> &dir_entries) {
+                                          FSNodeDirectory *nodeDir, uint64_t firstEntry,
+                                          uint64_t numberOfEntries,
+                                          std::vector<DirectoryEntry> &dirEntriesOut) {
 	uint64_t const SIGN_BIT_64(1ULL << 63ULL);
-	sassert(!(first_entry & SIGN_BIT_64));
+	sassert(!(firstEntry & SIGN_BIT_64));
 	// special entryIndex values
 	static constexpr uint64_t kDotEntryIndex = 0;
 	static constexpr uint64_t kDotDotEntryIndex = (static_cast<uint64_t>(1) << hstorage::Handle::kHashShift);
@@ -1034,187 +1014,183 @@ void FilesystemNodeOperationsBase::getDir(inode_t rootinode, uint32_t uid, uint3
 	inode_t inode;
 	Attributes attr;
 
-	if (first_entry == kDotEntryIndex && number_of_entries >= 1) {
-		inode = p->id != rootinode ? p->id : SPECIAL_INODE_ROOT;
-		parent = idToNodeVerify<FSNodeDirectory>(p->parents.empty() ? SPECIAL_INODE_ROOT
-		                                                            : p->parents[0].first);
-		fillAttr(p, parent, uid, gid, auid, agid, sesflags, attr);
-		dir_entries.emplace_back(kDotEntryIndex, kDotDotEntryIndex, std::move(inode), std::string("."), std::move(attr));
+	if (firstEntry == kDotEntryIndex && numberOfEntries >= 1) {
+		inode = nodeDir->id != rootINode ? nodeDir->id : SPECIAL_INODE_ROOT;
+		parent = idToNodeVerify<FSNodeDirectory>(
+		    nodeDir->parents.empty() ? SPECIAL_INODE_ROOT : nodeDir->parents[0].first);
+		fillAttr(nodeDir, parent, uid, gid, auid, agid, sesflags, attr);
+		dirEntriesOut.emplace_back(kDotEntryIndex, kDotDotEntryIndex, std::move(inode),
+		                           std::string("."), std::move(attr));
 
-		first_entry = kDotDotEntryIndex;
-		--number_of_entries;
+		firstEntry = kDotDotEntryIndex;
+		--numberOfEntries;
 	}
 
-	if (first_entry == kDotDotEntryIndex && number_of_entries >= 1) {
-		if (p->id == rootinode) {
+	if (firstEntry == kDotDotEntryIndex && numberOfEntries >= 1) {
+		if (nodeDir->id == rootINode) {
 			inode = SPECIAL_INODE_ROOT;
-			parent = idToNodeVerify<FSNodeDirectory>(p->parents.empty() ? SPECIAL_INODE_ROOT
-			                                                            : p->parents[0].first);
-			fillAttr(p, parent, uid, gid, auid, agid, sesflags, attr);
+			parent = idToNodeVerify<FSNodeDirectory>(
+			    nodeDir->parents.empty() ? SPECIAL_INODE_ROOT : nodeDir->parents[0].first);
+			fillAttr(nodeDir, parent, uid, gid, auid, agid, sesflags, attr);
 		} else {
-			if (!p->parents.empty() && p->parents[0].first != rootinode) {
-				inode = p->parents[0].first;
+			if (!nodeDir->parents.empty() && nodeDir->parents[0].first != rootINode) {
+				inode = nodeDir->parents[0].first;
 			} else {
 				inode = SPECIAL_INODE_ROOT;
 			}
 
 			FSNodeDirectory *grandparent;
-			parent = idToNodeVerify<FSNodeDirectory>(p->parents.empty() ? SPECIAL_INODE_ROOT
-			                                                            : p->parents[0].first);
+			parent = idToNodeVerify<FSNodeDirectory>(
+			    nodeDir->parents.empty() ? SPECIAL_INODE_ROOT : nodeDir->parents[0].first);
 			grandparent = idToNodeVerify<FSNodeDirectory>(
 			    parent->parents.empty() ? SPECIAL_INODE_ROOT : parent->parents[0].first);
 			fillAttr(parent, grandparent, uid, gid, auid, agid, sesflags, attr);
 		}
 
 		uint64_t next_index = kUnusedEntryIndex;
-		if (!p->entries.empty()) {
-			auto first_dirent_it = p->find_nth(0);
+		if (!nodeDir->entries.empty()) {
+			auto first_dirent_it = nodeDir->find_nth(0);
 			next_index = (*first_dirent_it).first->data() & ~SIGN_BIT_64;
 		}
-		dir_entries.emplace_back(kDotDotEntryIndex, next_index, std::move(inode), std::string(".."), std::move(attr));
+		dirEntriesOut.emplace_back(kDotDotEntryIndex, next_index, std::move(inode),
+		                           std::string(".."), std::move(attr));
 
-		first_entry = next_index;
-		--number_of_entries;
+		firstEntry = next_index;
+		--numberOfEntries;
 	}
 
-	if (number_of_entries == 0 || p->entries.empty()) {
-		return;
-	}
+	if (numberOfEntries == 0 || nodeDir->entries.empty()) { return; }
 
 	std::string name;
-	hstorage::Handle first_index(first_entry);
+	hstorage::Handle first_index(firstEntry);
 
 	// We're trying to find the first entry in the directory that has index
 	// equal to first_entry. We don't know the second part of the pair, so we
 	// use kUnknownNode as a placeholder, and it is also the minimum possible.
 	auto pair_to_find = std::make_pair(&first_index, kUnknownNode);
-	auto it = p->entries.lower_bound(pair_to_find);
-	if (it != p->entries.end() && (*it).first->data() != first_entry) {
+	auto it = nodeDir->entries.lower_bound(pair_to_find);
+	if (it != nodeDir->entries.end() && (*it).first->data() != firstEntry) {
 		// We assume that we received hash that had its most significant bit
 		// stripped so we try new find with this supposedly stripped bit set
 		// again.
 		first_index.unlink();  // do not try to unbind the resource under this
 		                       // possibly-fake handle in destructor
-		first_index = hstorage::Handle(first_entry | SIGN_BIT_64);
+		first_index = hstorage::Handle(firstEntry | SIGN_BIT_64);
 		pair_to_find = std::make_pair(&first_index, kUnknownNode);
-		it = p->entries.lower_bound(pair_to_find);
-		if (it != p->entries.end() &&
-		    (*it).first->data() != (first_entry | SIGN_BIT_64)) {
-			it = p->entries.end();
+		it = nodeDir->entries.lower_bound(pair_to_find);
+		if (it != nodeDir->entries.end() && (*it).first->data() != (firstEntry | SIGN_BIT_64)) {
+			it = nodeDir->entries.end();
 		}
 	}
 	pair_to_find.first->unlink();
 	first_index.unlink(); // do not try to unbind the resource under this possibly-fake handle in destructor
-	while (it != p->entries.end() && number_of_entries > 0) {
+	while (it != nodeDir->entries.end() && numberOfEntries > 0) {
 		name = static_cast<std::string>(*(*it).first);
 		inode = (*it).second->id;
-		fillAttr((*it).second, p, uid, gid, auid, agid, sesflags, attr);
+		fillAttr((*it).second, nodeDir, uid, gid, auid, agid, sesflags, attr);
 
-		first_entry = (*it).first->data() & ~SIGN_BIT_64;
+		firstEntry = (*it).first->data() & ~SIGN_BIT_64;
 
 		uint64_t next_index = kUnusedEntryIndex;
-		if (++it != p->entries.end()) {
-			next_index = (*it).first->data() & ~SIGN_BIT_64;
-		}
+		if (++it != nodeDir->entries.end()) { next_index = (*it).first->data() & ~SIGN_BIT_64; }
 
-		dir_entries.emplace_back(first_entry, next_index, std::move(inode), std::move(name), std::move(attr));
+		dirEntriesOut.emplace_back(firstEntry, next_index, std::move(inode), std::move(name),
+		                           std::move(attr));
 
-		--number_of_entries;
+		--numberOfEntries;
 	}
 }
 
-void FilesystemNodeOperationsBase::checkFile(FSNodeFile *p,
-                                             uint32_t chunk_count[CHUNK_MATRIX_SIZE]) {
+void FilesystemNodeOperationsBase::checkFile(FSNodeFile *nodeFile,
+                                             uint32_t chunkCount[CHUNK_MATRIX_SIZE]) {
 	uint8_t count;
 
-	for(int i = 0; i < CHUNK_MATRIX_SIZE; ++i) {
-		chunk_count[i] = 0;
-	}
+	for (int i = 0; i < CHUNK_MATRIX_SIZE; ++i) { chunkCount[i] = 0; }
 
-	for(const auto &chunkid : p->chunks) {
+	for (const auto &chunkid : nodeFile->chunks) {
 		if (chunkid > 0) {
 			chunk_get_fullcopies(chunkid, &count);
 			count = std::min<unsigned>(count, CHUNK_MATRIX_SIZE - 1);
-			chunk_count[count]++;
+			chunkCount[count]++;
 		}
 	}
 }
 #endif
 
-uint8_t FilesystemNodeOperationsBase::appendChunks(uint32_t ts, FSNodeFile *dst, FSNodeFile *src) {
-	if (src->chunks.empty()) {
-		return SAUNAFS_STATUS_OK;
-	}
+uint8_t FilesystemNodeOperationsBase::appendChunks(uint32_t timeStamp, FSNodeFile *destNodeFile,
+                                                   FSNodeFile *srcNodeFile) {
+	if (srcNodeFile->chunks.empty()) { return SAUNAFS_STATUS_OK; }
 
-	uint32_t src_chunks = src->chunkCount();
-	uint32_t dst_chunks = dst->chunkCount();
+	uint32_t src_chunks = srcNodeFile->chunkCount();
+	uint32_t dst_chunks = destNodeFile->chunkCount();
 
 	if (((uint64_t)src_chunks + (uint64_t)dst_chunks) > ((uint64_t)MAX_INDEX + 1)) {
 		return SAUNAFS_ERROR_INDEXTOOBIG;
 	}
 
 	StatsRecord psr, nsr;
-	getStats(dst, &psr);
+	getStats(destNodeFile, &psr);
 
 	uint32_t result_chunks = src_chunks + dst_chunks;
-	dst->chunks.resize(result_chunks, 0);
+	destNodeFile->chunks.resize(result_chunks, 0);
 
-	std::copy(src->chunks.begin(), src->chunks.begin() + src_chunks, dst->chunks.begin() + dst_chunks);
+	std::copy(srcNodeFile->chunks.begin(), srcNodeFile->chunks.begin() + src_chunks,
+	          destNodeFile->chunks.begin() + dst_chunks);
 
 	for(uint32_t i = 0; i < src_chunks; ++i) {
-		auto chunkid = src->chunks[i];
+		auto chunkid = srcNodeFile->chunks[i];
 		if (chunkid > 0) {
-			if (chunk_add_file(chunkid, dst->goal) != SAUNAFS_STATUS_OK) {
-				safs_pretty_syslog(LOG_ERR, "structure error - chunk %016" PRIX64 " not found (inode: %" PRIiNode
-				                " ; index: %" PRIu32 ")",
-				       chunkid, src->id, i);
+			if (chunk_add_file(chunkid, destNodeFile->goal) != SAUNAFS_STATUS_OK) {
+				safs_pretty_syslog(LOG_ERR,
+				                   "structure error - chunk %016" PRIX64
+				                   " not found (inode: %" PRIiNode " ; index: %" PRIu32 ")",
+				                   chunkid, srcNodeFile->id, i);
 			}
 		}
 	}
 
-	uint64_t length =
-	    (static_cast<uint64_t>(dst_chunks) << SFSCHUNKBITS) + src->length;
-	if (dst->type == FSNodeType::kTrash) {
-		gMetadata->trashSpace -= dst->length;
+	uint64_t length = (static_cast<uint64_t>(dst_chunks) << SFSCHUNKBITS) + srcNodeFile->length;
+	if (destNodeFile->type == FSNodeType::kTrash) {
+		gMetadata->trashSpace -= destNodeFile->length;
 		gMetadata->trashSpace += length;
-	} else if (dst->type == FSNodeType::kReserved) {
-		gMetadata->reservedSpace -= dst->length;
+	} else if (destNodeFile->type == FSNodeType::kReserved) {
+		gMetadata->reservedSpace -= destNodeFile->length;
 		gMetadata->reservedSpace += length;
 	}
-	dst->length = length;
-	getStats(dst, &nsr);
-	fsnodes_quota_update(dst, {{QuotaResource::kSize, nsr.size - psr.size}});
-	for (const auto &[parentId, _] : dst->parents) {
+	destNodeFile->length = length;
+	getStats(destNodeFile, &nsr);
+	fsnodes_quota_update(destNodeFile, {{QuotaResource::kSize, nsr.size - psr.size}});
+	for (const auto &[parentId, _] : destNodeFile->parents) {
 		auto *parent_node = idToNodeVerify<FSNodeDirectory>(parentId);
 		addSubStats(parent_node, &nsr, &psr);
 	}
-	dst->mtime = ts;
-	dst->atime = ts;
-	src->atime = ts;
-	fsnodes_update_checksum(src);
-	fsnodes_update_checksum(dst);
+	destNodeFile->mtime = timeStamp;
+	destNodeFile->atime = timeStamp;
+	srcNodeFile->atime = timeStamp;
+	fsnodes_update_checksum(srcNodeFile);
+	fsnodes_update_checksum(destNodeFile);
 	return SAUNAFS_STATUS_OK;
 }
 
-void FilesystemNodeOperationsBase::changeFileGoal(FSNodeFile *obj, uint8_t goal) {
-	uint8_t old_goal = obj->goal;
+void FilesystemNodeOperationsBase::changeFileGoal(FSNodeFile *nodeFile, uint8_t goal) {
+	uint8_t old_goal = nodeFile->goal;
 	StatsRecord psr, nsr;
 
-	getStats(obj, &psr);
-	obj->goal = goal;
+	getStats(nodeFile, &psr);
+	nodeFile->goal = goal;
 	nsr = psr;
-	nsr.realsize = file_realsize(obj, nsr.chunks, nsr.size);
-	for (const auto &[parentId, _] : obj->parents) {
+	nsr.realsize = file_realsize(nodeFile, nsr.chunks, nsr.size);
+	for (const auto &[parentId, _] : nodeFile->parents) {
 		auto *parent_node = idToNodeVerify<FSNodeDirectory>(parentId);
 		addSubStats(parent_node, &nsr, &psr);
 	}
-	for (const auto &chunkid : obj->chunks) {
+	for (const auto &chunkid : nodeFile->chunks) {
 		if (chunkid > 0) {
 			chunk_change_file(chunkid, old_goal, goal);
 		}
 	}
-	fsnodes_update_checksum(obj);
-	gMetadata->nodeChangedSignal.emit(obj);
+	fsnodes_update_checksum(nodeFile);
+	gMetadata->nodeChangedSignal.emit(nodeFile);
 }
 
 void FilesystemNodeOperationsBase::setLength(FSNodeFile *obj, uint64_t length,
@@ -1263,24 +1239,24 @@ void FilesystemNodeOperationsBase::setLength(FSNodeFile *obj, uint64_t length,
 	gMetadata->nodeChangedSignal.emit(obj);
 }
 
-void FilesystemNodeOperationsBase::changeUidGid(FSNode *p, uint32_t uid, uint32_t gid) {
+void FilesystemNodeOperationsBase::changeUidGid(FSNode *node, uint32_t uid, uint32_t gid) {
 	int64_t size = 0;
-	fsnodes_quota_update(p, {{QuotaResource::kInodes, -1}});
-	if (p->type == FSNodeType::kFile || p->type == FSNodeType::kTrash ||
-	    p->type == FSNodeType::kReserved) {
-		size = getSize(p);
-		fsnodes_quota_update(p, {{QuotaResource::kSize, -size}});
+	fsnodes_quota_update(node, {{QuotaResource::kInodes, -1}});
+	if (node->type == FSNodeType::kFile || node->type == FSNodeType::kTrash ||
+	    node->type == FSNodeType::kReserved) {
+		size = getSize(node);
+		fsnodes_quota_update(node, {{QuotaResource::kSize, -size}});
 	}
-	p->uid = uid;
-	p->gid = gid;
-	fsnodes_quota_update(p, {{QuotaResource::kInodes, +1}});
-	if (p->type == FSNodeType::kFile || p->type == FSNodeType::kTrash ||
-	    p->type == FSNodeType::kReserved) {
-		fsnodes_quota_update(p, {{QuotaResource::kSize, +size}});
+	node->uid = uid;
+	node->gid = gid;
+	fsnodes_quota_update(node, {{QuotaResource::kInodes, +1}});
+	if (node->type == FSNodeType::kFile || node->type == FSNodeType::kTrash ||
+	    node->type == FSNodeType::kReserved) {
+		fsnodes_quota_update(node, {{QuotaResource::kSize, +size}});
 	}
 }
 
-void FilesystemNodeOperationsBase::fsnodes_remove_node(uint32_t ts, FSNode *node) {
+void FilesystemNodeOperationsBase::fsnodes_remove_node(uint32_t timeStamp, FSNode *node) {
 	if (!node->parents.empty()) {
 		return;
 	}
@@ -1319,7 +1295,7 @@ void FilesystemNodeOperationsBase::fsnodes_remove_node(uint32_t ts, FSNode *node
 		gMetadata->linkNodes--;
 	}
 
-	gMetadata->inodePool.release(node->id, ts, true);
+	gMetadata->inodePool.release(node->id, timeStamp, true);
 	xattr_removeinode(node->id);
 	fsnodes_quota_update(node, {{QuotaResource::kInodes, -1}});
 	fsnodes_quota_remove(QuotaOwnerType::kInode, node->id);
@@ -1342,56 +1318,55 @@ void FilesystemNodeOperationsBase::fsnodes_remove_node(uint32_t ts, FSNode *node
 	}
 }
 
-void FilesystemNodeOperationsBase::unlink(uint32_t ts, FSNodeDirectory *parent,
-                                          const HString &child_name, FSNode *child) {
+void FilesystemNodeOperationsBase::unlink(uint32_t timeStamp, FSNodeDirectory *parent,
+                                          const HString &childName, FSNode *childNode) {
 	std::string path;
 
-	if (child->parents.size() == 1) {  // last link
-		if (child->type == FSNodeType::kFile &&
-		    (child->trashtime > 0 ||
-		     !static_cast<FSNodeFile*>(child)->sessionIds.empty())) {  // go to trash or reserved ? - get path
-			getPath(parent, child, path);
+	if (childNode->parents.size() == 1) {  // last link
+		// go to trash or reserved ? - get path
+		if (childNode->type == FSNodeType::kFile &&
+		    (childNode->trashtime > 0 ||
+		     !static_cast<FSNodeFile *>(childNode)->sessionIds.empty())) {
+			getPath(parent, childNode, path);
 		}
 	}
 
-	removeEdge(ts, parent, child_name, child);
-	if (!child->parents.empty()) {
-		return;
-	}
+	removeEdge(timeStamp, parent, childName, childNode);
+	if (!childNode->parents.empty()) { return; }
 
 	// last link
-	if (child->type == FSNodeType::kFile) {
-		auto *file_node = static_cast<FSNodeFile*>(child);
-		if (child->trashtime > 0) {
-			child->type = FSNodeType::kTrash;
-			child->ctime = ts;
-			fsnodes_update_checksum(child);
+	if (childNode->type == FSNodeType::kFile) {
+		auto *file_node = static_cast<FSNodeFile *>(childNode);
+		if (childNode->trashtime > 0) {
+			childNode->type = FSNodeType::kTrash;
+			childNode->ctime = timeStamp;
+			fsnodes_update_checksum(childNode);
 
 			addTrashEntry(gMetadata->trash, gMetadata->trashHandlesIndex,
-			              gMetadata->trashReservedToId, child, path);
+			              gMetadata->trashReservedToId, childNode, path);
 
 			gMetadata->trashSpace += file_node->length;
 			gMetadata->trashNodes++;
 		} else if (!file_node->sessionIds.empty()) {
-			child->type = FSNodeType::kReserved;
-			fsnodes_update_checksum(child);
+			childNode->type = FSNodeType::kReserved;
+			fsnodes_update_checksum(childNode);
 
 			addReservedEntry(gMetadata->reserved, gMetadata->reservedHandlesIndex,
-			                 gMetadata->trashReservedToId, child, path);
+			                 gMetadata->trashReservedToId, childNode, path);
 
 			gMetadata->reservedSpace += file_node->length;
 			gMetadata->reservedNodes++;
 		} else {
-			fsnodes_remove_node(ts, child);
+			fsnodes_remove_node(timeStamp, childNode);
 		}
 	} else {
-		fsnodes_remove_node(ts, child);
+		fsnodes_remove_node(timeStamp, childNode);
 	}
 }
 
-int FilesystemNodeOperationsBase::purge(uint32_t ts, FSNode *p) {
-	if (p->type == FSNodeType::kTrash) {
-		FSNodeFile *file_node = static_cast<FSNodeFile*>(p);
+int FilesystemNodeOperationsBase::purge(uint32_t timeStamp, FSNode *node) {
+	if (node->type == FSNodeType::kTrash) {
+		FSNodeFile *file_node = static_cast<FSNodeFile *>(node);
 		gMetadata->trashSpace -= file_node->length;
 		gMetadata->trashNodes--;
 
@@ -1403,36 +1378,36 @@ int FilesystemNodeOperationsBase::purge(uint32_t ts, FSNode *p) {
 
 			moveTrashToReservedEntry(gMetadata->trash, gMetadata->trashHandlesIndex,
 			                         gMetadata->reserved, gMetadata->reservedHandlesIndex,
-			                         gMetadata->trashReservedToId, p);
+			                         gMetadata->trashReservedToId, node);
 
 			return 0;
 		} else {
 			removeTrashEntry(gMetadata->trash, gMetadata->trashHandlesIndex,
-			                 gMetadata->trashReservedToId, p);
-			p->ctime = ts;
-			fsnodes_update_checksum(p);
-			fsnodes_remove_node(ts, p);
+			                 gMetadata->trashReservedToId, node);
+			node->ctime = timeStamp;
+			fsnodes_update_checksum(node);
+			fsnodes_remove_node(timeStamp, node);
 
 			return 1;
 		}
-	} else if (p->type == FSNodeType::kReserved) {
-		FSNodeFile *file_node = static_cast<FSNodeFile*>(p);
+	} else if (node->type == FSNodeType::kReserved) {
+		FSNodeFile *file_node = static_cast<FSNodeFile *>(node);
 
 		gMetadata->reservedSpace -= file_node->length;
 		gMetadata->reservedNodes--;
 
 		removeReservedEntry(gMetadata->reserved, gMetadata->reservedHandlesIndex,
-		                    gMetadata->trashReservedToId, p->id);
+		                    gMetadata->trashReservedToId, node->id);
 
-		file_node->ctime = ts;
+		file_node->ctime = timeStamp;
 		fsnodes_update_checksum(file_node);
-		fsnodes_remove_node(ts, file_node);
+		fsnodes_remove_node(timeStamp, file_node);
 		return 1;
 	}
 	return -1;
 }
 
-uint8_t FilesystemNodeOperationsBase::undel(uint32_t ts, FSNodeFile *node) {
+uint8_t FilesystemNodeOperationsBase::undel(uint32_t timeStamp, FSNodeFile *node) {
 	uint8_t is_new;
 	uint32_t i, partleng, dots;
 	/* check path */
@@ -1510,9 +1485,9 @@ uint8_t FilesystemNodeOperationsBase::undel(uint32_t ts, FSNodeFile *node) {
 			}
 
 			node->type = FSNodeType::kFile;
-			node->ctime = ts;
+			node->ctime = timeStamp;
 			fsnodes_update_checksum(node);
-			link(ts, p, node, name);
+			link(timeStamp, p, node, name);
 			gMetadata->trashSpace -= node->length;
 			gMetadata->trashNodes--;
 			return SAUNAFS_STATUS_OK;
@@ -1528,7 +1503,7 @@ uint8_t FilesystemNodeOperationsBase::undel(uint32_t ts, FSNodeFile *node) {
 				}
 			}
 			if (is_new == 1) {
-				n = createNode(ts, p, name, FSNodeType::kDirectory, 0755, 0, 0, 0, 0,
+				n = createNode(timeStamp, p, name, FSNodeType::kDirectory, 0755, 0, 0, 0, 0,
 				               AclInheritance::kDontInheritAcl);
 
 #ifndef METARESTORE
@@ -1536,7 +1511,7 @@ uint8_t FilesystemNodeOperationsBase::undel(uint32_t ts, FSNodeFile *node) {
 #endif
 
 				gFSOperations->changeLog(
-				    ts,
+				    timeStamp,
 				    "CREATE(%" PRIiNode ",%s,%c,%d,%" PRIu32 ",%" PRIu32 ",%" PRIu32 "):%" PRIiNode,
 				    p->id, escapeName(name).c_str(), static_cast<char>(FSNodeType::kDirectory),
 				    n->mode & 07777, (uint32_t)0, (uint32_t)0, (uint32_t)0, n->id);
@@ -1613,47 +1588,51 @@ void FilesystemNodeOperationsBase::getEAttrRecursive(FSNode *node, uint8_t gmode
 
 #endif  // METARESTORE
 
-void FilesystemNodeOperationsBase::setgoalRecursive(FSNode *node, uint32_t ts, uint32_t uid,
-                                                    uint8_t goal, uint8_t smode, inode_t *sinodes,
-                                                    inode_t *ncinodes, inode_t *nsinodes) {
+void FilesystemNodeOperationsBase::setgoalRecursive(FSNode *node, uint32_t timeStamp, uint32_t uid,
+                                                    uint8_t goal, uint8_t smode,
+                                                    inode_t *modifiedINodesOut,
+                                                    inode_t *unchangedINodesOut,
+                                                    inode_t *permissionDeniedINodesOut) {
 	if (node->type == FSNodeType::kFile || node->type == FSNodeType::kDirectory ||
 	    node->type == FSNodeType::kTrash || node->type == FSNodeType::kReserved) {
 		if ((node->mode & (EATTR_NOOWNER << 12)) == 0 && uid != 0 && node->uid != uid) {
-			(*nsinodes)++;
+			(*permissionDeniedINodesOut)++;
 		} else {
 			if ((smode & SMODE_TMASK) == SMODE_SET && node->goal != goal) {
 				if (node->type != FSNodeType::kDirectory) {
 					changeFileGoal(static_cast<FSNodeFile *>(node), goal);
-					(*sinodes)++;
+					(*modifiedINodesOut)++;
 				} else {
 					node->goal = goal;
 					gMetadata->nodeChangedSignal.emit(node);
-					(*sinodes)++;
+					(*modifiedINodesOut)++;
 				}
-				updateCTime(node, ts);
+				updateCTime(node, timeStamp);
 				fsnodes_update_checksum(node);
 			} else {
-				(*ncinodes)++;
+				(*unchangedINodesOut)++;
 			}
 		}
 		if (node->type == FSNodeType::kDirectory && (smode & SMODE_RMASK)) {
 			for (const auto &entry : static_cast<const FSNodeDirectory*>(node)->entries) {
-				setgoalRecursive(entry.second, ts, uid, goal, smode, sinodes, ncinodes, nsinodes);
+				setgoalRecursive(entry.second, timeStamp, uid, goal, smode, modifiedINodesOut,
+				                 unchangedINodesOut, permissionDeniedINodesOut);
 			}
 		}
 	}
 }
 
-void FilesystemNodeOperationsBase::setTrashTimeRecursive(FSNode *node, uint32_t ts, uint32_t uid,
-                                                         uint32_t trashtime, uint8_t smode,
-                                                         inode_t *sinodes, inode_t *ncinodes,
-                                                         inode_t *nsinodes) {
+void FilesystemNodeOperationsBase::setTrashTimeRecursive(FSNode *node, uint32_t timeStamp,
+                                                         uint32_t uid, uint32_t trashtime,
+                                                         uint8_t smode, inode_t *modifiedINodesOut,
+                                                         inode_t *unchangedINodesOut,
+                                                         inode_t *permissionDeniedINodesOut) {
 	uint8_t set;
 
 	if (node->type == FSNodeType::kFile || node->type == FSNodeType::kDirectory ||
 	    node->type == FSNodeType::kTrash || node->type == FSNodeType::kReserved) {
 		if ((node->mode & (EATTR_NOOWNER << 12)) == 0 && uid != 0 && node->uid != uid) {
-			(*nsinodes)++;
+			(*permissionDeniedINodesOut)++;
 		} else {
 			set = 0;
 			auto old_trash_key = TrashPathKey(node);
@@ -1678,32 +1657,35 @@ void FilesystemNodeOperationsBase::setTrashTimeRecursive(FSNode *node, uint32_t 
 				break;
 			}
 			if (set) {
-				(*sinodes)++;
-				node->ctime = ts;
+				(*modifiedINodesOut)++;
+				node->ctime = timeStamp;
 				if (node->type == FSNodeType::kTrash) {
 					updateTrashFromOldEntry(gMetadata->trash, node, old_trash_key);
 				}
 				fsnodes_update_checksum(node);
 			} else {
-				(*ncinodes)++;
+				(*unchangedINodesOut)++;
 			}
 		}
 		if (node->type == FSNodeType::kDirectory && (smode & SMODE_RMASK)) {
 			for(const auto &entry : static_cast<const FSNodeDirectory*>(node)->entries) {
-				setTrashTimeRecursive(entry.second, ts, uid, trashtime, smode, sinodes, ncinodes,
-				                      nsinodes);
+				setTrashTimeRecursive(entry.second, timeStamp, uid, trashtime, smode,
+				                      modifiedINodesOut, unchangedINodesOut,
+				                      permissionDeniedINodesOut);
 			}
 		}
 	}
 }
 
-void FilesystemNodeOperationsBase::setEAttrRecursive(FSNode *node, uint32_t ts, uint32_t uid,
-                                                     uint8_t eattr, uint8_t smode, inode_t *sinodes,
-                                                     inode_t *ncinodes, inode_t *nsinodes) {
+void FilesystemNodeOperationsBase::setEAttrRecursive(FSNode *node, uint32_t timeStamp, uint32_t uid,
+                                                     uint8_t eattr, uint8_t smode,
+                                                     inode_t *modifiedINodesOut,
+                                                     inode_t *unchangedINodesOut,
+                                                     inode_t *permissionDeniedINodesOut) {
 	uint8_t neweattr, seattr;
 
 	if ((node->mode & (EATTR_NOOWNER << 12)) == 0 && uid != 0 && node->uid != uid) {
-		(*nsinodes)++;
+		(*permissionDeniedINodesOut)++;
 	} else {
 		seattr = eattr;
 		if (node->type != FSNodeType::kDirectory) {
@@ -1729,108 +1711,105 @@ void FilesystemNodeOperationsBase::setEAttrRecursive(FSNode *node, uint32_t ts, 
 				gMetadata->aclStorage.setMode(node->id, node->mode,
 				                              node->type == FSNodeType::kDirectory);
 			}
-			(*sinodes)++;
-			updateCTime(node, ts);
+			(*modifiedINodesOut)++;
+			updateCTime(node, timeStamp);
 		} else {
-			(*ncinodes)++;
+			(*unchangedINodesOut)++;
 		}
 	}
 	if (node->type == FSNodeType::kDirectory && (smode & SMODE_RMASK)) {
 		const FSNodeDirectory *dir_node = static_cast<const FSNodeDirectory*>(node);
 		for (const auto &entry : dir_node->entries) {
-			setEAttrRecursive(entry.second, ts, uid, eattr, smode, sinodes, ncinodes, nsinodes);
+			setEAttrRecursive(entry.second, timeStamp, uid, eattr, smode, modifiedINodesOut,
+			                  unchangedINodesOut, permissionDeniedINodesOut);
 		}
 	}
 	fsnodes_update_checksum(node);
 }
 
-uint8_t FilesystemNodeOperationsBase::deleteAcl(FSNode *p, AclType type, uint32_t ts) {
+uint8_t FilesystemNodeOperationsBase::deleteAcl(FSNode *node, AclType type, uint32_t timeStamp) {
 	if (type == AclType::kRichACL) {
-		gMetadata->aclStorage.erase(p->id);
+		gMetadata->aclStorage.erase(node->id);
 	} else if (type == AclType::kDefault) {
-		if (p->type != FSNodeType::kDirectory) {
-			return SAUNAFS_ERROR_ENOTSUP;
-		}
-		const RichACL *node_acl = gMetadata->aclStorage.get(p->id);
+		if (node->type != FSNodeType::kDirectory) { return SAUNAFS_ERROR_ENOTSUP; }
+		const RichACL *node_acl = gMetadata->aclStorage.get(node->id);
 		if (node_acl) {
 			RichACL new_acl = *node_acl;
 			new_acl.createExplicitInheritance();
 			new_acl.removeInheritOnly(true);
 			if (new_acl.size() == 0) {
-				gMetadata->aclStorage.erase(p->id);
+				gMetadata->aclStorage.erase(node->id);
 			} else {
-				gMetadata->aclStorage.set(p->id, std::move(new_acl));
+				gMetadata->aclStorage.set(node->id, std::move(new_acl));
 			}
 		}
 	} else if (type == AclType::kAccess) {
-		const RichACL *node_acl = gMetadata->aclStorage.get(p->id);
+		const RichACL *node_acl = gMetadata->aclStorage.get(node->id);
 		if (node_acl) {
 			RichACL new_acl = *node_acl;
 			new_acl.createExplicitInheritance();
 			new_acl.removeInheritOnly(false);
 			if (new_acl.size() == 0) {
-				gMetadata->aclStorage.erase(p->id);
+				gMetadata->aclStorage.erase(node->id);
 			} else {
-				gMetadata->aclStorage.set(p->id, std::move(new_acl));
+				gMetadata->aclStorage.set(node->id, std::move(new_acl));
 			}
 		}
 	} else {
 		return SAUNAFS_ERROR_EINVAL;
 	}
-	updateCTime(p, ts);
-	fsnodes_update_checksum(p);
+	updateCTime(node, timeStamp);
+	fsnodes_update_checksum(node);
 	return SAUNAFS_STATUS_OK;
 }
 
 #ifndef METARESTORE
-uint8_t FilesystemNodeOperationsBase::getAcl(FSNode *p, RichACL &acl) {
-	const RichACL *richacl = gMetadata->aclStorage.get(p->id);
+uint8_t FilesystemNodeOperationsBase::getAcl(FSNode *node, RichACL &acl) {
+	const RichACL *richacl = gMetadata->aclStorage.get(node->id);
 	if (!richacl) {
 		return SAUNAFS_ERROR_ENOATTR;
 	}
 	acl = *richacl;
-	assert((p->mode & 0777) == richacl->getMode());
+	assert((node->mode & 0777) == richacl->getMode());
 	return SAUNAFS_STATUS_OK;
 }
 #endif
 
-uint8_t FilesystemNodeOperationsBase::setAcl(FSNode *p, const RichACL &acl, uint32_t ts) {
-	if (!acl.checkInheritFlags(p->type == FSNodeType::kDirectory)) {
+uint8_t FilesystemNodeOperationsBase::setAcl(FSNode *node, const RichACL &acl, uint32_t timeStamp) {
+	if (!acl.checkInheritFlags(node->type == FSNodeType::kDirectory)) {
 		return SAUNAFS_ERROR_ENOTSUP;
 	}
 
-	uint16_t mode = p->mode;
-	if (RichACL::equivMode(acl, mode, p->type == FSNodeType::kDirectory)) {
-		p->mode = (p->mode & ~0777) | (mode & 0777);
-		gMetadata->aclStorage.erase(p->id);
+	uint16_t mode = node->mode;
+	if (RichACL::equivMode(acl, mode, node->type == FSNodeType::kDirectory)) {
+		node->mode = (node->mode & ~0777) | (mode & 0777);
+		gMetadata->aclStorage.erase(node->id);
 	} else {
-		if (!acl.isAutoSetMode()) {
-			p->mode = (p->mode & ~0777) | (acl.getMode() & 0777);
-		}
+		if (!acl.isAutoSetMode()) { node->mode = (node->mode & ~0777) | (acl.getMode() & 0777); }
 		RichACL new_acl = acl;
 		if (acl.isAutoSetMode()) {
 			new_acl.setFlags(new_acl.getFlags() & ~RichACL::kAutoSetMode);
-			new_acl.setMode(p->mode, p->type == FSNodeType::kDirectory);
+			new_acl.setMode(node->mode, node->type == FSNodeType::kDirectory);
 		}
-		gMetadata->aclStorage.set(p->id, std::move(new_acl));
+		gMetadata->aclStorage.set(node->id, std::move(new_acl));
 	}
 
-	updateCTime(p, ts);
-	fsnodes_update_checksum(p);
+	updateCTime(node, timeStamp);
+	fsnodes_update_checksum(node);
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t FilesystemNodeOperationsBase::setAcl(FSNode *p, AclType type, const AccessControlList &acl,
-                                             uint32_t ts) {
+uint8_t FilesystemNodeOperationsBase::setAcl(FSNode *node, AclType type,
+                                             const AccessControlList &acl, uint32_t timeStamp) {
 	if (type != AclType::kDefault && type != AclType::kAccess) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
 
-	if (type == AclType::kDefault && p->type != FSNodeType::kDirectory) {
+	if (type == AclType::kDefault && node->type != FSNodeType::kDirectory) {
 		return SAUNAFS_ERROR_ENOTSUP;
 	}
 
-	const RichACL *node_acl = gMetadata->aclStorage.get(p->id);
+	const RichACL *node_acl = gMetadata->aclStorage.get(node->id);
 	RichACL new_acl;
 
 	if (node_acl) {
@@ -1841,15 +1820,15 @@ uint8_t FilesystemNodeOperationsBase::setAcl(FSNode *p, AclType type, const Acce
 
 	if (type == AclType::kDefault) {
 		new_acl.appendDefaultPosixACL(acl);
-		new_acl.setMode(p->mode, true);
+		new_acl.setMode(node->mode, true);
 	} else {
-		new_acl.appendPosixACL(acl, p->type == FSNodeType::kDirectory);
-		p->mode = (p->mode & ~0777) | (new_acl.getMode() & 0777);
+		new_acl.appendPosixACL(acl, node->type == FSNodeType::kDirectory);
+		node->mode = (node->mode & ~0777) | (new_acl.getMode() & 0777);
 	}
-	gMetadata->aclStorage.set(p->id, std::move(new_acl));
+	gMetadata->aclStorage.set(node->id, std::move(new_acl));
 
-	updateCTime(p, ts);
-	fsnodes_update_checksum(p);
+	updateCTime(node, timeStamp);
+	fsnodes_update_checksum(node);
 	return SAUNAFS_STATUS_OK;
 }
 
@@ -1934,18 +1913,11 @@ uint8_t FilesystemNodeOperationsBase::verifySession(const FsContext &context,
 	return SAUNAFS_STATUS_OK;
 }
 
-/*
- * Treating rootinode as the root of the hierarchy, converts (rootinode, inode) to fsnode*
- * ie:
- * * if inode == rootinode, then returns root node
- * * if inode != rootinode, then returns some node
- * Checks for permissions needed to perform the operation (defined by modemask)
- * Can return a reserved node or a node from trash
- */
 uint8_t FilesystemNodeOperationsBase::getNodeForOperation(const FsContext &context,
                                                           ExpectedNodeType expectedNodeType,
                                                           uint8_t modemask, inode_t inode,
-                                                          FSNode **ret, FSNodeDirectory **ret_rn) {
+                                                          FSNode **nodeOut,
+                                                          FSNodeDirectory **rootDirOut) {
 	FSNode *p;
 	FSNodeDirectory *rn;
 	if (!context.hasSessionData()) {
@@ -1998,9 +1970,7 @@ uint8_t FilesystemNodeOperationsBase::getNodeForOperation(const FsContext &conte
 	if (context.canCheckPermissions() && !access(context, p, modemask)) {
 		return SAUNAFS_ERROR_EACCES;
 	}
-	*ret = p;
-	if (ret_rn) {
-		*ret_rn = rn;
-	}
+	*nodeOut = p;
+	if (rootDirOut) { *rootDirOut = rn; }
 	return SAUNAFS_STATUS_OK;
 }

--- a/src/master/filesystem_node.h
+++ b/src/master/filesystem_node.h
@@ -64,7 +64,7 @@ public:
 	                     FSNodeFile *srcNodeFile) override;
 	void changeFileGoal(FSNodeFile *nodeFile, uint8_t goal) override;
 #ifndef METARESTORE
-	void checkFile(FSNodeFile *nodeFile, uint32_t chunkCount[CHUNK_MATRIX_SIZE]) override;
+	void checkFile(FSNodeFile *nodeFile, ChunkCountArray &chunkCount) override;
 #endif
 	int64_t getSize(FSNode *node) override;
 

--- a/src/master/filesystem_node.h
+++ b/src/master/filesystem_node.h
@@ -35,123 +35,113 @@
 /// assuming an in-memory metadata representation.
 class FilesystemNodeOperationsBase : public IFilesystemNodeOperations {
 public:
-	FSNode *fsnodes_lookup(FSNodeDirectory *node, const HString &name) const override;
+	FSNode *lookup(FSNodeDirectory *node, const HString &name) const override;
 
-	FSNode *fsnodes_create_node(uint32_t ts, FSNodeDirectory *parent, const HString &name,
-	                            FSNodeType type, uint16_t mode, uint16_t umask, uint32_t uid,
-	                            uint32_t gid, uint8_t copysgid, AclInheritance inheritacl,
-	                            inode_t req_inode = 0) override;
-	void fsnodes_link(uint32_t ts, FSNodeDirectory *parent, FSNode *child,
-	                  const HString &name) override;
-	void fsnodes_unlink(uint32_t ts, FSNodeDirectory *parent, const HString &node_name,
-	                    FSNode *node) override;
-	void fsnodes_remove_edge(uint32_t ts, FSNodeDirectory *parent, const HString &node_name,
-	                         FSNode *node) override;
+	FSNode *createNode(uint32_t ts, FSNodeDirectory *parent, const HString &name, FSNodeType type,
+	                   uint16_t mode, uint16_t umask, uint32_t uid, uint32_t gid, uint8_t copysgid,
+	                   AclInheritance inheritacl, inode_t req_inode = 0) override;
+	void link(uint32_t ts, FSNodeDirectory *parent, FSNode *child, const HString &name) override;
+	void unlink(uint32_t ts, FSNodeDirectory *parent, const HString &node_name,
+	            FSNode *node) override;
+	void removeEdge(uint32_t ts, FSNodeDirectory *parent, const HString &node_name,
+	                FSNode *node) override;
 
-	void fsnodes_update_ctime(FSNode *node, uint32_t ctime) override;
-	void fsnodes_fill_attr(FSNode *node, FSNode *parent, uint32_t uid, uint32_t gid, uint32_t auid,
-	                       uint32_t agid, uint8_t sesflags, Attributes &attr) override;
-	void fsnodes_fill_attr(const FsContext &context, FSNode *node, FSNode *parent,
-	                       Attributes &attr) override;
-	void fsnodes_get_stats(FSNode *node, StatsRecord *sr) override;
-	void fsnodes_add_stats(FSNodeDirectory *parent, StatsRecord *sr) override;
-	void fsnodes_add_sub_stats(FSNodeDirectory *parent, StatsRecord *newsr,
-	                           StatsRecord *prevsr) override;
-	void fsnodes_change_uid_gid(FSNode *p, uint32_t uid, uint32_t gid) override;
+	void updateCTime(FSNode *node, uint32_t ctime) override;
+	void fillAttr(FSNode *node, FSNode *parent, uint32_t uid, uint32_t gid, uint32_t auid,
+	              uint32_t agid, uint8_t sesflags, Attributes &attr) override;
+	void fillAttr(const FsContext &context, FSNode *node, FSNode *parent,
+	              Attributes &attr) override;
+	void getStats(FSNode *node, StatsRecord *sr) override;
+	void addStats(FSNodeDirectory *parent, StatsRecord *sr) override;
+	void addSubStats(FSNodeDirectory *parent, StatsRecord *newsr, StatsRecord *prevsr) override;
+	void changeUidGid(FSNode *p, uint32_t uid, uint32_t gid) override;
 
-	void fsnodes_setlength(FSNodeFile *obj, uint64_t length, bool eraseFurtherChunks) override;
-	uint8_t fsnodes_appendchunks(uint32_t ts, FSNodeFile *dstobj, FSNodeFile *srcobj) override;
-	void fsnodes_changefilegoal(FSNodeFile *obj, uint8_t goal) override;
+	void setLength(FSNodeFile *obj, uint64_t length, bool eraseFurtherChunks) override;
+	uint8_t appendChunks(uint32_t ts, FSNodeFile *dstobj, FSNodeFile *srcobj) override;
+	void changeFileGoal(FSNodeFile *obj, uint8_t goal) override;
 #ifndef METARESTORE
-	void fsnodes_checkfile(FSNodeFile *p, uint32_t chunkcount[CHUNK_MATRIX_SIZE]) override;
+	void checkFile(FSNodeFile *p, uint32_t chunkcount[CHUNK_MATRIX_SIZE]) override;
 #endif
-	int64_t fsnodes_get_size(FSNode *node) override;
+	int64_t getSize(FSNode *node) override;
 
 #ifndef METARESTORE
-	uint32_t fsnodes_getdirsize(const FSNodeDirectory *p, uint8_t withattr) override;
-	void fsnodes_getdirdata(inode_t rootinode, uint32_t uid, uint32_t gid, uint32_t auid,
-	                        uint32_t agid, uint8_t sesflags, FSNodeDirectory *p, uint8_t *dbuff,
-	                        uint8_t withattr) override;
-	void fsnodes_getdir(inode_t rootinode, uint32_t uid, uint32_t gid, uint32_t auid, uint32_t agid,
-	                    uint8_t sesflags, FSNodeDirectory *p, uint64_t first_entry,
-	                    uint64_t number_of_entries,
-	                    std::vector<DirectoryEntry> &dir_entries) override;
+	uint32_t getDirSize(const FSNodeDirectory *p, uint8_t withattr) override;
+	void getDirData(inode_t rootinode, uint32_t uid, uint32_t gid, uint32_t auid, uint32_t agid,
+	                uint8_t sesflags, FSNodeDirectory *p, uint8_t *dbuff,
+	                uint8_t withattr) override;
+	void getDir(inode_t rootinode, uint32_t uid, uint32_t gid, uint32_t auid, uint32_t agid,
+	            uint8_t sesflags, FSNodeDirectory *p, uint64_t first_entry,
+	            uint64_t number_of_entries, std::vector<DirectoryEntry> &dir_entries) override;
 #endif
-	int fsnodes_nameisused(FSNodeDirectory *node, const HString &name) override;
+	int isNameUsed(FSNodeDirectory *node, const HString &name) override;
 
 	// Trash/Reserved operations
-	int fsnodes_purge(uint32_t ts, FSNode *p) override;
-	uint8_t fsnodes_undel(uint32_t ts, FSNodeFile *node) override;
+	int purge(uint32_t ts, FSNode *p) override;
+	uint8_t undel(uint32_t ts, FSNodeFile *node) override;
 #ifndef METARESTORE
-	uint32_t fsnodes_getdetachedsize(const TrashPathContainer &data) override;
-	void fsnodes_getdetacheddata(const TrashPathContainer &data, uint8_t *dbuff) override;
-	void fsnodes_getdetacheddata(const TrashPathContainer &data, uint32_t off, uint32_t max_entries,
-	                             std::vector<NamedInodeEntry> &entries) override;
-	uint32_t fsnodes_getdetachedsize(const ReservedPathContainer &data) override;
-	void fsnodes_getdetacheddata(const ReservedPathContainer &data, uint8_t *dbuff) override;
-	void fsnodes_getdetacheddata(const ReservedPathContainer &data, uint32_t off,
-	                             uint32_t max_entries,
-	                             std::vector<NamedInodeEntry> &entries) override;
-	void fsnodes_getdetacheddata(const HandleIndexContainer &data, uint64_t handleOffset,
-	                             uint32_t maxEntries, std::vector<HandleInodeEntry> &entries,
-	                             bool fromTrash) override;
+	uint32_t getDetachedSize(const TrashPathContainer &data) override;
+	void getDetachedData(const TrashPathContainer &data, uint8_t *dbuff) override;
+	void getDetachedData(const TrashPathContainer &data, uint32_t off, uint32_t max_entries,
+	                     std::vector<NamedInodeEntry> &entries) override;
+	uint32_t getDetachedSize(const ReservedPathContainer &data) override;
+	void getDetachedData(const ReservedPathContainer &data, uint8_t *dbuff) override;
+	void getDetachedData(const ReservedPathContainer &data, uint32_t off, uint32_t max_entries,
+	                     std::vector<NamedInodeEntry> &entries) override;
+	void getDetachedData(const HandleIndexContainer &data, uint64_t handleOffset,
+	                     uint32_t maxEntries, std::vector<HandleInodeEntry> &entries,
+	                     bool fromTrash) override;
 #endif
 
 	// Path operations
-	void fsnodes_getpath(FSNodeDirectory *parent, FSNode *child, std::string &path) override;
-	uint32_t fsnodes_getpath_size(FSNodeDirectory *parent, FSNode *child) override;
-	void fsnodes_getpath_data(FSNodeDirectory *parent, FSNode *child, uint8_t *path,
-	                          uint32_t size) override;
-	std::string fsnodes_escape_name(const std::string &name) override;
+	void getPath(FSNodeDirectory *parent, FSNode *child, std::string &path) override;
+	uint32_t getPathSize(FSNodeDirectory *parent, FSNode *child) override;
+	void getPathData(FSNodeDirectory *parent, FSNode *child, uint8_t *path, uint32_t size) override;
+	std::string escapeName(const std::string &name) override;
 
 	// ACL operations
-	uint8_t fsnodes_setacl(FSNode *p, const RichACL &acl, uint32_t ts) override;
-	uint8_t fsnodes_setacl(FSNode *p, AclType type, const AccessControlList &acl,
-	                       uint32_t ts) override;
+	uint8_t setAcl(FSNode *p, const RichACL &acl, uint32_t ts) override;
+	uint8_t setAcl(FSNode *p, AclType type, const AccessControlList &acl, uint32_t ts) override;
 #ifndef METARESTORE
-	uint8_t fsnodes_getacl(FSNode *p, RichACL &acl) override;
+	uint8_t getAcl(FSNode *p, RichACL &acl) override;
 #endif  // METARESTORE
-	uint8_t fsnodes_deleteacl(FSNode *p, AclType type, uint32_t ts) override;
+	uint8_t deleteAcl(FSNode *p, AclType type, uint32_t ts) override;
 
 	// Recursive operations
 #ifndef METARESTORE
-	void fsnodes_getgoal_recursive(FSNode *node, uint8_t gmode, GoalStatistics &fgtab,
-	                               GoalStatistics &dgtab) override;
-	void fsnodes_gettrashtime_recursive(FSNode *node, uint8_t gmode, TrashtimeMap &fileTrashtimes,
-	                                    TrashtimeMap &dirTrashtimes) override;
-	void fsnodes_geteattr_recursive(FSNode *node, uint8_t gmode, uint32_t feattrtab[16],
-	                                uint32_t deattrtab[16]) override;
+	void getGoalRecursive(FSNode *node, uint8_t gmode, GoalStatistics &fgtab,
+	                      GoalStatistics &dgtab) override;
+	void getTrashTimeRecursive(FSNode *node, uint8_t gmode, TrashtimeMap &fileTrashtimes,
+	                           TrashtimeMap &dirTrashtimes) override;
+	void getEAttrRecursive(FSNode *node, uint8_t gmode, uint32_t feattrtab[16],
+	                       uint32_t deattrtab[16]) override;
 #endif  // METARESTORE
-	void fsnodes_setgoal_recursive(FSNode *node, uint32_t ts, uint32_t uid, uint8_t goal,
-	                               uint8_t smode, inode_t *sinodes, inode_t *ncinodes,
-	                               inode_t *nsinodes) override;
+	void setgoalRecursive(FSNode *node, uint32_t ts, uint32_t uid, uint8_t goal, uint8_t smode,
+	                      inode_t *sinodes, inode_t *ncinodes, inode_t *nsinodes) override;
 
-	void fsnodes_settrashtime_recursive(FSNode *node, uint32_t ts, uint32_t uid, uint32_t trashtime,
-	                                    uint8_t smode, inode_t *sinodes, inode_t *ncinodes,
-	                                    inode_t *nsinodes) override;
-	void fsnodes_seteattr_recursive(FSNode *node, uint32_t ts, uint32_t uid, uint8_t eattr,
-	                                uint8_t smode, inode_t *sinodes, inode_t *ncinodes,
-	                                inode_t *nsinodes) override;
+	void setTrashTimeRecursive(FSNode *node, uint32_t ts, uint32_t uid, uint32_t trashtime,
+	                           uint8_t smode, inode_t *sinodes, inode_t *ncinodes,
+	                           inode_t *nsinodes) override;
+	void setEAttrRecursive(FSNode *node, uint32_t ts, uint32_t uid, uint8_t eattr, uint8_t smode,
+	                       inode_t *sinodes, inode_t *ncinodes, inode_t *nsinodes) override;
 
 	// Access control operations
-	int fsnodes_access(const FsContext &context, FSNode *node, uint8_t modemask) override;
-	int fsnodes_sticky_access(FSNode *parent, FSNode *node, uint32_t uid) override;
-	int fsnodes_namecheck(const std::string &name) override;
-	uint8_t verify_session(const FsContext &context, OperationMode operationMode,
-	                       SessionType sessionType) override;
-	uint8_t fsnodes_get_node_for_operation(const FsContext &context,
-	                                       ExpectedNodeType expectedNodeType, uint8_t modemask,
-	                                       inode_t inode, FSNode **ret,
-	                                       FSNodeDirectory **ret_rn = nullptr) override;
+	int access(const FsContext &context, FSNode *node, uint8_t modemask) override;
+	int stickyAccess(FSNode *parent, FSNode *node, uint32_t uid) override;
+	int nameCheck(const std::string &name) override;
+	uint8_t verifySession(const FsContext &context, OperationMode operationMode,
+	                      SessionType sessionType) override;
+	uint8_t getNodeForOperation(const FsContext &context, ExpectedNodeType expectedNodeType,
+	                            uint8_t modemask, inode_t inode, FSNode **ret,
+	                            FSNodeDirectory **ret_rn = nullptr) override;
 
 	// Ancestry operations
-	bool fsnodes_isancestor(FSNodeDirectory *f, FSNode *p) override;
-	bool fsnodes_isancestor_or_node_reserved_or_trash(FSNodeDirectory *f, FSNode *p) override;
-	FSNodeDirectory *fsnodes_get_first_parent(FSNode *node) override;
+	bool isAncestor(FSNodeDirectory *f, FSNode *p) override;
+	bool isAncestorOrNodeReservedOrTrash(FSNodeDirectory *f, FSNode *p) override;
+	FSNodeDirectory *getFirstParent(FSNode *node) override;
 
 protected:
 	/// Internal node lookup operation - override in subclasses for custom storage
-	FSNode *fsnodes_id_to_node_internal(inode_t id) override;
+	FSNode *idToNodeInternal(inode_t id) override;
 
 private:
 	// Private helpers

--- a/src/master/filesystem_node.h
+++ b/src/master/filesystem_node.h
@@ -123,8 +123,8 @@ public:
 	                      GoalStatistics &dgtab) override;
 	void getTrashTimeRecursive(FSNode *node, uint8_t gmode, TrashtimeMap &fileTrashtimes,
 	                           TrashtimeMap &dirTrashtimes) override;
-	void getEAttrRecursive(FSNode *node, uint8_t gmode, uint32_t feattrtab[16],
-	                       uint32_t deattrtab[16]) override;
+	void getEAttrRecursive(FSNode *node, uint8_t gmode, ExtendedAttributesArray &fileEAttrTab,
+	                       ExtendedAttributesArray &dirEAttrTab) override;
 #endif  // METARESTORE
 	void setgoalRecursive(FSNode *node, uint32_t timeStamp, uint32_t uid, uint8_t goal,
 	                      uint8_t smode, inode_t *modifiedINodesOut, inode_t *unchangedINodesOut,

--- a/src/master/filesystem_node.h
+++ b/src/master/filesystem_node.h
@@ -123,8 +123,8 @@ public:
 	                      GoalStatistics &dgtab) override;
 	void getTrashTimeRecursive(FSNode *node, uint8_t gmode, TrashtimeMap &fileTrashtimes,
 	                           TrashtimeMap &dirTrashtimes) override;
-	void getEAttrRecursive(FSNode *node, uint8_t gmode, ExtendedAttributesArray &fileEAttrTab,
-	                       ExtendedAttributesArray &dirEAttrTab) override;
+	void getExtraAttrRecursive(FSNode *node, uint8_t gmode, ExtraAttributesArray &fileEAttrTab,
+	                           ExtraAttributesArray &dirEAttrTab) override;
 #endif  // METARESTORE
 	void setgoalRecursive(FSNode *node, uint32_t timeStamp, uint32_t uid, uint8_t goal,
 	                      uint8_t smode, inode_t *modifiedINodesOut, inode_t *unchangedINodesOut,
@@ -135,9 +135,10 @@ public:
 	                           inode_t *unchangedINodesOut,
 	                           inode_t *permissionDeniedINodesOut) override;
 
-	void setEAttrRecursive(FSNode *node, uint32_t timeStamp, uint32_t uid, uint8_t eattr,
-	                       uint8_t smode, inode_t *modifiedINodesOut, inode_t *unchangedINodesOut,
-	                       inode_t *permissionDeniedINodesOut) override;
+	void setExtraAttrRecursive(FSNode *node, uint32_t timeStamp, uint32_t uid, uint8_t eattr,
+	                           uint8_t smode, inode_t *modifiedINodesOut,
+	                           inode_t *unchangedINodesOut,
+	                           inode_t *permissionDeniedINodesOut) override;
 
 	// Access control operations
 	int access(const FsContext &context, FSNode *node, uint8_t modemask) override;

--- a/src/master/filesystem_node.h
+++ b/src/master/filesystem_node.h
@@ -37,56 +37,66 @@ class FilesystemNodeOperationsBase : public IFilesystemNodeOperations {
 public:
 	FSNode *lookup(FSNodeDirectory *node, const HString &name) const override;
 
-	FSNode *createNode(uint32_t ts, FSNodeDirectory *parent, const HString &name, FSNodeType type,
-	                   uint16_t mode, uint16_t umask, uint32_t uid, uint32_t gid, uint8_t copysgid,
-	                   AclInheritance inheritacl, inode_t req_inode = 0) override;
-	void link(uint32_t ts, FSNodeDirectory *parent, FSNode *child, const HString &name) override;
-	void unlink(uint32_t ts, FSNodeDirectory *parent, const HString &node_name,
-	            FSNode *node) override;
-	void removeEdge(uint32_t ts, FSNodeDirectory *parent, const HString &node_name,
-	                FSNode *node) override;
+	FSNode *createNode(uint32_t timeStamp, FSNodeDirectory *parent, const HString &name,
+	                   FSNodeType type, uint16_t mode, uint16_t umask, uint32_t uid, uint32_t gid,
+	                   uint8_t copysgid, AclInheritance inheritAcl,
+	                   inode_t requestedINode = 0) override;
+	void link(uint32_t timeStamp, FSNodeDirectory *parent, FSNode *child,
+	          const HString &name) override;
+	void unlink(uint32_t timeStamp, FSNodeDirectory *parent, const HString &childName,
+	            FSNode *childNode) override;
+	void removeEdge(uint32_t timeStamp, FSNodeDirectory *parent, const HString &childName,
+	                FSNode *childNode) override;
 
 	void updateCTime(FSNode *node, uint32_t ctime) override;
 	void fillAttr(FSNode *node, FSNode *parent, uint32_t uid, uint32_t gid, uint32_t auid,
 	              uint32_t agid, uint8_t sesflags, Attributes &attr) override;
 	void fillAttr(const FsContext &context, FSNode *node, FSNode *parent,
 	              Attributes &attr) override;
-	void getStats(FSNode *node, StatsRecord *sr) override;
-	void addStats(FSNodeDirectory *parent, StatsRecord *sr) override;
-	void addSubStats(FSNodeDirectory *parent, StatsRecord *newsr, StatsRecord *prevsr) override;
-	void changeUidGid(FSNode *p, uint32_t uid, uint32_t gid) override;
+	void getStats(FSNode *node, StatsRecord *statsOut) override;
+	void addStats(FSNodeDirectory *parent, StatsRecord *stats) override;
+	void addSubStats(FSNodeDirectory *parent, StatsRecord *newStats,
+	                 StatsRecord *previousStats) override;
+	void changeUidGid(FSNode *node, uint32_t uid, uint32_t gid) override;
 
 	void setLength(FSNodeFile *obj, uint64_t length, bool eraseFurtherChunks) override;
-	uint8_t appendChunks(uint32_t ts, FSNodeFile *dstobj, FSNodeFile *srcobj) override;
-	void changeFileGoal(FSNodeFile *obj, uint8_t goal) override;
+	uint8_t appendChunks(uint32_t timeStamp, FSNodeFile *destNodeFile,
+	                     FSNodeFile *srcNodeFile) override;
+	void changeFileGoal(FSNodeFile *nodeFile, uint8_t goal) override;
 #ifndef METARESTORE
-	void checkFile(FSNodeFile *p, uint32_t chunkcount[CHUNK_MATRIX_SIZE]) override;
+	void checkFile(FSNodeFile *nodeFile, uint32_t chunkCount[CHUNK_MATRIX_SIZE]) override;
 #endif
 	int64_t getSize(FSNode *node) override;
 
 #ifndef METARESTORE
-	uint32_t getDirSize(const FSNodeDirectory *p, uint8_t withattr) override;
-	void getDirData(inode_t rootinode, uint32_t uid, uint32_t gid, uint32_t auid, uint32_t agid,
-	                uint8_t sesflags, FSNodeDirectory *p, uint8_t *dbuff,
-	                uint8_t withattr) override;
-	void getDir(inode_t rootinode, uint32_t uid, uint32_t gid, uint32_t auid, uint32_t agid,
-	            uint8_t sesflags, FSNodeDirectory *p, uint64_t first_entry,
-	            uint64_t number_of_entries, std::vector<DirectoryEntry> &dir_entries) override;
+	uint32_t getDirSize(const FSNodeDirectory *nodeDir, uint8_t withAttr) override;
+	void getDirData(inode_t rootINode, uint32_t uid, uint32_t gid, uint32_t auid, uint32_t agid,
+	                uint8_t sesflags, FSNodeDirectory *nodeDir, uint8_t *outBuffer,
+	                uint8_t withAttr) override;
+
+	/// Get entries of directory node \a nodeDir.
+	/// @see IFilesystemNodeOperations::getDir
+	void getDir(inode_t rootINode, uint32_t uid, uint32_t gid, uint32_t auid, uint32_t agid,
+	            uint8_t sesflags, FSNodeDirectory *nodeDir, uint64_t firstEntry,
+	            uint64_t numberOfEntries, std::vector<DirectoryEntry> &dirEntriesOut) override;
 #endif
 	int isNameUsed(FSNodeDirectory *node, const HString &name) override;
 
 	// Trash/Reserved operations
-	int purge(uint32_t ts, FSNode *p) override;
-	uint8_t undel(uint32_t ts, FSNodeFile *node) override;
+	int purge(uint32_t timeStamp, FSNode *node) override;
+	uint8_t undel(uint32_t timeStamp, FSNodeFile *node) override;
 #ifndef METARESTORE
 	uint32_t getDetachedSize(const TrashPathContainer &data) override;
-	void getDetachedData(const TrashPathContainer &data, uint8_t *dbuff) override;
-	void getDetachedData(const TrashPathContainer &data, uint32_t off, uint32_t max_entries,
+	void getDetachedData(const TrashPathContainer &data, uint8_t *outBuffer) override;
+	void getDetachedData(const TrashPathContainer &data, uint32_t offset, uint32_t maxEntries,
 	                     std::vector<NamedInodeEntry> &entries) override;
 	uint32_t getDetachedSize(const ReservedPathContainer &data) override;
-	void getDetachedData(const ReservedPathContainer &data, uint8_t *dbuff) override;
-	void getDetachedData(const ReservedPathContainer &data, uint32_t off, uint32_t max_entries,
+	void getDetachedData(const ReservedPathContainer &data, uint8_t *outBuffer) override;
+	void getDetachedData(const ReservedPathContainer &data, uint32_t offset, uint32_t maxEntries,
 	                     std::vector<NamedInodeEntry> &entries) override;
+
+	/// Returns entries from a HandleIndexContainer starting at a given handleOffset.
+	/// @see IFilesystemNodeOperations::getDetachedData
 	void getDetachedData(const HandleIndexContainer &data, uint64_t handleOffset,
 	                     uint32_t maxEntries, std::vector<HandleInodeEntry> &entries,
 	                     bool fromTrash) override;
@@ -99,12 +109,13 @@ public:
 	std::string escapeName(const std::string &name) override;
 
 	// ACL operations
-	uint8_t setAcl(FSNode *p, const RichACL &acl, uint32_t ts) override;
-	uint8_t setAcl(FSNode *p, AclType type, const AccessControlList &acl, uint32_t ts) override;
+	uint8_t setAcl(FSNode *node, const RichACL &acl, uint32_t timeStamp) override;
+	uint8_t setAcl(FSNode *node, AclType type, const AccessControlList &acl,
+	               uint32_t timeStamp) override;
 #ifndef METARESTORE
-	uint8_t getAcl(FSNode *p, RichACL &acl) override;
+	uint8_t getAcl(FSNode *node, RichACL &acl) override;
 #endif  // METARESTORE
-	uint8_t deleteAcl(FSNode *p, AclType type, uint32_t ts) override;
+	uint8_t deleteAcl(FSNode *node, AclType type, uint32_t timeStamp) override;
 
 	// Recursive operations
 #ifndef METARESTORE
@@ -115,14 +126,18 @@ public:
 	void getEAttrRecursive(FSNode *node, uint8_t gmode, uint32_t feattrtab[16],
 	                       uint32_t deattrtab[16]) override;
 #endif  // METARESTORE
-	void setgoalRecursive(FSNode *node, uint32_t ts, uint32_t uid, uint8_t goal, uint8_t smode,
-	                      inode_t *sinodes, inode_t *ncinodes, inode_t *nsinodes) override;
+	void setgoalRecursive(FSNode *node, uint32_t timeStamp, uint32_t uid, uint8_t goal,
+	                      uint8_t smode, inode_t *modifiedINodesOut, inode_t *unchangedINodesOut,
+	                      inode_t *permissionDeniedINodesOut) override;
 
-	void setTrashTimeRecursive(FSNode *node, uint32_t ts, uint32_t uid, uint32_t trashtime,
-	                           uint8_t smode, inode_t *sinodes, inode_t *ncinodes,
-	                           inode_t *nsinodes) override;
-	void setEAttrRecursive(FSNode *node, uint32_t ts, uint32_t uid, uint8_t eattr, uint8_t smode,
-	                       inode_t *sinodes, inode_t *ncinodes, inode_t *nsinodes) override;
+	void setTrashTimeRecursive(FSNode *node, uint32_t timeStamp, uint32_t uid, uint32_t trashtime,
+	                           uint8_t smode, inode_t *modifiedINodesOut,
+	                           inode_t *unchangedINodesOut,
+	                           inode_t *permissionDeniedINodesOut) override;
+
+	void setEAttrRecursive(FSNode *node, uint32_t timeStamp, uint32_t uid, uint8_t eattr,
+	                       uint8_t smode, inode_t *modifiedINodesOut, inode_t *unchangedINodesOut,
+	                       inode_t *permissionDeniedINodesOut) override;
 
 	// Access control operations
 	int access(const FsContext &context, FSNode *node, uint8_t modemask) override;
@@ -130,23 +145,33 @@ public:
 	int nameCheck(const std::string &name) override;
 	uint8_t verifySession(const FsContext &context, OperationMode operationMode,
 	                      SessionType sessionType) override;
+
+	/// Treating rootinode as the root of the hierarchy, converts (rootinode, inode) to FSNode*.
+	/// @see IFilesystemNodeOperations::getNodeForOperation
 	uint8_t getNodeForOperation(const FsContext &context, ExpectedNodeType expectedNodeType,
-	                            uint8_t modemask, inode_t inode, FSNode **ret,
-	                            FSNodeDirectory **ret_rn = nullptr) override;
+	                            uint8_t modemask, inode_t inode, FSNode **nodeOut,
+	                            FSNodeDirectory **rootDirOut = nullptr) override;
 
 	// Ancestry operations
-	bool isAncestor(FSNodeDirectory *f, FSNode *p) override;
-	bool isAncestorOrNodeReservedOrTrash(FSNodeDirectory *f, FSNode *p) override;
+
+	/// Returns true if \a ancestor is ancestor of \a node.
+	/// @see IFilesystemNodeOperations::isAncestor
+	bool isAncestor(FSNodeDirectory *ancestor, FSNode *node) override;
+
+	/// Returns true if \a node is reserved or in trash or \a ancestor is ancestor of \a node.
+	/// @see IFilesystemNodeOperations::isAncestorOrNodeReservedOrTrash
+	bool isAncestorOrNodeReservedOrTrash(FSNodeDirectory *ancestor, FSNode *node) override;
+
 	FSNodeDirectory *getFirstParent(FSNode *node) override;
 
 protected:
 	/// Internal node lookup operation - override in subclasses for custom storage
-	FSNode *idToNodeInternal(inode_t id) override;
+	FSNode *idToNodeInternal(inode_t inode) override;
 
 private:
 	// Private helpers
-	void fsnodes_sub_stats(FSNodeDirectory *parent, StatsRecord *sr);
-	void fsnodes_remove_node(uint32_t ts, FSNode *node);
+	void fsnodes_sub_stats(FSNodeDirectory *parent, StatsRecord *stats);
+	void fsnodes_remove_node(uint32_t timeStamp, FSNode *node);
 
 	uint32_t last_chunk_blocks(FSNodeFile *node);
 	bool last_chunk_nonempty(FSNodeFile *node);

--- a/src/master/filesystem_node.h
+++ b/src/master/filesystem_node.h
@@ -170,16 +170,32 @@ protected:
 
 private:
 	// Private helpers
-	void fsnodes_sub_stats(FSNodeDirectory *parent, StatsRecord *stats);
-	void fsnodes_remove_node(uint32_t timeStamp, FSNode *node);
 
-	uint32_t last_chunk_blocks(FSNodeFile *node);
-	bool last_chunk_nonempty(FSNodeFile *node);
-	uint32_t file_chunks(FSNodeFile *node);
-	uint64_t file_size(FSNodeFile *node, uint32_t nonzero_chunks);
-	uint64_t file_realsize(FSNodeFile *node, uint32_t nonzero_chunks, uint64_t file_size);
+	void subStats(FSNodeDirectory *parent, StatsRecord *stats);
+	void removeNode(uint32_t timeStamp, FSNode *node);
+
+	/// Number of blocks in the last chunk before EOF
+	static uint32_t lastChunkBlocks(FSNodeFile *node);
+
+	/// Does the last chunk exist and contain non-zero data?
+	static bool isLastChunkNonEmpty(FSNodeFile *node);
+
+	/// Count chunks in a file, disregard sparse file holes
+	static uint32_t fileChunksCount(FSNodeFile *node);
+
+	/// Compute the "size" statistic for a file node
+	static uint64_t fileSize(FSNodeFile *node, uint32_t nonZeroChunks);
+
+	/// Compute the "realsize" statistic for a file node.
+	/// @param node file node (used e.g. to detect a partial last chunk and goal).
+	/// @param nonZeroChunks number of non-empty chunks (used for EC/XOR slice calculations).
+	/// @param logicalFileSize logical file "size" as returned by fileSize(...).
+	static uint64_t fileRealSize(FSNodeFile *node, uint32_t nonZeroChunks,
+	                             uint64_t logicalFileSize);
+
 #ifndef METARESTORE
-	uint32_t ec_chunk_realsize(uint32_t blocks, uint32_t data_part_count,
-	                           uint32_t parity_part_count);
+	/// Compute the disk space cost of all parts of a xor/ec chunk of given size
+	static uint32_t ecChunkRealSize(uint32_t blocks, uint32_t dataPartCount,
+	                                uint32_t parityPartCount);
 #endif
 };

--- a/src/master/filesystem_node_operations_interface.h
+++ b/src/master/filesystem_node_operations_interface.h
@@ -20,6 +20,7 @@
 
 #include "common/platform.h"
 
+#include <array>
 #include <string>
 #include <vector>
 
@@ -39,6 +40,8 @@ struct StatsRecord;
 struct DirectoryEntry;
 struct HandleInodeEntry;
 struct NamedInodeEntry;
+
+using ChunkCountArray = std::array<uint32_t, CHUNK_MATRIX_SIZE>;
 
 /// Interface for filesystem node operations extensibility.
 ///
@@ -102,7 +105,7 @@ public:
 	                             FSNodeFile *srcNodeFile) = 0;
 	virtual void changeFileGoal(FSNodeFile *nodeFile, uint8_t goal) = 0;
 #ifndef METARESTORE
-	virtual void checkFile(FSNodeFile *nodeFile, uint32_t chunkCount[CHUNK_MATRIX_SIZE]) = 0;
+	virtual void checkFile(FSNodeFile *nodeFile, ChunkCountArray &chunkCount) = 0;
 #endif
 	virtual int64_t getSize(FSNode *node) = 0;
 

--- a/src/master/filesystem_node_operations_interface.h
+++ b/src/master/filesystem_node_operations_interface.h
@@ -43,6 +43,10 @@ struct NamedInodeEntry;
 
 using ChunkCountArray = std::array<uint32_t, CHUNK_MATRIX_SIZE>;
 
+// Extended attributes constants and type aliases
+static constexpr uint8_t kMaxExtendedAttributes = 16;
+using ExtendedAttributesArray = std::array<uint32_t, kMaxExtendedAttributes>;
+
 /// Interface for filesystem node operations extensibility.
 ///
 /// Classes implementing this interface can be used to override default filesystem node behavior.
@@ -174,8 +178,9 @@ public:
 	                              GoalStatistics &dgtab) = 0;
 	virtual void getTrashTimeRecursive(FSNode *node, uint8_t gmode, TrashtimeMap &fileTrashtimes,
 	                                   TrashtimeMap &dirTrashtimes) = 0;
-	virtual void getEAttrRecursive(FSNode *node, uint8_t gmode, uint32_t feattrtab[16],
-	                               uint32_t deattrtab[16]) = 0;
+	virtual void getEAttrRecursive(FSNode *node, uint8_t gmode,
+	                               ExtendedAttributesArray &fileEAttrTab,
+	                               ExtendedAttributesArray &dirEAttrTab) = 0;
 #endif
 	virtual void setgoalRecursive(FSNode *node, uint32_t timeStamp, uint32_t uid, uint8_t goal,
 	                              uint8_t smode, inode_t *modifiedINodesOut,

--- a/src/master/filesystem_node_operations_interface.h
+++ b/src/master/filesystem_node_operations_interface.h
@@ -43,9 +43,9 @@ struct NamedInodeEntry;
 
 using ChunkCountArray = std::array<uint32_t, CHUNK_MATRIX_SIZE>;
 
-// Extended attributes constants and type aliases
-static constexpr uint8_t kMaxExtendedAttributes = 16;
-using ExtendedAttributesArray = std::array<uint32_t, kMaxExtendedAttributes>;
+// Extra attributes constants and type aliases
+static constexpr uint8_t kMaxExtraAttributes = 16;
+using ExtraAttributesArray = std::array<uint32_t, kMaxExtraAttributes>;
 
 /// Interface for filesystem node operations extensibility.
 ///
@@ -178,9 +178,9 @@ public:
 	                              GoalStatistics &dgtab) = 0;
 	virtual void getTrashTimeRecursive(FSNode *node, uint8_t gmode, TrashtimeMap &fileTrashtimes,
 	                                   TrashtimeMap &dirTrashtimes) = 0;
-	virtual void getEAttrRecursive(FSNode *node, uint8_t gmode,
-	                               ExtendedAttributesArray &fileEAttrTab,
-	                               ExtendedAttributesArray &dirEAttrTab) = 0;
+	virtual void getExtraAttrRecursive(FSNode *node, uint8_t gmode,
+	                                   ExtraAttributesArray &fileEAttrTab,
+	                                   ExtraAttributesArray &dirEAttrTab) = 0;
 #endif
 	virtual void setgoalRecursive(FSNode *node, uint32_t timeStamp, uint32_t uid, uint8_t goal,
 	                              uint8_t smode, inode_t *modifiedINodesOut,
@@ -192,10 +192,10 @@ public:
 	                                   inode_t *modifiedINodesOut, inode_t *unchangedINodesOut,
 	                                   inode_t *permissionDeniedINodesOut) = 0;
 
-	virtual void setEAttrRecursive(FSNode *node, uint32_t timeStamp, uint32_t uid, uint8_t eattr,
-	                               uint8_t smode, inode_t *modifiedINodesOut,
-	                               inode_t *unchangedINodesOut,
-	                               inode_t *permissionDeniedINodesOut) = 0;
+	virtual void setExtraAttrRecursive(FSNode *node, uint32_t timeStamp, uint32_t uid,
+	                                   uint8_t eattr, uint8_t smode, inode_t *modifiedINodesOut,
+	                                   inode_t *unchangedINodesOut,
+	                                   inode_t *permissionDeniedINodesOut) = 0;
 
 	// Access control operations
 	virtual int access(const FsContext &context, FSNode *node, uint8_t modemask) = 0;

--- a/src/master/filesystem_node_operations_interface.h
+++ b/src/master/filesystem_node_operations_interface.h
@@ -60,73 +60,90 @@ public:
 	// Type-safe node lookup operations
 
 	template <class NodeType>
-	NodeType *idToNodeVerify(inode_t id) {
-		auto *node = static_cast<NodeType *>(this->idToNodeInternal(id));
+	NodeType *idToNodeVerify(inode_t inode) {
+		auto *node = static_cast<NodeType *>(this->idToNodeInternal(inode));
 		this->checkNodeType(node);
 		return node;
 	}
 
 	template <class NodeType = FSNode>
-	NodeType *idToNode(inode_t id) {
-		return static_cast<NodeType *>(this->idToNodeInternal(id));
+	NodeType *idToNode(inode_t inode) {
+		return static_cast<NodeType *>(this->idToNodeInternal(inode));
 	}
 
 	// Main node operations
 
 	virtual FSNode *lookup(FSNodeDirectory *node, const HString &name) const = 0;
 
-	virtual FSNode *createNode(uint32_t ts, FSNodeDirectory *parent, const HString &name,
+	virtual FSNode *createNode(uint32_t timeStamp, FSNodeDirectory *parent, const HString &name,
 	                           FSNodeType type, uint16_t mode, uint16_t umask, uint32_t uid,
-	                           uint32_t gid, uint8_t copysgid, AclInheritance inheritacl,
-	                           inode_t req_inode = 0) = 0;
-	virtual void link(uint32_t ts, FSNodeDirectory *parent, FSNode *child, const HString &name) = 0;
-	virtual void unlink(uint32_t ts, FSNodeDirectory *parent, const HString &node_name,
-	                    FSNode *node) = 0;
-	virtual void removeEdge(uint32_t ts, FSNodeDirectory *parent, const HString &node_name,
-	                        FSNode *node) = 0;
+	                           uint32_t gid, uint8_t copysgid, AclInheritance inheritAcl,
+	                           inode_t requestedINode = 0) = 0;
+	virtual void link(uint32_t timeStamp, FSNodeDirectory *parent, FSNode *child,
+	                  const HString &name) = 0;
+	virtual void unlink(uint32_t timeStamp, FSNodeDirectory *parent, const HString &childName,
+	                    FSNode *childNode) = 0;
+	virtual void removeEdge(uint32_t timeStamp, FSNodeDirectory *parent, const HString &childName,
+	                        FSNode *childNode) = 0;
 
 	virtual void updateCTime(FSNode *node, uint32_t ctime) = 0;
 	virtual void fillAttr(FSNode *node, FSNode *parent, uint32_t uid, uint32_t gid, uint32_t auid,
 	                      uint32_t agid, uint8_t sesflags, Attributes &attr) = 0;
 	virtual void fillAttr(const FsContext &context, FSNode *node, FSNode *parent,
 	                      Attributes &attr) = 0;
-	virtual void getStats(FSNode *node, StatsRecord *sr) = 0;
-	virtual void addStats(FSNodeDirectory *parent, StatsRecord *sr) = 0;
-	virtual void addSubStats(FSNodeDirectory *parent, StatsRecord *newsr, StatsRecord *prevsr) = 0;
-	virtual void changeUidGid(FSNode *p, uint32_t uid, uint32_t gid) = 0;
+	virtual void getStats(FSNode *node, StatsRecord *statsOut) = 0;
+	virtual void addStats(FSNodeDirectory *parent, StatsRecord *stats) = 0;
+	virtual void addSubStats(FSNodeDirectory *parent, StatsRecord *newStats,
+	                         StatsRecord *previousStats) = 0;
+	virtual void changeUidGid(FSNode *node, uint32_t uid, uint32_t gid) = 0;
 
 	virtual void setLength(FSNodeFile *obj, uint64_t length, bool eraseFurtherChunks) = 0;
-	virtual uint8_t appendChunks(uint32_t ts, FSNodeFile *dstobj, FSNodeFile *srcobj) = 0;
-	virtual void changeFileGoal(FSNodeFile *obj, uint8_t goal) = 0;
+	virtual uint8_t appendChunks(uint32_t timeStamp, FSNodeFile *destNodeFile,
+	                             FSNodeFile *srcNodeFile) = 0;
+	virtual void changeFileGoal(FSNodeFile *nodeFile, uint8_t goal) = 0;
 #ifndef METARESTORE
-	virtual void checkFile(FSNodeFile *p, uint32_t chunkcount[CHUNK_MATRIX_SIZE]) = 0;
+	virtual void checkFile(FSNodeFile *nodeFile, uint32_t chunkCount[CHUNK_MATRIX_SIZE]) = 0;
 #endif
 	virtual int64_t getSize(FSNode *node) = 0;
 
 #ifndef METARESTORE
-	virtual uint32_t getDirSize(const FSNodeDirectory *p, uint8_t withattr) = 0;
-	virtual void getDirData(inode_t rootinode, uint32_t uid, uint32_t gid, uint32_t auid,
-	                        uint32_t agid, uint8_t sesflags, FSNodeDirectory *p, uint8_t *dbuff,
-	                        uint8_t withattr) = 0;
-	virtual void getDir(inode_t rootinode, uint32_t uid, uint32_t gid, uint32_t auid, uint32_t agid,
-	                    uint8_t sesflags, FSNodeDirectory *p, uint64_t first_entry,
-	                    uint64_t number_of_entries, std::vector<DirectoryEntry> &dir_entries) = 0;
+	virtual uint32_t getDirSize(const FSNodeDirectory *nodeDir, uint8_t withAttr) = 0;
+	virtual void getDirData(inode_t rootINode, uint32_t uid, uint32_t gid, uint32_t auid,
+	                        uint32_t agid, uint8_t sesflags, FSNodeDirectory *nodeDir,
+	                        uint8_t *outBuffer, uint8_t withAttr) = 0;
+
+	/// Get entries of directory node \a nodeDir.
+	///
+	/// Returns directory entries in \a dirEntriesOut container.
+	/// \a firstEntry == 0 means the very first entry in the directory.
+	/// \param nodeDir directory node to get the entries of
+	/// \param firstEntry index of the first dirent to get
+	/// \param numberOfEntries number of dirents to get
+	/// \param[out] dirEntriesOut container into which dirents are inserted
+	virtual void getDir(inode_t rootINode, uint32_t uid, uint32_t gid, uint32_t auid, uint32_t agid,
+	                    uint8_t sesflags, FSNodeDirectory *nodeDir, uint64_t firstEntry,
+	                    uint64_t numberOfEntries, std::vector<DirectoryEntry> &dirEntriesOut) = 0;
 #endif
 	virtual int isNameUsed(FSNodeDirectory *node, const HString &name) = 0;
 
 	// Trash/Reserved operations
 
-	virtual int purge(uint32_t ts, FSNode *p) = 0;
-	virtual uint8_t undel(uint32_t ts, FSNodeFile *node) = 0;
+	virtual int purge(uint32_t timeStamp, FSNode *node) = 0;
+	virtual uint8_t undel(uint32_t timeStamp, FSNodeFile *node) = 0;
 #ifndef METARESTORE
 	virtual uint32_t getDetachedSize(const TrashPathContainer &data) = 0;
-	virtual void getDetachedData(const TrashPathContainer &data, uint8_t *dbuff) = 0;
-	virtual void getDetachedData(const TrashPathContainer &data, uint32_t off, uint32_t max_entries,
-	                             std::vector<NamedInodeEntry> &entries) = 0;
+	virtual void getDetachedData(const TrashPathContainer &data, uint8_t *outBuffer) = 0;
+	virtual void getDetachedData(const TrashPathContainer &data, uint32_t offset,
+	                             uint32_t maxEntries, std::vector<NamedInodeEntry> &entries) = 0;
 	virtual uint32_t getDetachedSize(const ReservedPathContainer &data) = 0;
-	virtual void getDetachedData(const ReservedPathContainer &data, uint8_t *dbuff) = 0;
-	virtual void getDetachedData(const ReservedPathContainer &data, uint32_t off,
-	                             uint32_t max_entries, std::vector<NamedInodeEntry> &entries) = 0;
+	virtual void getDetachedData(const ReservedPathContainer &data, uint8_t *outBuffer) = 0;
+	virtual void getDetachedData(const ReservedPathContainer &data, uint32_t offset,
+	                             uint32_t maxEntries, std::vector<NamedInodeEntry> &entries) = 0;
+
+	/// Returns entries from a HandleIndexContainer starting at a given handleOffset.
+	/// The offset provided by the client (e.g., FUSE readdir) is always non-negative (sign bit 0).
+	/// Internally, the server may store offsets with the sign bit set (bit 63 = 1).
+	/// All lookups are enforced to be done ignoring the sign bit by setting it to 0.
 	virtual void getDetachedData(const HandleIndexContainer &data, uint64_t handleOffset,
 	                             uint32_t maxEntries, std::vector<HandleInodeEntry> &entries,
 	                             bool fromTrash) = 0;
@@ -140,12 +157,13 @@ public:
 	virtual std::string escapeName(const std::string &name) = 0;
 
 	// ACL operations
-	virtual uint8_t setAcl(FSNode *p, const RichACL &acl, uint32_t ts) = 0;
-	virtual uint8_t setAcl(FSNode *p, AclType type, const AccessControlList &acl, uint32_t ts) = 0;
+	virtual uint8_t setAcl(FSNode *node, const RichACL &acl, uint32_t timeStamp) = 0;
+	virtual uint8_t setAcl(FSNode *node, AclType type, const AccessControlList &acl,
+	                       uint32_t timeStamp) = 0;
 #ifndef METARESTORE
-	virtual uint8_t getAcl(FSNode *p, RichACL &acl) = 0;
+	virtual uint8_t getAcl(FSNode *node, RichACL &acl) = 0;
 #endif  // METARESTORE
-	virtual uint8_t deleteAcl(FSNode *p, AclType type, uint32_t ts) = 0;
+	virtual uint8_t deleteAcl(FSNode *node, AclType type, uint32_t timeStamp) = 0;
 
 	// Recursive operations
 #ifndef METARESTORE
@@ -156,17 +174,20 @@ public:
 	virtual void getEAttrRecursive(FSNode *node, uint8_t gmode, uint32_t feattrtab[16],
 	                               uint32_t deattrtab[16]) = 0;
 #endif
-	virtual void setgoalRecursive(FSNode *node, uint32_t ts, uint32_t uid, uint8_t goal,
-	                              uint8_t smode, inode_t *sinodes, inode_t *ncinodes,
-	                              inode_t *nsinodes) = 0;
+	virtual void setgoalRecursive(FSNode *node, uint32_t timeStamp, uint32_t uid, uint8_t goal,
+	                              uint8_t smode, inode_t *modifiedINodesOut,
+	                              inode_t *unchangedINodesOut,
+	                              inode_t *permissionDeniedINodesOut) = 0;
 
-	virtual void setTrashTimeRecursive(FSNode *node, uint32_t ts, uint32_t uid, uint32_t trashtime,
-	                                   uint8_t smode, inode_t *sinodes, inode_t *ncinodes,
-	                                   inode_t *nsinodes) = 0;
+	virtual void setTrashTimeRecursive(FSNode *node, uint32_t timeStamp, uint32_t uid,
+	                                   uint32_t trashtime, uint8_t smode,
+	                                   inode_t *modifiedINodesOut, inode_t *unchangedINodesOut,
+	                                   inode_t *permissionDeniedINodesOut) = 0;
 
-	virtual void setEAttrRecursive(FSNode *node, uint32_t ts, uint32_t uid, uint8_t eattr,
-	                               uint8_t smode, inode_t *sinodes, inode_t *ncinodes,
-	                               inode_t *nsinodes) = 0;
+	virtual void setEAttrRecursive(FSNode *node, uint32_t timeStamp, uint32_t uid, uint8_t eattr,
+	                               uint8_t smode, inode_t *modifiedINodesOut,
+	                               inode_t *unchangedINodesOut,
+	                               inode_t *permissionDeniedINodesOut) = 0;
 
 	// Access control operations
 	virtual int access(const FsContext &context, FSNode *node, uint8_t modemask) = 0;
@@ -174,18 +195,33 @@ public:
 	virtual int nameCheck(const std::string &name) = 0;
 	virtual uint8_t verifySession(const FsContext &context, OperationMode operationMode,
 	                              SessionType sessionType) = 0;
+
+	/// Treating rootinode as the root of the hierarchy, converts (rootinode, inode) to FSNode*.
+	/// ie:
+	/// if inode == rootinode, then returns root node
+	/// if inode != rootinode, then returns some node
+	/// Checks for permissions needed to perform the operation (defined by modemask).
+	/// Can return a reserved node or a node from trash.
 	virtual uint8_t getNodeForOperation(const FsContext &context, ExpectedNodeType expectedNodeType,
-	                                    uint8_t modemask, inode_t inode, FSNode **ret,
-	                                    FSNodeDirectory **ret_rn = nullptr) = 0;
+	                                    uint8_t modemask, inode_t inode, FSNode **nodeOut,
+	                                    FSNodeDirectory **rootDirOut = nullptr) = 0;
 
 	// Ancestry operations
-	virtual bool isAncestor(FSNodeDirectory *f, FSNode *p) = 0;
-	virtual bool isAncestorOrNodeReservedOrTrash(FSNodeDirectory *f, FSNode *p) = 0;
+
+	/// Returns true if \a ancestor is ancestor of \a node.
+	/// @param ancestor potential ancestor node
+	/// @param node potential descendant node
+	virtual bool isAncestor(FSNodeDirectory *ancestor, FSNode *node) = 0;
+
+	/// Returns true if \a node is reserved or in trash or \a ancestor is ancestor of \a node.
+	/// @param ancestor potential ancestor node
+	/// @param node potential reserved, trash or descendant node
+	virtual bool isAncestorOrNodeReservedOrTrash(FSNodeDirectory *ancestor, FSNode *node) = 0;
 	virtual FSNodeDirectory *getFirstParent(FSNode *node) = 0;
 
 protected:
 	// Core node lookup operation - override in subclasses for custom storage
-	virtual FSNode *idToNodeInternal(inode_t id) = 0;
+	virtual FSNode *idToNodeInternal(inode_t inode) = 0;
 
 	// Type checking helper - base case
 	template <class NodeType>

--- a/src/master/filesystem_node_operations_interface.h
+++ b/src/master/filesystem_node_operations_interface.h
@@ -60,146 +60,136 @@ public:
 	// Type-safe node lookup operations
 
 	template <class NodeType>
-	NodeType *fsnodes_id_to_node_verify(inode_t id) {
-		auto *node = static_cast<NodeType *>(this->fsnodes_id_to_node_internal(id));
-		this->fsnodes_check_node_type(node);
+	NodeType *idToNodeVerify(inode_t id) {
+		auto *node = static_cast<NodeType *>(this->idToNodeInternal(id));
+		this->checkNodeType(node);
 		return node;
 	}
 
 	template <class NodeType = FSNode>
-	NodeType *fsnodes_id_to_node(inode_t id) {
-		return static_cast<NodeType *>(this->fsnodes_id_to_node_internal(id));
+	NodeType *idToNode(inode_t id) {
+		return static_cast<NodeType *>(this->idToNodeInternal(id));
 	}
 
 	// Main node operations
 
-	virtual FSNode *fsnodes_lookup(FSNodeDirectory *node, const HString &name) const = 0;
+	virtual FSNode *lookup(FSNodeDirectory *node, const HString &name) const = 0;
 
-	virtual FSNode *fsnodes_create_node(uint32_t ts, FSNodeDirectory *parent, const HString &name,
-	                                    FSNodeType type, uint16_t mode, uint16_t umask,
-	                                    uint32_t uid, uint32_t gid, uint8_t copysgid,
-	                                    AclInheritance inheritacl, inode_t req_inode = 0) = 0;
-	virtual void fsnodes_link(uint32_t ts, FSNodeDirectory *parent, FSNode *child,
-	                          const HString &name) = 0;
-	virtual void fsnodes_unlink(uint32_t ts, FSNodeDirectory *parent, const HString &node_name,
-	                            FSNode *node) = 0;
-	virtual void fsnodes_remove_edge(uint32_t ts, FSNodeDirectory *parent, const HString &node_name,
-	                                 FSNode *node) = 0;
+	virtual FSNode *createNode(uint32_t ts, FSNodeDirectory *parent, const HString &name,
+	                           FSNodeType type, uint16_t mode, uint16_t umask, uint32_t uid,
+	                           uint32_t gid, uint8_t copysgid, AclInheritance inheritacl,
+	                           inode_t req_inode = 0) = 0;
+	virtual void link(uint32_t ts, FSNodeDirectory *parent, FSNode *child, const HString &name) = 0;
+	virtual void unlink(uint32_t ts, FSNodeDirectory *parent, const HString &node_name,
+	                    FSNode *node) = 0;
+	virtual void removeEdge(uint32_t ts, FSNodeDirectory *parent, const HString &node_name,
+	                        FSNode *node) = 0;
 
-	virtual void fsnodes_update_ctime(FSNode *node, uint32_t ctime) = 0;
-	virtual void fsnodes_fill_attr(FSNode *node, FSNode *parent, uint32_t uid, uint32_t gid,
-	                               uint32_t auid, uint32_t agid, uint8_t sesflags,
-	                               Attributes &attr) = 0;
-	virtual void fsnodes_fill_attr(const FsContext &context, FSNode *node, FSNode *parent,
-	                               Attributes &attr) = 0;
-	virtual void fsnodes_get_stats(FSNode *node, StatsRecord *sr) = 0;
-	virtual void fsnodes_add_stats(FSNodeDirectory *parent, StatsRecord *sr) = 0;
-	virtual void fsnodes_add_sub_stats(FSNodeDirectory *parent, StatsRecord *newsr,
-	                                   StatsRecord *prevsr) = 0;
-	virtual void fsnodes_change_uid_gid(FSNode *p, uint32_t uid, uint32_t gid) = 0;
+	virtual void updateCTime(FSNode *node, uint32_t ctime) = 0;
+	virtual void fillAttr(FSNode *node, FSNode *parent, uint32_t uid, uint32_t gid, uint32_t auid,
+	                      uint32_t agid, uint8_t sesflags, Attributes &attr) = 0;
+	virtual void fillAttr(const FsContext &context, FSNode *node, FSNode *parent,
+	                      Attributes &attr) = 0;
+	virtual void getStats(FSNode *node, StatsRecord *sr) = 0;
+	virtual void addStats(FSNodeDirectory *parent, StatsRecord *sr) = 0;
+	virtual void addSubStats(FSNodeDirectory *parent, StatsRecord *newsr, StatsRecord *prevsr) = 0;
+	virtual void changeUidGid(FSNode *p, uint32_t uid, uint32_t gid) = 0;
 
-	virtual void fsnodes_setlength(FSNodeFile *obj, uint64_t length, bool eraseFurtherChunks) = 0;
-	virtual uint8_t fsnodes_appendchunks(uint32_t ts, FSNodeFile *dstobj, FSNodeFile *srcobj) = 0;
-	virtual void fsnodes_changefilegoal(FSNodeFile *obj, uint8_t goal) = 0;
+	virtual void setLength(FSNodeFile *obj, uint64_t length, bool eraseFurtherChunks) = 0;
+	virtual uint8_t appendChunks(uint32_t ts, FSNodeFile *dstobj, FSNodeFile *srcobj) = 0;
+	virtual void changeFileGoal(FSNodeFile *obj, uint8_t goal) = 0;
 #ifndef METARESTORE
-	virtual void fsnodes_checkfile(FSNodeFile *p, uint32_t chunkcount[CHUNK_MATRIX_SIZE]) = 0;
+	virtual void checkFile(FSNodeFile *p, uint32_t chunkcount[CHUNK_MATRIX_SIZE]) = 0;
 #endif
-	virtual int64_t fsnodes_get_size(FSNode *node) = 0;
+	virtual int64_t getSize(FSNode *node) = 0;
 
 #ifndef METARESTORE
-	virtual uint32_t fsnodes_getdirsize(const FSNodeDirectory *p, uint8_t withattr) = 0;
-	virtual void fsnodes_getdirdata(inode_t rootinode, uint32_t uid, uint32_t gid, uint32_t auid,
-	                                uint32_t agid, uint8_t sesflags, FSNodeDirectory *p,
-	                                uint8_t *dbuff, uint8_t withattr) = 0;
-	virtual void fsnodes_getdir(inode_t rootinode, uint32_t uid, uint32_t gid, uint32_t auid,
-	                            uint32_t agid, uint8_t sesflags, FSNodeDirectory *p,
-	                            uint64_t first_entry, uint64_t number_of_entries,
-	                            std::vector<DirectoryEntry> &dir_entries) = 0;
+	virtual uint32_t getDirSize(const FSNodeDirectory *p, uint8_t withattr) = 0;
+	virtual void getDirData(inode_t rootinode, uint32_t uid, uint32_t gid, uint32_t auid,
+	                        uint32_t agid, uint8_t sesflags, FSNodeDirectory *p, uint8_t *dbuff,
+	                        uint8_t withattr) = 0;
+	virtual void getDir(inode_t rootinode, uint32_t uid, uint32_t gid, uint32_t auid, uint32_t agid,
+	                    uint8_t sesflags, FSNodeDirectory *p, uint64_t first_entry,
+	                    uint64_t number_of_entries, std::vector<DirectoryEntry> &dir_entries) = 0;
 #endif
-	virtual int fsnodes_nameisused(FSNodeDirectory *node, const HString &name) = 0;
+	virtual int isNameUsed(FSNodeDirectory *node, const HString &name) = 0;
 
 	// Trash/Reserved operations
 
-	virtual int fsnodes_purge(uint32_t ts, FSNode *p) = 0;
-	virtual uint8_t fsnodes_undel(uint32_t ts, FSNodeFile *node) = 0;
+	virtual int purge(uint32_t ts, FSNode *p) = 0;
+	virtual uint8_t undel(uint32_t ts, FSNodeFile *node) = 0;
 #ifndef METARESTORE
-	virtual uint32_t fsnodes_getdetachedsize(const TrashPathContainer &data) = 0;
-	virtual void fsnodes_getdetacheddata(const TrashPathContainer &data, uint8_t *dbuff) = 0;
-	virtual void fsnodes_getdetacheddata(const TrashPathContainer &data, uint32_t off,
-	                                     uint32_t max_entries,
-	                                     std::vector<NamedInodeEntry> &entries) = 0;
-	virtual uint32_t fsnodes_getdetachedsize(const ReservedPathContainer &data) = 0;
-	virtual void fsnodes_getdetacheddata(const ReservedPathContainer &data, uint8_t *dbuff) = 0;
-	virtual void fsnodes_getdetacheddata(const ReservedPathContainer &data, uint32_t off,
-	                                     uint32_t max_entries,
-	                                     std::vector<NamedInodeEntry> &entries) = 0;
-	virtual void fsnodes_getdetacheddata(const HandleIndexContainer &data, uint64_t handleOffset,
-	                                     uint32_t maxEntries,
-	                                     std::vector<HandleInodeEntry> &entries,
-	                                     bool fromTrash) = 0;
+	virtual uint32_t getDetachedSize(const TrashPathContainer &data) = 0;
+	virtual void getDetachedData(const TrashPathContainer &data, uint8_t *dbuff) = 0;
+	virtual void getDetachedData(const TrashPathContainer &data, uint32_t off, uint32_t max_entries,
+	                             std::vector<NamedInodeEntry> &entries) = 0;
+	virtual uint32_t getDetachedSize(const ReservedPathContainer &data) = 0;
+	virtual void getDetachedData(const ReservedPathContainer &data, uint8_t *dbuff) = 0;
+	virtual void getDetachedData(const ReservedPathContainer &data, uint32_t off,
+	                             uint32_t max_entries, std::vector<NamedInodeEntry> &entries) = 0;
+	virtual void getDetachedData(const HandleIndexContainer &data, uint64_t handleOffset,
+	                             uint32_t maxEntries, std::vector<HandleInodeEntry> &entries,
+	                             bool fromTrash) = 0;
 #endif
 
 	// Path operations
-	virtual void fsnodes_getpath(FSNodeDirectory *parent, FSNode *child, std::string &path) = 0;
-	virtual uint32_t fsnodes_getpath_size(FSNodeDirectory *parent, FSNode *child) = 0;
-	virtual void fsnodes_getpath_data(FSNodeDirectory *parent, FSNode *child, uint8_t *path,
-	                                  uint32_t size) = 0;
-	virtual std::string fsnodes_escape_name(const std::string &name) = 0;
+	virtual void getPath(FSNodeDirectory *parent, FSNode *child, std::string &path) = 0;
+	virtual uint32_t getPathSize(FSNodeDirectory *parent, FSNode *child) = 0;
+	virtual void getPathData(FSNodeDirectory *parent, FSNode *child, uint8_t *path,
+	                         uint32_t size) = 0;
+	virtual std::string escapeName(const std::string &name) = 0;
 
 	// ACL operations
-	virtual uint8_t fsnodes_setacl(FSNode *p, const RichACL &acl, uint32_t ts) = 0;
-	virtual uint8_t fsnodes_setacl(FSNode *p, AclType type, const AccessControlList &acl,
-	                               uint32_t ts) = 0;
+	virtual uint8_t setAcl(FSNode *p, const RichACL &acl, uint32_t ts) = 0;
+	virtual uint8_t setAcl(FSNode *p, AclType type, const AccessControlList &acl, uint32_t ts) = 0;
 #ifndef METARESTORE
-	virtual uint8_t fsnodes_getacl(FSNode *p, RichACL &acl) = 0;
+	virtual uint8_t getAcl(FSNode *p, RichACL &acl) = 0;
 #endif  // METARESTORE
-	virtual uint8_t fsnodes_deleteacl(FSNode *p, AclType type, uint32_t ts) = 0;
+	virtual uint8_t deleteAcl(FSNode *p, AclType type, uint32_t ts) = 0;
 
 	// Recursive operations
 #ifndef METARESTORE
-	virtual void fsnodes_getgoal_recursive(FSNode *node, uint8_t gmode, GoalStatistics &fgtab,
-	                                       GoalStatistics &dgtab) = 0;
-	virtual void fsnodes_gettrashtime_recursive(FSNode *node, uint8_t gmode,
-	                                            TrashtimeMap &fileTrashtimes,
-	                                            TrashtimeMap &dirTrashtimes) = 0;
-	virtual void fsnodes_geteattr_recursive(FSNode *node, uint8_t gmode, uint32_t feattrtab[16],
-	                                        uint32_t deattrtab[16]) = 0;
+	virtual void getGoalRecursive(FSNode *node, uint8_t gmode, GoalStatistics &fgtab,
+	                              GoalStatistics &dgtab) = 0;
+	virtual void getTrashTimeRecursive(FSNode *node, uint8_t gmode, TrashtimeMap &fileTrashtimes,
+	                                   TrashtimeMap &dirTrashtimes) = 0;
+	virtual void getEAttrRecursive(FSNode *node, uint8_t gmode, uint32_t feattrtab[16],
+	                               uint32_t deattrtab[16]) = 0;
 #endif
-	virtual void fsnodes_setgoal_recursive(FSNode *node, uint32_t ts, uint32_t uid, uint8_t goal,
-	                                       uint8_t smode, inode_t *sinodes, inode_t *ncinodes,
-	                                       inode_t *nsinodes) = 0;
+	virtual void setgoalRecursive(FSNode *node, uint32_t ts, uint32_t uid, uint8_t goal,
+	                              uint8_t smode, inode_t *sinodes, inode_t *ncinodes,
+	                              inode_t *nsinodes) = 0;
 
-	virtual void fsnodes_settrashtime_recursive(FSNode *node, uint32_t ts, uint32_t uid,
-	                                            uint32_t trashtime, uint8_t smode, inode_t *sinodes,
-	                                            inode_t *ncinodes, inode_t *nsinodes) = 0;
+	virtual void setTrashTimeRecursive(FSNode *node, uint32_t ts, uint32_t uid, uint32_t trashtime,
+	                                   uint8_t smode, inode_t *sinodes, inode_t *ncinodes,
+	                                   inode_t *nsinodes) = 0;
 
-	virtual void fsnodes_seteattr_recursive(FSNode *node, uint32_t ts, uint32_t uid, uint8_t eattr,
-	                                        uint8_t smode, inode_t *sinodes, inode_t *ncinodes,
-	                                        inode_t *nsinodes) = 0;
+	virtual void setEAttrRecursive(FSNode *node, uint32_t ts, uint32_t uid, uint8_t eattr,
+	                               uint8_t smode, inode_t *sinodes, inode_t *ncinodes,
+	                               inode_t *nsinodes) = 0;
 
 	// Access control operations
-	virtual int fsnodes_access(const FsContext &context, FSNode *node, uint8_t modemask) = 0;
-	virtual int fsnodes_sticky_access(FSNode *parent, FSNode *node, uint32_t uid) = 0;
-	virtual int fsnodes_namecheck(const std::string &name) = 0;
-	virtual uint8_t verify_session(const FsContext &context, OperationMode operationMode,
-	                               SessionType sessionType) = 0;
-	virtual uint8_t fsnodes_get_node_for_operation(const FsContext &context,
-	                                               ExpectedNodeType expectedNodeType,
-	                                               uint8_t modemask, inode_t inode, FSNode **ret,
-	                                               FSNodeDirectory **ret_rn = nullptr) = 0;
+	virtual int access(const FsContext &context, FSNode *node, uint8_t modemask) = 0;
+	virtual int stickyAccess(FSNode *parent, FSNode *node, uint32_t uid) = 0;
+	virtual int nameCheck(const std::string &name) = 0;
+	virtual uint8_t verifySession(const FsContext &context, OperationMode operationMode,
+	                              SessionType sessionType) = 0;
+	virtual uint8_t getNodeForOperation(const FsContext &context, ExpectedNodeType expectedNodeType,
+	                                    uint8_t modemask, inode_t inode, FSNode **ret,
+	                                    FSNodeDirectory **ret_rn = nullptr) = 0;
 
 	// Ancestry operations
-	virtual bool fsnodes_isancestor(FSNodeDirectory *f, FSNode *p) = 0;
-	virtual bool fsnodes_isancestor_or_node_reserved_or_trash(FSNodeDirectory *f, FSNode *p) = 0;
-	virtual FSNodeDirectory *fsnodes_get_first_parent(FSNode *node) = 0;
+	virtual bool isAncestor(FSNodeDirectory *f, FSNode *p) = 0;
+	virtual bool isAncestorOrNodeReservedOrTrash(FSNodeDirectory *f, FSNode *p) = 0;
+	virtual FSNodeDirectory *getFirstParent(FSNode *node) = 0;
 
 protected:
 	// Core node lookup operation - override in subclasses for custom storage
-	virtual FSNode *fsnodes_id_to_node_internal(inode_t id) = 0;
+	virtual FSNode *idToNodeInternal(inode_t id) = 0;
 
 	// Type checking helper - base case
 	template <class NodeType>
-	void fsnodes_check_node_type(const NodeType *node) {
+	void checkNodeType(const NodeType *node) {
 		assert(node);
 		(void)node;
 	}
@@ -207,26 +197,26 @@ protected:
 
 // Template specializations for type checking
 template <>
-inline void IFilesystemNodeOperations::fsnodes_check_node_type(const FSNodeFile *node) {
+inline void IFilesystemNodeOperations::checkNodeType(const FSNodeFile *node) {
 	assert(node && (node->type == FSNodeType::kFile || node->type == FSNodeType::kTrash ||
 	                node->type == FSNodeType::kReserved));
 	(void)node;
 }
 
 template <>
-inline void IFilesystemNodeOperations::fsnodes_check_node_type(const FSNodeDirectory *node) {
+inline void IFilesystemNodeOperations::checkNodeType(const FSNodeDirectory *node) {
 	assert(node && node->type == FSNodeType::kDirectory);
 	(void)node;
 }
 
 template <>
-inline void IFilesystemNodeOperations::fsnodes_check_node_type(const FSNodeSymlink *node) {
+inline void IFilesystemNodeOperations::checkNodeType(const FSNodeSymlink *node) {
 	assert(node && node->type == FSNodeType::kSymlink);
 	(void)node;
 }
 
 template <>
-inline void IFilesystemNodeOperations::fsnodes_check_node_type(const FSNodeDevice *node) {
+inline void IFilesystemNodeOperations::checkNodeType(const FSNodeDevice *node) {
 	assert(node && (node->type == FSNodeType::kBlockDev || node->type == FSNodeType::kCharDev));
 	(void)node;
 };

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -2454,11 +2454,13 @@ void FilesystemOperationsBase::getTrashTimeStore(TrashtimeMap &fileTrashtimes,
 }
 
 uint8_t FilesystemOperationsBase::getEAttr(const FsContext &context, inode_t inode, uint8_t gmode,
-                                           uint32_t feattrtab[16], uint32_t deattrtab[16]) {
+                                           ExtendedAttributesArray &fileEAttrTab,
+                                           ExtendedAttributesArray &dirEAttrTab) {
 	FSNode *p;
 
-	memset(feattrtab, 0, 16 * sizeof(uint32_t));
-	memset(deattrtab, 0, 16 * sizeof(uint32_t));
+	fileEAttrTab.fill(0);
+	dirEAttrTab.fill(0);
+
 	if (!GMODE_ISVALID(gmode)) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
@@ -2474,7 +2476,7 @@ uint8_t FilesystemOperationsBase::getEAttr(const FsContext &context, inode_t ino
 		return status;
 	}
 
-	nodeOperations_->getEAttrRecursive(p, gmode, feattrtab, deattrtab);
+	nodeOperations_->getEAttrRecursive(p, gmode, fileEAttrTab, dirEAttrTab);
 	return SAUNAFS_STATUS_OK;
 }
 

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -2453,9 +2453,9 @@ void FilesystemOperationsBase::getTrashTimeStore(TrashtimeMap &fileTrashtimes,
 	}
 }
 
-uint8_t FilesystemOperationsBase::getEAttr(const FsContext &context, inode_t inode, uint8_t gmode,
-                                           ExtendedAttributesArray &fileEAttrTab,
-                                           ExtendedAttributesArray &dirEAttrTab) {
+uint8_t FilesystemOperationsBase::getExtraAttr(const FsContext &context, inode_t inode,
+                                               uint8_t gmode, ExtraAttributesArray &fileEAttrTab,
+                                               ExtraAttributesArray &dirEAttrTab) {
 	FSNode *p;
 
 	fileEAttrTab.fill(0);
@@ -2476,7 +2476,7 @@ uint8_t FilesystemOperationsBase::getEAttr(const FsContext &context, inode_t ino
 		return status;
 	}
 
-	nodeOperations_->getEAttrRecursive(p, gmode, fileEAttrTab, dirEAttrTab);
+	nodeOperations_->getExtraAttrRecursive(p, gmode, fileEAttrTab, dirEAttrTab);
 	return SAUNAFS_STATUS_OK;
 }
 
@@ -2640,9 +2640,9 @@ uint8_t FilesystemOperationsBase::applySetTrashTime(const FsContext &context, in
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t FilesystemOperationsBase::setEAttr(const FsContext &context, inode_t inode, uint8_t eattr,
-                                           uint8_t smode, inode_t *sinodes, inode_t *ncinodes,
-                                           inode_t *nsinodes) {
+uint8_t FilesystemOperationsBase::setExtraAttr(const FsContext &context, inode_t inode,
+                                               uint8_t eattr, uint8_t smode, inode_t *sinodes,
+                                               inode_t *ncinodes, inode_t *nsinodes) {
 	ChecksumUpdater cu(context.ts());
 	if (!SMODE_ISVALID(smode) ||
 	    (eattr & (~(EATTR_NOOWNER | EATTR_NOACACHE | EATTR_NOECACHE | EATTR_NODATACACHE)))) {
@@ -2664,8 +2664,8 @@ uint8_t FilesystemOperationsBase::setEAttr(const FsContext &context, inode_t ino
 	inode_t nci = 0;
 	inode_t nsi = 0;
 	sassert(context.hasUidGidData());
-	nodeOperations_->setEAttrRecursive(p, context.ts(), context.uid(), eattr, smode, &si, &nci,
-	                                   &nsi);
+	nodeOperations_->setExtraAttrRecursive(p, context.ts(), context.uid(), eattr, smode, &si, &nci,
+	                                       &nsi);
 	if (context.isPersonalityMaster()) {
 		if ((smode & SMODE_RMASK) == 0 && nsi > 0 && si == 0 && nci == 0) {
 			return SAUNAFS_ERROR_EPERM;

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -123,7 +123,7 @@ uint8_t FilesystemOperationsBase::readReservedSize(inode_t rootinode, uint8_t se
 		return SAUNAFS_ERROR_EPERM;
 	}
 	(void)sesflags;
-	*dbuffsize = nodeOperations_->fsnodes_getdetachedsize(gMetadata->reserved);
+	*dbuffsize = nodeOperations_->getDetachedSize(gMetadata->reserved);
 	return SAUNAFS_STATUS_OK;
 }
 
@@ -131,18 +131,18 @@ void FilesystemOperationsBase::readReservedData(inode_t rootinode, uint8_t sesfl
                                                 uint8_t *dbuff) {
 	(void)rootinode;
 	(void)sesflags;
-	nodeOperations_->fsnodes_getdetacheddata(gMetadata->reserved, dbuff);
+	nodeOperations_->getDetachedData(gMetadata->reserved, dbuff);
 }
 
 void FilesystemOperationsBase::readReserved(uint32_t off, uint32_t max_entries,
                                             std::vector<NamedInodeEntry> &entries) {
-	nodeOperations_->fsnodes_getdetacheddata(gMetadata->reserved, off, max_entries, entries);
+	nodeOperations_->getDetachedData(gMetadata->reserved, off, max_entries, entries);
 }
 
 void FilesystemOperationsBase::readReserved(uint64_t handleOffset, uint32_t maxEntries,
                                             std::vector<HandleInodeEntry> &entries) {
-	nodeOperations_->fsnodes_getdetacheddata(gMetadata->reservedHandlesIndex, handleOffset,
-	                                         maxEntries, entries, false);
+	nodeOperations_->getDetachedData(gMetadata->reservedHandlesIndex, handleOffset, maxEntries,
+	                                 entries, false);
 }
 
 uint8_t FilesystemOperationsBase::readTrashSize(inode_t rootinode, uint8_t sesflags,
@@ -151,25 +151,25 @@ uint8_t FilesystemOperationsBase::readTrashSize(inode_t rootinode, uint8_t sesfl
 		return SAUNAFS_ERROR_EPERM;
 	}
 	(void)sesflags;
-	*dbuffsize = nodeOperations_->fsnodes_getdetachedsize(gMetadata->trash);
+	*dbuffsize = nodeOperations_->getDetachedSize(gMetadata->trash);
 	return SAUNAFS_STATUS_OK;
 }
 
 void FilesystemOperationsBase::readTrashData(inode_t rootinode, uint8_t sesflags, uint8_t *dbuff) {
 	(void)rootinode;
 	(void)sesflags;
-	nodeOperations_->fsnodes_getdetacheddata(gMetadata->trash, dbuff);
+	nodeOperations_->getDetachedData(gMetadata->trash, dbuff);
 }
 
 void FilesystemOperationsBase::readTrash(uint32_t off, uint32_t max_entries,
                                          std::vector<NamedInodeEntry> &entries) {
-	nodeOperations_->fsnodes_getdetacheddata(gMetadata->trash, off, max_entries, entries);
+	nodeOperations_->getDetachedData(gMetadata->trash, off, max_entries, entries);
 }
 
 void FilesystemOperationsBase::readTrash(uint64_t handleOffset, uint32_t maxEntries,
                                          std::vector<HandleInodeEntry> &entries) {
-	nodeOperations_->fsnodes_getdetacheddata(gMetadata->trashHandlesIndex, handleOffset, maxEntries,
-	                                         entries, true);
+	nodeOperations_->getDetachedData(gMetadata->trashHandlesIndex, handleOffset, maxEntries,
+	                                 entries, true);
 }
 
 /* common procedure for trash and reserved files */
@@ -184,7 +184,7 @@ uint8_t FilesystemOperationsBase::getDetachedAttr(inode_t rootinode, uint8_t ses
 	if (!DTYPE_ISVALID(dtype)) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
-	p = nodeOperations_->fsnodes_id_to_node(inode);
+	p = nodeOperations_->idToNode(inode);
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
@@ -197,7 +197,7 @@ uint8_t FilesystemOperationsBase::getDetachedAttr(inode_t rootinode, uint8_t ses
 	if (dtype == DTYPE_RESERVED && p->type == FSNodeType::kTrash) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
-	nodeOperations_->fsnodes_fill_attr(p, NULL, p->uid, p->gid, p->uid, p->gid, sesflags, attr);
+	nodeOperations_->fillAttr(p, NULL, p->uid, p->gid, p->uid, p->gid, sesflags, attr);
 	return SAUNAFS_STATUS_OK;
 }
 
@@ -208,7 +208,7 @@ uint8_t FilesystemOperationsBase::getTrashPath(inode_t rootinode, uint8_t sesfla
 		return SAUNAFS_ERROR_EPERM;
 	}
 	(void)sesflags;
-	p = nodeOperations_->fsnodes_id_to_node(inode);
+	p = nodeOperations_->idToNode(inode);
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
@@ -225,12 +225,12 @@ uint8_t FilesystemOperationsBase::setTrashPath(const FsContext &context, inode_t
 	ChecksumUpdater cu(context.ts());
 	FSNode *p;
 	uint8_t status =
-	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kOnlyMeta);
+	    nodeOperations_->verifySession(context, OperationMode::kReadWrite, SessionType::kOnlyMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny,
-	                                                         MODE_MASK_EMPTY, inode, &p);
+	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kAny, MODE_MASK_EMPTY,
+	                                              inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	} else if (p->type != FSNodeType::kTrash) {
@@ -249,7 +249,7 @@ uint8_t FilesystemOperationsBase::setTrashPath(const FsContext &context, inode_t
 
 	if (context.isPersonalityMaster()) {
 		changeLog(context.ts(), "SETPATH(%" PRIiNode ",%s)", p->id,
-		          nodeOperations_->fsnodes_escape_name(path).c_str());
+		          nodeOperations_->escapeName(path).c_str());
 	} else {
 		gMetadata->metadataVersion++;
 	}
@@ -260,19 +260,19 @@ uint8_t FilesystemOperationsBase::undel(const FsContext &context, inode_t inode)
 	ChecksumUpdater cu(context.ts());
 	FSNode *p;
 	uint8_t status =
-	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kOnlyMeta);
+	    nodeOperations_->verifySession(context, OperationMode::kReadWrite, SessionType::kOnlyMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny,
-	                                                         MODE_MASK_EMPTY, inode, &p);
+	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kAny, MODE_MASK_EMPTY,
+	                                              inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	} else if (p->type != FSNodeType::kTrash) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
 
-	status = nodeOperations_->fsnodes_undel(context.ts(), static_cast<FSNodeFile *>(p));
+	status = nodeOperations_->undel(context.ts(), static_cast<FSNodeFile *>(p));
 	if (context.isPersonalityMaster()) {
 		if (status == SAUNAFS_STATUS_OK) { changeLog(context.ts(), "UNDEL(%" PRIiNode ")", p->id); }
 	} else {
@@ -285,12 +285,12 @@ uint8_t FilesystemOperationsBase::purge(const FsContext &context, inode_t inode)
 	ChecksumUpdater cu(context.ts());
 	FSNode *p;
 	uint8_t status =
-	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kOnlyMeta);
+	    nodeOperations_->verifySession(context, OperationMode::kReadWrite, SessionType::kOnlyMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny,
-	                                                         MODE_MASK_EMPTY, inode, &p);
+	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kAny, MODE_MASK_EMPTY,
+	                                              inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	} else if (p->type != FSNodeType::kTrash) {
@@ -298,7 +298,7 @@ uint8_t FilesystemOperationsBase::purge(const FsContext &context, inode_t inode)
 	}
 	// This should be equal to inode, because p is not a directory
 	inode_t purged_inode = p->id;
-	nodeOperations_->fsnodes_purge(context.ts(), p);
+	nodeOperations_->purge(context.ts(), p);
 
 	if (context.isPersonalityMaster()) {
 		changeLog(context.ts(), "PURGE(%" PRIiNode ")", purged_inode);
@@ -346,8 +346,8 @@ uint8_t FilesystemOperationsBase::getRootInode(inode_t *rootinode, const uint8_t
 			nleng++;
 		}
 		hname = HString((const char*)name, nleng);
-		if (nodeOperations_->fsnodes_namecheck(hname) < 0) { return SAUNAFS_ERROR_EINVAL; }
-		FSNode *child = nodeOperations_->fsnodes_lookup(parent, hname);
+		if (nodeOperations_->nameCheck(hname) < 0) { return SAUNAFS_ERROR_EINVAL; }
+		FSNode *child = nodeOperations_->lookup(parent, hname);
 		if (!child) {
 			return SAUNAFS_ERROR_ENOENT;
 		}
@@ -371,7 +371,7 @@ void FilesystemOperationsBase::statfs(const FsContext &context, uint64_t *totals
 	} else {
 		*trspace = 0;
 		*respace = 0;
-		rn = nodeOperations_->fsnodes_id_to_node(context.rootinode());
+		rn = nodeOperations_->idToNode(context.rootinode());
 	}
 	if (!rn || rn->type != FSNodeType::kDirectory) {
 		*totalspace = 0;
@@ -380,7 +380,7 @@ void FilesystemOperationsBase::statfs(const FsContext &context, uint64_t *totals
 	} else {
 		matocsserv_getspace(totalspace, availspace);
 		fsnodes_quota_adjust_space(rn, *totalspace, *availspace);
-		nodeOperations_->fsnodes_get_stats(rn, &sr);
+		nodeOperations_->getStats(rn, &sr);
 		*inodes = sr.inodes;
 	}
 	incrementFSStat(FsStats::Statfs);
@@ -402,7 +402,7 @@ uint8_t FilesystemOperationsBase::applyChecksum(const std::string &version, uint
 
 uint8_t FilesystemOperationsBase::applyAccess(uint32_t timestamp, inode_t inode) {
 	FSNode *p;
-	p = nodeOperations_->fsnodes_id_to_node(inode);
+	p = nodeOperations_->idToNode(inode);
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
@@ -416,15 +416,15 @@ uint8_t FilesystemOperationsBase::applyAccess(uint32_t timestamp, inode_t inode)
 uint8_t FilesystemOperationsBase::access(const FsContext &context, inode_t inode, int modemask) {
 	FSNode *p;
 
-	uint8_t status = nodeOperations_->verify_session(
+	uint8_t status = nodeOperations_->verifySession(
 	    context, (modemask & MODE_MASK_W) ? OperationMode::kReadWrite : OperationMode::kReadOnly,
 	    SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	return nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny,
-	                                                       modemask, inode, &p);
+	return nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kAny, modemask, inode,
+	                                            &p);
 }
 
 uint8_t FilesystemOperationsBase::lookup(const FsContext &context, inode_t parent,
@@ -436,13 +436,13 @@ uint8_t FilesystemOperationsBase::lookup(const FsContext &context, inode_t paren
 	attr.fill(0);
 
 	uint8_t status =
-	    nodeOperations_->verify_session(context, OperationMode::kReadOnly, SessionType::kNotMeta);
+	    nodeOperations_->verifySession(context, OperationMode::kReadOnly, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kDirectory,
-	                                                         MODE_MASK_X, parent, &wd, &rn);
+	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kDirectory,
+	                                              MODE_MASK_X, parent, &wd, &rn);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
@@ -454,8 +454,8 @@ uint8_t FilesystemOperationsBase::lookup(const FsContext &context, inode_t paren
 			} else {
 				*inode = wd->id;
 			}
-			nodeOperations_->fsnodes_fill_attr(wd, wd, context.uid(), context.gid(), context.auid(),
-			                                   context.agid(), context.sesflags(), attr);
+			nodeOperations_->fillAttr(wd, wd, context.uid(), context.gid(), context.auid(),
+			                          context.agid(), context.sesflags(), attr);
 			incrementFSStat(FsStats::Lookup);
 			metrics::Counter::increment(metrics::Counter::Master::FS_LOOKUP);
 			return SAUNAFS_STATUS_OK;
@@ -463,9 +463,8 @@ uint8_t FilesystemOperationsBase::lookup(const FsContext &context, inode_t paren
 		if (name.length() == 2 && name[1] == '.') {  // parent
 			if (wd->id == context.rootinode()) {
 				*inode = SPECIAL_INODE_ROOT;
-				nodeOperations_->fsnodes_fill_attr(wd, wd, context.uid(), context.gid(),
-				                                   context.auid(), context.agid(),
-				                                   context.sesflags(), attr);
+				nodeOperations_->fillAttr(wd, wd, context.uid(), context.gid(), context.auid(),
+				                          context.agid(), context.sesflags(), attr);
 			} else {
 				if (!wd->parents.empty()) {
 					if (wd->parents[0].first == context.rootinode()) {
@@ -473,15 +472,13 @@ uint8_t FilesystemOperationsBase::lookup(const FsContext &context, inode_t paren
 					} else {
 						*inode = wd->parents[0].first;
 					}
-					FSNode *pp = nodeOperations_->fsnodes_id_to_node(wd->parents[0].first);
-					nodeOperations_->fsnodes_fill_attr(pp, wd, context.uid(), context.gid(),
-					                                   context.auid(), context.agid(),
-					                                   context.sesflags(), attr);
+					FSNode *pp = nodeOperations_->idToNode(wd->parents[0].first);
+					nodeOperations_->fillAttr(pp, wd, context.uid(), context.gid(), context.auid(),
+					                          context.agid(), context.sesflags(), attr);
 				} else {
 					*inode = SPECIAL_INODE_ROOT;  // rn->id;
-					nodeOperations_->fsnodes_fill_attr(rn, wd, context.uid(), context.gid(),
-					                                   context.auid(), context.agid(),
-					                                   context.sesflags(), attr);
+					nodeOperations_->fillAttr(rn, wd, context.uid(), context.gid(), context.auid(),
+					                          context.agid(), context.sesflags(), attr);
 				}
 			}
 			incrementFSStat(FsStats::Lookup);
@@ -489,15 +486,15 @@ uint8_t FilesystemOperationsBase::lookup(const FsContext &context, inode_t paren
 			return SAUNAFS_STATUS_OK;
 		}
 	}
-	if (nodeOperations_->fsnodes_namecheck(name) < 0) { return SAUNAFS_ERROR_EINVAL; }
+	if (nodeOperations_->nameCheck(name) < 0) { return SAUNAFS_ERROR_EINVAL; }
 
-	FSNode *child = nodeOperations_->fsnodes_lookup(static_cast<FSNodeDirectory *>(wd), name);
+	FSNode *child = nodeOperations_->lookup(static_cast<FSNodeDirectory *>(wd), name);
 	if (!child) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
 	*inode = child->id;
-	nodeOperations_->fsnodes_fill_attr(child, wd, context.uid(), context.gid(), context.auid(),
-	                                   context.agid(), context.sesflags(), attr);
+	nodeOperations_->fillAttr(child, wd, context.uid(), context.gid(), context.auid(),
+	                          context.agid(), context.sesflags(), attr);
 	incrementFSStat(FsStats::Lookup);
 	metrics::Counter::increment(metrics::Counter::Master::FS_LOOKUP);
 	return SAUNAFS_STATUS_OK;
@@ -539,11 +536,11 @@ uint8_t FilesystemOperationsBase::fullPathByInode(const FsContext &context, inod
 	std::string current_name = "";
 
 	uint8_t status =
-	    nodeOperations_->verify_session(context, OperationMode::kReadOnly, SessionType::kNotMeta);
+	    nodeOperations_->verifySession(context, OperationMode::kReadOnly, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) { return status; }
 
-	status = nodeOperations_->fsnodes_get_node_for_operation(
-	    context, ExpectedNodeType::kAny, MODE_MASK_R, initial_inode, &current_node);
+	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kAny, MODE_MASK_R,
+	                                              initial_inode, &current_node);
 	if (status != SAUNAFS_STATUS_OK) { return status; }
 
 	if (current_inode == SPECIAL_INODE_ROOT) {
@@ -566,8 +563,8 @@ uint8_t FilesystemOperationsBase::fullPathByInode(const FsContext &context, inod
 		}
 		auto [parentId, nameHandle] = current_node->parents[0];
 		if (!nameHandle) { return SAUNAFS_ERROR_ENOENT; }
-		status = nodeOperations_->fsnodes_get_node_for_operation(
-		    context, ExpectedNodeType::kAny, MODE_MASK_R, parentId, &parent_node);
+		status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kAny, MODE_MASK_R,
+		                                              parentId, &parent_node);
 		if (status != SAUNAFS_STATUS_OK) { return status; }
 		current_name = nameHandle->get();
 		fullPath = current_inode == initial_inode
@@ -583,7 +580,7 @@ uint8_t FilesystemOperationsBase::fullPathByInode(const FsContext &context, inod
 std::string FilesystemOperationsBase::fullPathByInode(inode_t initial_inode) {
 	std::string fullPath = "";
 	inode_t current_inode = initial_inode;
-	FSNode *current_node = nodeOperations_->fsnodes_id_to_node(current_inode);
+	FSNode *current_node = nodeOperations_->idToNode(current_inode);
 	std::string current_name = "";
 
 	while (current_inode != SPECIAL_INODE_ROOT) {
@@ -593,7 +590,7 @@ std::string FilesystemOperationsBase::fullPathByInode(inode_t initial_inode) {
 			break;
 		}
 		auto parent = current_node->parents[0].first;
-		auto parent_node = nodeOperations_->fsnodes_id_to_node<FSNodeDirectory>(parent);
+		auto parent_node = nodeOperations_->idToNode<FSNodeDirectory>(parent);
 		if (!parent_node) { return ""; }
 		current_name = parent_node->getChildName(current_node);
 		fullPath = current_inode == initial_inode ? current_name : current_name + "/" + fullPath;
@@ -612,19 +609,19 @@ uint8_t FilesystemOperationsBase::getAttr(const FsContext &context, inode_t inod
 	attr.fill(0);
 
 	uint8_t status =
-	    nodeOperations_->verify_session(context, OperationMode::kReadOnly, SessionType::kNotMeta);
+	    nodeOperations_->verifySession(context, OperationMode::kReadOnly, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny,
-	                                                         MODE_MASK_EMPTY, inode, &p);
+	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kAny, MODE_MASK_EMPTY,
+	                                              inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	nodeOperations_->fsnodes_fill_attr(p, NULL, context.uid(), context.gid(), context.auid(),
-	                                   context.agid(), context.sesflags(), attr);
+	nodeOperations_->fillAttr(p, NULL, context.uid(), context.gid(), context.auid(), context.agid(),
+	                          context.sesflags(), attr);
 	incrementFSStat(FsStats::Getattr);
 	metrics::Counter::increment(metrics::Counter::Master::FS_GETATTR);
 	return SAUNAFS_STATUS_OK;
@@ -640,12 +637,12 @@ uint8_t FilesystemOperationsBase::trySetLength(const FsContext &context, inode_t
 	attr.fill(0);
 
 	uint8_t status =
-	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
+	    nodeOperations_->verifySession(context, OperationMode::kReadWrite, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	status = nodeOperations_->fsnodes_get_node_for_operation(
+	status = nodeOperations_->getNodeForOperation(
 	    context, ExpectedNodeType::kFile, opened == 0 ? MODE_MASK_W : MODE_MASK_EMPTY, inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
@@ -677,8 +674,8 @@ uint8_t FilesystemOperationsBase::trySetLength(const FsContext &context, inode_t
 			}
 		}
 	}
-	nodeOperations_->fsnodes_fill_attr(p, NULL, context.uid(), context.gid(), context.auid(),
-	                                   context.agid(), context.sesflags(), attr);
+	nodeOperations_->fillAttr(p, NULL, context.uid(), context.gid(), context.auid(), context.agid(),
+	                          context.sesflags(), attr);
 	incrementFSStat(FsStats::Setattr);
 	metrics::Counter::increment(metrics::Counter::Master::FS_SETATTR);
 	return SAUNAFS_STATUS_OK;
@@ -689,7 +686,7 @@ uint8_t FilesystemOperationsBase::applyTrunc(uint32_t timestamp, inode_t inode, 
                                              uint64_t chunkid, uint32_t lockid) {
 	uint64_t ochunkid, nchunkid;
 	uint8_t status;
-	FSNodeFile *p = nodeOperations_->fsnodes_id_to_node<FSNodeFile>(inode);
+	FSNodeFile *p = nodeOperations_->idToNode<FSNodeFile>(inode);
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
@@ -758,13 +755,13 @@ uint8_t FilesystemOperationsBase::doSetLength(const FsContext &context, inode_t 
 	attr.fill(0);
 
 	uint8_t status =
-	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kAny);
+	    nodeOperations_->verifySession(context, OperationMode::kReadWrite, SessionType::kAny);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kFile,
-	                                                         MODE_MASK_EMPTY, inode, &p);
+	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kFile, MODE_MASK_EMPTY,
+	                                              inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
@@ -774,14 +771,14 @@ uint8_t FilesystemOperationsBase::doSetLength(const FsContext &context, inode_t 
 	// eraseFurtherChunks should be set to true because we are setting the
 	// length of the file and we should erase further chunks.
 	bool eraseFurtherChunks = true;
-	nodeOperations_->fsnodes_setlength(static_cast<FSNodeFile *>(p), length, eraseFurtherChunks);
+	nodeOperations_->setLength(static_cast<FSNodeFile *>(p), length, eraseFurtherChunks);
 	changeLog(ts, "LENGTH(%" PRIiNode ",%" PRIu64 ",%" PRIu32 ")", inode,
 	          static_cast<FSNodeFile *>(p)->length, static_cast<uint32_t>(eraseFurtherChunks));
 	p->mtime = ts;
-	nodeOperations_->fsnodes_update_ctime(p, ts);
+	nodeOperations_->updateCTime(p, ts);
 	fsnodes_update_checksum(p);
-	nodeOperations_->fsnodes_fill_attr(p, NULL, context.uid(), context.gid(), context.auid(),
-	                                   context.agid(), context.sesflags(), attr);
+	nodeOperations_->fillAttr(p, NULL, context.uid(), context.gid(), context.auid(), context.agid(),
+	                          context.sesflags(), attr);
 	incrementFSStat(FsStats::Setattr);
 	metrics::Counter::increment(metrics::Counter::Master::FS_SETATTR);
 	return SAUNAFS_STATUS_OK;
@@ -798,13 +795,13 @@ uint8_t FilesystemOperationsBase::setAttr(const FsContext &context, inode_t inod
 	attr.fill(0);
 
 	auto status =
-	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
+	    nodeOperations_->verifySession(context, OperationMode::kReadWrite, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny,
-	                                                         MODE_MASK_EMPTY, inode, &p);
+	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kAny, MODE_MASK_EMPTY,
+	                                              inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
@@ -823,7 +820,7 @@ uint8_t FilesystemOperationsBase::setAttr(const FsContext &context, inode_t inod
 			return SAUNAFS_ERROR_EPERM;
 		}
 		if ((setmask & (SET_ATIME_NOW_FLAG | SET_MTIME_NOW_FLAG)) &&
-		    !nodeOperations_->fsnodes_access(context, p, MODE_MASK_W)) {
+		    !nodeOperations_->access(context, p, MODE_MASK_W)) {
 			return SAUNAFS_ERROR_EACCES;
 		}
 	}
@@ -900,8 +897,8 @@ uint8_t FilesystemOperationsBase::setAttr(const FsContext &context, inode_t inod
 		gMetadata->aclStorage.setMode(p->id, p->mode, p->type == FSNodeType::kDirectory);
 	}
 	if (setmask & (SET_UID_FLAG | SET_GID_FLAG)) {
-		nodeOperations_->fsnodes_change_uid_gid(p, ((setmask & SET_UID_FLAG) ? attruid : p->uid),
-		                                        ((setmask & SET_GID_FLAG) ? attrgid : p->gid));
+		nodeOperations_->changeUidGid(p, ((setmask & SET_UID_FLAG) ? attruid : p->uid),
+		                              ((setmask & SET_GID_FLAG) ? attrgid : p->gid));
 	}
 	if (setmask & SET_ATIME_NOW_FLAG) {
 		p->atime = ts;
@@ -915,9 +912,9 @@ uint8_t FilesystemOperationsBase::setAttr(const FsContext &context, inode_t inod
 	}
 	changeLog(ts, "ATTR(%" PRIiNode ",%d,%" PRIu32 ",%" PRIu32 ",%" PRIu32 ",%" PRIu32 ")", p->id,
 	          p->mode & 07777, p->uid, p->gid, p->atime, p->mtime);
-	nodeOperations_->fsnodes_update_ctime(p, ts);
-	nodeOperations_->fsnodes_fill_attr(p, NULL, context.uid(), context.gid(), context.auid(),
-	                                   context.agid(), context.sesflags(), attr);
+	nodeOperations_->updateCTime(p, ts);
+	nodeOperations_->fillAttr(p, NULL, context.uid(), context.gid(), context.auid(), context.agid(),
+	                          context.sesflags(), attr);
 	fsnodes_update_checksum(p);
 	incrementFSStat(FsStats::Setattr);
 	metrics::Counter::increment(metrics::Counter::Master::FS_SETATTR);
@@ -928,7 +925,7 @@ uint8_t FilesystemOperationsBase::setAttr(const FsContext &context, inode_t inod
 uint8_t FilesystemOperationsBase::applyAttr(uint32_t timestamp, inode_t inode, uint32_t mode,
                                             uint32_t uid, uint32_t gid, uint32_t atime,
                                             uint32_t mtime) {
-	FSNode *p = nodeOperations_->fsnodes_id_to_node(inode);
+	FSNode *p = nodeOperations_->idToNode(inode);
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
@@ -937,10 +934,10 @@ uint8_t FilesystemOperationsBase::applyAttr(uint32_t timestamp, inode_t inode, u
 	}
 	p->mode = mode | (p->mode & 0xF000);
 	gMetadata->aclStorage.setMode(p->id, p->mode, p->type == FSNodeType::kDirectory);
-	if (p->uid != uid || p->gid != gid) { nodeOperations_->fsnodes_change_uid_gid(p, uid, gid); }
+	if (p->uid != uid || p->gid != gid) { nodeOperations_->changeUidGid(p, uid, gid); }
 	p->atime = atime;
 	p->mtime = mtime;
-	nodeOperations_->fsnodes_update_ctime(p, timestamp);
+	nodeOperations_->updateCTime(p, timestamp);
 	fsnodes_update_checksum(p);
 	gMetadata->metadataVersion++;
 	return SAUNAFS_STATUS_OK;
@@ -948,7 +945,7 @@ uint8_t FilesystemOperationsBase::applyAttr(uint32_t timestamp, inode_t inode, u
 
 uint8_t FilesystemOperationsBase::applyLength(uint32_t timestamp, inode_t inode, uint64_t length,
                                               bool eraseFurtherChunks) {
-	FSNode *p = nodeOperations_->fsnodes_id_to_node(inode);
+	FSNode *p = nodeOperations_->idToNode(inode);
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
@@ -956,9 +953,9 @@ uint8_t FilesystemOperationsBase::applyLength(uint32_t timestamp, inode_t inode,
 	    p->type != FSNodeType::kReserved) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
-	nodeOperations_->fsnodes_setlength(static_cast<FSNodeFile *>(p), length, eraseFurtherChunks);
+	nodeOperations_->setLength(static_cast<FSNodeFile *>(p), length, eraseFurtherChunks);
 	p->mtime = timestamp;
-	nodeOperations_->fsnodes_update_ctime(p, timestamp);
+	nodeOperations_->updateCTime(p, timestamp);
 	fsnodes_update_checksum(p);
 	gMetadata->metadataVersion++;
 	return SAUNAFS_STATUS_OK;
@@ -983,13 +980,13 @@ uint8_t FilesystemOperationsBase::readlink(const FsContext &context, inode_t ino
 	FSNode *p = NULL;
 
 	uint8_t status =
-	    nodeOperations_->verify_session(context, OperationMode::kReadOnly, SessionType::kNotMeta);
+	    nodeOperations_->verifySession(context, OperationMode::kReadOnly, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny,
-	                                                         MODE_MASK_EMPTY, inode, &p);
+	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kAny, MODE_MASK_EMPTY,
+	                                              inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
@@ -1011,12 +1008,12 @@ uint8_t FilesystemOperationsBase::symlink(const FsContext &context, inode_t pare
 	ChecksumUpdater cu(context.ts());
 	FSNode *wd;
 	uint8_t status =
-	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
+	    nodeOperations_->verifySession(context, OperationMode::kReadWrite, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kDirectory,
-	                                                         MODE_MASK_W, parent, &wd);
+	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kDirectory,
+	                                              MODE_MASK_W, parent, &wd);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
@@ -1028,8 +1025,8 @@ uint8_t FilesystemOperationsBase::symlink(const FsContext &context, inode_t pare
 			return SAUNAFS_ERROR_EINVAL;
 		}
 	}
-	if (nodeOperations_->fsnodes_namecheck(name) < 0) { return SAUNAFS_ERROR_EINVAL; }
-	if (nodeOperations_->fsnodes_nameisused(static_cast<FSNodeDirectory *>(wd), name)) {
+	if (nodeOperations_->nameCheck(name) < 0) { return SAUNAFS_ERROR_EINVAL; }
+	if (nodeOperations_->isNameUsed(static_cast<FSNodeDirectory *>(wd), name)) {
 		return SAUNAFS_ERROR_EEXIST;
 	}
 	if (context.isPersonalityMaster() &&
@@ -1037,7 +1034,7 @@ uint8_t FilesystemOperationsBase::symlink(const FsContext &context, inode_t pare
 	     fsnodes_quota_exceeded_dir(wd, {{QuotaResource::kInodes, 1}}))) {
 		return SAUNAFS_ERROR_QUOTA;
 	}
-	FSNodeSymlink *p = static_cast<FSNodeSymlink *>(nodeOperations_->fsnodes_create_node(
+	FSNodeSymlink *p = static_cast<FSNodeSymlink *>(nodeOperations_->createNode(
 	    context.ts(), static_cast<FSNodeDirectory *>(wd), name, FSNodeType::kSymlink, 0777, 0,
 	    context.uid(), context.gid(), 0, AclInheritance::kDontInheritAcl, *inode));
 	p->path = HString(path);
@@ -1046,15 +1043,14 @@ uint8_t FilesystemOperationsBase::symlink(const FsContext &context, inode_t pare
 	StatsRecord sr;
 	memset(&sr, 0, sizeof(StatsRecord));
 	sr.length = path.length();
-	nodeOperations_->fsnodes_add_stats(static_cast<FSNodeDirectory *>(wd), &sr);
-	if (attr != NULL) { nodeOperations_->fsnodes_fill_attr(context, p, wd, *attr); }
+	nodeOperations_->addStats(static_cast<FSNodeDirectory *>(wd), &sr);
+	if (attr != NULL) { nodeOperations_->fillAttr(context, p, wd, *attr); }
 	if (context.isPersonalityMaster()) {
 		assert(*inode == 0);
 		*inode = p->id;
 		changeLog(context.ts(), "SYMLINK(%" PRIiNode ",%s,%s,%" PRIu32 ",%" PRIu32 "):%" PRIiNode,
-		          wd->id, nodeOperations_->fsnodes_escape_name(name).c_str(),
-		          nodeOperations_->fsnodes_escape_name(path).c_str(), context.uid(), context.gid(),
-		          p->id);
+		          wd->id, nodeOperations_->escapeName(name).c_str(),
+		          nodeOperations_->escapeName(path).c_str(), context.uid(), context.gid(), p->id);
 	} else {
 		if (*inode != p->id) {
 			return SAUNAFS_ERROR_MISMATCH;
@@ -1080,7 +1076,7 @@ uint8_t FilesystemOperationsBase::mknod(const FsContext &context, inode_t parent
 	attr.fill(0);
 
 	uint8_t status =
-	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
+	    nodeOperations_->verifySession(context, OperationMode::kReadWrite, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
@@ -1090,14 +1086,14 @@ uint8_t FilesystemOperationsBase::mknod(const FsContext &context, inode_t parent
 		return SAUNAFS_ERROR_EINVAL;
 	}
 
-	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kDirectory,
-	                                                         MODE_MASK_W, parent, &wd);
+	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kDirectory,
+	                                              MODE_MASK_W, parent, &wd);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	if (nodeOperations_->fsnodes_namecheck(name) < 0) { return SAUNAFS_ERROR_EINVAL; }
-	if (nodeOperations_->fsnodes_nameisused(static_cast<FSNodeDirectory *>(wd), name)) {
+	if (nodeOperations_->nameCheck(name) < 0) { return SAUNAFS_ERROR_EINVAL; }
+	if (nodeOperations_->isNameUsed(static_cast<FSNodeDirectory *>(wd), name)) {
 		return SAUNAFS_ERROR_EEXIST;
 	}
 	if (fsnodes_quota_exceeded_ug(context.uid(), context.gid(), {{QuotaResource::kInodes, 1}}) ||
@@ -1107,17 +1103,16 @@ uint8_t FilesystemOperationsBase::mknod(const FsContext &context, inode_t parent
 
 	static_cast<FSNodeDirectory *>(wd)->case_insensitive =
 	    context.sesflags() & SESFLAG_CASEINSENSITIVE;
-	p = nodeOperations_->fsnodes_create_node(ts, static_cast<FSNodeDirectory *>(wd), name, type,
-	                                         mode, umask, context.uid(), context.gid(), 0,
-	                                         AclInheritance::kInheritAcl);
+	p = nodeOperations_->createNode(ts, static_cast<FSNodeDirectory *>(wd), name, type, mode, umask,
+	                                context.uid(), context.gid(), 0, AclInheritance::kInheritAcl);
 	if (type == FSNodeType::kBlockDev || type == FSNodeType::kCharDev) {
 		static_cast<FSNodeDevice*>(p)->rdev = rdev;
 	}
 	*inode = p->id;
-	nodeOperations_->fsnodes_fill_attr(p, wd, context.uid(), context.gid(), context.auid(),
-	                                   context.agid(), context.sesflags(), attr);
+	nodeOperations_->fillAttr(p, wd, context.uid(), context.gid(), context.auid(), context.agid(),
+	                          context.sesflags(), attr);
 	changeLog(ts, "CREATE(%" PRIiNode ",%s,%c,%d,%" PRIu32 ",%" PRIu32 ",%" PRIu32 "):%" PRIiNode,
-	          wd->id, nodeOperations_->fsnodes_escape_name(name).c_str(), static_cast<char>(type),
+	          wd->id, nodeOperations_->escapeName(name).c_str(), static_cast<char>(type),
 	          p->mode & 07777, context.uid(), context.gid(), rdev, p->id);
 	incrementFSStat(FsStats::Mknod);
 	metrics::Counter::increment(metrics::Counter::Master::FS_MKNOD);
@@ -1135,19 +1130,19 @@ uint8_t FilesystemOperationsBase::mkdir(const FsContext &context, inode_t parent
 	attr.fill(0);
 
 	uint8_t status =
-	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
+	    nodeOperations_->verifySession(context, OperationMode::kReadWrite, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kDirectory,
-	                                                         MODE_MASK_W, parent, &wd);
+	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kDirectory,
+	                                              MODE_MASK_W, parent, &wd);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	if (nodeOperations_->fsnodes_namecheck(name) < 0) { return SAUNAFS_ERROR_EINVAL; }
-	if (nodeOperations_->fsnodes_nameisused(static_cast<FSNodeDirectory *>(wd), name)) {
+	if (nodeOperations_->nameCheck(name) < 0) { return SAUNAFS_ERROR_EINVAL; }
+	if (nodeOperations_->isNameUsed(static_cast<FSNodeDirectory *>(wd), name)) {
 		return SAUNAFS_ERROR_EEXIST;
 	}
 	if (fsnodes_quota_exceeded_ug(context.uid(), context.gid(), {{QuotaResource::kInodes, 1}}) ||
@@ -1164,14 +1159,14 @@ uint8_t FilesystemOperationsBase::mkdir(const FsContext &context, inode_t parent
 
 	static_cast<FSNodeDirectory *>(wd)->case_insensitive =
 	    context.sesflags() & SESFLAG_CASEINSENSITIVE;
-	p = nodeOperations_->fsnodes_create_node(ts, static_cast<FSNodeDirectory *>(wd), name,
-	                                         FSNodeType::kDirectory, mode, umask, context.uid(),
-	                                         context.gid(), copysgid, AclInheritance::kInheritAcl);
+	p = nodeOperations_->createNode(ts, static_cast<FSNodeDirectory *>(wd), name,
+	                                FSNodeType::kDirectory, mode, umask, context.uid(),
+	                                context.gid(), copysgid, AclInheritance::kInheritAcl);
 	*inode = p->id;
-	nodeOperations_->fsnodes_fill_attr(p, wd, context.uid(), context.gid(), context.auid(),
-	                                   context.agid(), context.sesflags(), attr);
+	nodeOperations_->fillAttr(p, wd, context.uid(), context.gid(), context.auid(), context.agid(),
+	                          context.sesflags(), attr);
 	changeLog(ts, "CREATE(%" PRIiNode ",%s,%c,%d,%" PRIu32 ",%" PRIu32 ",%" PRIu32 "):%" PRIiNode,
-	          wd->id, nodeOperations_->fsnodes_escape_name(name).c_str(),
+	          wd->id, nodeOperations_->escapeName(name).c_str(),
 	          static_cast<char>(FSNodeType::kDirectory), p->mode & 07777, context.uid(),
 	          context.gid(), 0, p->id);
 	incrementFSStat(FsStats::Mkdir);
@@ -1190,20 +1185,19 @@ uint8_t FilesystemOperationsBase::applyCreate(uint32_t timestamp, inode_t parent
 	    type != FSNodeType::kDirectory) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
-	wd = nodeOperations_->fsnodes_id_to_node(parent);
+	wd = nodeOperations_->idToNode(parent);
 	if (!wd) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
 	if (wd->type != FSNodeType::kDirectory) {
 		return SAUNAFS_ERROR_ENOTDIR;
 	}
-	if (nodeOperations_->fsnodes_nameisused(static_cast<FSNodeDirectory *>(wd), name)) {
+	if (nodeOperations_->isNameUsed(static_cast<FSNodeDirectory *>(wd), name)) {
 		return SAUNAFS_ERROR_EEXIST;
 	}
 	// we pass requested inode number here
-	p = nodeOperations_->fsnodes_create_node(timestamp, static_cast<FSNodeDirectory *>(wd), name,
-	                                         type, mode, 0, uid, gid, 0,
-	                                         AclInheritance::kInheritAcl, inode);
+	p = nodeOperations_->createNode(timestamp, static_cast<FSNodeDirectory *>(wd), name, type, mode,
+	                                0, uid, gid, 0, AclInheritance::kInheritAcl, inode);
 	if (type == FSNodeType::kBlockDev || type == FSNodeType::kCharDev) {
 		static_cast<FSNodeDevice*>(p)->rdev = rdev;
 		fsnodes_update_checksum(p);
@@ -1224,31 +1218,29 @@ uint8_t FilesystemOperationsBase::unlink(const FsContext &context, inode_t paren
 	FSNode *wd;
 
 	uint8_t status =
-	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
+	    nodeOperations_->verifySession(context, OperationMode::kReadWrite, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kDirectory,
-	                                                         MODE_MASK_W, parent, &wd);
+	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kDirectory,
+	                                              MODE_MASK_W, parent, &wd);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	if (nodeOperations_->fsnodes_namecheck(name) < 0) { return SAUNAFS_ERROR_EINVAL; }
-	FSNode *child = nodeOperations_->fsnodes_lookup(static_cast<FSNodeDirectory *>(wd), name);
+	if (nodeOperations_->nameCheck(name) < 0) { return SAUNAFS_ERROR_EINVAL; }
+	FSNode *child = nodeOperations_->lookup(static_cast<FSNodeDirectory *>(wd), name);
 	if (!child) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
-	if (!nodeOperations_->fsnodes_sticky_access(wd, child, context.uid())) {
-		return SAUNAFS_ERROR_EPERM;
-	}
+	if (!nodeOperations_->stickyAccess(wd, child, context.uid())) { return SAUNAFS_ERROR_EPERM; }
 	if (child->type == FSNodeType::kDirectory) {
 		return SAUNAFS_ERROR_EPERM;
 	}
 	changeLog(ts, "UNLINK(%" PRIiNode ",%s):%" PRIiNode, wd->id,
-	          nodeOperations_->fsnodes_escape_name(name).c_str(), child->id);
-	nodeOperations_->fsnodes_unlink(ts, static_cast<FSNodeDirectory *>(wd), name, child);
+	          nodeOperations_->escapeName(name).c_str(), child->id);
+	nodeOperations_->unlink(ts, static_cast<FSNodeDirectory *>(wd), name, child);
 	incrementFSStat(FsStats::Unlink);
 	metrics::Counter::increment(metrics::Counter::Master::FS_UNLINK);
 	return SAUNAFS_STATUS_OK;
@@ -1262,17 +1254,17 @@ uint8_t FilesystemOperationsBase::recursiveRemove(const FsContext &context, inod
 	FSNode *wd_tmp;
 
 	uint8_t status =
-	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
+	    nodeOperations_->verifySession(context, OperationMode::kReadWrite, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kDirectory,
-	                                                         MODE_MASK_W, parent, &wd_tmp);
+	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kDirectory,
+	                                              MODE_MASK_W, parent, &wd_tmp);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	FSNode *child = nodeOperations_->fsnodes_lookup(static_cast<FSNodeDirectory *>(wd_tmp), name);
+	FSNode *child = nodeOperations_->lookup(static_cast<FSNodeDirectory *>(wd_tmp), name);
 	if (!child) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
@@ -1282,7 +1274,7 @@ uint8_t FilesystemOperationsBase::recursiveRemove(const FsContext &context, inod
 
 	std::string node_name;
 
-	nodeOperations_->fsnodes_getpath(static_cast<FSNodeDirectory *>(wd_tmp), child, node_name);
+	nodeOperations_->getPath(static_cast<FSNodeDirectory *>(wd_tmp), child, node_name);
 	return gMetadata->taskManager.submitTask(job_id, context.ts(), kInitialTaskBatchSize,
 	                                          task, RemoveTask::generateDescription(node_name),
 	                                          callback);
@@ -1295,25 +1287,23 @@ uint8_t FilesystemOperationsBase::rmdir(const FsContext &context, inode_t parent
 	FSNode *wd;
 
 	uint8_t status =
-	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
+	    nodeOperations_->verifySession(context, OperationMode::kReadWrite, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kDirectory,
-	                                                         MODE_MASK_W, parent, &wd);
+	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kDirectory,
+	                                              MODE_MASK_W, parent, &wd);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	if (nodeOperations_->fsnodes_namecheck(name) < 0) { return SAUNAFS_ERROR_EINVAL; }
-	FSNode *child = nodeOperations_->fsnodes_lookup(static_cast<FSNodeDirectory *>(wd), name);
+	if (nodeOperations_->nameCheck(name) < 0) { return SAUNAFS_ERROR_EINVAL; }
+	FSNode *child = nodeOperations_->lookup(static_cast<FSNodeDirectory *>(wd), name);
 	if (!child) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
-	if (!nodeOperations_->fsnodes_sticky_access(wd, child, context.uid())) {
-		return SAUNAFS_ERROR_EPERM;
-	}
+	if (!nodeOperations_->stickyAccess(wd, child, context.uid())) { return SAUNAFS_ERROR_EPERM; }
 	if (child->type != FSNodeType::kDirectory) {
 		return SAUNAFS_ERROR_ENOTDIR;
 	}
@@ -1321,8 +1311,8 @@ uint8_t FilesystemOperationsBase::rmdir(const FsContext &context, inode_t parent
 		return SAUNAFS_ERROR_ENOTEMPTY;
 	}
 	changeLog(ts, "UNLINK(%" PRIiNode ",%s):%" PRIiNode, wd->id,
-	          nodeOperations_->fsnodes_escape_name(name).c_str(), child->id);
-	nodeOperations_->fsnodes_unlink(ts, static_cast<FSNodeDirectory *>(wd), name, child);
+	          nodeOperations_->escapeName(name).c_str(), child->id);
+	nodeOperations_->unlink(ts, static_cast<FSNodeDirectory *>(wd), name, child);
 	incrementFSStat(FsStats::Rmdir);
 	metrics::Counter::increment(metrics::Counter::Master::FS_RMDIR);
 	return SAUNAFS_STATUS_OK;
@@ -1332,14 +1322,14 @@ uint8_t FilesystemOperationsBase::rmdir(const FsContext &context, inode_t parent
 uint8_t FilesystemOperationsBase::applyUnlink(uint32_t timestamp, inode_t parent,
                                               const HString &name, inode_t inode) {
 	FSNode *wd;
-	wd = nodeOperations_->fsnodes_id_to_node(parent);
+	wd = nodeOperations_->idToNode(parent);
 	if (!wd) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
 	if (wd->type != FSNodeType::kDirectory) {
 		return SAUNAFS_ERROR_ENOTDIR;
 	}
-	FSNode *child = nodeOperations_->fsnodes_lookup(static_cast<FSNodeDirectory *>(wd), name);
+	FSNode *child = nodeOperations_->lookup(static_cast<FSNodeDirectory *>(wd), name);
 	if (!child) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
@@ -1350,7 +1340,7 @@ uint8_t FilesystemOperationsBase::applyUnlink(uint32_t timestamp, inode_t parent
 	    !static_cast<FSNodeDirectory *>(child)->entries.empty()) {
 		return SAUNAFS_ERROR_ENOTEMPTY;
 	}
-	nodeOperations_->fsnodes_unlink(timestamp, static_cast<FSNodeDirectory *>(wd), name, child);
+	nodeOperations_->unlink(timestamp, static_cast<FSNodeDirectory *>(wd), name, child);
 	gMetadata->metadataVersion++;
 	return SAUNAFS_STATUS_OK;
 }
@@ -1363,28 +1353,27 @@ uint8_t FilesystemOperationsBase::rename(const FsContext &context, inode_t paren
 	FSNode *swd;
 	FSNode *dwd;
 	uint8_t status =
-	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kAny);
+	    nodeOperations_->verifySession(context, OperationMode::kReadWrite, SessionType::kAny);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kDirectory,
-	                                                         MODE_MASK_W, parent_dst, &dwd);
+	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kDirectory,
+	                                              MODE_MASK_W, parent_dst, &dwd);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kDirectory,
-	                                                         MODE_MASK_W, parent_src, &swd);
+	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kDirectory,
+	                                              MODE_MASK_W, parent_src, &swd);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	if (nodeOperations_->fsnodes_namecheck(name_src) < 0) { return SAUNAFS_ERROR_EINVAL; }
-	FSNode *se_child =
-	    nodeOperations_->fsnodes_lookup(static_cast<FSNodeDirectory *>(swd), name_src);
+	if (nodeOperations_->nameCheck(name_src) < 0) { return SAUNAFS_ERROR_EINVAL; }
+	FSNode *se_child = nodeOperations_->lookup(static_cast<FSNodeDirectory *>(swd), name_src);
 	if (!se_child) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
 	if (context.canCheckPermissions() &&
-	    !nodeOperations_->fsnodes_sticky_access(swd, se_child, context.uid())) {
+	    !nodeOperations_->stickyAccess(swd, se_child, context.uid())) {
 		return SAUNAFS_ERROR_EPERM;
 	}
 	if ((context.personality() != metadataserver::Personality::kMaster) &&
@@ -1395,17 +1384,16 @@ uint8_t FilesystemOperationsBase::rename(const FsContext &context, inode_t paren
 	}
 	std::array<int64_t, 2> quota_delta = {{1, 1}};
 	if (se_child->type == FSNodeType::kDirectory) {
-		if (nodeOperations_->fsnodes_isancestor(static_cast<FSNodeDirectory *>(se_child), dwd)) {
+		if (nodeOperations_->isAncestor(static_cast<FSNodeDirectory *>(se_child), dwd)) {
 			return SAUNAFS_ERROR_EINVAL;
 		}
 		const StatsRecord &stats = static_cast<FSNodeDirectory*>(se_child)->stats;
 		quota_delta = {{(int64_t)stats.inodes, (int64_t)stats.size}};
 	} else if (se_child->type == FSNodeType::kFile) {
-		quota_delta[(int)QuotaResource::kSize] = nodeOperations_->fsnodes_get_size(se_child);
+		quota_delta[(int)QuotaResource::kSize] = nodeOperations_->getSize(se_child);
 	}
-	if (nodeOperations_->fsnodes_namecheck(name_dst) < 0) { return SAUNAFS_ERROR_EINVAL; }
-	FSNode *de_child =
-	    nodeOperations_->fsnodes_lookup(static_cast<FSNodeDirectory *>(dwd), name_dst);
+	if (nodeOperations_->nameCheck(name_dst) < 0) { return SAUNAFS_ERROR_EINVAL; }
+	FSNode *de_child = nodeOperations_->lookup(static_cast<FSNodeDirectory *>(dwd), name_dst);
 
 	if (de_child == se_child) {
 		return SAUNAFS_STATUS_OK;
@@ -1417,7 +1405,7 @@ uint8_t FilesystemOperationsBase::rename(const FsContext &context, inode_t paren
 			return SAUNAFS_ERROR_ENOTEMPTY;
 		}
 		if (context.canCheckPermissions() &&
-		    !nodeOperations_->fsnodes_sticky_access(dwd, de_child, context.uid())) {
+		    !nodeOperations_->stickyAccess(dwd, de_child, context.uid())) {
 			return SAUNAFS_ERROR_EPERM;
 		}
 		if (de_child->type == FSNodeType::kDirectory) {
@@ -1427,7 +1415,7 @@ uint8_t FilesystemOperationsBase::rename(const FsContext &context, inode_t paren
 		} else if (de_child->type == FSNodeType::kFile) {
 			quota_delta[(int)QuotaResource::kInodes] -= 1;
 			quota_delta[(int)QuotaResource::kSize] -=
-			    nodeOperations_->fsnodes_get_size(static_cast<FSNodeFile *>(de_child));
+			    nodeOperations_->getSize(static_cast<FSNodeFile *>(de_child));
 		} else {
 			quota_delta[(int)QuotaResource::kInodes] -= 1;
 			quota_delta[(int)QuotaResource::kSize] -= 1;
@@ -1442,18 +1430,17 @@ uint8_t FilesystemOperationsBase::rename(const FsContext &context, inode_t paren
 	}
 
 	if (de_child) {
-		nodeOperations_->fsnodes_unlink(context.ts(), static_cast<FSNodeDirectory *>(dwd), name_dst,
-		                                de_child);
+		nodeOperations_->unlink(context.ts(), static_cast<FSNodeDirectory *>(dwd), name_dst,
+		                        de_child);
 	}
-	nodeOperations_->fsnodes_remove_edge(context.ts(), static_cast<FSNodeDirectory *>(swd),
-	                                     name_src, se_child);
-	nodeOperations_->fsnodes_link(context.ts(), static_cast<FSNodeDirectory *>(dwd), se_child,
-	                              name_dst);
-	if (attr) { nodeOperations_->fsnodes_fill_attr(context, se_child, dwd, *attr); }
+	nodeOperations_->removeEdge(context.ts(), static_cast<FSNodeDirectory *>(swd), name_src,
+	                            se_child);
+	nodeOperations_->link(context.ts(), static_cast<FSNodeDirectory *>(dwd), se_child, name_dst);
+	if (attr) { nodeOperations_->fillAttr(context, se_child, dwd, *attr); }
 	if (context.isPersonalityMaster()) {
 		changeLog(context.ts(), "MOVE(%" PRIiNode ",%s,%" PRIiNode ",%s):%" PRIiNode, swd->id,
-		          nodeOperations_->fsnodes_escape_name(name_src).c_str(), dwd->id,
-		          nodeOperations_->fsnodes_escape_name(name_dst).c_str(), se_child->id);
+		          nodeOperations_->escapeName(name_src).c_str(), dwd->id,
+		          nodeOperations_->escapeName(name_dst).c_str(), se_child->id);
 	} else {
 		gMetadata->metadataVersion++;
 	}
@@ -1471,35 +1458,35 @@ uint8_t FilesystemOperationsBase::link(const FsContext &context, inode_t inode_s
 	FSNode *sp;
 	FSNode *dwd;
 	uint8_t status =
-	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
+	    nodeOperations_->verifySession(context, OperationMode::kReadWrite, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kDirectory,
-	                                                         MODE_MASK_W, parent_dst, &dwd);
+	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kDirectory,
+	                                              MODE_MASK_W, parent_dst, &dwd);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	status = nodeOperations_->fsnodes_get_node_for_operation(
-	    context, ExpectedNodeType::kNotDirectory, MODE_MASK_EMPTY, inode_src, &sp);
+	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kNotDirectory,
+	                                              MODE_MASK_EMPTY, inode_src, &sp);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 	if (sp->type == FSNodeType::kTrash || sp->type == FSNodeType::kReserved) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
-	if (nodeOperations_->fsnodes_namecheck(name_dst) < 0) { return SAUNAFS_ERROR_EINVAL; }
-	if (nodeOperations_->fsnodes_nameisused(static_cast<FSNodeDirectory *>(dwd), name_dst)) {
+	if (nodeOperations_->nameCheck(name_dst) < 0) { return SAUNAFS_ERROR_EINVAL; }
+	if (nodeOperations_->isNameUsed(static_cast<FSNodeDirectory *>(dwd), name_dst)) {
 		return SAUNAFS_ERROR_EEXIST;
 	}
-	nodeOperations_->fsnodes_link(context.ts(), static_cast<FSNodeDirectory *>(dwd), sp, name_dst);
+	nodeOperations_->link(context.ts(), static_cast<FSNodeDirectory *>(dwd), sp, name_dst);
 	if (inode) {
 		*inode = inode_src;
 	}
-	if (attr) { nodeOperations_->fsnodes_fill_attr(context, sp, dwd, *attr); }
+	if (attr) { nodeOperations_->fillAttr(context, sp, dwd, *attr); }
 	if (context.isPersonalityMaster()) {
 		changeLog(context.ts(), "LINK(%" PRIiNode ",%" PRIiNode ",%s)", sp->id, dwd->id,
-		          nodeOperations_->fsnodes_escape_name(name_dst).c_str());
+		          nodeOperations_->escapeName(name_dst).c_str());
 	} else {
 		gMetadata->metadataVersion++;
 	}
@@ -1518,25 +1505,25 @@ uint8_t FilesystemOperationsBase::append(const FsContext &context, inode_t inode
 		return SAUNAFS_ERROR_EINVAL;
 	}
 	uint8_t status =
-	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
+	    nodeOperations_->verifySession(context, OperationMode::kReadWrite, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kFile,
-	                                                         MODE_MASK_W, inode, &p);
+	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kFile, MODE_MASK_W,
+	                                              inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kFile,
-	                                                         MODE_MASK_R, inode_src, &sp);
+	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kFile, MODE_MASK_R,
+	                                              inode_src, &sp);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 	if (context.isPersonalityMaster() && fsnodes_quota_exceeded(p, {{QuotaResource::kSize, 1}})) {
 		return SAUNAFS_ERROR_QUOTA;
 	}
-	status = nodeOperations_->fsnodes_appendchunks(context.ts(), static_cast<FSNodeFile *>(p),
-	                                               static_cast<FSNodeFile *>(sp));
+	status = nodeOperations_->appendChunks(context.ts(), static_cast<FSNodeFile *>(p),
+	                                       static_cast<FSNodeFile *>(sp));
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
@@ -1558,8 +1545,8 @@ static int fsnodes_check_lock_permissions(const FsContext &context, inode_t inod
 		modemask = MODE_MASK_R;
 	}
 
-	return gFSOperations->nodeOperations()->fsnodes_get_node_for_operation(
-	    context, ExpectedNodeType::kAny, modemask, inode, &dummy);
+	return gFSOperations->nodeOperations()->getNodeForOperation(context, ExpectedNodeType::kAny,
+	                                                            modemask, inode, &dummy);
 }
 
 int FilesystemOperationsBase::posixLockProbe(const FsContext &context, inode_t inode,
@@ -1850,20 +1837,20 @@ uint8_t FilesystemOperationsBase::readdirSize(const FsContext &context, inode_t 
 	*dbuffsize = 0;
 
 	uint8_t status =
-	    nodeOperations_->verify_session(context, OperationMode::kReadOnly, SessionType::kNotMeta);
+	    nodeOperations_->verifySession(context, OperationMode::kReadOnly, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kDirectory,
-	                                                         MODE_MASK_R, inode, &p);
+	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kDirectory,
+	                                              MODE_MASK_R, inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
 	*dnode = p;
-	*dbuffsize = nodeOperations_->fsnodes_getdirsize(static_cast<FSNodeDirectory *>(p),
-	                                                 flags & GETDIR_FLAG_WITHATTR);
+	*dbuffsize = nodeOperations_->getDirSize(static_cast<FSNodeDirectory *>(p),
+	                                         flags & GETDIR_FLAG_WITHATTR);
 	return SAUNAFS_STATUS_OK;
 }
 
@@ -1873,7 +1860,7 @@ void FilesystemOperationsBase::readdirData(const FsContext &context, uint8_t fla
 	ChecksumUpdater cu(ts);
 	FSNode *p = (FSNode *)dnode;
 	fs_update_atime(p, ts);
-	nodeOperations_->fsnodes_getdirdata(
+	nodeOperations_->getDirData(
 	    context.rootinode(), context.uid(), context.gid(), context.auid(), context.agid(),
 	    context.sesflags(), static_cast<FSNodeDirectory *>(p), dbuff, flags & GETDIR_FLAG_WITHATTR);
 	incrementFSStat(FsStats::Readdir);
@@ -1884,14 +1871,14 @@ uint8_t FilesystemOperationsBase::readdir(const FsContext &context, inode_t inod
                                           uint64_t first_entry, uint64_t number_of_entries,
                                           std::vector<DirectoryEntry> &dir_entries) {
 	uint8_t status =
-	    nodeOperations_->verify_session(context, OperationMode::kReadOnly, SessionType::kNotMeta);
+	    nodeOperations_->verifySession(context, OperationMode::kReadOnly, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
 	FSNode *dir;
-	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kDirectory,
-	                                                         MODE_MASK_R, inode, &dir);
+	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kDirectory,
+	                                              MODE_MASK_R, inode, &dir);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
@@ -1901,10 +1888,9 @@ uint8_t FilesystemOperationsBase::readdir(const FsContext &context, inode_t inod
 
 	fs_update_atime(dir, ts);
 
-	nodeOperations_->fsnodes_getdir(context.rootinode(), context.uid(), context.gid(),
-	                                context.auid(), context.agid(), context.sesflags(),
-	                                static_cast<FSNodeDirectory *>(dir), first_entry,
-	                                number_of_entries, dir_entries);
+	nodeOperations_->getDir(context.rootinode(), context.uid(), context.gid(), context.auid(),
+	                        context.agid(), context.sesflags(), static_cast<FSNodeDirectory *>(dir),
+	                        first_entry, number_of_entries, dir_entries);
 
 	incrementFSStat(FsStats::Readdir);
 	metrics::Counter::increment(metrics::Counter::Master::FS_READDIR);
@@ -1917,18 +1903,18 @@ uint8_t FilesystemOperationsBase::checkFile(const FsContext &context, inode_t in
 	FSNode *p;
 
 	uint8_t status =
-	    nodeOperations_->verify_session(context, OperationMode::kReadOnly, SessionType::kAny);
+	    nodeOperations_->verifySession(context, OperationMode::kReadOnly, SessionType::kAny);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kFile,
-	                                                         MODE_MASK_EMPTY, inode, &p);
+	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kFile, MODE_MASK_EMPTY,
+	                                              inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	nodeOperations_->fsnodes_checkfile(static_cast<FSNodeFile *>(p), chunkcount);
+	nodeOperations_->checkFile(static_cast<FSNodeFile *>(p), chunkcount);
 	return SAUNAFS_STATUS_OK;
 }
 
@@ -1936,15 +1922,15 @@ uint8_t FilesystemOperationsBase::openCheck(const FsContext &context, inode_t in
                                             Attributes &attr) {
 	FSNode *p;
 
-	uint8_t status = nodeOperations_->verify_session(
+	uint8_t status = nodeOperations_->verifySession(
 	    context, (flags & WANT_WRITE) ? OperationMode::kReadWrite : OperationMode::kReadOnly,
 	    SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kFile,
-	                                                         MODE_MASK_EMPTY, inode, &p);
+	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kFile, MODE_MASK_EMPTY,
+	                                              inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
@@ -1957,10 +1943,10 @@ uint8_t FilesystemOperationsBase::openCheck(const FsContext &context, inode_t in
 		if (flags & WANT_WRITE) {
 			modemask |= MODE_MASK_W;
 		}
-		if (!nodeOperations_->fsnodes_access(context, p, modemask)) { return SAUNAFS_ERROR_EACCES; }
+		if (!nodeOperations_->access(context, p, modemask)) { return SAUNAFS_ERROR_EACCES; }
 	}
-	nodeOperations_->fsnodes_fill_attr(p, NULL, context.uid(), context.gid(), context.auid(),
-	                                   context.agid(), context.sesflags(), attr);
+	nodeOperations_->fillAttr(p, NULL, context.uid(), context.gid(), context.auid(), context.agid(),
+	                          context.sesflags(), attr);
 	incrementFSStat(FsStats::Open);
 	metrics::Counter::increment(metrics::Counter::Master::FS_OPEN);
 	return SAUNAFS_STATUS_OK;
@@ -1975,7 +1961,7 @@ uint8_t FilesystemOperationsBase::acquire(const FsContext &context, inode_t inod
 		matoclserv_add_open_file(sessionid, inode);
 	}
 #endif /* #ifndef METARESTORE */
-	FSNodeFile *p = nodeOperations_->fsnodes_id_to_node<FSNodeFile>(inode);
+	FSNodeFile *p = nodeOperations_->idToNode<FSNodeFile>(inode);
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
@@ -1999,7 +1985,7 @@ uint8_t FilesystemOperationsBase::acquire(const FsContext &context, inode_t inod
 uint8_t FilesystemOperationsBase::release(const FsContext &context, inode_t inode,
                                           uint32_t sessionid) {
 	ChecksumUpdater cu(context.ts());
-	FSNodeFile *p = nodeOperations_->fsnodes_id_to_node<FSNodeFile>(inode);
+	FSNodeFile *p = nodeOperations_->idToNode<FSNodeFile>(inode);
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
@@ -2011,7 +1997,7 @@ uint8_t FilesystemOperationsBase::release(const FsContext &context, inode_t inod
 	if (it != p->sessionIds.end()) {
 		p->sessionIds.erase(it);
 		if (p->type == FSNodeType::kReserved && p->sessionIds.empty()) {
-			nodeOperations_->fsnodes_purge(context.ts(), p);
+			nodeOperations_->purge(context.ts(), p);
 		} else {
 			fsnodes_update_checksum(p);
 		}
@@ -2078,7 +2064,7 @@ uint8_t FilesystemOperationsBase::readChunk(inode_t inode, uint32_t indx, uint64
 
 	*chunkid = 0;
 	*length = 0;
-	p = nodeOperations_->fsnodes_id_to_node<FSNodeFile>(inode);
+	p = nodeOperations_->idToNode<FSNodeFile>(inode);
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
@@ -2116,12 +2102,12 @@ uint8_t FilesystemOperationsBase::writeChunk(const FsContext &context, inode_t i
 	FSNodeFile *p;
 
 	uint8_t status =
-	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
+	    nodeOperations_->verifySession(context, OperationMode::kReadWrite, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kFile,
-	                                                         MODE_MASK_EMPTY, inode, &node);
+	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kFile, MODE_MASK_EMPTY,
+	                                              inode, &node);
 	p = static_cast<FSNodeFile*>(node);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
@@ -2137,7 +2123,7 @@ uint8_t FilesystemOperationsBase::writeChunk(const FsContext &context, inode_t i
 
 	const bool quota_exceeded = fsnodes_quota_exceeded(p, {{QuotaResource::kSize, 1}});
 	StatsRecord psr;
-	nodeOperations_->fsnodes_get_stats(p, &psr);
+	nodeOperations_->getStats(p, &psr);
 
 	/* resize chunks structure */
 	if (index >= p->chunks.size()) {
@@ -2183,10 +2169,10 @@ uint8_t FilesystemOperationsBase::writeChunk(const FsContext &context, inode_t i
 	p->chunks[index] = nchunkid;
 	*chunkid = nchunkid;
 	StatsRecord nsr;
-	nodeOperations_->fsnodes_get_stats(p, &nsr);
+	nodeOperations_->getStats(p, &nsr);
 	for (const auto &[parentId, _] : p->parents) {
-		auto *parent = nodeOperations_->fsnodes_id_to_node_verify<FSNodeDirectory>(parentId);
-		nodeOperations_->fsnodes_add_sub_stats(parent, &nsr, &psr);
+		auto *parent = nodeOperations_->idToNodeVerify<FSNodeDirectory>(parentId);
+		nodeOperations_->addSubStats(parent, &nsr, &psr);
 	}
 	fsnodes_quota_update(p, {{QuotaResource::kSize, nsr.size - psr.size}});
 	if (length) {
@@ -2199,7 +2185,7 @@ uint8_t FilesystemOperationsBase::writeChunk(const FsContext &context, inode_t i
 		gMetadata->metadataVersion++;
 	}
 	p->mtime = context.ts();
-	nodeOperations_->fsnodes_update_ctime(p, context.ts());
+	nodeOperations_->updateCTime(p, context.ts());
 	fsnodes_update_checksum(p);
 #ifndef METARESTORE
 	incrementFSStat(FsStats::Write);
@@ -2218,7 +2204,7 @@ uint8_t FilesystemOperationsBase::writeEnd(inode_t inode, uint64_t length, uint6
 		return status;
 	}
 	if (length > 0) {
-		FSNodeFile *p = nodeOperations_->fsnodes_id_to_node<FSNodeFile>(inode);
+		FSNodeFile *p = nodeOperations_->idToNode<FSNodeFile>(inode);
 		if (!p) {
 			return SAUNAFS_ERROR_ENOENT;
 		}
@@ -2232,9 +2218,9 @@ uint8_t FilesystemOperationsBase::writeEnd(inode_t inode, uint64_t length, uint6
 			// reason is that those might be done by other clients and we don't
 			// want to erase the chunks other clients are writing.
 			bool eraseFurtherChunks = false;
-			nodeOperations_->fsnodes_setlength(p, length, eraseFurtherChunks);
+			nodeOperations_->setLength(p, length, eraseFurtherChunks);
 			p->mtime = ts;
-			nodeOperations_->fsnodes_update_ctime(p, ts);
+			nodeOperations_->updateCTime(p, ts);
 			fsnodes_update_checksum(p);
 			changeLog(ts, "LENGTH(%" PRIiNode ",%" PRIu64 ",%" PRIu32 ")", inode, length,
 			          static_cast<uint32_t>(eraseFurtherChunks));
@@ -2267,15 +2253,15 @@ uint8_t FilesystemOperationsBase::removeChunkFromFile(const FsContext &context, 
 	if (chunkId == 0) { return SAUNAFS_ERROR_NOCHUNK; }
 
 	uint8_t status =
-	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kAny);
+	    nodeOperations_->verifySession(context, OperationMode::kReadWrite, SessionType::kAny);
 	if (status != SAUNAFS_STATUS_OK) { return status; }
 
-	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kFile,
-	                                                         MODE_MASK_W, inode, &p);
+	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kFile, MODE_MASK_W,
+	                                              inode, &p);
 	if (status != SAUNAFS_STATUS_OK) { return status; }
 
 	auto *node_file = dynamic_cast<FSNodeFile *>(p);
-	nodeOperations_->fsnodes_get_stats(p, &psr);
+	nodeOperations_->getStats(p, &psr);
 	auto it = std::ranges::find(node_file->chunks, chunkId);
 	uint32_t indx = (it == node_file->chunks.end()) ? node_file->chunks.size()
 	                                                : std::distance(node_file->chunks.begin(), it);
@@ -2288,16 +2274,16 @@ uint8_t FilesystemOperationsBase::removeChunkFromFile(const FsContext &context, 
 
 	node_file->chunks[indx] = 0;
 	p->mtime = ts;
-	nodeOperations_->fsnodes_update_ctime(p, ts);
+	nodeOperations_->updateCTime(p, ts);
 
 	// Log the repair operation with new version 0 (indicating deletion)
 	uint32_t nversion = 0;
 	changeLog(ts, "REPAIR(%" PRIiNode ",%" PRIu32 "):%" PRIu32, inode, indx, nversion);
 
-	nodeOperations_->fsnodes_get_stats(p, &nsr);
+	nodeOperations_->getStats(p, &nsr);
 	for (const auto &[parentId, _] : p->parents) {
-		auto *parent = nodeOperations_->fsnodes_id_to_node_verify<FSNodeDirectory>(parentId);
-		nodeOperations_->fsnodes_add_sub_stats(parent, &nsr, &psr);
+		auto *parent = nodeOperations_->idToNodeVerify<FSNodeDirectory>(parentId);
+		nodeOperations_->addSubStats(parent, &nsr, &psr);
 	}
 	fsnodes_quota_update(p, {{QuotaResource::kSize, nsr.size - psr.size}});
 	fsnodes_update_checksum(p);
@@ -2320,24 +2306,24 @@ uint8_t FilesystemOperationsBase::repair(const FsContext &context, inode_t inode
 	*repaired = 0;
 
 	uint8_t status =
-	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kAny);
+	    nodeOperations_->verifySession(context, OperationMode::kReadWrite, SessionType::kAny);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kFile,
-	                                                         MODE_MASK_W, inode, &p);
+	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kFile, MODE_MASK_W,
+	                                              inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
 	FSNodeFile *node_file = static_cast<FSNodeFile*>(p);
-	nodeOperations_->fsnodes_get_stats(p, &psr);
+	nodeOperations_->getStats(p, &psr);
 	for (indx = 0; indx < node_file->chunks.size(); indx++) {
 		if (chunk_repair(p->goal, node_file->chunks[indx], &nversion, correct_only)) {
 			changeLog(ts, "REPAIR(%" PRIiNode ",%" PRIu32 "):%" PRIu32, inode, indx, nversion);
 			p->mtime = ts;
-			nodeOperations_->fsnodes_update_ctime(p, ts);
+			nodeOperations_->updateCTime(p, ts);
 			if (nversion > 0) {
 				(*repaired)++;
 			} else {
@@ -2348,11 +2334,10 @@ uint8_t FilesystemOperationsBase::repair(const FsContext &context, inode_t inode
 			(*notchanged)++;
 		}
 	}
-	nodeOperations_->fsnodes_get_stats(p, &nsr);
+	nodeOperations_->getStats(p, &nsr);
 	for (const auto &[parentId, _] : p->parents) {
-		FSNodeDirectory *parent =
-		    nodeOperations_->fsnodes_id_to_node_verify<FSNodeDirectory>(parentId);
-		nodeOperations_->fsnodes_add_sub_stats(parent, &nsr, &psr);
+		FSNodeDirectory *parent = nodeOperations_->idToNodeVerify<FSNodeDirectory>(parentId);
+		nodeOperations_->addSubStats(parent, &nsr, &psr);
 	}
 	fsnodes_quota_update(p, {{QuotaResource::kSize, nsr.size - psr.size}});
 	fsnodes_update_checksum(p);
@@ -2366,7 +2351,7 @@ uint8_t FilesystemOperationsBase::applyRepair(uint32_t timestamp, inode_t inode,
 	uint8_t status;
 	StatsRecord psr, nsr;
 
-	p = nodeOperations_->fsnodes_id_to_node<FSNodeFile>(inode);
+	p = nodeOperations_->idToNode<FSNodeFile>(inode);
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
@@ -2385,22 +2370,22 @@ uint8_t FilesystemOperationsBase::applyRepair(uint32_t timestamp, inode_t inode,
 		safs::log_err("fs_apply_repair: node chunks at index {} has no chunks, inode {}", indx, inode);
 		return SAUNAFS_ERROR_NOCHUNK;
 	}
-	nodeOperations_->fsnodes_get_stats(p, &psr);
+	nodeOperations_->getStats(p, &psr);
 	if (nversion == 0) {
 		status = chunk_delete_file(p->chunks[indx], p->goal);
 		p->chunks[indx] = 0;
 	} else {
 		status = chunk_set_version(p->chunks[indx], nversion);
 	}
-	nodeOperations_->fsnodes_get_stats(p, &nsr);
+	nodeOperations_->getStats(p, &nsr);
 	for (const auto &[parentId, _] : p->parents) {
-		auto *parent = nodeOperations_->fsnodes_id_to_node_verify<FSNodeDirectory>(parentId);
-		nodeOperations_->fsnodes_add_sub_stats(parent, &nsr, &psr);
+		auto *parent = nodeOperations_->idToNodeVerify<FSNodeDirectory>(parentId);
+		nodeOperations_->addSubStats(parent, &nsr, &psr);
 	}
 	fsnodes_quota_update(p, {{QuotaResource::kSize, nsr.size - psr.size}});
 	gMetadata->metadataVersion++;
 	p->mtime = timestamp;
-	nodeOperations_->fsnodes_update_ctime(p, timestamp);
+	nodeOperations_->updateCTime(p, timestamp);
 	fsnodes_update_checksum(p);
 	return status;
 }
@@ -2415,18 +2400,18 @@ uint8_t FilesystemOperationsBase::getGoal(const FsContext &context, inode_t inod
 	}
 
 	uint8_t status =
-	    nodeOperations_->verify_session(context, OperationMode::kReadOnly, SessionType::kAny);
+	    nodeOperations_->verifySession(context, OperationMode::kReadOnly, SessionType::kAny);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	status = nodeOperations_->fsnodes_get_node_for_operation(
-	    context, ExpectedNodeType::kFileOrDirectory, 0, inode, &p);
+	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kFileOrDirectory, 0,
+	                                              inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	nodeOperations_->fsnodes_getgoal_recursive(p, gmode, fgtab, dgtab);
+	nodeOperations_->getGoalRecursive(p, gmode, fgtab, dgtab);
 	return SAUNAFS_STATUS_OK;
 }
 
@@ -2440,18 +2425,18 @@ uint8_t FilesystemOperationsBase::getTrashTimePrepare(const FsContext &context, 
 	}
 
 	uint8_t status =
-	    nodeOperations_->verify_session(context, OperationMode::kReadOnly, SessionType::kAny);
+	    nodeOperations_->verifySession(context, OperationMode::kReadOnly, SessionType::kAny);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	status = nodeOperations_->fsnodes_get_node_for_operation(
-	    context, ExpectedNodeType::kFileOrDirectory, 0, inode, &p);
+	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kFileOrDirectory, 0,
+	                                              inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	nodeOperations_->fsnodes_gettrashtime_recursive(p, gmode, fileTrashtimes, dirTrashtimes);
+	nodeOperations_->getTrashTimeRecursive(p, gmode, fileTrashtimes, dirTrashtimes);
 
 	return SAUNAFS_STATUS_OK;
 }
@@ -2479,18 +2464,17 @@ uint8_t FilesystemOperationsBase::getEAttr(const FsContext &context, inode_t ino
 	}
 
 	uint8_t status =
-	    nodeOperations_->verify_session(context, OperationMode::kReadOnly, SessionType::kAny);
+	    nodeOperations_->verifySession(context, OperationMode::kReadOnly, SessionType::kAny);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny, 0,
-	                                                         inode, &p);
+	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kAny, 0, inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	nodeOperations_->fsnodes_geteattr_recursive(p, gmode, feattrtab, deattrtab);
+	nodeOperations_->getEAttrRecursive(p, gmode, feattrtab, deattrtab);
 	return SAUNAFS_STATUS_OK;
 }
 
@@ -2506,13 +2490,13 @@ uint8_t FilesystemOperationsBase::setGoal(const FsContext &context, inode_t inod
 		return SAUNAFS_ERROR_EINVAL;
 	}
 	uint8_t status =
-	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kAny);
+	    nodeOperations_->verifySession(context, OperationMode::kReadWrite, SessionType::kAny);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 	FSNode *p;
-	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny,
-	                                                         MODE_MASK_EMPTY, inode, &p);
+	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kAny, MODE_MASK_EMPTY,
+	                                              inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
@@ -2528,8 +2512,8 @@ uint8_t FilesystemOperationsBase::setGoal(const FsContext &context, inode_t inod
 	auto task = new SetGoalTask({p->id}, context.uid(), goal,
 							  smode, setgoal_stats);
 	std::string node_name;
-	FSNodeDirectory *parent = nodeOperations_->fsnodes_get_first_parent(p);
-	nodeOperations_->fsnodes_getpath(parent, p, node_name);
+	FSNodeDirectory *parent = nodeOperations_->getFirstParent(p);
+	nodeOperations_->getPath(parent, p, node_name);
 
 	std::string goal_name;
 #ifndef METARESTORE
@@ -2553,13 +2537,13 @@ uint8_t FilesystemOperationsBase::applySetGoal(const FsContext &context, inode_t
 		return SAUNAFS_ERROR_EINVAL;
 	}
 	uint8_t status =
-	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kAny);
+	    nodeOperations_->verifySession(context, OperationMode::kReadWrite, SessionType::kAny);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 	FSNode *p;
-	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny,
-	                                                         MODE_MASK_EMPTY, inode, &p);
+	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kAny, MODE_MASK_EMPTY,
+	                                              inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
@@ -2589,13 +2573,13 @@ uint8_t FilesystemOperationsBase::setTrashTime(
 		return SAUNAFS_ERROR_EINVAL;
 	}
 	uint8_t status =
-	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kAny);
+	    nodeOperations_->verifySession(context, OperationMode::kReadWrite, SessionType::kAny);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 	FSNode *p;
-	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny,
-	                                                         MODE_MASK_EMPTY, inode, &p);
+	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kAny, MODE_MASK_EMPTY,
+	                                              inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
@@ -2611,8 +2595,8 @@ uint8_t FilesystemOperationsBase::setTrashTime(
 	auto task = new SetTrashtimeTask({p->id}, context.uid(), trashtime,
 							  smode, settrashtime_stats);
 	std::string node_name;
-	FSNodeDirectory *parent = nodeOperations_->fsnodes_get_first_parent(p);
-	nodeOperations_->fsnodes_getpath(parent, p, node_name);
+	FSNodeDirectory *parent = nodeOperations_->getFirstParent(p);
+	nodeOperations_->getPath(parent, p, node_name);
 	return gMetadata->taskManager.submitTask(context.ts(), kInitialTaskBatchSize,
 	                                          task, SetTrashtimeTask::generateDescription(node_name, trashtime),
 	                                          callback);
@@ -2627,13 +2611,13 @@ uint8_t FilesystemOperationsBase::applySetTrashTime(const FsContext &context, in
 		return SAUNAFS_ERROR_EINVAL;
 	}
 	uint8_t status =
-	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kAny);
+	    nodeOperations_->verifySession(context, OperationMode::kReadWrite, SessionType::kAny);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 	FSNode *p;
-	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny,
-	                                                         MODE_MASK_EMPTY, inode, &p);
+	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kAny, MODE_MASK_EMPTY,
+	                                              inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
@@ -2663,13 +2647,13 @@ uint8_t FilesystemOperationsBase::setEAttr(const FsContext &context, inode_t ino
 		return SAUNAFS_ERROR_EINVAL;
 	}
 	uint8_t status =
-	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
+	    nodeOperations_->verifySession(context, OperationMode::kReadWrite, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 	FSNode *p;
-	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny,
-	                                                         MODE_MASK_EMPTY, inode, &p);
+	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kAny, MODE_MASK_EMPTY,
+	                                              inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
@@ -2678,8 +2662,8 @@ uint8_t FilesystemOperationsBase::setEAttr(const FsContext &context, inode_t ino
 	inode_t nci = 0;
 	inode_t nsi = 0;
 	sassert(context.hasUidGidData());
-	nodeOperations_->fsnodes_seteattr_recursive(p, context.ts(), context.uid(), eattr, smode, &si,
-	                                            &nci, &nsi);
+	nodeOperations_->setEAttrRecursive(p, context.ts(), context.uid(), eattr, smode, &si, &nci,
+	                                   &nsi);
 	if (context.isPersonalityMaster()) {
 		if ((smode & SMODE_RMASK) == 0 && nsi > 0 && si == 0 && nci == 0) {
 			return SAUNAFS_ERROR_EPERM;
@@ -2707,12 +2691,12 @@ uint8_t FilesystemOperationsBase::listXAttrLeng(const FsContext &context, inode_
 	FSNode *p;
 
 	uint8_t status =
-	    nodeOperations_->verify_session(context, OperationMode::kReadOnly, SessionType::kNotMeta);
+	    nodeOperations_->verifySession(context, OperationMode::kReadOnly, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	status = nodeOperations_->fsnodes_get_node_for_operation(
+	status = nodeOperations_->getNodeForOperation(
 	    context, ExpectedNodeType::kAny, opened == 0 ? MODE_MASK_R : MODE_MASK_EMPTY, inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
@@ -2736,12 +2720,12 @@ uint8_t FilesystemOperationsBase::setXAttr(const FsContext &context, inode_t ino
 	uint8_t status;
 
 	status =
-	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
+	    nodeOperations_->verifySession(context, OperationMode::kReadWrite, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	status = nodeOperations_->fsnodes_get_node_for_operation(
+	status = nodeOperations_->getNodeForOperation(
 	    context, ExpectedNodeType::kAny, opened == 0 ? MODE_MASK_W : MODE_MASK_EMPTY, inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
@@ -2757,13 +2741,12 @@ uint8_t FilesystemOperationsBase::setXAttr(const FsContext &context, inode_t ino
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	nodeOperations_->fsnodes_update_ctime(p, ts);
+	nodeOperations_->updateCTime(p, ts);
 	fsnodes_update_checksum(p);
-	changeLog(
-	    ts, "SETXATTR(%" PRIiNode ",%s,%s,%" PRIu8 ")", p->id,
-	    nodeOperations_->fsnodes_escape_name(std::string((const char *)attrname, anleng)).c_str(),
-	    nodeOperations_->fsnodes_escape_name(std::string((const char *)attrvalue, avleng)).c_str(),
-	    mode);
+	changeLog(ts, "SETXATTR(%" PRIiNode ",%s,%s,%" PRIu8 ")", p->id,
+	          nodeOperations_->escapeName(std::string((const char *)attrname, anleng)).c_str(),
+	          nodeOperations_->escapeName(std::string((const char *)attrvalue, avleng)).c_str(),
+	          mode);
 	return SAUNAFS_STATUS_OK;
 }
 
@@ -2773,12 +2756,12 @@ uint8_t FilesystemOperationsBase::getXAttr(const FsContext &context, inode_t ino
 	FSNode *p;
 
 	uint8_t status =
-	    nodeOperations_->verify_session(context, OperationMode::kReadOnly, SessionType::kNotMeta);
+	    nodeOperations_->verifySession(context, OperationMode::kReadOnly, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	status = nodeOperations_->fsnodes_get_node_for_operation(
+	status = nodeOperations_->getNodeForOperation(
 	    context, ExpectedNodeType::kAny, opened == 0 ? MODE_MASK_R : MODE_MASK_EMPTY, inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
@@ -2801,7 +2784,7 @@ uint8_t FilesystemOperationsBase::applySetXAttr(uint32_t timestamp, inode_t inod
 	    mode > XATTR_SMODE_REMOVE) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
-	p = nodeOperations_->fsnodes_id_to_node(inode);
+	p = nodeOperations_->idToNode(inode);
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
@@ -2810,7 +2793,7 @@ uint8_t FilesystemOperationsBase::applySetXAttr(uint32_t timestamp, inode_t inod
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	nodeOperations_->fsnodes_update_ctime(p, timestamp);
+	nodeOperations_->updateCTime(p, timestamp);
 	gMetadata->metadataVersion++;
 	fsnodes_update_checksum(p);
 	return status;
@@ -2820,16 +2803,16 @@ uint8_t FilesystemOperationsBase::deleteAcl(const FsContext &context, inode_t in
 	ChecksumUpdater cu(context.ts());
 	FSNode *p;
 	uint8_t status =
-	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
+	    nodeOperations_->verifySession(context, OperationMode::kReadWrite, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny,
-	                                                         MODE_MASK_EMPTY, inode, &p);
+	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kAny, MODE_MASK_EMPTY,
+	                                              inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	status = nodeOperations_->fsnodes_deleteacl(p, type, context.ts());
+	status = nodeOperations_->deleteAcl(p, type, context.ts());
 	if (context.isPersonalityMaster()) {
 		if (status == SAUNAFS_STATUS_OK) {
 			static char acl_type[3] = {'a', 'd', 'r'};
@@ -2854,17 +2837,17 @@ uint8_t FilesystemOperationsBase::setAcl(const FsContext &context, inode_t inode
 	ChecksumUpdater cu(context.ts());
 	FSNode *p;
 	uint8_t status =
-	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
+	    nodeOperations_->verifySession(context, OperationMode::kReadWrite, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny,
-	                                                         MODE_MASK_EMPTY, inode, &p);
+	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kAny, MODE_MASK_EMPTY,
+	                                              inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 	std::string acl_string = acl.toString();
-	status = nodeOperations_->fsnodes_setacl(p, acl, context.ts());
+	status = nodeOperations_->setAcl(p, acl, context.ts());
 	if (context.isPersonalityMaster()) {
 		if (status == SAUNAFS_STATUS_OK) {
 			changeLog(context.ts(), "SETRICHACL(%" PRIiNode ",%s)", p->id, acl_string.c_str());
@@ -2880,17 +2863,17 @@ uint8_t FilesystemOperationsBase::setAcl(const FsContext &context, inode_t inode
 	ChecksumUpdater cu(context.ts());
 	FSNode *p;
 	uint8_t status =
-	    nodeOperations_->verify_session(context, OperationMode::kReadWrite, SessionType::kNotMeta);
+	    nodeOperations_->verifySession(context, OperationMode::kReadWrite, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny,
-	                                                         MODE_MASK_EMPTY, inode, &p);
+	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kAny, MODE_MASK_EMPTY,
+	                                              inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 	std::string acl_string = acl.toString();
-	status = nodeOperations_->fsnodes_setacl(p, type, acl, context.ts());
+	status = nodeOperations_->setAcl(p, type, acl, context.ts());
 	if (context.isPersonalityMaster()) {
 		if (status == SAUNAFS_STATUS_OK) {
 			changeLog(context.ts(), "SETACL(%" PRIiNode ",%c,%s)", p->id,
@@ -2907,16 +2890,16 @@ uint8_t FilesystemOperationsBase::setAcl(const FsContext &context, inode_t inode
 uint8_t FilesystemOperationsBase::getAcl(const FsContext &context, inode_t inode, RichACL &acl) {
 	FSNode *p;
 	uint8_t status =
-	    nodeOperations_->verify_session(context, OperationMode::kReadOnly, SessionType::kAny);
+	    nodeOperations_->verifySession(context, OperationMode::kReadOnly, SessionType::kAny);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kAny,
-	                                                         MODE_MASK_EMPTY, inode, &p);
+	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kAny, MODE_MASK_EMPTY,
+	                                              inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	return nodeOperations_->fsnodes_getacl(p, acl);
+	return nodeOperations_->getAcl(p, acl);
 }
 
 #endif /* #ifndef METARESTORE */
@@ -2929,7 +2912,7 @@ uint8_t FilesystemOperationsBase::applySetAcl(uint32_t timestamp, inode_t inode,
 	} catch (Exception &) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
-	FSNode *p = nodeOperations_->fsnodes_id_to_node(inode);
+	FSNode *p = nodeOperations_->idToNode(inode);
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
@@ -2937,7 +2920,7 @@ uint8_t FilesystemOperationsBase::applySetAcl(uint32_t timestamp, inode_t inode,
 	if (!decodeChar("da", {AclType::kDefault, AclType::kAccess}, aclType, aclTypeEnum)) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
-	uint8_t status = nodeOperations_->fsnodes_setacl(p, aclTypeEnum, std::move(acl), timestamp);
+	uint8_t status = nodeOperations_->setAcl(p, aclTypeEnum, std::move(acl), timestamp);
 	if (status == SAUNAFS_STATUS_OK) {
 		gMetadata->metadataVersion++;
 	}
@@ -2952,11 +2935,11 @@ uint8_t FilesystemOperationsBase::applySetRichAcl(uint32_t timestamp, inode_t in
 	} catch (Exception &) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
-	FSNode *p = nodeOperations_->fsnodes_id_to_node(inode);
+	FSNode *p = nodeOperations_->idToNode(inode);
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
-	uint8_t status = nodeOperations_->fsnodes_setacl(p, std::move(acl), timestamp);
+	uint8_t status = nodeOperations_->setAcl(p, std::move(acl), timestamp);
 	if (status == SAUNAFS_STATUS_OK) {
 		gMetadata->metadataVersion++;
 	}
@@ -2966,17 +2949,16 @@ uint8_t FilesystemOperationsBase::applySetRichAcl(uint32_t timestamp, inode_t in
 #ifndef METARESTORE
 uint32_t FilesystemOperationsBase::getDirPathSize(inode_t inode) {
 	FSNode *node;
-	node = nodeOperations_->fsnodes_id_to_node(inode);
+	node = nodeOperations_->idToNode(inode);
 	if (node) {
 		if (node->type != FSNodeType::kDirectory) {
 			return 15;  // "(not directory)"
 		} else {
 			FSNodeDirectory *parent = nullptr;
 			if (!node->parents.empty()) {
-				parent = nodeOperations_->fsnodes_id_to_node_verify<FSNodeDirectory>(
-				    node->parents[0].first);
+				parent = nodeOperations_->idToNodeVerify<FSNodeDirectory>(node->parents[0].first);
 			}
-			return 1 + nodeOperations_->fsnodes_getpath_size(parent, node);
+			return 1 + nodeOperations_->getPathSize(parent, node);
 		}
 	} else {
 		return 11;  // "(not found)"
@@ -2986,7 +2968,7 @@ uint32_t FilesystemOperationsBase::getDirPathSize(inode_t inode) {
 
 void FilesystemOperationsBase::getDirPathData(inode_t inode, uint8_t *buff, uint32_t size) {
 	FSNode *node;
-	node = nodeOperations_->fsnodes_id_to_node(inode);
+	node = nodeOperations_->idToNode(inode);
 	if (node) {
 		if (node->type != FSNodeType::kDirectory) {
 			if (size >= 15) {
@@ -2997,12 +2979,12 @@ void FilesystemOperationsBase::getDirPathData(inode_t inode, uint8_t *buff, uint
 			if (size > 0) {
 				FSNodeDirectory *parent = nullptr;
 				if (!node->parents.empty()) {
-					parent = nodeOperations_->fsnodes_id_to_node_verify<FSNodeDirectory>(
-					    node->parents[0].first);
+					parent =
+					    nodeOperations_->idToNodeVerify<FSNodeDirectory>(node->parents[0].first);
 				}
 
 				buff[0] = '/';
-				nodeOperations_->fsnodes_getpath_data(parent, node, buff + 1, size - 1);
+				nodeOperations_->getPathData(parent, node, buff + 1, size - 1);
 				return;
 			}
 		}
@@ -3022,18 +3004,18 @@ uint8_t FilesystemOperationsBase::getDirStats(const FsContext &context, inode_t 
 	StatsRecord sr;
 
 	uint8_t status =
-	    nodeOperations_->verify_session(context, OperationMode::kReadOnly, SessionType::kAny);
+	    nodeOperations_->verifySession(context, OperationMode::kReadOnly, SessionType::kAny);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	status = nodeOperations_->fsnodes_get_node_for_operation(
-	    context, ExpectedNodeType::kFileOrDirectory, MODE_MASK_EMPTY, inode, &p);
+	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kFileOrDirectory,
+	                                              MODE_MASK_EMPTY, inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	nodeOperations_->fsnodes_get_stats(p, &sr);
+	nodeOperations_->getStats(p, &sr);
 	*inodes = sr.inodes;
 	*dirs = sr.dirs;
 	*files = sr.files;
@@ -3049,8 +3031,8 @@ uint8_t FilesystemOperationsBase::getDirStats(const FsContext &context, inode_t 
 uint8_t FilesystemOperationsBase::getChunkId(const FsContext &context, inode_t inode,
                                              uint32_t index, uint64_t *chunkid) {
 	FSNode *p;
-	uint8_t status = nodeOperations_->fsnodes_get_node_for_operation(
-	    context, ExpectedNodeType::kFile, MODE_MASK_EMPTY, inode, &p);
+	uint8_t status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kFile,
+	                                                      MODE_MASK_EMPTY, inode, &p);
 	FSNodeFile *node_file = static_cast<FSNodeFile*>(p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
@@ -3130,13 +3112,13 @@ uint8_t FilesystemOperationsBase::getChunksInfo(const FsContext &context, uint32
 	FSNode *p;
 
 	uint8_t status =
-	    nodeOperations_->verify_session(context, OperationMode::kReadOnly, SessionType::kAny);
+	    nodeOperations_->verifySession(context, OperationMode::kReadOnly, SessionType::kAny);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
-	status = nodeOperations_->fsnodes_get_node_for_operation(context, ExpectedNodeType::kFile,
-	                                                         MODE_MASK_R, inode, &p);
+	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kFile, MODE_MASK_R,
+	                                              inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -1899,7 +1899,7 @@ uint8_t FilesystemOperationsBase::readdir(const FsContext &context, inode_t inod
 }
 
 uint8_t FilesystemOperationsBase::checkFile(const FsContext &context, inode_t inode,
-                                            uint32_t chunkcount[CHUNK_MATRIX_SIZE]) {
+                                            ChunkCountArray &chunkCount) {
 	FSNode *p;
 
 	uint8_t status =
@@ -1914,7 +1914,7 @@ uint8_t FilesystemOperationsBase::checkFile(const FsContext &context, inode_t in
 		return status;
 	}
 
-	nodeOperations_->checkFile(static_cast<FSNodeFile *>(p), chunkcount);
+	nodeOperations_->checkFile(static_cast<FSNodeFile *>(p), chunkCount);
 	return SAUNAFS_STATUS_OK;
 }
 

--- a/src/master/filesystem_operations.h
+++ b/src/master/filesystem_operations.h
@@ -150,8 +150,9 @@ public:
 	                GoalStatistics &dgtab) override;
 	uint8_t getXAttr(const FsContext &context, inode_t inode, uint8_t opened, uint8_t anleng,
 	                 const uint8_t *attrname, uint32_t *avleng, uint8_t **attrvalue) override;
-	uint8_t getEAttr(const FsContext &context, inode_t inode, uint8_t gmode, uint32_t feattrtab[16],
-	                 uint32_t deattrtab[16]) override;
+	uint8_t getEAttr(const FsContext &context, inode_t inode, uint8_t gmode,
+	                 ExtendedAttributesArray &fileEAttrTab,
+	                 ExtendedAttributesArray &dirEAttrTab) override;
 	uint8_t listXAttrLeng(const FsContext &context, inode_t inode, uint8_t opened, void **xanode,
 	                      uint32_t *xasize) override;
 	uint8_t setXAttr(const FsContext &context, inode_t inode, uint8_t opened, uint8_t anleng,

--- a/src/master/filesystem_operations.h
+++ b/src/master/filesystem_operations.h
@@ -75,8 +75,8 @@ public:
 	               inode_t parent_dst, const HString &name_dst, inode_t *inode,
 	               Attributes *attr) override;
 	uint8_t release(const FsContext &context, inode_t inode, uint32_t sessionid) override;
-	uint8_t setEAttr(const FsContext &context, inode_t inode, uint8_t eattr, uint8_t smode,
-	                 inode_t *sinodes, inode_t *ncinodes, inode_t *nsinodes) override;
+	uint8_t setExtraAttr(const FsContext &context, inode_t inode, uint8_t eattr, uint8_t smode,
+	                     inode_t *sinodes, inode_t *ncinodes, inode_t *nsinodes) override;
 	uint8_t setGoal(const FsContext &context, inode_t inode, uint8_t goal, uint8_t smode,
 	                std::shared_ptr<SetGoalTask::StatsArray> setgoal_stats,
 	                const std::function<void(int)> &callback) override;
@@ -150,9 +150,9 @@ public:
 	                GoalStatistics &dgtab) override;
 	uint8_t getXAttr(const FsContext &context, inode_t inode, uint8_t opened, uint8_t anleng,
 	                 const uint8_t *attrname, uint32_t *avleng, uint8_t **attrvalue) override;
-	uint8_t getEAttr(const FsContext &context, inode_t inode, uint8_t gmode,
-	                 ExtendedAttributesArray &fileEAttrTab,
-	                 ExtendedAttributesArray &dirEAttrTab) override;
+	uint8_t getExtraAttr(const FsContext &context, inode_t inode, uint8_t gmode,
+	                     ExtraAttributesArray &fileEAttrTab,
+	                     ExtraAttributesArray &dirEAttrTab) override;
 	uint8_t listXAttrLeng(const FsContext &context, inode_t inode, uint8_t opened, void **xanode,
 	                      uint32_t *xasize) override;
 	uint8_t setXAttr(const FsContext &context, inode_t inode, uint8_t opened, uint8_t anleng,

--- a/src/master/filesystem_operations.h
+++ b/src/master/filesystem_operations.h
@@ -143,7 +143,7 @@ public:
 	                uint64_t number_of_entries, std::vector<DirectoryEntry> &dir_entries) override;
 
 	uint8_t checkFile(const FsContext &context, inode_t inode,
-	                  uint32_t chunkcount[CHUNK_MATRIX_SIZE]) override;
+	                  ChunkCountArray &chunkCount) override;
 	uint8_t openCheck(const FsContext &context, inode_t inode, uint8_t flags,
 	                  Attributes &attr) override;
 	uint8_t getGoal(const FsContext &context, inode_t inode, uint8_t gmode, GoalStatistics &fgtab,

--- a/src/master/filesystem_operations_interface.h
+++ b/src/master/filesystem_operations_interface.h
@@ -87,8 +87,9 @@ public:
 	                       inode_t parent_dst, const HString &name_dst, inode_t *inode,
 	                       Attributes *attr) = 0;
 	virtual uint8_t release(const FsContext &context, inode_t inode, uint32_t sessionid) = 0;
-	virtual uint8_t setEAttr(const FsContext &context, inode_t inode, uint8_t eattr, uint8_t smode,
-	                         inode_t *sinodes, inode_t *ncinodes, inode_t *nsinodes) = 0;
+	virtual uint8_t setExtraAttr(const FsContext &context, inode_t inode, uint8_t eattr,
+	                             uint8_t smode, inode_t *sinodes, inode_t *ncinodes,
+	                             inode_t *nsinodes) = 0;
 	virtual uint8_t setGoal(const FsContext &context, inode_t inode, uint8_t goal, uint8_t smode,
 	                        std::shared_ptr<SetGoalTask::StatsArray> setgoal_stats,
 	                        const std::function<void(int)> &callback) = 0;
@@ -170,9 +171,9 @@ public:
 	                          Attributes &attr) = 0;
 	virtual uint8_t getGoal(const FsContext &context, inode_t inode, uint8_t gmode,
 	                        GoalStatistics &fgtab, GoalStatistics &dgtab) = 0;
-	virtual uint8_t getEAttr(const FsContext &context, inode_t inode, uint8_t gmode,
-	                         ExtendedAttributesArray &fileEAttrTab,
-	                         ExtendedAttributesArray &dirEAttrTab) = 0;
+	virtual uint8_t getExtraAttr(const FsContext &context, inode_t inode, uint8_t gmode,
+	                             ExtraAttributesArray &fileEAttrTab,
+	                             ExtraAttributesArray &dirEAttrTab) = 0;
 	virtual uint8_t listXAttrLeng(const FsContext &context, inode_t inode, uint8_t opened,
 	                              void **xanode, uint32_t *xasize) = 0;
 	virtual uint8_t getXAttr(const FsContext &context, inode_t inode, uint8_t opened,

--- a/src/master/filesystem_operations_interface.h
+++ b/src/master/filesystem_operations_interface.h
@@ -165,7 +165,7 @@ public:
 	                        std::vector<DirectoryEntry> &dir_entries) = 0;
 
 	virtual uint8_t checkFile(const FsContext &context, inode_t inode,
-	                          uint32_t chunkcount[CHUNK_MATRIX_SIZE]) = 0;
+	                          ChunkCountArray &chunkCount) = 0;
 	virtual uint8_t openCheck(const FsContext &context, inode_t inode, uint8_t flags,
 	                          Attributes &attr) = 0;
 	virtual uint8_t getGoal(const FsContext &context, inode_t inode, uint8_t gmode,

--- a/src/master/filesystem_operations_interface.h
+++ b/src/master/filesystem_operations_interface.h
@@ -171,7 +171,8 @@ public:
 	virtual uint8_t getGoal(const FsContext &context, inode_t inode, uint8_t gmode,
 	                        GoalStatistics &fgtab, GoalStatistics &dgtab) = 0;
 	virtual uint8_t getEAttr(const FsContext &context, inode_t inode, uint8_t gmode,
-	                         uint32_t feattrtab[16], uint32_t deattrtab[16]) = 0;
+	                         ExtendedAttributesArray &fileEAttrTab,
+	                         ExtendedAttributesArray &dirEAttrTab) = 0;
 	virtual uint8_t listXAttrLeng(const FsContext &context, inode_t inode, uint8_t opened,
 	                              void **xanode, uint32_t *xasize) = 0;
 	virtual uint8_t getXAttr(const FsContext &context, inode_t inode, uint8_t opened,

--- a/src/master/filesystem_periodic.cc
+++ b/src/master/filesystem_periodic.cc
@@ -110,9 +110,8 @@ static std::string get_node_info(FSNode *node) {
 		for (const auto &[parentId, _] : node->parents) {
 			std::string path;
 			auto *parent =
-			    gFSOperations->nodeOperations()->fsnodes_id_to_node_verify<FSNodeDirectory>(
-			        parentId);
-			gFSOperations->nodeOperations()->fsnodes_getpath(parent, node, path);
+			    gFSOperations->nodeOperations()->idToNodeVerify<FSNodeDirectory>(parentId);
+			gFSOperations->nodeOperations()->getPath(parent, node, path);
 			if (!first) {
 				name += "|" + path;
 			} else {
@@ -125,14 +124,14 @@ static std::string get_node_info(FSNode *node) {
 		std::string path;
 		FSNodeDirectory *parent = nullptr;
 		if (!node->parents.empty()) {
-			parent = gFSOperations->nodeOperations()->fsnodes_id_to_node_verify<FSNodeDirectory>(
+			parent = gFSOperations->nodeOperations()->idToNodeVerify<FSNodeDirectory>(
 			    node->parents.front().first);
 		}
-		gFSOperations->nodeOperations()->fsnodes_getpath(parent, node, path);
+		gFSOperations->nodeOperations()->getPath(parent, node, path);
 		name += path;
 	}
 
-	return gFSOperations->nodeOperations()->fsnodes_escape_name(name);
+	return gFSOperations->nodeOperations()->escapeName(name);
 }
 
 std::vector<DefectiveFileInfo> fs_get_defective_nodes_info(uint8_t requested_flags, uint64_t max_entries,
@@ -145,7 +144,7 @@ std::vector<DefectiveFileInfo> fs_get_defective_nodes_info(uint8_t requested_fla
 	watchdog.start();
 	for (uint64_t i = 0; i < max_entries && it != gDefectiveNodes.end(); ++it) {
 		if (((*it).second & requested_flags) != 0) {
-			node = gFSOperations->nodeOperations()->fsnodes_id_to_node<FSNode>((*it).first);
+			node = gFSOperations->nodeOperations()->idToNode<FSNode>((*it).first);
 			std::string info = get_node_info(node);
 			defective_nodes_info.emplace_back(std::move(info), (*it).second);
 			++i;
@@ -170,7 +169,7 @@ void fs_test_getdata(uint32_t &loopstart, uint32_t &loopend, inode_t &files, ino
 			break;
 		}
 
-		FSNode *node = gFSOperations->nodeOperations()->fsnodes_id_to_node<FSNode>(entry.first);
+		FSNode *node = gFSOperations->nodeOperations()->idToNode<FSNode>(entry.first);
 		if (!node) {
 			report << "Structure error in defective list, entry " << std::to_string(entry.first) << "\n";
 			errors++;
@@ -537,7 +536,7 @@ static void fs_do_emptytrash(uint32_t ts) {
 	watchdog.start();
 	while (it != gMetadata->trash.end() && ((*it).first.timestamp < ts)) {
 		FSNodeFile *node =
-		    gFSOperations->nodeOperations()->fsnodes_id_to_node_verify<FSNodeFile>((*it).first.id);
+		    gFSOperations->nodeOperations()->idToNodeVerify<FSNodeFile>((*it).first.id);
 
 		if (!node) {
 			std::string pathName = (*it).second.get();
@@ -550,7 +549,7 @@ static void fs_do_emptytrash(uint32_t ts) {
 		assert(node->type == FSNodeType::kTrash);
 
 		auto node_id = node->id;
-		gFSOperations->nodeOperations()->fsnodes_purge(ts, node);
+		gFSOperations->nodeOperations()->purge(ts, node);
 
 		// Purge operation should be performed anyway - if it fails, inode will be reserved
 		gFSOperations->changeLog(ts, "PURGE(%" PRIiNode ")", node_id);
@@ -574,8 +573,7 @@ static void fs_do_emptyreserved(uint32_t ts) {
 	auto it = gMetadata->reserved.begin();
 	watchdog.start();
 	while (it != gMetadata->reserved.end()) {
-		FSNodeFile *node =
-		    gFSOperations->nodeOperations()->fsnodes_id_to_node_verify<FSNodeFile>((*it).first);
+		FSNodeFile *node = gFSOperations->nodeOperations()->idToNodeVerify<FSNodeFile>((*it).first);
 
 		if (!node) {
 			removeReservedEntry(gMetadata->reserved, gMetadata->reservedHandlesIndex,
@@ -587,7 +585,7 @@ static void fs_do_emptyreserved(uint32_t ts) {
 		assert(node->type == FSNodeType::kReserved);
 
 		auto node_id = node->id;
-		gFSOperations->nodeOperations()->fsnodes_purge(ts, node);
+		gFSOperations->nodeOperations()->purge(ts, node);
 
 		// Purge operation should be performed anyway
 		gFSOperations->changeLog(ts, "PURGE(%" PRIiNode ")", node_id);

--- a/src/master/filesystem_quota.cc
+++ b/src/master/filesystem_quota.cc
@@ -50,19 +50,18 @@ static void fs_remove_invisible_quota_entries(inode_t root_inode, std::vector<Qu
 	}
 
 	FSNodeDirectory *root_node =
-	    gFSOperations->nodeOperations()->fsnodes_id_to_node_verify<FSNodeDirectory>(root_inode);
+	    gFSOperations->nodeOperations()->idToNodeVerify<FSNodeDirectory>(root_inode);
 
 	auto it = std::remove_if(results.begin(), results.end(), [root_node](const QuotaEntry &entry) {
 		if (entry.entryKey.owner.ownerType == QuotaOwnerType::kInode) {
-			FSNode *node =
-			    gFSOperations->nodeOperations()->fsnodes_id_to_node(entry.entryKey.owner.ownerId);
+			FSNode *node = gFSOperations->nodeOperations()->idToNode(entry.entryKey.owner.ownerId);
 			if (!node) {
 				return true;
 			}
 			if (root_node->id == entry.entryKey.owner.ownerId) {
 				return false;
 			}
-			return !gFSOperations->nodeOperations()->fsnodes_isancestor(root_node, node);
+			return !gFSOperations->nodeOperations()->isAncestor(root_node, node);
 		}
 		return false;
 	});
@@ -82,8 +81,8 @@ static void fsnodes_getpath(inode_t root_inode, FSNode *node, std::string &ret) 
 	size = 0;
 	while (p != gMetadata->root && !p->parents.empty() && p->id != root_inode) {
 		// get first parent
-		auto *parent = gFSOperations->nodeOperations()->fsnodes_id_to_node_verify<FSNodeDirectory>(
-		    p->parents[0].first);
+		auto *parent =
+		    gFSOperations->nodeOperations()->idToNodeVerify<FSNodeDirectory>(p->parents[0].first);
 		size += parent->getChildName(p).length() + 1;
 		p = parent;
 	}
@@ -96,8 +95,8 @@ static void fsnodes_getpath(inode_t root_inode, FSNode *node, std::string &ret) 
 
 	p = node;
 	while (p != gMetadata->root && !p->parents.empty()) {
-		auto *parent = gFSOperations->nodeOperations()->fsnodes_id_to_node_verify<FSNodeDirectory>(
-		    p->parents[0].first);
+		auto *parent =
+		    gFSOperations->nodeOperations()->idToNodeVerify<FSNodeDirectory>(p->parents[0].first);
 		std::string name = parent->getChildName(p);
 		if (size >= name.length()) {
 			size -= name.length();
@@ -128,9 +127,8 @@ uint8_t fs_quota_get_all(const FsContext &context, std::vector<QuotaEntry> &resu
 			continue;
 		}
 
-		FSNodeDirectory *node =
-		    gFSOperations->nodeOperations()->fsnodes_id_to_node<FSNodeDirectory>(
-		        entry.entryKey.owner.ownerId);
+		FSNodeDirectory *node = gFSOperations->nodeOperations()->idToNode<FSNodeDirectory>(
+		    entry.entryKey.owner.ownerId);
 		if (!node || node->type != FSNodeType::kDirectory) { continue; }
 
 		switch (entry.entryKey.resource) {
@@ -164,8 +162,7 @@ uint8_t fs_quota_get(const FsContext &context, const std::vector<QuotaOwner> &ow
 				}
 				break;
 			case QuotaOwnerType::kInode:
-				node = gFSOperations->nodeOperations()->fsnodes_id_to_node<FSNodeDirectory>(
-				    owner.ownerId);
+				node = gFSOperations->nodeOperations()->idToNode<FSNodeDirectory>(owner.ownerId);
 				if (!node || node->type != FSNodeType::kDirectory) { return SAUNAFS_ERROR_EINVAL; }
 				if (node->uid != context.uid() ||
 				    (node->gid != context.gid() && !(context.sesflags() & SESFLAG_IGNOREGID))) {
@@ -180,8 +177,8 @@ uint8_t fs_quota_get(const FsContext &context, const std::vector<QuotaOwner> &ow
 		if (result) {
 			for (auto rigor : {QuotaRigor::kSoft, QuotaRigor::kHard, QuotaRigor::kUsed}) {
 				if (owner.ownerType == QuotaOwnerType::kInode && rigor == QuotaRigor::kUsed) {
-					node = gFSOperations->nodeOperations()->fsnodes_id_to_node<FSNodeDirectory>(
-					    owner.ownerId);
+					node =
+					    gFSOperations->nodeOperations()->idToNode<FSNodeDirectory>(owner.ownerId);
 					assert(node);
 					tmp.push_back(
 					    {{owner, rigor, QuotaResource::kInodes}, (uint64_t)node->stats.inodes});
@@ -210,8 +207,7 @@ uint8_t fs_quota_get_info(const FsContext &context, const std::vector<QuotaEntry
 	for (const auto &entry : entries) {
 		info.clear();
 		if (entry.entryKey.owner.ownerType == QuotaOwnerType::kInode) {
-			FSNode *node =
-			    gFSOperations->nodeOperations()->fsnodes_id_to_node(entry.entryKey.owner.ownerId);
+			FSNode *node = gFSOperations->nodeOperations()->idToNode(entry.entryKey.owner.ownerId);
 			if (node) {
 				fsnodes_getpath(context.rootinode(), node, info);
 			}
@@ -238,8 +234,7 @@ uint8_t fs_quota_set(const FsContext &context, const std::vector<QuotaEntry> &en
 		if(entry.entryKey.owner.ownerType != QuotaOwnerType::kInode) {
 			continue;
 		}
-		FSNode *node =
-		    gFSOperations->nodeOperations()->fsnodes_id_to_node(entry.entryKey.owner.ownerId);
+		FSNode *node = gFSOperations->nodeOperations()->idToNode(entry.entryKey.owner.ownerId);
 		if(!node) {
 			return SAUNAFS_ERROR_EINVAL;
 		}
@@ -290,8 +285,7 @@ static int fsnodes_find_depth(FSNodeDirectory *a) {
 	assert(a);
 	int depth = 1;
 	while (!a->parents.empty()) {
-		a = gFSOperations->nodeOperations()->fsnodes_id_to_node_verify<FSNodeDirectory>(
-		    a->parents[0].first);
+		a = gFSOperations->nodeOperations()->idToNodeVerify<FSNodeDirectory>(a->parents[0].first);
 		++depth;
 	}
 
@@ -318,13 +312,13 @@ static FSNode *fsnodes_find_common_ancestor(FSNodeDirectory *a, FSNodeDirectory 
 	if (depth_a > depth_b) {
 		for(;depth_a > depth_b;--depth_a) {
 			assert(a && !a->parents.empty());
-			a = gFSOperations->nodeOperations()->fsnodes_id_to_node_verify<FSNodeDirectory>(
+			a = gFSOperations->nodeOperations()->idToNodeVerify<FSNodeDirectory>(
 			    a->parents[0].first);
 		}
 	} else if (depth_b > depth_a) {
 		for(;depth_b > depth_a;--depth_b) {
 			assert(b && !b->parents.empty());
-			b = gFSOperations->nodeOperations()->fsnodes_id_to_node_verify<FSNodeDirectory>(
+			b = gFSOperations->nodeOperations()->idToNodeVerify<FSNodeDirectory>(
 			    b->parents[0].first);
 		}
 	}
@@ -336,10 +330,8 @@ static FSNode *fsnodes_find_common_ancestor(FSNodeDirectory *a, FSNodeDirectory 
 	while(!a->parents.empty()) {
 		assert(!b->parents.empty());
 
-		a = gFSOperations->nodeOperations()->fsnodes_id_to_node_verify<FSNodeDirectory>(
-		    a->parents[0].first);
-		b = gFSOperations->nodeOperations()->fsnodes_id_to_node_verify<FSNodeDirectory>(
-		    b->parents[0].first);
+		a = gFSOperations->nodeOperations()->idToNodeVerify<FSNodeDirectory>(a->parents[0].first);
+		b = gFSOperations->nodeOperations()->idToNodeVerify<FSNodeDirectory>(b->parents[0].first);
 
 		if (a == b) {
 			return a;
@@ -415,9 +407,8 @@ bool fsnodes_quota_exceeded_dir(FSNode *node,
 	if (node->type == FSNodeType::kDirectory) {
 		// Directory can have only one parent, so we get rid of recursion.
 		while(!node->parents.empty()) {
-			auto *parent =
-			    gFSOperations->nodeOperations()->fsnodes_id_to_node_verify<FSNodeDirectory>(
-			        node->parents[0].first);
+			auto *parent = gFSOperations->nodeOperations()->idToNodeVerify<FSNodeDirectory>(
+			    node->parents[0].first);
 			if (fsnodes_test_dir_quota_noparents(parent, resource_list)) {
 				return true;
 			}
@@ -426,8 +417,7 @@ bool fsnodes_quota_exceeded_dir(FSNode *node,
 	} else {
 		for (const auto &[parentId, _] : node->parents) {
 			auto *parent =
-			    gFSOperations->nodeOperations()->fsnodes_id_to_node_verify<FSNodeDirectory>(
-			        parentId);
+			    gFSOperations->nodeOperations()->idToNodeVerify<FSNodeDirectory>(parentId);
 			if (fsnodes_quota_exceeded_dir(parent, resource_list)) {
 				return true;
 			}
@@ -452,8 +442,8 @@ bool fsnodes_quota_exceeded_dir(FSNodeDirectory *node, FSNodeDirectory* prev_nod
 
 	// node is directory so it has only one parent.
 	while(!node->parents.empty()) {
-		auto *parent = gFSOperations->nodeOperations()->fsnodes_id_to_node<FSNodeDirectory>(
-		    node->parents[0].first);
+		auto *parent =
+		    gFSOperations->nodeOperations()->idToNode<FSNodeDirectory>(node->parents[0].first);
 
 		if (parent == common) {
 			return false;

--- a/src/master/filesystem_snapshot.cc
+++ b/src/master/filesystem_snapshot.cc
@@ -40,25 +40,25 @@ uint8_t fs_snapshot(const FsContext &context, inode_t inode_src, inode_t parent_
 	ChecksumUpdater cu(context.ts());
 	FSNode *src_node = nullptr;
 	FSNode *dst_parent_node = nullptr;
-	uint8_t status = gFSOperations->nodeOperations()->verify_session(
+	uint8_t status = gFSOperations->nodeOperations()->verifySession(
 	    context, OperationMode::kReadWrite, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	status = gFSOperations->nodeOperations()->fsnodes_get_node_for_operation(
+	status = gFSOperations->nodeOperations()->getNodeForOperation(
 	    context, ExpectedNodeType::kDirectory, MODE_MASK_W, parent_dst, &dst_parent_node);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	status = gFSOperations->nodeOperations()->fsnodes_get_node_for_operation(
+	status = gFSOperations->nodeOperations()->getNodeForOperation(
 	    context, ExpectedNodeType::kAny, MODE_MASK_R, inode_src, &src_node);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 	if (src_node->type == FSNodeType::kDirectory) {
 		if (src_node == dst_parent_node ||
-		    gFSOperations->nodeOperations()->fsnodes_isancestor(
-		        static_cast<FSNodeDirectory *>(src_node), dst_parent_node)) {
+		    gFSOperations->nodeOperations()->isAncestor(static_cast<FSNodeDirectory *>(src_node),
+		                                                dst_parent_node)) {
 			return SAUNAFS_ERROR_EINVAL;
 		}
 	}
@@ -69,13 +69,12 @@ uint8_t fs_snapshot(const FsContext &context, inode_t inode_src, inode_t parent_
 	                                   static_cast<FSNodeDirectory *>(dst_parent_node)->id,
 	                                   0, can_overwrite, ignore_missing_src, true, true);
 	std::string src_path;
-	FSNodeDirectory *parent = gFSOperations->nodeOperations()->fsnodes_get_first_parent(src_node);
-	gFSOperations->nodeOperations()->fsnodes_getpath(parent, src_node, src_path);
+	FSNodeDirectory *parent = gFSOperations->nodeOperations()->getFirstParent(src_node);
+	gFSOperations->nodeOperations()->getPath(parent, src_node, src_path);
 
 	std::string dst_path;
-	FSNodeDirectory *grandparent =
-	    gFSOperations->nodeOperations()->fsnodes_get_first_parent(dst_parent_node);
-	gFSOperations->nodeOperations()->fsnodes_getpath(grandparent, dst_parent_node, dst_path);
+	FSNodeDirectory *grandparent = gFSOperations->nodeOperations()->getFirstParent(dst_parent_node);
+	gFSOperations->nodeOperations()->getPath(grandparent, dst_parent_node, dst_path);
 	if (dst_path.size() > 1) {
 		dst_path += "/";
 	}

--- a/src/master/filesystem_store_acl.cc
+++ b/src/master/filesystem_store_acl.cc
@@ -106,7 +106,7 @@ static int fs_load_posix_acl(const std::shared_ptr<MemoryMappedFile> &metadataFi
 		AccessControlList posix_acl;
 		deserialize(ptr, size, inode, posix_acl);
 		offsetBegin += size;
-		FSNode *p = gFSOperations->nodeOperations()->fsnodes_id_to_node(inode);
+		FSNode *p = gFSOperations->nodeOperations()->idToNode(inode);
 		if (!p) {
 			throw Exception("unknown inode: " + std::to_string(inode));
 		}
@@ -176,7 +176,7 @@ static int fs_load_legacy_acl(const std::shared_ptr<MemoryMappedFile> &metadataF
 		std::unique_ptr<legacy::AccessControlList> default_acl;
 		deserialize(ptr, size, inode, extended_acl, default_acl);
 		offsetBegin += size;
-		FSNode *p = gFSOperations->nodeOperations()->fsnodes_id_to_node(inode);
+		FSNode *p = gFSOperations->nodeOperations()->idToNode(inode);
 		if (!p) {
 			throw Exception("unknown inode: " + std::to_string(inode));
 		}
@@ -275,7 +275,7 @@ int fs_load_acl(const std::shared_ptr<MemoryMappedFile> &metadataFile, size_t &o
 		RichACL acl;
 		deserialize(ptr, size, inode, acl);
 		offsetBegin += size;
-		FSNode *p = gFSOperations->nodeOperations()->fsnodes_id_to_node(inode);
+		FSNode *p = gFSOperations->nodeOperations()->idToNode(inode);
 		if (!p) {
 			throw Exception("unknown inode: " + std::to_string(inode));
 		}

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -2783,7 +2783,7 @@ void matoclserv_fuse_repair(matoclserventry *eptr, const uint8_t *data, uint32_t
 
 void matoclserv_fuse_check(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	inode_t inode;
-	uint32_t chunkcount[CHUNK_MATRIX_SIZE];
+	ChunkCountArray chunkCount;
 	uint32_t msgid;
 	uint8_t *ptr;
 	uint8_t status;
@@ -2800,7 +2800,7 @@ void matoclserv_fuse_check(matoclserventry *eptr, const uint8_t *data, uint32_t 
 	get32bit(&data, msgid);
 	getINode(&data, inode);
 
-	status = gFSOperations->checkFile(matoclserv_get_context(eptr), inode, chunkcount);
+	status = gFSOperations->checkFile(matoclserv_get_context(eptr), inode, chunkCount);
 
 	if (status != SAUNAFS_STATUS_OK) {
 		ptr = matoclserv_createpacket(eptr,MATOCL_FUSE_CHECK, sizeof(msgid) + sizeof(status));
@@ -2810,7 +2810,7 @@ void matoclserv_fuse_check(matoclserventry *eptr, const uint8_t *data, uint32_t 
 		ptr = matoclserv_createpacket(eptr, MATOCL_FUSE_CHECK,
 		                              sizeof(msgid) + CHUNK_MATRIX_SIZE * sizeof(uint32_t));
 		put32bit(&ptr, msgid);
-		for (uint32_t i = 0; i < CHUNK_MATRIX_SIZE; i++) { put32bit(&ptr, chunkcount[i]); }
+		for (uint32_t i = 0; i < CHUNK_MATRIX_SIZE; i++) { put32bit(&ptr, chunkCount[i]); }
 	}
 }
 

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -3055,8 +3055,8 @@ void matoclserv_fuse_setgoal(matoclserventry *eptr, PacketHeader header, const u
 void matoclserv_fuse_geteattr(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	inode_t inode;
 	uint32_t msgid;
-	ExtendedAttributesArray fileEAttrTab;
-	ExtendedAttributesArray dirEAttrTab;
+	ExtraAttributesArray fileEAttrTab;
+	ExtraAttributesArray dirEAttrTab;
 	uint8_t i, fn, dn, gmode;
 	uint8_t *ptr;
 	uint8_t status;
@@ -3075,13 +3075,13 @@ void matoclserv_fuse_geteattr(matoclserventry *eptr, const uint8_t *data, uint32
 	getINode(&data, inode);
 	gmode = get8bit(&data);
 
-	status = gFSOperations->getEAttr(matoclserv_get_context(eptr), inode, gmode, fileEAttrTab,
-	                                 dirEAttrTab);
+	status = gFSOperations->getExtraAttr(matoclserv_get_context(eptr), inode, gmode, fileEAttrTab,
+	                                     dirEAttrTab);
 	fn = 0;
 	dn = 0;
 
 	if (status == SAUNAFS_STATUS_OK) {
-		for (i = 0; i < kMaxExtendedAttributes; i++) {
+		for (i = 0; i < kMaxExtraAttributes; i++) {
 			if (fileEAttrTab[i]) { fn++; }
 			if (dirEAttrTab[i]) { dn++; }
 		}
@@ -3101,13 +3101,13 @@ void matoclserv_fuse_geteattr(matoclserventry *eptr, const uint8_t *data, uint32
 	} else {
 		put8bit(&ptr, fn);
 		put8bit(&ptr, dn);
-		for (i = 0; i < kMaxExtendedAttributes; i++) {
+		for (i = 0; i < kMaxExtraAttributes; i++) {
 			if (fileEAttrTab[i]) {
 				put8bit(&ptr, i);
 				put32bit(&ptr, fileEAttrTab[i]);
 			}
 		}
-		for (i = 0; i < kMaxExtendedAttributes; i++) {
+		for (i = 0; i < kMaxExtraAttributes; i++) {
 			if (dirEAttrTab[i]) {
 				put8bit(&ptr, i);
 				put32bit(&ptr, dirEAttrTab[i]);
@@ -3142,8 +3142,8 @@ void matoclserv_fuse_seteattr(matoclserventry *eptr, const uint8_t *data, uint32
 	eattr = get8bit(&data);
 	smode = get8bit(&data);
 
-	status = gFSOperations->setEAttr(matoclserv_get_context(eptr, uid, 0), inode, eattr, smode,
-	                                 &changed, &notchanged, &notpermitted);
+	status = gFSOperations->setExtraAttr(matoclserv_get_context(eptr, uid, 0), inode, eattr, smode,
+	                                     &changed, &notchanged, &notpermitted);
 
 	constexpr uint32_t kFailedSize = sizeof(msgid) + sizeof(status);
 	constexpr uint32_t kSuccessSize =

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -3055,9 +3055,8 @@ void matoclserv_fuse_setgoal(matoclserventry *eptr, PacketHeader header, const u
 void matoclserv_fuse_geteattr(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	inode_t inode;
 	uint32_t msgid;
-	constexpr uint8_t kMaxEattr = 16;
-	uint32_t feattrtab[kMaxEattr];
-	uint32_t deattrtab[kMaxEattr];
+	ExtendedAttributesArray fileEAttrTab;
+	ExtendedAttributesArray dirEAttrTab;
 	uint8_t i, fn, dn, gmode;
 	uint8_t *ptr;
 	uint8_t status;
@@ -3076,15 +3075,15 @@ void matoclserv_fuse_geteattr(matoclserventry *eptr, const uint8_t *data, uint32
 	getINode(&data, inode);
 	gmode = get8bit(&data);
 
-	status =
-	    gFSOperations->getEAttr(matoclserv_get_context(eptr), inode, gmode, feattrtab, deattrtab);
+	status = gFSOperations->getEAttr(matoclserv_get_context(eptr), inode, gmode, fileEAttrTab,
+	                                 dirEAttrTab);
 	fn = 0;
 	dn = 0;
 
 	if (status == SAUNAFS_STATUS_OK) {
-		for (i = 0; i < kMaxEattr; i++) {
-			if (feattrtab[i]) { fn++; }
-			if (deattrtab[i]) { dn++; }
+		for (i = 0; i < kMaxExtendedAttributes; i++) {
+			if (fileEAttrTab[i]) { fn++; }
+			if (dirEAttrTab[i]) { dn++; }
 		}
 	}
 
@@ -3102,16 +3101,16 @@ void matoclserv_fuse_geteattr(matoclserventry *eptr, const uint8_t *data, uint32
 	} else {
 		put8bit(&ptr, fn);
 		put8bit(&ptr, dn);
-		for (i = 0; i < kMaxEattr; i++) {
-			if (feattrtab[i]) {
+		for (i = 0; i < kMaxExtendedAttributes; i++) {
+			if (fileEAttrTab[i]) {
 				put8bit(&ptr, i);
-				put32bit(&ptr, feattrtab[i]);
+				put32bit(&ptr, fileEAttrTab[i]);
 			}
 		}
-		for (i = 0; i < kMaxEattr; i++) {
-			if (deattrtab[i]) {
+		for (i = 0; i < kMaxExtendedAttributes; i++) {
+			if (dirEAttrTab[i]) {
 				put8bit(&ptr, i);
-				put32bit(&ptr, deattrtab[i]);
+				put32bit(&ptr, dirEAttrTab[i]);
 			}
 		}
 	}

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -1665,9 +1665,9 @@ void matoclserv_sau_get_self_quota(matoclserventry *eptr, const uint8_t *data, u
 		status = gFSOperations->quotaGet(context, owners, results);
 
 		if (inode == context.rootinode() && !foundContextRootInodeResult(inode)) {
-			auto ino = gFSOperations->nodeOperations()->fsnodes_id_to_node(inode);
+			auto ino = gFSOperations->nodeOperations()->idToNode(inode);
 			StatsRecord rootInodeStatRec;
-			gFSOperations->nodeOperations()->fsnodes_get_stats(ino, &rootInodeStatRec);
+			gFSOperations->nodeOperations()->getStats(ino, &rootInodeStatRec);
 			results.emplace_back(QuotaEntry{QuotaEntryKey{QuotaOwner{QuotaOwnerType::kInode, inode},
 			                                              QuotaRigor::kUsed, QuotaResource::kSize},
 			                                rootInodeStatRec.size});
@@ -3853,7 +3853,7 @@ void matoclserv_fuse_getacl(matoclserventry *eptr, const uint8_t *data, uint32_t
 
 	if (status == SAUNAFS_STATUS_OK) {
 		if (eptr->version >= kRichACLVersion) {
-			FSNode *node = gFSOperations->nodeOperations()->fsnodes_id_to_node(inode);
+			FSNode *node = gFSOperations->nodeOperations()->idToNode(inode);
 			uint32_t owner_id = node ? node->uid : RichACL::Ace::kInvalidId;
 			matocl::fuseGetAcl::serialize(reply, messageId, owner_id, acl);
 		} else {

--- a/src/master/matontserv.cc
+++ b/src/master/matontserv.cc
@@ -250,8 +250,7 @@ void matontserv_get_path_type_inode(MatontservEntry *eptr, const uint8_t *data, 
 
 	inode_t inode = static_cast<inode_t>(responseInode);
 	std::string pathByInode;
-	FSNode *node =
-	    invalidInode ? nullptr : gFSOperations->nodeOperations()->fsnodes_id_to_node(inode);
+	FSNode *node = invalidInode ? nullptr : gFSOperations->nodeOperations()->idToNode(inode);
 	if (node == nullptr) {
 		safs::log_info("NTTOMA_GET_PATH_TYPE_INODE - inode {} not found", responseInode);
 		// Send back an empty path

--- a/src/master/metadata_backend_file.cc
+++ b/src/master/metadata_backend_file.cc
@@ -412,11 +412,11 @@ static int8_t fs_parseEdge(const std::shared_ptr<MemoryMappedFile> &metadataFile
 
 	std::string name(pSrc, pSrc + edgeNameSize);
 	sectionOffset += edgeNameSize;
-	FSNode *child = gFSOperations->nodeOperations()->fsnodes_id_to_node(childId);
+	FSNode *child = gFSOperations->nodeOperations()->idToNode(childId);
 	if (!child) {
 		safs_pretty_syslog(
 		    LOG_ERR, "loading edge: %" PRIiNode ",%s->%" PRIiNode " error: child not found",
-		    parentId, gFSOperations->nodeOperations()->fsnodes_escape_name(name).c_str(), childId);
+		    parentId, gFSOperations->nodeOperations()->escapeName(name).c_str(), childId);
 		if (ignoreFlag) {
 			return kSuccess;
 		}
@@ -435,14 +435,14 @@ static int8_t fs_parseEdge(const std::shared_ptr<MemoryMappedFile> &metadataFile
 			gMetadata->reservedNodes++;
 		} else {
 			safs::log_err("loading edge: {}, {}->{} error: bad child type ({})", parentId,
-			              gFSOperations->nodeOperations()->fsnodes_escape_name(name), childId,
+			              gFSOperations->nodeOperations()->escapeName(name), childId,
 			              static_cast<char>(child->type));
 			return kError;
 		}
 	} else {
 		FSNodeDirectory *parent;
 		if (currentParentId != parentId){
-			parent = gFSOperations->nodeOperations()->fsnodes_id_to_node<FSNodeDirectory>(parentId);
+			parent = gFSOperations->nodeOperations()->idToNode<FSNodeDirectory>(parentId);
 			currentParentNode = parent;
 		} else {
 			parent = currentParentNode;
@@ -450,25 +450,22 @@ static int8_t fs_parseEdge(const std::shared_ptr<MemoryMappedFile> &metadataFile
 		if (!parent) {
 			safs_pretty_syslog(
 			    LOG_ERR, "loading edge: %" PRIiNode ",%s->%" PRIiNode " error: parent not found",
-			    parentId, gFSOperations->nodeOperations()->fsnodes_escape_name(name).c_str(),
-			    childId);
+			    parentId, gFSOperations->nodeOperations()->escapeName(name).c_str(), childId);
 			if (ignoreFlag) {
-				parent = gFSOperations->nodeOperations()->fsnodes_id_to_node<FSNodeDirectory>(
-				    SPECIAL_INODE_ROOT);
+				parent =
+				    gFSOperations->nodeOperations()->idToNode<FSNodeDirectory>(SPECIAL_INODE_ROOT);
 				if (!parent || parent->type != FSNodeType::kDirectory) {
 					safs_pretty_syslog(
 					    LOG_ERR,
 					    "loading edge: %" PRIiNode ",%s->%" PRIiNode " root dir not found !!!",
-					    parentId,
-					    gFSOperations->nodeOperations()->fsnodes_escape_name(name).c_str(),
+					    parentId, gFSOperations->nodeOperations()->escapeName(name).c_str(),
 					    childId);
 					return kError;
 				}
 				safs_pretty_syslog(
 				    LOG_ERR,
 				    "loading edge: %" PRIiNode ",%s->%" PRIiNode " attaching node to root dir",
-				    parentId, gFSOperations->nodeOperations()->fsnodes_escape_name(name).c_str(),
-				    childId);
+				    parentId, gFSOperations->nodeOperations()->escapeName(name).c_str(), childId);
 				parentId = SPECIAL_INODE_ROOT;
 			} else {
 				safs_pretty_syslog(
@@ -480,25 +477,23 @@ static int8_t fs_parseEdge(const std::shared_ptr<MemoryMappedFile> &metadataFile
 		}
 		if (parent->type != FSNodeType::kDirectory) {
 			safs::log_err("loading edge: {}, {}->{} error: bad parent type ({})", parentId,
-			              gFSOperations->nodeOperations()->fsnodes_escape_name(name), childId,
+			              gFSOperations->nodeOperations()->escapeName(name), childId,
 			              static_cast<char>(parent->type));
 			if (ignoreFlag) {
-				parent = gFSOperations->nodeOperations()->fsnodes_id_to_node<FSNodeDirectory>(
-				    SPECIAL_INODE_ROOT);
+				parent =
+				    gFSOperations->nodeOperations()->idToNode<FSNodeDirectory>(SPECIAL_INODE_ROOT);
 				if (!parent || parent->type != FSNodeType::kDirectory) {
 					safs_pretty_syslog(
 					    LOG_ERR,
 					    "loading edge: %" PRIiNode ",%s->%" PRIiNode " root dir not found !!!",
-					    parentId,
-					    gFSOperations->nodeOperations()->fsnodes_escape_name(name).c_str(),
+					    parentId, gFSOperations->nodeOperations()->escapeName(name).c_str(),
 					    childId);
 					return kError;
 				}
 				safs_pretty_syslog(
 				    LOG_ERR,
 				    "loading edge: %" PRIiNode ",%s->%" PRIiNode " attaching node to root dir",
-				    parentId, gFSOperations->nodeOperations()->fsnodes_escape_name(name).c_str(),
-				    childId);
+				    parentId, gFSOperations->nodeOperations()->escapeName(name).c_str(), childId);
 				parentId = SPECIAL_INODE_ROOT;
 			} else {
 				safs_pretty_syslog(
@@ -514,8 +509,7 @@ static int8_t fs_parseEdge(const std::shared_ptr<MemoryMappedFile> &metadataFile
 				    LOG_ERR,
 				    "loading edge: %" PRIiNode ",%s->%" PRIiNode
 				    " error: parent node sequence error",
-				    parentId, gFSOperations->nodeOperations()->fsnodes_escape_name(name).c_str(),
-				    childId);
+				    parentId, gFSOperations->nodeOperations()->escapeName(name).c_str(), childId);
 				return kError;
 			}
 			currentParentId = parentId;
@@ -550,8 +544,8 @@ static int8_t fs_parseEdge(const std::shared_ptr<MemoryMappedFile> &metadataFile
 		}
 
 		StatsRecord sr;
-		gFSOperations->nodeOperations()->fsnodes_get_stats(child, &sr);
-		gFSOperations->nodeOperations()->fsnodes_add_stats(parent, &sr);
+		gFSOperations->nodeOperations()->getStats(child, &sr);
+		gFSOperations->nodeOperations()->addStats(parent, &sr);
 	}
 	return kSuccess;
 }
@@ -614,8 +608,8 @@ static int8_t fs_parseNode(const std::shared_ptr<MemoryMappedFile> &metadataFile
 			matoclserv_add_open_file(sessionId, node->id);
 		}
 #endif
-		fsnodes_quota_update(node, {{QuotaResource::kSize,
-		                             +gFSOperations->nodeOperations()->fsnodes_get_size(node)}});
+		fsnodes_quota_update(
+		    node, {{QuotaResource::kSize, +gFSOperations->nodeOperations()->getSize(node)}});
 		gMetadata->fileNodes++;
 		break;
 	default:
@@ -647,8 +641,8 @@ static int fs_lostnode(FSNode *p) {
 			             p->id, i);
 		}
 		HString name((const char *)artname, l);
-		if (!gFSOperations->nodeOperations()->fsnodes_nameisused(gMetadata->root, name)) {
-			gFSOperations->nodeOperations()->fsnodes_link(0, gMetadata->root, p, name);
+		if (!gFSOperations->nodeOperations()->isNameUsed(gMetadata->root, name)) {
+			gFSOperations->nodeOperations()->link(0, gMetadata->root, p, name);
 			return 1;
 		}
 		i++;
@@ -877,7 +871,7 @@ static int fs_load(const std::shared_ptr<MemoryMappedFile> &metadataFile, int ig
 	util::ScopedTimer timer("checking filesystem consistency of the metadata file took");
 
 	gMetadata->root =
-	    gFSOperations->nodeOperations()->fsnodes_id_to_node<FSNodeDirectory>(SPECIAL_INODE_ROOT);
+	    gFSOperations->nodeOperations()->idToNode<FSNodeDirectory>(SPECIAL_INODE_ROOT);
 	if (gMetadata->root == nullptr) {
 		safs::log_err("error reading metadata (root node not found)");
 		return kOpFailure;
@@ -1140,14 +1134,14 @@ void MetadataBackendFile::storeedgelist(FSNodeDirectory *parent, FILE *fd) {
 
 void MetadataBackendFile::storeedgelist(const TrashPathContainer &data, FILE *fd) {
 	for (const auto &entry : data) {
-		FSNode *child = gFSOperations->nodeOperations()->fsnodes_id_to_node(entry.first.id);
+		FSNode *child = gFSOperations->nodeOperations()->idToNode(entry.first.id);
 		storeedge(nullptr, child, (std::string)entry.second, fd);
 	}
 }
 
 void MetadataBackendFile::storeedgelist(const ReservedPathContainer &data, FILE *fd) {
 	for (const auto &entry : data) {
-		FSNode *child = gFSOperations->nodeOperations()->fsnodes_id_to_node(entry.first);
+		FSNode *child = gFSOperations->nodeOperations()->idToNode(entry.first);
 		storeedge(nullptr, child, (std::string)entry.second, fd);
 	}
 }

--- a/src/master/recursive_remove_task.cc
+++ b/src/master/recursive_remove_task.cc
@@ -29,29 +29,29 @@ bool RemoveTask::isFinished() const {
 }
 
 int RemoveTask::retrieveNodes(FSNodeDirectory *&wd, FSNode *&child) {
-	FSNode *wd_tmp = gFSOperations->nodeOperations()->fsnodes_id_to_node(parent_);
+	FSNode *wd_tmp = gFSOperations->nodeOperations()->idToNode(parent_);
 	if (!wd_tmp) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
-	if (!gFSOperations->nodeOperations()->fsnodes_access(*context_, wd_tmp, MODE_MASK_W)) {
+	if (!gFSOperations->nodeOperations()->access(*context_, wd_tmp, MODE_MASK_W)) {
 		return SAUNAFS_ERROR_EACCES;
 	}
 	wd = static_cast<FSNodeDirectory*>(wd_tmp);
-	child = gFSOperations->nodeOperations()->fsnodes_lookup(wd, *current_subtask_);
+	child = gFSOperations->nodeOperations()->lookup(wd, *current_subtask_);
 	if (!child) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
-	if (!gFSOperations->nodeOperations()->fsnodes_sticky_access(wd, child, context_->uid())) {
+	if (!gFSOperations->nodeOperations()->stickyAccess(wd, child, context_->uid())) {
 		return SAUNAFS_ERROR_EPERM;
 	}
 	return SAUNAFS_STATUS_OK;
 }
 
 void RemoveTask::doUnlink(uint32_t ts, FSNodeDirectory *wd, FSNode *child) {
-	gFSOperations->changeLog(
-	    ts, "UNLINK(%" PRIiNode ",%s):%" PRIiNode, parent_,
-	    gFSOperations->nodeOperations()->fsnodes_escape_name(*current_subtask_).c_str(), child->id);
-	gFSOperations->nodeOperations()->fsnodes_unlink(ts, wd, *current_subtask_, child);
+	gFSOperations->changeLog(ts, "UNLINK(%" PRIiNode ",%s):%" PRIiNode, parent_,
+	                         gFSOperations->nodeOperations()->escapeName(*current_subtask_).c_str(),
+	                         child->id);
+	gFSOperations->nodeOperations()->unlink(ts, wd, *current_subtask_, child);
 }
 
 int RemoveTask::execute(uint32_t ts, intrusive_list<Task> &work_queue) {

--- a/src/master/restore.cc
+++ b/src/master/restore.cc
@@ -521,8 +521,8 @@ int do_seteattr(const char* filename, uint64_t lv, uint32_t ts, const char* ptr)
 	GETINODE(nci,ptr);
 	EAT(ptr,filename,lv,',');
 	GETINODE(npi,ptr);
-	return gFSOperations->setEAttr(FsContext::getForRestoreWithUidGid(ts, uid, 0), inode, eattr,
-	                               smode, &ci, &nci, &npi);
+	return gFSOperations->setExtraAttr(FsContext::getForRestoreWithUidGid(ts, uid, 0), inode, eattr,
+	                                   smode, &ci, &nci, &npi);
 }
 
 int do_setgoal(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {

--- a/src/master/setgoal_task.cc
+++ b/src/master/setgoal_task.cc
@@ -31,7 +31,7 @@ int SetGoalTask::execute(uint32_t ts, intrusive_list<Task> &work_queue) {
 
 	inode_t inode = *current_inode_;
 	++current_inode_;
-	FSNode *node = gFSOperations->nodeOperations()->fsnodes_id_to_node(inode);
+	FSNode *node = gFSOperations->nodeOperations()->idToNode(inode);
 	if (!node) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
@@ -75,13 +75,13 @@ uint8_t SetGoalTask::setGoal(FSNode *node, uint32_t ts) {
 		} else {
 			if ((smode_ & SMODE_TMASK) == SMODE_SET && node->goal != goal_) {
 				if (node->type != FSNodeType::kDirectory) {
-					gFSOperations->nodeOperations()->fsnodes_changefilegoal(
-					    static_cast<FSNodeFile *>(node), goal_);
+					gFSOperations->nodeOperations()->changeFileGoal(static_cast<FSNodeFile *>(node),
+					                                                goal_);
 				} else {
 					node->goal = goal_;
 					gMetadata->nodeChangedSignal.emit(node);
 				}
-				gFSOperations->nodeOperations()->fsnodes_update_ctime(node, ts);
+				gFSOperations->nodeOperations()->updateCTime(node, ts);
 				fsnodes_update_checksum(node);
 				return SetGoalTask::kChanged;
 			} else {

--- a/src/master/settrashtime_task.cc
+++ b/src/master/settrashtime_task.cc
@@ -31,7 +31,7 @@ int SetTrashtimeTask::execute(uint32_t ts, intrusive_list<Task> &work_queue) {
 
 	inode_t inode = *current_inode_;
 	++current_inode_;
-	FSNode *node = gFSOperations->nodeOperations()->fsnodes_id_to_node(inode);
+	FSNode *node = gFSOperations->nodeOperations()->idToNode(inode);
 	if (!node) {
 		return SAUNAFS_ERROR_EINVAL;
 	}

--- a/src/master/snapshot_task.cc
+++ b/src/master/snapshot_task.cc
@@ -88,7 +88,7 @@ FSNode *SnapshotTask::cloneToExistingNode(uint32_t ts, FSNode *src_node,
 }
 
 FSNode *SnapshotTask::cloneToNewNode(uint32_t ts, FSNode *src_node, FSNodeDirectory *dst_parent) {
-	FSNode *dst_node = gFSOperations->nodeOperations()->fsnodes_create_node(
+	FSNode *dst_node = gFSOperations->nodeOperations()->createNode(
 	    ts, dst_parent, current_subtask_->second, src_node->type, src_node->mode, 0, src_node->uid,
 	    src_node->gid, 0, AclInheritance::kDontInheritAcl, dst_inode_);
 
@@ -131,9 +131,8 @@ FSNodeFile *SnapshotTask::cloneToExistingFileNode(uint32_t ts, FSNodeFile *src_n
 		return dst_node;
 	}
 
-	gFSOperations->nodeOperations()->fsnodes_unlink(ts, dst_parent, current_subtask_->second,
-	                                                dst_node);
-	dst_node = static_cast<FSNodeFile *>(gFSOperations->nodeOperations()->fsnodes_create_node(
+	gFSOperations->nodeOperations()->unlink(ts, dst_parent, current_subtask_->second, dst_node);
+	dst_node = static_cast<FSNodeFile *>(gFSOperations->nodeOperations()->createNode(
 	    ts, dst_parent, current_subtask_->second, FSNodeType::kFile, src_node->mode, 0,
 	    src_node->uid, src_node->gid, 0, AclInheritance::kDontInheritAcl, dst_inode_));
 
@@ -146,7 +145,7 @@ void SnapshotTask::cloneChunkData(const FSNodeFile *src_node, FSNodeFile *dst_no
 		FSNodeDirectory *dst_parent) {
 	StatsRecord psr, nsr;
 
-	gFSOperations->nodeOperations()->fsnodes_get_stats(dst_node, &psr);
+	gFSOperations->nodeOperations()->getStats(dst_node, &psr);
 
 	dst_node->goal = src_node->goal;
 	dst_node->trashtime = src_node->trashtime;
@@ -164,8 +163,8 @@ void SnapshotTask::cloneChunkData(const FSNodeFile *src_node, FSNodeFile *dst_no
 		}
 	}
 
-	gFSOperations->nodeOperations()->fsnodes_get_stats(dst_node, &nsr);
-	gFSOperations->nodeOperations()->fsnodes_add_sub_stats(dst_parent, &nsr, &psr);
+	gFSOperations->nodeOperations()->getStats(dst_node, &nsr);
+	gFSOperations->nodeOperations()->addSubStats(dst_parent, &nsr, &psr);
 	fsnodes_quota_update(dst_node, {{QuotaResource::kSize, nsr.size - psr.size}});
 }
 
@@ -190,13 +189,13 @@ void SnapshotTask::cloneSymlinkData(FSNodeSymlink *src_node, FSNodeSymlink *dst_
 		FSNodeDirectory *dst_parent) {
 	StatsRecord psr, nsr;
 
-	gFSOperations->nodeOperations()->fsnodes_get_stats(dst_node, &psr);
+	gFSOperations->nodeOperations()->getStats(dst_node, &psr);
 
 	dst_node->path = src_node->path;
 	dst_node->path_length = src_node->path_length;
 
-	gFSOperations->nodeOperations()->fsnodes_get_stats(dst_node, &nsr);
-	gFSOperations->nodeOperations()->fsnodes_add_sub_stats(dst_parent, &nsr, &psr);
+	gFSOperations->nodeOperations()->getStats(dst_node, &nsr);
+	gFSOperations->nodeOperations()->addSubStats(dst_parent, &nsr, &psr);
 }
 
 void SnapshotTask::emitChangelog(uint32_t ts, inode_t dst_inode) {
@@ -208,14 +207,14 @@ void SnapshotTask::emitChangelog(uint32_t ts, inode_t dst_inode) {
 	gFSOperations->changeLog(
 	    ts, "CLONE(%" PRIiNode ",%" PRIiNode ",%" PRIiNode ",%s,%" PRIu8 ")",
 	    current_subtask_->first, dst_parent_inode_, dst_inode,
-	    gFSOperations->nodeOperations()->fsnodes_escape_name(current_subtask_->second).c_str(),
+	    gFSOperations->nodeOperations()->escapeName(current_subtask_->second).c_str(),
 	    can_overwrite_);
 }
 
 int SnapshotTask::cloneNode(uint32_t ts) {
-	FSNode *src_node = gFSOperations->nodeOperations()->fsnodes_id_to_node(current_subtask_->first);
+	FSNode *src_node = gFSOperations->nodeOperations()->idToNode(current_subtask_->first);
 	FSNodeDirectory *dst_parent =
-	    gFSOperations->nodeOperations()->fsnodes_id_to_node<FSNodeDirectory>(dst_parent_inode_);
+	    gFSOperations->nodeOperations()->idToNode<FSNodeDirectory>(dst_parent_inode_);
 
 	if (!src_node || src_node->type == FSNodeType::kTrash ||
 	    src_node->type == FSNodeType::kReserved) {
@@ -226,7 +225,7 @@ int SnapshotTask::cloneNode(uint32_t ts) {
 	}
 
 	FSNode *dst_node =
-	    gFSOperations->nodeOperations()->fsnodes_lookup(dst_parent, current_subtask_->second);
+	    gFSOperations->nodeOperations()->lookup(dst_parent, current_subtask_->second);
 
 	int status = cloneNodeTest(src_node, dst_node, dst_parent);
 	if (status != SAUNAFS_STATUS_OK) {


### PR DESCRIPTION
This PR improves the code related to operations on top of nodes.
The commits introduce the following changes:

- rename FS node operations.
- rename FS node operations arguments.
- rename private node operations.
- use std::array in checkFile function.
- use std::array for eattr counters.

Please refer to the individual commits for extended descriptions.

Reviewers: I am pausing the refactor at this point to make the review easier/shorter, but I will continue immediately with it.