### PR TITLE
refactor(master): propagate transactions for lookups

### DIFF
--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -197,7 +197,9 @@ void FilesystemNodeOperationsBase::preserveEdge(const FilesystemOperationContext
 
 // Public methods
 
-FSNode *FilesystemNodeOperationsBase::lookup(FSNodeDirectory *node, const HString &name) const {
+FSNode *FilesystemNodeOperationsBase::lookup(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, FSNodeDirectory *node,
+    const HString &name) const {
 	auto iter = node->find(name);
 	if (iter != node->end()) { return (*iter).second; }
 
@@ -256,8 +258,9 @@ std::string FilesystemNodeOperationsBase::escapeName(const std::string &name) {
 	return result;
 }
 
-bool FilesystemNodeOperationsBase::isNameUsed(FSNodeDirectory *node, const HString &name) {
-	return lookup(node, name) != nullptr;
+bool FilesystemNodeOperationsBase::isNameUsed(const FilesystemOperationContext &fsOpContext,
+                                              FSNodeDirectory *node, const HString &name) {
+	return lookup(fsOpContext, node, name) != nullptr;
 }
 
 bool FilesystemNodeOperationsBase::isAncestor(FSNodeDirectory *ancestor, FSNode *node) {
@@ -1594,7 +1597,7 @@ uint8_t FilesystemNodeOperationsBase::undel(
 		HString name(path, partLength);
 
 		if (partLength == pathLength) {  // last name
-			if (isNameUsed(currentParent, name)) { return SAUNAFS_ERROR_EEXIST; }
+			if (isNameUsed(fsOpContext, currentParent, name)) { return SAUNAFS_ERROR_EEXIST; }
 
 			// remove from trash and link to new parent
 			if (node->type == FSNodeType::kTrash) {
@@ -1617,7 +1620,7 @@ uint8_t FilesystemNodeOperationsBase::undel(
 
 		// Directory handling (only runs for intermediate segments)
 		if (!isNew) {
-			currentNode = lookup(currentParent, name);
+			currentNode = lookup(fsOpContext, currentParent, name);
 			if (currentNode == nullptr) {
 				isNew = true;
 			} else {

--- a/src/master/filesystem_node.h
+++ b/src/master/filesystem_node.h
@@ -38,7 +38,10 @@ public:
 	/// Returns the root node of the filesystem.
 	FSNodeDirectory *getRootNode(const FilesystemOperationContext &fsOpContext) override;
 
-	FSNode *lookup(FSNodeDirectory *node, const HString &name) const override;
+	/// Looks up a child node by name within a directory.
+	/// @see IFilesystemNodeOperations::lookup
+	FSNode *lookup([[maybe_unused]] const FilesystemOperationContext &fsOpContext,
+	               FSNodeDirectory *node, const HString &name) const override;
 
 	FSNode *createNode(const FilesystemOperationContext &fsOpContext, uint32_t timeStamp,
 	                   FSNodeDirectory *parent, const HString &name, FSNodeType type, uint16_t mode,
@@ -103,7 +106,10 @@ public:
 	            FSNodeDirectory *nodeDir, uint64_t firstEntry, uint64_t numberOfEntries,
 	            std::vector<DirectoryEntry> &dirEntriesOut) override;
 #endif
-	bool isNameUsed(FSNodeDirectory *node, const HString &name) override;
+	/// Checks if a name is already used in the given directory.
+	/// @see IFilesystemNodeOperations::isNameUsed
+	bool isNameUsed(const FilesystemOperationContext &fsOpContext, FSNodeDirectory *node,
+	                const HString &name) override;
 
 	// Trash/Reserved operations
 	int purge(uint32_t timeStamp, FSNode *node) override;

--- a/src/master/filesystem_node_operations_interface.h
+++ b/src/master/filesystem_node_operations_interface.h
@@ -129,7 +129,16 @@ public:
 
 	// Main node operations
 
-	virtual FSNode *lookup(FSNodeDirectory *node, const HString &name) const = 0;
+	/// Looks up a child node by name within a directory.
+	///
+	/// Searches for a directory entry with the specified name in the given directory node.
+	///
+	/// @param fsOpContext The filesystem operation context (transaction).
+	/// @param node The directory node in which to search for the child.
+	/// @param name The name of the child node to look up.
+	/// @return Pointer to the child node if found, nullptr otherwise.
+	virtual FSNode *lookup([[maybe_unused]] const FilesystemOperationContext &fsOpContext,
+	                       FSNodeDirectory *node, const HString &name) const = 0;
 
 	virtual FSNode *createNode(const FilesystemOperationContext &fsOpContext, uint32_t timeStamp,
 	                           FSNodeDirectory *parent, const HString &name, FSNodeType type,
@@ -263,7 +272,18 @@ public:
 	                    FSNodeDirectory *nodeDir, uint64_t firstEntry, uint64_t numberOfEntries,
 	                    std::vector<DirectoryEntry> &dirEntriesOut) = 0;
 #endif
-	virtual bool isNameUsed(FSNodeDirectory *node, const HString &name) = 0;
+	/// Checks if a name is already used in the given directory.
+	///
+	/// Determines whether a directory entry with the specified name exists in the given
+	/// directory node. This is a convenience method that internally calls lookup() and
+	/// checks if the result is not null.
+	///
+	/// @param fsOpContext The filesystem operation context (transaction).
+	/// @param node The directory node to search in.
+	/// @param name The name to check for existence.
+	/// @return true if the name exists in the directory, false otherwise.
+	virtual bool isNameUsed(const FilesystemOperationContext &fsOpContext, FSNodeDirectory *node,
+	                        const HString &name) = 0;
 
 	// Trash/Reserved operations
 

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -343,6 +343,10 @@ uint8_t FilesystemOperationsBase::getRootInode(inode_t *rootinode, const uint8_t
 
 	name = path;
 	parent = gMetadata->root;
+
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadOnly);
+
 	for (;;) {
 		while (*name == '/') {
 			name++;
@@ -357,7 +361,8 @@ uint8_t FilesystemOperationsBase::getRootInode(inode_t *rootinode, const uint8_t
 		}
 		hname = HString((const char*)name, nleng);
 		if (nodeOperations_->nameCheck(hname) < 0) { return SAUNAFS_ERROR_EINVAL; }
-		FSNode *child = nodeOperations_->lookup(parent, hname);
+
+		FSNode *child = nodeOperations_->lookup(fsOpContext, parent, hname);
 		if (!child) {
 			return SAUNAFS_ERROR_ENOENT;
 		}
@@ -505,7 +510,8 @@ uint8_t FilesystemOperationsBase::lookup(const FsContext &context,
 
 	if (nodeOperations_->nameCheck(name) < 0) { return SAUNAFS_ERROR_EINVAL; }
 
-	FSNode *child = nodeOperations_->lookup(static_cast<FSNodeDirectory *>(workDir), name);
+	FSNode *child =
+	    nodeOperations_->lookup(fsOpContext, static_cast<FSNodeDirectory *>(workDir), name);
 
 	if (!child) {
 		return SAUNAFS_ERROR_ENOENT;
@@ -730,6 +736,7 @@ uint8_t FilesystemOperationsBase::trySetLength(const FsContext &context,
 #endif
 
 uint8_t FilesystemOperationsBase::getCanonicalPath(const FsContext &context,
+                                                   const FilesystemOperationContext &fsOpContext,
                                                    const std::string &inputPath,
                                                    std::string &canonicalPath) {
 	bool caseInsensitiveFS = context.sesflags() & SESFLAG_CASEINSENSITIVE;
@@ -762,7 +769,7 @@ uint8_t FilesystemOperationsBase::getCanonicalPath(const FsContext &context,
 				baseName = name;
 			}
 
-			FSNode *child = nodeOperations_->lookup(dir, HString(baseName));
+			FSNode *child = nodeOperations_->lookup(fsOpContext, dir, HString(baseName));
 			if (!child) { return SAUNAFS_ERROR_ENOENT; }
 
 			if (!resultPath.empty()) { resultPath += "/"; }
@@ -1136,7 +1143,7 @@ uint8_t FilesystemOperationsBase::symlink(const FsContext &context, inode_t pare
 
 	// If filesystem is case-insensitive, get the canonical path for the symlink target
 	if (static_cast<FSNodeDirectory *>(wd)->caseInsensitive) {
-		status = getCanonicalPath(context, path, basePath);
+		status = getCanonicalPath(context, fsOpContext, path, basePath);
 		if (status != SAUNAFS_STATUS_OK) {
 			// Unix-style symlinks allow dangling links, so if the path cannot be resolved,
 			// we just use the original path as-is
@@ -1155,7 +1162,7 @@ uint8_t FilesystemOperationsBase::symlink(const FsContext &context, inode_t pare
 		}
 	}
 	if (nodeOperations_->nameCheck(name) < 0) { return SAUNAFS_ERROR_EINVAL; }
-	if (nodeOperations_->isNameUsed(static_cast<FSNodeDirectory *>(wd), name)) {
+	if (nodeOperations_->isNameUsed(fsOpContext, static_cast<FSNodeDirectory *>(wd), name)) {
 		return SAUNAFS_ERROR_EEXIST;
 	}
 	if (context.isPersonalityMaster() &&
@@ -1232,7 +1239,8 @@ uint8_t FilesystemOperationsBase::mknod(const FsContext &context,
 	if (nodeOperations_->nameCheck(name) < 0) { return SAUNAFS_ERROR_EINVAL; }
 
 	// Check if name is already used in the parent directory (lookup)
-	if (nodeOperations_->isNameUsed(static_cast<FSNodeDirectory *>(parentNode), name)) {
+	if (nodeOperations_->isNameUsed(fsOpContext, static_cast<FSNodeDirectory *>(parentNode),
+	                                name)) {
 		return SAUNAFS_ERROR_EEXIST;
 	}
 
@@ -1296,7 +1304,7 @@ uint8_t FilesystemOperationsBase::mkdir(const FsContext &context,
 
 	auto *workDir = static_cast<FSNodeDirectory *>(workNode);
 
-	if (nodeOperations_->isNameUsed(workDir, name)) { return SAUNAFS_ERROR_EEXIST; }
+	if (nodeOperations_->isNameUsed(fsOpContext, workDir, name)) { return SAUNAFS_ERROR_EEXIST; }
 
 	if (fsnodes_quota_exceeded_ug(context.uid(), context.gid(), {{QuotaResource::kInodes, 1}}) ||
 	    fsnodes_quota_exceeded_dir(workNode, {{QuotaResource::kInodes, 1}})) {
@@ -1349,12 +1357,14 @@ uint8_t FilesystemOperationsBase::applyCreate(uint32_t timestamp, inode_t parent
 	if (wd->type != FSNodeType::kDirectory) {
 		return SAUNAFS_ERROR_ENOTDIR;
 	}
-	if (nodeOperations_->isNameUsed(static_cast<FSNodeDirectory *>(wd), name)) {
+
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+		FilesystemOperationContext::TransactionType::kReadWrite);
+
+	if (nodeOperations_->isNameUsed(fsOpContext, static_cast<FSNodeDirectory *>(wd), name)) {
 		return SAUNAFS_ERROR_EEXIST;
 	}
 
-	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
-	    FilesystemOperationContext::TransactionType::kReadWrite);
 
 	// we pass requested inode number here
 	p = nodeOperations_->createNode(fsOpContext, timestamp, static_cast<FSNodeDirectory *>(wd),
@@ -1400,7 +1410,7 @@ uint8_t FilesystemOperationsBase::unlink(const FsContext &context,
 
 	if (nodeOperations_->nameCheck(baseName) < 0) { return SAUNAFS_ERROR_EINVAL; }
 
-	FSNode *child = nodeOperations_->lookup(workDir, baseName);
+	FSNode *child = nodeOperations_->lookup(fsOpContext, workDir, baseName);
 
 	if (!child) { return SAUNAFS_ERROR_ENOENT; }
 
@@ -1444,7 +1454,8 @@ uint8_t FilesystemOperationsBase::recursiveRemove(const FsContext &context, inod
 		return status;
 	}
 
-	FSNode *child = nodeOperations_->lookup(static_cast<FSNodeDirectory *>(wd_tmp), name);
+	FSNode *child =
+	    nodeOperations_->lookup(fsOpContext, static_cast<FSNodeDirectory *>(wd_tmp), name);
 	if (!child) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
@@ -1480,7 +1491,7 @@ uint8_t FilesystemOperationsBase::rmdir(const FsContext &context,
 
 	if (nodeOperations_->nameCheck(name) < 0) { return SAUNAFS_ERROR_EINVAL; }
 
-	FSNode *child = nodeOperations_->lookup(workDir, name);
+	FSNode *child = nodeOperations_->lookup(fsOpContext, workDir, name);
 
 	if (!child) { return SAUNAFS_ERROR_ENOENT; }
 
@@ -1517,7 +1528,11 @@ uint8_t FilesystemOperationsBase::applyUnlink(uint32_t timestamp, inode_t parent
 
 	if (workDir->type != FSNodeType::kDirectory) { return SAUNAFS_ERROR_ENOTDIR; }
 
-	FSNode *child = nodeOperations_->lookup(static_cast<FSNodeDirectory *>(workDir), name);
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
+	FSNode *child =
+	    nodeOperations_->lookup(fsOpContext, static_cast<FSNodeDirectory *>(workDir), name);
 
 	if (!child) { return SAUNAFS_ERROR_ENOENT; }
 
@@ -1527,9 +1542,6 @@ uint8_t FilesystemOperationsBase::applyUnlink(uint32_t timestamp, inode_t parent
 	    !static_cast<FSNodeDirectory *>(child)->entries.empty()) {
 		return SAUNAFS_ERROR_ENOTEMPTY;
 	}
-
-	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
-	    FilesystemOperationContext::TransactionType::kReadWrite);
 
 	nodeOperations_->unlink(fsOpContext, timestamp, static_cast<FSNodeDirectory *>(workDir), name,
 	                        child);
@@ -1590,7 +1602,7 @@ uint8_t FilesystemOperationsBase::rename(const FsContext &context,
 
 	if (nodeOperations_->nameCheck(baseNameSrc) < 0) { return SAUNAFS_ERROR_EINVAL; }
 
-	FSNode *sourceChildNode = nodeOperations_->lookup(sourceWorkDir, baseNameSrc);
+	FSNode *sourceChildNode = nodeOperations_->lookup(fsOpContext, sourceWorkDir, baseNameSrc);
 
 	if (!sourceChildNode) { return SAUNAFS_ERROR_ENOENT; }
 
@@ -1621,7 +1633,7 @@ uint8_t FilesystemOperationsBase::rename(const FsContext &context,
 
 	if (nodeOperations_->nameCheck(baseNameDst) < 0) { return SAUNAFS_ERROR_EINVAL; }
 
-	FSNode *destinationChildNode = nodeOperations_->lookup(destWorkDir, baseNameDst);
+	FSNode *destinationChildNode = nodeOperations_->lookup(fsOpContext, destWorkDir, baseNameDst);
 
 	if (destinationChildNode == sourceChildNode) { return SAUNAFS_STATUS_OK; }
 
@@ -1717,7 +1729,7 @@ uint8_t FilesystemOperationsBase::link(const FsContext &context, inode_t inode_s
 
 	if (nodeOperations_->nameCheck(name_dst) < 0) { return SAUNAFS_ERROR_EINVAL; }
 
-	if (nodeOperations_->isNameUsed(static_cast<FSNodeDirectory *>(dwd), name_dst)) {
+	if (nodeOperations_->isNameUsed(fsOpContext, static_cast<FSNodeDirectory *>(dwd), name_dst)) {
 		return SAUNAFS_ERROR_EEXIST;
 	}
 

--- a/src/master/filesystem_operations.h
+++ b/src/master/filesystem_operations.h
@@ -108,8 +108,9 @@ public:
 	                   /* inout */ uint32_t *lockid, uint64_t *chunkid, uint8_t *opflag,
 	                   uint64_t *length, uint32_t min_server_version = 0) override;
 	uint8_t setNextChunkId(const FsContext &context, uint64_t nextChunkId) override;
-	uint8_t getCanonicalPath(const FsContext &context, const std::string &inputPath,
-	                         std::string &canonicalPath) override;
+	uint8_t getCanonicalPath(const FsContext &context,
+	                         const FilesystemOperationContext &fsOpContext,
+	                         const std::string &inputPath, std::string &canonicalPath) override;
 
 #ifndef METARESTORE
 	/// Returns a map with all defined goals.

--- a/src/master/filesystem_operations_interface.h
+++ b/src/master/filesystem_operations_interface.h
@@ -157,13 +157,15 @@ public:
 	                           /* inout */ uint32_t *lockid, uint64_t *chunkid, uint8_t *opflag,
 	                           uint64_t *length, uint32_t min_server_version = 0) = 0;
 	virtual uint8_t setNextChunkId(const FsContext &context, uint64_t nextChunkId) = 0;
+
 	/// Given a string representing a path, resolves and returns the canonical
 	/// name as actually stored in the filesystem, matching the true case and
 	/// spelling of each component. This is useful for implementing features
 	/// such as case-insensitive filesystem operations, where the input path
 	/// may differ in case or form from the stored names.
-	virtual uint8_t getCanonicalPath(const FsContext &context, const std::string &inputPath,
-	                                 std::string &canonicalPath) = 0;
+	virtual uint8_t getCanonicalPath(const FsContext &context,
+	                                 const FilesystemOperationContext &fsOpContext,
+	                                 const std::string &inputPath, std::string &canonicalPath) = 0;
 
 #ifndef METARESTORE
 	/// Returns a map with all defined goals.

--- a/src/master/metadata_backend_file.cc
+++ b/src/master/metadata_backend_file.cc
@@ -620,6 +620,10 @@ static int fs_lostnode(FSNode *p) {
 	uint8_t artname[40];
 	uint32_t i, l;
 	i = 0;
+
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
 	do {
 		if (i == 0) {
 			l = snprintf((char *)artname, 40, "lost_node_%" PRIiNode, p->id);
@@ -627,10 +631,10 @@ static int fs_lostnode(FSNode *p) {
 			l = snprintf((char *)artname, 40, "lost_node_%" PRIiNode ".%" PRIu32,
 			             p->id, i);
 		}
+
 		HString name((const char *)artname, l);
-		if (!gFSOperations->nodeOperations()->isNameUsed(gMetadata->root, name)) {
-			auto fsOpContext = gFSOperations->createFilesystemOperationContext(
-			    FilesystemOperationContext::TransactionType::kReadWrite);
+
+		if (!gFSOperations->nodeOperations()->isNameUsed(fsOpContext, gMetadata->root, name)) {
 
 			gFSOperations->nodeOperations()->link(fsOpContext, 0, gMetadata->root, p, name);
 

--- a/src/master/recursive_remove_task.cc
+++ b/src/master/recursive_remove_task.cc
@@ -28,8 +28,9 @@ bool RemoveTask::isFinished() const {
 	return current_subtask_ == subtask_.end();
 }
 
-int RemoveTask::retrieveNodes(FSNodeDirectory *&wd, FSNode *&child) {
-	FSNode *wd_tmp = gFSOperations->nodeOperations()->idToNode(parent_);
+int RemoveTask::retrieveNodes(const FilesystemOperationContext &fsOpContext, FSNodeDirectory *&wd,
+                              FSNode *&child) {
+	FSNode *wd_tmp = gFSOperations->nodeOperations()->idToNode(fsOpContext, parent_);
 	if (!wd_tmp) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
@@ -37,7 +38,7 @@ int RemoveTask::retrieveNodes(FSNodeDirectory *&wd, FSNode *&child) {
 		return SAUNAFS_ERROR_EACCES;
 	}
 	wd = static_cast<FSNodeDirectory*>(wd_tmp);
-	child = gFSOperations->nodeOperations()->lookup(wd, *current_subtask_);
+	child = gFSOperations->nodeOperations()->lookup(fsOpContext, wd, *current_subtask_);
 	if (!child) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
@@ -47,48 +48,55 @@ int RemoveTask::retrieveNodes(FSNodeDirectory *&wd, FSNode *&child) {
 	return SAUNAFS_STATUS_OK;
 }
 
-void RemoveTask::doUnlink(uint32_t ts, FSNodeDirectory *wd, FSNode *child) {
+void RemoveTask::doUnlink(const FilesystemOperationContext &fsOpContext, uint32_t ts,
+                          FSNodeDirectory *wd, FSNode *child) {
 	gFSOperations->changeLog(ts, "UNLINK(%" PRIiNode ",%s):%" PRIiNode, parent_,
 	                         gFSOperations->nodeOperations()->escapeName(*current_subtask_).c_str(),
 	                         child->id);
-	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
-	    FilesystemOperationContext::TransactionType::kReadWrite);
 
 	gFSOperations->nodeOperations()->unlink(fsOpContext, ts, wd, *current_subtask_, child);
-
-	// commit the transaction
-	if (fsOpContext.hasReadWriteTransaction() && !fsOpContext.getReadWriteTransaction()->commit()) {
-		throw std::runtime_error("Failed to commit unlink transaction");
-	}
 }
 
 int RemoveTask::execute(uint32_t ts, intrusive_list<Task> &work_queue) {
 	FSNodeDirectory *wd = nullptr;
 	FSNode *child = nullptr;
-	int status = retrieveNodes(wd, child);
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	}
+
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
+	int status = retrieveNodes(fsOpContext, wd, child);
+
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+
 	if (child->type == FSNodeType::kDirectory &&
 	    !static_cast<FSNodeDirectory *>(child)->entries.empty()) {
 		SubtaskContainer subtasks;
-		subtasks.reserve(
-			  static_cast<const FSNodeDirectory*>(child)->entries.size());
-		for (const auto &entry :
-				static_cast<FSNodeDirectory*>(child)->entries) {
+		subtasks.reserve(static_cast<const FSNodeDirectory *>(child)->entries.size());
+
+		for (const auto &entry : static_cast<FSNodeDirectory *>(child)->entries) {
 			subtasks.push_back(static_cast<HString>(*entry.first));
 		}
+
 		auto *task = new RemoveTask(std::move(subtasks), child->id, context_);
 		work_queue.push_front(*task);
+
 		if (++repeat_counter_ >= kMaxRepeatCounter) {
 			// something keeps adding files to a folder which is being deleted
 			return SAUNAFS_ERROR_ENOTEMPTY;
 		}
 	} else {
 		incrementFSStat(child->type == FSNodeType::kDirectory ? FsStats::Rmdir : FsStats::Unlink);
-		doUnlink(ts, wd, child);
+		doUnlink(fsOpContext, ts, wd, child);
+
+		// commit the transaction
+		if (fsOpContext.hasReadWriteTransaction() &&
+		    !fsOpContext.getReadWriteTransaction()->commit()) {
+			return SAUNAFS_ERROR_IO;
+		}
+
 		++current_subtask_;
 		repeat_counter_ = 0;
 	}
+
 	return SAUNAFS_STATUS_OK;
 }

--- a/src/master/recursive_remove_task.h
+++ b/src/master/recursive_remove_task.h
@@ -28,6 +28,8 @@
 #include "master/hstring.h"
 #include "master/task_manager.h"
 
+class FilesystemOperationContext;
+
 /*! \brief Implementation of Recursive Remove Task that works with Task Manager.
  *
  * RemoveTask class is used for removing files and directories with
@@ -68,10 +70,12 @@ public:
 	}
 
 private:
-	int retrieveNodes(FSNodeDirectory *&wd, FSNode *&child);
+	int retrieveNodes(const FilesystemOperationContext &fsOpContext, FSNodeDirectory *&wd,
+	                  FSNode *&child);
 
 	/*! \brief Execute unlink operation to remove node. */
-	void doUnlink(uint32_t ts, FSNodeDirectory *wd, FSNode *child);
+	void doUnlink(const FilesystemOperationContext &fsOpContext, uint32_t ts, FSNodeDirectory *wd,
+	              FSNode *child);
 
 private:
 	static const uint32_t kMaxRepeatCounter = 3;

--- a/src/master/snapshot_task.cc
+++ b/src/master/snapshot_task.cc
@@ -235,7 +235,7 @@ int SnapshotTask::cloneNode(uint32_t ts) {
 	}
 
 	FSNode *dst_node =
-	    gFSOperations->nodeOperations()->lookup(dst_parent, current_subtask_->second);
+	    gFSOperations->nodeOperations()->lookup(fsOpContext, dst_parent, current_subtask_->second);
 
 	int status = cloneNodeTest(src_node, dst_node, dst_parent);
 	if (status != SAUNAFS_STATUS_OK) {


### PR DESCRIPTION
Thread FilesystemOperationContext through lookup() and isNameUsed() to enable transactional isolation in alternative metadata backends.

The commit allows to reuse the transactions in lookup related operations to execute bigger atomic/transactional operations, while keeping backward compatibility with master behavior.

Related to: LS-248

Reviewers:
- I started using [[maybe_unused]] instead of (void)var, there will be a dedicated commit to change all existing usages.