### PR TITLE
refactor(master): modernize FS node operations

### DIFF
--- a/src/common/attributes.h
+++ b/src/common/attributes.h
@@ -30,7 +30,8 @@
 #include <array>
 #include <cstdint>
 
-typedef std::array<uint8_t, 35> Attributes;
+constexpr size_t kAttributesSize = 35;
+using Attributes = std::array<uint8_t, kAttributesSize>;
 
 #ifndef _WIN32
 constexpr int saunaFileTypeToPosix(unsigned char type) {

--- a/src/common/attributes.h
+++ b/src/common/attributes.h
@@ -30,7 +30,7 @@
 #include <array>
 #include <cstdint>
 
-constexpr size_t kAttributesSize = 35;
+inline constexpr size_t kAttributesSize = 35;
 using Attributes = std::array<uint8_t, kAttributesSize>;
 
 #ifndef _WIN32

--- a/src/master/filesystem_dump.cc
+++ b/src/master/filesystem_dump.cc
@@ -84,8 +84,8 @@ void fs_dumpnode(FSNode *f) {
 
 	printf("%c|i:%10" PRIiNode "|#:%" PRIu8 "|e:%1" PRIX16 "|m:%04" PRIo16 "|u:%10" PRIu32
 	       "|g:%10" PRIu32 "|a:%10" PRIu32 ",m:%10" PRIu32 ",c:%10" PRIu32 "|t:%10" PRIu32,
-	       c, f->id, f->goal, (uint16_t)(f->mode >> 12), (uint16_t)(f->mode & 0xFFF), f->uid,
-	       f->gid, f->atime, f->mtime, f->ctime, f->trashtime);
+	       c, f->id, f->goal, (uint16_t)(f->mode >> EATTR_BIT_OFFSET), (uint16_t)(f->mode & 0xFFF),
+	       f->uid, f->gid, f->atime, f->mtime, f->ctime, f->trashtime);
 
 	if (f->type == FSNodeType::kBlockDev || f->type == FSNodeType::kCharDev) {
 		printf("|d:%5" PRIu32 ",%5" PRIu32 "\n", static_cast<FSNodeDevice*>(f)->rdev >> 16,

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -43,45 +43,13 @@
 #include "master/fs_context.h"
 #include "slogger/slogger.h"
 
-#ifndef NDEBUG
-  #include "master/personality.h"
-#endif
+constexpr size_t kMaxFileNameLength = 255;
 
-#define LOOKUPNOHASHLIMIT 10
-
-#define MAXFNAMELENG 255
-
-
-FSNode *FSNode::create(FSNodeType type) {
-	switch (type) {
-	case FSNodeType::kFile:
-	case FSNodeType::kTrash:
-	case FSNodeType::kReserved:
-		return new FSNodeFile(type);
-	case FSNodeType::kDirectory:
-		return new FSNodeDirectory();
-	case FSNodeType::kSymlink:
-		return new FSNodeSymlink();
-	case FSNodeType::kFifo:
-	case FSNodeType::kSocket:
-		return new FSNode(type);
-	case FSNodeType::kBlockDev:
-	case FSNodeType::kCharDev:
-		return new FSNodeDevice(type);
-	case FSNodeType::kUnknown:
-	default:
-		assert(!"invalid node type");
-	}
-	return nullptr;
-}
-
-void FSNode::destroy(FSNode *node) {
-	for (auto const &[_, handlePtr] : node->parents) {
-		delete handlePtr;
-	}
-
-	delete node;
-}
+/// All permission bits (including setuid/setgid/sticky)
+constexpr uint16_t kPermissionsMask = 07777;
+/// Standard rwx permissions (excludes setuid/setgid/sticky)
+constexpr uint16_t kStandardPermissionsMask = 0777;
+constexpr uint16_t kExtraAttributesMask = 0xF000;  ///< Bits 12-15 for extra attributes
 
 // Private helper methods
 
@@ -117,21 +85,26 @@ uint32_t FilesystemNodeOperationsBase::fileChunksCount(FSNodeFile *node) {
 }
 
 uint64_t FilesystemNodeOperationsBase::fileSize(FSNodeFile *node, uint32_t nonZeroChunks) {
-	uint64_t size = (uint64_t)nonZeroChunks * (SFSCHUNKSIZE + SFSHDRSIZE);
+	uint64_t size = static_cast<uint64_t>(nonZeroChunks) * (SFSCHUNKSIZE + SFSHDRSIZE);
+
 	if (isLastChunkNonEmpty(node)) {
 		size -= SFSCHUNKSIZE;
 		size += lastChunkBlocks(node) * SFSBLOCKSIZE;
 	}
+
 	return size;
 }
 
 #ifndef METARESTORE
 uint32_t FilesystemNodeOperationsBase::ecChunkRealSize(uint32_t blocks, uint32_t dataPartCount,
                                                        uint32_t parityPartCount) {
+	constexpr uint32_t kCrcSize = SFSBLOCKSINCHUNK * sizeof(uint32_t);  // CRC size per chunk
+
 	const uint32_t stripes = (blocks + dataPartCount - 1) / dataPartCount;
-	uint32_t size = blocks * SFSBLOCKSIZE;             // file data
-	size += parityPartCount * stripes * SFSBLOCKSIZE;  // parity data
-	size += 4096 * (dataPartCount + parityPartCount);  // headers of data and parity parts
+	uint32_t size = blocks * SFSBLOCKSIZE;                 // file data
+	size += parityPartCount * stripes * SFSBLOCKSIZE;      // parity data
+	size += kCrcSize * (dataPartCount + parityPartCount);  // headers of data and parity parts
+
 	return size;
 }
 #endif
@@ -189,8 +162,8 @@ FSNode *FilesystemNodeOperationsBase::idToNodeInternal(inode_t inode) {
 // Public methods
 
 FSNode *FilesystemNodeOperationsBase::lookup(FSNodeDirectory *node, const HString &name) const {
-	auto it = node->find(name);
-	if (it != node->end()) { return (*it).second; }
+	auto iter = node->find(name);
+	if (iter != node->end()) { return (*iter).second; }
 
 	return nullptr;
 }
@@ -199,8 +172,8 @@ void FilesystemNodeOperationsBase::updateCTime(FSNode *node, uint32_t ctime) {
 	if (node->type == FSNodeType::kTrash && node->ctime != ctime) {
 		auto old_key = TrashPathKey(node);
 		node->ctime = ctime;
-		auto it = gMetadata->trash.find(old_key);
-		if (it != gMetadata->trash.end()) {
+		auto iter = gMetadata->trash.find(old_key);
+		if (iter != gMetadata->trash.end()) {
 			updateTrashFromOldEntry(gMetadata->trash, node, old_key);
 		}
 	} else {
@@ -209,8 +182,15 @@ void FilesystemNodeOperationsBase::updateCTime(FSNode *node, uint32_t ctime) {
 }
 
 std::string FilesystemNodeOperationsBase::escapeName(const std::string &name) {
-	constexpr std::array<char, 16> hex_digit = {{'0', '1', '2', '3', '4', '5', '6', '7',
-	                                             '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'}};
+	constexpr std::array<char, 16> hexDigits = {
+	    {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'}};
+
+	constexpr uint8_t kControlCharThreshold = 32;
+	constexpr uint8_t kHighByteThreshold = 127;
+	constexpr uint8_t kHexDigitShift = 4;
+	constexpr uint8_t kHexDigitMask = 0xF;
+	constexpr size_t kBytesPerEscapedChar = 3;  // '%' + 2 hex digits
+
 	std::string result;
 
 	// It could be possible to reserve 3 * name.length() bytes in result,
@@ -218,43 +198,46 @@ std::string FilesystemNodeOperationsBase::escapeName(const std::string &name) {
 	// This would take much more time than computation of exact result size.
 	// Hint: remember that std::string uses static allocation
 	// for small string sizes.
-	int long_count = std::count_if(name.begin(), name.end(), [](char c) {
-		return c < 32 || c >= 127 || c == ',' || c == '%' || c == '(' || c == ')';
+	auto longCount = std::count_if(name.begin(), name.end(), [](char chr) {
+		return chr < kControlCharThreshold || chr >= kHighByteThreshold || chr == ',' ||
+		       chr == '%' || chr == '(' || chr == ')';
 	});
-	result.reserve(2 * long_count + name.length());
 
-	for (char c : name) {
-		if (c < 32 || c >= 127 || c == ',' || c == '%' || c == '(' || c == ')') {
+	result.reserve(((kBytesPerEscapedChar - 1) * longCount) + name.length());
+
+	for (char chr : name) {
+		if (chr < kControlCharThreshold || chr >= kHighByteThreshold || chr == ',' || chr == '%' ||
+		    chr == '(' || chr == ')') {
 			result.push_back('%');
-			result.push_back(hex_digit[(c >> 4) & 0xF]);
-			result.push_back(hex_digit[c & 0xF]);
+			// Linter will complain about possible out-of-bounds access, but it is masked by
+			// kHexDigitMask and kHexDigitShift constants. So it will aleways be in range 0..15.
+			result.push_back(hexDigits[(chr >> kHexDigitShift) & kHexDigitMask]);  // NOLINT
+			result.push_back(hexDigits[chr & kHexDigitMask]);                      // NOLINT
 		} else {
-			result.push_back(c);
+			result.push_back(chr);
 		}
 	}
 
 	return result;
 }
 
-int FilesystemNodeOperationsBase::isNameUsed(FSNodeDirectory *node, const HString &name) {
+bool FilesystemNodeOperationsBase::isNameUsed(FSNodeDirectory *node, const HString &name) {
 	return lookup(node, name) != nullptr;
 }
 
 bool FilesystemNodeOperationsBase::isAncestor(FSNodeDirectory *ancestor, FSNode *node) {
 	for (const auto &[parentId, _] : node->parents) {
-		auto *dir_node = idToNodeVerify<FSNodeDirectory>(parentId);
+		auto *dirNode = idToNodeVerify<FSNodeDirectory>(parentId);
 
-		while(dir_node) {
-			if (ancestor == dir_node) {
-				return true;
-			}
+		while (dirNode != nullptr) {
+			if (ancestor == dirNode) { return true; }
 
-			assert(dir_node->parents.size() <= 1);
+			assert(dirNode->parents.size() <= 1);
 
-			if (!dir_node->parents.empty()) {
-				dir_node = idToNodeVerify<FSNodeDirectory>(dir_node->parents[0].first);
+			if (!dirNode->parents.empty()) {
+				dirNode = idToNodeVerify<FSNodeDirectory>(dirNode->parents[0].first);
 			} else {
-				dir_node = nullptr;
+				dirNode = nullptr;
 			}
 		}
 	}
@@ -317,34 +300,31 @@ void FilesystemNodeOperationsBase::getStats(FSNode *node, StatsRecord *statsOut)
 }
 
 int64_t FilesystemNodeOperationsBase::getSize(FSNode *node) {
-	StatsRecord sr;
-	getStats(node, &sr);
-	return sr.size;
+	StatsRecord stats;
+	getStats(node, &stats);
+	return static_cast<int64_t>(stats.size);
 }
 
 FSNodeDirectory *FilesystemNodeOperationsBase::getFirstParent(FSNode *node) {
 	assert(node);
-	FSNodeDirectory *parent;
-	if (!node->parents.empty()) {
-		parent = idToNodeVerify<FSNodeDirectory>(node->parents[0].first);
-	} else {
-		parent = gMetadata->root;
-	}
-	return parent;
+
+	if (!node->parents.empty()) { return idToNodeVerify<FSNodeDirectory>(node->parents[0].first); }
+
+	return gMetadata->root;
 }
 
 void FilesystemNodeOperationsBase::subStats(FSNodeDirectory *parent, StatsRecord *stats) {
-	StatsRecord *psr;
-	if (parent) {
-		psr = &parent->stats;
-		psr->inodes -= stats->inodes;
-		psr->dirs -= stats->dirs;
-		psr->files -= stats->files;
-		psr->links -= stats->links;
-		psr->chunks -= stats->chunks;
-		psr->length -= stats->length;
-		psr->size -= stats->size;
-		psr->realsize -= stats->realsize;
+	if (parent != nullptr) {
+		StatsRecord *parentStats = &parent->stats;
+		parentStats->inodes -= stats->inodes;
+		parentStats->dirs -= stats->dirs;
+		parentStats->files -= stats->files;
+		parentStats->links -= stats->links;
+		parentStats->chunks -= stats->chunks;
+		parentStats->length -= stats->length;
+		parentStats->size -= stats->size;
+		parentStats->realsize -= stats->realsize;
+
 		if (parent != gMetadata->root) {
 			for (auto const &[parentId, _] : parent->parents) {
 				auto *node = idToNodeVerify<FSNodeDirectory>(parentId);
@@ -355,17 +335,17 @@ void FilesystemNodeOperationsBase::subStats(FSNodeDirectory *parent, StatsRecord
 }
 
 void FilesystemNodeOperationsBase::addStats(FSNodeDirectory *parent, StatsRecord *stats) {
-	StatsRecord *psr;
-	if (parent) {
-		psr = &parent->stats;
-		psr->inodes += stats->inodes;
-		psr->dirs += stats->dirs;
-		psr->files += stats->files;
-		psr->links += stats->links;
-		psr->chunks += stats->chunks;
-		psr->length += stats->length;
-		psr->size += stats->size;
-		psr->realsize += stats->realsize;
+	if (parent != nullptr) {
+		StatsRecord *parentStats = &parent->stats;
+		parentStats->inodes += stats->inodes;
+		parentStats->dirs += stats->dirs;
+		parentStats->files += stats->files;
+		parentStats->links += stats->links;
+		parentStats->chunks += stats->chunks;
+		parentStats->length += stats->length;
+		parentStats->size += stats->size;
+		parentStats->realsize += stats->realsize;
+
 		if (parent != gMetadata->root) {
 			for (auto const &[parentId, _] : parent->parents) {
 				auto *node = idToNodeVerify<FSNodeDirectory>(parentId);
@@ -377,16 +357,16 @@ void FilesystemNodeOperationsBase::addStats(FSNodeDirectory *parent, StatsRecord
 
 void FilesystemNodeOperationsBase::addSubStats(FSNodeDirectory *parent, StatsRecord *newStats,
                                                StatsRecord *previousStats) {
-	StatsRecord sr;
-	sr.inodes = newStats->inodes - previousStats->inodes;
-	sr.dirs = newStats->dirs - previousStats->dirs;
-	sr.files = newStats->files - previousStats->files;
-	sr.links = newStats->links - previousStats->links;
-	sr.chunks = newStats->chunks - previousStats->chunks;
-	sr.length = newStats->length - previousStats->length;
-	sr.size = newStats->size - previousStats->size;
-	sr.realsize = newStats->realsize - previousStats->realsize;
-	addStats(parent, &sr);
+	StatsRecord resultStats;
+	resultStats.inodes = newStats->inodes - previousStats->inodes;
+	resultStats.dirs = newStats->dirs - previousStats->dirs;
+	resultStats.files = newStats->files - previousStats->files;
+	resultStats.links = newStats->links - previousStats->links;
+	resultStats.chunks = newStats->chunks - previousStats->chunks;
+	resultStats.length = newStats->length - previousStats->length;
+	resultStats.size = newStats->size - previousStats->size;
+	resultStats.realsize = newStats->realsize - previousStats->realsize;
+	addStats(parent, &resultStats);
 }
 
 void FilesystemNodeOperationsBase::fillAttr(FSNode *node, FSNode *parent, uint32_t uid,
@@ -395,31 +375,42 @@ void FilesystemNodeOperationsBase::fillAttr(FSNode *node, FSNode *parent, uint32
 #ifdef METARESTORE
 	mabort("Bad code path - fsnodes_fill_attr() shall not be executed in metarestore context.");
 #endif /* METARESTORE */
-	uint8_t *ptr;
-	uint16_t mode;
+	uint8_t *ptr = attr.data();
 	uint32_t nlink;
-	(void)sesflags;
-	ptr = attr.data();
+
+	// Type
 	if (node->type == FSNodeType::kTrash || node->type == FSNodeType::kReserved) {
 		put8bit(&ptr, FSNodeType::kFile);
 	} else {
 		put8bit(&ptr, node->type);
 	}
-	mode = node->mode & 07777;
-	if (parent) {
-		if (parent->mode & (EATTR_NOECACHE << 12)) {
-			mode |= (MATTR_NOECACHE << 12);
+
+	// Extract permission bits and discard extra attributes to allow selective re-application
+	// based on inheritance and session flags
+	uint16_t mode = node->mode & kPermissionsMask;
+
+	// Inherit entry cache disable flag from parent directory
+	if (parent != nullptr) {
+		if (parent->mode & (EATTR_NOECACHE << EATTR_BIT_OFFSET)) {
+			mode |= (MATTR_NOECACHE << EATTR_BIT_OFFSET);
 		}
 	}
-	if ((node->mode & ((EATTR_NOOWNER | EATTR_NOACACHE) << 12)) ||
+
+	// Disable attribute caching if node has NOOWNER/NOACACHE or client is mapped to all users
+	if ((node->mode & ((EATTR_NOOWNER | EATTR_NOACACHE) << EATTR_BIT_OFFSET)) ||
 	    (sesflags & SESFLAG_MAPALL)) {
-		mode |= (MATTR_NOACACHE << 12);
+		mode |= (MATTR_NOACACHE << EATTR_BIT_OFFSET);
 	}
-	if ((node->mode & (EATTR_NODATACACHE << 12)) == 0) {
-		mode |= (MATTR_ALLOWDATACACHE << 12);
+
+	// Enable data caching unless node has NODATACACHE attribute
+	if ((node->mode & (EATTR_NODATACACHE << EATTR_BIT_OFFSET)) == 0) {
+		mode |= (MATTR_ALLOWDATACACHE << EATTR_BIT_OFFSET);
 	}
+
 	put16bit(&ptr, mode);
-	if ((node->mode & (EATTR_NOOWNER << 12)) && uid != 0) {
+
+	// Effective UID and GID
+	if ((node->mode & (EATTR_NOOWNER << EATTR_BIT_OFFSET)) && uid != 0) {
 		if (sesflags & SESFLAG_MAPALL) {
 			put32bit(&ptr, auid);
 			put32bit(&ptr, agid);
@@ -444,10 +435,19 @@ void FilesystemNodeOperationsBase::fillAttr(FSNode *node, FSNode *parent, uint32
 			put32bit(&ptr, node->gid);
 		}
 	}
+
+	// Timestamps
 	put32bit(&ptr, node->atime);
 	put32bit(&ptr, node->mtime);
 	put32bit(&ptr, node->ctime);
+
+	// Number of links
 	nlink = node->parents.size();
+
+	// Type-specific attributes
+
+	constexpr uint32_t kGBBitShift = 30;  // Shift to convert bytes to GB
+
 	switch (node->type) {
 	case FSNodeType::kFile:
 	case FSNodeType::kTrash:
@@ -457,8 +457,8 @@ void FilesystemNodeOperationsBase::fillAttr(FSNode *node, FSNode *parent, uint32
 		break;
 	case FSNodeType::kDirectory:
 		put32bit(&ptr, static_cast<FSNodeDirectory*>(node)->nlink);
-		put64bit(&ptr, static_cast<FSNodeDirectory*>(node)->stats.length >>
-		                       30);  // Rescale length to GB (reduces size to 32-bit length)
+		// Rescale length to GB (reduces size to 32-bit length)
+		put64bit(&ptr, static_cast<FSNodeDirectory *>(node)->stats.length >> kGBBitShift);
 		break;
 	case FSNodeType::kSymlink:
 		put32bit(&ptr, nlink);
@@ -504,12 +504,13 @@ void FilesystemNodeOperationsBase::removeEdge(uint32_t timeStamp, FSNodeDirector
                                               const HString &childName, FSNode *childNode) {
 	assert(parent);
 
-	auto dir_it = parent->find(childName);
-	assert(dir_it != parent->end());
-	assert((*dir_it).second == childNode);
-	auto handlePtrToErase = dir_it->first;
-	if (dir_it != parent->end()) {
-		parent->entries.erase(dir_it);
+	auto dirIter = parent->find(childName);
+	assert(dirIter != parent->end());
+	assert((*dirIter).second == childNode);
+	auto *handlePtrToErase = dirIter->first;
+
+	if (dirIter != parent->end()) {
+		parent->entries.erase(dirIter);
 		parent->entries_hash ^= childName.hash();
 
 		if (parent->case_insensitive) {
@@ -521,10 +522,10 @@ void FilesystemNodeOperationsBase::removeEdge(uint32_t timeStamp, FSNodeDirector
 		}
 	}
 
-	StatsRecord sr;
+	StatsRecord childStats;
 
-	getStats(childNode, &sr);
-	subStats(parent, &sr);
+	getStats(childNode, &childStats);
+	subStats(parent, &childStats);
 	parent->mtime = parent->ctime = timeStamp;
 	if (childNode->type == FSNodeType::kDirectory) { parent->nlink--; }
 
@@ -532,15 +533,16 @@ void FilesystemNodeOperationsBase::removeEdge(uint32_t timeStamp, FSNodeDirector
 	HString currentName = childName;
 	if (parent->case_insensitive) { currentName = HString::hstringToLowerCase(childName); }
 
-	auto it = std::find_if(
+	auto iter = std::find_if(
 	    childNode->parents.begin(), childNode->parents.end(),
-	    [parent, currentName](const std::pair<inode_t, const hstorage::Handle *> &p) {
-		    return p.first == parent->id &&
-		           (parent->case_insensitive ? HString::hstringToLowerCase(p.second->get())
-		                                     : p.second->get()) == currentName;
+	    [parent, currentName](const std::pair<inode_t, const hstorage::Handle *> &parentEntry) {
+		    return parentEntry.first == parent->id &&
+		           (parent->case_insensitive
+		                ? HString::hstringToLowerCase(parentEntry.second->get())
+		                : parentEntry.second->get()) == currentName;
 	    });
 
-	if (it != childNode->parents.end()) { childNode->parents.erase(it); }
+	if (iter != childNode->parents.end()) { childNode->parents.erase(iter); }
 
 	// Delete the handle after the check in the parent vector in the son is done.
 	delete handlePtrToErase;
@@ -574,9 +576,10 @@ void FilesystemNodeOperationsBase::link(uint32_t timeStamp, FSNodeDirectory *par
 		parent->nlink++;
 	}
 
-	StatsRecord sr;
-	getStats(child, &sr);
-	addStats(parent, &sr);
+	StatsRecord childStats;
+	getStats(child, &childStats);
+	addStats(parent, &childStats);
+
 	if (timeStamp > 0) {
 		parent->mtime = parent->ctime = timeStamp;
 		fsnodes_update_checksum(parent);
@@ -595,6 +598,8 @@ FSNode *FilesystemNodeOperationsBase::createNode(uint32_t timeStamp, FSNodeDirec
 	assert(type != FSNodeType::kTrash);
 
 	FSNode *node = FSNode::create(type);
+
+	// update metadata counters
 	gMetadata->nodes++;
 	if (type == FSNodeType::kDirectory) {
 		gMetadata->dirNodes++;
@@ -605,10 +610,14 @@ FSNode *FilesystemNodeOperationsBase::createNode(uint32_t timeStamp, FSNodeDirec
 	if (type == FSNodeType::kSymlink) {
 		gMetadata->linkNodes++;
 	}
-	/* create node */
+
+	// Ask for a node id
 	node->id = gInodeIdGenerator->getNextId(timeStamp, requestedINode);
 
+	// Init timestamps
 	node->ctime = node->mtime = node->atime = timeStamp;
+
+	// Inherit goal and trashtime from parent if applicable
 	if (type == FSNodeType::kDirectory || type == FSNodeType::kFile) {
 		node->goal = parent->goal;
 		node->trashtime = parent->trashtime;
@@ -616,33 +625,38 @@ FSNode *FilesystemNodeOperationsBase::createNode(uint32_t timeStamp, FSNodeDirec
 		node->goal = DEFAULT_GOAL;
 		node->trashtime = kDefaultTrashTime;
 	}
+
+	// Set mode (attributes + extra flags)
 	if (type == FSNodeType::kDirectory) {
-		node->mode = (mode & 07777) | (parent->mode & 0xF000);
+		node->mode = (mode & kPermissionsMask) | (parent->mode & kExtraAttributesMask);
 	} else {
-		node->mode = (mode & 07777) | (parent->mode & (0xF000 & (~(EATTR_NOECACHE << 12))));
+		node->mode =
+		    (mode & kPermissionsMask) |
+		    (parent->mode & (kExtraAttributesMask & (~(EATTR_NOECACHE << EATTR_BIT_OFFSET))));
 	}
+
 	// If desired, node inherits permissions from parent's default ACL
-	const RichACL *parent_acl = (inheritAcl == AclInheritance::kInheritAcl)
-	                                ? gMetadata->aclStorage.get(parent->id)
-	                                : nullptr;
-	if (parent_acl) {
+	const RichACL *parentAcl = (inheritAcl == AclInheritance::kInheritAcl)
+	                               ? gMetadata->aclStorage.get(parent->id)
+	                               : nullptr;
+	if (parentAcl != nullptr) {
 		RichACL acl;
 		uint16_t mode = node->mode;
-		if (RichACL::inheritInode(*parent_acl, mode, acl, umask, type == FSNodeType::kDirectory)) {
+		if (RichACL::inheritInode(*parentAcl, mode, acl, umask, type == FSNodeType::kDirectory)) {
 			gMetadata->aclStorage.set(node->id, std::move(acl));
 		}
 		// Set effective permissions as the intersection of mode and ACL
-		node->mode &= mode | ~0777;
+		node->mode &= mode | ~kStandardPermissionsMask;
 	} else {
 		// Apply umask
-		node->mode &= ~(umask & 0777);  // umask must be applied manually
+		node->mode &= ~(umask & kStandardPermissionsMask);  // umask must be applied manually
 	}
-	node->uid = uid;
-	if ((parent->mode & 02000) == 02000) {  // set gid flag is set in the parent directory ?
+
+	node->uid = uid;  // owner
+
+	if ((parent->mode & S_ISGID) == S_ISGID) {  // set gid flag is set in the parent directory?
 		node->gid = parent->gid;
-		if (copysgid && type == FSNodeType::kDirectory) {
-			node->mode |= 02000;
-		}
+		if (copysgid && type == FSNodeType::kDirectory) { node->mode |= S_ISGID; }
 	} else {
 		node->gid = gid;
 	}
@@ -661,15 +675,12 @@ FSNode *FilesystemNodeOperationsBase::createNode(uint32_t timeStamp, FSNodeDirec
 }
 
 uint32_t FilesystemNodeOperationsBase::getPathSize(FSNodeDirectory *parent, FSNode *child) {
-	std::string name;
-	uint32_t size;
-
 	if (parent == nullptr || child == nullptr) {
 		return 0;
 	}
 
-	name = parent->getChildName(child);
-	size = name.length();
+	std::string name = parent->getChildName(child);
+	uint32_t size = name.length();
 
 	while (parent != gMetadata->root && !parent->parents.empty()) {
 		child = parent;
@@ -684,13 +695,11 @@ uint32_t FilesystemNodeOperationsBase::getPathSize(FSNodeDirectory *parent, FSNo
 
 void FilesystemNodeOperationsBase::getPathData(FSNodeDirectory *parent, FSNode *child,
                                                uint8_t *path, uint32_t size) {
-	std::string name;
-
 	if (parent == nullptr || child == nullptr) {
 		return;
 	}
 
-	name = parent->getChildName(child);
+	std::string name = parent->getChildName(child);
 
 	if (size >= name.length()) {
 		size -= name.length();
@@ -699,14 +708,17 @@ void FilesystemNodeOperationsBase::getPathData(FSNodeDirectory *parent, FSNode *
 		memcpy(path, name.c_str() + (name.length() - size), size);
 		size = 0;
 	}
+
 	if (size > 0) {
 		path[--size] = '/';
 	}
+
 	while (parent != gMetadata->root && !parent->parents.empty()) {
 		child = parent;
 		assert(child->parents.size() == 1);
 		parent = idToNodeVerify<FSNodeDirectory>(child->parents[0].first);
 		name = parent->getChildName(child);
+
 		if (size >= name.length()) {
 			size -= name.length();
 			memcpy(path + size, name.c_str(), name.length());
@@ -714,6 +726,7 @@ void FilesystemNodeOperationsBase::getPathData(FSNodeDirectory *parent, FSNode *
 			memcpy(path, name.c_str() + (name.length() - size), size);
 			size = 0;
 		}
+
 		if (size > 0) {
 			path[--size] = '/';
 		}
@@ -724,9 +737,9 @@ void FilesystemNodeOperationsBase::getPath(FSNodeDirectory *parent, FSNode *chil
                                            std::string &path) {
 	uint32_t size = getPathSize(parent, child);
 
-	if (size > 65535) {
+	if (size > FSNode::kEdgeNameMaxSize) {
 		safs_pretty_syslog(LOG_WARNING, "path too long !!! - truncate");
-		size = 65535;
+		size = FSNode::kEdgeNameMaxSize;
 	}
 
 	path.resize(size);
@@ -737,47 +750,60 @@ void FilesystemNodeOperationsBase::getPath(FSNodeDirectory *parent, FSNode *chil
 #ifndef METARESTORE
 constexpr uint32_t kOldPathContainerLimit = 1000000;
 
-template<class T>
-static inline uint32_t getdetachedsize(const T &data) {
-	static_assert(std::is_same<T, TrashPathContainer>::value
-	              || std::is_same<T, ReservedPathContainer>::value, "unsupported container");
+// Constants for detached data handling
+constexpr uint32_t kDetachedMaxNameLength = 240;
+constexpr uint32_t kDetachedEllipsisLength = 5;  // length of "(...)"
+constexpr uint32_t kDetachedTruncatedLength = kDetachedMaxNameLength - kDetachedEllipsisLength;
+constexpr uint32_t kDetachedSizeByteLength = 1;  // Size of the length byte for detached names
+
+// Inlined implementation details for detached data
+
+template <class T>
+static inline uint32_t getDetachedSizeGenericInternal(const T &data) {
+	static_assert(std::is_same_v<T, TrashPathContainer> || std::is_same_v<T, ReservedPathContainer>,
+	              "unsupported container");
 	uint32_t result = 0;
 	std::string name;
 	uint32_t count = 0;
+
 	for (const auto &entry : data) {
 		if (count > kOldPathContainerLimit) {
-			// See explanation in getdetacheddata
+			// See explanation in getDetachedData
 			break;
 		}
+
 		name = (std::string)entry.second;
-		if (name.length() > 240) {
-			result += 245;
+
+		if (name.length() > kDetachedMaxNameLength) {
+			result += kDetachedSizeByteLength + kDetachedEllipsisLength + kDetachedTruncatedLength +
+			          kinode_t_size;
 		} else {
-			result += 5 + name.length();
+			result += kDetachedSizeByteLength + name.length() + kinode_t_size;
 		}
+
 		count++;
 	}
+
 	return result;
 }
 
-static inline inode_t getdetacheddata_getNodeId(const TrashPathContainer::key_type &key) {
+static inline inode_t getDetachedDataNodeId(const TrashPathContainer::key_type &key) {
 	return key.id;
 }
 
-static inline inode_t getdetacheddata_getNodeId(const inode_t &key) {
-	return key;
-}
+static inline inode_t getDetachedDataNodeId(const inode_t &key) { return key; }
 
-template<class T>
-static inline void getdetacheddata(const T &data, uint8_t *dbuff) {
-	static_assert(std::is_same<T, TrashPathContainer>::value
-	              || std::is_same<T, ReservedPathContainer>::value, "unsupported container");
+template <class T>
+static inline void getDetachedDataGenericInternal(const T &data, uint8_t *dbuff) {
+	static_assert(std::is_same_v<T, TrashPathContainer> || std::is_same_v<T, ReservedPathContainer>,
+	              "unsupported container");
 
 	uint8_t *sptr;
 	uint8_t c;
 	std::string name;
 	// Limit to 1 million, see explanation below
 	uint32_t count = 0;
+
 	for (const auto &entry : data) {
 		if (count > kOldPathContainerLimit) {
 			// Due to the size limit of packets (at time of writing,
@@ -789,15 +815,16 @@ static inline void getdetacheddata(const T &data, uint8_t *dbuff) {
 				  kOldPathContainerLimit);
 			break;
 		}
+
 		name = (std::string)entry.second;
 
-		if (name.length() > 240) {
-			*dbuff = 240;
+		if (name.length() > kDetachedMaxNameLength) {
+			*dbuff = kDetachedMaxNameLength;  // Serialize name length byte
 			dbuff++;
-			memcpy(dbuff, "(...)", 5);
-			dbuff += 5;
-			sptr = (uint8_t*)name.c_str() + (name.length() - 235);
-			for (c = 0; c < 235; c++) {
+			memcpy(dbuff, "(...)", kDetachedEllipsisLength);
+			dbuff += kDetachedEllipsisLength;
+			sptr = (uint8_t *)name.c_str() + (name.length() - kDetachedTruncatedLength);
+			for (c = 0; c < kDetachedTruncatedLength; c++) {
 				if (*sptr == '/') {
 					*dbuff = '|';
 				} else {
@@ -807,7 +834,7 @@ static inline void getdetacheddata(const T &data, uint8_t *dbuff) {
 				dbuff++;
 			}
 		} else {
-			*dbuff = name.length();
+			*dbuff = name.length();  // Serialize name length byte
 			dbuff++;
 			sptr = (uint8_t*)name.c_str();
 			for (c = 0; c < name.length(); c++) {
@@ -820,30 +847,31 @@ static inline void getdetacheddata(const T &data, uint8_t *dbuff) {
 				dbuff++;
 			}
 		}
+
 		count++;
-		putINode(&dbuff, getdetacheddata_getNodeId(entry.first));
+		putINode(&dbuff, getDetachedDataNodeId(entry.first));
 	}
 }
 
 uint32_t FilesystemNodeOperationsBase::getDetachedSize(const TrashPathContainer &data) {
-	return getdetachedsize(data);
+	return getDetachedSizeGenericInternal(data);
 }
 
 void FilesystemNodeOperationsBase::getDetachedData(const TrashPathContainer &data,
                                                    uint8_t *outBuffer) {
-	getdetacheddata(data, outBuffer);
+	getDetachedDataGenericInternal(data, outBuffer);
 }
 
 void FilesystemNodeOperationsBase::getDetachedData(const TrashPathContainer &data, uint32_t offset,
                                                    uint32_t maxEntries,
                                                    std::vector<NamedInodeEntry> &entries) {
 #if defined(SAUNAFS_HAVE_64BIT_JUDY) && !defined(DISABLE_JUDY_FOR_TRASHPATHCONTAINER)
-	auto it = data.find_nth(offset);
+	auto iter = data.find_nth(offset);
 #else
-	auto it = offset < data.size() ? std::next(data.begin(), offset) : data.end();
+	auto iter = offset < data.size() ? std::next(data.begin(), offset) : data.end();
 #endif
-	for (; maxEntries > 0 && it != data.end(); maxEntries--, ++it) {
-		entries.emplace_back((std::string)(*it).second, (*it).first.id);
+	for (; maxEntries > 0 && iter != data.end(); maxEntries--, ++iter) {
+		entries.emplace_back((std::string)(*iter).second, (*iter).first.id);
 	}
 }
 
@@ -852,54 +880,59 @@ void FilesystemNodeOperationsBase::getDetachedData(const HandleIndexContainer &d
                                                    std::vector<HandleInodeEntry> &entries,
                                                    bool fromTrash) {
 	uint64_t start = (handleOffset & ~k64SignBitMask);
-	auto it = data.lower_bound(HandleIndexKey(start));
+	auto iter = data.lower_bound(HandleIndexKey(start));
 
-	for (; maxEntries > 0 && it != data.end(); --maxEntries, ++it) {
+	for (; maxEntries > 0 && iter != data.end(); --maxEntries, ++iter) {
 		// Ensure we only return entries with the sign bit cleared
 		// to the client to avoid sending negative offsets to fuse
 		// when requesting next one
-		uint64_t handleValueForClient = (*it).first.data & ~k64SignBitMask;
-		std::string nameForClient = "";
+		uint64_t handleValueForClient = (*iter).first.data & ~k64SignBitMask;
+		std::string nameForClient;
+
 		if (fromTrash) {
-			FSNode *node = idToNode((*it).second);
+			FSNode *node = idToNode((*iter).second);
 			nameForClient = gMetadata->trash.at(TrashPathKey(node)).get().c_str();
 		} else {
-			nameForClient = gMetadata->reserved.at((*it).second).get().c_str();
+			nameForClient = gMetadata->reserved.at((*iter).second).get().c_str();
 		}
-		entries.emplace_back(handleValueForClient, nameForClient, (*it).second);
+
+		entries.emplace_back(handleValueForClient, nameForClient, (*iter).second);
 	}
 }
 
 uint32_t FilesystemNodeOperationsBase::getDetachedSize(const ReservedPathContainer &data) {
-	return getdetachedsize(data);
+	return getDetachedSizeGenericInternal(data);
 }
 
 void FilesystemNodeOperationsBase::getDetachedData(const ReservedPathContainer &data,
                                                    uint8_t *outBuffer) {
-	getdetacheddata(data, outBuffer);
+	getDetachedDataGenericInternal(data, outBuffer);
 }
 
 void FilesystemNodeOperationsBase::getDetachedData(const ReservedPathContainer &data,
                                                    uint32_t offset, uint32_t maxEntries,
                                                    std::vector<NamedInodeEntry> &entries) {
 #if defined(SAUNAFS_HAVE_64BIT_JUDY) && !defined(DISABLE_JUDY_FOR_RESERVEDPATHCONTAINER)
-	auto it = data.find_nth(offset);
+	auto iter = data.find_nth(offset);
 #else
-	auto it = offset < data.size() ? std::next(data.begin(), offset) : data.end();
+	auto iter = offset < data.size() ? std::next(data.begin(), offset) : data.end();
 #endif
-	for (; maxEntries > 0 && it != data.end(); maxEntries--, ++it) {
-		entries.emplace_back((std::string)(*it).second, (*it).first);
+	for (; maxEntries > 0 && iter != data.end(); maxEntries--, ++iter) {
+		entries.emplace_back((std::string)(*iter).second, (*iter).first);
 	}
 }
 
 uint32_t FilesystemNodeOperationsBase::getDirSize(const FSNodeDirectory *nodeDir,
                                                   uint8_t withAttr) {
-	uint32_t result = (((withAttr) ? 40 : 6) * 2) + 3;  // for '.' and '..'
+	uint32_t entrySize = (withAttr) ? kDirEntryWithAttributesSize : kDirEntryWithoutAttributesSize;
+	uint32_t result = (entrySize * 2) + kDotEntrySize + kDotDotEntrySize;  // for '.' and '..'
 	std::string name;
+
 	for (const auto &entry : nodeDir->entries) {
 		name = (std::string)(*entry.first);
-		result += ((withAttr) ? 40 : 6) + name.length();
+		result += entrySize + name.length();
 	}
+
 	return result;
 }
 
@@ -908,15 +941,18 @@ void FilesystemNodeOperationsBase::getDirData(inode_t rootINode, uint32_t uid, u
                                               FSNodeDirectory *nodeDir, uint8_t *outBuffer,
                                               uint8_t withAttr) {
 	// '.' - self
-	outBuffer[0] = 1;
+	outBuffer[0] = 1;  // name length
 	outBuffer[1] = '.';
-	outBuffer += 2;
+	outBuffer += kDotEntrySize;
 	if (nodeDir->id != rootINode) {
 		putINode(&outBuffer, nodeDir->id);
 	} else {
 		putINode(&outBuffer, SPECIAL_INODE_ROOT);
 	}
+
+	// attributes
 	Attributes attr;
+
 	if (withAttr) {
 		fillAttr(nodeDir, nodeDir, uid, gid, auid, agid, sesflags, attr);
 		::memcpy(outBuffer, attr.data(), attr.size());
@@ -924,13 +960,17 @@ void FilesystemNodeOperationsBase::getDirData(inode_t rootINode, uint32_t uid, u
 	} else {
 		put8bit(&outBuffer, static_cast<uint8_t>(FSNodeType::kDirectory));
 	}
+
 	// '..' - parent
-	outBuffer[0] = 2;
+	outBuffer[0] = 2;  // name length
 	outBuffer[1] = '.';
 	outBuffer[2] = '.';
-	outBuffer += 3;
+	outBuffer += kDotDotEntrySize;
+
 	if (nodeDir->id == rootINode) {  // root node should returns self as its parent
 		putINode(&outBuffer, SPECIAL_INODE_ROOT);
+
+		// parent attributes
 		if (withAttr) {
 			fillAttr(nodeDir, nodeDir, uid, gid, auid, agid, sesflags, attr);
 			::memcpy(outBuffer, attr.data(), attr.size());
@@ -944,6 +984,8 @@ void FilesystemNodeOperationsBase::getDirData(inode_t rootINode, uint32_t uid, u
 		} else {
 			putINode(&outBuffer, SPECIAL_INODE_ROOT);
 		}
+
+		// parent attributes
 		if (withAttr) {
 			if (!nodeDir->parents.empty()) {
 				auto *parent = idToNodeVerify<FSNode>(nodeDir->parents[0].first);
@@ -954,30 +996,35 @@ void FilesystemNodeOperationsBase::getDirData(inode_t rootINode, uint32_t uid, u
 					fillAttr(gMetadata->root, nodeDir, uid, gid, auid, agid, sesflags, attr);
 					::memcpy(outBuffer, attr.data(), attr.size());
 				} else {
-					FSNode *rn = idToNode(rootINode);
-					if (rn) {  // it should be always true because it's checked
-						   // before, but better check than sorry
-						   fillAttr(rn, nodeDir, uid, gid, auid, agid, sesflags, attr);
-						   ::memcpy(outBuffer, attr.data(), attr.size());
+					FSNode *foundRootNode = idToNode(rootINode);
+					if (foundRootNode) {  // it should be always true because it's checked
+						// before, but better check than sorry
+						fillAttr(foundRootNode, nodeDir, uid, gid, auid, agid, sesflags, attr);
+						::memcpy(outBuffer, attr.data(), attr.size());
 					} else {
 						memset(outBuffer, 0, attr.size());
 					}
 				}
 			}
+
 			outBuffer += attr.size();
 		} else {
 			put8bit(&outBuffer, static_cast<uint8_t>(FSNodeType::kDirectory));
 		}
 	}
+
 	// entries
 	std::string name;
 	for (const auto &entry : nodeDir->entries) {
+		// entry name and inode
 		name = (std::string)(*entry.first);
 		outBuffer[0] = name.size();
 		outBuffer++;
 		memcpy(outBuffer, name.c_str(), name.length());
 		outBuffer += name.length();
 		putINode(&outBuffer, entry.second->id);
+
+		// entry attributes
 		if (withAttr) {
 			fillAttr(entry.second, nodeDir, uid, gid, auid, agid, sesflags, attr);
 			::memcpy(outBuffer, attr.data(), attr.size());
@@ -1440,9 +1487,7 @@ uint8_t FilesystemNodeOperationsBase::undel(uint32_t timeStamp, FSNodeFile *node
 				dots++;
 			}
 			partleng++;
-			if (partleng > MAXFNAMELENG) {
-				return SAUNAFS_ERROR_CANTCREATEPATH;
-			}
+			if (partleng > kMaxFileNameLength) { return SAUNAFS_ERROR_CANTCREATEPATH; }
 		}
 	}
 	if (partleng == 0) {  // last part cannot be empty - it's the name of undeleted file
@@ -1503,7 +1548,7 @@ uint8_t FilesystemNodeOperationsBase::undel(uint32_t timeStamp, FSNodeFile *node
 				    timeStamp,
 				    "CREATE(%" PRIiNode ",%s,%c,%d,%" PRIu32 ",%" PRIu32 ",%" PRIu32 "):%" PRIiNode,
 				    p->id, escapeName(name).c_str(), static_cast<char>(FSNodeType::kDirectory),
-				    n->mode & 07777, (uint32_t)0, (uint32_t)0, (uint32_t)0, n->id);
+				    n->mode & kPermissionsMask, (uint32_t)0, (uint32_t)0, (uint32_t)0, n->id);
 			}
 			p = static_cast<FSNodeDirectory*>(n);
 			assert(n->type == FSNodeType::kDirectory);
@@ -1562,9 +1607,10 @@ void FilesystemNodeOperationsBase::getExtraAttrRecursive(FSNode *node, uint8_t g
                                                          ExtraAttributesArray &fileEAttrTab,
                                                          ExtraAttributesArray &dirEAttrTab) {
 	if (node->type != FSNodeType::kDirectory) {
-		fileEAttrTab[(node->mode >> 12) & (EATTR_NOOWNER | EATTR_NOACACHE | EATTR_NODATACACHE)]++;
+		fileEAttrTab[(node->mode >> EATTR_BIT_OFFSET) &
+		             (EATTR_NOOWNER | EATTR_NOACACHE | EATTR_NODATACACHE)]++;
 	} else {
-		dirEAttrTab[(node->mode >> 12)]++;
+		dirEAttrTab[(node->mode >> EATTR_BIT_OFFSET)]++;
 		if (gmode == GMODE_RECURSIVE) {
 			const FSNodeDirectory *dir_node = static_cast<const FSNodeDirectory*>(node);
 			for (const auto &entry : dir_node->entries) {
@@ -1583,7 +1629,8 @@ void FilesystemNodeOperationsBase::setgoalRecursive(FSNode *node, uint32_t timeS
                                                     inode_t *permissionDeniedINodesOut) {
 	if (node->type == FSNodeType::kFile || node->type == FSNodeType::kDirectory ||
 	    node->type == FSNodeType::kTrash || node->type == FSNodeType::kReserved) {
-		if ((node->mode & (EATTR_NOOWNER << 12)) == 0 && uid != 0 && node->uid != uid) {
+		if ((node->mode & (EATTR_NOOWNER << EATTR_BIT_OFFSET)) == 0 && uid != 0 &&
+		    node->uid != uid) {
 			(*permissionDeniedINodesOut)++;
 		} else {
 			if ((smode & SMODE_TMASK) == SMODE_SET && node->goal != goal) {
@@ -1619,7 +1666,8 @@ void FilesystemNodeOperationsBase::setTrashTimeRecursive(FSNode *node, uint32_t 
 
 	if (node->type == FSNodeType::kFile || node->type == FSNodeType::kDirectory ||
 	    node->type == FSNodeType::kTrash || node->type == FSNodeType::kReserved) {
-		if ((node->mode & (EATTR_NOOWNER << 12)) == 0 && uid != 0 && node->uid != uid) {
+		if ((node->mode & (EATTR_NOOWNER << EATTR_BIT_OFFSET)) == 0 && uid != 0 &&
+		    node->uid != uid) {
 			(*permissionDeniedINodesOut)++;
 		} else {
 			set = 0;
@@ -1672,15 +1720,15 @@ void FilesystemNodeOperationsBase::setExtraAttrRecursive(FSNode *node, uint32_t 
                                                      inode_t *permissionDeniedINodesOut) {
 	uint8_t neweattr, seattr;
 
-	if ((node->mode & (EATTR_NOOWNER << 12)) == 0 && uid != 0 && node->uid != uid) {
+	if ((node->mode & (EATTR_NOOWNER << EATTR_BIT_OFFSET)) == 0 && uid != 0 && node->uid != uid) {
 		(*permissionDeniedINodesOut)++;
 	} else {
 		seattr = eattr;
 		if (node->type != FSNodeType::kDirectory) {
-			node->mode &= ~(EATTR_NOECACHE << 12);
+			node->mode &= ~(EATTR_NOECACHE << EATTR_BIT_OFFSET);
 			seattr &= ~(EATTR_NOECACHE);
 		}
-		neweattr = (node->mode >> 12);
+		neweattr = (node->mode >> EATTR_BIT_OFFSET);
 		switch (smode & SMODE_TMASK) {
 		case SMODE_SET:
 			neweattr = seattr;
@@ -1692,8 +1740,8 @@ void FilesystemNodeOperationsBase::setExtraAttrRecursive(FSNode *node, uint32_t 
 			neweattr &= ~seattr;
 			break;
 		}
-		if (neweattr != (node->mode >> 12)) {
-			node->mode = (node->mode & 0xFFF) | (((uint16_t)neweattr) << 12);
+		if (neweattr != (node->mode >> EATTR_BIT_OFFSET)) {
+			node->mode = (node->mode & 0xFFF) | (((uint16_t)neweattr) << EATTR_BIT_OFFSET);
 			const RichACL *node_acl = gMetadata->aclStorage.get(node->id);
 			if (node_acl) {
 				gMetadata->aclStorage.setMode(node->id, node->mode,
@@ -1758,7 +1806,7 @@ uint8_t FilesystemNodeOperationsBase::getAcl(FSNode *node, RichACL &acl) {
 		return SAUNAFS_ERROR_ENOATTR;
 	}
 	acl = *richacl;
-	assert((node->mode & 0777) == richacl->getMode());
+	assert((node->mode & kStandardPermissionsMask) == richacl->getMode());
 	return SAUNAFS_STATUS_OK;
 }
 #endif
@@ -1770,10 +1818,13 @@ uint8_t FilesystemNodeOperationsBase::setAcl(FSNode *node, const RichACL &acl, u
 
 	uint16_t mode = node->mode;
 	if (RichACL::equivMode(acl, mode, node->type == FSNodeType::kDirectory)) {
-		node->mode = (node->mode & ~0777) | (mode & 0777);
+		node->mode = (node->mode & ~kStandardPermissionsMask) | (mode & kStandardPermissionsMask);
 		gMetadata->aclStorage.erase(node->id);
 	} else {
-		if (!acl.isAutoSetMode()) { node->mode = (node->mode & ~0777) | (acl.getMode() & 0777); }
+		if (!acl.isAutoSetMode()) {
+			node->mode = (node->mode & ~kStandardPermissionsMask) |
+			             (acl.getMode() & kStandardPermissionsMask);
+		}
 		RichACL new_acl = acl;
 		if (acl.isAutoSetMode()) {
 			new_acl.setFlags(new_acl.getFlags() & ~RichACL::kAutoSetMode);
@@ -1811,7 +1862,8 @@ uint8_t FilesystemNodeOperationsBase::setAcl(FSNode *node, AclType type,
 		new_acl.setMode(node->mode, true);
 	} else {
 		new_acl.appendPosixACL(acl, node->type == FSNodeType::kDirectory);
-		node->mode = (node->mode & ~0777) | (new_acl.getMode() & 0777);
+		node->mode = (node->mode & ~kStandardPermissionsMask) |
+		             (new_acl.getMode() & kStandardPermissionsMask);
 	}
 	gMetadata->aclStorage.set(node->id, std::move(new_acl));
 
@@ -1821,10 +1873,8 @@ uint8_t FilesystemNodeOperationsBase::setAcl(FSNode *node, AclType type,
 }
 
 int FilesystemNodeOperationsBase::nameCheck(const std::string &name) {
-	uint32_t i;
-	if (name.length() == 0 || name.length() > MAXFNAMELENG) {
-		return -1;
-	}
+	if (name.length() == 0 || name.length() > kMaxFileNameLength) { return -1; }
+
 	if (name[0] == '.') {
 		if (name.length() == 1) {
 			return -1;
@@ -1833,11 +1883,13 @@ int FilesystemNodeOperationsBase::nameCheck(const std::string &name) {
 			return -1;
 		}
 	}
-	for (i = 0; i < name.length(); i++) {
+
+	for (uint32_t i = 0; i < name.length(); i++) {
 		if (name[i] == '\0' || name[i] == '/') {
 			return -1;
 		}
 	}
+
 	return 0;
 }
 
@@ -1848,7 +1900,7 @@ int FilesystemNodeOperationsBase::access(const FsContext &context, FSNode *node,
 	}
 	const RichACL *node_acl = gMetadata->aclStorage.get(node->id);
 	if (node_acl) {
-		assert((node->mode & 0777) == node_acl->getMode());
+		assert((node->mode & kStandardPermissionsMask) == node_acl->getMode());
 
 		uint32_t mask = RichACL::convertMode2Mask(modemask);
 		if (node->type != FSNodeType::kDirectory) {
@@ -1856,7 +1908,7 @@ int FilesystemNodeOperationsBase::access(const FsContext &context, FSNode *node,
 		}
 		return node_acl->checkPermission(mask, node->uid, node->gid, context.uid(), context.groups());
 	} else {
-		if (context.uid() == node->uid || (node->mode & (EATTR_NOOWNER << 12))) {
+		if (context.uid() == node->uid || (node->mode & (EATTR_NOOWNER << EATTR_BIT_OFFSET))) {
 			nodemode = ((node->mode) >> 6) & 7;
 		} else if (context.sesflags() & SESFLAG_IGNOREGID) {
 			nodemode = (((node->mode) >> 3) | (node->mode)) & 7;
@@ -1876,8 +1928,8 @@ int FilesystemNodeOperationsBase::stickyAccess(FSNode *parent, FSNode *node, uin
 	if (uid == 0 || (parent->mode & 01000) == 0) {  // super user or sticky bit is not set
 		return 1;
 	}
-	if (uid == parent->uid || (parent->mode & (EATTR_NOOWNER << 12)) || uid == node->uid ||
-	    (node->mode & (EATTR_NOOWNER << 12))) {
+	if (uid == parent->uid || (parent->mode & (EATTR_NOOWNER << EATTR_BIT_OFFSET)) ||
+	    uid == node->uid || (node->mode & (EATTR_NOOWNER << EATTR_BIT_OFFSET))) {
 		return 1;
 	}
 	return 0;

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -24,6 +24,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cstddef>
 #include <cstdint>
 #include <cstdlib>
 #include <type_traits>
@@ -101,12 +102,13 @@ uint64_t FilesystemNodeOperationsBase::fileSize(FSNodeFile *node, uint32_t nonZe
 #ifndef METARESTORE
 uint32_t FilesystemNodeOperationsBase::ecChunkRealSize(uint32_t blocks, uint32_t dataPartCount,
                                                        uint32_t parityPartCount) {
-	constexpr uint32_t kCrcSize = SFSBLOCKSINCHUNK * sizeof(uint32_t);  // CRC size per chunk
+	constexpr uint32_t kTotalCrcSizePerChunkPart = SFSBLOCKSINCHUNK * sizeof(uint32_t);
 
 	const uint32_t stripes = (blocks + dataPartCount - 1) / dataPartCount;
-	uint32_t size = blocks * SFSBLOCKSIZE;                 // file data
-	size += parityPartCount * stripes * SFSBLOCKSIZE;      // parity data
-	size += kCrcSize * (dataPartCount + parityPartCount);  // headers of data and parity parts
+	uint32_t size = blocks * SFSBLOCKSIZE;             // file data
+	size += parityPartCount * stripes * SFSBLOCKSIZE;  // parity data
+	// CRCs of data and parity parts
+	size += kTotalCrcSizePerChunkPart * (dataPartCount + parityPartCount);
 
 	return size;
 }
@@ -200,10 +202,10 @@ std::string FilesystemNodeOperationsBase::escapeName(const std::string &name) {
 	// This would take much more time than computation of exact result size.
 	// Hint: remember that std::string uses static allocation
 	// for small string sizes.
-	auto longCount = std::count_if(name.begin(), name.end(), [](char chr) {
+	auto longCount = static_cast<size_t>(std::count_if(name.begin(), name.end(), [](char chr) {
 		return chr < kControlCharThreshold || chr >= kHighByteThreshold || chr == ',' ||
 		       chr == '%' || chr == '(' || chr == ')';
-	});
+	}));
 
 	result.reserve(((kBytesPerEscapedChar - 1) * longCount) + name.length());
 
@@ -211,10 +213,9 @@ std::string FilesystemNodeOperationsBase::escapeName(const std::string &name) {
 		if (chr < kControlCharThreshold || chr >= kHighByteThreshold || chr == ',' || chr == '%' ||
 		    chr == '(' || chr == ')') {
 			result.push_back('%');
-			// Linter will complain about possible out-of-bounds access, but it is masked by
-			// kHexDigitMask and kHexDigitShift constants. So it will aleways be in range 0..15.
-			result.push_back(hexDigits[(chr >> kHexDigitShift) & kHexDigitMask]);  // NOLINT
-			result.push_back(hexDigits[chr & kHexDigitMask]);                      // NOLINT
+			// Guaranteed to be in range 0-15 due to masking with kHexDigitMask (0xF)
+			result.push_back(hexDigits[(chr >> kHexDigitShift) & kHexDigitMask]);
+			result.push_back(hexDigits[chr & kHexDigitMask]);
 		} else {
 			result.push_back(chr);
 		}
@@ -304,7 +305,7 @@ void FilesystemNodeOperationsBase::getStats(FSNode *node, StatsRecord *statsOut)
 int64_t FilesystemNodeOperationsBase::getSize(FSNode *node) {
 	StatsRecord stats;
 	getStats(node, &stats);
-	return static_cast<int64_t>(stats.size);
+	return stats.size;
 }
 
 FSNodeDirectory *FilesystemNodeOperationsBase::getFirstParent(FSNode *node) {
@@ -656,7 +657,7 @@ FSNode *FilesystemNodeOperationsBase::createNode(uint32_t timeStamp, FSNodeDirec
 
 	node->uid = uid;  // owner
 
-	if ((parent->mode & S_ISGID) == S_ISGID) {  // set gid flag is set in the parent directory?
+	if ((parent->mode & S_ISGID) == S_ISGID) {  // Set-GID flag is set in the parent directory?
 		node->gid = parent->gid;
 		if (copysgid && type == FSNodeType::kDirectory) { node->mode |= S_ISGID; }
 	} else {
@@ -752,7 +753,8 @@ void FilesystemNodeOperationsBase::getPath(FSNodeDirectory *parent, FSNode *chil
 #ifndef METARESTORE
 constexpr uint32_t kOldPathContainerLimit = 1000000;
 
-// Constants for detached data handling
+// Constants for detached data handling (trash/reserved paths)
+
 constexpr uint32_t kDetachedMaxNameLength = 240;
 constexpr uint32_t kDetachedEllipsisLength = 5;  // length of "(...)"
 constexpr uint32_t kDetachedTruncatedLength = kDetachedMaxNameLength - kDetachedEllipsisLength;
@@ -926,13 +928,14 @@ void FilesystemNodeOperationsBase::getDetachedData(const ReservedPathContainer &
 
 uint32_t FilesystemNodeOperationsBase::getDirSize(const FSNodeDirectory *nodeDir,
                                                   uint8_t withAttr) {
-	uint32_t entrySize = (withAttr) ? kDirEntryWithAttributesSize : kDirEntryWithoutAttributesSize;
-	uint32_t result = (entrySize * 2) + kDotEntrySize + kDotDotEntrySize;  // for '.' and '..'
+	uint32_t entryBaseSize = kDetachedSizeByteLength + (withAttr ? kDirEntryWithAttributesSize
+	                                                             : kDirEntryWithoutAttributesSize);
+	uint32_t result = (entryBaseSize * 2) + kDotEntrySize + kDotDotEntrySize;  // for '.' and '..'
 	std::string name;
 
 	for (const auto &entry : nodeDir->entries) {
 		name = (std::string)(*entry.first);
-		result += entrySize + name.length();
+		result += entryBaseSize + name.length();
 	}
 
 	return result;
@@ -943,9 +946,9 @@ void FilesystemNodeOperationsBase::getDirData(inode_t rootINode, uint32_t uid, u
                                               FSNodeDirectory *nodeDir, uint8_t *outBuffer,
                                               uint8_t withAttr) {
 	// '.' - self
-	outBuffer[0] = 1;  // name length
+	outBuffer[0] = kDotEntrySize;
 	outBuffer[1] = '.';
-	outBuffer += kDotEntrySize;
+	outBuffer += kDotEntrySize + kDetachedSizeByteLength;
 	if (nodeDir->id != rootINode) {
 		putINode(&outBuffer, nodeDir->id);
 	} else {
@@ -964,10 +967,10 @@ void FilesystemNodeOperationsBase::getDirData(inode_t rootINode, uint32_t uid, u
 	}
 
 	// '..' - parent
-	outBuffer[0] = 2;  // name length
+	outBuffer[0] = kDotDotEntrySize;
 	outBuffer[1] = '.';
 	outBuffer[2] = '.';
-	outBuffer += kDotDotEntrySize;
+	outBuffer += kDotDotEntrySize + kDetachedSizeByteLength;
 
 	if (nodeDir->id == rootINode) {  // root node should returns self as its parent
 		putINode(&outBuffer, SPECIAL_INODE_ROOT);
@@ -1049,8 +1052,8 @@ void FilesystemNodeOperationsBase::getDir(inode_t rootINode, uint32_t uid, uint3
 	static constexpr uint64_t kDotDotEntryIndex = (static_cast<uint64_t>(1) << hstorage::Handle::kHashShift);
 	static constexpr uint64_t kUnusedEntryIndex = (static_cast<uint64_t>(2) << hstorage::Handle::kHashShift);
 
-	FSNodeDirectory *parent{};
-	inode_t inode{};
+	FSNodeDirectory *parent;
+	inode_t inode;
 	Attributes attr;
 
 	// Handle the "." entry if starting from there and entries are requested
@@ -1059,8 +1062,7 @@ void FilesystemNodeOperationsBase::getDir(inode_t rootINode, uint32_t uid, uint3
 		parent = idToNodeVerify<FSNodeDirectory>(
 		    nodeDir->parents.empty() ? SPECIAL_INODE_ROOT : nodeDir->parents[0].first);
 		fillAttr(nodeDir, parent, uid, gid, auid, agid, sesflags, attr);
-		dirEntriesOut.emplace_back(kDotEntryIndex, kDotDotEntryIndex, inode, std::string("."),
-		                           attr);
+		dirEntriesOut.emplace_back(kDotEntryIndex, kDotDotEntryIndex, inode, ".", attr);
 
 		firstEntry = kDotDotEntryIndex;
 		--numberOfEntries;
@@ -1092,7 +1094,7 @@ void FilesystemNodeOperationsBase::getDir(inode_t rootINode, uint32_t uid, uint3
 			auto firstDirentIt = nodeDir->find_nth(0);
 			nextIndex = (*firstDirentIt).first->data() & ~kSignBit64;
 		}
-		dirEntriesOut.emplace_back(kDotDotEntryIndex, nextIndex, inode, std::string(".."), attr);
+		dirEntriesOut.emplace_back(kDotDotEntryIndex, nextIndex, inode, "..", attr);
 
 		firstEntry = nextIndex;
 		--numberOfEntries;
@@ -1123,9 +1125,8 @@ void FilesystemNodeOperationsBase::getDir(inode_t rootINode, uint32_t uid, uint3
 		}
 	}
 
+	// Do not try to unbind the resource under this possibly-fake handle in destructor
 	pairToFind.first->unlink();
-	// do not try to unbind the resource under this possibly-fake handle in destructor
-	firstIndex.unlink();
 
 	// Iterate through the directory entries, collecting up to numberOfEntries entries
 	while (iter != nodeDir->entries.end() && numberOfEntries > 0) {
@@ -1145,7 +1146,7 @@ void FilesystemNodeOperationsBase::getDir(inode_t rootINode, uint32_t uid, uint3
 }
 
 void FilesystemNodeOperationsBase::checkFile(FSNodeFile *nodeFile, ChunkCountArray &chunkCount) {
-	uint8_t count{};
+	uint8_t count;
 
 	chunkCount.fill(0);
 
@@ -1256,7 +1257,7 @@ void FilesystemNodeOperationsBase::changeFileGoal(FSNodeFile *nodeFile, uint8_t 
 
 void FilesystemNodeOperationsBase::setLength(FSNodeFile *nodeFile, uint64_t length,
                                              bool eraseFurtherChunks) {
-	uint32_t chunks{};
+	uint32_t chunks = 0;
 	StatsRecord previousStats;
 	StatsRecord newStats;
 	getStats(nodeFile, &previousStats);
@@ -1576,7 +1577,7 @@ uint8_t FilesystemNodeOperationsBase::undel(uint32_t timeStamp, FSNodeFile *node
 			gMetadata->trashSpace -= node->length;
 			gMetadata->trashNodes--;
 
-			return SAUNAFS_STATUS_OK;  // early return
+			return SAUNAFS_STATUS_OK;
 		}
 
 		// Directory handling (only runs for intermediate segments)
@@ -1735,31 +1736,31 @@ void FilesystemNodeOperationsBase::setTrashTimeRecursive(FSNode *node, uint32_t 
 		    node->uid != uid) {
 			(*permissionDeniedINodesOut)++;
 		} else {
-			bool set = false;
+			bool wasSet = false;
 			auto oldTrashKey = TrashPathKey(node);
 
 			switch (smode & SMODE_TMASK) {
 			case SMODE_SET:
 				if (node->trashtime != trashtime) {
 					node->trashtime = trashtime;
-					set = true;
+					wasSet = true;
 				}
 				break;
 			case SMODE_INCREASE:
 				if (node->trashtime < trashtime) {
 					node->trashtime = trashtime;
-					set = true;
+					wasSet = true;
 				}
 				break;
 			case SMODE_DECREASE:
 				if (node->trashtime > trashtime) {
 					node->trashtime = trashtime;
-					set = true;
+					wasSet = true;
 				}
 				break;
 			}
 
-			if (set) {
+			if (wasSet) {
 				(*modifiedINodesOut)++;
 				node->ctime = timeStamp;
 
@@ -1854,6 +1855,7 @@ uint8_t FilesystemNodeOperationsBase::deleteAcl(FSNode *node, AclType type, uint
 		if (nodeAcl != nullptr) {
 			RichACL newAcl = *nodeAcl;
 			newAcl.createExplicitInheritance();
+
 			newAcl.removeInheritOnly(true);
 			if (newAcl.size() == 0) {
 				gMetadata->aclStorage.erase(node->id);
@@ -1867,6 +1869,7 @@ uint8_t FilesystemNodeOperationsBase::deleteAcl(FSNode *node, AclType type, uint
 			RichACL newAcl = *nodeAcl;
 			newAcl.createExplicitInheritance();
 			newAcl.removeInheritOnly(false);
+
 			if (newAcl.size() == 0) {
 				gMetadata->aclStorage.erase(node->id);
 			} else {
@@ -1886,9 +1889,12 @@ uint8_t FilesystemNodeOperationsBase::deleteAcl(FSNode *node, AclType type, uint
 #ifndef METARESTORE
 uint8_t FilesystemNodeOperationsBase::getAcl(FSNode *node, RichACL &acl) {
 	const RichACL *richAcl = gMetadata->aclStorage.get(node->id);
+
 	if (!richAcl) { return SAUNAFS_ERROR_ENOATTR; }
+
 	acl = *richAcl;
 	assert((node->mode & kStandardPermissionsMask) == richAcl->getMode());
+
 	return SAUNAFS_STATUS_OK;
 }
 #endif
@@ -1907,11 +1913,14 @@ uint8_t FilesystemNodeOperationsBase::setAcl(FSNode *node, const RichACL &acl, u
 			node->mode = (node->mode & ~kStandardPermissionsMask) |
 			             (acl.getMode() & kStandardPermissionsMask);
 		}
+
 		RichACL newAcl = acl;
+
 		if (acl.isAutoSetMode()) {
 			newAcl.setFlags(newAcl.getFlags() & ~RichACL::kAutoSetMode);
 			newAcl.setMode(node->mode, node->type == FSNodeType::kDirectory);
 		}
+
 		gMetadata->aclStorage.set(node->id, std::move(newAcl));
 	}
 
@@ -2001,7 +2010,7 @@ int FilesystemNodeOperationsBase::access(const FsContext &context, FSNode *node,
 	constexpr uint8_t kGroupModeBits = 3;           // >> 3 for group bits
 	constexpr uint8_t kSingleClassPermissions = 7;  // & 7 to extract 3 bits
 
-	uint8_t nodeMode;  // NOLINT: will be assigned before use
+	uint8_t nodeMode;
 
 	// Determine which permission class applies to the requesting user
 	if (context.uid() == node->uid || (node->mode & (EATTR_NOOWNER << EATTR_BIT_OFFSET))) {
@@ -2065,8 +2074,8 @@ uint8_t FilesystemNodeOperationsBase::getNodeForOperation(const FsContext &conte
                                                           uint8_t modeMask, inode_t inode,
                                                           FSNode **nodeOut,
                                                           FSNodeDirectory **rootDirOut) {
-	FSNode *candidateNode;           // NOLINT: will be assigned before use
-	FSNodeDirectory *candidateRoot;  // NOLINT: will be assigned before use
+	FSNode *candidateNode;
+	FSNodeDirectory *candidateRoot;
 
 	// Node lookup
 

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -139,8 +139,7 @@ uint64_t FilesystemNodeOperationsBase::fileRealSize(FSNodeFile *node, uint32_t n
 			}
 			fullSize += size;
 		} else {
-			safs_pretty_syslog(LOG_ERR, "file_realsize: inode %" PRIiNode " has unknown goal 0x%" PRIx8, node->id,
-			       node->goal);
+			safs::log_err("file_realsize: inode {} has unknown goal {:#x}", node->id, node->goal);
 			return 0;
 		}
 	}
@@ -741,7 +740,7 @@ void FilesystemNodeOperationsBase::getPath(FSNodeDirectory *parent, FSNode *chil
 	uint32_t size = getPathSize(parent, child);
 
 	if (size > FSNode::kEdgeNameMaxSize) {
-		safs_pretty_syslog(LOG_WARNING, "path too long !!! - truncate");
+		safs::log_warn("path too long !!! - truncate");
 		size = FSNode::kEdgeNameMaxSize;
 	}
 
@@ -815,7 +814,7 @@ static inline void getDetachedDataGenericInternal(const T &data, uint8_t *dbuff)
 			// there's already an alternative in client library that allows
 			// buffered reads from trash/reserved.
 			safs::log_warn("getdetachedsize: path container size longer than {}, truncating",
-				  kOldPathContainerLimit);
+			               kOldPathContainerLimit);
 			break;
 		}
 
@@ -1187,10 +1186,8 @@ uint8_t FilesystemNodeOperationsBase::appendChunks(uint32_t timeStamp, FSNodeFil
 		auto chunkId = srcNodeFile->chunks[i];
 		if (chunkId > 0) {
 			if (chunk_add_file(chunkId, destNodeFile->goal) != SAUNAFS_STATUS_OK) {
-				safs_pretty_syslog(LOG_ERR,
-				                   "structure error - chunk %016" PRIX64
-				                   " not found (inode: %" PRIiNode " ; index: %" PRIu32 ")",
-				                   chunkId, srcNodeFile->id, i);
+				safs::log_err("structure error - chunk {:016X} not found (inode: {} ; index: {})",
+				              chunkId, srcNodeFile->id, i);
 			}
 		}
 	}
@@ -1627,16 +1624,14 @@ void FilesystemNodeOperationsBase::getGoalRecursive(FSNode *node, uint8_t gmode,
 	if (node->type == FSNodeType::kFile || node->type == FSNodeType::kTrash ||
 	    node->type == FSNodeType::kReserved) {
 		if (!GoalId::isValid(node->goal)) {
-			safs_pretty_syslog(LOG_WARNING, "file inode %" PRIiNode ": unknown goal !!! - fixing",
-			       node->id);
+			safs::log_warn("file inode {}: unknown goal !!! - fixing", node->id);
 			changeFileGoal(static_cast<FSNodeFile *>(node), DEFAULT_GOAL);
 		}
 
 		fileGoalsTab[node->goal]++;
 	} else if (node->type == FSNodeType::kDirectory) {
 		if (!GoalId::isValid(node->goal)) {
-			safs_pretty_syslog(LOG_WARNING,
-			       "directory inode %" PRIiNode ": unknown goal !!! - fixing", node->id);
+			safs::log_warn("directory inode {}: unknown goal !!! - fixing", node->id);
 			node->goal = DEFAULT_GOAL;
 		}
 

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -51,14 +51,17 @@ constexpr uint16_t kPermissionsMask = 07777;
 constexpr uint16_t kStandardPermissionsMask = 0777;
 constexpr uint16_t kExtraAttributesMask = 0xF000;  ///< Bits 12-15 for extra attributes
 
+/// Default undelete directory mode
+constexpr uint16_t kUndelDirectoryMode = 0755;
+
 // Private helper methods
 
 uint32_t FilesystemNodeOperationsBase::lastChunkBlocks(FSNodeFile *node) {
-	const uint64_t last_byte = node->length - 1;
-	const uint32_t last_byte_offset = last_byte % SFSCHUNKSIZE;
-	const uint32_t last_block = last_byte_offset / SFSBLOCKSIZE;
-	const uint32_t block_count = last_block + 1;
-	return block_count;
+	const uint64_t lastByte = node->length - 1;
+	const uint32_t lastByteOffset = lastByte % SFSCHUNKSIZE;
+	const uint32_t lastBlock = lastByteOffset / SFSBLOCKSIZE;
+	const uint32_t blockCount = lastBlock + 1;
+	return blockCount;
 }
 
 bool FilesystemNodeOperationsBase::isLastChunkNonEmpty(FSNodeFile *node) {
@@ -69,11 +72,11 @@ bool FilesystemNodeOperationsBase::isLastChunkNonEmpty(FSNodeFile *node) {
 	}
 
 	// file has non-zero length and contains at least one chunk
-	const uint64_t last_byte = node->length - 1;
-	const uint32_t last_chunk = last_byte / SFSCHUNKSIZE;
-	if (last_chunk < chunks) {
+	const uint64_t lastByte = node->length - 1;
+	const uint32_t lastChunk = lastByte / SFSCHUNKSIZE;
+	if (lastChunk < chunks) {
 		// last chunk exists, check if it isn't the zero chunk
-		return node->chunks[last_chunk] != 0;
+		return node->chunks[lastChunk] != 0;
 	}
 	// last chunk hasn't been allocated yet
 	return false;
@@ -119,22 +122,22 @@ uint64_t FilesystemNodeOperationsBase::fileRealSize(FSNodeFile *node, uint32_t n
 #else
 	const Goal &goal = gFSOperations->getGoalDefinition(node->goal);
 
-	uint64_t full_size = 0;
+	uint64_t fullSize = 0;
 	for (const auto &slice : goal) {
 		if (slice_traits::isStandard(slice) || slice_traits::isTape(slice)) {
-			full_size += logicalFileSize * slice.getExpectedCopies();
+			fullSize += logicalFileSize * slice.getExpectedCopies();
 		} else if (slice_traits::isXor(slice) || slice_traits::isEC(slice)) {
-			int data_part_count = slice_traits::getNumberOfDataParts(slice);
-			int parity_part_count = slice_traits::getNumberOfParityParts(slice);
+			int dataPartCount = slice_traits::getNumberOfDataParts(slice);
+			int parityPartCount = slice_traits::getNumberOfParityParts(slice);
 
-			uint32_t full_chunk_realsize =
-			    ecChunkRealSize(SFSBLOCKSINCHUNK, data_part_count, parity_part_count);
-			uint64_t size = (uint64_t)nonZeroChunks * full_chunk_realsize;
+			uint32_t fullChunkRealSize =
+			    ecChunkRealSize(SFSBLOCKSINCHUNK, dataPartCount, parityPartCount);
+			uint64_t size = (uint64_t)nonZeroChunks * fullChunkRealSize;
 			if (isLastChunkNonEmpty(node)) {
-				size -= full_chunk_realsize;
-				size += ecChunkRealSize(lastChunkBlocks(node), data_part_count, parity_part_count);
+				size -= fullChunkRealSize;
+				size += ecChunkRealSize(lastChunkBlocks(node), dataPartCount, parityPartCount);
 			}
-			full_size += size;
+			fullSize += size;
 		} else {
 			safs_pretty_syslog(LOG_ERR, "file_realsize: inode %" PRIiNode " has unknown goal 0x%" PRIx8, node->id,
 			       node->goal);
@@ -142,7 +145,7 @@ uint64_t FilesystemNodeOperationsBase::fileRealSize(FSNodeFile *node, uint32_t n
 		}
 	}
 
-	return full_size;
+	return fullSize;
 #endif
 }
 
@@ -170,11 +173,11 @@ FSNode *FilesystemNodeOperationsBase::lookup(FSNodeDirectory *node, const HStrin
 
 void FilesystemNodeOperationsBase::updateCTime(FSNode *node, uint32_t ctime) {
 	if (node->type == FSNodeType::kTrash && node->ctime != ctime) {
-		auto old_key = TrashPathKey(node);
+		auto oldKey = TrashPathKey(node);
 		node->ctime = ctime;
-		auto iter = gMetadata->trash.find(old_key);
+		auto iter = gMetadata->trash.find(oldKey);
 		if (iter != gMetadata->trash.end()) {
-			updateTrashFromOldEntry(gMetadata->trash, node, old_key);
+			updateTrashFromOldEntry(gMetadata->trash, node, oldKey);
 		}
 	} else {
 		node->ctime = ctime;
@@ -1040,29 +1043,31 @@ void FilesystemNodeOperationsBase::getDir(inode_t rootINode, uint32_t uid, uint3
                                           FSNodeDirectory *nodeDir, uint64_t firstEntry,
                                           uint64_t numberOfEntries,
                                           std::vector<DirectoryEntry> &dirEntriesOut) {
-	uint64_t const SIGN_BIT_64(1ULL << 63ULL);
-	sassert(!(firstEntry & SIGN_BIT_64));
+	static constexpr uint64_t kSignBit64 = (1ULL << 63ULL);
+	sassert(!(firstEntry & kSignBit64));
 	// special entryIndex values
 	static constexpr uint64_t kDotEntryIndex = 0;
 	static constexpr uint64_t kDotDotEntryIndex = (static_cast<uint64_t>(1) << hstorage::Handle::kHashShift);
 	static constexpr uint64_t kUnusedEntryIndex = (static_cast<uint64_t>(2) << hstorage::Handle::kHashShift);
 
-	FSNodeDirectory *parent;
-	inode_t inode;
+	FSNodeDirectory *parent{};
+	inode_t inode{};
 	Attributes attr;
 
+	// Handle the "." entry if starting from there and entries are requested
 	if (firstEntry == kDotEntryIndex && numberOfEntries >= 1) {
 		inode = nodeDir->id != rootINode ? nodeDir->id : SPECIAL_INODE_ROOT;
 		parent = idToNodeVerify<FSNodeDirectory>(
 		    nodeDir->parents.empty() ? SPECIAL_INODE_ROOT : nodeDir->parents[0].first);
 		fillAttr(nodeDir, parent, uid, gid, auid, agid, sesflags, attr);
-		dirEntriesOut.emplace_back(kDotEntryIndex, kDotDotEntryIndex, std::move(inode),
-		                           std::string("."), std::move(attr));
+		dirEntriesOut.emplace_back(kDotEntryIndex, kDotDotEntryIndex, inode, std::string("."),
+		                           attr);
 
 		firstEntry = kDotDotEntryIndex;
 		--numberOfEntries;
 	}
 
+	// Handle the ".." entry if starting from its index and entries are requested
 	if (firstEntry == kDotDotEntryIndex && numberOfEntries >= 1) {
 		if (nodeDir->id == rootINode) {
 			inode = SPECIAL_INODE_ROOT;
@@ -1076,70 +1081,72 @@ void FilesystemNodeOperationsBase::getDir(inode_t rootINode, uint32_t uid, uint3
 				inode = SPECIAL_INODE_ROOT;
 			}
 
-			FSNodeDirectory *grandparent;
 			parent = idToNodeVerify<FSNodeDirectory>(
 			    nodeDir->parents.empty() ? SPECIAL_INODE_ROOT : nodeDir->parents[0].first);
-			grandparent = idToNodeVerify<FSNodeDirectory>(
+			auto *grandparent = idToNodeVerify<FSNodeDirectory>(
 			    parent->parents.empty() ? SPECIAL_INODE_ROOT : parent->parents[0].first);
 			fillAttr(parent, grandparent, uid, gid, auid, agid, sesflags, attr);
 		}
 
-		uint64_t next_index = kUnusedEntryIndex;
+		uint64_t nextIndex = kUnusedEntryIndex;
 		if (!nodeDir->entries.empty()) {
-			auto first_dirent_it = nodeDir->find_nth(0);
-			next_index = (*first_dirent_it).first->data() & ~SIGN_BIT_64;
+			auto firstDirentIt = nodeDir->find_nth(0);
+			nextIndex = (*firstDirentIt).first->data() & ~kSignBit64;
 		}
-		dirEntriesOut.emplace_back(kDotDotEntryIndex, next_index, std::move(inode),
-		                           std::string(".."), std::move(attr));
+		dirEntriesOut.emplace_back(kDotDotEntryIndex, nextIndex, inode, std::string(".."), attr);
 
-		firstEntry = next_index;
+		firstEntry = nextIndex;
 		--numberOfEntries;
 	}
 
+	// Early exit if no more entries to process or directory is empty
 	if (numberOfEntries == 0 || nodeDir->entries.empty()) { return; }
 
 	std::string name;
-	hstorage::Handle first_index(firstEntry);
+	hstorage::Handle firstIndex(firstEntry);
 
 	// We're trying to find the first entry in the directory that has index
-	// equal to first_entry. We don't know the second part of the pair, so we
+	// equal to firstEntry. We don't know the second part of the pair, so we
 	// use kUnknownNode as a placeholder, and it is also the minimum possible.
-	auto pair_to_find = std::make_pair(&first_index, kUnknownNode);
-	auto it = nodeDir->entries.lower_bound(pair_to_find);
-	if (it != nodeDir->entries.end() && (*it).first->data() != firstEntry) {
-		// We assume that we received hash that had its most significant bit
-		// stripped so we try new find with this supposedly stripped bit set
-		// again.
-		first_index.unlink();  // do not try to unbind the resource under this
-		                       // possibly-fake handle in destructor
-		first_index = hstorage::Handle(firstEntry | SIGN_BIT_64);
-		pair_to_find = std::make_pair(&first_index, kUnknownNode);
-		it = nodeDir->entries.lower_bound(pair_to_find);
-		if (it != nodeDir->entries.end() && (*it).first->data() != (firstEntry | SIGN_BIT_64)) {
-			it = nodeDir->entries.end();
+	auto pairToFind = std::make_pair(&firstIndex, kUnknownNode);
+	auto iter = nodeDir->entries.lower_bound(pairToFind);
+
+	if (iter != nodeDir->entries.end() && (*iter).first->data() != firstEntry) {
+		// We assume that we received hash that had its most significant bit stripped so we try new
+		// find with this supposedly stripped bit set again.
+		firstIndex.unlink();  // do not try to unbind the resource under this
+		                      // possibly-fake handle in destructor
+		firstIndex = hstorage::Handle(firstEntry | kSignBit64);
+		pairToFind = std::make_pair(&firstIndex, kUnknownNode);
+		iter = nodeDir->entries.lower_bound(pairToFind);
+		if (iter != nodeDir->entries.end() && (*iter).first->data() != (firstEntry | kSignBit64)) {
+			iter = nodeDir->entries.end();
 		}
 	}
-	pair_to_find.first->unlink();
-	first_index.unlink(); // do not try to unbind the resource under this possibly-fake handle in destructor
-	while (it != nodeDir->entries.end() && numberOfEntries > 0) {
-		name = static_cast<std::string>(*(*it).first);
-		inode = (*it).second->id;
-		fillAttr((*it).second, nodeDir, uid, gid, auid, agid, sesflags, attr);
 
-		firstEntry = (*it).first->data() & ~SIGN_BIT_64;
+	pairToFind.first->unlink();
+	// do not try to unbind the resource under this possibly-fake handle in destructor
+	firstIndex.unlink();
 
-		uint64_t next_index = kUnusedEntryIndex;
-		if (++it != nodeDir->entries.end()) { next_index = (*it).first->data() & ~SIGN_BIT_64; }
+	// Iterate through the directory entries, collecting up to numberOfEntries entries
+	while (iter != nodeDir->entries.end() && numberOfEntries > 0) {
+		name = static_cast<std::string>(*(*iter).first);
+		inode = (*iter).second->id;
+		fillAttr((*iter).second, nodeDir, uid, gid, auid, agid, sesflags, attr);
 
-		dirEntriesOut.emplace_back(firstEntry, next_index, std::move(inode), std::move(name),
-		                           std::move(attr));
+		firstEntry = (*iter).first->data() & ~kSignBit64;
+
+		uint64_t nextIndex = kUnusedEntryIndex;
+		if (++iter != nodeDir->entries.end()) { nextIndex = (*iter).first->data() & ~kSignBit64; }
+
+		dirEntriesOut.emplace_back(firstEntry, nextIndex, inode, std::move(name), attr);
 
 		--numberOfEntries;
 	}
 }
 
 void FilesystemNodeOperationsBase::checkFile(FSNodeFile *nodeFile, ChunkCountArray &chunkCount) {
-	uint8_t count;
+	uint8_t count{};
 
 	chunkCount.fill(0);
 
@@ -1157,35 +1164,41 @@ uint8_t FilesystemNodeOperationsBase::appendChunks(uint32_t timeStamp, FSNodeFil
                                                    FSNodeFile *srcNodeFile) {
 	if (srcNodeFile->chunks.empty()) { return SAUNAFS_STATUS_OK; }
 
-	uint32_t src_chunks = srcNodeFile->chunkCount();
-	uint32_t dst_chunks = destNodeFile->chunkCount();
+	uint32_t srcChunks = srcNodeFile->chunkCount();
+	uint32_t dstChunks = destNodeFile->chunkCount();
 
-	if (((uint64_t)src_chunks + (uint64_t)dst_chunks) > ((uint64_t)MAX_INDEX + 1)) {
+	if (((uint64_t)srcChunks + (uint64_t)dstChunks) > ((uint64_t)kMaxChunkIndex + 1)) {
 		return SAUNAFS_ERROR_INDEXTOOBIG;
 	}
 
-	StatsRecord psr, nsr;
-	getStats(destNodeFile, &psr);
+	StatsRecord previousStats;
+	StatsRecord newStats;
+	getStats(destNodeFile, &previousStats);
 
-	uint32_t result_chunks = src_chunks + dst_chunks;
-	destNodeFile->chunks.resize(result_chunks, 0);
+	uint32_t resultChunks = srcChunks + dstChunks;
+	destNodeFile->chunks.resize(resultChunks, 0);
 
-	std::copy(srcNodeFile->chunks.begin(), srcNodeFile->chunks.begin() + src_chunks,
-	          destNodeFile->chunks.begin() + dst_chunks);
+	// Copy source chunks to the end of destination chunks
+	std::copy(srcNodeFile->chunks.begin(), srcNodeFile->chunks.begin() + srcChunks,
+	          destNodeFile->chunks.begin() + dstChunks);
 
-	for(uint32_t i = 0; i < src_chunks; ++i) {
-		auto chunkid = srcNodeFile->chunks[i];
-		if (chunkid > 0) {
-			if (chunk_add_file(chunkid, destNodeFile->goal) != SAUNAFS_STATUS_OK) {
+	// Add each source chunk to the destination file's goal and handle errors
+	for (uint32_t i = 0; i < srcChunks; ++i) {
+		auto chunkId = srcNodeFile->chunks[i];
+		if (chunkId > 0) {
+			if (chunk_add_file(chunkId, destNodeFile->goal) != SAUNAFS_STATUS_OK) {
 				safs_pretty_syslog(LOG_ERR,
 				                   "structure error - chunk %016" PRIX64
 				                   " not found (inode: %" PRIiNode " ; index: %" PRIu32 ")",
-				                   chunkid, srcNodeFile->id, i);
+				                   chunkId, srcNodeFile->id, i);
 			}
 		}
 	}
 
-	uint64_t length = (static_cast<uint64_t>(dst_chunks) << SFSCHUNKBITS) + srcNodeFile->length;
+	// Calculate the new total length after appending
+	uint64_t length = (static_cast<uint64_t>(dstChunks) << SFSCHUNKBITS) + srcNodeFile->length;
+
+	// Update trash or reserved space counters if the destination is in trash or reserved
 	if (destNodeFile->type == FSNodeType::kTrash) {
 		gMetadata->trashSpace -= destNodeFile->length;
 		gMetadata->trashSpace += length;
@@ -1193,55 +1206,73 @@ uint8_t FilesystemNodeOperationsBase::appendChunks(uint32_t timeStamp, FSNodeFil
 		gMetadata->reservedSpace -= destNodeFile->length;
 		gMetadata->reservedSpace += length;
 	}
+
 	destNodeFile->length = length;
-	getStats(destNodeFile, &nsr);
-	fsnodes_quota_update(destNodeFile, {{QuotaResource::kSize, nsr.size - psr.size}});
+	getStats(destNodeFile, &newStats);
+
+	// Update quotas based on the change in file size
+	fsnodes_quota_update(destNodeFile,
+	                     {{QuotaResource::kSize, newStats.size - previousStats.size}});
+
+	// Update stats for all parent directories
 	for (const auto &[parentId, _] : destNodeFile->parents) {
-		auto *parent_node = idToNodeVerify<FSNodeDirectory>(parentId);
-		addSubStats(parent_node, &nsr, &psr);
+		auto *parentNode = idToNodeVerify<FSNodeDirectory>(parentId);
+		addSubStats(parentNode, &newStats, &previousStats);
 	}
+
+	// Update timestamps and checksums
+
 	destNodeFile->mtime = timeStamp;
 	destNodeFile->atime = timeStamp;
 	srcNodeFile->atime = timeStamp;
+
 	fsnodes_update_checksum(srcNodeFile);
 	fsnodes_update_checksum(destNodeFile);
+
 	return SAUNAFS_STATUS_OK;
 }
 
 void FilesystemNodeOperationsBase::changeFileGoal(FSNodeFile *nodeFile, uint8_t goal) {
-	uint8_t old_goal = nodeFile->goal;
-	StatsRecord psr, nsr;
+	uint8_t oldGoal = nodeFile->goal;
+	StatsRecord previousStats;
+	StatsRecord newStats;
 
-	getStats(nodeFile, &psr);
+	getStats(nodeFile, &previousStats);
 	nodeFile->goal = goal;
-	nsr = psr;
-	nsr.realsize = fileRealSize(nodeFile, nsr.chunks, nsr.size);
+
+	newStats = previousStats;
+	newStats.realsize = fileRealSize(nodeFile, newStats.chunks, newStats.size);
+
 	for (const auto &[parentId, _] : nodeFile->parents) {
-		auto *parent_node = idToNodeVerify<FSNodeDirectory>(parentId);
-		addSubStats(parent_node, &nsr, &psr);
+		auto *parentNode = idToNodeVerify<FSNodeDirectory>(parentId);
+		addSubStats(parentNode, &newStats, &previousStats);
 	}
-	for (const auto &chunkid : nodeFile->chunks) {
-		if (chunkid > 0) {
-			chunk_change_file(chunkid, old_goal, goal);
-		}
+
+	for (const auto &chunkId : nodeFile->chunks) {
+		if (chunkId > 0) { chunk_change_file(chunkId, oldGoal, goal); }
 	}
+
 	fsnodes_update_checksum(nodeFile);
+
 	gMetadata->nodeChangedSignal.emit(nodeFile);
 }
 
-void FilesystemNodeOperationsBase::setLength(FSNodeFile *obj, uint64_t length,
+void FilesystemNodeOperationsBase::setLength(FSNodeFile *nodeFile, uint64_t length,
                                              bool eraseFurtherChunks) {
-	uint32_t chunks;
-	StatsRecord psr, nsr;
-	getStats(obj, &psr);
-	if (obj->type == FSNodeType::kTrash) {
-		gMetadata->trashSpace -= obj->length;
+	uint32_t chunks{};
+	StatsRecord previousStats;
+	StatsRecord newStats;
+	getStats(nodeFile, &previousStats);
+
+	if (nodeFile->type == FSNodeType::kTrash) {
+		gMetadata->trashSpace -= nodeFile->length;
 		gMetadata->trashSpace += length;
-	} else if (obj->type == FSNodeType::kReserved) {
-		gMetadata->reservedSpace -= obj->length;
+	} else if (nodeFile->type == FSNodeType::kReserved) {
+		gMetadata->reservedSpace -= nodeFile->length;
 		gMetadata->reservedSpace += length;
 	}
-	obj->length = length;
+
+	nodeFile->length = length;
 
 	if (eraseFurtherChunks) {
 		if (length > 0) {
@@ -1249,43 +1280,54 @@ void FilesystemNodeOperationsBase::setLength(FSNodeFile *obj, uint64_t length,
 		} else {
 			chunks = 0;
 		}
-		for (uint32_t i = chunks; i < obj->chunks.size(); i++) {
-			uint64_t chunkid = obj->chunks[i];
-			if (chunkid > 0) {
-				if (chunk_delete_file(chunkid, obj->goal) != SAUNAFS_STATUS_OK) {
+
+		for (uint32_t i = chunks; i < nodeFile->chunks.size(); i++) {
+			uint64_t chunkId = nodeFile->chunks[i];
+			if (chunkId > 0) {
+				if (chunk_delete_file(chunkId, nodeFile->goal) != SAUNAFS_STATUS_OK) {
 					safs::log_err(
 					    "structure error - chunk {:#016x} not found (inode: {} ; index: {})",
-					    chunkid, obj->id, i);
+					    chunkId, nodeFile->id, i);
 				}
 			}
 		}
 
-		if (chunks < obj->chunks.size()) {
-			obj->chunks.resize(chunks);
-		}
+		if (chunks < nodeFile->chunks.size()) { nodeFile->chunks.resize(chunks); }
 	}
 
-	getStats(obj, &nsr);
-	fsnodes_quota_update(obj, {{QuotaResource::kSize, nsr.size - psr.size}});
-	for (const auto &[parentId, _] : obj->parents) {
-		auto *parent_node = idToNodeVerify<FSNodeDirectory>(parentId);
-		addSubStats(parent_node, &nsr, &psr);
+	getStats(nodeFile, &newStats);
+
+	fsnodes_quota_update(nodeFile, {{QuotaResource::kSize, newStats.size - previousStats.size}});
+
+	for (const auto &[parentId, _] : nodeFile->parents) {
+		auto *parentNode = idToNodeVerify<FSNodeDirectory>(parentId);
+		addSubStats(parentNode, &newStats, &previousStats);
 	}
-	fsnodes_update_checksum(obj);
-	gMetadata->nodeChangedSignal.emit(obj);
+
+	fsnodes_update_checksum(nodeFile);
+
+	gMetadata->nodeChangedSignal.emit(nodeFile);
 }
 
 void FilesystemNodeOperationsBase::changeUidGid(FSNode *node, uint32_t uid, uint32_t gid) {
 	int64_t size = 0;
+
+	// Decrease quota for old owner
 	fsnodes_quota_update(node, {{QuotaResource::kInodes, -1}});
+
 	if (node->type == FSNodeType::kFile || node->type == FSNodeType::kTrash ||
 	    node->type == FSNodeType::kReserved) {
 		size = getSize(node);
 		fsnodes_quota_update(node, {{QuotaResource::kSize, -size}});
 	}
+
+	// Change ownership
 	node->uid = uid;
 	node->gid = gid;
+
+	// Increase quota for new owner
 	fsnodes_quota_update(node, {{QuotaResource::kInodes, +1}});
+
 	if (node->type == FSNodeType::kFile || node->type == FSNodeType::kTrash ||
 	    node->type == FSNodeType::kReserved) {
 		fsnodes_quota_update(node, {{QuotaResource::kSize, +size}});
@@ -1372,7 +1414,7 @@ void FilesystemNodeOperationsBase::unlink(uint32_t timeStamp, FSNodeDirectory *p
 
 	// last link
 	if (childNode->type == FSNodeType::kFile) {
-		auto *file_node = static_cast<FSNodeFile *>(childNode);
+		auto *fileNode = static_cast<FSNodeFile *>(childNode);
 		if (childNode->trashtime > 0) {
 			childNode->type = FSNodeType::kTrash;
 			childNode->ctime = timeStamp;
@@ -1381,16 +1423,16 @@ void FilesystemNodeOperationsBase::unlink(uint32_t timeStamp, FSNodeDirectory *p
 			addTrashEntry(gMetadata->trash, gMetadata->trashHandlesIndex,
 			              gMetadata->trashReservedToId, childNode, path);
 
-			gMetadata->trashSpace += file_node->length;
+			gMetadata->trashSpace += fileNode->length;
 			gMetadata->trashNodes++;
-		} else if (!file_node->sessionIds.empty()) {
+		} else if (!fileNode->sessionIds.empty()) {
 			childNode->type = FSNodeType::kReserved;
 			fsnodes_update_checksum(childNode);
 
 			addReservedEntry(gMetadata->reserved, gMetadata->reservedHandlesIndex,
 			                 gMetadata->trashReservedToId, childNode, path);
 
-			gMetadata->reservedSpace += file_node->length;
+			gMetadata->reservedSpace += fileNode->length;
 			gMetadata->reservedNodes++;
 		} else {
 			removeNode(timeStamp, childNode);
@@ -1402,113 +1444,125 @@ void FilesystemNodeOperationsBase::unlink(uint32_t timeStamp, FSNodeDirectory *p
 
 int FilesystemNodeOperationsBase::purge(uint32_t timeStamp, FSNode *node) {
 	if (node->type == FSNodeType::kTrash) {
-		FSNodeFile *file_node = static_cast<FSNodeFile *>(node);
-		gMetadata->trashSpace -= file_node->length;
+		auto *fileNode = static_cast<FSNodeFile *>(node);
+		gMetadata->trashSpace -= fileNode->length;
 		gMetadata->trashNodes--;
 
-		if (!file_node->sessionIds.empty()) {
-			file_node->type = FSNodeType::kReserved;
-			fsnodes_update_checksum(file_node);
-			gMetadata->reservedSpace += file_node->length;
+		// If the file has active sessions, move it to Reserved instead of deleting
+		if (!fileNode->sessionIds.empty()) {
+			fileNode->type = FSNodeType::kReserved;
+			fsnodes_update_checksum(fileNode);
+			gMetadata->reservedSpace += fileNode->length;
 			gMetadata->reservedNodes++;
 
 			moveTrashToReservedEntry(gMetadata->trash, gMetadata->trashHandlesIndex,
 			                         gMetadata->reserved, gMetadata->reservedHandlesIndex,
 			                         gMetadata->trashReservedToId, node);
 
-			return 0;
-		} else {
-			removeTrashEntry(gMetadata->trash, gMetadata->trashHandlesIndex,
-			                 gMetadata->trashReservedToId, node);
-			node->ctime = timeStamp;
-			fsnodes_update_checksum(node);
-			removeNode(timeStamp, node);
-
-			return 1;
+			return 0;  // Return 0 to indicate the node was moved to Reserved, not deleted
 		}
-	} else if (node->type == FSNodeType::kReserved) {
-		FSNodeFile *file_node = static_cast<FSNodeFile *>(node);
 
-		gMetadata->reservedSpace -= file_node->length;
+		removeTrashEntry(gMetadata->trash, gMetadata->trashHandlesIndex,
+		                 gMetadata->trashReservedToId, node);
+		node->ctime = timeStamp;
+		fsnodes_update_checksum(node);
+		removeNode(timeStamp, node);
+
+		return 1;  // Return 1 to indicate the node was successfully deleted
+	}
+
+	if (node->type == FSNodeType::kReserved) {
+		auto *fileNode = static_cast<FSNodeFile *>(node);
+
+		gMetadata->reservedSpace -= fileNode->length;
 		gMetadata->reservedNodes--;
 
 		removeReservedEntry(gMetadata->reserved, gMetadata->reservedHandlesIndex,
 		                    gMetadata->trashReservedToId, node->id);
 
-		file_node->ctime = timeStamp;
-		fsnodes_update_checksum(file_node);
-		removeNode(timeStamp, file_node);
+		fileNode->ctime = timeStamp;
+		fsnodes_update_checksum(fileNode);
+		removeNode(timeStamp, fileNode);
 		return 1;
 	}
+
 	return -1;
 }
 
 uint8_t FilesystemNodeOperationsBase::undel(uint32_t timeStamp, FSNodeFile *node) {
-	uint8_t is_new;
-	uint32_t i, partleng, dots;
-	/* check path */
-	std::string path_str;
+	// Path validation
+
+	std::string pathStr;
+
 	if (node->type == FSNodeType::kTrash) {
-		path_str = (std::string)gMetadata->trash.at(TrashPathKey(node));
+		pathStr = (std::string)gMetadata->trash.at(TrashPathKey(node));
 	} else {
 		assert(node->type == FSNodeType::kReserved);
-		path_str = (std::string)gMetadata->reserved.at(node->id);
+		pathStr = (std::string)gMetadata->reserved.at(node->id);
 	}
 
-	const char *path = path_str.c_str();
-	unsigned pleng = path_str.length();
+	const char *path = pathStr.c_str();
+	unsigned pathLength = pathStr.length();
 
-	if (path_str.empty()) {
-		return SAUNAFS_ERROR_CANTCREATEPATH;
-	}
-	while (*path == '/' && pleng > 0) {
+	if (pathStr.empty()) { return SAUNAFS_ERROR_CANTCREATEPATH; }
+
+	while (*path == '/' && pathLength > 0) {
 		path++;
-		pleng--;
+		pathLength--;
 	}
-	if (pleng == 0) {
-		return SAUNAFS_ERROR_CANTCREATEPATH;
-	}
-	partleng = 0;
-	dots = 0;
-	for (i = 0; i < pleng; i++) {
+
+	if (pathLength == 0) { return SAUNAFS_ERROR_CANTCREATEPATH; }
+
+	uint32_t partLength = 0;
+	uint32_t dots = 0;
+
+	for (uint32_t i = 0; i < pathLength; i++) {
 		if (path[i] == 0) {  // incorrect name character
 			return SAUNAFS_ERROR_CANTCREATEPATH;
-		} else if (path[i] == '/') {
-			if (partleng == 0) {  // "//" in path
+		}
+
+		if (path[i] == '/') {
+			if (partLength == 0) {  // "//" in path
 				return SAUNAFS_ERROR_CANTCREATEPATH;
 			}
-			if (partleng == dots && partleng <= 2) {  // '.' or '..' in path
+			if (partLength == dots && partLength <= 2) {  // '.' or '..' in path
 				return SAUNAFS_ERROR_CANTCREATEPATH;
 			}
-			partleng = 0;
+			partLength = 0;
 			dots = 0;
 		} else {
 			if (path[i] == '.') {
 				dots++;
 			}
-			partleng++;
-			if (partleng > kMaxFileNameLength) { return SAUNAFS_ERROR_CANTCREATEPATH; }
+			partLength++;
+			if (partLength > kMaxFileNameLength) { return SAUNAFS_ERROR_CANTCREATEPATH; }
 		}
 	}
-	if (partleng == 0) {  // last part cannot be empty - it's the name of undeleted file
-		return SAUNAFS_ERROR_CANTCREATEPATH;
-	}
-	if (partleng == dots && partleng <= 2) {  // '.' or '..' in path
+
+	if (partLength == 0) {  // last part cannot be empty - it's the name of undeleted file
 		return SAUNAFS_ERROR_CANTCREATEPATH;
 	}
 
-	// create path
-	FSNode *n = nullptr;
-	FSNodeDirectory *p = gMetadata->root;
-	is_new = 0;
+	if (partLength == dots && partLength <= 2) {  // '.' or '..' in path
+		return SAUNAFS_ERROR_CANTCREATEPATH;
+	}
+
+	// Path reconstruction
+
+	FSNode *currentNode = nullptr;
+	FSNodeDirectory *currentParent = gMetadata->root;
+
+	bool isNew = false;
+
 	for (;;) {
-		partleng = 0;
-		while ((partleng < pleng) && (path[partleng] != '/')) {
-			partleng++;
-		}
-		HString name(path, partleng);
-		if (partleng == pleng) {  // last name
-			if (isNameUsed(p, name)) { return SAUNAFS_ERROR_EEXIST; }
+		partLength = 0;
+		while ((partLength < pathLength) && (path[partLength] != '/')) { partLength++; }
+
+		HString name(path, partLength);
+
+		if (partLength == pathLength) {  // last name
+			if (isNameUsed(currentParent, name)) { return SAUNAFS_ERROR_EEXIST; }
+
 			// remove from trash and link to new parent
 			if (node->type == FSNodeType::kTrash) {
 				removeTrashEntry(gMetadata->trash, gMetadata->trashHandlesIndex,
@@ -1521,47 +1575,55 @@ uint8_t FilesystemNodeOperationsBase::undel(uint32_t timeStamp, FSNodeFile *node
 			node->type = FSNodeType::kFile;
 			node->ctime = timeStamp;
 			fsnodes_update_checksum(node);
-			link(timeStamp, p, node, name);
+			link(timeStamp, currentParent, node, name);
 			gMetadata->trashSpace -= node->length;
 			gMetadata->trashNodes--;
-			return SAUNAFS_STATUS_OK;
-		} else {
-			if (is_new == 0) {
-				n = lookup(p, name);
-				if (n == nullptr) {
-					is_new = 1;
-				} else {
-					if (n->type != FSNodeType::kDirectory) {
-						return SAUNAFS_ERROR_CANTCREATEPATH;
-					}
+
+			return SAUNAFS_STATUS_OK;  // early return
+		}
+
+		// Directory handling (only runs for intermediate segments)
+		if (!isNew) {
+			currentNode = lookup(currentParent, name);
+			if (currentNode == nullptr) {
+				isNew = true;
+			} else {
+				if (currentNode->type != FSNodeType::kDirectory) {
+					return SAUNAFS_ERROR_CANTCREATEPATH;
 				}
 			}
-			if (is_new == 1) {
-				n = createNode(timeStamp, p, name, FSNodeType::kDirectory, 0755, 0, 0, 0, 0,
-				               AclInheritance::kDontInheritAcl);
+		}
+
+		if (isNew) {
+			currentNode =
+			    createNode(timeStamp, currentParent, name, FSNodeType::kDirectory,
+			               kUndelDirectoryMode, 0, 0, 0, 0, AclInheritance::kDontInheritAcl);
 
 #ifndef METARESTORE
-				assert(metadataserver::isMaster());
+			assert(metadataserver::isMaster());
 #endif
 
-				gFSOperations->changeLog(
-				    timeStamp,
-				    "CREATE(%" PRIiNode ",%s,%c,%d,%" PRIu32 ",%" PRIu32 ",%" PRIu32 "):%" PRIiNode,
-				    p->id, escapeName(name).c_str(), static_cast<char>(FSNodeType::kDirectory),
-				    n->mode & kPermissionsMask, (uint32_t)0, (uint32_t)0, (uint32_t)0, n->id);
-			}
-			p = static_cast<FSNodeDirectory*>(n);
-			assert(n->type == FSNodeType::kDirectory);
+			gFSOperations->changeLog(
+			    timeStamp,
+			    "CREATE(%" PRIiNode ",%s,%c,%d,%" PRIu32 ",%" PRIu32 ",%" PRIu32 "):%" PRIiNode,
+			    currentParent->id, escapeName(name).c_str(),
+			    static_cast<char>(FSNodeType::kDirectory), currentNode->mode & kPermissionsMask,
+			    (uint32_t)0, (uint32_t)0, (uint32_t)0, currentNode->id);
 		}
-		path += partleng + 1;
-		pleng -= partleng + 1;
+
+		currentParent = static_cast<FSNodeDirectory *>(currentNode);
+		assert(currentNode->type == FSNodeType::kDirectory);
+
+		path += partLength + 1;
+		pathLength -= partLength + 1;
 	}
 }
 
 #ifndef METARESTORE
 
 void FilesystemNodeOperationsBase::getGoalRecursive(FSNode *node, uint8_t gmode,
-                                                    GoalStatistics &fgtab, GoalStatistics &dgtab) {
+                                                    GoalStatistics &fileGoalsTab,
+                                                    GoalStatistics &dirGoalsTab) {
 	if (node->type == FSNodeType::kFile || node->type == FSNodeType::kTrash ||
 	    node->type == FSNodeType::kReserved) {
 		if (!GoalId::isValid(node->goal)) {
@@ -1569,18 +1631,22 @@ void FilesystemNodeOperationsBase::getGoalRecursive(FSNode *node, uint8_t gmode,
 			       node->id);
 			changeFileGoal(static_cast<FSNodeFile *>(node), DEFAULT_GOAL);
 		}
-		fgtab[node->goal]++;
+
+		fileGoalsTab[node->goal]++;
 	} else if (node->type == FSNodeType::kDirectory) {
 		if (!GoalId::isValid(node->goal)) {
 			safs_pretty_syslog(LOG_WARNING,
 			       "directory inode %" PRIiNode ": unknown goal !!! - fixing", node->id);
 			node->goal = DEFAULT_GOAL;
 		}
-		dgtab[node->goal]++;
+
+		dirGoalsTab[node->goal]++;
+
 		if (gmode == GMODE_RECURSIVE) {
-			const FSNodeDirectory *dir_node = static_cast<const FSNodeDirectory*>(node);
-			for (const auto &entry : dir_node->entries) {
-				getGoalRecursive(entry.second, gmode, fgtab, dgtab);
+			const auto *dirNode = static_cast<const FSNodeDirectory *>(node);
+
+			for (const auto &entry : dirNode->entries) {
+				getGoalRecursive(entry.second, gmode, fileGoalsTab, dirGoalsTab);
 			}
 		}
 	}
@@ -1594,9 +1660,11 @@ void FilesystemNodeOperationsBase::getTrashTimeRecursive(FSNode *node, uint8_t g
 		fileTrashtimes[node->trashtime] += 1;
 	} else if (node->type == FSNodeType::kDirectory) {
 		dirTrashtimes[node->trashtime] += 1;
+
 		if (gmode == GMODE_RECURSIVE) {
-			const FSNodeDirectory *dir_node = static_cast<const FSNodeDirectory*>(node);
-			for (const auto &entry : dir_node->entries) {
+			const auto *dirNode = static_cast<const FSNodeDirectory *>(node);
+
+			for (const auto &entry : dirNode->entries) {
 				getTrashTimeRecursive(entry.second, gmode, fileTrashtimes, dirTrashtimes);
 			}
 		}
@@ -1611,9 +1679,11 @@ void FilesystemNodeOperationsBase::getExtraAttrRecursive(FSNode *node, uint8_t g
 		             (EATTR_NOOWNER | EATTR_NOACACHE | EATTR_NODATACACHE)]++;
 	} else {
 		dirEAttrTab[(node->mode >> EATTR_BIT_OFFSET)]++;
+
 		if (gmode == GMODE_RECURSIVE) {
-			const FSNodeDirectory *dir_node = static_cast<const FSNodeDirectory*>(node);
-			for (const auto &entry : dir_node->entries) {
+			const auto *dirNode = static_cast<const FSNodeDirectory *>(node);
+
+			for (const auto &entry : dirNode->entries) {
 				getExtraAttrRecursive(entry.second, gmode, fileEAttrTab, dirEAttrTab);
 			}
 		}
@@ -1642,12 +1712,14 @@ void FilesystemNodeOperationsBase::setgoalRecursive(FSNode *node, uint32_t timeS
 					gMetadata->nodeChangedSignal.emit(node);
 					(*modifiedINodesOut)++;
 				}
+
 				updateCTime(node, timeStamp);
 				fsnodes_update_checksum(node);
 			} else {
 				(*unchangedINodesOut)++;
 			}
 		}
+
 		if (node->type == FSNodeType::kDirectory && (smode & SMODE_RMASK)) {
 			for (const auto &entry : static_cast<const FSNodeDirectory*>(node)->entries) {
 				setgoalRecursive(entry.second, timeStamp, uid, goal, smode, modifiedINodesOut,
@@ -1662,47 +1734,50 @@ void FilesystemNodeOperationsBase::setTrashTimeRecursive(FSNode *node, uint32_t 
                                                          uint8_t smode, inode_t *modifiedINodesOut,
                                                          inode_t *unchangedINodesOut,
                                                          inode_t *permissionDeniedINodesOut) {
-	uint8_t set;
-
 	if (node->type == FSNodeType::kFile || node->type == FSNodeType::kDirectory ||
 	    node->type == FSNodeType::kTrash || node->type == FSNodeType::kReserved) {
 		if ((node->mode & (EATTR_NOOWNER << EATTR_BIT_OFFSET)) == 0 && uid != 0 &&
 		    node->uid != uid) {
 			(*permissionDeniedINodesOut)++;
 		} else {
-			set = 0;
-			auto old_trash_key = TrashPathKey(node);
+			bool set = false;
+			auto oldTrashKey = TrashPathKey(node);
+
 			switch (smode & SMODE_TMASK) {
 			case SMODE_SET:
 				if (node->trashtime != trashtime) {
 					node->trashtime = trashtime;
-					set = 1;
+					set = true;
 				}
 				break;
 			case SMODE_INCREASE:
 				if (node->trashtime < trashtime) {
 					node->trashtime = trashtime;
-					set = 1;
+					set = true;
 				}
 				break;
 			case SMODE_DECREASE:
 				if (node->trashtime > trashtime) {
 					node->trashtime = trashtime;
-					set = 1;
+					set = true;
 				}
 				break;
 			}
+
 			if (set) {
 				(*modifiedINodesOut)++;
 				node->ctime = timeStamp;
+
 				if (node->type == FSNodeType::kTrash) {
-					updateTrashFromOldEntry(gMetadata->trash, node, old_trash_key);
+					updateTrashFromOldEntry(gMetadata->trash, node, oldTrashKey);
 				}
+
 				fsnodes_update_checksum(node);
 			} else {
 				(*unchangedINodesOut)++;
 			}
 		}
+
 		if (node->type == FSNodeType::kDirectory && (smode & SMODE_RMASK)) {
 			for(const auto &entry : static_cast<const FSNodeDirectory*>(node)->entries) {
 				setTrashTimeRecursive(entry.second, timeStamp, uid, trashtime, smode,
@@ -1713,53 +1788,65 @@ void FilesystemNodeOperationsBase::setTrashTimeRecursive(FSNode *node, uint32_t 
 	}
 }
 
-void FilesystemNodeOperationsBase::setExtraAttrRecursive(FSNode *node, uint32_t timeStamp, uint32_t uid,
-                                                     uint8_t eattr, uint8_t smode,
-                                                     inode_t *modifiedINodesOut,
-                                                     inode_t *unchangedINodesOut,
-                                                     inode_t *permissionDeniedINodesOut) {
-	uint8_t neweattr, seattr;
-
+void FilesystemNodeOperationsBase::setExtraAttrRecursive(FSNode *node, uint32_t timeStamp,
+                                                         uint32_t uid, uint8_t eattr, uint8_t smode,
+                                                         inode_t *modifiedINodesOut,
+                                                         inode_t *unchangedINodesOut,
+                                                         inode_t *permissionDeniedINodesOut) {
+	// Check permission
 	if ((node->mode & (EATTR_NOOWNER << EATTR_BIT_OFFSET)) == 0 && uid != 0 && node->uid != uid) {
 		(*permissionDeniedINodesOut)++;
 	} else {
-		seattr = eattr;
+		// Sanitize attributes: remove NOECACHE flag for non-directory nodes
+		uint8_t adjustedExtraAttr = eattr;
 		if (node->type != FSNodeType::kDirectory) {
 			node->mode &= ~(EATTR_NOECACHE << EATTR_BIT_OFFSET);
-			seattr &= ~(EATTR_NOECACHE);
+			adjustedExtraAttr &= ~(EATTR_NOECACHE);
 		}
-		neweattr = (node->mode >> EATTR_BIT_OFFSET);
+
+		// Compute new extra attributes based on smode
+		uint8_t newExtraAttr = (node->mode >> EATTR_BIT_OFFSET);
+
 		switch (smode & SMODE_TMASK) {
 		case SMODE_SET:
-			neweattr = seattr;
+			newExtraAttr = adjustedExtraAttr;
 			break;
 		case SMODE_INCREASE:
-			neweattr |= seattr;
+			newExtraAttr |= adjustedExtraAttr;
 			break;
 		case SMODE_DECREASE:
-			neweattr &= ~seattr;
+			newExtraAttr &= ~adjustedExtraAttr;
 			break;
 		}
-		if (neweattr != (node->mode >> EATTR_BIT_OFFSET)) {
-			node->mode = (node->mode & 0xFFF) | (((uint16_t)neweattr) << EATTR_BIT_OFFSET);
-			const RichACL *node_acl = gMetadata->aclStorage.get(node->id);
-			if (node_acl) {
+
+		// Update node if attributes changed
+		if (newExtraAttr != (node->mode >> EATTR_BIT_OFFSET)) {
+			node->mode =
+			    (node->mode & kPermissionsMask) | (((uint16_t)newExtraAttr) << EATTR_BIT_OFFSET);
+			const RichACL *nodeAcl = gMetadata->aclStorage.get(node->id);
+
+			if (nodeAcl != nullptr) {
 				gMetadata->aclStorage.setMode(node->id, node->mode,
 				                              node->type == FSNodeType::kDirectory);
 			}
+
 			(*modifiedINodesOut)++;
 			updateCTime(node, timeStamp);
 		} else {
 			(*unchangedINodesOut)++;
 		}
 	}
+
+	// Recursively apply to directory children
 	if (node->type == FSNodeType::kDirectory && (smode & SMODE_RMASK)) {
-		const FSNodeDirectory *dir_node = static_cast<const FSNodeDirectory*>(node);
-		for (const auto &entry : dir_node->entries) {
+		const auto *dirNode = static_cast<const FSNodeDirectory *>(node);
+
+		for (const auto &entry : dirNode->entries) {
 			setExtraAttrRecursive(entry.second, timeStamp, uid, eattr, smode, modifiedINodesOut,
 			                  unchangedINodesOut, permissionDeniedINodesOut);
 		}
 	}
+
 	fsnodes_update_checksum(node);
 }
 
@@ -1768,45 +1855,45 @@ uint8_t FilesystemNodeOperationsBase::deleteAcl(FSNode *node, AclType type, uint
 		gMetadata->aclStorage.erase(node->id);
 	} else if (type == AclType::kDefault) {
 		if (node->type != FSNodeType::kDirectory) { return SAUNAFS_ERROR_ENOTSUP; }
-		const RichACL *node_acl = gMetadata->aclStorage.get(node->id);
-		if (node_acl) {
-			RichACL new_acl = *node_acl;
-			new_acl.createExplicitInheritance();
-			new_acl.removeInheritOnly(true);
-			if (new_acl.size() == 0) {
+		const RichACL *nodeAcl = gMetadata->aclStorage.get(node->id);
+		if (nodeAcl != nullptr) {
+			RichACL newAcl = *nodeAcl;
+			newAcl.createExplicitInheritance();
+			newAcl.removeInheritOnly(true);
+			if (newAcl.size() == 0) {
 				gMetadata->aclStorage.erase(node->id);
 			} else {
-				gMetadata->aclStorage.set(node->id, std::move(new_acl));
+				gMetadata->aclStorage.set(node->id, std::move(newAcl));
 			}
 		}
 	} else if (type == AclType::kAccess) {
-		const RichACL *node_acl = gMetadata->aclStorage.get(node->id);
-		if (node_acl) {
-			RichACL new_acl = *node_acl;
-			new_acl.createExplicitInheritance();
-			new_acl.removeInheritOnly(false);
-			if (new_acl.size() == 0) {
+		const RichACL *nodeAcl = gMetadata->aclStorage.get(node->id);
+		if (nodeAcl != nullptr) {
+			RichACL newAcl = *nodeAcl;
+			newAcl.createExplicitInheritance();
+			newAcl.removeInheritOnly(false);
+			if (newAcl.size() == 0) {
 				gMetadata->aclStorage.erase(node->id);
 			} else {
-				gMetadata->aclStorage.set(node->id, std::move(new_acl));
+				gMetadata->aclStorage.set(node->id, std::move(newAcl));
 			}
 		}
 	} else {
 		return SAUNAFS_ERROR_EINVAL;
 	}
+
 	updateCTime(node, timeStamp);
 	fsnodes_update_checksum(node);
+
 	return SAUNAFS_STATUS_OK;
 }
 
 #ifndef METARESTORE
 uint8_t FilesystemNodeOperationsBase::getAcl(FSNode *node, RichACL &acl) {
-	const RichACL *richacl = gMetadata->aclStorage.get(node->id);
-	if (!richacl) {
-		return SAUNAFS_ERROR_ENOATTR;
-	}
-	acl = *richacl;
-	assert((node->mode & kStandardPermissionsMask) == richacl->getMode());
+	const RichACL *richAcl = gMetadata->aclStorage.get(node->id);
+	if (!richAcl) { return SAUNAFS_ERROR_ENOATTR; }
+	acl = *richAcl;
+	assert((node->mode & kStandardPermissionsMask) == richAcl->getMode());
 	return SAUNAFS_STATUS_OK;
 }
 #endif
@@ -1825,12 +1912,12 @@ uint8_t FilesystemNodeOperationsBase::setAcl(FSNode *node, const RichACL &acl, u
 			node->mode = (node->mode & ~kStandardPermissionsMask) |
 			             (acl.getMode() & kStandardPermissionsMask);
 		}
-		RichACL new_acl = acl;
+		RichACL newAcl = acl;
 		if (acl.isAutoSetMode()) {
-			new_acl.setFlags(new_acl.getFlags() & ~RichACL::kAutoSetMode);
-			new_acl.setMode(node->mode, node->type == FSNodeType::kDirectory);
+			newAcl.setFlags(newAcl.getFlags() & ~RichACL::kAutoSetMode);
+			newAcl.setMode(node->mode, node->type == FSNodeType::kDirectory);
 		}
-		gMetadata->aclStorage.set(node->id, std::move(new_acl));
+		gMetadata->aclStorage.set(node->id, std::move(newAcl));
 	}
 
 	updateCTime(node, timeStamp);
@@ -1848,24 +1935,24 @@ uint8_t FilesystemNodeOperationsBase::setAcl(FSNode *node, AclType type,
 		return SAUNAFS_ERROR_ENOTSUP;
 	}
 
-	const RichACL *node_acl = gMetadata->aclStorage.get(node->id);
-	RichACL new_acl;
+	const RichACL *nodeAcl = gMetadata->aclStorage.get(node->id);
+	RichACL newAcl;
 
-	if (node_acl) {
-		new_acl = *node_acl;
-		new_acl.createExplicitInheritance();
-		new_acl.removeInheritOnly(type == AclType::kDefault);
+	if (nodeAcl != nullptr) {
+		newAcl = *nodeAcl;
+		newAcl.createExplicitInheritance();
+		newAcl.removeInheritOnly(type == AclType::kDefault);
 	}
 
 	if (type == AclType::kDefault) {
-		new_acl.appendDefaultPosixACL(acl);
-		new_acl.setMode(node->mode, true);
+		newAcl.appendDefaultPosixACL(acl);
+		newAcl.setMode(node->mode, true);
 	} else {
-		new_acl.appendPosixACL(acl, node->type == FSNodeType::kDirectory);
+		newAcl.appendPosixACL(acl, node->type == FSNodeType::kDirectory);
 		node->mode = (node->mode & ~kStandardPermissionsMask) |
-		             (new_acl.getMode() & kStandardPermissionsMask);
+		             (newAcl.getMode() & kStandardPermissionsMask);
 	}
-	gMetadata->aclStorage.set(node->id, std::move(new_acl));
+	gMetadata->aclStorage.set(node->id, std::move(newAcl));
 
 	updateCTime(node, timeStamp);
 	fsnodes_update_checksum(node);
@@ -1893,45 +1980,67 @@ int FilesystemNodeOperationsBase::nameCheck(const std::string &name) {
 	return 0;
 }
 
-int FilesystemNodeOperationsBase::access(const FsContext &context, FSNode *node, uint8_t modemask) {
-	uint8_t nodemode;
+int FilesystemNodeOperationsBase::access(const FsContext &context, FSNode *node, uint8_t modeMask) {
 	if ((context.sesflags() & SESFLAG_NOMASTERPERMCHECK) || context.uid() == 0) {
-		return 1;
+		return 1;  // super user or no permission check
 	}
-	const RichACL *node_acl = gMetadata->aclStorage.get(node->id);
-	if (node_acl) {
-		assert((node->mode & kStandardPermissionsMask) == node_acl->getMode());
 
-		uint32_t mask = RichACL::convertMode2Mask(modemask);
+	const RichACL *nodeAcl = gMetadata->aclStorage.get(node->id);
+
+	// If ACLs are present, use it for permission checking
+	if (nodeAcl != nullptr) {
+		assert((node->mode & kStandardPermissionsMask) == nodeAcl->getMode());
+
+		uint32_t mask = RichACL::convertMode2Mask(modeMask);
 		if (node->type != FSNodeType::kDirectory) {
 			mask &= ~RichACL::Ace::kDeleteChild;
 		}
-		return node_acl->checkPermission(mask, node->uid, node->gid, context.uid(), context.groups());
+
+		return nodeAcl->checkPermission(mask, node->uid, node->gid, context.uid(),
+		                                context.groups());
+	}
+
+	// No ACLs: use traditional Unix permission checking
+
+	constexpr uint8_t kUserModeBits = 6;            // >> 6 for user bits
+	constexpr uint8_t kGroupModeBits = 3;           // >> 3 for group bits
+	constexpr uint8_t kSingleClassPermissions = 7;  // & 7 to extract 3 bits
+
+	uint8_t nodeMode;  // NOLINT: will be assigned before use
+
+	// Determine which permission class applies to the requesting user
+	if (context.uid() == node->uid || (node->mode & (EATTR_NOOWNER << EATTR_BIT_OFFSET))) {
+		// User owns the file: use user permissions (bits 6-8)
+		nodeMode = ((node->mode) >> kUserModeBits) & kSingleClassPermissions;
+	} else if (context.sesflags() & SESFLAG_IGNOREGID) {
+		// IGNOREGID flag: use group OR other permissions
+		nodeMode = (((node->mode) >> kGroupModeBits) | (node->mode)) & kSingleClassPermissions;
+	} else if (context.hasGroup(node->gid)) {
+		// User in file's group: use group permissions (bits 3-5)
+		nodeMode = ((node->mode) >> kGroupModeBits) & kSingleClassPermissions;
 	} else {
-		if (context.uid() == node->uid || (node->mode & (EATTR_NOOWNER << EATTR_BIT_OFFSET))) {
-			nodemode = ((node->mode) >> 6) & 7;
-		} else if (context.sesflags() & SESFLAG_IGNOREGID) {
-			nodemode = (((node->mode) >> 3) | (node->mode)) & 7;
-		} else if (context.hasGroup(node->gid)) {
-			nodemode = ((node->mode) >> 3) & 7;
-		} else {
-			nodemode = (node->mode & 7);
-		}
+		// Otherwise: use other permissions (bits 0-2)
+		nodeMode = (node->mode & kSingleClassPermissions);
 	}
-	if ((nodemode & modemask) == modemask) {
-		return 1;
-	}
+
+	// Check if extracted permissions satisfy the request
+	if ((nodeMode & modeMask) == modeMask) { return 1; }
+
 	return 0;
 }
 
 int FilesystemNodeOperationsBase::stickyAccess(FSNode *parent, FSNode *node, uint32_t uid) {
-	if (uid == 0 || (parent->mode & 01000) == 0) {  // super user or sticky bit is not set
+	constexpr uint16_t kStickyBit = 01000;  // sticky bit is at bit position 9
+
+	if (uid == 0 || (parent->mode & kStickyBit) == 0) {  // super user or sticky bit is not set
 		return 1;
 	}
+
 	if (uid == parent->uid || (parent->mode & (EATTR_NOOWNER << EATTR_BIT_OFFSET)) ||
 	    uid == node->uid || (node->mode & (EATTR_NOOWNER << EATTR_BIT_OFFSET))) {
 		return 1;
 	}
+
 	return 0;
 }
 
@@ -1942,75 +2051,98 @@ uint8_t FilesystemNodeOperationsBase::verifySession(const FsContext &context,
 	    (operationMode == OperationMode::kReadWrite)) {
 		return SAUNAFS_ERROR_EROFS;
 	}
+
 	if (context.hasSessionData() && (context.rootinode() == 0) &&
 	    (sessionType == SessionType::kNotMeta)) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
+
 	if (context.hasSessionData() && (context.rootinode() != 0) &&
 	    (sessionType == SessionType::kOnlyMeta)) {
 		return SAUNAFS_ERROR_EPERM;
 	}
+
 	return SAUNAFS_STATUS_OK;
 }
 
 uint8_t FilesystemNodeOperationsBase::getNodeForOperation(const FsContext &context,
                                                           ExpectedNodeType expectedNodeType,
-                                                          uint8_t modemask, inode_t inode,
+                                                          uint8_t modeMask, inode_t inode,
                                                           FSNode **nodeOut,
                                                           FSNodeDirectory **rootDirOut) {
-	FSNode *p;
-	FSNodeDirectory *rn;
+	FSNode *candidateNode;           // NOLINT: will be assigned before use
+	FSNodeDirectory *candidateRoot;  // NOLINT: will be assigned before use
+
+	// Node lookup
+
 	if (!context.hasSessionData()) {
-		rn = nullptr;
-		p = idToNode(inode);
-		if (!p) {
-			return SAUNAFS_ERROR_ENOENT;
-		}
+		candidateRoot = nullptr;
+		candidateNode = idToNode(inode);
+
+		if (candidateNode == nullptr) { return SAUNAFS_ERROR_ENOENT; }
 	} else if (context.rootinode() == SPECIAL_INODE_ROOT || (context.rootinode() == 0)) {
-		rn = gMetadata->root;
-		p = idToNode(inode);
-		if (!p) {
-			return SAUNAFS_ERROR_ENOENT;
-		}
-		if (context.rootinode() == 0 && p->type != FSNodeType::kTrash &&
-		    p->type != FSNodeType::kReserved) {
+		candidateRoot = gMetadata->root;
+		candidateNode = idToNode(inode);
+
+		if (candidateNode == nullptr) { return SAUNAFS_ERROR_ENOENT; }
+
+		if (context.rootinode() == 0 && candidateNode->type != FSNodeType::kTrash &&
+		    candidateNode->type != FSNodeType::kReserved) {
 			return SAUNAFS_ERROR_EPERM;
 		}
 	} else {
-		rn = idToNode<FSNodeDirectory>(context.rootinode());
-		if (!rn || rn->type != FSNodeType::kDirectory) {
+		candidateRoot = idToNode<FSNodeDirectory>(context.rootinode());
+
+		if ((candidateRoot == nullptr) || candidateRoot->type != FSNodeType::kDirectory) {
 			return SAUNAFS_ERROR_ENOENT;
 		}
+
 		if (inode == SPECIAL_INODE_ROOT || inode == context.rootinode()) {
-			p = rn;
+			candidateNode = candidateRoot;
 		} else {
-			p = idToNode(inode);
-			if (!p) {
-				return SAUNAFS_ERROR_ENOENT;
+			candidateNode = idToNode(inode);
+
+			if (candidateNode == nullptr) { return SAUNAFS_ERROR_ENOENT; }
+
+			if (!isAncestorOrNodeReservedOrTrash(candidateRoot, candidateNode)) {
+				return SAUNAFS_ERROR_EPERM;
 			}
-			if (!isAncestorOrNodeReservedOrTrash(rn, p)) { return SAUNAFS_ERROR_EPERM; }
 		}
 	}
-	if ((expectedNodeType == ExpectedNodeType::kDirectory) && (p->type != FSNodeType::kDirectory)) {
+
+	// Node type validation
+
+	if ((expectedNodeType == ExpectedNodeType::kDirectory) &&
+	    (candidateNode->type != FSNodeType::kDirectory)) {
 		return SAUNAFS_ERROR_ENOTDIR;
 	}
+
 	if ((expectedNodeType == ExpectedNodeType::kNotDirectory) &&
-	    (p->type == FSNodeType::kDirectory)) {
+	    (candidateNode->type == FSNodeType::kDirectory)) {
 		return SAUNAFS_ERROR_EPERM;
 	}
-	if ((expectedNodeType == ExpectedNodeType::kFile) && (p->type != FSNodeType::kFile) &&
-	    (p->type != FSNodeType::kReserved) && (p->type != FSNodeType::kTrash)) {
+
+	if ((expectedNodeType == ExpectedNodeType::kFile) &&
+	    (candidateNode->type != FSNodeType::kFile) &&
+	    (candidateNode->type != FSNodeType::kReserved) &&
+	    (candidateNode->type != FSNodeType::kTrash)) {
 		return SAUNAFS_ERROR_EPERM;
 	}
+
 	if ((expectedNodeType == ExpectedNodeType::kFileOrDirectory) &&
-	    (p->type != FSNodeType::kDirectory) && (p->type != FSNodeType::kFile) &&
-	    (p->type != FSNodeType::kReserved) && (p->type != FSNodeType::kTrash)) {
+	    (candidateNode->type != FSNodeType::kDirectory) &&
+	    (candidateNode->type != FSNodeType::kFile) &&
+	    (candidateNode->type != FSNodeType::kReserved) &&
+	    (candidateNode->type != FSNodeType::kTrash)) {
 		return SAUNAFS_ERROR_EPERM;
 	}
-	if (context.canCheckPermissions() && !access(context, p, modemask)) {
+
+	if (context.canCheckPermissions() && !access(context, candidateNode, modeMask)) {
 		return SAUNAFS_ERROR_EACCES;
 	}
-	*nodeOut = p;
-	if (rootDirOut) { *rootDirOut = rn; }
+
+	*nodeOut = candidateNode;
+	if (rootDirOut != nullptr) { *rootDirOut = candidateRoot; }
+
 	return SAUNAFS_STATUS_OK;
 }

--- a/src/master/filesystem_node.h
+++ b/src/master/filesystem_node.h
@@ -59,7 +59,7 @@ public:
 	                 StatsRecord *previousStats) override;
 	void changeUidGid(FSNode *node, uint32_t uid, uint32_t gid) override;
 
-	void setLength(FSNodeFile *obj, uint64_t length, bool eraseFurtherChunks) override;
+	void setLength(FSNodeFile *nodeFile, uint64_t length, bool eraseFurtherChunks) override;
 	uint8_t appendChunks(uint32_t timeStamp, FSNodeFile *destNodeFile,
 	                     FSNodeFile *srcNodeFile) override;
 	void changeFileGoal(FSNodeFile *nodeFile, uint8_t goal) override;
@@ -119,8 +119,8 @@ public:
 
 	// Recursive operations
 #ifndef METARESTORE
-	void getGoalRecursive(FSNode *node, uint8_t gmode, GoalStatistics &fgtab,
-	                      GoalStatistics &dgtab) override;
+	void getGoalRecursive(FSNode *node, uint8_t gmode, GoalStatistics &fileGoalsTab,
+	                      GoalStatistics &dirGoalsTab) override;
 	void getTrashTimeRecursive(FSNode *node, uint8_t gmode, TrashtimeMap &fileTrashtimes,
 	                           TrashtimeMap &dirTrashtimes) override;
 	void getExtraAttrRecursive(FSNode *node, uint8_t gmode, ExtraAttributesArray &fileEAttrTab,
@@ -141,7 +141,7 @@ public:
 	                           inode_t *permissionDeniedINodesOut) override;
 
 	// Access control operations
-	int access(const FsContext &context, FSNode *node, uint8_t modemask) override;
+	int access(const FsContext &context, FSNode *node, uint8_t modeMask) override;
 	int stickyAccess(FSNode *parent, FSNode *node, uint32_t uid) override;
 	int nameCheck(const std::string &name) override;
 	uint8_t verifySession(const FsContext &context, OperationMode operationMode,
@@ -150,7 +150,7 @@ public:
 	/// Treating rootinode as the root of the hierarchy, converts (rootinode, inode) to FSNode*.
 	/// @see IFilesystemNodeOperations::getNodeForOperation
 	uint8_t getNodeForOperation(const FsContext &context, ExpectedNodeType expectedNodeType,
-	                            uint8_t modemask, inode_t inode, FSNode **nodeOut,
+	                            uint8_t modeMask, inode_t inode, FSNode **nodeOut,
 	                            FSNodeDirectory **rootDirOut = nullptr) override;
 
 	// Ancestry operations

--- a/src/master/filesystem_node.h
+++ b/src/master/filesystem_node.h
@@ -80,7 +80,7 @@ public:
 	            uint8_t sesflags, FSNodeDirectory *nodeDir, uint64_t firstEntry,
 	            uint64_t numberOfEntries, std::vector<DirectoryEntry> &dirEntriesOut) override;
 #endif
-	int isNameUsed(FSNodeDirectory *node, const HString &name) override;
+	bool isNameUsed(FSNodeDirectory *node, const HString &name) override;
 
 	// Trash/Reserved operations
 	int purge(uint32_t timeStamp, FSNode *node) override;

--- a/src/master/filesystem_node_operations_interface.h
+++ b/src/master/filesystem_node_operations_interface.h
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "common/attributes.h"
+#include "common/type_defs.h"
 #include "master/filesystem_node_types.h"
 #include "master/filesystem_trash_reserved_files.h"
 #include "master/fs_context.h"
@@ -46,6 +47,12 @@ using ChunkCountArray = std::array<uint32_t, CHUNK_MATRIX_SIZE>;
 // Extra attributes constants and type aliases
 static constexpr uint8_t kMaxExtraAttributes = 16;
 using ExtraAttributesArray = std::array<uint32_t, kMaxExtraAttributes>;
+
+// Directory entry serialization constants
+static constexpr size_t kDirEntryWithAttributesSize = kinode_t_size + kAttributesSize;
+static constexpr size_t kDirEntryWithoutAttributesSize = kinode_t_size + 1;
+static constexpr size_t kDotEntrySize = 2;      // name length (1 byte) + "." (1 byte)
+static constexpr size_t kDotDotEntrySize = 3;   // name length (1 byte) + ".." (2 bytes)
 
 /// Interface for filesystem node operations extensibility.
 ///
@@ -131,7 +138,7 @@ public:
 	                    uint8_t sesflags, FSNodeDirectory *nodeDir, uint64_t firstEntry,
 	                    uint64_t numberOfEntries, std::vector<DirectoryEntry> &dirEntriesOut) = 0;
 #endif
-	virtual int isNameUsed(FSNodeDirectory *node, const HString &name) = 0;
+	virtual bool isNameUsed(FSNodeDirectory *node, const HString &name) = 0;
 
 	// Trash/Reserved operations
 

--- a/src/master/filesystem_node_operations_interface.h
+++ b/src/master/filesystem_node_operations_interface.h
@@ -111,7 +111,7 @@ public:
 	                         StatsRecord *previousStats) = 0;
 	virtual void changeUidGid(FSNode *node, uint32_t uid, uint32_t gid) = 0;
 
-	virtual void setLength(FSNodeFile *obj, uint64_t length, bool eraseFurtherChunks) = 0;
+	virtual void setLength(FSNodeFile *nodeFile, uint64_t length, bool eraseFurtherChunks) = 0;
 	virtual uint8_t appendChunks(uint32_t timeStamp, FSNodeFile *destNodeFile,
 	                             FSNodeFile *srcNodeFile) = 0;
 	virtual void changeFileGoal(FSNodeFile *nodeFile, uint8_t goal) = 0;
@@ -181,8 +181,8 @@ public:
 
 	// Recursive operations
 #ifndef METARESTORE
-	virtual void getGoalRecursive(FSNode *node, uint8_t gmode, GoalStatistics &fgtab,
-	                              GoalStatistics &dgtab) = 0;
+	virtual void getGoalRecursive(FSNode *node, uint8_t gmode, GoalStatistics &fileGoalsTab,
+	                              GoalStatistics &dirGoalsTab) = 0;
 	virtual void getTrashTimeRecursive(FSNode *node, uint8_t gmode, TrashtimeMap &fileTrashtimes,
 	                                   TrashtimeMap &dirTrashtimes) = 0;
 	virtual void getExtraAttrRecursive(FSNode *node, uint8_t gmode,
@@ -205,7 +205,7 @@ public:
 	                                   inode_t *permissionDeniedINodesOut) = 0;
 
 	// Access control operations
-	virtual int access(const FsContext &context, FSNode *node, uint8_t modemask) = 0;
+	virtual int access(const FsContext &context, FSNode *node, uint8_t modeMask) = 0;
 	virtual int stickyAccess(FSNode *parent, FSNode *node, uint32_t uid) = 0;
 	virtual int nameCheck(const std::string &name) = 0;
 	virtual uint8_t verifySession(const FsContext &context, OperationMode operationMode,
@@ -215,10 +215,10 @@ public:
 	/// ie:
 	/// if inode == rootinode, then returns root node
 	/// if inode != rootinode, then returns some node
-	/// Checks for permissions needed to perform the operation (defined by modemask).
+	/// Checks for permissions needed to perform the operation (defined by modeMask).
 	/// Can return a reserved node or a node from trash.
 	virtual uint8_t getNodeForOperation(const FsContext &context, ExpectedNodeType expectedNodeType,
-	                                    uint8_t modemask, inode_t inode, FSNode **nodeOut,
+	                                    uint8_t modeMask, inode_t inode, FSNode **nodeOut,
 	                                    FSNodeDirectory **rootDirOut = nullptr) = 0;
 
 	// Ancestry operations

--- a/src/master/filesystem_node_operations_interface.h
+++ b/src/master/filesystem_node_operations_interface.h
@@ -50,9 +50,9 @@ using ExtraAttributesArray = std::array<uint32_t, kMaxExtraAttributes>;
 
 // Directory entry serialization constants
 static constexpr size_t kDirEntryWithAttributesSize = kinode_t_size + kAttributesSize;
-static constexpr size_t kDirEntryWithoutAttributesSize = kinode_t_size + 1;
-static constexpr size_t kDotEntrySize = 2;      // name length (1 byte) + "." (1 byte)
-static constexpr size_t kDotDotEntrySize = 3;   // name length (1 byte) + ".." (2 bytes)
+static constexpr size_t kDirEntryWithoutAttributesSize = kinode_t_size + 1;  // +1 for node type
+static constexpr size_t kDotEntrySize = 1;      // "." (1 byte)
+static constexpr size_t kDotDotEntrySize = 2;   // ".." (2 bytes)
 
 /// Interface for filesystem node operations extensibility.
 ///

--- a/src/master/filesystem_node_types.cc
+++ b/src/master/filesystem_node_types.cc
@@ -1,0 +1,53 @@
+/*
+   Copyright 2005-2010 Jakub Kruszona-Zawadzki, Gemius SA
+   Copyright 2013-2014 EditShare
+   Copyright 2013-2016 Skytechnology sp. z o.o.
+   Copyright 2023      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "common/platform.h"
+
+#include "master/filesystem_node_types.h"
+
+FSNode *FSNode::create(FSNodeType type) {
+	switch (type) {
+	case FSNodeType::kFile:
+	case FSNodeType::kTrash:
+	case FSNodeType::kReserved:
+		return new FSNodeFile(type);
+	case FSNodeType::kDirectory:
+		return new FSNodeDirectory();
+	case FSNodeType::kSymlink:
+		return new FSNodeSymlink();
+	case FSNodeType::kFifo:
+	case FSNodeType::kSocket:
+		return new FSNode(type);
+	case FSNodeType::kBlockDev:
+	case FSNodeType::kCharDev:
+		return new FSNodeDevice(type);
+	case FSNodeType::kUnknown:
+	default:
+		assert(!"invalid node type");
+	}
+	return nullptr;
+}
+
+void FSNode::destroy(FSNode *node) {
+	for (auto const &[_, handlePtr] : node->parents) { delete handlePtr; }
+
+	delete node;
+}

--- a/src/master/filesystem_node_types.h
+++ b/src/master/filesystem_node_types.h
@@ -142,6 +142,10 @@ public:
 	    sizeof(type) + sizeof(id) + sizeof(goal) + sizeof(mode) + sizeof(uid) + sizeof(gid) +
 	    sizeof(atime) + sizeof(mtime) + sizeof(ctime) + sizeof(trashtime);
 
+	static constexpr uint16_t kEdgeNameMaxSize = 65535;
+	static constexpr uint8_t kEdgeHeaderSize =
+	    sizeof(FSNode::id) + sizeof(FSNode::id) + sizeof(kEdgeNameMaxSize);
+
 	explicit FSNode(FSNodeType type_) : type(type_) {}
 
 	/*! \brief Static function used for creating proper node for given type.

--- a/src/master/filesystem_node_types.h
+++ b/src/master/filesystem_node_types.h
@@ -51,7 +51,7 @@
 #define EDGEHASHPOS(hash) ((hash) & (EDGEHASHSIZE - 1))
 #define EDGECHECKSUMSEED 1231241261
 
-#define MAX_INDEX 0x7FFFFFFF
+constexpr uint32_t kMaxChunkIndex = 0x7FFFFFFFU;
 
 enum class AclInheritance : std::uint8_t {
 	kInheritAcl,

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -686,33 +686,44 @@ uint8_t FilesystemOperationsBase::applyTrunc(uint32_t timestamp, inode_t inode, 
                                              uint64_t chunkid, uint32_t lockid) {
 	uint64_t ochunkid, nchunkid;
 	uint8_t status;
-	FSNodeFile *p = nodeOperations_->idToNode<FSNodeFile>(inode);
+	auto *p = nodeOperations_->idToNode<FSNodeFile>(inode);
+
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
+
 	if (p->type != FSNodeType::kFile && p->type != FSNodeType::kTrash &&
 	    p->type != FSNodeType::kReserved) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
+
 	if (indx > kMaxChunkIndex) { return SAUNAFS_ERROR_INDEXTOOBIG; }
+
 	if (indx >= p->chunks.size()) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
+
 	ochunkid = p->chunks[indx];
+
 	if (ochunkid == 0) {
 		safs::log_err("fs_apply_trunc: node does not have a chunk at index {} chunks, inode {}", indx, inode);
 		return SAUNAFS_ERROR_NOCHUNK;
 	}
+
 	status = chunk_apply_modification(timestamp, ochunkid, lockid, p->goal, true, &nchunkid);
+
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
+
 	if (chunkid != nchunkid) {
 		return SAUNAFS_ERROR_MISMATCH;
 	}
+
 	p->chunks[indx] = nchunkid;
 	gMetadata->metadataVersion++;
 	fsnodes_update_checksum(p);
+
 	return SAUNAFS_STATUS_OK;
 }
 
@@ -2347,39 +2358,50 @@ uint8_t FilesystemOperationsBase::applyRepair(uint32_t timestamp, inode_t inode,
 	StatsRecord psr, nsr;
 
 	p = nodeOperations_->idToNode<FSNodeFile>(inode);
+
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
+
 	if (p->type != FSNodeType::kFile && p->type != FSNodeType::kTrash &&
 	    p->type != FSNodeType::kReserved) {
 		return SAUNAFS_ERROR_EPERM;
 	}
+
 	if (indx > kMaxChunkIndex) { return SAUNAFS_ERROR_INDEXTOOBIG; }
+
 	if (indx >= p->chunks.size()) {
 		return SAUNAFS_ERROR_NOCHUNK;
 		safs::log_err("fs_apply_repair: indx {} is greater than number of chunks ({}), inode {}", indx, p->chunks.size(), inode);
 	}
+
 	if (p->chunks[indx] == 0) {
 		safs::log_err("fs_apply_repair: node chunks at index {} has no chunks, inode {}", indx, inode);
 		return SAUNAFS_ERROR_NOCHUNK;
 	}
+
 	nodeOperations_->getStats(p, &psr);
+
 	if (nversion == 0) {
 		status = chunk_delete_file(p->chunks[indx], p->goal);
 		p->chunks[indx] = 0;
 	} else {
 		status = chunk_set_version(p->chunks[indx], nversion);
 	}
+
 	nodeOperations_->getStats(p, &nsr);
+
 	for (const auto &[parentId, _] : p->parents) {
 		auto *parent = nodeOperations_->idToNodeVerify<FSNodeDirectory>(parentId);
 		nodeOperations_->addSubStats(parent, &nsr, &psr);
 	}
+
 	fsnodes_quota_update(p, {{QuotaResource::kSize, nsr.size - psr.size}});
 	gMetadata->metadataVersion++;
 	p->mtime = timestamp;
 	nodeOperations_->updateCTime(p, timestamp);
 	fsnodes_update_checksum(p);
+
 	return status;
 }
 

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -809,7 +809,8 @@ uint8_t FilesystemOperationsBase::setAttr(const FsContext &context, inode_t inod
 	if (context.uid() != 0 && (context.sesflags() & SESFLAG_MAPALL) && (setmask & (SET_UID_FLAG | SET_GID_FLAG))) {
 		return SAUNAFS_ERROR_EPERM;
 	}
-	if ((p->mode & (EATTR_NOOWNER << 12)) == 0 && context.uid() != 0 && context.uid() != p->uid) {
+	if ((p->mode & (EATTR_NOOWNER << EATTR_BIT_OFFSET)) == 0 && context.uid() != 0 &&
+	    context.uid() != p->uid) {
 		if (setmask & (SET_MODE_FLAG | SET_UID_FLAG | SET_GID_FLAG)) {
 			return SAUNAFS_ERROR_EPERM;
 		}

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -694,9 +694,7 @@ uint8_t FilesystemOperationsBase::applyTrunc(uint32_t timestamp, inode_t inode, 
 	    p->type != FSNodeType::kReserved) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
-	if (indx > MAX_INDEX) {
-		return SAUNAFS_ERROR_INDEXTOOBIG;
-	}
+	if (indx > kMaxChunkIndex) { return SAUNAFS_ERROR_INDEXTOOBIG; }
 	if (indx >= p->chunks.size()) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
@@ -2073,9 +2071,7 @@ uint8_t FilesystemOperationsBase::readChunk(inode_t inode, uint32_t indx, uint64
 	    p->type != FSNodeType::kReserved) {
 		return SAUNAFS_ERROR_EPERM;
 	}
-	if (indx > MAX_INDEX) {
-		return SAUNAFS_ERROR_INDEXTOOBIG;
-	}
+	if (indx > kMaxChunkIndex) { return SAUNAFS_ERROR_INDEXTOOBIG; }
 #ifndef METARESTORE
 	if (gMagicAutoFileRepair) {
 		fs_auto_repair_if_needed(p, indx);
@@ -2113,9 +2109,7 @@ uint8_t FilesystemOperationsBase::writeChunk(const FsContext &context, inode_t i
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	if (index > MAX_INDEX) {
-		return SAUNAFS_ERROR_INDEXTOOBIG;
-	}
+	if (index > kMaxChunkIndex) { return SAUNAFS_ERROR_INDEXTOOBIG; }
 #ifndef METARESTORE
 	if (gMagicAutoFileRepair && context.isPersonalityMaster()) {
 		fs_auto_repair_if_needed(p, index);
@@ -2360,9 +2354,7 @@ uint8_t FilesystemOperationsBase::applyRepair(uint32_t timestamp, inode_t inode,
 	    p->type != FSNodeType::kReserved) {
 		return SAUNAFS_ERROR_EPERM;
 	}
-	if (indx > MAX_INDEX) {
-		return SAUNAFS_ERROR_INDEXTOOBIG;
-	}
+	if (indx > kMaxChunkIndex) { return SAUNAFS_ERROR_INDEXTOOBIG; }
 	if (indx >= p->chunks.size()) {
 		return SAUNAFS_ERROR_NOCHUNK;
 		safs::log_err("fs_apply_repair: indx {} is greater than number of chunks ({}), inode {}", indx, p->chunks.size(), inode);
@@ -3040,9 +3032,7 @@ uint8_t FilesystemOperationsBase::getChunkId(const FsContext &context, inode_t i
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	if (index > MAX_INDEX) {
-		return SAUNAFS_ERROR_INDEXTOOBIG;
-	}
+	if (index > kMaxChunkIndex) { return SAUNAFS_ERROR_INDEXTOOBIG; }
 	if (index < node_file->chunks.size()) {
 		*chunkid = node_file->chunks[index];
 	} else {
@@ -3125,9 +3115,7 @@ uint8_t FilesystemOperationsBase::getChunksInfo(const FsContext &context, uint32
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	if (chunk_index > MAX_INDEX) {
-		return SAUNAFS_ERROR_INDEXTOOBIG;
-	}
+	if (chunk_index > kMaxChunkIndex) { return SAUNAFS_ERROR_INDEXTOOBIG; }
 
 	FSNodeFile *file_node = static_cast<FSNodeFile *>(p);
 

--- a/src/master/metadata_backend_file.cc
+++ b/src/master/metadata_backend_file.cc
@@ -1106,9 +1106,9 @@ void MetadataBackendFile::storeedge(FSNodeDirectory *parent, FSNode *child,
                                     const std::string &name, FILE *fd) {
 	uint8_t *ptr;
 	if (child == nullptr) {  // last edge
-		memset(gEdgeStoreBuffer, 0, kEdgeHeaderSize);
-		if (fwrite(gEdgeStoreBuffer, 1, kEdgeHeaderSize, fd) !=
-		    (size_t)(kEdgeHeaderSize)) {
+		memset(gEdgeStoreBuffer, 0, FSNode::kEdgeHeaderSize);
+		if (fwrite(gEdgeStoreBuffer, 1, FSNode::kEdgeHeaderSize, fd) !=
+		    (size_t)(FSNode::kEdgeHeaderSize)) {
 			safs_pretty_syslog(LOG_NOTICE, "fwrite error");
 			return;
 		}
@@ -1119,8 +1119,8 @@ void MetadataBackendFile::storeedge(FSNodeDirectory *parent, FSNode *child,
 	putINode(&ptr, child->id);
 	put16bit(&ptr, name.length());
 	memcpy(ptr, name.c_str(), name.length());
-	if (fwrite(gEdgeStoreBuffer, 1, kEdgeHeaderSize + name.length(), fd) !=
-	    (size_t)(kEdgeHeaderSize + name.length())) {
+	if (fwrite(gEdgeStoreBuffer, 1, FSNode::kEdgeHeaderSize + name.length(), fd) !=
+	    (size_t)(FSNode::kEdgeHeaderSize + name.length())) {
 		safs_pretty_syslog(LOG_NOTICE, "fwrite error");
 		return;
 	}

--- a/src/master/metadata_backend_interface.h
+++ b/src/master/metadata_backend_interface.h
@@ -29,11 +29,6 @@
 #include <master/filesystem_node_types.h>
 #include <master/metadata_dumper_interface.h>
 
-// Constants
-constexpr uint16_t kEdgeNameMaxSize = 65535;
-constexpr uint8_t kEdgeHeaderSize =
-    sizeof(FSNode::id) + sizeof(FSNode::id) + sizeof(kEdgeNameMaxSize);
-
 // TODO (Baldor): Review the need for these constants below
 constexpr uint8_t kMetadataVersionLegacy = 0x15;
 constexpr uint8_t kMetadataVersionSaunaFS = 0x16;
@@ -44,7 +39,7 @@ constexpr int8_t kOpFailure = -1;
 constexpr char const MetadataStructureReadErrorMsg[] = "error reading metadata (structure)";
 
 // Global variables
-inline uint8_t gEdgeStoreBuffer[kEdgeHeaderSize + kEdgeNameMaxSize];
+inline uint8_t gEdgeStoreBuffer[FSNode::kEdgeHeaderSize + FSNode::kEdgeNameMaxSize];
 inline uint8_t gNodeStoreBuffer[FSNodeFile::kMaxBufferSize];
 
 // Number of metadata file versions to keep

--- a/src/master/setgoal_task.cc
+++ b/src/master/setgoal_task.cc
@@ -70,7 +70,8 @@ bool SetGoalTask::isFinished() const {
 uint8_t SetGoalTask::setGoal(FSNode *node, uint32_t ts) {
 	if (node->type == FSNodeType::kFile || node->type == FSNodeType::kDirectory ||
 	    node->type == FSNodeType::kTrash || node->type == FSNodeType::kReserved) {
-		if ((node->mode & (EATTR_NOOWNER << 12)) == 0 && uid_ != 0 && node->uid != uid_) {
+		if ((node->mode & (EATTR_NOOWNER << EATTR_BIT_OFFSET)) == 0 && uid_ != 0 &&
+		    node->uid != uid_) {
 			return SetGoalTask::kNotPermitted;
 		} else {
 			if ((smode_ & SMODE_TMASK) == SMODE_SET && node->goal != goal_) {

--- a/src/master/settrashtime_task.cc
+++ b/src/master/settrashtime_task.cc
@@ -73,7 +73,8 @@ uint8_t SetTrashtimeTask::setTrashtime(FSNode *node, uint32_t ts) {
 
 	if (node->type == FSNodeType::kFile || node->type == FSNodeType::kDirectory ||
 	    node->type == FSNodeType::kTrash || node->type == FSNodeType::kReserved) {
-		if ((node->mode & (EATTR_NOOWNER << 12)) == 0 && uid_ != 0 && node->uid != uid_) {
+		if ((node->mode & (EATTR_NOOWNER << EATTR_BIT_OFFSET)) == 0 && uid_ != 0 &&
+		    node->uid != uid_) {
 			return SetTrashtimeTask::kNotPermitted;
 		} else {
 			set = 0;

--- a/src/metadump/sfsmetadump.cc
+++ b/src/metadump/sfsmetadump.cc
@@ -35,9 +35,6 @@
 #define STR_AUX(x) #x
 #define STR(x) STR_AUX(x)
 
-#define MAX_INDEX 0x7FFFFFFF
-#define MAX_CHUNKS_PER_FILE (MAX_INDEX+1)
-
 static inline char dispchar(uint8_t c) {
 	return (c>=32 && c<=126)?c:'.';
 }

--- a/src/metadump/sfsmetadump.cc
+++ b/src/metadump/sfsmetadump.cc
@@ -220,8 +220,8 @@ int fs_loadnode(FILE *fd) {
 
 	printf("%c|i:%10" PRIiNode "|#:%" PRIu8 "|e:%1" PRIX16 "|m:%04" PRIo16 "|u:%10" PRIu32
 	       "|g:%10" PRIu32 "|a:%10" PRIu32 ",m:%10" PRIu32 ",c:%10" PRIu32 "|t:%10" PRIu32,
-	       c, nodeid, goal, (uint16_t)(mode >> 12), (uint16_t)(mode & 0xFFF), uid, gid, atimestamp,
-	       mtimestamp, ctimestamp, trashtime);
+	       c, nodeid, goal, (uint16_t)(mode >> EATTR_BIT_OFFSET), (uint16_t)(mode & 0xFFF), uid,
+	       gid, atimestamp, mtimestamp, ctimestamp, trashtime);
 
 	if (type==TYPE_BLOCKDEV || type==TYPE_CHARDEV) {
 		uint32_t rdev;

--- a/src/protocol/SFSCommunication.h
+++ b/src/protocol/SFSCommunication.h
@@ -155,6 +155,8 @@
 #define EATTR_NODATACACHE      0x08
 
 #define EATTR_BITS             4
+// shift for extraattr in mode field
+#define EATTR_BIT_OFFSET       12
 
 #define EATTR_STRINGS \
 	"noowner", \


### PR DESCRIPTION
Refactors and modernizes FS node operations in the master server to
improve structure, style, and readability. Includes better logging,
naming consistency, and documentation.

Main changes:
- Replace magic numbers with compile-time constants.
- Rename variables for clarity and consistency.
- Document complex code paths.
- Modernize logging statements.
- Add spacing for logical block separation.
- Remove numerous clang-tidy warnings.