### PR TITLE
feat(notifier): Add trash path by inode support

### DIFF
--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -577,25 +577,41 @@ uint8_t FilesystemOperationsBase::fullPathByInode(const FsContext &context, inod
 	return SAUNAFS_STATUS_OK;
 }
 
-std::string FilesystemOperationsBase::fullPathByInode(inode_t initial_inode) {
+std::string FilesystemOperationsBase::fullPathByInode(inode_t initialInode) {
 	std::string fullPath = "";
-	inode_t current_inode = initial_inode;
-	FSNode *current_node = nodeOperations_->idToNode(current_inode);
-	std::string current_name = "";
+	inode_t currentInode = initialInode;
+	FSNode *currentNode = nodeOperations_->idToNode(currentInode);
+	std::string currentName = "";
 
-	while (current_inode != SPECIAL_INODE_ROOT) {
-		if (!current_node) {
+	while (currentInode != SPECIAL_INODE_ROOT) {
+		if (!currentNode) {
 			return "";
-		} else if (current_node->parents.empty()) {
+		} else if (currentNode->parents.empty()) {
+			if (currentNode->type == FSNodeType::kReserved ||
+			    currentNode->type == FSNodeType::kTrash) {
+				std::string pathFromTrashOrReserved;
+				if (currentNode->type == FSNodeType::kTrash) {
+					const auto key = TrashPathKey(currentNode);
+					auto it = gMetadata->trash.find(key);
+					if (it == gMetadata->trash.end()) { return ""; }
+					pathFromTrashOrReserved = (*it).second.get() + " (trash)";
+				} else {
+					auto it = gMetadata->reserved.find(currentInode);
+					if (it == gMetadata->reserved.end()) { return ""; }
+					pathFromTrashOrReserved = (*it).second.get() + " (reserved)";
+				}
+				return "/" + pathFromTrashOrReserved;
+			}
 			break;
 		}
-		auto parent = current_node->parents[0].first;
-		auto parent_node = nodeOperations_->idToNode<FSNodeDirectory>(parent);
-		if (!parent_node) { return ""; }
-		current_name = parent_node->getChildName(current_node);
-		fullPath = current_inode == initial_inode ? current_name : current_name + "/" + fullPath;
-		current_inode = parent;
-		current_node = parent_node;
+
+		auto parent = currentNode->parents[0].first;
+		auto parentNode = nodeOperations_->idToNode<FSNodeDirectory>(parent);
+		if (!parentNode) { return ""; }
+		currentName = parentNode->getChildName(currentNode);
+		fullPath = currentInode == initialInode ? currentName : currentName + "/" + fullPath;
+		currentInode = parent;
+		currentNode = parentNode;
 	}
 
 	fullPath = "/" + fullPath;

--- a/src/master/filesystem_operations.h
+++ b/src/master/filesystem_operations.h
@@ -222,7 +222,7 @@ public:
 
 	uint8_t fullPathByInode(const FsContext &context, inode_t inode,
 	                        std::string &fullPath) override;
-	std::string fullPathByInode(inode_t initial_inode) override;
+	std::string fullPathByInode(inode_t initialInode) override;
 
 	// QUOTAS
 

--- a/src/master/filesystem_operations_interface.h
+++ b/src/master/filesystem_operations_interface.h
@@ -248,7 +248,7 @@ public:
 
 	virtual uint8_t fullPathByInode(const FsContext &context, inode_t inode,
 	                                std::string &fullPath) = 0;
-	virtual std::string fullPathByInode(inode_t initial_inode) = 0;
+	virtual std::string fullPathByInode(inode_t initialInode) = 0;
 
 	// QUOTAS
 

--- a/tests/test_suites/ShortSystemTests/test_metadata_notifier.sh
+++ b/tests/test_suites/ShortSystemTests/test_metadata_notifier.sh
@@ -1,5 +1,6 @@
 CHUNKSERVERS=1 \
 	USE_RAMDISK=YES \
+	MASTER_EXTRA_CONFIG="EMPTY_RESERVED_FILES_PERIOD_MSECONDS = 1000"\
 	setup_local_empty_saunafs info
 
 # Start the metadata notifier which will log all the messages to a file
@@ -24,6 +25,18 @@ for f in "${folders[@]}"; do
     sleep 1
 done
 
+# Remove a created file to generate an UNLINK notification
+saunafs settrashtime 10 folder1
+touch folder1/file1
+rm folder1/file1
+sleep 1 # wait for the notifier to process the unlink event
+
+# Remove a created file with no trash time to retrieve from reserved files
+saunafs settrashtime 0 folder1
+touch folder1/file2
+rm folder1/file2
+sleep 3 # wait for the notifier to process the unlink and purge events
+
 # Stop the notifier and print the log file
 kill -s SIGKILL $NOTIFIER_PID
 cat "${TEMP_DIR}/notifier.log"
@@ -40,6 +53,12 @@ expected=(
     "inode 4: type=d path=/folder1/subfolder1"
     "ACCESS(5)"
     "inode 5: type=d path=/folder1/subfolder2"
+    "UNLINK(2,file1):6"
+    "inode 6: type=t path=/folder1/file1 (trash)"
+    "UNLINK(2,file2):7"
+    "inode 7: type=r path=/folder1/file2 (reserved)"
+    "PURGE(7)"
+    "inode 7: type=? path="
 )
 for e in "${expected[@]}"; do
     assert_success grep -q "$e" "${TEMP_DIR}/notifier.log"

--- a/utils/metadata_notifier.cc
+++ b/utils/metadata_notifier.cc
@@ -163,7 +163,9 @@ int main(int argc, char *argv[]) {
 
 	std::vector<uint8_t> recvBuffer;
 	recvBuffer.reserve(4096);
-	std::regex access_regex(R"(ACCESS\((\d+)\))");
+	std::regex accessRegex(R"(ACCESS\((\d+)\))");
+	std::regex unlinkRegex(R"(UNLINK\([^)]*\):(\d+))");
+	std::regex purgeRegex(R"(PURGE\((\d+)\))");
 
 	while (true) {
 		uint8_t temp[4096];
@@ -199,9 +201,13 @@ int main(int argc, char *argv[]) {
 				// Print log string
 				fprintf(stderr, "%s\n", str.c_str());
 
-				// If log string starts with ACCESS(<inode>), send request for path/type
+				// If log string starts with ACCESS(<inode>), PURGE(<inode>) or
+				// UNLINK(<parent_inode>,<name>):<unlinked_inode>, send request for path/type of
+				// that inode
 				std::smatch match;
-				if (std::regex_search(str, match, access_regex)) {
+				if (std::regex_search(str, match, accessRegex) ||
+				    std::regex_search(str, match, unlinkRegex) ||
+				    std::regex_search(str, match, purgeRegex)) {
 					uint64_t inode = std::stoull(match[1].str());
 					sendGetPathTypeInode(sockfd, inode);
 				}


### PR DESCRIPTION
Previous version of the supported endpoint on the master side for answering path and type values by a given inode from metadata-notifier applications was not returning correct path when the requested inode was on trash or reserved files entries. This commit ensures to add support for that kind of requests with the expected response and also improves some variables naming on the
`std::string FilesystemOperationsBase::fullPathByInode` function to be camel cased.