### PR TITLE
refactor(master): allow symlink to use transaction context

### DIFF
--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -1134,30 +1134,29 @@ uint8_t FilesystemOperationsBase::readlink(const FsContext &context, inode_t ino
 }
 #endif
 
-uint8_t FilesystemOperationsBase::symlink(const FsContext &context, inode_t parent,
-                                          const HString &name, const std::string &path,
-                                          inode_t *inode, Attributes *attr) {
+uint8_t FilesystemOperationsBase::symlink(const FsContext &context,
+                                          const FilesystemOperationContext &fsOpContext,
+                                          inode_t parent, const HString &name,
+                                          const std::string &path, inode_t *inode,
+                                          Attributes *attr) {
 	ChecksumUpdater cu(context.ts());
 	std::string basePath;
-	FSNode *wd;
+	FSNode *workNode;
+
 	uint8_t status =
 	    nodeOperations_->verifySession(context, OperationMode::kReadWrite, SessionType::kNotMeta);
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	}
 
-	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
-	    FilesystemOperationContext::TransactionType::kReadWrite);
+	if (status != SAUNAFS_STATUS_OK) { return status; }
 
 	status = nodeOperations_->getNodeForOperation(
-	    context, fsOpContext, ExpectedNodeType::kDirectory, MODE_MASK_W, parent, &wd);
+	    context, fsOpContext, ExpectedNodeType::kDirectory, MODE_MASK_W, parent, &workNode);
 
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	}
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+
+	auto *workDir = static_cast<FSNodeDirectory *>(workNode);
 
 	// If filesystem is case-insensitive, get the canonical path for the symlink target
