### PR TITLE
ci: Run unit tests in Jenkins instead of GH action

### DIFF
--- a/.github/workflows/run-ganesha-tests.yml
+++ b/.github/workflows/run-ganesha-tests.yml
@@ -1,4 +1,4 @@
-name: Run Unit and Ganesha Tests
+name: Run Ganesha Tests
 
 on:
     merge_group:
@@ -8,7 +8,7 @@ on:
             - dev
 
 jobs:
-    Run-Unit-Tests-and-Ganesha:
+    Run-Ganesha-Tests:
         runs-on: ubuntu-24.04
 
         env:
@@ -153,10 +153,6 @@ jobs:
                 sudo mkdir -p /etc/systemd/coredump.conf.d
                 echo -e "[Coredump]\nStorage=external\nProcessSizeMax=2G" | sudo tee /etc/systemd/coredump.conf.d/coredump.conf
                 sudo systemctl daemon-reexec
-
-            - name: Run Unit Tests suite
-              run: |
-                  "${GITHUB_WORKSPACE}/build/src/unittests/unittests" --gtest_color=yes
 
             - name: Run Ganesha suite
               run: |

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ def buildSfstests() {
 def buildImage(imageName) {
     sh """
         cd $WORKSPACE
-        mkdir build
+        mkdir -p build
         docker buildx build --build-arg BASE_IMAGE=${imageName} --tag saunafs-test:latest -f tests/docker/Dockerfile.test $WORKSPACE
         """
 }
@@ -180,6 +180,57 @@ pipeline {
         }
         stage('Build and test') {
             parallel {
+                stage('Build and run unittests (Ubuntu 24.04)') {
+                    agent {label 'unittests'}
+                    stages {
+                        stage("Checkout source") {
+                            steps {
+                                checkout scm
+                            }
+                        }
+                        stage("Build and test") {
+                            steps {
+                                sh """
+                                    export PATH="/usr/lib/ccache:$PATH"
+                                    cd vcpkg
+                                    ./bootstrap-vcpkg.sh
+                                    cd ..
+                                    mkdir -p build
+                                    cd build
+                                    nice cmake \
+                                         -DCMAKE_TOOLCHAIN_FILE="../vcpkg/scripts/buildsystems/vcpkg.cmake" \
+                                         -DENABLE_CLIENT_LIB=ON \
+                                         -DENABLE_DOCS=ON \
+                                         -DENABLE_NFS_GANESHA=ON \
+                                         -DENABLE_POLONAISE=OFF \
+                                         -DENABLE_URAFT=ON \
+                                         -DGSH_CAN_HOST_LOCAL_FS=ON \
+                                         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+                                         -DCMAKE_INSTALL_PREFIX="../install/saunafs/" \
+                                         -DENABLE_TESTS=ON \
+                                         -DCODE_COVERAGE=OFF \
+                                         -DSAUNAFS_TEST_POINTER_OBFUSCATION=ON \
+                                         -DENABLE_WERROR=ON \
+                                         -DENABLE_FOUNDATIONDB=ON \
+                                    ..
+                                    cd src/unittests
+                                    nice make -j\$((\$(nproc) / 2))
+                                    # Make sure that failures do NOT fail the pipeline
+                                    ./unittests || true
+                                """
+                                publishJunit("build/src/unittests/*test_detail.xml")
+                            }
+                        }
+                    }
+                    post {
+                        failure {
+                            slackBadMessage(
+                                "Unit tests failed on ${BRANCH_NAME}",
+                                "Unit tests failed on branch ${BRANCH_NAME}, build number ${BUILD_NUMBER}"
+                            )
+                        }
+                    }
+                }
                 stage('Build with clang') {
                     agent {label 'build'}
                     steps {

--- a/src/unittests/unittests.in
+++ b/src/unittests/unittests.in
@@ -6,5 +6,5 @@ TEST_LIST="@UNITTEST_TEST_NAMES@"
 SCRIPT_DIRECTORY=$(dirname "${BASH_SOURCE[0]}")
 
 for test in ${TEST_LIST}; do
-	"$SCRIPT_DIRECTORY/unittest_$test" $@ || exit 1
+	"$SCRIPT_DIRECTORY/unittest_$test" --gtest_output="xml:${test}_test_detail.xml" "$@" || exit 1
 done


### PR DESCRIPTION
Due to recent issues on the Github action, where FDB tests were failing, it was decided to move the unit testing back to Jenkins. For a start, a VM was created specifically to run the unittests. Later on improvements could be made, for example running in Docker or sharing the build from the docker image.

The unittests script was also improved to save the XML files, which can be parsed by junit