### PR TITLE
refactor(master): persist write operations in KV backends

### DIFF
--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -371,6 +371,16 @@ FSNodeDirectory *FilesystemNodeOperationsBase::getFirstParent(FSNode *node) {
 	return gMetadata->root;
 }
 
+std::vector<inode_t> FilesystemNodeOperationsBase::getParentIds(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, FSNode *node) {
+	assert(node);
+
+	std::vector<inode_t> parentIds;
+	parentIds.reserve(node->parents.size());
+	for (const auto &parent : node->parents) { parentIds.push_back(parent.first); }
+	return parentIds;
+}
+
 void FilesystemNodeOperationsBase::subStats(const FilesystemOperationContext &fsOpContext,
                                             FSNodeDirectory *parent, StatsRecord *stats) {
 	if (parent != nullptr) {
@@ -428,6 +438,15 @@ void FilesystemNodeOperationsBase::addSubStats(const FilesystemOperationContext 
 	resultStats.size = newStats->size - previousStats->size;
 	resultStats.realsize = newStats->realsize - previousStats->realsize;
 	addStats(fsOpContext, parent, &resultStats);
+}
+
+void FilesystemNodeOperationsBase::updateParentStatsForNode(
+    const FilesystemOperationContext &fsOpContext, FSNode *node, StatsRecord *newStats,
+    StatsRecord *previousStats) {
+	for (const auto &[parentId, _] : node->parents) {
+		auto *parentNode = idToNodeVerify<FSNodeDirectory>(fsOpContext, parentId);
+		addSubStats(fsOpContext, parentNode, newStats, previousStats);
+	}
 }
 
 void FilesystemNodeOperationsBase::fillAttr(const FilesystemOperationContext &fsOpContext,
@@ -1363,14 +1382,13 @@ void FilesystemNodeOperationsBase::setLength(const FilesystemOperationContext &f
 
 	fsnodes_quota_update(nodeFile, {{QuotaResource::kSize, newStats.size - previousStats.size}});
 
-	for (const auto &[parentId, _] : nodeFile->parents) {
-		auto *parentNode = idToNodeVerify<FSNodeDirectory>(fsOpContext, parentId);
-		addSubStats(fsOpContext, parentNode, &newStats, &previousStats);
-	}
+	updateParentStatsForNode(fsOpContext, nodeFile, &newStats, &previousStats);
 
 	fsnodes_update_checksum(nodeFile);
 
-	gMetadata->nodeChangedSignal.emit(nodeFile);
+	if (!fsOpContext.hasTransaction()) {
+		gMetadata->nodeChangedSignal.emit(nodeFile);
+	}
 }
 
 void FilesystemNodeOperationsBase::changeUidGid(const FilesystemOperationContext &fsOpContext,

--- a/src/master/filesystem_node.h
+++ b/src/master/filesystem_node.h
@@ -96,6 +96,11 @@ public:
 	void addSubStats(const FilesystemOperationContext &fsOpContext, FSNodeDirectory *parent,
 	                 StatsRecord *newStats, StatsRecord *previousStats) override;
 
+	/// Updates all parent directories' statistics based on a node's stats change.
+	/// @see IFilesystemNodeOperations::updateParentStatsForNode
+	void updateParentStatsForNode(const FilesystemOperationContext &fsOpContext, FSNode *node,
+	                              StatsRecord *newStats, StatsRecord *previousStats) override;
+
 	void changeUidGid(const FilesystemOperationContext &fsOpContext, FSNode *node, uint32_t uid,
 	                  uint32_t gid) override;
 
@@ -227,6 +232,11 @@ public:
 	bool isAncestorOrNodeReservedOrTrash(FSNodeDirectory *ancestor, FSNode *node) override;
 
 	FSNodeDirectory *getFirstParent(FSNode *node) override;
+
+	/// Returns the IDs of all parents of the given node.
+	/// @see IFilesystemNodeOperations::getParentIds
+	std::vector<inode_t> getParentIds(
+	    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, FSNode *node) override;
 
 protected:
 	/// Internal node lookup operation - override in subclasses for custom storage.

--- a/src/master/filesystem_node_operations_interface.h
+++ b/src/master/filesystem_node_operations_interface.h
@@ -329,6 +329,17 @@ public:
 	virtual void addSubStats(const FilesystemOperationContext &fsOpContext, FSNodeDirectory *parent,
 	                         StatsRecord *newStats, StatsRecord *previousStats) = 0;
 
+	/// Updates all parent directories' statistics based on a node's stats change.
+	/// This is a convenience method that retrieves all parent directories of the given node
+	/// and calls addSubStats() for each parent to propagate the stats changes.
+	/// @param fsOpContext The filesystem operation context (transaction).
+	/// @param node The node whose parents' statistics should be updated.
+	/// @param newStats Pointer to a StatsRecord containing the node's new statistics.
+	/// @param previousStats Pointer to a StatsRecord containing the node's previous statistics.
+	virtual void updateParentStatsForNode(const FilesystemOperationContext &fsOpContext,
+	                                      FSNode *node, StatsRecord *newStats,
+	                                      StatsRecord *previousStats) = 0;
+
 	virtual void changeUidGid(const FilesystemOperationContext &fsOpContext, FSNode *node,
 	                          uint32_t uid, uint32_t gid) = 0;
 
@@ -519,7 +530,15 @@ public:
 	/// @param ancestor potential ancestor node
 	/// @param node potential reserved, trash or descendant node
 	virtual bool isAncestorOrNodeReservedOrTrash(FSNodeDirectory *ancestor, FSNode *node) = 0;
+
 	virtual FSNodeDirectory *getFirstParent(FSNode *node) = 0;
+
+	/// Returns all parent ids of the given node.
+	/// @param fsOpContext The filesystem operation context potentially containing a transaction.
+	/// @param node The node whose parents are to be retrieved.
+	/// @return A vector of inode_t representing the parent ids of the node.
+	virtual std::vector<inode_t> getParentIds(const FilesystemOperationContext &fsOpContext,
+	                                          FSNode *node) = 0;
 
 protected:
 	/// Core node lookup operation - override in subclasses for custom storage.

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -2405,7 +2405,6 @@ uint8_t FilesystemOperationsBase::writeChunk(const FsContext &context,
 	ChecksumUpdater cu(context.ts());
 	uint64_t ochunkid, nchunkid;
 	FSNode *node;
-	FSNodeFile *p;
 
 	uint8_t status =
 	    nodeOperations_->verifySession(context, OperationMode::kReadWrite, SessionType::kNotMeta);
@@ -2415,23 +2414,27 @@ uint8_t FilesystemOperationsBase::writeChunk(const FsContext &context,
 
 	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kFile,
 	                                              MODE_MASK_EMPTY, inode, &node);
-	p = static_cast<FSNodeFile*>(node);
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	}
+
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+
 	if (index > kMaxChunkIndex) { return SAUNAFS_ERROR_INDEXTOOBIG; }
+
+	auto *fileNode = static_cast<FSNodeFile *>(node);
+
 #ifndef METARESTORE
 	if (gMagicAutoFileRepair && context.isPersonalityMaster()) {
-		fs_auto_repair_if_needed(p, index);
+		fs_auto_repair_if_needed(fileNode, index);
 	}
 #endif
 
-	const bool quota_exceeded = fsnodes_quota_exceeded(p, {{QuotaResource::kSize, 1}});
-	StatsRecord psr;
-	nodeOperations_->getStats(fsOpContext, p, &psr);
+	const bool quota_exceeded = fsnodes_quota_exceeded(fileNode, {{QuotaResource::kSize, 1}});
+
+	// Cache original stats for quota and parent update
+	StatsRecord originalStats;
+	nodeOperations_->getStats(fsOpContext, fileNode, &originalStats);
 
 	/* resize chunks structure */
-	if (index >= p->chunks.size()) {
+	if (index >= fileNode->chunks.size()) {
 		if (context.isPersonalityMaster() && quota_exceeded) {
 			return SAUNAFS_ERROR_QUOTA;
 		}
@@ -2444,13 +2447,13 @@ uint8_t FilesystemOperationsBase::writeChunk(const FsContext &context,
 			new_size = (index & 0xFFFFFFC0) + 64;
 		}
 		assert(new_size > index);
-		p->chunks.resize(new_size, 0);
+		fileNode->chunks.resize(new_size, 0);
 	}
 
-	ochunkid = p->chunks[index];
+	ochunkid = fileNode->chunks[index];
 	if (context.isPersonalityMaster()) {
 #ifndef METARESTORE
-		status = chunk_multi_modify(ochunkid, lockid, p->goal, usedummylockid,
+		status = chunk_multi_modify(ochunkid, lockid, fileNode->goal, usedummylockid,
 		                            quota_exceeded, opflag, &nchunkid, min_server_version);
 #else
 		(void)usedummylockid;
@@ -2460,38 +2463,45 @@ uint8_t FilesystemOperationsBase::writeChunk(const FsContext &context,
 #endif
 	} else {
 		bool increaseVersion = (*opflag != 0);
-		status = chunk_apply_modification(context.ts(), ochunkid, *lockid, p->goal,
+		status = chunk_apply_modification(context.ts(), ochunkid, *lockid, fileNode->goal,
 		                                  increaseVersion, &nchunkid);
 	}
 	if (status != SAUNAFS_STATUS_OK) {
-		fsnodes_update_checksum(p);
+		fsnodes_update_checksum(fileNode);
 		return status;
 	}
 	if (context.isPersonalityShadow() && nchunkid != *chunkid) {
-		fsnodes_update_checksum(p);
+		fsnodes_update_checksum(fileNode);
 		return SAUNAFS_ERROR_MISMATCH;
 	}
-	p->chunks[index] = nchunkid;
+
+	fileNode->chunks[index] = nchunkid;
 	*chunkid = nchunkid;
-	StatsRecord nsr;
-	nodeOperations_->getStats(fsOpContext, p, &nsr);
-	for (const auto &[parentId, _] : p->parents) {
-		auto *parent = nodeOperations_->idToNodeVerify<FSNodeDirectory>(fsOpContext, parentId);
-		nodeOperations_->addSubStats(fsOpContext, parent, &nsr, &psr);
-	}
-	fsnodes_quota_update(p, {{QuotaResource::kSize, nsr.size - psr.size}});
+
+	// Propagate size changes to parent directories
+	StatsRecord newStats;
+	nodeOperations_->getStats(fsOpContext, fileNode, &newStats);
+	nodeOperations_->updateParentStatsForNode(fsOpContext, fileNode, &newStats, &originalStats);
+
+	fsnodes_quota_update(fileNode, {{QuotaResource::kSize, newStats.size - originalStats.size}});
 	if (length) {
-		*length = p->length;
+		*length = fileNode->length;
 	}
+
 	if (context.isPersonalityMaster()) {
 		changeLog(context.ts(), "WRITE(%" PRIiNode ",%" PRIu32 ",%" PRIu8 ",%" PRIu32 "):%" PRIu64,
 		          inode, index, *opflag, *lockid, nchunkid);
 	} else {
 		gMetadata->metadataVersion++;
 	}
-	p->mtime = context.ts();
-	nodeOperations_->updateCTime(p, context.ts());
-	fsnodes_update_checksum(p);
+
+	fileNode->mtime = context.ts();
+	nodeOperations_->updateCTime(fileNode, context.ts());
+	fsnodes_update_checksum(fileNode);
+
+	// Make the change persistent for KV backends
+	if (fsOpContext.hasReadWriteTransaction()) { nodeOperations_->updateNode(fsOpContext, fileNode); }
+
 #ifndef METARESTORE
 	incrementFSStat(FsStats::Write);
 	metrics::Counter::increment(metrics::Counter::Master::FS_WRITE);
@@ -2510,7 +2520,7 @@ uint8_t FilesystemOperationsBase::writeEnd(const FilesystemOperationContext &fsO
 		return status;
 	}
 	if (length > 0) {
-		FSNodeFile *p = nodeOperations_->idToNode<FSNodeFile>(inode);
+		auto *p = nodeOperations_->idToNode<FSNodeFile>(fsOpContext, inode);
 		if (!p) {
 			return SAUNAFS_ERROR_ENOENT;
 		}
@@ -2528,10 +2538,17 @@ uint8_t FilesystemOperationsBase::writeEnd(const FilesystemOperationContext &fsO
 			p->mtime = ts;
 			nodeOperations_->updateCTime(p, ts);
 			fsnodes_update_checksum(p);
+
+			// Make the change persistent for KV backends
+			if (fsOpContext.hasReadWriteTransaction()) {
+				nodeOperations_->updateNode(fsOpContext, p);
+			}
+
 			changeLog(ts, "LENGTH(%" PRIiNode ",%" PRIu64 ",%" PRIu32 ")", inode, length,
 			          static_cast<uint32_t>(eraseFurtherChunks));
 		}
 	}
+
 	changeLog(ts, "UNLOCK(%" PRIu64 ")", chunkid);
 	return chunk_unlock(chunkid);
 }

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -2852,10 +2852,19 @@ void matoclserv_fuse_write_chunk(matoclserventry *eptr, PacketHeader header, con
 	    FilesystemOperationContext::TransactionType::kReadWrite);
 
 	// Original Legacy (1.6.27) does not use lock ID's
-	bool useDummyLockId = false;
+	constexpr bool kUseDummyLockId = false;
 	status = gFSOperations->writeChunk(matoclserv_get_context(eptr), fsOpContext, inode, chunkIndex,
-	                                   useDummyLockId, &lockId, &chunkId, &opflag, &fileLength,
+	                                   kUseDummyLockId, &lockId, &chunkId, &opflag, &fileLength,
 	                                   min_server_version);
+
+	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
+		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+			safs::log_err("{}: transaction failed to commit: inode {}, chunk index {}", __func__,
+			              inode, chunkIndex);
+
+			status = SAUNAFS_ERROR_IO;
+		}
+	}
 
 	if (status != SAUNAFS_STATUS_OK) {
 		serializer->serializeFuseWriteChunk(outMessage, messageId, status);
@@ -2876,11 +2885,24 @@ void matoclserv_fuse_write_chunk(matoclserventry *eptr, PacketHeader header, con
 		operation->serializer = serializer;
 		eptr->delayedChunkOperations.push_back(std::move(operation));
 	} else {        // return status immediately
-		dcm_modify(inode,eptr->sessionData->sessionId);
-		status = matoclserv_fuse_write_chunk_respond(eptr, serializer,
-				chunkId, messageId, fileLength, lockId);
+		dcm_modify(inode, eptr->sessionData->sessionId);
+		status = matoclserv_fuse_write_chunk_respond(eptr, serializer, chunkId, messageId,
+		                                             fileLength, lockId);
 		if (status != SAUNAFS_STATUS_OK) {
-			gFSOperations->writeEnd(fsOpContext, 0, 0, chunkId, 0);  // ignore status - just do it.
+			// The previous transaction was already committed, so we need a new one here
+			auto fsOpContextEnd = gFSOperations->createFilesystemOperationContext(
+			    FilesystemOperationContext::TransactionType::kReadWrite);
+
+			// ignore status, just do it.
+			gFSOperations->writeEnd(fsOpContextEnd, 0, 0, chunkId, 0);
+
+			if (fsOpContextEnd.hasReadWriteTransaction()) {
+				if (!fsOpContextEnd.getReadWriteTransaction()->commit()) {
+					safs::log_err(
+					    "{}: transaction failed to commit during write end: inode {}, chunk index {}",
+					    __func__, inode, chunkIndex);
+				}
+			}
 		}
 	}
 
@@ -2913,7 +2935,17 @@ void matoclserv_fuse_write_chunk_end(matoclserventry *eptr, PacketHeader header,
 	} else {
 		auto fsOpContext = gFSOperations->createFilesystemOperationContext(
 		    FilesystemOperationContext::TransactionType::kReadWrite);
+
 		status = gFSOperations->writeEnd(fsOpContext, inode, fileLength, chunkId, lockId);
+
+		if (fsOpContext.hasReadWriteTransaction()) {
+			if (!fsOpContext.getReadWriteTransaction()->commit()) {
+				safs::log_err("{}: transaction failed to commit: inode {}, chunk id {}",
+				              __func__, inode, chunkId);
+
+				status = SAUNAFS_ERROR_IO;
+			}
+		}
 	}
 
 	dcm_modify(inode,eptr->sessionData->sessionId);

--- a/tests/tools/saunafs.sh
+++ b/tests/tools/saunafs.sh
@@ -1110,3 +1110,12 @@ sfschunkserver_check_no_buffer_in_use() {
 	assert_equals "${chunkserver_count}" "${full_zeroes}"
 	assert_equals "${chunkserver_count}" "${unique_count}"
 }
+
+# The output lines from `dirinfo` and `admin info` are formatted as:
+# "key (possibly with spaces): value"
+# For example: "FS objects: 5"
+function get_value_from_dirinfo_and_admin_info() {
+	local content="${1}"
+	local key="${2}"
+	echo "${content}" | grep "${key}:" | cut -d: -f2- | sed 's/^[[:space:]]*//; s/[[:space:]]*$//'
+}


### PR DESCRIPTION
When using KV backends like FDB, metadata changes must be explicitly committed to be persisted. This change adds transaction commit calls to the write related operations.

The implementation is backward compatible with the in-memory backend, transaction commits are only executed when a read-write transaction is available, ensuring seamless operation across both in-memory and KV-based implementations.

Some blank lines were also added for readability.

Related to: LS-189

Signed-off-by: guillex <guillex@leil.io>