-	if (static_cast<FSNodeDirectory *>(wd)->caseInsensitive) {
+	if (workDir->caseInsensitive) {
 		status = getCanonicalPath(context, fsOpContext, path, basePath);
 		if (status != SAUNAFS_STATUS_OK) {
 			// Unix-style symlinks allow dangling links, so if the path cannot be resolved,
@@ -1168,58 +1167,60 @@ uint8_t FilesystemOperationsBase::symlink(const FsContext &context, inode_t pare
 		basePath = path;
 	}
 
-	if (basePath.length() == 0) {
-		return SAUNAFS_ERROR_EINVAL;
-	}
+	if (basePath.length() == 0) { return SAUNAFS_ERROR_EINVAL; }
+
+	// Check for null bytes in the symlink path
 	for (uint32_t i = 0; i < basePath.length(); i++) {
-		if (basePath[i] == 0) {
-			return SAUNAFS_ERROR_EINVAL;
-		}
+		if (basePath[i] == 0) { return SAUNAFS_ERROR_EINVAL; }
 	}
 
 	if (nodeOperations_->nameCheck(name) < 0) { return SAUNAFS_ERROR_EINVAL; }
 
-	if (nodeOperations_->isNameUsed(fsOpContext, static_cast<FSNodeDirectory *>(wd), name,
-	                                context.isCaseInsensitive())) {
+	if (nodeOperations_->isNameUsed(fsOpContext, workDir, name, context.isCaseInsensitive())) {
 		return SAUNAFS_ERROR_EEXIST;
 	}
 
 	if (context.isPersonalityMaster() &&
 	    (fsnodes_quota_exceeded_ug(context.uid(), context.gid(), {{QuotaResource::kInodes, 1}}) ||
-	     fsnodes_quota_exceeded_dir(wd, {{QuotaResource::kInodes, 1}}))) {
+	     fsnodes_quota_exceeded_dir(workDir, {{QuotaResource::kInodes, 1}}))) {
 		return SAUNAFS_ERROR_QUOTA;
 	}
 
-	FSNodeSymlink *p = static_cast<FSNodeSymlink *>(nodeOperations_->createNode(
-	    fsOpContext, context.ts(), static_cast<FSNodeDirectory *>(wd), name, FSNodeType::kSymlink,
-	    kStandardPermissionsMask, 0, context.uid(), context.gid(), 0,
-	    AclInheritance::kDontInheritAcl, *inode));
+	auto *newNode = static_cast<FSNodeSymlink *>(nodeOperations_->createNode(
+	    fsOpContext, context.ts(), workDir, name, FSNodeType::kSymlink, kStandardPermissionsMask, 0,
+	    context.uid(), context.gid(), 0, AclInheritance::kDontInheritAcl, *inode));
 
-	p->path = HString(basePath);
-	p->path_length = basePath.length();
-	fsnodes_update_checksum(p);
+	newNode->path = HString(basePath);
+	newNode->path_length = basePath.length();
+
+	fsnodes_update_checksum(newNode);
+
 	StatsRecord sr;
 	memset(&sr, 0, sizeof(StatsRecord));
 	sr.length = basePath.length();
-	nodeOperations_->addStats(fsOpContext, static_cast<FSNodeDirectory *>(wd), &sr);
-	if (attr != NULL) { nodeOperations_->fillAttr(context, fsOpContext, p, wd, *attr); }
+	nodeOperations_->addStats(fsOpContext, workDir, &sr);
+
+	if (attr != NULL) { nodeOperations_->fillAttr(context, fsOpContext, newNode, workDir, *attr); }
+
 	if (context.isPersonalityMaster()) {
 		assert(*inode == 0);
-		*inode = p->id;
+		*inode = newNode->id;
 		changeLog(context.ts(), "SYMLINK(%" PRIiNode ",%s,%s,%" PRIu32 ",%" PRIu32 "):%" PRIiNode,
-		          wd->id, nodeOperations_->escapeName(name).c_str(),
+		          workNode->id, nodeOperations_->escapeName(name).c_str(),
 		          nodeOperations_->escapeName(basePath).c_str(), context.uid(), context.gid(),
-		          p->id);
+		          newNode->id);
 	} else {
-		if (*inode != p->id) {
+		if (*inode != newNode->id) {
 			return SAUNAFS_ERROR_MISMATCH;
 		}
 		gMetadata->metadataVersion++;
 	}
+
 #ifndef METARESTORE
 	incrementFSStat(FsStats::Symlink);
 	metrics::Counter::increment(metrics::Counter::Master::FS_SYMLINK);
 #endif /* #ifndef METARESTORE */
+
 	return SAUNAFS_STATUS_OK;
 }
 

--- a/src/master/filesystem_operations.h
+++ b/src/master/filesystem_operations.h
@@ -109,8 +109,13 @@ public:
 	                     const std::function<void(int)> &callback) override;
 	uint8_t applySetTrashTime(const FsContext &context, inode_t inode, uint32_t trashtime,
 	                          uint8_t smode, uint32_t master_result) override;
-	uint8_t symlink(const FsContext &context, inode_t parent, const HString &name,
-	                const std::string &path, inode_t *inode, Attributes *attr) override;
+
+	/// Creates a symbolic link (symlink) in the filesystem.
+	/// @see IFilesystemOperations::symlink
+	uint8_t symlink(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                inode_t parent, const HString &name, const std::string &path, inode_t *inode,
+	                Attributes *attr) override;
+
 	uint8_t undel(const FsContext &context, inode_t inode) override;
 	uint8_t writeChunk(const FsContext &context, const FilesystemOperationContext &fsOpContext,
 	                   inode_t inode, uint32_t index, bool usedummylockid,

--- a/src/master/filesystem_operations_interface.h
+++ b/src/master/filesystem_operations_interface.h
@@ -197,8 +197,62 @@ public:
 	                             const std::function<void(int)> &callback) = 0;
 	virtual uint8_t applySetTrashTime(const FsContext &context, inode_t inode, uint32_t trashtime,
 	                                  uint8_t smode, uint32_t master_result) = 0;
-	virtual uint8_t symlink(const FsContext &context, inode_t parent, const HString &name,
-	                        const std::string &path, inode_t *inode, Attributes *attr) = 0;
+
+	/// Creates a symbolic link (symlink) in the filesystem.
+	///
+	/// This method creates a new symbolic link with the specified name in the given parent
+	/// directory that points to the provided target path. Symbolic links are special files
+	/// that contain a reference to another file or directory path. Unlike hard links, symlinks
+	/// can point to non-existent targets (dangling links), directories, and files across
+	/// different filesystems. The operation performs comprehensive validation including:
+	/// - Session verification (must be read-write, non-meta session)
+	/// - Write permission check on the parent directory
+	/// - Name validation and uniqueness check in the parent
+	/// - On master personalities, quota verification (ensures inode quota limits are not exceeded)
+	/// - Path validation (empty paths and paths containing null bytes are rejected)
+	/// - For case-insensitive filesystems, attempts to canonicalize the target path
+	///   (but allows dangling links if the target cannot be resolved)
+	///
+	/// After successful validation, a new symlink node is created with standard permissions
+	/// (0777 by default), and its statistics (including path length) are propagated up
+	/// through all ancestor directories.
+	///
+	/// @param context The FS operation context containing user credentials and session info.
+	/// @param fsOpContext The filesystem operation context (transaction).
+	/// @param parent The inode number of the parent directory where the symlink will be created.
+	/// @param name The name of the new symlink within the parent directory.
+	/// @param path The target path that the symlink will point to. Can be relative or absolute.
+	///             The path is stored as-is and is not required to exist at creation time.
+	/// @param[in,out] inode Pointer to inode_t.
+	///                      - On master, must be set to 0 on input (will be assigned).
+	///                      - On shadow/metarestore, must be set to the expected inode value from
+	///                        the changelog. If the created inode does not match,
+	///                        SAUNAFS_ERROR_MISMATCH should be returned.
+	///                      On output, contains the inode number of the created symlink.
+	/// @param[out] attr Optional pointer to Attributes to be filled with the symlink's attributes
+	///                  after creation. Can be nullptr if not needed.
+	///
+	/// @return SAUNAFS_STATUS_OK on success, or one of the following error codes:
+	///         - SAUNAFS_ERROR_EROFS if the session is read-only
+	///         - SAUNAFS_ERROR_ENOENT if the session is meta-only or parent doesn't exist
+	///         - SAUNAFS_ERROR_ENOTDIR if parent is not a directory
+	///         - SAUNAFS_ERROR_EACCES if write permission denied on parent directory
+	///         - SAUNAFS_ERROR_EINVAL if name validation fails, path is empty, or path contains
+	///           null bytes
+	///         - SAUNAFS_ERROR_EEXIST if name already exists in parent directory
+	///         - SAUNAFS_ERROR_QUOTA if quota limits would be exceeded
+	///         - SAUNAFS_ERROR_MISMATCH if inode doesn't match expected value (shadow/metarestore
+	///           only)
+	///         - Other error codes as returned by node operations
+	///
+	/// @note Unlike hard links, symbolic links can point to directories and non-existent paths.
+	/// @note The symlink's path length contributes to the parent directory's statistics.
+	/// @note For case-insensitive filesystems, the target path is canonicalized when possible,
+	///       but dangling symlinks are still permitted.
+	virtual uint8_t symlink(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                        inode_t parent, const HString &name, const std::string &path,
+	                        inode_t *inode, Attributes *attr) = 0;
+
 	virtual uint8_t undel(const FsContext &context, inode_t inode) = 0;
 	virtual uint8_t writeChunk(const FsContext &context,
 	                           const FilesystemOperationContext &fsOpContext, inode_t inode,

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -2094,9 +2094,22 @@ void matoclserv_fuse_symlink(matoclserventry *eptr, const uint8_t *data, uint32_
 	status = matoclserv_check_group_cache(eptr, gid);
 	if (status == SAUNAFS_STATUS_OK) {
 		auto context = matoclserv_get_context(eptr, uid, gid);
+		auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+		    FilesystemOperationContext::TransactionType::kReadWrite);
+
 		status = gFSOperations->symlink(
-		    context, inode, HString(reinterpret_cast<const char *>(name), nleng),
+		    context, fsOpContext, inode, HString(reinterpret_cast<const char *>(name), nleng),
 		    std::string(reinterpret_cast<const char *>(path), pleng), &newinode, &attr);
+
+		if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
+			if (!fsOpContext.getReadWriteTransaction()->commit()) {
+				safs::log_err("{}: transaction failed to commit: parent inode {}, name {}, path {}",
+				              __func__, inode,
+				              std::string(reinterpret_cast<const char *>(name), nleng),
+				              std::string(reinterpret_cast<const char *>(path), pleng));
+				status = SAUNAFS_ERROR_IO;
+			}
+		}
 	}
 
 	constexpr uint32_t kFailedAnswerSize = sizeof(msgid) + sizeof(status);

--- a/src/master/restore.cc
+++ b/src/master/restore.cc
@@ -844,9 +844,24 @@ int do_symlink(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) 
 	EAT(ptr,filename,lv,')');
 	EAT(ptr,filename,lv,':');
 	GETINODE(inode,ptr);
-	return gFSOperations->symlink(FsContext::getForRestoreWithUidGid(ts, uid, gid), parent,
-	                              HString((char *)name), std::string((char *)path), &inode,
-	                              nullptr);
+
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
+	int status = gFSOperations->symlink(FsContext::getForRestoreWithUidGid(ts, uid, gid),
+	                                   fsOpContext, parent, HString((char *)name),
+	                                   std::string((char *)path), &inode, nullptr);
+
+	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
+		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+			safs::log_err("{}: transaction failed to commit: parent inode {}, name {}, path {}",
+			              __func__, parent, reinterpret_cast<const char *>(name),
+			              reinterpret_cast<const char *>(path));
+			status = SAUNAFS_ERROR_IO;
+		}
+	}
+
+	return status;
 }
 
 int do_undel(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {


### PR DESCRIPTION
Update the symlink operation to accept FilesystemOperationContext as a parameter instead of creating it internally. This change makes symlink consistent with other filesystem operations and enables proper transaction support for KV-backed storage.

Changes include:
- Add fsOpContext parameter to symlink method signature in IFilesystemOperations interface and FilesystemOperationsBase
- Update callers in matoclserv.cc and restore.cc to create fsOpContext and handle transaction commits
- Refactor symlink implementation for improved readability: rename variables (wd→workNode, p→newNode), consolidate checks, and add clarifying comments
- Add comprehensive documentation to symlink interface method

The refactoring ensures symlink operations can participate in transactions when using KV backends, maintaining consistency with other filesystem operations like link, rename and mknod.

Related to LS-177

Signed-off-by: guillex <guillex@leil.io>