### PR TITLE
refactor(master): enable setAttr for KV backends

### DIFF
--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -729,6 +729,11 @@ FSNode *FilesystemNodeOperationsBase::createNode(
 	return node;
 }
 
+void FilesystemNodeOperationsBase::updateNode(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, [[maybe_unused]] FSNode *node) {
+	// Default implementation does nothing, it is not needed for the in-memory backend
+}
+
 uint32_t FilesystemNodeOperationsBase::getPathSize(FSNodeDirectory *parent, FSNode *child) {
 	if (parent == nullptr || child == nullptr) {
 		return 0;

--- a/src/master/filesystem_node.h
+++ b/src/master/filesystem_node.h
@@ -48,6 +48,13 @@ public:
 	                   FSNodeDirectory *parent, const HString &name, FSNodeType type, uint16_t mode,
 	                   uint16_t umask, uint32_t uid, uint32_t gid, uint8_t copysgid,
 	                   AclInheritance inheritAcl, inode_t requestedINode = 0) override;
+
+	/// Syncs the current state of the node to persistent storage on backends that need it.
+	/// @see IFilesystemNodeOperations::updateNode
+	/// @note This implementation is a no-op for in-memory storage.
+	void updateNode([[maybe_unused]] const FilesystemOperationContext &fsOpContext,
+	                [[maybe_unused]] FSNode *node) override;
+
 	void link(const FilesystemOperationContext &fsOpContext, uint32_t timeStamp,
 	          FSNodeDirectory *parent, FSNode *child, const HString &name) override;
 

--- a/src/master/filesystem_node_operations_interface.h
+++ b/src/master/filesystem_node_operations_interface.h
@@ -150,6 +150,14 @@ public:
 	                           uint8_t copysgid, AclInheritance inheritAcl,
 	                           inode_t requestedINode = 0) = 0;
 
