### PR TITLE
feat(tls): Allow client runtime update for TLS LS-286

### DIFF
--- a/doc/sfsmount.1.adoc
+++ b/doc/sfsmount.1.adoc
@@ -81,17 +81,9 @@ Authenticate to SaunaFS master with 'PASSWORD'.
 Authenticate to SaunaFS master using directly given 'MD5' (only if
 *sfspassword* option is not specified).
 
-*-o tlscertfile=*'PATH'::
-Path to the TLS certificate file the client will use for TLS connections
+*-o tlsconfigfile=*'PATH'::
+Path to the TLS configuration file for client-side TLS settings.
 (there is no default value).
-
-*-o tlskeyfile=*'PATH'::
-Path to the TLS private key file the client will use for TLS connections
-(there is no default value).
-
-*-o tlsservercacertfile=*'PATH'::
-Path to the trusted CA certificate which is used to authenticate
-to the master (there is no default value).
 
 *-o sfsdelayedinit*::
 Connection with master is done in background - with this option mount can be

--- a/src/common/tls_session.cc
+++ b/src/common/tls_session.cc
@@ -19,6 +19,11 @@
 #include "common/platform.h"
 #include "slogger/slogger.h"
 
+#include <algorithm>
+#include <cctype>
+#include <fstream>
+#include <sstream>
+
 #include <malloc.h>
 #include <openssl/err.h>
 #include <openssl/ssl.h>
@@ -37,6 +42,67 @@ int checkX509Errors(int preverify_ok, X509_STORE_CTX *x509_ctx) {
 }
 
 }  // namespace
+
+inline void tlsTrim(std::string &s) {
+	auto notspace = [](unsigned char c) { return !std::isspace(c); };
+	auto b = std::find_if(s.begin(), s.end(), notspace);
+	auto e = std::find_if(s.rbegin(), s.rend(), notspace).base();
+	if (b < e) {
+		s.assign(b, e);
+	} else {
+		s.clear();
+	}
+}
+
+inline void tlsParseKV(std::string_view kv, TlsSession::TlsConfig &cfg) {
+	auto pos = kv.find('=');
+	if (pos == std::string_view::npos) { return; }
+
+	std::string key(kv.substr(0, pos));
+	std::string val(kv.substr(pos + 1));
+	tlsTrim(key);
+	tlsTrim(val);
+
+	if (key.empty()) { return; }
+
+	// Lowercase keys, one per line (exact format):
+	// tlsisserver, tlscertfile, tlskeyfile, tlsservercacertfile, tlsexpectedhostname
+	if (key == "tlsisserver") {
+		cfg.isServer = (val == "true" || val == "1" || val == "yes");
+	} else if (key == "tlscertfile") {
+		cfg.certFile = val;
+	} else if (key == "tlskeyfile") {
+		cfg.keyFile = val;
+	} else if (key == "tlsservercacertfile") {
+		cfg.caFile = val;
+	} else if (key == "tlsexpectedhostname") {
+		cfg.expectedHostname = val;
+	}
+}
+
+TlsSession::TlsConfig TlsSession::TlsConfig::fromFile(const std::string &path) {
+	TlsSession::TlsConfig cfg;
+	std::ifstream in(path);
+	if (!in) {
+		safs::log_err("TLS config open failed: {}", path);
+		return cfg;
+	}
+
+	std::string line;
+	while (std::getline(in, line)) {
+		tlsTrim(line);
+		if (line.empty() || line[0] == '#') { continue; }
+
+		// Allow comma-separated key=value pairs in one line
+		std::stringstream ss(line);
+		std::string part;
+		while (std::getline(ss, part, ',')) {
+			tlsTrim(part);
+			if (!part.empty()) { tlsParseKV(part, cfg); }
+		}
+	}
+	return cfg;
+}
 
 TlsSession::TlsSession(int socket, bool isServer, const std::string &keyFile,
                        const std::string &certFile, const std::string &trustedCAFile,
@@ -121,3 +187,7 @@ TlsSession::TlsSession(int socket, bool isServer, const std::string &keyFile,
 		}
 	}
 }
+
+TlsSession::TlsSession(int socket, const TlsConfig &cfg)
+    : TlsSession(socket, cfg.isServer, cfg.keyFile, cfg.certFile, cfg.caFile,
+                 cfg.expectedHostname) {}

--- a/src/common/tls_session.h
+++ b/src/common/tls_session.h
@@ -59,6 +59,28 @@ public:
 	// NOLINTNEXTLINE(readability-redundant-string-init)
 	static constexpr std::string_view kNoFile = "";
 
