### PR TITLE
ci: Fix Jenkins unable to delete build files

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -228,6 +228,7 @@ pipeline {
                                     export PATH="/usr/lib/ccache:$PATH"
                                     cd build
                                     sudo nice make -j\$((\$(nproc) / 2)) install
+                                    sudo chown \$(id -u):\$(id -g) . -R
                                     saunafs-tests --gtest_filter="RebalancingTests*" --gtest_output="xml:./rebalance_test_detail.xml" || true
                                 """
                                 publishJunit("build/*test_detail.xml")


### PR DESCRIPTION
Due to a bug where build files would be root owned after build, Jenkins could not later clean them up. This commit works around that by chowning the directory recursively as jenkins user.