### PR TITLE
chore: Add Windows helpers for non-ASCII texts

### DIFF
--- a/src/common/args_stat_encoding.h
+++ b/src/common/args_stat_encoding.h
@@ -20,14 +20,17 @@
 
 #include "common/platform.h"
 
+#include <filesystem>
+#include <fstream>
+#include <string>
 #include <sys/stat.h>
 
 #ifdef _WIN32
 #include <windows.h>
 #include <cstdint>
 #include <shellapi.h>
-#include <string>
 #include <vector>
+#include <memory>
 
 using saunafs_stat_t = struct _stat64;
 
@@ -153,3 +156,29 @@ using saunafs_stat_t = struct stat;
 // On POSIX just call stat
 inline int stat_portable(const char *path, saunafs_stat_t *st) { return stat(path, st); }
 #endif
+
+// Reads the entire file into a std::string (UTF-8)
+inline bool read_file_to_string(const std::string &path, std::string &out) {
+#ifdef _WIN32
+	std::filesystem::path fsPath{utf8_to_wstring(path)};
+#else
+	std::filesystem::path fsPath{path};
+#endif
+	std::ifstream ifs(fsPath, std::ios::binary);
+	if (!ifs) { return false; }
+
+	ifs.seekg(0, std::ios::end);
+	std::streampos size = ifs.tellg();
+	if (size < 0) { return false; }
+	ifs.seekg(0, std::ios::beg);
+
+	out.clear();
+	if (size == 0) { return true; }
+
+	out.resize(static_cast<std::size_t>(size));
+	if (!ifs.read(out.data(), size)) {
+		out.clear();
+		return false;
+	}
+	return true;
+}

--- a/src/common/args_stat_encoding.h
+++ b/src/common/args_stat_encoding.h
@@ -24,6 +24,7 @@
 
 #ifdef _WIN32
 #include <windows.h>
+#include <cstdint>
 #include <shellapi.h>
 #include <string>
 #include <vector>
@@ -42,6 +43,22 @@ inline std::wstring utf8_to_wstring(const std::string &str) {
 	if (!wstr.empty() && wstr.back() == L'\0') { wstr.pop_back(); }
 
 	return wstr;
+}
+
+inline void print_unicode_console(const std::wstring &msg) {
+	HANDLE hConsole = GetStdHandle(STD_OUTPUT_HANDLE);
+	DWORD written;
+	if (hConsole && hConsole != INVALID_HANDLE_VALUE) {
+		WriteConsoleW(hConsole, msg.c_str(), (DWORD)msg.size(), &written, nullptr);
+	}
+}
+
+inline void print_unicode_console_error(const std::wstring &msg) {
+	HANDLE hConsole = GetStdHandle(STD_ERROR_HANDLE);
+	DWORD written;
+	if (hConsole && hConsole != INVALID_HANDLE_VALUE) {
+		WriteConsoleW(hConsole, msg.c_str(), (DWORD)msg.size(), &written, nullptr);
+	}
 }
 
 // This class is a RAII guard to restore console code pages on destruction on

--- a/src/common/args_stat_encoding.h
+++ b/src/common/args_stat_encoding.h
@@ -30,7 +30,6 @@
 #include <cstdint>
 #include <shellapi.h>
 #include <vector>
-#include <memory>
 
 using saunafs_stat_t = struct _stat64;
 
@@ -48,21 +47,38 @@ inline std::wstring utf8_to_wstring(const std::string &str) {
 	return wstr;
 }
 
