### PR TITLE
docs(chunkserver): add `zonefs:` prefix documentation LS-58

### DIFF
--- a/doc/sfshdd.cfg.5.adoc
+++ b/doc/sfshdd.cfg.5.adoc
@@ -17,10 +17,31 @@ parts contain information about the chunks, while data parts are only aligned
 data. It is possible to store the metadata parts in a different directory, or
 even in a separate drive, by splitting both paths using ' | ':
 
+----
 /path/to/metadata | /path/to/data
+----
 
 This way, the metadata parts can be stored, for instance, in NVMe and the data
 parts in HDD.
+
+=== HOST-MANAGED SMR SPECIFICS
+
+With the proprietary chunkserver plugin for Host-Managed SMR drives, use the
+`zonefs:` prefix with the following syntax:
+
+----
+[*]zonefs:/path/to/metadata | /path/to/data
+----
+
+For example:
+
+----
+zonefs:/mnt/nvme1 | /mnt/host-managed-smr1
+----
+
+Note that the `/path/to/metadata` should always be on a non-SMR drive. The
+optional `*` has the same meaning as described above and marks the drive for
+removal.
 
 == REPORTING BUGS
 

--- a/src/data/sfshdd.cfg
+++ b/src/data/sfshdd.cfg
@@ -2,7 +2,7 @@
 #
 # Chunks are divided into metadata (.met) and data (.dat) parts.
 # Each line of this file must match the following syntax:
-# [*]metadata_dir[ | data_dir]
+# [*]/path/to/metadata[ | /path/to/data]
 #
 # Sample file for two HDD drives with metadata and data in the same location:
 #/mnt/hdd1
@@ -14,3 +14,15 @@
 # The next line can be used to store the metadata chunk parts in a different
 # drive than the data parts:
 #/mnt/nvme1 | /mnt/hhd1
+#
+# Host-Managed SMR specifics
+#
+# With the proprietary chunkserver plugin for Host-Managed SMR drives, use the
+# `zonefs:` prefix with the following syntax:
+# [*]zonefs:/path/to/metadata | /path/to/data
+#
+# For example:
+# zonefs:/mnt/nvme1 | /mnt/host-managed-smr1
+#
+# Note that the `/path/to/metadata` should always be on a non-SMR drive.
+# The optional '*' marks the drive for removal as described above.


### PR DESCRIPTION
Extends the documentation for the sfshdd.cfg file to include the
`zonefs:` prefix used with the chunkserver plugin for Host-Managed SMR
drives.

Signed-off-by: guillex <guillex@leil.io>