### PR TITLE
test: Stabilize admin list notifiers test

### DIFF
--- a/tests/test_suites/ShortSystemTests/test_admin_list_notifiers.sh
+++ b/tests/test_suites/ShortSystemTests/test_admin_list_notifiers.sh
@@ -4,6 +4,7 @@ USE_RAMDISK=YES \
 for i in {1..4}; do
 	# Start the metadata notifier which will log all the messages to a file
 	metadata-notifier localhost "${info[matont]}" > "${TEMP_DIR}/notifier_${i}.log" 2>&1 &
+	sleep 1 # Add a small delay to ensure the notifier starts properly and connects to master
 done
 
 pgrep -fa metadata-notifier


### PR DESCRIPTION
Previous version of the test_admin_list_notifiers test was flaky due to no enough time for the metadata-notifier applications to connect and register to the master server when started. This commit ensures to solve this issue and allow test stability.