### PR TITLE
refactor(master): allow stats operations in kv backends

### DIFF
--- a/src/fdb/fdb_unittest.cc
+++ b/src/fdb/fdb_unittest.cc
@@ -27,6 +27,7 @@
 
 #include <gtest/gtest.h>
 #include <cstddef>
+#include <cstdint>
 #include <vector>
 
 /// Fixture for testing the FDBKVEngine.
@@ -313,4 +314,113 @@ TEST_F(FDBKVEngineTest, GetAsync) {
 
 	safs::log_info("Non-existent key test passed: key '{}' correctly returned no value",
 	               nonExistentKeyStr);
+}
+
+/// Tests extractIntegralLEFromFuture with various integral types and scenarios.
+TEST_F(FDBKVEngineTest, ExtractIntegralLEFromFuture) {
+	// Test with int64_t
+	{
+		std::string_view keyStr = "integral_key_int64";
+		auto key = kv::toBytes(keyStr);
+		constexpr int64_t expectedValue = 42;
+
+		auto txn = kvEngine->createReadWriteTransaction();
+		txn->set(key, kv::toBytesLE(expectedValue));
+		ASSERT_TRUE(txn->commit()) << "Failed to commit transaction for int64_t test.";
+
+		auto txn2 = kvEngine->createReadOnlyTransaction();
+		auto future = txn2->getAsync(key);
+		ASSERT_TRUE(future != nullptr) << "Failed to create async future for int64_t test.";
+
+		auto extractedValue = kv::extractIntegralLEFromFuture<int64_t>(future, keyStr);
+		ASSERT_EQ(extractedValue, expectedValue) << "Extracted int64_t value does not match.";
+	}
+
+	// Test with uint64_t
+	{
+		std::string_view keyStr = "integral_key_uint64";
+		auto key = kv::toBytes(keyStr);
+		constexpr uint64_t expectedValue = 0xDEADBEEFCAFEBABE;
+
+		auto txn = kvEngine->createReadWriteTransaction();
+		txn->set(key, kv::toBytesLE(expectedValue));
+		ASSERT_TRUE(txn->commit()) << "Failed to commit transaction for uint64_t test.";
+
+		auto txn2 = kvEngine->createReadOnlyTransaction();
+		auto future = txn2->getAsync(key);
+		ASSERT_TRUE(future != nullptr) << "Failed to create async future for uint64_t test.";
+
+		auto extractedValue = kv::extractIntegralLEFromFuture<uint64_t>(future, keyStr);
+		ASSERT_EQ(extractedValue, expectedValue) << "Extracted uint64_t value does not match.";
+	}
+
+	// Test with int32_t
+	{
+		std::string_view keyStr = "integral_key_int32";
+		auto key = kv::toBytes(keyStr);
+		constexpr int32_t expectedValue = -12345;
+
+		auto txn = kvEngine->createReadWriteTransaction();
+		txn->set(key, kv::toBytesLE(expectedValue));
+		ASSERT_TRUE(txn->commit()) << "Failed to commit transaction for int32_t test.";
+
+		auto txn2 = kvEngine->createReadOnlyTransaction();
+		auto future = txn2->getAsync(key);
+		ASSERT_TRUE(future != nullptr) << "Failed to create async future for int32_t test.";
+
+		auto extractedValue = kv::extractIntegralLEFromFuture<int32_t>(future, keyStr);
+		ASSERT_EQ(extractedValue, expectedValue) << "Extracted int32_t value does not match.";
+	}
+
+	// Test parallel extraction of multiple values
+	{
+		constexpr int64_t value1 = 100;
+		constexpr int64_t value2 = 200;
+		constexpr int64_t value3 = 300;
+
+		auto key1 = kv::toBytes("parallel_key_1");
+		auto key2 = kv::toBytes("parallel_key_2");
+		auto key3 = kv::toBytes("parallel_key_3");
+
+		auto txn = kvEngine->createReadWriteTransaction();
+		txn->set(key1, kv::toBytesLE(value1));
+		txn->set(key2, kv::toBytesLE(value2));
+		txn->set(key3, kv::toBytesLE(value3));
+		ASSERT_TRUE(txn->commit()) << "Failed to commit transaction for parallel test.";
+
+		// Issue all async reads in parallel
+		auto txn2 = kvEngine->createReadOnlyTransaction();
+		auto future1 = txn2->getAsync(key1);
+		auto future2 = txn2->getAsync(key2);
+		auto future3 = txn2->getAsync(key3);
+
+		ASSERT_TRUE(future1 != nullptr && future2 != nullptr && future3 != nullptr)
+		    << "Failed to create async futures for parallel test.";
+
+		// Extract all values
+		auto extracted1 = kv::extractIntegralLEFromFuture<int64_t>(future1, "parallel_key_1");
+		auto extracted2 = kv::extractIntegralLEFromFuture<int64_t>(future2, "parallel_key_2");
+		auto extracted3 = kv::extractIntegralLEFromFuture<int64_t>(future3, "parallel_key_3");
+
+		ASSERT_EQ(extracted1, value1) << "Parallel extraction 1 failed.";
+		ASSERT_EQ(extracted2, value2) << "Parallel extraction 2 failed.";
+		ASSERT_EQ(extracted3, value3) << "Parallel extraction 3 failed.";
+	}
+
+	// Test error case: missing key should throw exception
+	{
+		std::string_view nonExistentKeyStr = "non_existent_integral_key";
+		auto nonExistentKey = kv::toBytes(nonExistentKeyStr);
+
+		auto txn = kvEngine->createReadOnlyTransaction();
+		auto future = txn->getAsync(nonExistentKey);
+		ASSERT_TRUE(future != nullptr) << "Failed to create async future for missing key test.";
+
+		EXPECT_THROW(
+		    { kv::extractIntegralLEFromFuture<int64_t>(future, nonExistentKeyStr); },
+		    std::runtime_error)
+		    << "Expected exception for missing key was not thrown.";
+	}
+
+	safs::log_info("All extractIntegralLEFromFuture tests passed successfully.");
 }

--- a/src/kv/ifuture.h
+++ b/src/kv/ifuture.h
@@ -20,7 +20,7 @@
 
 #include <optional>
 
