### PR TITLE
fix: Delayed chunk operations missing from shadow changelogs

### DIFF
--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -5804,16 +5804,25 @@ void matoclserv_wantexit() {
 	exiting = 1;
 }
 
+bool matoclserv_client_async_operations_finished() {
+	for (const auto &eptr : matoclservList) {
+		if (!eptr->delayedChunkOperations.empty()) {
+			return false;
+		}
+	}
+	return true;
+}
+
 int matoclserv_canexit() {
 	matoclserventry *adminTerminator = nullptr;
 	static bool terminatorPacketSent = false;
 
+	if (!matoclserv_client_async_operations_finished()) {
+		return 0;
+	}
+
 	for (const auto &eptr : matoclservList) {
 		if (!eptr->outputPackets.empty()) {
-			return 0;
-		}
-
-		if (!eptr->delayedChunkOperations.empty()) {
 			return 0;
 		}
 

--- a/src/master/matoclserv.h
+++ b/src/master/matoclserv.h
@@ -57,3 +57,6 @@ void matoclserv_broadcast_metadata_saved(uint8_t status);
 /// Notify interested clients about the status of metadata checksum recalculation process.
 /// @param status Status of the metadata checksum recalculation process
 void matoclserv_broadcast_metadata_checksum_recalculated(uint8_t status);
+
+/// Check whether there are any async filesystem operations that still need to finished (e.g delayed chunk operations)
+bool matoclserv_client_async_operations_finished();

--- a/src/master/matomlserv.cc
+++ b/src/master/matomlserv.cc
@@ -50,6 +50,7 @@
 #include "common/tls_session.h"
 #include "config/cfg.h"
 #include "master/filesystem.h"
+#include "master/matoclserv.h"
 #include "master/filesystem_operations_interface.h"
 #include "master/metadata_backend_common.h"
 #include "master/metadata_backend_interface.h"
@@ -102,6 +103,7 @@ static std::deque<MatomlservEntry> matomlservList;
 static int listenSocket;
 static int32_t listenSocketPollFdIndex;
 static bool gExiting = false;
+static bool gClientOpsFinished = false;
 
 // from config
 static std::string gListenHost;
@@ -912,18 +914,22 @@ void matomlserv_serve(const std::vector<pollfd> &pdesc) {
 	}
 }
 
-void matomlserv_wantexit(void) {
+void matomlserv_wantexit() {
 	gExiting = true;
-	for (auto &eptr : matomlservList) {
-		matomlserv_createpacket(&eptr, matoml::endSession::build());
-	}
-	// Now we won't create any new packets, but we will wait for all existing packets to be
-	// transmitted to shadow masters and metaloggers
 }
 
-int matomlserv_canexit(void) {
+int matomlserv_canexit() {
+	if (!gClientOpsFinished && matoclserv_client_async_operations_finished()) {
+		gClientOpsFinished = true;
+		for (auto &eptr : matomlservList) {
+			matomlserv_createpacket(&eptr, matoml::endSession::build());
+		}
+		// Now we won't create any new packets, but we will wait for all existing packets to be
+		// transmitted to shadow masters and metaloggers
+		return 0;
+	}
 	// Exit when all connections are closed
-	return matomlservList.empty();
+	return static_cast<int>(matomlservList.empty());
 }
 
 void matomlserv_become_master() {


### PR DESCRIPTION
When master begins shutting down, it will end sessions with the metaloggers/shadows. However, if there are delayed chunk operations that are still performed and they are successful, it will send to client that these have succeeded and bump the metadata version, but the metaloggers and shadows will be unaware of these changes. This can cause problems with uraft for example, when a client tries now connecting to a shadow that became master, and expects operations that it did to be done on it, causing metadata loss.

This fixes that issue by ensuring that it will end the session only when all async operations affecting the metadata are finished.

This still leaves the possibility that some metadata will be lost if master crashes or disappears abnormally (as changes to shadows/metaloggers are send async), but it should fix it for normal shutdowns.

Closes LS-317