### PR TITLE
refactor(master): enable hard links support on kv backends

### DIFF
--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -430,7 +430,8 @@ void FilesystemNodeOperationsBase::addSubStats(const FilesystemOperationContext 
 	addStats(fsOpContext, parent, &resultStats);
 }
 
-void FilesystemNodeOperationsBase::fillAttr(FSNode *node, FSNode *parent, uint32_t uid,
+void FilesystemNodeOperationsBase::fillAttr(const FilesystemOperationContext &fsOpContext,
+                                            FSNode *node, FSNode *parent, uint32_t uid,
                                             uint32_t gid, uint32_t auid, uint32_t agid,
                                             uint8_t sesflags, Attributes &attr) {
 #ifdef METARESTORE
@@ -503,7 +504,7 @@ void FilesystemNodeOperationsBase::fillAttr(FSNode *node, FSNode *parent, uint32
 	put32bit(&ptr, node->ctime);
 
 	// Number of links
-	nlink = node->parents.size();
+	nlink = getNumberOfParents(fsOpContext, node);
 
 	// Type-specific attributes
 
@@ -551,14 +552,15 @@ void FilesystemNodeOperationsBase::fillAttr(FSNode *node, FSNode *parent, uint32
 	}
 }
 
-void FilesystemNodeOperationsBase::fillAttr(const FsContext &context, FSNode *node, FSNode *parent,
-                                            Attributes &attr) {
+void FilesystemNodeOperationsBase::fillAttr(const FsContext &context,
+                                            const FilesystemOperationContext &fsOpContext,
+                                            FSNode *node, FSNode *parent, Attributes &attr) {
 #ifdef METARESTORE
 	mabort("Bad code path - fsnodes_fill_attr() shall not be executed in metarestore context.");
 #endif /* METARESTORE */
 	sassert(context.hasSessionData() && context.hasUidGidData());
-	fillAttr(node, parent, context.uid(), context.gid(), context.auid(), context.agid(),
-	         context.sesflags(), attr);
+	fillAttr(fsOpContext, node, parent, context.uid(), context.gid(), context.auid(),
+	         context.agid(), context.sesflags(), attr);
 }
 
 void FilesystemNodeOperationsBase::removeEdge(const FilesystemOperationContext &fsOpContext,
@@ -991,7 +993,8 @@ uint32_t FilesystemNodeOperationsBase::getDirSize(const FSNodeDirectory *nodeDir
 	return result;
 }
 
-void FilesystemNodeOperationsBase::getDirData(inode_t rootINode, uint32_t uid, uint32_t gid,
+void FilesystemNodeOperationsBase::getDirData(const FilesystemOperationContext &fsOpContext,
+                                              inode_t rootINode, uint32_t uid, uint32_t gid,
                                               uint32_t auid, uint32_t agid, uint8_t sesflags,
                                               FSNodeDirectory *nodeDir, uint8_t *outBuffer,
                                               uint8_t withAttr) {
@@ -1009,7 +1012,7 @@ void FilesystemNodeOperationsBase::getDirData(inode_t rootINode, uint32_t uid, u
 	Attributes attr;
 
 	if (withAttr) {
-		fillAttr(nodeDir, nodeDir, uid, gid, auid, agid, sesflags, attr);
+		fillAttr(fsOpContext, nodeDir, nodeDir, uid, gid, auid, agid, sesflags, attr);
 		::memcpy(outBuffer, attr.data(), attr.size());
 		outBuffer += attr.size();
 	} else {
@@ -1027,7 +1030,7 @@ void FilesystemNodeOperationsBase::getDirData(inode_t rootINode, uint32_t uid, u
 
 		// parent attributes
 		if (withAttr) {
-			fillAttr(nodeDir, nodeDir, uid, gid, auid, agid, sesflags, attr);
+			fillAttr(fsOpContext, nodeDir, nodeDir, uid, gid, auid, agid, sesflags, attr);
 			::memcpy(outBuffer, attr.data(), attr.size());
 			outBuffer += attr.size();
 		} else {
@@ -1044,17 +1047,19 @@ void FilesystemNodeOperationsBase::getDirData(inode_t rootINode, uint32_t uid, u
 		if (withAttr) {
 			if (!nodeDir->parents.empty()) {
 				auto *parent = idToNodeVerify<FSNode>(nodeDir->parents[0].first);
-				fillAttr(parent, nodeDir, uid, gid, auid, agid, sesflags, attr);
+				fillAttr(fsOpContext, parent, nodeDir, uid, gid, auid, agid, sesflags, attr);
 				::memcpy(outBuffer, attr.data(), attr.size());
 			} else {
 				if (rootINode == SPECIAL_INODE_ROOT) {
-					fillAttr(gMetadata->root, nodeDir, uid, gid, auid, agid, sesflags, attr);
+					fillAttr(fsOpContext, gMetadata->root, nodeDir, uid, gid, auid, agid, sesflags,
+					         attr);
 					::memcpy(outBuffer, attr.data(), attr.size());
 				} else {
 					FSNode *foundRootNode = idToNode(rootINode);
 					if (foundRootNode) {  // it should be always true because it's checked
 						// before, but better check than sorry
-						fillAttr(foundRootNode, nodeDir, uid, gid, auid, agid, sesflags, attr);
+						fillAttr(fsOpContext, foundRootNode, nodeDir, uid, gid, auid, agid,
+						         sesflags, attr);
 						::memcpy(outBuffer, attr.data(), attr.size());
 					} else {
 						memset(outBuffer, 0, attr.size());
@@ -1081,7 +1086,7 @@ void FilesystemNodeOperationsBase::getDirData(inode_t rootINode, uint32_t uid, u
 
 		// entry attributes
 		if (withAttr) {
-			fillAttr(entry.second, nodeDir, uid, gid, auid, agid, sesflags, attr);
+			fillAttr(fsOpContext, entry.second, nodeDir, uid, gid, auid, agid, sesflags, attr);
 			::memcpy(outBuffer, attr.data(), attr.size());
 			outBuffer += attr.size();
 		} else {
@@ -1114,7 +1119,7 @@ void FilesystemNodeOperationsBase::getDir(const FilesystemOperationContext &fsOp
 		inode = nodeDir->id != rootINode ? nodeDir->id : SPECIAL_INODE_ROOT;
 		parent = idToNodeVerify<FSNodeDirectory>(
 		    nodeDir->parents.empty() ? SPECIAL_INODE_ROOT : nodeDir->parents[0].first);
-		fillAttr(nodeDir, parent, uid, gid, auid, agid, sesflags, attr);
+		fillAttr(fsOpContext, nodeDir, parent, uid, gid, auid, agid, sesflags, attr);
 		dirEntriesOut.emplace_back(kDotEntryIndex, kDotDotEntryIndex, inode, ".", attr);
 
 		firstEntry = kDotDotEntryIndex;
@@ -1127,7 +1132,7 @@ void FilesystemNodeOperationsBase::getDir(const FilesystemOperationContext &fsOp
 			inode = SPECIAL_INODE_ROOT;
 			parent = idToNodeVerify<FSNodeDirectory>(
 			    nodeDir->parents.empty() ? SPECIAL_INODE_ROOT : nodeDir->parents[0].first);
-			fillAttr(nodeDir, parent, uid, gid, auid, agid, sesflags, attr);
+			fillAttr(fsOpContext, nodeDir, parent, uid, gid, auid, agid, sesflags, attr);
 		} else {
 			if (!nodeDir->parents.empty() && nodeDir->parents[0].first != rootINode) {
 				inode = nodeDir->parents[0].first;
@@ -1139,7 +1144,7 @@ void FilesystemNodeOperationsBase::getDir(const FilesystemOperationContext &fsOp
 			    nodeDir->parents.empty() ? SPECIAL_INODE_ROOT : nodeDir->parents[0].first);
 			auto *grandparent = idToNodeVerify<FSNodeDirectory>(
 			    parent->parents.empty() ? SPECIAL_INODE_ROOT : parent->parents[0].first);
-			fillAttr(parent, grandparent, uid, gid, auid, agid, sesflags, attr);
+			fillAttr(fsOpContext, parent, grandparent, uid, gid, auid, agid, sesflags, attr);
 		}
 
 		uint64_t nextIndex = kUnusedEntryIndex;
@@ -1185,7 +1190,7 @@ void FilesystemNodeOperationsBase::getDir(const FilesystemOperationContext &fsOp
 	while (iter != nodeDir->entries.end() && numberOfEntries > 0) {
 		name = static_cast<std::string>(*(*iter).first);
 		inode = (*iter).second->id;
-		fillAttr((*iter).second, nodeDir, uid, gid, auid, agid, sesflags, attr);
+		fillAttr(fsOpContext, (*iter).second, nodeDir, uid, gid, auid, agid, sesflags, attr);
 
 		firstEntry = (*iter).first->data() & ~kSignBit64;
 

--- a/src/master/filesystem_node.h
+++ b/src/master/filesystem_node.h
@@ -62,10 +62,12 @@ public:
 	                FSNodeDirectory *parent, const HString &childName, FSNode *childNode) override;
 
 	void updateCTime(FSNode *node, uint32_t ctime) override;
-	void fillAttr(FSNode *node, FSNode *parent, uint32_t uid, uint32_t gid, uint32_t auid,
-	              uint32_t agid, uint8_t sesflags, Attributes &attr) override;
-	void fillAttr(const FsContext &context, FSNode *node, FSNode *parent,
+
+	void fillAttr(const FilesystemOperationContext &fsOpContext, FSNode *node, FSNode *parent,
+	              uint32_t uid, uint32_t gid, uint32_t auid, uint32_t agid, uint8_t sesflags,
 	              Attributes &attr) override;
+	void fillAttr(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	              FSNode *node, FSNode *parent, Attributes &attr) override;
 
 	/// Retrieves statistics for a filesystem node.
 	/// @see IFilesystemNodeOperations::getStats
@@ -109,9 +111,9 @@ public:
 
 #ifndef METARESTORE
 	uint32_t getDirSize(const FSNodeDirectory *nodeDir, uint8_t withAttr) override;
-	void getDirData(inode_t rootINode, uint32_t uid, uint32_t gid, uint32_t auid, uint32_t agid,
-	                uint8_t sesflags, FSNodeDirectory *nodeDir, uint8_t *outBuffer,
-	                uint8_t withAttr) override;
+	void getDirData(const FilesystemOperationContext &fsOpContext, inode_t rootINode, uint32_t uid,
+	                uint32_t gid, uint32_t auid, uint32_t agid, uint8_t sesflags,
+	                FSNodeDirectory *nodeDir, uint8_t *outBuffer, uint8_t withAttr) override;
 
 	/// Returns the number of entries in the given directory.
 	/// @see IFilesystemNodeOperations::getNumberOfDirEntries

--- a/src/master/filesystem_node_operations_interface.h
+++ b/src/master/filesystem_node_operations_interface.h
@@ -149,6 +149,28 @@ public:
 	                           uint16_t mode, uint16_t umask, uint32_t uid, uint32_t gid,
 	                           uint8_t copysgid, AclInheritance inheritAcl,
 	                           inode_t requestedINode = 0) = 0;
+
+	/// Creates a hard link (directory entry) between a parent directory and an existing node.
+	///
+	/// This method establishes a new edge from a parent directory to an existing child node,
+	/// creating a hard link. The child node must already exist in the filesystem. This operation:
+	/// - Adds a directory entry with the specified name to the parent directory
+	/// - Adds the parent to the child's parent list
+	/// - Updates the parent's nlink count (incremented if child is a directory)
+	/// - Updates parent directory statistics (size)
+	/// - Updates parent and child ctime/mtime when timeStamp > 0
+	/// - Propagates statistics changes to all ancestor directories
+	///
+	/// @param fsOpContext The filesystem operation context (transaction).
+	/// @param timeStamp The current timestamp for updating mtime/ctime.
+	/// @param parent The parent directory where the new link will be created.
+	/// @param child The existing child node to link into the parent directory.
+	/// @param name The name of the new directory entry (link name).
+	///
+	/// @note Directories cannot have multiple parents (to maintain tree structure), but files
+	///       can have multiple hard links to the same inode.
+	/// @note The caller must ensure that the name does not already exist in the parent directory.
+	/// @note This method automatically propagates statistics up the directory tree.
 	virtual void link(const FilesystemOperationContext &fsOpContext, uint32_t timeStamp,
 	                  FSNodeDirectory *parent, FSNode *child, const HString &name) = 0;
 
@@ -195,10 +217,12 @@ public:
 	                        FSNode *childNode) = 0;
 
 	virtual void updateCTime(FSNode *node, uint32_t ctime) = 0;
-	virtual void fillAttr(FSNode *node, FSNode *parent, uint32_t uid, uint32_t gid, uint32_t auid,
-	                      uint32_t agid, uint8_t sesflags, Attributes &attr) = 0;
-	virtual void fillAttr(const FsContext &context, FSNode *node, FSNode *parent,
-	                      Attributes &attr) = 0;
+
+	virtual void fillAttr(const FilesystemOperationContext &fsOpContext, FSNode *node,
+	                      FSNode *parent, uint32_t uid, uint32_t gid, uint32_t auid, uint32_t agid,
+	                      uint8_t sesflags, Attributes &attr) = 0;
+	virtual void fillAttr(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                      FSNode *node, FSNode *parent, Attributes &attr) = 0;
 
 	/// Retrieves statistics for a filesystem node.
 	///
@@ -325,9 +349,11 @@ public:
 
 #ifndef METARESTORE
 	virtual uint32_t getDirSize(const FSNodeDirectory *nodeDir, uint8_t withAttr) = 0;
-	virtual void getDirData(inode_t rootINode, uint32_t uid, uint32_t gid, uint32_t auid,
-	                        uint32_t agid, uint8_t sesflags, FSNodeDirectory *nodeDir,
-	                        uint8_t *outBuffer, uint8_t withAttr) = 0;
+
+	virtual void getDirData(const FilesystemOperationContext &fsOpContext, inode_t rootINode,
+	                        uint32_t uid, uint32_t gid, uint32_t auid, uint32_t agid,
+	                        uint8_t sesflags, FSNodeDirectory *nodeDir, uint8_t *outBuffer,
+	                        uint8_t withAttr) = 0;
 
 	/// Returns the number of entries in the given directory, possibly reusing the transaction
 	/// inside fsOpContext.

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -198,7 +198,12 @@ uint8_t FilesystemOperationsBase::getDetachedAttr(inode_t rootinode, uint8_t ses
 	if (dtype == DTYPE_RESERVED && p->type == FSNodeType::kTrash) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
-	nodeOperations_->fillAttr(p, NULL, p->uid, p->gid, p->uid, p->gid, sesflags, attr);
+
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadOnly);
+
+	nodeOperations_->fillAttr(fsOpContext, p, NULL, p->uid, p->gid, p->uid, p->gid, sesflags, attr);
+
 	return SAUNAFS_STATUS_OK;
 }
 
@@ -475,8 +480,8 @@ uint8_t FilesystemOperationsBase::lookup(const FsContext &context,
 			} else {
 				*inode = workDir->id;
 			}
-			nodeOperations_->fillAttr(workDir, workDir, context.uid(), context.gid(), context.auid(),
-			                          context.agid(), context.sesflags(), attr);
+			nodeOperations_->fillAttr(fsOpContext, workDir, workDir, context.uid(), context.gid(),
+			                          context.auid(), context.agid(), context.sesflags(), attr);
 			incrementFSStat(FsStats::Lookup);
 			metrics::Counter::increment(metrics::Counter::Master::FS_LOOKUP);
 			return SAUNAFS_STATUS_OK;
@@ -485,8 +490,9 @@ uint8_t FilesystemOperationsBase::lookup(const FsContext &context,
 		if (name.length() == 2 && name[1] == '.') {  // parent
 			if (workDir->id == context.rootinode()) {
 				*inode = SPECIAL_INODE_ROOT;
-				nodeOperations_->fillAttr(workDir, workDir, context.uid(), context.gid(), context.auid(),
-				                          context.agid(), context.sesflags(), attr);
+				nodeOperations_->fillAttr(fsOpContext, workDir, workDir, context.uid(),
+				                          context.gid(), context.auid(), context.agid(),
+				                          context.sesflags(), attr);
 			} else {
 				if (!workDir->parents.empty()) {
 					if (workDir->parents[0].first == context.rootinode()) {
@@ -495,12 +501,14 @@ uint8_t FilesystemOperationsBase::lookup(const FsContext &context,
 						*inode = workDir->parents[0].first;
 					}
 					FSNode *pp = nodeOperations_->idToNode(workDir->parents[0].first);
-					nodeOperations_->fillAttr(pp, workDir, context.uid(), context.gid(), context.auid(),
-					                          context.agid(), context.sesflags(), attr);
+					nodeOperations_->fillAttr(fsOpContext, pp, workDir, context.uid(),
+					                          context.gid(), context.auid(), context.agid(),
+					                          context.sesflags(), attr);
 				} else {
 					*inode = SPECIAL_INODE_ROOT;  // rn->id;
-					nodeOperations_->fillAttr(effectiveRootDir, workDir, context.uid(), context.gid(), context.auid(),
-					                          context.agid(), context.sesflags(), attr);
+					nodeOperations_->fillAttr(fsOpContext, effectiveRootDir, workDir, context.uid(),
+					                          context.gid(), context.auid(), context.agid(),
+					                          context.sesflags(), attr);
 				}
 			}
 			incrementFSStat(FsStats::Lookup);
@@ -519,8 +527,8 @@ uint8_t FilesystemOperationsBase::lookup(const FsContext &context,
 	}
 
 	*inode = child->id;
-	nodeOperations_->fillAttr(child, workDir, context.uid(), context.gid(), context.auid(),
-	                          context.agid(), context.sesflags(), attr);
+	nodeOperations_->fillAttr(fsOpContext, child, workDir, context.uid(), context.gid(),
+	                          context.auid(), context.agid(), context.sesflags(), attr);
 
 	incrementFSStat(FsStats::Lookup);
 	metrics::Counter::increment(metrics::Counter::Master::FS_LOOKUP);
@@ -672,10 +680,12 @@ uint8_t FilesystemOperationsBase::getAttr(const FsContext &context,
 		return status;
 	}
 
-	nodeOperations_->fillAttr(p, NULL, context.uid(), context.gid(), context.auid(), context.agid(),
-	                          context.sesflags(), attr);
+	nodeOperations_->fillAttr(fsOpContext, p, NULL, context.uid(), context.gid(), context.auid(),
+	                          context.agid(), context.sesflags(), attr);
+
 	incrementFSStat(FsStats::Getattr);
 	metrics::Counter::increment(metrics::Counter::Master::FS_GETATTR);
+
 	return SAUNAFS_STATUS_OK;
 }
 
@@ -728,8 +738,8 @@ uint8_t FilesystemOperationsBase::trySetLength(const FsContext &context,
 			}
 		}
 	}
-	nodeOperations_->fillAttr(p, NULL, context.uid(), context.gid(), context.auid(), context.agid(),
-	                          context.sesflags(), attr);
+	nodeOperations_->fillAttr(fsOpContext, p, NULL, context.uid(), context.gid(), context.auid(),
+	                          context.agid(), context.sesflags(), attr);
 	incrementFSStat(FsStats::Setattr);
 	metrics::Counter::increment(metrics::Counter::Master::FS_SETATTR);
 	return SAUNAFS_STATUS_OK;
@@ -892,8 +902,8 @@ uint8_t FilesystemOperationsBase::doSetLength(const FsContext &context,
 	p->mtime = ts;
 	nodeOperations_->updateCTime(p, ts);
 	fsnodes_update_checksum(p);
-	nodeOperations_->fillAttr(p, NULL, context.uid(), context.gid(), context.auid(), context.agid(),
-	                          context.sesflags(), attr);
+	nodeOperations_->fillAttr(fsOpContext, p, NULL, context.uid(), context.gid(), context.auid(),
+	                          context.agid(), context.sesflags(), attr);
 	incrementFSStat(FsStats::Setattr);
 	metrics::Counter::increment(metrics::Counter::Master::FS_SETATTR);
 	return SAUNAFS_STATUS_OK;
@@ -1031,8 +1041,8 @@ uint8_t FilesystemOperationsBase::setAttr(const FsContext &context, inode_t inod
 	changeLog(ts, "ATTR(%" PRIiNode ",%d,%" PRIu32 ",%" PRIu32 ",%" PRIu32 ",%" PRIu32 ")", p->id,
 	          p->mode & 07777, p->uid, p->gid, p->atime, p->mtime);
 	nodeOperations_->updateCTime(p, ts);
-	nodeOperations_->fillAttr(p, NULL, context.uid(), context.gid(), context.auid(), context.agid(),
-	                          context.sesflags(), attr);
+	nodeOperations_->fillAttr(fsOpContext, p, NULL, context.uid(), context.gid(), context.auid(),
+	                          context.agid(), context.sesflags(), attr);
 	fsnodes_update_checksum(p);
 	incrementFSStat(FsStats::Setattr);
 	metrics::Counter::increment(metrics::Counter::Master::FS_SETATTR);
@@ -1192,7 +1202,7 @@ uint8_t FilesystemOperationsBase::symlink(const FsContext &context, inode_t pare
 	memset(&sr, 0, sizeof(StatsRecord));
 	sr.length = basePath.length();
 	nodeOperations_->addStats(fsOpContext, static_cast<FSNodeDirectory *>(wd), &sr);
-	if (attr != NULL) { nodeOperations_->fillAttr(context, p, wd, *attr); }
+	if (attr != NULL) { nodeOperations_->fillAttr(context, fsOpContext, p, wd, *attr); }
 	if (context.isPersonalityMaster()) {
 		assert(*inode == 0);
 		*inode = p->id;
@@ -1273,8 +1283,8 @@ uint8_t FilesystemOperationsBase::mknod(const FsContext &context,
 	}
 
 	*inode = newNode->id;
-	nodeOperations_->fillAttr(newNode, parentNode, context.uid(), context.gid(), context.auid(),
-	                          context.agid(), context.sesflags(), attr);
+	nodeOperations_->fillAttr(fsOpContext, newNode, parentNode, context.uid(), context.gid(),
+	                          context.auid(), context.agid(), context.sesflags(), attr);
 
 	changeLog(timeStamp,
 	          "CREATE(%" PRIiNode ",%s,%c,%d,%" PRIu32 ",%" PRIu32 ",%" PRIu32 "):%" PRIiNode,
@@ -1338,8 +1348,8 @@ uint8_t FilesystemOperationsBase::mkdir(const FsContext &context,
 	                                      FSNodeType::kDirectory, mode, umask, context.uid(),
 	                                      context.gid(), copysgid, AclInheritance::kInheritAcl);
 	*inode = newNode->id;
-	nodeOperations_->fillAttr(newNode, workDir, context.uid(), context.gid(), context.auid(),
-	                          context.agid(), context.sesflags(), attr);
+	nodeOperations_->fillAttr(fsOpContext, newNode, workDir, context.uid(), context.gid(),
+	                          context.auid(), context.agid(), context.sesflags(), attr);
 
 	changeLog(timeStamp,
 	          "CREATE(%" PRIiNode ",%s,%c,%d,%" PRIu32 ",%" PRIu32 ",%" PRIu32 "):%" PRIiNode,
@@ -1695,7 +1705,9 @@ uint8_t FilesystemOperationsBase::rename(const FsContext &context,
 
 	nodeOperations_->link(fsOpContext, context.ts(), destWorkDir, sourceChildNode, baseNameDst);
 
-	if (attr) { nodeOperations_->fillAttr(context, sourceChildNode, destWorkNode, *attr); }
+	if (attr) {
+		nodeOperations_->fillAttr(context, fsOpContext, sourceChildNode, destWorkNode, *attr);
+	}
 
 	if (context.isPersonalityMaster()) {
 		changeLog(context.ts(), "MOVE(%" PRIiNode ",%s,%" PRIiNode ",%s):%" PRIiNode,
@@ -1714,20 +1726,18 @@ uint8_t FilesystemOperationsBase::rename(const FsContext &context,
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t FilesystemOperationsBase::link(const FsContext &context, inode_t inode_src,
-                                       inode_t parent_dst, const HString &name_dst, inode_t *inode,
-                                       Attributes *attr) {
+uint8_t FilesystemOperationsBase::link(const FsContext &context,
+                                       const FilesystemOperationContext &fsOpContext,
+                                       inode_t inode_src, inode_t parent_dst,
+                                       const HString &name_dst, inode_t *inode, Attributes *attr) {
 	ChecksumUpdater cu(context.ts());
 	FSNode *sp;
 	FSNode *dwd;
+
 	uint8_t status =
 	    nodeOperations_->verifySession(context, OperationMode::kReadWrite, SessionType::kNotMeta);
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	}
 
-	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
-	    FilesystemOperationContext::TransactionType::kReadWrite);
+	if (status != SAUNAFS_STATUS_OK) { return status; }
 
 	status = nodeOperations_->getNodeForOperation(
 	    context, fsOpContext, ExpectedNodeType::kDirectory, MODE_MASK_W, parent_dst, &dwd);
@@ -1755,7 +1765,7 @@ uint8_t FilesystemOperationsBase::link(const FsContext &context, inode_t inode_s
 
 	if (inode) { *inode = inode_src; }
 
-	if (attr) { nodeOperations_->fillAttr(context, sp, dwd, *attr); }
+	if (attr) { nodeOperations_->fillAttr(context, fsOpContext, sp, dwd, *attr); }
 
 	if (context.isPersonalityMaster()) {
 		changeLog(context.ts(), "LINK(%" PRIiNode ",%" PRIiNode ",%s)", sp->id, dwd->id,
@@ -2141,9 +2151,12 @@ void FilesystemOperationsBase::readdirData(const FsContext &context, uint8_t fla
 	ChecksumUpdater cu(ts);
 	FSNode *p = (FSNode *)dnode;
 	fs_update_atime(p, ts);
-	nodeOperations_->getDirData(
-	    context.rootinode(), context.uid(), context.gid(), context.auid(), context.agid(),
-	    context.sesflags(), static_cast<FSNodeDirectory *>(p), dbuff, flags & GETDIR_FLAG_WITHATTR);
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadOnly);
+	nodeOperations_->getDirData(fsOpContext, context.rootinode(), context.uid(), context.gid(),
+	                            context.auid(), context.agid(), context.sesflags(),
+	                            static_cast<FSNodeDirectory *>(p), dbuff,
+	                            flags & GETDIR_FLAG_WITHATTR);
 	incrementFSStat(FsStats::Readdir);
 	metrics::Counter::increment(metrics::Counter::Master::FS_READDIR);
 }
@@ -2233,8 +2246,8 @@ uint8_t FilesystemOperationsBase::openCheck(const FsContext &context, inode_t in
 		}
 		if (!nodeOperations_->access(context, p, modemask)) { return SAUNAFS_ERROR_EACCES; }
 	}
-	nodeOperations_->fillAttr(p, NULL, context.uid(), context.gid(), context.auid(), context.agid(),
-	                          context.sesflags(), attr);
+	nodeOperations_->fillAttr(fsOpContext, p, NULL, context.uid(), context.gid(), context.auid(),
+	                          context.agid(), context.sesflags(), attr);
 	incrementFSStat(FsStats::Open);
 	metrics::Counter::increment(metrics::Counter::Master::FS_OPEN);
 	return SAUNAFS_STATUS_OK;

--- a/src/master/filesystem_operations.h
+++ b/src/master/filesystem_operations.h
@@ -78,8 +78,13 @@ public:
 	uint8_t append(const FsContext &context, const FilesystemOperationContext &fsOpContext,
 	               inode_t inode, inode_t inode_src) override;
 	uint8_t deleteAcl(const FsContext &context, inode_t inode, AclType type) override;
-	uint8_t link(const FsContext &context, inode_t inode_src, inode_t parent_dst,
-	             const HString &name_dst, inode_t *inode, Attributes *attr) override;
+
+	/// Creates a hard link to an existing file in a destination directory.
+	/// @see IFilesystemOperations::link
+	uint8_t link(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	             inode_t inode_src, inode_t parent_dst, const HString &name_dst, inode_t *inode,
+	             Attributes *attr) override;
+
 	uint8_t purge(const FsContext &context, const FilesystemOperationContext &fsOpContext,
 	              inode_t inode) override;
 

--- a/src/master/filesystem_operations_interface.h
+++ b/src/master/filesystem_operations_interface.h
@@ -87,8 +87,53 @@ public:
 	virtual uint8_t append(const FsContext &context, const FilesystemOperationContext &fsOpContext,
 	                       inode_t inode, inode_t inode_src) = 0;
 	virtual uint8_t deleteAcl(const FsContext &context, inode_t inode, AclType type) = 0;
-	virtual uint8_t link(const FsContext &context, inode_t inode_src, inode_t parent_dst,
-	                     const HString &name_dst, inode_t *inode, Attributes *attr) = 0;
+
+	/// Creates a hard link to an existing file in a destination directory.
+	///
+	/// This method creates a new directory entry (hard link) in the destination parent directory
+	/// that points to an existing source node (file, symlink, device, etc.). Hard links allow
+	/// multiple names to reference the same inode, enabling multiple paths to the same file.
+	/// The operation should perform comprehensive validation, including:
+	/// - Session verification (must be read-write, non-meta session)
+	/// - Permission checks (write access required on destination parent)
+	/// - Source node accessibility verification
+	/// - Type validation (source cannot be a directory to maintain tree structure)
+	/// - State validation (source cannot be in trash or reserved)
+	/// - Name validation and uniqueness check in destination
+	///
+	/// After successful validation, the link is created by calling nodeOperations_->link(),
+	/// which increments the node's link count, updates parent statistics, and propagates
+	/// changes up the directory tree.
+	///
+	/// @param context The FS operation context containing user credentials and session info.
+	/// @param fsOpContext The extra operation context (transaction in some implementations).
+	/// @param inode_src The inode number of the existing node to link to (source).
+	/// @param parent_dst The inode number of the destination parent directory where the link
+	///                   will be created.
+	/// @param name_dst The name for the new directory entry (link name) in the destination parent.
+	/// @param[out] inode Pointer to inode_t where the source inode number will be stored.
+	///                   Can be nullptr if not needed.
+	/// @param[out] attr Pointer to Attributes to be filled with the source node's attributes
+	///                  after the link operation. Can be nullptr if not needed.
+	///
+	/// @return SAUNAFS_STATUS_OK on success, or one of the following error codes:
+	///         - SAUNAFS_ERROR_EROFS if the session is read-only
+	///         - SAUNAFS_ERROR_ENOENT if the session is meta-only or the source node doesn't
+	///           exist or is in trash/reserved
+	///         - SAUNAFS_ERROR_ENOTDIR if parent_dst is not a directory
+	///         - SAUNAFS_ERROR_EACCES if write permission denied on destination parent
+	///         - SAUNAFS_ERROR_EPERM if source is a directory
+	///         - SAUNAFS_ERROR_EINVAL if name_dst validation fails
+	///         - SAUNAFS_ERROR_EEXIST if name_dst already exists in destination parent
+	///         - Other error codes as returned by node operations
+	///
+	/// @note Directories cannot have multiple hard links (to maintain tree structure).
+	/// @note The source node's link count is incremented.
+	/// @note Statistics are propagated up through all ancestor directories.
+	virtual uint8_t link(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                     inode_t inode_src, inode_t parent_dst, const HString &name_dst,
+	                     inode_t *inode, Attributes *attr) = 0;
+
 	virtual uint8_t purge(const FsContext &context, const FilesystemOperationContext &fsOpContext,
 	                      inode_t inode) = 0;
 

--- a/src/master/kv_common_keys.h
+++ b/src/master/kv_common_keys.h
@@ -65,7 +65,7 @@ inline constexpr std::string_view kEdgeLowerKeyPrefix = "LOWER_EDGE_";
 inline constexpr std::string_view kDirParentKeyPrefix = "DIR_PARENT_";
 
 /// Prefix for reverse index for files and links (multiple parents allowed via hard links)
-/// Format: PARENT_<ChildId><ParentId>:<Empty value>
+/// Format: PARENT_<ChildId><ParentId><EdgeName>:<EmptyValue>
 inline constexpr std::string_view kParentKeyPrefix = "PARENT_";
 
 /// Prefix for counting directory nodes without querying all entries

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -2528,9 +2528,22 @@ void matoclserv_fuse_link(matoclserventry *eptr, const uint8_t *data, uint32_t l
 
 	if (status == SAUNAFS_STATUS_OK) {
 		auto context = matoclserv_get_context(eptr, uid, gid);
-		status = gFSOperations->link(context, inode, inode_dst,
+		auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+		    FilesystemOperationContext::TransactionType::kReadWrite);
+
+		status = gFSOperations->link(context, fsOpContext, inode, inode_dst,
 		                             HString(reinterpret_cast<const char *>(name_dst), nleng_dst),
 		                             &newinode, &attr);
+
+		if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
+			if (!fsOpContext.getReadWriteTransaction()->commit()) {
+				safs::log_err(
+				    "{}: transaction failed to commit: src inode {}, dst inode {}, name {}",
+				    __func__, inode, inode_dst,
+				    std::string(reinterpret_cast<const char *>(name_dst), nleng_dst));
+				status = SAUNAFS_ERROR_IO;
+			}
+		}
 	}
 
 	constexpr uint32_t kFailedAnswerSize = sizeof(msgid) + sizeof(status);

--- a/src/master/restore.cc
+++ b/src/master/restore.cc
@@ -349,8 +349,23 @@ int do_link(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
 	EAT(ptr,filename,lv,',');
 	GETNAME(name,ptr,filename,lv,')');
 	EAT(ptr,filename,lv,')');
-	return gFSOperations->link(FsContext::getForRestore(ts), inode, parent,
-	                           HString((const char *)name), nullptr, nullptr);
+
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
+	int status = gFSOperations->link(FsContext::getForRestore(ts), fsOpContext, inode, parent,
+	                                 HString((const char *)name), nullptr, nullptr);
+
+	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
+		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+			safs::log_err("{}: transaction failed to commit: inode {}, parent inode {}, name {}",
+			              __func__, inode, parent,
+			              std::string(reinterpret_cast<const char *>(name)));
+			status = SAUNAFS_ERROR_IO;
+		}
+	}
+
+	return status;
 }
 
 int do_length(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {


### PR DESCRIPTION
Contains two main changes:
- Fix key format for PARENT_ entries in KV backends to keep them unique.
- Add and propagate a FilesystemOperationContext parameter to operations related to link().

Related to: LS-186

Signed-off-by: guillex <guillex@leil.io>

Note: the tests and implementation are in the MDS repository.