### PR TITLE
refactor(master): propagate transactions in FS operations

### DIFF
--- a/src/kv/kv_utils.h
+++ b/src/kv/kv_utils.h
@@ -35,6 +35,11 @@ using Value = Bytes;
 /// Converts string, string_view and const char* to a vector of uint8_t.
 inline Bytes toBytes(std::string_view str) { return {str.begin(), str.end()}; }
 
+/// Appends a string or string_view to a vector of uint8_t.
+inline void appendStr(Bytes &destination, std::string_view str) {
+	destination.insert(destination.end(), str.begin(), str.end());
+}
+
 /// Converts integral types to a vector of uint8_t encoded in little-endian order.
 template <typename T>
     requires(std::is_integral_v<T>)

--- a/src/master/filesystem_metadata.h
+++ b/src/master/filesystem_metadata.h
@@ -97,7 +97,7 @@ public:
 	Signal<FSNodeDirectory *, FSNode *, hstorage::Handle *> edgeChangedSignal;
 
 	/// Signal emitted when an edge is removed
-	Signal<inode_t, inode_t> edgeRemovedSignal;
+	Signal<inode_t, const HString &> edgeRemovedSignal;
 
 	FilesystemMetadata()
 	    : inodePool{SFS_INODE_REUSE_DELAY,

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -32,6 +32,7 @@
 #include "common/attributes.h"
 #include "common/massert.h"
 #include "common/slice_traits.h"
+#include "common/special_inode_defs.h"
 #include "common/type_defs.h"
 #include "master/chunks.h"
 #include "master/datacachemgr.h"
@@ -43,17 +44,6 @@
 #include "master/filesystem_quota.h"
 #include "master/fs_context.h"
 #include "slogger/slogger.h"
-
-constexpr size_t kMaxFileNameLength = 255;
-
-/// All permission bits (including setuid/setgid/sticky)
-constexpr uint16_t kPermissionsMask = 07777;
-/// Standard rwx permissions (excludes setuid/setgid/sticky)
-constexpr uint16_t kStandardPermissionsMask = 0777;
-constexpr uint16_t kExtraAttributesMask = 0xF000;  ///< Bits 12-15 for extra attributes
-
-/// Default undelete directory mode
-constexpr uint16_t kUndelDirectoryMode = 0755;
 
 // Private helper methods
 
@@ -152,7 +142,7 @@ uint64_t FilesystemNodeOperationsBase::fileRealSize(FSNodeFile *node, uint32_t n
 
 // Protected methods
 
-FSNode *FilesystemNodeOperationsBase::idToNodeInternal(inode_t inode) {
+FSNode *FilesystemNodeOperationsBase::idToNodeInternal(inode_t inode) const {
 	// Find the node with the given id
 	uint32_t nodeHashIndex = NODEHASHPOS(inode);
 
@@ -161,6 +151,48 @@ FSNode *FilesystemNodeOperationsBase::idToNodeInternal(inode_t inode) {
 	}
 
 	return nullptr;
+}
+
+FSNode *FilesystemNodeOperationsBase::idToNodeInternal(
+    const FilesystemOperationContext &fsOpContext, inode_t inode) const {
+	(void)fsOpContext;  // Unused parameter in this implementation
+	return idToNodeInternal(inode);
+}
+
+void FilesystemNodeOperationsBase::incrementNodeCounters(
+    const FilesystemOperationContext &fsOpContext, FSNodeType type) {
+	(void)fsOpContext;  // Unused parameter in this implementation
+
+	gMetadata->nodes++;
+
+	switch (type) {
+	case FSNodeType::kDirectory:
+		gMetadata->dirNodes++;
+		break;
+	case FSNodeType::kFile:
+		gMetadata->fileNodes++;
+		break;
+	case FSNodeType::kSymlink:
+		gMetadata->linkNodes++;
+		break;
+	default:
+		break;
+	}
+}
+
+void FilesystemNodeOperationsBase::preserveNode(const FilesystemOperationContext &fsOpContext,
+                                                FSNode *node) {
+	(void)fsOpContext;  // Unused parameter in this implementation
+	gMetadata->addNode(node);
+}
+
+void FilesystemNodeOperationsBase::preserveEdge(const FilesystemOperationContext &fsOpContext,
+                                                FSNodeDirectory *parent, FSNode *child,
+                                                hstorage::Handle *handlePtr) {
+	(void)fsOpContext;  // Unused parameter in this implementation
+
+	// Just to keep the previous behavior
+	gMetadata->edgeChangedSignal.emit(parent, child, handlePtr);
 }
 
 // Public methods
@@ -553,10 +585,11 @@ void FilesystemNodeOperationsBase::removeEdge(uint32_t timeStamp, FSNodeDirector
 	childNode->ctime = timeStamp;
 	fsnodes_update_checksum(childNode);
 
-	gMetadata->edgeRemovedSignal.emit(parent->id, childNode->id);
+	gMetadata->edgeRemovedSignal.emit(parent->id, childName);
 }
 
-void FilesystemNodeOperationsBase::link(uint32_t timeStamp, FSNodeDirectory *parent, FSNode *child,
+void FilesystemNodeOperationsBase::link(const FilesystemOperationContext &fsOpContext,
+                                        uint32_t timeStamp, FSNodeDirectory *parent, FSNode *child,
                                         const HString &name) {
 	// Needs to be freed in fsnodes_remove_edge
 	auto *handlePtr = new hstorage::Handle(name);
@@ -571,7 +604,9 @@ void FilesystemNodeOperationsBase::link(uint32_t timeStamp, FSNodeDirectory *par
 	}
 
 	child->parents.push_back({parent->id, handlePtr});
-	gMetadata->edgeChangedSignal.emit(parent, child, handlePtr);
+
+	// Implementation specific (virtual) edge preservation (in-memory, FDB, etc.)
+	preserveEdge(fsOpContext, parent, child, handlePtr);
 
 	if (child->type == FSNodeType::kDirectory) {
 		parent->nlink++;
@@ -590,27 +625,14 @@ void FilesystemNodeOperationsBase::link(uint32_t timeStamp, FSNodeDirectory *par
 	}
 }
 
-FSNode *FilesystemNodeOperationsBase::createNode(uint32_t timeStamp, FSNodeDirectory *parent,
-                                                 const HString &name, FSNodeType type,
-                                                 uint16_t mode, uint16_t umask, uint32_t uid,
-                                                 uint32_t gid, uint8_t copysgid,
-                                                 AclInheritance inheritAcl,
-                                                 inode_t requestedINode) {
+FSNode *FilesystemNodeOperationsBase::createNode(
+    const FilesystemOperationContext &fsOpContext, uint32_t timeStamp, FSNodeDirectory *parent,
+    const HString &name, FSNodeType type, uint16_t mode, uint16_t umask, uint32_t uid, uint32_t gid,
+    uint8_t copysgid, AclInheritance inheritAcl, inode_t requestedINode) {
 	assert(type != FSNodeType::kTrash);
 
 	FSNode *node = FSNode::create(type);
-
-	// update metadata counters
-	gMetadata->nodes++;
-	if (type == FSNodeType::kDirectory) {
-		gMetadata->dirNodes++;
-	}
-	if (type == FSNodeType::kFile) {
-		gMetadata->fileNodes++;
-	}
-	if (type == FSNodeType::kSymlink) {
-		gMetadata->linkNodes++;
-	}
+	incrementNodeCounters(fsOpContext, type);  // Increment global metadata counters
 
 	// Ask for a node id
 	node->id = gInodeIdGenerator->getNextId(timeStamp, requestedINode);
@@ -662,10 +684,11 @@ FSNode *FilesystemNodeOperationsBase::createNode(uint32_t timeStamp, FSNodeDirec
 		node->gid = gid;
 	}
 
-	gMetadata->addNode(node);
+	// Implementation specific (virtual) node preservation (in-memory, FDB, etc.)
+	preserveNode(fsOpContext, node);
 
 	fsnodes_update_checksum(node);
-	link(timeStamp, parent, node, name);
+	link(fsOpContext, timeStamp, parent, node, name);
 	fsnodes_quota_update(node, {{QuotaResource::kInodes, +1}});
 
 	if (type == FSNodeType::kFile) {
@@ -1038,17 +1061,14 @@ void FilesystemNodeOperationsBase::getDirData(inode_t rootINode, uint32_t uid, u
 	}
 }
 
-void FilesystemNodeOperationsBase::getDir(inode_t rootINode, uint32_t uid, uint32_t gid,
+void FilesystemNodeOperationsBase::getDir(const FilesystemOperationContext &fsOpContext,
+                                          inode_t rootINode, uint32_t uid, uint32_t gid,
                                           uint32_t auid, uint32_t agid, uint8_t sesflags,
                                           FSNodeDirectory *nodeDir, uint64_t firstEntry,
                                           uint64_t numberOfEntries,
                                           std::vector<DirectoryEntry> &dirEntriesOut) {
-	static constexpr uint64_t kSignBit64 = (1ULL << 63ULL);
+	(void)fsOpContext;  // unused in this implementation
 	sassert(!(firstEntry & kSignBit64));
-	// special entryIndex values
-	static constexpr uint64_t kDotEntryIndex = 0;
-	static constexpr uint64_t kDotDotEntryIndex = (static_cast<uint64_t>(1) << hstorage::Handle::kHashShift);
-	static constexpr uint64_t kUnusedEntryIndex = (static_cast<uint64_t>(2) << hstorage::Handle::kHashShift);
 
 	FSNodeDirectory *parent;
 	inode_t inode;
@@ -1485,7 +1505,8 @@ int FilesystemNodeOperationsBase::purge(uint32_t timeStamp, FSNode *node) {
 	return -1;
 }
 
-uint8_t FilesystemNodeOperationsBase::undel(uint32_t timeStamp, FSNodeFile *node) {
+uint8_t FilesystemNodeOperationsBase::undel(
+    const FilesystemOperationContext &fsOpContext, uint32_t timeStamp, FSNodeFile *node) {
 	// Path validation
 
 	std::string pathStr;
@@ -1571,7 +1592,7 @@ uint8_t FilesystemNodeOperationsBase::undel(uint32_t timeStamp, FSNodeFile *node
 			node->type = FSNodeType::kFile;
 			node->ctime = timeStamp;
 			fsnodes_update_checksum(node);
-			link(timeStamp, currentParent, node, name);
+			link(fsOpContext, timeStamp, currentParent, node, name);
 			gMetadata->trashSpace -= node->length;
 			gMetadata->trashNodes--;
 
@@ -1592,7 +1613,7 @@ uint8_t FilesystemNodeOperationsBase::undel(uint32_t timeStamp, FSNodeFile *node
 
 		if (isNew) {
 			currentNode =
-			    createNode(timeStamp, currentParent, name, FSNodeType::kDirectory,
+			    createNode(fsOpContext, timeStamp, currentParent, name, FSNodeType::kDirectory,
 			               kUndelDirectoryMode, 0, 0, 0, 0, AclInheritance::kDontInheritAcl);
 
 #ifndef METARESTORE
@@ -2067,11 +2088,16 @@ uint8_t FilesystemNodeOperationsBase::verifySession(const FsContext &context,
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t FilesystemNodeOperationsBase::getNodeForOperation(const FsContext &context,
-                                                          ExpectedNodeType expectedNodeType,
-                                                          uint8_t modeMask, inode_t inode,
-                                                          FSNode **nodeOut,
-                                                          FSNodeDirectory **rootDirOut) {
+FSNodeDirectory *FilesystemNodeOperationsBase::getRootNode(
+    const FilesystemOperationContext &fsOpContext) {
+	(void)fsOpContext;  // unused parameter in this implementation
+	return gMetadata->root;
+}
+
+uint8_t FilesystemNodeOperationsBase::getNodeForOperation(
+    const FsContext &context, const FilesystemOperationContext &fsOpContext,
+    ExpectedNodeType expectedNodeType, uint8_t modeMask, inode_t inode, FSNode **nodeOut,
+    FSNodeDirectory **rootDirOut) {
 	FSNode *candidateNode;
 	FSNodeDirectory *candidateRoot;
 
@@ -2083,8 +2109,8 @@ uint8_t FilesystemNodeOperationsBase::getNodeForOperation(const FsContext &conte
 
 		if (candidateNode == nullptr) { return SAUNAFS_ERROR_ENOENT; }
 	} else if (context.rootinode() == SPECIAL_INODE_ROOT || (context.rootinode() == 0)) {
-		candidateRoot = gMetadata->root;
-		candidateNode = idToNode(inode);
+		candidateRoot = getRootNode(fsOpContext);
+		candidateNode = idToNode(fsOpContext, inode);
 
 		if (candidateNode == nullptr) { return SAUNAFS_ERROR_ENOENT; }
 
@@ -2093,7 +2119,7 @@ uint8_t FilesystemNodeOperationsBase::getNodeForOperation(const FsContext &conte
 			return SAUNAFS_ERROR_EPERM;
 		}
 	} else {
-		candidateRoot = idToNode<FSNodeDirectory>(context.rootinode());
+		candidateRoot = idToNode<FSNodeDirectory>(fsOpContext, context.rootinode());
 
 		if ((candidateRoot == nullptr) || candidateRoot->type != FSNodeType::kDirectory) {
 			return SAUNAFS_ERROR_ENOENT;
@@ -2102,7 +2128,7 @@ uint8_t FilesystemNodeOperationsBase::getNodeForOperation(const FsContext &conte
 		if (inode == SPECIAL_INODE_ROOT || inode == context.rootinode()) {
 			candidateNode = candidateRoot;
 		} else {
-			candidateNode = idToNode(inode);
+			candidateNode = idToNode(fsOpContext, inode);
 
 			if (candidateNode == nullptr) { return SAUNAFS_ERROR_ENOENT; }
 

--- a/src/master/filesystem_node.h
+++ b/src/master/filesystem_node.h
@@ -35,14 +35,17 @@
 /// assuming an in-memory metadata representation.
 class FilesystemNodeOperationsBase : public IFilesystemNodeOperations {
 public:
+	/// Returns the root node of the filesystem.
+	FSNodeDirectory *getRootNode(const FilesystemOperationContext &fsOpContext) override;
+
 	FSNode *lookup(FSNodeDirectory *node, const HString &name) const override;
 
-	FSNode *createNode(uint32_t timeStamp, FSNodeDirectory *parent, const HString &name,
-	                   FSNodeType type, uint16_t mode, uint16_t umask, uint32_t uid, uint32_t gid,
-	                   uint8_t copysgid, AclInheritance inheritAcl,
-	                   inode_t requestedINode = 0) override;
-	void link(uint32_t timeStamp, FSNodeDirectory *parent, FSNode *child,
-	          const HString &name) override;
+	FSNode *createNode(const FilesystemOperationContext &fsOpContext, uint32_t timeStamp,
+	                   FSNodeDirectory *parent, const HString &name, FSNodeType type, uint16_t mode,
+	                   uint16_t umask, uint32_t uid, uint32_t gid, uint8_t copysgid,
+	                   AclInheritance inheritAcl, inode_t requestedINode = 0) override;
+	void link(const FilesystemOperationContext &fsOpContext, uint32_t timeStamp,
+	          FSNodeDirectory *parent, FSNode *child, const HString &name) override;
 	void unlink(uint32_t timeStamp, FSNodeDirectory *parent, const HString &childName,
 	            FSNode *childNode) override;
 	void removeEdge(uint32_t timeStamp, FSNodeDirectory *parent, const HString &childName,
@@ -76,15 +79,17 @@ public:
 
 	/// Get entries of directory node \a nodeDir.
 	/// @see IFilesystemNodeOperations::getDir
-	void getDir(inode_t rootINode, uint32_t uid, uint32_t gid, uint32_t auid, uint32_t agid,
-	            uint8_t sesflags, FSNodeDirectory *nodeDir, uint64_t firstEntry,
-	            uint64_t numberOfEntries, std::vector<DirectoryEntry> &dirEntriesOut) override;
+	void getDir(const FilesystemOperationContext &fsOpContext, inode_t rootINode, uint32_t uid,
+	            uint32_t gid, uint32_t auid, uint32_t agid, uint8_t sesflags,
+	            FSNodeDirectory *nodeDir, uint64_t firstEntry, uint64_t numberOfEntries,
+	            std::vector<DirectoryEntry> &dirEntriesOut) override;
 #endif
 	bool isNameUsed(FSNodeDirectory *node, const HString &name) override;
 
 	// Trash/Reserved operations
 	int purge(uint32_t timeStamp, FSNode *node) override;
-	uint8_t undel(uint32_t timeStamp, FSNodeFile *node) override;
+	uint8_t undel(const FilesystemOperationContext &fsOpContext, uint32_t timeStamp,
+	              FSNodeFile *node) override;
 #ifndef METARESTORE
 	uint32_t getDetachedSize(const TrashPathContainer &data) override;
 	void getDetachedData(const TrashPathContainer &data, uint8_t *outBuffer) override;
@@ -149,9 +154,10 @@ public:
 
 	/// Treating rootinode as the root of the hierarchy, converts (rootinode, inode) to FSNode*.
 	/// @see IFilesystemNodeOperations::getNodeForOperation
-	uint8_t getNodeForOperation(const FsContext &context, ExpectedNodeType expectedNodeType,
-	                            uint8_t modeMask, inode_t inode, FSNode **nodeOut,
-	                            FSNodeDirectory **rootDirOut = nullptr) override;
+	uint8_t getNodeForOperation(const FsContext &context,
+	                            const FilesystemOperationContext &fsOpContext,
+	                            ExpectedNodeType expectedNodeType, uint8_t modeMask, inode_t inode,
+	                            FSNode **nodeOut, FSNodeDirectory **rootDirOut = nullptr) override;
 
 	// Ancestry operations
 
@@ -166,8 +172,29 @@ public:
 	FSNodeDirectory *getFirstParent(FSNode *node) override;
 
 protected:
-	/// Internal node lookup operation - override in subclasses for custom storage
-	FSNode *idToNodeInternal(inode_t inode) override;
+	/// Internal node lookup operation - override in subclasses for custom storage.
+	/// @see IFilesystemNodeOperations::idToNodeInternal
+	FSNode *idToNodeInternal(inode_t inode) const override;
+
+	/// Internal node lookup operation with context - override in subclasses for custom storage.
+	/// @see IFilesystemNodeOperations::idToNodeInternal
+	FSNode *idToNodeInternal(const FilesystemOperationContext &fsOpContext,
+	                         inode_t inode) const override;
+
+	/// Increases the node counters for the specified type.
+	/// @see IFilesystemNodeOperations::incrementNodeCounters
+	void incrementNodeCounters(const FilesystemOperationContext &fsOpContext,
+	                           FSNodeType type) override;
+
+	/// Preserves the given node in the underlying storage (in-memory in this implementation).
+	/// @see IFilesystemNodeOperations::preserveNode
+	void preserveNode(const FilesystemOperationContext &fsOpContext, FSNode *node) override;
+
+	/// Preserves the edge between parent and child in the underlying storage (in-memory in this
+	/// implementation).
+	/// @see IFilesystemNodeOperations::preserveEdge
+	void preserveEdge(const FilesystemOperationContext &fsOpContext, FSNodeDirectory *parent,
+	                  FSNode *child, hstorage::Handle *handlePtr) override;
 
 private:
 	// Private helpers

--- a/src/master/filesystem_node_operations_interface.h
+++ b/src/master/filesystem_node_operations_interface.h
@@ -27,6 +27,7 @@
 #include "common/attributes.h"
 #include "common/type_defs.h"
 #include "master/filesystem_node_types.h"
+#include "master/filesystem_operation_context.h"
 #include "master/filesystem_trash_reserved_files.h"
 #include "master/fs_context.h"
 #include "protocol/directory_entry.h"
@@ -44,15 +45,36 @@ struct NamedInodeEntry;
 
 using ChunkCountArray = std::array<uint32_t, CHUNK_MATRIX_SIZE>;
 
+/// Maximum length for a file or directory name in bytes
+inline constexpr size_t kMaxFileNameLength = 255;
+
+/// All permission bits (including setuid/setgid/sticky)
+inline constexpr uint16_t kPermissionsMask = 07777;
+/// Standard rwx permissions (excludes setuid/setgid/sticky)
+inline constexpr uint16_t kStandardPermissionsMask = 0777;
+inline constexpr uint16_t kExtraAttributesMask = 0xF000;  ///< Bits 12-15 for extra attributes
+
+/// Default undelete directory mode
+inline constexpr uint16_t kUndelDirectoryMode = 0755;
+
 // Extra attributes constants and type aliases
-static constexpr uint8_t kMaxExtraAttributes = 16;
+inline constexpr uint8_t kMaxExtraAttributes = 16;
 using ExtraAttributesArray = std::array<uint32_t, kMaxExtraAttributes>;
 
 // Directory entry serialization constants
-static constexpr size_t kDirEntryWithAttributesSize = kinode_t_size + kAttributesSize;
-static constexpr size_t kDirEntryWithoutAttributesSize = kinode_t_size + 1;  // +1 for node type
-static constexpr size_t kDotEntrySize = 1;      // "." (1 byte)
-static constexpr size_t kDotDotEntrySize = 2;   // ".." (2 bytes)
+inline constexpr size_t kDirEntryWithAttributesSize = kinode_t_size + kAttributesSize;
+inline constexpr size_t kDirEntryWithoutAttributesSize = kinode_t_size + 1;  // +1 for node type
+inline constexpr size_t kDotEntrySize = 1;                                   // "." (1 byte)
+inline constexpr size_t kDotDotEntrySize = 2;                                // ".." (2 bytes)
+
+// For readdir related operations
+inline constexpr uint64_t kSignBit64 = (1ULL << 63ULL);
+// special entryIndex values
+inline constexpr uint64_t kDotEntryIndex = 0;
+inline constexpr uint64_t kDotDotEntryIndex =
+    (static_cast<uint64_t>(1) << hstorage::Handle::kHashShift);
+inline constexpr uint64_t kUnusedEntryIndex =
+    (static_cast<uint64_t>(2) << hstorage::Handle::kHashShift);
 
 /// Interface for filesystem node operations extensibility.
 ///
@@ -73,6 +95,7 @@ public:
 
 	// Type-safe node lookup operations
 
+	/// Looks up a node by its inode and verifies its type.
 	template <class NodeType>
 	NodeType *idToNodeVerify(inode_t inode) {
 		auto *node = static_cast<NodeType *>(this->idToNodeInternal(inode));
@@ -80,21 +103,40 @@ public:
 		return node;
 	}
 
+	/// Looks up a node by its inode and context, and verifies its type.
+	template <class NodeType>
+	NodeType *idToNodeVerify(const FilesystemOperationContext &fsOpContext, inode_t inode) {
+		auto *node = static_cast<NodeType *>(this->idToNodeInternal(fsOpContext, inode));
+		this->checkNodeType(node);
+		return node;
+	}
+
+	/// Looks up a node by its inode.
 	template <class NodeType = FSNode>
 	NodeType *idToNode(inode_t inode) {
 		return static_cast<NodeType *>(this->idToNodeInternal(inode));
 	}
 
+	/// Looks up a node by its inode and context.
+	template <class NodeType = FSNode>
+	NodeType *idToNode(const FilesystemOperationContext &fsOpContext, inode_t inode) {
+		return static_cast<NodeType *>(this->idToNodeInternal(fsOpContext, inode));
+	}
+
+	/// Returns the root node of the filesystem.
+	virtual FSNodeDirectory *getRootNode(const FilesystemOperationContext &fsOpContext) = 0;
+
 	// Main node operations
 
 	virtual FSNode *lookup(FSNodeDirectory *node, const HString &name) const = 0;
 
-	virtual FSNode *createNode(uint32_t timeStamp, FSNodeDirectory *parent, const HString &name,
-	                           FSNodeType type, uint16_t mode, uint16_t umask, uint32_t uid,
-	                           uint32_t gid, uint8_t copysgid, AclInheritance inheritAcl,
+	virtual FSNode *createNode(const FilesystemOperationContext &fsOpContext, uint32_t timeStamp,
+	                           FSNodeDirectory *parent, const HString &name, FSNodeType type,
+	                           uint16_t mode, uint16_t umask, uint32_t uid, uint32_t gid,
+	                           uint8_t copysgid, AclInheritance inheritAcl,
 	                           inode_t requestedINode = 0) = 0;
-	virtual void link(uint32_t timeStamp, FSNodeDirectory *parent, FSNode *child,
-	                  const HString &name) = 0;
+	virtual void link(const FilesystemOperationContext &fsOpContext, uint32_t timeStamp,
+	                  FSNodeDirectory *parent, FSNode *child, const HString &name) = 0;
 	virtual void unlink(uint32_t timeStamp, FSNodeDirectory *parent, const HString &childName,
 	                    FSNode *childNode) = 0;
 	virtual void removeEdge(uint32_t timeStamp, FSNodeDirectory *parent, const HString &childName,
@@ -126,24 +168,46 @@ public:
 	                        uint32_t agid, uint8_t sesflags, FSNodeDirectory *nodeDir,
 	                        uint8_t *outBuffer, uint8_t withAttr) = 0;
 
-	/// Get entries of directory node \a nodeDir.
+	/// @brief Get entries of directory node using pagination.
 	///
-	/// Returns directory entries in \a dirEntriesOut container.
-	/// \a firstEntry == 0 means the very first entry in the directory.
-	/// \param nodeDir directory node to get the entries of
-	/// \param firstEntry index of the first dirent to get
-	/// \param numberOfEntries number of dirents to get
-	/// \param[out] dirEntriesOut container into which dirents are inserted
-	virtual void getDir(inode_t rootINode, uint32_t uid, uint32_t gid, uint32_t auid, uint32_t agid,
-	                    uint8_t sesflags, FSNodeDirectory *nodeDir, uint64_t firstEntry,
-	                    uint64_t numberOfEntries, std::vector<DirectoryEntry> &dirEntriesOut) = 0;
+	/// Returns directory entries in the output container, handling special entries
+	/// "." and ".." automatically when starting from index 0. The function uses
+	/// Handle-based indexing where the sign bit (bit 63) is stripped from indices
+	/// returned to clients.
+	///
+	/// @param fsOpContext Filesystem operation context (used by some implementations).
+	/// @param rootINode The root inode of the session's visible hierarchy. Used to determine if the
+	///                  directory is the root (affects "." and ".." inode values).
+	/// @param uid User ID for attribute filling.
+	/// @param gid Group ID for attribute filling.
+	/// @param auid Access User ID for attribute filling.
+	/// @param agid Access Group ID for attribute filling.
+	/// @param sesflags Session flags for attribute filling.
+	/// @param nodeDir Directory node to get the entries of.
+	/// @param firstEntry Index of the first directory entry to retrieve. Use 0 for
+	///                   the "." entry. Subsequent calls should use the `next_index`
+	///                   value from the last returned entry for continuation.
+	/// @param numberOfEntries Maximum number of directory entries to retrieve (page size).
+	/// @param[out] dirEntriesOut Container into which directory entries are inserted.
+	///
+	/// @note The special index values are:
+	///       - 0: represents the "." entry
+	///       - (1 << kHashShift): represents the ".." entry
+	///       - (2 << kHashShift): represents an unused/end marker
+	/// @note The `next_index` in the last entry will be the unused marker if there
+	///       are no more entries in the directory.
+	virtual void getDir(const FilesystemOperationContext &fsOpContext, inode_t rootINode,
+	                    uint32_t uid, uint32_t gid, uint32_t auid, uint32_t agid, uint8_t sesflags,
+	                    FSNodeDirectory *nodeDir, uint64_t firstEntry, uint64_t numberOfEntries,
+	                    std::vector<DirectoryEntry> &dirEntriesOut) = 0;
 #endif
 	virtual bool isNameUsed(FSNodeDirectory *node, const HString &name) = 0;
 
 	// Trash/Reserved operations
 
 	virtual int purge(uint32_t timeStamp, FSNode *node) = 0;
-	virtual uint8_t undel(uint32_t timeStamp, FSNodeFile *node) = 0;
+	virtual uint8_t undel(const FilesystemOperationContext &fsOpContext, uint32_t timeStamp,
+	                      FSNodeFile *node) = 0;
 #ifndef METARESTORE
 	virtual uint32_t getDetachedSize(const TrashPathContainer &data) = 0;
 	virtual void getDetachedData(const TrashPathContainer &data, uint8_t *outBuffer) = 0;
@@ -217,8 +281,10 @@ public:
 	/// if inode != rootinode, then returns some node
 	/// Checks for permissions needed to perform the operation (defined by modeMask).
 	/// Can return a reserved node or a node from trash.
-	virtual uint8_t getNodeForOperation(const FsContext &context, ExpectedNodeType expectedNodeType,
-	                                    uint8_t modeMask, inode_t inode, FSNode **nodeOut,
+	virtual uint8_t getNodeForOperation(const FsContext &context,
+	                                    const FilesystemOperationContext &fsOpContext,
+	                                    ExpectedNodeType expectedNodeType, uint8_t modeMask,
+	                                    inode_t inode, FSNode **nodeOut,
 	                                    FSNodeDirectory **rootDirOut = nullptr) = 0;
 
 	// Ancestry operations
@@ -235,8 +301,41 @@ public:
 	virtual FSNodeDirectory *getFirstParent(FSNode *node) = 0;
 
 protected:
-	// Core node lookup operation - override in subclasses for custom storage
-	virtual FSNode *idToNodeInternal(inode_t inode) = 0;
+	/// Core node lookup operation - override in subclasses for custom storage.
+	/// @param inode The inode of the node to look up.
+	/// @return Pointer to the node if found, nullptr otherwise.
+	virtual FSNode *idToNodeInternal(inode_t inode) const = 0;
+
+	/// Core node lookup operation with context - override in subclasses for custom storage.
+	/// @param context The FS context for the operation, potentially carrying a transaction.
+	/// @param inode The inode of the node to look up.
+	/// @return Pointer to the node if found, nullptr otherwise.
+	virtual FSNode *idToNodeInternal(const FilesystemOperationContext &fsOpContext,
+	                                 inode_t inode) const = 0;
+
+	/// Increases the node counters for the specified type.
+	/// @param fsOpContext The operation context carrying a transaction in some implementations.
+	/// @param type The node type of whose related counters are to be updated.
+	virtual void incrementNodeCounters(const FilesystemOperationContext &fsOpContext,
+	                                   FSNodeType type) = 0;
+
+	/// Implementation specific node preservation (in-memory, FDB, etc.)
+	/// Usually called after creating or modifying a node to persist changes. An in-memory
+	/// implementation most likely will add it to a hash map or similar structure. A KV-store
+	/// implementation will write the node data to the store within the current transaction.
+	/// @param fsOpContext The filesystem operation context (transaction).
+	/// @param node The node to preserve.
+	virtual void preserveNode(const FilesystemOperationContext &fsOpContext, FSNode *node) = 0;
+
+	/// Implementation specific edge preservation (in-memory, FDB, etc.)
+	/// Similar to preserveNode, but for edges (directory entries).
+	/// @param fsOpContext The filesystem operation context (transaction).
+	/// @param parent The parent directory node.
+	/// @param child The child node.
+	/// @param handlePtr The edge name.
+	virtual void preserveEdge(const FilesystemOperationContext &fsOpContext,
+	                          FSNodeDirectory *parent, FSNode *child,
+	                          hstorage::Handle *handlePtr) = 0;
 
 	// Type checking helper - base case
 	template <class NodeType>

--- a/src/master/filesystem_operation_context.cc
+++ b/src/master/filesystem_operation_context.cc
@@ -1,0 +1,52 @@
+/*
+   Copyright 2025      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "common/platform.h"
+
+#include "master/filesystem_operation_context.h"
+
+#include "kv/itransaction.h"
+
+FilesystemOperationContext::FilesystemOperationContext(
+    std::unique_ptr<kv::IReadOnlyTransaction> txn)
+    : roTransaction_(std::move(txn)), transactionType_(TransactionType::kReadOnly) {}
+
+FilesystemOperationContext::FilesystemOperationContext(
+    std::unique_ptr<kv::IReadWriteTransaction> txn)
+    : rwTransaction_(std::move(txn)), transactionType_(TransactionType::kReadWrite) {}
+
+bool FilesystemOperationContext::hasTransaction() const {
+	return rwTransaction_ != nullptr || roTransaction_ != nullptr;
+}
+
+bool FilesystemOperationContext::hasReadWriteTransaction() const {
+	return rwTransaction_ != nullptr;
+}
+
+kv::IReadOnlyTransaction *FilesystemOperationContext::getReadOnlyTransaction() const {
+	if (rwTransaction_) {
+		// Read-write transaction can be used as read-only
+		return rwTransaction_.get();
+	}
+
+	return roTransaction_.get();
+}
+
+kv::IReadWriteTransaction *FilesystemOperationContext::getReadWriteTransaction() const {
+	return rwTransaction_.get();
+}

--- a/src/master/filesystem_operation_context.h
+++ b/src/master/filesystem_operation_context.h
@@ -1,0 +1,100 @@
+/*
+   Copyright 2025      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "common/platform.h"
+
+#include <memory>
+
+#include "kv/itransaction.h"
+
+namespace kv {
+class IReadOnlyTransaction;
+class IReadWriteTransaction;
+}  // namespace kv
+
+/// Context for filesystem operations that may require database transactions.
+///
+/// This class provides an optional transaction context that can be propagated through the call
+/// stack during filesystem operations. It enables grouping multiple database operations into a
+/// single atomic unit, ensuring consistency and improving performance.
+///
+/// Usage patterns:
+/// - **In-memory implementation** (Master, Shadows): Transactions are not used; the context
+///   remains empty and is effectively ignored.
+/// - **Distributed implementations** (e.g., FoundationDB-based MDS): The context carries an
+///   active transaction, allowing efficient batching and atomic commits.
+///
+/// The class supports both read-only and read-write transactions, with move-only semantics
+/// to ensure proper ownership of transaction resources.
+class FilesystemOperationContext {
+public:
+	/// Type of transaction required for this operation
+	enum class TransactionType : std::uint8_t {
+		kNone,      ///< No transaction
+		kReadOnly,  ///< Read-only transaction
+		kReadWrite  ///< Read-write transaction
+	};
+
+	/// Create an empty context (no transaction)
+	FilesystemOperationContext() = default;
+
+	/// Create a context with a read-only transaction
+	explicit FilesystemOperationContext(std::unique_ptr<kv::IReadOnlyTransaction> txn);
+
+	/// Create a context with a read-write transaction
+	explicit FilesystemOperationContext(std::unique_ptr<kv::IReadWriteTransaction> txn);
+
+	/// Move-only semantics (transactions cannot be copied)
+	FilesystemOperationContext(const FilesystemOperationContext &) = delete;
+	FilesystemOperationContext &operator=(const FilesystemOperationContext &) = delete;
+	FilesystemOperationContext(FilesystemOperationContext &&) = default;
+	FilesystemOperationContext &operator=(FilesystemOperationContext &&) = default;
+
+	/// Destructor.
+	/// Destroying the context only releases any owned transaction objects. It does not implicitly
+	/// commit or rollback transactions; callers must ensure that any required commit or rollback is
+	/// performed via the transaction interfaces before the context is destroyed.
+	~FilesystemOperationContext() = default;
+
+	/// Returns true if this context has an active transaction
+	bool hasTransaction() const;
+
+	/// Returns true if this context has a read-write transaction
+	bool hasReadWriteTransaction() const;
+
+	/// Get the read-only transaction (null if none)
+	kv::IReadOnlyTransaction *getReadOnlyTransaction() const;
+
+	/// Get the read-write transaction (null if none or read-only)
+	kv::IReadWriteTransaction *getReadWriteTransaction() const;
+
+	/// Get the transaction type hint
+	TransactionType getTransactionType() const { return transactionType_; }
+
+private:
+	/// The active read-write transaction (if any)
+	std::unique_ptr<kv::IReadWriteTransaction> rwTransaction_ = nullptr;
+
+	/// The active read-only transaction (if any and rwTransaction_ is null)
+	std::unique_ptr<kv::IReadOnlyTransaction> roTransaction_ = nullptr;
+
+	/// Hint about what transaction type to create if lazy initialization is needed
+	TransactionType transactionType_ = TransactionType::kNone;
+};

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -38,6 +38,7 @@
 #include "master/filesystem_metadata.h"
 #include "master/filesystem_node.h"
 #include "master/filesystem_node_types.h"
+#include "master/filesystem_operation_context.h"
 #include "master/filesystem_operations_interface.h"
 #include "master/filesystem_quota.h"
 #include "master/filesystem_stats.h"
@@ -229,8 +230,11 @@ uint8_t FilesystemOperationsBase::setTrashPath(const FsContext &context, inode_t
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kAny, MODE_MASK_EMPTY,
-	                                              inode, &p);
+
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kAny,
+	                                              MODE_MASK_EMPTY, inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	} else if (p->type != FSNodeType::kTrash) {
@@ -264,15 +268,18 @@ uint8_t FilesystemOperationsBase::undel(const FsContext &context, inode_t inode)
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kAny, MODE_MASK_EMPTY,
-	                                              inode, &p);
+
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kAny,
+	                                              MODE_MASK_EMPTY, inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	} else if (p->type != FSNodeType::kTrash) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
 
-	status = nodeOperations_->undel(context.ts(), static_cast<FSNodeFile *>(p));
+	status = nodeOperations_->undel(fsOpContext, context.ts(), static_cast<FSNodeFile *>(p));
 	if (context.isPersonalityMaster()) {
 		if (status == SAUNAFS_STATUS_OK) { changeLog(context.ts(), "UNDEL(%" PRIiNode ")", p->id); }
 	} else {
@@ -289,8 +296,11 @@ uint8_t FilesystemOperationsBase::purge(const FsContext &context, inode_t inode)
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kAny, MODE_MASK_EMPTY,
-	                                              inode, &p);
+
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kAny,
+	                                              MODE_MASK_EMPTY, inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	} else if (p->type != FSNodeType::kTrash) {
@@ -423,14 +433,19 @@ uint8_t FilesystemOperationsBase::access(const FsContext &context, inode_t inode
 		return status;
 	}
 
-	return nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kAny, modemask, inode,
-	                                            &p);
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadOnly);
+
+	return nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kAny,
+	                                            modemask, inode, &p);
 }
 
-uint8_t FilesystemOperationsBase::lookup(const FsContext &context, inode_t parent,
-                                         const HString &name, inode_t *inode, Attributes &attr) {
-	FSNode *wd;
-	FSNodeDirectory *rn;
+uint8_t FilesystemOperationsBase::lookup(const FsContext &context,
+                                         const FilesystemOperationContext &fsOpContext,
+                                         inode_t parent, const HString &name, inode_t *inode,
+                                         Attributes &attr) {
+	FSNode *workDir;
+	FSNodeDirectory *effectiveRootDir;
 
 	*inode = 0;
 	attr.fill(0);
@@ -441,43 +456,44 @@ uint8_t FilesystemOperationsBase::lookup(const FsContext &context, inode_t paren
 		return status;
 	}
 
-	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kDirectory,
-	                                              MODE_MASK_X, parent, &wd, &rn);
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	}
+	status =
+	    nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kDirectory,
+	                                         MODE_MASK_X, parent, &workDir, &effectiveRootDir);
+
+	if (status != SAUNAFS_STATUS_OK) { return status; }
 
 	if (!name.empty() && name[0] == '.') {
 		if (name.length() == 1) {  // self
-			if (wd->id == context.rootinode()) {
+			if (workDir->id == context.rootinode()) {
 				*inode = SPECIAL_INODE_ROOT;
 			} else {
-				*inode = wd->id;
+				*inode = workDir->id;
 			}
-			nodeOperations_->fillAttr(wd, wd, context.uid(), context.gid(), context.auid(),
+			nodeOperations_->fillAttr(workDir, workDir, context.uid(), context.gid(), context.auid(),
 			                          context.agid(), context.sesflags(), attr);
 			incrementFSStat(FsStats::Lookup);
 			metrics::Counter::increment(metrics::Counter::Master::FS_LOOKUP);
 			return SAUNAFS_STATUS_OK;
 		}
+
 		if (name.length() == 2 && name[1] == '.') {  // parent
-			if (wd->id == context.rootinode()) {
+			if (workDir->id == context.rootinode()) {
 				*inode = SPECIAL_INODE_ROOT;
-				nodeOperations_->fillAttr(wd, wd, context.uid(), context.gid(), context.auid(),
+				nodeOperations_->fillAttr(workDir, workDir, context.uid(), context.gid(), context.auid(),
 				                          context.agid(), context.sesflags(), attr);
 			} else {
-				if (!wd->parents.empty()) {
-					if (wd->parents[0].first == context.rootinode()) {
+				if (!workDir->parents.empty()) {
+					if (workDir->parents[0].first == context.rootinode()) {
 						*inode = SPECIAL_INODE_ROOT;
 					} else {
-						*inode = wd->parents[0].first;
+						*inode = workDir->parents[0].first;
 					}
-					FSNode *pp = nodeOperations_->idToNode(wd->parents[0].first);
-					nodeOperations_->fillAttr(pp, wd, context.uid(), context.gid(), context.auid(),
+					FSNode *pp = nodeOperations_->idToNode(workDir->parents[0].first);
+					nodeOperations_->fillAttr(pp, workDir, context.uid(), context.gid(), context.auid(),
 					                          context.agid(), context.sesflags(), attr);
 				} else {
 					*inode = SPECIAL_INODE_ROOT;  // rn->id;
-					nodeOperations_->fillAttr(rn, wd, context.uid(), context.gid(), context.auid(),
+					nodeOperations_->fillAttr(effectiveRootDir, workDir, context.uid(), context.gid(), context.auid(),
 					                          context.agid(), context.sesflags(), attr);
 				}
 			}
@@ -486,15 +502,19 @@ uint8_t FilesystemOperationsBase::lookup(const FsContext &context, inode_t paren
 			return SAUNAFS_STATUS_OK;
 		}
 	}
+
 	if (nodeOperations_->nameCheck(name) < 0) { return SAUNAFS_ERROR_EINVAL; }
 
-	FSNode *child = nodeOperations_->lookup(static_cast<FSNodeDirectory *>(wd), name);
+	FSNode *child = nodeOperations_->lookup(static_cast<FSNodeDirectory *>(workDir), name);
+
 	if (!child) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
+
 	*inode = child->id;
-	nodeOperations_->fillAttr(child, wd, context.uid(), context.gid(), context.auid(),
+	nodeOperations_->fillAttr(child, workDir, context.uid(), context.gid(), context.auid(),
 	                          context.agid(), context.sesflags(), attr);
+
 	incrementFSStat(FsStats::Lookup);
 	metrics::Counter::increment(metrics::Counter::Master::FS_LOOKUP);
 	return SAUNAFS_STATUS_OK;
@@ -506,12 +526,15 @@ uint8_t FilesystemOperationsBase::wholePathLookup(const FsContext &context, inod
 	uint8_t status;
 	inode_t tmp_inode = context.rootinode();
 
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadOnly);
+
 	auto current_it = path.begin();
 	while (current_it != path.end()) {
 		auto delim_it = std::find(current_it, path.end(), '/');
 		if (current_it != delim_it) {
 			HString hstr(current_it, delim_it);
-			status = lookup(context, parent, hstr, &tmp_inode, attr);
+			status = lookup(context, fsOpContext, parent, hstr, &tmp_inode, attr);
 			if (status != SAUNAFS_STATUS_OK) {
 				return status;
 			}
@@ -524,7 +547,9 @@ uint8_t FilesystemOperationsBase::wholePathLookup(const FsContext &context, inod
 	}
 
 	*found_inode = tmp_inode;
-	if (tmp_inode == context.rootinode()) { return getAttr(context, SPECIAL_INODE_ROOT, attr); }
+	if (tmp_inode == context.rootinode()) {
+		return getAttr(context, fsOpContext, SPECIAL_INODE_ROOT, attr);
+	}
 	return SAUNAFS_STATUS_OK;
 }
 
@@ -539,8 +564,11 @@ uint8_t FilesystemOperationsBase::fullPathByInode(const FsContext &context, inod
 	    nodeOperations_->verifySession(context, OperationMode::kReadOnly, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) { return status; }
 
-	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kAny, MODE_MASK_R,
-	                                              initial_inode, &current_node);
+	FilesystemOperationContext fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadOnly);
+
+	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kAny,
+	                                              MODE_MASK_R, initial_inode, &current_node);
 	if (status != SAUNAFS_STATUS_OK) { return status; }
 
 	if (current_inode == SPECIAL_INODE_ROOT) {
@@ -563,8 +591,8 @@ uint8_t FilesystemOperationsBase::fullPathByInode(const FsContext &context, inod
 		}
 		auto [parentId, nameHandle] = current_node->parents[0];
 		if (!nameHandle) { return SAUNAFS_ERROR_ENOENT; }
-		status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kAny, MODE_MASK_R,
-		                                              parentId, &parent_node);
+		status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kAny,
+		                                              MODE_MASK_R, parentId, &parent_node);
 		if (status != SAUNAFS_STATUS_OK) { return status; }
 		current_name = nameHandle->get();
 		fullPath = current_inode == initial_inode
@@ -618,8 +646,9 @@ std::string FilesystemOperationsBase::fullPathByInode(inode_t initialInode) {
 	return fullPath;
 }
 
-uint8_t FilesystemOperationsBase::getAttr(const FsContext &context, inode_t inode,
-                                          Attributes &attr) {
+uint8_t FilesystemOperationsBase::getAttr(const FsContext &context,
+                                          const FilesystemOperationContext &fsOpContext,
+                                          inode_t inode, Attributes &attr) {
 	FSNode *p;
 
 	attr.fill(0);
@@ -630,8 +659,8 @@ uint8_t FilesystemOperationsBase::getAttr(const FsContext &context, inode_t inod
 		return status;
 	}
 
-	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kAny, MODE_MASK_EMPTY,
-	                                              inode, &p);
+	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kAny,
+	                                              MODE_MASK_EMPTY, inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
@@ -643,8 +672,9 @@ uint8_t FilesystemOperationsBase::getAttr(const FsContext &context, inode_t inod
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t FilesystemOperationsBase::trySetLength(const FsContext &context, inode_t inode,
-                                               uint8_t opened, uint64_t length,
+uint8_t FilesystemOperationsBase::trySetLength(const FsContext &context,
+                                               const FilesystemOperationContext &fsOpContext,
+                                               inode_t inode, uint8_t opened, uint64_t length,
                                                bool denyTruncatingParity, uint32_t lockId,
                                                Attributes &attr, uint64_t *chunkid) {
 	uint32_t ts = eventloop_time();
@@ -658,8 +688,9 @@ uint8_t FilesystemOperationsBase::trySetLength(const FsContext &context, inode_t
 		return status;
 	}
 
-	status = nodeOperations_->getNodeForOperation(
-	    context, ExpectedNodeType::kFile, opened == 0 ? MODE_MASK_W : MODE_MASK_EMPTY, inode, &p);
+	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kFile,
+	                                              opened == 0 ? MODE_MASK_W : MODE_MASK_EMPTY,
+	                                              inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
@@ -820,8 +851,9 @@ uint8_t FilesystemOperationsBase::applyUnlock(uint64_t chunkid) {
 }
 
 #ifndef METARESTORE
-uint8_t FilesystemOperationsBase::doSetLength(const FsContext &context, inode_t inode,
-                                              uint64_t length, Attributes &attr) {
+uint8_t FilesystemOperationsBase::doSetLength(const FsContext &context,
+                                              const FilesystemOperationContext &fsOpContext,
+                                              inode_t inode, uint64_t length, Attributes &attr) {
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
 	FSNode *p = NULL;
@@ -834,8 +866,8 @@ uint8_t FilesystemOperationsBase::doSetLength(const FsContext &context, inode_t 
 		return status;
 	}
 
-	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kFile, MODE_MASK_EMPTY,
-	                                              inode, &p);
+	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kFile,
+	                                              MODE_MASK_EMPTY, inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
@@ -874,8 +906,10 @@ uint8_t FilesystemOperationsBase::setAttr(const FsContext &context, inode_t inod
 		return status;
 	}
 
-	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kAny, MODE_MASK_EMPTY,
-	                                              inode, &p);
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kAny,
+	                                              MODE_MASK_EMPTY, inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
@@ -1060,14 +1094,15 @@ uint8_t FilesystemOperationsBase::readlink(const FsContext &context, inode_t ino
 		return status;
 	}
 
-	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kAny, MODE_MASK_EMPTY,
-	                                              inode, &p);
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	}
-	if (p->type != FSNodeType::kSymlink) {
-		return SAUNAFS_ERROR_EINVAL;
-	}
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadOnly);
+
+	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kAny,
+	                                              MODE_MASK_EMPTY, inode, &p);
+
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+
+	if (p->type != FSNodeType::kSymlink) { return SAUNAFS_ERROR_EINVAL; }
 
 	path = (std::string)static_cast<FSNodeSymlink*>(p)->path;
 	fs_update_atime(p, ts);
@@ -1088,8 +1123,13 @@ uint8_t FilesystemOperationsBase::symlink(const FsContext &context, inode_t pare
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kDirectory,
-	                                              MODE_MASK_W, parent, &wd);
+
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
+	status = nodeOperations_->getNodeForOperation(
+	    context, fsOpContext, ExpectedNodeType::kDirectory, MODE_MASK_W, parent, &wd);
+
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
@@ -1123,9 +1163,12 @@ uint8_t FilesystemOperationsBase::symlink(const FsContext &context, inode_t pare
 	     fsnodes_quota_exceeded_dir(wd, {{QuotaResource::kInodes, 1}}))) {
 		return SAUNAFS_ERROR_QUOTA;
 	}
+
 	FSNodeSymlink *p = static_cast<FSNodeSymlink *>(nodeOperations_->createNode(
-	    context.ts(), static_cast<FSNodeDirectory *>(wd), name, FSNodeType::kSymlink, 0777, 0,
-	    context.uid(), context.gid(), 0, AclInheritance::kDontInheritAcl, *inode));
+	    fsOpContext, context.ts(), static_cast<FSNodeDirectory *>(wd), name, FSNodeType::kSymlink,
+	    kStandardPermissionsMask, 0, context.uid(), context.gid(), 0,
+	    AclInheritance::kDontInheritAcl, *inode));
+
 	p->path = HString(basePath);
 	p->path_length = basePath.length();
 	fsnodes_update_checksum(p);
@@ -1155,58 +1198,75 @@ uint8_t FilesystemOperationsBase::symlink(const FsContext &context, inode_t pare
 }
 
 #ifndef METARESTORE
-uint8_t FilesystemOperationsBase::mknod(const FsContext &context, inode_t parent,
-                                        const HString &name, FSNodeType type, uint16_t mode,
-                                        uint16_t umask, uint32_t rdev, inode_t *inode,
-                                        Attributes &attr) {
-	uint32_t ts = eventloop_time();
-	ChecksumUpdater cu(ts);
-	FSNode *wd, *p;
+uint8_t FilesystemOperationsBase::mknod(const FsContext &context,
+                                        const FilesystemOperationContext &fsOpContext,
+                                        inode_t parent, const HString &name, FSNodeType type,
+                                        uint16_t mode, uint16_t umask, uint32_t rdev,
+                                        inode_t *inode, Attributes &attr) {
+	uint32_t timeStamp = eventloop_time();
+	ChecksumUpdater checksumUpdater(timeStamp);
+	FSNode *parentNode;
+	FSNode *newNode;
 	*inode = 0;
 	attr.fill(0);
 
+	// Session verification
 	uint8_t status =
 	    nodeOperations_->verifySession(context, OperationMode::kReadWrite, SessionType::kNotMeta);
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	}
 
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+
+	// Node type verification
 	if (type != FSNodeType::kFile && type != FSNodeType::kSocket && type != FSNodeType::kFifo &&
 	    type != FSNodeType::kBlockDev && type != FSNodeType::kCharDev) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
 
-	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kDirectory,
-	                                              MODE_MASK_W, parent, &wd);
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	}
+	// Get parent node
+	status = nodeOperations_->getNodeForOperation(
+	    context, fsOpContext, ExpectedNodeType::kDirectory, MODE_MASK_W, parent, &parentNode);
 
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+
+	// Name verification
 	if (nodeOperations_->nameCheck(name) < 0) { return SAUNAFS_ERROR_EINVAL; }
-	if (nodeOperations_->isNameUsed(static_cast<FSNodeDirectory *>(wd), name)) {
+
+	// Check if name is already used in the parent directory (lookup)
+	if (nodeOperations_->isNameUsed(static_cast<FSNodeDirectory *>(parentNode), name)) {
 		return SAUNAFS_ERROR_EEXIST;
 	}
+
+	// Quota verification
 	if (fsnodes_quota_exceeded_ug(context.uid(), context.gid(), {{QuotaResource::kInodes, 1}}) ||
-	    fsnodes_quota_exceeded_dir(wd, {{QuotaResource::kInodes, 1}})) {
+	    fsnodes_quota_exceeded_dir(parentNode, {{QuotaResource::kInodes, 1}})) {
 		return SAUNAFS_ERROR_QUOTA;
 	}
 
-	static_cast<FSNodeDirectory *>(wd)->caseInsensitive =
+	static_cast<FSNodeDirectory *>(parentNode)->caseInsensitive =
 	    context.sesflags() & SESFLAG_CASEINSENSITIVE;
-	p = nodeOperations_->createNode(ts, static_cast<FSNodeDirectory *>(wd), name, type, mode, umask,
-	                                context.uid(), context.gid(), 0, AclInheritance::kInheritAcl);
+
+	// Create node linked to parent directory
+	newNode = nodeOperations_->createNode(
+	    fsOpContext, timeStamp, static_cast<FSNodeDirectory *>(parentNode), name, type, mode, umask,
+	    context.uid(), context.gid(), 0, AclInheritance::kInheritAcl);
+
 	if (type == FSNodeType::kBlockDev || type == FSNodeType::kCharDev) {
-		static_cast<FSNodeDevice*>(p)->rdev = rdev;
+		static_cast<FSNodeDevice *>(newNode)->rdev = rdev;
 	}
-	*inode = p->id;
-	nodeOperations_->fillAttr(p, wd, context.uid(), context.gid(), context.auid(), context.agid(),
-	                          context.sesflags(), attr);
-	changeLog(ts, "CREATE(%" PRIiNode ",%s,%c,%d,%" PRIu32 ",%" PRIu32 ",%" PRIu32 "):%" PRIiNode,
-	          wd->id, nodeOperations_->escapeName(name).c_str(), static_cast<char>(type),
-	          p->mode & 07777, context.uid(), context.gid(), rdev, p->id);
+
+	*inode = newNode->id;
+	nodeOperations_->fillAttr(newNode, parentNode, context.uid(), context.gid(), context.auid(),
+	                          context.agid(), context.sesflags(), attr);
+
+	changeLog(timeStamp,
+	          "CREATE(%" PRIiNode ",%s,%c,%d,%" PRIu32 ",%" PRIu32 ",%" PRIu32 "):%" PRIiNode,
+	          parentNode->id, nodeOperations_->escapeName(name).c_str(), static_cast<char>(type),
+	          newNode->mode & kPermissionsMask, context.uid(), context.gid(), rdev, newNode->id);
+
 	incrementFSStat(FsStats::Mknod);
 	metrics::Counter::increment(metrics::Counter::Master::FS_MKNOD);
-	fsnodes_update_checksum(p);
+	fsnodes_update_checksum(newNode);
+
 	return SAUNAFS_STATUS_OK;
 }
 
@@ -1225,16 +1285,22 @@ uint8_t FilesystemOperationsBase::mkdir(const FsContext &context, inode_t parent
 		return status;
 	}
 
-	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kDirectory,
-	                                              MODE_MASK_W, parent, &wd);
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
+	status = nodeOperations_->getNodeForOperation(
+	    context, fsOpContext, ExpectedNodeType::kDirectory, MODE_MASK_W, parent, &wd);
+
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
 
 	if (nodeOperations_->nameCheck(name) < 0) { return SAUNAFS_ERROR_EINVAL; }
+
 	if (nodeOperations_->isNameUsed(static_cast<FSNodeDirectory *>(wd), name)) {
 		return SAUNAFS_ERROR_EEXIST;
 	}
+
 	if (fsnodes_quota_exceeded_ug(context.uid(), context.gid(), {{QuotaResource::kInodes, 1}}) ||
 	    fsnodes_quota_exceeded_dir(wd, {{QuotaResource::kInodes, 1}})) {
 		return SAUNAFS_ERROR_QUOTA;
@@ -1249,7 +1315,7 @@ uint8_t FilesystemOperationsBase::mkdir(const FsContext &context, inode_t parent
 
 	static_cast<FSNodeDirectory *>(wd)->caseInsensitive =
 	    context.sesflags() & SESFLAG_CASEINSENSITIVE;
-	p = nodeOperations_->createNode(ts, static_cast<FSNodeDirectory *>(wd), name,
+	p = nodeOperations_->createNode(fsOpContext, ts, static_cast<FSNodeDirectory *>(wd), name,
 	                                FSNodeType::kDirectory, mode, umask, context.uid(),
 	                                context.gid(), copysgid, AclInheritance::kInheritAcl);
 	*inode = p->id;
@@ -1285,9 +1351,14 @@ uint8_t FilesystemOperationsBase::applyCreate(uint32_t timestamp, inode_t parent
 	if (nodeOperations_->isNameUsed(static_cast<FSNodeDirectory *>(wd), name)) {
 		return SAUNAFS_ERROR_EEXIST;
 	}
+
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
 	// we pass requested inode number here
-	p = nodeOperations_->createNode(timestamp, static_cast<FSNodeDirectory *>(wd), name, type, mode,
-	                                0, uid, gid, 0, AclInheritance::kInheritAcl, inode);
+	p = nodeOperations_->createNode(fsOpContext, timestamp, static_cast<FSNodeDirectory *>(wd),
+	                                name, type, mode, 0, uid, gid, 0, AclInheritance::kInheritAcl,
+	                                inode);
 	if (type == FSNodeType::kBlockDev || type == FSNodeType::kCharDev) {
 		static_cast<FSNodeDevice*>(p)->rdev = rdev;
 		fsnodes_update_checksum(p);
@@ -1314,8 +1385,11 @@ uint8_t FilesystemOperationsBase::unlink(const FsContext &context, inode_t paren
 		return status;
 	}
 
-	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kDirectory,
-	                                              MODE_MASK_W, parent, &wd);
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
+	status = nodeOperations_->getNodeForOperation(
+	    context, fsOpContext, ExpectedNodeType::kDirectory, MODE_MASK_W, parent, &wd);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
@@ -1354,8 +1428,13 @@ uint8_t FilesystemOperationsBase::recursiveRemove(const FsContext &context, inod
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kDirectory,
-	                                              MODE_MASK_W, parent, &wd_tmp);
+
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
+	status = nodeOperations_->getNodeForOperation(
+	    context, fsOpContext, ExpectedNodeType::kDirectory, MODE_MASK_W, parent, &wd_tmp);
+
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
@@ -1371,9 +1450,8 @@ uint8_t FilesystemOperationsBase::recursiveRemove(const FsContext &context, inod
 	std::string node_name;
 
 	nodeOperations_->getPath(static_cast<FSNodeDirectory *>(wd_tmp), child, node_name);
-	return gMetadata->taskManager.submitTask(job_id, context.ts(), kInitialTaskBatchSize,
-	                                          task, RemoveTask::generateDescription(node_name),
-	                                          callback);
+	return gMetadata->taskManager.submitTask(job_id, context.ts(), kInitialTaskBatchSize, task,
+	                                         RemoveTask::generateDescription(node_name), callback);
 }
 
 uint8_t FilesystemOperationsBase::rmdir(const FsContext &context, inode_t parent,
@@ -1388,11 +1466,13 @@ uint8_t FilesystemOperationsBase::rmdir(const FsContext &context, inode_t parent
 		return status;
 	}
 
-	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kDirectory,
-	                                              MODE_MASK_W, parent, &wd);
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	}
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
+	status = nodeOperations_->getNodeForOperation(
+	    context, fsOpContext, ExpectedNodeType::kDirectory, MODE_MASK_W, parent, &wd);
+
+	if (status != SAUNAFS_STATUS_OK) { return status; }
 
 	if (nodeOperations_->nameCheck(name) < 0) { return SAUNAFS_ERROR_EINVAL; }
 	FSNode *child = nodeOperations_->lookup(static_cast<FSNodeDirectory *>(wd), name);
@@ -1453,11 +1533,18 @@ uint8_t FilesystemOperationsBase::rename(const FsContext &context, inode_t paren
 	uint8_t status =
 	    nodeOperations_->verifySession(context, OperationMode::kReadWrite, SessionType::kAny);
 	if (status != SAUNAFS_STATUS_OK) { return status; }
-	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kDirectory,
+
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
+	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kDirectory,
 	                                              MODE_MASK_W, parent_dst, &dwd);
+
 	if (status != SAUNAFS_STATUS_OK) { return status; }
-	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kDirectory,
+
+	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kDirectory,
 	                                              MODE_MASK_W, parent_src, &swd);
+
 	if (status != SAUNAFS_STATUS_OK) { return status; }
 
 	if (static_cast<FSNodeDirectory *>(swd)->caseInsensitive) {
@@ -1465,6 +1552,7 @@ uint8_t FilesystemOperationsBase::rename(const FsContext &context, inode_t paren
 		    static_cast<FSNodeDirectory *>(swd)->getBaseStoredChildName(name_src);
 		if (!resolvedName.empty()) { baseNameSrc = HString(resolvedName); }
 	}
+
 	if (static_cast<FSNodeDirectory *>(dwd)->caseInsensitive) {
 		std::string resolvedName =
 		    static_cast<FSNodeDirectory *>(dwd)->getBaseStoredChildName(name_dst);
@@ -1472,9 +1560,12 @@ uint8_t FilesystemOperationsBase::rename(const FsContext &context, inode_t paren
 	}
 
 	if (nodeOperations_->nameCheck(baseNameSrc) < 0) { return SAUNAFS_ERROR_EINVAL; }
+
 	FSNode *sourceChildNode =
 	    nodeOperations_->lookup(static_cast<FSNodeDirectory *>(swd), baseNameSrc);
+
 	if (!sourceChildNode) { return SAUNAFS_ERROR_ENOENT; }
+
 	if (context.canCheckPermissions() &&
 	    !nodeOperations_->stickyAccess(swd, sourceChildNode, context.uid())) {
 		return SAUNAFS_ERROR_EPERM;
@@ -1537,9 +1628,12 @@ uint8_t FilesystemOperationsBase::rename(const FsContext &context, inode_t paren
 	}
 	nodeOperations_->removeEdge(context.ts(), static_cast<FSNodeDirectory *>(swd), baseNameSrc,
 	                            sourceChildNode);
-	nodeOperations_->link(context.ts(), static_cast<FSNodeDirectory *>(dwd), sourceChildNode,
-	                      baseNameDst);
+
+	nodeOperations_->link(fsOpContext, context.ts(), static_cast<FSNodeDirectory *>(dwd),
+	                      sourceChildNode, baseNameDst);
+
 	if (attr) { nodeOperations_->fillAttr(context, sourceChildNode, dwd, *attr); }
+
 	if (context.isPersonalityMaster()) {
 		changeLog(context.ts(), "MOVE(%" PRIiNode ",%s,%" PRIiNode ",%s):%" PRIiNode, swd->id,
 		          nodeOperations_->escapeName(baseNameSrc).c_str(), dwd->id,
@@ -1565,34 +1659,44 @@ uint8_t FilesystemOperationsBase::link(const FsContext &context, inode_t inode_s
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kDirectory,
-	                                              MODE_MASK_W, parent_dst, &dwd);
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	}
-	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kNotDirectory,
-	                                              MODE_MASK_EMPTY, inode_src, &sp);
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	}
+
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
+	status = nodeOperations_->getNodeForOperation(
+	    context, fsOpContext, ExpectedNodeType::kDirectory, MODE_MASK_W, parent_dst, &dwd);
+
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+
+	status = nodeOperations_->getNodeForOperation(
+	    context, fsOpContext, ExpectedNodeType::kNotDirectory, MODE_MASK_EMPTY, inode_src, &sp);
+
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+
 	if (sp->type == FSNodeType::kTrash || sp->type == FSNodeType::kReserved) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
+
 	if (nodeOperations_->nameCheck(name_dst) < 0) { return SAUNAFS_ERROR_EINVAL; }
+
 	if (nodeOperations_->isNameUsed(static_cast<FSNodeDirectory *>(dwd), name_dst)) {
 		return SAUNAFS_ERROR_EEXIST;
 	}
-	nodeOperations_->link(context.ts(), static_cast<FSNodeDirectory *>(dwd), sp, name_dst);
-	if (inode) {
-		*inode = inode_src;
-	}
+
+	nodeOperations_->link(fsOpContext, context.ts(), static_cast<FSNodeDirectory *>(dwd), sp,
+	                      name_dst);
+
+	if (inode) { *inode = inode_src; }
+
 	if (attr) { nodeOperations_->fillAttr(context, sp, dwd, *attr); }
+
 	if (context.isPersonalityMaster()) {
 		changeLog(context.ts(), "LINK(%" PRIiNode ",%" PRIiNode ",%s)", sp->id, dwd->id,
 		          nodeOperations_->escapeName(name_dst).c_str());
 	} else {
 		gMetadata->metadataVersion++;
 	}
+
 #ifndef METARESTORE
 	incrementFSStat(FsStats::Link);
 	metrics::Counter::increment(metrics::Counter::Master::FS_LINK);
@@ -1612,16 +1716,20 @@ uint8_t FilesystemOperationsBase::append(const FsContext &context, inode_t inode
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kFile, MODE_MASK_W,
-	                                              inode, &p);
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	}
-	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kFile, MODE_MASK_R,
-	                                              inode_src, &sp);
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	}
+
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
+	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kFile,
+	                                              MODE_MASK_W, inode, &p);
+
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+
+	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kFile,
+	                                              MODE_MASK_R, inode_src, &sp);
+
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+
 	if (context.isPersonalityMaster() && fsnodes_quota_exceeded(p, {{QuotaResource::kSize, 1}})) {
 		return SAUNAFS_ERROR_QUOTA;
 	}
@@ -1648,8 +1756,11 @@ static int fsnodes_check_lock_permissions(const FsContext &context, inode_t inod
 		modemask = MODE_MASK_R;
 	}
 
-	return gFSOperations->nodeOperations()->getNodeForOperation(context, ExpectedNodeType::kAny,
-	                                                            modemask, inode, &dummy);
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadOnly);
+
+	return gFSOperations->nodeOperations()->getNodeForOperation(
+	    context, fsOpContext, ExpectedNodeType::kAny, modemask, inode, &dummy);
 }
 
 int FilesystemOperationsBase::posixLockProbe(const FsContext &context, inode_t inode,
@@ -1945,11 +2056,13 @@ uint8_t FilesystemOperationsBase::readdirSize(const FsContext &context, inode_t 
 		return status;
 	}
 
-	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kDirectory,
-	                                              MODE_MASK_R, inode, &p);
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	}
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadOnly);
+
+	status = nodeOperations_->getNodeForOperation(
+	    context, fsOpContext, ExpectedNodeType::kDirectory, MODE_MASK_R, inode, &p);
+
+	if (status != SAUNAFS_STATUS_OK) { return status; }
 
 	*dnode = p;
 	*dbuffsize = nodeOperations_->getDirSize(static_cast<FSNodeDirectory *>(p),
@@ -1979,21 +2092,24 @@ uint8_t FilesystemOperationsBase::readdir(const FsContext &context, inode_t inod
 		return status;
 	}
 
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadOnly);
+
 	FSNode *dir;
-	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kDirectory,
-	                                              MODE_MASK_R, inode, &dir);
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	}
+	status = nodeOperations_->getNodeForOperation(
+	    context, fsOpContext, ExpectedNodeType::kDirectory, MODE_MASK_R, inode, &dir);
+
+	if (status != SAUNAFS_STATUS_OK) { return status; }
 
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
 
 	fs_update_atime(dir, ts);
 
-	nodeOperations_->getDir(context.rootinode(), context.uid(), context.gid(), context.auid(),
-	                        context.agid(), context.sesflags(), static_cast<FSNodeDirectory *>(dir),
-	                        first_entry, number_of_entries, dir_entries);
+	nodeOperations_->getDir(fsOpContext, context.rootinode(), context.uid(), context.gid(),
+	                        context.auid(), context.agid(), context.sesflags(),
+	                        static_cast<FSNodeDirectory *>(dir), first_entry, number_of_entries,
+	                        dir_entries);
 
 	incrementFSStat(FsStats::Readdir);
 	metrics::Counter::increment(metrics::Counter::Master::FS_READDIR);
@@ -2011,11 +2127,13 @@ uint8_t FilesystemOperationsBase::checkFile(const FsContext &context, inode_t in
 		return status;
 	}
 
-	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kFile, MODE_MASK_EMPTY,
-	                                              inode, &p);
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	}
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadOnly);
+
+	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kFile,
+	                                              MODE_MASK_EMPTY, inode, &p);
+
+	if (status != SAUNAFS_STATUS_OK) { return status; }
 
 	nodeOperations_->checkFile(static_cast<FSNodeFile *>(p), chunkCount);
 	return SAUNAFS_STATUS_OK;
@@ -2032,11 +2150,13 @@ uint8_t FilesystemOperationsBase::openCheck(const FsContext &context, inode_t in
 		return status;
 	}
 
-	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kFile, MODE_MASK_EMPTY,
-	                                              inode, &p);
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	}
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadOnly);
+
+	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kFile,
+	                                              MODE_MASK_EMPTY, inode, &p);
+
+	if (status != SAUNAFS_STATUS_OK) { return status; }
 
 	if ((flags & AFTER_CREATE) == 0) {
 		uint8_t modemask = 0;
@@ -2207,8 +2327,12 @@ uint8_t FilesystemOperationsBase::writeChunk(const FsContext &context, inode_t i
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kFile, MODE_MASK_EMPTY,
-	                                              inode, &node);
+
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
+	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kFile,
+	                                              MODE_MASK_EMPTY, inode, &node);
 	p = static_cast<FSNodeFile*>(node);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
@@ -2342,8 +2466,9 @@ uint8_t FilesystemOperationsBase::applyIncreaseChunkVersion(uint64_t chunkid) {
 }
 
 #ifndef METARESTORE
-uint8_t FilesystemOperationsBase::removeChunkFromFile(const FsContext &context, inode_t inode,
-                                                      uint64_t chunkId) {
+uint8_t FilesystemOperationsBase::removeChunkFromFile(const FsContext &context,
+                                                      const FilesystemOperationContext &fsOpContext,
+                                                      inode_t inode, uint64_t chunkId) {
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
 	StatsRecord psr, nsr;
@@ -2355,8 +2480,8 @@ uint8_t FilesystemOperationsBase::removeChunkFromFile(const FsContext &context, 
 	    nodeOperations_->verifySession(context, OperationMode::kReadWrite, SessionType::kAny);
 	if (status != SAUNAFS_STATUS_OK) { return status; }
 
-	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kFile, MODE_MASK_W,
-	                                              inode, &p);
+	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kFile,
+	                                              MODE_MASK_W, inode, &p);
 	if (status != SAUNAFS_STATUS_OK) { return status; }
 
 	auto *node_file = dynamic_cast<FSNodeFile *>(p);
@@ -2410,11 +2535,13 @@ uint8_t FilesystemOperationsBase::repair(const FsContext &context, inode_t inode
 		return status;
 	}
 
-	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kFile, MODE_MASK_W,
-	                                              inode, &p);
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	}
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
+	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kFile,
+	                                              MODE_MASK_W, inode, &p);
+
+	if (status != SAUNAFS_STATUS_OK) { return status; }
 
 	FSNodeFile *node_file = static_cast<FSNodeFile*>(p);
 	nodeOperations_->getStats(p, &psr);
@@ -2513,11 +2640,13 @@ uint8_t FilesystemOperationsBase::getGoal(const FsContext &context, inode_t inod
 		return status;
 	}
 
-	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kFileOrDirectory, 0,
-	                                              inode, &p);
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	}
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadOnly);
+
+	status = nodeOperations_->getNodeForOperation(context, fsOpContext,
+	                                              ExpectedNodeType::kFileOrDirectory, 0, inode, &p);
+
+	if (status != SAUNAFS_STATUS_OK) { return status; }
 
 	nodeOperations_->getGoalRecursive(p, gmode, fgtab, dgtab);
 	return SAUNAFS_STATUS_OK;
@@ -2538,11 +2667,13 @@ uint8_t FilesystemOperationsBase::getTrashTimePrepare(const FsContext &context, 
 		return status;
 	}
 
-	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kFileOrDirectory, 0,
-	                                              inode, &p);
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	}
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadOnly);
+
+	status = nodeOperations_->getNodeForOperation(context, fsOpContext,
+	                                              ExpectedNodeType::kFileOrDirectory, 0, inode, &p);
+
+	if (status != SAUNAFS_STATUS_OK) { return status; }
 
 	nodeOperations_->getTrashTimeRecursive(p, gmode, fileTrashtimes, dirTrashtimes);
 
@@ -2579,10 +2710,13 @@ uint8_t FilesystemOperationsBase::getExtraAttr(const FsContext &context, inode_t
 		return status;
 	}
 
-	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kAny, 0, inode, &p);
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	}
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadOnly);
+
+	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kAny, 0,
+	                                              inode, &p);
+
+	if (status != SAUNAFS_STATUS_OK) { return status; }
 
 	nodeOperations_->getExtraAttrRecursive(p, gmode, fileEAttrTab, dirEAttrTab);
 	return SAUNAFS_STATUS_OK;
@@ -2604,12 +2738,16 @@ uint8_t FilesystemOperationsBase::setGoal(const FsContext &context, inode_t inod
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
+
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
 	FSNode *p;
-	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kAny, MODE_MASK_EMPTY,
-	                                              inode, &p);
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	}
+	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kAny,
+	                                              MODE_MASK_EMPTY, inode, &p);
+
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+
 	if (p->type != FSNodeType::kDirectory && p->type != FSNodeType::kFile &&
 	    p->type != FSNodeType::kTrash && p->type != FSNodeType::kReserved) {
 		return SAUNAFS_ERROR_EPERM;
@@ -2651,12 +2789,16 @@ uint8_t FilesystemOperationsBase::applySetGoal(const FsContext &context, inode_t
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
+
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
 	FSNode *p;
-	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kAny, MODE_MASK_EMPTY,
-	                                              inode, &p);
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	}
+	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kAny,
+	                                              MODE_MASK_EMPTY, inode, &p);
+
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+
 	if (p->type != FSNodeType::kDirectory && p->type != FSNodeType::kFile &&
 	    p->type != FSNodeType::kTrash && p->type != FSNodeType::kReserved) {
 		return SAUNAFS_ERROR_EPERM;
@@ -2687,12 +2829,16 @@ uint8_t FilesystemOperationsBase::setTrashTime(
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
+
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
 	FSNode *p;
-	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kAny, MODE_MASK_EMPTY,
-	                                              inode, &p);
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	}
+	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kAny,
+	                                              MODE_MASK_EMPTY, inode, &p);
+
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+
 	if (p->type != FSNodeType::kDirectory && p->type != FSNodeType::kFile &&
 	    p->type != FSNodeType::kTrash && p->type != FSNodeType::kReserved) {
 		return SAUNAFS_ERROR_EPERM;
@@ -2725,12 +2871,16 @@ uint8_t FilesystemOperationsBase::applySetTrashTime(const FsContext &context, in
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
+
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
 	FSNode *p;
-	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kAny, MODE_MASK_EMPTY,
-	                                              inode, &p);
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	}
+	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kAny,
+	                                              MODE_MASK_EMPTY, inode, &p);
+
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+
 	if (p->type != FSNodeType::kDirectory && p->type != FSNodeType::kFile &&
 	    p->type != FSNodeType::kTrash && p->type != FSNodeType::kReserved) {
 		return SAUNAFS_ERROR_EPERM;
@@ -2761,12 +2911,15 @@ uint8_t FilesystemOperationsBase::setExtraAttr(const FsContext &context, inode_t
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
+
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
 	FSNode *p;
-	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kAny, MODE_MASK_EMPTY,
-	                                              inode, &p);
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	}
+	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kAny,
+	                                              MODE_MASK_EMPTY, inode, &p);
+
+	if (status != SAUNAFS_STATUS_OK) { return status; }
 
 	inode_t si = 0;
 	inode_t nci = 0;
@@ -2796,8 +2949,10 @@ uint8_t FilesystemOperationsBase::setExtraAttr(const FsContext &context, inode_t
 
 #ifndef METARESTORE
 
-uint8_t FilesystemOperationsBase::listXAttrLeng(const FsContext &context, inode_t inode,
-                                                uint8_t opened, void **xanode, uint32_t *xasize) {
+uint8_t FilesystemOperationsBase::listXAttrLeng(const FsContext &context,
+                                                const FilesystemOperationContext &fsOpContext,
+                                                inode_t inode, uint8_t opened, void **xanode,
+                                                uint32_t *xasize) {
 	FSNode *p;
 
 	uint8_t status =
@@ -2806,11 +2961,11 @@ uint8_t FilesystemOperationsBase::listXAttrLeng(const FsContext &context, inode_
 		return status;
 	}
 
-	status = nodeOperations_->getNodeForOperation(
-	    context, ExpectedNodeType::kAny, opened == 0 ? MODE_MASK_R : MODE_MASK_EMPTY, inode, &p);
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	}
+	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kAny,
+	                                              opened == 0 ? MODE_MASK_R : MODE_MASK_EMPTY,
+	                                              inode, &p);
+
+	if (status != SAUNAFS_STATUS_OK) { return status; }
 
 	*xasize = sizeof(kAclXattrs);
 	return get_xattrs_length_for_inode(p->id, xanode, xasize);
@@ -2835,11 +2990,14 @@ uint8_t FilesystemOperationsBase::setXAttr(const FsContext &context, inode_t ino
 		return status;
 	}
 
-	status = nodeOperations_->getNodeForOperation(
-	    context, ExpectedNodeType::kAny, opened == 0 ? MODE_MASK_W : MODE_MASK_EMPTY, inode, &p);
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	}
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
+	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kAny,
+	                                              opened == 0 ? MODE_MASK_W : MODE_MASK_EMPTY,
+	                                              inode, &p);
+
+	if (status != SAUNAFS_STATUS_OK) { return status; }
 
 	if (xattr_namecheck(anleng, attrname) < 0) {
 		return SAUNAFS_ERROR_EINVAL;
@@ -2860,9 +3018,11 @@ uint8_t FilesystemOperationsBase::setXAttr(const FsContext &context, inode_t ino
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t FilesystemOperationsBase::getXAttr(const FsContext &context, inode_t inode, uint8_t opened,
-                                           uint8_t anleng, const uint8_t *attrname,
-                                           uint32_t *avleng, uint8_t **attrvalue) {
+uint8_t FilesystemOperationsBase::getXAttr(const FsContext &context,
+                                           const FilesystemOperationContext &fsOpContext,
+                                           inode_t inode, uint8_t opened, uint8_t anleng,
+                                           const uint8_t *attrname, uint32_t *avleng,
+                                           uint8_t **attrvalue) {
 	FSNode *p;
 
 	uint8_t status =
@@ -2871,11 +3031,11 @@ uint8_t FilesystemOperationsBase::getXAttr(const FsContext &context, inode_t ino
 		return status;
 	}
 
-	status = nodeOperations_->getNodeForOperation(
-	    context, ExpectedNodeType::kAny, opened == 0 ? MODE_MASK_R : MODE_MASK_EMPTY, inode, &p);
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	}
+	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kAny,
+	                                              opened == 0 ? MODE_MASK_R : MODE_MASK_EMPTY,
+	                                              inode, &p);
+
+	if (status != SAUNAFS_STATUS_OK) { return status; }
 
 	if (xattr_namecheck(anleng, attrname) < 0) {
 		return SAUNAFS_ERROR_EINVAL;
@@ -2917,12 +3077,17 @@ uint8_t FilesystemOperationsBase::deleteAcl(const FsContext &context, inode_t in
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kAny, MODE_MASK_EMPTY,
-	                                              inode, &p);
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	}
+
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
+	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kAny,
+	                                              MODE_MASK_EMPTY, inode, &p);
+
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+
 	status = nodeOperations_->deleteAcl(p, type, context.ts());
+
 	if (context.isPersonalityMaster()) {
 		if (status == SAUNAFS_STATUS_OK) {
 			static char acl_type[3] = {'a', 'd', 'r'};
@@ -2951,11 +3116,15 @@ uint8_t FilesystemOperationsBase::setAcl(const FsContext &context, inode_t inode
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kAny, MODE_MASK_EMPTY,
-	                                              inode, &p);
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	}
+
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
+	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kAny,
+	                                              MODE_MASK_EMPTY, inode, &p);
+
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+
 	std::string acl_string = acl.toString();
 	status = nodeOperations_->setAcl(p, acl, context.ts());
 	if (context.isPersonalityMaster()) {
@@ -2977,11 +3146,15 @@ uint8_t FilesystemOperationsBase::setAcl(const FsContext &context, inode_t inode
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kAny, MODE_MASK_EMPTY,
-	                                              inode, &p);
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	}
+
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
+	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kAny,
+	                                              MODE_MASK_EMPTY, inode, &p);
+
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+
 	std::string acl_string = acl.toString();
 	status = nodeOperations_->setAcl(p, type, acl, context.ts());
 	if (context.isPersonalityMaster()) {
@@ -3004,11 +3177,15 @@ uint8_t FilesystemOperationsBase::getAcl(const FsContext &context, inode_t inode
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kAny, MODE_MASK_EMPTY,
-	                                              inode, &p);
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	}
+
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadOnly);
+
+	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kAny,
+	                                              MODE_MASK_EMPTY, inode, &p);
+
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+
 	return nodeOperations_->getAcl(p, acl);
 }
 
@@ -3119,11 +3296,13 @@ uint8_t FilesystemOperationsBase::getDirStats(const FsContext &context, inode_t 
 		return status;
 	}
 
-	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kFileOrDirectory,
-	                                              MODE_MASK_EMPTY, inode, &p);
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	}
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadOnly);
+
+	status = nodeOperations_->getNodeForOperation(
+	    context, fsOpContext, ExpectedNodeType::kFileOrDirectory, MODE_MASK_EMPTY, inode, &p);
+
+	if (status != SAUNAFS_STATUS_OK) { return status; }
 
 	nodeOperations_->getStats(p, &sr);
 	*inodes = sr.inodes;
@@ -3138,11 +3317,12 @@ uint8_t FilesystemOperationsBase::getDirStats(const FsContext &context, inode_t 
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t FilesystemOperationsBase::getChunkId(const FsContext &context, inode_t inode,
-                                             uint32_t index, uint64_t *chunkid) {
+uint8_t FilesystemOperationsBase::getChunkId(const FsContext &context,
+                                             const FilesystemOperationContext &fsOpContext,
+                                             inode_t inode, uint32_t index, uint64_t *chunkid) {
 	FSNode *p;
-	uint8_t status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kFile,
-	                                                      MODE_MASK_EMPTY, inode, &p);
+	uint8_t status = nodeOperations_->getNodeForOperation(
+	    context, fsOpContext, ExpectedNodeType::kFile, MODE_MASK_EMPTY, inode, &p);
 	FSNodeFile *node_file = static_cast<FSNodeFile*>(p);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
@@ -3225,11 +3405,14 @@ uint8_t FilesystemOperationsBase::getChunksInfo(const FsContext &context, uint32
 		return status;
 	}
 
-	status = nodeOperations_->getNodeForOperation(context, ExpectedNodeType::kFile, MODE_MASK_R,
-	                                              inode, &p);
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	}
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadOnly);
+
+	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kFile,
+	                                              MODE_MASK_R, inode, &p);
+
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+
 	if (chunk_index > kMaxChunkIndex) { return SAUNAFS_ERROR_INDEXTOOBIG; }
 
 	FSNodeFile *file_node = static_cast<FSNodeFile *>(p);

--- a/src/master/filesystem_operations.h
+++ b/src/master/filesystem_operations.h
@@ -55,6 +55,15 @@ public:
 	/// Returns the concrete node operations implementation.
 	IFilesystemNodeOperations *nodeOperations() override { return nodeOperations_.get(); }
 
+	/// Creates a filesystem operation context for the specified transaction type.
+	/// This implementation (in-memory) returns a context without transactions.
+	/// @see IFilesystemOperations::createFilesystemOperationContext
+	FilesystemOperationContext createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType type) override {
+		(void)type;  // Unused parameter in this implementation
+		return {};
+	}
+
 	/// Returns version of the loaded metadata.
 	uint64_t getMetadataVersion() override;
 
@@ -110,28 +119,32 @@ public:
 	std::vector<JobInfo> getCurrentTasksInfo() override;
 
 	uint8_t access(const FsContext &context, inode_t inode, int modemask) override;
-	uint8_t lookup(const FsContext &context, inode_t parent, const HString &name, inode_t *inode,
-	               Attributes &attr) override;
+	uint8_t lookup(const FsContext &context,
+	               const FilesystemOperationContext &fsOpContext, inode_t parent, const HString &name,
+	               inode_t *inode, Attributes &attr) override;
 	uint8_t wholePathLookup(const FsContext &context, inode_t parent, const std::string &path,
 	                        inode_t *found_inode, Attributes &attr) override;
-	uint8_t getAttr(const FsContext &context, inode_t inode, Attributes &attr) override;
-	uint8_t trySetLength(const FsContext &context, inode_t inode, uint8_t opened, uint64_t length,
-	                     bool denyTruncatingParity, uint32_t lockid, Attributes &attr,
-	                     uint64_t *chunkid) override;
-	uint8_t doSetLength(const FsContext &context, inode_t inode, uint64_t length,
-	                    Attributes &attr) override;
+	uint8_t getAttr(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                inode_t inode, Attributes &attr) override;
+	uint8_t trySetLength(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                     inode_t inode, uint8_t opened, uint64_t length, bool denyTruncatingParity,
+	                     uint32_t lockid, Attributes &attr, uint64_t *chunkid) override;
+	uint8_t doSetLength(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                    inode_t inode, uint64_t length, Attributes &attr) override;
 	uint8_t setAttr(const FsContext &context, inode_t inode, uint8_t setmask, uint16_t attrmode,
 	                uint32_t attruid, uint32_t attrgid, uint32_t attratime, uint32_t attrmtime,
 	                SugidClearMode sugidclearmode, Attributes &attr) override;
 	uint8_t readlink(const FsContext &context, inode_t inode, std::string &path) override;
 	void statfs(const FsContext &context, uint64_t *totalspace, uint64_t *availspace,
 	            uint64_t *trashspace, uint64_t *reservedspace, inode_t *inodes) override;
-	uint8_t mknod(const FsContext &context, inode_t parent, const HString &name, FSNodeType type,
-	              uint16_t mode, uint16_t umask, uint32_t rdev, inode_t *inode,
-	              Attributes &attr) override;
+	uint8_t mknod(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	              inode_t parent, const HString &name, FSNodeType type, uint16_t mode,
+	              uint16_t umask, uint32_t rdev, inode_t *inode, Attributes &attr) override;
 	uint8_t mkdir(const FsContext &context, inode_t parent, const HString &name, uint16_t mode,
 	              uint16_t umask, uint8_t copysgid, inode_t *inode, Attributes &attr) override;
-	uint8_t removeChunkFromFile(const FsContext &context, inode_t inode, uint64_t chunkId) override;
+	uint8_t removeChunkFromFile(const FsContext &context,
+	                            const FilesystemOperationContext &fsOpContext, inode_t inode,
+	                            uint64_t chunkId) override;
 	uint8_t repair(const FsContext &context, inode_t inode, uint8_t correct_only,
 	               uint32_t *notchanged, uint32_t *erased, uint32_t *repaired) override;
 	uint8_t rmdir(const FsContext &context, inode_t parent, const HString &name) override;
@@ -141,6 +154,8 @@ public:
 	                    uint32_t *dbuffsize) override;
 	void readdirData(const FsContext &context, uint8_t flags, void *dnode, uint8_t *dbuff) override;
 
+	/// Reads a paginated list of entries from a directory.
+	/// @see IFilesystemOperations::readdir
 	uint8_t readdir(const FsContext &context, inode_t inode, uint64_t first_entry,
 	                uint64_t number_of_entries, std::vector<DirectoryEntry> &dir_entries) override;
 
@@ -150,13 +165,15 @@ public:
 	                  Attributes &attr) override;
 	uint8_t getGoal(const FsContext &context, inode_t inode, uint8_t gmode, GoalStatistics &fgtab,
 	                GoalStatistics &dgtab) override;
-	uint8_t getXAttr(const FsContext &context, inode_t inode, uint8_t opened, uint8_t anleng,
-	                 const uint8_t *attrname, uint32_t *avleng, uint8_t **attrvalue) override;
+	uint8_t getXAttr(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                 inode_t inode, uint8_t opened, uint8_t anleng, const uint8_t *attrname,
+	                 uint32_t *avleng, uint8_t **attrvalue) override;
 	uint8_t getExtraAttr(const FsContext &context, inode_t inode, uint8_t gmode,
 	                     ExtraAttributesArray &fileEAttrTab,
 	                     ExtraAttributesArray &dirEAttrTab) override;
-	uint8_t listXAttrLeng(const FsContext &context, inode_t inode, uint8_t opened, void **xanode,
-	                      uint32_t *xasize) override;
+	uint8_t listXAttrLeng(const FsContext &context,
+	                      const FilesystemOperationContext &fsOpContext, inode_t inode,
+	                      uint8_t opened, void **xanode, uint32_t *xasize) override;
 	uint8_t setXAttr(const FsContext &context, inode_t inode, uint8_t opened, uint8_t anleng,
 	                 const uint8_t *attrname, uint32_t avleng, const uint8_t *attrvalue,
 	                 uint8_t mode) override;
@@ -216,7 +233,8 @@ public:
 	uint8_t getDirStats(const FsContext &context, inode_t inode, inode_t *inodes, inode_t *dirs,
 	                    inode_t *files, inode_t *links, uint32_t *chunks, uint64_t *length,
 	                    uint64_t *size, uint64_t *rsize) override;
-	uint8_t getChunkId(const FsContext &context, inode_t inode, uint32_t index,
+	uint8_t getChunkId(const FsContext &context,
+	                   const FilesystemOperationContext &fsOpContext, inode_t inode, uint32_t index,
 	                   uint64_t *chunkid) override;
 
 	// SPECIAL - LOG EMERGENCY INCREASE VERSION FROM CHUNKS-MODULE

--- a/src/master/filesystem_operations_interface.h
+++ b/src/master/filesystem_operations_interface.h
@@ -28,6 +28,7 @@
 #include "master/checksum.h"
 #include "master/filesystem_node_operations_interface.h"
 #include "master/filesystem_node_types.h"
+#include "master/filesystem_operation_context.h"
 #include "master/fs_context.h"
 #include "master/locks.h"
 #include "master/setgoal_task.h"
@@ -64,6 +65,11 @@ public:
 
 	/// Returns the concrete node operations implementation.
 	virtual IFilesystemNodeOperations *nodeOperations() = 0;
+
+	/// Creates a filesystem operation context for the specified transaction type.
+	/// In-memory implementation should return a context without transactions.
+	virtual FilesystemOperationContext createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType type) = 0;
 
 	/// Returns version of the loaded metadata.
 	virtual uint64_t getMetadataVersion() = 0;
@@ -132,17 +138,21 @@ public:
 	virtual std::vector<JobInfo> getCurrentTasksInfo() = 0;
 
 	virtual uint8_t access(const FsContext &context, inode_t inode, int modemask) = 0;
-	virtual uint8_t lookup(const FsContext &context, inode_t parent, const HString &name,
-	                       inode_t *inode, Attributes &attr) = 0;
+	virtual uint8_t lookup(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                       inode_t parent, const HString &name, inode_t *inode,
+	                       Attributes &attr) = 0;
 	virtual uint8_t wholePathLookup(const FsContext &context, inode_t parent,
 	                                const std::string &path, inode_t *found_inode,
 	                                Attributes &attr) = 0;
-	virtual uint8_t getAttr(const FsContext &context, inode_t inode, Attributes &attr) = 0;
-	virtual uint8_t trySetLength(const FsContext &context, inode_t inode, uint8_t opened,
-	                             uint64_t length, bool denyTruncatingParity, uint32_t lockid,
-	                             Attributes &attr, uint64_t *chunkid) = 0;
-	virtual uint8_t doSetLength(const FsContext &context, inode_t inode, uint64_t length,
-	                            Attributes &attr) = 0;
+	virtual uint8_t getAttr(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                        inode_t inode, Attributes &attr) = 0;
+	virtual uint8_t trySetLength(const FsContext &context,
+	                             const FilesystemOperationContext &fsOpContext, inode_t inode,
+	                             uint8_t opened, uint64_t length, bool denyTruncatingParity,
+	                             uint32_t lockid, Attributes &attr, uint64_t *chunkid) = 0;
+	virtual uint8_t doSetLength(const FsContext &context,
+	                            const FilesystemOperationContext &fsOpContext, inode_t inode,
+	                            uint64_t length, Attributes &attr) = 0;
 	virtual uint8_t setAttr(const FsContext &context, inode_t inode, uint8_t setmask,
 	                        uint16_t attrmode, uint32_t attruid, uint32_t attrgid,
 	                        uint32_t attratime, uint32_t attrmtime, SugidClearMode sugidclearmode,
@@ -150,14 +160,41 @@ public:
 	virtual uint8_t readlink(const FsContext &context, inode_t inode, std::string &path) = 0;
 	virtual void statfs(const FsContext &context, uint64_t *totalspace, uint64_t *availspace,
 	                    uint64_t *trashspace, uint64_t *reservedspace, inode_t *inodes) = 0;
-	virtual uint8_t mknod(const FsContext &context, inode_t parent, const HString &name,
-	                      FSNodeType type, uint16_t mode, uint16_t umask, uint32_t rdev,
-	                      inode_t *inode, Attributes &attr) = 0;
+
+	/// Creates a filesystem node (file, socket, FIFO, or device).
+	///
+	/// Creates a new node of the specified type in the given parent directory.
+	/// The function performs comprehensive validation including session verification,
+	/// node type checking, quota verification, and name uniqueness.
+	///
+	/// @param context The FS operation context containing user credentials and session info.
+	/// @param fsOpContext The extra operation context carrying a transaction in some
+	/// implementations.
+	/// @param parent The inode number of the parent directory.
+	/// @param name The name of the new node within the parent directory.
+	/// @param type The type of node to create (kFile, kSocket, kFifo, kBlockDev, or kCharDev).
+	/// @param mode The file mode/permissions for the new node.
+	/// @param umask The umask to apply when creating the node.
+	/// @param rdev The device number for block/character devices (ignored for other types).
+	/// @param inode Pointer to inode_t where the created node's inode number will be stored.
+	/// @param attr Reference to Attributes structure to be filled with the new node's attributes.
+	///
+	/// @return SAUNAFS_STATUS_OK on success, or one of the following error codes:
+	///         - SAUNAFS_ERROR_EINVAL if type is invalid or name verification fails
+	///         - SAUNAFS_ERROR_EEXIST if a node with the given name already exists in the parent
+	///         - SAUNAFS_ERROR_QUOTA if quota limits would be exceeded
+	///         - SAUNAFS_ERROR_EPERM if session permissions are insufficient
+	///         - Other error codes as returned by node operations
+	virtual uint8_t mknod(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                      inode_t parent, const HString &name, FSNodeType type, uint16_t mode,
+	                      uint16_t umask, uint32_t rdev, inode_t *inode, Attributes &attr) = 0;
+
 	virtual uint8_t mkdir(const FsContext &context, inode_t parent, const HString &name,
 	                      uint16_t mode, uint16_t umask, uint8_t copysgid, inode_t *inode,
 	                      Attributes &attr) = 0;
-	virtual uint8_t removeChunkFromFile(const FsContext &context, inode_t inode,
-	                                    uint64_t chunkId) = 0;
+	virtual uint8_t removeChunkFromFile(const FsContext &context,
+	                                    const FilesystemOperationContext &fsOpContext,
+	                                    inode_t inode, uint64_t chunkId) = 0;
 	virtual uint8_t repair(const FsContext &context, inode_t inode, uint8_t correct_only,
 	                       uint32_t *notchanged, uint32_t *erased, uint32_t *repaired) = 0;
 	virtual uint8_t rmdir(const FsContext &context, inode_t parent, const HString &name) = 0;
@@ -168,6 +205,22 @@ public:
 	virtual void readdirData(const FsContext &context, uint8_t flags, void *dnode,
 	                         uint8_t *dbuff) = 0;
 
+	/// Reads a paginated list of entries from a directory.
+	///
+	/// Retrieves directory entries starting from a specified index, with support for
+	/// pagination. Verifies session validity and read permissions before accessing
+	/// the directory contents. Updates the directory's access time upon successful read.
+	///
+	/// @param context Session context containing user credentials (uid, gid), session
+	///                flags, and root inode information.
+	/// @param inode The inode number of the directory to read.
+	/// @param first_entry Starting index for pagination (offset into the directory listing).
+	/// @param number_of_entries Maximum number of entries to return.
+	/// @param[out] dir_entries Output vector populated with directory entries, each
+	///                         containing index, next_index, inode, name, and attributes.
+	/// @return SAUNAFS_STATUS_OK on success, or an appropriate error code on failure
+	///         (e.g., SAUNAFS_ERROR_ENOENT if directory not found,
+	///         SAUNAFS_ERROR_EACCES if permission denied).
 	virtual uint8_t readdir(const FsContext &context, inode_t inode, uint64_t first_entry,
 	                        uint64_t number_of_entries,
 	                        std::vector<DirectoryEntry> &dir_entries) = 0;
@@ -181,11 +234,13 @@ public:
 	virtual uint8_t getExtraAttr(const FsContext &context, inode_t inode, uint8_t gmode,
 	                             ExtraAttributesArray &fileEAttrTab,
 	                             ExtraAttributesArray &dirEAttrTab) = 0;
-	virtual uint8_t listXAttrLeng(const FsContext &context, inode_t inode, uint8_t opened,
-	                              void **xanode, uint32_t *xasize) = 0;
-	virtual uint8_t getXAttr(const FsContext &context, inode_t inode, uint8_t opened,
-	                         uint8_t anleng, const uint8_t *attrname, uint32_t *avleng,
-	                         uint8_t **attrvalue) = 0;
+	virtual uint8_t listXAttrLeng(const FsContext &context,
+	                              const FilesystemOperationContext &fsOpContext, inode_t inode,
+	                              uint8_t opened, void **xanode, uint32_t *xasize) = 0;
+	virtual uint8_t getXAttr(const FsContext &context,
+	                         const FilesystemOperationContext &fsOpContext, inode_t inode,
+	                         uint8_t opened, uint8_t anleng, const uint8_t *attrname,
+	                         uint32_t *avleng, uint8_t **attrvalue) = 0;
 	virtual uint8_t setXAttr(const FsContext &context, inode_t inode, uint8_t opened,
 	                         uint8_t anleng, const uint8_t *attrname, uint32_t avleng,
 	                         const uint8_t *attrvalue, uint8_t mode) = 0;
@@ -247,8 +302,9 @@ public:
 	virtual uint8_t getDirStats(const FsContext &context, inode_t inode, inode_t *inodes,
 	                            inode_t *dirs, inode_t *files, inode_t *links, uint32_t *chunks,
 	                            uint64_t *length, uint64_t *size, uint64_t *rsize) = 0;
-	virtual uint8_t getChunkId(const FsContext &context, inode_t inode, uint32_t index,
-	                           uint64_t *chunkid) = 0;
+	virtual uint8_t getChunkId(const FsContext &context,
+	                           const FilesystemOperationContext &fsOpContext, inode_t inode,
+	                           uint32_t index, uint64_t *chunkid) = 0;
 
 	// SPECIAL - LOG EMERGENCY INCREASE VERSION FROM CHUNKS-MODULE
 	virtual void increaseChunkVersion(uint64_t chunkid) = 0;

--- a/src/master/filesystem_snapshot.cc
+++ b/src/master/filesystem_snapshot.cc
@@ -40,21 +40,26 @@ uint8_t fs_snapshot(const FsContext &context, inode_t inode_src, inode_t parent_
 	ChecksumUpdater cu(context.ts());
 	FSNode *src_node = nullptr;
 	FSNode *dst_parent_node = nullptr;
+
 	uint8_t status = gFSOperations->nodeOperations()->verifySession(
 	    context, OperationMode::kReadWrite, SessionType::kNotMeta);
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	}
+
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+
+	FilesystemOperationContext fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadOnly);
+
 	status = gFSOperations->nodeOperations()->getNodeForOperation(
-	    context, ExpectedNodeType::kDirectory, MODE_MASK_W, parent_dst, &dst_parent_node);
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	}
+	    context, fsOpContext, ExpectedNodeType::kDirectory, MODE_MASK_W, parent_dst,
+	    &dst_parent_node);
+
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+
 	status = gFSOperations->nodeOperations()->getNodeForOperation(
-	    context, ExpectedNodeType::kAny, MODE_MASK_R, inode_src, &src_node);
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	}
+	    context, fsOpContext, ExpectedNodeType::kAny, MODE_MASK_R, inode_src, &src_node);
+
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+
 	if (src_node->type == FSNodeType::kDirectory) {
 		if (src_node == dst_parent_node ||
 		    gFSOperations->nodeOperations()->isAncestor(static_cast<FSNodeDirectory *>(src_node),

--- a/src/master/kv_connector_fdb.cc
+++ b/src/master/kv_connector_fdb.cc
@@ -25,10 +25,11 @@
 #include "fdb/fdb_context.h"
 #include "fdb/fdb_kv_engine.h"
 #include "kv/itransaction.h"
+#include "kv/kv_utils.h"
 #include "master/changelog.h"
+#include "master/filesystem_metadata.h"
 #include "master/kv_common_keys.h"
 #include "master/kv_connector_interface.h"
-#include "master/filesystem_metadata.h"
 
 bool KVConnectorFDB::init() {
 	std::string clusterFile = cfg_getstring("FDB_CLUSTER_FILE", "");
@@ -161,29 +162,32 @@ void KVConnectorFDB::onEdgeChanged(FSNodeDirectory *parent, FSNode *child,
                                    hstorage::Handle *handlePtr) {
 	auto transaction = kvEngine_->createReadWriteTransaction();
 
+	// EDGE_<ParentId><Name>: <ChildId>. e.g.: EDGE_1999ChildName: 2535
+
 	// Key
-	auto key = kv::encodeKeyBE(kEdgeKeyPrefix, parent->id, child->id);
+	auto key = kv::encodeKeyBE(kEdgeKeyPrefix, parent->id);
+	kv::appendStr(key, handlePtr->get());
 
 	// Value
-	auto name = handlePtr->get();
-	kv::Value value(name.size());
-	std::memcpy(value.data(), name.data(), name.size());
+	kv::Value value(kv::toBytesBE(child->id));
 
 	transaction->set(key, value);
 
 	if (!transaction->commit()) {
-		safs::log_err("Failed to store edge: {} -> {} : {}", parent->id, child->id, name);
+		safs::log_err("Failed to store edge: {} -> {} : {}", parent->id, child->id,
+		              handlePtr->get());
 	}
 }
 
-void KVConnectorFDB::onEdgeRemoved(inode_t parentId, inode_t childId) {
+void KVConnectorFDB::onEdgeRemoved(inode_t parentId, const HString &edgeName) {
 	auto transaction = kvEngine_->createReadWriteTransaction();
 
-	auto key = kv::encodeKeyBE(kEdgeKeyPrefix, parentId, childId);
+	auto key = kv::encodeKeyBE(kEdgeKeyPrefix, parentId);
+	kv::appendStr(key, edgeName);
 
 	transaction->remove(key);
 
 	if (!transaction->commit()) {
-		safs::log_err("Failed to remove edge: {} -> {}", parentId, childId);
+		safs::log_err("Failed to remove edge: {} -> {}", parentId, edgeName);
 	}
 }

--- a/src/master/kv_connector_fdb.h
+++ b/src/master/kv_connector_fdb.h
@@ -62,7 +62,7 @@ public:
 
 	void onEdgeChanged(FSNodeDirectory *parent, FSNode *child,
 	                   hstorage::Handle *handlePtr) override;
-	void onEdgeRemoved(inode_t parentId, inode_t childId) override;
+	void onEdgeRemoved(inode_t parentId, const HString &edgeName) override;
 
 private:
 	std::shared_ptr<fdb::FDBContext> fdbContext_;  ///< FDBContext needed by the engine

--- a/src/master/kv_connector_interface.h
+++ b/src/master/kv_connector_interface.h
@@ -93,5 +93,5 @@ public:
 	                           hstorage::Handle *handlePtr) = 0;
 
 	/// Reacts on edge removals.
-	virtual void onEdgeRemoved(inode_t parentId, inode_t childId) = 0;
+	virtual void onEdgeRemoved(inode_t parentId, const HString &edgeName) = 0;
 };

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -70,6 +70,7 @@
 #include "common/type_defs.h"
 #include "common/user_groups.h"
 #include "config/cfg.h"
+#include "kv/itransaction.h"
 #include "master/changelog.h"
 #include "master/chartsdata.h"
 #include "master/chunks.h"
@@ -79,6 +80,7 @@
 #include "master/filesystem.h"
 #include "master/filesystem_node.h"
 #include "master/filesystem_node_types.h"
+#include "master/filesystem_operation_context.h"
 #include "master/filesystem_operations.h"
 #include "master/filesystem_operations_interface.h"
 #include "master/filesystem_periodic.h"
@@ -450,12 +452,14 @@ void matoclserv_chunk_status(uint64_t chunkId, uint8_t status, bool isFailedCrea
 	FsContext context =
 	    FsContext::getForMasterWithSession(eventloop_time(), eptr->sessionData->rootInode,
 	                                       eptr->sessionData->flags, uid, gid, auid, agid);
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
 
 	switch (operationType) {
 	case FUSE_WRITE:
 		if (status != SAUNAFS_STATUS_OK) {
 			if (isFailedCreateOperation) {
-				gFSOperations->removeChunkFromFile(context, inode, chunkId);
+				gFSOperations->removeChunkFromFile(context, fsOpContext, inode, chunkId);
 			}
 			serializer->serializeFuseWriteChunk(reply, messageId, status);
 			matoclserv_createpacket(eptr, std::move(reply));
@@ -482,7 +486,7 @@ void matoclserv_chunk_status(uint64_t chunkId, uint8_t status, bool isFailedCrea
 			serializer->serializeFuseTruncate(reply, operationType, messageId, status);
 		} else {
 			Attributes attr;
-			gFSOperations->doSetLength(context, inode, fileLength, attr);
+			gFSOperations->doSetLength(context, fsOpContext, inode, fileLength, attr);
 			serializer->serializeFuseTruncate(reply, operationType, messageId, attr);
 		}
 		matoclserv_createpacket(eptr, std::move(reply));
@@ -1582,19 +1586,19 @@ void matoclserv_fuse_access(matoclserventry *eptr, const uint8_t *data, uint32_t
 
 void matoclserv_sau_whole_path_lookup(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	uint32_t msgid;
-	inode_t inode;
+	inode_t parentInode;
 	inode_t found_inode;
 	std::string path;
 	uint32_t uid, gid;
 	Attributes attr;
 	uint8_t status = SAUNAFS_STATUS_OK;
 
-	cltoma::wholePathLookup::deserialize(data, length, msgid, inode, path, uid, gid);
+	cltoma::wholePathLookup::deserialize(data, length, msgid, parentInode, path, uid, gid);
 
 	status = matoclserv_check_group_cache(eptr, gid);
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = gFSOperations->wholePathLookup(context, inode, path, &found_inode, attr);
+		status = gFSOperations->wholePathLookup(context, parentInode, path, &found_inode, attr);
 	}
 
 	if (status != SAUNAFS_STATUS_OK) {
@@ -1708,7 +1712,9 @@ void matoclserv_fuse_getattr(matoclserventry *eptr, const uint8_t *data, uint32_
 	status = matoclserv_check_group_cache(eptr, gid);
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = gFSOperations->getAttr(context, inode, attr);
+		auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+		    FilesystemOperationContext::TransactionType::kReadOnly);
+		status = gFSOperations->getAttr(context, fsOpContext, inode, attr);
 	}
 
 	constexpr uint32_t kFailedAnswerSize = sizeof(msgid) + sizeof(status);
@@ -1808,7 +1814,10 @@ void matoclserv_fuse_truncate(matoclserventry *eptr, PacketHeader header, const 
 	uint32_t lockId = 0;
 	bool opened;
 	uint64_t chunkId, length;
+
 	FsContext context = matoclserv_get_context(eptr);
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
 
 	const PacketSerializer *serializer = PacketSerializer::getSerializer(header.type, eptr->version);
 	if (header.type == SAU_CLTOMA_FUSE_TRUNCATE_END) {
@@ -1824,7 +1833,8 @@ void matoclserv_fuse_truncate(matoclserventry *eptr, PacketHeader header, const 
 				status = SAUNAFS_ERROR_WRONGLOCKID;
 			} else {
 				// let's check if chunk is still locked by us
-				status = gFSOperations->getChunkId(context, inode, length / SFSCHUNKSIZE, &chunkId);
+				status = gFSOperations->getChunkId(context, fsOpContext, inode,
+				                                   length / SFSCHUNKSIZE, &chunkId);
 				if (status == SAUNAFS_STATUS_OK) {
 					status = chunk_can_unlock(chunkId, lockId);
 				}
@@ -1843,7 +1853,7 @@ void matoclserv_fuse_truncate(matoclserventry *eptr, PacketHeader header, const 
 	// Try to do the truncate
 	Attributes attr;
 	if (status == SAUNAFS_STATUS_OK) {
-		status = gFSOperations->trySetLength(context, inode, opened, length,
+		status = gFSOperations->trySetLength(context, fsOpContext, inode, opened, length,
 		                                     (type != FUSE_TRUNCATE_END), lockId, attr, &chunkId);
 	}
 
@@ -1893,7 +1903,7 @@ void matoclserv_fuse_truncate(matoclserventry *eptr, PacketHeader header, const 
 		return;
 	}
 	if (status == SAUNAFS_STATUS_OK) {
-		status = gFSOperations->doSetLength(context, inode, length, attr);
+		status = gFSOperations->doSetLength(context, fsOpContext, inode, length, attr);
 	}
 	if (status == SAUNAFS_STATUS_OK) {
 		dcm_modify(inode, eptr->sessionData->sessionId);
@@ -2042,37 +2052,56 @@ void matoclserv_fuse_symlink(matoclserventry *eptr, const uint8_t *data, uint32_
 
 void matoclserv_fuse_mknod(matoclserventry *eptr, PacketHeader header, const uint8_t *data) {
 	uint32_t messageId, uid, gid, rdev;
-	inode_t inode;
+	inode_t parentInode;
 	LegacyString<uint8_t> name;
 	uint8_t type;
-	uint16_t mode, umask;
+	uint16_t mode;
+	uint16_t umask;
 
 	if (header.type == SAU_CLTOMA_FUSE_MKNOD) {
-		cltoma::fuseMknod::deserialize(data, header.length,
-				messageId, inode, name, type, mode, umask, uid, gid, rdev);
+		cltoma::fuseMknod::deserialize(data, header.length, messageId, parentInode, name, type,
+		                               mode, umask, uid, gid, rdev);
 	} else {
 		throw IncorrectDeserializationException(
 				"Unknown packet type for matoclserv_fuse_mknod: " + std::to_string(header.type));
 	}
 
-	inode_t newinode;
+	inode_t newInode;
 	Attributes attr;
 	uint8_t status = matoclserv_check_group_cache(eptr, gid);
+
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
+		auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+		    FilesystemOperationContext::TransactionType::kReadWrite);
+
+		HString edgeName(name);
 
 		status =
-		    gFSOperations->mknod(context, inode, HString(std::move(name)),
-		                         static_cast<FSNodeType>(type), mode, umask, rdev, &newinode, attr);
+		    gFSOperations->mknod(context, fsOpContext, parentInode, edgeName,
+		                         static_cast<FSNodeType>(type), mode, umask, rdev, &newInode, attr);
+
+		if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
+			if (!fsOpContext.getReadWriteTransaction()->commit()) {
+				safs::log_err(
+				    "matoclserv_fuse_mknod: transaction failed to commit: parent inode {}, name {}",
+				    parentInode, edgeName);
+
+				status = SAUNAFS_ERROR_IO;
+			}
+		}
 	}
 
 	MessageBuffer reply;
+
 	if (status == SAUNAFS_STATUS_OK) {
-		matocl::fuseMknod::serialize(reply, messageId, newinode, attr);
+		matocl::fuseMknod::serialize(reply, messageId, newInode, attr);
 	} else {
 		matocl::fuseMknod::serialize(reply, messageId, status);
 	}
+
 	matoclserv_createpacket(eptr, std::move(reply));
+
 	if (eptr->sessionData) {
 		eptr->sessionData->currHourOperationsStats[8]++;
 	}
@@ -3214,6 +3243,8 @@ void matoclserv_fuse_getxattr(matoclserventry *eptr, const uint8_t *data, uint32
 	}
 
 	FsContext context = matoclserv_get_context(eptr, uid, gid);
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadOnly);
 
 	mode = get8bit(&data);
 
@@ -3224,7 +3255,8 @@ void matoclserv_fuse_getxattr(matoclserventry *eptr, const uint8_t *data, uint32
 	} else if (anleng == 0) {
 		void *xanode;
 		uint32_t xasize;
-		status = gFSOperations->listXAttrLeng(context, inode, opened, &xanode, &xasize);
+		status =
+		    gFSOperations->listXAttrLeng(context, fsOpContext, inode, opened, &xanode, &xasize);
 		const uint32_t kSuccessSize =
 		    sizeof(msgid) + sizeof(xasize) + ((mode == XATTR_GMODE_GET_DATA) ? xasize : 0);
 		ptr = matoclserv_createpacket(eptr, MATOCL_FUSE_GETXATTR,
@@ -3243,8 +3275,8 @@ void matoclserv_fuse_getxattr(matoclserventry *eptr, const uint8_t *data, uint32
 	} else {
 		uint8_t *attrvalue;
 		uint32_t avleng;
-		status =
-		    gFSOperations->getXAttr(context, inode, opened, anleng, attrname, &avleng, &attrvalue);
+		status = gFSOperations->getXAttr(context, fsOpContext, inode, opened, anleng, attrname,
+		                                 &avleng, &attrvalue);
 		const uint32_t kSuccessSize =
 		    sizeof(msgid) + sizeof(avleng) + ((mode == XATTR_GMODE_GET_DATA) ? avleng : 0);
 		ptr = matoclserv_createpacket(eptr, MATOCL_FUSE_GETXATTR,

--- a/src/master/metadata_backend_file.cc
+++ b/src/master/metadata_backend_file.cc
@@ -629,7 +629,14 @@ static int fs_lostnode(FSNode *p) {
 		}
 		HString name((const char *)artname, l);
 		if (!gFSOperations->nodeOperations()->isNameUsed(gMetadata->root, name)) {
-			gFSOperations->nodeOperations()->link(0, gMetadata->root, p, name);
+			auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+			    FilesystemOperationContext::TransactionType::kReadWrite);
+
+			gFSOperations->nodeOperations()->link(fsOpContext, 0, gMetadata->root, p, name);
+
+			// No need to commit the transaction here, the file backend doesn't use transactions for
+			// persistence, but we need to provide the context for API compatibility.
+
 			return 1;
 		}
 		i++;

--- a/src/master/snapshot_task.cc
+++ b/src/master/snapshot_task.cc
@@ -24,6 +24,7 @@
 #include "master/chunks.h"
 #include "master/filesystem_checksum.h"
 #include "master/filesystem_metadata.h"
+#include "master/filesystem_operation_context.h"
 #include "master/filesystem_operations_interface.h"
 #include "master/filesystem_quota.h"
 
@@ -51,8 +52,9 @@ int SnapshotTask::cloneNodeTest(FSNode *src_node, FSNode *dst_node, FSNodeDirect
 	return SAUNAFS_STATUS_OK;
 }
 
-FSNode *SnapshotTask::cloneToExistingNode(uint32_t ts, FSNode *src_node,
-		FSNodeDirectory *dst_parent, FSNode *dst_node) {
+FSNode *SnapshotTask::cloneToExistingNode(const FilesystemOperationContext &fsOpContext,
+                                          uint32_t ts, FSNode *src_node,
+                                          FSNodeDirectory *dst_parent, FSNode *dst_node) {
 	assert(src_node->type == dst_node->type);
 
 	switch (src_node->type) {
@@ -61,7 +63,7 @@ FSNode *SnapshotTask::cloneToExistingNode(uint32_t ts, FSNode *src_node,
 		                   static_cast<FSNodeDirectory *>(dst_node));
 		break;
 	case FSNodeType::kFile:
-		dst_node = cloneToExistingFileNode(ts, static_cast<FSNodeFile *>(src_node),
+		dst_node = cloneToExistingFileNode(fsOpContext, ts, static_cast<FSNodeFile *>(src_node),
 		                                   dst_parent, static_cast<FSNodeFile *>(dst_node));
 		break;
 	case FSNodeType::kSymlink:
@@ -87,8 +89,9 @@ FSNode *SnapshotTask::cloneToExistingNode(uint32_t ts, FSNode *src_node,
 	return dst_node;
 }
 
-FSNode *SnapshotTask::cloneToNewNode(uint32_t ts, FSNode *src_node, FSNodeDirectory *dst_parent) {
-	FSNode *dst_node = gFSOperations->nodeOperations()->createNode(
+FSNode *SnapshotTask::cloneToNewNode(const FilesystemOperationContext &fsOpContext, uint32_t ts,
+                                     FSNode *src_node, FSNodeDirectory *dst_parent) {
+	FSNode *dst_node = gFSOperations->nodeOperations()->createNode(fsOpContext,
 	    ts, dst_parent, current_subtask_->second, src_node->type, src_node->mode, 0, src_node->uid,
 	    src_node->gid, 0, AclInheritance::kDontInheritAcl, dst_inode_);
 
@@ -123,8 +126,10 @@ FSNode *SnapshotTask::cloneToNewNode(uint32_t ts, FSNode *src_node, FSNodeDirect
 	return dst_node;
 }
 
-FSNodeFile *SnapshotTask::cloneToExistingFileNode(uint32_t ts, FSNodeFile *src_node,
-		FSNodeDirectory *dst_parent, FSNodeFile *dst_node) {
+FSNodeFile *SnapshotTask::cloneToExistingFileNode(const FilesystemOperationContext &fsOpContext,
+                                                  uint32_t ts, FSNodeFile *src_node,
+                                                  FSNodeDirectory *dst_parent,
+                                                  FSNodeFile *dst_node) {
 	bool same = dst_node->length == src_node->length && dst_node->chunks == src_node->chunks;
 
 	if (same) {
@@ -132,8 +137,9 @@ FSNodeFile *SnapshotTask::cloneToExistingFileNode(uint32_t ts, FSNodeFile *src_n
 	}
 
 	gFSOperations->nodeOperations()->unlink(ts, dst_parent, current_subtask_->second, dst_node);
+
 	dst_node = static_cast<FSNodeFile *>(gFSOperations->nodeOperations()->createNode(
-	    ts, dst_parent, current_subtask_->second, FSNodeType::kFile, src_node->mode, 0,
+	    fsOpContext, ts, dst_parent, current_subtask_->second, FSNodeType::kFile, src_node->mode, 0,
 	    src_node->uid, src_node->gid, 0, AclInheritance::kDontInheritAcl, dst_inode_));
 
 	cloneChunkData(src_node, dst_node, dst_parent);
@@ -212,9 +218,12 @@ void SnapshotTask::emitChangelog(uint32_t ts, inode_t dst_inode) {
 }
 
 int SnapshotTask::cloneNode(uint32_t ts) {
-	FSNode *src_node = gFSOperations->nodeOperations()->idToNode(current_subtask_->first);
-	FSNodeDirectory *dst_parent =
-	    gFSOperations->nodeOperations()->idToNode<FSNodeDirectory>(dst_parent_inode_);
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+	FSNode *src_node =
+	    gFSOperations->nodeOperations()->idToNode(fsOpContext, current_subtask_->first);
+	auto *dst_parent =
+	    gFSOperations->nodeOperations()->idToNode<FSNodeDirectory>(fsOpContext, dst_parent_inode_);
 
 	if (!src_node || src_node->type == FSNodeType::kTrash ||
 	    src_node->type == FSNodeType::kReserved) {
@@ -233,9 +242,9 @@ int SnapshotTask::cloneNode(uint32_t ts) {
 	}
 
 	if (dst_node) {
-		dst_node = cloneToExistingNode(ts, src_node, dst_parent, dst_node);
+		dst_node = cloneToExistingNode(fsOpContext, ts, src_node, dst_parent, dst_node);
 	} else {
-		dst_node = cloneToNewNode(ts, src_node, dst_parent);
+		dst_node = cloneToNewNode(fsOpContext, ts, src_node, dst_parent);
 	}
 
 	assert(dst_node);
@@ -245,6 +254,16 @@ int SnapshotTask::cloneNode(uint32_t ts) {
 	if (dst_inode_ != 0 && dst_inode_ != dst_node->id) {
 		return SAUNAFS_ERROR_MISMATCH;
 	}
+
+	if (fsOpContext.hasReadWriteTransaction()) {
+		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+			safs::log_err(
+			    "SnapshotTask::cloneNode: transaction failed to commit: source inode {}, destination parent inode {}, name {}",
+			    current_subtask_->first, dst_parent_inode_, current_subtask_->second);
+			return SAUNAFS_ERROR_IO;
+		}
+	}
+
 	return SAUNAFS_STATUS_OK;
 }
 

--- a/src/master/snapshot_task.h
+++ b/src/master/snapshot_task.h
@@ -28,6 +28,8 @@
 #include "master/hstring.h"
 #include "master/task_manager.h"
 
+class FilesystemOperationContext;
+
 /*! \brief Implementation of Snapshot Task to work with Task Manager.
  *
  * This class uses new approach to executing snapshots.
@@ -86,11 +88,13 @@ public:
 protected:
 	/*! \brief Test if node can be cloned. */
 	int cloneNodeTest(FSNode *src_node, FSNode *dst_node, FSNodeDirectory *dst_parent);
-	FSNode *cloneToExistingNode(uint32_t ts, FSNode *src_node, FSNodeDirectory *dst_parent,
-				    FSNode *dst_node);
-	FSNode *cloneToNewNode(uint32_t ts, FSNode *src_node, FSNodeDirectory *dst_parent);
-	FSNodeFile *cloneToExistingFileNode(uint32_t ts, FSNodeFile *src_node,
-	                                    FSNodeDirectory *dst_parent, FSNodeFile *dst_node);
+	FSNode *cloneToExistingNode(const FilesystemOperationContext &fsOpContext, uint32_t ts,
+	                            FSNode *src_node, FSNodeDirectory *dst_parent, FSNode *dst_node);
+	FSNode *cloneToNewNode(const FilesystemOperationContext &fsOpContext, uint32_t ts,
+	                       FSNode *src_node, FSNodeDirectory *dst_parent);
+	FSNodeFile *cloneToExistingFileNode(const FilesystemOperationContext &fsOpContext, uint32_t ts,
+	                                    FSNodeFile *src_node, FSNodeDirectory *dst_parent,
+	                                    FSNodeFile *dst_node);
 	void cloneChunkData(const FSNodeFile *src_node, FSNodeFile *dst_node,
 	                    FSNodeDirectory *dst_parent);
 	void cloneDirectoryData(const FSNodeDirectory *src_node, FSNodeDirectory *dst_node);


### PR DESCRIPTION
Ensure that a single transaction (stored in FilesystemOperationContext) is consistently propagated through filesystem operations. This enables correct reuse of transactions and paves the way for implementing KV-based mknod and readdir.

Additionally update the EDGE_ entry storage format to:
  EDGE_<ParentId><Name>: <ChildId>

Example:
  EDGE_1999ChildName: 2535

Meaning:
  Directory inode 1999 contains node 2535 named ChildName.

The new format enables efficient KV lookups and supports lexicographically sorted and paginated readdir operations.

Reviewers:
- The complement in the MDS is here: https://github.com/leil-io/saunafs_mds/pull/17