### PR TITLE
chore: Add code signing to Windows compiled bins LS-205

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,7 @@ tests/test_suites/FDBTests
 src/mount/windows
 create-win-release.bat
 deliver-win-release.bat
+sign-windows-client-binary.ps1
 
 # Test setup #
 ##############

--- a/cmake/WindowsVersion.cmake
+++ b/cmake/WindowsVersion.cmake
@@ -1,0 +1,55 @@
+#  Copyright 2023 Leil Storage OÜ
+#
+#  This file is part of SaunaFS.
+#
+#  SaunaFS is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, version 3.
+#
+#  SaunaFS is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SaunaFS  If not, see <http://www.gnu.org/licenses/>.
+
+# Central helper to configure Windows version resource RCs
+# Usage:
+#   sfs_configure_version_rc(OUTPUT_PATH PRODUCT_NAME FILE_DESCRIPTION INTERNAL_NAME ORIGINAL_FILENAME)
+# The function sets default version variables and runs configure_file with the shared template.
+
+function(sfs_configure_version_rc OUTPUT_PATH PRODUCT_NAME FILE_DESCRIPTION INTERNAL_NAME ORIGINAL_FILENAME)
+  if(DEFINED WINCLIENT_APP_VERSION)
+    set(_WIN_APP_VER ${WINCLIENT_APP_VERSION})
+  else()
+    set(_WIN_APP_VER "1.0.0")
+  endif()
+
+  set(_FILE_VERSION_COMMAS "${_WIN_APP_VER},0")
+  string(REPLACE "." "," _FILE_VERSION_COMMAS "${_FILE_VERSION_COMMAS}")
+
+  set(_PRODUCT_NAME "${PRODUCT_NAME}")
+  set(_FILE_DESCRIPTION "${FILE_DESCRIPTION}")
+  set(_COMPANY_NAME "Leil Storage OÜ")
+
+  if(NOT DEFINED CURRENT_YEAR)
+    string(TIMESTAMP CURRENT_YEAR "%Y")
+  endif()
+  set(_LEGAL_COPYRIGHT "Copyright © ${_COMPANY_NAME} ${CURRENT_YEAR}")
+
+  set(_INTERNAL_NAME "${INTERNAL_NAME}")
+  set(_ORIGINAL_FILENAME "${ORIGINAL_FILENAME}")
+
+  if(DEFINED WINCLIENT_PACKAGE_VERSION)
+    set(_PRODUCT_VERSION_STR "${WINCLIENT_PACKAGE_VERSION}")
+    set(_FILE_VERSION_STR "${WINCLIENT_PACKAGE_VERSION}.0")
+  else()
+    set(_PRODUCT_VERSION_STR "${_WIN_APP_VER}")
+    set(_FILE_VERSION_STR "${_WIN_APP_VER}.0")
+  endif()
+
+  configure_file(
+    ${CMAKE_SOURCE_DIR}/src/mount/windows/resources/version.rc.in
+    ${OUTPUT_PATH} @ONLY)
+endfunction()

--- a/src/admin/CMakeLists.txt
+++ b/src/admin/CMakeLists.txt
@@ -5,10 +5,23 @@ target_link_libraries(saunafs-admin-lib sfscommon)
 create_unittest(saunafs-admin-lib ${SAUNAFS_ADMIN_TESTS})
 link_unittest(saunafs-admin-lib sfscommon)
 
+set(ADMIN_RC_FILE "")
+if(MINGW)
+  include(WindowsVersion)
+  sfs_configure_version_rc(
+    "${CMAKE_CURRENT_BINARY_DIR}/saunafs-admin-version.rc"
+    "SaunaFS Admin"
+    "Administrative Tool for SaunaFS"
+    "saunafs-admin"
+    "saunafs-admin.exe"
+  )
+  set(ADMIN_RC_FILE "${CMAKE_CURRENT_BINARY_DIR}/saunafs-admin-version.rc")
+endif()
+
 if(ICON_RESOURCE_FILE STREQUAL "")
-  add_executable(saunafs-admin ${SAUNAFS_ADMIN_MAIN})
+  add_executable(saunafs-admin ${SAUNAFS_ADMIN_MAIN} ${ADMIN_RC_FILE})
 else()
-  add_executable(saunafs-admin ${SAUNAFS_ADMIN_MAIN} ${ICON_RESOURCE_FILE})
+  add_executable(saunafs-admin ${SAUNAFS_ADMIN_MAIN} ${ICON_RESOURCE_FILE} ${ADMIN_RC_FILE})
 endif()
 target_link_libraries(saunafs-admin saunafs-admin-lib)
 install(TARGETS saunafs-admin RUNTIME DESTINATION ${BIN_SUBDIR})

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -2,10 +2,24 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 collect_sources(TOOLS)
 
+set(TOOLS_RC_FILE "")
+if(MINGW)
+  include(WindowsVersion)
+  sfs_configure_version_rc(
+    "${CMAKE_CURRENT_BINARY_DIR}/saunafs-version.rc"
+    "SaunaFS Tools"
+    "Tools for SaunaFS"
+    "saunafs"
+    "saunafs.exe"
+  )
+  set(TOOLS_RC_FILE "${CMAKE_CURRENT_BINARY_DIR}/saunafs-version.rc")
+endif()
+
 if(ICON_RESOURCE_FILE STREQUAL "")
-  add_executable(saunafs ${TOOLS_MAIN} ${TOOLS_SOURCES})
+  add_executable(saunafs ${TOOLS_MAIN} ${TOOLS_SOURCES} ${TOOLS_RC_FILE})
 else()
-  add_executable(saunafs ${TOOLS_MAIN} ${TOOLS_SOURCES} ${ICON_RESOURCE_FILE})
+  add_executable(saunafs ${TOOLS_MAIN} ${TOOLS_SOURCES} ${ICON_RESOURCE_FILE} ${TOOLS_RC_FILE})
 endif()
 target_link_libraries(saunafs sfscommon)
+
 install(TARGETS saunafs DESTINATION ${BIN_SUBDIR})


### PR DESCRIPTION
As code signing procedure is added for Windows client installer, it should also be applied to the Windows client binaries to ensure consistency and  security across all distributed executables. This change adds the signing script from Windows client specific code to the .gitingnore and changes the way the Window binaries metadata is placed during the build process to ensure this procedure is done before signing the binaries.