### PR TITLE
feat(mount): Add string support on tweaks file LS-192

### DIFF
--- a/src/mount/g_io_limiters.h
+++ b/src/mount/g_io_limiters.h
@@ -22,9 +22,41 @@
 
 #include "common/platform.h"
 
+#include "common/args_stat_encoding.h"
 #include "common/io_limiting.h"
 #include "mount/global_io_limiter.h"
+
+// Mount iolimits configuration file path
+inline std::string gIOLimitsConfigFilePath;
+inline std::mutex gIOLimitsConfigFilePathMutex;
+inline std::atomic<bool> gIOLimitsInitialized{false};
 
 ioLimiting::MountLimiter& gMountLimiter();
 ioLimiting::LimiterProxy& gLocalIoLimiter();
 ioLimiting::LimiterProxy& gGlobalIoLimiter();
+
+inline void fsLoadMountIoLimits() {
+	std::unique_lock ioLimitsLock(gIOLimitsConfigFilePathMutex);
+	IoLimitsConfigLoader loader;
+
+	if (!gIOLimitsConfigFilePath.empty()) {
+		std::string fileContent;
+		if (!read_file_to_string(gIOLimitsConfigFilePath, fileContent)) {
+			const char *strError = std::strerror(errno);
+			safs::log_warn(
+			    "iolimits: cannot open I/O limits configuration file '{}': {}; using master-provided limits if available, otherwise no client-side limiting.",
+			    gIOLimitsConfigFilePath, strError);
+		} else {
+			try {
+				std::istringstream iss(fileContent);
+				loader.load(std::move(iss));
+			} catch (const Exception &ex) {
+				safs::log_warn(
+				    "iolimits: failed to parse I/O limits configuration file '{}': {}; using master-provided limits if available, otherwise no client-side limiting.",
+				    gIOLimitsConfigFilePath, ex.what());
+			}
+		}
+	}
+
+	gMountLimiter().loadConfiguration(loader);
+}

--- a/src/mount/mastercomm.cc
+++ b/src/mount/mastercomm.cc
@@ -57,6 +57,7 @@
 #include "common/sockets.h"
 #include "common/type_defs.h"
 #include "errors/sfserr.h"
+#include "mount/g_io_limiters.h"
 #include "mount/exports.h"
 #include "mount/notification_area_logging.h"
 #include "mount/stats.h"
@@ -1322,29 +1323,33 @@ void* fs_nop_thread(void *arg) {
 				free(inodespacket);
 			}
 
