### PR TITLE
chore(master): Improve empty reserved files docs LS-336

### DIFF
--- a/doc/sfsmaster.cfg.5.adoc
+++ b/doc/sfsmaster.cfg.5.adoc
@@ -290,6 +290,23 @@ for TLS connections (there is no default value).
 Path to the trusted CA certificate which is used to authenticate
 the TLS connection (there is no default value).
 
+*EMPTY_RESERVED_FILES_PERIOD_MSECONDS (EXPERIMENTAL)*::
+Interval for periodic cleaning of reserved files, in milliseconds.
+If set to 0, the reserved files deletion is disabled. (Default: 0)
+
+[WARNING]
+====
+Administrator-only option. Enabling periodic deletion may remove master-side
+references to reserved files that are still held by other applications or
+client instances that have not released them yet. This can disrupt ongoing
+operations and lead to unexpected errors.
+
+Recommended approach: Do not enable automatic deletion unless you fully
+understand the impact on running workloads. Prefer manually freeing reserved
+files by locating each reference or process using them and stopping it before
+releasing the reservation.
+====
+
 == NOTES
 
 Chunks in master are tested in loop. Speed (or frequency) is regulated by two

--- a/src/data/sfsmaster.cfg.in
+++ b/src/data/sfsmaster.cfg.in
@@ -244,11 +244,6 @@
 ## (Default: 3600)
 # METADATA_DUMP_PERIOD_SECONDS = 3600
 
-## Interval for periodically cleaning of reserved files, in milliseconds. If set to 0, the reserved files
-## deletion is disabled.
-## (Default: 0)
-# EMPTY_RESERVED_FILES_PERIOD_MSECONDS = 0
-
 # deprecated:
 # CHUNKS_DEL_LIMIT - use CHUNKS_SOFT_DEL_LIMIT instead
 
@@ -355,3 +350,14 @@
 ## Example: /etc/saunafs/ssl/ca.crt
 ## (There is no default)
 # TLS_CA_CERT_FILE =
+
+## Interval for periodic cleaning of reserved files, in milliseconds.
+## If set to 0, the reserved files deletion is disabled.
+## (Default: 0)
+##
+## Note: Administrator-only option. Enabling periodic deletion may remove
+## master-side references to reserved files that are still held by other
+## applications or client instances that have not released them yet. This
+## can disrupt ongoing operations and lead to unexpected errors.
+##
+# EMPTY_RESERVED_FILES_PERIOD_MSECONDS = 0


### PR DESCRIPTION
Explicitly mark EMPTY_RESERVED_FILES_PERIOD_MSECONDS as experimental and add a detailed warning to clarify the potential risks of enabling periodic reserved file cleanup.

The warning highlights possible disruption of active workloads and advises administrators to use this option with caution.