### PR TITLE
docs: Update saunafs repo reference on docs files LS-274

### DIFF
--- a/doc/saunafs-admin.8.adoc
+++ b/doc/saunafs-admin.8.adoc
@@ -155,7 +155,7 @@ Print version and exit
 
 == REPORTING BUGS
 
-Report bugs to the Github repository <https://github.com/leil/saunafs> as an
+Report bugs to the GitHub repository <https://github.com/leil-io/saunafs> as an
 issue
 
 

--- a/doc/saunafs-appendchunks.1.adoc
+++ b/doc/saunafs-appendchunks.1.adoc
@@ -20,7 +20,7 @@ are merged into one target file in the way that each file begins at 'chunk'
 
 == REPORTING BUGS
 
-Report bugs to the Github repository <https://github.com/leil/saunafs> as an
+Report bugs to the GitHub repository <https://github.com/leil-io/saunafs> as an
 issue.
 
 == COPYRIGHT

--- a/doc/saunafs-checkfile.1.adoc
+++ b/doc/saunafs-checkfile.1.adoc
@@ -18,7 +18,7 @@ specified file(s). It can be used on any file, included deleted ('trash').
 
 == REPORTING BUGS
 
-Report bugs to the Github repository <https://github.com/leil/saunafs> as an
+Report bugs to the GitHub repository <https://github.com/leil-io/saunafs> as an
 issue.
 
 == COPYRIGHT

--- a/doc/saunafs-dirinfo.1.adoc
+++ b/doc/saunafs-dirinfo.1.adoc
@@ -22,7 +22,7 @@ These options are described in saunafs(1).
 
 == REPORTING BUGS
 
-Report bugs to the Github repository <https://github.com/leil/saunafs> as an
+Report bugs to the GitHub repository <https://github.com/leil-io/saunafs> as an
 issue.
 
 == COPYRIGHT

--- a/doc/saunafs-fileinfo.1.adoc
+++ b/doc/saunafs-fileinfo.1.adoc
@@ -18,7 +18,7 @@ belonging to specified file(s). It can be used on any file, included deleted
 
 == REPORTING BUGS
 
-Report bugs to the Github repository <https://github.com/leil/saunafs> as an
+Report bugs to the GitHub repository <https://github.com/leil-io/saunafs> as an
 issue.
 
 == COPYRIGHT

--- a/doc/saunafs-filerepair.1.adoc
+++ b/doc/saunafs-filerepair.1.adoc
@@ -32,7 +32,7 @@ These options are described in saunafs(1).
 
 == REPORTING BUGS
 
-Report bugs to the Github repository <https://github.com/leil/saunafs> as an
+Report bugs to the GitHub repository <https://github.com/leil-io/saunafs> as an
 issue.
 
 == COPYRIGHT

--- a/doc/saunafs-geteattr.1.adoc
+++ b/doc/saunafs-geteattr.1.adoc
@@ -46,7 +46,7 @@ from being cached in kernel.
 
 == REPORTING BUGS
 
-Report bugs to the Github repository <https://github.com/leil/saunafs> as an
+Report bugs to the GitHub repository <https://github.com/leil-io/saunafs> as an
 issue.
 
 == COPYRIGHT

--- a/doc/saunafs-getgoal.1.adoc
+++ b/doc/saunafs-getgoal.1.adoc
@@ -30,7 +30,7 @@ contained objects (files and directories).
 
 == REPORTING BUGS
 
-Report bugs to the Github repository <https://github.com/leil/saunafs> as an
+Report bugs to the GitHub repository <https://github.com/leil-io/saunafs> as an
 issue.
 
 == COPYRIGHT

--- a/doc/saunafs-gettrashtime.1.adoc
+++ b/doc/saunafs-gettrashtime.1.adoc
@@ -38,7 +38,7 @@ file.
 
 == REPORTING BUGS
 
-Report bugs to the Github repository <https://github.com/leil/saunafs> as an
+Report bugs to the GitHub repository <https://github.com/leil-io/saunafs> as an
 issue.
 
 == COPYRIGHT

--- a/doc/saunafs-makesnapshot.1.adoc
+++ b/doc/saunafs-makesnapshot.1.adoc
@@ -23,7 +23,7 @@ by trailing slash, only directory content is copied.
 
 == REPORTING BUGS
 
-Report bugs to the Github repository <https://github.com/leil/saunafs> as an
+Report bugs to the GitHub repository <https://github.com/leil-io/saunafs> as an
 issue.
 
 == COPYRIGHT

--- a/doc/saunafs-migrations.7.adoc
+++ b/doc/saunafs-migrations.7.adoc
@@ -101,7 +101,7 @@ Apply this change to master, metalogger and shadow changelogs.
 
 == REPORTING BUGS
 
