### PR TITLE
refactor(master): allow acquire and release in KV backends

### DIFF
--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -2233,8 +2233,9 @@ uint8_t FilesystemOperationsBase::checkFile(const FsContext &context, inode_t in
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t FilesystemOperationsBase::openCheck(const FsContext &context, inode_t inode, uint8_t flags,
-                                            Attributes &attr) {
+uint8_t FilesystemOperationsBase::openCheck(const FsContext &context,
+                                            const FilesystemOperationContext &fsOpContext,
+                                            inode_t inode, uint8_t flags, Attributes &attr) {
 	FSNode *p;
 
 	uint8_t status = nodeOperations_->verifySession(
@@ -2243,9 +2244,6 @@ uint8_t FilesystemOperationsBase::openCheck(const FsContext &context, inode_t in
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
-
-	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
-	    FilesystemOperationContext::TransactionType::kReadOnly);
 
 	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kFile,
 	                                              MODE_MASK_EMPTY, inode, &p);
@@ -2270,70 +2268,95 @@ uint8_t FilesystemOperationsBase::openCheck(const FsContext &context, inode_t in
 }
 #endif
 
-uint8_t FilesystemOperationsBase::acquire(const FsContext &context, inode_t inode,
-                                          uint32_t sessionid) {
-	ChecksumUpdater cu(context.ts());
+uint8_t FilesystemOperationsBase::acquire(const FsContext &context,
+                                          const FilesystemOperationContext &fsOpContext,
+                                          inode_t inode, uint32_t sessionid) {
+	ChecksumUpdater checksumUpdater(context.ts());
 #ifndef METARESTORE
 	if (context.isPersonalityShadow()) {
 		matoclserv_add_open_file(sessionid, inode);
 	}
 #endif /* #ifndef METARESTORE */
-	FSNodeFile *p = nodeOperations_->idToNode<FSNodeFile>(inode);
-	if (!p) {
-		return SAUNAFS_ERROR_ENOENT;
-	}
-	if (p->type != FSNodeType::kFile && p->type != FSNodeType::kTrash &&
-	    p->type != FSNodeType::kReserved) {
+	auto *fileNode = nodeOperations_->idToNode<FSNodeFile>(fsOpContext, inode);
+	if (!fileNode) { return SAUNAFS_ERROR_ENOENT; }
+
+	if (fileNode->type != FSNodeType::kFile && fileNode->type != FSNodeType::kTrash &&
+	    fileNode->type != FSNodeType::kReserved) {
 		return SAUNAFS_ERROR_EPERM;
 	}
-	if (std::find(p->sessionIds.begin(), p->sessionIds.end(), sessionid) != p->sessionIds.end()) {
+
+	if (std::find(fileNode->sessionIds.begin(), fileNode->sessionIds.end(), sessionid) !=
+	    fileNode->sessionIds.end()) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
-	p->sessionIds.push_back(sessionid);
-	fsnodes_update_checksum(p);
+
+	fileNode->sessionIds.push_back(sessionid);
+
+	fsnodes_update_checksum(fileNode);
+
+	// Persist the changes in KV backends
+	if (fsOpContext.hasReadWriteTransaction()) {
+		nodeOperations_->updateNode(fsOpContext, fileNode);
+	}
+
 	if (context.isPersonalityMaster()) {
 		changeLog(context.ts(), "ACQUIRE(%" PRIiNode ",%" PRIu32 ")", inode, sessionid);
 	} else {
 		gMetadata->metadataVersion++;
 	}
+
 	return SAUNAFS_STATUS_OK;
 }
 
 uint8_t FilesystemOperationsBase::release(const FsContext &context,
                                           const FilesystemOperationContext &fsOpContext,
                                           inode_t inode, uint32_t sessionid) {
-	ChecksumUpdater cu(context.ts());
-	FSNodeFile *p = nodeOperations_->idToNode<FSNodeFile>(fsOpContext, inode);
-	if (!p) {
-		return SAUNAFS_ERROR_ENOENT;
-	}
-	if (p->type != FSNodeType::kFile && p->type != FSNodeType::kTrash &&
-	    p->type != FSNodeType::kReserved) {
+	ChecksumUpdater checksumUpdater(context.ts());
+
+	auto *fileNode = nodeOperations_->idToNode<FSNodeFile>(fsOpContext, inode);
+
+	if (!fileNode) { return SAUNAFS_ERROR_ENOENT; }
+
+	if (fileNode->type != FSNodeType::kFile && fileNode->type != FSNodeType::kTrash &&
+	    fileNode->type != FSNodeType::kReserved) {
 		return SAUNAFS_ERROR_EPERM;
 	}
-	auto it = std::find(p->sessionIds.begin(), p->sessionIds.end(), sessionid);
-	if (it != p->sessionIds.end()) {
-		p->sessionIds.erase(it);
-		if (p->type == FSNodeType::kReserved && p->sessionIds.empty()) {
-			nodeOperations_->purge(fsOpContext, context.ts(), p);
+
+	auto iter = std::find(fileNode->sessionIds.begin(), fileNode->sessionIds.end(), sessionid);
+
+	if (iter != fileNode->sessionIds.end()) {
+		fileNode->sessionIds.erase(iter);
+
+		if (fileNode->type == FSNodeType::kReserved && fileNode->sessionIds.empty()) {
+			nodeOperations_->purge(fsOpContext, context.ts(), fileNode);
 		} else {
-			fsnodes_update_checksum(p);
+			fsnodes_update_checksum(fileNode);
+
+			// Persist the changes in KV backends
+			if (fsOpContext.hasReadWriteTransaction()) {
+				nodeOperations_->updateNode(fsOpContext, fileNode);
+			}
 		}
+
 #ifndef METARESTORE
 		if (context.isPersonalityShadow()) {
 			matoclserv_remove_open_file(sessionid, inode);
 		}
 #endif /* #ifndef METARESTORE */
+
 		if (context.isPersonalityMaster()) {
 			changeLog(context.ts(), "RELEASE(%" PRIiNode ",%" PRIu32 ")", inode, sessionid);
 		} else {
 			gMetadata->metadataVersion++;
 		}
+
 		return SAUNAFS_STATUS_OK;
 	}
+
 #ifndef METARESTORE
-	safs_pretty_syslog(LOG_WARNING, "release: session not found");
+	safs::log_warn("{}: session {} not found for inode {}", __func__, sessionid, inode);
 #endif
+
 	return SAUNAFS_ERROR_EINVAL;
 }
 

--- a/src/master/filesystem_operations.h
+++ b/src/master/filesystem_operations.h
@@ -74,7 +74,16 @@ public:
 	// Functions which create/apply (depending on the given context) changes to the metadata.
 	// Common for metarestore and master server (both personalities)
 
-	uint8_t acquire(const FsContext &context, inode_t inode, uint32_t sessionid) override;
+	/// Registers a session as having acquired (opened) a file.
+	/// @see IFilesystemOperations::acquire
+	uint8_t acquire(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                inode_t inode, uint32_t sessionid) override;
+
+	/// Registers a session as having released (closed) a file.
+	/// @see IFilesystemOperations::release
+	uint8_t release(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                inode_t inode, uint32_t sessionid) override;
+
 	uint8_t append(const FsContext &context, const FilesystemOperationContext &fsOpContext,
 	               inode_t inode, inode_t inode_src) override;
 	uint8_t deleteAcl(const FsContext &context, inode_t inode, AclType type) override;
@@ -94,8 +103,6 @@ public:
 	               inode_t parent_src, const HString &name_src, inode_t parent_dst,
 	               const HString &name_dst, inode_t *inode, Attributes *attr) override;
 
-	uint8_t release(const FsContext &context, const FilesystemOperationContext &fsOpContext,
-	                inode_t inode, uint32_t sessionid) override;
 	uint8_t setExtraAttr(const FsContext &context, inode_t inode, uint8_t eattr, uint8_t smode,
 	                     inode_t *sinodes, inode_t *ncinodes, inode_t *nsinodes) override;
 	uint8_t setGoal(const FsContext &context, inode_t inode, uint8_t goal, uint8_t smode,
@@ -212,8 +219,8 @@ public:
 
 	uint8_t checkFile(const FsContext &context, inode_t inode,
 	                  ChunkCountArray &chunkCount) override;
-	uint8_t openCheck(const FsContext &context, inode_t inode, uint8_t flags,
-	                  Attributes &attr) override;
+	uint8_t openCheck(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                  inode_t inode, uint8_t flags, Attributes &attr) override;
 	uint8_t getGoal(const FsContext &context, const FilesystemOperationContext &fsOpContext,
 	                inode_t inode, uint8_t gmode, GoalStatistics &fgtab,
 	                GoalStatistics &dgtab) override;

--- a/src/master/filesystem_operations_interface.h
+++ b/src/master/filesystem_operations_interface.h
@@ -83,7 +83,71 @@ public:
 	// Functions which create/apply (depending on the given context) changes to the metadata.
 	// Common for metarestore and master server (both personalities)
 
-	virtual uint8_t acquire(const FsContext &context, inode_t inode, uint32_t sessionid) = 0;
+	/// Registers a session as having acquired (opened) a file.
+	///
+	/// This method adds the specified session ID to the file's list of sessions that have
+	/// the file open. It is called when a client opens a file and is used to track file
+	/// usage across sessions. The operation ensures that:
+	/// - The target inode exists and is a valid file node (regular file, trash, or reserved)
+	/// - The session has not already acquired this file (prevents duplicate acquisitions)
+	///
+	/// For shadow personalities, this operation also updates the internal open file tracking
+	/// used by the metalogger service (matoclserv_add_open_file).
+	///
+	/// The operation updates the file node's checksum and logs the change to the changelog
+	/// on master personalities (as "ACQUIRE").
+	///
+	/// @param context The FS operation context containing user credentials, session info,
+	///                and timestamp.
+	/// @param fsOpContext The filesystem operation context (transaction).
+	/// @param inode The inode number of the file to acquire.
+	/// @param sessionid The session identifier that is acquiring the file.
+	///
+	/// @return SAUNAFS_STATUS_OK on success, or one of the following error codes:
+	///         - SAUNAFS_ERROR_ENOENT if the inode does not exist
+	///         - SAUNAFS_ERROR_EPERM if the inode is not a file, trash, or reserved node
+	///         - SAUNAFS_ERROR_EINVAL if the session has already acquired this file
+	///
+	/// @note This operation must be paired with a corresponding release() call when the
+	///       file is closed.
+	/// @note Multiple sessions can acquire the same file simultaneously.
+	virtual uint8_t acquire(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                        inode_t inode, uint32_t sessionid) = 0;
+
+	/// Unregisters a session that has released (closed) a file.
+	///
+	/// This method removes the specified session ID from the file's list of sessions that
+	/// have the file open. It is called when a client closes a file and is the counterpart
+	/// to the acquire() operation. The operation:
+	/// - Verifies the target inode exists and is a valid file node (regular file, trash,
+	///   or reserved)
+	/// - Removes the session ID from the file's session list
+	/// - For reserved files with no remaining sessions, automatically purges the file
+	///   (deletes it permanently)
+	/// - Updates the file node's checksum
+	///
+	/// For shadow personalities, this operation also updates the internal open file tracking
+	/// used by the metalogger service (matoclserv_remove_open_file).
+	///
+	/// The operation logs the change to the changelog on master personalities (as "RELEASE").
+	///
+	/// @param context The FS operation context containing user credentials, session info,
+	///                and timestamp.
+	/// @param fsOpContext The filesystem operation context (transaction).
+	/// @param inode The inode number of the file to release.
+	/// @param sessionid The session identifier that is releasing the file.
+	///
+	/// @return SAUNAFS_STATUS_OK on success, or one of the following error codes:
+	///         - SAUNAFS_ERROR_ENOENT if the inode does not exist
+	///         - SAUNAFS_ERROR_EPERM if the inode is not a file, trash, or reserved node
+	///         - SAUNAFS_ERROR_EINVAL if the session was not found in the file's session list
+	///
+	/// @note This operation should only be called after a successful acquire() for the same
+	///       session and inode.
+	/// @note Reserved files are automatically purged when their last session is released.
+	virtual uint8_t release(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                        inode_t inode, uint32_t sessionid) = 0;
+
 	virtual uint8_t append(const FsContext &context, const FilesystemOperationContext &fsOpContext,
 	                       inode_t inode, inode_t inode_src) = 0;
 	virtual uint8_t deleteAcl(const FsContext &context, inode_t inode, AclType type) = 0;
@@ -179,8 +243,7 @@ public:
 	virtual uint8_t rename(const FsContext &context, const FilesystemOperationContext &fsOpContext,
 	                       inode_t parent_src, const HString &name_src, inode_t parent_dst,
 	                       const HString &name_dst, inode_t *inode, Attributes *attr) = 0;
-	virtual uint8_t release(const FsContext &context, const FilesystemOperationContext &fsOpContext,
-	                        inode_t inode, uint32_t sessionid) = 0;
+
 	virtual uint8_t setExtraAttr(const FsContext &context, inode_t inode, uint8_t eattr,
 	                             uint8_t smode, inode_t *sinodes, inode_t *ncinodes,
 	                             inode_t *nsinodes) = 0;
@@ -732,8 +795,9 @@ public:
 
 	virtual uint8_t checkFile(const FsContext &context, inode_t inode,
 	                          ChunkCountArray &chunkCount) = 0;
-	virtual uint8_t openCheck(const FsContext &context, inode_t inode, uint8_t flags,
-	                          Attributes &attr) = 0;
+	virtual uint8_t openCheck(const FsContext &context,
+	                          const FilesystemOperationContext &fsOpContext, inode_t inode,
+	                          uint8_t flags, Attributes &attr) = 0;
 	virtual uint8_t getGoal(const FsContext &context, const FilesystemOperationContext &fsOpContext,
 	                        inode_t inode, uint8_t gmode, GoalStatistics &fgtab,
 	                        GoalStatistics &dgtab) = 0;

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -114,6 +114,10 @@ enum class ClientConnectionMode : std::uint8_t {
 const uint32_t kMaxNumberOfChunkCopies = 100U;
 constexpr uint8_t kClientInactivityTimeout = 10;
 
+/// Batch size for committing transactions.
+/// Used to avoid transaction too old errors in KV backends.
+constexpr size_t kTransactionBatchSize = 100;
+
 struct matoclserventry;
 
 // locked chunks
@@ -1538,6 +1542,24 @@ void matoclserv_update_mount_info(matoclserventry *eptr, const uint8_t *data, ui
 	}
 }
 
+/// Helper function to commit transaction batches for bulk operations.
+/// Committing in batches avoids transaction too old issues in KV backends.
+/// @param fsOpContext The filesystem operation context to commit and replace with a fresh
+/// context.
+/// @param operationCount Reference to the current operation count; reset after commit.
+[[nodiscard]] bool commitTransactionBatch(FilesystemOperationContext &fsOpContext,
+                                          size_t &operationCount) {
+	assert(fsOpContext.hasReadWriteTransaction());
+
+	auto commitResult = fsOpContext.getReadWriteTransaction()->commit();
+
+	fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+	operationCount = 0;
+
+	return commitResult;
+}
+
 void matoclserv_fuse_reserved_inodes(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	const uint8_t *ptr;
 
@@ -1561,33 +1583,64 @@ void matoclserv_fuse_reserved_inodes(matoclserventry *eptr, const uint8_t *data,
 	}
 
 	FsContext context = FsContext::getForMaster(eventloop_time());
+
 	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
 	    FilesystemOperationContext::TransactionType::kReadWrite);
 
 	changelog_disable_flush();
-	auto it = eptr->sessionData->openFilesSet.begin();
+	auto iter = eptr->sessionData->openFilesSet.begin();
 
-	while (it != eptr->sessionData->openFilesSet.end()) {
-		inode_t openFileIno = *it;
+	size_t operationCount = 0;
+
+	while (iter != eptr->sessionData->openFilesSet.end()) {
+		inode_t openFileIno = *iter;
 		if (!inodes_to_reserve.contains(openFileIno)) {
 			// erase files not belonging to the reserve inodes list provided
 			gFSOperations->release(context, fsOpContext, openFileIno, eptr->sessionData->sessionId);
-			it = eptr->sessionData->openFilesSet.erase(it);
+			iter = eptr->sessionData->openFilesSet.erase(iter);
+			operationCount++;
+
+			if (fsOpContext.hasReadWriteTransaction() && operationCount >= kTransactionBatchSize) {
+				if (!commitTransactionBatch(fsOpContext, operationCount)) {
+					safs::log_err("{}: failed to commit transaction batch for reserving inodes",
+					              __func__);
+					// KV-backends: Continue for now until the transaction retry strategy is
+					// implemented
+				}
+			}
 		} else {
 			// skip files already in session
-			it++;
+			iter++;
 			// no need to remind this file as reserved, as it is already open
 			inodes_to_reserve.erase(openFileIno);
 		}
 	}
 
 	for (const auto &inode_to_reserve : inodes_to_reserve) {
-		if (gFSOperations->acquire(context, inode_to_reserve, eptr->sessionData->sessionId) ==
-		    SAUNAFS_STATUS_OK) {
+		if (gFSOperations->acquire(context, fsOpContext, inode_to_reserve,
+		                           eptr->sessionData->sessionId) == SAUNAFS_STATUS_OK) {
 			// Insert reserved inodes into the opened files set
 			eptr->sessionData->openFilesSet.insert(inode_to_reserve);
+			operationCount++;
+
+			if (fsOpContext.hasReadWriteTransaction() && operationCount >= kTransactionBatchSize) {
+				if (!commitTransactionBatch(fsOpContext, operationCount)) {
+					safs::log_err("{}: failed to commit transaction batch for reserving inodes",
+					              __func__);
+					// KV-backends: Continue for now until the transaction retry strategy is
+					// implemented
+				}
+			}
 		}
 	}
+
+	// Commit the final batch for KV backends
+	if (fsOpContext.hasReadWriteTransaction() && operationCount > 0) {
+		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+			safs::log_err("{}: failed to commit final transaction for reserving inodes", __func__);
+		}
+	}
+
 	changelog_enable_flush();
 }
 
@@ -2804,9 +2857,20 @@ void matoclserv_fuse_open(matoclserventry *eptr, const uint8_t *data, uint32_t l
 
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = matoclserv_insert_open_file(eptr->sessionData, inode);
+		auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+		    FilesystemOperationContext::TransactionType::kReadWrite);
+
+		status = matoclserv_insert_open_file(fsOpContext, eptr->sessionData, inode);
+
 		if (status == SAUNAFS_STATUS_OK) {
-			status = gFSOperations->openCheck(context, inode, flags, attr);
+			status = gFSOperations->openCheck(context, fsOpContext, inode, flags, attr);
+		}
+
+		if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
+			if (!fsOpContext.getReadWriteTransaction()->commit()) {
+				safs::log_err("{}: transaction failed to commit: inode {}", __func__, inode);
+				status = SAUNAFS_ERROR_IO;
+			}
 		}
 	}
 
@@ -4938,12 +5002,34 @@ void matocl_locks_release(const FsContext &context, inode_t inode, uint32_t sess
 
 void matocl_close_files(Session *currentSession) {
 	FsContext context = FsContext::getForMaster(eventloop_time());
+
 	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
 	    FilesystemOperationContext::TransactionType::kReadWrite);
+
+	size_t operationCount = 0;
 
 	for (const auto &openFileInode : currentSession->openFilesSet) {
 		gFSOperations->release(context, fsOpContext, openFileInode, currentSession->sessionId);
 		matocl_locks_release(context, openFileInode, currentSession->sessionId);
+		operationCount++;
+
+		if (fsOpContext.hasReadWriteTransaction() && operationCount >= kTransactionBatchSize) {
+			if (!commitTransactionBatch(fsOpContext, operationCount)) {
+				safs::log_err(
+				    "{}: failed to commit transaction batch while closing files for session {}",
+				    __func__, currentSession->sessionId);
+				// KV-backends: Continue for now until the transaction retry strategy is implemented
+			}
+		}
+	}
+
+	// Commit the final batch for KV backends
+	if (fsOpContext.hasReadWriteTransaction() && operationCount > 0) {
+		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+			safs::log_err(
+			    "{}: failed to commit final transaction while closing files for session {}",
+			    __func__, currentSession->sessionId);
+		}
 	}
 
 	currentSession->openFilesSet.clear();

--- a/src/master/matoclserv_sessions.cc
+++ b/src/master/matoclserv_sessions.cc
@@ -28,6 +28,7 @@
 #include "common/massert.h"
 #include "common/type_defs.h"
 #include "config/cfg.h"
+#include "master/filesystem_operation_context.h"
 #include "master/filesystem_operations_interface.h"
 #include "master/metadata_backend_common.h"
 #include "protocol/SFSCommunication.h"
@@ -327,13 +328,14 @@ int matoclserv_load_sessions() {
 }
 #undef MFSSIGNATURE
 
-int matoclserv_insert_open_file(Session *currentSession, inode_t inode) {
+int matoclserv_insert_open_file(const FilesystemOperationContext &fsOpContext,
+                                Session *currentSession, inode_t inode) {
 	if (currentSession->openFilesSet.contains(inode)) {
 		return SAUNAFS_STATUS_OK;  // file already acquired - nothing to do
 	}
 
-	int status = gFSOperations->acquire(FsContext::getForMaster(eventloop_time()), inode,
-	                                    currentSession->sessionId);
+	int status = gFSOperations->acquire(FsContext::getForMaster(eventloop_time()), fsOpContext,
+	                                    inode, currentSession->sessionId);
 
 	if (status == SAUNAFS_STATUS_OK) { currentSession->openFilesSet.insert(inode); }
 

--- a/src/master/matoclserv_sessions.h
+++ b/src/master/matoclserv_sessions.h
@@ -36,6 +36,8 @@
 // From configuration
 inline uint32_t gSessionSustainTime;
 
+class FilesystemOperationContext;
+
 struct Session {
 	using GroupCache = GenericLruCache<uint32_t, FsContext::GroupsContainer, 1024>;
 	using OpenFilesSet = std::set<inode_t>;
@@ -132,7 +134,8 @@ void matoclserv_reset_session_timeouts();
 /// @param currentSession Pointer to the session
 /// @param inode The inode of the open file
 /// @return SAUNAFS_STATUS_OK if the file was successfully acquired, or an error code otherwise
-int matoclserv_insert_open_file(Session *currentSession, inode_t inode);
+int matoclserv_insert_open_file(const FilesystemOperationContext &fsOpContext,
+                                Session *currentSession, inode_t inode);
 
 /// Adds an open file to the list of open files for a given session.
 /// @param sessionId The ID of the session to which the open file will be added

--- a/src/master/restore.cc
+++ b/src/master/restore.cc
@@ -244,7 +244,21 @@ int do_acquire(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) 
 	EAT(ptr,filename,lv,',');
 	GETU32(cuid,ptr);
 	EAT(ptr,filename,lv,')');
-	return gFSOperations->acquire(FsContext::getForRestore(ts), inode, cuid);
+
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
+	int status = gFSOperations->acquire(FsContext::getForRestore(ts), fsOpContext, inode, cuid);
+
+	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
+		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+			safs::log_err("{}: transaction failed to commit: inode {}, session id {}", __func__,
+			              inode, cuid);
+			status = SAUNAFS_ERROR_IO;
+		}
+	}
+
+	return status;
 }
 
 int do_attr(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {


### PR DESCRIPTION
Enable acquire() and release() operations to persist changes in KV backends by passing FilesystemOperationContext through the call chain. These operations now call updateNode() to persist session tracking when needed.

Key changes:
- Add fsOpContext parameter to acquire(), release(), and openCheck()
- Implement transaction batching (kTransactionBatchSize=100) to avoid "transaction too old" errors in KV backends
- Add commitTransactionBatch() helper for bulk operation batching
- Update all call sites consistently

Error handling for batch operations (matoclserv_fuse_reserved_inodes, matocl_close_files) logs failures but continues with a new transaction context. This is pending a transaction retry strategy implementation. Single-operation paths properly propagate errors to callers.

The in-memory backend remains unaffected. The KV backend (under development) now has persistence infrastructure; improved error recovery will follow.

Related to: LS-311

Note: Already fixes the session not found warning in the FDB test suite (MDS).