### PR TITLE
perf: wake up writes after locked chunk status

### DIFF
--- a/src/common/saunafs_version.h
+++ b/src/common/saunafs_version.h
@@ -53,3 +53,4 @@ constexpr uint32_t kFirstVersionWithMountInfoOnMonitoring = saunafsVersion(5, 0,
 constexpr uint32_t kFirstVersionWithChunkBasedWriteAlgorithm = saunafsVersion(5, 0, 0);
 constexpr uint32_t kFirstVersionWithClusterId = saunafsVersion(5, 0, 0);
 constexpr uint32_t kFirstVersionWithReadTrashReservedByHandleOffset = saunafsVersion(5, 3, 0);
+constexpr uint32_t kFirstVersionWithUnlockChunkNotice = saunafsVersion(5, 7, 0);

--- a/src/master/chunks.cc
+++ b/src/master/chunks.cc
@@ -1021,9 +1021,9 @@ int chunk_can_unlock(uint64_t chunkid, uint32_t lockid) {
 		return SAUNAFS_STATUS_OK;
 	} else if (c->lockedto == 0) {
 		return SAUNAFS_ERROR_NOTLOCKED;
-	} else {
-		return SAUNAFS_ERROR_WRONGLOCKID;
 	}
+	// Case lockid != c->lockid
+	return SAUNAFS_ERROR_WRONGLOCKID;
 }
 
 int chunk_unlock(uint64_t chunkid) {
@@ -1037,6 +1037,12 @@ int chunk_unlock(uint64_t chunkid) {
 	c->lockedto = 0;
 	chunk_update_checksum(c);
 	emit_chunk_changed(c);
+
+#ifndef METARESTORE
+	// If the chunk is not locked anymore, we can try to send notices about the operation
+	// status to clients waiting for the lock release.
+	matoclserv_notify_unlock_list(chunkid);
+#endif
 	return SAUNAFS_STATUS_OK;
 }
 
@@ -1145,6 +1151,7 @@ uint8_t chunk_multi_modify(uint64_t ochunkid, uint32_t *lockid, uint8_t goal,
 			}
 		}
 		if (*lockid == 0 && oc->isLocked()) {
+			*nchunkid = ochunkid;
 			return SAUNAFS_ERROR_LOCKED;
 		}
 		if (!oc->isWritable()) {

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -2501,6 +2501,7 @@ uint8_t FilesystemOperationsBase::writeChunk(const FsContext &context,
 		                                  increaseVersion, &nchunkid);
 	}
 	if (status != SAUNAFS_STATUS_OK) {
+		if (status == SAUNAFS_ERROR_LOCKED) { *chunkid = nchunkid; }
 		fsnodes_update_checksum(fileNode);
 		return status;
 	}

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -191,6 +191,23 @@ struct matoclserventry {
 	std::vector<std::unique_ptr<DelayedChunkOperation>> delayedChunkOperations;
 };
 
+using WaitEntry = std::tuple<matoclserventry *, inode_t, uint32_t>;
+
+struct WaitEntryCmp {
+	bool operator()(const WaitEntry &a, const WaitEntry &b) const noexcept {
+		matoclserventry *pa = std::get<0>(a), *pb = std::get<0>(b);
+		if (pa != pb) { return std::less<matoclserventry *>()(pa, pb); }
+		inode_t ia = std::get<1>(a), ib = std::get<1>(b);
+		if (ia != ib) { return ia < ib; }
+		return std::get<2>(a) < std::get<2>(b);
+	}
+};
+
+// This map stores, for each chunk ID, the list of clients that are waiting for this chunk to be
+// unlocked and the inode and chunk index of the chunk they are waiting for. When a chunk is
+// unlocked, all clients in the corresponding list are notified and removed from the map.
+std::unordered_map<uint64_t, std::set<WaitEntry, WaitEntryCmp>> gWaitForUnlockMap;
+
 static std::list<std::unique_ptr<matoclserventry>> matoclservList;
 
 static int masterSocket;             ///< Master socket for accepting new connections
