### PR TITLE
feat(mount): Implement negative cache

### DIFF
--- a/src/mount/fuse/main.cc
+++ b/src/mount/fuse/main.cc
@@ -254,6 +254,8 @@ static int mainloop(struct fuse_args *args, struct fuse_cmdline_opts *fuse_opts,
 	params.keep_cache = gMountOptions.keepcache;
 	params.direntry_cache_timeout = gMountOptions.direntrycacheto;
 	params.direntry_cache_size = gMountOptions.direntrycachesize;
+	params.negative_cache_timeout = gMountOptions.negativecachetimeout;
+	params.negative_cache_size = gMountOptions.negativecachesize;
 	params.entry_cache_timeout = gMountOptions.entrycacheto;
 	params.attr_cache_timeout = gMountOptions.attrcacheto;
 	params.mkdir_copy_sgid = gMountOptions.mkdircopysgid;

--- a/src/mount/fuse/mount_config.cc
+++ b/src/mount/fuse/mount_config.cc
@@ -76,6 +76,8 @@ struct fuse_opt gSfsOptsStage2[] = {
 	SFS_OPT("sfsentrycacheto=%lf", entrycacheto, 0),
 	SFS_OPT("sfsdirectio=%d", directio, 0),
 	SFS_OPT("sfsdirentrycacheto=%lf", direntrycacheto, 0),
+	SFS_OPT("sfsnegativecachetimeout=%u", negativecachetimeout, 0),
+	SFS_OPT("sfsnegativecachesize=%u", negativecachesize, 0),
 	SFS_OPT("sfsaclcacheto=%lf", aclcacheto, 0),
 	SFS_OPT("sfsreportreservedperiod=%u", reportreservedperiod, 0),
 	SFS_OPT("sfsiolimits=%s", iolimits, 0),
@@ -168,6 +170,8 @@ void initialize_opts_name_values() {
 	gOptsNameValues["sfsentrycacheto"] = std::to_string(gMountOptions.entrycacheto);
 	gOptsNameValues["sfsdirectio"] = std::to_string(gMountOptions.directio);
 	gOptsNameValues["sfsdirentrycacheto"] = std::to_string(gMountOptions.direntrycacheto);
+	gOptsNameValues["sfsnegativecachetimeout"] = std::to_string(gMountOptions.negativecachetimeout);
+	gOptsNameValues["sfsnegativecachesize"] = std::to_string(gMountOptions.negativecachesize);
 	gOptsNameValues["sfsaclcacheto"] = std::to_string(gMountOptions.aclcacheto);
 	gOptsNameValues["sfsreportreservedperiod"] = std::to_string(gMountOptions.reportreservedperiod);
 	gOptsNameValues["sfsiolimits"] =
@@ -317,6 +321,14 @@ void usage(const char *progname) {
 				"(default: %.2f)\n"
 "    -o sfsdirentrycachesize=N   define directory entry cache size in number "
 				"of entries (default: %u)\n"
+"    -o sfsnegativecachetimeout=MSEC  set negative cache timeout to determine "
+				"how long client remembers a failed lookup. When equal to 0 "
+    			"disabled for both internal and Linux kernel-level negative caching. " 
+				"If changed in .saunafs_tweaks clears the whole cache (default: %u)\n"
+"    -o sfsnegativecachesize=N   define internal negative cache max size in number of entries. "
+				"Prevents network requests if the kernel evicts entries early. "
+				"When equal to 0 disabled for both internal and Linux kernel-level negative caching. "
+				"If changed in .saunafs_tweaks clears the whole cache (default: %u)\n"
 "    -o sfsaclcacheto=SEC        set ACL cache timeout in seconds (default: %.2f)\n"
 "    -o sfsreportreservedperiod=SEC  set reporting reserved inodes interval in "
 				"seconds (default: %u)\n"
@@ -392,6 +404,8 @@ void usage(const char *progname) {
 		SaunaClient::FsInitParams::kDefaultEntryCacheTimeout,
 		SaunaClient::FsInitParams::kDefaultDirentryCacheTimeout,
 		SaunaClient::FsInitParams::kDefaultDirentryCacheSize,
+		SaunaClient::FsInitParams::kDefaultNegativeCacheTo,
+		SaunaClient::FsInitParams::kDefaultNegativeCacheSize,
 		SaunaClient::FsInitParams::kDefaultAclCacheTimeout,
 		SaunaClient::FsInitParams::kDefaultReportReservedPeriod,
 		SaunaClient::FsInitParams::kDefaultRoundTime,

--- a/src/mount/fuse/mount_config.h
+++ b/src/mount/fuse/mount_config.h
@@ -97,6 +97,8 @@ struct sfsopts_ {
 	double entrycacheto;
 	double direntrycacheto;
 	unsigned direntrycachesize;
+	unsigned negativecachetimeout;
+	unsigned negativecachesize;
 	unsigned reportreservedperiod;
 	char *iolimits;
 	int chunkserverrtt;
@@ -164,6 +166,8 @@ struct sfsopts_ {
 		entrycacheto(SaunaClient::FsInitParams::kDefaultEntryCacheTimeout),
 		direntrycacheto(SaunaClient::FsInitParams::kDefaultDirentryCacheTimeout),
 		direntrycachesize(SaunaClient::FsInitParams::kDefaultDirentryCacheSize),
+		negativecachetimeout(SaunaClient::FsInitParams::kDefaultNegativeCacheTo),
+		negativecachesize(SaunaClient::FsInitParams::kDefaultNegativeCacheSize),
 		reportreservedperiod(SaunaClient::FsInitParams::kDefaultReportReservedPeriod),
 		iolimits(NULL),
 		chunkserverrtt(SaunaClient::FsInitParams::kDefaultRoundTime),

--- a/src/mount/negative_cache.h
+++ b/src/mount/negative_cache.h
@@ -1,0 +1,223 @@
+/*
+
+   Copyright 2026 Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <list>
+#include <mutex>
+#include <unordered_map>
+
+#include "common/hashfn.h"
+#include "common/shared_mutex.h"
+#include "common/type_defs.h"
+#include "common/time_utils.h"
+
+inline std::atomic<uint32_t> gNegativeCacheTimeoutMs;
+inline std::atomic<uint32_t> gNegativeCacheMaxSize;
+
+class NegativeCache {
+public:
+    NegativeCache() = default;
+
+	// To prevent accidental copies of the lock/map/list
+    NegativeCache(const NegativeCache&) = delete;
+    NegativeCache& operator=(const NegativeCache&) = delete;
+    NegativeCache(NegativeCache&&) = delete;
+    NegativeCache& operator=(NegativeCache&&) = delete;
+
+	// Atomic access
+	static uint32_t getGlobalMaxSize() noexcept {
+		return gNegativeCacheMaxSize.load();
+	}
+
+	// Atomic access
+	static void setGlobalMaxSize(uint32_t maxSize) noexcept {
+		gNegativeCacheMaxSize.store(maxSize);
+	}
+
+	// Locked
+    // Reserve enough buckets without the map needing to rehash
+    void setMaxSize(uint32_t maxSize) {
+		std::unique_lock<shared_mutex> lock(rwLock_);
+        maxSize_ = maxSize;
+		negativeCache_.reserve(maxSize_);
+	}
+
+	// Atomic access
+	static uint32_t getGlobalTimeoutMs() noexcept {
+		return gNegativeCacheTimeoutMs.load();
+	}
+
+	// Atomic access
+	static void setGlobalTimeoutMs(uint32_t timeoutMs) noexcept {
+		gNegativeCacheTimeoutMs.store(timeoutMs);
+	}
+
+	// Locked
+	void setTimeoutMs(uint32_t timeoutMs) {
+		std::unique_lock<shared_mutex> lock(rwLock_);
+		timeoutMs_ = timeoutMs;
+	}
+
+	// Locked
+	size_t size() const {
+		shared_lock<shared_mutex> lock(rwLock_);
+		return negativeCache_.size();
+	}
+
+	// Locked
+	bool isMaxSizeAndTimeoutMsSet() const {
+		shared_lock<shared_mutex> lock(rwLock_);
+		return (maxSize_ > 0) && (timeoutMs_ > 0);
+	}
+
+	// Locked
+	// Works only if max size and timeout are set
+	bool lookup(inode_t parent, std::string_view name) const {
+		if (!isMaxSizeAndTimeoutMsSet()) { return false; }
+
+		shared_lock<shared_mutex> lock(rwLock_);
+		auto it = negativeCache_.find(InodeNameLookupPair{ parent, name });
+		if (it != negativeCache_.end()) {
+			NegativeCacheEntry entry = it->second;
+			if (static_cast<uint64_t>(timer_.elapsed_ms()) < entry.timeoutMs) {
+				return true;
+			} // else ignore expired
+		}
+		return false;
+	}
+
+	// Locked, LRU eviction policy, entries refreshed
+	// Works only if max size and timeout are set
+	void add(inode_t parent, std::string_view name) {
+		if (!isMaxSizeAndTimeoutMsSet()) { return; }
+
+		std::unique_lock<shared_mutex> lock(rwLock_);
+
+		// sfsnegativecachetimeout and sfsnegativecachesize
+		// are not changed in Tweaks frequently, so it is okay
+		// for consistency
+		bool clearCache = false;
+		uint32_t globalTimeoutMs = getGlobalTimeoutMs();
+		if (timeoutMs_ != globalTimeoutMs) {
+			timeoutMs_ = globalTimeoutMs;
+			clearCache = true;
+		}
+		uint32_t globalMaxSize = getGlobalMaxSize();
+		if (maxSize_ != globalMaxSize) {
+			maxSize_ = globalMaxSize;
+			negativeCache_.reserve(maxSize_); // doesn't shrink
+			clearCache = true;
+		}
+		if (clearCache) {
+			negativeCache_.clear();
+			timeoutList_.clear();
+		}
+
+		InodeNamePairPtr inodeNamePtr;
+		
+		// Update existing
+		auto it = negativeCache_.find(InodeNameLookupPair{ parent, name });
+		if (it != negativeCache_.end()) {
+			inodeNamePtr = it->first;
+			timeoutList_.erase(it->second.listIt);
+		} else {
+			if (negativeCache_.size() >= maxSize_) {
+				// Remove oldest
+				negativeCache_.erase(timeoutList_.front());
+				timeoutList_.pop_front();
+			}
+			inodeNamePtr = std::make_shared<const InodeNamePair>(parent, name);
+		}
+		timeoutList_.push_back(inodeNamePtr);
+		
+		// Update timeout if the same parent/name
+		negativeCache_.insert_or_assign(inodeNamePtr, NegativeCacheEntry{
+			.timeoutMs = static_cast<uint64_t>(timer_.elapsed_ms()) + timeoutMs_,
+			.listIt = std::prev(timeoutList_.end())
+		});
+	}
+
+private:
+	using InodeNamePair = std::pair<inode_t, std::string>;
+	using InodeNamePairPtr = std::shared_ptr<const InodeNamePair>;
+	using InodeNameLookupPair = std::pair<inode_t, std::string_view>;
+
+	struct NegativeCacheEntry {
+		uint64_t timeoutMs;
+		std::list<InodeNamePairPtr>::iterator listIt;
+	};
+
+	struct InodeNameHash {
+		using is_transparent = void; // zero allocation for string
+
+		static uint64_t hashCompute(inode_t parent, std::string_view name) noexcept {
+			uint64_t seed = 0;
+			hashCombine(seed, parent, ByteArray(name.data(), name.size()));
+			return seed;
+		}
+
+		// Storage hash calculation
+		size_t operator()(const InodeNamePairPtr& obj) const noexcept {
+			return hashCompute(obj->first, obj->second);
+		}
+
+		// Lookup hash calculation
+		size_t operator()(const InodeNameLookupPair& obj) const noexcept {
+			return hashCompute(obj.first, obj.second);
+		}
+	};
+
+	struct InodeNameEqual {
+		using is_transparent = void; // zero allocation for string
+
+		// Compare two stored pairs
+		bool operator()(const InodeNamePairPtr& lsp,
+						const InodeNamePairPtr& rsp) const noexcept {
+			return lsp->first == rsp->first && lsp->second == rsp->second;
+		}
+
+		// Compare stored pair against lookup pair
+		bool operator()(const InodeNamePairPtr& lsp,
+						const InodeNameLookupPair& rsp) const noexcept {
+			return lsp->first == rsp.first && lsp->second == rsp.second;
+		}
+
+		bool operator()(const InodeNameLookupPair& lsp,
+						const InodeNamePairPtr& rsp) const noexcept {
+			return lsp.first == rsp->first && lsp.second == rsp->second;
+		}
+	};
+
+	mutable shared_mutex rwLock_;
+	std::unordered_map<
+		InodeNamePairPtr,
+		NegativeCacheEntry,
+		InodeNameHash,
+		InodeNameEqual
+	> negativeCache_;
+	Timer timer_;
+    size_t maxSize_;
+	uint32_t timeoutMs_;
+	std::list<InodeNamePairPtr> timeoutList_;
+};
+
+inline NegativeCache gNegativeCache;

--- a/src/mount/negative_cache_unittest.cc
+++ b/src/mount/negative_cache_unittest.cc
@@ -1,0 +1,102 @@
+/*
+
+   Copyright 2026 Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "mount/negative_cache.h"
+
+#include <ranges>
+
+#include <gtest/gtest.h>
+
+class NegativeCacheTest : public testing::Test {
+protected:
+    void SetUp() override {
+        NegativeCache::setGlobalMaxSize(kMaxSize);
+        negativeCache.setMaxSize(NegativeCache::getGlobalMaxSize());
+        NegativeCache::setGlobalTimeoutMs(k1000ms);
+        negativeCache.setTimeoutMs(NegativeCache::getGlobalTimeoutMs());
+    }
+
+    static constexpr uint32_t kMaxSize = 10;
+    static constexpr uint32_t k1000ms = 1000;
+    static constexpr inode_t kParent = 0;
+    static constexpr std::string_view kName = "some_file";
+
+    NegativeCache negativeCache;
+};
+
+TEST_F(NegativeCacheTest, InitiallyEmpty) {
+    EXPECT_EQ(negativeCache.size(), 0U);
+}
+
+TEST_F(NegativeCacheTest, SingleInsertion) {
+    negativeCache.add(kParent, kName);
+    EXPECT_EQ(negativeCache.size(), 1U);
+}
+
+TEST_F(NegativeCacheTest, RemoveOldestWithLRUUpdate) {
+    NegativeCache::setGlobalMaxSize(2);
+    negativeCache.setMaxSize(NegativeCache::getGlobalMaxSize());
+    EXPECT_EQ(negativeCache.size(), 0U);
+    negativeCache.add(1, "A");
+    negativeCache.add(1, "B");
+    EXPECT_EQ(negativeCache.size(), 2U);
+    EXPECT_TRUE(negativeCache.lookup(1, "A"));
+    EXPECT_TRUE(negativeCache.lookup(1, "B"));
+
+    negativeCache.add(1, "A");
+    EXPECT_EQ(negativeCache.size(), 2U);
+    EXPECT_TRUE(negativeCache.lookup(1, "A"));
+    EXPECT_TRUE(negativeCache.lookup(1, "B"));
+
+    negativeCache.add(1, "C");
+    EXPECT_EQ(negativeCache.size(), 2U);
+    EXPECT_TRUE(negativeCache.lookup(1, "A"));
+    EXPECT_FALSE(negativeCache.lookup(1, "B"));
+    EXPECT_TRUE(negativeCache.lookup(1, "C"));
+}
+
+TEST_F(NegativeCacheTest, LookupSuccess) {
+    negativeCache.add(kParent, kName);
+    EXPECT_TRUE(negativeCache.lookup(kParent, kName));
+}
+
+TEST_F(NegativeCacheTest, LookupTimeoutOrNotFound) {
+    NegativeCache::setGlobalTimeoutMs(0);
+    negativeCache.setTimeoutMs(NegativeCache::getGlobalTimeoutMs());
+    negativeCache.add(kParent, kName);
+    EXPECT_FALSE(negativeCache.lookup(kParent, kName));
+    EXPECT_FALSE(negativeCache.lookup(1, "not-added-to-ncache"));
+}
+
+TEST_F(NegativeCacheTest, TimeoutOrMaxSizeChangeClearAll) {
+    for (auto parent : std::views::iota(1U, kMaxSize)) {
+        negativeCache.add(parent, kName);
+    }
+    EXPECT_EQ(negativeCache.size(), 9U);
+    NegativeCache::setGlobalTimeoutMs(1001);
+    negativeCache.add(kParent, kName);
+    EXPECT_EQ(negativeCache.size(), 1U);
+    for (auto parent : std::views::iota(1U, kMaxSize)) {
+        negativeCache.add(parent, kName);
+    }
+    EXPECT_EQ(negativeCache.size(), 10U);
+    NegativeCache::setGlobalMaxSize(11);
+    negativeCache.add(kParent, kName);
+    EXPECT_EQ(negativeCache.size(), 1U);
+}

--- a/src/mount/sauna_client.cc
+++ b/src/mount/sauna_client.cc
@@ -69,6 +69,7 @@
 #include "mount/mastercomm.h"
 #include "mount/masterproxy.h"
 #include "mount/mount_info.h"
+#include "mount/negative_cache.h"
 #include "mount/notification_area_logging.h"
 #include "mount/oplog.h"
 #include "mount/readdata.h"
@@ -896,6 +897,19 @@ void access(Context &ctx, inode_t ino, int mask) {
 }
 
 EntryParam lookup(Context &ctx, inode_t parent, const char *name) {
+	if (gNegativeCache.lookup(parent, name)) {
+		if (debug_mode) {
+			safs::log_debug("lookup: ({},{}) negative cache hit, skipping master lookup",
+							parent, name);
+		}
+		// Negative cache hit, early return
+		// Kernel may cache negative entries for entry_timeout seconds
+		EntryParam e{};
+		e.ino = 0;
+		e.entry_timeout = NegativeCache::getGlobalTimeoutMs() / 1000.0;
+		return e;
+	}
+
 	if (debug_mode) {
 #ifdef _WIN32
 		if (parent != SPECIAL_INODE_ROOT || strcmp(name, SPECIAL_FILE_NAME_OPLOG) != 0) {
@@ -979,6 +993,16 @@ EntryParam lookup(Context &ctx, inode_t parent, const char *name) {
 	if (status != SAUNAFS_STATUS_OK) {
 		oplog_printf(ctx, "lookup (%" PRIiNode ",%s): %s", parent, name,
 		             saunafs_error_string(status));
+
+		// Negative cache entry miss, adding to negative cache, return early
+		// Kernel may cache negative entries for entry_timeout seconds
+		if (status == SAUNAFS_ERROR_ENOENT && gNegativeCache.isMaxSizeAndTimeoutMsSet()) {
+			gNegativeCache.add(parent, name);
+			EntryParam e{};
+			e.ino = 0;
+			e.entry_timeout = NegativeCache::getGlobalTimeoutMs() / 1000.0;
+			return e;
+		}
 		throw RequestException(status);
 	}
 	uint64_t maxFileLen = (attr[0] == TYPE_FILE) ? write_data_getmaxfleng(inode) : 0;
@@ -3546,6 +3570,7 @@ std::vector<ChunkserverListEntry> getchunkservers() {
 }
 
 void init(int debug_mode_, int keep_cache_, double direntry_cache_timeout_, unsigned direntry_cache_size_,
+		unsigned negative_cache_timeout_, unsigned negative_cache_size_,
 		double entry_cache_timeout_, double attr_cache_timeout_, int mkdir_copy_sgid_,
 		SugidClearMode sugid_clear_mode_, bool use_rwlock_,
 		double acl_cache_timeout_, unsigned acl_cache_size_, bool direct_io,
@@ -3570,6 +3595,10 @@ void init(int debug_mode_, int keep_cache_, double direntry_cache_timeout_, unsi
 	debug_mode = debug_mode_;
 	keep_cache = keep_cache_;
 	direntry_cache_timeout = direntry_cache_timeout_;
+	NegativeCache::setGlobalTimeoutMs(negative_cache_timeout_);
+	gNegativeCache.setTimeoutMs(NegativeCache::getGlobalTimeoutMs());
+	NegativeCache::setGlobalMaxSize(negative_cache_size_);
+	gNegativeCache.setMaxSize(NegativeCache::getGlobalMaxSize());
 	entry_cache_timeout = entry_cache_timeout_;
 	attr_cache_timeout = attr_cache_timeout_;
 	mkdir_copy_sgid = mkdir_copy_sgid_;
@@ -3606,6 +3635,8 @@ void init(int debug_mode_, int keep_cache_, double direntry_cache_timeout_, unsi
 	std::lock_guard lock(gMountInfoMtx);
 	gTweaks.registerVariable("DirectIO", gDirectIo, "sfsdirectio");
 	gTweaks.registerVariable("IgnoreFlush", gIgnoreFlush, "sfsignoreflush");
+	gTweaks.registerVariable("NegativeCacheTimeout", gNegativeCacheTimeoutMs, "sfsnegativecachetimeout");
+	gTweaks.registerVariable("NegativeCacheMaxSize", gNegativeCacheMaxSize, "sfsnegativecachesize");
 	gTweaks.registerVariable("StatfsCacheTimeout", gStatfsCacheTimeout, "statfscachetimeout");
 	gTweaks.registerVariable("UseQuotaInVolumeSize", gUseQuotaInVolumeSize, "usequotainvolumesize");
 #ifdef _WIN32
@@ -3695,6 +3726,7 @@ void fs_init(FsInitParams &params) {
 	);
 
 	init(params.debug_mode, params.keep_cache, params.direntry_cache_timeout, params.direntry_cache_size,
+		params.negative_cache_timeout, params.negative_cache_size,
 		params.entry_cache_timeout, params.attr_cache_timeout, params.mkdir_copy_sgid,
 		params.sugid_clear_mode, params.use_rw_lock,
 		params.acl_cache_timeout, params.acl_cache_size, params.direct_io,

--- a/src/mount/sauna_client.cc
+++ b/src/mount/sauna_client.cc
@@ -896,136 +896,127 @@ void access(Context &ctx, inode_t ino, int mask) {
 }
 
 EntryParam lookup(Context &ctx, inode_t parent, const char *name) {
-	EntryParam e;
-	uint64_t maxfleng;
-	inode_t inode;
-	uint32_t nleng;
-	Attributes attr;
-	char attrstr[256];
-	uint8_t mattr;
-	uint8_t icacheflag;
-	int status;
-
 	if (debug_mode) {
 #ifdef _WIN32
-		if (parent != SPECIAL_INODE_ROOT ||
-		    strcmp(name, SPECIAL_FILE_NAME_OPLOG) != 0) {
+		if (parent != SPECIAL_INODE_ROOT || strcmp(name, SPECIAL_FILE_NAME_OPLOG) != 0) {
 			oplog_printf(ctx, "lookup (%" PRIiNode ",%s) ...", parent, name);
 		}
 #else
 		oplog_printf(ctx, "lookup (%" PRIiNode ",%s) ...", parent, name);
 #endif
 	}
-	nleng = strlen(name);
-	if (nleng > SFS_NAME_MAX) {
+
+	uint32_t nameLen = strlen(name);
+	if (nameLen > SFS_NAME_MAX) {
 		stats_inc(OP_LOOKUP);
-		oplog_printf(ctx, "lookup (%" PRIiNode ",%s): %s", parent, name, saunafs_error_string(SAUNAFS_ERROR_ENAMETOOLONG));
+		oplog_printf(ctx, "lookup (%" PRIiNode ",%s): %s", parent, name,
+		             saunafs_error_string(SAUNAFS_ERROR_ENAMETOOLONG));
 		throw RequestException(SAUNAFS_ERROR_ENAMETOOLONG);
 	}
+
+	constexpr uint32_t kAttrStrSize = 256;
+	char attrStr[kAttrStrSize];
 	if (parent == SPECIAL_INODE_ROOT) {
-		if (nleng == 2 && name[0] == '.' && name[1] == '.') {
-			nleng = 1;
+		if (std::string_view(name, nameLen) == "..") {
+			nameLen = 1;
 		}
 
-		inode_t ino = getSpecialInodeByName(name);
-		if (IS_SPECIAL_INODE(ino)) {
-			return special_lookup(ino, ctx, parent, name, attrstr);
+		inode_t inode = getSpecialInodeByName(name);
+		if (IS_SPECIAL_INODE(inode)) { 
+			return special_lookup(inode, ctx, parent, name, attrStr);
 		}
 	}
+
+	inode_t inode;
+	Attributes attr;
+	bool cacheHit = false;
+	int status;
 	if (parent == SPECIAL_INODE_FILE_BY_INODE) {
-		char *endptr = nullptr;
-		inode = strtol(name, &endptr, 10);
-		if (endptr == nullptr || *endptr != '\0') {
+		char *endPtr = nullptr;
+		inode = strtol(name, &endPtr, 10);
+		if (endPtr == nullptr || *endPtr != '\0') {
 			throw RequestException(SAUNAFS_ERROR_EINVAL);
 		}
 		RETRY_ON_ERROR_WITH_UPDATED_CREDENTIALS(status, ctx,
 			fs_getattr(inode, ctx.uid, ctx.gid, attr));
-		icacheflag = 0;
 	} else if (parent == SPECIAL_INODE_PATH_BY_INODE) {
-		char *endptr = nullptr;
-		inode = strtol(name, &endptr, 10);
-		if (endptr == nullptr || *endptr != '\0') {
+		char *endPtr = nullptr;
+		inode = strtol(name, &endPtr, 10);
+		if (endPtr == nullptr || *endPtr != '\0') {
 			throw RequestException(SAUNAFS_ERROR_EINVAL);
 		}
 		std::unique_lock<std::mutex> lock(gInodePathInfo.mtx);
-		std::string fullPath = "";
+		std::string fullPath;
 		int lookupStatus = SAUNAFS_STATUS_OK;
 		int getattrStatus = SAUNAFS_STATUS_OK;
 		RETRY_ON_ERROR_WITH_UPDATED_CREDENTIALS(lookupStatus, ctx,
-		fs_fullpath(inode, ctx.uid, ctx.gid, fullPath));
+			fs_fullpath(inode, ctx.uid, ctx.gid, fullPath));
 		RETRY_ON_ERROR_WITH_UPDATED_CREDENTIALS(getattrStatus, ctx,
 			fs_getattr(inode, ctx.uid, ctx.gid, attr));
 		if (lookupStatus != SAUNAFS_STATUS_OK || getattrStatus != SAUNAFS_STATUS_OK) {
-			status = lookupStatus != SAUNAFS_STATUS_OK ? lookupStatus : getattrStatus;
+			status = (lookupStatus != SAUNAFS_STATUS_OK) ? lookupStatus : getattrStatus;
 			lock.unlock();
 			throw RequestException(status);
 		}
 		status = SAUNAFS_STATUS_OK;
 		if (ctx.pid > 0) {
-			PidPathEntry entry{ctx.pid, fullPath};
+			PidPathEntry entry{ .pid = ctx.pid, .path = fullPath };
 			gInodePathInfo.contextPidToPath[entry]++;
 		}
 		attr[0] = TYPE_FILE;
 		inode = parent;
-		icacheflag = 0;
-	} else if (usedircache && gDirEntryCache.lookup(ctx,parent,std::string(name,nleng),inode,attr)) {
-		if (debug_mode) {
-			safs::log_debug("lookup: sending data from dircache");
-		}
+	} else if (usedircache &&
+	           gDirEntryCache.lookup(ctx, parent, std::string(name, nameLen), inode, attr)) {
+		if (debug_mode) { safs::log_debug("lookup: sending data from dircache"); }
 		stats_inc(OP_DIRCACHE_LOOKUP);
-		status = 0;
-		icacheflag = 1;
-	} else {
+		status = SAUNAFS_STATUS_OK;
+		cacheHit = true;
+	} else {  // dentry miss
 		stats_inc(OP_LOOKUP);
 		RETRY_ON_ERROR_WITH_UPDATED_CREDENTIALS(status, ctx,
-		fs_lookup(parent, std::string(name, nleng), ctx.uid, ctx.gid, &inode, attr));
-		icacheflag = 0;
+			fs_lookup(parent, std::string(name, nameLen), ctx.uid, ctx.gid, &inode, attr));
 	}
 	if (status != SAUNAFS_STATUS_OK) {
-		oplog_printf(ctx, "lookup (%" PRIiNode ",%s): %s", parent, name, saunafs_error_string(status));
+		oplog_printf(ctx, "lookup (%" PRIiNode ",%s): %s", parent, name,
+		             saunafs_error_string(status));
 		throw RequestException(status);
 	}
-	if (attr[0]==TYPE_FILE) {
-		maxfleng = write_data_getmaxfleng(inode);
-	} else {
-		maxfleng = 0;
-	}
+	uint64_t maxFileLen = (attr[0] == TYPE_FILE) ? write_data_getmaxfleng(inode) : 0;
+	EntryParam e;
 	e.ino = inode;
-	mattr = attr_get_mattr(attr);
-	e.attr_timeout = (mattr&MATTR_NOACACHE)?0.0:attr_cache_timeout;
-	e.entry_timeout = (mattr&MATTR_NOECACHE)?0.0:((attr[0]==TYPE_DIRECTORY)?direntry_cache_timeout:entry_cache_timeout);
-	attr_to_stat(inode,attr,&e.attr);
-	if (maxfleng>(uint64_t)(e.attr.st_size)) {
-		update_attr_size(attr, maxfleng);
-		e.attr.st_size=maxfleng;
+	uint8_t modeAttr = attr_get_mattr(attr);
+	e.attr_timeout = (modeAttr & MATTR_NOACACHE) ? 0.0 : attr_cache_timeout;
+	if (modeAttr & MATTR_NOECACHE) {
+		e.entry_timeout = 0.0;
+	} else {
+		e.entry_timeout =
+		    (attr[0] == TYPE_DIRECTORY) ? direntry_cache_timeout : entry_cache_timeout;
+	}
+	attr_to_stat(inode, attr, &e.attr);
+	if (maxFileLen > static_cast<uint64_t>(e.attr.st_size)) {
+		update_attr_size(attr, maxFileLen);
+		e.attr.st_size = static_cast<__off_t>(maxFileLen);
 	}
 
 	// If lookup succeeded and data did not come from cache, then cache it.
-	// Files with at least one hardlink are impossible to keep track of, so it is
-	// better to don't track them.
-	if (!icacheflag && !(e.attr.st_nlink > 1 && attr[0] == TYPE_FILE)) {
-		auto data_acquire_time = gDirEntryCache.updateTime();
-
+	// Files with at least one hardlink are impossible to keep track of, so better not track them.
+	if (!cacheHit && (attr[0] != TYPE_FILE || e.attr.st_nlink <= 1)) {
 		std::unique_lock<shared_mutex> write_guard(gDirEntryCache.rwlock());
-		gDirEntryCache.updateTime();
-
-		gDirEntryCache.insert(ctx, parent, e.ino, std::string(name), attr,
-		                      data_acquire_time);
+		uint64_t data_acquire_time = gDirEntryCache.updateTime();
+		gDirEntryCache.insert(ctx, parent, e.ino, std::string(name), attr, data_acquire_time);
 		if (gDirEntryCache.size() > gDirEntryCacheMaxSize) {
-			gDirEntryCache.removeOldest(gDirEntryCache.size() -
-			                            gDirEntryCacheMaxSize);
+			gDirEntryCache.removeOldest(gDirEntryCache.size() - gDirEntryCacheMaxSize);
 		}
 	}
-
-	makeattrstr(attrstr,256,&e.attr);
+	makeattrstr(attrStr, kAttrStrSize, &e.attr);
 	oplog_printf(ctx, "lookup (%" PRIiNode ",%s)%s: OK (%.1f,%" PRIiNode ",%.1f,%s)",
 			parent,
 			name,
-			icacheflag?" (using open dir cache)":"",
+			cacheHit ? " (using open dir cache)" : "",
 			e.entry_timeout,
 			e.ino,
 			e.attr_timeout,
-			attrstr);
+			attrStr);
 	return e;
 }
 

--- a/src/mount/sauna_client.h
+++ b/src/mount/sauna_client.h
@@ -117,6 +117,8 @@ struct FsInitParams {
 	static constexpr int      kDefaultKeepCache = 0;
 	static constexpr double   kDefaultDirentryCacheTimeout = 0.25;
 	static constexpr unsigned kDefaultDirentryCacheSize = 100000;
+	static constexpr unsigned kDefaultNegativeCacheTo = 0;
+	static constexpr unsigned kDefaultNegativeCacheSize = 0;
 	static constexpr double   kDefaultEntryCacheTimeout = 0.0;
 	static constexpr double   kDefaultAttrCacheTimeout = 1.0;
 #if defined(DEFAULT_SUGID_CLEAR_MODE_EXT)
@@ -163,6 +165,7 @@ struct FsInitParams {
 	             symlink_cache_timeout_s(kDefaultSymlinkCacheTimeout),
 	             debug_mode(kDefaultDebugMode), keep_cache(kDefaultKeepCache),
 	             direntry_cache_timeout(kDefaultDirentryCacheTimeout), direntry_cache_size(kDefaultDirentryCacheSize),
+				 negative_cache_timeout(kDefaultNegativeCacheTo), negative_cache_size(kDefaultNegativeCacheSize),
 	             entry_cache_timeout(kDefaultEntryCacheTimeout), attr_cache_timeout(kDefaultAttrCacheTimeout),
 	             mkdir_copy_sgid(kDefaultMkdirCopySgid), sugid_clear_mode(kDefaultSugidClearMode),
 	             use_rw_lock(kDefaultUseRwLock),
@@ -212,6 +215,7 @@ struct FsInitParams {
 	             symlink_cache_timeout_s(kDefaultSymlinkCacheTimeout),
 	             debug_mode(kDefaultDebugMode), keep_cache(kDefaultKeepCache),
 	             direntry_cache_timeout(kDefaultDirentryCacheTimeout), direntry_cache_size(kDefaultDirentryCacheSize),
+				 negative_cache_timeout(kDefaultNegativeCacheTo), negative_cache_size(kDefaultNegativeCacheSize),
 	             entry_cache_timeout(kDefaultEntryCacheTimeout), attr_cache_timeout(kDefaultAttrCacheTimeout),
 	             mkdir_copy_sgid(kDefaultMkdirCopySgid), sugid_clear_mode(kDefaultSugidClearMode),
 	             use_rw_lock(kDefaultUseRwLock),
@@ -274,6 +278,8 @@ struct FsInitParams {
 	int keep_cache;
 	double direntry_cache_timeout;
 	unsigned direntry_cache_size;
+	unsigned negative_cache_timeout;
+	unsigned negative_cache_size;
 	double entry_cache_timeout;
 	double attr_cache_timeout;
 	bool mkdir_copy_sgid;

--- a/tests/test_suites/ShortSystemTests/test_negative_cache.sh
+++ b/tests/test_suites/ShortSystemTests/test_negative_cache.sh
@@ -1,0 +1,48 @@
+timeout_set "40 seconds"
+MOUNT_EXTRA_CONFIG="sfsnegativecachesize=4,sfsnegativecachetimeout=9000" \
+	USE_RAMDISK=YES \
+	setup_local_empty_saunafs info
+
+cd ${info[mount0]}
+
+# Tweaks test
+expect_equals "9000" "$(cat ${info[mount0]}/.saunafs_tweaks | grep -i negativecachetimeout | awk '{print $2}')"
+expect_equals "4" "$(cat ${info[mount0]}/.saunafs_tweaks | grep -i negativecachemaxsize | awk '{print $2}')"
+
+echo "NegativeCacheTimeout=9001" | sudo tee ${info[mount0]}/.saunafs_tweaks
+echo "NegativeCacheMaxSize=5" | sudo tee ${info[mount0]}/.saunafs_tweaks
+
+expect_equals "9001" "$(cat ${info[mount0]}/.saunafs_tweaks | grep -i negativecachetimeout | awk '{print $2}')"
+expect_equals "5" "$(cat ${info[mount0]}/.saunafs_tweaks | grep -i negativecachemaxsize | awk '{print $2}')"
+
+# Timeout test
+test_file=nonexistent_file
+assert_failure ls ${test_file}
+
+touch ${test_file}
+assert_failure ls ${test_file}
+
+assert_eventually "ls ${test_file}" "20 seconds"
+
+# LRU eviction test, remove oldest when exceeds max size
+files1=({a..f}) # 6 files
+
+# When file f is added, a is removed because it is oldest
+for file in ${files1[@]}; do assert_failure ls ${file}; done
+touch ${files1[0]}
+assert_success ls ${files1[0]}
+
+# Tweaks change clears whole cache
+files2=({A..C})
+for file in ${files2[@]}; do assert_failure ls ${file}; done
+echo "NegativeCacheTimeout=9000" | sudo tee ${info[mount0]}/.saunafs_tweaks
+assert_failure ls D # clears caches
+touch ${files2[@]}
+for file in ${files2[@]}; do assert_success ls ${file}; done
+rm ${files2[@]}
+
+for file in ${files2[@]}; do assert_failure ls ${file}; done
+echo "NegativeCacheMaxSize=4" | sudo tee ${info[mount0]}/.saunafs_tweaks
+assert_failure ls E # clears caches
+touch ${files2[@]}
+for file in ${files2[@]}; do assert_success ls ${file}; done


### PR DESCRIPTION
All lookups must go through the network to master which is time consuming. This is especially a problem if it constantly asks for files that don't exist.

Implement a thread-safe negative cache that reduces network latency by avoiding repeated calls to the master server by replying early with fuse_entry_param with fields .ino=0 and .entry_timeout=sfsnegativecachetimeout.

Kernel **may** cache negative entries, but with internal negative cache implementation it is guaranteed if both options sfsnegativecachesize and sfsnegativecachetimeout are set.

When any option equals to 0, both internal and Linux kernel-level negative caching are disabled.

Refactor lookup() in sauna_client.cc to improve readability and code style.