+	/// Syncs the current state of the node to persistent storage on backends that need it.
+	///
+	/// @param fsOpContext The filesystem operation context (transaction).
+	/// @param node The node to update.
+	/// @note In-memory backend: no-op.
+	/// @note KV backends: could schedule the set operation for later commit.
+	virtual void updateNode(const FilesystemOperationContext &fsOpContext, FSNode *node) = 0;
+
 	/// Creates a hard link (directory entry) between a parent directory and an existing node.
 	///
 	/// This method establishes a new edge from a parent directory to an existing child node,

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -909,10 +909,12 @@ uint8_t FilesystemOperationsBase::doSetLength(const FsContext &context,
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t FilesystemOperationsBase::setAttr(const FsContext &context, inode_t inode, uint8_t setmask,
-                                          uint16_t attrmode, uint32_t attruid, uint32_t attrgid,
-                                          uint32_t attratime, uint32_t attrmtime,
-                                          SugidClearMode sugidclearmode, Attributes &attr) {
+uint8_t FilesystemOperationsBase::setAttr(const FsContext &context,
+                                          const FilesystemOperationContext &fsOpContext,
+                                          inode_t inode, uint8_t setmask, uint16_t attrmode,
+                                          uint32_t attruid, uint32_t attrgid, uint32_t attratime,
+                                          uint32_t attrmtime, SugidClearMode sugidclearmode,
+                                          Attributes &attr) {
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
 	FSNode *p = NULL;
@@ -925,8 +927,6 @@ uint8_t FilesystemOperationsBase::setAttr(const FsContext &context, inode_t inod
 		return status;
 	}
 
-	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
-	    FilesystemOperationContext::TransactionType::kReadWrite);
 	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kAny,
 	                                              MODE_MASK_EMPTY, inode, &p);
 	if (status != SAUNAFS_STATUS_OK) {
@@ -1044,6 +1044,10 @@ uint8_t FilesystemOperationsBase::setAttr(const FsContext &context, inode_t inod
 	nodeOperations_->fillAttr(fsOpContext, p, NULL, context.uid(), context.gid(), context.auid(),
 	                          context.agid(), context.sesflags(), attr);
 	fsnodes_update_checksum(p);
+
+	// Make persistent the changes on KV backends
+	if (fsOpContext.hasReadWriteTransaction()) { nodeOperations_->updateNode(fsOpContext, p); }
+
 	incrementFSStat(FsStats::Setattr);
 	metrics::Counter::increment(metrics::Counter::Master::FS_SETATTR);
 	return SAUNAFS_STATUS_OK;

--- a/src/master/filesystem_operations.h
+++ b/src/master/filesystem_operations.h
@@ -150,9 +150,14 @@ public:
 	                     uint32_t lockid, Attributes &attr, uint64_t *chunkid) override;
 	uint8_t doSetLength(const FsContext &context, const FilesystemOperationContext &fsOpContext,
 	                    inode_t inode, uint64_t length, Attributes &attr) override;
-	uint8_t setAttr(const FsContext &context, inode_t inode, uint8_t setmask, uint16_t attrmode,
-	                uint32_t attruid, uint32_t attrgid, uint32_t attratime, uint32_t attrmtime,
+
+	/// Sets attributes for a filesystem node (file, directory, etc.).
+	/// @see IFilesystemOperations::setAttr
+	uint8_t setAttr(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                inode_t inode, uint8_t setmask, uint16_t attrmode, uint32_t attruid,
+	                uint32_t attrgid, uint32_t attratime, uint32_t attrmtime,
 	                SugidClearMode sugidclearmode, Attributes &attr) override;
+
 	uint8_t readlink(const FsContext &context, inode_t inode, std::string &path) override;
 	void statfs(const FsContext &context, const FilesystemOperationContext &fsOpContext,
 	            uint64_t *totalspace, uint64_t *availspace, uint64_t *trashspace,

--- a/src/master/filesystem_operations_interface.h
+++ b/src/master/filesystem_operations_interface.h
@@ -298,10 +298,63 @@ public:
 	virtual uint8_t doSetLength(const FsContext &context,
 	                            const FilesystemOperationContext &fsOpContext, inode_t inode,
 	                            uint64_t length, Attributes &attr) = 0;
-	virtual uint8_t setAttr(const FsContext &context, inode_t inode, uint8_t setmask,
-	                        uint16_t attrmode, uint32_t attruid, uint32_t attrgid,
-	                        uint32_t attratime, uint32_t attrmtime, SugidClearMode sugidclearmode,
-	                        Attributes &attr) = 0;
+
+	/// Sets attributes for a filesystem node (file, directory, etc.).
+	///
+	/// This method modifies various attributes of a filesystem node, including permissions (mode),
+	/// ownership (uid/gid), and timestamps (atime/mtime). It performs comprehensive validation
+	/// including session verification, permission checks, and quota enforcement. The operation
+	/// supports selective attribute modification through the setmask parameter, allowing
+	/// operations like chmod, chown, and touch to be performed individually or in combination.
+	///
+	/// Key features and validations:
+	/// - Session verification (must be read-write, non-meta session)
+	/// - Node existence and accessibility verification
+	/// - Permission checks based on user privileges and ownership
+	/// - SUID/SGID bit clearing based on sugidclearmode policy
+	/// - Timestamp updates with proper access time handling
+	///
+	/// The setmask parameter controls which attributes are modified:
+	/// - SET_MODE_FLAG: Update file permissions (mode)
+	/// - SET_UID_FLAG: Change user ownership
+	/// - SET_GID_FLAG: Change group ownership
+	/// - SET_ATIME_FLAG/SET_ATIME_NOW_FLAG: Update access time
+	/// - SET_MTIME_FLAG/SET_MTIME_NOW_FLAG: Update modification time
+	///
+	/// SUID/SGID clearing follows different policies based on sugidclearmode:
+	/// - kAlways: Always clear both bits on chown
+	/// - kOsx: Clear on chown by non-root users
+	/// - kBsd: Clear on gid change by non-root users
+	/// - kExt: Clear based on group execute permission
+	/// - kSfs: Extended policy for directories and files
+	/// - kNever: Never clear (not recommended for security)
+	///
+	/// @param context The FS operation context containing user credentials and session info.
+	/// @param fsOpContext The filesystem operation context (transaction).
+	/// @param inode The inode number of the node whose attributes to modify.
+	/// @param setmask Bitmask indicating which attributes to set (SET_MODE_FLAG, SET_UID_FLAG, etc.).
+	/// @param attrmode New file mode/permissions (used if SET_MODE_FLAG is set).
+	/// @param attruid New user ID (used if SET_UID_FLAG is set).
+	/// @param attrgid New group ID (used if SET_GID_FLAG is set).
+	/// @param attratime New access time (used if SET_ATIME_FLAG is set).
+	/// @param attrmtime New modification time (used if SET_MTIME_FLAG is set).
+	/// @param sugidclearmode Policy for clearing SUID/SGID bits on ownership changes.
+	/// @param[out] attr Attributes structure to be filled with the node's updated attributes.
+	///
+	/// @return SAUNAFS_STATUS_OK on success, or one of the following error codes:
+	///         - SAUNAFS_ERROR_EPERM if permission denied (not owner, invalid uid/gid, etc.)
+	///         - SAUNAFS_ERROR_EACCES if access denied based on current permissions
+	///         - SAUNAFS_ERROR_ENOENT if node doesn't exist
+	///         - Other error codes as returned by node operations
+	///
+	/// @note This operation updates the node's ctime (change time) to the current timestamp.
+	/// @note SUID/SGID bits are cleared according to the specified sugidclearmode policy.
+	/// @note For non-root users, various restrictions apply to prevent privilege escalation.
+	virtual uint8_t setAttr(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                        inode_t inode, uint8_t setmask, uint16_t attrmode, uint32_t attruid,
+	                        uint32_t attrgid, uint32_t attratime, uint32_t attrmtime,
+	                        SugidClearMode sugidclearmode, Attributes &attr) = 0;
+
 	virtual uint8_t readlink(const FsContext &context, inode_t inode, std::string &path) = 0;
 	virtual void statfs(const FsContext &context, const FilesystemOperationContext &fsOpContext,
 	                    uint64_t *totalspace, uint64_t *availspace, uint64_t *trashspace,

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -1848,8 +1848,18 @@ void matoclserv_fuse_setattr(matoclserventry *eptr, const uint8_t *data, uint32_
 
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = gFSOperations->setAttr(context, inode, setmask, attrmode, attruid, attrgid,
-		                                attratime, attrmtime, sugidclearmode, attr);
+		auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+		    FilesystemOperationContext::TransactionType::kReadWrite);
+
+		status = gFSOperations->setAttr(context, fsOpContext, inode, setmask, attrmode, attruid,
+		                                attrgid, attratime, attrmtime, sugidclearmode, attr);
+
+		if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
+			if (!fsOpContext.getReadWriteTransaction()->commit()) {
+				safs::log_err("{}: transaction failed to commit: inode {}", __func__, inode);
+				status = SAUNAFS_ERROR_IO;
+			}
+		}
 	}
 
 	constexpr uint32_t kFailedAnswerSize = sizeof(msgid) + sizeof(status);


### PR DESCRIPTION
Add FilesystemOperationContext parameter to setAttr method to support transactions and persistence on KV backends. Introduce updateNode method in filesystem node operations for syncing node state to storage. Update matoclserv.cc to handle transaction commits for setAttr calls.

Related to LS-184

Notes:
- No changes from the in-memory implementation POV.
- The integration tests are in the MDS repository.