### PR TITLE
fix(uraft): stabilize tcp status queries

### DIFF
--- a/src/uraft/uraftstatus.cc
+++ b/src/uraft/uraftstatus.cc
@@ -1,20 +1,104 @@
-#include "common/platform.h"
+#include "common/platform.h"  // IWYU pragma: keep
+
+#include <iterator>
+
+#include <syslog.h>
+
+#include <fmt/format.h>
+
 #include "uraftstatus.h"
 
-#include <iostream>
-#include <boost/format.hpp>
+namespace {
+constexpr int kStatusCachePeriodMs = 100;
+constexpr int kRetryBackoffPeriodMs = 500;
+
+enum class AcceptAction : uint8_t {
+	ImmediateRetry,  // re-arm accept immediately
+	BackoffRetry,    // retry after delay
+	Stop             // stop accepting (close acceptor)
+};
+
+AcceptAction classifyAcceptError(const boost::system::error_code &errorCode) {
+	using namespace boost::asio::error;
+
+	// Explicit shutdown / cancellation
+	// Happens on io_context stop(), acceptor.close(), or destructor.
+	if (errorCode == operation_aborted) { return AcceptAction::Stop; }
+
+	// Resource exhaustion (can cause tight loops)
+	// These MUST back off or they will spin at 100% CPU.
+	if (errorCode == no_descriptors ||  // EMFILE / ENFILE
+	    errorCode == no_memory) {       // ENOMEM
+		return AcceptAction::BackoffRetry;
+	}
+
+	// Transient / recoverable conditions
+	// Very common on Linux; retry immediately is safe.
+	if (errorCode == interrupted ||         // EINTR
+	    errorCode == try_again ||           // EAGAIN
+	    errorCode == would_block ||         // EWOULDBLOCK
+	    errorCode == connection_aborted ||  // ECONNABORTED
+	    errorCode == network_down ||        // ENETDOWN
+	    errorCode == network_reset ||       // ENETRESET
+	    errorCode == host_unreachable) {    // EHOSTUNREACH
+		return AcceptAction::ImmediateRetry;
+	}
+
+	// Programming / configuration errors
+	// These indicate a broken acceptor; continuing is pointless.
+	if (errorCode == bad_descriptor ||  // EBADF
+	    errorCode == access_denied ||   // EACCES
+	    errorCode == address_family_not_supported || errorCode == invalid_argument) {
+		return AcceptAction::Stop;
+	}
+
+	// Default: be resilient
+	// For unknown errors, prefer liveness over silence.
+	return AcceptAction::ImmediateRetry;
+}
+
+void logAsioError(int priority, const char *what, const boost::system::error_code &error) {
+	if (!error) { return; }
+	syslog(priority, "uRaftStatus: %s: %s (%d)", what, error.message().c_str(), error.value());
+}
+
+void shutdownAndCloseSocket(boost::asio::ip::tcp::socket &socket) {
+	boost::system::error_code result_error;
+
+	// Shutdown the socket on both ends.
+	socket.shutdown(boost::asio::socket_base::shutdown_both, result_error);
+	logAsioError(LOG_DEBUG, "socket shutdown failed", result_error);
+
+	// Close the socket.
+	socket.close(result_error);
+	logAsioError(LOG_DEBUG, "socket close failed", result_error);
+}
+}  // namespace
 
 uRaftStatusConnection::uRaftStatusConnection(boost::asio::io_context &ios)
