### PR TITLE
fix(master): Fix reserved files forced cleaning LS-316

### DIFF
--- a/src/master/filesystem_periodic.cc
+++ b/src/master/filesystem_periodic.cc
@@ -575,6 +575,8 @@ static void fs_do_emptyreserved(uint32_t ts) {
 	auto it = gMetadata->reserved.begin();
 	watchdog.start();
 	while (it != gMetadata->reserved.end()) {
+		if (watchdog.expired()) { break; }
+
 		auto fsOpContext = gFSOperations->createFilesystemOperationContext(
 		    FilesystemOperationContext::TransactionType::kReadWrite);
 		auto *node =
@@ -590,16 +592,26 @@ static void fs_do_emptyreserved(uint32_t ts) {
 		assert(node->type == FSNodeType::kReserved);
 
 		auto node_id = node->id;
-		gFSOperations->nodeOperations()->purge(fsOpContext, ts, node);
+		FsContext context = FsContext::getForMaster(ts);
 
-		// Purge operation should be performed anyway
-		gFSOperations->changeLog(ts, "PURGE(%" PRIiNode ")", node_id);
+		assert(!node->sessionIds.empty());
+		auto sessionIds = node->sessionIds;
+		if (!sessionIds.empty()) {
+			for (auto &sessionId : sessionIds) {
+				uint8_t status = gFSOperations->release(context, fsOpContext, node_id, sessionId);
+				if (status != SAUNAFS_STATUS_OK) {
+					safs::log_err(
+					    "Failed to release from periodic cleaning reserved file: {}, session: {}, status: {}",
+					    node_id, sessionId, status);
+				}
+			}
+		} else {
+			safs::log_critical(
+			    "Failed to release from periodic cleaning reserved file: {}, no session associated with the file",
+			    node_id);
+		}
 
 		it = gMetadata->reserved.begin();
-
-		if (watchdog.expired()) {
-			break;
-		}
 	}
 }
 

--- a/tests/test_suites/ShortSystemTests/test_metadata_notifier.sh
+++ b/tests/test_suites/ShortSystemTests/test_metadata_notifier.sh
@@ -43,10 +43,10 @@ run_metadata_operations() {
 		sleep 1
 	done
 
-	saunafs settrashtime 10 folder1
+	saunafs settrashtime 3 folder1
 	touch folder1/file1
 	rm folder1/file1
-	sleep 1
+	sleep 6
 
 	saunafs settrashtime 0 folder1
 	touch folder1/file2
@@ -72,8 +72,9 @@ assert_notifier_log_plain() {
 		"inode 6: type=t path=/folder1/file1 (trash)"
 		"UNLINK(2,file2):7"
 		"inode 7: type=r path=/folder1/file2 (reserved)"
-		"PURGE(7)"
-		"inode 7: type=? path="
+		"PURGE(6)"
+		"RELEASE(6,1)"
+		"inode 6: type=? path="
 	)
 
 	for e in "${expected[@]}"; do
@@ -97,8 +98,9 @@ assert_notifier_log_tls() {
 		"inode 12: type=t path=/folder1/file1 (trash)"
 		"UNLINK(8,file2):13"
 		"inode 13: type=r path=/folder1/file2 (reserved)"
-		"PURGE(13)"
-		"inode 13: type=? path="
+		"PURGE(12)"
+		"RELEASE(12,1)"
+		"inode 12: type=? path="
 	)
 
 	for e in "${expected[@]}"; do

--- a/utils/metadata_notifier.cc
+++ b/utils/metadata_notifier.cc
@@ -282,6 +282,7 @@ int main(int argc, char *argv[]) {
 	std::regex accessRegex(R"(ACCESS\((\d+)\))");
 	std::regex unlinkRegex(R"(UNLINK\([^)]*\):(\d+))");
 	std::regex purgeRegex(R"(PURGE\((\d+)\))");
+	std::regex releaseRegex(R"(RELEASE\((\d+),(\d+)\))");
 
 	while (true) {
 		uint8_t temp[4096];
@@ -317,12 +318,14 @@ int main(int argc, char *argv[]) {
 				// Print log string
 				fprintf(stderr, "%s\n", str.c_str());
 
-				// If log string starts with ACCESS(<inode>), PURGE(<inode>) or
+				// If log string starts with ACCESS(<inode>), PURGE(<inode>),
+				// RELEASE(<inode>,<session_id>) or
 				// UNLINK(<parent_inode>,<name>):<unlinked_inode>, send request for path/type of
 				// that inode
 				std::smatch match;
 				if (std::regex_search(str, match, accessRegex) ||
 				    std::regex_search(str, match, unlinkRegex) ||
+				    std::regex_search(str, match, releaseRegex) ||
 				    std::regex_search(str, match, purgeRegex)) {
 					uint64_t inode = std::stoull(match[1].str());
 					sendGetPathTypeInode(sockfd, inode);


### PR DESCRIPTION
This commit fixes a bug when option EMPTY_RESERVED_FILES_PERIOD_MSECONDS is enabled on master, provoking shadow metadata servers to fail on consistent changelog sync when receiving a forced PURGE operation over a reserved file inode. This happends because our filesystem base implementation expects the changelog PURGE to be executed over trashed files only, and the priority for now is avoid any update on this core logic.

This change also includes an update on metadata notifier related test, in order to make it consistent with the new fixed behavior for the master metadata changelog generation.