### PR TITLE
refactor(master): Allow mkdir directly on FDB LS-176

### DIFF
--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -1270,39 +1270,36 @@ uint8_t FilesystemOperationsBase::mknod(const FsContext &context,
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t FilesystemOperationsBase::mkdir(const FsContext &context, inode_t parent,
-                                        const HString &name, uint16_t mode, uint16_t umask,
-                                        uint8_t copysgid, inode_t *inode, Attributes &attr) {
-	uint32_t ts = eventloop_time();
-	ChecksumUpdater cu(ts);
-	FSNode *wd, *p;
+uint8_t FilesystemOperationsBase::mkdir(const FsContext &context,
+                                        const FilesystemOperationContext &fsOpContext,
+                                        inode_t parent, const HString &name, uint16_t mode,
+                                        uint16_t umask, uint8_t copysgid, inode_t *inode,
+                                        Attributes &attr) {
+	uint32_t timeStamp = eventloop_time();
+	ChecksumUpdater checksumUpdater(timeStamp);
+	FSNode *workNode;
+	FSNode *newNode;
 	*inode = 0;
 	attr.fill(0);
 
 	uint8_t status =
 	    nodeOperations_->verifySession(context, OperationMode::kReadWrite, SessionType::kNotMeta);
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	}
 
-	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
-	    FilesystemOperationContext::TransactionType::kReadWrite);
+	if (status != SAUNAFS_STATUS_OK) { return status; }
 
 	status = nodeOperations_->getNodeForOperation(
-	    context, fsOpContext, ExpectedNodeType::kDirectory, MODE_MASK_W, parent, &wd);
+	    context, fsOpContext, ExpectedNodeType::kDirectory, MODE_MASK_W, parent, &workNode);
 
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	}
+	if (status != SAUNAFS_STATUS_OK) { return status; }
 
 	if (nodeOperations_->nameCheck(name) < 0) { return SAUNAFS_ERROR_EINVAL; }
 
-	if (nodeOperations_->isNameUsed(static_cast<FSNodeDirectory *>(wd), name)) {
-		return SAUNAFS_ERROR_EEXIST;
-	}
+	auto *workDir = static_cast<FSNodeDirectory *>(workNode);
+
+	if (nodeOperations_->isNameUsed(workDir, name)) { return SAUNAFS_ERROR_EEXIST; }
 
 	if (fsnodes_quota_exceeded_ug(context.uid(), context.gid(), {{QuotaResource::kInodes, 1}}) ||
-	    fsnodes_quota_exceeded_dir(wd, {{QuotaResource::kInodes, 1}})) {
+	    fsnodes_quota_exceeded_dir(workNode, {{QuotaResource::kInodes, 1}})) {
 		return SAUNAFS_ERROR_QUOTA;
 	}
 
@@ -1313,20 +1310,24 @@ uint8_t FilesystemOperationsBase::mkdir(const FsContext &context, inode_t parent
 		}
 	}
 
-	static_cast<FSNodeDirectory *>(wd)->caseInsensitive =
-	    context.sesflags() & SESFLAG_CASEINSENSITIVE;
-	p = nodeOperations_->createNode(fsOpContext, ts, static_cast<FSNodeDirectory *>(wd), name,
-	                                FSNodeType::kDirectory, mode, umask, context.uid(),
-	                                context.gid(), copysgid, AclInheritance::kInheritAcl);
-	*inode = p->id;
-	nodeOperations_->fillAttr(p, wd, context.uid(), context.gid(), context.auid(), context.agid(),
-	                          context.sesflags(), attr);
-	changeLog(ts, "CREATE(%" PRIiNode ",%s,%c,%d,%" PRIu32 ",%" PRIu32 ",%" PRIu32 "):%" PRIiNode,
-	          wd->id, nodeOperations_->escapeName(name).c_str(),
-	          static_cast<char>(FSNodeType::kDirectory), p->mode & 07777, context.uid(),
-	          context.gid(), 0, p->id);
+	workDir->caseInsensitive = context.sesflags() & SESFLAG_CASEINSENSITIVE;
+
+	newNode = nodeOperations_->createNode(fsOpContext, timeStamp, workDir, name,
+	                                      FSNodeType::kDirectory, mode, umask, context.uid(),
+	                                      context.gid(), copysgid, AclInheritance::kInheritAcl);
+	*inode = newNode->id;
+	nodeOperations_->fillAttr(newNode, workDir, context.uid(), context.gid(), context.auid(),
+	                          context.agid(), context.sesflags(), attr);
+
+	changeLog(timeStamp,
+	          "CREATE(%" PRIiNode ",%s,%c,%d,%" PRIu32 ",%" PRIu32 ",%" PRIu32 "):%" PRIiNode,
+	          workDir->id, nodeOperations_->escapeName(name).c_str(),
+	          static_cast<char>(FSNodeType::kDirectory), newNode->mode & kPermissionsMask,
+	          context.uid(), context.gid(), 0, newNode->id);
+
 	incrementFSStat(FsStats::Mkdir);
 	metrics::Counter::increment(metrics::Counter::Master::FS_MKDIR);
