### PR TITLE
Fix uraft leadership ping-ponging issues

### DIFF
--- a/doc/saunafs-uraft.cfg.5.adoc
+++ b/doc/saunafs-uraft.cfg.5.adoc
@@ -330,14 +330,6 @@ The most common causes are repeated `isalive` timeouts or repeated `dead` status
 *Leader churn / ping-pong leadership*::
 Increase election timeouts and quorum-loss grace, and ensure voting nodes have stable connectivity.
 
-*QUORUM_LOSS_GRACE_HEARTBEATS*:: *[advanced]* Number of consecutive missed heartbeats allowed before
-quorum is considered lost.
-
-This parameter defines how many heartbeats may be missed in a row before the system declares quorum
-loss and demotes the current Leader. Increasing this value helps tolerate short-lived network
-glitches or transient latency spikes, reducing unnecessary demotions and improving overall
-cluster stability. The default value is 5.
-
 == REPORTING BUGS
 
 Report bugs to the GitHub repository <https://github.com/leil-io/saunafs> as an issue.

--- a/doc/saunafs-uraft.cfg.5.adoc
+++ b/doc/saunafs-uraft.cfg.5.adoc
@@ -330,6 +330,14 @@ The most common causes are repeated `isalive` timeouts or repeated `dead` status
 *Leader churn / ping-pong leadership*::
 Increase election timeouts and quorum-loss grace, and ensure voting nodes have stable connectivity.
 
+*QUORUM_LOSS_GRACE_HEARTBEATS*:: *[advanced]* Number of consecutive missed heartbeats allowed before
+quorum is considered lost.
+
+This parameter defines how many heartbeats may be missed in a row before the system declares quorum
+loss and demotes the current Leader. Increasing this value helps tolerate short-lived network
+glitches or transient latency spikes, reducing unnecessary demotions and improving overall
+cluster stability. The default value is 5.
+
 == REPORTING BUGS
 
 Report bugs to the GitHub repository <https://github.com/leil-io/saunafs> as an issue.

--- a/doc/saunafs-uraft.cfg.5.adoc
+++ b/doc/saunafs-uraft.cfg.5.adoc
@@ -111,7 +111,7 @@ expected to be fast, such as:
 
 If this timeout is too low, the daemon may repeatedly log timeouts and keep a node blocked for
 promotions (`blocked_promote=1`), +
-preventing elections. (default: 200).
+preventing elections. (default: 100).
 
 *URAFT_PROMOTE_TIMEOUT*:: *[advanced]* Timeout in milliseconds for promotion
 (`saunafs-uraft-helper promote`).

