### PR TITLE
fix(tools): Quit on invalid option

### DIFF
--- a/src/tools/append_file.cc
+++ b/src/tools/append_file.cc
@@ -73,7 +73,7 @@ static int append_file(const char *fname, const char *afname) {
 
 	uid = getUId();
 	gid = getGId();
-	
+
 	wptr = reqbuff;
 	put32bit(&wptr, CLTOMA_FUSE_APPEND);
 	put32bit(&wptr, kAppendFilePayload);
@@ -148,7 +148,11 @@ int append_file_run(int argc, char **argv) {
 	char *appendfname = nullptr;
 	int i, status;
 
-	while (getopt(argc, argv, "") != -1) {
+	while (int ch = getopt(argc, argv, "") != -1) {
+		if (ch == '?') {
+			append_file_usage();
+			return 1;
+		}
 	}
 	argc -= optind;
 	argv += optind;

--- a/src/tools/check_file.cc
+++ b/src/tools/check_file.cc
@@ -167,6 +167,9 @@ int check_file_run(int argc, char **argv) {
 		case 'H':
 			humode = 2;
 			break;
+		case '?':
+			check_file_usage();
+			return 1;
 		}
 	}
 	argc -= optind;

--- a/src/tools/dir_info.cc
+++ b/src/tools/dir_info.cc
@@ -177,6 +177,9 @@ int dir_info_run(int argc, char **argv) {
 		case 'H':
 			humode = 2;
 			break;
+		case '?':
+			dir_info_usage();
+			return 1;
 		}
 	}
 	argc -= optind;

--- a/src/tools/file_repair.cc
+++ b/src/tools/file_repair.cc
@@ -160,6 +160,9 @@ int file_repair_run(int argc, char **argv) {
 		case 'c':
 			correct_only = 1;
 			break;
+		case '?':
+			file_repair_usage();
+			return 1;
 		}
 	}
 	argc -= optind;

--- a/src/tools/get_eattr.cc
+++ b/src/tools/get_eattr.cc
@@ -203,6 +203,9 @@ int get_eattr_run(int argc, char **argv) {
 		case 'r':
 			rflag = 1;
 			break;
+		case '?':
+			get_eattr_usage();
+			return 1;
 		}
 	}
 	argc -= optind;

--- a/src/tools/get_goal.cc
+++ b/src/tools/get_goal.cc
@@ -106,6 +106,9 @@ static int gene_get_goal_run(int argc, char **argv, int rflag) {
 		case 'r':
 			rflag = 1;
 			break;
+		case '?':
+			get_goal_usage();
+			return 1;
 		}
 	}
 	argc -= optind;

--- a/src/tools/get_trashtime.cc
+++ b/src/tools/get_trashtime.cc
@@ -175,6 +175,9 @@ static int gene_get_trashtime_run(int argc, char **argv, int rflag) {
 		case 'r':
 			rflag = 1;
 			break;
+		case '?':
+			get_trashtime_usage();
+			return 1;
 		}
 	}
 	argc -= optind;

--- a/src/tools/quota_rep.cc
+++ b/src/tools/quota_rep.cc
@@ -263,8 +263,7 @@ int quota_rep_run(int argc, char **argv) {
 		case 'a':
 			reportAll = true;
 			break;
-		default:
-			fprintf(stderr, "invalid argument: %c", (char)ch);
+		case '?':
 			quota_rep_usage();
 			return 1;
 		}

--- a/src/tools/quota_set.cc
+++ b/src/tools/quota_set.cc
@@ -111,8 +111,7 @@ int quota_set_run(int argc, char **argv) {
 		case 'd':
 			per_directory_quota = true;
 			break;
-		default:
-			fprintf(stderr, "invalid argument: %c", (char)ch);
+		case '?':
 			quota_set_usage();
 			return 1;
 		}

--- a/src/tools/set_eattr.cc
+++ b/src/tools/set_eattr.cc
@@ -192,6 +192,9 @@ static int gene_eattr_run(int argc, char **argv, uint8_t mode, void (*usage_func
 				return 1;
 			}
 			break;
+		case '?':
+			usage_func();
+			return 1;
 		}
 	}
 	argc -= optind;

--- a/src/tools/set_goal.cc
+++ b/src/tools/set_goal.cc
@@ -34,11 +34,10 @@ static int kInfiniteTimeout = 10 * 24 * 3600 * 1000; // simulate infinite timeou
 
 static void set_goal_usage() {
 	fprintf(stderr,
-	        "set objects goal (desired number of copies)\n\nusage:\n saunafs setgoal [-l] GOAL name "
+	        "set objects goal (desired number of copies)\n\nusage:\n saunafs setgoal GOAL name "
 	        "[name ...]\n");
 	print_numberformat_options();
 	print_recursive_option();
-	fprintf(stderr, " -l - wait until setgoal will finish (otherwise there is 30s timeout) (will be default in 5.0.0)\n");
 	fprintf(stderr, " GOAL - set goal to given goal name\n");
 }
 
@@ -95,7 +94,7 @@ static int gene_set_goal_run(int argc, char **argv, int rflag) {
 	int ch, status;
 	std::string goal;
 
-	while ((ch = getopt(argc, argv, "rnhHl")) != -1) {
+	while ((ch = getopt(argc, argv, "rnhH")) != -1) {
 		switch (ch) {
 		case 'n':
 			humode = 0;
@@ -109,6 +108,9 @@ static int gene_set_goal_run(int argc, char **argv, int rflag) {
 		case 'r':
 			rflag = 1;
 			break;
+		case '?':
+			set_goal_usage();
+			return 1;
 		}
 	}
 	argc -= optind;

--- a/src/tools/set_trashtime.cc
+++ b/src/tools/set_trashtime.cc
@@ -143,7 +143,7 @@ static int gene_set_trashtime_run(int argc, char **argv, int rflag) {
 	uint32_t trashtime = 86400;
 	uint8_t smode = SMODE_SET;
 
-	while ((ch = getopt(argc, argv, "rnhHl")) != -1) {
+	while ((ch = getopt(argc, argv, "rnhH")) != -1) {
 		switch (ch) {
 		case 'n':
 			humode = 0;
@@ -157,6 +157,9 @@ static int gene_set_trashtime_run(int argc, char **argv, int rflag) {
 		case 'r':
 			rflag = 1;
 			break;
+		case '?':
+			set_trashtime_usage();
+			return 1;
 		}
 	}
 	argc -= optind;

--- a/src/tools/snapshot.cc
+++ b/src/tools/snapshot.cc
@@ -49,7 +49,7 @@ static saunafs_stat_t kDefaultEmptyStat = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
 static void snapshot_usage() {
 	fprintf(stderr,
-	        "make snapshot (lazy copy)\n\nusage:\n saunafs makesnapshot [-ofl] src [src ...] dst\n");
+	        "make snapshot (lazy copy)\n\nusage:\n saunafs makesnapshot [-of] src [src ...] dst\n");
 	fprintf(stderr, " -o,-f - allow to overwrite existing objects\n");
 }
 
@@ -379,6 +379,9 @@ int snapshot_run(int argc, char **argv) {
 		case 's':
 			initial_batch_size = std::stoi(optarg);
 			break;
+		case '?':
+			snapshot_usage();
+			return 1;
 		}
 	}
 	argc -= optind;


### PR DESCRIPTION
If the command was given an invalid option, it would still run the command and show an error. This is faulty behavior that could cause unintended behavior. It's safest to exit and give the user the opportunity to correct the command.

* Remove missing usage option for makesnapshot (-l)
* Fix wrong error checking of some options (e.g do not use default keyword, instead check for '?')