### PR TITLE
fix(master): Remove unused case insensitive check

### DIFF
--- a/src/master/metadata_backend_file.cc
+++ b/src/master/metadata_backend_file.cc
@@ -525,16 +525,6 @@ static int8_t fs_parseEdge(const std::shared_ptr<MemoryMappedFile> &metadataFile
 			return kError;
 		}
 
-		if (parent->caseInsensitive) {
-			HString lowerCaseName = HString::hstringToLowerCase(HString(name));
-			auto *lowercaseHandlePtr = new hstorage::Handle(lowerCaseName);
-			if (!parent->lowerCaseEntries.insert({lowercaseHandlePtr, child}).second) {
-				// insert failed → nobody owns lowercaseHandlePtr → delete it
-				delete lowercaseHandlePtr;
-				return kError;
-			}
-		}
-
 		child->parents.push_back({parentId, handlePtr});
 		if (child->type == FSNodeType::kDirectory) {
 			parent->nlink++;


### PR DESCRIPTION
Adding lowercase entries for each inode and its children during edge parsing is unnecessary when loading metadata as part of filesystem initialization on the master. At that point, there is no context about case-insensitive client connections, so the  case-insensitive check for each inode and its children always  evaluates to false and the code never executes. This commit removes that dead code.