### PR TITLE
refactor(master): allow truncates in KV backends

### DIFF
--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -734,6 +734,12 @@ uint8_t FilesystemOperationsBase::trySetLength(const FsContext &context,
 				changeLog(ts, "TRUNC(%" PRIiNode ",%" PRIu32 ",%" PRIu32 "):%" PRIu64, p->id, indx,
 				          lockId, nchunkid);
 				fsnodes_update_checksum(p);
+
+				// Make the change persistent for KV backends
+				if (fsOpContext.hasReadWriteTransaction()) {
+					nodeOperations_->updateNode(fsOpContext, p);
+				}
+
 				return SAUNAFS_ERROR_DELAYED;
 			}
 		}
@@ -904,8 +910,13 @@ uint8_t FilesystemOperationsBase::doSetLength(const FsContext &context,
 	fsnodes_update_checksum(p);
 	nodeOperations_->fillAttr(fsOpContext, p, NULL, context.uid(), context.gid(), context.auid(),
 	                          context.agid(), context.sesflags(), attr);
+
+	// Make the change persistent for KV backends
+	if (fsOpContext.hasReadWriteTransaction()) { nodeOperations_->updateNode(fsOpContext, p); }
+
 	incrementFSStat(FsStats::Setattr);
 	metrics::Counter::increment(metrics::Counter::Master::FS_SETATTR);
+
 	return SAUNAFS_STATUS_OK;
 }
 

--- a/src/master/filesystem_operations.h
+++ b/src/master/filesystem_operations.h
@@ -153,11 +153,21 @@ public:
 
 	uint8_t getAttr(const FsContext &context, const FilesystemOperationContext &fsOpContext,
 	                inode_t inode, Attributes &attr) override;
+
+	/// Attempts to initiate a file truncate operation (phase 1).
+	/// @see IFilesystemOperations::trySetLength
 	uint8_t trySetLength(const FsContext &context, const FilesystemOperationContext &fsOpContext,
 	                     inode_t inode, uint8_t opened, uint64_t length, bool denyTruncatingParity,
 	                     uint32_t lockid, Attributes &attr, uint64_t *chunkid) override;
+
+	/// Finalizes a file truncate operation by setting the file length metadata (phase 2).
+	/// @see IFilesystemOperations::doSetLength
 	uint8_t doSetLength(const FsContext &context, const FilesystemOperationContext &fsOpContext,
 	                    inode_t inode, uint64_t length, Attributes &attr) override;
+
+	/// Unlocks a chunk after a truncate operation completes (phase 1.5).
+	/// @see IFilesystemOperations::endSetLength
+	uint8_t endSetLength(uint64_t chunkid) override;
 
 	/// Sets attributes for a filesystem node (file, directory, etc.).
 	/// @see IFilesystemOperations::setAttr
@@ -245,7 +255,6 @@ public:
 	uint32_t getDirPathSize(inode_t inode) override;
 	void getDirPathData(inode_t inode, uint8_t *buff, uint32_t size) override;
 	uint8_t getRootInode(inode_t *rootinode, const uint8_t *path) override;
-	uint8_t endSetLength(uint64_t chunkid) override;
 	uint8_t readChunk(inode_t inode, uint32_t indx, uint64_t *chunkid, uint64_t *length) override;
 	uint8_t writeEnd(const FilesystemOperationContext &fsOpContext, inode_t inode, uint64_t length,
 	                 uint64_t chunkid, uint32_t lockid) override;

--- a/src/master/filesystem_operations_interface.h
+++ b/src/master/filesystem_operations_interface.h
@@ -392,13 +392,158 @@ public:
 
 	virtual uint8_t getAttr(const FsContext &context, const FilesystemOperationContext &fsOpContext,
 	                        inode_t inode, Attributes &attr) = 0;
