### PR TITLE
chore: Delete unused options on tests LS-319

### DIFF
--- a/tests/test_suites/SanityChecks/test_metadata_reload.sh
+++ b/tests/test_suites/SanityChecks/test_metadata_reload.sh
@@ -1,8 +1,6 @@
 timeout_set 2 minutes
 
 master_cfg="METADATA_DUMP_PERIOD_SECONDS = 0"
-master_cfg+="|EMPTY_TRASH_PERIOD = 1"
-master_cfg+="|EMPTY_RESERVED_INODES_PERIOD = 1"
 
 CHUNKSERVERS=3 \
 	MOUNTS=2 \

--- a/tests/test_suites/ShortSystemTests/test_metadata_recovery.sh
+++ b/tests/test_suites/ShortSystemTests/test_metadata_recovery.sh
@@ -2,8 +2,6 @@ timeout_set 3 minutes
 
 master_cfg="METADATA_DUMP_PERIOD_SECONDS = 0"
 master_cfg+="|AUTO_RECOVERY = 1"
-master_cfg+="|EMPTY_TRASH_PERIOD = 1"
-master_cfg+="|EMPTY_RESERVED_INODES_PERIOD = 1"
 
 CHUNKSERVERS=3 \
 	MOUNTS=2 \


### PR DESCRIPTION
This commit deletes the unused options EMPTY_TRASH_PERIOD and EMPTY_RESERVED_INODES_PERIOD on the tests where they are being referenced on, in order to avoid other reviewers of the codebase to consider they are still maintained.