### PR TITLE
chore(master): add KV keys for case-insensitive and stats LS-243

### DIFF
--- a/src/master/kv_common_keys.h
+++ b/src/master/kv_common_keys.h
@@ -20,6 +20,7 @@
 
 #include "common/platform.h"
 
+#include <cstdint>
 #include <string_view>
 
 inline constexpr std::string_view kMetaFormatKey = "META_FORMAT";
@@ -50,6 +51,12 @@ inline constexpr std::string_view kQuotasKeyPrefix = "QUOT_";  // Section QUOT 1
 inline constexpr std::string_view kLocksKeyPrefix = "FLCK_";   // Section FLCK 1.0
 inline constexpr std::string_view kChunkKeyPrefix = "CHNK_";   // Section CHNK 1.0
 
+// Case-insensitive directory support
+
+/// Prefix for case-insensitive edges
+/// Format: LOWER_EDGE_<ParentId><LowercaseName>:<ChildId>
+inline constexpr std::string_view kEdgeLowerKeyPrefix = "LOWER_EDGE_";
+
 // Extra indexes for edges' reverse lookups/traversals
 
 /// Prefix for reverse index for directories
@@ -63,5 +70,33 @@ inline constexpr std::string_view kParentKeyPrefix = "PARENT_";
 
 /// Prefix for counting directory nodes without querying all entries
 /// Format: DIR_NODES_COUNT_<ParentId>:<DirEntriesCount>.
-/// DirEntriesCount is stored as little-endian uint64_t for atomic updates.
+/// DirEntriesCount is stored as little-endian int64_t for atomic updates.
+/// Note: Signed integers are used in FDB storage to enable simpler atomic add/subtract
+/// operations without unsigned arithmetic underflow concerns.
 inline constexpr std::string_view kDirNodesCountPrefix = "DIR_NODES_COUNT_";
+
+// Directory stats
+
+/// Prefix for directory statistics
+/// Format: DIR_STATS_<DirId><SuffixByte>:<Value>
+/// Each directory has 8 keys with different suffix bytes for each stat field.
+/// Values are stored as little-endian int64_t for atomic updates.
+/// Note: Although StatsRecord uses unsigned types in memory, signed integers are used
+/// in FDB storage to enable simpler atomic add/subtract operations without unsigned
+/// arithmetic underflow concerns. Values are converted between types during serialization.
+/// Stats are recursively aggregated (sum of all descendants) and maintained incrementally
+/// as children are added/removed, enabling efficient queries like 'saunafs dirinfo'.
+inline constexpr std::string_view kDirStatsPrefix = "DIR_STATS_";
+
+/// Suffix bytes for directory statistics fields.
+/// Used to differentiate the 8 stats keys per directory without string comparisons.
+enum class StatsSuffix : uint8_t {
+	Inodes = 0x01,   // Total inode count
+	Dirs = 0x02,     // Subdirectory count
+	Files = 0x03,    // File count
+	Links = 0x04,    // Symlink count
+	Chunks = 0x05,   // Total chunk count
+	Length = 0x06,   // Logical size
+	Size = 0x07,     // Physical size
+	Realsize = 0x08  // Real storage size
+};


### PR DESCRIPTION
Add new key prefixes and suffix constants to support:

- Case-insensitive directory lookups via EDGE_LOWER_ prefix, enabling dual-index storage for case-insensitive directories.

- Directory statistics tracking via DIR_STATS_ prefix with 8 suffix bytes (one per StatsRecord field), enabling efficient recursive stat queries without tree traversal.

Stats will be maintained incrementally as children are added/removed, supporting commands like 'saunafs dirinfo' with efficient lookups.