@@ -278,6 +295,65 @@ static inline void matoclserv_ugid_remap(matoclserventry *eptr, uint32_t *auid, 
 			*agid = eptr->sessionData->mapAllGid;
 		}
 	}
+}
+
+/// Adds a client connection to the wait-for-unlock list for a given chunk ID.
+/// @param eptr Pointer to the client connection in the master
+/// @param chunkId The ID of the chunk to wait for
+/// @param inode The inode of the chunk to wait for
+/// @param chunkIndex The index of the chunk to wait for
+static inline void matoclserv_add_to_wait_for_unlock_list(matoclserventry *eptr, uint64_t chunkId,
+                                                          inode_t inode, uint32_t chunkIndex) {
+	gWaitForUnlockMap[chunkId].emplace(eptr, inode, chunkIndex);
+}
+
+/// Removes a client connection from the wait-for-unlock list for all chunk IDs.
+/// @param eptr Pointer to the client connection in the master
+static inline void matoclserv_remove_entry_from_unlock_list(matoclserventry *eptr) {
+	for (auto waitMapIt = gWaitForUnlockMap.begin(); waitMapIt != gWaitForUnlockMap.end();) {
+		auto& waitSet = waitMapIt->second;
+
+		for (auto it = waitSet.begin(); it != waitSet.end();) {
+			if (std::get<0>(*it) == eptr) {
+				it = waitSet.erase(it);
+			} else {
+				++it;
+			}
+		}
+
+		if (waitSet.empty()) {
+			waitMapIt = gWaitForUnlockMap.erase(waitMapIt);
+		} else {
+			++waitMapIt;
+		}
+	}
+}
+
+void matoclserv_notify_unlock_list(uint64_t chunkId) {
+	auto it = gWaitForUnlockMap.find(chunkId);
+	if (it != gWaitForUnlockMap.end()) {
+		auto &clientsWaitingForUnlock = it->second;
+		for (auto &[waitingClient, inode, chunkIndex] : clientsWaitingForUnlock) {
+			// Don't send notices to clients that are being killed or that don't support notices
+			// about unlocked chunks
+			if (waitingClient->mode == ClientConnectionMode::KILL ||
+			    waitingClient->version < kFirstVersionWithUnlockChunkNotice) {
+				continue;
+			}
+
+			std::vector<uint8_t> outMessage;
+			matocl::unlockChunkNotice::serialize(outMessage, inode, chunkIndex);
+			matoclserv_createpacket(waitingClient, outMessage);
+		}
+		gWaitForUnlockMap.erase(it);
+	}
+	// If nothing is found, do nothing
+}
+
+/// Clears the wait-for-unlock list for all chunk IDs. This is called periodically to remove chunks
+/// that are no longer relevant or to clean up stale entries.
+static void matocl_clean_unlock_chunks_list() {
+	gWaitForUnlockMap.clear();
 }
 
 /// Checks whether a given group ID is registered in the session cache.
@@ -3011,6 +3087,11 @@ void matoclserv_fuse_write_chunk(matoclserventry *eptr, PacketHeader header, con
 	}
 
 	if (status != SAUNAFS_STATUS_OK) {
+		if (status == SAUNAFS_ERROR_LOCKED) {
+			// The chunk is locked, so we need to add this client to the wait-for-unlock list.
+			// The chunkId must have been set by writeChunk above.
+			matoclserv_add_to_wait_for_unlock_list(eptr, chunkId, inode, chunkIndex);
+		}
 		serializer->serializeFuseWriteChunk(outMessage, messageId, status);
 		matoclserv_createpacket(eptr, outMessage);
 		return;
@@ -5131,6 +5212,8 @@ void matocl_before_disconnect(matoclserventry *eptr) {
 			eptr->sessionData->disconnectedTimestamp = eventloop_time();
 		}
 	}
