### PR TITLE
feat: chunkserver side chunk lock

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ if(ENABLE_CCACHE AND CCACHE_FOUND)
   message(STATUS "Using ccache")
 endif()
 
-set(DEFAULT_MIN_VERSION "5.7.0")
+set(DEFAULT_MIN_VERSION "5.8.0")
 
 include(GNUInstallDirs)
 

--- a/doc/sfsmaster.cfg.5.adoc
+++ b/doc/sfsmaster.cfg.5.adoc
@@ -290,6 +290,10 @@ for TLS connections (there is no default value).
 Path to the trusted CA certificate which is used to authenticate
 the TLS connection (there is no default value).
 
+*USE_CHUNKSERVER_SIDE_CHUNK_LOCK (EXPERIMENTAL)*:: When set to 1, enables sending
+chunk part lock messages to the chunkservers. This can be useful to track down which
+chunk parts are currently being written. Reloadable (default: 0).
+
 *EMPTY_RESERVED_FILES_PERIOD_MSECONDS (EXPERIMENTAL)*::
 Interval for periodic cleaning of reserved files, in milliseconds.
 If set to 0, the reserved files deletion is disabled. (Default: 0)

--- a/src/admin/dump_config_command.cc
+++ b/src/admin/dump_config_command.cc
@@ -128,6 +128,7 @@ const static std::unordered_map<std::string, std::string> defaultOptionsMaster =
     {"SNAPSHOT_INITIAL_BATCH_SIZE_LIMIT", "10000"},
     {"FILE_TEST_LOOP_MIN_TIME", "3600"},
     {"PRIORITIZE_DATA_PARTS", "1"},
+    {"USE_CHUNKSERVER_SIDE_CHUNK_LOCK", "0"},
     {"CREATE_EMPTY_FOLDERS_WHEN_SPACE_DEPLETED", "1"},
 };
 

--- a/src/chunkserver/bgjobs.cc
+++ b/src/chunkserver/bgjobs.cc
@@ -26,6 +26,7 @@
 #include "common/chunk_part_type.h"
 #include "common/chunk_type_with_address.h"
 #include "common/massert.h"
+#include "common/output_packet.h"
 #include "common/pcqueue.h"
 #include "devtools/TracePrinter.h"
 #include "devtools/request_log.h"
@@ -100,12 +101,37 @@ JobPool::~JobPool() {
 	for (auto &listenerInfo : listenerInfos_) { close(listenerInfo.notifierFD); }
 }
 
+uint32_t JobPool::addJobIfNotLocked(ChunkWithType chunkWithType, ChunkOperation operation,
+                                    JobCallback callback, void *extra,
+                                    ProcessJobCallback processJob, uint32_t listenerId) {
+	std::unique_lock lockedChunkLock(chunkToJobReplyMapMutex_);
+	auto it = chunkToJobReplyMap_.find(chunkWithType);
+	if (it != chunkToJobReplyMap_.end() && it->second.writeInitReceived) {
+		// Chunk is locked, store the job to be added later
+		auto &lockedChunkData = it->second;
+
+		lockedChunkData.pendingAddJobs.emplace_back(
+		    [this, operation, extra, listenerId, callback = std::move(callback),
+		     processJob = std::move(processJob)]() mutable -> uint32_t {
+			    return addJob(operation, std::move(callback), extra, std::move(processJob),
+			                  listenerId);
+		    });
+
+		return lockedChunkData.lockJobId;  // Lock guard is released here
+	}
+	lockedChunkLock.unlock();  // Release the lock before adding the job to avoid deadlocks
+
+	// Chunk is not locked, add the job immediately
+	return JobPool::addJob(operation, std::move(callback), extra, std::move(processJob),
+	                       listenerId);
+}
+
 uint32_t JobPool::addJob(ChunkOperation operation, JobCallback callback, void *extra,
                          ProcessJobCallback processJob, uint32_t listenerId) {
 	// Check if the listenerId is valid
 	if (listenerId >= listenerInfos_.size()) {
-		safs::log_warn("JobPool: addJob: Invalid listenerId {} for operation {}, resetting to 0",
-		               listenerId, static_cast<int>(operation));
+		safs::log_warn("JobPool: {}: Invalid listenerId {} for operation {}, resetting to 0",
+		               __func__, listenerId, static_cast<int>(operation));
 		listenerId = 0;  // Reset to the first listener
 	}
 
@@ -124,6 +150,29 @@ uint32_t JobPool::addJob(ChunkOperation operation, JobCallback callback, void *e
 	jobsQueue->put(
 	    jobId, operation, reinterpret_cast<uint8_t *>(listenerInfo.jobHash[jobId].get()), 1,
 	    (operation == ChunkOperation::Open || operation == ChunkOperation::GetBlocks) ? 0 : 1);
+	return jobId;
+}
+
+uint32_t JobPool::addLockJob(JobCallback callback, void *extra, uint32_t listenerId) {
+	// Check if the listenerId is valid
+	if (listenerId >= listenerInfos_.size()) {
+		safs::log_warn("JobPool: {}: Invalid listenerId {} for operation LOCK, resetting to 0",
+		               __func__, listenerId);
+		listenerId = 0;  // Reset to the first listener
+	}
+
+	auto &listenerInfo = listenerInfos_[listenerId];
+	std::unique_lock lock(listenerInfo.jobsMutex);
+	uint32_t jobId = listenerInfo.nextJobId++;
+	auto job = std::make_unique<Job>();
+	job->jobId = jobId;
+	job->callback = std::move(callback);
+	// No processJob for lock jobs, as they are just markers for locked chunks
+	job->extra = extra;
+	job->state = JobPool::State::Enabled;
+	job->listenerId = listenerId;
+	listenerInfo.jobHash[jobId] = std::move(job);
+	// Not an actual job, but a marker for a locked chunk, so never inserted into the job queue.
 	return jobId;
 }
 
@@ -531,8 +580,9 @@ uint32_t job_delete(JobPool &jobPool, JobPool::JobCallback callback, void *extra
 	JobPool::ProcessJobCallback processJob = [=]() -> uint8_t {
 		return hddInternalDelete(chunkId, chunkVersion, chunkType);
 	};
-	return jobPool.addJob(JobPool::ChunkOperation::Delete, std::move(callback), extra, processJob,
-	                      listenerId);
+	return jobPool.addJobIfNotLocked(ChunkWithType{chunkId, chunkType},
+	                                 JobPool::ChunkOperation::Delete, std::move(callback), extra,
+	                                 processJob, listenerId);
 }
 
 uint32_t job_create(JobPool &jobPool, JobPool::JobCallback callback, void *extra, uint64_t chunkId,
@@ -551,8 +601,9 @@ uint32_t job_version(JobPool &jobPool, const JobPool::JobCallback &callback, voi
 		JobPool::ProcessJobCallback processJob = [=]() -> uint8_t {
 			return hddInternalUpdateVersion(chunkId, chunkVersion, newChunkVersion, chunkType);
 		};
-		return jobPool.addJob(JobPool::ChunkOperation::ChangeVersion, callback, extra, processJob,
-		                      listenerId);
+		return jobPool.addJobIfNotLocked(ChunkWithType{chunkId, chunkType},
+		                                 JobPool::ChunkOperation::ChangeVersion, callback, extra,
+		                                 processJob, listenerId);
 	}
 	return job_invalid(jobPool, callback, extra, listenerId);
 }
@@ -564,8 +615,9 @@ uint32_t job_truncate(JobPool &jobPool, const JobPool::JobCallback &callback, vo
 		JobPool::ProcessJobCallback processJob = [=]() -> uint8_t {
 			return hddTruncate(chunkId, chunkVersion, chunkType, newChunkVersion, length);
 		};
-		return jobPool.addJob(JobPool::ChunkOperation::Truncate, callback, extra, processJob,
-		                      listenerId);
+		return jobPool.addJobIfNotLocked(ChunkWithType{chunkId, chunkType},
+		                                 JobPool::ChunkOperation::Truncate, callback, extra,
+		                                 processJob, listenerId);
 	}
 	return job_invalid(jobPool, callback, extra, listenerId);
 }
@@ -579,8 +631,9 @@ uint32_t job_duplicate(JobPool &jobPool, const JobPool::JobCallback &callback, v
 			return hddDuplicate(chunkId, chunkVersion, newChunkVersion, chunkType, chunkIdCopy,
 			                    chunkVersionCopy);
 		};
-		return jobPool.addJob(JobPool::ChunkOperation::Duplicate, callback, extra, processJob,
-		                      listenerId);
+		return jobPool.addJobIfNotLocked(ChunkWithType{chunkId, chunkType},
+		                                 JobPool::ChunkOperation::Duplicate, callback, extra,
+		                                 processJob, listenerId);
 	}
 	return job_invalid(jobPool, callback, extra, listenerId);
 }
@@ -594,8 +647,103 @@ uint32_t job_duptrunc(JobPool &jobPool, const JobPool::JobCallback &callback, vo
 			return hddDuplicateTruncate(chunkId, chunkVersion, newChunkVersion, chunkType,
 			                            chunkIdCopy, chunkVersionCopy, length);
 		};
-		return jobPool.addJob(JobPool::ChunkOperation::DuplicateTruncate, callback, extra,
-		                      processJob, listenerId);
+		return jobPool.addJobIfNotLocked(ChunkWithType{chunkId, chunkType},
+		                                 JobPool::ChunkOperation::DuplicateTruncate, callback,
+		                                 extra, processJob, listenerId);
 	}
 	return job_invalid(jobPool, callback, extra, listenerId);
+}
+
+bool JobPool::startChunkLock(const JobPool::JobCallback &callback, void *packet, uint64_t chunkId,
+                             ChunkPartType chunkType, uint32_t listenerId) {
+	std::unique_lock lock(chunkToJobReplyMapMutex_);
+	if (chunkToJobReplyMap_.contains(ChunkWithType{chunkId, chunkType})) {
+		lock.unlock();  // Release the lock before logging to avoid extra contention
+
+		safs::log_warn(
+		    "{}: Chunk lock job already exists for chunkId {:016X}, chunkType {}. Treating request "
+		    "as retransmission; not adding a new lock job.",
+		    __func__, chunkId, chunkType.toString());
+		return false;
+	}
+
+	chunkToJobReplyMap_[ChunkWithType{chunkId, chunkType}] =
+	    LockedChunkData(addLockJob(callback, packet, listenerId), listenerId);
+	return true;
+}
+
+bool JobPool::enforceChunkLock(uint64_t chunkId, ChunkPartType chunkType) {
+	std::unique_lock lock(chunkToJobReplyMapMutex_);
+	auto entry = chunkToJobReplyMap_.find(ChunkWithType{chunkId, chunkType});
+	if (entry == chunkToJobReplyMap_.end()) {
+		lock.unlock();  // Release the lock before logging to avoid extra contention
+
+		// Master was not waiting for this lock, just log and return
+		safs::log_trace("{}: No chunk lock job found for chunkId {:016X}, chunkType {}. Ignoring.",
+		                __func__, chunkId, chunkType.toString());
+		return false;
+	}
+
+	entry->second.writeInitReceived = true;
+	return true;
+}
+
+bool JobPool::releaseChunkLockEntry(uint64_t chunkId, ChunkPartType chunkType,
+                                    const char *callerName, uint32_t &lockJobId,
+                                    uint32_t &listenerId, std::vector<AddJobFunc> &pendingAddJobs) {
+	std::unique_lock lock(chunkToJobReplyMapMutex_);
+	auto entry = chunkToJobReplyMap_.find(ChunkWithType{chunkId, chunkType});
+	if (entry == chunkToJobReplyMap_.end()) {
+		lock.unlock();  // Release the lock before logging to avoid extra contention
+
+		// Master was not waiting for this lock, just log and return
+		safs::log_warn("{}: No chunk lock job found for chunkId {:016X}, chunkType {}. Ignoring.",
+		               callerName, chunkId, chunkType.toString());
+		return false;
+	}
+
+	lockJobId = entry->second.lockJobId;
+	listenerId = entry->second.listenerId;
+	pendingAddJobs = std::move(entry->second.pendingAddJobs);
+	chunkToJobReplyMap_.erase(entry);
+	return true;
+}
+
+void JobPool::endChunkLock(uint64_t chunkId, ChunkPartType chunkType, uint8_t status) {
+	uint32_t lockJobId;
+	uint32_t listenerId;
+	std::vector<AddJobFunc> pendingAddJobs;
+
+	if (!releaseChunkLockEntry(chunkId, chunkType, __func__, lockJobId, listenerId,
+	                           pendingAddJobs)) {
+		return;  // No lock job found, just return
+	}
+
+	for (const auto &addJobFunc : pendingAddJobs) { addJobFunc(); }
+
+	sendStatus(lockJobId, status, listenerId);
+}
+
+void JobPool::eraseChunkLock(uint64_t chunkId, ChunkPartType chunkType) {
+	uint32_t lockJobId;
+	uint32_t listenerId;
+	std::vector<AddJobFunc> pendingAddJobs;
+
+	if (!releaseChunkLockEntry(chunkId, chunkType, __func__, lockJobId, listenerId,
+	                           pendingAddJobs)) {
+		return;  // No lock job found, just return
+	}
+
+	for (const auto &addJobFunc : pendingAddJobs) { addJobFunc(); }
+
+	// Remove the lock job and the related packet
+	auto &listenerInfo = listenerInfos_[listenerId];
+	std::unique_lock jobsUniqueLock(listenerInfo.jobsMutex);
+	auto lockJobIterator = listenerInfo.jobHash.find(lockJobId);
+
+	if (lockJobIterator != listenerInfo.jobHash.end()) {
+		auto *outputPacket = reinterpret_cast<OutputPacket *>(lockJobIterator->second->extra);
+		delete outputPacket;
+		listenerInfo.jobHash.erase(lockJobIterator);
+	}
 }

--- a/src/chunkserver/bgjobs.h
+++ b/src/chunkserver/bgjobs.h
@@ -22,6 +22,7 @@
 
 #include "common/platform.h"
 
+#include "chunkserver-common/chunk_map.h"
 #include "chunkserver/io_buffers.h"
 #include "common/pcqueue.h"
 
@@ -87,6 +88,11 @@ public:
 	/// @return The status of the job processing.
 	using ProcessJobCallback = std::function<uint8_t()>;
 
+	/// @brief Add job functions type. It is a lambda that contains the expected parameters for add
+	/// job call.
+	/// @return The ID of the added job.
+	using AddJobFunc = std::function<uint32_t()>;
+
 	/// @brief Constructor for JobPool.
 	///
 	/// @param name Human readable name for this pool, useful for debugging.
@@ -111,6 +117,27 @@ public:
 	/// @return The ID of the added job.
 	uint32_t addJob(ChunkOperation operation, JobCallback callback, void *extra,
 	                ProcessJobCallback processJob, uint32_t listenerId = 0);
+
+	/// @brief Adds a job to the JobPool if the chunk is not locked.
+	/// If the chunk is locked, the job will be stored and added once the lock is released.
+	/// @param chunkWithType The chunk and its type associated with the job.
+	/// @param operation The type of operation to be performed on the chunk.
+	/// @param callback The callback function to be called upon job completion.
+	/// @param extra Additional data to be passed to the callback.
+	/// @param processJob The callback function to process the job.
+	/// @param listenerId The ID of the listener associated with the job.
+	/// @return The ID of the added job, or the lock job ID if the chunk is locked.
+	uint32_t addJobIfNotLocked(ChunkWithType chunkWithType, ChunkOperation operation,
+	                           JobCallback callback, void *extra, ProcessJobCallback processJob,
+	                           uint32_t listenerId = 0);
+
+	/// @brief Adds a lock job to the JobPool for a specific chunk and type.
+	/// This function is used to create a lock job that will be associated with a locked chunk.
+	/// @param callback The callback function to be called when the lock is released.
+	/// @param extra Additional data to be passed to the callback.
+	/// @param listenerId The ID of the listener associated with the job.
+	/// @return The ID of the added lock job.
+	uint32_t addLockJob(JobCallback callback, void *extra, uint32_t listenerId = 0);
 
 	/// @brief Gets the number of jobs in the JobPool.
 	uint32_t getJobCount() const;
@@ -155,6 +182,61 @@ public:
 	void changeCallback(std::list<uint32_t> &jobIds, const JobCallback &callback,
 	                    uint32_t listenerId = 0);
 
+	/// @brief Starts a chunk lock job for a specific chunk and type.
+	/// This function is triggered when the master server sends a chunk lock request for a chunk
+	/// that is not currently locked. It adds a lock job to the JobPool and associates it with the
+	/// locked chunk. If the chunk is already locked, it returns false and does not add a new job,
+	/// as the existing lock job will be responsible for handling the lock.
+	/// @param callback The callback function to be called when the lock is released.
+	/// @param packet The packet to be sent to the master server with the write end status.
+	/// @param chunkId The ID of the chunk to be locked.
+	/// @param chunkType The type of the chunk to be locked.
+	/// @param listenerId The ID of the listener associated with the job.
+	/// @return true if the lock job was successfully added, false if the chunk is already locked.
+	bool startChunkLock(const JobPool::JobCallback &callback, void *packet, uint64_t chunkId,
+	                    ChunkPartType chunkType, uint32_t listenerId = 0);
+
+	/// @brief Enforces a chunk lock for a specific chunk and type.
+	/// This function is called when the client sends a write initialization for a chunk that is
+	/// already locked, to ensure that the lock is properly enforced. From now on, the master
+	/// requests on the locked chunk will wait for the lock to be released before being processed.
+	/// @param chunkId The ID of the chunk to enforce the lock on.
+	/// @param chunkType The type of the chunk to enforce the lock on.
+	/// @return true if the lock was successfully enforced, false if no lock job was found for the
+	/// chunk.
+	bool enforceChunkLock(uint64_t chunkId, ChunkPartType chunkType);
+
+	/// @brief Releases a chunk lock entry for a specific chunk and type.
+	/// This is a helper function that returns the lock job ID, listener ID, and pending jobs
+	/// associated with a locked chunk if found, and removes the lock entry from the internal map.
+	/// @param chunkId The ID of the chunk to release the lock on.
+	/// @param chunkType The type of the chunk to release the lock on.
+	/// @param callerName The name of the function calling this helper, used for logging.
+	/// @param lockJobId The ID of the lock job associated with the chunk.
+	/// @param listenerId The ID of the listener associated with the lock job.
+	/// @param pendingAddJobs The list of pending jobs associated with the locked chunk.
+	/// @return true if the lock entry was found and released, false otherwise.
+	bool releaseChunkLockEntry(uint64_t chunkId, ChunkPartType chunkType, const char *callerName,
+	                           uint32_t &lockJobId, uint32_t &listenerId,
+	                           std::vector<AddJobFunc> &pendingAddJobs);
+
+	/// @brief Ends a chunk lock for a specific chunk and type.
+	/// This function is called when cleaning up the write operation on the locked chunk, to end the
+	/// lock and allow any pending jobs to be added and processed. It sends the write end status to
+	/// the master server and removes the lock job from the JobPool.
+	/// @param chunkId The ID of the chunk to end the lock on.
+	/// @param chunkType The type of the chunk to end the lock on.
+	/// @param status The status to be sent to the master server for the write end.
+	void endChunkLock(uint64_t chunkId, ChunkPartType chunkType, uint8_t status);
+
+	/// @brief Erases a chunk lock for a specific chunk and type.
+	/// This function is called when the master server sends a chunk unlock request for a chunk that
+	/// is currently locked. It removes the lock job from the JobPool and allows any pending jobs
+	/// that were waiting for the lock to be released to be added and processed.
+	/// @param chunkId The ID of the chunk to erase the lock on.
+	/// @param chunkType The type of the chunk to erase the lock on.
+	void eraseChunkLock(uint64_t chunkId, ChunkPartType chunkType);
+
 private:
 	/// @brief Represents a job in the JobPool.
 	struct Job {
@@ -196,6 +278,26 @@ private:
 		uint32_t nextJobId;                                          /// Next job ID to be assigned.
 	};
 