+
+	/// Attempts to initiate a file truncate operation (phase 1).
+	///
+	/// This method is the first phase of a file truncate operation. The complete workflow
+	/// depends on whether asynchronous chunk operations are required:
+	/// - Simple path: trySetLength() → doSetLength() (2 phases)
+	/// - Async path: trySetLength() → [async chunk work] → endSetLength() → doSetLength() (3 phases)
+	///
+	/// This function checks whether the truncate can proceed immediately or requires
+	/// asynchronous chunk operations on chunkservers. If the new length is not chunk-aligned
+	/// and a chunk exists at the truncation point, the chunk must be truncated, which is an
+	/// asynchronous operation handled by chunkservers.
+	///
+	/// The function performs the following validations and operations:
+	/// - Session verification (must be read-write, non-meta session)
+	/// - Node verification (must be a file and exist)
+	/// - Permission checks (write permission if file not opened, otherwise just existence)
+	/// - Chunk truncation initiation if the new length falls within an existing chunk
+	///
+	/// Chunk truncation workflow:
+	/// - If the new length is not chunk-aligned (length & SFSCHUNKMASK != 0), the function
+	///   checks if a chunk exists at the truncation index
+	/// - If a chunk exists, it initiates an asynchronous chunk truncation via chunk_multi_truncate
+	/// - The chunk operation is logged to the changelog (TRUNC entry)
+	/// - Returns SAUNAFS_ERROR_DELAYED to indicate the operation is pending
+	///
+	/// The denyTruncatingParity parameter prevents truncation of parity chunks (used for
+	/// erasure-coded files) when truncating down. This is necessary because parity chunks
+	/// cannot be partially truncated.
+	///
+	/// @param context The FS operation context containing user credentials and session info.
+	/// @param fsOpContext The filesystem operation context (transaction).
+	/// @param inode The inode number of the file to truncate.
+	/// @param opened Non-zero if the file is currently opened (affects permission checking:
+	///               if 0, write permission is required; if non-zero, only existence is checked).
+	/// @param length The new target length for the file in bytes.
+	/// @param denyTruncatingParity If true, prevents truncation of parity chunks when truncating
+	///                             down (used for erasure-coded files).
+	/// @param lockid Lock identifier for the chunk operation (used to prevent concurrent
+	///               modifications).
+	/// @param[out] attr Attributes structure to be filled with the file's current attributes
+	///                  (only filled if operation completes immediately).
+	/// @param[out] chunkid Pointer to receive the chunk ID if chunk truncation is initiated
+	///                     (used to track the async operation).
+	///
+	/// @return SAUNAFS_STATUS_OK if the operation can proceed immediately (no chunk work needed),
+	///         SAUNAFS_ERROR_DELAYED if chunk truncation was initiated (operation pending),
+	///         or one of the following error codes:
+	///         - SAUNAFS_ERROR_EPERM if session permissions are insufficient
+	///         - SAUNAFS_ERROR_EACCES if write access is denied
+	///         - SAUNAFS_ERROR_ENOENT if the file doesn't exist
+	///         - SAUNAFS_ERROR_NOTPOSSIBLE if truncation of parity chunks is denied
+	///         - Other error codes from chunk operations
+	///
+	/// @note If this function returns SAUNAFS_STATUS_OK, call doSetLength() immediately.
+	/// @note If this function returns SAUNAFS_ERROR_DELAYED, call endSetLength() after the
+	///       async chunk operation completes, then call doSetLength() to finalize.
+	/// @note The actual file length metadata is not modified by this function; only doSetLength()
+	///       modifies the file length and removes chunks beyond the new length.
+	/// @see endSetLength, doSetLength
 	virtual uint8_t trySetLength(const FsContext &context,
 	                             const FilesystemOperationContext &fsOpContext, inode_t inode,
 	                             uint8_t opened, uint64_t length, bool denyTruncatingParity,
 	                             uint32_t lockid, Attributes &attr, uint64_t *chunkid) = 0;