-Report bugs to the Github repository <https://github.com/leil/saunafs> as an
+Report bugs to the GitHub repository <https://github.com/leil-io/saunafs> as an
 issue. Include version information and relevant logs when reporting bugs.
 
 == COPYRIGHT

--- a/doc/saunafs-repquota.1.adoc
+++ b/doc/saunafs-repquota.1.adoc
@@ -71,7 +71,7 @@ created).
 
 == REPORTING BUGS
 
-Report bugs to the Github repository <https://github.com/leil/saunafs> as an
+Report bugs to the GitHub repository <https://github.com/leil-io/saunafs> as an
 issue.
 
 == COPYRIGHT

--- a/doc/saunafs-rremove.1.adoc
+++ b/doc/saunafs-rremove.1.adoc
@@ -16,7 +16,7 @@ saunafs-rremove - remove recursively
 
 == REPORTING BUGS
 
-Report bugs to the Github repository <https://github.com/leil/saunafs> as an
+Report bugs to the GitHub repository <https://github.com/leil-io/saunafs> as an
 issue.
 
 == COPYRIGHT

--- a/doc/saunafs.1.adoc
+++ b/doc/saunafs.1.adoc
@@ -100,7 +100,7 @@ change an attribute for a directory and all of its children use `'-r'` option.
 
 == REPORTING BUGS
 
-Report bugs to the Github repository <https://github.com/leil/saunafs> as an
+Report bugs to the GitHub repository <https://github.com/leil-io/saunafs> as an
 issue.
 
 == COPYRIGHT

--- a/doc/saunafs.7.adoc
+++ b/doc/saunafs.7.adoc
@@ -73,7 +73,7 @@ given file.
 
 == REPORTING BUGS
 
-Report bugs to the Github repository <https://github.com/leil/saunafs> as an
+Report bugs to the GitHub repository <https://github.com/leil-io/saunafs> as an
 issue.
 
 == COPYRIGHT

--- a/doc/sfschunkserver.8.adoc
+++ b/doc/sfschunkserver.8.adoc
@@ -72,7 +72,7 @@ Chunkserver charts state
 
 == REPORTING BUGS
 
-Report bugs to the Github repository <https://github.com/leil/saunafs> as an
+Report bugs to the GitHub repository <https://github.com/leil-io/saunafs> as an
 issue.
 
 == COPYRIGHT

--- a/doc/sfschunkserver.cfg.5.adoc
+++ b/doc/sfschunkserver.cfg.5.adoc
@@ -218,7 +218,7 @@ config value LOG_LEVEL to determine logging level. Valid log levels are
 
 == REPORTING BUGS
 
-Report bugs to the Github repository <https://github.com/leil/saunafs> as an
+Report bugs to the GitHub repository <https://github.com/leil-io/saunafs> as an
 issue.
 
 

--- a/doc/sfsexports.cfg.5.adoc
+++ b/doc/sfsexports.cfg.5.adoc
@@ -120,7 +120,7 @@ turned off.
 
 == REPORTING BUGS
 
-Report bugs to the Github repository <https://github.com/leil/saunafs> as an
+Report bugs to the GitHub repository <https://github.com/leil-io/saunafs> as an
 issue.
 
 

--- a/doc/sfsglobaliolimits.cfg.5.adoc
+++ b/doc/sfsglobaliolimits.cfg.5.adoc
@@ -89,7 +89,7 @@ independently from each other.
 
 == REPORTING BUGS
 
-Report bugs to the Github repository <https://github.com/leil/saunafs> as an
+Report bugs to the GitHub repository <https://github.com/leil-io/saunafs> as an
 issue.
 
 == COPYRIGHT

--- a/doc/sfsgoals.cfg.5.adoc
+++ b/doc/sfsgoals.cfg.5.adoc
@@ -96,7 +96,7 @@ the goal with higher 'id' of the two.
 
 == REPORTING BUGS
 
-Report bugs to the Github repository <https://github.com/leil/saunafs> as an
+Report bugs to the GitHub repository <https://github.com/leil-io/saunafs> as an
 issue.
 
 == COPYRIGHT

--- a/doc/sfshdd.cfg.5.adoc
+++ b/doc/sfshdd.cfg.5.adoc
@@ -45,7 +45,7 @@ removal.
 
 == REPORTING BUGS
 
-Report bugs to the Github repository <https://github.com/leil/saunafs> as an
+Report bugs to the GitHub repository <https://github.com/leil-io/saunafs> as an
 issue.
 
 == COPYRIGHT

--- a/doc/sfsiolimits.cfg.5.adoc
+++ b/doc/sfsiolimits.cfg.5.adoc
@@ -15,7 +15,7 @@ The same as in sfsglobaliolimits.cfg(5).
 
 == REPORTING BUGS
 