+	/// @brief Structure to hold information about a locked chunk.
+	struct LockedChunkData {
+		uint32_t lockJobId;   /// The ID of the lock job associated with the locked chunk.
+		uint32_t listenerId;  /// The ID of the listener associated with the locked chunk.
+		/// A vector of functions to add pending jobs to be executed once the lock is released.
+		std::vector<AddJobFunc> pendingAddJobs;
+		/// Flag to indicate if the write initialization has been received for the locked chunk.
+		bool writeInitReceived = false;
+
+		LockedChunkData(uint32_t lockJobId, uint32_t listenerId)
+		    : lockJobId(lockJobId), listenerId(listenerId) {}
+
+		LockedChunkData() = default;
+	};
+
+	/// Mutex to protect access to the chunkToJobReplyMap_.
+	std::mutex chunkToJobReplyMapMutex_;
+	/// Map to associate locked chunks with their corresponding lock job and pending jobs.
+	std::unordered_map<ChunkWithType, LockedChunkData, KeyOperations, KeyOperations>
+	    chunkToJobReplyMap_;
 	std::vector<ListenerInfo> listenerInfos_;          /// Vector of listener information.
 	std::string name_;                                 /// Human readable id of the JobPool.
 	uint8_t workers;                                   /// Number of worker threads in the pool.

--- a/src/chunkserver/bgjobs_unittest.cc
+++ b/src/chunkserver/bgjobs_unittest.cc
@@ -22,6 +22,8 @@
 #include <sys/poll.h>
 #include <thread>
 
