### PR TITLE
refactor(master): prepare unlink related ops for KV backend LS-179

### DIFF
--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -340,6 +340,12 @@ int64_t FilesystemNodeOperationsBase::getSize(FSNode *node) {
 	return stats.size;
 }
 
+uint64_t FilesystemNodeOperationsBase::getNumberOfParents(
+    const FilesystemOperationContext &fsOpContext, const FSNode *node) {
+	(void)fsOpContext;  // unused in this implementation
+	return node->parents.size();
+}
+
 FSNodeDirectory *FilesystemNodeOperationsBase::getFirstParent(FSNode *node) {
 	assert(node);
 
@@ -535,8 +541,10 @@ void FilesystemNodeOperationsBase::fillAttr(const FsContext &context, FSNode *no
 	         context.sesflags(), attr);
 }
 
-void FilesystemNodeOperationsBase::removeEdge(uint32_t timeStamp, FSNodeDirectory *parent,
+void FilesystemNodeOperationsBase::removeEdge(const FilesystemOperationContext &fsOpContext,
+                                              uint32_t timeStamp, FSNodeDirectory *parent,
                                               const HString &childName, FSNode *childNode) {
+	(void)fsOpContext;  // Unused in this implementation
 	assert(parent);
 
 	auto dirIter = parent->find(childName);
@@ -1061,6 +1069,12 @@ void FilesystemNodeOperationsBase::getDirData(inode_t rootINode, uint32_t uid, u
 	}
 }
 
+uint64_t FilesystemNodeOperationsBase::getNumberOfDirEntries(
+    const FilesystemOperationContext &fsOpContext, const FSNodeDirectory *nodeDir) {
+	(void)fsOpContext;  // unused in this implementation
+	return nodeDir->entries.size();
+}
+
 void FilesystemNodeOperationsBase::getDir(const FilesystemOperationContext &fsOpContext,
                                           inode_t rootINode, uint32_t uid, uint32_t gid,
                                           uint32_t auid, uint32_t agid, uint8_t sesflags,
@@ -1412,11 +1426,12 @@ void FilesystemNodeOperationsBase::removeNode(uint32_t timeStamp, FSNode *node) 
 	}
 }
 
