### PR TITLE
refactor(master): add case-sensitivity parameter to lookup

### DIFF
--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -199,7 +199,17 @@ void FilesystemNodeOperationsBase::preserveEdge(const FilesystemOperationContext
 
 FSNode *FilesystemNodeOperationsBase::lookup(
     [[maybe_unused]] const FilesystemOperationContext &fsOpContext, FSNodeDirectory *node,
-    const HString &name) const {
+    const HString &name, bool isCaseInsensitive) const {
+	// In-memory implementation: parameter intentionally unused to preserve legacy
+	// behavior. This relies on the directory's caseInsensitive flag via find().
+	// That flag is updated in getNodeForOperation when a directory node is accessed,
+	// but may not reflect the current session's case-sensitivity for directories
+	// previously accessed under different sessions. Alternative backend
+	// implementations can override this method to use the isCaseInsensitive
+	// parameter directly for consistent session-based lookups without relying on
+	// mutable directory state.
+	(void)isCaseInsensitive;
+
 	auto iter = node->find(name);
 	if (iter != node->end()) { return (*iter).second; }
 
@@ -259,8 +269,9 @@ std::string FilesystemNodeOperationsBase::escapeName(const std::string &name) {
 }
 
 bool FilesystemNodeOperationsBase::isNameUsed(const FilesystemOperationContext &fsOpContext,
-                                              FSNodeDirectory *node, const HString &name) {
-	return lookup(fsOpContext, node, name) != nullptr;
+                                              FSNodeDirectory *node, const HString &name,
+                                              bool isCaseInsensitive) {
+	return lookup(fsOpContext, node, name, isCaseInsensitive) != nullptr;
 }
 
 bool FilesystemNodeOperationsBase::isAncestor(FSNodeDirectory *ancestor, FSNode *node) {

--- a/src/master/filesystem_node.h
+++ b/src/master/filesystem_node.h
@@ -41,7 +41,8 @@ public:
 	/// Looks up a child node by name within a directory.
 	/// @see IFilesystemNodeOperations::lookup
 	FSNode *lookup([[maybe_unused]] const FilesystemOperationContext &fsOpContext,
-	               FSNodeDirectory *node, const HString &name) const override;
+	               FSNodeDirectory *node, const HString &name,
+	               bool isCaseInsensitive = false) const override;
 
 	FSNode *createNode(const FilesystemOperationContext &fsOpContext, uint32_t timeStamp,
 	                   FSNodeDirectory *parent, const HString &name, FSNodeType type, uint16_t mode,
@@ -109,7 +110,7 @@ public:
 	/// Checks if a name is already used in the given directory.
 	/// @see IFilesystemNodeOperations::isNameUsed
 	bool isNameUsed(const FilesystemOperationContext &fsOpContext, FSNodeDirectory *node,
-	                const HString &name) override;
+	                const HString &name, bool isCaseInsensitive = false) override;
 
 	// Trash/Reserved operations
 	int purge(uint32_t timeStamp, FSNode *node) override;

--- a/src/master/filesystem_node_operations_interface.h
+++ b/src/master/filesystem_node_operations_interface.h
@@ -136,9 +136,13 @@ public:
 	/// @param fsOpContext The filesystem operation context (transaction).
 	/// @param node The directory node in which to search for the child.
 	/// @param name The name of the child node to look up.
+	/// @param isCaseInsensitive Whether the lookup should perform case-insensitive matching.
+	///                          When true, lookups will match names regardless of case.
+	///                          When false, lookups will be case-sensitive.
 	/// @return Pointer to the child node if found, nullptr otherwise.
 	virtual FSNode *lookup([[maybe_unused]] const FilesystemOperationContext &fsOpContext,
-	                       FSNodeDirectory *node, const HString &name) const = 0;
+	                       FSNodeDirectory *node, const HString &name,
+	                       bool isCaseInsensitive = false) const = 0;
 
 	virtual FSNode *createNode(const FilesystemOperationContext &fsOpContext, uint32_t timeStamp,
 	                           FSNodeDirectory *parent, const HString &name, FSNodeType type,
@@ -281,9 +285,12 @@ public:
 	/// @param fsOpContext The filesystem operation context (transaction).
 	/// @param node The directory node to search in.
 	/// @param name The name to check for existence.
+	/// @param isCaseInsensitive Whether the lookup should perform case-insensitive matching.
+	///                          When true, lookups will match names regardless of case.
+	///                          When false, lookups will be case-sensitive.
 	/// @return true if the name exists in the directory, false otherwise.
 	virtual bool isNameUsed(const FilesystemOperationContext &fsOpContext, FSNodeDirectory *node,
-	                        const HString &name) = 0;
+	                        const HString &name, bool isCaseInsensitive = false) = 0;
 
 	// Trash/Reserved operations
 

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -510,8 +510,8 @@ uint8_t FilesystemOperationsBase::lookup(const FsContext &context,
 
 	if (nodeOperations_->nameCheck(name) < 0) { return SAUNAFS_ERROR_EINVAL; }
 
-	FSNode *child =
-	    nodeOperations_->lookup(fsOpContext, static_cast<FSNodeDirectory *>(workDir), name);
+	FSNode *child = nodeOperations_->lookup(fsOpContext, static_cast<FSNodeDirectory *>(workDir),
+	                                        name, context.isCaseInsensitive());
 
 	if (!child) {
 		return SAUNAFS_ERROR_ENOENT;
@@ -739,7 +739,7 @@ uint8_t FilesystemOperationsBase::getCanonicalPath(const FsContext &context,
                                                    const FilesystemOperationContext &fsOpContext,
                                                    const std::string &inputPath,
                                                    std::string &canonicalPath) {
-	bool caseInsensitiveFS = context.sesflags() & SESFLAG_CASEINSENSITIVE;
+	bool caseInsensitiveFS = context.isCaseInsensitive();
 	FSNode *currentNode = nodeOperations_->idToNode(context.rootinode());
 	std::string resultPath;
 
@@ -1161,10 +1161,14 @@ uint8_t FilesystemOperationsBase::symlink(const FsContext &context, inode_t pare
 			return SAUNAFS_ERROR_EINVAL;
 		}
 	}
+
 	if (nodeOperations_->nameCheck(name) < 0) { return SAUNAFS_ERROR_EINVAL; }
-	if (nodeOperations_->isNameUsed(fsOpContext, static_cast<FSNodeDirectory *>(wd), name)) {
+
+	if (nodeOperations_->isNameUsed(fsOpContext, static_cast<FSNodeDirectory *>(wd), name,
+	                                context.isCaseInsensitive())) {
 		return SAUNAFS_ERROR_EEXIST;
 	}
+
 	if (context.isPersonalityMaster() &&
 	    (fsnodes_quota_exceeded_ug(context.uid(), context.gid(), {{QuotaResource::kInodes, 1}}) ||
 	     fsnodes_quota_exceeded_dir(wd, {{QuotaResource::kInodes, 1}}))) {
@@ -1239,8 +1243,10 @@ uint8_t FilesystemOperationsBase::mknod(const FsContext &context,
 	if (nodeOperations_->nameCheck(name) < 0) { return SAUNAFS_ERROR_EINVAL; }
 
 	// Check if name is already used in the parent directory (lookup)
-	if (nodeOperations_->isNameUsed(fsOpContext, static_cast<FSNodeDirectory *>(parentNode),
-	                                name)) {
+	bool isCaseInsensitive = context.isCaseInsensitive();
+
+	if (nodeOperations_->isNameUsed(fsOpContext, static_cast<FSNodeDirectory *>(parentNode), name,
+	                                isCaseInsensitive)) {
 		return SAUNAFS_ERROR_EEXIST;
 	}
 
@@ -1250,8 +1256,7 @@ uint8_t FilesystemOperationsBase::mknod(const FsContext &context,
 		return SAUNAFS_ERROR_QUOTA;
 	}
 
-	static_cast<FSNodeDirectory *>(parentNode)->caseInsensitive =
-	    context.sesflags() & SESFLAG_CASEINSENSITIVE;
+	static_cast<FSNodeDirectory *>(parentNode)->caseInsensitive = isCaseInsensitive;
 
 	// Create node linked to parent directory
 	newNode = nodeOperations_->createNode(
@@ -1304,7 +1309,11 @@ uint8_t FilesystemOperationsBase::mkdir(const FsContext &context,
 
 	auto *workDir = static_cast<FSNodeDirectory *>(workNode);
 
-	if (nodeOperations_->isNameUsed(fsOpContext, workDir, name)) { return SAUNAFS_ERROR_EEXIST; }
+	bool isCaseInsensitive = context.isCaseInsensitive();
+
+	if (nodeOperations_->isNameUsed(fsOpContext, workDir, name, isCaseInsensitive)) {
+		return SAUNAFS_ERROR_EEXIST;
+	}
 
 	if (fsnodes_quota_exceeded_ug(context.uid(), context.gid(), {{QuotaResource::kInodes, 1}}) ||
 	    fsnodes_quota_exceeded_dir(workNode, {{QuotaResource::kInodes, 1}})) {
@@ -1318,7 +1327,7 @@ uint8_t FilesystemOperationsBase::mkdir(const FsContext &context,
 		}
 	}
 
-	workDir->caseInsensitive = context.sesflags() & SESFLAG_CASEINSENSITIVE;
+	workDir->caseInsensitive = isCaseInsensitive;
 
 	newNode = nodeOperations_->createNode(fsOpContext, timeStamp, workDir, name,
 	                                      FSNodeType::kDirectory, mode, umask, context.uid(),
@@ -1361,6 +1370,7 @@ uint8_t FilesystemOperationsBase::applyCreate(uint32_t timestamp, inode_t parent
 	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
 		FilesystemOperationContext::TransactionType::kReadWrite);
 
+	// For metadata restore operations, use default case-sensitive behavior
 	if (nodeOperations_->isNameUsed(fsOpContext, static_cast<FSNodeDirectory *>(wd), name)) {
 		return SAUNAFS_ERROR_EEXIST;
 	}
@@ -1729,7 +1739,8 @@ uint8_t FilesystemOperationsBase::link(const FsContext &context, inode_t inode_s
 
 	if (nodeOperations_->nameCheck(name_dst) < 0) { return SAUNAFS_ERROR_EINVAL; }
 
-	if (nodeOperations_->isNameUsed(fsOpContext, static_cast<FSNodeDirectory *>(dwd), name_dst)) {
+	if (nodeOperations_->isNameUsed(fsOpContext, static_cast<FSNodeDirectory *>(dwd), name_dst,
+	                                context.isCaseInsensitive())) {
 		return SAUNAFS_ERROR_EEXIST;
 	}
 

--- a/src/master/fs_context.h
+++ b/src/master/fs_context.h
@@ -247,6 +247,15 @@ public:
 	}
 
 	/**
+	 * Returns true if the session is case-insensitive.
+	 * Returns false if there's no session data (restore/shadow contexts)
+	 * or if the case-insensitive flag is not set.
+	 */
+	bool isCaseInsensitive() const {
+		return hasSessionData_ && (sesflags_ & SESFLAG_CASEINSENSITIVE) != 0;
+	}
+
+	/**
 	 * Returns timestamp.
 	 * This is a timestamp of any operations performed in this context.
 	 */
@@ -368,4 +377,3 @@ private:
 			  agid_(agid) {
 	}
 };
-


### PR DESCRIPTION
refactor(master): add case-sensitivity parameter to lookup

Enable alternative backend implementations to perform session-based
case-insensitive lookups by adding an isCaseInsensitive parameter to
the lookup() and isNameUsed() interface methods, with a default value
of false (case-sensitive) for semantic correctness.

The in-memory implementation intentionally ignores this parameter to
preserve existing behavior and maintain backward compatibility. This
avoids introducing breaking changes to the master server while allowing
future backend implementations to implement case-insensitive lookups
based on session flags rather than directory state.

The main lookup call site in filesystem_operations.cc now extracts the
SESFLAG_CASEINSENSITIVE flag and passes it explicitly, establishing the
correct pattern for session-based lookups.

Creation operations (symlink, mknod, mkdir, link) now extract and pass
the session's case-sensitivity flag to isNameUsed(), ensuring collision
checks respect the session mode. The applyCreate operation uses the
default parameter (case-sensitive) since it lacks session context and is
used for metadata restore operations.

Related to: LS-249