-#include "kv/kv_utils.h"
+#include "kv/kv_types.h"
 
 namespace kv {
 

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -1,0 +1,32 @@
+/*
+   Copyright 2023      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "common/platform.h"
+
+#include <cstdint>
+#include <vector>
+
+namespace kv {
+
+using Bytes = std::vector<uint8_t>;
+using Key = Bytes;
+using Value = Bytes;
+
+}  // namespace kv

--- a/src/kv/kv_utils.h
+++ b/src/kv/kv_utils.h
@@ -21,16 +21,16 @@
 #include "common/platform.h"
 
 #include <bit>
-#include <cstdint>
 #include <cstring>
+#include <memory>
+#include <sstream>
 #include <stdexcept>
 #include <vector>
 
-namespace kv {
+#include "kv/ifuture.h"
+#include "kv/kv_types.h"
 
-using Bytes = std::vector<uint8_t>;
-using Key = Bytes;
-using Value = Bytes;
+namespace kv {
 
 /// Converts string, string_view and const char* to a vector of uint8_t.
 inline Bytes toBytes(std::string_view str) { return {str.begin(), str.end()}; }
@@ -97,6 +97,30 @@ Key encodeKeyBE(std::string_view prefix, Args... values) {
 	(encodeValue(values), ...);
 
 	return key;
+}
+
+/// Extracts an integral value encoded in little-endian format from an async future result.
+/// Throws std::runtime_error if the key is not found or an error occurs.
+/// @param future The future containing the async get operation result.
+/// @param key The key name used for error reporting.
+/// @return The decoded integral value in native byte order.
+template <typename T>
+    requires(std::is_integral_v<T>)
+T extractIntegralLEFromFuture(std::unique_ptr<kv::IFuture> &future, std::string_view key) {
+	int error = 0;
+	auto result = future->get(&error);
+
+	if (error == 0 && result.has_value()) { return kv::fromBytesLE<T>(result.value()); }
+
+	if (error == 0 && !result.has_value()) {
+		std::ostringstream oss;
+		oss << "Key not found in future result for key '" << key << "'";
+		throw std::runtime_error(oss.str());
+	}
+
+	std::ostringstream oss;
+	oss << "Failed to extract value from future for key '" << key << "': error code " << error;
+	throw std::runtime_error(oss.str());
 }
 
 }  // namespace kv

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -306,7 +306,9 @@ bool FilesystemNodeOperationsBase::isAncestorOrNodeReservedOrTrash(FSNodeDirecto
 
 // stats
 
-void FilesystemNodeOperationsBase::getStats(FSNode *node, StatsRecord *statsOut) {
+void FilesystemNodeOperationsBase::getStats(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, FSNode *node,
+    StatsRecord *statsOut) {
 	switch (node->type) {
 	case FSNodeType::kDirectory:
 		*statsOut = static_cast<FSNodeDirectory *>(node)->stats;
@@ -348,9 +350,10 @@ void FilesystemNodeOperationsBase::getStats(FSNode *node, StatsRecord *statsOut)
 	}
 }
 
-int64_t FilesystemNodeOperationsBase::getSize(FSNode *node) {
+int64_t FilesystemNodeOperationsBase::getSize(const FilesystemOperationContext &fsOpContext,
+                                              FSNode *node) {
 	StatsRecord stats;
-	getStats(node, &stats);
+	getStats(fsOpContext, node, &stats);
 	return stats.size;
 }
 
@@ -580,7 +583,7 @@ void FilesystemNodeOperationsBase::removeEdge(const FilesystemOperationContext &
 
 	StatsRecord childStats;
 
-	getStats(childNode, &childStats);
+	getStats(fsOpContext, childNode, &childStats);
 	subStats(parent, &childStats);
 	parent->mtime = parent->ctime = timeStamp;
 	if (childNode->type == FSNodeType::kDirectory) { parent->nlink--; }
@@ -635,7 +638,7 @@ void FilesystemNodeOperationsBase::link(const FilesystemOperationContext &fsOpCo
 	}
 
 	StatsRecord childStats;
-	getStats(child, &childStats);
+	getStats(fsOpContext, child, &childStats);
 	addStats(parent, &childStats);
 
 	if (timeStamp > 0) {
@@ -714,7 +717,7 @@ FSNode *FilesystemNodeOperationsBase::createNode(
 	fsnodes_quota_update(node, {{QuotaResource::kInodes, +1}});
 
 	if (type == FSNodeType::kFile) {
-		fsnodes_quota_update(node, {{QuotaResource::kSize, +getSize(node)}});
+		fsnodes_quota_update(node, {{QuotaResource::kSize, +getSize(fsOpContext, node)}});
 	}
 
 	return node;
@@ -1206,7 +1209,8 @@ void FilesystemNodeOperationsBase::checkFile(FSNodeFile *nodeFile, ChunkCountArr
 }
 #endif
 
-uint8_t FilesystemNodeOperationsBase::appendChunks(uint32_t timeStamp, FSNodeFile *destNodeFile,
+uint8_t FilesystemNodeOperationsBase::appendChunks(const FilesystemOperationContext &fsOpContext,
+                                                   uint32_t timeStamp, FSNodeFile *destNodeFile,
                                                    FSNodeFile *srcNodeFile) {
 	if (srcNodeFile->chunks.empty()) { return SAUNAFS_STATUS_OK; }
 
@@ -1219,7 +1223,7 @@ uint8_t FilesystemNodeOperationsBase::appendChunks(uint32_t timeStamp, FSNodeFil
 
 	StatsRecord previousStats;
 	StatsRecord newStats;
-	getStats(destNodeFile, &previousStats);
+	getStats(fsOpContext, destNodeFile, &previousStats);
 
 	uint32_t resultChunks = srcChunks + dstChunks;
 	destNodeFile->chunks.resize(resultChunks, 0);
@@ -1252,7 +1256,7 @@ uint8_t FilesystemNodeOperationsBase::appendChunks(uint32_t timeStamp, FSNodeFil
 	}
 
 	destNodeFile->length = length;
-	getStats(destNodeFile, &newStats);
+	getStats(fsOpContext, destNodeFile, &newStats);
 
 	// Update quotas based on the change in file size
 	fsnodes_quota_update(destNodeFile,
@@ -1276,12 +1280,13 @@ uint8_t FilesystemNodeOperationsBase::appendChunks(uint32_t timeStamp, FSNodeFil
 	return SAUNAFS_STATUS_OK;
 }
 
-void FilesystemNodeOperationsBase::changeFileGoal(FSNodeFile *nodeFile, uint8_t goal) {
+void FilesystemNodeOperationsBase::changeFileGoal(const FilesystemOperationContext &fsOpContext,
+                                                  FSNodeFile *nodeFile, uint8_t goal) {
 	uint8_t oldGoal = nodeFile->goal;
 	StatsRecord previousStats;
 	StatsRecord newStats;
 
-	getStats(nodeFile, &previousStats);
+	getStats(fsOpContext, nodeFile, &previousStats);
 	nodeFile->goal = goal;
 
 	newStats = previousStats;
@@ -1301,12 +1306,13 @@ void FilesystemNodeOperationsBase::changeFileGoal(FSNodeFile *nodeFile, uint8_t 
 	gMetadata->nodeChangedSignal.emit(nodeFile);
 }
 
-void FilesystemNodeOperationsBase::setLength(FSNodeFile *nodeFile, uint64_t length,
+void FilesystemNodeOperationsBase::setLength(const FilesystemOperationContext &fsOpContext,
+                                             FSNodeFile *nodeFile, uint64_t length,
                                              bool eraseFurtherChunks) {
 	uint32_t chunks = 0;
 	StatsRecord previousStats;
 	StatsRecord newStats;
-	getStats(nodeFile, &previousStats);
+	getStats(fsOpContext, nodeFile, &previousStats);
 
 	if (nodeFile->type == FSNodeType::kTrash) {
 		gMetadata->trashSpace -= nodeFile->length;
@@ -1339,7 +1345,7 @@ void FilesystemNodeOperationsBase::setLength(FSNodeFile *nodeFile, uint64_t leng
 		if (chunks < nodeFile->chunks.size()) { nodeFile->chunks.resize(chunks); }
 	}
 
-	getStats(nodeFile, &newStats);
+	getStats(fsOpContext, nodeFile, &newStats);
 
 	fsnodes_quota_update(nodeFile, {{QuotaResource::kSize, newStats.size - previousStats.size}});
 
@@ -1353,7 +1359,8 @@ void FilesystemNodeOperationsBase::setLength(FSNodeFile *nodeFile, uint64_t leng
 	gMetadata->nodeChangedSignal.emit(nodeFile);
 }
 
-void FilesystemNodeOperationsBase::changeUidGid(FSNode *node, uint32_t uid, uint32_t gid) {
+void FilesystemNodeOperationsBase::changeUidGid(const FilesystemOperationContext &fsOpContext,
+                                                FSNode *node, uint32_t uid, uint32_t gid) {
 	int64_t size = 0;
 
 	// Decrease quota for old owner
@@ -1361,7 +1368,7 @@ void FilesystemNodeOperationsBase::changeUidGid(FSNode *node, uint32_t uid, uint
 
 	if (node->type == FSNodeType::kFile || node->type == FSNodeType::kTrash ||
 	    node->type == FSNodeType::kReserved) {
-		size = getSize(node);
+		size = getSize(fsOpContext, node);
 		fsnodes_quota_update(node, {{QuotaResource::kSize, -size}});
 	}
 
@@ -1378,7 +1385,8 @@ void FilesystemNodeOperationsBase::changeUidGid(FSNode *node, uint32_t uid, uint
 	}
 }
 
-void FilesystemNodeOperationsBase::removeNode(uint32_t timeStamp, FSNode *node) {
+void FilesystemNodeOperationsBase::removeNode(const FilesystemOperationContext &fsOpContext,
+                                              uint32_t timeStamp, FSNode *node) {
 	if (!node->parents.empty()) {
 		return;
 	}
@@ -1399,7 +1407,7 @@ void FilesystemNodeOperationsBase::removeNode(uint32_t timeStamp, FSNode *node) 
 
 	if (node->type == FSNodeType::kFile || node->type == FSNodeType::kTrash ||
 	    node->type == FSNodeType::kReserved) {
-		fsnodes_quota_update(node, {{QuotaResource::kSize, -getSize(node)}});
+		fsnodes_quota_update(node, {{QuotaResource::kSize, -getSize(fsOpContext, node)}});
 		gMetadata->fileNodes--;
 		for (uint32_t i = 0; i < static_cast<FSNodeFile*>(node)->chunks.size(); ++i) {
 			uint64_t chunkid = static_cast<FSNodeFile*>(node)->chunks[i];
@@ -1481,14 +1489,15 @@ void FilesystemNodeOperationsBase::unlink(const FilesystemOperationContext &fsOp
 			gMetadata->reservedSpace += fileNode->length;
 			gMetadata->reservedNodes++;
 		} else {
-			removeNode(timeStamp, childNode);
+			removeNode(fsOpContext, timeStamp, childNode);
 		}
 	} else {
-		removeNode(timeStamp, childNode);
+		removeNode(fsOpContext, timeStamp, childNode);
 	}
 }
 
-int FilesystemNodeOperationsBase::purge(uint32_t timeStamp, FSNode *node) {
+int FilesystemNodeOperationsBase::purge(const FilesystemOperationContext &fsOpContext,
+                                        uint32_t timeStamp, FSNode *node) {
 	if (node->type == FSNodeType::kTrash) {
 		auto *fileNode = static_cast<FSNodeFile *>(node);
 		gMetadata->trashSpace -= fileNode->length;
@@ -1512,7 +1521,7 @@ int FilesystemNodeOperationsBase::purge(uint32_t timeStamp, FSNode *node) {
 		                 gMetadata->trashReservedToId, node);
 		node->ctime = timeStamp;
 		fsnodes_update_checksum(node);
-		removeNode(timeStamp, node);
+		removeNode(fsOpContext, timeStamp, node);
 
 		return 1;  // Return 1 to indicate the node was successfully deleted
 	}
@@ -1528,7 +1537,7 @@ int FilesystemNodeOperationsBase::purge(uint32_t timeStamp, FSNode *node) {
 
 		fileNode->ctime = timeStamp;
 		fsnodes_update_checksum(fileNode);
-		removeNode(timeStamp, fileNode);
+		removeNode(fsOpContext, timeStamp, fileNode);
 		return 1;
 	}
 
@@ -1668,14 +1677,15 @@ uint8_t FilesystemNodeOperationsBase::undel(
 
 #ifndef METARESTORE
 
-void FilesystemNodeOperationsBase::getGoalRecursive(FSNode *node, uint8_t gmode,
+void FilesystemNodeOperationsBase::getGoalRecursive(const FilesystemOperationContext &fsOpContext,
+                                                    FSNode *node, uint8_t gmode,
                                                     GoalStatistics &fileGoalsTab,
                                                     GoalStatistics &dirGoalsTab) {
 	if (node->type == FSNodeType::kFile || node->type == FSNodeType::kTrash ||
 	    node->type == FSNodeType::kReserved) {
 		if (!GoalId::isValid(node->goal)) {
 			safs::log_warn("file inode {}: unknown goal !!! - fixing", node->id);
-			changeFileGoal(static_cast<FSNodeFile *>(node), DEFAULT_GOAL);
+			changeFileGoal(fsOpContext, static_cast<FSNodeFile *>(node), DEFAULT_GOAL);
 		}
 
 		fileGoalsTab[node->goal]++;
@@ -1691,7 +1701,7 @@ void FilesystemNodeOperationsBase::getGoalRecursive(FSNode *node, uint8_t gmode,
 			const auto *dirNode = static_cast<const FSNodeDirectory *>(node);
 
 			for (const auto &entry : dirNode->entries) {
-				getGoalRecursive(entry.second, gmode, fileGoalsTab, dirGoalsTab);
+				getGoalRecursive(fsOpContext, entry.second, gmode, fileGoalsTab, dirGoalsTab);
 			}
 		}
 	}
@@ -1737,7 +1747,8 @@ void FilesystemNodeOperationsBase::getExtraAttrRecursive(FSNode *node, uint8_t g
 
 #endif  // METARESTORE
 
-void FilesystemNodeOperationsBase::setgoalRecursive(FSNode *node, uint32_t timeStamp, uint32_t uid,
+void FilesystemNodeOperationsBase::setgoalRecursive(const FilesystemOperationContext &fsOpContext,
+                                                    FSNode *node, uint32_t timeStamp, uint32_t uid,
                                                     uint8_t goal, uint8_t smode,
                                                     inode_t *modifiedINodesOut,
                                                     inode_t *unchangedINodesOut,
@@ -1750,7 +1761,7 @@ void FilesystemNodeOperationsBase::setgoalRecursive(FSNode *node, uint32_t timeS
 		} else {
 			if ((smode & SMODE_TMASK) == SMODE_SET && node->goal != goal) {
 				if (node->type != FSNodeType::kDirectory) {
-					changeFileGoal(static_cast<FSNodeFile *>(node), goal);
+					changeFileGoal(fsOpContext, static_cast<FSNodeFile *>(node), goal);
 					(*modifiedINodesOut)++;
 				} else {
 					node->goal = goal;
@@ -1767,8 +1778,8 @@ void FilesystemNodeOperationsBase::setgoalRecursive(FSNode *node, uint32_t timeS
 
 		if (node->type == FSNodeType::kDirectory && (smode & SMODE_RMASK)) {
 			for (const auto &entry : static_cast<const FSNodeDirectory*>(node)->entries) {
-				setgoalRecursive(entry.second, timeStamp, uid, goal, smode, modifiedINodesOut,
-				                 unchangedINodesOut, permissionDeniedINodesOut);
+				setgoalRecursive(fsOpContext, entry.second, timeStamp, uid, goal, smode,
+				                 modifiedINodesOut, unchangedINodesOut, permissionDeniedINodesOut);
 			}
 		}
 	}

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -392,7 +392,8 @@ void FilesystemNodeOperationsBase::subStats(FSNodeDirectory *parent, StatsRecord
 	}
 }
 
-void FilesystemNodeOperationsBase::addStats(FSNodeDirectory *parent, StatsRecord *stats) {
+void FilesystemNodeOperationsBase::addStats(const FilesystemOperationContext &fsOpContext,
+                                            FSNodeDirectory *parent, StatsRecord *stats) {
 	if (parent != nullptr) {
 		StatsRecord *parentStats = &parent->stats;
 		parentStats->inodes += stats->inodes;
@@ -406,14 +407,15 @@ void FilesystemNodeOperationsBase::addStats(FSNodeDirectory *parent, StatsRecord
 
 		if (parent != gMetadata->root) {
 			for (auto const &[parentId, _] : parent->parents) {
-				auto *node = idToNodeVerify<FSNodeDirectory>(parentId);
-				addStats(node, stats);
+				auto *node = idToNodeVerify<FSNodeDirectory>(fsOpContext, parentId);
+				addStats(fsOpContext, node, stats);
 			}
 		}
 	}
 }
 
-void FilesystemNodeOperationsBase::addSubStats(FSNodeDirectory *parent, StatsRecord *newStats,
+void FilesystemNodeOperationsBase::addSubStats(const FilesystemOperationContext &fsOpContext,
+                                               FSNodeDirectory *parent, StatsRecord *newStats,
                                                StatsRecord *previousStats) {
 	StatsRecord resultStats;
 	resultStats.inodes = newStats->inodes - previousStats->inodes;
@@ -424,7 +426,7 @@ void FilesystemNodeOperationsBase::addSubStats(FSNodeDirectory *parent, StatsRec
 	resultStats.length = newStats->length - previousStats->length;
 	resultStats.size = newStats->size - previousStats->size;
 	resultStats.realsize = newStats->realsize - previousStats->realsize;
-	addStats(parent, &resultStats);
+	addStats(fsOpContext, parent, &resultStats);
 }
 
 void FilesystemNodeOperationsBase::fillAttr(FSNode *node, FSNode *parent, uint32_t uid,
@@ -639,7 +641,7 @@ void FilesystemNodeOperationsBase::link(const FilesystemOperationContext &fsOpCo
 
 	StatsRecord childStats;
 	getStats(fsOpContext, child, &childStats);
-	addStats(parent, &childStats);
+	addStats(fsOpContext, parent, &childStats);
 
 	if (timeStamp > 0) {
 		parent->mtime = parent->ctime = timeStamp;
@@ -1264,8 +1266,8 @@ uint8_t FilesystemNodeOperationsBase::appendChunks(const FilesystemOperationCont
 
 	// Update stats for all parent directories
 	for (const auto &[parentId, _] : destNodeFile->parents) {
-		auto *parentNode = idToNodeVerify<FSNodeDirectory>(parentId);
-		addSubStats(parentNode, &newStats, &previousStats);
+		auto *parentNode = idToNodeVerify<FSNodeDirectory>(fsOpContext, parentId);
+		addSubStats(fsOpContext, parentNode, &newStats, &previousStats);
 	}
 
 	// Update timestamps and checksums
@@ -1293,8 +1295,8 @@ void FilesystemNodeOperationsBase::changeFileGoal(const FilesystemOperationConte
 	newStats.realsize = fileRealSize(nodeFile, newStats.chunks, newStats.size);
 
 	for (const auto &[parentId, _] : nodeFile->parents) {
-		auto *parentNode = idToNodeVerify<FSNodeDirectory>(parentId);
-		addSubStats(parentNode, &newStats, &previousStats);
+		auto *parentNode = idToNodeVerify<FSNodeDirectory>(fsOpContext, parentId);
+		addSubStats(fsOpContext, parentNode, &newStats, &previousStats);
 	}
 
 	for (const auto &chunkId : nodeFile->chunks) {
@@ -1350,8 +1352,8 @@ void FilesystemNodeOperationsBase::setLength(const FilesystemOperationContext &f
 	fsnodes_quota_update(nodeFile, {{QuotaResource::kSize, newStats.size - previousStats.size}});
 
 	for (const auto &[parentId, _] : nodeFile->parents) {
-		auto *parentNode = idToNodeVerify<FSNodeDirectory>(parentId);
-		addSubStats(parentNode, &newStats, &previousStats);
+		auto *parentNode = idToNodeVerify<FSNodeDirectory>(fsOpContext, parentId);
+		addSubStats(fsOpContext, parentNode, &newStats, &previousStats);
 	}
 
 	fsnodes_update_checksum(nodeFile);

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -371,7 +371,8 @@ FSNodeDirectory *FilesystemNodeOperationsBase::getFirstParent(FSNode *node) {
 	return gMetadata->root;
 }
 
-void FilesystemNodeOperationsBase::subStats(FSNodeDirectory *parent, StatsRecord *stats) {
+void FilesystemNodeOperationsBase::subStats(const FilesystemOperationContext &fsOpContext,
+                                            FSNodeDirectory *parent, StatsRecord *stats) {
 	if (parent != nullptr) {
 		StatsRecord *parentStats = &parent->stats;
 		parentStats->inodes -= stats->inodes;
@@ -385,8 +386,8 @@ void FilesystemNodeOperationsBase::subStats(FSNodeDirectory *parent, StatsRecord
 
 		if (parent != gMetadata->root) {
 			for (auto const &[parentId, _] : parent->parents) {
-				auto *node = idToNodeVerify<FSNodeDirectory>(parentId);
-				subStats(node, stats);
+				auto *node = idToNodeVerify<FSNodeDirectory>(fsOpContext, parentId);
+				subStats(fsOpContext, node, stats);
 			}
 		}
 	}
@@ -584,10 +585,11 @@ void FilesystemNodeOperationsBase::removeEdge(const FilesystemOperationContext &
 	}
 
 	StatsRecord childStats;
-
 	getStats(fsOpContext, childNode, &childStats);
-	subStats(parent, &childStats);
+	subStats(fsOpContext, parent, &childStats);
+
 	parent->mtime = parent->ctime = timeStamp;
+
 	if (childNode->type == FSNodeType::kDirectory) { parent->nlink--; }
 
 	fsnodes_update_checksum(parent);

--- a/src/master/filesystem_node.h
+++ b/src/master/filesystem_node.h
@@ -66,11 +66,24 @@ public:
 	              uint32_t agid, uint8_t sesflags, Attributes &attr) override;
 	void fillAttr(const FsContext &context, FSNode *node, FSNode *parent,
 	              Attributes &attr) override;
+
+	/// Retrieves statistics for a filesystem node.
+	/// @see IFilesystemNodeOperations::getStats
 	void getStats(FSNode *node, StatsRecord *statsOut) override;
+
+	/// Adds statistics to a directory and recursively propagates to all ancestors.
+	/// @see IFilesystemNodeOperations::addStats
 	void addStats(FSNodeDirectory *parent, StatsRecord *stats) override;
+
+	/// Subtracts statistics from a directory and recursively propagates to all ancestors.
+	/// @see IFilesystemNodeOperations::subStats
 	void subStats(FSNodeDirectory *parent, StatsRecord *stats) override;
+
+	/// Updates directory statistics by propagating the delta between old and new stats.
+	/// @see IFilesystemNodeOperations::addSubStats
 	void addSubStats(FSNodeDirectory *parent, StatsRecord *newStats,
 	                 StatsRecord *previousStats) override;
+
 	void changeUidGid(FSNode *node, uint32_t uid, uint32_t gid) override;
 
 	void setLength(FSNodeFile *nodeFile, uint64_t length, bool eraseFurtherChunks) override;

--- a/src/master/filesystem_node.h
+++ b/src/master/filesystem_node.h
@@ -74,7 +74,8 @@ public:
 
 	/// Adds statistics to a directory and recursively propagates to all ancestors.
 	/// @see IFilesystemNodeOperations::addStats
-	void addStats(FSNodeDirectory *parent, StatsRecord *stats) override;
+	void addStats(const FilesystemOperationContext &fsOpContext, FSNodeDirectory *parent,
+	              StatsRecord *stats) override;
 
 	/// Subtracts statistics from a directory and recursively propagates to all ancestors.
 	/// @see IFilesystemNodeOperations::subStats
@@ -82,8 +83,8 @@ public:
 
 	/// Updates directory statistics by propagating the delta between old and new stats.
 	/// @see IFilesystemNodeOperations::addSubStats
-	void addSubStats(FSNodeDirectory *parent, StatsRecord *newStats,
-	                 StatsRecord *previousStats) override;
+	void addSubStats(const FilesystemOperationContext &fsOpContext, FSNodeDirectory *parent,
+	                 StatsRecord *newStats, StatsRecord *previousStats) override;
 
 	void changeUidGid(const FilesystemOperationContext &fsOpContext, FSNode *node, uint32_t uid,
 	                  uint32_t gid) override;

--- a/src/master/filesystem_node.h
+++ b/src/master/filesystem_node.h
@@ -79,7 +79,8 @@ public:
 
 	/// Subtracts statistics from a directory and recursively propagates to all ancestors.
 	/// @see IFilesystemNodeOperations::subStats
-	void subStats(FSNodeDirectory *parent, StatsRecord *stats) override;
+	void subStats(const FilesystemOperationContext &fsOpContext, FSNodeDirectory *parent,
+	              StatsRecord *stats) override;
 
 	/// Updates directory statistics by propagating the delta between old and new stats.
 	/// @see IFilesystemNodeOperations::addSubStats

--- a/src/master/filesystem_node.h
+++ b/src/master/filesystem_node.h
@@ -69,7 +69,8 @@ public:
 
 	/// Retrieves statistics for a filesystem node.
 	/// @see IFilesystemNodeOperations::getStats
-	void getStats(FSNode *node, StatsRecord *statsOut) override;
+	void getStats([[maybe_unused]] const FilesystemOperationContext &fsOpContext, FSNode *node,
+	              StatsRecord *statsOut) override;
 
 	/// Adds statistics to a directory and recursively propagates to all ancestors.
 	/// @see IFilesystemNodeOperations::addStats
@@ -84,16 +85,19 @@ public:
 	void addSubStats(FSNodeDirectory *parent, StatsRecord *newStats,
 	                 StatsRecord *previousStats) override;
 
-	void changeUidGid(FSNode *node, uint32_t uid, uint32_t gid) override;
+	void changeUidGid(const FilesystemOperationContext &fsOpContext, FSNode *node, uint32_t uid,
+	                  uint32_t gid) override;
 
-	void setLength(FSNodeFile *nodeFile, uint64_t length, bool eraseFurtherChunks) override;
-	uint8_t appendChunks(uint32_t timeStamp, FSNodeFile *destNodeFile,
-	                     FSNodeFile *srcNodeFile) override;
-	void changeFileGoal(FSNodeFile *nodeFile, uint8_t goal) override;
+	void setLength(const FilesystemOperationContext &fsOpContext, FSNodeFile *nodeFile,
+	               uint64_t length, bool eraseFurtherChunks) override;
+	uint8_t appendChunks(const FilesystemOperationContext &fsOpContext, uint32_t timeStamp,
+	                     FSNodeFile *destNodeFile, FSNodeFile *srcNodeFile) override;
+	void changeFileGoal(const FilesystemOperationContext &fsOpContext, FSNodeFile *nodeFile,
+	                    uint8_t goal) override;
 #ifndef METARESTORE
 	void checkFile(FSNodeFile *nodeFile, ChunkCountArray &chunkCount) override;
 #endif
-	int64_t getSize(FSNode *node) override;
+	int64_t getSize(const FilesystemOperationContext &fsOpContext, FSNode *node) override;
 
 	/// Returns the number of parents of the given node.
 	/// @see IFilesystemNodeOperations::getNumberOfParents
@@ -126,7 +130,8 @@ public:
 	                const HString &name, bool isCaseInsensitive = false) override;
 
 	// Trash/Reserved operations
-	int purge(uint32_t timeStamp, FSNode *node) override;
+	int purge(const FilesystemOperationContext &fsOpContext, uint32_t timeStamp,
+	          FSNode *node) override;
 	uint8_t undel(const FilesystemOperationContext &fsOpContext, uint32_t timeStamp,
 	              FSNodeFile *node) override;
 #ifndef METARESTORE
@@ -163,15 +168,17 @@ public:
 
 	// Recursive operations
 #ifndef METARESTORE
-	void getGoalRecursive(FSNode *node, uint8_t gmode, GoalStatistics &fileGoalsTab,
+	void getGoalRecursive(const FilesystemOperationContext &fsOpContext, FSNode *node,
+	                      uint8_t gmode, GoalStatistics &fileGoalsTab,
 	                      GoalStatistics &dirGoalsTab) override;
 	void getTrashTimeRecursive(FSNode *node, uint8_t gmode, TrashtimeMap &fileTrashtimes,
 	                           TrashtimeMap &dirTrashtimes) override;
 	void getExtraAttrRecursive(FSNode *node, uint8_t gmode, ExtraAttributesArray &fileEAttrTab,
 	                           ExtraAttributesArray &dirEAttrTab) override;
 #endif  // METARESTORE
-	void setgoalRecursive(FSNode *node, uint32_t timeStamp, uint32_t uid, uint8_t goal,
-	                      uint8_t smode, inode_t *modifiedINodesOut, inode_t *unchangedINodesOut,
+	void setgoalRecursive(const FilesystemOperationContext &fsOpContext, FSNode *node,
+	                      uint32_t timeStamp, uint32_t uid, uint8_t goal, uint8_t smode,
+	                      inode_t *modifiedINodesOut, inode_t *unchangedINodesOut,
 	                      inode_t *permissionDeniedINodesOut) override;
 
 	void setTrashTimeRecursive(FSNode *node, uint32_t timeStamp, uint32_t uid, uint32_t trashtime,
@@ -238,7 +245,8 @@ protected:
 private:
 	// Private helpers
 
-	void removeNode(uint32_t timeStamp, FSNode *node);
+	void removeNode(const FilesystemOperationContext &fsOpContext, uint32_t timeStamp,
+	                FSNode *node);
 
 	/// Number of blocks in the last chunk before EOF
 	static uint32_t lastChunkBlocks(FSNodeFile *node);

--- a/src/master/filesystem_node_operations_interface.h
+++ b/src/master/filesystem_node_operations_interface.h
@@ -255,6 +255,7 @@ public:
 	/// statistics decremented appropriately, maintaining the invariant that each directory's stats
 	/// represent the aggregate of all its descendants.
 	///
+	/// @param fsOpContext The filesystem operation context (transaction).
 	/// @param parent The parent directory whose statistics should be updated. Propagation should
 	///               stop at the root node. For files with hard links, this must be called for each
 	///               parent directory from which the link is removed.
@@ -266,7 +267,8 @@ public:
 	///       unlinked.
 	/// @note Recursion must stop at the root node.
 	/// @note Implementations should handle underflow gracefully (stats should not become negative).
-	virtual void subStats(FSNodeDirectory *parent, StatsRecord *stats) = 0;
+	virtual void subStats(const FilesystemOperationContext &fsOpContext, FSNodeDirectory *parent,
+	                      StatsRecord *stats) = 0;
 
 	/// Updates directory statistics by propagating the delta between old and new stats.
 	///

--- a/src/master/filesystem_node_operations_interface.h
+++ b/src/master/filesystem_node_operations_interface.h
@@ -229,6 +229,7 @@ public:
 	/// great-grandparents, etc.) are automatically updated, allowing any directory to report total
 	/// statistics for its entire subtree in O(1) time via getStats().
 	///
+	/// @param fsOpContext The filesystem operation context (transaction).
 	/// @param parent The parent directory whose statistics should be updated. Propagation should
 	///               stop at the root node. For files with hard links, this must be called for each
 	///               parent directory.
@@ -240,7 +241,8 @@ public:
 	///       - A node is moved from trash/reserved back into the active filesystem (after undel())
 	/// @note For files with multiple hard links, this must be called for each parent directory.
 	/// @note Recursion must stop at the root node.
-	virtual void addStats(FSNodeDirectory *parent, StatsRecord *stats) = 0;
+	virtual void addStats(const FilesystemOperationContext &fsOpContext, FSNodeDirectory *parent,
+	                      StatsRecord *stats) = 0;
 
 	/// Subtracts statistics from a directory and recursively propagates to all ancestors.
 	///
@@ -276,6 +278,7 @@ public:
 	/// This optimization reduces the number of recursive tree walks and operations needed when
 	/// modifying existing nodes, compared to calling subStats() followed by addStats() separately.
 	///
+	/// @param fsOpContext The filesystem operation context (transaction).
 	/// @param parent The parent directory whose statistics should be updated. Propagation should
 	///               stop at the root node. For files with hard links, this must be called for each
 	///               parent directory.
@@ -289,8 +292,8 @@ public:
 	/// @note If the delta is zero (no change), implementations may skip propagation (optimization).
 	/// @note Recursion must stop at the root node.
 	/// @note Implementations must handle both positive and negative deltas correctly.
-	virtual void addSubStats(FSNodeDirectory *parent, StatsRecord *newStats,
-	                         StatsRecord *previousStats) = 0;
+	virtual void addSubStats(const FilesystemOperationContext &fsOpContext, FSNodeDirectory *parent,
+	                         StatsRecord *newStats, StatsRecord *previousStats) = 0;
 
 	virtual void changeUidGid(const FilesystemOperationContext &fsOpContext, FSNode *node,
 	                          uint32_t uid, uint32_t gid) = 0;

--- a/src/master/filesystem_node_operations_interface.h
+++ b/src/master/filesystem_node_operations_interface.h
@@ -209,12 +209,14 @@ public:
 	/// For non-directory nodes (files, symlinks, devices), statistics are calculated on-the-fly
 	/// from the node's current state (chunk count, size, etc.) without using any cache.
 	///
+	/// @param fsOpContext The filesystem operation context (transaction).
 	/// @param node The filesystem node for which to retrieve statistics.
 	/// @param[out] statsOut Pointer to a StatsRecord structure that will be filled with the
 	///                      node's statistics. For directories, the returned stats must include:
 	///                      - All descendant nodes' aggregated stats
 	///                      - The directory itself (+1 to inodes and dirs counts)
-	virtual void getStats(FSNode *node, StatsRecord *statsOut) = 0;
+	virtual void getStats([[maybe_unused]] const FilesystemOperationContext &fsOpContext,
+	                      FSNode *node, StatsRecord *statsOut) = 0;
 
 	/// Adds statistics to a directory and recursively propagates the changes to all ancestors.
 	///
@@ -290,16 +292,19 @@ public:
 	virtual void addSubStats(FSNodeDirectory *parent, StatsRecord *newStats,
 	                         StatsRecord *previousStats) = 0;
 
-	virtual void changeUidGid(FSNode *node, uint32_t uid, uint32_t gid) = 0;
+	virtual void changeUidGid(const FilesystemOperationContext &fsOpContext, FSNode *node,
+	                          uint32_t uid, uint32_t gid) = 0;
 
-	virtual void setLength(FSNodeFile *nodeFile, uint64_t length, bool eraseFurtherChunks) = 0;
-	virtual uint8_t appendChunks(uint32_t timeStamp, FSNodeFile *destNodeFile,
-	                             FSNodeFile *srcNodeFile) = 0;
-	virtual void changeFileGoal(FSNodeFile *nodeFile, uint8_t goal) = 0;
+	virtual void setLength(const FilesystemOperationContext &fsOpContext, FSNodeFile *nodeFile,
+	                       uint64_t length, bool eraseFurtherChunks) = 0;
+	virtual uint8_t appendChunks(const FilesystemOperationContext &fsOpContext, uint32_t timeStamp,
+	                             FSNodeFile *destNodeFile, FSNodeFile *srcNodeFile) = 0;
+	virtual void changeFileGoal(const FilesystemOperationContext &fsOpContext, FSNodeFile *nodeFile,
+	                            uint8_t goal) = 0;
 #ifndef METARESTORE
 	virtual void checkFile(FSNodeFile *nodeFile, ChunkCountArray &chunkCount) = 0;
 #endif
-	virtual int64_t getSize(FSNode *node) = 0;
+	virtual int64_t getSize(const FilesystemOperationContext &fsOpContext, FSNode *node) = 0;
 
 	/// Returns the number of parents of the given node, possibly reusing the transaction
 	/// inside fsOpContext.
@@ -380,7 +385,8 @@ public:
 
 	// Trash/Reserved operations
 
-	virtual int purge(uint32_t timeStamp, FSNode *node) = 0;
+	virtual int purge(const FilesystemOperationContext &fsOpContext, uint32_t timeStamp,
+	                  FSNode *node) = 0;
 	virtual uint8_t undel(const FilesystemOperationContext &fsOpContext, uint32_t timeStamp,
 	                      FSNodeFile *node) = 0;
 #ifndef METARESTORE
@@ -420,7 +426,8 @@ public:
 
 	// Recursive operations
 #ifndef METARESTORE
-	virtual void getGoalRecursive(FSNode *node, uint8_t gmode, GoalStatistics &fileGoalsTab,
+	virtual void getGoalRecursive(const FilesystemOperationContext &fsOpContext, FSNode *node,
+	                              uint8_t gmode, GoalStatistics &fileGoalsTab,
 	                              GoalStatistics &dirGoalsTab) = 0;
 	virtual void getTrashTimeRecursive(FSNode *node, uint8_t gmode, TrashtimeMap &fileTrashtimes,
 	                                   TrashtimeMap &dirTrashtimes) = 0;
@@ -428,9 +435,9 @@ public:
 	                                   ExtraAttributesArray &fileEAttrTab,
 	                                   ExtraAttributesArray &dirEAttrTab) = 0;
 #endif
-	virtual void setgoalRecursive(FSNode *node, uint32_t timeStamp, uint32_t uid, uint8_t goal,
-	                              uint8_t smode, inode_t *modifiedINodesOut,
-	                              inode_t *unchangedINodesOut,
+	virtual void setgoalRecursive(const FilesystemOperationContext &fsOpContext, FSNode *node,
+	                              uint32_t timeStamp, uint32_t uid, uint8_t goal, uint8_t smode,
+	                              inode_t *modifiedINodesOut, inode_t *unchangedINodesOut,
 	                              inode_t *permissionDeniedINodesOut) = 0;
 
 	virtual void setTrashTimeRecursive(FSNode *node, uint32_t timeStamp, uint32_t uid,

--- a/src/master/filesystem_node_operations_interface.h
+++ b/src/master/filesystem_node_operations_interface.h
@@ -199,11 +199,97 @@ public:
 	                      uint32_t agid, uint8_t sesflags, Attributes &attr) = 0;
 	virtual void fillAttr(const FsContext &context, FSNode *node, FSNode *parent,
 	                      Attributes &attr) = 0;
+
+	/// Retrieves statistics for a filesystem node.
+	///
+	/// For directories, this returns cached statistics that represent the aggregate of all
+	/// descendants (files, subdirectories, chunks, sizes, etc.). The cached stats enable O(1)
+	/// retrieval for operations like `saunafs dirinfo` without requiring expensive tree traversals.
+	///
+	/// For non-directory nodes (files, symlinks, devices), statistics are calculated on-the-fly
+	/// from the node's current state (chunk count, size, etc.) without using any cache.
+	///
+	/// @param node The filesystem node for which to retrieve statistics.
+	/// @param[out] statsOut Pointer to a StatsRecord structure that will be filled with the
+	///                      node's statistics. For directories, the returned stats must include:
+	///                      - All descendant nodes' aggregated stats
+	///                      - The directory itself (+1 to inodes and dirs counts)
 	virtual void getStats(FSNode *node, StatsRecord *statsOut) = 0;
+
+	/// Adds statistics to a directory and recursively propagates the changes to all ancestors.
+	///
+	/// This function must update the cached statistics of a directory by adding the provided stats,
+	/// then recursively propagate the same changes up through all parent directories to the root.
+	/// This maintains the invariant that each directory's cached stats represent the aggregate
+	/// of all its descendants.
+	///
+	/// The recursive propagation must ensure that ancestor directories (grandparents,
+	/// great-grandparents, etc.) are automatically updated, allowing any directory to report total
+	/// statistics for its entire subtree in O(1) time via getStats().
+	///
+	/// @param parent The parent directory whose statistics should be updated. Propagation should
+	///               stop at the root node. For files with hard links, this must be called for each
+	///               parent directory.
+	/// @param stats Pointer to a StatsRecord containing the statistics to add. These values must be
+	///              added to the parent's cached stats and propagated to all ancestors.
+	///
+	/// @note Implementations must call this when:
+	///       - A new node is created and linked into the filesystem (after link())
+	///       - A node is moved from trash/reserved back into the active filesystem (after undel())
+	/// @note For files with multiple hard links, this must be called for each parent directory.
+	/// @note Recursion must stop at the root node.
 	virtual void addStats(FSNodeDirectory *parent, StatsRecord *stats) = 0;
+
+	/// Subtracts statistics from a directory and recursively propagates to all ancestors.
+	///
+	/// This function must update the cached statistics of a directory by subtracting the provided
+	/// stats, then recursively propagate the same changes up through all parent directories to the
+	/// root. This is the inverse operation of addStats() and must be used when nodes are removed
+	/// from the filesystem tree.
+	///
+	/// The recursive propagation must ensure that all ancestor directories have their cached
+	/// statistics decremented appropriately, maintaining the invariant that each directory's stats
+	/// represent the aggregate of all its descendants.
+	///
+	/// @param parent The parent directory whose statistics should be updated. Propagation should
+	///               stop at the root node. For files with hard links, this must be called for each
+	///               parent directory from which the link is removed.
+	/// @param stats Pointer to a StatsRecord containing the statistics to subtract. These values
+	///              must be subtracted from the parent's cached stats and propagated to all
+	///              ancestors.
+	///
+	/// @note For files with multiple hard links, only call this for the specific parent(s) being
+	///       unlinked.
+	/// @note Recursion must stop at the root node.
+	/// @note Implementations should handle underflow gracefully (stats should not become negative).
 	virtual void subStats(FSNodeDirectory *parent, StatsRecord *stats) = 0;
+
+	/// Updates directory statistics by propagating the delta between old and new stats.
+	///
+	/// This function must efficiently update cached statistics when a node's stats change (e.g.,
+	/// file size changes, goal/replication changes, chunks added). Implementations should compute
+	/// the delta (newStats - previousStats) and propagate only the difference up through all
+	/// ancestors in a single traversal.
+	///
+	/// This optimization reduces the number of recursive tree walks and operations needed when
+	/// modifying existing nodes, compared to calling subStats() followed by addStats() separately.
+	///
+	/// @param parent The parent directory whose statistics should be updated. Propagation should
+	///               stop at the root node. For files with hard links, this must be called for each
+	///               parent directory.
+	/// @param newStats Pointer to a StatsRecord containing the node's new (modified) statistics.
+	/// @param previousStats Pointer to a StatsRecord containing the node's previous statistics
+	///                      (before modification). Callers typically obtain this by calling
+	///                      getStats() before making changes to the node.
+	///
+	/// @note For files with multiple hard links, this must be called for each parent directory.
+	/// @note Implementations should do: delta = newStats - previousStats, then propagate delta.
+	/// @note If the delta is zero (no change), implementations may skip propagation (optimization).
+	/// @note Recursion must stop at the root node.
+	/// @note Implementations must handle both positive and negative deltas correctly.
 	virtual void addSubStats(FSNodeDirectory *parent, StatsRecord *newStats,
 	                         StatsRecord *previousStats) = 0;
+
 	virtual void changeUidGid(FSNode *node, uint32_t uid, uint32_t gid) = 0;
 
 	virtual void setLength(FSNodeFile *nodeFile, uint64_t length, bool eraseFurtherChunks) = 0;

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -288,7 +288,9 @@ uint8_t FilesystemOperationsBase::undel(const FsContext &context, inode_t inode)
 	return status;
 }
 
-uint8_t FilesystemOperationsBase::purge(const FsContext &context, inode_t inode) {
+uint8_t FilesystemOperationsBase::purge(const FsContext &context,
+                                        const FilesystemOperationContext &fsOpContext,
+                                        inode_t inode) {
 	ChecksumUpdater cu(context.ts());
 	FSNode *p;
 	uint8_t status =
@@ -297,8 +299,6 @@ uint8_t FilesystemOperationsBase::purge(const FsContext &context, inode_t inode)
 		return status;
 	}
 
-	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
-	    FilesystemOperationContext::TransactionType::kReadWrite);
 	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kAny,
 	                                              MODE_MASK_EMPTY, inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
@@ -308,7 +308,7 @@ uint8_t FilesystemOperationsBase::purge(const FsContext &context, inode_t inode)
 	}
 	// This should be equal to inode, because p is not a directory
 	inode_t purged_inode = p->id;
-	nodeOperations_->purge(context.ts(), p);
+	nodeOperations_->purge(fsOpContext, context.ts(), p);
 
 	if (context.isPersonalityMaster()) {
 		changeLog(context.ts(), "PURGE(%" PRIiNode ")", purged_inode);
@@ -374,9 +374,10 @@ uint8_t FilesystemOperationsBase::getRootInode(inode_t *rootinode, const uint8_t
 	}
 }
 
-void FilesystemOperationsBase::statfs(const FsContext &context, uint64_t *totalspace,
-                                      uint64_t *availspace, uint64_t *trspace, uint64_t *respace,
-                                      inode_t *inodes) {
+void FilesystemOperationsBase::statfs(const FsContext &context,
+                                      const FilesystemOperationContext &fsOpContext,
+                                      uint64_t *totalspace, uint64_t *availspace, uint64_t *trspace,
+                                      uint64_t *respace, inode_t *inodes) {
 	FSNode *rn;
 	StatsRecord sr;
 	if (context.rootinode() == SPECIAL_INODE_ROOT) {
@@ -395,7 +396,7 @@ void FilesystemOperationsBase::statfs(const FsContext &context, uint64_t *totals
 	} else {
 		matocsserv_getspace(totalspace, availspace);
 		fsnodes_quota_adjust_space(rn, *totalspace, *availspace);
-		nodeOperations_->getStats(rn, &sr);
+		nodeOperations_->getStats(fsOpContext, rn, &sr);
 		*inodes = sr.inodes;
 	}
 	incrementFSStat(FsStats::Statfs);
@@ -884,7 +885,8 @@ uint8_t FilesystemOperationsBase::doSetLength(const FsContext &context,
 	// eraseFurtherChunks should be set to true because we are setting the
 	// length of the file and we should erase further chunks.
 	bool eraseFurtherChunks = true;
-	nodeOperations_->setLength(static_cast<FSNodeFile *>(p), length, eraseFurtherChunks);
+	nodeOperations_->setLength(fsOpContext, static_cast<FSNodeFile *>(p), length,
+	                           eraseFurtherChunks);
 	changeLog(ts, "LENGTH(%" PRIiNode ",%" PRIu64 ",%" PRIu32 ")", inode,
 	          static_cast<FSNodeFile *>(p)->length, static_cast<uint32_t>(eraseFurtherChunks));
 	p->mtime = ts;
@@ -1013,7 +1015,7 @@ uint8_t FilesystemOperationsBase::setAttr(const FsContext &context, inode_t inod
 		gMetadata->aclStorage.setMode(p->id, p->mode, p->type == FSNodeType::kDirectory);
 	}
 	if (setmask & (SET_UID_FLAG | SET_GID_FLAG)) {
-		nodeOperations_->changeUidGid(p, ((setmask & SET_UID_FLAG) ? attruid : p->uid),
+		nodeOperations_->changeUidGid(fsOpContext, p, ((setmask & SET_UID_FLAG) ? attruid : p->uid),
 		                              ((setmask & SET_GID_FLAG) ? attrgid : p->gid));
 	}
 	if (setmask & SET_ATIME_NOW_FLAG) {
@@ -1038,7 +1040,8 @@ uint8_t FilesystemOperationsBase::setAttr(const FsContext &context, inode_t inod
 }
 #endif
 
-uint8_t FilesystemOperationsBase::applyAttr(uint32_t timestamp, inode_t inode, uint32_t mode,
+uint8_t FilesystemOperationsBase::applyAttr(const FilesystemOperationContext &fsOpContext,
+                                            uint32_t timestamp, inode_t inode, uint32_t mode,
                                             uint32_t uid, uint32_t gid, uint32_t atime,
                                             uint32_t mtime) {
 	FSNode *p = nodeOperations_->idToNode(inode);
@@ -1050,7 +1053,7 @@ uint8_t FilesystemOperationsBase::applyAttr(uint32_t timestamp, inode_t inode, u
 	}
 	p->mode = mode | (p->mode & 0xF000);
 	gMetadata->aclStorage.setMode(p->id, p->mode, p->type == FSNodeType::kDirectory);
-	if (p->uid != uid || p->gid != gid) { nodeOperations_->changeUidGid(p, uid, gid); }
+	if (p->uid != uid || p->gid != gid) { nodeOperations_->changeUidGid(fsOpContext, p, uid, gid); }
 	p->atime = atime;
 	p->mtime = mtime;
 	nodeOperations_->updateCTime(p, timestamp);
@@ -1059,7 +1062,8 @@ uint8_t FilesystemOperationsBase::applyAttr(uint32_t timestamp, inode_t inode, u
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t FilesystemOperationsBase::applyLength(uint32_t timestamp, inode_t inode, uint64_t length,
+uint8_t FilesystemOperationsBase::applyLength(const FilesystemOperationContext &fsOpContext,
+                                              uint32_t timestamp, inode_t inode, uint64_t length,
                                               bool eraseFurtherChunks) {
 	FSNode *p = nodeOperations_->idToNode(inode);
 	if (!p) {
@@ -1069,7 +1073,8 @@ uint8_t FilesystemOperationsBase::applyLength(uint32_t timestamp, inode_t inode,
 	    p->type != FSNodeType::kReserved) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
-	nodeOperations_->setLength(static_cast<FSNodeFile *>(p), length, eraseFurtherChunks);
+	nodeOperations_->setLength(fsOpContext, static_cast<FSNodeFile *>(p), length,
+	                           eraseFurtherChunks);
 	p->mtime = timestamp;
 	nodeOperations_->updateCTime(p, timestamp);
 	fsnodes_update_checksum(p);
@@ -1638,7 +1643,8 @@ uint8_t FilesystemOperationsBase::rename(const FsContext &context,
 		const StatsRecord &stats = static_cast<FSNodeDirectory *>(sourceChildNode)->stats;
 		quota_delta = {{(int64_t)stats.inodes, (int64_t)stats.size}};
 	} else if (sourceChildNode->type == FSNodeType::kFile) {
-		quota_delta[(int)QuotaResource::kSize] = nodeOperations_->getSize(sourceChildNode);
+		quota_delta[(int)QuotaResource::kSize] =
+		    nodeOperations_->getSize(fsOpContext, sourceChildNode);
 	}
 
 	if (nodeOperations_->nameCheck(baseNameDst) < 0) { return SAUNAFS_ERROR_EINVAL; }
@@ -1664,8 +1670,8 @@ uint8_t FilesystemOperationsBase::rename(const FsContext &context,
 			quota_delta[(int)QuotaResource::kSize] -= stats.size;
 		} else if (destinationChildNode->type == FSNodeType::kFile) {
 			quota_delta[(int)QuotaResource::kInodes] -= 1;
-			quota_delta[(int)QuotaResource::kSize] -=
-			    nodeOperations_->getSize(static_cast<FSNodeFile *>(destinationChildNode));
+			quota_delta[(int)QuotaResource::kSize] -= nodeOperations_->getSize(
+			    fsOpContext, static_cast<FSNodeFile *>(destinationChildNode));
 		} else {
 			quota_delta[(int)QuotaResource::kInodes] -= 1;
 			quota_delta[(int)QuotaResource::kSize] -= 1;
@@ -1765,8 +1771,9 @@ uint8_t FilesystemOperationsBase::link(const FsContext &context, inode_t inode_s
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t FilesystemOperationsBase::append(const FsContext &context, inode_t inode,
-                                         inode_t inode_src) {
+uint8_t FilesystemOperationsBase::append(const FsContext &context,
+                                         const FilesystemOperationContext &fsOpContext,
+                                         inode_t inode, inode_t inode_src) {
 	ChecksumUpdater cu(context.ts());
 	FSNode *p, *sp;
 	if (inode == inode_src) {
@@ -1777,9 +1784,6 @@ uint8_t FilesystemOperationsBase::append(const FsContext &context, inode_t inode
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-
-	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
-	    FilesystemOperationContext::TransactionType::kReadWrite);
 
 	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kFile,
 	                                              MODE_MASK_W, inode, &p);
@@ -1794,7 +1798,7 @@ uint8_t FilesystemOperationsBase::append(const FsContext &context, inode_t inode
 	if (context.isPersonalityMaster() && fsnodes_quota_exceeded(p, {{QuotaResource::kSize, 1}})) {
 		return SAUNAFS_ERROR_QUOTA;
 	}
-	status = nodeOperations_->appendChunks(context.ts(), static_cast<FSNodeFile *>(p),
+	status = nodeOperations_->appendChunks(fsOpContext, context.ts(), static_cast<FSNodeFile *>(p),
 	                                       static_cast<FSNodeFile *>(sp));
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
@@ -2266,10 +2270,11 @@ uint8_t FilesystemOperationsBase::acquire(const FsContext &context, inode_t inod
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t FilesystemOperationsBase::release(const FsContext &context, inode_t inode,
-                                          uint32_t sessionid) {
+uint8_t FilesystemOperationsBase::release(const FsContext &context,
+                                          const FilesystemOperationContext &fsOpContext,
+                                          inode_t inode, uint32_t sessionid) {
 	ChecksumUpdater cu(context.ts());
-	FSNodeFile *p = nodeOperations_->idToNode<FSNodeFile>(inode);
+	FSNodeFile *p = nodeOperations_->idToNode<FSNodeFile>(fsOpContext, inode);
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
@@ -2281,7 +2286,7 @@ uint8_t FilesystemOperationsBase::release(const FsContext &context, inode_t inod
 	if (it != p->sessionIds.end()) {
 		p->sessionIds.erase(it);
 		if (p->type == FSNodeType::kReserved && p->sessionIds.empty()) {
-			nodeOperations_->purge(context.ts(), p);
+			nodeOperations_->purge(fsOpContext, context.ts(), p);
 		} else {
 			fsnodes_update_checksum(p);
 		}
@@ -2373,8 +2378,9 @@ uint8_t FilesystemOperationsBase::readChunk(inode_t inode, uint32_t indx, uint64
 }
 #endif
 
-uint8_t FilesystemOperationsBase::writeChunk(const FsContext &context, inode_t inode,
-                                             uint32_t index, bool usedummylockid,
+uint8_t FilesystemOperationsBase::writeChunk(const FsContext &context,
+                                             const FilesystemOperationContext &fsOpContext,
+                                             inode_t inode, uint32_t index, bool usedummylockid,
                                              /* inout */ uint32_t *lockid, uint64_t *chunkid,
                                              uint8_t *opflag, uint64_t *length,
                                              uint32_t min_server_version) {
@@ -2388,9 +2394,6 @@ uint8_t FilesystemOperationsBase::writeChunk(const FsContext &context, inode_t i
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-
-	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
-	    FilesystemOperationContext::TransactionType::kReadWrite);
 
 	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kFile,
 	                                              MODE_MASK_EMPTY, inode, &node);