-void FilesystemNodeOperationsBase::unlink(uint32_t timeStamp, FSNodeDirectory *parent,
+void FilesystemNodeOperationsBase::unlink(const FilesystemOperationContext &fsOpContext,
+                                          uint32_t timeStamp, FSNodeDirectory *parent,
                                           const HString &childName, FSNode *childNode) {
 	std::string path;
 
-	if (childNode->parents.size() == 1) {  // last link
+	if (getNumberOfParents(fsOpContext, childNode) == 1) {  // last link
 		// go to trash or reserved ? - get path
 		if (childNode->type == FSNodeType::kFile &&
 		    (childNode->trashtime > 0 ||
@@ -1425,8 +1440,9 @@ void FilesystemNodeOperationsBase::unlink(uint32_t timeStamp, FSNodeDirectory *p
 		}
 	}
 
-	removeEdge(timeStamp, parent, childName, childNode);
-	if (!childNode->parents.empty()) { return; }
+	removeEdge(fsOpContext, timeStamp, parent, childName, childNode);
+
+	if (getNumberOfParents(fsOpContext, childNode) != 0) { return; }
 
 	// last link
 	if (childNode->type == FSNodeType::kFile) {

--- a/src/master/filesystem_node.h
+++ b/src/master/filesystem_node.h
@@ -46,10 +46,16 @@ public:
 	                   AclInheritance inheritAcl, inode_t requestedINode = 0) override;
 	void link(const FilesystemOperationContext &fsOpContext, uint32_t timeStamp,
 	          FSNodeDirectory *parent, FSNode *child, const HString &name) override;
-	void unlink(uint32_t timeStamp, FSNodeDirectory *parent, const HString &childName,
-	            FSNode *childNode) override;
-	void removeEdge(uint32_t timeStamp, FSNodeDirectory *parent, const HString &childName,
-	                FSNode *childNode) override;
+
+	/// Unlink the child node from the parent directory.
+	/// @see IFilesystemNodeOperations::unlink
+	void unlink(const FilesystemOperationContext &fsOpContext, uint32_t timeStamp,
+	            FSNodeDirectory *parent, const HString &childName, FSNode *childNode) override;
+
+	/// Remove the edge between parent and child nodes.
+	/// @see IFilesystemNodeOperations::removeEdge
+	void removeEdge(const FilesystemOperationContext &fsOpContext, uint32_t timeStamp,
+	                FSNodeDirectory *parent, const HString &childName, FSNode *childNode) override;
 
 	void updateCTime(FSNode *node, uint32_t ctime) override;
 	void fillAttr(FSNode *node, FSNode *parent, uint32_t uid, uint32_t gid, uint32_t auid,
@@ -58,6 +64,7 @@ public:
 	              Attributes &attr) override;
 	void getStats(FSNode *node, StatsRecord *statsOut) override;
 	void addStats(FSNodeDirectory *parent, StatsRecord *stats) override;
+	void subStats(FSNodeDirectory *parent, StatsRecord *stats) override;
 	void addSubStats(FSNodeDirectory *parent, StatsRecord *newStats,
 	                 StatsRecord *previousStats) override;
 	void changeUidGid(FSNode *node, uint32_t uid, uint32_t gid) override;
@@ -71,11 +78,23 @@ public:
 #endif
 	int64_t getSize(FSNode *node) override;
 
+	/// Returns the number of parents of the given node.
+	/// @see IFilesystemNodeOperations::getNumberOfParents
+	/// @note fsOpContext is unused in this in-memory implementation.
+	uint64_t getNumberOfParents(const FilesystemOperationContext &fsOpContext,
+	                            const FSNode *node) override;
+
 #ifndef METARESTORE
 	uint32_t getDirSize(const FSNodeDirectory *nodeDir, uint8_t withAttr) override;
 	void getDirData(inode_t rootINode, uint32_t uid, uint32_t gid, uint32_t auid, uint32_t agid,
 	                uint8_t sesflags, FSNodeDirectory *nodeDir, uint8_t *outBuffer,
 	                uint8_t withAttr) override;
+
+	/// Returns the number of entries in the given directory.
+	/// @see IFilesystemNodeOperations::getNumberOfDirEntries
+	/// @note fsOpContext is unused in this in-memory implementation.
+	uint64_t getNumberOfDirEntries(const FilesystemOperationContext &fsOpContext,
+	                               const FSNodeDirectory *nodeDir) override;
 
 	/// Get entries of directory node \a nodeDir.
 	/// @see IFilesystemNodeOperations::getDir
@@ -199,7 +218,6 @@ protected:
 private:
 	// Private helpers
 
-	void subStats(FSNodeDirectory *parent, StatsRecord *stats);
 	void removeNode(uint32_t timeStamp, FSNode *node);
 
 	/// Number of blocks in the last chunk before EOF

--- a/src/master/filesystem_node_operations_interface.h
+++ b/src/master/filesystem_node_operations_interface.h
@@ -21,6 +21,7 @@
 #include "common/platform.h"
 
 #include <array>
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -137,9 +138,47 @@ public:
 	                           inode_t requestedINode = 0) = 0;
 	virtual void link(const FilesystemOperationContext &fsOpContext, uint32_t timeStamp,
 	                  FSNodeDirectory *parent, FSNode *child, const HString &name) = 0;
-	virtual void unlink(uint32_t timeStamp, FSNodeDirectory *parent, const HString &childName,
-	                    FSNode *childNode) = 0;
-	virtual void removeEdge(uint32_t timeStamp, FSNodeDirectory *parent, const HString &childName,
+
+	/// Removes the last link to a node from the filesystem.
+	///
+	/// This method handles the removal of the edge between parent and child, and manages
+	/// the final disposal of the node if this was its last parent link. Depending on the
+	/// node's configuration and state, the node may be:
+	/// - Moved to trash (if trashtime > 0)
+	/// - Moved to reserved (if still has open sessions)
+	/// - Permanently deleted (if neither condition applies)
+	///
+	/// @param fsOpContext The filesystem operation context (transaction).
+	/// @param timeStamp The current timestamp for the operation.
+	/// @param parent The parent directory containing the child.
+	/// @param childName The name of the child entry in the parent directory.
+	/// @param childNode The child node to unlink.
+	///
+	/// @note Directories can only have one parent, but files may have multiple hard links.
+	///       The node is only removed/trashed when the last link is removed.
+	/// @note This method calls removeEdge() to handle the edge removal and parent updates.
+	virtual void unlink(const FilesystemOperationContext &fsOpContext, uint32_t timeStamp,
+	                    FSNodeDirectory *parent, const HString &childName, FSNode *childNode) = 0;
+
+	/// Removes an edge (directory entry) between a parent directory and a child node.
+	///
+	/// This method removes the directory entry from the parent, updates the child's parent list,
+	/// adjusts parent directory statistics (size, timestamps, nlink), and handles case-insensitive
+	/// filesystems. Unlike unlink(), this method only removes the link itself and does NOT handle
+	/// the final disposal of nodes (moving to trash/reserved or deletion).
+	///
+	/// @param fsOpContext The filesystem operation context (transaction).
+	/// @param timeStamp The current timestamp for updating mtime/ctime.
+	/// @param parent The parent directory containing the edge.
+	/// @param childName The name of the child entry to remove.
+	/// @param childNode The child node being unlinked from the parent.
+	///
+	/// @note This is called by unlink() as part of the unlinking process.
+	/// @note After removing the edge, the child may still exist if it has other parent links.
+	/// @note Parent directory's nlink is decremented only if the child is a directory.
+	/// @note Emits an edgeRemovedSignal after the edge is removed.
+	virtual void removeEdge(const FilesystemOperationContext &fsOpContext, uint32_t timeStamp,
+	                        FSNodeDirectory *parent, const HString &childName,
 	                        FSNode *childNode) = 0;
 
 	virtual void updateCTime(FSNode *node, uint32_t ctime) = 0;
@@ -149,6 +188,7 @@ public:
 	                      Attributes &attr) = 0;
 	virtual void getStats(FSNode *node, StatsRecord *statsOut) = 0;
 	virtual void addStats(FSNodeDirectory *parent, StatsRecord *stats) = 0;
+	virtual void subStats(FSNodeDirectory *parent, StatsRecord *stats) = 0;
 	virtual void addSubStats(FSNodeDirectory *parent, StatsRecord *newStats,
 	                         StatsRecord *previousStats) = 0;
 	virtual void changeUidGid(FSNode *node, uint32_t uid, uint32_t gid) = 0;
@@ -162,11 +202,33 @@ public:
 #endif
 	virtual int64_t getSize(FSNode *node) = 0;
 
+	/// Returns the number of parents of the given node, possibly reusing the transaction
+	/// inside fsOpContext.
+	/// @param fsOpContext The filesystem operation context potentially containing a transaction.
+	/// @param node The node whose parents are to be counted.
+	/// @return The number of parents of the node.
+	/// @note Directories can't have multiple parents to keep a tree structure, but files can have
+	///       multiple hard links.
+	/// @note In-memory backend: could return node->parents.size() directly.
+	/// @note KV backend: should use kDirParentKeyPrefix or kParentKeyPrefix according to node type.
+	virtual uint64_t getNumberOfParents(const FilesystemOperationContext &fsOpContext,
+	                                    const FSNode *node) = 0;
+
 #ifndef METARESTORE
 	virtual uint32_t getDirSize(const FSNodeDirectory *nodeDir, uint8_t withAttr) = 0;
 	virtual void getDirData(inode_t rootINode, uint32_t uid, uint32_t gid, uint32_t auid,
 	                        uint32_t agid, uint8_t sesflags, FSNodeDirectory *nodeDir,
 	                        uint8_t *outBuffer, uint8_t withAttr) = 0;
+
+	/// Returns the number of entries in the given directory, possibly reusing the transaction
+	/// inside fsOpContext.
+	/// @param fsOpContext The filesystem operation context potentially containing a transaction.
+	/// @param nodeDir The directory node whose entries are to be counted.
+	/// @return The number of entries in the directory.
+	/// @note In-memory backend: could return entries.size() directly.
+	/// @note KV backend: gets atomic counter at kDirNodesCountPrefix_<inode> for O(1) access.
+	virtual uint64_t getNumberOfDirEntries(const FilesystemOperationContext &fsOpContext,
+	                                       const FSNodeDirectory *nodeDir) = 0;
 
 	/// @brief Get entries of directory node using pagination.
 	///

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -1373,47 +1373,51 @@ uint8_t FilesystemOperationsBase::applyCreate(uint32_t timestamp, inode_t parent
 }
 
 #ifndef METARESTORE
-uint8_t FilesystemOperationsBase::unlink(const FsContext &context, inode_t parent,
-                                         const HString &name) {
-	uint32_t ts = eventloop_time();
-	ChecksumUpdater cu(ts);
-	FSNode *wd;
+uint8_t FilesystemOperationsBase::unlink(const FsContext &context,
+                                         const FilesystemOperationContext &fsOpContext,
+                                         inode_t parent, const HString &name) {
+	uint32_t timeStamp = eventloop_time();
+	ChecksumUpdater checksumUpdater(timeStamp);
+	FSNode *workNode;
 	HString baseName = name;
 
 	uint8_t status =
 	    nodeOperations_->verifySession(context, OperationMode::kReadWrite, SessionType::kNotMeta);
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	}
 
-	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
-	    FilesystemOperationContext::TransactionType::kReadWrite);
+	if (status != SAUNAFS_STATUS_OK) { return status; }
 
 	status = nodeOperations_->getNodeForOperation(
-	    context, fsOpContext, ExpectedNodeType::kDirectory, MODE_MASK_W, parent, &wd);
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	}
+	    context, fsOpContext, ExpectedNodeType::kDirectory, MODE_MASK_W, parent, &workNode);
 
-	if (static_cast<FSNodeDirectory *>(wd)->caseInsensitive) {
-		std::string resolvedName = static_cast<FSNodeDirectory *>(wd)->getBaseStoredChildName(name);
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+
+	auto *workDir = static_cast<FSNodeDirectory *>(workNode);
+
+	if (workDir->caseInsensitive) {
+		std::string resolvedName = workDir->getBaseStoredChildName(name);
 		if (!resolvedName.empty()) { baseName = HString(resolvedName); }
 	}
 
 	if (nodeOperations_->nameCheck(baseName) < 0) { return SAUNAFS_ERROR_EINVAL; }
-	FSNode *child = nodeOperations_->lookup(static_cast<FSNodeDirectory *>(wd), baseName);
-	if (!child) {
-		return SAUNAFS_ERROR_ENOENT;
-	}
-	if (!nodeOperations_->stickyAccess(wd, child, context.uid())) { return SAUNAFS_ERROR_EPERM; }
-	if (child->type == FSNodeType::kDirectory) {
+
+	FSNode *child = nodeOperations_->lookup(workDir, baseName);
+
+	if (!child) { return SAUNAFS_ERROR_ENOENT; }
+
+	if (!nodeOperations_->stickyAccess(workDir, child, context.uid())) {
 		return SAUNAFS_ERROR_EPERM;
 	}
-	changeLog(ts, "UNLINK(%" PRIiNode ",%s):%" PRIiNode, wd->id,
+
+	if (child->type == FSNodeType::kDirectory) { return SAUNAFS_ERROR_EPERM; }
+
+	changeLog(timeStamp, "UNLINK(%" PRIiNode ",%s):%" PRIiNode, workDir->id,
 	          nodeOperations_->escapeName(baseName).c_str(), child->id);
-	nodeOperations_->unlink(ts, static_cast<FSNodeDirectory *>(wd), baseName, child);
+
+	nodeOperations_->unlink(fsOpContext, timeStamp, workDir, baseName, child);
+
 	incrementFSStat(FsStats::Unlink);
 	metrics::Counter::increment(metrics::Counter::Master::FS_UNLINK);
+
 	return SAUNAFS_STATUS_OK;
 }
 
@@ -1455,131 +1459,158 @@ uint8_t FilesystemOperationsBase::recursiveRemove(const FsContext &context, inod
 	                                         RemoveTask::generateDescription(node_name), callback);
 }
 
-uint8_t FilesystemOperationsBase::rmdir(const FsContext &context, inode_t parent,
-                                        const HString &name) {
-	uint32_t ts = eventloop_time();
-	ChecksumUpdater cu(ts);
-	FSNode *wd;
+uint8_t FilesystemOperationsBase::rmdir(const FsContext &context,
+                                        const FilesystemOperationContext &fsOpContext,
+                                        inode_t parent, const HString &name) {
+	uint32_t timeStamp = eventloop_time();
+	ChecksumUpdater checksumUpdater(timeStamp);
+	FSNode *workNode;
 
 	uint8_t status =
 	    nodeOperations_->verifySession(context, OperationMode::kReadWrite, SessionType::kNotMeta);
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	}
-
-	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
-	    FilesystemOperationContext::TransactionType::kReadWrite);
-
-	status = nodeOperations_->getNodeForOperation(
-	    context, fsOpContext, ExpectedNodeType::kDirectory, MODE_MASK_W, parent, &wd);
 
 	if (status != SAUNAFS_STATUS_OK) { return status; }
 
+	status = nodeOperations_->getNodeForOperation(
+	    context, fsOpContext, ExpectedNodeType::kDirectory, MODE_MASK_W, parent, &workNode);
+
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+
+	auto *workDir = static_cast<FSNodeDirectory *>(workNode);
+
 	if (nodeOperations_->nameCheck(name) < 0) { return SAUNAFS_ERROR_EINVAL; }
-	FSNode *child = nodeOperations_->lookup(static_cast<FSNodeDirectory *>(wd), name);
-	if (!child) {
-		return SAUNAFS_ERROR_ENOENT;
+
+	FSNode *child = nodeOperations_->lookup(workDir, name);
+
+	if (!child) { return SAUNAFS_ERROR_ENOENT; }
+
+	if (!nodeOperations_->stickyAccess(workDir, child, context.uid())) {
+		return SAUNAFS_ERROR_EPERM;
 	}
-	if (!nodeOperations_->stickyAccess(wd, child, context.uid())) { return SAUNAFS_ERROR_EPERM; }
+
 	if (child->type != FSNodeType::kDirectory) {
 		return SAUNAFS_ERROR_ENOTDIR;
 	}
-	if (!static_cast<FSNodeDirectory*>(child)->entries.empty()) {
+
+	if (nodeOperations_->getNumberOfDirEntries(fsOpContext, static_cast<FSNodeDirectory *>(child)) >
+	    0) {
 		return SAUNAFS_ERROR_ENOTEMPTY;
 	}
-	changeLog(ts, "UNLINK(%" PRIiNode ",%s):%" PRIiNode, wd->id,
+
+	changeLog(timeStamp, "UNLINK(%" PRIiNode ",%s):%" PRIiNode, workNode->id,
 	          nodeOperations_->escapeName(name).c_str(), child->id);
-	nodeOperations_->unlink(ts, static_cast<FSNodeDirectory *>(wd), name, child);
+
+	nodeOperations_->unlink(fsOpContext, timeStamp, workDir, name, child);
+
 	incrementFSStat(FsStats::Rmdir);
 	metrics::Counter::increment(metrics::Counter::Master::FS_RMDIR);
+
 	return SAUNAFS_STATUS_OK;
 }
 #endif
 
 uint8_t FilesystemOperationsBase::applyUnlink(uint32_t timestamp, inode_t parent,
                                               const HString &name, inode_t inode) {
-	FSNode *wd;
-	wd = nodeOperations_->idToNode(parent);
-	if (!wd) {
-		return SAUNAFS_ERROR_ENOENT;
-	}
-	if (wd->type != FSNodeType::kDirectory) {
-		return SAUNAFS_ERROR_ENOTDIR;
-	}
-	FSNode *child = nodeOperations_->lookup(static_cast<FSNodeDirectory *>(wd), name);
-	if (!child) {
-		return SAUNAFS_ERROR_ENOENT;
-	}
-	if (child->id != inode) {
-		return SAUNAFS_ERROR_MISMATCH;
-	}
+	FSNode *workDir = nodeOperations_->idToNode(parent);
+
+	if (!workDir) { return SAUNAFS_ERROR_ENOENT; }
+
+	if (workDir->type != FSNodeType::kDirectory) { return SAUNAFS_ERROR_ENOTDIR; }
+
+	FSNode *child = nodeOperations_->lookup(static_cast<FSNodeDirectory *>(workDir), name);
+
+	if (!child) { return SAUNAFS_ERROR_ENOENT; }
+
+	if (child->id != inode) { return SAUNAFS_ERROR_MISMATCH; }
+
 	if (child->type == FSNodeType::kDirectory &&
 	    !static_cast<FSNodeDirectory *>(child)->entries.empty()) {
 		return SAUNAFS_ERROR_ENOTEMPTY;
 	}
-	nodeOperations_->unlink(timestamp, static_cast<FSNodeDirectory *>(wd), name, child);
-	gMetadata->metadataVersion++;
-	return SAUNAFS_STATUS_OK;
-}
-
-uint8_t FilesystemOperationsBase::rename(const FsContext &context, inode_t parent_src,
-                                         const HString &name_src, inode_t parent_dst,
-                                         const HString &name_dst, inode_t *inode,
-                                         Attributes *attr) {
-	ChecksumUpdater cu(context.ts());
-	HString baseNameSrc = name_src;
-	HString baseNameDst = name_dst;
-	FSNode *swd;
-	FSNode *dwd;
-	uint8_t status =
-	    nodeOperations_->verifySession(context, OperationMode::kReadWrite, SessionType::kAny);
-	if (status != SAUNAFS_STATUS_OK) { return status; }
 
 	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
 	    FilesystemOperationContext::TransactionType::kReadWrite);
 
-	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kDirectory,
-	                                              MODE_MASK_W, parent_dst, &dwd);
+	nodeOperations_->unlink(fsOpContext, timestamp, static_cast<FSNodeDirectory *>(workDir), name,
+	                        child);
+
+	// Commit the transaction
+	if (fsOpContext.hasReadWriteTransaction() && !fsOpContext.getReadWriteTransaction()->commit()) {
+		safs::log_err("applyUnlink: failed to commit transaction");
+
+		return SAUNAFS_ERROR_IO;
+	}
+
+	gMetadata->metadataVersion++;
+
+	return SAUNAFS_STATUS_OK;
+}
+
+uint8_t FilesystemOperationsBase::rename(const FsContext &context,
+                                         const FilesystemOperationContext &fsOpContext,
+                                         inode_t parent_src, const HString &name_src,
+                                         inode_t parent_dst, const HString &name_dst,
+                                         inode_t *inode, Attributes *attr) {
+	ChecksumUpdater checksumUpdater(context.ts());
+
+	HString baseNameSrc = name_src;
+	HString baseNameDst = name_dst;
+	FSNode *sourceWorkNode;
+	FSNode *destWorkNode;
+
+	uint8_t status =
+	    nodeOperations_->verifySession(context, OperationMode::kReadWrite, SessionType::kAny);
 
 	if (status != SAUNAFS_STATUS_OK) { return status; }
 
-	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kDirectory,
-	                                              MODE_MASK_W, parent_src, &swd);
+	status = nodeOperations_->getNodeForOperation(
+	    context, fsOpContext, ExpectedNodeType::kDirectory, MODE_MASK_W, parent_dst, &destWorkNode);
 
 	if (status != SAUNAFS_STATUS_OK) { return status; }
 
-	if (static_cast<FSNodeDirectory *>(swd)->caseInsensitive) {
-		std::string resolvedName =
-		    static_cast<FSNodeDirectory *>(swd)->getBaseStoredChildName(name_src);
+	auto *destWorkDir = static_cast<FSNodeDirectory *>(destWorkNode);
+
+	status =
+	    nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kDirectory,
+	                                         MODE_MASK_W, parent_src, &sourceWorkNode);
+
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+
+	auto *sourceWorkDir = static_cast<FSNodeDirectory *>(sourceWorkNode);
+
+	if (sourceWorkDir->caseInsensitive) {
+		std::string resolvedName = sourceWorkDir->getBaseStoredChildName(name_src);
 		if (!resolvedName.empty()) { baseNameSrc = HString(resolvedName); }
 	}
 
-	if (static_cast<FSNodeDirectory *>(dwd)->caseInsensitive) {
-		std::string resolvedName =
-		    static_cast<FSNodeDirectory *>(dwd)->getBaseStoredChildName(name_dst);
+	if (destWorkDir->caseInsensitive) {
+		std::string resolvedName = destWorkDir->getBaseStoredChildName(name_dst);
 		if (!resolvedName.empty()) { baseNameDst = HString(resolvedName); }
 	}
 
 	if (nodeOperations_->nameCheck(baseNameSrc) < 0) { return SAUNAFS_ERROR_EINVAL; }
 
-	FSNode *sourceChildNode =
-	    nodeOperations_->lookup(static_cast<FSNodeDirectory *>(swd), baseNameSrc);
+	FSNode *sourceChildNode = nodeOperations_->lookup(sourceWorkDir, baseNameSrc);
 
 	if (!sourceChildNode) { return SAUNAFS_ERROR_ENOENT; }
 
 	if (context.canCheckPermissions() &&
-	    !nodeOperations_->stickyAccess(swd, sourceChildNode, context.uid())) {
+	    !nodeOperations_->stickyAccess(sourceWorkDir, sourceChildNode, context.uid())) {
 		return SAUNAFS_ERROR_EPERM;
 	}
+
 	if ((context.personality() != metadataserver::Personality::kMaster) &&
 	    (sourceChildNode->id != *inode)) {
 		return SAUNAFS_ERROR_MISMATCH;
-	} else {
-		*inode = sourceChildNode->id;
 	}
+
+	*inode = sourceChildNode->id;
+
 	std::array<int64_t, 2> quota_delta = {{1, 1}};
+
 	if (sourceChildNode->type == FSNodeType::kDirectory) {
-		if (nodeOperations_->isAncestor(static_cast<FSNodeDirectory *>(sourceChildNode), dwd)) {
+		if (nodeOperations_->isAncestor(static_cast<FSNodeDirectory *>(sourceChildNode),
+		                                destWorkDir)) {
 			return SAUNAFS_ERROR_EINVAL;
 		}
 		const StatsRecord &stats = static_cast<FSNodeDirectory *>(sourceChildNode)->stats;
@@ -1587,9 +1618,10 @@ uint8_t FilesystemOperationsBase::rename(const FsContext &context, inode_t paren
 	} else if (sourceChildNode->type == FSNodeType::kFile) {
 		quota_delta[(int)QuotaResource::kSize] = nodeOperations_->getSize(sourceChildNode);
 	}
+
 	if (nodeOperations_->nameCheck(baseNameDst) < 0) { return SAUNAFS_ERROR_EINVAL; }
-	FSNode *destinationChildNode =
-	    nodeOperations_->lookup(static_cast<FSNodeDirectory *>(dwd), baseNameDst);
+
+	FSNode *destinationChildNode = nodeOperations_->lookup(destWorkDir, baseNameDst);
 
 	if (destinationChildNode == sourceChildNode) { return SAUNAFS_STATUS_OK; }
 
@@ -1598,10 +1630,12 @@ uint8_t FilesystemOperationsBase::rename(const FsContext &context, inode_t paren
 		    !static_cast<FSNodeDirectory *>(destinationChildNode)->entries.empty()) {
 			return SAUNAFS_ERROR_ENOTEMPTY;
 		}
+
 		if (context.canCheckPermissions() &&
-		    !nodeOperations_->stickyAccess(dwd, destinationChildNode, context.uid())) {
+		    !nodeOperations_->stickyAccess(destWorkNode, destinationChildNode, context.uid())) {
 			return SAUNAFS_ERROR_EPERM;
 		}
+
 		if (destinationChildNode->type == FSNodeType::kDirectory) {
 			const StatsRecord &stats = static_cast<FSNodeDirectory *>(destinationChildNode)->stats;
 			quota_delta[(int)QuotaResource::kInodes] -= stats.inodes;
@@ -1617,35 +1651,38 @@ uint8_t FilesystemOperationsBase::rename(const FsContext &context, inode_t paren
 	}
 
 	if (fsnodes_quota_exceeded_dir(
-	        static_cast<FSNodeDirectory *>(dwd), static_cast<FSNodeDirectory *>(swd),
+	        destWorkDir, sourceWorkDir,
 	        {{QuotaResource::kInodes, quota_delta[(int)QuotaResource::kInodes]},
 	         {QuotaResource::kSize, quota_delta[(int)QuotaResource::kSize]}})) {
 		return SAUNAFS_ERROR_QUOTA;
 	}
 
 	if (destinationChildNode) {
-		nodeOperations_->unlink(context.ts(), static_cast<FSNodeDirectory *>(dwd), baseNameDst,
+		nodeOperations_->unlink(fsOpContext, context.ts(), destWorkDir, baseNameDst,
 		                        destinationChildNode);
 	}
-	nodeOperations_->removeEdge(context.ts(), static_cast<FSNodeDirectory *>(swd), baseNameSrc,
+
+	nodeOperations_->removeEdge(fsOpContext, context.ts(), sourceWorkDir, baseNameSrc,
 	                            sourceChildNode);
 
-	nodeOperations_->link(fsOpContext, context.ts(), static_cast<FSNodeDirectory *>(dwd),
-	                      sourceChildNode, baseNameDst);
+	nodeOperations_->link(fsOpContext, context.ts(), destWorkDir, sourceChildNode, baseNameDst);
 
-	if (attr) { nodeOperations_->fillAttr(context, sourceChildNode, dwd, *attr); }
+	if (attr) { nodeOperations_->fillAttr(context, sourceChildNode, destWorkNode, *attr); }
 
 	if (context.isPersonalityMaster()) {
-		changeLog(context.ts(), "MOVE(%" PRIiNode ",%s,%" PRIiNode ",%s):%" PRIiNode, swd->id,
-		          nodeOperations_->escapeName(baseNameSrc).c_str(), dwd->id,
-		          nodeOperations_->escapeName(baseNameDst).c_str(), sourceChildNode->id);
+		changeLog(context.ts(), "MOVE(%" PRIiNode ",%s,%" PRIiNode ",%s):%" PRIiNode,
+		          sourceWorkNode->id, nodeOperations_->escapeName(baseNameSrc).c_str(),
+		          destWorkNode->id, nodeOperations_->escapeName(baseNameDst).c_str(),
+		          sourceChildNode->id);
 	} else {
 		gMetadata->metadataVersion++;
 	}
+
 #ifndef METARESTORE
 	incrementFSStat(FsStats::Rename);
 	metrics::Counter::increment(metrics::Counter::Master::FS_RENAME);
 #endif
+
 	return SAUNAFS_STATUS_OK;
 }
 

--- a/src/master/filesystem_operations.h
+++ b/src/master/filesystem_operations.h
@@ -80,9 +80,13 @@ public:
 	uint8_t link(const FsContext &context, inode_t inode_src, inode_t parent_dst,
 	             const HString &name_dst, inode_t *inode, Attributes *attr) override;
 	uint8_t purge(const FsContext &context, inode_t inode) override;
-	uint8_t rename(const FsContext &context, inode_t parent_src, const HString &name_src,
-	               inode_t parent_dst, const HString &name_dst, inode_t *inode,
-	               Attributes *attr) override;
+
+	/// Renames (moves) a filesystem node from one location to another.
+	/// @see IFilesystemOperations::rename
+	uint8_t rename(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	               inode_t parent_src, const HString &name_src, inode_t parent_dst,
+	               const HString &name_dst, inode_t *inode, Attributes *attr) override;
+
 	uint8_t release(const FsContext &context, inode_t inode, uint32_t sessionid) override;
 	uint8_t setExtraAttr(const FsContext &context, inode_t inode, uint8_t eattr, uint8_t smode,
 	                     inode_t *sinodes, inode_t *ncinodes, inode_t *nsinodes) override;
@@ -150,7 +154,12 @@ public:
 	                            uint64_t chunkId) override;
 	uint8_t repair(const FsContext &context, inode_t inode, uint8_t correct_only,
 	               uint32_t *notchanged, uint32_t *erased, uint32_t *repaired) override;
-	uint8_t rmdir(const FsContext &context, inode_t parent, const HString &name) override;
+
+	/// Removes an empty directory from the filesystem.
+	/// @see IFilesystemOperations::rmdir
+	uint8_t rmdir(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	              inode_t parent, const HString &name) override;
+
 	uint8_t recursiveRemove(const FsContext &context, inode_t parent, const HString &name,
 	                        const std::function<void(int)> &callback, uint32_t job_id) override;
 	uint8_t readdirSize(const FsContext &context, inode_t inode, uint8_t flags, void **dnode,
@@ -180,7 +189,12 @@ public:
 	uint8_t setXAttr(const FsContext &context, inode_t inode, uint8_t opened, uint8_t anleng,
 	                 const uint8_t *attrname, uint32_t avleng, const uint8_t *attrvalue,
 	                 uint8_t mode) override;
-	uint8_t unlink(const FsContext &context, inode_t parent, const HString &name) override;
+
+	/// Removes (unlinks) a file or non-directory node from the filesystem.
+	/// @see IFilesystemOperations::unlink
+	uint8_t unlink(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	               inode_t parent, const HString &name) override;
+
 	uint8_t getChunksInfo(const FsContext &context, uint32_t current_ip, inode_t inode,
 	                      uint32_t chunk_index, uint32_t chunk_count,
 	                      std::vector<ChunkWithAddressAndLabel> &chunks) override;

--- a/src/master/filesystem_operations_interface.h
+++ b/src/master/filesystem_operations_interface.h
@@ -89,9 +89,49 @@ public:
 	virtual uint8_t link(const FsContext &context, inode_t inode_src, inode_t parent_dst,
 	                     const HString &name_dst, inode_t *inode, Attributes *attr) = 0;
 	virtual uint8_t purge(const FsContext &context, inode_t inode) = 0;
-	virtual uint8_t rename(const FsContext &context, inode_t parent_src, const HString &name_src,
-	                       inode_t parent_dst, const HString &name_dst, inode_t *inode,
-	                       Attributes *attr) = 0;
+
+	/// Renames (moves) a filesystem node from one location to another.
+	///
+	/// This method performs an atomic rename operation, moving a node from the source
+	/// location (parent_src/name_src) to the destination location (parent_dst/name_dst).
+	/// If a node already exists at the destination, it will be unlinked first (subject
+	/// to validation). The operation handles various constraints including:
+	/// - Directory ancestry checks (cannot move a directory into its own subtree)
+	/// - Quota validation (checks if the operation would exceed quota limits)
+	/// - Sticky bit permissions on both source and destination
+	/// - Case-insensitive filesystem support
+	/// - Non-empty directory collision prevention
+	///
+	/// The actual rename is performed by: unlinking the destination (if exists),
+	/// removing the edge from source parent, and creating a new link in the destination parent.
+	///
+	/// @param context The FS operation context containing user credentials and session info.
+	/// @param fsOpContext The extra operation context carrying a transaction in some
+	/// implementations.
+	/// @param parent_src The inode number of the source parent directory.
+	/// @param name_src The name of the node in the source directory.
+	/// @param parent_dst The inode number of the destination parent directory.
+	/// @param name_dst The desired name in the destination directory.
+	/// @param[in,out] inode Pointer to inode_t. On input (for shadow/metarestore), the expected
+	///                      inode to verify. On output, contains the inode of the renamed node.
+	/// @param[out] attr Optional pointer to Attributes to be filled with the node's attributes
+	///                  after the rename operation.
+	///
+	/// @return SAUNAFS_STATUS_OK on success, or one of the following error codes:
+	///         - SAUNAFS_ERROR_EINVAL if name validation fails or trying to move directory into
+	///           its own subtree
+	///         - SAUNAFS_ERROR_ENOENT if source node doesn't exist
+	///         - SAUNAFS_ERROR_EPERM if sticky bit access check fails
+	///         - SAUNAFS_ERROR_ENOTEMPTY if destination is a non-empty directory
+	///         - SAUNAFS_ERROR_QUOTA if quota limits would be exceeded
+	///         - SAUNAFS_ERROR_MISMATCH if inode doesn't match (shadow/metarestore only)
+	///         - Other error codes as returned by node operations
+	///
+	/// @note If source and destination are the same, returns SAUNAFS_STATUS_OK immediately.
+	/// @note Logs the operation as "MOVE" in the changelog for master personality.
+	virtual uint8_t rename(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                       inode_t parent_src, const HString &name_src, inode_t parent_dst,
+	                       const HString &name_dst, inode_t *inode, Attributes *attr) = 0;
 	virtual uint8_t release(const FsContext &context, inode_t inode, uint32_t sessionid) = 0;
 	virtual uint8_t setExtraAttr(const FsContext &context, inode_t inode, uint8_t eattr,
 	                             uint8_t smode, inode_t *sinodes, inode_t *ncinodes,
@@ -224,7 +264,40 @@ public:
 	                                    inode_t inode, uint64_t chunkId) = 0;
 	virtual uint8_t repair(const FsContext &context, inode_t inode, uint8_t correct_only,
 	                       uint32_t *notchanged, uint32_t *erased, uint32_t *repaired) = 0;
-	virtual uint8_t rmdir(const FsContext &context, inode_t parent, const HString &name) = 0;
+
+	/// Removes an empty directory from the filesystem.
+	///
+	/// This method removes a directory if and only if it is empty (contains no entries).
+	/// The operation performs comprehensive validation including:
+	/// - Session verification (must be a non-meta session)
+	/// - Write permission check on the parent directory
+	/// - Name validation
+	/// - Node existence and type verification (must be a directory)
+	/// - Sticky bit access control
+	/// - Empty directory check (must have 0 entries)
+	///
+	/// If all checks pass, the directory is unlinked from its parent, which may move it
+	/// to trash or delete it permanently depending on trashtime and session state.
+	///
+	/// @param context The FS operation context containing user credentials and session info.
+	/// @param fsOpContext The extra operation context carrying a transaction in some
+	///                    implementations.
+	/// @param parent The inode number of the parent directory containing the directory to remove.
+	/// @param name The name of the directory to remove.
+	///
+	/// @return SAUNAFS_STATUS_OK on success, or one of the following error codes:
+	///         - SAUNAFS_ERROR_EINVAL if name validation fails
+	///         - SAUNAFS_ERROR_ENOENT if the directory doesn't exist
+	///         - SAUNAFS_ERROR_ENOTDIR if the node exists but is not a directory
+	///         - SAUNAFS_ERROR_ENOTEMPTY if the directory contains entries
+	///         - SAUNAFS_ERROR_EPERM if sticky bit access check fails
+	///         - Other error codes as returned by node operations
+	///
+	/// @note Logs the operation as "UNLINK" (not "RMDIR") in the changelog.
+	/// @note The actual deletion is performed by calling unlink() on the node operations.
+	virtual uint8_t rmdir(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                      inode_t parent, const HString &name) = 0;
+
 	virtual uint8_t recursiveRemove(const FsContext &context, inode_t parent, const HString &name,
 	                                const std::function<void(int)> &callback, uint32_t job_id) = 0;
 	virtual uint8_t readdirSize(const FsContext &context, inode_t inode, uint8_t flags,
@@ -271,7 +344,41 @@ public:
 	virtual uint8_t setXAttr(const FsContext &context, inode_t inode, uint8_t opened,
 	                         uint8_t anleng, const uint8_t *attrname, uint32_t avleng,
 	                         const uint8_t *attrvalue, uint8_t mode) = 0;
-	virtual uint8_t unlink(const FsContext &context, inode_t parent, const HString &name) = 0;
+
+	/// Removes (unlinks) a file or non-directory node from the filesystem.
+	///
+	/// This method removes a non-directory node (regular file, symlink, socket, FIFO, or device)
+	/// from the specified parent directory. The operation performs comprehensive validation:
+	/// - Session verification (must be a non-meta session)
+	/// - Write permission check on the parent directory
+	/// - Case-insensitive name resolution (if applicable)
+	/// - Name validation
+	/// - Node existence verification
+	/// - Sticky bit access control
+	/// - Directory rejection (cannot unlink directories - use rmdir instead)
+	///
+	/// If all checks pass, the node is unlinked. If this is the last link to the node,
+	/// it may be moved to trash (if trashtime > 0), moved to reserved (if has open sessions),
+	/// or deleted permanently.
+	///
+	/// @param context The FS operation context containing user credentials and session info.
+	/// @param fsOpContext The extra operation context carrying a transaction in some
+	///                    implementations.
+	/// @param parent The inode number of the parent directory containing the node.
+	/// @param name The name of the node to unlink.
+	///
+	/// @return SAUNAFS_STATUS_OK on success, or one of the following error codes:
+	///         - SAUNAFS_ERROR_EINVAL if name validation fails
+	///         - SAUNAFS_ERROR_ENOENT if the node doesn't exist
+	///         - SAUNAFS_ERROR_EPERM if the node is a directory or sticky bit access check fails
+	///         - Other error codes as returned by node operations
+	///
+	/// @note This operation only works on non-directory nodes. Use rmdir() for directories.
+	/// @note Logs the operation as "UNLINK" in the changelog.
+	/// @note Supports case-insensitive filesystems with automatic name resolution.
+	virtual uint8_t unlink(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                       inode_t parent, const HString &name) = 0;
+
 	virtual uint8_t getChunksInfo(const FsContext &context, uint32_t current_ip, inode_t inode,
 	                              uint32_t chunk_index, uint32_t chunk_count,
 	                              std::vector<ChunkWithAddressAndLabel> &chunks) = 0;

--- a/src/master/kv_common_keys.h
+++ b/src/master/kv_common_keys.h
@@ -60,3 +60,8 @@ inline constexpr std::string_view kDirParentKeyPrefix = "DIR_PARENT_";
 /// Prefix for reverse index for files and links (multiple parents allowed via hard links)
 /// Format: PARENT_<ChildId><ParentId>:<Empty value>
 inline constexpr std::string_view kParentKeyPrefix = "PARENT_";
+
+/// Prefix for counting directory nodes without querying all entries
+/// Format: DIR_NODES_COUNT_<ParentId>:<DirEntriesCount>.
+/// DirEntriesCount is stored as little-endian uint64_t for atomic updates.
+inline constexpr std::string_view kDirNodesCountPrefix = "DIR_NODES_COUNT_";

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -2195,7 +2195,20 @@ void matoclserv_fuse_unlink(matoclserventry *eptr, const uint8_t *data, uint32_t
 
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = gFSOperations->unlink(context, inode, HString((char *)name, nleng));
+		auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+		    FilesystemOperationContext::TransactionType::kReadWrite);
+
+		status = gFSOperations->unlink(context, fsOpContext, inode, HString((char *)name, nleng));
+
+		if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
+			if (!fsOpContext.getReadWriteTransaction()->commit()) {
+				safs::log_err(
+				    "matoclserv_fuse_unlink: transaction failed to commit: parent inode {}, name {}",
+				    inode, std::string(reinterpret_cast<const char*>(name), nleng));
+
+				status = SAUNAFS_ERROR_IO;
+			}
+		}
 	}
 
 	ptr = matoclserv_createpacket(eptr, MATOCL_FUSE_UNLINK, sizeof(msgid) + sizeof(status));
@@ -2278,7 +2291,20 @@ void matoclserv_fuse_rmdir(matoclserventry *eptr, const uint8_t *data, uint32_t 
 
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = gFSOperations->rmdir(context, inode, HString((char *)name, nleng));
+		auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+		    FilesystemOperationContext::TransactionType::kReadWrite);
+
+		status = gFSOperations->rmdir(context, fsOpContext, inode, HString((char *)name, nleng));
+
+		if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
+			if (!fsOpContext.getReadWriteTransaction()->commit()) {
+				safs::log_err(
+				    "matoclserv_fuse_rmdir: transaction failed to commit: parent inode {}, name {}",
+				    inode, std::string(reinterpret_cast<const char*>(name), nleng));
+
+				status = SAUNAFS_ERROR_IO;
+			}
+		}
 	}
 
 	ptr = matoclserv_createpacket(eptr, MATOCL_FUSE_RMDIR, sizeof(msgid) + sizeof(status));
@@ -2348,9 +2374,22 @@ void matoclserv_fuse_rename(matoclserventry *eptr, const uint8_t *data, uint32_t
 
 	if (status == SAUNAFS_STATUS_OK) {
 		auto context = matoclserv_get_context(eptr, uid, gid);
-		status =
-		    gFSOperations->rename(context, inode_src, HString((char *)name_src, nleng_src),
-		                          inode_dst, HString((char *)name_dst, nleng_dst), &inode, &attr);
+		auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+		    FilesystemOperationContext::TransactionType::kReadWrite);
+
+		status = gFSOperations->rename(context, fsOpContext, inode_src,
+		                               HString((char *)name_src, nleng_src), inode_dst,
+		                               HString((char *)name_dst, nleng_dst), &inode, &attr);
+
+		if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
+			if (!fsOpContext.getReadWriteTransaction()->commit()) {
+				safs::log_err(
+				    "matoclserv_fuse_rename: transaction failed to commit: src inode {}, src name {}, dst inode {}, dst name {}",
+				    inode_src, std::string(reinterpret_cast<const char*>(name_src), nleng_src),
+				    inode_dst, std::string(reinterpret_cast<const char*>(name_dst), nleng_dst));
+				status = SAUNAFS_ERROR_IO;
+			}
+		}
 	}
 
 	if (status == SAUNAFS_STATUS_OK) {

--- a/src/master/recursive_remove_task.cc
+++ b/src/master/recursive_remove_task.cc
@@ -51,7 +51,15 @@ void RemoveTask::doUnlink(uint32_t ts, FSNodeDirectory *wd, FSNode *child) {
 	gFSOperations->changeLog(ts, "UNLINK(%" PRIiNode ",%s):%" PRIiNode, parent_,
 	                         gFSOperations->nodeOperations()->escapeName(*current_subtask_).c_str(),
 	                         child->id);
-	gFSOperations->nodeOperations()->unlink(ts, wd, *current_subtask_, child);
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
+	gFSOperations->nodeOperations()->unlink(fsOpContext, ts, wd, *current_subtask_, child);
+
+	// commit the transaction
+	if (fsOpContext.hasReadWriteTransaction() && !fsOpContext.getReadWriteTransaction()->commit()) {
+		throw std::runtime_error("Failed to commit unlink transaction");
+	}
 }
 
 int RemoveTask::execute(uint32_t ts, intrusive_list<Task> &work_queue) {

--- a/src/master/restore.cc
+++ b/src/master/restore.cc
@@ -360,9 +360,24 @@ int do_move(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
 	EAT(ptr,filename,lv,')');
 	EAT(ptr,filename,lv,':');
 	GETINODE(inode,ptr);
-	return gFSOperations->rename(FsContext::getForRestore(ts), parent_src,
-	                             HString((const char *)name_src), parent_dst,
-	                             HString((const char *)name_dst), &inode, nullptr);
+
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
+	int status = gFSOperations->rename(FsContext::getForRestore(ts), fsOpContext, parent_src,
+	                                   HString((const char *)name_src), parent_dst,
+	                                   HString((const char *)name_dst), &inode, nullptr);
+
+	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
+		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+			safs::log_err(
+			    "do_move: transaction failed to commit: src inode {}, src name {}, dst inode {}, dst name {}",
+			    parent_src, (char *)name_src, parent_dst, (char *)name_dst);
+			status = SAUNAFS_ERROR_IO;
+		}
+	}
+
+	return status;
 }
 
 int do_lock_op(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {

--- a/src/master/snapshot_task.cc
+++ b/src/master/snapshot_task.cc
@@ -136,7 +136,8 @@ FSNodeFile *SnapshotTask::cloneToExistingFileNode(const FilesystemOperationConte
 		return dst_node;
 	}
 
-	gFSOperations->nodeOperations()->unlink(ts, dst_parent, current_subtask_->second, dst_node);
+	gFSOperations->nodeOperations()->unlink(fsOpContext, ts, dst_parent, current_subtask_->second,
+	                                        dst_node);
 
 	dst_node = static_cast<FSNodeFile *>(gFSOperations->nodeOperations()->createNode(
 	    fsOpContext, ts, dst_parent, current_subtask_->second, FSNodeType::kFile, src_node->mode, 0,


### PR DESCRIPTION
This change updates unlink, removeEdge, and rename operations to accept and utilize FilesystemOperationContext, enabling transaction support for key-value backend implementations.

Key changes:
- Added FilesystemOperationContext parameter to unlink(), removeEdge(), and getNumberOfParents() methods in both interface and implementation
- Introduced getNumberOfDirEntries() for transaction-aware directory entry counting (supports KV backend optimization)
- Added kDirNodesCountPrefix to kv_common_keys.h for atomic directory entry counting in KV store
- Updated all callers (matoclserv, recursive_remove_task, restore, snapshot_task) to create and commit transactions
- Modified rmdir() and rename() to accept fsOpContext parameter
- Enhanced documentation with comprehensive Doxygen comments for all modified operations

The changes maintain backward compatibility with in-memory backend while establishing the foundation for FoundationDB-based metadata storage. Transaction commits are explicitly handled at call sites to ensure atomicity of operations.

For reviewers:
- 3 new basic tests were created in the MDS repo for the FDB implementation:
  - test_fdb_operation_rmdir.sh
  - test_fdb_operation_unlink.sh
  - test_fdb_operation_move.sh
- Check this branch for tests and FDB implementation: https://github.com/leil-io/saunafs_mds/commits/feat-initial-rmdir-unlink-rename/