+#include "common/slice_traits.h"
+
 #include "gtest/gtest.h"
 
 void mockJobCallback(uint8_t  /*status*/, void *extra) {
@@ -218,4 +220,65 @@ TEST_F(JobPoolTest, JobStatusHandling) {
 	for (uint32_t i = 0; i < kNrOperationTypes; ++i) {
 		EXPECT_EQ(counters[i].load(), 1);  // Each job should have been processed once
 	}
+}
+
+TEST_F(JobPoolTest, ChunkLocking) {
+	const uint64_t chunkId1 = 12345;
+	const uint64_t chunkId2 = 123456;
+	const uint64_t chunkId3 = 1234567;
+	const uint64_t chunkId4 = 12345678;
+	const ChunkPartType chunkType = slice_traits::standard::ChunkPartType();
+	ChunkWithType chunkWithType1{chunkId1, chunkType};
+	ChunkWithType chunkWithType2{chunkId2, chunkType};
+	ChunkWithType chunkWithType3{chunkId3, chunkType};
+	ChunkWithType chunkWithType4{chunkId4, chunkType};
+
+	jobPool->startChunkLock(mockJobCallback, &counters[0], chunkId1, chunkType, 0);
+	jobPool->startChunkLock(mockJobCallback, &counters[0], chunkId2, chunkType, 0);
+	jobPool->startChunkLock(mockJobCallback, nullptr, chunkId4, chunkType, 0);
+	jobPool->enforceChunkLock(chunkId1, chunkType);
+	jobPool->enforceChunkLock(chunkId4, chunkType);
+
+	jobPool->addJobIfNotLocked(chunkWithType1, JobPool::ChunkOperation::Read, mockJobCallback,
+	                           &counters[0], mockProcessJob);
+	std::this_thread::sleep_for(std::chrono::milliseconds(kWaitTimeMs));
+	// Job should not be processed because chunk is locked and enforced
+	EXPECT_EQ(counters[0].load(), 0);
+
+	jobPool->addJobIfNotLocked(chunkWithType2, JobPool::ChunkOperation::Read, mockJobCallback,
+	                           &counters[0], mockProcessJob);
+	std::this_thread::sleep_for(std::chrono::milliseconds(kWaitTimeMs));
+	// Job should be processed because chunk is locked but not enforced
+	EXPECT_EQ(counters[0].load(), 1);
+
+	jobPool->addJobIfNotLocked(chunkWithType3, JobPool::ChunkOperation::Read, mockJobCallback,
+	                           &counters[0], mockProcessJob);
+	std::this_thread::sleep_for(std::chrono::milliseconds(kWaitTimeMs));
+	// Job should be processed because chunk is not locked
+	EXPECT_EQ(counters[0].load(), 2);
+
+	jobPool->addJobIfNotLocked(chunkWithType4, JobPool::ChunkOperation::Read, mockJobCallback,
+	                           &counters[0], mockProcessJob);
+	jobPool->addJobIfNotLocked(chunkWithType4, JobPool::ChunkOperation::Read, mockJobCallback,
+	                           &counters[0], mockProcessJob);
+	std::this_thread::sleep_for(std::chrono::milliseconds(kWaitTimeMs));
+	// Job should not be processed because chunk is locked and enforced
+	EXPECT_EQ(counters[0].load(), 2);
+
+	jobPool->endChunkLock(chunkId1, chunkType, SAUNAFS_STATUS_OK);
+	std::this_thread::sleep_for(std::chrono::milliseconds(kWaitTimeMs));
+	// Now the job for chunkWithType1 should be processed because the lock is released and the
+	// callback for the lock job should be called
+	EXPECT_EQ(counters[0].load(), 4);
+
+	jobPool->endChunkLock(chunkId2, chunkType, SAUNAFS_STATUS_OK);
+	std::this_thread::sleep_for(std::chrono::milliseconds(kWaitTimeMs));
+	// Now the callback for the lock job of chunkWithType2 should be called
+	EXPECT_EQ(counters[0].load(), 5);
+
+	jobPool->eraseChunkLock(chunkId4, chunkType);
+	std::this_thread::sleep_for(std::chrono::milliseconds(kWaitTimeMs));
+	// Now the jobs for chunkWithType4 should be processed because the lock is released, but the
+	// callback for the lock job should not be called
+	EXPECT_EQ(counters[0].load(), 7);
 }

--- a/src/chunkserver/chunk_high_level_ops.cc
+++ b/src/chunkserver/chunk_high_level_ops.cc
@@ -24,6 +24,7 @@
 #include "chunkserver/bgjobs.h"
 #include "chunkserver/chunkserver_entry.h"
 #include "chunkserver/hdd_readahead.h"
+#include "chunkserver/masterconn.h"
 #include "chunkserver/network_stats.h"
 #include "protocol/cstocl.h"
 #include "protocol/cstocs.h"
@@ -315,6 +316,10 @@ void ReadHighLevelOp::cleanup() {
 		job_close(*workerJobPool(), kEmptyCallback, chunkId_, chunkType_);
 		isChunkOpen_ = false;
 	}
+
+	chunkId_ = 0;
+	chunkVersion_ = 0;
+	chunkType_ = slice_traits::standard::ChunkPartType();
 }
 
 bool WriteHighLevelOp::isOpenWriteJobBeingProcessed() const {
@@ -467,6 +472,7 @@ void WriteHighLevelOp::setup(uint64_t chunkId, uint32_t chunkVersion, ChunkPartT
 	chunkVersion_ = chunkVersion;
 	chunkType_ = chunkType;
 
+	isChunkLocked_ = masterconn_get_job_pool()->enforceChunkLock(chunkId_, chunkType_);
 	startOpenWriteJob();
 }
 
@@ -527,6 +533,11 @@ void WriteHighLevelOp::delayedClose() {
 }
 
 void WriteHighLevelOp::cleanup() {
+	if (chunkId_ == 0) {
+		safs::log_info("(WriteHighLevelOp::{}) Called with no chunk associated.", __func__);
+		return;
+	}
+
 	while (!writeDataBuffers_.empty()) {
 		getWriteInputBufferPool().put(std::move(writeDataBuffers_.front()));
 		writeDataBuffers_.pop_front();
@@ -541,4 +552,13 @@ void WriteHighLevelOp::cleanup() {
 		job_close(*workerJobPool(), kEmptyCallback, chunkId_, chunkType_);
 		isChunkOpen_ = false;
 	}
+
+	if (isChunkLocked_) {
+		masterconn_get_job_pool()->endChunkLock(chunkId_, chunkType_, SAUNAFS_STATUS_OK);
+	}
+	isChunkLocked_ = false;
+	partiallyCompletedWrites_.clear();
+	chunkId_ = 0;
+	chunkVersion_ = 0;
+	chunkType_ = slice_traits::standard::ChunkPartType();
 }

--- a/src/chunkserver/chunk_high_level_ops.h
+++ b/src/chunkserver/chunk_high_level_ops.h
@@ -303,6 +303,9 @@ protected:
 	///< Number of blocks to write to the device in one write job.
 	uint16_t maxBlocksPerHddWriteJob_;
 
+	/// Indicates if the chunk is locked for writing. If true, master will be waiting for the lock
+	/// to be released when the write operation finishes.
+	bool isChunkLocked_ = false;
 	uint32_t writeJobId_ = 0;       ///< ID of the current write job being processed
 	uint32_t writeJobWriteId_ = 0;  ///< Specific write operation from client
 	std::shared_ptr<InputBuffer> inputBuffer_ = nullptr;  ///< Buffer for the current write job

--- a/src/chunkserver/chunkserver_entry.cc
+++ b/src/chunkserver/chunkserver_entry.cc
@@ -200,8 +200,8 @@ void ChunkserverEntry::retryConnect() {
 void ChunkserverEntry::checkAndApplyClosed() {
 	if (writeHLO_->pendingDelayedJobs() == 0 && readHLO_->pendingDelayedJobs() == 0 &&
 	    getBlocksHLO_->pendingDelayedJobs() == 0) {
-		writeHLO_->cleanup();
-		readHLO_->cleanup();
+		if (writeHLO_->chunkId() != 0) { writeHLO_->cleanup(); }
+		if (readHLO_->chunkId() != 0) { readHLO_->cleanup(); }
 
 		state = State::Closed;
 	}

--- a/src/chunkserver/master_connection.cc
+++ b/src/chunkserver/master_connection.cc
@@ -626,14 +626,29 @@ void MasterConn::gotPacket(PacketHeader header, const MessageBuffer &message) tr
 	case SAU_MATOCS_CREATE_CHUNK:
 		createChunk(message);
 		break;
+	case SAU_MATOCS_CREATE_AND_LOCK_CHUNK:
+		createAndLockChunk(message);
+		break;
 	case SAU_MATOCS_DELETE_CHUNK:
 		deleteChunk(message);
 		break;
 	case SAU_MATOCS_SET_VERSION:
 		setChunkVersion(message);
 		break;
+	case SAU_MATOCS_SET_VERSION_AND_LOCK:
+		setChunkVersionAndLock(message);
+		break;
+	case SAU_MATOCS_LOCK_CHUNK:
+		lockChunk(message);
+		break;
+	case SAU_MATOCS_UNLOCK_CHUNK:
+		unlockChunk(message);
+		break;
 	case SAU_MATOCS_DUPLICATE_CHUNK:
 		duplicateChunk(message);
+		break;
+	case SAU_MATOCS_DUPLICATE_AND_LOCK_CHUNK:
+		duplicateAndLockChunk(message);
 		break;
 	case SAU_MATOCS_REPLICATE_CHUNK:
 		replicateChunk(message);
@@ -676,6 +691,23 @@ void MasterConn::createChunk(const std::vector<uint8_t> &data) {
 	}
 }
 
+void MasterConn::createAndLockChunk(const std::vector<uint8_t> &data) {
+	uint64_t chunkId = 0;
+	ChunkPartType chunkType = slice_traits::standard::ChunkPartType();
+	uint32_t chunkVersion = 0;
+
+	matocs::createAndLockChunk::deserialize(data, chunkId, chunkType, chunkVersion);
+	auto *outputPacket = new OutputPacket;
+	cstoma::createChunk::serialize(outputPacket->packet, chunkId, chunkType, SAUNAFS_STATUS_OK);
+	if (jobPool_) {
+		job_create(*jobPool_, sauJobFinishedAndLock(this, chunkId, chunkType), outputPacket,
+		           chunkId, chunkVersion, chunkType);
+	} else {
+		safs::log_err("MasterConn::{}: jobPool is null.", __func__);
+		delete outputPacket;
+	}
+}
+
 void MasterConn::deleteChunk(const std::vector<uint8_t> &data) {
 	uint64_t chunkId;
 	uint32_t chunkVersion;
@@ -710,6 +742,63 @@ void MasterConn::setChunkVersion(const std::vector<uint8_t> &data) {
 	}
 }
 
+void MasterConn::setChunkVersionAndLock(const std::vector<uint8_t> &data) {
+	uint64_t chunkId = 0;
+	uint32_t chunkVersion = 0;
+	uint32_t newVersion = 0;
+	ChunkPartType chunkType = slice_traits::standard::ChunkPartType();
+
+	matocs::setVersionAndLock::deserialize(data, chunkId, chunkType, chunkVersion, newVersion);
+	auto *outputPacket = new OutputPacket;
+	cstoma::setVersion::serialize(outputPacket->packet, chunkId, chunkType, 0);
+	if (jobPool_) {
+		job_version(*jobPool_, sauJobFinishedAndLock(this, chunkId, chunkType), outputPacket,
+		            chunkId, chunkVersion, chunkType, newVersion);
+	} else {
+		safs::log_err("MasterConn::{}: jobPool is null.", __func__);
+		delete outputPacket;
+	}
+}
+
+void MasterConn::lockChunk(const std::vector<uint8_t> &data) {
+	uint64_t chunkId = 0;
+	ChunkPartType chunkType = slice_traits::standard::ChunkPartType();
+	
+	matocs::chunkLock::deserialize(data, chunkId, chunkType);
+
+	auto *chunkLockOutputPacket = new OutputPacket;
+	auto *writeEndStatusOutputPacket = new OutputPacket;
+	cstoma::chunkLock::serialize(chunkLockOutputPacket->packet, chunkId, chunkType, 0);
+	cstoma::writeEndStatus::serialize(writeEndStatusOutputPacket->packet, chunkId, chunkType, 0);
+	if (jobPool_) {
+		bool createdNewLockJob = jobPool_->startChunkLock(
+		    sauJobFinished(this), writeEndStatusOutputPacket, chunkId, chunkType);
+		if (!createdNewLockJob) {
+			// A lock job for this chunk and type is already in progress, so we can free the output
+			// packet recently allocated for the job callback, as it won't be used.
+			delete writeEndStatusOutputPacket;
+		}
+
+		sauJobFinished(SAUNAFS_STATUS_OK, chunkLockOutputPacket);
+	} else {
+		safs::log_err("MasterConn::{}: jobPool is null.", __func__);
+		sauJobFinished(SAUNAFS_ERROR_NOTDONE, chunkLockOutputPacket);
+		delete writeEndStatusOutputPacket;
+	}
+}
+
+void MasterConn::unlockChunk(const std::vector<uint8_t> &data) {
+	uint64_t chunkId = 0;
+	ChunkPartType chunkType = slice_traits::standard::ChunkPartType();
+	
+	matocs::chunkUnlock::deserialize(data, chunkId, chunkType);
+	if (jobPool_) {
+		jobPool_->eraseChunkLock(chunkId, chunkType);
+	} else {
+		safs::log_err("MasterConn::{}: jobPool is null.", __func__);
+	}
+}
+
 void MasterConn::duplicateChunk(const std::vector<uint8_t> &data) {
 	uint64_t newChunkId, oldChunkId;
 	uint32_t newChunkVersion, oldChunkVersion;
@@ -724,6 +813,25 @@ void MasterConn::duplicateChunk(const std::vector<uint8_t> &data) {
 		              oldChunkVersion, chunkType, newChunkId, newChunkVersion);
 	} else {
 		safs::log_err("MasterConn::duplicateChunk: jobPool is null.");
+		delete outputPacket;
+	}
+}
+
+void MasterConn::duplicateAndLockChunk(const std::vector<uint8_t> &data) {
+	uint64_t newChunkId, oldChunkId;
+	uint32_t newChunkVersion, oldChunkVersion;
+	ChunkPartType chunkType = slice_traits::standard::ChunkPartType();
+
+	matocs::duplicateAndLockChunk::deserialize(data, newChunkId, newChunkVersion, chunkType,
+	                                           oldChunkId, oldChunkVersion);
+	auto *outputPacket = new OutputPacket;
+	cstoma::duplicateChunk::serialize(outputPacket->packet, newChunkId, chunkType, 0);
+	if (jobPool_) {
+		job_duplicate(*jobPool_, sauJobFinishedAndLock(this, newChunkId, chunkType), outputPacket,
+		              oldChunkId, oldChunkVersion, oldChunkVersion, chunkType, newChunkId,
+		              newChunkVersion);
+	} else {
+		safs::log_err("MasterConn::{}: jobPool is null.", __func__);
 		delete outputPacket;
 	}
 }
@@ -798,6 +906,30 @@ void MasterConn::replicateChunk(const std::vector<uint8_t> &data) {
 }
 
 // Callbacks
+
+std::function<void(uint8_t status, void *packet)> MasterConn::sauJobFinishedAndLock(
+    MasterConn *masterConn, uint64_t chunkId, ChunkPartType chunkType) {
+	return [masterConn, chunkId, chunkType](uint8_t status, void *packet) {
+		// The original job's output packet is sent as the response to the master's request
+		masterConn->sauJobFinished(status, packet);
+
+		if (status != SAUNAFS_STATUS_OK) {
+			return;  // If the original job failed, do not prepare the chunk lock
+		}
+
+		// After the original job is finished, we need to prepare the chunk lock
+		auto *writeEndStatusOutputPacket = new OutputPacket;
+		cstoma::writeEndStatus::serialize(writeEndStatusOutputPacket->packet, chunkId, chunkType,
+		                                  status);
+		bool createdNewLockJob = masterConn->jobPool_->startChunkLock(
+		    masterConn->sauJobFinished(masterConn), writeEndStatusOutputPacket, chunkId, chunkType);
+		if (!createdNewLockJob) {
+			// A lock job for this chunk and type is already in progress, so we can free the output
+			// packet recently allocated for the job callback, as it won't be used.
+			delete writeEndStatusOutputPacket;
+		}
+	};
+}
 
 std::function<void(uint8_t status, void *packet)> MasterConn::sauJobFinished(
     MasterConn *masterConn) {

--- a/src/chunkserver/master_connection.h
+++ b/src/chunkserver/master_connection.h
@@ -28,6 +28,7 @@
 #include <memory>
 #include <string>
 
+#include "common/chunk_part_type.h"
 #include "common/input_packet.h"
 #include "common/network_address.h"
 #include "common/output_packet.h"
@@ -140,11 +141,21 @@ public:
 
 	void createChunk(const std::vector<uint8_t> &data);
 
+	void createAndLockChunk(const std::vector<uint8_t> &data);
+
 	void deleteChunk(const std::vector<uint8_t> &data);
 
 	void setChunkVersion(const std::vector<uint8_t> &data);
 
+	void setChunkVersionAndLock(const std::vector<uint8_t> &data);
+
+	void lockChunk(const std::vector<uint8_t> &data);
+
+	void unlockChunk(const std::vector<uint8_t> &data);
+
 	void duplicateChunk(const std::vector<uint8_t> &data);
+
+	void duplicateAndLockChunk(const std::vector<uint8_t> &data);
 
 	void truncateChunk(const std::vector<uint8_t> &data);
 
@@ -155,6 +166,9 @@ public:
 	// Callbacks
 
 	static std::function<void(uint8_t status, void *packet)> sauJobFinished(MasterConn *masterConn);
+
+	static std::function<void(uint8_t status, void *packet)> sauJobFinishedAndLock(
+	    MasterConn *masterConn, uint64_t chunkId, ChunkPartType chunkType);
 
 	void sauJobFinished(uint8_t status, void *packet);
 

--- a/src/chunkserver/masterconn.cc
+++ b/src/chunkserver/masterconn.cc
@@ -141,6 +141,10 @@ void masterconn_unwantedjobfinished(uint8_t status, void *packet) {
 	MasterConn::deletePacket(packet);
 }
 
+JobPool* masterconn_get_job_pool() {
+	return gJobPool.get();
+}
+
 void masterconn_wantexit(void) { gDoTerminate.store(true); }
 
 int masterconn_canexit(void) {

--- a/src/chunkserver/masterconn.h
+++ b/src/chunkserver/masterconn.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include "chunkserver/bgjobs.h"
 #include "common/platform.h"
 
 #include <cstdint>
@@ -27,3 +28,4 @@
 void masterconn_stats(uint64_t *bin, uint64_t *bout, uint32_t *maxjobscnt);
 int masterconn_init(void);
 int masterconn_init_threads(void);
+JobPool* masterconn_get_job_pool();

--- a/src/common/event_loop.h
+++ b/src/common/event_loop.h
@@ -139,7 +139,7 @@ void eventloop_destruct();
 /*! \brief Returns event loop time. The time is updated before call to handler functions
  * and doesn't change during handlers execution.
  *
- * \return time in milliseconds.
+ * \return time in seconds.
  */
 uint32_t eventloop_time(void);
 

--- a/src/common/saunafs_version.h
+++ b/src/common/saunafs_version.h
@@ -54,3 +54,4 @@ constexpr uint32_t kFirstVersionWithChunkBasedWriteAlgorithm = saunafsVersion(5,
 constexpr uint32_t kFirstVersionWithClusterId = saunafsVersion(5, 0, 0);
 constexpr uint32_t kFirstVersionWithReadTrashReservedByHandleOffset = saunafsVersion(5, 3, 0);
 constexpr uint32_t kFirstVersionWithUnlockChunkNotice = saunafsVersion(5, 7, 0);
+constexpr uint32_t kFirstVersionWithChunkserverSideChunkLock = saunafsVersion(5, 8, 0);

--- a/src/data/sfsmaster.cfg.in
+++ b/src/data/sfsmaster.cfg.in
@@ -351,6 +351,12 @@
 ## (There is no default)
 # TLS_CA_CERT_FILE =
 
+## When set to 1, enables sending chunk part lock messages to the chunkservers.
+## This can be useful to track down which chunk parts are currently being
+## written. Reloadable. 
+## (Default: 0)
+# USE_CHUNKSERVER_SIDE_CHUNK_LOCK = 0
+
 ## Interval for periodic cleaning of reserved files, in milliseconds.
 ## If set to 0, the reserved files deletion is disabled.
 ## (Default: 0)

--- a/src/master/chunks.cc
+++ b/src/master/chunks.cc
@@ -1379,15 +1379,18 @@ uint8_t chunk_create(bool quotaExceeded, uint8_t goal, uint8_t *operation, uint6
 	if (quotaExceeded) { return SAUNAFS_ERROR_QUOTA; }
 
 	// Next check availability of chunkservers for the given goal
-	auto serversWithChunkTypes = matocsserv_getservers_for_new_chunk(goal, minServerVersion);
+	uint16_t minServerCount = 0;
+	auto serversWithChunkTypes =
+	    matocsserv_getservers_for_new_chunk(goal, minServerCount, minServerVersion);
 	if (serversWithChunkTypes.empty()) {
 		uint16_t usableChunkservers, totalChunkservers;
 		double minUsage, maxUsage;
 		matocsserv_usagedifference(&minUsage, &maxUsage, &usableChunkservers, &totalChunkservers);
 
-		if (usableChunkservers > 0 && eventloop_time() > starttime + kStartupGracePeriodSeconds) {
-			// if there are chunkservers and it's at least one minute after start then it means that
-			// there is no space left
+		if (usableChunkservers >= minServerCount &&
+		    eventloop_time() > starttime + kStartupGracePeriodSeconds) {
+			// if there are enough chunkservers and it's at least one minute after start then it
+			// means that there is no space left
 			return SAUNAFS_ERROR_NOSPACE;
 		}
 

--- a/src/master/chunks.cc
+++ b/src/master/chunks.cc
@@ -109,6 +109,7 @@ static uint64_t gEndangeredChunksMaxCapacity;
 static uint64_t gDisconnectedCounter = 0;
 inline LinearAssignmentCache gLinearAssignmentCache;
 inline bool gUseLinearAssignmentOptimizer;
+static bool gUseChunkserverSideChunkLock;
 bool gAvoidSameIpChunkservers = false;
 
 struct ChunkPart {
@@ -1176,10 +1177,11 @@ int chunk_get_partstomodify(uint64_t chunkid, int &recover, int &remove) {
 
 // Chunk operations
 
-/// @brief Performs the chunk creation operation, which consists of creating a new chunk with 
+/// @brief Performs the chunk creation operation, which consists of creating a new chunk with
 /// version 1, associating it with the given goal and sending create chunk messages to the provided
 /// chunkservers. The parts in the chunk are marked as being written (it is expecteted that client
-/// starts writing) if the corresponding chunkserver supports locking and the create chunk message was sent with locking.
+/// starts writing) if the corresponding chunkserver supports locking and the create chunk message
+/// was sent with locking.
 /// @param createdChunk A reference to a pointer where the created chunk will be stored.
 /// @param goal The goal that will be associated with the created chunk.
 /// @param serversWithChunkTypes The list of chunkservers to create the chunk on.
@@ -1197,7 +1199,8 @@ void chunk_create_operation(
 		                                        server_with_type.second));
 		bool sentChunkLock = false;
 		matocsserv_send_createchunk(server_with_type.first, createdChunk->chunkid,
-		                            server_with_type.second, createdChunk->version, sentChunkLock);
+		                            server_with_type.second, createdChunk->version,
+		                            gUseChunkserverSideChunkLock, sentChunkLock);
 
 		if (sentChunkLock) { createdChunk->parts.back().mark_being_written(); }
 		// If the chunk lock was not sent, it means that the chunkserver does not support locking,
@@ -1221,14 +1224,14 @@ void chunk_increase_version_operation(Chunk *chunk, bool needsLocking) {
 			part.version = chunk->version + 1;
 			// If part is already being written then we don't need to ask the chunkserver to lock
 			// it again, and we can just increase the version.
-			bool partNeedsLocking = !part.is_being_written() && needsLocking;
+			bool partNeedsLocking =
+			    !part.is_being_written() && needsLocking && gUseChunkserverSideChunkLock;
 			bool sentChunkLock = false;
 			matocsserv_send_setchunkversion(part.server(), chunk->chunkid, chunk->version + 1,
-			                                chunk->version, part.type, partNeedsLocking, sentChunkLock);
+			                                chunk->version, part.type, partNeedsLocking,
+			                                sentChunkLock);
 
-			if (partNeedsLocking && sentChunkLock) {
-				part.mark_being_written();
-			}
+			if (partNeedsLocking && sentChunkLock) { part.mark_being_written(); }
 		}
 	}
 
@@ -1244,18 +1247,20 @@ void chunk_increase_version_operation(Chunk *chunk, bool needsLocking) {
 void chunk_lock_operation(Chunk *chunk) {
 	bool mustWaitForReply = false;
 	assert(chunk->isWritable());
-	for (auto &part : chunk->parts) {
-		if (part.is_valid()) {
-			if (part.is_busy()) { continue; }
-			// No busy parts from now on
+	if (gUseChunkserverSideChunkLock) {
+		for (auto &part : chunk->parts) {
+			if (part.is_valid()) {
+				if (part.is_busy()) { continue; }
+				// No busy parts from now on
 
-			bool sentChunkLock = false;
-			matocsserv_send_chunklock(part.server(), chunk->chunkid, part.type,
-			                          !part.is_being_written(), sentChunkLock);
-			if (sentChunkLock) {
-				part.mark_being_written();
-				mustWaitForReply = true;
-				part.mark_busy();
+				bool sentChunkLock = false;
+				matocsserv_send_chunklock(part.server(), chunk->chunkid, part.type,
+				                          !part.is_being_written(), sentChunkLock);
+				if (sentChunkLock) {
+					part.mark_being_written();
+					mustWaitForReply = true;
+					part.mark_busy();
+				}
 			}
 		}
 	}
@@ -1294,7 +1299,8 @@ void chunk_duplicate_operation(Chunk *originalChunk, uint8_t goal, Chunk *&newCh
 			bool sentChunkLock = false;
 			matocsserv_send_duplicatechunk(oldPart.server(), newChunk->chunkid, newChunk->version,
 			                               oldPart.type, originalChunk->chunkid,
-			                               originalChunk->version, sentChunkLock);
+			                               originalChunk->version, gUseChunkserverSideChunkLock,
+			                               sentChunkLock);
 
 			if (sentChunkLock) { newChunk->parts.back().mark_being_written(); }
 		}
@@ -3232,6 +3238,7 @@ void chunk_reload(void) {
 	gAvoidSameIpChunkservers = cfg_getuint32("AVOID_SAME_IP_CHUNKSERVERS", 0);
 	gRedundancyLevel = cfg_getuint32("REDUNDANCY_LEVEL", 0);
 	gUseLinearAssignmentOptimizer = cfg_getuint32("USE_LINEAR_ASSIGNMENT_OPTIMIZER", 1);
+	gUseChunkserverSideChunkLock = cfg_getuint32("USE_CHUNKSERVER_SIDE_CHUNK_LOCK", 0);
 
 	uint32_t disableChunksDel = cfg_getuint32("DISABLE_CHUNKS_DEL", 0);
 	if (disableChunksDel) {
@@ -3327,6 +3334,7 @@ int chunk_strinit(void) {
 	gAvoidSameIpChunkservers = cfg_getuint32("AVOID_SAME_IP_CHUNKSERVERS", 0);
 	gRedundancyLevel = cfg_getuint32("REDUNDANCY_LEVEL", 0);
 	gUseLinearAssignmentOptimizer = cfg_getuint32("USE_LINEAR_ASSIGNMENT_OPTIMIZER", 1);
+	gUseChunkserverSideChunkLock = cfg_getuint32("USE_CHUNKSERVER_SIDE_CHUNK_LOCK", 0);
 
 	if (disableChunksDel) {
 		MaxDelHardLimit = MaxDelSoftLimit = 0;

--- a/src/master/chunks.cc
+++ b/src/master/chunks.cc
@@ -126,14 +126,13 @@ struct ChunkPart {
 	ChunkPartType type; /*!< Part type. */
 	uint16_t csid : 13; /*!< Chunkserver id. */
 	uint16_t state : 3; /*!< Chunk part state. */
+	bool beingWritten = false;  /*!< Indicates if the chunk part is being written, i.e locked. */
 
-	ChunkPart() : version(0), type(), csid(0), state(INVALID) {
-	}
+	ChunkPart() : version(0), type(), csid(0), state(INVALID) {}
 
 	ChunkPart(uint16_t part_csid, int part_state, uint32_t part_version,
 	          const ChunkPartType &part_type)
-	    : version(part_version), type(part_type), csid(part_csid), state(part_state) {
-	}
+	    : version(part_version), type(part_type), csid(part_csid), state(part_state) {}
 
 	bool is_busy() const {
 		return state == BUSY || state == TDBUSY;
@@ -147,6 +146,12 @@ struct ChunkPart {
 		return state == TDVALID || state == TDBUSY;
 	}
 
+	bool is_being_written() const { return beingWritten; }
+
+	void mark_being_written() { beingWritten = true; }
+
+	void unmark_being_written() { beingWritten = false; }
+
 	void mark_busy() {
 		switch (state) {
 		case VALID:
@@ -159,6 +164,7 @@ struct ChunkPart {
 			sassert(!"ChunkPartInfo::mark_busy(): wrong state");
 		}
 	}
+
 	void unmark_busy() {
 		switch (state) {
 		case BUSY:
@@ -171,6 +177,7 @@ struct ChunkPart {
 			sassert(!"ChunkPartInfo::unmark_busy(): wrong state");
 		}
 	}
+
 	void mark_todel() {
 		switch (state) {
 		case VALID:
@@ -183,6 +190,7 @@ struct ChunkPart {
 			sassert(!"ChunkPartInfo::mark_todel(): wrong state");
 		}
 	}
+
 	void unmark_todel() {
 		switch (state) {
 		case TDVALID:
@@ -223,6 +231,7 @@ static bool     RebalancingBetweenLabels = false;
 
 static uint32_t jobsnorepbefore;
 
+constexpr uint32_t kStartupGracePeriodSeconds = 60;
 static uint32_t starttime;
 #endif // METARESTORE
 
@@ -232,14 +241,15 @@ class Chunk {
 	static_assert(ChunksAvailabilityState::kStateCount <= 3, "not enough space for chunk state");
 
 public:
-	/* chunk.operation */
-	enum {
+	/// @brief Current operation being performed on the chunk by chunkservers
+	enum ChunkOperation : uint8_t {
 		NONE,
 		CREATE,
 		SET_VERSION,
 		DUPLICATE,
 		TRUNCATE,
-		DUPTRUNC
+		DUPTRUNC,
+		LOCK
 	};
 
 	uint64_t chunkid;
@@ -256,9 +266,19 @@ public:
 	uint32_t lockedto;
 #ifndef METARESTORE
 	uint8_t inEndangeredQueue:1;
-	uint8_t needverincrease:1;
-	uint8_t interrupted:1;
-	uint8_t operation:3;
+	/// @brief Indicates whether the chunk version needs to be increased. This may be needed due to
+	///        a variety of reasons, e.g., disconnected parts, repair and replicate operations, etc.
+	///        The use of this flag happens at the beginning of the next write operation, forcing
+	///        the chunk version to be increased.
+	uint8_t needVersionIncrease : 1;
+	/// @brief Indicates whether the chunk operation or write was interrupted. This may happen when
+	///        chunkserver disconnects during the operation or sends an error status. The use
+	///        of this flag happens at the end of the current operation, forcing the chunk version
+	///        to be increased to avoid inconsistencies.
+	uint8_t interrupted : 1;
+	/// @brief Current operation being performed on the chunk by chunkservers
+	uint8_t operation : 3;
+
 private:
 	uint8_t allAvailabilityState_:2;
 	uint8_t copiesInStats_:4;
@@ -287,7 +307,7 @@ public:
 		checksum = 0;
 #ifndef METARESTORE
 		inEndangeredQueue = 0;
-		needverincrease = 1;
+		needVersionIncrease = 1;
 		interrupted = 0;
 		operation = Chunk::NONE;
 		parts.clear();
@@ -453,7 +473,15 @@ public:
 	}
 
 	bool isLocked() const {
-		return lockedto >= eventloop_time();
+		/// Chunk is considered locked if the current time is less than lockedto (not unlocked by
+		/// client) or if it is being written and lockedto is 0: which means client has unlocked the
+		/// chunk but the chunk parts are still being written.
+		if (lockedto >= eventloop_time()) { return true; }
+
+		bool isChunkBeingWritten = std::any_of(
+		    parts.begin(), parts.end(),
+		    [](const ChunkPart &part) { return part.is_being_written() && part.is_valid(); });
+		return isChunkBeingWritten && lockedto == 0;
 	}
 
 	void markCopyAsHavingWrongVersion(ChunkPart &part) {
@@ -463,6 +491,7 @@ public:
 
 	void invalidateCopy(ChunkPart &part) {
 		part.state = ChunkPart::INVALID;
+		part.beingWritten = false;
 		part.version = 0;
 		updateStats();
 	}
@@ -811,58 +840,100 @@ Chunk *chunk_new(uint64_t chunkid, uint32_t chunkversion) {
 }
 
 #ifndef METARESTORE
+void chunk_increase_version_operation(Chunk *targetChunk, bool needsLocking);
+
 void chunk_emergency_increase_version(Chunk *c) {
-	assert(c->isWritable());
-	for (auto &part : c->parts) {
-		if (part.is_valid()) {
-			if (!part.is_busy()) {
-				part.mark_busy();
-			}
-			part.version = c->version+1;
-			matocsserv_send_setchunkversion(part.server(),c->chunkid,c->version+1,c->version,
-					part.type);
-		}
-	}
-	c->interrupted = 0;
-	c->operation = Chunk::SET_VERSION;
-	c->version++;
+	chunk_increase_version_operation(c, false);
 	chunk_update_checksum(c);
 	gFSOperations->increaseChunkVersion(c->chunkid);
 	emit_chunk_changed(c);
 }
 
+/// @brief This function should be called when an operation on a chunk fails (chunk not writable)
+/// and the client should be notified about it after all the operation replies are received.
+/// @param c The chunk on which the operation was performed.
 void chunk_finalize_failed_operation(Chunk *c) {
 	if (c->operation == Chunk::CREATE) {
 		matoclserv_chunk_status(c->chunkid, SAUNAFS_ERROR_CHUNKLOST, true);
+	} else if (c->operation == Chunk::LOCK) {
+		// The client tried to lock the chunk, but it is not writable anymore. We need to notify the
+		// client about it, so that it can retry the operation and get a chance to lock the chunk
+		// when it becomes writable again.
+		matoclserv_chunk_status(c->chunkid, SAUNAFS_ERROR_CHUNKLOST);
 	} else {
 		matoclserv_chunk_status(c->chunkid, SAUNAFS_ERROR_NOTDONE);
 	}
 	c->operation = Chunk::NONE;
+
+	for (auto &part : c->parts) {
+		if (!part.is_valid() || part.is_busy() || part.is_todel() || !part.is_being_written()) {
+			continue;
+		}
+		// No valid parts should be busy, but some of them may be marked as being written if the
+		// failure happened when expecting writes to start right away. We need to unlock the parts
+		// in the chunkserver side and mark them as not being written to avoid inconsistencies.
+		part.unmark_being_written();
+		matocsserv_send_chunkunlock(part.server(), c->chunkid, part.type);
+	}
 }
 
 void chunk_handle_disconnected_copies(Chunk *c) {
-	auto it = std::remove_if(c->parts.begin(), c->parts.end(), [](const ChunkPart &part) {
-		return csdb_find(part.csid)->eptr == nullptr;
+	bool any_lost_copy_being_written = false;
+	auto it = std::remove_if(c->parts.begin(), c->parts.end(), [&](const ChunkPart &part) {
+		if (csdb_find(part.csid)->eptr == nullptr) {
+			if (part.is_being_written()) { any_lost_copy_being_written = true; }
+			return true;
+		}
+		return false;
 	});
 	bool lost_copy_found = it != c->parts.end();
 
 	if (lost_copy_found) {
 		c->parts.erase(it, c->parts.end());
-		c->needverincrease = 1;
+		c->needVersionIncrease = 1;
 		c->updateStats();
 	}
 
+	if (any_lost_copy_being_written) {
+		// The lost copy while being written may lead to inconsistencies, so we
+		// mark the operation as interrupted to increase the chunk version later.
+		c->interrupted = 1;
+	}
+
 	if (lost_copy_found && c->operation != Chunk::NONE) {
-		bool any_copy_busy = std::any_of(c->parts.begin(), c->parts.end(), [](const ChunkPart &part) {
-			return part.is_busy();
-		});
+		bool any_copy_busy = std::any_of(c->parts.begin(), c->parts.end(),
+		                                 [](const ChunkPart &part) { return part.is_busy(); });
+
 		if (any_copy_busy) {
+			// Wait for the remaining operation replies to arrive, but mark the operation as
+			// interrupted to increase the chunk version later (when the other replies arrive).
 			c->interrupted = 1;
 		} else {
 			if (c->isWritable()) {
 				chunk_emergency_increase_version(c);
 			} else {
 				chunk_finalize_failed_operation(c);
+			}
+		}
+	} else if (any_lost_copy_being_written) {
+		// implies operation == NONE
+		bool any_copy_being_written =
+		    std::any_of(c->parts.begin(), c->parts.end(),
+		                [](const ChunkPart &part) { return part.is_being_written(); });
+
+		if (any_copy_being_written) {
+			// Wait for remaining write replies to arrive, but mark the operation as interrupted
+			// to increase the chunk version later (when the other replies arrive).
+			c->interrupted = 1;
+		} else if (c->interrupted) {
+			if (c->isWritable()) {
+				// If there was an interrupted write, we need to increase the version
+				chunk_emergency_increase_version(c);
+			} else {
+				// If the chunk is not writable anymore, log the error
+				safs::log_warn(
+				    "{}: Chunk {} became not writable after losing copies during an operation.",
+				    __func__, c->chunkid);
 			}
 		}
 	}
@@ -1039,11 +1110,18 @@ int chunk_unlock(uint64_t chunkid) {
 	emit_chunk_changed(c);
 
 #ifndef METARESTORE
-	// If the chunk is not locked anymore, we can try to send notices about the operation
-	// status to clients waiting for the lock release.
-	matoclserv_notify_unlock_list(chunkid);
+	if (!c->isLocked()) {
+		// If the chunk is not locked anymore, we can try to send notices about the operation
+		// status to clients waiting for the lock release.
+		matoclserv_notify_unlock_list(chunkid);
+	}
 #endif
 	return SAUNAFS_STATUS_OK;
+}
+
+bool should_increase_chunk_version_on_modification(uint8_t operation) {
+	return operation == Chunk::CREATE || operation == Chunk::SET_VERSION ||
+	       operation == Chunk::TRUNCATE;
 }
 
 #ifndef METARESTORE
@@ -1096,218 +1174,432 @@ int chunk_get_partstomodify(uint64_t chunkid, int &recover, int &remove) {
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t chunk_multi_modify(uint64_t ochunkid, uint32_t *lockid, uint8_t goal,
-		bool usedummylockid, bool quota_exceeded, uint8_t *opflag, uint64_t *nchunkid,
-		uint32_t min_server_version = 0) {
-	Chunk *c = NULL;
-	if (ochunkid == 0) { // new chunk
-		if (quota_exceeded) {
-			return SAUNAFS_ERROR_QUOTA;
-		}
-		auto serversWithChunkTypes = matocsserv_getservers_for_new_chunk(goal, min_server_version);
-		if (serversWithChunkTypes.empty()) {
-			uint16_t uscount,tscount;
-			double minusage,maxusage;
-			matocsserv_usagedifference(&minusage,&maxusage,&uscount,&tscount);
-			if ((uscount > 0) && (eventloop_time() > (starttime+600))) { // if there are chunkservers and it's at least one minute after start then it means that there is no space left
-				return SAUNAFS_ERROR_NOSPACE;
-			} else {
-				return SAUNAFS_ERROR_NOCHUNKSERVERS;
+// Chunk operations
+
+/// @brief Performs the chunk creation operation, which consists of creating a new chunk with 
+/// version 1, associating it with the given goal and sending create chunk messages to the provided
+/// chunkservers. The parts in the chunk are marked as being written (it is expecteted that client
+/// starts writing) if the corresponding chunkserver supports locking and the create chunk message was sent with locking.
+/// @param createdChunk A reference to a pointer where the created chunk will be stored.
+/// @param goal The goal that will be associated with the created chunk.
+/// @param serversWithChunkTypes The list of chunkservers to create the chunk on.
+void chunk_create_operation(
+    Chunk *&createdChunk, uint8_t goal,
+    std::vector<std::pair<matocsserventry *, ChunkPartType>> &serversWithChunkTypes) {
+	createdChunk = chunk_new(ChunksMetadata::getAndIncrementNextChunkId(), 1);
+	createdChunk->interrupted = 0;
+	createdChunk->operation = Chunk::CREATE;
+	chunk_add_file_int(createdChunk, goal);
+
+	for (const auto &server_with_type : serversWithChunkTypes) {
+		createdChunk->parts.push_back(ChunkPart(matocsserv_get_csdb(server_with_type.first)->csid,
+		                                        ChunkPart::BUSY, createdChunk->version,
+		                                        server_with_type.second));
+		bool sentChunkLock = false;
+		matocsserv_send_createchunk(server_with_type.first, createdChunk->chunkid,
+		                            server_with_type.second, createdChunk->version, sentChunkLock);
+
+		if (sentChunkLock) { createdChunk->parts.back().mark_being_written(); }
+		// If the chunk lock was not sent, it means that the chunkserver does not support locking,
+		// so the part is not marked as being written.
+	}
+
+	createdChunk->updateStats();
+}
+
+/// @brief Performs the chunk version increase operation, which consists of increasing the chunk
+/// version and sending setchunkversion messages to all valid parts in the chunk.
+/// @param chunk A pointer to the chunk whose version will be increased.
+/// @param needsLocking A boolean indicating whether locking is needed, i.e it is expected that
+/// client will start writing right after the version increase.
+void chunk_increase_version_operation(Chunk *chunk, bool needsLocking) {
+	assert(chunk->isWritable());
+	for (auto &part : chunk->parts) {
+		if (part.is_valid()) {
+			if (!part.is_busy()) { part.mark_busy(); }
+
+			part.version = chunk->version + 1;
+			// If part is already being written then we don't need to ask the chunkserver to lock
+			// it again, and we can just increase the version.
+			bool partNeedsLocking = !part.is_being_written() && needsLocking;
+			bool sentChunkLock = false;
+			matocsserv_send_setchunkversion(part.server(), chunk->chunkid, chunk->version + 1,
+			                                chunk->version, part.type, partNeedsLocking, sentChunkLock);
+
+			if (partNeedsLocking && sentChunkLock) {
+				part.mark_being_written();
 			}
 		}
-		ChunkCopiesCalculator calculator(gFSOperations->getGoalDefinition(goal));
-		for (const auto &server_with_type : serversWithChunkTypes) {
-			calculator.addPart(server_with_type.second, MediaLabel::kWildcard);
+	}
+
+	chunk->interrupted = 0;
+	chunk->operation = Chunk::SET_VERSION;
+	chunk->version++;
+}
+
+/// @brief Performs the chunk lock operation, which consists of sending chunk lock messages to all
+/// valid parts in the chunk and marking the parts as being written if the chunk lock message was
+/// sent with locking.
+/// @param chunk A pointer to the chunk to lock.
+void chunk_lock_operation(Chunk *chunk) {
+	bool mustWaitForReply = false;
+	assert(chunk->isWritable());
+	for (auto &part : chunk->parts) {
+		if (part.is_valid()) {
+			if (part.is_busy()) { continue; }
+			// No busy parts from now on
+
+			bool sentChunkLock = false;
+			matocsserv_send_chunklock(part.server(), chunk->chunkid, part.type,
+			                          !part.is_being_written(), sentChunkLock);
+			if (sentChunkLock) {
+				part.mark_being_written();
+				mustWaitForReply = true;
+				part.mark_busy();
+			}
 		}
-		calculator.evalRedundancyLevel();
-		if (!calculator.isSafeEnoughToWrite(gRedundancyLevel)) {
-			return SAUNAFS_ERROR_NOCHUNKSERVERS;
-		}
-		c = chunk_new(ChunksMetadata::getAndIncrementNextChunkId(), 1);
-		c->interrupted = 0;
-		c->operation = Chunk::CREATE;
-		chunk_add_file_int(c,goal);
-		for (const auto &server_with_type : serversWithChunkTypes) {
-			c->parts.push_back(ChunkPart(matocsserv_get_csdb(server_with_type.first)->csid,
-			                             ChunkPart::BUSY, c->version, server_with_type.second));
-			matocsserv_send_createchunk(server_with_type.first, c->chunkid, server_with_type.second,
-			                            c->version);
-		}
-		c->updateStats();
-		*opflag=1;
-		*nchunkid = c->chunkid;
+	}
+
+	chunk->interrupted = 0;
+	if (mustWaitForReply) {
+		// We'll need to wait for some replies
+		chunk->operation = Chunk::LOCK;
 	} else {
-		Chunk *oc = chunk_find(ochunkid);
-		if (oc==NULL) {
-			safs::log_err("chunk_multi_modify: could not find chunkid {}", ochunkid);
-			return SAUNAFS_ERROR_NOCHUNK;
-		}
-		if (*lockid != 0 && *lockid != oc->lockid) {
-			if (oc->lockid == 0 || oc->lockedto == 0) {
-				// Lock was removed by some chunk operation or by a different client
-				return SAUNAFS_ERROR_NOTLOCKED;
-			} else {
-				return SAUNAFS_ERROR_WRONGLOCKID;
-			}
-		}
-		if (*lockid == 0 && oc->isLocked()) {
-			*nchunkid = ochunkid;
-			return SAUNAFS_ERROR_LOCKED;
-		}
-		if (!oc->isWritable()) {
-			return SAUNAFS_ERROR_CHUNKLOST;
-		}
-		ChunkCopiesCalculator calculator(oc->getGoal());
-		for (auto &part : oc->parts) {
-			calculator.addPart(part.type, MediaLabel::kWildcard);
-		}
-		calculator.evalRedundancyLevel();
-		if (!calculator.isSafeEnoughToWrite(gRedundancyLevel)) {
-			return SAUNAFS_ERROR_NOCHUNKSERVERS;
-		}
+		// No need to wait, parts have been set to be written
+		chunk->operation = Chunk::NONE;
+	}
+}
 
-		if (oc->fileCount() == 1) { // refcount==1
-			*nchunkid = ochunkid;
-			c = oc;
-			if (c->operation != Chunk::NONE) {
-				return SAUNAFS_ERROR_CHUNKBUSY;
-			}
-			if (c->needverincrease) {
-				assert(c->isWritable());
-				for (auto &part : c->parts) {
-					if (part.is_valid()) {
-						if (!part.is_busy()) {
-							part.mark_busy();
-						}
-						part.version = c->version+1;
-						matocsserv_send_setchunkversion(part.server(), ochunkid, c->version+1, c->version,
-								part.type);
-					}
-				}
-				c->interrupted = 0;
-				c->operation = Chunk::SET_VERSION;
-				c->version++;
-				*opflag=1;
-			} else {
-				*opflag=0;
-			}
-		} else {
-			if (oc->fileCount() == 0) { // it's serious structure error
-				safs_pretty_syslog(LOG_WARNING,"serious structure inconsistency: (chunkid:%016" PRIX64 ")",ochunkid);
-				return SAUNAFS_ERROR_CHUNKLOST; // ERROR_STRUCTURE
-			}
-			if (quota_exceeded) {
-				return SAUNAFS_ERROR_QUOTA;
-			}
-			assert(oc->isWritable());
-			c = chunk_new(ChunksMetadata::getAndIncrementNextChunkId(), 1);
-			c->interrupted = 0;
-			c->operation = Chunk::DUPLICATE;
-			chunk_delete_file_int(oc,goal);
-			chunk_add_file_int(c,goal);
-			for (const auto &old_part : oc->parts) {
-				if (old_part.is_valid()) {
-					c->parts.push_back(ChunkPart(old_part.csid, ChunkPart::BUSY, c->version, old_part.type));
-					matocsserv_send_duplicatechunk(old_part.server(), c->chunkid, c->version, old_part.type,
-							oc->chunkid, oc->version);
-				}
-			}
-			c->updateStats();
-			*nchunkid = c->chunkid;
-			*opflag=1;
+/// @brief Performs the chunk duplication operation, which consists of creating a new chunk with
+/// version 1, associating it with the given goal, sending duplicate chunk messages to the
+/// corresponding chunkservers and marking the parts in the new chunk as being written if the
+/// corresponding duplicate chunk message was sent with locking. It is expected that client will
+/// start writing to the new chunk right after the duplication.
+/// @param originalChunk A pointer to the original chunk to duplicate.
+/// @param goal The goal associated with the new chunk.
+/// @param newChunk A reference to a pointer where the new chunk will be stored.
+void chunk_duplicate_operation(Chunk *originalChunk, uint8_t goal, Chunk *&newChunk) {
+	assert(originalChunk->isWritable());
+	newChunk = chunk_new(ChunksMetadata::getAndIncrementNextChunkId(), 1);
+	newChunk->interrupted = 0;
+	newChunk->operation = Chunk::DUPLICATE;
+	chunk_delete_file_int(originalChunk, goal);
+	chunk_add_file_int(newChunk, goal);
+
+	for (const auto &oldPart : originalChunk->parts) {
+		if (oldPart.is_valid()) {
+			newChunk->parts.push_back(
+			    ChunkPart(oldPart.csid, ChunkPart::BUSY, newChunk->version, oldPart.type));
+
+			bool sentChunkLock = false;
+			matocsserv_send_duplicatechunk(oldPart.server(), newChunk->chunkid, newChunk->version,
+			                               oldPart.type, originalChunk->chunkid,
+			                               originalChunk->version, sentChunkLock);
+
+			if (sentChunkLock) { newChunk->parts.back().mark_being_written(); }
 		}
 	}
 
-	c->lockedto = eventloop_time() + LOCKTIMEOUT;
-	if (*lockid == 0) {
-		if (usedummylockid) {
-			*lockid = 1;
-		} else {
-			*lockid = 2 + rnd_ranged<uint32_t>(0xFFFFFFF0); // some random number greater than 1
+	newChunk->updateStats();
+}
+
+/// @brief Performs the chunk truncate operation, which consists of increasing the chunk version and
+/// sending truncate chunk messages to all valid parts in the chunk. It is not expected that client
+/// will start writing right after the truncation.
+/// @param chunk A pointer to the chunk to truncate.
+/// @param length The new length of the chunk.
+void chunk_truncate_operation(Chunk *chunk, uint32_t length) {
+	assert(chunk->isWritable());
+	for (auto &part : chunk->parts) {
+		if (part.is_valid()) {
+			if (!part.is_busy()) { part.mark_busy(); }
+			part.version = chunk->version + 1;
+			uint32_t chunkTypeLength =
+			    slice_traits::chunkLengthToChunkPartLength(part.type, length);
+			matocsserv_send_truncatechunk(part.server(), chunk->chunkid, part.type, chunkTypeLength,
+			                              chunk->version + 1, chunk->version);
 		}
 	}
-	c->lockid = *lockid;
-	chunk_update_checksum(c);
-	emit_chunk_changed(c);
+
+	chunk->interrupted = 0;
+	chunk->operation = Chunk::TRUNCATE;
+	chunk->version++;
+}
+
+/// @brief Performs the chunk duplicate and truncate operation, which consists of creating a new
+/// chunk with version 1, associating it with the given goal, sending duplicate and truncate chunk
+/// messages to the corresponding chunkservers. It is not expected that client will start writing to
+/// the new chunk right after the duplication and truncation.
+/// @param originalChunk A pointer to the original chunk to duplicate and truncate.
+/// @param goal The goal associated with the new chunk.
+/// @param newChunk A reference to a pointer where the new chunk will be stored.
+/// @param length The new length of the chunk.
+void chunk_duplicate_and_truncate_operation(Chunk *originalChunk, uint8_t goal, Chunk *&newChunk,
+                                            uint32_t length) {
+	assert(originalChunk->isWritable());
+	newChunk = chunk_new(ChunksMetadata::getAndIncrementNextChunkId(), 1);
+	newChunk->interrupted = 0;
+	newChunk->operation = Chunk::DUPTRUNC;
+	chunk_delete_file_int(originalChunk, goal);
+	chunk_add_file_int(newChunk, goal);
+
+	for (const auto &oldPart : originalChunk->parts) {
+		if (oldPart.is_valid()) {
+			newChunk->parts.push_back(
+			    ChunkPart(oldPart.csid, ChunkPart::BUSY, newChunk->version, oldPart.type));
+			uint32_t chunkTypeLength =
+			    slice_traits::chunkLengthToChunkPartLength(oldPart.type, length);
+			matocsserv_send_duptruncchunk(oldPart.server(), newChunk->chunkid, newChunk->version,
+			                              oldPart.type, originalChunk->chunkid,
+			                              originalChunk->version, chunkTypeLength);
+		}
+	}
+
+	newChunk->updateStats();
+}
+
+/// @brief Handles the chunk creation case of the chunk_multi_modify operation, which consists of
+/// checking if the chunk can be created with the given goal and proceed if so.
+/// @param quotaExceeded Whether the quota has been exceeded.
+/// @param goal The goal for the chunk creation.
+/// @param operation Pointer to the operation code.
+/// @param newChunkId Pointer to the new chunk ID.
+/// @param minServerVersion The minimum server version required.
+/// @param createdChunk Pointer to the created chunk.
+/// @return The status code of the operation.
+uint8_t chunk_create(bool quotaExceeded, uint8_t goal, uint8_t *operation, uint64_t *newChunkId,
+                     uint32_t minServerVersion, Chunk *&createdChunk) {
+	// First check if quota is exceeded
+	if (quotaExceeded) { return SAUNAFS_ERROR_QUOTA; }
+
+	// Next check availability of chunkservers for the given goal
+	auto serversWithChunkTypes = matocsserv_getservers_for_new_chunk(goal, minServerVersion);
+	if (serversWithChunkTypes.empty()) {
+		uint16_t usableChunkservers, totalChunkservers;
+		double minUsage, maxUsage;
+		matocsserv_usagedifference(&minUsage, &maxUsage, &usableChunkservers, &totalChunkservers);
+
+		if (usableChunkservers > 0 && eventloop_time() > starttime + kStartupGracePeriodSeconds) {
+			// if there are chunkservers and it's at least one minute after start then it means that
+			// there is no space left
+			return SAUNAFS_ERROR_NOSPACE;
+		}
+
+		return SAUNAFS_ERROR_NOCHUNKSERVERS;
+	}
+
+	// Check if the chunk would be safe to write with the current redundancy level
+	ChunkCopiesCalculator calculator(gFSOperations->getGoalDefinition(goal));
+	for (const auto &serverWithType : serversWithChunkTypes) {
+		calculator.addPart(serverWithType.second, MediaLabel::kWildcard);
+	}
+	calculator.evalRedundancyLevel();
+	if (!calculator.isSafeEnoughToWrite(gRedundancyLevel)) { return SAUNAFS_ERROR_NOCHUNKSERVERS; }
+
+	// All checks passed, we can create the chunk
+	chunk_create_operation(createdChunk, goal, serversWithChunkTypes);
+	*operation = Chunk::CREATE;
+	*newChunkId = createdChunk->chunkid;
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t chunk_multi_truncate(uint64_t ochunkid, uint32_t lockid, uint32_t length,
-		uint8_t goal, bool denyTruncatingParityParts, bool quota_exceeded, uint64_t *nchunkid) {
-	Chunk *oc, *c;
+/// @brief Handles the chunk modification case of the chunk_multi_modify operation, which consists
+/// of checking if the chunk can be modified with the given parameters and proceed if so.
+/// @param currentChunkId The ID of the chunk to modify.
+/// @param lockId Pointer to the lock ID for the chunk modification.
+/// @param goal The goal for the chunk modification.
+/// @param quotaExceeded Whether the quota has been exceeded.
+/// @param operation Pointer to the operation code.
+/// @param targetChunkId Pointer to the target chunk ID after modification.
+/// @param targetChunk Reference to a pointer where the target chunk after modification will be
+/// stored.
+/// @return The status code of the operation.
+uint8_t chunk_modify(uint64_t currentChunkId, uint32_t *lockId, uint8_t goal, bool quotaExceeded,
+                     uint8_t *operation, uint64_t *targetChunkId, Chunk *&targetChunk) {
+	// First find the chunk
+	Chunk *currentChunk = chunk_find(currentChunkId);
+	if (currentChunk == nullptr) { return SAUNAFS_ERROR_NOCHUNK; }
 
-	c=NULL;
-	oc = chunk_find(ochunkid);
-	if (oc==NULL) {
-		safs::log_err("chunk_multi_truncate: could not find chunkid {}", ochunkid);
-		return SAUNAFS_ERROR_NOCHUNK;
+	// Next check if the chunk is locked and if the lockid matches
+	if (*lockId != 0 && *lockId != currentChunk->lockid) {
+		if (currentChunk->lockid == 0 || currentChunk->lockedto == 0) {
+			// Lock was removed by some chunk operation or by a different client
+			return SAUNAFS_ERROR_NOTLOCKED;
+		}
+
+		// Case *lockid != currentChunk->lockid
+		return SAUNAFS_ERROR_WRONGLOCKID;
 	}
-	if (!oc->isWritable()) {
-		return SAUNAFS_ERROR_CHUNKLOST;
-	}
-	if (oc->isLocked() && (lockid == 0 || lockid != oc->lockid)) {
+	if (*lockId == 0 && currentChunk->isLocked()) {
+		*targetChunkId = currentChunkId;
 		return SAUNAFS_ERROR_LOCKED;
 	}
-	if (denyTruncatingParityParts) {
-		for (const auto &part : oc->parts) {
-			if (slice_traits::isParityPart(part.type)) {
-				return SAUNAFS_ERROR_NOTPOSSIBLE;
-			}
+
+	// Check if the chunk is writable
+	if (!currentChunk->isWritable()) { return SAUNAFS_ERROR_CHUNKLOST; }
+
+	// Check if the chunk would be safe to write with the desired redundancy level
+	ChunkCopiesCalculator calculator(currentChunk->getGoal());
+	for (auto &part : currentChunk->parts) { calculator.addPart(part.type, MediaLabel::kWildcard); }
+	calculator.evalRedundancyLevel();
+	if (!calculator.isSafeEnoughToWrite(gRedundancyLevel)) { return SAUNAFS_ERROR_NOCHUNKSERVERS; }
+
+	if (currentChunk->fileCount() == 1) {
+		// Only one reference case
+		*targetChunkId = currentChunkId;
+		targetChunk = currentChunk;
+		if (targetChunk->operation != Chunk::NONE) { return SAUNAFS_ERROR_CHUNKBUSY; }
+
+		if (targetChunk->needVersionIncrease) {
+			// We are expected to start writing to the chunk, but it has lost some copies and we
+			// haven't increased its version yet, so we need to increase the version before allowing
+			// the write operation to proceed.
+			chunk_increase_version_operation(targetChunk, true);
+		} else {
+			chunk_lock_operation(targetChunk);
 		}
-	}
-	if (oc->fileCount() == 1) { // refcount==1
-		*nchunkid = ochunkid;
-		c = oc;
-		if (c->operation != Chunk::NONE) {
-			return SAUNAFS_ERROR_CHUNKBUSY;
-		}
-		assert(c->isWritable());
-		for (auto &part : c->parts) {
-			if (part.is_valid()) {
-				if (!part.is_busy()) {
-					part.mark_busy();
-				}
-				part.version = c->version+1;
-				uint32_t chunkTypeLength =
-						slice_traits::chunkLengthToChunkPartLength(part.type, length);
-				matocsserv_send_truncatechunk(part.server(), ochunkid, part.type, chunkTypeLength,
-						c->version + 1, c->version);
-			}
-		}
-		c->interrupted = 0;
-		c->operation = Chunk::TRUNCATE;
-		c->version++;
 	} else {
-		if (oc->fileCount() == 0) { // it's serious structure error
-			safs_pretty_syslog(LOG_WARNING,"serious structure inconsistency: (chunkid:%016" PRIX64 ")",ochunkid);
-			return SAUNAFS_ERROR_CHUNKLOST; // ERROR_STRUCTURE
+		if (currentChunk->fileCount() == 0) {  // it's serious structure error
+			safs::log_warn("serious structure inconsistency: (chunkid:{:016X})", currentChunkId);
+			return SAUNAFS_ERROR_CHUNKLOST;  // ERROR_STRUCTURE
 		}
-		if (quota_exceeded) {
-			return SAUNAFS_ERROR_QUOTA;
-		}
+		// More than one reference case
+		if (quotaExceeded) { return SAUNAFS_ERROR_QUOTA; }
 
-		assert(oc->isWritable());
-		c = chunk_new(ChunksMetadata::getAndIncrementNextChunkId(), 1);
-		c->interrupted = 0;
-		c->operation = Chunk::DUPTRUNC;
-		chunk_delete_file_int(oc,goal);
-		chunk_add_file_int(c,goal);
-		for (const auto &old_part : oc->parts) {
-			if (old_part.is_valid()) {
-				c->parts.push_back(ChunkPart(old_part.csid, ChunkPart::BUSY, c->version, old_part.type));
-				matocsserv_send_duptruncchunk(old_part.server(), c->chunkid, c->version,
-						old_part.type, oc->chunkid, oc->version,
-						slice_traits::chunkLengthToChunkPartLength(old_part.type, length));
-			}
-		}
-		c->updateStats();
-		*nchunkid = c->chunkid;
+		chunk_duplicate_operation(currentChunk, goal, targetChunk);
+		*targetChunkId = targetChunk->chunkid;
+	}
+	*operation = targetChunk->operation;
+
+	return SAUNAFS_STATUS_OK;
+}
+
+/// @brief Handles the chunk_multi_modify operation, which consists of performing either chunk
+/// creation or modification. Called when writing on the chunk is needed.
+///
+/// Since the chunk is going to be modified, the chunk is locked and a lock ID is
+/// assigned if the chunk is not already locked. After any of the operations, the chunk is expected
+/// to be written to by the client, so if enabled, the chunkserver side locking is used to lock the
+/// chunk, so the parts in the chunk are marked as being written and the corresponding chunk lock
+/// messages are sent to the chunkservers.
+///
+/// @param currentChunkId The current chunk ID in the file layout, 0 means no chunk in current
+/// index.
+/// @param lockid Pointer to the lock ID, used to transmit the assigned lock ID to the caller and to
+/// check the lock ID in case of modification. The lock ID is assigned in case of creation or
+/// modification if the chunk is not already locked. If the chunk is already locked, then the lock
+/// ID is used to verify the lock ownership.
+/// @param goal The goal for the chunk creation or modification.
+/// @param quotaExceeded Whether the quota has been exceeded, used to check if the operation can be
+/// performed.
+/// @param operation Pointer to the operation code, used to transmit the performed operation code to
+/// the caller.
+/// @param targetChunkId Pointer to the target chunk ID after modification, used to transmit the
+/// target chunk ID to the caller in case of modification.
+/// @param minServerVersion The minimum server version required for the chunk creation, used to
+/// check if the operation can be performed in case of creation.
+/// @return The status of the operation.
+uint8_t chunk_multi_modify(uint64_t currentChunkId, uint32_t *lockid, uint8_t goal,
+                           bool quotaExceeded, uint8_t *operation, uint64_t *targetChunkId,
+                           uint32_t minServerVersion = 0) {
+	Chunk *targetChunk = nullptr;
+	uint8_t status = SAUNAFS_STATUS_OK;
+	if (currentChunkId == 0) {
+		// New chunk case
+		status = chunk_create(quotaExceeded, goal, operation, targetChunkId, minServerVersion,
+		                      targetChunk);
+	} else {
+		// Existing chunk case
+		status = chunk_modify(currentChunkId, lockid, goal, quotaExceeded, operation, targetChunkId,
+		                      targetChunk);
 	}
 
-	c->lockedto=(uint32_t)eventloop_time()+LOCKTIMEOUT;
-	c->lockid = lockid;
-	chunk_update_checksum(c);
-	emit_chunk_changed(c);
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+
+	// Set the lock if needed
+	targetChunk->lockedto = eventloop_time() + LOCKTIMEOUT;
+	if (*lockid == 0) {
+		*lockid = 1 + rnd_ranged<uint32_t>(0xFFFFFFF0);  // some random number greater than 0
+	}
+	targetChunk->lockid = *lockid;
+
+	chunk_update_checksum(targetChunk);
+	emit_chunk_changed(targetChunk);
+	return SAUNAFS_STATUS_OK;
+}
+
+/// @brief Handles the chunk_multi_truncate operation, which consists of performing either chunk
+/// truncation or duplication and truncation.
+///
+/// Since the chunk is going to be modified, the chunk is locked and a lock ID is
+/// assigned if the chunk is not already locked.
+///
+/// @param currentChunkId The current chunk ID in the file layout. Should be non-zero since
+/// truncation of a non-existing chunk doesn't make sense.
+/// @param lockid The lock ID, used to check if the chunk is locked and to assign a new lock ID if
+/// needed.
+/// @param length The length to truncate the chunk to.
+/// @param goal The goal for the chunk truncation.
+/// @param denyTruncatingParityParts Whether truncating parity parts is denied.
+/// @param quotaExceeded Whether the quota has been exceeded, used to check if the operation can be
+/// performed.
+/// @param targetChunkId Pointer to the target chunk ID after truncation, used to transmit the
+/// target chunk ID to the caller in case of truncation.
+/// @return The status of the operation.
+uint8_t chunk_multi_truncate(uint64_t currentChunkId, uint32_t lockid, uint32_t length,
+                             uint8_t goal, bool denyTruncatingParityParts, bool quotaExceeded,
+                             uint64_t *targetChunkId) {
+	Chunk *currentChunk = nullptr;
+	Chunk *targetChunk = nullptr;
+
+	// First find the chunk
+	currentChunk = chunk_find(currentChunkId);
+	if (currentChunk == nullptr) {
+		safs::log_err("chunk_multi_truncate: could not find chunkid {}", currentChunkId);
+		return SAUNAFS_ERROR_NOCHUNK;
+	}
+
+	// Chunk must be writable to be truncated
+	if (!currentChunk->isWritable()) { return SAUNAFS_ERROR_CHUNKLOST; }
+
+	// Check if the chunk is locked and if the lockid matches
+	if (currentChunk->isLocked() && (lockid == 0 || lockid != currentChunk->lockid)) {
+		return SAUNAFS_ERROR_LOCKED;
+	}
+
+	// Deny truncating parity parts if initiating a truncate operation while reducing the file size
+	if (denyTruncatingParityParts) {
+		for (const auto &part : currentChunk->parts) {
+			if (slice_traits::isParityPart(part.type)) { return SAUNAFS_ERROR_NOTPOSSIBLE; }
+		}
+	}
+
+	if (currentChunk->fileCount() == 1) {
+		// Only one reference case - we can truncate the chunk without duplication
+		*targetChunkId = currentChunkId;
+		targetChunk = currentChunk;
+		if (targetChunk->operation != Chunk::NONE) { return SAUNAFS_ERROR_CHUNKBUSY; }
+
+		chunk_truncate_operation(targetChunk, length);
+	} else {
+		if (currentChunk->fileCount() == 0) {  // it's serious structure error
+			safs_pretty_syslog(LOG_WARNING,
+			                   "serious structure inconsistency: (chunkid:%016" PRIX64 ")",
+			                   currentChunkId);
+			return SAUNAFS_ERROR_CHUNKLOST;  // ERROR_STRUCTURE
+		}
+		// More than one reference case - need to duplicate and truncate
+		if (quotaExceeded) { return SAUNAFS_ERROR_QUOTA; }
+
+		chunk_duplicate_and_truncate_operation(currentChunk, goal, targetChunk, length);
+		*targetChunkId = targetChunk->chunkid;
+	}
+
+	targetChunk->lockedto = eventloop_time() + LOCKTIMEOUT;
+	targetChunk->lockid = lockid;
+
+	chunk_update_checksum(targetChunk);
+	emit_chunk_changed(targetChunk);
 	return SAUNAFS_STATUS_OK;
 }
 #endif // ! METARESTORE
@@ -1412,7 +1704,7 @@ int chunk_repair(uint8_t goal, uint64_t ochunkid, uint32_t *nversion, uint8_t co
 		}
 	}
 	*nversion = best_version;
-	c->needverincrease=1;
+	c->needVersionIncrease = 1;
 	c->updateStats();
 	chunk_update_checksum(c);
 	emit_chunk_changed(c);
@@ -1656,13 +1948,13 @@ void chunk_damaged(matocsserventry *ptr, uint64_t chunkid, ChunkPartType chunk_t
 	for (auto &part : c->parts) {
 		if (part.csid == server_csid && part.type == chunk_type) {
 			c->invalidateCopy(part);
-			c->needverincrease=1;
+			c->needVersionIncrease = 1;
 			return;
 		}
 	}
 	c->parts.push_back(ChunkPart(server_csid, ChunkPart::INVALID, 0, slice_traits::standard::ChunkPartType()));
 	c->updateStats();
-	c->needverincrease=1;
+	c->needVersionIncrease = 1;
 }
 
 void chunk_lost(matocsserventry *ptr,uint64_t chunkid, ChunkPartType chunk_type) {
@@ -1677,7 +1969,7 @@ void chunk_lost(matocsserventry *ptr,uint64_t chunkid, ChunkPartType chunk_type)
 	if (it != c->parts.end()) {
 		c->parts.erase(it, c->parts.end());
 		c->updateStats();
-		c->needverincrease = 1;
+		c->needVersionIncrease = 1;
 	}
 }
 
@@ -1789,34 +2081,77 @@ void chunk_got_replicate_status(matocsserventry *ptr, uint64_t chunkId, uint32_t
 	c->updateStats();
 }
 
-void chunk_operation_status(Chunk *c, ChunkPartType chunkType, uint8_t status,matocsserventry *ptr) {
+void chunk_operation_status(Chunk *c, ChunkPartType chunkType, uint8_t status,
+                            matocsserventry *ptr) {
 	bool any_copy_busy = false;
 	auto server_csid = matocsserv_get_csdb(ptr)->csid;
 	for (auto &part : c->parts) {
 		if (part.csid == server_csid && part.type == chunkType) {
-			if (status!=0) {
-				c->interrupted = 1; // increase version after finish, just in case
+			if (status != SAUNAFS_STATUS_OK) {
+				c->interrupted = 1;  // increase version after finish, just in case
 				c->invalidateCopy(part);
 			} else {
-				if (part.is_busy()) {
-					part.unmark_busy();
-				}
+				if (part.is_busy()) { part.unmark_busy(); }
 			}
 		}
+
 		any_copy_busy |= part.is_busy();
 	}
+
 	if (!any_copy_busy) {
 		if (c->isWritable()) {
 			if (c->interrupted) {
 				chunk_emergency_increase_version(c);
 			} else {
-				matoclserv_chunk_status(c->chunkid,SAUNAFS_STATUS_OK);
+				matoclserv_chunk_status(c->chunkid, SAUNAFS_STATUS_OK);
 				c->operation = Chunk::NONE;
-				c->needverincrease = 0;
+				c->needVersionIncrease = 0;
 			}
 		} else {
 			chunk_finalize_failed_operation(c);
 		}
+	}
+}
+
+/// @brief Handles the end of a chunk write operation.
+/// This function is called when a chunkserver reports the status of a write operation on a chunk
+/// part. It checks the status and updates the chunk's state accordingly. If the write operation was
+/// not successful, it marks the corresponding copy as invalid and sets the interrupted flag on the
+/// chunk. The status sent by the chunkserver is expected to be the one not told to the clients.
+/// @param chunk The chunk that was written.
+/// @param chunkType The type of the chunk part.
+/// @param status The status of the write operation.
+/// @param ptr The server entry associated with the operation.
+void chunk_write_end_status(Chunk *chunk, ChunkPartType chunkType, uint8_t status,
+                            matocsserventry *ptr) {
+	bool anyCopyBeingWritten = false;
+	auto server_csid = matocsserv_get_csdb(ptr)->csid;
+	for (auto &part : chunk->parts) {
+		if (part.csid == server_csid && part.type == chunkType) {
+			if (status != SAUNAFS_STATUS_OK) {
+				chunk->interrupted = 1;  // increase version after finish, just in case
+				chunk->invalidateCopy(part);
+			} else {
+				if (part.is_being_written()) { part.unmark_being_written(); }
+			}
+		}
+
+		anyCopyBeingWritten |= part.is_being_written();
+	}
+
+	if (!anyCopyBeingWritten && chunk->interrupted) {
+		if (chunk->isWritable()) {
+			chunk_emergency_increase_version(chunk);
+		} else {
+			// If chunk is not writable, we probably have a lost chunk here
+			safs::log_warn("{}: chunk {} is not writable. Lost chunk?", __func__, chunk->chunkid);
+		}
+	}
+
+	if (!anyCopyBeingWritten && !chunk->isLocked()) {
+		// If the chunk is not locked anymore, we can try to send notices about the operation
+		// status to clients waiting for the lock release.
+		matoclserv_notify_unlock_list(chunk->chunkid);
 	}
 }
 
@@ -1836,6 +2171,34 @@ void chunk_got_duplicate_status(matocsserventry *ptr, uint64_t chunkId, ChunkPar
 		return ;
 	}
 	chunk_operation_status(c, chunkType, status, ptr);
+}
+
+/// @brief Handles the status of a chunk lock operation.
+/// @param ptr The server entry associated with the operation.
+/// @param chunkId The ID of the chunk.
+/// @param chunkType The type of the chunk part.
+/// @param status The status of the chunk lock operation.
+void chunk_got_chunklock_status(matocsserventry *ptr, uint64_t chunkId, ChunkPartType chunkType,
+                                uint8_t status) {
+	Chunk *chunk;
+	chunk = chunk_find(chunkId);
+	if (chunk == nullptr) { return; }
+
+	chunk_operation_status(chunk, chunkType, status, ptr);
+}
+
+/// @brief Handles the status of a chunk write end operation.
+/// @param ptr The server entry associated with the operation.
+/// @param chunkId The ID of the chunk.
+/// @param chunkType The type of the chunk part.
+/// @param status The status of the chunk write end operation.
+void chunk_got_writeend_status(matocsserventry *ptr, uint64_t chunkId, ChunkPartType chunkType,
+                               uint8_t status) {
+	Chunk *chunk;
+	chunk = chunk_find(chunkId);
+	if (chunk == nullptr) { return; }
+
+	chunk_write_end_status(chunk, chunkType, status, ptr);
 }
 
 void chunk_got_setversion_status(matocsserventry *ptr, uint64_t chunkId, ChunkPartType chunkType, uint8_t status) {
@@ -2053,7 +2416,7 @@ bool ChunkWorker::tryReplication(Chunk *c, ChunkPartType part_to_recover,
 	                                   all_servers, all_parts);
 	stats_replications++;
 	metrics::Counter::increment(metrics::Counter::Master::CHUNK_REPLICATE);
-	c->needverincrease = 1;
+	c->needVersionIncrease = 1;
 	return true;
 }
 
@@ -2087,7 +2450,7 @@ void ChunkWorker::deleteAllChunkParts(Chunk *c) {
 		if (matocsserv_deletion_counter(part.server()) < TmpMaxDel) {
 			if (part.is_valid() && !part.is_busy()) {
 				c->deleteCopy(part);
-				c->needverincrease = 1;
+				c->needVersionIncrease = 1;
 				stats_deletions++;
 				metrics::Counter::increment(metrics::Counter::Master::CHUNK_DELETE);
 				matocsserv_send_deletechunk(part.server(), c->chunkid, c->version,
@@ -2267,7 +2630,7 @@ bool ChunkWorker::removeUnneededChunkPart(Chunk *c, Goal::Slice::Type slice_type
 	if (candidate &&
 	    calc.canRemovePart(slice_type, slice_part, matocsserv_get_label(candidate->server()))) {
 		c->deleteCopy(*candidate);
-		c->needverincrease = 1;
+		c->needVersionIncrease = 1;
 		stats_deletions++;
 		metrics::Counter::increment(metrics::Counter::Master::CHUNK_DELETE);
 		matocsserv_send_deletechunk(candidate->server(), c->chunkid, 0, candidate->type);

--- a/src/master/chunks.h
+++ b/src/master/chunks.h
@@ -57,15 +57,16 @@ int chunk_unlock(uint64_t chunkid);
 uint8_t chunk_apply_modification(uint32_t ts, uint64_t oldChunkId, uint32_t lockid, uint8_t goal,
 		bool doIncreaseVersion, uint64_t *newChunkId);
 
+bool should_increase_chunk_version_on_modification(uint8_t operation);
+
 // Tries to set next chunk id to a passed value, returns status
 uint8_t chunk_set_next_chunkid(uint64_t nextChunkIdToBeSet);
 
 #ifdef METARESTORE
 void chunk_dump(void);
 #else
-uint8_t chunk_multi_modify(uint64_t ochunkid, uint32_t *lockid, uint8_t goal,
-		bool usedummylockid, bool quota_exceeded, uint8_t *opflag, uint64_t *nchunkid,
-		uint32_t min_server_version);
+uint8_t chunk_multi_modify(uint64_t ochunkid, uint32_t *lockid, uint8_t goal, bool quota_exceeded,
+                           uint8_t *opflag, uint64_t *nchunkid, uint32_t min_server_version);
 uint8_t chunk_multi_truncate(uint64_t ochunkid, uint32_t lockid, uint32_t length,
 		uint8_t goal, bool denyTruncatingParityParts, bool quota_exceeded, uint64_t *nchunkid);
 void chunk_stats(uint32_t *del,uint32_t *repl);
@@ -102,6 +103,10 @@ void chunk_got_replicate_status(matocsserventry *ptr, uint64_t chunkId, uint32_t
 
 void chunk_got_create_status(matocsserventry *ptr, uint64_t chunkid, ChunkPartType chunkType, uint8_t status);
 void chunk_got_duplicate_status(matocsserventry *ptr, uint64_t chunkId, ChunkPartType chunkType, uint8_t status);
+void chunk_got_chunklock_status(matocsserventry *ptr, uint64_t chunkId, ChunkPartType chunkType,
+                                uint8_t status);
+void chunk_got_writeend_status(matocsserventry *ptr, uint64_t chunkId, ChunkPartType chunkType,
+                               uint8_t status);
 void chunk_got_setversion_status(matocsserventry *ptr, uint64_t chunkId, ChunkPartType chunkType, uint8_t status);
 void chunk_got_truncate_status(matocsserventry *ptr, uint64_t chunkId, ChunkPartType chunkType, uint8_t status);
 void chunk_got_duptrunc_status(matocsserventry *ptr, uint64_t chunkId, ChunkPartType chunkType, uint8_t status);

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -2432,7 +2432,7 @@ uint8_t FilesystemOperationsBase::readChunk(inode_t inode, uint32_t indx, uint64
 
 uint8_t FilesystemOperationsBase::writeChunk(const FsContext &context,
                                              const FilesystemOperationContext &fsOpContext,
-                                             inode_t inode, uint32_t index, bool usedummylockid,
+                                             inode_t inode, uint32_t index,
                                              /* inout */ uint32_t *lockid, uint64_t *chunkid,
                                              uint8_t *opflag, uint64_t *length,
                                              uint32_t min_server_version) {
@@ -2487,10 +2487,9 @@ uint8_t FilesystemOperationsBase::writeChunk(const FsContext &context,
 	ochunkid = fileNode->chunks[index];
 	if (context.isPersonalityMaster()) {
 #ifndef METARESTORE
-		status = chunk_multi_modify(ochunkid, lockid, fileNode->goal, usedummylockid,
-		                            quota_exceeded, opflag, &nchunkid, min_server_version);
+		status = chunk_multi_modify(ochunkid, lockid, fileNode->goal, quota_exceeded, opflag,
+		                            &nchunkid, min_server_version);
 #else
-		(void)usedummylockid;
 		(void)min_server_version;
 		// This will NEVER happen (metarestore doesn't call this in master context)
 		mabort("bad code path: fs_writechunk");
@@ -2525,7 +2524,8 @@ uint8_t FilesystemOperationsBase::writeChunk(const FsContext &context,
 
 	if (context.isPersonalityMaster()) {
 		changeLog(context.ts(), "WRITE(%" PRIiNode ",%" PRIu32 ",%" PRIu8 ",%" PRIu32 "):%" PRIu64,
-		          inode, index, *opflag, *lockid, nchunkid);
+		          inode, index, should_increase_chunk_version_on_modification(*opflag), *lockid,
+		          nchunkid);
 	} else {
 		gMetadata->metadataVersion++;
 	}

--- a/src/master/filesystem_operations.h
+++ b/src/master/filesystem_operations.h
@@ -125,7 +125,7 @@ public:
 
 	uint8_t undel(const FsContext &context, inode_t inode) override;
 	uint8_t writeChunk(const FsContext &context, const FilesystemOperationContext &fsOpContext,
-	                   inode_t inode, uint32_t index, bool usedummylockid,
+	                   inode_t inode, uint32_t index,
 	                   /* inout */ uint32_t *lockid, uint64_t *chunkid, uint8_t *opflag,
 	                   uint64_t *length, uint32_t min_server_version = 0) override;
 	uint8_t setNextChunkId(const FsContext &context, uint64_t nextChunkId) override;

--- a/src/master/filesystem_operations_interface.h
+++ b/src/master/filesystem_operations_interface.h
@@ -319,7 +319,7 @@ public:
 	virtual uint8_t undel(const FsContext &context, inode_t inode) = 0;
 	virtual uint8_t writeChunk(const FsContext &context,
 	                           const FilesystemOperationContext &fsOpContext, inode_t inode,
-	                           uint32_t index, bool usedummylockid,
+	                           uint32_t index,
 	                           /* inout */ uint32_t *lockid, uint64_t *chunkid, uint8_t *opflag,
 	                           uint64_t *length, uint32_t min_server_version = 0) = 0;
 	virtual uint8_t setNextChunkId(const FsContext &context, uint64_t nextChunkId) = 0;

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -2087,7 +2087,7 @@ void matoclserv_fuse_truncate(matoclserventry *eptr, PacketHeader header, const 
 		uint8_t chunkOperationPending;
 
 		status =
-		    gFSOperations->writeChunk(context, fsOpContext, inode, length / SFSCHUNKSIZE, false,
+		    gFSOperations->writeChunk(context, fsOpContext, inode, length / SFSCHUNKSIZE,
 		                              &lockId, &chunkId, &chunkOperationPending, &fileLength);
 
 		if (status != SAUNAFS_STATUS_OK) {
@@ -3071,11 +3071,8 @@ void matoclserv_fuse_write_chunk(matoclserventry *eptr, PacketHeader header, con
 	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
 	    FilesystemOperationContext::TransactionType::kReadWrite);
 
-	// Original Legacy (1.6.27) does not use lock ID's
-	constexpr bool kUseDummyLockId = false;
 	status = gFSOperations->writeChunk(matoclserv_get_context(eptr), fsOpContext, inode, chunkIndex,
-	                                   kUseDummyLockId, &lockId, &chunkId, &opflag, &fileLength,
-	                                   min_server_version);
+	                                   &lockId, &chunkId, &opflag, &fileLength, min_server_version);
 
 	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
 		if (!fsOpContext.getReadWriteTransaction()->commit()) {

--- a/src/master/matocsserv.cc
+++ b/src/master/matocsserv.cc
@@ -604,12 +604,12 @@ void matocsserv_got_chunk_checksum(matocsserventry *eptr, const uint8_t *data, u
 }
 
 int matocsserv_send_createchunk(matocsserventry *eptr, uint64_t chunkId, ChunkPartType chunkType,
-                                uint32_t chunkVersion, bool &sentChunkLock) {
+                                uint32_t chunkVersion, bool needsLock, bool &sentChunkLock) {
 	sentChunkLock = false;
 	if (eptr->mode != ChunkserverConnectionMode::KILL) {
 		eptr->outputPackets.push_back(OutputPacket());
 		sassert(eptr->version >= kFirstECVersion);
-		if (eptr->version >= kFirstVersionWithChunkserverSideChunkLock) {
+		if (eptr->version >= kFirstVersionWithChunkserverSideChunkLock && needsLock) {
 			// For newer chunkservers, create and lock part
 			matocs::createAndLockChunk::serialize(eptr->outputPackets.back().packet, chunkId,
 			                                      chunkType, chunkVersion);
@@ -730,11 +730,11 @@ void matocsserv_got_replicatechunk_status(matocsserventry *eptr, const std::vect
 }
 
 int matocsserv_send_chunklock(matocsserventry *eptr, uint64_t chunkId, ChunkPartType chunkType,
-                              bool needLock, bool &sentChunkLock) {
+                              bool needsLock, bool &sentChunkLock) {
 	sentChunkLock = false;
 	if (eptr->mode != ChunkserverConnectionMode::KILL) {
 		sassert(eptr->version >= kFirstECVersion);
-		if (eptr->version >= kFirstVersionWithChunkserverSideChunkLock && needLock) {
+		if (eptr->version >= kFirstVersionWithChunkserverSideChunkLock && needsLock) {
 			eptr->outputPackets.emplace_back();
 			matocs::chunkLock::serialize(eptr->outputPackets.back().packet, chunkId, chunkType);
 			sentChunkLock = true;
@@ -794,12 +794,12 @@ int matocsserv_send_chunkunlock(matocsserventry *eptr, uint64_t chunkId, ChunkPa
 }
 
 int matocsserv_send_setchunkversion(matocsserventry *eptr, uint64_t chunkId, uint32_t newVersion,
-		uint32_t chunkVersion, ChunkPartType chunkType, bool needChunkLock, bool &sentChunkLock) {
+		uint32_t chunkVersion, ChunkPartType chunkType, bool needsLock, bool &sentChunkLock) {
 	sentChunkLock = false;
 	if (eptr->mode != ChunkserverConnectionMode::KILL) {
 		eptr->outputPackets.emplace_back();
 		sassert(eptr->version >= kFirstECVersion);
-		if (eptr->version >= kFirstVersionWithChunkserverSideChunkLock && needChunkLock) {
+		if (eptr->version >= kFirstVersionWithChunkserverSideChunkLock && needsLock) {
 			// For newer chunkservers, set version with chunk lock
 			matocs::setVersionAndLock::serialize(eptr->outputPackets.back().packet, chunkId,
 			                                     chunkType, chunkVersion, newVersion);
@@ -835,13 +835,14 @@ void matocsserv_got_setchunkversion_status(matocsserventry *eptr,
 
 int matocsserv_send_duplicatechunk(matocsserventry *eptr, uint64_t newChunkId,
                                    uint32_t newChunkVersion, ChunkPartType chunkType,
-                                   uint64_t chunkId, uint32_t chunkVersion, bool &sentChunkLock) {
+                                   uint64_t chunkId, uint32_t chunkVersion, bool needsLock,
+                                   bool &sentChunkLock) {
 	sentChunkLock = false;
 	if (eptr->mode == ChunkserverConnectionMode::KILL) { return 0; }
 
 	OutputPacket outPacket;
 	sassert(eptr->version >= kFirstECVersion);
-	if (eptr->version >= kFirstVersionWithChunkserverSideChunkLock) {
+	if (eptr->version >= kFirstVersionWithChunkserverSideChunkLock && needsLock) {
 		// For newer chunkservers, duplicate with chunk lock
 		matocs::duplicateAndLockChunk::serialize(outPacket.packet, newChunkId, newChunkVersion,
 		                                         chunkType, chunkId, chunkVersion);

--- a/src/master/matocsserv.cc
+++ b/src/master/matocsserv.cc
@@ -604,12 +604,21 @@ void matocsserv_got_chunk_checksum(matocsserventry *eptr, const uint8_t *data, u
 }
 
 int matocsserv_send_createchunk(matocsserventry *eptr, uint64_t chunkId, ChunkPartType chunkType,
-		uint32_t chunkVersion) {
+                                uint32_t chunkVersion, bool &sentChunkLock) {
+	sentChunkLock = false;
 	if (eptr->mode != ChunkserverConnectionMode::KILL) {
 		eptr->outputPackets.push_back(OutputPacket());
 		sassert(eptr->version >= kFirstECVersion);
-		matocs::createChunk::serialize(eptr->outputPackets.back().packet, chunkId, chunkType,
-				chunkVersion);
+		if (eptr->version >= kFirstVersionWithChunkserverSideChunkLock) {
+			// For newer chunkservers, create and lock part
+			matocs::createAndLockChunk::serialize(eptr->outputPackets.back().packet, chunkId,
+			                                      chunkType, chunkVersion);
+			sentChunkLock = true;
+		} else {
+			// For older chunkservers, create chunk without chunk lock, as they don't support it.
+			matocs::createChunk::serialize(eptr->outputPackets.back().packet, chunkId, chunkType,
+			                               chunkVersion);
+		}
 	}
 
 	return 0;
@@ -720,13 +729,87 @@ void matocsserv_got_replicatechunk_status(matocsserventry *eptr, const std::vect
 	}
 }
 
+int matocsserv_send_chunklock(matocsserventry *eptr, uint64_t chunkId, ChunkPartType chunkType,
+                              bool needLock, bool &sentChunkLock) {
+	sentChunkLock = false;
+	if (eptr->mode != ChunkserverConnectionMode::KILL) {
+		sassert(eptr->version >= kFirstECVersion);
+		if (eptr->version >= kFirstVersionWithChunkserverSideChunkLock && needLock) {
+			eptr->outputPackets.emplace_back();
+			matocs::chunkLock::serialize(eptr->outputPackets.back().packet, chunkId, chunkType);
+			sentChunkLock = true;
+		}
+		// For older chunkservers or if lock is not needed, we don't send chunk lock packet, as they
+		// don't support it or it's not needed.
+	}
+	return 0;
+}
+
+void matocsserv_got_chunklock_status(matocsserventry *eptr, const std::vector<uint8_t> &data) {
+	uint64_t chunkId;
+	ChunkPartType chunkType = slice_traits::standard::ChunkPartType();
+	uint8_t status;
+
+	sassert(eptr->version >= kFirstECVersion);
+	PacketVersion v;
+	deserializePacketVersionNoHeader(data, v);
+	sassert(v == cstoma::chunkLock::kECChunks);
+	cstoma::chunkLock::deserialize(data, chunkId, chunkType, status);
+
+	chunk_got_chunklock_status(eptr, chunkId, chunkType, status);
+	if (status != SAUNAFS_STATUS_OK) {
+		safs::log_info("({}:{}) chunk: {:016X} chunk lock status: {}", eptr->serviceStrIp,
+		               eptr->servport, chunkId, saunafs_error_string(status));
+	}
+}
+
+void matocsserv_got_writeend_status(matocsserventry *eptr, const std::vector<uint8_t> &data) {
+	uint64_t chunkId;
+	ChunkPartType chunkType = slice_traits::standard::ChunkPartType();
+	uint8_t status;
+
+	sassert(eptr->version >= kFirstECVersion);
+	PacketVersion v;
+	deserializePacketVersionNoHeader(data, v);
+	sassert(v == cstoma::writeEndStatus::kECChunks);
+	cstoma::writeEndStatus::deserialize(data, chunkId, chunkType, status);
+
+	chunk_got_writeend_status(eptr, chunkId, chunkType, status);
+	if (status != SAUNAFS_STATUS_OK) {
+		safs::log_info("({}:{}) chunk: {:016X} chunk write end status: {}", eptr->serviceStrIp,
+		               eptr->servport, chunkId, saunafs_error_string(status));
+	}
+}
+
+int matocsserv_send_chunkunlock(matocsserventry *eptr, uint64_t chunkId, ChunkPartType chunkType) {
+	if (eptr->mode != ChunkserverConnectionMode::KILL) {
+		sassert(eptr->version >= kFirstECVersion);
+		if (eptr->version >= kFirstVersionWithChunkserverSideChunkLock) {
+			eptr->outputPackets.emplace_back();
+			matocs::chunkUnlock::serialize(eptr->outputPackets.back().packet, chunkId, chunkType);
+		}
+		// For older chunkservers, we don't send chunk unlock packet, as they don't support it.
+	}
+	return 0;
+}
+
 int matocsserv_send_setchunkversion(matocsserventry *eptr, uint64_t chunkId, uint32_t newVersion,
-		uint32_t chunkVersion, ChunkPartType chunkType) {
+		uint32_t chunkVersion, ChunkPartType chunkType, bool needChunkLock, bool &sentChunkLock) {
+	sentChunkLock = false;
 	if (eptr->mode != ChunkserverConnectionMode::KILL) {
 		eptr->outputPackets.emplace_back();
 		sassert(eptr->version >= kFirstECVersion);
-		matocs::setVersion::serialize(eptr->outputPackets.back().packet, chunkId, chunkType,
-				chunkVersion, newVersion);
+		if (eptr->version >= kFirstVersionWithChunkserverSideChunkLock && needChunkLock) {
+			// For newer chunkservers, set version with chunk lock
+			matocs::setVersionAndLock::serialize(eptr->outputPackets.back().packet, chunkId,
+			                                     chunkType, chunkVersion, newVersion);
+			sentChunkLock = true;
+		} else {
+			// For older chunkservers or if lock is not needed, set version without chunk lock, as
+			// they don't support it or it's not needed.
+			matocs::setVersion::serialize(eptr->outputPackets.back().packet, chunkId, chunkType,
+			                              chunkVersion, newVersion);
+		}
 	}
 	return 0;
 }
@@ -750,16 +833,24 @@ void matocsserv_got_setchunkversion_status(matocsserventry *eptr,
 	}
 }
 
-int matocsserv_send_duplicatechunk(matocsserventry* eptr, uint64_t newChunkId, uint32_t newChunkVersion,
-		ChunkPartType chunkType, uint64_t chunkId, uint32_t chunkVersion) {
-	if (eptr->mode == ChunkserverConnectionMode::KILL) {
-		return 0;
-	}
+int matocsserv_send_duplicatechunk(matocsserventry *eptr, uint64_t newChunkId,
+                                   uint32_t newChunkVersion, ChunkPartType chunkType,
+                                   uint64_t chunkId, uint32_t chunkVersion, bool &sentChunkLock) {
+	sentChunkLock = false;
+	if (eptr->mode == ChunkserverConnectionMode::KILL) { return 0; }
 
 	OutputPacket outPacket;
 	sassert(eptr->version >= kFirstECVersion);
-	matocs::duplicateChunk::serialize(outPacket.packet, newChunkId, newChunkVersion, chunkType,
-	                                  chunkId, chunkVersion);
+	if (eptr->version >= kFirstVersionWithChunkserverSideChunkLock) {
+		// For newer chunkservers, duplicate with chunk lock
+		matocs::duplicateAndLockChunk::serialize(outPacket.packet, newChunkId, newChunkVersion,
+		                                         chunkType, chunkId, chunkVersion);
+		sentChunkLock = true;
+	} else {
+		// For older chunkservers, duplicate without chunk lock, as they don't support it.
+		matocs::duplicateChunk::serialize(outPacket.packet, newChunkId, newChunkVersion, chunkType,
+		                                  chunkId, chunkVersion);
+	}
 	eptr->outputPackets.push_back(std::move(outPacket));
 	return 0;
 }
@@ -1166,6 +1257,12 @@ void matocsserv_gotpacket(matocsserventry *eptr, PacketHeader header, const Mess
 				break;
 			case SAU_CSTOMA_DUPLICATE_CHUNK:
 				matocsserv_got_duplicatechunk_status(eptr, data);
+				break;
+			case SAU_CSTOMA_LOCK_CHUNK:
+				matocsserv_got_chunklock_status(eptr, data);
+				break;
+			case SAU_CSTOMA_WRITE_END_STATUS:
+				matocsserv_got_writeend_status(eptr, data);
 				break;
 			case SAU_CSTOMA_SET_VERSION:
 				matocsserv_got_setchunkversion_status(eptr, data);

--- a/src/master/matocsserv.cc
+++ b/src/master/matocsserv.cc
@@ -352,10 +352,12 @@ std::vector<ServerWithUsage> matocsserv_getservers_sorted() {
 }
 
 std::vector<std::pair<matocsserventry *, ChunkPartType>> matocsserv_getservers_for_new_chunk(
-		uint8_t goal_id, uint32_t min_server_version) {
+    uint8_t goal_id, uint16_t &min_server_count, uint32_t min_server_version) {
 	static std::array<ChunkCreationHistory, GoalId::kMax + 1> history;
 	GetServersForNewChunk getter;
 	const Goal &goal(gFSOperations->getGoalDefinition(goal_id));
+
+	min_server_count = std::numeric_limits<uint16_t>::max();
 
 	for (const auto &eptr : matocsservList) {
 		if (eptr->mode != ChunkserverConnectionMode::KILL && eptr->totalspace > 0 &&
@@ -386,6 +388,9 @@ std::vector<std::pair<matocsserventry *, ChunkPartType>> matocsserv_getservers_f
 	// we don't use any chunkserver twice if not necessary.
 	for (const auto &slice : goal) {
 		std::vector<std::pair<matocsserventry *, ChunkPartType>> slice_ret;
+		min_server_count =
+		    std::min(min_server_count,
+		             static_cast<uint16_t>(slice_traits::getNumberOfDataParts(slice.getType())));
 
 		// add parts index permutation here
 		std::array<int, Goal::Slice::kMaxPartsCount> shuffle;

--- a/src/master/matocsserv.h
+++ b/src/master/matocsserv.h
@@ -107,16 +107,17 @@ int matocsserv_send_sau_replicatechunk(matocsserventry* eptr,
 int matocsserv_send_deletechunk(matocsserventry* eptr,
 		uint64_t chunkId, uint32_t chunkVersion, ChunkPartType chunkType);
 int matocsserv_send_createchunk(matocsserventry *eptr, uint64_t chunkid, ChunkPartType chunkType,
-                                uint32_t version, bool &sentChunkLock);
+                                uint32_t version, bool needsLock, bool &sentChunkLock);
 int matocsserv_send_chunklock(matocsserventry *eptr, uint64_t chunkId, ChunkPartType chunkType,
-                              bool needLock, bool &sentChunkLock);
+                              bool needsLock, bool &sentChunkLock);
 int matocsserv_send_chunkunlock(matocsserventry *eptr, uint64_t chunkId, ChunkPartType chunkType);
 int matocsserv_send_setchunkversion(matocsserventry *eptr, uint64_t chunkId, uint32_t newVersion,
-                                    uint32_t chunkVersion, ChunkPartType chunkType,
-                                    bool needsLocking, bool &sentChunkLock);
+                                    uint32_t chunkVersion, ChunkPartType chunkType, bool needsLock,
+                                    bool &sentChunkLock);
 int matocsserv_send_duplicatechunk(matocsserventry *eptr, uint64_t newChunkId,
                                    uint32_t newChunkVersion, ChunkPartType chunkType,
-                                   uint64_t chunkId, uint32_t chunkVersion, bool &sentChunkLock);
+                                   uint64_t chunkId, uint32_t chunkVersion, bool needsLock,
+                                   bool &sentChunkLock);
 void matocsserv_send_truncatechunk(matocsserventry* eptr,
 		uint64_t chunkid, ChunkPartType chunkType, uint32_t length,
 		uint32_t version, uint32_t oldversion);

--- a/src/master/matocsserv.h
+++ b/src/master/matocsserv.h
@@ -89,8 +89,22 @@ std::vector<ServerWithUsage> matocsserv_getservers_sorted();
 uint32_t matocsserv_get_version(matocsserventry* eptr);
 void matocsserv_usagedifference(double *minusage, double *maxusage, uint16_t *usablescount,
                                 uint16_t *totalscount);
-std::vector<std::pair<matocsserventry*, ChunkPartType>> matocsserv_getservers_for_new_chunk(
-		uint8_t goalId, uint32_t min_server_version = 0);
+
+/*! \brief Get chunkservers for a new chunk.
+ *
+ * This function returns a list of chunkservers that can be used for a new chunk creation. The
+ * returned servers are randomly shuffled and sorted by disk usage, so the least used and least
+ * loaded servers are returned first.
+ *
+ * \param goalId - the id of the goal for which the chunk is being created.
+ * \param min_server_count[out] - the minimum number of servers that should be returned for each
+ *                                slice in the goal. This is needed to determine if there are
+ *                                enough servers to create a chunk with the given goal.
+ * \param min_server_version - return only chunkservers with higher (or equal) version.
+ * \return List of chunkservers for new chunk creation with their types.
+ */
+std::vector<std::pair<matocsserventry *, ChunkPartType>> matocsserv_getservers_for_new_chunk(
+    uint8_t goalId, uint16_t &min_server_count, uint32_t min_server_version = 0);
 void matocsserv_getspace(uint64_t* totalspace, uint64_t* availspace);
 const char* matocsserv_getstrip(matocsserventry* eptr);
 uint32_t matocsserv_get_servip(matocsserventry *eptr);

--- a/src/master/matocsserv.h
+++ b/src/master/matocsserv.h
@@ -106,13 +106,17 @@ int matocsserv_send_sau_replicatechunk(matocsserventry* eptr,
 
 int matocsserv_send_deletechunk(matocsserventry* eptr,
 		uint64_t chunkId, uint32_t chunkVersion, ChunkPartType chunkType);
-int matocsserv_send_createchunk(matocsserventry* eptr,
-		uint64_t chunkid, ChunkPartType chunkType, uint32_t version);
-int matocsserv_send_setchunkversion(matocsserventry* eptr,
-		uint64_t chunkId, uint32_t newVersion, uint32_t chunkVersion, ChunkPartType chunkType);
-int matocsserv_send_duplicatechunk(matocsserventry* eptr,
-		uint64_t newChunkId, uint32_t newChunkVersion,
-		ChunkPartType chunkType, uint64_t chunkId, uint32_t chunkVersion);
+int matocsserv_send_createchunk(matocsserventry *eptr, uint64_t chunkid, ChunkPartType chunkType,
+                                uint32_t version, bool &sentChunkLock);
+int matocsserv_send_chunklock(matocsserventry *eptr, uint64_t chunkId, ChunkPartType chunkType,
+                              bool needLock, bool &sentChunkLock);
+int matocsserv_send_chunkunlock(matocsserventry *eptr, uint64_t chunkId, ChunkPartType chunkType);
+int matocsserv_send_setchunkversion(matocsserventry *eptr, uint64_t chunkId, uint32_t newVersion,
+                                    uint32_t chunkVersion, ChunkPartType chunkType,
+                                    bool needsLocking, bool &sentChunkLock);
+int matocsserv_send_duplicatechunk(matocsserventry *eptr, uint64_t newChunkId,
+                                   uint32_t newChunkVersion, ChunkPartType chunkType,
+                                   uint64_t chunkId, uint32_t chunkVersion, bool &sentChunkLock);
 void matocsserv_send_truncatechunk(matocsserventry* eptr,
 		uint64_t chunkid, ChunkPartType chunkType, uint32_t length,
 		uint32_t version, uint32_t oldversion);

--- a/src/master/restore.cc
+++ b/src/master/restore.cc
@@ -969,7 +969,7 @@ int do_write(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
 	    FilesystemOperationContext::TransactionType::kReadWrite);
 
 	int status = gFSOperations->writeChunk(FsContext::getForRestore(ts), fsOpContext, inode, indx,
-	                                       false, &lockid, &chunkid, &opflag, nullptr);
+	                                       &lockid, &chunkid, &opflag, nullptr);
 
 	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
 		if (!fsOpContext.getReadWriteTransaction()->commit()) {

--- a/src/mount/writedata.cc
+++ b/src/mount/writedata.cc
@@ -528,20 +528,16 @@ void InodeChunkWriter::processJob(inodedata *inodeData) {
 	// First, choose index of some chunk to write
 	Glock lock(gMutex);
 	int status = inodeData_->status;
-	bool haveDataToWrite;
 	if (inodeData_->locator) {
 		// There is a chunk lock left by a previous unfinished job -- let's finish it!
 		chunkIndex_ = inodeData_->locator->chunkIndex();
-		haveDataToWrite = haveAnyBlockInCurrentChunk(lock);
 	} else if (!inodeData_->dataChain.empty()) {
 		// There is no unfinished job, but there is some data to write -- let's start a new job
 		chunkIndex_ = inodeData_->dataChain.front().chunkIndex;
-		haveDataToWrite = true;
 	} else {
 		// No data, no unfinished jobs -- something wrong!
 		// This should never happen, so the status doesn't really matter
 		safs::log_warn("got inode with no data to write!!!");
-		haveDataToWrite = false;
 		status = SAUNAFS_ERROR_EINVAL;
 	}
 	if (status != SAUNAFS_STATUS_OK) {
@@ -564,17 +560,15 @@ void InodeChunkWriter::processJob(inodedata *inodeData) {
 			inodeData_->maxfleng = std::max(inodeData_->maxfleng, locator->fileLength());
 			lock.unlock();
 
-			// Optimization -- talk with chunkservers only if we have to write any data.
-			// Don't do this if we just have to release some previously unlocked lock.
-			if (haveDataToWrite) {
-				writer.init(locator.get(), gChunkserverTimeout_ms);
-				processDataChain(writer);
-				writer.finish(kTimeToFinishOperations * 1000);
+			// Talk always to chunkservers, in order to release the locks sent to them.
+			writer.init(locator.get(), gChunkserverTimeout_ms);
+			processDataChain(writer);
+			writer.finish(kTimeToFinishOperations * 1000);
 
-				lock.lock();
-				returnJournalToDataChain(writer.releaseJournal(), lock);
-				lock.unlock();
-			}
+			lock.lock();
+			returnJournalToDataChain(writer.releaseJournal(), lock);
+			lock.unlock();
+
 			locator->unlockChunk();
 			read_inode_reconnect_and_clear_cache(inodeData_->inode, chunkIndex_);
 
@@ -621,7 +615,7 @@ void InodeChunkWriter::processJob(inodedata *inodeData) {
 
 			safs::log_warn("write file error, inode: {}, index: {} - {}", inodeData_->inode,
 			               chunkIndex_, errorString.c_str());
-			if (inodeData_->trycnt >= maxretries) {
+			if (inodeData_->trycnt >= maxretries && e.status() != SAUNAFS_ERROR_LOCKED) {
 				// Convert error to an unrecoverable error
 				throw UnrecoverableWriteException(e.message(), e.status());
 			} else {
@@ -1713,17 +1707,14 @@ void ChunkJobWriter::processJob(ChunkData *chunkData) {
 			Lock inodeLock(parent->mutex);
 			parent->maxfleng = std::max(parent->maxfleng, locator->fileLength());
 
-			// Optimization -- talk with chunkservers only if we have to write any data.
-			// Don't do this if we just have to release some previously unlocked lock.
-			if (haveAnyBlockInCurrentChunk()) {
-				inodeLock.unlock();
-				writer.init(locator.get(), gChunkserverTimeout_ms);
-				processDataChain(writer);
-				writer.finish(kTimeToFinishOperations * 1000);
+			// Talk always to chunkservers, in order to release the locks sent to them.
+			inodeLock.unlock();
+			writer.init(locator.get(), gChunkserverTimeout_ms);
+			processDataChain(writer);
+			writer.finish(kTimeToFinishOperations * 1000);
 
-				inodeLock.lock();
-				returnJournalToDataChain(writer.releaseJournal(), inodeLock);
-			}
+			inodeLock.lock();
+			returnJournalToDataChain(writer.releaseJournal(), inodeLock);
 			inodeLock.unlock();
 
 			locator->unlockChunk();
@@ -1770,7 +1761,7 @@ void ChunkJobWriter::processJob(ChunkData *chunkData) {
 
 			safs::log_warn("write file error, inode: {}, index: {} - {}", parent->inode,
 			               chunkIndex_, errorString.c_str());
-			if (chunkData_->tryCounter >= maxretries) {
+			if (chunkData_->tryCounter >= maxretries && e.status() != SAUNAFS_ERROR_LOCKED) {
 				// Convert error to an unrecoverable error
 				throw UnrecoverableWriteException(e.message(), e.status());
 			} else {

--- a/src/protocol/SFSCommunication.h
+++ b/src/protocol/SFSCommunication.h
@@ -451,6 +451,10 @@ enum class SugidClearMode : uint8_t {
 /// version==0 chunkid:64 chunktype:8 status:8
 /// version==1 chunkid:64 chunktype:16 status:8
 
+// 0x0459
+#define SAU_MATOCS_CREATE_AND_LOCK_CHUNK (1000U + 113U)
+/// version==0 chunkid:64 chunktype:16 chunkversion:32
+
 // 0x0460
 #define SAU_MATOCS_DELETE_CHUNK (1000U + 120U)
 /// version==0 chunkid:64 chunkversion:32 chunktype:8
@@ -471,6 +475,10 @@ enum class SugidClearMode : uint8_t {
 /// version==0 chunkid:64 chunktype:8 status:8
 /// version==1 chunkid:64 chunktype:16 status:8
 
+// 0x046C
+#define SAU_MATOCS_DUPLICATE_AND_LOCK_CHUNK (1000U + 132U)
+/// version==0 chunkid:64 chunkversion:32 chunktype:16 oldchunkid:64 oldchunkversion:32
+
 // 0x0474
 #define SAU_MATOCS_SET_VERSION (1000U + 140U)
 /// version==0 chunkid:64 chunkversion:32 chunktype:8 newchunkversion:32
@@ -480,6 +488,26 @@ enum class SugidClearMode : uint8_t {
 #define SAU_CSTOMA_SET_VERSION (1000U + 141U)
 /// version==0 chunkid:64 chunktype:8 status:8
 /// version==1 chunkid:64 chunktype:16 status:8
+
+// 0x0476
+#define SAU_MATOCS_SET_VERSION_AND_LOCK (1000U + 142U)
+/// version==0 chunkid:64 chunkversion:32 chunktype:16 newchunkversion:32
+
+// 0x0477
+#define SAU_MATOCS_LOCK_CHUNK (1000U + 143U)
+/// version==0 chunkid:64 chunktype:16
+
+// 0x0478
+#define SAU_CSTOMA_LOCK_CHUNK (1000U + 144U)
+/// version==0 chunkid:64 chunktype:16 status:8
+
+// 0x0479
+#define SAU_CSTOMA_WRITE_END_STATUS (1000U + 145U)
+/// version==0 chunkid:64 chunktype:16 status:8
+
+// 0x047A
+#define SAU_MATOCS_UNLOCK_CHUNK (1000U + 146U)
+/// version==0 chunkid:64 chunktype:16
 
 // 0x047e
 #define SAU_MATOCS_REPLICATE_CHUNK (1000U + 150U)

--- a/src/protocol/cstoma.h
+++ b/src/protocol/cstoma.h
@@ -111,6 +111,20 @@ SAUNAFS_DEFINE_PACKET_SERIALIZATION(
 		ChunkPartType, chunkType,
 		uint8_t,   status)
 
+SAUNAFS_DEFINE_PACKET_VERSION(cstoma, chunkLock, kECChunks, 0)
+SAUNAFS_DEFINE_PACKET_SERIALIZATION(
+		cstoma, chunkLock, SAU_CSTOMA_LOCK_CHUNK, kECChunks,
+		uint64_t,  chunkId,
+		ChunkPartType, chunkType,
+		uint8_t,   status)
+
+SAUNAFS_DEFINE_PACKET_VERSION(cstoma, writeEndStatus, kECChunks, 0)
+SAUNAFS_DEFINE_PACKET_SERIALIZATION(
+		cstoma, writeEndStatus, SAU_CSTOMA_WRITE_END_STATUS, kECChunks,
+		uint64_t,  chunkId,
+		ChunkPartType, chunkType,
+		uint8_t,   status)
+
 SAUNAFS_DEFINE_PACKET_VERSION(cstoma, deleteChunk, kStandardAndXorChunks, 0)
 SAUNAFS_DEFINE_PACKET_VERSION(cstoma, deleteChunk, kECChunks, 1)
 SAUNAFS_DEFINE_PACKET_SERIALIZATION(

--- a/src/protocol/cstoma_unittest.cc
+++ b/src/protocol/cstoma_unittest.cc
@@ -147,6 +147,40 @@ TEST(CstomaCommunicationTests, DeleteChunk) {
 	SAUNAFS_VERIFY_INOUT_PAIR(status);
 }
 
+TEST(CstomaCommunicationTests, ChunkLock) {
+	SAUNAFS_DEFINE_INOUT_PAIR(uint64_t, chunkId, 0xFFFFFFFFFFFFFFFF, 0);
+	SAUNAFS_DEFINE_INOUT_PAIR(ChunkPartType, chunkType, xor_p_of_3, standard);
+	SAUNAFS_DEFINE_INOUT_PAIR(uint8_t, status, 2, 0);
+
+	std::vector<uint8_t> buffer;
+	ASSERT_NO_THROW(cstoma::chunkLock::serialize(buffer, chunkIdIn, chunkTypeIn, statusIn));
+
+	verifyHeader(buffer, SAU_CSTOMA_LOCK_CHUNK);
+	removeHeaderInPlace(buffer);
+	ASSERT_NO_THROW(cstoma::chunkLock::deserialize(buffer, chunkIdOut, chunkTypeOut, statusOut));
+
+	SAUNAFS_VERIFY_INOUT_PAIR(chunkId);
+	SAUNAFS_VERIFY_INOUT_PAIR(chunkType);
+	SAUNAFS_VERIFY_INOUT_PAIR(status);
+}
+
+TEST(CstomaCommunicationTests, WriteEndStatus) {
+	SAUNAFS_DEFINE_INOUT_PAIR(uint64_t, chunkId, 0xFFFFFFFFFFFFFFFF, 0);
+	SAUNAFS_DEFINE_INOUT_PAIR(ChunkPartType, chunkType, xor_p_of_3, standard);
+	SAUNAFS_DEFINE_INOUT_PAIR(uint8_t, status, 2, 0);
+
+	std::vector<uint8_t> buffer;
+	ASSERT_NO_THROW(cstoma::writeEndStatus::serialize(buffer, chunkIdIn, chunkTypeIn, statusIn));
+
+	verifyHeader(buffer, SAU_CSTOMA_WRITE_END_STATUS);
+	removeHeaderInPlace(buffer);
+	ASSERT_NO_THROW(cstoma::writeEndStatus::deserialize(buffer, chunkIdOut, chunkTypeOut, statusOut));
+
+	SAUNAFS_VERIFY_INOUT_PAIR(chunkId);
+	SAUNAFS_VERIFY_INOUT_PAIR(chunkType);
+	SAUNAFS_VERIFY_INOUT_PAIR(status);
+}
+
 TEST(CstomaCommunicationTests, Replicate) {
 	SAUNAFS_DEFINE_INOUT_PAIR(uint64_t, chunkId, 0xFFFFFFFFFFFFFFFF, 0);
 	SAUNAFS_DEFINE_INOUT_PAIR(ChunkPartType, chunkType, xor_p_of_3, standard);

--- a/src/protocol/matocs.h
+++ b/src/protocol/matocs.h
@@ -47,6 +47,26 @@ SAUNAFS_DEFINE_PACKET_SERIALIZATION(
 		uint32_t,  chunkVersion,
 		uint32_t,  newVersion)
 
+SAUNAFS_DEFINE_PACKET_VERSION(matocs, setVersionAndLock, kECChunks, 0)
+SAUNAFS_DEFINE_PACKET_SERIALIZATION(
+		matocs, setVersionAndLock, SAU_MATOCS_SET_VERSION_AND_LOCK, kECChunks,
+		uint64_t,  chunkId,
+		ChunkPartType, chunkType,
+		uint32_t,  chunkVersion,
+		uint32_t,  newVersion)
+
+SAUNAFS_DEFINE_PACKET_VERSION(matocs, chunkLock, kECChunks, 0)
+SAUNAFS_DEFINE_PACKET_SERIALIZATION(
+		matocs, chunkLock, SAU_MATOCS_LOCK_CHUNK, kECChunks,
+		uint64_t,  chunkId,
+		ChunkPartType, chunkType)
+
+SAUNAFS_DEFINE_PACKET_VERSION(matocs, chunkUnlock, kECChunks, 0)
+SAUNAFS_DEFINE_PACKET_SERIALIZATION(
+	matocs, chunkUnlock, SAU_MATOCS_UNLOCK_CHUNK, kECChunks,
+	uint64_t,  chunkId,
+	ChunkPartType, chunkType)
+
 SAUNAFS_DEFINE_PACKET_VERSION(matocs, deleteChunk, kStandardAndXorChunks, 0)
 SAUNAFS_DEFINE_PACKET_VERSION(matocs, deleteChunk, kECChunks, 1)
 SAUNAFS_DEFINE_PACKET_SERIALIZATION(
@@ -69,6 +89,13 @@ SAUNAFS_DEFINE_PACKET_SERIALIZATION(
 		uint32_t,  chunkVersion)
 SAUNAFS_DEFINE_PACKET_SERIALIZATION(
 		matocs, createChunk, SAU_MATOCS_CREATE_CHUNK, kECChunks,
+		uint64_t,  chunkId,
+		ChunkPartType, chunkType,
+		uint32_t,  chunkVersion)
+
+SAUNAFS_DEFINE_PACKET_VERSION(matocs, createAndLockChunk, kECChunks, 0)
+SAUNAFS_DEFINE_PACKET_SERIALIZATION(
+		matocs, createAndLockChunk, SAU_MATOCS_CREATE_AND_LOCK_CHUNK, kECChunks,
 		uint64_t,  chunkId,
 		ChunkPartType, chunkType,
 		uint32_t,  chunkVersion)
@@ -103,6 +130,15 @@ SAUNAFS_DEFINE_PACKET_SERIALIZATION(
 		matocs, duplicateChunk, SAU_MATOCS_DUPLICATE_CHUNK, kECChunks,
 		uint64_t, newChunkId,
 		uint32_t, newchunkVersion,
+		ChunkPartType, chunkType,
+		uint64_t, oldChunkId,
+		uint32_t, oldChunkVersion)
+
+SAUNAFS_DEFINE_PACKET_VERSION(matocs, duplicateAndLockChunk, kECChunks, 0)
+SAUNAFS_DEFINE_PACKET_SERIALIZATION(
+		matocs, duplicateAndLockChunk, SAU_MATOCS_DUPLICATE_AND_LOCK_CHUNK, kECChunks,
+		uint64_t, newChunkId,
+		uint32_t, newChunkVersion,
 		ChunkPartType, chunkType,
 		uint64_t, oldChunkId,
 		uint32_t, oldChunkVersion)

--- a/src/protocol/matocs_unittest.cc
+++ b/src/protocol/matocs_unittest.cc
@@ -48,6 +48,44 @@ TEST(MatocsCommunicationTests, SetVersion) {
 	SAUNAFS_VERIFY_INOUT_PAIR(newVersion);
 }
 
+TEST(MatocsCommunicationTests, SetVersionAndLock) {
+	SAUNAFS_DEFINE_INOUT_PAIR(uint64_t, chunkId, 87, 0);
+	SAUNAFS_DEFINE_INOUT_PAIR(uint32_t, chunkVersion, 52, 0);
+	SAUNAFS_DEFINE_INOUT_PAIR(ChunkPartType, chunkType, xor_p_of_3, standard);
+	SAUNAFS_DEFINE_INOUT_PAIR(uint32_t, newVersion, 53, 0);
+
+	std::vector<uint8_t> buffer;
+	ASSERT_NO_THROW(matocs::setVersionAndLock::serialize(buffer, chunkIdIn, chunkTypeIn,
+	                                                     chunkVersionIn, newVersionIn));
+
+	verifyHeader(buffer, SAU_MATOCS_SET_VERSION_AND_LOCK);
+	removeHeaderInPlace(buffer);
+	verifyVersion(buffer, matocs::setVersionAndLock::kECChunks);
+	ASSERT_NO_THROW(matocs::setVersionAndLock::deserialize(buffer, chunkIdOut, chunkTypeOut,
+	                                                       chunkVersionOut, newVersionOut));
+
+	SAUNAFS_VERIFY_INOUT_PAIR(chunkId);
+	SAUNAFS_VERIFY_INOUT_PAIR(chunkVersion);
+	SAUNAFS_VERIFY_INOUT_PAIR(chunkType);
+	SAUNAFS_VERIFY_INOUT_PAIR(newVersion);
+}
+
+TEST(MatocsCommunicationTests, ChunkLock) {
+	SAUNAFS_DEFINE_INOUT_PAIR(uint64_t, chunkId, 87, 0);
+	SAUNAFS_DEFINE_INOUT_PAIR(ChunkPartType, chunkType, xor_p_of_3, standard);
+
+	std::vector<uint8_t> buffer;
+	ASSERT_NO_THROW(matocs::chunkLock::serialize(buffer, chunkIdIn, chunkTypeIn));
+
+	verifyHeader(buffer, SAU_MATOCS_LOCK_CHUNK);
+	removeHeaderInPlace(buffer);
+	verifyVersion(buffer, matocs::chunkLock::kECChunks);
+	ASSERT_NO_THROW(matocs::chunkLock::deserialize(buffer, chunkIdOut, chunkTypeOut));
+
+	SAUNAFS_VERIFY_INOUT_PAIR(chunkId);
+	SAUNAFS_VERIFY_INOUT_PAIR(chunkType);
+}
+
 TEST(MatocsCommunicationTests, DeleteChunk) {
 	SAUNAFS_DEFINE_INOUT_PAIR(uint64_t, chunkId, 87,  0);
 	SAUNAFS_DEFINE_INOUT_PAIR(uint32_t, chunkVersion, 52,  0);

--- a/tests/test_suites/ShortSystemTests/test_concurrent_random_writes_on_chunk.sh
+++ b/tests/test_suites/ShortSystemTests/test_concurrent_random_writes_on_chunk.sh
@@ -1,4 +1,4 @@
-timeout_set 30 seconds
+timeout_set 45 seconds
 
 CHUNKSERVERS=8 \
 	USE_RAMDISK=YES \
@@ -12,22 +12,51 @@ cd "${info[mount0]}"
 mkdir dir
 saunafs setgoal ec62 dir
 
-times_to_repeat=512
+times_to_repeat=1024
 FILE_SIZE=$(( times_to_repeat * 4 * 1024 )) file-generate ${TEMP_DIR}/original_file
 
-# Write 4KB at a time, 1KB in each of 4 mounts, and repeat this 512 times, so that the file is
+# Write 4KB at a time, 1KB in each of 4 mounts, and repeat this 1024 times, so that the file is
 # written in random order and with many concurrent writes.
+
+master_reloading_loop_file=${TEMP_DIR}/master_reloading_loop_file
+switch_use_chunkserver_side_chunk_lock_thread() {
+	touch ${master_reloading_loop_file}
+	while true; do
+		if [ ! -e ${master_reloading_loop_file} ]; then
+			break
+		fi
+		sleep 0.15
+		current=$(grep USE_CHUNKSERVER_SIDE_CHUNK_LOCK ${info[master0_cfg]} | tail -n 1 | awk '{print $3}')
+		echo "Switching USE_CHUNKSERVER_SIDE_CHUNK_LOCK to $(( 1 - current ))"
+		sed -i "s/USE_CHUNKSERVER_SIDE_CHUNK_LOCK = ./USE_CHUNKSERVER_SIDE_CHUNK_LOCK = $(( 1 - current ))/g" ${info[master0_cfg]}
+		saunafs_master_daemon reload
+	done
+	echo "switch_use_chunkserver_side_chunk_lock_thread stopped"
+}
+
+stop_switch_use_chunkserver_side_chunk_lock_thread() {
+	rm -f ${master_reloading_loop_file}
+}
+
+switch_use_chunkserver_side_chunk_lock_thread &
+switch_use_chunkserver_side_chunk_lock_thread_pid=$!
 
 for i in $(seq 0 $((times_to_repeat - 1))); do
 	shuffled_seq=($(shuf -e $(seq 0 3)))
+	pids=()
 	for mount in $(seq 0 3); do
 		dd if="${TEMP_DIR}/original_file" of="${info[mount${mount}]}/dir/file" bs=1K \
 			skip=$(( i * 4 + ${shuffled_seq[$mount]} )) \
 			seek=$(( i * 4 + ${shuffled_seq[$mount]} )) \
 			count=1 conv=notrunc 2>/dev/null &
+		pids+=("$!")
 	done
-	wait
+	if [ ${#pids[@]} -gt 0 ]; then
+		wait "${pids[@]}"
+	fi
 	echo "Done writing $i-th block of 4KB"
 done
+
+stop_switch_use_chunkserver_side_chunk_lock_thread
 
 MESSAGE="Validating file after concurrent random writes" expect_success file-validate dir/file

--- a/tests/tools/saunafs.sh
+++ b/tests/tools/saunafs.sh
@@ -379,6 +379,12 @@ create_sfsmaster_master_cfg_() {
 	echo "METADATA_BACKEND = ${saunafs_info_[metadata_backend]}"
 }
 
+add_lines_master_cfg_() {
+	lines=$1
+	lines_with_newline=$(echo "${lines}" | tr '|' '\n')
+	echo "${lines_with_newline}" >> "${saunafs_info_[master${saunafs_info_[current_master]}_cfg]}"
+}
+
 create_sfsmaster_shadow_cfg_() {
 	local this_module_cfg_variable="MASTER_${masterserver_id}_EXTRA_CONFIG"
 	echo "PERSONALITY = shadow"
@@ -1084,6 +1090,9 @@ function is_zoned_device() {
 # Adds around 15s to the test.
 sfschunkserver_check_no_buffer_in_use() {
 	# Make sure some time passes to get dead csentries cleaned up
+	add_lines_master_cfg_ "CHUNKS_WRITE_REP_LIMIT = 1|CHUNKS_READ_REP_LIMIT = 1|`
+		`CHUNKS_LOOP_MIN_TIME = 10000"
+	saunafs_master_daemon reload
 	sleep 10
 
 	chunkserver_count=${saunafs_info_[chunkserver_count]}

--- a/tests/tools/saunafs.sh
+++ b/tests/tools/saunafs.sh
@@ -372,6 +372,7 @@ create_sfsmaster_master_cfg_() {
 	echo "MATOTS_LISTEN_PORT = ${saunafs_info_[matots]}"
 	echo "METADATA_CHECKSUM_INTERVAL = 1"
 	echo "ADMIN_PASSWORD = ${saunafs_info_[admin_password]}"
+	echo "USE_CHUNKSERVER_SIDE_CHUNK_LOCK = 1"
 	create_magic_debug_log_entry_ "master_${masterserver_id}"
 	echo "${MASTER_EXTRA_CONFIG-}" | tr '|' '\n'
 	echo "${!this_module_cfg_variable-}" | tr '|' '\n'


### PR DESCRIPTION
The current implementation of the chunk locking in the system relies only in the client responses when finishing write and truncate operations. This commit targets including also chunkserver side replies after receiving an actual stream of write operations to decide whether the chunk is locked or not. This is not useful in the current state of code and must not affect the behavior of the system because the client responses to the master in order to unlock the chunk happen after the data is already in the chunkserver or there is some error.

The idea of the change is to keep track in each of the chunk parts of whether it is expected to be written at the time. Please note this affects all the writes coming from the client and some truncates. Those cases trigger one these functions:
- chunk_create_operation
- chunk_increase_version_operation
- chunk_lock_operation
- chunk_duplicate_operation

which can be traced back to the chunk_multi_modify function. After checking some conditions (specially if the CS version supports this feature) the new packets arrive to the CS and in most of the cases the write operation needs to wait for its responses, and the chunk parts are considered being written.

In the CS side, the locking is handled by the master's main JobPool. It can start, enforce, end and erase chunk lock jobs. The locked chunks are special the way that after ending the write operations on it, the master receives the status of the write operations that was not told to the clients, so far it is always OK because everything is told to the clients. Master jobs on enforced locked chunks will have to wait until the chunk is released, i.e finish writing.

Back again in the master side, it handles disconnection of parts being written and errors on those writes the same way: increasing version when the chance appears.

Side changes:
- refactor chunk_multi_modify and chunk_multi_truncate functions.
- change the effective grace time when starting and trying to create
chunk before responding "no space" from 600s to 60s.
- add documentation to some members of the Chunk class deeply involved
in the change.
- remove `usedummylockid` from `chunk_multi_modify` and `writeChunk`
functions.
- in the client side, always talk to the chunkservers when writing.
- the main SaunaFS package version was updated to 5.8.0.
- the cases that return SAUNAFS_ERROR_NOSPACE in the master side
were improved.

The new behavior implemented previously can be now enabled and disabled
via the option USE_CHUNKSERVER_SIDE_CHUNK_LOCK. This option is
reloadable. The decision making instant is at the moment of sending the
specific packet type to the chunkservers.

The testing framework was modified in order to enable this option in
all tests, while the default master behavior has it disabled.

Closes [LS-314](https://linear.app/leil/issue/LS-314/chunkserver-side-chunk-locking).

Signed-off-by: Dave <dave@leil.io>