-			if (masterVersion >= kFirstVersionWithMountInfoOnMonitoring && !disconnect &&
-			    (gChangedTweaksValue || lastDisconnectedStatus)) {
+			if (gChangedTweaksValue || lastDisconnectedStatus) {
 				gChangedTweaksValue = false;
-				std::string mountInfoStr;
-				{
-					std::lock_guard lock(gMountInfoMtx);
-					gMountInfo.buildMountInfoStr();
-					mountInfoStr = gMountInfo.getMountInfoStr();
-				}
-				auto message = cltoma::updateMountInfo::build(mountInfoStr);
 
-				uint32_t messageLength = message.size();
-				std::vector<uint8_t> mountInfoPacket(messageLength);
-				std::copy(message.begin(), message.end(), mountInfoPacket.begin());
+				if (masterVersion >= kFirstVersionWithMountInfoOnMonitoring && !disconnect) {
+					std::string mountInfoStr;
+					{
+						std::lock_guard lock(gMountInfoMtx);
+						gMountInfo.buildMountInfoStr();
+						mountInfoStr = gMountInfo.getMountInfoStr();
+					}
+					auto message = cltoma::updateMountInfo::build(mountInfoStr);
 
-				if (tcptowrite(fd, mountInfoPacket.data(), messageLength,
-				               kDefaultTcpCommTimeoutMSeconds) != (int32_t)messageLength) {
-					safs::log_warn("Failed to send mount info to master");
-					disconnect = true;
-				} else {
-					stats_inc(MASTER_BYTESSENT, statsptr, messageLength);
-					stats_inc(MASTER_PACKETSSENT, statsptr);
+					uint32_t messageLength = message.size();
+					std::vector<uint8_t> mountInfoPacket(messageLength);
+					std::copy(message.begin(), message.end(), mountInfoPacket.begin());
+
+					if (tcptowrite(fd, mountInfoPacket.data(), messageLength,
+					               kDefaultTcpCommTimeoutMSeconds) != (int32_t)messageLength) {
+						safs::log_warn("Failed to send mount info to master");
+						disconnect = true;
+					} else {
+						stats_inc(MASTER_BYTESSENT, statsptr, messageLength);
+						stats_inc(MASTER_PACKETSSENT, statsptr);
+					}
 				}
+
+				if (gIOLimitsInitialized) { fsLoadMountIoLimits(); }
 			}
 		}
 

--- a/src/mount/sauna_client.cc
+++ b/src/mount/sauna_client.cc
@@ -3628,6 +3628,15 @@ void fs_init(FsInitParams &params) {
 		throw std::runtime_error("Can't initialize connection with master server");
 	}
 	symlink_cache_init(params.symlink_cache_timeout_s);
+
+	{
+		std::unique_lock ioLimitsLock(gIOLimitsConfigFilePathMutex);
+		gIOLimitsConfigFilePath = params.io_limits_config_file;
+		ioLimitsLock.unlock();
+		gTweaks.registerVariable("IOLimitsFilePath", gIOLimitsConfigFilePath,
+		                         gIOLimitsConfigFilePathMutex, "sfsiolimits");
+	}
+
 	gGlobalIoLimiter();
 	fs_init_threads(params.io_retries, params.max_wait_retry_time,
 	                params.mastercomm_sleep_time_divisor);
@@ -3635,26 +3644,8 @@ void fs_init(FsInitParams &params) {
 
 	gLocalIoLimiter();
 	try {
-		IoLimitsConfigLoader loader;
-		if (!params.io_limits_config_file.empty()) {
-			std::string fileContent;
-			if (!read_file_to_string(params.io_limits_config_file, fileContent)) {
-				const char *strError = std::strerror(errno);
-				safs::log_warn(
-				    "fs_init: cannot open I/O limits configuration file '{}': {}; using master-provided limits if available, otherwise no client-side limiting.",
-				    params.io_limits_config_file.c_str(), strError);
-			} else {
-				try {
-					std::istringstream iss(fileContent);
-					loader.load(std::move(iss));
-				} catch (const Exception &ex) {
-					safs::log_warn(
-					    "fs_init: failed to parse I/O limits configuration file '{}': {}; using master-provided limits if available, otherwise no client-side limiting.",
-					    params.io_limits_config_file.c_str(), ex.what());
-				}
-			}
-		}
-		gMountLimiter().loadConfiguration(loader);
+		fsLoadMountIoLimits();
+		gIOLimitsInitialized = true;
 	} catch (Exception &ex) {
 		safs_pretty_syslog(LOG_ERR, "Can't initialize I/O limiting: %s", ex.what());
 		masterproxy_term();

--- a/src/mount/tweaks.cc
+++ b/src/mount/tweaks.cc
@@ -62,7 +62,7 @@ std::unique_ptr<Variable> makeVariable(std::atomic<T>& v) {
 
 class StringVariableImpl : public Variable {
 public:
-	StringVariableImpl(std::string &v, std::mutex &m) : value_(&v), mutex_(&m) {}
+	StringVariableImpl(std::string &value, std::mutex &mutex) : value_(&value), mutex_(&mutex) {}
 
 	void setValue(const std::string &value) override {
 		std::lock_guard<std::mutex> lock(*mutex_);
@@ -79,8 +79,8 @@ private:
 	std::mutex *mutex_;
 };
 
-std::unique_ptr<Variable> makeVariable(std::string &v, std::mutex &m) {
-	return std::unique_ptr<Variable>(new StringVariableImpl(v, m));
+std::unique_ptr<Variable> makeVariable(std::string &value, std::mutex &mutex) {
+	return std::make_unique<StringVariableImpl>(value, mutex);
 }
 
 class Tweaks::Impl {
@@ -117,7 +117,7 @@ void Tweaks::registerVariable(const std::string &name, std::string &variable, st
                               const std::string optionName) {
 	if (!gChangedTweaksValue) { gChangedTweaksValue = true; }
 
-	impl_->variables.push_back({name, makeVariable(variable, mutex), optionName});
+	impl_->variables.emplace_back(name, makeVariable(variable, mutex), optionName);
 }
 
 void Tweaks::setValue(const std::string& name, const std::string& value) {

--- a/src/mount/tweaks.cc
+++ b/src/mount/tweaks.cc
@@ -60,6 +60,29 @@ std::unique_ptr<Variable> makeVariable(std::atomic<T>& v) {
 	return std::unique_ptr<Variable>(new VariableImpl<T>(v));
 }
 
+class StringVariableImpl : public Variable {
+public:
+	StringVariableImpl(std::string &v, std::mutex &m) : value_(&v), mutex_(&m) {}
+
+	void setValue(const std::string &value) override {
+		std::lock_guard<std::mutex> lock(*mutex_);
+		*value_ = value;
+	}
+
+	std::string getValue() const override {
+		std::lock_guard<std::mutex> lock(*mutex_);
+		return *value_;
+	}
+
+private:
+	std::string *value_;
+	std::mutex *mutex_;
+};
+
+std::unique_ptr<Variable> makeVariable(std::string &v, std::mutex &m) {
+	return std::unique_ptr<Variable>(new StringVariableImpl(v, m));
+}
+
 class Tweaks::Impl {
 public:
 	std::list<std::tuple<std::string, std::unique_ptr<Variable>, std::string>> variables;
@@ -88,6 +111,13 @@ void Tweaks::registerVariable(const std::string& name, std::atomic<uint64_t>& va
 		gChangedTweaksValue = true;
 	}
 	impl_->variables.push_back({name, makeVariable(variable), optionName});
+}
+
+void Tweaks::registerVariable(const std::string &name, std::string &variable, std::mutex &mutex,
+                              const std::string optionName) {
+	if (!gChangedTweaksValue) { gChangedTweaksValue = true; }
+
+	impl_->variables.push_back({name, makeVariable(variable, mutex), optionName});
 }
 
 void Tweaks::setValue(const std::string& name, const std::string& value) {

--- a/src/mount/tweaks.h
+++ b/src/mount/tweaks.h
@@ -42,6 +42,10 @@ public:
 	/// Adds a new uint64_t variable.
 	void registerVariable(const std::string& name, std::atomic<uint64_t>& variable, const std::string optionName = "");
 
+	/// Adds a new string variable.
+	void registerVariable(const std::string &name, std::string &variable, std::mutex &mutex,
+	                      const std::string optionName = "");
+
 	/// Changes value of all variables with the given name.
 	void setValue(const std::string& name, const std::string& value);
 

--- a/src/mount/tweaks_unittest.cc
+++ b/src/mount/tweaks_unittest.cc
@@ -70,3 +70,49 @@ TEST(TweaksTests, SetValue) {
 	t.setValue("bool", "true\n");
 	ASSERT_TRUE(b.load());
 }
+
+TEST(TweaksTests, StringVariableBasicUsage) {
+	std::string s = "initial";
+	std::mutex sMutex;
+
+	Tweaks t;
+	t.registerVariable("str", s, sMutex);
+
+	ASSERT_EQ("str\tinitial\n", t.getAllValues());
+	ASSERT_EQ("initial", t.getValue("str"));
+
+	t.setValue("str", "updated");
+
+	ASSERT_EQ("updated", t.getValue("str"));
+
+	{
+		std::lock_guard<std::mutex> lock(sMutex);
+		ASSERT_EQ("updated", s);
+	}
+}
+
+TEST(TweaksTests, MixedTypesIncludingString) {
+	std::atomic<uint32_t> u32(1);
+	std::atomic<bool> b(false);
+	std::string s = "foo";
+	std::mutex sMutex;
+
+	Tweaks t;
+	t.registerVariable("u32", u32);
+	t.registerVariable("bool", b);
+	t.registerVariable("str", s, sMutex);
+
+	t.setValue("u32", "42");
+	t.setValue("bool", "true");
+	t.setValue("str", "bar");
+
+	ASSERT_EQ(42U, u32.load());
+	ASSERT_TRUE(b.load());
+
+	{
+		std::lock_guard<std::mutex> lock(sMutex);
+		ASSERT_EQ("bar", s);
+	}
+
+	ASSERT_EQ("bar", t.getValue("str"));
+}

--- a/tests/test_suites/ShortSystemTests/test_io_limits.sh
+++ b/tests/test_suites/ShortSystemTests/test_io_limits.sh
@@ -4,6 +4,41 @@ timeout_set 2 minutes
 iolimits="$TEMP_DIR/iolimits.cfg"
 echo "limit unclassified 1024" > "$iolimits"
 
+# Create a second config file with a limit of 2 MB/s for all processes
+iolimits2="$TEMP_DIR/iolimits2.cfg"
+echo "limit unclassified 2048" > "$iolimits2"
+
+run_io_test() {
+	local limit_mbps=$1
+	local expected_time_divisor=$2
+
+	time=$(which time) # We need /usr/bin/time or something like this in this test, not a bash built-in
+	head -c 1M /dev/zero > warmup
+
+	for mb in 9 5 3 1; do
+		export FILE_SIZE="${mb}M"
+		expected_time_ms=$(( mb * 1000 / expected_time_divisor ))
+
+		export MESSAGE="Writing $mb MB at $limit_mbps MB/s"
+		echo "$MESSAGE"
+		seconds=$("$time" -f %e file-generate "file_${mb}" 2>&1)
+		actual_time_ms=$(bc <<< "scale=0; $seconds * 1000 / 1")
+		assert_near "${expected_time_ms}" "${actual_time_ms}" "$(rescale_value 250)"
+
+		export MESSAGE="Reading $mb MB at $limit_mbps MB/s"
+		echo "$MESSAGE"
+		seconds=$("$time" -f %e file-validate "file_${mb}" 2>&1)
+		actual_time_ms=$(bc <<< "scale=0; $seconds * 1000 / 1")
+		assert_near "${expected_time_ms}" "${actual_time_ms}" "$(rescale_value 250)"
+
+		export MESSAGE="Reading + writing $mb MB at $limit_mbps MB/s"
+		echo "$MESSAGE"
+		seconds=$("$time" -f %e bash -c "file-validate file_${mb} & file-generate garbage & wait" 2>&1)
+		actual_time_ms=$(bc <<< "scale=0; $seconds * 1000 / 1")
+		assert_near "$((2 * expected_time_ms))" "${actual_time_ms}" "$(rescale_value 250)"
+	done
+}
+
 CHUNKSERVERS=3 \
 	USE_RAMDISK=YES \
 	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER|sfsiolimits=$iolimits" \
@@ -19,27 +54,11 @@ rescale_value() {
 	fi
 }
 
-time=$(which time) # We need /usr/bin/time or something like this in this test, not a bash built-in
-head -c 1M /dev/zero > warmup
-for mb in 9 5 3 1; do
-	export FILE_SIZE="${mb}M"
-	expected_time_ms=$((mb * 1000))
 
-	export MESSAGE="Writing $mb MB at 1 MB/s"
-	echo "$MESSAGE"
-	seconds=$("$time" -f %e file-generate file_${mb} 2>&1)
-	actual_time_ms=$(bc <<< "scale=0; $seconds * 1000 / 1")
-	assert_near $expected_time_ms $actual_time_ms $(rescale_value 250)
+run_io_test 1 1
 
-	export MESSAGE="Reading $mb MB at 1 MB/s"
-	echo "$MESSAGE"
-	seconds=$("$time" -f %e file-validate file_${mb} 2>&1)
-	actual_time_ms=$(bc <<< "scale=0; $seconds * 1000 / 1")
-	assert_near $expected_time_ms $actual_time_ms $(rescale_value 250)
+# check that iolimits could be changed at runtime using .saunafs_tweaks file
+echo "IOLimitsFilePath=${iolimits2}" | sudo tee "${info[mount0]}/.saunafs_tweaks"
+sleep 1 # wait a bit for the change to be reloaded on client
 
-	export MESSAGE="Reading + writing $mb MB at 1 MB/s"
-	echo "$MESSAGE"
-	seconds=$("$time" -f %e bash -c "file-validate file_${mb} & file-generate garbage & wait" 2>&1)
-	actual_time_ms=$(bc <<< "scale=0; $seconds * 1000 / 1")
-	assert_near $((2 * expected_time_ms)) $actual_time_ms $(rescale_value 250)
-done
+run_io_test 2 2


### PR DESCRIPTION
This PR enables dynamic runtime updates for client-side string configuration options via the .saunafs_tweaks special inode. Previously, updating performance-related settings like I/O limits required a manual client restart, leading to unnecessary service interruptions.

With these changes, users can now update the I/O limits configuration file path on-the-fly, and the client will adopt the new performance constraints immediately.

Key Changes
- Core Infrastructure: Extended the Tweaks class to support the registration and handling of string-type variables.
- Dynamic I/O Limits: Implemented runtime support for the IOLimitsFilePath option. The client now monitors this tweak and reloads configuration files dynamically.
- Stability: Eliminates the need for stopping/starting the client to apply performance tuning, ensuring continuous availability.