+
 	return SAUNAFS_STATUS_OK;
 }
 #endif

--- a/src/master/filesystem_operations.h
+++ b/src/master/filesystem_operations.h
@@ -140,8 +140,11 @@ public:
 	uint8_t mknod(const FsContext &context, const FilesystemOperationContext &fsOpContext,
 	              inode_t parent, const HString &name, FSNodeType type, uint16_t mode,
 	              uint16_t umask, uint32_t rdev, inode_t *inode, Attributes &attr) override;
-	uint8_t mkdir(const FsContext &context, inode_t parent, const HString &name, uint16_t mode,
-	              uint16_t umask, uint8_t copysgid, inode_t *inode, Attributes &attr) override;
+	/// Creates a new directory in the filesystem.
+	/// @see IFilesystemOperations::mkdir
+	uint8_t mkdir(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	              inode_t parent, const HString &name, uint16_t mode, uint16_t umask,
+	              uint8_t copysgid, inode_t *inode, Attributes &attr) override;
 	uint8_t removeChunkFromFile(const FsContext &context,
 	                            const FilesystemOperationContext &fsOpContext, inode_t inode,
 	                            uint64_t chunkId) override;

--- a/src/master/filesystem_operations_interface.h
+++ b/src/master/filesystem_operations_interface.h
@@ -189,9 +189,36 @@ public:
 	                      inode_t parent, const HString &name, FSNodeType type, uint16_t mode,
 	                      uint16_t umask, uint32_t rdev, inode_t *inode, Attributes &attr) = 0;
 
-	virtual uint8_t mkdir(const FsContext &context, inode_t parent, const HString &name,
-	                      uint16_t mode, uint16_t umask, uint8_t copysgid, inode_t *inode,
-	                      Attributes &attr) = 0;
+	/// Creates a new directory in the filesystem.
+	///
+	/// Creates a new directory with the specified name in the given parent directory.
+	/// The function performs comprehensive validation including session verification,
+	/// write permission checking, quota verification, name uniqueness, and optional
+	/// disk space checks. The directory inherits ACLs from the parent if applicable.
+	///
+	/// @param context The FS operation context containing user credentials and session info.
+	/// @param fsOpContext The extra operation context carrying a transaction in some
+	/// implementations.
+	/// @param parent The inode number of the parent directory.
+	/// @param name The name of the new directory within the parent directory.
+	/// @param mode The file mode/permissions for the new directory.
+	/// @param umask The umask to apply when creating the directory.
+	/// @param copysgid If non-zero, copies the SGID bit from parent directory.
+	/// @param inode Pointer to inode_t where the created directory's inode number will be stored.
+	/// @param attr Reference to Attributes to be filled with the new directory's attributes.
+	///
+	/// @return SAUNAFS_STATUS_OK on success, or one of the following error codes:
+	///         - SAUNAFS_ERROR_EINVAL if name verification fails
+	///         - SAUNAFS_ERROR_ENOTDIR if parent is not a directory
+	///         - SAUNAFS_ERROR_EEXIST if a node with the given name already exists in the parent
+	///         - SAUNAFS_ERROR_QUOTA if quota limits would be exceeded
+	///         - SAUNAFS_ERROR_NOSPACE if disk space is depleted (when
+	///         gDisableEmptyFoldersMetadataOnFullDisk is enabled)
+	///         - SAUNAFS_ERROR_EPERM if session permissions are insufficient
+	///         - Other error codes as returned by node operations
+	virtual uint8_t mkdir(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                      inode_t parent, const HString &name, uint16_t mode, uint16_t umask,
+	                      uint8_t copysgid, inode_t *inode, Attributes &attr) = 0;
 	virtual uint8_t removeChunkFromFile(const FsContext &context,
 	                                    const FilesystemOperationContext &fsOpContext,
 	                                    inode_t inode, uint64_t chunkId) = 0;

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -2127,9 +2127,21 @@ void matoclserv_fuse_mkdir(matoclserventry *eptr, PacketHeader header, const uin
 	uint8_t status = matoclserv_check_group_cache(eptr, gid);
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
+		auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+		    FilesystemOperationContext::TransactionType::kReadWrite);
 
-		status = gFSOperations->mkdir(context, inode, HString(std::move(name)), mode, umask,
+		status = gFSOperations->mkdir(context, fsOpContext, inode, HString(name), mode, umask,
 		                              copysgid, &newinode, attr);
+
+		if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
+			if (!fsOpContext.getReadWriteTransaction()->commit()) {
+				safs::log_err(
+				    "matoclserv_fuse_mkdir: transaction failed to commit: parent inode {}, name {}",
+				    inode, name);
+
+				status = SAUNAFS_ERROR_IO;
+			}
+		}
 	}
 
 	MessageBuffer reply;


### PR DESCRIPTION
This commit refactors the mkdir related code to allow seamless implementation using the FDB backend. It also applies minor changes to improve code readability and documentation.

Reviewers: the tests is on the FDB implementation here:
https://github.com/leil-io/saunafs_mds/pull/18