+
+	/// Finalizes a file truncate operation by setting the file length metadata (phase 2).
+	///
+	/// This method is the final phase of a file truncate operation. It updates the file's
+	/// length metadata, removes all chunks beyond the new length, updates timestamps, and
+	/// logs the operation to the changelog. This function always erases chunks beyond the
+	/// new length because it's only called when finalizing a truncate operation.
+	///
+	/// This function is called in two scenarios:
+	/// 1. Immediately after trySetLength() returns SAUNAFS_STATUS_OK (no async work needed)
+	/// 2. After endSetLength() unlocks the chunk (when trySetLength returned DELAYED and
+	///    the async chunk operation completed)
+	///
+	/// The function performs the following operations:
+	/// - Session verification (must be read-write session)
+	/// - Node verification (must be a file and exist)
+	/// - Sets the file's length to the specified value
+	/// - Removes all chunks beyond the new length (eraseFurtherChunks = true)
+	/// - Updates the file's modification time (mtime) to current timestamp
+	/// - Updates the file's change time (ctime) to current timestamp
+	/// - Logs the LENGTH operation to the changelog for replication
+	/// - Updates filesystem statistics
+	/// - Returns updated file attributes
+	///
+	/// Changelog entry:
+	/// - Format: LENGTH(inode, length, eraseFurtherChunks)
+	/// - The eraseFurtherChunks flag is always 1 (true) for doSetLength
+	///
+	/// @param context The FS operation context containing user credentials and session info.
+	/// @param fsOpContext The filesystem operation context (transaction).
+	/// @param inode The inode number of the file to set the length for.
+	/// @param length The new length for the file in bytes.
+	/// @param[out] attr Attributes structure to be filled with the file's updated attributes
+	///                  after the length change.
+	///
+	/// @return SAUNAFS_STATUS_OK on success, or one of the following error codes:
+	///         - SAUNAFS_ERROR_EPERM if session permissions are insufficient
+	///         - SAUNAFS_ERROR_ENOENT if the file doesn't exist
+	///         - SAUNAFS_ERROR_EINVAL if the node is not a file
+	///         - Other error codes from node operations
+	///
+	/// @note This function must only be called after trySetLength() completes successfully
+	///       (and after endSetLength() if the async path was taken).
+	/// @note The function always removes chunks beyond the new length (eraseFurtherChunks=true).
+	/// @see trySetLength, endSetLength
 	virtual uint8_t doSetLength(const FsContext &context,
 	                            const FilesystemOperationContext &fsOpContext, inode_t inode,
 	                            uint64_t length, Attributes &attr) = 0;
+
+	/// Unlocks a chunk after a truncate operation completes (phase 1.5).
+	///
+	/// This method is called to release the chunk lock acquired during a truncate operation
+	/// initiated by trySetLength(). It's an intermediate cleanup step in the truncate workflow
+	/// that occurs after the asynchronous chunk operation completes on the chunkservers but
+	/// before the final doSetLength() call that updates the file metadata.
+	///
+	/// The complete truncate workflow is:
+	/// 1. trySetLength() - Initiates truncate, may lock a chunk for truncation (returns DELAYED)
+	/// 2. [Asynchronous chunk truncation on chunkservers]
+	/// 3. endSetLength() - Unlocks the chunk (this function)
+	/// 4. doSetLength() - Finalizes by updating file length metadata
+	///
+	/// The function performs the following operations:
+	/// - Logs an UNLOCK operation to the changelog for replication
+	/// - Unlocks the specified chunk via chunk_unlock()
+	/// - Updates filesystem checksum
+	///
+	/// Changelog entry:
+	/// - Format: UNLOCK(chunkid)
+	///
+	/// This function is called in two scenarios:
+	/// 1. After a FUSE_TRUNCATE or FUSE_TRUNCATE_END delayed operation completes
+	/// 2. When cleaning up after a failed truncate operation
+	///
+	/// @param chunkid The chunk ID to unlock (obtained from trySetLength's chunkid output).
+	///
+	/// @return SAUNAFS_STATUS_OK on success, or SAUNAFS_ERROR_NOCHUNK if the chunk doesn't exist.
+	///
+	/// @note This function does not modify file metadata; it only unlocks the chunk.
+	/// @note The chunk lock is maintained between trySetLength and endSetLength to prevent
+	///       concurrent modifications during the asynchronous chunk operation.
+	/// @note After calling this function, doSetLength() should be called to complete the truncate.
+	/// @note This function must be called for any truncate flow in which trySetLength()
+	///       acquired a chunk lock, including both delayed chunkserver truncation
+	///       (SAUNAFS_ERROR_DELAYED) and client-performs truncate/end flows where
+	///       trySetLength() can return SAUNAFS_ERROR_NOTPOSSIBLE (e.g. FUSE_TRUNCATE_END).
+	/// @see trySetLength, doSetLength
+	virtual uint8_t endSetLength(uint64_t chunkid) = 0;
 
 	/// Sets attributes for a filesystem node (file, directory, etc.).
 	///