@@ -2407,7 +2410,7 @@ uint8_t FilesystemOperationsBase::writeChunk(const FsContext &context, inode_t i
 
 	const bool quota_exceeded = fsnodes_quota_exceeded(p, {{QuotaResource::kSize, 1}});
 	StatsRecord psr;
-	nodeOperations_->getStats(p, &psr);
+	nodeOperations_->getStats(fsOpContext, p, &psr);
 
 	/* resize chunks structure */
 	if (index >= p->chunks.size()) {
@@ -2453,7 +2456,7 @@ uint8_t FilesystemOperationsBase::writeChunk(const FsContext &context, inode_t i
 	p->chunks[index] = nchunkid;
 	*chunkid = nchunkid;
 	StatsRecord nsr;
-	nodeOperations_->getStats(p, &nsr);
+	nodeOperations_->getStats(fsOpContext, p, &nsr);
 	for (const auto &[parentId, _] : p->parents) {
 		auto *parent = nodeOperations_->idToNodeVerify<FSNodeDirectory>(parentId);
 		nodeOperations_->addSubStats(parent, &nsr, &psr);
@@ -2479,7 +2482,8 @@ uint8_t FilesystemOperationsBase::writeChunk(const FsContext &context, inode_t i
 }
 
 #ifndef METARESTORE
-uint8_t FilesystemOperationsBase::writeEnd(inode_t inode, uint64_t length, uint64_t chunkid,
+uint8_t FilesystemOperationsBase::writeEnd(const FilesystemOperationContext &fsOpContext,
+                                           inode_t inode, uint64_t length, uint64_t chunkid,
                                            uint32_t lockid) {
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
@@ -2502,7 +2506,7 @@ uint8_t FilesystemOperationsBase::writeEnd(inode_t inode, uint64_t length, uint6
 			// reason is that those might be done by other clients and we don't
 			// want to erase the chunks other clients are writing.
 			bool eraseFurtherChunks = false;
-			nodeOperations_->setLength(p, length, eraseFurtherChunks);
+			nodeOperations_->setLength(fsOpContext, p, length, eraseFurtherChunks);
 			p->mtime = ts;
 			nodeOperations_->updateCTime(p, ts);
 			fsnodes_update_checksum(p);
@@ -2546,7 +2550,7 @@ uint8_t FilesystemOperationsBase::removeChunkFromFile(const FsContext &context,
 	if (status != SAUNAFS_STATUS_OK) { return status; }
 
 	auto *node_file = dynamic_cast<FSNodeFile *>(p);
-	nodeOperations_->getStats(p, &psr);
+	nodeOperations_->getStats(fsOpContext, p, &psr);
 	auto it = std::ranges::find(node_file->chunks, chunkId);
 	uint32_t indx = (it == node_file->chunks.end()) ? node_file->chunks.size()
 	                                                : std::distance(node_file->chunks.begin(), it);
@@ -2565,7 +2569,7 @@ uint8_t FilesystemOperationsBase::removeChunkFromFile(const FsContext &context,
 	uint32_t nversion = 0;
 	changeLog(ts, "REPAIR(%" PRIiNode ",%" PRIu32 "):%" PRIu32, inode, indx, nversion);
 
-	nodeOperations_->getStats(p, &nsr);
+	nodeOperations_->getStats(fsOpContext, p, &nsr);
 	for (const auto &[parentId, _] : p->parents) {
 		auto *parent = nodeOperations_->idToNodeVerify<FSNodeDirectory>(parentId);
 		nodeOperations_->addSubStats(parent, &nsr, &psr);
@@ -2605,7 +2609,7 @@ uint8_t FilesystemOperationsBase::repair(const FsContext &context, inode_t inode
 	if (status != SAUNAFS_STATUS_OK) { return status; }
 
 	FSNodeFile *node_file = static_cast<FSNodeFile*>(p);
-	nodeOperations_->getStats(p, &psr);
+	nodeOperations_->getStats(fsOpContext, p, &psr);
 	for (indx = 0; indx < node_file->chunks.size(); indx++) {
 		if (chunk_repair(p->goal, node_file->chunks[indx], &nversion, correct_only)) {
 			changeLog(ts, "REPAIR(%" PRIiNode ",%" PRIu32 "):%" PRIu32, inode, indx, nversion);
@@ -2621,7 +2625,7 @@ uint8_t FilesystemOperationsBase::repair(const FsContext &context, inode_t inode
 			(*notchanged)++;
 		}
 	}
-	nodeOperations_->getStats(p, &nsr);
+	nodeOperations_->getStats(fsOpContext, p, &nsr);
 	for (const auto &[parentId, _] : p->parents) {
 		FSNodeDirectory *parent = nodeOperations_->idToNodeVerify<FSNodeDirectory>(parentId);
 		nodeOperations_->addSubStats(parent, &nsr, &psr);
@@ -2632,13 +2636,14 @@ uint8_t FilesystemOperationsBase::repair(const FsContext &context, inode_t inode
 }
 #endif /* #ifndef METARESTORE */
 
-uint8_t FilesystemOperationsBase::applyRepair(uint32_t timestamp, inode_t inode, uint32_t indx,
+uint8_t FilesystemOperationsBase::applyRepair(const FilesystemOperationContext &fsOpContext,
+                                              uint32_t timestamp, inode_t inode, uint32_t indx,
                                               uint32_t nversion) {
 	FSNodeFile *p;
 	uint8_t status;
 	StatsRecord psr, nsr;
 
-	p = nodeOperations_->idToNode<FSNodeFile>(inode);
+	p = nodeOperations_->idToNode<FSNodeFile>(fsOpContext, inode);
 
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
@@ -2652,16 +2657,18 @@ uint8_t FilesystemOperationsBase::applyRepair(uint32_t timestamp, inode_t inode,
 	if (indx > kMaxChunkIndex) { return SAUNAFS_ERROR_INDEXTOOBIG; }
 
 	if (indx >= p->chunks.size()) {
+		safs::log_err("fs_apply_repair: indx {} is greater than number of chunks ({}), inode {}",
+		              indx, p->chunks.size(), inode);
 		return SAUNAFS_ERROR_NOCHUNK;
-		safs::log_err("fs_apply_repair: indx {} is greater than number of chunks ({}), inode {}", indx, p->chunks.size(), inode);
 	}
 
 	if (p->chunks[indx] == 0) {
-		safs::log_err("fs_apply_repair: node chunks at index {} has no chunks, inode {}", indx, inode);
+		safs::log_err("fs_apply_repair: node chunks at index {} has no chunks, inode {}", indx,
+		              inode);
 		return SAUNAFS_ERROR_NOCHUNK;
 	}
 
-	nodeOperations_->getStats(p, &psr);
+	nodeOperations_->getStats(fsOpContext, p, &psr);
 
 	if (nversion == 0) {
 		status = chunk_delete_file(p->chunks[indx], p->goal);
@@ -2670,7 +2677,7 @@ uint8_t FilesystemOperationsBase::applyRepair(uint32_t timestamp, inode_t inode,
 		status = chunk_set_version(p->chunks[indx], nversion);
 	}
 
-	nodeOperations_->getStats(p, &nsr);
+	nodeOperations_->getStats(fsOpContext, p, &nsr);
 
 	for (const auto &[parentId, _] : p->parents) {
 		auto *parent = nodeOperations_->idToNodeVerify<FSNodeDirectory>(parentId);
@@ -2678,17 +2685,21 @@ uint8_t FilesystemOperationsBase::applyRepair(uint32_t timestamp, inode_t inode,
 	}
 
 	fsnodes_quota_update(p, {{QuotaResource::kSize, nsr.size - psr.size}});
+
 	gMetadata->metadataVersion++;
 	p->mtime = timestamp;
 	nodeOperations_->updateCTime(p, timestamp);
+
 	fsnodes_update_checksum(p);
 
 	return status;
 }
 
 #ifndef METARESTORE
-uint8_t FilesystemOperationsBase::getGoal(const FsContext &context, inode_t inode, uint8_t gmode,
-                                          GoalStatistics &fgtab, GoalStatistics &dgtab) {
+uint8_t FilesystemOperationsBase::getGoal(const FsContext &context,
+                                          const FilesystemOperationContext &fsOpContext,
+                                          inode_t inode, uint8_t gmode, GoalStatistics &fgtab,
+                                          GoalStatistics &dgtab) {
 	FSNode *p;
 
 	if (!GMODE_ISVALID(gmode)) {
@@ -2701,15 +2712,13 @@ uint8_t FilesystemOperationsBase::getGoal(const FsContext &context, inode_t inod
 		return status;
 	}
 
-	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
-	    FilesystemOperationContext::TransactionType::kReadOnly);
-
 	status = nodeOperations_->getNodeForOperation(context, fsOpContext,
 	                                              ExpectedNodeType::kFileOrDirectory, 0, inode, &p);
 
 	if (status != SAUNAFS_STATUS_OK) { return status; }
 
-	nodeOperations_->getGoalRecursive(p, gmode, fgtab, dgtab);
+	nodeOperations_->getGoalRecursive(fsOpContext, p, gmode, fgtab, dgtab);
+
 	return SAUNAFS_STATUS_OK;
 }
 
@@ -2867,7 +2876,7 @@ uint8_t FilesystemOperationsBase::applySetGoal(const FsContext &context, inode_t
 	sassert(context.hasUidGidData());
 
 	SetGoalTask task(context.uid(), goal, smode);
-	uint32_t my_result = task.setGoal(p, context.ts());
+	uint32_t my_result = task.setGoal(fsOpContext, p, context.ts());
 
 	gMetadata->metadataVersion++;
 	if (master_result != my_result) {
@@ -3365,7 +3374,7 @@ uint8_t FilesystemOperationsBase::getDirStats(const FsContext &context, inode_t 
 
 	if (status != SAUNAFS_STATUS_OK) { return status; }
 
-	nodeOperations_->getStats(p, &sr);
+	nodeOperations_->getStats(fsOpContext, p, &sr);
 	*inodes = sr.inodes;
 	*dirs = sr.dirs;
 	*files = sr.files;

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -1191,7 +1191,7 @@ uint8_t FilesystemOperationsBase::symlink(const FsContext &context, inode_t pare
 	StatsRecord sr;
 	memset(&sr, 0, sizeof(StatsRecord));
 	sr.length = basePath.length();
-	nodeOperations_->addStats(static_cast<FSNodeDirectory *>(wd), &sr);
+	nodeOperations_->addStats(fsOpContext, static_cast<FSNodeDirectory *>(wd), &sr);
 	if (attr != NULL) { nodeOperations_->fillAttr(context, p, wd, *attr); }
 	if (context.isPersonalityMaster()) {
 		assert(*inode == 0);
@@ -2458,8 +2458,8 @@ uint8_t FilesystemOperationsBase::writeChunk(const FsContext &context,
 	StatsRecord nsr;
 	nodeOperations_->getStats(fsOpContext, p, &nsr);
 	for (const auto &[parentId, _] : p->parents) {
-		auto *parent = nodeOperations_->idToNodeVerify<FSNodeDirectory>(parentId);
-		nodeOperations_->addSubStats(parent, &nsr, &psr);
+		auto *parent = nodeOperations_->idToNodeVerify<FSNodeDirectory>(fsOpContext, parentId);
+		nodeOperations_->addSubStats(fsOpContext, parent, &nsr, &psr);
 	}
 	fsnodes_quota_update(p, {{QuotaResource::kSize, nsr.size - psr.size}});
 	if (length) {
@@ -2571,8 +2571,8 @@ uint8_t FilesystemOperationsBase::removeChunkFromFile(const FsContext &context,
 
 	nodeOperations_->getStats(fsOpContext, p, &nsr);
 	for (const auto &[parentId, _] : p->parents) {
-		auto *parent = nodeOperations_->idToNodeVerify<FSNodeDirectory>(parentId);
-		nodeOperations_->addSubStats(parent, &nsr, &psr);
+		auto *parent = nodeOperations_->idToNodeVerify<FSNodeDirectory>(fsOpContext, parentId);
+		nodeOperations_->addSubStats(fsOpContext, parent, &nsr, &psr);
 	}
 	fsnodes_quota_update(p, {{QuotaResource::kSize, nsr.size - psr.size}});
 	fsnodes_update_checksum(p);
@@ -2627,8 +2627,8 @@ uint8_t FilesystemOperationsBase::repair(const FsContext &context, inode_t inode
 	}
 	nodeOperations_->getStats(fsOpContext, p, &nsr);
 	for (const auto &[parentId, _] : p->parents) {
-		FSNodeDirectory *parent = nodeOperations_->idToNodeVerify<FSNodeDirectory>(parentId);
-		nodeOperations_->addSubStats(parent, &nsr, &psr);
+		auto *parent = nodeOperations_->idToNodeVerify<FSNodeDirectory>(fsOpContext, parentId);
+		nodeOperations_->addSubStats(fsOpContext, parent, &nsr, &psr);
 	}
 	fsnodes_quota_update(p, {{QuotaResource::kSize, nsr.size - psr.size}});
 	fsnodes_update_checksum(p);
@@ -2680,8 +2680,8 @@ uint8_t FilesystemOperationsBase::applyRepair(const FilesystemOperationContext &
 	nodeOperations_->getStats(fsOpContext, p, &nsr);
 
 	for (const auto &[parentId, _] : p->parents) {
-		auto *parent = nodeOperations_->idToNodeVerify<FSNodeDirectory>(parentId);
-		nodeOperations_->addSubStats(parent, &nsr, &psr);
+		auto *parent = nodeOperations_->idToNodeVerify<FSNodeDirectory>(fsOpContext, parentId);
+		nodeOperations_->addSubStats(fsOpContext, parent, &nsr, &psr);
 	}
 
 	fsnodes_quota_update(p, {{QuotaResource::kSize, nsr.size - psr.size}});

--- a/src/master/filesystem_operations.h
+++ b/src/master/filesystem_operations.h
@@ -75,11 +75,13 @@ public:
 	// Common for metarestore and master server (both personalities)
 
 	uint8_t acquire(const FsContext &context, inode_t inode, uint32_t sessionid) override;
-	uint8_t append(const FsContext &context, inode_t inode, inode_t inode_src) override;
+	uint8_t append(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	               inode_t inode, inode_t inode_src) override;
 	uint8_t deleteAcl(const FsContext &context, inode_t inode, AclType type) override;
 	uint8_t link(const FsContext &context, inode_t inode_src, inode_t parent_dst,
 	             const HString &name_dst, inode_t *inode, Attributes *attr) override;
-	uint8_t purge(const FsContext &context, inode_t inode) override;
+	uint8_t purge(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	              inode_t inode) override;
 
 	/// Renames (moves) a filesystem node from one location to another.
 	/// @see IFilesystemOperations::rename
@@ -87,7 +89,8 @@ public:
 	               inode_t parent_src, const HString &name_src, inode_t parent_dst,
 	               const HString &name_dst, inode_t *inode, Attributes *attr) override;
 
-	uint8_t release(const FsContext &context, inode_t inode, uint32_t sessionid) override;
+	uint8_t release(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                inode_t inode, uint32_t sessionid) override;
 	uint8_t setExtraAttr(const FsContext &context, inode_t inode, uint8_t eattr, uint8_t smode,
 	                     inode_t *sinodes, inode_t *ncinodes, inode_t *nsinodes) override;
 	uint8_t setGoal(const FsContext &context, inode_t inode, uint8_t goal, uint8_t smode,
@@ -104,7 +107,8 @@ public:
 	uint8_t symlink(const FsContext &context, inode_t parent, const HString &name,
 	                const std::string &path, inode_t *inode, Attributes *attr) override;
 	uint8_t undel(const FsContext &context, inode_t inode) override;
-	uint8_t writeChunk(const FsContext &context, inode_t inode, uint32_t index, bool usedummylockid,
+	uint8_t writeChunk(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                   inode_t inode, uint32_t index, bool usedummylockid,
 	                   /* inout */ uint32_t *lockid, uint64_t *chunkid, uint8_t *opflag,
 	                   uint64_t *length, uint32_t min_server_version = 0) override;
 	uint8_t setNextChunkId(const FsContext &context, uint64_t nextChunkId) override;
@@ -140,8 +144,9 @@ public:
 	                uint32_t attruid, uint32_t attrgid, uint32_t attratime, uint32_t attrmtime,
 	                SugidClearMode sugidclearmode, Attributes &attr) override;
 	uint8_t readlink(const FsContext &context, inode_t inode, std::string &path) override;
-	void statfs(const FsContext &context, uint64_t *totalspace, uint64_t *availspace,
-	            uint64_t *trashspace, uint64_t *reservedspace, inode_t *inodes) override;
+	void statfs(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	            uint64_t *totalspace, uint64_t *availspace, uint64_t *trashspace,
+	            uint64_t *reservedspace, inode_t *inodes) override;
 	uint8_t mknod(const FsContext &context, const FilesystemOperationContext &fsOpContext,
 	              inode_t parent, const HString &name, FSNodeType type, uint16_t mode,
 	              uint16_t umask, uint32_t rdev, inode_t *inode, Attributes &attr) override;
@@ -176,7 +181,8 @@ public:
 	                  ChunkCountArray &chunkCount) override;
 	uint8_t openCheck(const FsContext &context, inode_t inode, uint8_t flags,
 	                  Attributes &attr) override;
-	uint8_t getGoal(const FsContext &context, inode_t inode, uint8_t gmode, GoalStatistics &fgtab,
+	uint8_t getGoal(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                inode_t inode, uint8_t gmode, GoalStatistics &fgtab,
 	                GoalStatistics &dgtab) override;
 	uint8_t getXAttr(const FsContext &context, const FilesystemOperationContext &fsOpContext,
 	                 inode_t inode, uint8_t opened, uint8_t anleng, const uint8_t *attrname,
@@ -218,7 +224,8 @@ public:
 	uint8_t getRootInode(inode_t *rootinode, const uint8_t *path) override;
 	uint8_t endSetLength(uint64_t chunkid) override;
 	uint8_t readChunk(inode_t inode, uint32_t indx, uint64_t *chunkid, uint64_t *length) override;
-	uint8_t writeEnd(inode_t inode, uint64_t length, uint64_t chunkid, uint32_t lockid) override;
+	uint8_t writeEnd(const FilesystemOperationContext &fsOpContext, inode_t inode, uint64_t length,
+	                 uint64_t chunkid, uint32_t lockid) override;
 	void getTrashTimeStore(TrashtimeMap &fileTrashtimes, TrashtimeMap &dirTrashtimes,
 	                       uint8_t *buff) override;
 	void listXAttrData(void *xanode, uint8_t *xabuff) override;
@@ -286,14 +293,15 @@ public:
 	                    uint32_t mode, uint32_t uid, uint32_t gid, uint32_t rdev,
 	                    inode_t inode) override;
 	uint8_t applyAccess(uint32_t timestamp, inode_t inode) override;
-	uint8_t applyAttr(uint32_t timestamp, inode_t inode, uint32_t mode, uint32_t uid, uint32_t gid,
-	                  uint32_t atime, uint32_t mtime) override;
+	uint8_t applyAttr(const FilesystemOperationContext &fsOpContext, uint32_t timestamp,
+	                  inode_t inode, uint32_t mode, uint32_t uid, uint32_t gid, uint32_t atime,
+	                  uint32_t mtime) override;
 	uint8_t applySession(uint32_t sessionid) override;
 	uint8_t applyIncreaseChunkVersion(uint64_t chunkid) override;
-	uint8_t applyLength(uint32_t timestamp, inode_t inode, uint64_t length,
-	                    bool eraseFurtherChunks) override;
-	uint8_t applyRepair(uint32_t timestamp, inode_t inode, uint32_t indx,
-	                    uint32_t nversion) override;
+	uint8_t applyLength(const FilesystemOperationContext &fsOpContext, uint32_t timestamp,
+	                    inode_t inode, uint64_t length, bool eraseFurtherChunks) override;
+	uint8_t applyRepair(const FilesystemOperationContext &fsOpContext, uint32_t timestamp,
+	                    inode_t inode, uint32_t indx, uint32_t nversion) override;
 	uint8_t applySetXAttr(uint32_t timestamp, inode_t inode, uint32_t anleng,
 	                      const uint8_t *attrname, uint32_t avleng, const uint8_t *attrvalue,
 	                      uint32_t mode) override;

--- a/src/master/filesystem_operations_interface.h
+++ b/src/master/filesystem_operations_interface.h
@@ -84,11 +84,13 @@ public:
 	// Common for metarestore and master server (both personalities)
 
 	virtual uint8_t acquire(const FsContext &context, inode_t inode, uint32_t sessionid) = 0;
-	virtual uint8_t append(const FsContext &context, inode_t inode, inode_t inode_src) = 0;
+	virtual uint8_t append(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                       inode_t inode, inode_t inode_src) = 0;
 	virtual uint8_t deleteAcl(const FsContext &context, inode_t inode, AclType type) = 0;
 	virtual uint8_t link(const FsContext &context, inode_t inode_src, inode_t parent_dst,
 	                     const HString &name_dst, inode_t *inode, Attributes *attr) = 0;
-	virtual uint8_t purge(const FsContext &context, inode_t inode) = 0;
+	virtual uint8_t purge(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                      inode_t inode) = 0;
 
 	/// Renames (moves) a filesystem node from one location to another.
 	///
@@ -132,7 +134,8 @@ public:
 	virtual uint8_t rename(const FsContext &context, const FilesystemOperationContext &fsOpContext,
 	                       inode_t parent_src, const HString &name_src, inode_t parent_dst,
 	                       const HString &name_dst, inode_t *inode, Attributes *attr) = 0;
-	virtual uint8_t release(const FsContext &context, inode_t inode, uint32_t sessionid) = 0;
+	virtual uint8_t release(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                        inode_t inode, uint32_t sessionid) = 0;
 	virtual uint8_t setExtraAttr(const FsContext &context, inode_t inode, uint8_t eattr,
 	                             uint8_t smode, inode_t *sinodes, inode_t *ncinodes,
 	                             inode_t *nsinodes) = 0;
@@ -152,8 +155,9 @@ public:
 	virtual uint8_t symlink(const FsContext &context, inode_t parent, const HString &name,
 	                        const std::string &path, inode_t *inode, Attributes *attr) = 0;
 	virtual uint8_t undel(const FsContext &context, inode_t inode) = 0;
-	virtual uint8_t writeChunk(const FsContext &context, inode_t inode, uint32_t index,
-	                           bool usedummylockid,
+	virtual uint8_t writeChunk(const FsContext &context,
+	                           const FilesystemOperationContext &fsOpContext, inode_t inode,
+	                           uint32_t index, bool usedummylockid,
 	                           /* inout */ uint32_t *lockid, uint64_t *chunkid, uint8_t *opflag,
 	                           uint64_t *length, uint32_t min_server_version = 0) = 0;
 	virtual uint8_t setNextChunkId(const FsContext &context, uint64_t nextChunkId) = 0;
@@ -200,8 +204,9 @@ public:
 	                        uint32_t attratime, uint32_t attrmtime, SugidClearMode sugidclearmode,
 	                        Attributes &attr) = 0;
 	virtual uint8_t readlink(const FsContext &context, inode_t inode, std::string &path) = 0;
-	virtual void statfs(const FsContext &context, uint64_t *totalspace, uint64_t *availspace,
-	                    uint64_t *trashspace, uint64_t *reservedspace, inode_t *inodes) = 0;
+	virtual void statfs(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                    uint64_t *totalspace, uint64_t *availspace, uint64_t *trashspace,
+	                    uint64_t *reservedspace, inode_t *inodes) = 0;
 
 	/// Creates a filesystem node (file, socket, FIFO, or device).
 	///
@@ -331,8 +336,9 @@ public:
 	                          ChunkCountArray &chunkCount) = 0;
 	virtual uint8_t openCheck(const FsContext &context, inode_t inode, uint8_t flags,
 	                          Attributes &attr) = 0;
-	virtual uint8_t getGoal(const FsContext &context, inode_t inode, uint8_t gmode,
-	                        GoalStatistics &fgtab, GoalStatistics &dgtab) = 0;
+	virtual uint8_t getGoal(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                        inode_t inode, uint8_t gmode, GoalStatistics &fgtab,
+	                        GoalStatistics &dgtab) = 0;
 	virtual uint8_t getExtraAttr(const FsContext &context, inode_t inode, uint8_t gmode,
 	                             ExtraAttributesArray &fileEAttrTab,
 	                             ExtraAttributesArray &dirEAttrTab) = 0;
@@ -405,7 +411,8 @@ public:
 	virtual uint8_t endSetLength(uint64_t chunkid) = 0;
 	virtual uint8_t readChunk(inode_t inode, uint32_t indx, uint64_t *chunkid,
 	                          uint64_t *length) = 0;
-	virtual uint8_t writeEnd(inode_t inode, uint64_t length, uint64_t chunkid, uint32_t lockid) = 0;
+	virtual uint8_t writeEnd(const FilesystemOperationContext &fsOpContext, inode_t inode,
+	                         uint64_t length, uint64_t chunkid, uint32_t lockid) = 0;
 	virtual void getTrashTimeStore(TrashtimeMap &fileTrashtimes, TrashtimeMap &dirTrashtimes,
 	                               uint8_t *buff) = 0;
 	virtual void listXAttrData(void *xanode, uint8_t *xabuff) = 0;
@@ -472,14 +479,15 @@ public:
 	                            FSNodeType type, uint32_t mode, uint32_t uid, uint32_t gid,
 	                            uint32_t rdev, inode_t inode) = 0;
 	virtual uint8_t applyAccess(uint32_t timestamp, inode_t inode) = 0;
-	virtual uint8_t applyAttr(uint32_t timestamp, inode_t inode, uint32_t mode, uint32_t uid,
-	                          uint32_t gid, uint32_t atime, uint32_t mtime) = 0;
+	virtual uint8_t applyAttr(const FilesystemOperationContext &fsOpContext, uint32_t timestamp,
+	                          inode_t inode, uint32_t mode, uint32_t uid, uint32_t gid,
+	                          uint32_t atime, uint32_t mtime) = 0;
 	virtual uint8_t applySession(uint32_t sessionid) = 0;
 	virtual uint8_t applyIncreaseChunkVersion(uint64_t chunkid) = 0;
-	virtual uint8_t applyLength(uint32_t timestamp, inode_t inode, uint64_t length,
-	                            bool eraseFurtherChunks) = 0;
-	virtual uint8_t applyRepair(uint32_t timestamp, inode_t inode, uint32_t indx,
-	                            uint32_t nversion) = 0;
+	virtual uint8_t applyLength(const FilesystemOperationContext &fsOpContext, uint32_t timestamp,
+	                            inode_t inode, uint64_t length, bool eraseFurtherChunks) = 0;
+	virtual uint8_t applyRepair(const FilesystemOperationContext &fsOpContext, uint32_t timestamp,
+	                            inode_t inode, uint32_t indx, uint32_t nversion) = 0;
 	virtual uint8_t applySetXAttr(uint32_t timestamp, inode_t inode, uint32_t anleng,
 	                              const uint8_t *attrname, uint32_t avleng,
 	                              const uint8_t *attrvalue, uint32_t mode) = 0;

--- a/src/master/filesystem_periodic.cc
+++ b/src/master/filesystem_periodic.cc
@@ -535,8 +535,10 @@ static void fs_do_emptytrash(uint32_t ts) {
 	auto it = gMetadata->trash.begin();
 	watchdog.start();
 	while (it != gMetadata->trash.end() && ((*it).first.timestamp < ts)) {
-		FSNodeFile *node =
-		    gFSOperations->nodeOperations()->idToNodeVerify<FSNodeFile>((*it).first.id);
+		auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+		    FilesystemOperationContext::TransactionType::kReadWrite);
+		FSNodeFile *node = gFSOperations->nodeOperations()->idToNodeVerify<FSNodeFile>(
+		    fsOpContext, (*it).first.id);
 
 		if (!node) {
 			std::string pathName = (*it).second.get();
@@ -549,7 +551,7 @@ static void fs_do_emptytrash(uint32_t ts) {
 		assert(node->type == FSNodeType::kTrash);
 
 		auto node_id = node->id;
-		gFSOperations->nodeOperations()->purge(ts, node);
+		gFSOperations->nodeOperations()->purge(fsOpContext, ts, node);
 
 		// Purge operation should be performed anyway - if it fails, inode will be reserved
 		gFSOperations->changeLog(ts, "PURGE(%" PRIiNode ")", node_id);
@@ -573,7 +575,10 @@ static void fs_do_emptyreserved(uint32_t ts) {
 	auto it = gMetadata->reserved.begin();
 	watchdog.start();
 	while (it != gMetadata->reserved.end()) {
-		FSNodeFile *node = gFSOperations->nodeOperations()->idToNodeVerify<FSNodeFile>((*it).first);
+		auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+		    FilesystemOperationContext::TransactionType::kReadWrite);
+		auto *node =
+		    gFSOperations->nodeOperations()->idToNodeVerify<FSNodeFile>(fsOpContext, (*it).first);
 
 		if (!node) {
 			removeReservedEntry(gMetadata->reserved, gMetadata->reservedHandlesIndex,
@@ -585,7 +590,7 @@ static void fs_do_emptyreserved(uint32_t ts) {
 		assert(node->type == FSNodeType::kReserved);
 
 		auto node_id = node->id;
-		gFSOperations->nodeOperations()->purge(ts, node);
+		gFSOperations->nodeOperations()->purge(fsOpContext, ts, node);
 
 		// Purge operation should be performed anyway
 		gFSOperations->changeLog(ts, "PURGE(%" PRIiNode ")", node_id);

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -475,7 +475,7 @@ void matoclserv_chunk_status(uint64_t chunkId, uint8_t status, bool isFailedCrea
 					chunkId, messageId, fileLength, lockId);
 		}
 		if (status != SAUNAFS_STATUS_OK) {
-			gFSOperations->writeEnd(0, 0, chunkId, 0);  // ignore status - just do it.
+			gFSOperations->writeEnd(fsOpContext, 0, 0, chunkId, 0);  // ignore status - just do it.
 		}
 		return;
 	case FUSE_TRUNCATE_BEGIN:
@@ -1547,13 +1547,17 @@ void matoclserv_fuse_reserved_inodes(matoclserventry *eptr, const uint8_t *data,
 	}
 
 	FsContext context = FsContext::getForMaster(eventloop_time());
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
 	changelog_disable_flush();
 	auto it = eptr->sessionData->openFilesSet.begin();
+
 	while (it != eptr->sessionData->openFilesSet.end()) {
 		inode_t openFileIno = *it;
 		if (!inodes_to_reserve.contains(openFileIno)) {
 			// erase files not belonging to the reserve inodes list provided
-			gFSOperations->release(context, openFileIno, eptr->sessionData->sessionId);
+			gFSOperations->release(context, fsOpContext, openFileIno, eptr->sessionData->sessionId);
 			it = eptr->sessionData->openFilesSet.erase(it);
 		} else {
 			// skip files already in session
@@ -1589,8 +1593,13 @@ void matoclserv_fuse_statfs(matoclserventry *eptr, const uint8_t *data, uint32_t
 	}
 
 	get32bit(&data, msgid);
+
 	FsContext context = matoclserv_get_context(eptr);
-	gFSOperations->statfs(context, &totalspace, &availspace, &trashspace, &reservedspace, &inodes);
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadOnly);
+
+	gFSOperations->statfs(context, fsOpContext, &totalspace, &availspace, &trashspace,
+	                      &reservedspace, &inodes);
 
 	constexpr uint32_t kPacketSize = sizeof(msgid) + sizeof(totalspace) + sizeof(availspace) +
 	                                 sizeof(trashspace) + sizeof(reservedspace) + sizeof(inodes);
@@ -1726,9 +1735,11 @@ void matoclserv_sau_get_self_quota(matoclserventry *eptr, const uint8_t *data, u
 		status = gFSOperations->quotaGet(context, owners, results);
 
 		if (inode == context.rootinode() && !foundContextRootInodeResult(inode)) {
-			auto ino = gFSOperations->nodeOperations()->idToNode(inode);
+			auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+			    FilesystemOperationContext::TransactionType::kReadOnly);
+			auto *ino = gFSOperations->nodeOperations()->idToNode(fsOpContext, inode);
 			StatsRecord rootInodeStatRec;
-			gFSOperations->nodeOperations()->getStats(ino, &rootInodeStatRec);
+			gFSOperations->nodeOperations()->getStats(fsOpContext, ino, &rootInodeStatRec);
 			results.emplace_back(QuotaEntry{QuotaEntryKey{QuotaOwner{QuotaOwnerType::kInode, inode},
 			                                              QuotaRigor::kUsed, QuotaResource::kSize},
 			                                rootInodeStatRec.size});
@@ -1919,8 +1930,8 @@ void matoclserv_fuse_truncate(matoclserventry *eptr, PacketHeader header, const 
 		// New client requested to truncate xor chunk. He has to do it himself.
 		uint64_t fileLength;
 		uint8_t opflag;
-		gFSOperations->writeChunk(context, inode, length / SFSCHUNKSIZE, false, &lockId, &chunkId,
-		                          &opflag, &fileLength);
+		gFSOperations->writeChunk(context, fsOpContext, inode, length / SFSCHUNKSIZE, false,
+		                          &lockId, &chunkId, &opflag, &fileLength);
 		if (opflag) {
 			// But first we have to duplicate chunk :)
 			type = FUSE_TRUNCATE_BEGIN;
@@ -2802,11 +2813,14 @@ void matoclserv_fuse_write_chunk(matoclserventry *eptr, PacketHeader header, con
 
 	uint32_t min_server_version = kFirstXorVersion;
 
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
 	// Original Legacy (1.6.27) does not use lock ID's
 	bool useDummyLockId = false;
-	status =
-	    gFSOperations->writeChunk(matoclserv_get_context(eptr), inode, chunkIndex, useDummyLockId,
-	                              &lockId, &chunkId, &opflag, &fileLength, min_server_version);
+	status = gFSOperations->writeChunk(matoclserv_get_context(eptr), fsOpContext, inode, chunkIndex,
+	                                   useDummyLockId, &lockId, &chunkId, &opflag, &fileLength,
+	                                   min_server_version);
 
 	if (status != SAUNAFS_STATUS_OK) {
 		serializer->serializeFuseWriteChunk(outMessage, messageId, status);
@@ -2831,7 +2845,7 @@ void matoclserv_fuse_write_chunk(matoclserventry *eptr, PacketHeader header, con
 		status = matoclserv_fuse_write_chunk_respond(eptr, serializer,
 				chunkId, messageId, fileLength, lockId);
 		if (status != SAUNAFS_STATUS_OK) {
-			gFSOperations->writeEnd(0, 0, chunkId, 0);  // ignore status - just do it.
+			gFSOperations->writeEnd(fsOpContext, 0, 0, chunkId, 0);  // ignore status - just do it.
 		}
 	}
 
@@ -2862,7 +2876,9 @@ void matoclserv_fuse_write_chunk_end(matoclserventry *eptr, PacketHeader header,
 	} else if (eptr->sessionData->flags & SESFLAG_READONLY) {
 		status = SAUNAFS_ERROR_EROFS;
 	} else {
-		status = gFSOperations->writeEnd(inode, fileLength, chunkId, lockId);
+		auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+		    FilesystemOperationContext::TransactionType::kReadWrite);
+		status = gFSOperations->writeEnd(fsOpContext, inode, fileLength, chunkId, lockId);
 	}
 
 	dcm_modify(inode,eptr->sessionData->sessionId);
@@ -3092,11 +3108,26 @@ void matoclserv_fuse_getgoal(matoclserventry *eptr, PacketHeader header, const u
 				"Unknown packet type for matoclserv_fuse_getgoal: " + std::to_string(header.type));
 	}
 
+	// getGoal could attempt to change the stored goal if invalid.
+	// So we need a read-write transaction.
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
 	GoalStatistics fgtab{{0}}, dgtab{{0}}; // explicit value initialization to clear variables
 	uint8_t status =
-	    gFSOperations->getGoal(matoclserv_get_context(eptr), inode, gmode, fgtab, dgtab);
+	    gFSOperations->getGoal(matoclserv_get_context(eptr), fsOpContext, inode, gmode, fgtab, dgtab);
+
+	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
+		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+			safs::log_err(
+			    "matoclserv_fuse_getgoal: transaction failed to commit: inode {}, gmode {}", inode,
+			    static_cast<uint32_t>(gmode));
+			status = SAUNAFS_ERROR_IO;
+		}
+	}
 
 	MessageBuffer reply;
+
 	if (status == SAUNAFS_STATUS_OK) {
 		const std::map<int, Goal> &goalDefinitions = gFSOperations->getAllGoalDefinitions();
 		std::vector<FuseGetGoalStats> sauReply;
@@ -3109,6 +3140,7 @@ void matoclserv_fuse_getgoal(matoclserventry *eptr, PacketHeader header, const u
 	} else {
 		matocl::fuseGetGoal::serialize(reply, msgid, status);
 	}
+
 	matoclserv_createpacket(eptr, std::move(reply));
 }
 
@@ -3504,7 +3536,19 @@ void matoclserv_fuse_append(matoclserventry *eptr, const uint8_t *data, uint32_t
 
 	if (status == SAUNAFS_STATUS_OK) {
 		auto context = matoclserv_get_context(eptr, uid, gid);
-		status = gFSOperations->append(context, inode, inode_src);
+		auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+		    FilesystemOperationContext::TransactionType::kReadWrite);
+
+		status = gFSOperations->append(context, fsOpContext, inode, inode_src);
+
+		if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
+			if (!fsOpContext.getReadWriteTransaction()->commit()) {
+				safs::log_err(
+				    "matoclserv_fuse_append: transaction failed to commit: inode {}, source inode {}",
+				    inode, inode_src);
+				status = SAUNAFS_ERROR_IO;
+			}
+		}
 	}
 
 	ptr = matoclserv_createpacket(eptr, MATOCL_FUSE_APPEND, sizeof(msgid) + sizeof(status));
@@ -3892,7 +3936,17 @@ void matoclserv_fuse_purge(matoclserventry *eptr, const uint8_t *data, uint32_t 
 	get32bit(&data, msgid);
 	getINode(&data, inode);
 
-	status = gFSOperations->purge(matoclserv_get_context(eptr), inode);
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
+	status = gFSOperations->purge(matoclserv_get_context(eptr), fsOpContext, inode);
+
+	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
+		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+			safs::log_err("matoclserv_fuse_purge: transaction failed to commit: inode {}", inode);
+			status = SAUNAFS_ERROR_IO;
+		}
+	}
 
 	ptr = matoclserv_createpacket(eptr, MATOCL_FUSE_PURGE, sizeof(msgid) + sizeof(status));
 	put32bit(&ptr, msgid);
@@ -4739,9 +4793,11 @@ void matocl_locks_release(const FsContext &context, inode_t inode, uint32_t sess
 
 void matocl_close_files(Session *currentSession) {
 	FsContext context = FsContext::getForMaster(eventloop_time());
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
 
 	for (const auto &openFileInode : currentSession->openFilesSet) {
-		gFSOperations->release(context, openFileInode, currentSession->sessionId);
+		gFSOperations->release(context, fsOpContext, openFileInode, currentSession->sessionId);
 		matocl_locks_release(context, openFileInode, currentSession->sessionId);
 	}
 

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -2152,9 +2152,8 @@ void matoclserv_fuse_mknod(matoclserventry *eptr, PacketHeader header, const uin
 
 		if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
 			if (!fsOpContext.getReadWriteTransaction()->commit()) {
-				safs::log_err(
-				    "matoclserv_fuse_mknod: transaction failed to commit: parent inode {}, name {}",
-				    parentInode, edgeName);
+				safs::log_err("{}: transaction failed to commit: parent inode {}, name {}",
+				              __func__, parentInode, edgeName);
 
 				status = SAUNAFS_ERROR_IO;
 			}
@@ -2204,9 +2203,8 @@ void matoclserv_fuse_mkdir(matoclserventry *eptr, PacketHeader header, const uin
 
 		if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
 			if (!fsOpContext.getReadWriteTransaction()->commit()) {
-				safs::log_err(
-				    "matoclserv_fuse_mkdir: transaction failed to commit: parent inode {}, name {}",
-				    inode, name);
+				safs::log_err("{}: transaction failed to commit: parent inode {}, name {}",
+				              __func__, inode, name);
 
 				status = SAUNAFS_ERROR_IO;
 			}
@@ -2272,9 +2270,9 @@ void matoclserv_fuse_unlink(matoclserventry *eptr, const uint8_t *data, uint32_t
 
 		if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
 			if (!fsOpContext.getReadWriteTransaction()->commit()) {
-				safs::log_err(
-				    "matoclserv_fuse_unlink: transaction failed to commit: parent inode {}, name {}",
-				    inode, std::string(reinterpret_cast<const char*>(name), nleng));
+				safs::log_err("{}: transaction failed to commit: parent inode {}, name {}",
+				              __func__, inode,
+				              std::string(reinterpret_cast<const char *>(name), nleng));
 
 				status = SAUNAFS_ERROR_IO;
 			}
@@ -2369,9 +2367,9 @@ void matoclserv_fuse_rmdir(matoclserventry *eptr, const uint8_t *data, uint32_t 
 
 		if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
 			if (!fsOpContext.getReadWriteTransaction()->commit()) {
-				safs::log_err(
-				    "matoclserv_fuse_rmdir: transaction failed to commit: parent inode {}, name {}",
-				    inode, std::string(reinterpret_cast<const char*>(name), nleng));
+				safs::log_err("{}: transaction failed to commit: parent inode {}, name {}",
+				              __func__, inode,
+				              std::string(reinterpret_cast<const char *>(name), nleng));
 
 				status = SAUNAFS_ERROR_IO;
 			}
@@ -2456,9 +2454,10 @@ void matoclserv_fuse_rename(matoclserventry *eptr, const uint8_t *data, uint32_t
 		if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
 			if (!fsOpContext.getReadWriteTransaction()->commit()) {
 				safs::log_err(
-				    "matoclserv_fuse_rename: transaction failed to commit: src inode {}, src name {}, dst inode {}, dst name {}",
-				    inode_src, std::string(reinterpret_cast<const char*>(name_src), nleng_src),
-				    inode_dst, std::string(reinterpret_cast<const char*>(name_dst), nleng_dst));
+				    "{}: transaction failed to commit: src inode {}, src name {}, dst inode {}, dst name {}",
+				    __func__, inode_src,
+				    std::string(reinterpret_cast<const char *>(name_src), nleng_src), inode_dst,
+				    std::string(reinterpret_cast<const char *>(name_dst), nleng_dst));
 				status = SAUNAFS_ERROR_IO;
 			}
 		}
@@ -3119,9 +3118,8 @@ void matoclserv_fuse_getgoal(matoclserventry *eptr, PacketHeader header, const u
 
 	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
 		if (!fsOpContext.getReadWriteTransaction()->commit()) {
-			safs::log_err(
-			    "matoclserv_fuse_getgoal: transaction failed to commit: inode {}, gmode {}", inode,
-			    static_cast<uint32_t>(gmode));
+			safs::log_err("{}: transaction failed to commit: inode {}, gmode {}", __func__, inode,
+			              static_cast<uint32_t>(gmode));
 			status = SAUNAFS_ERROR_IO;
 		}
 	}
@@ -3543,9 +3541,8 @@ void matoclserv_fuse_append(matoclserventry *eptr, const uint8_t *data, uint32_t
 
 		if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
 			if (!fsOpContext.getReadWriteTransaction()->commit()) {
-				safs::log_err(
-				    "matoclserv_fuse_append: transaction failed to commit: inode {}, source inode {}",
-				    inode, inode_src);
+				safs::log_err("{}: transaction failed to commit: inode {}, source inode {}",
+				              __func__, inode, inode_src);
 				status = SAUNAFS_ERROR_IO;
 			}
 		}
@@ -3943,7 +3940,7 @@ void matoclserv_fuse_purge(matoclserventry *eptr, const uint8_t *data, uint32_t 
 
 	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
 		if (!fsOpContext.getReadWriteTransaction()->commit()) {
-			safs::log_err("matoclserv_fuse_purge: transaction failed to commit: inode {}", inode);
+			safs::log_err("{}: transaction failed to commit: inode {}", __func__, inode);
 			status = SAUNAFS_ERROR_IO;
 		}
 	}

--- a/src/master/metadata_backend_file.cc
+++ b/src/master/metadata_backend_file.cc
@@ -373,13 +373,15 @@ static bool fs_load_generic(const std::shared_ptr<MemoryMappedFile> &metadataFil
 
 /**
  * @brief Parse an edge from the metadata file.
+ * @param fsOpContext The filesystem operation context (transaction).
  * @param metadataFile A reference to the memory mapped metadata file.
  * @param sectionOffset A reference to point to the next edge attribute.
  * @param ignoreFlag A flag to indicate whether to ignore the error.
  * @param init A flag to indicate whether to initialize the static variable.
  * @return 0 on success, 1 if last edge mark is found, -1 if unknown node type.
  */
-static int8_t fs_parseEdge(const std::shared_ptr<MemoryMappedFile> &metadataFile,
+static int8_t fs_parseEdge(const FilesystemOperationContext &fsOpContext,
+                           const std::shared_ptr<MemoryMappedFile> &metadataFile,
                            size_t &sectionOffset, int ignoreFlag, bool init = false) {
 	static const int8_t kError = -1;
 	static const int8_t kSuccess = 0;
@@ -531,19 +533,21 @@ static int8_t fs_parseEdge(const std::shared_ptr<MemoryMappedFile> &metadataFile
 		}
 
 		StatsRecord sr;
-		gFSOperations->nodeOperations()->getStats(child, &sr);
+		gFSOperations->nodeOperations()->getStats(fsOpContext, child, &sr);
 		gFSOperations->nodeOperations()->addStats(parent, &sr);
 	}
 	return kSuccess;
 }
 
 /**
- * @brief
- * @param pSrc A pointer to the data storing all nodes.
+ * @brief Parse a node from the metadata file.
+ * @param fsOpContext The filesystem operation context (transaction).
+ * @param metadataFile A reference to the memory mapped metadata file.
  * @param sectionOffset A reference to point to the next node attribute.
  * @return 0 on success, 1 if last node mark is found, -1 if unknown node type.
  */
-static int8_t fs_parseNode(const std::shared_ptr<MemoryMappedFile> &metadataFile,
+static int8_t fs_parseNode(const FilesystemOperationContext &fsOpContext,
+                           const std::shared_ptr<MemoryMappedFile> &metadataFile,
                            size_t &sectionOffset) {
 	static constexpr int8_t kError = -1;
 	static constexpr int8_t kSuccess = 0;
@@ -596,7 +600,8 @@ static int8_t fs_parseNode(const std::shared_ptr<MemoryMappedFile> &metadataFile
 		}
 #endif
 		fsnodes_quota_update(
-		    node, {{QuotaResource::kSize, +gFSOperations->nodeOperations()->getSize(node)}});
+		    node,
+		    {{QuotaResource::kSize, +gFSOperations->nodeOperations()->getSize(fsOpContext, node)}});
 		gMetadata->fileNodes++;
 		break;
 	default:
@@ -669,9 +674,11 @@ int fs_checknodes(int ignoreflag) {
 }
 
 static bool fs_loadnodes(MetadataLoader::Options options) {
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadOnly);
 	int8_t status;
 	do {
-		status = fs_parseNode(options.metadataFile, options.offset);
+		status = fs_parseNode(fsOpContext, options.metadataFile, options.offset);
 		if (status < 0) {
 			return false;
 		}
@@ -680,10 +687,13 @@ static bool fs_loadnodes(MetadataLoader::Options options) {
 }
 
 static bool fs_loadedges(MetadataLoader::Options options) {
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadOnly);
 	int8_t status;
-	fs_parseEdge(options.metadataFile, options.offset, options.ignoreFlag, true);
+	fs_parseEdge(fsOpContext, options.metadataFile, options.offset, options.ignoreFlag, true);
 	do {
-		status = fs_parseEdge(options.metadataFile, options.offset, options.ignoreFlag);
+		status =
+		    fs_parseEdge(fsOpContext, options.metadataFile, options.offset, options.ignoreFlag);
 		if (status < 0) {
 			return false;
 		}

--- a/src/master/metadata_backend_file.cc
+++ b/src/master/metadata_backend_file.cc
@@ -534,7 +534,7 @@ static int8_t fs_parseEdge(const FilesystemOperationContext &fsOpContext,
 
 		StatsRecord sr;
 		gFSOperations->nodeOperations()->getStats(fsOpContext, child, &sr);
-		gFSOperations->nodeOperations()->addStats(parent, &sr);
+		gFSOperations->nodeOperations()->addStats(fsOpContext, parent, &sr);
 	}
 	return kSuccess;
 }

--- a/src/master/restore.cc
+++ b/src/master/restore.cc
@@ -227,9 +227,8 @@ int do_append(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
 
 	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
 		if (!fsOpContext.getReadWriteTransaction()->commit()) {
-			safs::log_err(
-			    "do_append: transaction failed to commit: inode {}, source inode {}",
-			    inode, inode_src);
+			safs::log_err("{}: transaction failed to commit: inode {}, source inode {}", __func__,
+			              inode, inode_src);
 			status = SAUNAFS_ERROR_IO;
 		}
 	}
@@ -273,8 +272,8 @@ int do_attr(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
 	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
 		if (!fsOpContext.getReadWriteTransaction()->commit()) {
 			safs::log_err(
-			    "do_attr: transaction failed to commit: inode {}, mode {}, uid {}, gid {}, atime {}, mtime {}",
-			    inode, mode, uid, gid, atime, mtime);
+			    "{}: transaction failed to commit: inode {}, mode {}, uid {}, gid {}, atime {}, mtime {}",
+			    __func__, inode, mode, uid, gid, atime, mtime);
 			status = SAUNAFS_ERROR_IO;
 		}
 	}
@@ -381,8 +380,8 @@ int do_length(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
 	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
 		if (!fsOpContext.getReadWriteTransaction()->commit()) {
 			safs::log_err(
-			    "do_length: transaction failed to commit: inode {}, length {}, eraseFurtherChunks {}",
-			    inode, length, eraseFurtherChunks);
+			    "{}: transaction failed to commit: inode {}, length {}, eraseFurtherChunks {}",
+			    __func__, inode, length, eraseFurtherChunks);
 			status = SAUNAFS_ERROR_IO;
 		}
 	}
@@ -417,8 +416,8 @@ int do_move(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
 	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
 		if (!fsOpContext.getReadWriteTransaction()->commit()) {
 			safs::log_err(
-			    "do_move: transaction failed to commit: src inode {}, src name {}, dst inode {}, dst name {}",
-			    parent_src, (char *)name_src, parent_dst, (char *)name_dst);
+			    "{}: transaction failed to commit: src inode {}, src name {}, dst inode {}, dst name {}",
+			    __func__, parent_src, (char *)name_src, parent_dst, (char *)name_dst);
 			status = SAUNAFS_ERROR_IO;
 		}
 	}
@@ -540,7 +539,7 @@ int do_purge(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
 
 	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
 		if (!fsOpContext.getReadWriteTransaction()->commit()) {
-			safs::log_err("do_purge: transaction failed to commit: inode {}", inode);
+			safs::log_err("{}: transaction failed to commit: inode {}", __func__, inode);
 			status = SAUNAFS_ERROR_IO;
 		}
 	}
@@ -564,7 +563,7 @@ int do_release(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) 
 
 	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
 		if (!fsOpContext.getReadWriteTransaction()->commit()) {
-			safs::log_err("do_release: transaction failed to commit: inode {}, cuid {}", inode,
+			safs::log_err("{}: transaction failed to commit: inode {}, cuid {}", __func__, inode,
 			              cuid);
 			status = SAUNAFS_ERROR_IO;
 		}
@@ -592,9 +591,8 @@ int do_repair(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
 
 	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
 		if (!fsOpContext.getReadWriteTransaction()->commit()) {
-			safs::log_err(
-			    "do_repair: transaction failed to commit: inode {}, chunk index {}, version {}",
-			    inode, indx, version);
+			safs::log_err("{}: transaction failed to commit: inode {}, chunk index {}, version {}",
+			              __func__, inode, indx, version);
 			status = SAUNAFS_ERROR_IO;
 		}
 	}
@@ -931,9 +929,8 @@ int do_write(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
 
 	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
 		if (!fsOpContext.getReadWriteTransaction()->commit()) {
-			safs::log_err(
-			    "do_write: transaction failed to commit: inode {}, chunk index {}, chunk id {}",
-			    inode, indx, chunkid);
+			safs::log_err("{}: transaction failed to commit: inode {}, chunk index {}, chunk id {}",
+			              __func__, inode, indx, chunkid);
 			status = SAUNAFS_ERROR_IO;
 		}
 	}

--- a/src/master/restore.cc
+++ b/src/master/restore.cc
@@ -219,7 +219,22 @@ int do_append(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
 	EAT(ptr,filename,lv,',');
 	GETINODE(inode_src,ptr);
 	EAT(ptr,filename,lv,')');
-	return gFSOperations->append(FsContext::getForRestore(ts), inode, inode_src);
+
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
+	int status = gFSOperations->append(FsContext::getForRestore(ts), fsOpContext, inode, inode_src);
+
+	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
+		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+			safs::log_err(
+			    "do_append: transaction failed to commit: inode {}, source inode {}",
+			    inode, inode_src);
+			status = SAUNAFS_ERROR_IO;
+		}
+	}
+
+	return status;
 }
 
 int do_acquire(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -249,7 +264,22 @@ int do_attr(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
 	EAT(ptr,filename,lv,',');
 	GETU32(mtime,ptr);
 	EAT(ptr,filename,lv,')');
-	return gFSOperations->applyAttr(ts, inode, mode, uid, gid, atime, mtime);
+
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
+	int status = gFSOperations->applyAttr(fsOpContext, ts, inode, mode, uid, gid, atime, mtime);
+
+	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
+		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+			safs::log_err(
+			    "do_attr: transaction failed to commit: inode {}, mode {}, uid {}, gid {}, atime {}, mtime {}",
+			    inode, mode, uid, gid, atime, mtime);
+			status = SAUNAFS_ERROR_IO;
+		}
+	}
+
+	return status;
 }
 
 int do_checksum(const char *filename, uint64_t lv, uint32_t, const char *ptr) {
@@ -341,7 +371,23 @@ int do_length(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
 		GETU32(eraseFurtherChunks, ptr);
 	}
 	EAT(ptr, filename, lv, ')');
-	return gFSOperations->applyLength(ts, inode, length, eraseFurtherChunks != 0);
+
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
+	int status =
+	    gFSOperations->applyLength(fsOpContext, ts, inode, length, eraseFurtherChunks != 0);
+
+	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
+		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+			safs::log_err(
+			    "do_length: transaction failed to commit: inode {}, length {}, eraseFurtherChunks {}",
+			    inode, length, eraseFurtherChunks);
+			status = SAUNAFS_ERROR_IO;
+		}
+	}
+
+	return status;
 }
 
 int do_move(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
@@ -486,7 +532,20 @@ int do_purge(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
 	EAT(ptr,filename,lv,'(');
 	GETINODE(inode,ptr);
 	EAT(ptr,filename,lv,')');
-	return gFSOperations->purge(FsContext::getForRestore(ts), inode);
+
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
+	int status = gFSOperations->purge(FsContext::getForRestore(ts), fsOpContext, inode);
+
+	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
+		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+			safs::log_err("do_purge: transaction failed to commit: inode {}", inode);
+			status = SAUNAFS_ERROR_IO;
+		}
+	}
+
+	return status;
 }
 
 int do_release(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
@@ -497,7 +556,21 @@ int do_release(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) 
 	EAT(ptr,filename,lv,',');
 	GETU32(cuid,ptr);
 	EAT(ptr,filename,lv,')');
-	return gFSOperations->release(FsContext::getForRestore(ts), inode, cuid);
+
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
+	int status = gFSOperations->release(FsContext::getForRestore(ts), fsOpContext, inode, cuid);
+
+	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
+		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+			safs::log_err("do_release: transaction failed to commit: inode {}, cuid {}", inode,
+			              cuid);
+			status = SAUNAFS_ERROR_IO;
+		}
+	}
+
+	return status;
 }
 
 int do_repair(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
@@ -511,7 +584,22 @@ int do_repair(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
 	EAT(ptr,filename,lv,')');
 	EAT(ptr,filename,lv,':');
 	GETU32(version,ptr);
-	return gFSOperations->applyRepair(ts, inode, indx, version);
+
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
+	int status = gFSOperations->applyRepair(fsOpContext, ts, inode, indx, version);
+
+	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
+		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+			safs::log_err(
+			    "do_repair: transaction failed to commit: inode {}, chunk index {}, version {}",
+			    inode, indx, version);
+			status = SAUNAFS_ERROR_IO;
+		}
+	}
+
+	return status;
 }
 
 int do_seteattr(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
@@ -834,8 +922,23 @@ int do_write(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
 	EAT(ptr,filename,lv,')');
 	EAT(ptr,filename,lv,':');
 	GETU64(chunkid,ptr);
-	return gFSOperations->writeChunk(FsContext::getForRestore(ts), inode, indx, false, &lockid,
-	                                 &chunkid, &opflag, nullptr);
+
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
+	int status = gFSOperations->writeChunk(FsContext::getForRestore(ts), fsOpContext, inode, indx,
+	                                       false, &lockid, &chunkid, &opflag, nullptr);
+
+	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
+		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+			safs::log_err(
+			    "do_write: transaction failed to commit: inode {}, chunk index {}, chunk id {}",
+			    inode, indx, chunkid);
+			status = SAUNAFS_ERROR_IO;
+		}
+	}
+
+	return status;
 }
 
 int restore_line(const char* filename, uint64_t lv, const char* line) {

--- a/src/master/setgoal_task.cc
+++ b/src/master/setgoal_task.cc
@@ -31,12 +31,15 @@ int SetGoalTask::execute(uint32_t ts, intrusive_list<Task> &work_queue) {
 
 	inode_t inode = *current_inode_;
 	++current_inode_;
-	FSNode *node = gFSOperations->nodeOperations()->idToNode(inode);
-	if (!node) {
-		return SAUNAFS_ERROR_EINVAL;
-	}
 
-	uint8_t result = setGoal(node, ts);
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
+	FSNode *node = gFSOperations->nodeOperations()->idToNode(fsOpContext, inode);
+
+	if (!node) { return SAUNAFS_ERROR_EINVAL; }
+
+	uint8_t result = setGoal(fsOpContext, node, ts);
 
 	if (result != kNoAction) {
 		if (node->type == FSNodeType::kDirectory && (smode_ & SMODE_RMASK) &&
@@ -67,7 +70,8 @@ bool SetGoalTask::isFinished() const {
 	return current_inode_ == inode_list_.end();
 }
 
-uint8_t SetGoalTask::setGoal(FSNode *node, uint32_t ts) {
+uint8_t SetGoalTask::setGoal(const FilesystemOperationContext &fsOpContext, FSNode *node,
+                             uint32_t ts) {
 	if (node->type == FSNodeType::kFile || node->type == FSNodeType::kDirectory ||
 	    node->type == FSNodeType::kTrash || node->type == FSNodeType::kReserved) {
 		if ((node->mode & (EATTR_NOOWNER << EATTR_BIT_OFFSET)) == 0 && uid_ != 0 &&
@@ -76,8 +80,8 @@ uint8_t SetGoalTask::setGoal(FSNode *node, uint32_t ts) {
 		} else {
 			if ((smode_ & SMODE_TMASK) == SMODE_SET && node->goal != goal_) {
 				if (node->type != FSNodeType::kDirectory) {
-					gFSOperations->nodeOperations()->changeFileGoal(static_cast<FSNodeFile *>(node),
-					                                                goal_);
+					gFSOperations->nodeOperations()->changeFileGoal(
+					    fsOpContext, static_cast<FSNodeFile *>(node), goal_);
 				} else {
 					node->goal = goal_;
 					gMetadata->nodeChangedSignal.emit(node);

--- a/src/master/setgoal_task.h
+++ b/src/master/setgoal_task.h
@@ -24,6 +24,8 @@
 #include "master/filesystem_node_types.h"
 #include "master/task_manager.h"
 
+class FilesystemOperationContext;
+
 class SetGoalTask : public TaskManager::Task {
 public:
 	enum {
@@ -67,7 +69,7 @@ public:
 		return "Setting goal (" + goal + "): " + target;
 	}
 
-	uint8_t setGoal(FSNode *node, uint32_t ts);
+	uint8_t setGoal(const FilesystemOperationContext &fsOpContext, FSNode *node, uint32_t ts);
 
 private:
 	std::vector<inode_t> inode_list_;
@@ -81,4 +83,3 @@ private:
 			                    [kNotChanged] - number of inodes with not changed goal
 			                  [kNotPermitted] - number of inodes with permission denied */
 };
-

--- a/src/master/snapshot_task.cc
+++ b/src/master/snapshot_task.cc
@@ -67,7 +67,7 @@ FSNode *SnapshotTask::cloneToExistingNode(const FilesystemOperationContext &fsOp
 		                                   dst_parent, static_cast<FSNodeFile *>(dst_node));
 		break;
 	case FSNodeType::kSymlink:
-		cloneSymlinkData(static_cast<FSNodeSymlink *>(src_node),
+		cloneSymlinkData(fsOpContext, static_cast<FSNodeSymlink *>(src_node),
 		                 static_cast<FSNodeSymlink *>(dst_node), dst_parent);
 		break;
 	case FSNodeType::kBlockDev:
@@ -107,11 +107,11 @@ FSNode *SnapshotTask::cloneToNewNode(const FilesystemOperationContext &fsOpConte
 		                   static_cast<FSNodeDirectory *>(dst_node));
 		break;
 	case FSNodeType::kFile:
-		cloneChunkData(static_cast<FSNodeFile *>(src_node),
+		cloneChunkData(fsOpContext, static_cast<FSNodeFile *>(src_node),
 		               static_cast<FSNodeFile *>(dst_node), dst_parent);
 		break;
 	case FSNodeType::kSymlink:
-		cloneSymlinkData(static_cast<FSNodeSymlink *>(src_node),
+		cloneSymlinkData(fsOpContext, static_cast<FSNodeSymlink *>(src_node),
 		                 static_cast<FSNodeSymlink *>(dst_node), dst_parent);
 		break;
 	case FSNodeType::kBlockDev:
@@ -143,16 +143,17 @@ FSNodeFile *SnapshotTask::cloneToExistingFileNode(const FilesystemOperationConte
 	    fsOpContext, ts, dst_parent, current_subtask_->second, FSNodeType::kFile, src_node->mode, 0,
 	    src_node->uid, src_node->gid, 0, AclInheritance::kDontInheritAcl, dst_inode_));
 
-	cloneChunkData(src_node, dst_node, dst_parent);
+	cloneChunkData(fsOpContext, src_node, dst_node, dst_parent);
 
 	return dst_node;
 }
 
-void SnapshotTask::cloneChunkData(const FSNodeFile *src_node, FSNodeFile *dst_node,
-		FSNodeDirectory *dst_parent) {
+void SnapshotTask::cloneChunkData(const FilesystemOperationContext &fsOpContext,
+                                  const FSNodeFile *src_node, FSNodeFile *dst_node,
+                                  FSNodeDirectory *dst_parent) {
 	StatsRecord psr, nsr;
 
-	gFSOperations->nodeOperations()->getStats(dst_node, &psr);
+	gFSOperations->nodeOperations()->getStats(fsOpContext, dst_node, &psr);
 
 	dst_node->goal = src_node->goal;
 	dst_node->trashtime = src_node->trashtime;
@@ -170,7 +171,7 @@ void SnapshotTask::cloneChunkData(const FSNodeFile *src_node, FSNodeFile *dst_no
 		}
 	}
 
-	gFSOperations->nodeOperations()->getStats(dst_node, &nsr);
+	gFSOperations->nodeOperations()->getStats(fsOpContext, dst_node, &nsr);
 	gFSOperations->nodeOperations()->addSubStats(dst_parent, &nsr, &psr);
 	fsnodes_quota_update(dst_node, {{QuotaResource::kSize, nsr.size - psr.size}});
 }
@@ -192,16 +193,17 @@ void SnapshotTask::cloneDirectoryData(const FSNodeDirectory *src_node, FSNodeDir
 	}
 }
 
-void SnapshotTask::cloneSymlinkData(FSNodeSymlink *src_node, FSNodeSymlink *dst_node,
-		FSNodeDirectory *dst_parent) {
+void SnapshotTask::cloneSymlinkData(const FilesystemOperationContext &fsOpContext,
+                                    FSNodeSymlink *src_node, FSNodeSymlink *dst_node,
+                                    FSNodeDirectory *dst_parent) {
 	StatsRecord psr, nsr;
 
-	gFSOperations->nodeOperations()->getStats(dst_node, &psr);
+	gFSOperations->nodeOperations()->getStats(fsOpContext, dst_node, &psr);
 
 	dst_node->path = src_node->path;
 	dst_node->path_length = src_node->path_length;
 
-	gFSOperations->nodeOperations()->getStats(dst_node, &nsr);
+	gFSOperations->nodeOperations()->getStats(fsOpContext, dst_node, &nsr);
 	gFSOperations->nodeOperations()->addSubStats(dst_parent, &nsr, &psr);
 }
 

--- a/src/master/snapshot_task.cc
+++ b/src/master/snapshot_task.cc
@@ -172,7 +172,7 @@ void SnapshotTask::cloneChunkData(const FilesystemOperationContext &fsOpContext,
 	}
 
 	gFSOperations->nodeOperations()->getStats(fsOpContext, dst_node, &nsr);
-	gFSOperations->nodeOperations()->addSubStats(dst_parent, &nsr, &psr);
+	gFSOperations->nodeOperations()->addSubStats(fsOpContext, dst_parent, &nsr, &psr);
 	fsnodes_quota_update(dst_node, {{QuotaResource::kSize, nsr.size - psr.size}});
 }
 
@@ -204,7 +204,7 @@ void SnapshotTask::cloneSymlinkData(const FilesystemOperationContext &fsOpContex
 	dst_node->path_length = src_node->path_length;
 
 	gFSOperations->nodeOperations()->getStats(fsOpContext, dst_node, &nsr);
-	gFSOperations->nodeOperations()->addSubStats(dst_parent, &nsr, &psr);
+	gFSOperations->nodeOperations()->addSubStats(fsOpContext, dst_parent, &nsr, &psr);
 }
 
 void SnapshotTask::emitChangelog(uint32_t ts, inode_t dst_inode) {

--- a/src/master/snapshot_task.cc
+++ b/src/master/snapshot_task.cc
@@ -261,8 +261,8 @@ int SnapshotTask::cloneNode(uint32_t ts) {
 	if (fsOpContext.hasReadWriteTransaction()) {
 		if (!fsOpContext.getReadWriteTransaction()->commit()) {
 			safs::log_err(
-			    "SnapshotTask::cloneNode: transaction failed to commit: source inode {}, destination parent inode {}, name {}",
-			    current_subtask_->first, dst_parent_inode_, current_subtask_->second);
+			    "{}: transaction failed to commit: source inode {}, destination parent inode {}, name {}",
+			    __func__, current_subtask_->first, dst_parent_inode_, current_subtask_->second);
 			return SAUNAFS_ERROR_IO;
 		}
 	}

--- a/src/master/snapshot_task.h
+++ b/src/master/snapshot_task.h
@@ -95,12 +95,12 @@ protected:
 	FSNodeFile *cloneToExistingFileNode(const FilesystemOperationContext &fsOpContext, uint32_t ts,
 	                                    FSNodeFile *src_node, FSNodeDirectory *dst_parent,
 	                                    FSNodeFile *dst_node);
-	void cloneChunkData(const FSNodeFile *src_node, FSNodeFile *dst_node,
-	                    FSNodeDirectory *dst_parent);
+	void cloneChunkData(const FilesystemOperationContext &fsOpContext, const FSNodeFile *src_node,
+	                    FSNodeFile *dst_node, FSNodeDirectory *dst_parent);
 	void cloneDirectoryData(const FSNodeDirectory *src_node, FSNodeDirectory *dst_node);
 	void cloneDirectoryData(FSNodeDirectory *src_node, FSNodeDirectory *dst_node);
-	void cloneSymlinkData(FSNodeSymlink *src_node, FSNodeSymlink *dst_node,
-	                      FSNodeDirectory *dst_parent);
+	void cloneSymlinkData(const FilesystemOperationContext &fsOpContext, FSNodeSymlink *src_node,
+	                      FSNodeSymlink *dst_node, FSNodeDirectory *dst_parent);
 
 	/*! \brief Emit metadata changelog.
 	 *


### PR DESCRIPTION
Propagate transaction context to stats-related operations (getStats,
addStats, subStats, and addSubStats) to enable efficient and consistent
transactional behavior for alternative KV backends.

Main changes:
- Added FilesystemOperationContext parameter to all stats operations,
  allowing them to access parent nodes via idToNodeVerify() when
  recursively propagating stat changes up the directory tree
- Introduced extractIntegralLEFromFuture utility in the KV library to
  parallelize retrieval of the 8 directory statistics using getAsync
- Refactored KV types into separate header (kv_types.h) to resolve
  circular dependencies between ifuture.h and kv_utils.h
- Cascading updates throughout the filesystem layer due to the
  fundamental nature of getStats() and getSize() operations

Since getStats() and related operations are called throughout the
codebase, adding the FilesystemOperationContext parameter required
propagating changes through numerous functions across multiple layers.

The KV backend now gains the ability to:
- Perform directory statistics operations within a single transaction
- Efficiently traverse the filesystem hierarchy when updating ancestor
  directories
- Read cached statistics using the provided transaction context

Notes:
- The in-memory backend remains unaffected by these changes
- Some read-write transactions were intentionally left uncommitted in
  this refactoring; commits will be added as related KV operations are
  implemented
- Integration tests and the FDB implementation are located in the MDS
  repository

Related to LS-242

Signed-off-by: guillex <guillex@leil.io>