### PR TITLE
ci: fix bzip2 from vcpkg and improve caching

### DIFF
--- a/.github/workflows/run-unit-and-ganesha-tests.yml
+++ b/.github/workflows/run-unit-and-ganesha-tests.yml
@@ -124,12 +124,13 @@ jobs:
                   cd $GITHUB_WORKSPACE/tests
                   sudo ./setup_machine.sh setup /mnt/hdb /mnt/hdc /mnt/hdd
 
-            - name: Cache vcpkg downloads
+            - name: Cache vcpkg
               uses: actions/cache@v4
               with:
                 path: |
+                  ~/vcpkg
                   ~/.cache/vcpkg
-                key: ${{ runner.os }}-vcpkg-${{ hashFiles('vcpkg.json') }}
+                key: ${{ runner.os }}-vcpkg-${{ hashFiles('vcpkg.json', 'utils/vcpkg_setup.sh') }}
                 restore-keys: |
                   ${{ runner.os }}-vcpkg-
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -6,6 +6,7 @@
     "boost-iostreams",
     "boost-program-options",
     "boost-system",
+    "bzip2",
     "fmt",
     "gtest",
     "prometheus-cpp",
@@ -279,10 +280,6 @@
     {
       "name": "boost-winapi",
       "version": "1.86.0"
-    },
-    {
-      "name": "bzip2",
-      "version": "1.0.8"
     },
     {
       "name": "civetweb",


### PR DESCRIPTION
Contains two main changes:
- Cache also the ~/vcpkg directory to improve build time in github actions.
- Fix bzip2 dependency from vcpkg.