@@ -661,7 +806,6 @@ public:
 	virtual uint32_t getDirPathSize(inode_t inode) = 0;
 	virtual void getDirPathData(inode_t inode, uint8_t *buff, uint32_t size) = 0;
 	virtual uint8_t getRootInode(inode_t *rootinode, const uint8_t *path) = 0;
-	virtual uint8_t endSetLength(uint64_t chunkid) = 0;
 	virtual uint8_t readChunk(inode_t inode, uint32_t indx, uint64_t *chunkid,
 	                          uint64_t *length) = 0;
 	virtual uint8_t writeEnd(const FilesystemOperationContext &fsOpContext, inode_t inode,

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -493,8 +493,22 @@ void matoclserv_chunk_status(uint64_t chunkId, uint8_t status, bool isFailedCrea
 			serializer->serializeFuseTruncate(reply, operationType, messageId, status);
 		} else {
 			Attributes attr;
-			gFSOperations->doSetLength(context, fsOpContext, inode, fileLength, attr);
-			serializer->serializeFuseTruncate(reply, operationType, messageId, attr);
+			status = gFSOperations->doSetLength(context, fsOpContext, inode, fileLength, attr);
+
+			if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
+				if (!fsOpContext.getReadWriteTransaction()->commit()) {
+					safs::log_err(
+					    "{}: transaction failed to commit: inode {}, length {}, operation type {}",
+					    __func__, inode, fileLength, operationType);
+					status = SAUNAFS_ERROR_IO;
+				}
+			}
+
+			if (status == SAUNAFS_STATUS_OK) {
+				serializer->serializeFuseTruncate(reply, operationType, messageId, attr);
+			} else {
+				serializer->serializeFuseTruncate(reply, operationType, messageId, status);
+			}
 		}
 		matoclserv_createpacket(eptr, std::move(reply));
 		return;
@@ -1897,15 +1911,18 @@ void matoclserv_fuse_truncate(matoclserventry *eptr, PacketHeader header, const 
 	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
 	    FilesystemOperationContext::TransactionType::kReadWrite);
 
