### PR TITLE
refactor: make CS wait for received jobs at stop

### DIFF
--- a/src/chunkserver/master_connection.cc
+++ b/src/chunkserver/master_connection.cc
@@ -386,20 +386,23 @@ void MasterConn::onConnected() {
 
 // Polling
 
-void MasterConn::providePollDescriptors(std::vector<pollfd> &pdesc) {
+void MasterConn::providePollDescriptors(std::vector<pollfd> &pdesc, bool doTerminate) {
 	pDescPos_ = -1;
 
 	if (mode_ == ConnectionMode::FREE || socketFD_ < 0) { return; }
 
 	if (mode_ == ConnectionMode::CONNECTED) {
-		if (jobPool_->getJobCount() < kMaxBackgroundJobsThreshold ||
-		    replicationJobPool_->getJobCount() < kMaxBackgroundJobsThreshold) {
+		if (!doTerminate && (jobPool_->getJobCount() < kMaxBackgroundJobsThreshold ||
+		    replicationJobPool_->getJobCount() < kMaxBackgroundJobsThreshold)) {
 			pdesc.emplace_back(socketFD_, POLLIN, 0);
 			pDescPos_ = static_cast<int32_t>(pdesc.size() - 1);
 		}
 	}
 
 	if (mode_ == ConnectionMode::HANDSHAKE) {
+		// Let's proceed with the handshake even if doTerminate is true, to avoid leaving a
+		// half-open connection. The handshake will be attempted to be completed, but if it fails,
+		// the connection will be closed and the thread will be able to terminate.
 		short event = 0;
 		switch (lastHandshakeError_) {
 		case SSL_ERROR_WANT_READ:

--- a/src/chunkserver/master_connection.h
+++ b/src/chunkserver/master_connection.h
@@ -124,7 +124,7 @@ public:
 
 	// Polling
 
-	void providePollDescriptors(std::vector<pollfd> &pdesc);
+	void providePollDescriptors(std::vector<pollfd> &pdesc, bool doTerminate);
 
 	void handlePollErrors(const std::vector<pollfd> &pdesc);
 
@@ -209,6 +209,8 @@ public:
 	const std::string &clusterId() const { return clusterId_; }
 
 	bool isTlsEnabled() const { return !tlsCertFile_.empty() && !tlsKeyFile_.empty(); }
+
+	bool isOutputQueueEmpty() const { return outputPackets_.empty(); }
 
 private:
 	std::string masterHostStr_;                     ///< Hostname of the master server.

--- a/src/chunkserver/masterconn.cc
+++ b/src/chunkserver/masterconn.cc
@@ -77,6 +77,8 @@ constexpr uint32_t kDefaultReplicationNumberOfWorkers = 5;
 constexpr uint32_t kMinReplicationNumberOfWorkers = 1;
 static uint32_t gReplicationNumberOfWorkers = kDefaultReplicationNumberOfWorkers;
 
+static std::atomic<bool> gDoTerminate = false;
+
 static void* gReconnectHook;
 
 //  Stats
@@ -139,6 +141,16 @@ void masterconn_unwantedjobfinished(uint8_t status, void *packet) {
 	MasterConn::deletePacket(packet);
 }
 
+void masterconn_wantexit(void) { gDoTerminate.store(true); }
+
+int masterconn_canexit(void) {
+	if (gJobPool->getJobCount() == 0 && gReplicationJobPool->getJobCount() == 0 &&
+	    gMasterConnSingleton->isOutputQueueEmpty()) {
+		return 1;
+	}
+	return 0;
+}
+
 void masterconn_term(void) {
 	//  For each connection (currently only one), release its resources.
 	MasterConn *eptr = gMasterConnSingleton.get();
@@ -171,7 +183,7 @@ void masterconn_desc(std::vector<pollfd> &pdesc) {
 		}
 	}
 
-	eptr->providePollDescriptors(pdesc);
+	eptr->providePollDescriptors(pdesc, gDoTerminate.load());
 }
 
 void masterconn_send_status() {
@@ -307,6 +319,8 @@ int masterconn_init(void) {
 	gReconnectHook =
 	    eventloop_timeregister(TIMEMODE_RUN_LATE, reconnectionDelay,
 	                           rnd_ranged<uint32_t>(reconnectionDelay), masterconn_reconnect);
+	eventloop_wantexitregister(masterconn_wantexit);
+	eventloop_canexitregister(masterconn_canexit);
 	eventloop_destructregister(masterconn_term);
 	eventloop_pollregister(masterconn_desc, masterconn_serve);
 	eventloop_reloadregister(masterconn_reload);

--- a/src/chunkserver/network_main_thread.cc
+++ b/src/chunkserver/network_main_thread.cc
@@ -181,17 +181,36 @@ void mainNetworkThreadDesc(std::vector<pollfd> &pdesc) {
 	lsockpdescpos = pdesc.size() - 1;
 }
 
-void mainNetworkThreadTerm(void) {
+void mainNetworkThreadWantExit(void) {
 	TRACETHIS();
 	safs::log_info("closing {}:{}", ListenHost, ListenPort);
+	// Closing the listening socket will cause the main thread to stop accepting new connections and
+	// eventually exit after processing existing ones.
 	tcpclose(lsock);
 
 	free(ListenHost);
 	free(ListenPort);
 
+	// Ask worker threads to terminate and close their connections. They will be forcefully
+	// terminated after a timeout if they don't exit on their own.
 	for (auto& threadObject : networkThreadObjects) {
 		threadObject.askForTermination();
 	}
+}
+
+int mainNetworkThreadCanExit(void) {
+	TRACETHIS();
+	bool allTerminated = true;
+	for (auto &threadObject : networkThreadObjects) {
+		if (!threadObject.updateAndCheckTerminationStatus()) {
+			allTerminated = false;
+		}
+	}
+	return allTerminated ? 1 : 0;
+}
+
+void mainNetworkThreadTerm(void) {
+	TRACETHIS();
 
 	for (auto &thread : networkThreads) {
 		if (thread.joinable()) { thread.join(); }
@@ -277,6 +296,8 @@ int mainNetworkThreadInit(void) {
 	safs_pretty_syslog(LOG_NOTICE, "main server module: listen on %s:%s", ListenHost, ListenPort);
 
 	eventloop_reloadregister(mainNetworkThreadReload);
+	eventloop_wantexitregister(mainNetworkThreadWantExit);
+	eventloop_canexitregister(mainNetworkThreadCanExit);
 	eventloop_destructregister(mainNetworkThreadTerm);
 	eventloop_pollregister(mainNetworkThreadDesc, mainNetworkThreadServe);
 

--- a/src/chunkserver/network_worker_thread.cc
+++ b/src/chunkserver/network_worker_thread.cc
@@ -44,6 +44,8 @@
 
 // connection timeout in seconds
 constexpr uint32_t kCSServTimeout = 10;
+// forceful termination timeout in milliseconds
+constexpr uint32_t kNWForcefulTerminationTimeout_ms = 30000;
 
 constexpr int kTimeoutOdd = 300000;
 constexpr int kTimeoutEven = 200000;
@@ -84,18 +86,19 @@ void NetworkWorkerThread::operator()() {
 	std::string threadName = "netWorker_" + std::to_string(threadCounter++);
 	pthread_setname_np(pthread_self(), threadName.c_str());
 
-	while (!doTerminate) {
-		preparePollFds();
-		int i = poll(pdesc.data(), pdesc.size(), gPollTimeout);
-		if (i < 0) {
+	while (!canTerminate_.load()) {
+		preparePollFds(doTerminate.load());
+		int fdWithEvents = poll(pdesc.data(), pdesc.size(), gPollTimeout);
+
+		if (fdWithEvents < 0) {
 			if (errno == EAGAIN) {
-				safs_pretty_syslog(LOG_WARNING, "poll returned EAGAIN");
+				safs::log_warn("{}: poll returned EAGAIN", __func__);
 				usleep(100000);
 				continue;
 			}
+
 			if (errno != EINTR) {
-				safs_pretty_syslog(LOG_WARNING, "poll error: %s",
-				                   strerr(errno));
+				safs::log_warn("{}: poll error: {}", __func__, strerr(errno));
 				break;
 			}
 		} else {
@@ -104,9 +107,19 @@ void NetworkWorkerThread::operator()() {
 				eassert(read(pdesc[0].fd, &notifyByte, 1) == 1);
 			}
 		}
+
 		servePoll();
 	}
 	this->terminate();
+}
+
+bool NetworkWorkerThread::updateAndCheckTerminationStatus() {
+	std::lock_guard lock(csservheadLock);
+	bool canTerminate =
+	    doTerminate.load() && (csservEntries.empty() ||
+	                           terminationTimer_.elapsed_ms() > kNWForcefulTerminationTimeout_ms);
+	canTerminate_.store(canTerminate);
+	return canTerminate;
 }
 
 void NetworkWorkerThread::terminate() {
@@ -126,7 +139,7 @@ void NetworkWorkerThread::terminate() {
 	}
 }
 
-void NetworkWorkerThread::preparePollFds() {
+void NetworkWorkerThread::preparePollFds(bool isTerminating) {
 	LOG_AVG_TILL_END_OF_SCOPE0("preparePollFds");
 	TRACETHIS();
 	pdesc.clear();
@@ -145,7 +158,7 @@ void NetworkWorkerThread::preparePollFds() {
 			case ChunkserverEntry::State::WriteLast:
 				pdesc.emplace_back(pollfd(entry.sock, 0, 0));
 				entry.pDescPos = pdesc.size() - 1;
-				if (entry.inputPacket.bytesLeft > 0) {
+				if (entry.inputPacket.bytesLeft > 0 && !isTerminating) {
 					pdesc.back().events |= POLLIN;
 				}
 				if (!entry.outputPackets.empty()) {
@@ -165,13 +178,13 @@ void NetworkWorkerThread::preparePollFds() {
 			case ChunkserverEntry::State::WriteForward:
 				pdesc.emplace_back(pollfd(entry.fwdSocket, POLLIN, 0));
 				entry.fwdPDescPos = pdesc.size() - 1;
-				if (entry.fwdOutputPacket.bytesLeft > 0) {
+				if (entry.fwdOutputPacket.bytesLeft > 0 && !isTerminating) {
 					pdesc.back().events |= POLLOUT;
 				}
 
 				pdesc.emplace_back(pollfd(entry.sock, 0, 0));
 				entry.pDescPos = pdesc.size() - 1;
-				if (entry.inputPacket.bytesLeft > 0) {
+				if (entry.inputPacket.bytesLeft > 0 && !isTerminating) {
 					pdesc.back().events |= POLLIN;
 				}
 				if (!entry.outputPackets.empty()) {
@@ -319,6 +332,9 @@ void NetworkWorkerThread::servePoll() {
 void NetworkWorkerThread::askForTermination() {
 	TRACETHIS();
 	doTerminate = true;
+	std::unique_lock lock(csservheadLock);
+	terminationTimer_.reset();
+	for (auto &entry : csservEntries) { entry.closeJobs(); }
 }
 
 void NetworkWorkerThread::addConnection(int newSocketFD) {

--- a/src/chunkserver/network_worker_thread.h
+++ b/src/chunkserver/network_worker_thread.h
@@ -59,21 +59,25 @@ public:
 		return bgJobPool_.get();
 	}
 
+	bool updateAndCheckTerminationStatus();
+
 private:
-	void preparePollFds();
-	void servePoll() ;
+	void preparePollFds(bool isTerminating);
+	void servePoll();
 	void terminate();
 
 	/// Human readable name for the thread
 	std::string name_;
 
-	std::atomic<bool> doTerminate;
+	std::atomic<bool> doTerminate;  ///< Whether the thread should terminate
 	std::mutex csservheadLock;
 	std::list<ChunkserverEntry> csservEntries;
 
 	std::unique_ptr<JobPool> bgJobPool_;
+	std::atomic<bool> canTerminate_{false};  ///< Whether it is safe to terminate the thread
 	int bgJobPoolWakeUpFd_;
 	static const uint32_t JOB_FD_PDESC_POS = 1;
 	std::vector<struct pollfd> pdesc;
 	int notify_pipe[2];
+	Timer terminationTimer_{};
 };


### PR DESCRIPTION
This PR targets making the chunkserver to wait for the closing of the already received jobs. Currently, the chunkserver receives the stop signal and stops processing everything: no more work in the jobs pools and no more replies to clients and master sent. The change consists of using the wantexit and canexit registers of functions to:
- do not read more data from the socket, so only already received jobs
are going to be wait for.
- close jobs in current active chunkserver entries (client
connections), but wait until the MasterConn job pools are empty. Client should retry operations right away, master can take a while.
- wait until all the replies has been sent.

Closes to [LS-312](https://linear.app/leil/issue/LS-312/).

Signed-off-by: Dave <dave@leil.io>