### PR TITLE
doc: Remove info about 5.0.0 deprecations

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -20,11 +20,7 @@ set(MANPAGES
     saunafs-migrations.7
     saunafs-probe.8          # not a source
     saunafs-repquota.1
-    saunafs-rgetgoal.1       # not a source
-    saunafs-rgettrashtime.1  # not a source
     saunafs-rremove.1
-    saunafs-rsetgoal.1       # not a source
-    saunafs-rsettrashtime.1  # not a source
     saunafs-seteattr.1       # not a source
     saunafs-setgoal.1        # not a source
     saunafs-setquota.1       # not a source

--- a/doc/saunafs-fileinfo.1.adoc
+++ b/doc/saunafs-fileinfo.1.adoc
@@ -16,14 +16,6 @@ saunafs-fileinfo - locate chunks
 belonging to specified file(s). It can be used on any file, included deleted
 ('trash').
 
-== OPTIONS
-
-*-l*::
-This option disables timeout set for this operation. (default timeout is 10 seconds)
-
-This behavior will be default and the option removed starting from 5.0.0. If you wish
-to have timeouts use the `timeout` command.
-
 == REPORTING BUGS
 
 Report bugs to the Github repository <https://github.com/leil/saunafs> as an

--- a/doc/saunafs-getgoal.1.adoc
+++ b/doc/saunafs-getgoal.1.adoc
@@ -3,8 +3,7 @@ saunafs-getgoal(1)
 
 == NAME
 
-saunafs-getgoal, saunafs-setgoal, saunafs-rgetgoal, saunafs-rsetgoal - change
-or retrieve goal
+saunafs-getgoal, saunafs-setgoal - change or retrieve goal
 
 == SYNOPSIS
 
@@ -12,13 +11,7 @@ or retrieve goal
 *saunafs getgoal* [*-r*] [*-n*|*-h*|*-H*] 'OBJECT'...
 
 [verse]
-*saunafs rgetgoal* [*-n*|*-h*|*-H*] 'OBJECT'...
-
-[verse]
 *saunafs setgoal* [*-r*] [*-n*|*-h*|*-H*] GOAL_NAME 'OBJECT'...
-
-[verse]
-*saunafs rsetgoal* [*-n*|*-h*|*-H*] GOAL_NAME 'OBJECT'...
 
 == DESCRIPTION
 
@@ -34,17 +27,6 @@ file, but for every given directory additionally prints current value of all
 contained objects (files and directories).
 
 *-n*, *-h*, *-H*:: These options are described in saunafs(1).
-
-*-l*::
-This option disables timeout set for setgoal. (default timeout is 30 seconds)
-
-This behavior will be default and the option removed starting from 5.0.0. If you wish
-to have timeouts use the `timeout` command.
-
-== NOTE
-
-*rgetgoal* and *rsetgoal* are deprecated aliases for *getgoal -r* and *setgoal
--r* respectively. They will be removed in 5.0.0.
 
 == REPORTING BUGS
 

--- a/doc/saunafs-gettrashtime.1.adoc
+++ b/doc/saunafs-gettrashtime.1.adoc
@@ -3,8 +3,7 @@ saunafs-gettrashtime(1)
 
 == NAME
 
-saunafs-gettrashtime, saunafs-settrashtime, saunafs-rgettrashtime,
-saunafs-rsettrashtime - get or set trash time
+saunafs-gettrashtime, saunafs-settrashtime - get or set trash time
 
 == SYNOPSIS
 
@@ -36,17 +35,6 @@ the rest. These tools can be used on any file, directory or deleted ('trash')
 file.
 
 *-n*, *-h*, *-H*:: These options are described in saunafs(1).
-
-*-l*::
-This option disables timeout set for setgoal. (default timeout is 30 seconds)
-
-This behavior will be default and the option removed starting from 5.0.0. If you wish
-to have timeouts use the `timeout` command.
-
-== NOTE
-
-*rgettrashtime* and *-rsettrashtime* are deprecated aliases for *rgettrashtime
--r* and *rsettrashtime -r* respectively. They will be removed in 5.0.0.
 
 == REPORTING BUGS
 

--- a/doc/saunafs-makesnapshot.1.adoc
+++ b/doc/saunafs-makesnapshot.1.adoc
@@ -21,14 +21,6 @@ it's alias *-o* (overwrite) option is given.
 NOTE: if 'SOURCE' is a directory, it's copied as a whole; but if it's followed
 by trailing slash, only directory content is copied.
 
-== OPTIONS
-
-*-l*::
-This option disables timeout set for this operation. (default timeout is 60 seconds)
-
-This behavior will be default and the option removed starting from 5.0.0. If you wish
-to have timeouts use the `timeout` command.
-
 == REPORTING BUGS
 
 Report bugs to the Github repository <https://github.com/leil/saunafs> as an

--- a/doc/saunafs-rremove.1.adoc
+++ b/doc/saunafs-rremove.1.adoc
@@ -14,14 +14,6 @@ saunafs-rremove - remove recursively
 
 *rremove* deletes object(s) recursively. This tool can be used on either file or directory.
 
-== OPTIONS
-
-*-l*::
-This option disables timeout set for this operation. (default timeout is 60 seconds)
-
-This behavior will be default and the option removed starting from 5.0.0. If you wish
-to have timeouts use the `timeout` command.
-
 == REPORTING BUGS
 
 Report bugs to the Github repository <https://github.com/leil/saunafs> as an

--- a/doc/saunafs.1.adoc
+++ b/doc/saunafs.1.adoc
@@ -11,13 +11,7 @@ saunafs - open prompt to perform SaunaFS-specific operations
 *saunafs getgoal* [*-r*] [*-n*|*-h*|*-H*] 'OBJECT'...
 
 [verse]
-*saunafs rgetgoal* [*-n*|*-h*|*-H*] 'OBJECT'...
-
-[verse]
 *saunafs setgoal* [*-r*] [*-n*|*-h*|*-H*] 'NAME' 'OBJECT'...
-
-[verse]
-*saunafs rsetgoal* [*-n*|*-h*|*-H*] [*+*|*-*]N 'OBJECT'...
 
 [verse]
 *saunafs setquota* (*-u* 'UID' | *-g* 'GID') 'SOFT-LIMIT-SIZE' 'HARD-LIMIT-SIZE'
@@ -31,13 +25,7 @@ saunafs - open prompt to perform SaunaFS-specific operations
 *saunafs gettrashtime* [*-r*] [*-n*|*-h*|*-H*] 'OBJECT'...
 
 [verse]
-*saunafs rgettrashtime* [*-n*|*-h*|*-H*] 'OBJECT'...
-
-[verse]
 *saunafs settrashtime* [*-r*] [*-n*|*-h*|*-H*] [*+*|*-*]SECONDS 'OBJECT'...
-
-[verse]
-*saunafs rsettrashtime* [*-n*|*-h*|*-H*] [*+*|*-*]SECONDS 'OBJECT'...
 
 [verse]
 *saunafs geteattr* [*-r*] [*-n*|*-h*|*-H*] 'OBJECT'...
@@ -139,7 +127,6 @@ SaunaFS. If not, see <http://www.gnu.org/licenses/>.
 sfsmount(1), saunafs-appendchunks(1), saunafs-checkfile(1),
 saunafs-deleattr(1), saunafs-dirinfo(1), saunafs-fileinfo(1),
 saunafs-filerepair(1), saunafs-geteattr(1), saunafs-getgoal(1),
-saunafs-gettrashtime(1), saunafs-makesnapshot(1), saunafs-rgetgoal(1),
-saunafs-rgettrashtime(1), saunafs-rsetgoal(1), saunafs-rsettrashtime(1),
-saunafs-seteattr(1), saunafs-setgoal(1), saunafs-settrashtime(1),
-saunafs-rremove(1), saunafs-repquota(1), saunafs-setquota(1), sfs(7)
+saunafs-gettrashtime(1), saunafs-makesnapshot(1), saunafs-seteattr(1),
+saunafs-setgoal(1), saunafs-settrashtime(1), saunafs-rremove(1),
+saunafs-repquota(1), saunafs-setquota(1), sfs(7)


### PR DESCRIPTION
Since 5.0.0 has been out for a while now, there's no need to inform people about removed options anymore.