+
+	matoclserv_remove_entry_from_unlock_list(eptr);
 }
 
 void matoclserv_gotpacket(matoclserventry *eptr, uint32_t type, const uint8_t *data,
@@ -5940,6 +6023,7 @@ void matoclserv_become_master() {
 
 	eventloop_timeregister(TIMEMODE_RUN_LATE, 10, 0, matocl_session_check);
 	eventloop_timeregister(TIMEMODE_RUN_LATE, 3600, 0, matocl_session_stats_rotate);
+	eventloop_timeregister(TIMEMODE_RUN_LATE, 3600, 0, matocl_clean_unlock_chunks_list);
 	return;
 }
 

--- a/src/master/matoclserv.h
+++ b/src/master/matoclserv.h
@@ -42,6 +42,10 @@ void matoclserv_stats(uint64_t stats[5]);
 void matoclserv_chunk_status(uint64_t chunkId, uint8_t status,
                              bool isFailedCreateOperation = false);
 
+/// Notifies all clients waiting for a given chunk ID to be unlocked.
+/// @param chunkId The ID of the chunk that has been unlocked
+void matoclserv_notify_unlock_list(uint64_t chunkId);
+
 /// Initializes the network configuration and register the eventloop callbacks.
 /// @return 0 on success, negative value on error
 int matoclserv_network_init();

--- a/src/mount/writedata.cc
+++ b/src/mount/writedata.cc
@@ -61,6 +61,7 @@
 #include "mount/notification_area_logging.h"
 #include "mount/write_cache_block.h"
 #include "protocol/cltocs.h"
+#include "protocol/matocl.h"
 #include "protocol/SFSCommunication.h"
 
 #define IDLE_CONNECTION_TIMEOUT 6
@@ -125,6 +126,32 @@ static void updateStats(uint32_t freeCacheBlocks) {
 	statsAdd(WriteStats::CACHED_BYTES, gCachedBytes.exchange(0));
 }
 
+static std::mutex gUnlockChunkNoticeHandlerMutex;
+static std::condition_variable gUnlockChunkNoticeHandlerCond;
+/// List of <inode, chunkIndex> pairs
+static std::list<std::pair<inode_t, uint32_t>> gRecentlyUnlockedChunks;
+
+class UnlockChunkNoticeHandler : public PacketHandler {
+public:
+	bool handle(MessageBuffer buffer) override {
+		try {
+			inode_t inode;
+			uint32_t chunkIndex;
+			matocl::unlockChunkNotice::deserialize(buffer, inode, chunkIndex);
+	
+			std::unique_lock lock(gUnlockChunkNoticeHandlerMutex);
+			gRecentlyUnlockedChunks.emplace_back(inode, chunkIndex);
+			gUnlockChunkNoticeHandlerCond.notify_one();
+			return true;
+		} catch (IncorrectDeserializationException& ex) {
+			safs::log_err("Malformed MATOCL_UNLOCK_CHUNK_NOTICE: {}", ex.what());
+			return false;
+		}
+	}
+};
+
+static UnlockChunkNoticeHandler unlockChunkNoticeHandler;
+
 static bool gUseInodeBasedWriteAlgorithm = false;
 
 namespace InodeBasedWriteAlgorithm {
@@ -138,6 +165,7 @@ struct inodedata {
 	uint16_t lcnt;
 	uint32_t trycnt;
 	bool inqueue;  // true it this inode is waiting in one of the queues or is being processed
+	std::atomic_bool recentlyUnlockNoticeReceived = false;
 	uint32_t minimumBlocksToWrite;
 	std::list<WriteCacheBlock> dataChain;
 	int alterations_in_chain;  // number of adherent blocks with different chunk ids in chain
@@ -359,6 +387,8 @@ static bool delayed_queue_remove(inodedata *id, Glock &) {
 	return false;
 }
 
+void write_enqueue(inodedata *id, Glock &);
+
 void *delayed_queue_worker(void *) {
 	pthread_setname_np(pthread_self(), "delQueueWriter");
 
@@ -380,7 +410,41 @@ void *delayed_queue_worker(void *) {
 		updateStats(freecacheblocks);
 
 		lock.unlock();
-		usleep(timeout.remaining_us());
+
+		do {
+			Glock unlockChunkNoticeLock(gUnlockChunkNoticeHandlerMutex);
+			if (!gRecentlyUnlockedChunks.empty()) {
+				std::list<std::pair<inode_t, uint32_t>> recentlyUnlockedChunksCopy;
+				recentlyUnlockedChunksCopy.swap(gRecentlyUnlockedChunks);
+				unlockChunkNoticeLock.unlock();
+
+				Glock globalLock(gMutex);
+				for (const auto &[inode, _] : recentlyUnlockedChunksCopy) {
+					auto inodeData = write_find_inodedata(inode, globalLock);
+					if (inodeData != NO_INODEDATA) {
+						if (delayed_queue_remove(inodeData, globalLock)) {
+							write_enqueue(inodeData, globalLock);
+							// job done, no need to set recentlyUnlockNoticeReceived flag
+						} else {
+							// job is being processed or waiting in the queue, so we just set
+							// recentlyUnlockNoticeReceived flag and write worker will check it
+							// when it finishes the job
+							inodeData->recentlyUnlockNoticeReceived = true;
+						}
+					}
+				}
+
+				unlockChunkNoticeLock.lock();
+			}
+
+			auto status = gUnlockChunkNoticeHandlerCond.wait_for(
+			    unlockChunkNoticeLock, std::chrono::microseconds(timeout.remaining_us()));
+			if (status == std::cv_status::no_timeout) {
+				// We have been notified about recently unlocked chunk, so we need to check it
+				// immediately
+				continue;
+			}
+		} while (timeout.remaining_us() > 0);
 	}
 	return NULL;
 }
@@ -495,6 +559,7 @@ void InodeChunkWriter::processJob(inodedata *inodeData) {
 	try {
 		try {
 			locator->locateAndLockChunk(inodeData_->inode, chunkIndex_);
+			inodeData_->recentlyUnlockNoticeReceived = false;
 			Glock lock(gMutex);
 			inodeData_->maxfleng = std::max(inodeData_->maxfleng, locator->fileLength());
 			lock.unlock();
@@ -586,6 +651,16 @@ void InodeChunkWriter::processJob(inodedata *inodeData) {
 		Glock lock(gMutex);
 		int waitTime = 1;
 		if (inodeData_->trycnt > 10) { waitTime = std::min<int>(10, inodeData_->trycnt - 9); }
+
+		if (inodeData_->recentlyUnlockNoticeReceived) {
+			// If we have received unlock notice while processing the inode data, we should try to
+			// write the inode data immediately, without waiting for a timeout, because the unlock
+			// notice is a strong signal that the inode data is now writable and we won't get any
+			// more unlock notices until we try to write the inode data again.
+			waitTime = 0;
+			inodeData_->recentlyUnlockNoticeReceived = false;
+		}
+
 		write_delayed_enqueue(inodeData_, waitTime, lock);
 	}
 }
@@ -780,6 +855,7 @@ void write_data_init(uint32_t cachesize, uint32_t retries, uint32_t workers,
 	std::lock_guard lock(gMountInfoMtx);
 	gTweaks.registerVariable("WriteMaxRetries", maxretries, "sfsioretries (write)");
 	gTweaks.registerVariable("WriteWaveTimeout", gWriteWaveTimeout, "sfschunkserverwavewriteto");
+	fs_register_packet_type_handler(SAU_MATOCL_UNLOCK_CHUNK_NOTICE, &unlockChunkNoticeHandler);
 
 	gIsInitialized = true;
 }
@@ -797,6 +873,7 @@ void write_data_term(void) {
 	jobsQueue.reset();
 	for (const auto &[_, id] : inodedataMap) { delete id; }
 	inodedataMap.clear();
+	fs_unregister_packet_type_handler(SAU_MATOCL_UNLOCK_CHUNK_NOTICE, &unlockChunkNoticeHandler);
 
 	gIsInitialized = false;
 }
@@ -1164,6 +1241,7 @@ struct ChunkData {
 	int newDataInChainPipe[2];
 	uint32_t minimumBlocksToWrite = 1;
 	std::list<WriteCacheBlock> dataChain;
+	std::atomic_bool recentlyUnlockNoticeReceived = false;
 	bool inQueue =
 	    false;  // true if this chunk is waiting in one of the queues or is being processed
 	bool workerWaitingForData = false;
@@ -1416,6 +1494,9 @@ static std::vector<ChunkData *> delayed_queue_remove(inodedata *id, Lock &) {
 	return removedChunkData;
 }
 
+// Forward declaration, needed for delayed_queue_worker to call write_enqueue
+void write_enqueue(ChunkData *chunkData, Lock &);
+
 void *delayed_queue_worker(void *) {
 	pthread_setname_np(pthread_self(), "delQueueWriter");
 
@@ -1438,7 +1519,53 @@ void *delayed_queue_worker(void *) {
 		// Update the write stats
 		updateStats(freecacheblocks);
 
-		usleep(timeout.remaining_us());
+		do {
+			Lock unlockChunkNoticeLock(gUnlockChunkNoticeHandlerMutex);
+			if (!gRecentlyUnlockedChunks.empty()) {
+				std::list<std::pair<inode_t, uint32_t>> recentlyUnlockedChunksCopy;
+				recentlyUnlockedChunksCopy.swap(gRecentlyUnlockedChunks);
+				unlockChunkNoticeLock.unlock();
+
+				Lock globalLock(gMutex);
+				for (const auto &[inode, chunkIndex] : recentlyUnlockedChunksCopy) {
+					auto inodeData = write_find_inodedata(inode, globalLock);
+					if (inodeData != NO_INODEDATA) {
+						Lock inodeLock(inodeData->mutex);
+
+						auto chunkDataListIt = std::find_if(
+						    inodeData->chunkDataList.begin(), inodeData->chunkDataList.end(),
+						    [&](ChunkDataPtr &chunkData) {
+							    return chunkData->chunkIndex == chunkIndex;
+						    });
+
+						if (chunkDataListIt != inodeData->chunkDataList.end()) {
+							ChunkData *chunkData = chunkDataListIt->get();
+							inodeLock.unlock();
+
+							if (delayed_queue_remove(chunkData, globalLock)) {
+								write_enqueue(chunkData, globalLock);
+								// job done, no need to set recentlyUnlockNoticeReceived flag
+							} else {
+								// job is being processed or waiting in the queue, so we just set
+								// recentlyUnlockNoticeReceived flag and write worker will check it
+								// when it finishes the job
+								chunkData->recentlyUnlockNoticeReceived = true;
+							}
+						}
+					}
+				}
+
+				unlockChunkNoticeLock.lock();
+			}
+
+			auto status = gUnlockChunkNoticeHandlerCond.wait_for(
+			    unlockChunkNoticeLock, std::chrono::microseconds(timeout.remaining_us()));
+			if (status == std::cv_status::no_timeout) {
+				// We have been notified about recently unlocked chunk, so we need to check it
+				// immediately
+				continue;
+			}
+		} while (timeout.remaining_us() > 0);
 	}
 	return NULL;
 }
@@ -1544,7 +1671,7 @@ private:
 	 * Check if there is any data in the same chunk waiting to be written.
 	 * inodeLock: LOCKED
 	 */
-	bool haveAnyBlockInCurrentChunk(Lock &);
+	bool haveAnyBlockInCurrentChunk();
 
 	/*
 	 * Check if there is any data worth sending to the chunkserver.
@@ -1552,7 +1679,7 @@ private:
 	 * These can be taken only if we are close to run out of tasks to do.
 	 * inodeLock: LOCKED
 	 */
-	bool haveBlockWorthWriting(uint32_t unfinishedOperationCount, Lock &);
+	bool haveBlockWorthWriting(uint32_t unfinishedOperationCount);
 	ChunkData *chunkData_ = NO_CHUNKDATA;
 	uint32_t chunkIndex_ = 0;
 	Timer wholeOperationTimer;
@@ -1582,12 +1709,13 @@ void ChunkJobWriter::processJob(ChunkData *chunkData) {
 	try {
 		try {
 			locator->locateAndLockChunk(parent->inode, chunkIndex_);
+			chunkData_->recentlyUnlockNoticeReceived = false;
 			Lock inodeLock(parent->mutex);
 			parent->maxfleng = std::max(parent->maxfleng, locator->fileLength());
 
 			// Optimization -- talk with chunkservers only if we have to write any data.
 			// Don't do this if we just have to release some previously unlocked lock.
-			if (haveAnyBlockInCurrentChunk(inodeLock)) {
+			if (haveAnyBlockInCurrentChunk()) {
 				inodeLock.unlock();
 				writer.init(locator.get(), gChunkserverTimeout_ms);
 				processDataChain(writer);
@@ -1604,7 +1732,7 @@ void ChunkJobWriter::processJob(ChunkData *chunkData) {
 			inodeLock.lock();
 			chunkData_->minimumBlocksToWrite = writer.getMinimumBlockCountWorthWriting();
 			bool canWait = !chunkData_->requiresFlushing();
-			if (!haveAnyBlockInCurrentChunk(inodeLock)) {
+			if (!haveAnyBlockInCurrentChunk()) {
 				// There is no need to wait if we have just finished writing some chunk.
 				// Let's immediately start writing the next chunk (if there is any).
 				canWait = false;
@@ -1674,6 +1802,16 @@ void ChunkJobWriter::processJob(ChunkData *chunkData) {
 		if (chunkData_->tryCounter > 10) {
 			waitTime = std::min<int>(10, chunkData_->tryCounter - 9);
 		}
+
+		if (chunkData_->recentlyUnlockNoticeReceived) {
+			// If we have received unlock notice while processing the chunk, we should try to write
+			// the chunk immediately, without waiting for a timeout, because the unlock notice is
+			// a strong signal that the chunk is now writable and we won't get any more unlock
+			// notices until we try to write the chunk again.
+			waitTime = 0;
+			chunkData_->recentlyUnlockNoticeReceived = false;
+		}
+
 		write_delayed_enqueue(chunkData_, waitTime, globalLock);
 	}
 }
@@ -1705,7 +1843,7 @@ void ChunkJobWriter::processDataChain(ChunkWriter &writer) {
 		    writer.acceptsNewOperations()) {
 			Lock inodeLock(parent->mutex);
 			// While there is any block worth sending, we add new write operation
-			while (haveBlockWorthWriting(writer.getUnfinishedOperationsCount(), inodeLock)) {
+			while (haveBlockWorthWriting(writer.getUnfinishedOperationsCount())) {
 				// Remove block from cache and pass it to the writer
 				writer.addOperation(std::move(chunkData_->dataChain.front()));
 				chunkData_->popFromChain();
@@ -1715,7 +1853,7 @@ void ChunkJobWriter::processDataChain(ChunkWriter &writer) {
 
 				inodeLock.lock();
 			}
-			if (chunkData_->requiresFlushing() && !haveAnyBlockInCurrentChunk(inodeLock)) {
+			if (chunkData_->requiresFlushing() && !haveAnyBlockInCurrentChunk()) {
 				// No more data and some flushing is needed or required, so flush everything
 				writer.startFlushMode();
 			}
@@ -1723,7 +1861,7 @@ void ChunkJobWriter::processDataChain(ChunkWriter &writer) {
 				chunkData_->workerWaitingForData = true;
 			}
 			can_expect_next_block =
-			    haveAnyBlockInCurrentChunk(inodeLock) ||
+			    haveAnyBlockInCurrentChunk() ||
 			    (parent->wasLastBlockRecentlyWritten() && chunkData_->dataChain.empty());
 		} else if (writer.acceptsNewOperations()) {
 			// We are running out of time...
@@ -1738,7 +1876,7 @@ void ChunkJobWriter::processDataChain(ChunkWriter &writer) {
 				writer.startFlushMode();
 			}
 			can_expect_next_block =
-			    haveAnyBlockInCurrentChunk(inodeLock) ||
+			    haveAnyBlockInCurrentChunk() ||
 			    (parent->wasLastBlockRecentlyWritten() && chunkData_->dataChain.empty());
 		}
 
@@ -1775,10 +1913,10 @@ void ChunkJobWriter::returnJournalToDataChain(std::list<WriteCacheBlock> &&journ
 	}
 }
 
-bool ChunkJobWriter::haveAnyBlockInCurrentChunk(Lock &) { return !chunkData_->dataChain.empty(); }
+bool ChunkJobWriter::haveAnyBlockInCurrentChunk() { return !chunkData_->dataChain.empty(); }
 
-bool ChunkJobWriter::haveBlockWorthWriting(uint32_t unfinishedOperationCount, Lock &inodeLock) {
-	if (!haveAnyBlockInCurrentChunk(inodeLock)) { return false; }
+bool ChunkJobWriter::haveBlockWorthWriting(uint32_t unfinishedOperationCount) {
+	if (!haveAnyBlockInCurrentChunk()) { return false; }
 	const auto &block = chunkData_->dataChain.front();
 	if (block.type != WriteCacheBlock::kWritableBlock) {
 		// Always write data, that was previously written
@@ -1852,6 +1990,7 @@ void write_data_init(uint32_t cachesize, uint32_t retries, uint32_t workers,
 
 	gTweaks.registerVariable("WriteMaxRetries", maxretries, "sfsioretries (write)");
 	gTweaks.registerVariable("WriteWaveTimeout", gWriteWaveTimeout, "sfschunkserverwavewriteto");
+	fs_register_packet_type_handler(SAU_MATOCL_UNLOCK_CHUNK_NOTICE, &unlockChunkNoticeHandler);
 
 	gIsInitialized = true;
 }
@@ -1870,6 +2009,7 @@ void write_data_term(void) {
 	for (const auto &[_, id] : inodedataMap) { delete id; }
 	inodedataMap.clear();
 	truncateLocatorsData.clear();
+	fs_unregister_packet_type_handler(SAU_MATOCL_UNLOCK_CHUNK_NOTICE, &unlockChunkNoticeHandler);
 
 	gIsInitialized = false;
 }

--- a/src/protocol/SFSCommunication.h
+++ b/src/protocol/SFSCommunication.h
@@ -1103,6 +1103,10 @@ enum class SugidClearMode : uint8_t {
 #define SAU_CLTOMA_UPDATE_MOUNT_INFO (1000U + 487U)
 /// mount_info:STDSTRING
 
+//0x05D0
+#define SAU_MATOCL_UNLOCK_CHUNK_NOTICE (1000U + 488U)
+/// inode:32 chunkindex:32
+
 /// version==0 msgid:32 status:8
 /// version==1 msgid:32 filelength:64 chunkid:64 chunkversion:32 locations:(N * [ip:32 port:16 label:STDSTRING chunktype:8])
 /// version==2 msgid:32 filelength:64 chunkid:64 chunkversion:32 locations:(N * [ip:32 port:16 label:STDSTRING chunktype:16])

--- a/src/protocol/matocl.h
+++ b/src/protocol/matocl.h
@@ -317,6 +317,13 @@ SAUNAFS_DEFINE_PACKET_SERIALIZATION(
 		matocl, adminRecalculateMetadataChecksum, SAU_MATOCL_ADMIN_RECALCULATE_METADATA_CHECKSUM, 0,
 		uint8_t, status)
 
+// SAU_MATOCL_UNLOCK_CHUNK_NOTICE
+SAUNAFS_DEFINE_PACKET_VERSION(matocl, unlockChunkNotice, kInodeAndChunkIndex, 0)
+SAUNAFS_DEFINE_PACKET_SERIALIZATION(
+		matocl, unlockChunkNotice, SAU_MATOCL_UNLOCK_CHUNK_NOTICE, kInodeAndChunkIndex,
+		inode_t, inode,
+		uint32_t, chunkIndex)
+
 // SAU_MATOCL_FUSE_TRUNCATE
 SAUNAFS_DEFINE_PACKET_VERSION(matocl, fuseTruncate, kStatusPacketVersion, 0)
 SAUNAFS_DEFINE_PACKET_VERSION(matocl, fuseTruncate, kFinishedPacketVersion, 1)

--- a/tests/test_suites/ShortSystemTests/test_concurrent_random_writes_on_chunk.sh
+++ b/tests/test_suites/ShortSystemTests/test_concurrent_random_writes_on_chunk.sh
@@ -1,0 +1,33 @@
+timeout_set 30 seconds
+
+CHUNKSERVERS=8 \
+	USE_RAMDISK=YES \
+	MOUNTS=4 \
+	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER" \
+	MASTER_CUSTOM_GOALS="8 ec62: \$ec(6,2)"
+	setup_local_empty_saunafs info
+
+cd "${info[mount0]}"
+
+mkdir dir
+saunafs setgoal ec62 dir
+
+times_to_repeat=512
+FILE_SIZE=$(( times_to_repeat * 4 * 1024 )) file-generate ${TEMP_DIR}/original_file
+
+# Write 4KB at a time, 1KB in each of 4 mounts, and repeat this 512 times, so that the file is
+# written in random order and with many concurrent writes.
+
+for i in $(seq 0 $((times_to_repeat - 1))); do
+	shuffled_seq=($(shuf -e $(seq 0 3)))
+	for mount in $(seq 0 3); do
+		dd if="${TEMP_DIR}/original_file" of="${info[mount${mount}]}/dir/file" bs=1K \
+			skip=$(( i * 4 + ${shuffled_seq[$mount]} )) \
+			seek=$(( i * 4 + ${shuffled_seq[$mount]} )) \
+			count=1 conv=notrunc 2>/dev/null &
+	done
+	wait
+	echo "Done writing $i-th block of 4KB"
+done
+
+MESSAGE="Validating file after concurrent random writes" expect_success file-validate dir/file


### PR DESCRIPTION
This commit targets improving the system behavior when successive write attempts happen to the same chunk.

The current behavior only let's one write operation to happen at a time, and the other operations receive usually a "chunk locked" reply. The retry procedure in the client makes this operation to sleep for 1s unless some conditions are met (like re-enqueuing it again after a certain level of writes target the same chunk). This behavior can be acceptable in the current state of code because it should only happen if the write operations come from different mounts, but this could change in the future.

The proposed changes can be described the following away:
- added gWaitForUnlockMap to store the client entries in the master
that have received "chunk locked" response from master.
- reply to those clients the new packet "unlockChunkNotice" with to
signal them that the chunk is up for new writes again.
- implemented UnlockChunkNoticeHandler in the client side to handle
those new packets. This is code ran by the receiver thread (fs_receive_thread) so it only wakes up and passes the job to the delayed queue worker thread.

The test test_concurrent_random_writes_on_chunk was added to prove the
new achieved behavior.

Closes [LS-313](https://linear.app/leil/issue/LS-313/).

Signed-off-by: Dave <dave@leil.io>