-	: data_(),
-	  socket_(ios) {
+	: socket_(ios) {
+}
+
+void uRaftStatusConnection::set_data(std::shared_ptr<const std::vector<uint8_t>> data) {
+	// Safe to move: the parameter is passed by value (not a reference), so the caller's
+	// shared_ptr is unaffected. The underlying vector data remains valid until this
+	// connection destroys its reference, even if the cache is refreshed with new data.
+	data_ = std::move(data);
 }
 
 void uRaftStatusConnection::init() {
 	auto self(shared_from_this());
+	if (!data_ || data_->empty()) {
+		shutdownAndCloseSocket(socket_);
+		return;
+	}
 
-	boost::asio::async_write(socket_, boost::asio::buffer(data_),
-	[self](const boost::system::error_code & /*error*/, std::size_t /*length*/) {
-		//if (error) log();
+	boost::asio::async_write(socket_, boost::asio::buffer(*data_),
+	[self](const boost::system::error_code &error, std::size_t /*length*/) {
+		if (error && error != boost::asio::error::operation_aborted) {
+			logAsioError(LOG_WARNING, "async_write failed", error);
+		}
+		shutdownAndCloseSocket(self->socket_);
 	});
 }
 
@@ -24,23 +108,82 @@ boost::asio::ip::tcp::socket &uRaftStatusConnection::socket() {
 
 uRaftStatus::uRaftStatus(boost::asio::io_context &ios)
 	: uRaft(ios),
-	  acceptor_(ios),
-	  socket_(ios) {
+	  status_work_guard_(boost::asio::make_work_guard(status_io_)),
+	  status_cache_timer_(ios),
+	  retry_timer_(status_io_),
+	  cached_status_(std::make_shared<const std::vector<uint8_t>>()),
+	  acceptor_(status_io_) {
 }
 
 uRaftStatus::~uRaftStatus() {
+	status_work_guard_.reset();
+
+	boost::system::error_code error;
+	status_cache_timer_.cancel(error);
+	logAsioError(LOG_WARNING, "status cache timer cancel failed", error);
+
+	if (acceptor_.is_open()) {
+		acceptor_.close(error);
+		logAsioError(LOG_WARNING, "acceptor close failed", error);
+	}
+
+	status_io_.stop();
+	if (status_thread_.joinable()) {
+		status_thread_.join();
+	}
 }
 
 void uRaftStatus::init() {
 	uRaft::init();
 
-	boost::asio::ip::tcp::endpoint endpoint(boost::asio::ip::tcp::v4(), opt_.status_port);
+	// Populate the cache immediately so the first connection never returns empty.
+	{
+		std::vector<uint8_t> response;
+		storeData(response);
+		cached_status_.store(std::make_shared<const std::vector<uint8_t>>(std::move(response)),
+		                     std::memory_order_release);
+	}
 
-	acceptor_.open(endpoint.protocol());
-	acceptor_.bind(endpoint);
-	acceptor_.listen(10);
+	// IPv4-only listener
+	{
+		boost::system::error_code error_code;
+		boost::asio::ip::tcp::endpoint endpoint(boost::asio::ip::tcp::v4(), opt_.status_port);
+		using socket_base = boost::asio::socket_base;
 
+		acceptor_.open(endpoint.protocol(), error_code);
+		if (error_code) {
+			logAsioError(LOG_ERR, "acceptor.open failed", error_code);
+			return;
+		}
+
+		acceptor_.set_option(socket_base::reuse_address(true), error_code);
+		logAsioError(LOG_WARNING, "acceptor.set_option(reuse_address) failed", error_code);
+
+		acceptor_.bind(endpoint, error_code);
+		if (error_code) {
+			logAsioError(LOG_ERR, "acceptor.bind failed", error_code);
+			return;
+		}
+
+		acceptor_.listen(socket_base::max_listen_connections, error_code);
+		if (error_code) {
+			logAsioError(LOG_ERR, "acceptor.listen failed", error_code);
+			return;
+		}
+	}
+
+	// Refresh cache frequently from the main Raft io_context.
+	status_cache_timer_.expires_from_now(boost::posix_time::millisec(kStatusCachePeriodMs));
+	status_cache_timer_.async_wait([this](const boost::system::error_code &error) {
+		refreshStatusCache(error);
+	});
+
+	// Start accepting connections
 	acceptConnection();
+
+	status_thread_ = std::thread([this]() {
+		status_io_.run();
+	});
 }
 
 void uRaftStatus::set_options(const Options &opt) {
@@ -48,102 +191,134 @@ void uRaftStatus::set_options(const Options &opt) {
 	opt_ = opt;
 }
 
-/*
 void uRaftStatus::storeData(std::vector<uint8_t> &response) {
-	std::vector<uRaftStatusNodeEntry> ndata;
+	response.clear();
+	auto out = std::back_inserter(response);
 
-	ndata.reserve(node_.size());
-	for (const auto & node : node_) {
-		uRaftStatusNodeEntry entry;
-
-		entry.vote      = node.vote_granted;
-		entry.heartbeat = node.heartbeat;
-		entry.version   = node.data_version;
-		entry.valid     = node.recv;
-
-		ndata.push_back(entry);
+	const char *stateName = "UNKNOWN";
+	switch (state_.type) {
+		case kFollower:
+			stateName = "FOLLOWER";
+			break;
+		case kCandidate:
+			stateName = "CANDIDATE";
+			break;
+		case kLeader:
+			stateName = "LEADER";
+			break;
+		default:
+			break;
 	}
+	static constexpr double kMillisPerSecond = 1000.0;
 
-	matocl::uraftStatus::serialize(response,
-	                               (uint32_t)opt_.id,
-	                               (uint8_t)state_.type,
-	                               (uint64_t)state_.current_term,
-	                               (int32_t)state_.voted_for,
-	                               (int32_t)state_.leader_id,
-	                               (uint64_t)state_.data_version,
-	                               ndata);
-}
-*/
-
-void uRaftStatus::storeData(std::vector<uint8_t> &response) {
-	static const char *state_txt[kStateLast] = {"FOLLOWER", "CANDIDATE", "LEADER"};
-	std::string res;
-
-	res  = str(boost::format("SERVER ID %i\n") % opt_.id);
-	if (state_.president) res += "I'M THE BOOSSSS\n";
-	res += str(boost::format("president=%i\n") % state_.president);
-	res += str(boost::format("state=%s\n") % state_txt[state_.type]);
-	res += str(boost::format("term=%i\n") % state_.current_term);
-	res += str(boost::format("voted_for=%i\n") % state_.voted_for);
-	res += str(boost::format("leader_id=%i\n") % state_.leader_id);
-	res += str(boost::format("data_version=%i\n") % state_.data_version);
-	res += str(boost::format("loyalty_agreement=%i\n") % state_.loyalty_agreement);
-	res += str(boost::format("local_time=%i\n") % state_.local_time);
-	res += str(boost::format("blocked_promote=%i\n") % block_leader_promotion_);
+	fmt::format_to(out, "SERVER ID {}\n", opt_.id);
+	if (state_.president) {
+		fmt::format_to(out, "I'M THE BOOSSSS\n");
+	}
+	fmt::format_to(out, "president={}\n", static_cast<int>(state_.president));
+	fmt::format_to(out, "state={}\n", stateName);
+	fmt::format_to(out, "term={}\n", state_.current_term);
+	fmt::format_to(out, "voted_for={}\n", state_.voted_for);
+	fmt::format_to(out, "leader_id={}\n", state_.leader_id);
+	fmt::format_to(out, "data_version={}\n", state_.data_version);
+	fmt::format_to(out, "loyalty_agreement={}\n", static_cast<int>(state_.loyalty_agreement));
+	fmt::format_to(out, "local_time={}\n", state_.local_time);
+	fmt::format_to(out, "blocked_promote={}\n", static_cast<int>(block_leader_promotion_));
 
 	if (state_.type != kFollower) {
-		res += "votes=[";
-		for (int i = 0; i < (int)node_.size(); i++) {
-			if (i > 0) {
-				res += "|";
+		auto appendNodeLine = [&](const char *prefix, auto &&formatValue) {
+			fmt::format_to(out, "{}", prefix);
+			const int nodeCount = static_cast<int>(node_.size());
+			for (int i = 0; i < nodeCount; i++) {
+				if (i > 0) { fmt::format_to(out, "|"); }
+				formatValue(out, i);
 			}
-			res += str(boost::format("%8i") % node_[i].vote_granted);
-		}
-		res += "]\n";
+			fmt::format_to(out, "]\n");
+		};
 
-		res += "heart=[";
-		for (int i = 0; i < (int)node_.size(); i++) {
-			if (i > 0) {
-				res += "|";
-			}
-			int tm = opt_.heartbeat_period * (state_.local_time - node_[i].heartbeat);
-			res += str(boost::format("%8.2f") % (tm / 1000.));
-		}
-		res += "]\n";
+		appendNodeLine("votes=[", [&](auto outIt, int nodeIndex) {
+			fmt::format_to(outIt, "{:8}", static_cast<int>(node_[nodeIndex].vote_granted));
+		});
 
-		res += "recv =[";
-		for (int i = 0; i < (int)node_.size(); i++) {
-			if (i > 0) {
-				res += "|";
-			}
-			res += str(boost::format("%8i") % node_[i].recv);
-		}
-		res += "]\n";
+		appendNodeLine("heart=[", [&](auto outIt, int nodeIndex) {
+			const auto deltaHeartbeats = (state_.local_time >= node_[nodeIndex].heartbeat)
+			                               ? (state_.local_time - node_[nodeIndex].heartbeat)
+			                               : 0;
+			const double deltaMillis = static_cast<double>(opt_.heartbeat_period) *
+			                          static_cast<double>(deltaHeartbeats);
+			fmt::format_to(outIt, "{:8.2f}", (deltaMillis / kMillisPerSecond));
+		});
 
-		res += "ver  =[";
-		for (int i = 0; i < (int)node_.size(); i++) {
-			if (i > 0) {
-				res += "|";
-			}
-			res += str(boost::format("%8i") % node_[i].data_version);
-		}
-		res += "]\n";
+		appendNodeLine("recv =[", [&](auto outIt, int nodeIndex) {
+			fmt::format_to(outIt, "{:8}", static_cast<int>(node_[nodeIndex].recv));
+		});
+
+		appendNodeLine("ver  =[", [&](auto outIt, int nodeIndex) {
+			fmt::format_to(outIt, "{:8}", node_[nodeIndex].data_version);
+		});
 	}
-
-	response.resize(res.size());
-	std::copy(begin(res), end(res), begin(response));
 }
 
 void uRaftStatus::acceptConnection() {
-	auto conn = std::make_shared<uRaftStatusConnection>(uRaft::io_service_);
+	if (!acceptor_.is_open()) {
+		return;
+	}
 
-	acceptor_.async_accept(conn->socket(),
-	[this, conn](const boost::system::error_code & error) {
-		if (!error) {
-			storeData(conn->data_);
+	auto conn = std::make_shared<uRaftStatusConnection>(status_io_);
+	acceptor_.async_accept(conn->socket(), [this, conn](const boost::system::error_code &error) {
+		if (!error) { // Successful accept
+			// Schedule the next accept on completion (1 outstanding accept at a time).
+			acceptConnection();
+
+			boost::system::error_code result_error;
+			conn->socket().set_option(boost::asio::ip::tcp::no_delay(true), result_error);
+			logAsioError(LOG_WARNING, "set_option(TCP_NODELAY) failed", result_error);
+
+			// The atomic load increases the shared_ptr ref count, ensuring the data remains valid
+			// until the connection completes. This is safe even if the cache is refreshed with new
+			// data while the connection is active.
+			conn->set_data(cached_status_.load(std::memory_order_acquire));
 			conn->init();
+			return;
 		}
 
-		acceptConnection();
+		if (error == boost::asio::error::operation_aborted) {
+			logAsioError(LOG_DEBUG, "async_accept cancelled (shutdown)", error);
+		} else {
+			logAsioError(LOG_WARNING, "async_accept failed", error);
+		}
+
+		switch (classifyAcceptError(error)) {
+		case AcceptAction::ImmediateRetry:
+			acceptConnection();
+			break;
+		case AcceptAction::BackoffRetry:
+			retry_timer_.expires_from_now(boost::posix_time::milliseconds(kRetryBackoffPeriodMs));
+			retry_timer_.async_wait([this](const boost::system::error_code &tec) {
+				if (!tec && acceptor_.is_open()) { acceptConnection(); }
+			});
+			break;
+		case AcceptAction::Stop:
+			boost::system::error_code close_error;
+			acceptor_.close(close_error);
+			logAsioError(LOG_WARNING, "acceptor close failed", close_error);
+			return;
+		}
+	});
+}
+
+void uRaftStatus::refreshStatusCache(const boost::system::error_code &error) {
+	if (error) {
+		return;
+	}
+
+	std::vector<uint8_t> response;
+	storeData(response);
+	cached_status_.store(std::make_shared<const std::vector<uint8_t>>(std::move(response)),
+	                     std::memory_order_release);
+
+	status_cache_timer_.expires_from_now(boost::posix_time::millisec(kStatusCachePeriodMs));
+	status_cache_timer_.async_wait([this](const boost::system::error_code &error) {
+		refreshStatusCache(error);
 	});
 }

--- a/src/uraft/uraftstatus.h
+++ b/src/uraft/uraftstatus.h
@@ -1,8 +1,13 @@
 #pragma once
 
-#include "common/platform.h"
+// NOLINTNEXTLINE(misc-include-cleaner)
+#include "common/platform.h"  // IWYU pragma: keep
 
-#include <list>
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <thread>
+#include <vector>
 
 #include "uraft.h"
 
@@ -13,15 +18,19 @@
 class uRaftStatusConnection : public std::enable_shared_from_this<uRaftStatusConnection> {
 public:
 	uRaftStatusConnection(boost::asio::io_context &ios);
+	~uRaftStatusConnection() = default;
+	uRaftStatusConnection(const uRaftStatusConnection &) = delete;
+	uRaftStatusConnection &operator=(const uRaftStatusConnection &) = delete;
+	uRaftStatusConnection(uRaftStatusConnection &&) = delete;
+	uRaftStatusConnection &operator=(uRaftStatusConnection &&) = delete;
 
 	void init();
 	boost::asio::ip::tcp::socket& socket();
+	void set_data(std::shared_ptr<const std::vector<uint8_t>> data);
 
-public:
-	std::vector<uint8_t>         data_;
-
-protected:
+private:
 	boost::asio::ip::tcp::socket socket_;
+	std::shared_ptr<const std::vector<uint8_t>> data_;
 
 };
 
@@ -33,12 +42,15 @@ protected:
 class uRaftStatus : public uRaft {
 public:
 	struct Options : uRaft::Options {
-		int status_port;
+		int status_port = 0;
 	};
 
-public:
 	uRaftStatus(boost::asio::io_context &ios);
-	virtual ~uRaftStatus();
+	~uRaftStatus() override;
+	uRaftStatus(const uRaftStatus &) = delete;
+	uRaftStatus &operator=(const uRaftStatus &) = delete;
+	uRaftStatus(uRaftStatus &&) = delete;
+	uRaftStatus &operator=(uRaftStatus &&) = delete;
 
 	//! Initialize server.
 	void init();
@@ -50,8 +62,52 @@ protected:
 	void acceptConnection();
 	void storeData(std::vector<uint8_t> &response);
 
+	/// @brief Refresh the cached TCP status payload.
+	///
+	/// The TCP status server runs on a dedicated io_context thread so it can keep accepting and
+	/// replying even when the main uRaft/controller io_context is temporarily busy (e.g. due to
+	/// blocking helper invocations).
+	///
+	/// This callback periodically rebuilds the status payload on the main uRaft io_context thread
+	/// and publishes it via an atomic shared_ptr. Status connections then only read the already
+	/// prepared payload, avoiding any heavy work in the status-thread hot path.
+	///
+	/// \param error Timer completion status. When set, the refresh is skipped (e.g. shutdown).
+	void refreshStatusCache(const boost::system::error_code &error);
+
 private:
+	/// @brief Dedicated io_context used for the TCP status listener and connection I/O.
+	///
+	/// This is intentionally decoupled from the main uRaft io_context to prevent status queries
+	/// from stalling when the controller performs blocking operations on the main event loop.
+	boost::asio::io_context status_io_;
+
+	/// @brief Work guard keeping the status io_context alive until destruction.
+	boost::asio::executor_work_guard<boost::asio::io_context::executor_type> status_work_guard_;
+
+	/// @brief Thread running the status io_context event loop.
+	/// This is the thread where the TCP listener and connections run.
+	std::thread status_thread_;
+
+	/// @brief Timer used to periodically refresh the cached status payload on the main io_context.
+	/// By default, the cache is refreshed every 100ms.
+	boost::asio::deadline_timer status_cache_timer_;
+
+	/// @brief Timer used to back off accept retries on resource exhaustion.
+	///
+	/// This prevents tight accept() failure loops (e.g. file descriptor exhaustion) from spinning
+	/// at 100% CPU on the status thread.
+	boost::asio::deadline_timer retry_timer_;
+
+	/// @brief Latest serialized status payload served to TCP clients.
+	///
+	/// The payload is stored as an atomic shared_ptr so connections can safely keep a reference
+	/// to the buffer while writing, even if the cache is refreshed concurrently.
+	std::atomic<std::shared_ptr<const std::vector<uint8_t>>> cached_status_;
+
+	/// @brief TCP acceptor bound to the status port (runs on status_io_).
 	boost::asio::ip::tcp::acceptor acceptor_;
-	boost::asio::ip::tcp::socket   socket_;
+
+	/// @brief uRaft status configuration (includes the status port).
 	Options                        opt_;
 };


### PR DESCRIPTION
Previously, the uRaft process executed blocking helper operations (e.g. fork(), poll(), read()) inside runCommand(), all on the same io_context thread that also handled TCP status accept/write operations. As a result, the status handler could be delayed under load, and short-lived clients (such as nc) could disconnect before a response was written. This made the TCP status endpoint sensitive to contention and timing, leading to sporadic query failures.

This commit restructures the uRaft status server to decouple status serving from Raft execution, eliminating the random failures observed during TCP status queries.

Key changes:
- Introduce a dedicated io_context and thread for TCP status handling.
- Maintain a frequently refreshed, immutable cache of the serialized status response.
- Serve incoming status connections directly from the cached snapshot instead of generating responses per connection.
- Improve socket lifecycle handling and error reporting.

This commit fixes LS-282.

For testing the new feature, it was created `test-fix-uraft-tcp-status` branch in the Ansible repo.
This branch modifies the `uraft_deadlock_multiple_elections` scenario to validate the uRaft TCP status stability.
The new test is expected to fail for SaunaFS v5.6.0 and should pass for the branches including the fix.

Signed-off-by: Crash <<crash@leil.io>>