--- a/src/uraft/main.cc
+++ b/src/uraft/main.cc
@@ -51,7 +51,8 @@ void parseOptions(int argc, char **argv, uRaftController::Options &opt, bool &ma
 	("URAFT_STATUS_PORT", po::value<int>()->default_value(9428), "node status port")
 	("URAFT_FLOATING_IP", po::value<std::string>(), "floating IP address")
 	("URAFT_FLOATING_IFACE", po::value<std::string>(), "floating IP interface")
-	("URAFT_FLOATING_IP_CHECK_PERIOD", po::value<uint>()->default_value(500), "floating IP check status period");
+	("URAFT_FLOATING_IP_CHECK_PERIOD", po::value<uint>()->default_value(500), "floating IP check status period")
+	("QUORUM_LOSS_GRACE_HEARTBEATS", po::value<int>()->default_value(5), "consecutive misses before demotion");
 
 	po::options_description cmdline_options;
 	cmdline_options.add(generic).add(config).add(hidden);
@@ -116,6 +117,7 @@ void parseOptions(int argc, char **argv, uRaftController::Options &opt, bool &ma
 	opt.floating_ip               = vm["URAFT_FLOATING_IP"].as<std::string>();
 	opt.floating_iface            = vm["URAFT_FLOATING_IFACE"].as<std::string>();
 	opt.check_floating_ip_period  = vm["URAFT_FLOATING_IP_CHECK_PERIOD"].as<uint>();
+	opt.quorum_loss_grace_heartbeats = vm["QUORUM_LOSS_GRACE_HEARTBEATS"].as<int>();
 	make_daemon                   = vm["start-daemon"].as<bool>();
 
 	if (vm.count("id")) {

--- a/src/uraft/main.cc
+++ b/src/uraft/main.cc
@@ -43,7 +43,7 @@ void parseOptions(int argc, char **argv, uRaftController::Options &opt, bool &ma
 	("LOCAL_MASTER_MATOCL_PORT", po::value<int>()->default_value(9421), "local master matocl port")
 	("LOCAL_MASTER_CHECK_PERIOD", po::value<int>()->default_value(250), "local master check status period")
 	("URAFT_ELECTOR_MODE", po::value<int>()->default_value(0), "run in elector mode")
-	("URAFT_GETVERSION_TIMEOUT", po::value<int>()->default_value(50), "getversion timeout (ms)")
+	("URAFT_GETVERSION_TIMEOUT", po::value<int>()->default_value(100), "getversion timeout (ms)")
 	("URAFT_PROMOTE_TIMEOUT", po::value<int>()->default_value(1000000000), "promote timeout (ms)")
 	("URAFT_DEMOTE_TIMEOUT", po::value<int>()->default_value(1000000000), "demote timeout (ms)")
 	("URAFT_DEAD_HANDLER_TIMEOUT", po::value<int>()->default_value(1000000000), "metadata server dead handler timeout (ms)")

--- a/src/uraft/saunafs-uraft-helper.in
+++ b/src/uraft/saunafs-uraft-helper.in
@@ -299,48 +299,61 @@ saunafs_isalive() {
 	fi
 }
 
+assign_floating_ip() {
+	local ip="${1}"
+	local netmask="${2}"
+	local iface="${3}"
+
+	if [[ -z "${ip}" ]]; then
+		return 0
+	fi
+
+	if is_ip_present "${ip}" "${iface}"; then
+		log "Floating IP ${ip} already present on interface: ${iface} - skipping assignment"
+		return 0
+	fi
+
+	log "Assigning floating IP: ${ip} to interface: ${iface}"
+	if sudo ip -f inet addr add "${ip}/${netmask}" dev "${iface}"; then
+		local iface_base="${iface%%:*}" # handle interface aliases (e.g., eth0:0 -> eth0)
+		arping -q -U -c5 -w1 "${ip}" -I "${iface_base}"
+		log "Successfully assigned floating IP: ${ip}"
+	else
+		log "Error: Failed to assign floating IP: ${ip}"
+	fi
+}
+
 saunafs_assign_ip() {
 	load_config
-	sudo ip -f inet addr add $ipaddr/$netmask dev $iface
-	iface_base=$(echo $iface | cut -f1 -d':') # for alias handling
-	arping -q -U -c5 -w1 $ipaddr -I $iface_base
+	assign_floating_ip "${ipaddr}" "${netmask}" "${iface}"
+	assign_floating_ip "${ipaddr2}" "${netmask2}" "${iface2}"
+}
 
-	if [[ "$ipaddr2" != "" ]]; then
-		sudo ip -f inet addr add $ipaddr2/$netmask2 dev $iface2
-		iface_base2=$(echo $iface2 | cut -f1 -d':') # for alias handling
-		arping -q -U -c5 -w1 $ipaddr2 -I $iface_base2
+drop_floating_ip() {
+	local ip="${1}"
+	local netmask="${2}"
+	local iface="${3}"
+
+	if [[ -z "${ip}" ]]; then
+		return 0
+	fi
+
+	if is_ip_present "${ip}" "${iface}"; then
+		log "Dropping floating IP: ${ip} from interface: ${iface}"
+		if ! sudo ip -f inet addr delete "${ip}/${netmask}" dev "${iface}"; then
+			log "Warning: Failed to drop floating IP: ${ip}"
+		else
+			log "Successfully dropped floating IP: ${ip}"
+		fi
+	else
+		log "Floating IP ${ip} not present - nothing to drop"
 	fi
 }
 
 saunafs_drop_ip() {
 	load_config
-
-	# Check if floating IP exists before trying to drop it
-	if [[ -n "$ipaddr" ]]; then
-		if is_ip_present "${ipaddr}" "${iface}"; then
-			log "Dropping floating IP: ${ipaddr} from interface: ${iface}"
-			if ! sudo ip -f inet addr delete $ipaddr/$netmask dev $iface; then
-				log "Warning: Failed to drop floating IP: ${ipaddr}"
-			else
-				log "Successfully dropped floating IP: ${ipaddr}"
-			fi
-		else
-			log "Floating IP ${ipaddr} not present - nothing to drop"
-		fi
-	fi
-
-	if [[ -n "$ipaddr2" ]]; then
-		if is_ip_present "$ipaddr2" "$iface2"; then
-			log "Dropping floating IP: ${ipaddr2} from interface: ${iface2}"
-			if ! sudo ip -f inet addr delete $ipaddr2/$netmask2 dev $iface2; then
-				log "Warning: Failed to drop floating IP: ${ipaddr2}"
-			else
-				log "Successfully dropped floating IP: ${ipaddr2}"
-			fi
-		else
-			log "Floating IP ${ipaddr2} not present - nothing to drop"
-		fi
-	fi
+	drop_floating_ip "${ipaddr}" "${netmask}" "${iface}"
+	drop_floating_ip "${ipaddr2}" "${netmask2}" "${iface2}"
 }
 
 saunafs_dead() {

--- a/src/uraft/uraft.cc
+++ b/src/uraft/uraft.cc
@@ -28,6 +28,7 @@ uRaft::uRaft(boost::asio::io_context &ios)
 	opt_.heartbeat_period       = 20;
 	opt_.id                     = -1;
 	opt_.port                   = 9425;
+	opt_.quorum_loss_grace_heartbeats = 5;
 
 	state_.id           = 0;
 	state_.type         = kFollower;
@@ -97,10 +98,14 @@ void uRaft::checkTerm(int /*id*/, const RpcHeader &data) {
 	if (data.term > state_.current_term) {
 		if (state_.president) {
 			assert(state_.type != kFollower);
-			syslog(LOG_NOTICE, "(%s): Higher term detected (%lu): Node %s starting new election",
+			syslog(LOG_NOTICE, "(%s): Higher term detected (%lu): stepping down Leader %s",
 			       __func__, data.term, nodeToString(state_.id).c_str());
 			state_.current_term = data.term;
-			electionTimeout(boost::system::error_code());
+			state_.type = kFollower;
+			state_.president = false;
+			state_.voted_for = -1;
+			state_.leader_id = -1;
+			startElectionTimer();
 			return;
 		}
 
@@ -246,11 +251,31 @@ void uRaft::heartbeat(const boost::system::error_code &error) {
 	state_.local_time++;
 	node_[state_.id].heartbeat = state_.local_time;
 
+	int loyal_votes = -1;
+	bool has_quorum = false;
+
+	if (state_.type == kLeader) {
+		loyal_votes = voteCount(true);
+		has_quorum = loyal_votes >= opt_.quorum;
+	}
+
 	// Roll back from being the leader if there are less than quorum
 	// loyal nodes alive
 	if (state_.president) {
 		assert(state_.type != kFollower);
-		if (voteCount(true) < opt_.quorum) {
+		if (!has_quorum) {
+			quorum_loss_streak_++;
+
+			syslog(LOG_WARNING,
+			       "(%s): Reported quorum loss: %d out of %d before demoting Leader %s", __func__,
+			       quorum_loss_streak_, opt_.quorum_loss_grace_heartbeats,
+			       nodeToString(state_.id).c_str());
+
+			if (quorum_loss_streak_ < opt_.quorum_loss_grace_heartbeats) {
+				sendHeartbeat();  // Heartbeat still needs to be sent
+				return;  // Quorum hysteresis: tolerate transient loss
+			}
+
 			if (state_.type == kLeader) {
 				state_.type      = kFollower;
 				state_.voted_for = -1;
@@ -258,14 +283,16 @@ void uRaft::heartbeat(const boost::system::error_code &error) {
 			}
 
 			syslog(LOG_WARNING,
-			       "(%s): Heartbeat quorum lost: Demoting current Leader %s to follower", __func__,
-			       nodeToString(state_.id).c_str());
+			       "(%s): Heartbeat quorum lost: %d out of %d nodes voted for Leader; "
+			       "demoting Leader %s to follower",
+			       __func__, loyal_votes, opt_.quorum, nodeToString(state_.id).c_str());
 			state_.president = false;
-
+			quorum_loss_streak_ = 0;
 			nodeDemote();
 
 			return;
 		}
+		quorum_loss_streak_ = 0;
 	}
 
 	if (state_.type == kCandidate) {
@@ -275,7 +302,7 @@ void uRaft::heartbeat(const boost::system::error_code &error) {
 	if (state_.type == kLeader) {
 		sendHeartbeat();
 		if (!state_.president) {
-			if (voteCount(true) >= opt_.quorum) {
+			if (has_quorum) {
 				state_.president = true;
 				syslog(LOG_NOTICE, "(%s): Heartbeat quorum confirmed: Node %s is now active Leader",
 				       __func__, nodeToString(state_.id).c_str());

--- a/src/uraft/uraft.cc
+++ b/src/uraft/uraft.cc
@@ -111,21 +111,31 @@ void uRaft::checkTerm(int /*id*/, const RpcHeader &data) {
 	}
 }
 
-/*! \brief Checks if packet is valid.
+/*! \brief Checks if a received packet is structurally valid.
  *
- * Packet with lower term than current is discarded by Raft algorithm. So we can consider it as
- * invalid.
+ * This function validates only the packet shape (RPC type and expected message size).
+ * It deliberately does NOT discard packets with a term lower than the local `state_.current_term`.
+ *
+ * Rationale:
+ * In Raft, a follower should respond to stale RPCs (e.g. RequestVote/AppendEntries with
+ * older terms) with `success/result = false` and include its current term in the response.
+ * This allows candidates that are behind (for example after a restart) to learn the higher
+ * term immediately, step down if needed, and catch up without waiting to increment term
+ * across many election timeouts.
+ *
+ * Dropping lower-term RPCs at the packet-validation layer can significantly increase convergence
+ * time, because it prevents the sender from observing the receiver’s higher term.
+ * This is especially noticeable where metadata servers restart and then, elections are delayed
+ * until the restarted node catches up its term via timeouts.
+ *
+ * \note Term handling is therefore performed inside the RPC handlers.
  */
 bool uRaft::validPacket(const uint8_t *data, size_t size) {
 	static unsigned packet_size[kRpcLast] = {sizeof(RpcRequest), sizeof(RpcRequest),
 	                                        sizeof(RpcResponse), sizeof(RpcResponse)
 	                                        };
 
-	if (data[0] >= kRpcLast || size != packet_size[data[0]]) {
-		return false;
-	}
-
-	return reinterpret_cast<const RpcHeader *>(data)->term >= state_.current_term;
+	return (data[0] < kRpcLast && size == packet_size[data[0]]);
 }
 
 void uRaft::startElectionTimer() {
@@ -280,7 +290,19 @@ void uRaft::rpcAppend(int id, const RpcRequest &data) {
 	RpcResponse res;
 
 	assert(state_.type != kLeader);
-	assert(data.term >= state_.current_term);
+
+	// Reply false if term is older than current term, but still send current term back to the
+	// sender to let it catch up its term and step down if needed.
+	if (data.term < state_.current_term) {
+		RpcResponse res{};
+		res.type = kRpcAEResponse;
+		res.term = state_.current_term;
+		res.result = 0;
+		res.req_time = data.time;
+		res.data_version = state_.data_version;
+		socketSend(boost::asio::buffer(&res, sizeof(res)), sender_endpoint_);
+		return;
+	}
 
 	if (isElectorNode()) {
 		// Electors preserve the highest data version from the Leader in every heartbeat,
@@ -314,6 +336,9 @@ void uRaft::rpcAppend(int id, const RpcRequest &data) {
 
 /*! \brief Handling of RPC Append Response packet. */
 void uRaft::rpcAppendResponse(int id, const RpcResponse &data) {
+	// Stale response
+	if (data.term < state_.current_term) { return; }
+
 	if (state_.type != kLeader) {
 		return;
 	}
@@ -356,6 +381,9 @@ void uRaft::rpcReqVote(int id, const RpcRequest &data) {
 
 /*! \brief Handling of RPC Request Vote Response packet. */
 void uRaft::rpcReqVoteResponse(int id, const RpcResponse &data) {
+	// Stale response
+	if (data.term < state_.current_term) { return; }
+
 	if (state_.type != kCandidate) {
 		return;
 	}

--- a/src/uraft/uraft.cc
+++ b/src/uraft/uraft.cc
@@ -282,7 +282,17 @@ void uRaft::rpcAppend(int id, const RpcRequest &data) {
 	assert(state_.type != kLeader);
 	assert(data.term >= state_.current_term);
 
-	if (id != state_.leader_id) {
+	if (isElectorNode()) {
+		// Electors preserve the highest data version from the Leader in every heartbeat,
+		// as they do not have a local metadata server to fetch it from.
+		// This ensures that electors always have the latest metadata version sent by the Leader and
+		// will not vote for candidates with outdated versions.
+		state_.data_version = std::max(state_.data_version, data.data_version);
+	}
+
+	if (id != state_.leader_id && !isElectorNode()) {
+		// When the Leader changes, metadata nodes (non-electors) update their data version from
+		// their local metadata server through the nodeGetVersion() function.
 		state_.data_version = nodeGetVersion();
 	}
 
@@ -318,7 +328,10 @@ void uRaft::rpcAppendResponse(int id, const RpcResponse &data) {
 void uRaft::rpcReqVote(int id, const RpcRequest &data) {
 	RpcResponse res;
 
-	if (state_.voted_for < 0) {
+	if (state_.voted_for < 0 && !isElectorNode()) {
+		// Only metadata nodes (non-electors) update their data version from local metadata server.
+		// Electors have no local metadata server, so they preserve the highest version ever seen
+		// through heartbeats in rpcAppend().
 		state_.data_version = nodeGetVersion();
 	}
 

--- a/src/uraft/uraft.cc
+++ b/src/uraft/uraft.cc
@@ -100,20 +100,26 @@ void uRaft::checkTerm(int /*id*/, const RpcHeader &data) {
 			assert(state_.type != kFollower);
 			syslog(LOG_NOTICE, "(%s): Higher term detected (%lu): stepping down Leader %s",
 			       __func__, data.term, nodeToString(state_.id).c_str());
-			state_.current_term = data.term;
-			state_.type = kFollower;
-			state_.president = false;
-			state_.voted_for = -1;
-			state_.leader_id = -1;
-			startElectionTimer();
-			return;
 		}
-
-		if (state_.type != kFollower) startElectionTimer();
-		state_.type         = kFollower;
-		state_.voted_for    = -1;
-		state_.current_term = data.term;
+		stepDownToFollower(StepDownPolicy::kDemoteIfPresident, data.term);
 	}
+}
+
+void uRaft::stepDownToFollower(StepDownPolicy policy, uint64_t newTerm) {
+	const bool wasPresident = state_.president;
+
+	if (newTerm > 0U) { state_.current_term = newTerm; }
+
+	state_.type = kFollower;
+	state_.president = false;
+	state_.voted_for = -1;
+	state_.leader_id = -1;
+
+	quorum_loss_streak_ = 0;
+
+	if (wasPresident && policy == StepDownPolicy::kDemoteIfPresident) { nodeDemote(); }
+
+	startElectionTimer();
 }
 
 /*! \brief Checks if a received packet is structurally valid.
@@ -276,20 +282,12 @@ void uRaft::heartbeat(const boost::system::error_code &error) {
 				return;  // Quorum hysteresis: tolerate transient loss
 			}
 
-			if (state_.type == kLeader) {
-				state_.type      = kFollower;
-				state_.voted_for = -1;
-				startElectionTimer();
-			}
-
 			syslog(LOG_WARNING,
 			       "(%s): Heartbeat quorum lost: %d out of %d nodes voted for Leader; "
 			       "demoting Leader %s to follower",
 			       __func__, loyal_votes, opt_.quorum, nodeToString(state_.id).c_str());
-			state_.president = false;
-			quorum_loss_streak_ = 0;
-			nodeDemote();
 
+			stepDownToFollower(StepDownPolicy::kDemoteIfPresident);
 			return;
 		}
 		quorum_loss_streak_ = 0;
@@ -524,12 +522,8 @@ void uRaft::demoteLeader() {
 
 	syslog(LOG_NOTICE, "(%s): Manual demotion: Stepping down Leader %s to follower", __func__,
 	       nodeToString(state_.id).c_str());
-	state_.type      = kFollower;
-	state_.voted_for = -1;
-	state_.leader_id = -1;
-	state_.president = false;
 
-	startElectionTimer();
+	stepDownToFollower(StepDownPolicy::kRaftOnly);
 }
 
 void uRaft::set_block_promotion(bool block) {

--- a/src/uraft/uraft.h
+++ b/src/uraft/uraft.h
@@ -141,6 +141,13 @@ public:
 
 protected:
 	void checkTerm(int id, const RpcHeader &data);
+
+	/*! \brief Checks if a received packet is structurally valid.
+	 *
+	 * \param data Pointer to the received packet data.
+	 * \param size Size of the received packet data.
+	 * \return true if the packet is valid, false otherwise.
+	 */
 	bool validPacket(const uint8_t *data, size_t size);
 	int  findNodeID(const boost::asio::ip::udp::endpoint &addr);
 	int  voteCount(bool count_loyal);

--- a/src/uraft/uraft.h
+++ b/src/uraft/uraft.h
@@ -25,6 +25,8 @@ public:
 		int                      election_timeout_max;
 		int                      heartbeat_period;
 		int                      quorum;  /// Minimum number of votes to get to become the leader.
+		/// Number of heartbeats to wait before considering quorum lost.
+		int quorum_loss_grace_heartbeats;
 	};
 
 protected:
@@ -189,4 +191,7 @@ protected:
 	bool                                    block_leader_promotion_;  /// If true this node cannot be promoted to leader.
 
 	Options                                 opt_;
+
+	/// Number of consecutive heartbeats with lost quorum before demoting leader.
+	int quorum_loss_streak_ = 0;
 };

--- a/src/uraft/uraft.h
+++ b/src/uraft/uraft.h
@@ -45,6 +45,30 @@ protected:
 	    kRpcLast
 	};
 
+	/// @brief Policy controlling side effects when stepping down to follower.
+	///
+	/// The policy selects whether stepping down is a Raft-only state transition, or whether it
+	/// also triggers a demotion of the local metadata server (via nodeDemote()) when stepping
+	/// down from an active Leader (President).
+	///
+	/// Typical usage:
+	/// - kRaftOnly:
+	///   Step down in Raft (become follower, restart election timer) without invoking nodeDemote().
+	///   Use this when the controller owns metadata-side effects, e.g.:
+	///   - manual demotion via demoteLeader() (promotion failure recovery),
+	///   - local "metadata dead" handling where VIP release / restarts are scheduled elsewhere.
+	///
+	/// - kDemoteIfPresident:
+	///   Step down in Raft and, if we were President, also call nodeDemote() so the local metadata
+	///   server is not left in master mode while we are no longer eligible to lead. Use this for
+	///   Raft-driven stepdowns, e.g.:
+	///   - observing a higher term in received RPCs (checkTerm),
+	///   - quorum loss while being President (heartbeat).
+	enum class StepDownPolicy : uint8_t {
+		kRaftOnly,          // Update Raft state and restart election timer
+		kDemoteIfPresident  // Additionally call nodeDemote() if we were president
+	};
+
 	static const int kMaxPacketLength = 1024;
 
 	//! Information about node.
@@ -143,6 +167,23 @@ public:
 
 protected:
 	void checkTerm(int id, const RpcHeader &data);
+
+	/// @brief Step down to follower state (optionally updating term and demoting metadata).
+	///
+	/// This is the shared implementation used by different "step down" triggers:
+	/// - observing a higher term (checkTerm),
+	/// - quorum loss while being President (heartbeat),
+	/// - manual demotion (demoteLeader).
+	///
+	/// The caller chooses the StepDownPolicy:
+	/// - kRaftOnly: only updates Raft state and restarts the election timer.
+	/// - kDemoteIfPresident: if the node was President, also calls nodeDemote() so the local
+	///   metadata server is not left in master mode while stepping down in Raft.
+	///
+	/// @param policy StepDownPolicy used to control side effects.
+	/// @param newTerm Optional new term; if non-zero and greater than current, updates
+	/// current_term. This is used for stepping down when observing a higher term.
+	void stepDownToFollower(StepDownPolicy policy, uint64_t newTerm = 0);
 
 	/*! \brief Checks if a received packet is structurally valid.
 	 *

--- a/src/uraft/uraft.h
+++ b/src/uraft/uraft.h
@@ -131,6 +131,14 @@ public:
 	 */
 	virtual uint64_t nodeGetVersion();
 
+	/*! \brief Returns true when this node runs in elector mode, false otherwise.
+	 *
+	 * Electors do not have a local metadata server, so some version-related logic may need to
+	 * behave differently.
+	 * \note This function is overridden in uRaftController class, which implements elector mode.
+	 */
+	virtual bool isElectorNode() const = 0;
+
 protected:
 	void checkTerm(int id, const RpcHeader &data);
 	bool validPacket(const uint8_t *data, size_t size);

--- a/src/uraft/uraftcontroller.cc
+++ b/src/uraft/uraftcontroller.cc
@@ -254,7 +254,8 @@ void uRaftController::checkNodeStatus(const boost::system::error_code &error) {
 				syslog(LOG_ERR, "Invalid metadata server status.");
 			}
 		} else {
-			syslog(LOG_WARNING, "Isalive timeout.");
+			syslog(LOG_WARNING, "(%s): Isalive timeout reported after %d ms.", __func__,
+			       opt_.getversion_timeout);
 		}
 
 		// Always reconcile promotion blocking
@@ -268,6 +269,7 @@ void uRaftController::checkNodeStatus(const boost::system::error_code &error) {
 				syslog(LOG_NOTICE, "Metadata server is dead");
 				stopFloatingIpManager();
 				demoteLeader();
+				set_block_promotion(true);
 				setSlowCommandTimeout(opt_.dead_handler_timeout);
 				if (runSlowCommand("saunafs-uraft-helper dead")) {
 					command_type_ = kCmdStatusDead;

--- a/src/uraft/uraftcontroller.cc
+++ b/src/uraft/uraftcontroller.cc
@@ -18,11 +18,14 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/version.hpp>
 
+constexpr int kCommandTimeoutMs = 5000;  ///< Default command timeout in milliseconds.
+
 uRaftController::uRaftController(boost::asio::io_context &ios)
 	: uRaftStatus(ios),
 	  check_cmd_status_timer_(ios),
 	  check_node_status_timer_(ios),
-	  cmd_timeout_timer_(ios) {
+	  cmd_timeout_timer_(ios),
+	  promotion_backoff_timer_(ios) {
 	command_pid_  = -1;
 	command_type_ = kCmdNone;
 	is_demote_pending_ = false;
@@ -66,6 +69,11 @@ void uRaftController::set_options(const uRaftController::Options &opt) {
 }
 
 void uRaftController::nodePromote() {
+	if (promotion_backoff_active_) {
+		syslog(LOG_WARNING, "Skipping promotion: backoff active");
+		return;
+	}
+
 	syslog(LOG_NOTICE, "Starting metadata server switch to master mode");
 
 	// Prevent concurrent transitions
@@ -186,6 +194,7 @@ void uRaftController::checkCommandStatus(const boost::system::error_code &error)
 		} else if (command_type_ == kCmdPromote) {
 			if (commandSucceeded) {
 				syslog(LOG_NOTICE, "Metadata server switch to master mode done");
+				startPromotionBackoff(/*reset=*/true);
 				node_alive_ = true;
 
 				if (state_.type == kLeader) {
@@ -248,10 +257,13 @@ void uRaftController::checkNodeStatus(const boost::system::error_code &error) {
 			syslog(LOG_WARNING, "Isalive timeout.");
 		}
 
+		// Always reconcile promotion blocking
+		const bool block_promotion = (!is_alive) || promotion_backoff_active_;
+		set_block_promotion(block_promotion);
+
 		if (is_alive != node_alive_) {
 			if (is_alive) {
 				syslog(LOG_NOTICE, "Metadata server is alive");
-				set_block_promotion(false);
 			} else {
 				syslog(LOG_NOTICE, "Metadata server is dead");
 				stopFloatingIpManager();
@@ -484,7 +496,7 @@ void uRaftController::cleanupDirtyPromotion() {
 	std::vector<std::string> cleanup = {"saunafs-uraft-helper", "cleanup"};
 	std::string result;
 
-	if (!runCommand(cleanup, result, 5000)) {
+	if (!runCommand(cleanup, result, kCommandTimeoutMs)) {
 		syslog(LOG_ERR, "Failed to cleanup dirty state: %s", result.c_str());
 	}
 }
@@ -500,6 +512,58 @@ void uRaftController::cleanupDirtyPromotion() {
 /// - Other nodes cannot win elections due to Raft term constraints.
 /// - Manual intervention becomes necessary to restore cluster operation.
 void uRaftController::handlePromotionFailure() {
-	demoteLeader();
+	// Promotion failed while kCmdPromote is active (we're inside checkCommandStatus).
+	// Do NOT call nodeDemote() here: that would run a demote script while promotion is still
+	// active, racing the controller command state machine and causing double scheduling.
+	//
+	// Instead we:
+	// - clean up promotion leftovers,
+	// - step down in uRaft (Raft-only) so a different node can become Leader/President,
+	// - request a pending demotion that will be executed once kCmdPromote is cleared,
+	// - enable a bounded backoff to avoid a tight promote/fail loop.
 	cleanupDirtyPromotion();
+
+	// Raft-only: stop being Leader/Candidate so another node can win.
+	demoteLeader();
+
+	// Controller-owned: schedule demotion after kCmdPromote is cleared.
+	// checkCommandStatus() already has logic to run pending demotion after promotion finishes.
+	is_demote_pending_ = true;
+
+	startPromotionBackoff(/*reset=*/false);
+}
+
+int uRaftController::computePromotionBackoffMs() const {
+	// 1s * 2^(streak-1), capped at 60s
+	constexpr int kMaxPromotionBackoffMs = 60000;
+	if (promotion_failure_streak_ <= 0) { return 0; }
+	const int capped = std::min(promotion_failure_streak_ - 1, 6);  // 1,2,4,8,16,32,64
+	const int promotionBackoffTimeMs = 1000 * (1 << capped);
+	return std::min(promotionBackoffTimeMs, kMaxPromotionBackoffMs);
+}
+
+void uRaftController::startPromotionBackoff(bool reset) {
+	if (reset) {
+		promotion_failure_streak_ = 0;
+		promotion_backoff_active_ = false;
+		promotion_backoff_timer_.cancel();
+		return;
+	}
+
+	promotion_failure_streak_++;
+	const int backoff_ms = computePromotionBackoffMs();
+	if (backoff_ms <= 0) { return; }
+
+	promotion_backoff_active_ = true;
+	set_block_promotion(true);
+	syslog(LOG_WARNING, "Promotion backoff enabled (%d ms), streak=%d", backoff_ms,
+	       promotion_failure_streak_);
+
+	promotion_backoff_timer_.expires_from_now(boost::posix_time::millisec(backoff_ms));
+	promotion_backoff_timer_.async_wait([this](const boost::system::error_code &ec) {
+		if (ec) { return; }
+		promotion_backoff_active_ = false;
+		syslog(LOG_WARNING, "Promotion backoff expired");
+		// We will update block_leader_promotion_ in the next checkNodeStatus() call.
+	});
 }

--- a/src/uraft/uraftcontroller.cc
+++ b/src/uraft/uraftcontroller.cc
@@ -169,8 +169,15 @@ void uRaftController::checkCommandStatus(const boost::system::error_code &error)
 			command_pid_  = -1;
 
 			if (is_promote_pending_) {
-				syslog(LOG_WARNING, "Starting pending promotion to master mode");
-				nodePromote();
+				// Only execute pending promotion if node is still Leader. This prevents
+				// synchronization issues between uRaft state and SaunaFS state.
+				if (state_.type == kLeader) {
+					syslog(LOG_WARNING, "Starting pending promotion to master mode to the Leader");
+					nodePromote();
+				} else {
+					syslog(LOG_WARNING, "Canceling pending promotion (no longer Leader, state=%d)",
+					       state_.type);
+				}
 				is_promote_pending_ = false;
 			}
 		} else if (command_type_ == kCmdPromote) {
@@ -178,8 +185,16 @@ void uRaftController::checkCommandStatus(const boost::system::error_code &error)
 				syslog(LOG_NOTICE, "Metadata server switch to master mode done");
 				node_alive_ = true;
 
-				// Start floating IP only after successful promotion
-				startFloatingIpManager();
+				if (state_.type == kLeader) {
+					// Start floating IP only if promoted node is still Leader
+					startFloatingIpManager();
+				} else {
+					syslog(LOG_ERR,
+					       "Promotion completed but no longer uRaft Leader (state=%d) - reverting",
+					       state_.type);
+					// Immediately demote to fix inconsistency
+					nodeDemote();
+				}
 			} else {
 				syslog(LOG_ERR, "Promotion failed with exit code: %d", WEXITSTATUS(status));
 				handlePromotionFailure();
@@ -189,8 +204,14 @@ void uRaftController::checkCommandStatus(const boost::system::error_code &error)
 			command_pid_  = -1;
 
 			if (is_demote_pending_) {
-				syslog(LOG_WARNING, "Starting pending demotion to slave mode");
-				nodeDemote();
+				// Only demote if node is no longer Leader
+				if (state_.type != kLeader) {
+					syslog(LOG_WARNING,
+					       "Starting pending demotion to slave mode: no longer the Leader");
+					nodeDemote();
+				} else {
+					syslog(LOG_WARNING, "Cancelling pending demotion: still Leader)");
+				}
 				is_demote_pending_ = false;
 			}
 		} else if (command_type_ == kCmdStatusDead) {

--- a/src/uraft/uraftcontroller.cc
+++ b/src/uraft/uraftcontroller.cc
@@ -20,12 +20,17 @@
 
 constexpr int kCommandTimeoutMs = 5000;  ///< Default command timeout in milliseconds.
 
+// Delay used both as a grace period for transient failures and as the retry interval while the
+// metadata server remains dead (single knob).
+constexpr int kDeadRecoveryDelayMs = 2000;
+
 uRaftController::uRaftController(boost::asio::io_context &ios)
 	: uRaftStatus(ios),
 	  check_cmd_status_timer_(ios),
 	  check_node_status_timer_(ios),
 	  cmd_timeout_timer_(ios),
-	  promotion_backoff_timer_(ios) {
+	  promotion_backoff_timer_(ios),
+	  dead_recovery_timer_(ios) {
 	command_pid_  = -1;
 	command_type_ = kCmdNone;
 	is_demote_pending_ = false;
@@ -79,10 +84,13 @@ void uRaftController::nodePromote() {
 	// Prevent concurrent transitions
 	if (command_pid_ >= 0) {
 		if (command_type_ == kCmdDemote) {
-			syslog(
-			    LOG_WARNING,
-			    "Promotion requested during demotion - will be started after completing demotion");
-			is_promote_pending_ = true;
+			// Make nodePromote() idempotent with respect to pending promotions
+			if (!is_promote_pending_) {
+				syslog(
+				    LOG_WARNING,
+				    "Promotion requested during demotion - will be started after completing demotion");
+				is_promote_pending_ = true;
+			}
 			return;
 		}
 		// Already promoting
@@ -105,10 +113,13 @@ void uRaftController::nodeDemote() {
 
 	if (command_pid_ >= 0) {
 		if (command_type_ == kCmdPromote) {
-			syslog(
-			    LOG_WARNING,
-			    "Demotion requested during promotion - will be started after completing promotion");
-			is_demote_pending_ = true;
+			// Make nodeDemote() idempotent with respect to pending demotions
+			if (!is_demote_pending_) {
+				syslog(
+				    LOG_WARNING,
+				    "Demotion requested during promotion - will be started after completing promotion");
+				is_demote_pending_ = true;
+			}
 			return;
 		}
 		syslog(LOG_DEBUG, "Demotion already in progress (PID %d)", command_pid_);
@@ -183,7 +194,7 @@ void uRaftController::checkCommandStatus(const boost::system::error_code &error)
 				// Only execute pending promotion if node is still Leader. This prevents
 				// synchronization issues between uRaft state and SaunaFS state.
 				if (state_.type == kLeader) {
-					syslog(LOG_WARNING, "Starting pending promotion to master mode to the Leader");
+					syslog(LOG_WARNING, "Starting pending promotion to master mode for the Leader");
 					nodePromote();
 				} else {
 					syslog(LOG_WARNING, "Canceling pending promotion (no longer Leader, state=%d)",
@@ -195,7 +206,6 @@ void uRaftController::checkCommandStatus(const boost::system::error_code &error)
 			if (commandSucceeded) {
 				syslog(LOG_NOTICE, "Metadata server switch to master mode done");
 				startPromotionBackoff(/*reset=*/true);
-				node_alive_ = true;
 
 				if (state_.type == kLeader) {
 					// Start floating IP only if promoted node is still Leader
@@ -204,11 +214,12 @@ void uRaftController::checkCommandStatus(const boost::system::error_code &error)
 					syslog(LOG_ERR,
 					       "Promotion completed but no longer uRaft Leader (state=%d) - reverting",
 					       state_.type);
-					// Immediately demote to fix inconsistency
+					// Request demotion to fix inconsistency (may be deferred)
 					nodeDemote();
 				}
 			} else {
-				syslog(LOG_ERR, "Promotion failed with exit code: %d", WEXITSTATUS(status));
+				syslog(LOG_ERR, "Promotion failed with exit code: %d",
+				       WIFEXITED(status) ? WEXITSTATUS(status) : -1);
 				handlePromotionFailure();
 			}
 
@@ -222,12 +233,17 @@ void uRaftController::checkCommandStatus(const boost::system::error_code &error)
 					       "Starting pending demotion to slave mode: no longer the Leader");
 					nodeDemote();
 				} else {
-					syslog(LOG_WARNING, "Cancelling pending demotion: still Leader)");
+					syslog(LOG_WARNING, "Canceling pending demotion: still Leader");
 				}
 				is_demote_pending_ = false;
 			}
 		} else if (command_type_ == kCmdStatusDead) {
-			syslog(LOG_NOTICE, "Waiting for new metadata server instance to be available");
+			if (commandSucceeded) {
+				syslog(LOG_NOTICE, "Dead-metadata handler completed");
+			} else {
+				syslog(LOG_ERR, "Dead-metadata handler failed with exit code: %d",
+				       WIFEXITED(status) ? WEXITSTATUS(status) : -1);
+			}
 			command_type_ = kCmdNone;
 			command_pid_  = -1;
 		}
@@ -265,15 +281,15 @@ void uRaftController::checkNodeStatus(const boost::system::error_code &error) {
 		if (is_alive != node_alive_) {
 			if (is_alive) {
 				syslog(LOG_NOTICE, "Metadata server is alive");
+				cancelDeadRecovery();
 			} else {
 				syslog(LOG_NOTICE, "Metadata server is dead");
-				stopFloatingIpManager();
-				demoteLeader();
-				set_block_promotion(true);
-				setSlowCommandTimeout(opt_.dead_handler_timeout);
-				if (runSlowCommand("saunafs-uraft-helper dead")) {
-					command_type_ = kCmdStatusDead;
-				}
+				// Controller-owned dead handling:
+				// 1) Raft-only step-down (no implicit nodeDemote()) so another node can take over.
+				// 2) Run the helper's 'dead' command to release floating IPs without restarting sfsmaster.
+				stepDownToFollower(StepDownPolicy::kRaftOnly);
+				startDeadMetadataHandler();
+				scheduleDeadRecovery();
 			}
 			node_alive_ = is_alive;
 		}
@@ -282,6 +298,58 @@ void uRaftController::checkNodeStatus(const boost::system::error_code &error) {
 	check_node_status_timer_.expires_from_now(boost::posix_time::millisec(opt_.check_node_status_period));
 	check_node_status_timer_.async_wait(boost::bind(&uRaftController::checkNodeStatus, this,
 	                                    boost::asio::placeholders::error));
+}
+
+void uRaftController::startDeadMetadataHandler() {
+	// Ensure floating IP manager stops trying to restore IPs.
+	stopFloatingIpManager();
+
+	// Prevent concurrent transitions; caller should already ensure kCmdNone.
+	if (command_pid_ >= 0) {
+		syslog(LOG_WARNING,
+		       "Dead-metadata handler requested while another command is running (type=%d pid=%d)",
+		       command_type_, command_pid_);
+		return;
+	}
+
+	setSlowCommandTimeout(opt_.dead_handler_timeout);
+	if (runSlowCommand("saunafs-uraft-helper dead")) {
+		command_type_ = kCmdStatusDead;
+	}
+}
+
+void uRaftController::cancelDeadRecovery() {
+	dead_recovery_pending_ = false;
+	dead_recovery_timer_.cancel();
+}
+
+void uRaftController::scheduleDeadRecovery() {
+	// Idempotent: don't stack multiple recovery timers
+	if (dead_recovery_pending_) { return; }
+	dead_recovery_pending_ = true;
+
+	dead_recovery_timer_.expires_from_now(boost::posix_time::millisec(kDeadRecoveryDelayMs));
+	dead_recovery_timer_.async_wait([this](const boost::system::error_code &ec) {
+		if (ec) { return; }
+
+		// If metadata recovered, stop dead recovery process
+		if (node_alive_) {
+			cancelDeadRecovery();
+			return;
+		}
+
+		// If another command is running, retry after the same delay
+		if (command_pid_ >= 0 || command_type_ != kCmdNone) {
+			cancelDeadRecovery();
+			scheduleDeadRecovery();
+			return;
+		}
+
+		// Still dead and safe to act: restart shadow via demote path
+		syslog(LOG_WARNING, "Metadata still dead: restarting shadow via demote");
+		dead_recovery_pending_ = false;
+		nodeDemote();
+	});
 }
 
 void uRaftController::setSlowCommandTimeout(int timeout) {
@@ -484,6 +552,8 @@ void uRaftController::stopFloatingIpManager() {
 	if (haFloatingIpManager) {
 		haFloatingIpManager->stop();
 		haFloatingIpManager.reset();
+	} else {
+		syslog(LOG_INFO, "Floating IP Manager is not running, nothing to stop");
 	}
 }
 
@@ -539,7 +609,7 @@ int uRaftController::computePromotionBackoffMs() const {
 	// 1s * 2^(streak-1), capped at 60s
 	constexpr int kMaxPromotionBackoffMs = 60000;
 	if (promotion_failure_streak_ <= 0) { return 0; }
-	const int capped = std::min(promotion_failure_streak_ - 1, 6);  // 1,2,4,8,16,32,64
+	const int capped = std::min(promotion_failure_streak_ - 1, 6);  // cap exponent at 6
 	const int promotionBackoffTimeMs = 1000 * (1 << capped);
 	return std::min(promotionBackoffTimeMs, kMaxPromotionBackoffMs);
 }

--- a/src/uraft/uraftcontroller.cc
+++ b/src/uraft/uraftcontroller.cc
@@ -32,7 +32,7 @@ uRaftController::uRaftController(boost::asio::io_context &ios)
 	opt_.check_node_status_period = 250;
 	opt_.check_cmd_status_period  = 100;
 	opt_.check_floating_ip_period = 500;
-	opt_.getversion_timeout       = 50;
+	opt_.getversion_timeout       = 100;
 	opt_.promote_timeout          = 1000000;
 	opt_.demote_timeout           = 1000000;
 	opt_.dead_handler_timeout     = 1000000;
@@ -118,28 +118,31 @@ uint64_t uRaftController::nodeGetVersion() {
 		return 0;
 	}
 
-	uint64_t    res;
+	std::string versionStr;
+	std::vector<std::string> params = {"saunafs-uraft-helper", "metadata-version",
+	                                   opt_.local_master_server,
+	                                   boost::lexical_cast<std::string>(opt_.local_master_port)};
 
-	try {
-		std::string version;
-
-		std::vector<std::string> params = {
-			"saunafs-uraft-helper", "metadata-version", opt_.local_master_server,
-			boost::lexical_cast<std::string>(opt_.local_master_port)
-		};
-
-		if (!runCommand(params, version, opt_.getversion_timeout)) {
-			syslog(LOG_WARNING, "Get metadata version timeout.");
-			return state_.data_version;
-		}
-
-		res = boost::lexical_cast<uint64_t>(version.c_str());
-	} catch (...) {
-		syslog(LOG_ERR, "Invalid metadata version value.");
-		res = state_.data_version;
+	if (!runCommand(params, versionStr, opt_.getversion_timeout)) {
+		syslog(LOG_WARNING, "Get metadata version timeout - metadata server may be hung");
+		// Return 0 instead of cached version to prevent stale node from being elected
+		return 0;
 	}
 
-	return res;
+	try {
+		auto version = boost::lexical_cast<uint64_t>(versionStr.c_str());
+		return version;
+	} catch (...) {
+		syslog(LOG_ERR,
+		       "Invalid metadata version output (got: '%s') - metadata server appears hung",
+		       versionStr.substr(0, 100).c_str());
+		// Return 0 to prevent unhealthy node from being elected
+		return 0;
+	}
+}
+
+bool uRaftController::isElectorNode() const {
+	return opt_.elector_mode != 0;
 }
 
 void uRaftController::nodeLeader(int id) {

--- a/src/uraft/uraftcontroller.h
+++ b/src/uraft/uraftcontroller.h
@@ -78,6 +78,27 @@ private:
 	void startFloatingIpManager();
 	void stopFloatingIpManager();
 
+	/// @brief Run the controller-owned "dead metadata" handler.
+	///
+	/// This invokes the helper's 'dead' command to release floating IPs without restarting
+	/// the metadata process. It is used when local health checks report that metadata is dead,
+	/// so the VIP is immediately released while follow-up recovery is scheduled separately.
+	void startDeadMetadataHandler();
+
+	/// @brief Schedule a delayed dead recovery attempt (restart shadow).
+	///
+	/// The recovery is implemented as a single-delay retry loop: after the timer fires, it
+	/// either performs the recovery action if safe (no other command running), or reschedules
+	/// itself with the same delay. In case the metadata is alive again and the demotion is not
+	/// performed, the timer is canceled.
+	void scheduleDeadRecovery();
+
+	/// @brief Cancel pending dead recovery attempts.
+	///
+	/// Clears the pending flag and cancels the recovery timer so no further demote/restart
+	/// actions are attempted after metadata is observed alive again.
+	void cancelDeadRecovery();
+
 	/// @brief Clean up dirty metadata state after failed promotion.
 	///
 	/// This function is called when a promotion fails or times out, leaving the metadata server in
@@ -143,6 +164,11 @@ protected:
 	int promotion_failure_streak_ = 0;
 	/// @brief True while promotion backoff is active (promotions are temporarily blocked).
 	bool promotion_backoff_active_ = false;
+
+	/// @brief Timer used to schedule delayed recovery after detecting dead metadata.
+	boost::asio::deadline_timer dead_recovery_timer_;
+	/// @brief True while a dead recovery timer is scheduled (prevents stacking retries).
+	bool dead_recovery_pending_ = false;
 
 	pid_t                       command_pid_;   /// Last run command pid.
 	int                         command_type_;  /// Last run command type.

--- a/src/uraft/uraftcontroller.h
+++ b/src/uraft/uraftcontroller.h
@@ -48,19 +48,19 @@ public:
 	void set_options(const Options &opt);
 
 	//! called by uRaft when node is becoming leader.
-	virtual void     nodePromote();
+	void nodePromote() override;
 
 	//! called by uRaft when node is not longer a leader.
-	virtual void     nodeDemote();
+	void nodeDemote() override;
 
 	//! called by uRaft when it needs to know metadata version.
-	virtual uint64_t nodeGetVersion();
+	uint64_t nodeGetVersion() override;
 
 	//! Returns true when this node runs in elector mode.
 	bool isElectorNode() const override;
 
 	//! called by uRaft with new leader id.
-	virtual void     nodeLeader(int id);
+	void nodeLeader(int id) override;
 
 protected:
 	void  checkCommandStatus(const boost::system::error_code &error);

--- a/src/uraft/uraftcontroller.h
+++ b/src/uraft/uraftcontroller.h
@@ -56,6 +56,9 @@ public:
 	//! called by uRaft when it needs to know metadata version.
 	virtual uint64_t nodeGetVersion();
 
+	//! Returns true when this node runs in elector mode.
+	bool isElectorNode() const override;
+
 	//! called by uRaft with new leader id.
 	virtual void     nodeLeader(int id);
 

--- a/src/uraft/uraftcontroller.h
+++ b/src/uraft/uraftcontroller.h
@@ -93,25 +93,57 @@ private:
 	/// @brief Handle failed promotion attempts and restore cluster consistency.
 	///
 	/// This prevents the cluster from getting stuck when a node wins an election but fails
-	/// to complete the promotion to master, ensuring the cluster can recover by electing
-	/// a different leader.
+	/// to complete the promotion to master. The controller will step down in uRaft so another
+	/// node can take over, and will schedule a safe demotion of the local metadata server after
+	/// the promotion command completes.
 	///
 	/// This function is invoked in two scenarios:
 	/// 1. When a promotion command exits with a non-zero status (checkCommandStatus).
 	/// 2. When a promotion times out (setSlowCommandTimeout).
 	///
 	/// It performs the following recovery steps:
-	/// - Demotes the node from Leader state in the Raft algorithm.
 	/// - Cleans up any dirty metadata state left by the failed promotion.
+	/// - Demotes the node from Leader/Candidate state in the uRaft algorithm (Raft-only step-down).
+	/// - Schedules a demotion of the local metadata server after the promotion command finishes,
+	///   to avoid promote/demote command-state races.
+	/// - Enables a temporary promotion backoff (blocks new promotions for a bounded time) to avoid
+	///   tight promote/fail loops under unhealthy local state.
 	///
 	/// \see cleanupDirtyPromotion()
 	/// \see demoteLeader()
+	/// \see startPromotionBackoff()
+	/// \see computePromotionBackoffMs()
 	void handlePromotionFailure();
+
+	/// @brief Start or reset the promotion backoff state.
+	///
+	/// When enabled, backoff blocks uRaft leader promotion by calling set_block_promotion(true)
+	/// and keeps it blocked until the backoff timer expires (or until reset is requested).
+	///
+	/// \param reset If true, clears the failure streak, disables backoff, and cancels the timer.
+	void startPromotionBackoff(bool reset);
+
+	/// @brief Compute the current promotion backoff duration in milliseconds.
+	///
+	/// The duration grows exponentially with the promotion failure streak and is capped to a
+	/// bounded maximum to avoid long recovery delays.
+	///
+	/// \return Backoff duration in milliseconds (0 means no backoff should be applied).
+	int computePromotionBackoffMs() const;
 
 protected:
 	boost::asio::deadline_timer check_cmd_status_timer_;
 	boost::asio::deadline_timer check_node_status_timer_;
 	boost::asio::deadline_timer cmd_timeout_timer_;
+
+	/// @brief Timer used to implement promotion backoff after failed promotions.
+	boost::asio::deadline_timer promotion_backoff_timer_;
+	/// @brief Number of consecutive promotion failures used to compute exponential backoff.
+	/// This value is reset on successful promotion.
+	int promotion_failure_streak_ = 0;
+	/// @brief True while promotion backoff is active (promotions are temporarily blocked).
+	bool promotion_backoff_active_ = false;
+
 	pid_t                       command_pid_;   /// Last run command pid.
 	int                         command_type_;  /// Last run command type.
 	Timer                       command_timer_;


### PR DESCRIPTION
This PR is intended to addresse synchronization and state consistency issues between the Raft consensus state machine and SaunaFS metadata server (MDS) transitions. These issues could lead to leadership “ping-ponging”, stale metadata propagation, and inconsistent floating IP management.

The fixes ensure that uRaft’s internal Raft state remains correctly aligned with SaunaFS master/shadow roles, improving cluster stability and reliability under leadership changes.

**Key Changes:**

**State validation & transitions**

- Add explicit Raft state checks before and after promotion/demotion transitions to prevent actions based on stale state.
- Ensures state transitions only proceed when the node is truly in the expected Raft role (Leader vs Follower).

**Metadata versioning & election safety**

- Electors now track and respect the highest metadata version seen via leader heartbeats.
- Increased metadata version query timeout for more robust behavior under load.
- Prevents outdated nodes from being elected leader.

**Floating IP handling**

- Avoid re-assigning floating IPs that are already present.
- Ensure floating IPs are released cleanly on promotion failure.
- Idempotent and safer handling of primary/secondary floating IP assignments.

**Stale RPC / packet handling**

- Improve RPC handling to avoid dropping useful messages based on term comparisons.
- Respond properly to out-of-term RPC requests while ignoring their stale responses, improving convergence.

**Leader failure handling**

- When a metadata server that was leader is detected as dead, ensure the former leader is restarted and set to the correct shadow personality.

**Election stability**

- Add quorum hysteresis to elections to avoid rapid leader flapping due to transient conditions.

**Testing**

To validate the new changes, there were created three new Molecule scenarios:
- `uraft_fast_promoting_unique_candidate:` verify that a fresh restarted metadata server can quickly become the Leader and the election process is not sensitive to delays caused by differences in the `data_version` or the `current_term` between the restarted metadata server and other nodes.

- `uraft_hung_shadow_not_promoted:` verify a hung shadow metadata server is never promoted to Leader by uRaft.

- `uraft_isalive_failure_on_leader:` verify that when the current Leader reports itself as dead via the `isalive` helper call, the cluster elects a new Leader and blocks the failing node from being promoted.

See more details in this [tests-sync-uraft-vs-saunafs](https://github.com/leil-io/deployment/tree/tests-sync-uraft-vs-saunafs).

These changes are expected to fix the root causes described in issue #576.

Related to [LS-213](https://linear.app/leil/issue/LS-213/).