-	const PacketSerializer *serializer = PacketSerializer::getSerializer(header.type, eptr->version);
+	const PacketSerializer *serializer =
+	    PacketSerializer::getSerializer(header.type, eptr->version);
+
 	if (header.type == SAU_CLTOMA_FUSE_TRUNCATE_END) {
-		cltoma::fuseTruncateEnd::deserialize(request,
-				messageId, inode, uid, gid, length, lockId);
+		cltoma::fuseTruncateEnd::deserialize(request, messageId, inode, uid, gid, length, lockId);
 		type = FUSE_TRUNCATE_END;
 		status = matoclserv_check_group_cache(eptr, gid);
+
 		if (status == SAUNAFS_STATUS_OK) {
 			opened = true; // permissions have already been checked on SAU_CLTOMA_TRUNCATE
 			context = matoclserv_get_context(eptr, uid, gid);
+
 			// We have to verify lockid in this request
 			if (lockId == 0) { // unlocking with lockid == 0 means "force unlock", this is not allowed
 				status = SAUNAFS_ERROR_WRONGLOCKID;
@@ -1913,19 +1930,18 @@ void matoclserv_fuse_truncate(matoclserventry *eptr, PacketHeader header, const 
 				// let's check if chunk is still locked by us
 				status = gFSOperations->getChunkId(context, fsOpContext, inode,
 				                                   length / SFSCHUNKSIZE, &chunkId);
-				if (status == SAUNAFS_STATUS_OK) {
-					status = chunk_can_unlock(chunkId, lockId);
-				}
-				gFSOperations->endSetLength(chunkId);
+
+				if (status == SAUNAFS_STATUS_OK) { status = chunk_can_unlock(chunkId, lockId); }
+
+				if (status == SAUNAFS_STATUS_OK) { gFSOperations->endSetLength(chunkId); }
 			}
 		}
 	} else {
 		serializer->deserializeFuseTruncate(request, messageId, inode, opened, uid, gid, length);
 		type = FUSE_TRUNCATE;
 		status = matoclserv_check_group_cache(eptr, gid);
-		if (status == SAUNAFS_STATUS_OK) {
-			context = matoclserv_get_context(eptr, uid, gid);
-		}
+
+		if (status == SAUNAFS_STATUS_OK) { context = matoclserv_get_context(eptr, uid, gid); }
 	}
 
 	// Try to do the truncate
@@ -1939,27 +1955,81 @@ void matoclserv_fuse_truncate(matoclserventry *eptr, PacketHeader header, const 
 	if (status == SAUNAFS_ERROR_NOTPOSSIBLE && header.type == SAU_CLTOMA_FUSE_TRUNCATE) {
 		// New client requested to truncate xor chunk. He has to do it himself.
 		uint64_t fileLength;
-		uint8_t opflag;
-		gFSOperations->writeChunk(context, fsOpContext, inode, length / SFSCHUNKSIZE, false,
-		                          &lockId, &chunkId, &opflag, &fileLength);
-		if (opflag) {
+		uint8_t chunkOperationPending;
+
+		status =
+		    gFSOperations->writeChunk(context, fsOpContext, inode, length / SFSCHUNKSIZE, false,
+		                              &lockId, &chunkId, &chunkOperationPending, &fileLength);
+
+		if (status != SAUNAFS_STATUS_OK) {
+			// writeChunk failed, don't use potentially uninitialized output parameters
+			// Fall through to error handling below
+		} else if (chunkOperationPending) {
 			// But first we have to duplicate chunk :)
 			type = FUSE_TRUNCATE_BEGIN;
 			length = fileLength;
 			status = SAUNAFS_ERROR_DELAYED;
 		} else {
 			// No duplication is needed
-			std::vector<uint8_t> reply;
-			matocl::fuseTruncate::serialize(reply, messageId, fileLength, lockId);
-			matoclserv_createpacket(eptr, std::move(reply));
-			if (eptr->sessionData) {
-				eptr->sessionData->currHourOperationsStats[2]++;
+
+			uint8_t commitStatus = SAUNAFS_STATUS_OK;
+
+			// Commit the transaction to persist metadata updates from writeChunk()
+			if (fsOpContext.hasReadWriteTransaction()) {
+				if (!fsOpContext.getReadWriteTransaction()->commit()) {
+					safs::log_err(
+					    "{}: transaction failed to commit: (no duplication) inode {}, length {}",
+					    __func__, inode, length);
+					commitStatus = SAUNAFS_ERROR_IO;
+				}
 			}
+
+			std::vector<uint8_t> reply;
+
+			if (commitStatus == SAUNAFS_STATUS_OK) {
+				matocl::fuseTruncate::serialize(reply, messageId, fileLength, lockId);
+			} else {
+				serializer->serializeFuseTruncate(reply, type, messageId, commitStatus);
+			}
+
+			matoclserv_createpacket(eptr, reply);
+
+			// Update client stats
+			if (eptr->sessionData) { eptr->sessionData->currHourOperationsStats[2]++; }
+
 			return;
 		}
 	}
 
+	// Handle delayed operations: status is SAUNAFS_ERROR_DELAYED either from trySetLength()
+	// or when chunk duplication is needed before truncation
 	if (status == SAUNAFS_ERROR_DELAYED) {
+		// Commit the transaction before enqueuing the delayed chunk operation so that
+		// metadata updates performed earlier in this request are persisted.
+		if (fsOpContext.hasReadWriteTransaction()) {
+			if (!fsOpContext.getReadWriteTransaction()->commit()) {
+				safs::log_err("{}: transaction failed to commit: (delayed) inode {}, length {}",
+				              __func__, inode, length);
+				// Commit failure is a critical error here. Return immediately rather than
+				// enqueuing a delayed operation, as the metadata state is inconsistent.
+				// Note: chunk operations may have been sent to chunkservers, but without
+				// persisted metadata, we cannot safely complete the operation.
+				std::vector<uint8_t> reply;
+
+				if (type == FUSE_TRUNCATE_BEGIN) {
+					// For BEGIN operations, use the status packet format
+					matocl::fuseTruncate::serialize(reply, messageId, SAUNAFS_ERROR_IO);
+				} else {
+					// For TRUNCATE / TRUNCATE_END, use the standard truncate serializer
+					serializer->serializeFuseTruncate(reply, type, messageId, SAUNAFS_ERROR_IO);
+				}
+
+				matoclserv_createpacket(eptr, reply);
+				if (eptr->sessionData) { eptr->sessionData->currHourOperationsStats[2]++; }
+				return;
+			}
+		}
+
 		// Duplicate or truncate request has been sent to chunkservers, delay the reply
 		auto chunkOperationPtr = std::make_unique<DelayedChunkOperation>();
 		passert(chunkOperationPtr.get());
@@ -1975,29 +2045,39 @@ void matoclserv_fuse_truncate(matoclserventry *eptr, PacketHeader header, const 
 		chunkOperationPtr->type = type;
 		chunkOperationPtr->serializer = serializer;
 		eptr->delayedChunkOperations.push_back(std::move(chunkOperationPtr));
-		if (eptr->sessionData) {
-			eptr->sessionData->currHourOperationsStats[2]++;
-		}
+
+		// Update client stats
+		if (eptr->sessionData) { eptr->sessionData->currHourOperationsStats[2]++; }
+
 		return;
 	}
+
 	if (status == SAUNAFS_STATUS_OK) {
 		status = gFSOperations->doSetLength(context, fsOpContext, inode, length, attr);
+
+		if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
+			if (!fsOpContext.getReadWriteTransaction()->commit()) {
+				safs::log_err("{}: transaction failed to commit: inode {}, length {}", __func__,
+				              inode, length);
+				status = SAUNAFS_ERROR_IO;
+			}
+		}
 	}
-	if (status == SAUNAFS_STATUS_OK) {
-		dcm_modify(inode, eptr->sessionData->sessionId);
-	}
+
+	if (status == SAUNAFS_STATUS_OK) { dcm_modify(inode, eptr->sessionData->sessionId); }
 
 	std::vector<uint8_t> reply;
 	if (status == SAUNAFS_STATUS_OK) {
 		serializer->serializeFuseTruncate(reply, type, messageId, attr);
 	} else {
-		safs::log_debug("matoclserv_fuse_truncate: Failed to truncate: {} (code {})", saunafs_error_string(status));
+		safs::log_debug("matoclserv_fuse_truncate: Failed to truncate: {} (code {})",
+		                saunafs_error_string(status), status);
 		serializer->serializeFuseTruncate(reply, type, messageId, status);
 	}
-	matoclserv_createpacket(eptr, std::move(reply));
-	if (eptr->sessionData) {
-		eptr->sessionData->currHourOperationsStats[2]++;
-	}
+
+	matoclserv_createpacket(eptr, reply);
+
+	if (eptr->sessionData) { eptr->sessionData->currHourOperationsStats[2]++; }
 }
 
 void matoclserv_fuse_readlink(matoclserventry *eptr, const uint8_t *data, uint32_t length) {


### PR DESCRIPTION
Enable file truncate operations to work with KV-based metadata backends by adding transaction commits at critical points in the truncate workflow.

Main changes:
- Add transaction commits in matoclserv_chunk_status() and matoclserv_fuse_truncate() to persist KV backend changes
- Call nodeOperations_->updateNode() in doSetLength() for KV backends
- Reorganize method declarations to group related phases together
- Add comprehensive documentation for the truncate workflow phases
- Improve variable naming (opflag -> needChunkDuplication)

This allows KV backends (like FDB) to properly persist metadata changes during truncate operations.

Related to: LS-185