+	// Convenience: construct from a reusable configuration
+	struct TlsConfig {
+		bool isServer{false};
+		std::string keyFile;           // PEM
+		std::string certFile;          // PEM
+		std::string caFile;            // PEM
+		std::string expectedHostname;  // client-side: DNS or IP literal
+
+		// Parse a simple kv file. Supports multiple key=value pairs per line,
+		// separated by commas.
+		// Recognized keys: tlsisserver, tlscertfile, tlskeyfile, tlsservercacertfile,
+		// tlsexpectedhostname
+		static TlsConfig fromFile(const std::string &path);
+	};
+
+	/**
+	 * Constructs a TLS session for the given socket using the provided configuration.
+	 * @param socket The underlying connected socket file descriptor.
+	 * @param config The TLS configuration to use.
+	 **/
+	TlsSession(int socket, const TlsConfig &config);
+
 	/**
 	 * Constructs a TLS session for the given socket.
 	 * @param socket The underlying connected socket file descriptor.
@@ -77,8 +99,6 @@ public:
 
 	// Returns the context (for advanced tweaks if needed)
 	SSL_CTX *context() const { return ctx_.get(); }
-
-	// Returns the context (for advanced tweaks if needed)
 
 private:
 	struct CtxDeleter {

--- a/src/data/CMakeLists.txt
+++ b/src/data/CMakeLists.txt
@@ -13,6 +13,7 @@ install(FILES sfsgoals.cfg                                   DESTINATION ${SFSMA
 install(FILES sfshdd.cfg                                     DESTINATION ${CHUNKSERVER_EXAMPLES_SUBDIR})
 install(FILES sfsmount.cfg                                   DESTINATION ${CLIENT_EXAMPLES_SUBDIR})
 install(FILES sfsiolimits.cfg                                   DESTINATION ${CLIENT_EXAMPLES_SUBDIR})
+install(FILES sfstls.cfg                                     DESTINATION ${CLIENT_EXAMPLES_SUBDIR})
 install(FILES sfstopology.cfg                                DESTINATION ${SFSMASTER_EXAMPLES_SUBDIR})
 install(FILES sfsglobaliolimits.cfg                             DESTINATION ${SFSMASTER_EXAMPLES_SUBDIR})
 install(FILES saunafs-uraft.cfg                             DESTINATION ${URAFT_EXAMPLES_SUBDIR})

--- a/src/data/sfstls.cfg
+++ b/src/data/sfstls.cfg
@@ -1,0 +1,10 @@
+# The optional sfstls.cfg file can be used to specify defaults for SaunaFS TLS settings.
+# Default TLS options can be specified on one line separated by commas or
+# over several lines.
+# Examples:
+#
+# tlsisserver=false
+# tlscertfile=/path/to/certfile.pem
+# tlskeyfile=/path/to/keyfile.pem
+# tlsservercacertfile=/path/to/cacertfile.pem
+# tlsexpectedhostname=master.saunafs.local

--- a/src/mount/fuse/main.cc
+++ b/src/mount/fuse/main.cc
@@ -273,9 +273,7 @@ static int mainloop(struct fuse_args *args, struct fuse_cmdline_opts *fuse_opts,
 	params.use_quota_in_volume_size = gMountOptions.usequotainvolumesize;
 	params.max_wait_retry_time = gMountOptions.maxwaitretrytime;
 	params.mastercomm_sleep_time_divisor = gMountOptions.mastercommsleeptimedivisor;
-	params.tls_cert_file = gMountOptions.tlscertfile;
-	params.tls_key_file = gMountOptions.tlskeyfile;
-	params.tls_server_ca_cert_file = gMountOptions.tlsservercacertfile;
+	params.tls_config_file = gMountOptions.tlsconfigfile;
 
 	if (!gMountOptions.meta) {
 		SaunaClient::fs_init(params);
@@ -703,17 +701,9 @@ int main(int argc, char *argv[]) try {
 		gMountOptions.direntrycachesize = 10000000;
 	}
 
-	if (!gMountOptions.tlscertfile) {
-		gMountOptions.tlscertfile = strdup(SaunaClient::FsInitParams::kDefaultTlsCertFile.data());
-	}
-
-	if (!gMountOptions.tlskeyfile) {
-		gMountOptions.tlskeyfile = strdup(SaunaClient::FsInitParams::kDefaultTlsKeyFile.data());
-	}
-
-	if (!gMountOptions.tlsservercacertfile) {
-		gMountOptions.tlsservercacertfile =
-		    strdup(SaunaClient::FsInitParams::kDefaultTlsServerCACertFile.data());
+	if (!gMountOptions.tlsconfigfile) {
+		gMountOptions.tlsconfigfile =
+		    strdup(SaunaClient::FsInitParams::kDefaultTlsConfigFile.data());
 	}
 
 	gLimitGlibcArenas = gMountOptions.limitglibcmallocarenas;
@@ -793,9 +783,7 @@ int main(int argc, char *argv[]) try {
 		free(gMountOptions.iolimits);
 	if (gDefaultMountpoint && gDefaultMountpoint != fuse_opts.mountpoint)
 		free(gDefaultMountpoint);
-	free(gMountOptions.tlscertfile);
-	free(gMountOptions.tlskeyfile);
-	free(gMountOptions.tlsservercacertfile);
+	free(gMountOptions.tlsconfigfile);
 	free(fuse_opts.mountpoint);
 	free(conn_opts);
 	stats_term();

--- a/src/mount/fuse/mount_config.cc
+++ b/src/mount/fuse/mount_config.cc
@@ -105,9 +105,7 @@ struct fuse_opt gSfsOptsStage2[] = {
 	SFS_OPT("usequotainvolumesize=%d", usequotainvolumesize, 0),
 	SFS_OPT("maxwaitretrytime=%u", maxwaitretrytime, 0),
 	SFS_OPT("mastercommsleeptimedivisor=%u", mastercommsleeptimedivisor, 0),
-	SFS_OPT("tlscertfile=%s", tlscertfile, 0),
-	SFS_OPT("tlskeyfile=%s", tlskeyfile, 0),
-	SFS_OPT("tlsservercacertfile=%s", tlsservercacertfile, 0),
+	SFS_OPT("tlsconfigfile=%s", tlsconfigfile, 0),
 
 	SFS_OPT("enablefilelocks=%u", filelocks, 0),
 	SFS_OPT("nonempty", nonemptymount, 1),
@@ -212,12 +210,8 @@ void initialize_opts_name_values() {
 	    std::to_string(gMountOptions.mastercommsleeptimedivisor);
 	gOptsNameValues["enablefilelocks"] = std::to_string(gMountOptions.filelocks);
 	gOptsNameValues["nonempty"] = std::to_string(gMountOptions.nonemptymount);
-	gOptsNameValues["tlscertfile"] =
-	    gMountOptions.tlscertfile ? std::string(gMountOptions.tlscertfile) : "";
-	gOptsNameValues["tlskeyfile"] =
-	    gMountOptions.tlskeyfile ? std::string(gMountOptions.tlskeyfile) : "";
-	gOptsNameValues["tlsservercacertfile"] =
-	    gMountOptions.tlsservercacertfile ? std::string(gMountOptions.tlsservercacertfile) : "";
+	gOptsNameValues["tlsconfigfile"] =
+	    gMountOptions.tlsconfigfile ? std::string(gMountOptions.tlsconfigfile) : "";
 
 	gMountInfo.setMountOptions(gOptsNameValues);
 }
@@ -371,11 +365,7 @@ void usage(const char *progname) {
 "    -o mastercommsleeptimedivisor=N  number of retries between each time increase of the "
 				"master-communication sleep interval, up to maxwaitretrytime; smaller N "
 				"converges faster—ideal for critical fast-reconnect scenarios (default: %u)\n"
-"    -o tlscertfile=PATH         path to the TLS certificate file the client will use "
-				"for TLS connections (default: %s)\n"
-"    -o tlskeyfile=PATH          path to the TLS private key file the client will use "
-				"for TLS connections (default: %s)\n"
-"    -o tlsservercacertfile=PATH  path to the file with trusted CA certificate which is "
+"    -o tlsconfigfile=PATH       path to the file with client config TLS option values "
 				"used to authenticate the master server (default: %s)\n"
 "\n",
 		SaunaClient::FsInitParams::kDefaultCacheExpirationTime,
@@ -418,9 +408,7 @@ void usage(const char *progname) {
 		SaunaClient::FsInitParams::kDefaultUseQuotaInVolumeSize,
 		SaunaClient::FsInitParams::kDefaultMaxWaitRetryTime,
 		SaunaClient::FsInitParams::kDefaultMasterCommSleepTimeDivisor,
-		SaunaClient::FsInitParams::kDefaultTlsCertFile.data(),
-		SaunaClient::FsInitParams::kDefaultTlsKeyFile.data(),
-		SaunaClient::FsInitParams::kDefaultTlsServerCACertFile.data()
+		SaunaClient::FsInitParams::kDefaultTlsConfigFile.data()
 	);
 	printf(
 "CMODE can be set to:\n"

--- a/src/mount/fuse/mount_config.h
+++ b/src/mount/fuse/mount_config.h
@@ -125,10 +125,7 @@ struct sfsopts_ {
 	int usequotainvolumesize;
 	unsigned maxwaitretrytime;
 	unsigned mastercommsleeptimedivisor;
-	char *tlscertfile;
-	char *tlskeyfile;
-	char *tlsservercacertfile;
-
+	char *tlsconfigfile;
 	sfsopts_()
 		: masterhost(NULL),
 		masterport(NULL),
@@ -193,9 +190,7 @@ struct sfsopts_ {
 		usequotainvolumesize(SaunaClient::FsInitParams::kDefaultUseQuotaInVolumeSize),
 		maxwaitretrytime(SaunaClient::FsInitParams::kDefaultMaxWaitRetryTime),
 		mastercommsleeptimedivisor(SaunaClient::FsInitParams::kDefaultMasterCommSleepTimeDivisor),
-		tlscertfile(nullptr),
-		tlskeyfile(nullptr),
-		tlsservercacertfile(nullptr)
+		tlsconfigfile(nullptr)
 	{ }
 };
 

--- a/src/mount/mastercomm.cc
+++ b/src/mount/mastercomm.cc
@@ -96,13 +96,11 @@ struct threc {
 std::unique_ptr<TlsSession> tlsSession;
 int lastHandshakeError = 0;
 
-/// TLS related parameters
+/// TLS related values
 /// These are usually initialized as TlsSession::kNoFile on client startup (see
 /// FsInitParams)
-bool gIsTlsEnabled = false;
-std::string tlsCertFile = "";
-std::string tlsKeyFile = "";
-std::string tlsServerCaCertFile = "";
+std::string tlsConfigFile = "";
+std::mutex tlsConfigFileMutex;
 
 #define DEFAULT_OUTPUT_BUFFSIZE 0x1000
 #define DEFAULT_INPUT_BUFFSIZE 0x10000
@@ -235,6 +233,15 @@ struct InitParams {
 };
 
 static InitParams gInitParams;
+
+// Check if TLS connection is enabled to be tried,
+// at least client certificate and key files should be available.
+// Also, TLS config file can be used to configure TLS connection,
+// and should be prioritized if provided.
+bool isTlsEnabled() {
+	std::lock_guard lock(tlsConfigFileMutex);
+	return !tlsConfigFile.empty();
+}
 
 /// Starts or continues a TLS handshake.
 /// \return true if the handshake completed successfully, false otherwise.
@@ -1202,8 +1209,23 @@ int fs_register_with_new_session(std::vector<std::uint8_t> &registrationMessageB
 
 bool fs_starttls_connection() {
 	try {
-		tlsSession = std::make_unique<TlsSession>(fd, false, tlsKeyFile, tlsCertFile,
-		                                          tlsServerCaCertFile, gInitParams.host);
+		std::string tlsConfigFileCopy;
+		{
+			std::lock_guard<std::mutex> lock(tlsConfigFileMutex);
+			tlsConfigFileCopy = tlsConfigFile;
+		}
+
+		if (!tlsConfigFileCopy.empty()) {
+			TlsSession::TlsConfig tlsCfg = TlsSession::TlsConfig::fromFile(tlsConfigFileCopy);
+
+			if (tlsCfg.expectedHostname.empty()) { tlsCfg.expectedHostname = gInitParams.host; }
+
+			tlsSession = std::make_unique<TlsSession>(fd, tlsCfg);
+		} else {
+			safs::log_warn(
+			    "TLS configuration file not specified, not using TLS for connection to SFS master");
+			return false;
+		}
 		safs::log_info("initiating TLS handshake with SFS master");
 
 		auto startTlsRequest = cltoma::startTls::build();
@@ -1298,7 +1320,7 @@ int fs_connect(bool verbose) {
 	fd = fs_open_master_connection(verbose);
 	if (fd < 0) { return -1; }
 
-	if (gIsTlsEnabled && !fs_starttls_connection()) { return -1; }
+	if (isTlsEnabled() && !fs_starttls_connection()) { return -1; }
 
 	if (havepassword &&
 	    fs_register_with_get_random(registrationMessageBuffer, passwordDigest, verbose) < 0) {
@@ -1341,7 +1363,7 @@ void fs_reconnect() {
 	fd = fs_open_master_connection();
 	if (fd < 0) { return; }
 
-	if (gIsTlsEnabled && !fs_starttls_connection()) { return; }
+	if (isTlsEnabled() && !fs_starttls_connection()) { return; }
 
 	stats_inc(MASTER_CONNECTS, statsptr);
 	messageToMaster = registrationMessageBuffer.data();
@@ -1501,6 +1523,7 @@ void* fs_nop_thread(void *arg) {
 
 	uint64_t lastTweaksGlobalEpoch = gTweaks.getGlobalLastChangeEpoch();
 	uint64_t lastIOLimitsEpoch = gTweaks.getVarLastChangeEpochByName("IOLimitsFilePath");
+	uint64_t lastTlsConfigFileEpoch = gTweaks.getVarLastChangeEpochByName("TlsConfigFile");
 
 	for (;;) {
 		now = time(NULL);
@@ -1600,7 +1623,16 @@ void* fs_nop_thread(void *arg) {
 					}
 				}
 
+				const uint64_t currentTlsConfigFileEpoch =
+				    gTweaks.getVarLastChangeEpochByName("TlsConfigFile");
+
+				if (currentTlsConfigFileEpoch > lastTlsConfigFileEpoch) {
+					safs::log_warn("TLS configuration changed, starting reconnection...");
+					disconnect = true;
+				}
+
 				lastTweaksGlobalEpoch = currentTweaksGlobalEpoch;
+				lastTlsConfigFileEpoch = currentTlsConfigFileEpoch;
 			}
 		}
 
@@ -1834,10 +1866,10 @@ int fs_init_master_connection(SaunaClient::FsInitParams &params
 	disconnect = false;
 
     // TLS parameters
-	gIsTlsEnabled = params.tls_key_file != TlsSession::kNoFile && params.tls_cert_file != TlsSession::kNoFile;
-	tlsKeyFile = params.tls_key_file;
-	tlsCertFile = params.tls_cert_file;
-	tlsServerCaCertFile = params.tls_server_ca_cert_file;
+	{
+		std::lock_guard lock(tlsConfigFileMutex);
+		tlsConfigFile = params.tls_config_file;
+	}
 
 	if (params.delayed_init) {
 		return 1;
@@ -1868,6 +1900,7 @@ void fs_init_threads(uint32_t retries, uint32_t maxWaitTimeForRetry, uint32_t sl
 	gTweaks.registerVariable("MaxRetriesMasterComm", maxretries, "maxretriesmastercomm");
 	gTweaks.registerVariable("MaxWaitRetryTimeMasterComm", maxWaitRetryTime, "maxwaitretrytime");
 	gTweaks.registerVariable("MasterCommSleepTimeDivisor", mastercommSleepTimeDivisor, "mastercommsleeptimedivisor");
+	gTweaks.registerVariable("TlsConfigFile", tlsConfigFile, tlsConfigFileMutex, "tlsconfigfile");
 	mountInfoLock.unlock();
 
 	pthread_attr_init(&thattr);

--- a/src/mount/sauna_client.h
+++ b/src/mount/sauna_client.h
@@ -135,9 +135,7 @@ struct FsInitParams {
 	static constexpr bool     kDirectIO = false;
 
 	// TLS related parameters
-	static constexpr std::string_view kDefaultTlsCertFile = TlsSession::kNoFile;
-	static constexpr std::string_view kDefaultTlsKeyFile = TlsSession::kNoFile;
-	static constexpr std::string_view kDefaultTlsServerCACertFile = TlsSession::kNoFile;
+	static constexpr std::string_view kDefaultTlsConfigFile = TlsSession::kNoFile;
 
 	// Thank you, GCC 4.6, for no delegating constructors
 	FsInitParams()
@@ -186,9 +184,7 @@ struct FsInitParams {
 	             verbose(kDefaultVerbose), direct_io(kDirectIO),
 	             log_notifications_area(kDefaultLogNotificationArea),
 	             message_suppression_period(kDefaultMessageSuppressionPeriod),
-	             tls_cert_file(kDefaultTlsCertFile),
-	             tls_key_file(kDefaultTlsKeyFile),
-	             tls_server_ca_cert_file(kDefaultTlsServerCACertFile) {
+	             tls_config_file(kDefaultTlsConfigFile) {
 	}
 
 	FsInitParams(const std::string &bind_host, const std::string &host, const std::string &port, const std::string &mountpoint)
@@ -237,9 +233,7 @@ struct FsInitParams {
 	             verbose(kDefaultVerbose), direct_io(kDirectIO),
 	             log_notifications_area(kDefaultLogNotificationArea),
 	             message_suppression_period(kDefaultMessageSuppressionPeriod),
-	             tls_cert_file(kDefaultTlsCertFile),
-	             tls_key_file(kDefaultTlsKeyFile),
-	             tls_server_ca_cert_file(kDefaultTlsServerCACertFile) {
+	             tls_config_file(kDefaultTlsConfigFile) {
 	}
 
 	std::string bind_host;
@@ -311,9 +305,7 @@ struct FsInitParams {
 	unsigned message_suppression_period;
 
 	// TLS related parameters
-	std::string tls_cert_file;
-	std::string tls_key_file;
-	std::string tls_server_ca_cert_file;
+	std::string tls_config_file;
 
 	std::string io_limits_config_file;
 };

--- a/tests/test_suites/ShortSystemTests/test_tls_master_chunkserver_communication.sh
+++ b/tests/test_suites/ShortSystemTests/test_tls_master_chunkserver_communication.sh
@@ -23,6 +23,15 @@ generate_certs ${TLS_CERTS_DIR}
 INVALID_TLS_CERTS_DIR=${TEMP_DIR}/invalid_testcerts
 generate_certs ${INVALID_TLS_CERTS_DIR}
 
+# Create TLS config file pointing to reload TLS config on client side
+cat > ${TEMP_DIR}/sfstls.cfg <<EOF
+tlscertfile=${TLS_CERTS_DIR}/client.crt
+tlskeyfile=${TLS_CERTS_DIR}/client.key
+tlsservercacertfile=${TLS_CERTS_DIR}/ca.crt
+tlsisserver=false
+tlsexpectedhostname=sfsmaster
+EOF
+
 # Configure master to use TLS certs
 master_cfg="|TLS_CERT_FILE = ${TLS_CERTS_DIR}/server.crt"
 master_cfg+="|TLS_KEY_FILE = ${TLS_CERTS_DIR}/server.key"
@@ -39,7 +48,7 @@ cs_cfg+="|TLS_CA_CERT_FILE = ${TLS_CERTS_DIR}/ca.crt"
 export SSL_CERT_FILE="${TLS_CERTS_DIR}/ca.crt"
 
 USE_RAMDISK=YES \
-	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER,sfsioretries=5,tlscertfile=${TLS_CERTS_DIR}/client.crt,tlskeyfile=${TLS_CERTS_DIR}/client.key" \
+	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER,sfsioretries=5,tlsconfigfile=${TEMP_DIR}/sfstls.cfg" \
 	MASTER_EXTRA_CONFIG="${master_cfg}" \
 	CHUNKSERVER_EXTRA_CONFIG="${cs_cfg}" \
 	setup_local_empty_saunafs info

--- a/tests/test_suites/ShortSystemTests/test_tls_master_client_communication.sh
+++ b/tests/test_suites/ShortSystemTests/test_tls_master_client_communication.sh
@@ -6,9 +6,31 @@ echo "Generating TLS certificates for master-client communication test..."
 TLS_CERTS_DIR=${TEMP_DIR}/testcerts
 generate_certs ${TLS_CERTS_DIR}
 
+echo "generating TLS certificates for reload TLS config testing for master-client communication test..."
+TLS_CERTS_DIR_RELOAD=${TEMP_DIR}/testcerts_reload
+generate_certs ${TLS_CERTS_DIR_RELOAD}
+
+# Create TLS config file pointing to reload TLS config
+cat > ${TEMP_DIR}/sfstls.cfg <<EOF
+tlscertfile=${TLS_CERTS_DIR}/client.crt
+tlskeyfile=${TLS_CERTS_DIR}/client.key
+tlsservercacertfile=
+tlsisserver=false
+tlsexpectedhostname=sfsmaster
+EOF
+
 # Generate a second CA and client certs (invalid for master trust)
 INVALID_TLS_CERTS_DIR=${TEMP_DIR}/invalid_testcerts
 generate_certs ${INVALID_TLS_CERTS_DIR}
+
+# Create TLS config file pointing to reload invalid TLS config
+cat > ${TEMP_DIR}/sfstls_invalid.cfg <<EOF
+tlscertfile=${INVALID_TLS_CERTS_DIR}/client.crt
+tlskeyfile=${INVALID_TLS_CERTS_DIR}/client.key
+tlsservercacertfile=${INVALID_TLS_CERTS_DIR}/ca.crt
+tlsisserver=false
+tlsexpectedhostname=sfsmaster
+EOF
 
 # Configure master to use TLS certs
 master_cfg="|TLS_CERT_FILE = ${TLS_CERTS_DIR}/server.crt"
@@ -21,13 +43,13 @@ master_cfg+="|TLS_CA_CERT_FILE = ${TLS_CERTS_DIR}/ca.crt"
 export SSL_CERT_FILE="${TLS_CERTS_DIR}/ca.crt"
 
 USE_RAMDISK=YES \
-	MOUNT_EXTRA_CONFIG="tlscertfile=${TLS_CERTS_DIR}/client.crt,tlskeyfile=${TLS_CERTS_DIR}/client.key" \
+	MOUNT_EXTRA_CONFIG="tlsconfigfile=${TEMP_DIR}/sfstls.cfg" \
 	MASTER_EXTRA_CONFIG="$master_cfg" \
 	setup_local_empty_saunafs info
 
 cd "${info[mount0]}"
 
-# Create multiple files to test TLS communication
+# 1) Create multiple files to test TLS communication
 for i in {1..5}; do
     touch file_tls_$i.txt
 done
@@ -35,13 +57,15 @@ done
 # Verify that all files were created successfully
 assert_equals "5" "$(ls | grep '^file_tls_' | wc -l)"
 
-# Try mounting client with correct certs again but with CA given by configuration
+# 2) Try mounting client with correct certs again but with CA given by configuration
 cd ..
 
 saunafs_mount_unmount 0
 
-# Use new mount config with TLS CA file
-echo "tlscertfile=${TLS_CERTS_DIR}/client.crt,tlskeyfile=${TLS_CERTS_DIR}/client.key,tlsservercacertfile=${TLS_CERTS_DIR}/ca.crt" >> "${info[mount0_cfg]}"
+# Use new mount config with TLS CA file value manually set
+sed -i \
+  "s|^tlsservercacertfile=.*|tlsservercacertfile=${TLS_CERTS_DIR}/ca.crt|" \
+  "${TEMP_DIR}/sfstls.cfg"
 
 saunafs_mount_start 0 &
 
@@ -53,12 +77,63 @@ cd "${info[mount0]}"
 # Verify that all previously created files are accessible
 assert_equals "5" "$(ls | grep '^file_tls_' | wc -l)"
 
-# Now test that with invalid certs, client will not mount and it
+# 3) Now restart master with new TLS certs, then update client TLS config
+# on runtime and then check that reconnection is OK
 cd ..
 
 saunafs_mount_unmount 0
 
-echo "tlscertfile=${INVALID_TLS_CERTS_DIR}/client.crt,tlskeyfile=${INVALID_TLS_CERTS_DIR}/client.key,tlsservercacertfile=${INVALID_TLS_CERTS_DIR}/ca.crt" >> "${info[mount0_cfg]}"
+tmp_cfg="${TEMP_DIR}/master.cfg.new"
+
+# Create a modified copy
+sed \
+  -e "s|^TLS_CERT_FILE *=.*|TLS_CERT_FILE = ${TLS_CERTS_DIR_RELOAD}/server.crt|" \
+  -e "s|^TLS_KEY_FILE *=.*|TLS_KEY_FILE = ${TLS_CERTS_DIR_RELOAD}/server.key|" \
+  -e "s|^TLS_CA_CERT_FILE *=.*|TLS_CA_CERT_FILE = ${TLS_CERTS_DIR_RELOAD}/ca.crt|" \
+  "${info[master_cfg]}" > "$tmp_cfg"
+
+# Atomically replace the original file (same path)
+mv "$tmp_cfg" "${info[master_cfg]}"
+
+# Explicit reload of master
+saunafs_master_daemon reload
+saunafs_wait_for_all_ready_chunkservers
+
+# Use new mount config via config file to ensure it tries first with new files
+rm "${TEMP_DIR}/sfstls.cfg"
+cat > ${TEMP_DIR}/sfstls.cfg <<EOF
+tlscertfile=${TLS_CERTS_DIR_RELOAD}/client.crt
+tlskeyfile=${TLS_CERTS_DIR_RELOAD}/client.key
+tlsservercacertfile=${TLS_CERTS_DIR_RELOAD}/ca.crt
+tlsisserver=false
+tlsexpectedhostname=sfsmaster
+EOF
+
+# Start the client again
+saunafs_mount_start 0
+
+# Now check that filesystem started
+cd "${info[mount0]}"
+assert_equals "5" "$(ls | grep '^file_tls_' | wc -l)"
+
+# Check TLS config file value from Tweaks file.
+expect_equals "${TEMP_DIR}/sfstls.cfg" "$(cat ${info[mount0]}/.saunafs_tweaks | grep -i tlsconfigfile | awk '{print $2}')"
+
+# Copy TLS client config file and update through Tweaks to force runtime update and reconnection
+cp ${TEMP_DIR}/sfstls.cfg ${TEMP_DIR}/sfstls_copy.cfg
+echo "TlsConfigFile=${TEMP_DIR}/sfstls_copy.cfg" | sudo tee ${info[mount0]}/.saunafs_tweaks
+# Wait a bit to allow reconnection to happen
+sleep 3
+
+# Check new updated value, which confirms reconnection was performed and update was correct
+expect_equals "${TEMP_DIR}/sfstls_copy.cfg" "$(cat ${info[mount0]}/.saunafs_tweaks | grep -i tlsconfigfile | awk '{print $2}')"
+
+# 4) Now test that with invalid certs, client will not mount and it
+cd ..
+
+saunafs_mount_unmount 0
+
+echo "tlsconfigfile=${TEMP_DIR}/sfstls_invalid.cfg" >> "${info[mount0_cfg]}"
 
 saunafs_mount_start 0 &
 

--- a/tests/test_suites/ShortSystemTests/test_tls_master_shadow_metalogger_communication.sh
+++ b/tests/test_suites/ShortSystemTests/test_tls_master_shadow_metalogger_communication.sh
@@ -21,6 +21,15 @@ metalogger_cfg="|TLS_CERT_FILE = ${TLS_CERTS_DIR}/ml.crt"
 metalogger_cfg+="|TLS_KEY_FILE = ${TLS_CERTS_DIR}/ml.key"
 metalogger_cfg+="|TLS_CA_CERT_FILE = ${TLS_CERTS_DIR}/ca.crt"
 
+# Create TLS config file pointing to reload TLS config on client side
+cat > ${TEMP_DIR}/sfstls.cfg <<EOF
+tlscertfile=${TLS_CERTS_DIR}/client.crt
+tlskeyfile=${TLS_CERTS_DIR}/client.key
+tlsservercacertfile=${TLS_CERTS_DIR}/ca.crt
+tlsisserver=false
+tlsexpectedhostname=sfsmaster
+EOF
+
 # Set environment variable for client to find CA cert and check that
 # expected logic trying to use value from SSL_CERT_FILE when no CA
 # is given in mount configuration works.
@@ -28,7 +37,7 @@ export SSL_CERT_FILE="${TLS_CERTS_DIR}/ca.crt"
 
 USE_RAMDISK=YES \
 	MASTERSERVERS=2 \
-	MOUNT_EXTRA_CONFIG="tlscertfile=${TLS_CERTS_DIR}/client.crt,tlskeyfile=${TLS_CERTS_DIR}/client.key" \
+	MOUNT_EXTRA_CONFIG="tlsconfigfile=${TEMP_DIR}/sfstls.cfg" \
 	SFSEXPORTS_EXTRA_OPTIONS="allcanchangequota" \
 	MASTER_0_EXTRA_CONFIG="${master_cfg0}|MASTER_TIMEOUT = 10|METADATA_DUMP_PERIOD_SECONDS = 0" \
 	MASTER_1_EXTRA_CONFIG="${master_cfg1}|MASTER_TIMEOUT = 10|METADATA_DUMP_PERIOD_SECONDS = 0" \


### PR DESCRIPTION
This change introduces support for reloading client-side TLS configuration at runtime using a dedicated TLS config file, enabling safe certificate rotation without restarting the client.

Changes in this commit:

- Introduce a dedicated TLS configuration file (sfstls.cfg) and parser for loading complete TLS session parameters.

- Add a new client option to specify the TLS config file path.

- Update TLS initialization logic to prioritize loading from the TLS config file; if unavailable or invalid, fall back to explicitly provided TLS options.

- Integrate the TLS config path into the tweaks-based reload mechanism to trigger client-side TLS reconnection on configuration changes.

This approach ensures atomic TLS updates and avoids inconsistent TLS state during certificate reloads.