### PR TITLE
fix(cs): Fix test force read timeouts flakiness

### DIFF
--- a/src/chunkserver/bgjobs.cc
+++ b/src/chunkserver/bgjobs.cc
@@ -232,7 +232,7 @@ void JobPool::changeCallback(uint32_t jobId, JobCallback callback, void *extra,
 	}
 }
 
-void JobPool::changeCallback(std::list<uint32_t> &jobIds, const JobCallback &callback, void *extra,
+void JobPool::changeCallback(std::list<uint32_t> &jobIds, const JobCallback &callback,
                              uint32_t listenerId) {
 	// Check if the listenerId is valid
 	if (listenerId >= listenerInfos_.size()) {
@@ -243,10 +243,7 @@ void JobPool::changeCallback(std::list<uint32_t> &jobIds, const JobCallback &cal
 	auto &listenerInfo = listenerInfos_[listenerId];
 	for (auto jobId : jobIds) {
 		auto jobIterator = listenerInfo.jobHash.find(jobId);
-		if (jobIterator != listenerInfo.jobHash.end()) {
-			jobIterator->second->callback = callback;
-			jobIterator->second->extra = extra;
-		}
+		if (jobIterator != listenerInfo.jobHash.end()) { jobIterator->second->callback = callback; }
 	}
 }
 
@@ -368,14 +365,12 @@ uint32_t job_read(JobPool &jobPool, JobPool::JobCallback callback, uint64_t chun
 		if (performHddOpen) {
 			status = hddOpen(chunkId, chunkType);
 			if (status != SAUNAFS_STATUS_OK) {
-				outputBuffer->setStatus(status);
 				return status;
 			}
 		}
 
 		status = hddRead(chunkId, version, chunkType, offset, size, maxBlocksToBeReadBehind,
 		                 blocksToBeReadAhead, outputBuffer);
-		outputBuffer->setStatus(status);
 
 		if (performHddOpen && status != SAUNAFS_STATUS_OK) {
 			int ret = hddClose(chunkId, chunkType);
@@ -386,7 +381,7 @@ uint32_t job_read(JobPool &jobPool, JobPool::JobCallback callback, uint64_t chun
 		}
 		return status;
 	};
-	return jobPool.addJob(JobPool::ChunkOperation::Read, std::move(callback), kEmptyExtra,
+	return jobPool.addJob(JobPool::ChunkOperation::Read, std::move(callback), outputBuffer,
 	                      processJob, listenerId);
 }
 

--- a/src/chunkserver/bgjobs.h
+++ b/src/chunkserver/bgjobs.h
@@ -151,9 +151,8 @@ public:
 	///
 	/// @param jobIds The list of jobs by IDs.
 	/// @param callback The new callback function.
-	/// @param extra Additional data to be passed to the new callback.
 	/// @param listenerId The ID of the listener associated with the jobs.
-	void changeCallback(std::list<uint32_t> &jobIds, const JobCallback &callback, void *extra,
+	void changeCallback(std::list<uint32_t> &jobIds, const JobCallback &callback,
 	                    uint32_t listenerId = 0);
 
 private:

--- a/src/chunkserver/chunk_high_level_ops.cc
+++ b/src/chunkserver/chunk_high_level_ops.cc
@@ -68,13 +68,16 @@ void GetBlocksHighLevelOp::delayedClose() {
 	pendingDelayedJobs_++;
 }
 
-void ReadHighLevelOp::delayedCloseCallback(uint8_t status, void * /*entry*/) {
+void ReadHighLevelOp::delayedCloseCallback(uint8_t status, void *buffer) {
 	assert(getParentState() == ChunkserverEntry::State::CloseWait);
+	auto outputBuffer = static_cast<OutputBuffer *>(buffer);
+	passert(outputBuffer);
+	outputBuffer->setIsCallbackStarted(true);
 
 	if (status == SAUNAFS_STATUS_OK) { isChunkOpen_ = true; }
 
 	while (!toDiscardReadDataBuffers_.empty() &&
-	       toDiscardReadDataBuffers_.front()->getStatus() != kNotSaunafsStatus) {
+	       toDiscardReadDataBuffers_.front()->isCallbackStarted()) {
 		getReadOutputBufferPool().put(std::move(toDiscardReadDataBuffers_.front()));
 		toDiscardReadDataBuffers_.pop_front();
 		toDiscardReadJobIds_.pop_front();
@@ -85,8 +88,11 @@ void ReadHighLevelOp::delayedCloseCallback(uint8_t status, void * /*entry*/) {
 	checkAndApplyClosedOnParent();
 }
 
-void ReadHighLevelOp::readDiscardCallback(uint8_t status, void * /*entry*/) {
+void ReadHighLevelOp::readDiscardCallback(uint8_t status, void *buffer) {
 	(void)status;
+	auto outputBuffer = static_cast<OutputBuffer *>(buffer);
+	passert(outputBuffer);
+	outputBuffer->setIsCallbackStarted(true);
 
 	// jobId <--> related packet, maintaining the order
 	assert(toDiscardReadJobIds_.size() == toDiscardReadDataBuffers_.size());
@@ -94,7 +100,7 @@ void ReadHighLevelOp::readDiscardCallback(uint8_t status, void * /*entry*/) {
 	auto jobsIt = toDiscardReadJobIds_.begin();
 	for (auto buffersIt = toDiscardReadDataBuffers_.begin();
 	     buffersIt != toDiscardReadDataBuffers_.end();) {
-		if ((*buffersIt)->getStatus() != kNotSaunafsStatus) {
+		if ((*buffersIt)->isCallbackStarted()) {
 			getReadOutputBufferPool().put(std::move(*buffersIt));
 			buffersIt = toDiscardReadDataBuffers_.erase(buffersIt);
 			jobsIt = toDiscardReadJobIds_.erase(jobsIt);
@@ -113,15 +119,14 @@ void ReadHighLevelOp::prepareDiscardReadJobs() {
 
 	// The jobs which are not going to be processed: all but the ones in progress
 	auto disabledJobIds = workerJobPool()->disableJobs(pendingReadJobIds_);
-	workerJobPool()->changeCallback(
-	    pendingReadJobIds_,
-	    [this](uint8_t status, void *entry) { this->readDiscardCallback(status, entry); },
-	    kEmptyExtra);
-	workerJobPool()->changeCallback(disabledJobIds, kEmptyCallback, kEmptyExtra);
+	workerJobPool()->changeCallback(pendingReadJobIds_, [this](uint8_t status, void *entry) {
+		this->readDiscardCallback(status, entry);
+	});
+	workerJobPool()->changeCallback(disabledJobIds, kEmptyCallback);
 	while (!pendingReadJobIds_.empty()) {
 		// pendingReadJobIds and pendingReadDataBuffers should have the related elements in the
 		// correct order
-		if (pendingReadDataBuffers_.front()->getStatus() == kNotSaunafsStatus &&
+		if (!pendingReadDataBuffers_.front()->isCallbackStarted() &&
 		    (disabledJobIds.empty() || disabledJobIds.front() != pendingReadJobIds_.front())) {
 			toDiscardReadJobIds_.push_back(pendingReadJobIds_.front());
 			toDiscardReadDataBuffers_.emplace_back(std::move(pendingReadDataBuffers_.front()));
@@ -142,7 +147,11 @@ void ReadHighLevelOp::prepareDiscardReadJobs() {
 	assert(pendingReadDataBuffers_.empty());
 }
 
-void ReadHighLevelOp::readFinishedCallback(uint8_t status, void * /*entry*/) {
+void ReadHighLevelOp::readFinishedCallback(uint8_t status, void *buffer) {
+	auto outputBuffer = static_cast<OutputBuffer *>(buffer);
+	passert(outputBuffer);
+	outputBuffer->setIsCallbackStarted(true);
+
 	if (status == SAUNAFS_STATUS_OK) {
 		isChunkOpen_ = true;
 		readContinue(maxParallelHddReadJobs_);
@@ -199,10 +208,9 @@ std::shared_ptr<OutputBuffer> ReadHighLevelOp::prepareReadDataPacket(
 
 void ReadHighLevelOp::readContinue(uint16_t callMaxParallelHddReadJobs) {
 	while (!pendingReadDataBuffers_.empty() &&
-	       pendingReadDataBuffers_.front()->getStatus() == SAUNAFS_STATUS_OK) {
+	       pendingReadDataBuffers_.front()->isCallbackStarted()) {
 		attachBuffer(std::move(pendingReadDataBuffers_.front()));
 		pendingReadDataBuffers_.pop_front();
-		workerJobPool()->changeCallback(pendingReadJobIds_.front(), kEmptyCallback, kEmptyExtra);
 		pendingReadJobIds_.pop_front();
 	}
 
@@ -295,10 +303,9 @@ bool ReadHighLevelOp::prepareForDelayedClose() {
 
 void ReadHighLevelOp::delayedClose() {
 	// Already disabled jobs
-	workerJobPool()->changeCallback(
-	    toDiscardReadJobIds_,
-	    [this](uint8_t status, void *entry) { this->delayedCloseCallback(status, entry); },
-	    kEmptyExtra);
+	workerJobPool()->changeCallback(toDiscardReadJobIds_, [this](uint8_t status, void *entry) {
+		this->delayedCloseCallback(status, entry);
+	});
 
 	pendingDelayedJobs_ += toDiscardReadJobIds_.size();
 }

--- a/src/chunkserver/chunk_high_level_ops.h
+++ b/src/chunkserver/chunk_high_level_ops.h
@@ -152,13 +152,13 @@ public:
 
 protected:
 	/// Callback after delayed close operations.
-	void delayedCloseCallback(uint8_t status, void * /*entry*/);
+	void delayedCloseCallback(uint8_t status, void *buffer);
 
 	/// Callback for when a discarded read operation finishes.
-	void readDiscardCallback(uint8_t status, void * /*entry*/);
+	void readDiscardCallback(uint8_t status, void *buffer);
 
 	/// Callback for when a read operation finishes.
-	void readFinishedCallback(uint8_t status, void * /*entry*/);
+	void readFinishedCallback(uint8_t status, void *buffer);
 
 	/// Prepares the discard of the current ongoing read operations.
 	///

--- a/src/chunkserver/io_buffers.cc
+++ b/src/chunkserver/io_buffers.cc
@@ -82,7 +82,7 @@ void OutputBuffer::clear() {
 	crcBuffer_.clear();
 	headerBuffer_.clear();
 
-	setStatus(kNotSaunafsStatus);
+	setIsCallbackStarted(false);
 }
 
 bool OutputBuffer::checkCRC(size_t bytes, uint32_t crc, uint32_t startingOffset) const {

--- a/src/chunkserver/io_buffers.h
+++ b/src/chunkserver/io_buffers.h
@@ -32,8 +32,6 @@
 #include "chunkserver/buffers_pool.h"
 #include "common/aligned_allocator.h"
 
-constexpr uint8_t kNotSaunafsStatus = 255;
-
 inline std::atomic<uint32_t> gCurrentTotalOutputBufferBlocks = 0;
 inline std::atomic<uint32_t> gCurrentTotalInputBufferBlocks = 0;
 inline std::atomic<uint32_t> gCurrentTotalReplicatorBufferBlocks = 0;
@@ -284,16 +282,13 @@ public:
 	/// @brief Clears the buffer.
 	void clear();
 
-	/// @brief Returns the `status` in a thread-safe manner.
-	uint8_t getStatus() {
-		std::lock_guard<std::mutex> lock(mutex_);
-		return status;
-	}
+	/// @brief Returns the `isCallbackStarted` flag.
+	/// Whether the buffer's related callback has started processing or has been processed.
+	bool isCallbackStarted() const { return isCallbackStarted_; }
 
-	/// @brief Sets the `status` in a thread-safe manner.
-	void setStatus(uint8_t newStatus) {
-		std::lock_guard<std::mutex> lock(mutex_);
-		status = newStatus;
+	/// @brief Sets the `isProcessed` flag.
+	void setIsCallbackStarted(bool newIsCallbackStarted) {
+		isCallbackStarted_ = newIsCallbackStarted;
 	}
 
 private:
@@ -306,11 +301,8 @@ private:
 	/// The number of blocks.
 	const size_t numBlocks_;
 
-	/// Protects the `status` member variable used for custom thread synchronization.
-	std::mutex mutex_;
-
-	/// Status of the buffer's related read operation.
-	uint8_t status{kNotSaunafsStatus};
+	/// Whether the buffer's related callback has started processing or has been processed.
+	bool isCallbackStarted_{false};
 
 	/// The buffer for the block data.
 	Buffer<std::vector<uint8_t, AlignedAllocator<uint8_t, disk::kIoBlockSize>>> blockBuffer_;
@@ -370,8 +362,7 @@ struct WriteOperation {
  * supposed to have the same length, which must be provided during the buffer creation.
  *
  * The InputBuffer is prepared to be updated with new data read from the file descriptor while
- * being processed by the JobPool workers. The protection is done by the `state_` member variable
- * and the `mutex_` mutex.
+ * being processed by the JobPool workers.
  */
 class InputBuffer {
 public:


### PR DESCRIPTION
This change targets fixing the instability of the test
test_chunkserver_force_timeout_reads. The test failed due to sudden
stop of one or several of the chunkservers, causing failed checks in
the end or timeout.

The chunkserver stop seems to be related to inconsistencies in the
assumptions of the jobs to be discarded. Those jobs needs to be not
processed at the moment of adding them to the discarded lists in order
to make pendingDelayedJobs_ hold the correct value. The proposed
solution substitutes the status member of the OutputBuffer for a
isProcessed flag to better maintain whether the callback related to the
OutputBuffer has already started or not.

Side changes:
- the ReadHighLevelOp callbacks will use the second parameter to update
the related OutputBuffer.
- since there will be no status updates from the pool worker threads,
there is no need for a mutex member in OutputBuffer.

Signed-off-by: Dave <dave@leil.io>