### PR TITLE
fix: Fix issues with case insensitiveness

### DIFF
--- a/doc/sfsexports.cfg.5.adoc
+++ b/doc/sfsexports.cfg.5.adoc
@@ -47,6 +47,16 @@ only user primary group information)
 names as case-insensitive. When enabled, the client will not differentiate 
 between uppercase and lowercase characters in file and folder names.
 
+[NOTE]
+====
+System administrators are strongly advised **not** to allow simultaneous access
+to the same directory or subdirectory by multiple clients where some have the
+*caseinsensitive* option enabled and others do not, especially if these clients
+connect from different session IPs. This configuration can lead to filesystem
+inconsistencies and unpredictable behavior. For any given path or subfolder,
+ensure that all accessing clients either use this option or none do.
+====
+
 *dynamicip*:: allows reconnecting of already authenticated client from any IP
 address (the default is to check IP address on reconnect)
 

--- a/src/master/filesystem_checksum.cc
+++ b/src/master/filesystem_checksum.cc
@@ -46,19 +46,8 @@ static uint64_t fsnodes_checksum(FSNode *node, bool full_update = false) {
 				static_cast<FSNodeDirectory *>(node)->entries_hash ^=
 				    entry.first->hash();
 			}
-
-			// Case insensitive
-			if (static_cast<FSNodeDirectory *>(node)->case_insensitive) {
-				static_cast<FSNodeDirectory *>(node)->lowerCaseEntriesHash = 0;
-				for (const auto &entry :
-				     static_cast<FSNodeDirectory *>(node)->lowerCaseEntries) {
-					static_cast<FSNodeDirectory *>(node)
-					    ->lowerCaseEntriesHash ^= entry.first->hash();
-				}
-			}
 		}
 		hashCombine(seed, static_cast<const FSNodeDirectory*>(node)->entries_hash);
-		hashCombine(seed, static_cast<const FSNodeDirectory*>(node)->lowerCaseEntriesHash);
 		break;
 	case FSNodeType::kSocket:
 	case FSNodeType::kFifo:

--- a/src/master/filesystem_dump.cc
+++ b/src/master/filesystem_dump.cc
@@ -136,7 +136,7 @@ void fs_dumpedgelist(FSNodeDirectory *parent) {
 	for (const auto &entry : parent->entries) {
 		fs_dumpedge(parent, entry.second, (std::string)(*entry.first));
 	}
-	if (parent->case_insensitive) {
+	if (parent->caseInsensitive) {
 		for (const auto &entry : parent->lowerCaseEntries) {
 			fs_dumpedge(parent, entry.second, (std::string)(*entry.first));
 		}
@@ -165,7 +165,7 @@ void fs_dumpedges(FSNodeDirectory *parent) {
 			fs_dumpedges(static_cast<FSNodeDirectory*>(child));
 		}
 	}
-	if (parent->case_insensitive) {
+	if (parent->caseInsensitive) {
 		for (const auto &entry : parent->lowerCaseEntries) {
 			FSNode *child = entry.second;
 			if (child->type == FSNodeType::kDirectory) {

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -516,12 +516,11 @@ void FilesystemNodeOperationsBase::removeEdge(uint32_t timeStamp, FSNodeDirector
 		parent->entries.erase(dirIter);
 		parent->entries_hash ^= childName.hash();
 
-		if (parent->case_insensitive) {
+		if (parent->caseInsensitive) {
 			auto lowerCaseIt = parent->find_lowercase_container(childName);
 			delete lowerCaseIt->first;
 			parent->lowerCaseEntries.erase(lowerCaseIt);
 			HString lowerCaseName = HString::hstringToLowerCase(childName);
-			parent->lowerCaseEntriesHash ^= lowerCaseName.hash();
 		}
 	}
 
@@ -534,13 +533,13 @@ void FilesystemNodeOperationsBase::removeEdge(uint32_t timeStamp, FSNodeDirector
 
 	fsnodes_update_checksum(parent);
 	HString currentName = childName;
-	if (parent->case_insensitive) { currentName = HString::hstringToLowerCase(childName); }
+	if (parent->caseInsensitive) { currentName = HString::hstringToLowerCase(childName); }
 
 	auto iter = std::find_if(
 	    childNode->parents.begin(), childNode->parents.end(),
 	    [parent, currentName](const std::pair<inode_t, const hstorage::Handle *> &parentEntry) {
 		    return parentEntry.first == parent->id &&
-		           (parent->case_insensitive
+		           (parent->caseInsensitive
 		                ? HString::hstringToLowerCase(parentEntry.second->get())
 		                : parentEntry.second->get()) == currentName;
 	    });
@@ -564,12 +563,11 @@ void FilesystemNodeOperationsBase::link(uint32_t timeStamp, FSNodeDirectory *par
 	parent->entries.insert({handlePtr, child});
 	parent->entries_hash ^= name.hash();
 
-	if (parent->case_insensitive) {
+	if (parent->caseInsensitive) {
 		HString lowerCaseName = HString::hstringToLowerCase(name);
 		// Needs to be freed in fsnodes_remove_edge
 		auto *lowercaseHandlePtr = new hstorage::Handle(std::string(lowerCaseName.c_str()));
 		parent->lowerCaseEntries.insert({lowercaseHandlePtr, child});
-		parent->lowerCaseEntriesHash ^= lowerCaseName.hash();
 	}
 
 	child->parents.push_back({parent->id, handlePtr});
@@ -2143,6 +2141,16 @@ uint8_t FilesystemNodeOperationsBase::getNodeForOperation(const FsContext &conte
 
 	if (context.canCheckPermissions() && !access(context, candidateNode, modeMask)) {
 		return SAUNAFS_ERROR_EACCES;
+	}
+
+	// Case insensitive update check for the given context
+	if (context.hasSessionData() && candidateNode->type == FSNodeType::kDirectory) {
+		auto *dir = static_cast<FSNodeDirectory *>(candidateNode);
+		const bool sessionIsCaseInsensitive = (context.sesflags() & SESFLAG_CASEINSENSITIVE) != 0;
+		if (dir->caseInsensitive != sessionIsCaseInsensitive) {
+			dir->caseInsensitive = sessionIsCaseInsensitive;
+			dir->updateLowerCaseEntries();
+		}
 	}
 
 	*nodeOut = candidateNode;

--- a/src/master/filesystem_node_types.h
+++ b/src/master/filesystem_node_types.h
@@ -36,6 +36,7 @@
 #include "common/skip_list.h"
 #include "common/type_defs.h"
 #include "protocol/SFSCommunication.h"
+#include "slogger/slogger.h"
 
 #include "master/hstring_storage.h"
 
@@ -397,11 +398,10 @@ public:
 	EntriesContainer entries;  ///< Directory entries (entry: name + pointer to child node).
 	/// Directory entries with lower case name (entry: name + pointer to child node).
 	EntriesContainer lowerCaseEntries;
-	bool case_insensitive = false;  ///< Flag for case insensitive search.
+	bool caseInsensitive = false;  ///< Flag for case insensitive search.
 	StatsRecord stats;              ///< Directory statistics (including subdirectories).
 	uint32_t nlink{2};              ///< Number of directories linking to this directory.
 	uint16_t entries_hash{};
-	uint16_t lowerCaseEntriesHash{};
 
 	explicit FSNodeDirectory() : FSNode(FSNodeType::kDirectory) {
 		memset(&stats, 0, sizeof(stats));
@@ -416,7 +416,7 @@ public:
 	iterator find(const HString &name) {
 		uint64_t name_hash = (hstorage::Handle::HashType)name.hash();
 
-		if (case_insensitive) {
+		if (caseInsensitive) {
 			HString lowerCaseNameHandle = HString::hstringToLowerCase(name);
 			name_hash = (hstorage::Handle::HashType)lowerCaseNameHandle.hash();
 			auto tmp_handle = hstorage::Handle(name_hash << hstorage::Handle::kHashShift);
@@ -447,7 +447,7 @@ public:
 	iterator find_lowercase_container(const HString &name) {
 		uint64_t name_hash = (hstorage::Handle::HashType)name.hash();
 
-		if (case_insensitive) {
+		if (caseInsensitive) {
 			HString lowerCaseNameHandle = HString::hstringToLowerCase(name);
 			name_hash = (hstorage::Handle::HashType)lowerCaseNameHandle.hash();
 			auto tmp_handle = hstorage::Handle(name_hash << hstorage::Handle::kHashShift);
@@ -499,6 +499,101 @@ public:
 			if (parentId == this->id) { return hstring->get(); }
 		}
 		return {};
+	}
+
+	/*! \brief Returns the original stored child name for any-case input.
+	 *
+	 * This function is only meaningful for directories with the case-insensitive flag set.
+	 * If the directory is not case-insensitive, it will always return an empty string.
+	 *
+	 * The function works as follows:
+	 * - It takes any-case input (e.g., "FoO").
+	 * - It converts the input to lower case and looks up the corresponding entry in
+	 *   the lowerCaseEntries container (e.g., "foo").
+	 * - If a match is found, it returns the original stored name as it was first added
+	 *   to the parent directory (e.g., returns "Foo" if that was the original casing).
+	 * - If no match is found, or the directory is not case-insensitive, it returns an empty string.
+	 *
+	 * Example:
+	 *   - Directory contains an entry stored as "Foo".
+	 *   - getBaseStoredChildName("FoO") will return "Foo".
+	 *
+	 * \param anyCaseName Any-case name to look up.
+	 * \return The original stored child name (with original casing), or empty string if not found.
+	 */
+	std::string getBaseStoredChildName(const std::string &anyCaseName) {
+		if (!caseInsensitive) { return {}; }
+
+		// caseInsensitive path
+		HString inputH(anyCaseName);
+		HString lowerCaseNameHandle = HString::hstringToLowerCase(inputH);
+		uint64_t lowerCaseHash = (hstorage::Handle::HashType)lowerCaseNameHandle.hash();
+		hstorage::Handle tmp(lowerCaseHash << hstorage::Handle::kHashShift);
+		auto pairToFind = std::make_pair(&tmp, kUnknownNode);
+		auto lowerIt = lowerCaseEntries.lower_bound(pairToFind);
+
+		for (; lowerIt != lowerCaseEntries.end(); ++lowerIt) {
+			if ((*lowerIt).first->hash() != lowerCaseHash) { break; }
+			if (*((*lowerIt).first) == lowerCaseNameHandle) {
+				FSNode *child = (*lowerIt).second;
+				if (!child) { return {}; }
+				// ORIGINAL name from parents vector (first stored casing).
+				for (const auto &[parentId, hstring] : child->parents) {
+					if (parentId == this->id) { return std::string(hstring->get()); }
+				}
+
+				// Fallback: scan entries for pointer equality (should rarely be needed).
+				for (auto it = entries.begin(); it != entries.end(); ++it) {
+					if ((*it).second == child) {
+						safs::log_warn(
+						    "Inconsistent filesystem tree: fallback used in getBaseStoredChildName for directory id {}",
+						    this->id);
+						return std::string((*it).first->get());
+					}
+				}
+				return {};
+			}
+		}
+		return {};
+	}
+
+	/*!
+	 * \brief Updates lowerCaseEntries for all entries according to caseInsensitive flag.
+	 *
+	 * For case-insensitive directories, this populates lowerCaseEntries so that
+	 * lookups can be performed in a case-insensitive manner. If multiple entries
+	 * exist whose names differ only by case (e.g., "foo" and "Foo"), only one of
+	 * them will be present in lowerCaseEntries after this operation—the first one
+	 * encountered during iteration. This means only one will be found by a
+	 * case-insensitive lookup, and others will be hidden.
+	 */
+	void updateLowerCaseEntries() {
+		if (!caseInsensitive) {
+			// Clear and free all lowerCaseEntries
+			for (auto it = lowerCaseEntries.begin(); it != lowerCaseEntries.end();) {
+				delete it->first;
+				auto entryToErase = it++;
+				lowerCaseEntries.erase(entryToErase);
+			}
+
+			lowerCaseEntries.clear();
+			return;
+		}
+
+		// Populate lowerCaseEntries for all entries in entries
+		for (const auto &entry : entries) {
+			FSNode *child = entry.second;
+			HString lowerCaseName = HString::hstringToLowerCase(entry.first->get());
+
+			// Reuse find_lowercase_container to check if already present
+			auto lowerCaseIt = find_lowercase_container(lowerCaseName);
+			bool found = (lowerCaseIt != lowerCaseEntries.end());
+
+			if (!found) {
+				auto *lowercaseHandlePtr = new hstorage::Handle(lowerCaseName);
+				lowerCaseEntries.insert({lowercaseHandlePtr, child});
+			}
+		}
 	}
 
 	iterator begin() { return entries.begin(); }

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -698,6 +698,55 @@ uint8_t FilesystemOperationsBase::trySetLength(const FsContext &context, inode_t
 }
 #endif
 
+uint8_t FilesystemOperationsBase::getCanonicalPath(const FsContext &context,
+                                                   const std::string &inputPath,
+                                                   std::string &canonicalPath) {
+	bool caseInsensitiveFS = context.sesflags() & SESFLAG_CASEINSENSITIVE;
+	FSNode *currentNode = nodeOperations_->idToNode(context.rootinode());
+	std::string resultPath;
+
+	if (!currentNode || currentNode->type != FSNodeType::kDirectory) {
+		return SAUNAFS_ERROR_ENOTDIR;
+	}
+
+	auto it = inputPath.begin();
+	while (it != inputPath.end()) {
+		auto delim = std::find(it, inputPath.end(), '/');
+		if (it != delim) {
+			HString name(it, delim);
+			if (currentNode->type != FSNodeType::kDirectory) { return SAUNAFS_ERROR_ENOTDIR; }
+
+			auto *dir = static_cast<FSNodeDirectory *>(currentNode);
+			if (dir->caseInsensitive != caseInsensitiveFS) {
+				dir->caseInsensitive = caseInsensitiveFS;
+				dir->updateLowerCaseEntries();
+			}
+
+			// Case-insensitive: resolve canonical casing using getBaseStoredChildName
+			std::string baseName;
+			if (caseInsensitiveFS) {
+				baseName = dir->getBaseStoredChildName(name);
+				if (baseName.empty()) { return SAUNAFS_ERROR_ENOENT; }
+			} else {
+				baseName = name;
+			}
+
+			FSNode *child = nodeOperations_->lookup(dir, HString(baseName));
+			if (!child) { return SAUNAFS_ERROR_ENOENT; }
+
+			if (!resultPath.empty()) { resultPath += "/"; }
+			resultPath += baseName;
+			currentNode = child;
+		}
+
+		if (delim == inputPath.end()) { break; }
+		it = std::next(delim);
+	}
+
+	canonicalPath = resultPath;
+	return SAUNAFS_STATUS_OK;
+}
+
 uint8_t FilesystemOperationsBase::applyTrunc(uint32_t timestamp, inode_t inode, uint32_t indx,
                                              uint64_t chunkid, uint32_t lockid) {
 	uint64_t ochunkid, nchunkid;
@@ -1032,6 +1081,7 @@ uint8_t FilesystemOperationsBase::symlink(const FsContext &context, inode_t pare
                                           const HString &name, const std::string &path,
                                           inode_t *inode, Attributes *attr) {
 	ChecksumUpdater cu(context.ts());
+	std::string basePath;
 	FSNode *wd;
 	uint8_t status =
 	    nodeOperations_->verifySession(context, OperationMode::kReadWrite, SessionType::kNotMeta);
@@ -1043,11 +1093,24 @@ uint8_t FilesystemOperationsBase::symlink(const FsContext &context, inode_t pare
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	if (path.length() == 0) {
+
+	// If filesystem is case-insensitive, get the canonical path for the symlink target
+	if (static_cast<FSNodeDirectory *>(wd)->caseInsensitive) {
+		status = getCanonicalPath(context, path, basePath);
+		if (status != SAUNAFS_STATUS_OK) {
+			// Unix-style symlinks allow dangling links, so if the path cannot be resolved,
+			// we just use the original path as-is
+			basePath = path;
+		}
+	} else {
+		basePath = path;
+	}
+
+	if (basePath.length() == 0) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
-	for (uint32_t i = 0; i < path.length(); i++) {
-		if (path[i] == 0) {
+	for (uint32_t i = 0; i < basePath.length(); i++) {
+		if (basePath[i] == 0) {
 			return SAUNAFS_ERROR_EINVAL;
 		}
 	}
@@ -1063,12 +1126,12 @@ uint8_t FilesystemOperationsBase::symlink(const FsContext &context, inode_t pare
 	FSNodeSymlink *p = static_cast<FSNodeSymlink *>(nodeOperations_->createNode(
 	    context.ts(), static_cast<FSNodeDirectory *>(wd), name, FSNodeType::kSymlink, 0777, 0,
 	    context.uid(), context.gid(), 0, AclInheritance::kDontInheritAcl, *inode));
-	p->path = HString(path);
-	p->path_length = path.length();
+	p->path = HString(basePath);
+	p->path_length = basePath.length();
 	fsnodes_update_checksum(p);
 	StatsRecord sr;
 	memset(&sr, 0, sizeof(StatsRecord));
-	sr.length = path.length();
+	sr.length = basePath.length();
 	nodeOperations_->addStats(static_cast<FSNodeDirectory *>(wd), &sr);
 	if (attr != NULL) { nodeOperations_->fillAttr(context, p, wd, *attr); }
 	if (context.isPersonalityMaster()) {
@@ -1076,7 +1139,8 @@ uint8_t FilesystemOperationsBase::symlink(const FsContext &context, inode_t pare
 		*inode = p->id;
 		changeLog(context.ts(), "SYMLINK(%" PRIiNode ",%s,%s,%" PRIu32 ",%" PRIu32 "):%" PRIiNode,
 		          wd->id, nodeOperations_->escapeName(name).c_str(),
-		          nodeOperations_->escapeName(path).c_str(), context.uid(), context.gid(), p->id);
+		          nodeOperations_->escapeName(basePath).c_str(), context.uid(), context.gid(),
+		          p->id);
 	} else {
 		if (*inode != p->id) {
 			return SAUNAFS_ERROR_MISMATCH;
@@ -1127,7 +1191,7 @@ uint8_t FilesystemOperationsBase::mknod(const FsContext &context, inode_t parent
 		return SAUNAFS_ERROR_QUOTA;
 	}
 
-	static_cast<FSNodeDirectory *>(wd)->case_insensitive =
+	static_cast<FSNodeDirectory *>(wd)->caseInsensitive =
 	    context.sesflags() & SESFLAG_CASEINSENSITIVE;
 	p = nodeOperations_->createNode(ts, static_cast<FSNodeDirectory *>(wd), name, type, mode, umask,
 	                                context.uid(), context.gid(), 0, AclInheritance::kInheritAcl);
@@ -1183,7 +1247,7 @@ uint8_t FilesystemOperationsBase::mkdir(const FsContext &context, inode_t parent
 		}
 	}
 
-	static_cast<FSNodeDirectory *>(wd)->case_insensitive =
+	static_cast<FSNodeDirectory *>(wd)->caseInsensitive =
 	    context.sesflags() & SESFLAG_CASEINSENSITIVE;
 	p = nodeOperations_->createNode(ts, static_cast<FSNodeDirectory *>(wd), name,
 	                                FSNodeType::kDirectory, mode, umask, context.uid(),
@@ -1242,6 +1306,7 @@ uint8_t FilesystemOperationsBase::unlink(const FsContext &context, inode_t paren
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
 	FSNode *wd;
+	HString baseName = name;
 
 	uint8_t status =
 	    nodeOperations_->verifySession(context, OperationMode::kReadWrite, SessionType::kNotMeta);
@@ -1255,8 +1320,13 @@ uint8_t FilesystemOperationsBase::unlink(const FsContext &context, inode_t paren
 		return status;
 	}
 
-	if (nodeOperations_->nameCheck(name) < 0) { return SAUNAFS_ERROR_EINVAL; }
-	FSNode *child = nodeOperations_->lookup(static_cast<FSNodeDirectory *>(wd), name);
+	if (static_cast<FSNodeDirectory *>(wd)->caseInsensitive) {
+		std::string resolvedName = static_cast<FSNodeDirectory *>(wd)->getBaseStoredChildName(name);
+		if (!resolvedName.empty()) { baseName = HString(resolvedName); }
+	}
+
+	if (nodeOperations_->nameCheck(baseName) < 0) { return SAUNAFS_ERROR_EINVAL; }
+	FSNode *child = nodeOperations_->lookup(static_cast<FSNodeDirectory *>(wd), baseName);
 	if (!child) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
@@ -1265,8 +1335,8 @@ uint8_t FilesystemOperationsBase::unlink(const FsContext &context, inode_t paren
 		return SAUNAFS_ERROR_EPERM;
 	}
 	changeLog(ts, "UNLINK(%" PRIiNode ",%s):%" PRIiNode, wd->id,
-	          nodeOperations_->escapeName(name).c_str(), child->id);
-	nodeOperations_->unlink(ts, static_cast<FSNodeDirectory *>(wd), name, child);
+	          nodeOperations_->escapeName(baseName).c_str(), child->id);
+	nodeOperations_->unlink(ts, static_cast<FSNodeDirectory *>(wd), baseName, child);
 	incrementFSStat(FsStats::Unlink);
 	metrics::Counter::increment(metrics::Counter::Master::FS_UNLINK);
 	return SAUNAFS_STATUS_OK;
@@ -1376,72 +1446,78 @@ uint8_t FilesystemOperationsBase::rename(const FsContext &context, inode_t paren
                                          const HString &name_dst, inode_t *inode,
                                          Attributes *attr) {
 	ChecksumUpdater cu(context.ts());
+	HString baseNameSrc = name_src;
+	HString baseNameDst = name_dst;
 	FSNode *swd;
 	FSNode *dwd;
 	uint8_t status =
 	    nodeOperations_->verifySession(context, OperationMode::kReadWrite, SessionType::kAny);
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	}
+	if (status != SAUNAFS_STATUS_OK) { return status; }
 	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kDirectory,
 	                                              MODE_MASK_W, parent_dst, &dwd);
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	}
+	if (status != SAUNAFS_STATUS_OK) { return status; }
 	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kDirectory,
 	                                              MODE_MASK_W, parent_src, &swd);
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+
+	if (static_cast<FSNodeDirectory *>(swd)->caseInsensitive) {
+		std::string resolvedName =
+		    static_cast<FSNodeDirectory *>(swd)->getBaseStoredChildName(name_src);
+		if (!resolvedName.empty()) { baseNameSrc = HString(resolvedName); }
 	}
-	if (nodeOperations_->nameCheck(name_src) < 0) { return SAUNAFS_ERROR_EINVAL; }
-	FSNode *se_child = nodeOperations_->lookup(static_cast<FSNodeDirectory *>(swd), name_src);
-	if (!se_child) {
-		return SAUNAFS_ERROR_ENOENT;
+	if (static_cast<FSNodeDirectory *>(dwd)->caseInsensitive) {
+		std::string resolvedName =
+		    static_cast<FSNodeDirectory *>(dwd)->getBaseStoredChildName(name_dst);
+		if (!resolvedName.empty()) { baseNameDst = HString(resolvedName); }
 	}
+
+	if (nodeOperations_->nameCheck(baseNameSrc) < 0) { return SAUNAFS_ERROR_EINVAL; }
+	FSNode *sourceChildNode =
+	    nodeOperations_->lookup(static_cast<FSNodeDirectory *>(swd), baseNameSrc);
+	if (!sourceChildNode) { return SAUNAFS_ERROR_ENOENT; }
 	if (context.canCheckPermissions() &&
-	    !nodeOperations_->stickyAccess(swd, se_child, context.uid())) {
+	    !nodeOperations_->stickyAccess(swd, sourceChildNode, context.uid())) {
 		return SAUNAFS_ERROR_EPERM;
 	}
 	if ((context.personality() != metadataserver::Personality::kMaster) &&
-	    (se_child->id != *inode)) {
+	    (sourceChildNode->id != *inode)) {
 		return SAUNAFS_ERROR_MISMATCH;
 	} else {
-		*inode = se_child->id;
+		*inode = sourceChildNode->id;
 	}
 	std::array<int64_t, 2> quota_delta = {{1, 1}};
-	if (se_child->type == FSNodeType::kDirectory) {
-		if (nodeOperations_->isAncestor(static_cast<FSNodeDirectory *>(se_child), dwd)) {
+	if (sourceChildNode->type == FSNodeType::kDirectory) {
+		if (nodeOperations_->isAncestor(static_cast<FSNodeDirectory *>(sourceChildNode), dwd)) {
 			return SAUNAFS_ERROR_EINVAL;
 		}
-		const StatsRecord &stats = static_cast<FSNodeDirectory*>(se_child)->stats;
+		const StatsRecord &stats = static_cast<FSNodeDirectory *>(sourceChildNode)->stats;
 		quota_delta = {{(int64_t)stats.inodes, (int64_t)stats.size}};
-	} else if (se_child->type == FSNodeType::kFile) {
-		quota_delta[(int)QuotaResource::kSize] = nodeOperations_->getSize(se_child);
+	} else if (sourceChildNode->type == FSNodeType::kFile) {
+		quota_delta[(int)QuotaResource::kSize] = nodeOperations_->getSize(sourceChildNode);
 	}
-	if (nodeOperations_->nameCheck(name_dst) < 0) { return SAUNAFS_ERROR_EINVAL; }
-	FSNode *de_child = nodeOperations_->lookup(static_cast<FSNodeDirectory *>(dwd), name_dst);
+	if (nodeOperations_->nameCheck(baseNameDst) < 0) { return SAUNAFS_ERROR_EINVAL; }
+	FSNode *destinationChildNode =
+	    nodeOperations_->lookup(static_cast<FSNodeDirectory *>(dwd), baseNameDst);
 
-	if (de_child == se_child) {
-		return SAUNAFS_STATUS_OK;
-	}
+	if (destinationChildNode == sourceChildNode) { return SAUNAFS_STATUS_OK; }
 
-	if (de_child) {
-		if (de_child->type == FSNodeType::kDirectory &&
-		    !static_cast<FSNodeDirectory *>(de_child)->entries.empty()) {
+	if (destinationChildNode) {
+		if (destinationChildNode->type == FSNodeType::kDirectory &&
+		    !static_cast<FSNodeDirectory *>(destinationChildNode)->entries.empty()) {
 			return SAUNAFS_ERROR_ENOTEMPTY;
 		}
 		if (context.canCheckPermissions() &&
-		    !nodeOperations_->stickyAccess(dwd, de_child, context.uid())) {
+		    !nodeOperations_->stickyAccess(dwd, destinationChildNode, context.uid())) {
 			return SAUNAFS_ERROR_EPERM;
 		}
-		if (de_child->type == FSNodeType::kDirectory) {
-			const StatsRecord &stats = static_cast<FSNodeDirectory*>(de_child)->stats;
+		if (destinationChildNode->type == FSNodeType::kDirectory) {
+			const StatsRecord &stats = static_cast<FSNodeDirectory *>(destinationChildNode)->stats;
 			quota_delta[(int)QuotaResource::kInodes] -= stats.inodes;
 			quota_delta[(int)QuotaResource::kSize] -= stats.size;
-		} else if (de_child->type == FSNodeType::kFile) {
+		} else if (destinationChildNode->type == FSNodeType::kFile) {
 			quota_delta[(int)QuotaResource::kInodes] -= 1;
 			quota_delta[(int)QuotaResource::kSize] -=
-			    nodeOperations_->getSize(static_cast<FSNodeFile *>(de_child));
+			    nodeOperations_->getSize(static_cast<FSNodeFile *>(destinationChildNode));
 		} else {
 			quota_delta[(int)QuotaResource::kInodes] -= 1;
 			quota_delta[(int)QuotaResource::kSize] -= 1;
@@ -1455,18 +1531,19 @@ uint8_t FilesystemOperationsBase::rename(const FsContext &context, inode_t paren
 		return SAUNAFS_ERROR_QUOTA;
 	}
 
-	if (de_child) {
-		nodeOperations_->unlink(context.ts(), static_cast<FSNodeDirectory *>(dwd), name_dst,
-		                        de_child);
+	if (destinationChildNode) {
+		nodeOperations_->unlink(context.ts(), static_cast<FSNodeDirectory *>(dwd), baseNameDst,
+		                        destinationChildNode);
 	}
-	nodeOperations_->removeEdge(context.ts(), static_cast<FSNodeDirectory *>(swd), name_src,
-	                            se_child);
-	nodeOperations_->link(context.ts(), static_cast<FSNodeDirectory *>(dwd), se_child, name_dst);
-	if (attr) { nodeOperations_->fillAttr(context, se_child, dwd, *attr); }
+	nodeOperations_->removeEdge(context.ts(), static_cast<FSNodeDirectory *>(swd), baseNameSrc,
+	                            sourceChildNode);
+	nodeOperations_->link(context.ts(), static_cast<FSNodeDirectory *>(dwd), sourceChildNode,
+	                      baseNameDst);
+	if (attr) { nodeOperations_->fillAttr(context, sourceChildNode, dwd, *attr); }
 	if (context.isPersonalityMaster()) {
 		changeLog(context.ts(), "MOVE(%" PRIiNode ",%s,%" PRIiNode ",%s):%" PRIiNode, swd->id,
-		          nodeOperations_->escapeName(name_src).c_str(), dwd->id,
-		          nodeOperations_->escapeName(name_dst).c_str(), se_child->id);
+		          nodeOperations_->escapeName(baseNameSrc).c_str(), dwd->id,
+		          nodeOperations_->escapeName(baseNameDst).c_str(), sourceChildNode->id);
 	} else {
 		gMetadata->metadataVersion++;
 	}

--- a/src/master/filesystem_operations.h
+++ b/src/master/filesystem_operations.h
@@ -95,6 +95,8 @@ public:
 	                   /* inout */ uint32_t *lockid, uint64_t *chunkid, uint8_t *opflag,
 	                   uint64_t *length, uint32_t min_server_version = 0) override;
 	uint8_t setNextChunkId(const FsContext &context, uint64_t nextChunkId) override;
+	uint8_t getCanonicalPath(const FsContext &context, const std::string &inputPath,
+	                         std::string &canonicalPath) override;
 
 #ifndef METARESTORE
 	/// Returns a map with all defined goals.

--- a/src/master/filesystem_operations_interface.h
+++ b/src/master/filesystem_operations_interface.h
@@ -111,6 +111,13 @@ public:
 	                           /* inout */ uint32_t *lockid, uint64_t *chunkid, uint8_t *opflag,
 	                           uint64_t *length, uint32_t min_server_version = 0) = 0;
 	virtual uint8_t setNextChunkId(const FsContext &context, uint64_t nextChunkId) = 0;
+	/// Given a string representing a path, resolves and returns the canonical
+	/// name as actually stored in the filesystem, matching the true case and
+	/// spelling of each component. This is useful for implementing features
+	/// such as case-insensitive filesystem operations, where the input path
+	/// may differ in case or form from the stored names.
+	virtual uint8_t getCanonicalPath(const FsContext &context, const std::string &inputPath,
+	                                 std::string &canonicalPath) = 0;
 
 #ifndef METARESTORE
 	/// Returns a map with all defined goals.

--- a/src/master/metadata_backend_file.cc
+++ b/src/master/metadata_backend_file.cc
@@ -525,13 +525,10 @@ static int8_t fs_parseEdge(const std::shared_ptr<MemoryMappedFile> &metadataFile
 			return kError;
 		}
 
-		if (parent->case_insensitive) {
+		if (parent->caseInsensitive) {
 			HString lowerCaseName = HString::hstringToLowerCase(HString(name));
 			auto *lowercaseHandlePtr = new hstorage::Handle(lowerCaseName);
-			if (parent->lowerCaseEntries.insert({lowercaseHandlePtr, child}).second) {
-				// On successful insert update the hash
-				parent->lowerCaseEntriesHash ^= lowercaseHandlePtr->hash();
-			} else {
+			if (!parent->lowerCaseEntries.insert({lowercaseHandlePtr, child}).second) {
 				// insert failed → nobody owns lowercaseHandlePtr → delete it
 				delete lowercaseHandlePtr;
 				return kError;

--- a/tests/test_suites/ShortSystemTests/test_case_insensitive_filesystem.sh
+++ b/tests/test_suites/ShortSystemTests/test_case_insensitive_filesystem.sh
@@ -1,7 +1,12 @@
-MOUNTS=1 \
-CHUNKSERVERS=1 \
-	USE_RAMDISK=YES \
+timeout_set "1 minute"
+
+master_cfg="METADATA_DUMP_PERIOD_SECONDS = 0"
+master_cfg+="|MAGIC_DEBUG_LOG = ${TEMP_DIR}/log|LOG_FLUSH_ON=DEBUG"
+master_cfg+="|METADATA_SAVE_REQUEST_MIN_PERIOD = $(timeout_rescale_seconds 10)"
+
+USE_RAMDISK=YES \
 	SFSEXPORTS_EXTRA_OPTIONS="caseinsensitive" \
+	MASTER_EXTRA_CONFIG="$master_cfg" \
 	setup_local_empty_saunafs info
 
 cd "${info[mount0]}"
@@ -23,13 +28,11 @@ assert_equals "data" "$(cat FilE1)"
 assert_equals "data" "$(cat fOlDeR1/fILe2)"
 
 # test rename case insensitive same file
+# expected behavior is that if target file exists, it is overwritten
+# but its name case is preserved, because otherwise it would send
+# inconsistent information to shadow masters
 touch file3
 mv file3 filE1
-if ls | grep -q "^filE1$"; then
-    echo "File filE1 exists"
-else
-    test_fail "No file named filE1 found"
-fi
 
 # test rename case insensitive new file to existing file
 touch file3
@@ -57,6 +60,18 @@ echo "data" > FOldER2/fOLdeR3/folDEr4/fIlE4
 assert_equals "data" "$(cat folder2/folder3/folder4/file4)"
 assert_equals "data" "$(cat folder2/folder3/folder4/fIlE4)"
 
+# test hardlink case insensitive
+ln FOldER2/fOLdeR3/folDEr4/fIlE4 file4_hardlink
+assert_equals "data" "$(cat file4_HARDLINK)"
+
+# test symlink case insensitive
+ln -s FOldER2/fOLdeR3/folDEr4/fIlE4 file4_symlink
+assert_equals "data" "$(cat FILE4_SYMLINK)"
+
+# test creating a broken symlink (target does not exist)
+ln -s NonExistent/Path/File broken_link
+assert_failure cat broken_link
+
 # test removing case insensitive in mountpoint
 cd ..
 saunafs_mount_unmount 0
@@ -77,3 +92,41 @@ touch file5
 echo "data" > file5
 assert_success cat file5
 assert_failure cat fiLE5
+
+# test hardlink after disabling case insensitive
+assert_failure cat file4_HARDLINK
+assert_equals "data" "$(cat file4_hardlink)"
+
+# test symlink after disabling case insensitive
+assert_failure cat FILE4_SYMLINK
+assert_equals "data" "$(cat file4_symlink)"
+
+# create new file and check normal behavior
+touch TestFile
+echo "data" > TestFile
+assert_equals "data" "$(cat TestFile)"
+assert_failure cat testfile
+
+# enable case insensitive again, for ensuring that 
+# previous files are accessible
+cd ..
+saunafs_mount_unmount 0
+assert_success saunafs_master_daemon stop
+sleep 5
+SFSEXPORTS_EXTRA_OPTIONS="caseinsensitive"
+number_of_mounts=1
+rm "$TEMP_DIR/saunafs/etc/sfsexports.cfg"
+create_sfsexports_cfg_ >"$TEMP_DIR/saunafs/etc/sfsexports.cfg"
+saunafs_master_daemon start
+saunafs_mount_start 0
+
+cd "${info[mount0]}"
+# test previous created file with case insensitive enabled
+assert_equals "data" "$(cat TESTFILE)"
+assert_equals "data" "$(cat testfile)"
+
+# Verify that no checksum or changelog apply errors were logged
+log=$(cat "${TEMP_DIR}/log")
+assert_awk_finds_no '/master.mismatch/' "$log"
+assert_awk_finds_no '/master.fs.checksum.mismatch/' "$log"
+assert_awk_finds_no '/master.mltoma_changelog_apply_error/' "$log"


### PR DESCRIPTION
This pull request addresses several issues related to case-insensitive filesystem support and shadow synchronization:

- Improved case-insensitive mode re-enabling:
Fixes a bug where enabling case-insensitive mode in an existing session did not update previously created inodes, causing failures to resolve those inodes during case-insensitive lookups. The update now uses a lazy approach to ensure all relevant entries are properly indexed.

- Correct case-insensitive handling for symlinks and hard links:
Ensures that symlink and hard link creation consistently uses the canonical path, providing reliable behavior when toggling the case-insensitive option.

- Consistent shadow sync for case-insensitive operations:
Ensures that the shadow metadata server correctly replicates case-insensitive settings and operations. The changelog now records canonical casing, and hash updates use consistent casing. The auxiliary lower-case index no longer affects checksums, and shadow replay of MOVE/UNLINK operations is now deterministic.

These changes collectively improve the reliability and consistency of case-insensitive filesystem operations and shadow synchronization.