-Report bugs to the Github repository <https://github.com/leil/saunafs> as an
+Report bugs to the GitHub repository <https://github.com/leil-io/saunafs> as an
 issue.
 
 == COPYRIGHT

--- a/doc/sfsmaster.8.adoc
+++ b/doc/sfsmaster.8.adoc
@@ -100,7 +100,7 @@ data directory)
 
 == REPORTING BUGS
 
-Report bugs to the Github repository <https://github.com/leil/saunafs> as an
+Report bugs to the GitHub repository <https://github.com/leil-io/saunafs> as an
 issue.
 
 == COPYRIGHT

--- a/doc/sfsmaster.cfg.5.adoc
+++ b/doc/sfsmaster.cfg.5.adoc
@@ -305,7 +305,7 @@ increased above soft limit, but never above hard limit.
 
 == REPORTING BUGS
 
-Report bugs to the Github repository <https://github.com/leil/saunafs> as an
+Report bugs to the GitHub repository <https://github.com/leil-io/saunafs> as an
 issue.
 
 == COPYRIGHT

--- a/doc/sfsmetadump.8.adoc
+++ b/doc/sfsmetadump.8.adoc
@@ -17,7 +17,7 @@ dumps file system metadata into specified file.
 
 == REPORTING BUGS
 
-Report bugs to the Github repository <https://github.com/leil/saunafs> as an
+Report bugs to the GitHub repository <https://github.com/leil-io/saunafs> as an
 issue.
 
 == COPYRIGHT

--- a/doc/sfsmetalogger.8.adoc
+++ b/doc/sfsmetalogger.8.adoc
@@ -74,7 +74,7 @@ Latest copy of sessions.sfs file from SaunaFS master.
 
 == REPORTING BUGS
 
-Report bugs to the Github repository <https://github.com/leil/saunafs> as an
+Report bugs to the GitHub repository <https://github.com/leil-io/saunafs> as an
 issue.
 
 == COPYRIGHT

--- a/doc/sfsmetalogger.cfg.5.adoc
+++ b/doc/sfsmetalogger.cfg.5.adoc
@@ -80,7 +80,7 @@ config value LOG_LEVEL to determine logging level. Valid log levels are
 
 == REPORTING BUGS
 
-Report bugs to the Github repository <https://github.com/leil/saunafs> as an
+Report bugs to the GitHub repository <https://github.com/leil-io/saunafs> as an
 issue.
 
 == COPYRIGHT

--- a/doc/sfsmetarestore.8.adoc
+++ b/doc/sfsmetarestore.8.adoc
@@ -73,7 +73,7 @@ Sauna File System metadata change logs
 
 == REPORTING BUGS
 
-Report bugs to the Github repository <https://github.com/leil/saunafs> as an
+Report bugs to the GitHub repository <https://github.com/leil-io/saunafs> as an
 issue.
 
 == COPYRIGHT

--- a/doc/sfsmount.1.adoc
+++ b/doc/sfsmount.1.adoc
@@ -359,7 +359,7 @@ You can define your `/etc/fstab` SaunaFS share like this:
 
 == REPORTING BUGS
 
-Report bugs to the Github repository <https://github.com/leil/saunafs> as an
+Report bugs to the GitHub repository <https://github.com/leil-io/saunafs> as an
 issue.
 
 == NOTES

--- a/doc/sfsmount.cfg.5.adoc
+++ b/doc/sfsmount.cfg.5.adoc
@@ -40,7 +40,7 @@ path. Lines starting with the *#* character are ignored.
 
 === REPORTING BUGS
 
-Report bugs to the Github repository <https://github.com/leil/saunafs> as an
+Report bugs to the GitHub repository <https://github.com/leil-io/saunafs> as an
 issue.
 
 === COPYRIGHT

--- a/doc/sfsrestoremaster.8.adoc
+++ b/doc/sfsrestoremaster.8.adoc
@@ -31,7 +31,7 @@ This scripts performs the following steps:
 
 == REPORTING BUGS
 
-Report bugs to the Github repository <https://github.com/leil/saunafs> as an
+Report bugs to the GitHub repository <https://github.com/leil-io/saunafs> as an
 issue.
 
 == COPYRIGHT

--- a/doc/sfstopology.cfg.5.adoc
+++ b/doc/sfstopology.cfg.5.adoc
@@ -47,7 +47,7 @@ created randomly. Also rebalance routines do not take distances into account.
 
 == REPORTING BUGS
 
-Report bugs to the Github repository <https://github.com/leil/saunafs> as an
+Report bugs to the GitHub repository <https://github.com/leil-io/saunafs> as an
 issue.
 
 


### PR DESCRIPTION
Update saunafs repo reference on doc files. Does not include the fix on the uraft related docs as those are already being treated on PR: https://github.com/leil-io/saunafs/pull/713