-inline void print_unicode_console(const std::wstring &msg) {
-	HANDLE hConsole = GetStdHandle(STD_OUTPUT_HANDLE);
-	DWORD written;
-	if (hConsole && hConsole != INVALID_HANDLE_VALUE) {
-		WriteConsoleW(hConsole, msg.c_str(), (DWORD)msg.size(), &written, nullptr);
+// Prints a UTF-16 string to console or file, handling console vs pipe/file redirection.
+inline void winapi_print(const std::wstring &msg, bool is_error = false) {
+	HANDLE h = GetStdHandle(is_error ? STD_ERROR_HANDLE : STD_OUTPUT_HANDLE);
+	if (h == nullptr || h == INVALID_HANDLE_VALUE) return;
+
+	DWORD mode = 0;
+	BOOL isConsole = GetConsoleMode(h, &mode);
+
+	if (isConsole) {
+		// Console → Write UTF-16 directly
+		DWORD written;
+		WriteConsoleW(h, msg.c_str(), (DWORD)msg.size(), &written, nullptr);
+	} else {
+		// Pipe / file / redirection → must convert to UTF-8
+		int utf8len = WideCharToMultiByte(CP_UTF8, 0, msg.c_str(), (int)msg.size(), nullptr, 0,
+		                                  nullptr, nullptr);
+
+		if (utf8len <= 0) { return; }
+
+		std::string utf8(utf8len, '\0');
+
+		WideCharToMultiByte(CP_UTF8, 0, msg.c_str(), (int)msg.size(), utf8.data(), utf8len, nullptr,
+		                    nullptr);
+
+		DWORD written;
+		WriteFile(h, utf8.data(), (DWORD)utf8.size(), &written, nullptr);
 	}
 }
 
-inline void print_unicode_console_error(const std::wstring &msg) {
-	HANDLE hConsole = GetStdHandle(STD_ERROR_HANDLE);
-	DWORD written;
-	if (hConsole && hConsole != INVALID_HANDLE_VALUE) {
-		WriteConsoleW(hConsole, msg.c_str(), (DWORD)msg.size(), &written, nullptr);
-	}
-}
+inline void print_unicode_console(const std::wstring &msg) { winapi_print(msg, false); }
+
+inline void print_unicode_console_error(const std::wstring &msg) { winapi_print(msg, true); }
 
 // This class is a RAII guard to restore console code pages on destruction on
 // Windows.

--- a/src/common/args_stat_encoding.h
+++ b/src/common/args_stat_encoding.h
@@ -23,12 +23,26 @@
 #include <sys/stat.h>
 
 #ifdef _WIN32
-#include <shellapi.h>
 #include <windows.h>
+#include <shellapi.h>
 #include <string>
 #include <vector>
 
 using saunafs_stat_t = struct _stat64;
+
+// Converts a UTF-8 string to a wide string (UTF-16) on Windows.
+inline std::wstring utf8_to_wstring(const std::string &str) {
+	int wlen = MultiByteToWideChar(CP_UTF8, 0, str.c_str(), -1, nullptr, 0);
+
+	if (wlen <= 0) { return L""; }
+
+	std::wstring wstr(wlen, L'\0');
+	MultiByteToWideChar(CP_UTF8, 0, str.c_str(), -1, &wstr[0], wlen);
+
+	if (!wstr.empty() && wstr.back() == L'\0') { wstr.pop_back(); }
+
+	return wstr;
+}
 
 // This class is a RAII guard to restore console code pages on destruction on
 // Windows.

--- a/src/mount/mount_info.cc
+++ b/src/mount/mount_info.cc
@@ -20,6 +20,9 @@
 
 #include "common/platform.h"
 
+#ifdef _WIN32
+#include "common/args_stat_encoding.h"
+#endif
 #include "mount/mount_info.h"
 
 // Constructor
@@ -135,16 +138,18 @@ std::string get_current_user_sid() {
 
 	// Open the access token associated with the current process
 	if (!OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &hToken)) {
-		std::wcerr << L"OpenProcessToken failed: " << GetLastError()
-		           << std::endl;
+		const DWORD lastError = GetLastError();
+		print_unicode_console_error(L"OpenProcessToken failed: " + std::to_wstring(lastError) +
+		                            L"\n");
 		return "";
 	}
 
 	// Get the size of the user information in the token
 	if (!GetTokenInformation(hToken, TokenUser, nullptr, 0, &dwSize) &&
 	    GetLastError() != ERROR_INSUFFICIENT_BUFFER) {
-		std::wcerr << L"GetTokenInformation failed: " << GetLastError()
-		           << std::endl;
+		const DWORD lastError = GetLastError();
+		print_unicode_console_error(L"GetTokenInformation failed: " + std::to_wstring(lastError) +
+		                            L"\n");
 		CloseHandle(hToken);
 		return "";
 	}
@@ -152,15 +157,16 @@ std::string get_current_user_sid() {
 	// Allocate memory for the user information
 	pTokenUser = (PTOKEN_USER)malloc(dwSize);
 	if (!pTokenUser) {
-		std::wcerr << L"Memory allocation failed" << std::endl;
+		print_unicode_console_error(L"Memory allocation failed\n");
 		CloseHandle(hToken);
 		return "";
 	}
 
 	// Retrieve the user information from the token
 	if (!GetTokenInformation(hToken, TokenUser, pTokenUser, dwSize, &dwSize)) {
-		std::wcerr << L"GetTokenInformation failed: " << GetLastError()
-		           << std::endl;
+		const DWORD lastError = GetLastError();
+		print_unicode_console_error(L"GetTokenInformation failed: " +
+		                            std::to_wstring(lastError) + L"\n");
 		free(pTokenUser);
 		CloseHandle(hToken);
 		return "";
@@ -168,8 +174,9 @@ std::string get_current_user_sid() {
 
 	// Convert the SID to a string
 	if (!ConvertSidToStringSid(pTokenUser->User.Sid, &pStringSid)) {
-		std::wcerr << L"ConvertSidToStringSid failed: " << GetLastError()
-		           << std::endl;
+		const DWORD lastError = GetLastError();
+		print_unicode_console_error(L"ConvertSidToStringSid failed: " +
+		                            std::to_wstring(lastError) + L"\n");
 		free(pTokenUser);
 		CloseHandle(hToken);
 		return "";

--- a/src/mount/sauna_client.cc
+++ b/src/mount/sauna_client.cc
@@ -45,6 +45,7 @@
 #include "common/access_control_list.h"
 #include "common/acl_converter.h"
 #include "common/acl_type.h"
+#include "common/args_stat_encoding.h"
 #include "common/crc.h"
 #include "common/datapack.h"
 #include "common/errno_defs.h"
@@ -3636,15 +3637,16 @@ void fs_init(FsInitParams &params) {
 	try {
 		IoLimitsConfigLoader loader;
 		if (!params.io_limits_config_file.empty()) {
-			std::ifstream ifs(params.io_limits_config_file);
-			if (!ifs.is_open()) {
+			std::string fileContent;
+			if (!read_file_to_string(params.io_limits_config_file, fileContent)) {
 				const char *strError = std::strerror(errno);
 				safs::log_warn(
 				    "fs_init: cannot open I/O limits configuration file '{}': {}; using master-provided limits if available, otherwise no client-side limiting.",
 				    params.io_limits_config_file.c_str(), strError);
 			} else {
 				try {
-					loader.load(std::move(ifs));
+					std::istringstream iss(fileContent);
+					loader.load(std::move(iss));
 				} catch (const Exception &ex) {
 					safs::log_warn(
 					    "fs_init: failed to parse I/O limits configuration file '{}': {}; using master-provided limits if available, otherwise no client-side limiting.",

--- a/src/slogger/slogger.cc
+++ b/src/slogger/slogger.cc
@@ -19,6 +19,7 @@
  */
 
 #include "common/platform.h"
+#include "common/args_stat_encoding.h"
 #include "slogger/slogger.h"
 #include "config/cfg.h"
 
@@ -165,7 +166,12 @@ bool safs_add_log_stderr(int priority) {
 
 bool safs::add_log_file(const char *path, log_level::LogLevel level, int max_file_size, int max_file_count) {
 	try {
+#ifndef _WIN32
 		LoggerPtr logger = spdlog::rotating_logger_mt(path, path, max_file_size, max_file_count);
+#else
+		LoggerPtr logger =
+		    spdlog::rotating_logger_mt(path, utf8_to_wstring(path), max_file_size, max_file_count);
+#endif
 		logger->set_level((spdlog::level::level_enum)level);
 		// Format: DATE TIME [LEVEL] [PID:TID] : MESSAGE
 		logger->set_pattern("%D %H:%M:%S.%e [%l] [%P:%t] : %v");

--- a/src/slogger/slogger.h
+++ b/src/slogger/slogger.h
@@ -24,7 +24,9 @@
 
 #include <expected>
 
+#ifdef _WIN32
 #include "common/syslog_defs.h"
+#endif
 #include "errors/saunafs_error_codes.h"
 
 #ifndef _WIN32

--- a/src/slogger/slogger.h
+++ b/src/slogger/slogger.h
@@ -29,17 +29,34 @@
 #endif
 #include "errors/saunafs_error_codes.h"
 
+// Enable Unicode log file paths only on Windows
+#ifdef _WIN32
+#define SPDLOG_WCHAR_FILENAMES
+#define SPDLOG_WCHAR_TO_UTF8_SUPPORT
+#endif
+
 #ifndef _WIN32
 #define SPDLOG_ENABLE_SYSLOG
 #define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_TRACE
 #endif
 #include "common/small_vector.h"
-#include "spdlog/spdlog.h"
+
+// Suppress sign-compare warnings from spdlog when compiling with GCC on Windows
+#if defined(_WIN32) && defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-compare"
+#endif
+
 #include "spdlog/sinks/rotating_file_sink.h"
 #ifndef _WIN32
 #include "spdlog/sinks/syslog_sink.h"
 #endif
 #include "spdlog/sinks/stdout_color_sinks.h"
+#include "spdlog/spdlog.h"
+
+#if defined(_WIN32) && defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 typedef std::shared_ptr<spdlog::logger> LoggerPtr;
 


### PR DESCRIPTION
This PR introduces utility functions to handle non-ASCII text encoding on Windows platforms for printing and logging purposes. These utilities enable correct output of Unicode text when using `std::wcout` and `std::wcerr` streams, addressing limitations where standard streams could not properly display non-ASCII characters, even after setting the console code pages to UTF-8. The changes improve the reliability and correctness of console output for internationalized file paths, messages, and logs in SaunaFS tools and services. This PR is a helper step for supporting UTF-8 command line arguments, ensuring that command line inputs containing non-ASCII characters are correctly processed and displayed throughout the application.