### PR TITLE
feat(tls): Secure master-admin with TLS layer LS-245

### DIFF
--- a/src/admin/chunk_health_command.cc
+++ b/src/admin/chunk_health_command.cc
@@ -44,6 +44,7 @@ SaunaFsAdminCommand::SupportedOptions ChunksHealthCommand::supportedOptions() co
 		{kOptionAvailability, "Print report about availability of chunks."},
 		{kOptionReplication,  "Print report about about number of chunks that need replication."},
 		{kOptionDeletion,     "Print report about about number of chunks that need deletion."},
+		{kTlsMode,            kTlsModeDescription},
 	};
 }
 
@@ -76,7 +77,10 @@ void ChunksHealthCommand::run(const Options& options) const {
 		throw WrongUsageException("Expected <master ip> and <master port> for " + name() + '\n');
 	}
 
-	ServerConnection connection(options.argument(0), options.argument(1));
+	auto tlsCfg =
+	    options.getValue<std::string>("--tlsconfigfile", std::string(TlsSession::kNoFile));
+
+	ServerConnection connection(options.argument(0), options.argument(1), tlsCfg);
 	bool regularOnly = false;
 	auto request = cltoma::chunksHealth::build(regularOnly);
 	auto response = connection.sendAndReceive(request, SAU_MATOCL_CHUNKS_HEALTH);

--- a/src/admin/delete_sessions_command.cc
+++ b/src/admin/delete_sessions_command.cc
@@ -31,12 +31,21 @@ void DeleteSessionsCommand::usage() const {
 	std::cerr << "    Deletes the specified session." << std::endl;
 }
 
+SaunaFsAdminCommand::SupportedOptions DeleteSessionsCommand::supportedOptions() const {
+	return {
+	    {kTlsMode, kTlsModeDescription},
+	};
+}
+
 void DeleteSessionsCommand::run(const Options& options) const {
 	if (options.arguments().size() != 3) {
 		throw WrongUsageException("Expected <master ip>, <master port>, and <session_id> for " + name());
 	}
 
-	ServerConnection connection(options.argument(0), options.argument(1));
+	auto tlsCfg =
+	    options.getValue<std::string>("--tlsconfigfile", std::string(TlsSession::kNoFile));
+
+	ServerConnection connection(options.argument(0), options.argument(1), tlsCfg);
 	uint64_t sessionId = std::stoull(options.argument(2));
 
 	auto request = cltoma::deleteSession::build(sessionId);

--- a/src/admin/delete_sessions_command.h
+++ b/src/admin/delete_sessions_command.h
@@ -24,4 +24,5 @@ public:
 	std::string name() const final;
 	void usage() const final;
 	void run(const Options& options) const final;
+	virtual SupportedOptions supportedOptions() const;
 };

--- a/src/admin/dump_config_command.cc
+++ b/src/admin/dump_config_command.cc
@@ -44,6 +44,9 @@ SaunaFsAdminCommand::SupportedOptions DumpConfigurationCommand::supportedOptions
 			defaultsMode,
 			    "Return default values as well. This is informational and may "
 			    "not be correct in all cases."
+		},
+		{
+			kTlsMode, kTlsModeDescription
 		}
 	};
 }
@@ -54,8 +57,10 @@ void DumpConfigurationCommand::run(const Options &options) const {
 		    "Expected <master ip> and <master port> for " + name());
 	}
 
-	auto connection = RegisteredAdminConnection::create(options.argument(0),
-	                                                    options.argument(1));
+	auto tlsCfg =
+	    options.getValue<std::string>("--tlsconfigfile", std::string(TlsSession::kNoFile));
+
+	auto connection = RegisteredAdminConnection::create(options.argument(0), options.argument(1), tlsCfg);
 	auto adminResponse = connection->sendAndReceive(
 	    cltoma::adminDumpConfiguration::build(), SAU_MATOCL_ADMIN_DUMP_CONFIG);
 

--- a/src/admin/info_command.cc
+++ b/src/admin/info_command.cc
@@ -35,6 +35,7 @@ std::string InfoCommand::name() const {
 SaunaFsAdminCommand::SupportedOptions InfoCommand::supportedOptions() const {
 	return {
 		{kPorcelainMode, kPorcelainModeDescription},
+		{kTlsMode, kTlsModeDescription},
 	};
 }
 
@@ -48,7 +49,11 @@ void InfoCommand::run(const Options& options) const {
 		throw WrongUsageException("Expected <master ip> and <master port> for " + name());
 	}
 
-	ServerConnection connection(options.argument(0), options.argument(1));
+	const std::string host = options.argument(0);
+	const std::string port = options.argument(1);
+	auto tlsCfg =
+	    options.getValue<std::string>("--tlsconfigfile", std::string(TlsSession::kNoFile));
+	ServerConnection connection(host, port, tlsCfg);
 	std::vector<uint8_t> request, response;
 	serializeLegacyPacket(request, CLTOMA_INFO);
 	response = connection.sendAndReceive(request, MATOCL_INFO);

--- a/src/admin/io_limits_status_command.cc
+++ b/src/admin/io_limits_status_command.cc
@@ -37,7 +37,7 @@ void IoLimitsStatusCommand::usage() const {
 }
 
 SaunaFsAdminCommand::SupportedOptions IoLimitsStatusCommand::supportedOptions() const {
-	return { {kPorcelainMode, kPorcelainModeDescription} };
+	return {{kPorcelainMode, kPorcelainModeDescription}, {kTlsMode, kTlsModeDescription}};
 }
 
 void IoLimitsStatusCommand::run(const Options& options) const {
@@ -45,7 +45,10 @@ void IoLimitsStatusCommand::run(const Options& options) const {
 		throw WrongUsageException("Expected <master ip> and <master port> for " + name());
 	}
 
-	ServerConnection connection(options.argument(0), options.argument(1));
+	auto tlsCfg =
+	    options.getValue<std::string>("--tlsconfigfile", std::string(TlsSession::kNoFile));
+
+	ServerConnection connection(options.argument(0), options.argument(1), tlsCfg);
 	auto request = cltoma::iolimitsStatus::build(1);
 	auto response = connection.sendAndReceive(request, SAU_MATOCL_IOLIMITS_STATUS);
 

--- a/src/admin/list_chunkservers_command.cc
+++ b/src/admin/list_chunkservers_command.cc
@@ -37,6 +37,7 @@ std::string ListChunkserversCommand::name() const {
 SaunaFsAdminCommand::SupportedOptions ListChunkserversCommand::supportedOptions() const {
 	return {
 		{kPorcelainMode, kPorcelainModeDescription},
+		{kTlsMode, kTlsModeDescription},
 	};
 }
 
@@ -49,7 +50,11 @@ void ListChunkserversCommand::run(const Options& options) const {
 	if (options.arguments().size() != 2) {
 		throw WrongUsageException("Expected <master ip> and <master port> for " + name());
 	}
-	for (const auto& cs : getChunkserversList(options.argument(0), options.argument(1))) {
+
+	auto tlsCfg =
+	    options.getValue<std::string>("--tlsconfigfile", std::string(TlsSession::kNoFile));
+
+	for (const auto& cs : getChunkserversList(options.argument(0), options.argument(1), tlsCfg)) {
 		auto address = NetworkAddress(cs.servip, cs.servport);
 		if (cs.version == kDisconnectedChunkserverVersion) {
 			if (options.isSet(kPorcelainMode)) {
@@ -89,8 +94,8 @@ void ListChunkserversCommand::run(const Options& options) const {
 }
 
 std::vector<ChunkserverListEntry> ListChunkserversCommand::getChunkserversList (
-		const std::string& masterHost, const std::string& masterPort) {
-	ServerConnection connection(masterHost, masterPort);
+		const std::string& masterHost, const std::string& masterPort, const std::string& tlsCfg) {
+	ServerConnection connection(masterHost, masterPort, tlsCfg);
 	auto request = cltoma::cservList::build(true);
 	auto response = connection.sendAndReceive(request, SAU_MATOCL_CSERV_LIST);
 	std::vector<ChunkserverListEntry> result;

--- a/src/admin/list_chunkservers_command.h
+++ b/src/admin/list_chunkservers_command.h
@@ -35,6 +35,7 @@ public:
 	virtual void usage() const;
 	virtual void run(const Options& options) const;
 
-	static std::vector<ChunkserverListEntry> getChunkserversList (
-			const std::string& masterHost, const std::string& masterPort);
+	static std::vector<ChunkserverListEntry> getChunkserversList(const std::string &masterHost,
+	                                                             const std::string &masterPort,
+	                                                             const std::string &tlsCfg);
 };

--- a/src/admin/list_defective_files_command.cc
+++ b/src/admin/list_defective_files_command.cc
@@ -48,6 +48,7 @@ void ListDefectiveFilesCommand::usage() const {
 SaunaFsAdminCommand::SupportedOptions ListDefectiveFilesCommand::supportedOptions() const {
 	return {
 		{kPorcelainMode, kPorcelainModeDescription},
+		{kTlsMode, kTlsModeDescription},
 		{"--unavailable", "Print unavailable files"},
 		{"--undergoal", "Print files with undergoal chunks"},
 		{"--structure-error", "Print files/directories with structure error"},
@@ -80,7 +81,10 @@ void ListDefectiveFilesCommand::run(const Options &options) const {
 		throw WrongUsageException("Expected <master ip> and <master port> for " + name());
 	}
 
-	ServerConnection connection(options.argument(0), options.argument(1));
+	auto tlsCfg =
+	    options.getValue<std::string>("--tlsconfigfile", std::string(TlsSession::kNoFile));
+
+	ServerConnection connection(options.argument(0), options.argument(1), tlsCfg);
 	uint8_t flags_set = 0;
 	if (options.isSet("--unavailable")) {
 		flags_set |= kChunkUnavailable;

--- a/src/admin/list_disk_groups_command.cc
+++ b/src/admin/list_disk_groups_command.cc
@@ -29,6 +29,12 @@
 
 std::string ListDiskGroupsCommand::name() const { return "list-disk-groups"; }
 
+SaunaFsAdminCommand::SupportedOptions ListDiskGroupsCommand::supportedOptions() const {
+	return {
+	    {kTlsMode, kTlsModeDescription},
+	};
+}
+
 void ListDiskGroupsCommand::usage() const {
 	std::cerr << name() << " <master ip> <master port>\n";
 	std::cerr << "    Prints disk groups configuration in chunkservers.\n";
@@ -40,8 +46,11 @@ void ListDiskGroupsCommand::run(const Options &options) const {
 		    "Expected <master ip> and <master port> for " + name());
 	}
 
+	auto tlsCfg =
+	    options.getValue<std::string>("--tlsconfigfile", std::string(TlsSession::kNoFile));
+
 	auto chunkservers = ListChunkserversCommand::getChunkserversList(
-	    options.argument(0), options.argument(1));
+	    options.argument(0), options.argument(1), tlsCfg);
 
 	YAML::Emitter yaml;
 	yaml << YAML::BeginMap;  // start root map

--- a/src/admin/list_disk_groups_command.h
+++ b/src/admin/list_disk_groups_command.h
@@ -27,4 +27,5 @@ public:
 	std::string name() const override;
 	void usage() const override;
 	void run(const Options& options) const override;
+	SupportedOptions supportedOptions() const override;
 };

--- a/src/admin/list_disks_command.cc
+++ b/src/admin/list_disks_command.cc
@@ -186,6 +186,7 @@ std::string ListDisksCommand::name() const {
 SaunaFsAdminCommand::SupportedOptions ListDisksCommand::supportedOptions() const {
 	return {
 		{kPorcelainMode, kPorcelainModeDescription},
+		{kTlsMode, kTlsModeDescription},
 		{kVerboseMode,   "Be a little more verbose and show operations statistics."},
 	};
 }
@@ -199,8 +200,12 @@ void ListDisksCommand::run(const Options& options) const {
 	if (options.arguments().size() != 2) {
 		throw WrongUsageException("Expected <master ip> and <master port> for " + name());
 	}
+
+	auto tlsCfg =
+	    options.getValue<std::string>("--tlsconfigfile", std::string(TlsSession::kNoFile));
+
 	auto chunkservers = ListChunkserversCommand::getChunkserversList(
-			options.argument(0), options.argument(1));
+			options.argument(0), options.argument(1), tlsCfg);
 	for (const auto& cs : chunkservers) {
 		if (cs.version == kDisconnectedChunkserverVersion) {
 			continue; // skip disconnected chunkservers -- these surely won't respond

--- a/src/admin/list_goals_command.cc
+++ b/src/admin/list_goals_command.cc
@@ -40,6 +40,7 @@ std::string ListGoalsCommand::name() const {
 SaunaFsAdminCommand::SupportedOptions ListGoalsCommand::supportedOptions() const {
 	return {
 		{kPorcelainMode, kPorcelainModeDescription},
+		{kTlsMode, kTlsModeDescription},
 		{"--pretty", "Print nice table"}
 	};
 }
@@ -54,7 +55,10 @@ void ListGoalsCommand::run(const Options& options) const {
 		throw WrongUsageException("Expected <master ip> and <master port> for " + name());
 	}
 
-	ServerConnection connection(options.argument(0), options.argument(1));
+	auto tlsCfg =
+	    options.getValue<std::string>("--tlsconfigfile", std::string(TlsSession::kNoFile));
+
+	ServerConnection connection(options.argument(0), options.argument(1), tlsCfg);
 	std::vector<SerializedGoal> serializedGoals;
 	auto request = cltoma::listGoals::build(true);
 	auto response = connection.sendAndReceive(request, SAU_MATOCL_LIST_GOALS);

--- a/src/admin/list_inotifiers_command.cc
+++ b/src/admin/list_inotifiers_command.cc
@@ -38,7 +38,7 @@ void ListInotifiersCommand::usage() const {
 }
 
 SaunaFsAdminCommand::SupportedOptions ListInotifiersCommand::supportedOptions() const {
-	return {{kPorcelainMode, kPorcelainModeDescription}};
+	return {{kPorcelainMode, kPorcelainModeDescription}, {kTlsMode, kTlsModeDescription}};
 }
 
 template <class T>
@@ -74,9 +74,11 @@ void ListInotifiersCommand::run(const Options &options) const {
 	uint16_t port = 0;
 	const std::string &masterIp = options.argument(kIpArgOffset);
 	const std::string &masterPort = options.argument(kPortArgOffset);
+	auto tlsCfg =
+	    options.getValue<std::string>("--tlsconfigfile", std::string(TlsSession::kNoFile));
 
 	tcpresolve(masterIp.c_str(), masterPort.c_str(), &ip, &port, false);
-	ServerConnection conn(NetworkAddress(ip, port));
+	ServerConnection conn(NetworkAddress(ip, port), tlsCfg);
 	auto request = cltoma::inotifierList::build();
 	auto response = conn.sendAndReceive(request, SAU_MATOCL_INOTIFIER_LIST);
 

--- a/src/admin/list_metadataservers_command.cc
+++ b/src/admin/list_metadataservers_command.cc
@@ -42,7 +42,7 @@ void ListMetadataserversCommand::usage() const {
 }
 
 SaunaFsAdminCommand::SupportedOptions ListMetadataserversCommand::supportedOptions() const {
-	return { {kPorcelainMode, kPorcelainModeDescription} };
+	return {{kPorcelainMode, kPorcelainModeDescription}, {kTlsMode, kTlsModeDescription}};
 }
 
 template<class T>
@@ -76,8 +76,10 @@ void ListMetadataserversCommand::run(const Options& options) const {
 	uint16_t port = 0;
 	std::string ipString = options.argument(0);
 	std::string portString = options.argument(1);
+	auto tlsCfg =
+	    options.getValue<std::string>("--tlsconfigfile", std::string(TlsSession::kNoFile));
 	tcpresolve(ipString.c_str(), portString.c_str(), &ip, &port, false);
-	ServerConnection connection(NetworkAddress(ip, port));
+	ServerConnection connection(NetworkAddress(ip, port), tlsCfg);
 	auto request = cltoma::metadataserversList::build();
 	auto response = connection.sendAndReceive(request, SAU_MATOCL_METADATASERVERS_LIST);
 
@@ -95,7 +97,7 @@ void ListMetadataserversCommand::run(const Options& options) const {
 		// If information about MATOCL_SERV_PORT used by shadows isn't available we cannot query it
 		// for its hostname, metaversion etc.
 		if (e.port != 0) {
-			ServerConnection shadowConnection(NetworkAddress(e.ip, e.port));
+			ServerConnection shadowConnection(NetworkAddress(e.ip, e.port), tlsCfg);
 			s = MetadataserverStatusCommand::getStatus(shadowConnection);
 
 			auto request = cltoma::hostname::build();

--- a/src/admin/list_mounts_command.cc
+++ b/src/admin/list_mounts_command.cc
@@ -65,6 +65,7 @@ std::string ListMountsCommand::name() const {
 SaunaFsAdminCommand::SupportedOptions ListMountsCommand::supportedOptions() const {
 	return {
 		{kPorcelainMode, kPorcelainModeDescription},
+		{kTlsMode, kTlsModeDescription},
 		{kVerboseMode,   "Be a little more verbose and show goal and trash time limits."},
 	};
 }

--- a/src/admin/list_sessions_command.cc
+++ b/src/admin/list_sessions_command.cc
@@ -39,14 +39,18 @@ void ListSessionsCommand::usage() const {
 }
 
 SaunaFsAdminCommand::SupportedOptions ListSessionsCommand::supportedOptions() const {
-	return {};
+	return {{kTlsMode, kTlsModeDescription}};
 }
 
 void ListSessionsCommand::run(const Options& options) const {
 	if (options.arguments().size() != 2) {
 		throw WrongUsageException("Expected <master ip> and <master port> for " + name());
 	}
-	ServerConnection connection(options.argument(0), options.argument(1));
+
+	auto tlsCfg =
+	    options.getValue<std::string>("--tlsconfigfile", std::string(TlsSession::kNoFile));
+
+	ServerConnection connection(options.argument(0), options.argument(1), tlsCfg);
 	LegacyVector<SessionFiles> sessions;
 
 	auto request = cltoma::listSessions::build();

--- a/src/admin/list_tasks_command.cc
+++ b/src/admin/list_tasks_command.cc
@@ -32,6 +32,10 @@ std::string ListTasksCommand::name() const {
 	return "list-tasks";
 }
 
+SaunaFsAdminCommand::SupportedOptions ListTasksCommand::supportedOptions() const {
+	return {{kTlsMode, kTlsModeDescription}};
+}
+
 void ListTasksCommand::usage() const {
 	std::cerr << name() << " <master ip> <master port>" << std::endl;
 	std::cerr << "    Lists tasks which are currently executed by master" << std::endl;
@@ -42,7 +46,10 @@ void ListTasksCommand::run(const Options& options) const {
 		throw WrongUsageException("Expected <master ip> and <master port> for " + name());
 	}
 
-	ServerConnection connection(options.argument(0), options.argument(1));
+	auto tlsCfg =
+	    options.getValue<std::string>("--tlsconfigfile", std::string(TlsSession::kNoFile));
+
+	ServerConnection connection(options.argument(0), options.argument(1), tlsCfg);
 	std::vector<JobInfo> jobs_info;
 
 	auto request = cltoma::listTasks::build(true);

--- a/src/admin/list_tasks_command.h
+++ b/src/admin/list_tasks_command.h
@@ -30,4 +30,5 @@ public:
 	std::string name() const override;
 	void usage() const override;
 	void run(const Options& options) const override;
+	SupportedOptions supportedOptions() const override;
 };

--- a/src/admin/magic_recalculate_metadata_checksum_command.cc
+++ b/src/admin/magic_recalculate_metadata_checksum_command.cc
@@ -37,16 +37,21 @@ void MagicRecalculateMetadataChecksumCommand::usage() const {
 	std::cerr << "    Authentication with the admin password is required." << std::endl;
 }
 
-SaunaFsAdminCommand::SupportedOptions MagicRecalculateMetadataChecksumCommand::supportedOptions() const {
-	return { {"--async", "Don't wait for the task to finish."},
-	         {"--timeout=", "Operation timeout" }};
+SaunaFsAdminCommand::SupportedOptions MagicRecalculateMetadataChecksumCommand::supportedOptions()
+    const {
+	return {{"--async", "Don't wait for the task to finish."},
+	        {"--timeout=", "Operation timeout"},
+	        {kTlsMode, kTlsModeDescription}};
 }
 
 void MagicRecalculateMetadataChecksumCommand::run(const Options& options) const {
 	bool async = options.isSet("--async");
 
 	int timeout = 1000 * options.getValue<int>("--timeout", ServerConnection::kDefaultTimeout / 1000);
-	auto connection = RegisteredAdminConnection::create(options.argument(0), options.argument(1), timeout);
+	auto tlsCfg =
+	    options.getValue<std::string>("--tlsconfigfile", std::string(TlsSession::kNoFile));
+	auto connection = RegisteredAdminConnection::create(options.argument(0), options.argument(1),
+	                                                    tlsCfg, timeout);
 	auto request = cltoma::adminRecalculateMetadataChecksum::build(async);
 	auto response = connection->sendAndReceive(request, SAU_MATOCL_ADMIN_RECALCULATE_METADATA_CHECKSUM);
 	uint8_t status;

--- a/src/admin/manage_locks_command.cc
+++ b/src/admin/manage_locks_command.cc
@@ -45,6 +45,7 @@ void ManageLocksCommand::usage() const {
 SaunaFsAdminCommand::SupportedOptions ManageLocksCommand::supportedOptions() const {
 	return {
 		{kPorcelainMode, kPorcelainModeDescription},
+		{kTlsMode, kTlsModeDescription},
 		{"--active", "Print only active locks"},
 		{"--pending", "Print only pending locks"},
 		{"--inode=", "Specify an inode for operation"},
@@ -184,7 +185,12 @@ void ManageLocksCommand::run(const Options &options) const {
 		throw WrongUsageException("<master ip> <master port> [list/unlock] [flock/posix/all] for "
 				+ name());
 	}
-	auto connection = RegisteredAdminConnection::create(options.argument(0), options.argument(1));
+
+	auto tlsCfg =
+	    options.getValue<std::string>("--tlsconfigfile", std::string(TlsSession::kNoFile));
+
+	auto connection =
+	    RegisteredAdminConnection::create(options.argument(0), options.argument(1), tlsCfg);
 
 	if (options.argument(2) == "unlock") {
 		processUnlock(*connection, options);

--- a/src/admin/metadataserver_status_command.cc
+++ b/src/admin/metadataserver_status_command.cc
@@ -37,7 +37,7 @@ void MetadataserverStatusCommand::usage() const {
 }
 
 SaunaFsAdminCommand::SupportedOptions MetadataserverStatusCommand::supportedOptions() const {
-	return { {kPorcelainMode, kPorcelainModeDescription} };
+	return {{kPorcelainMode, kPorcelainModeDescription}, {kTlsMode, kTlsModeDescription}};
 }
 
 void MetadataserverStatusCommand::run(const Options& options) const {
@@ -45,7 +45,10 @@ void MetadataserverStatusCommand::run(const Options& options) const {
 		throw WrongUsageException("Expected <master ip> and <master port> for " + name());
 	}
 
-	ServerConnection connection(options.argument(0), options.argument(1));
+	auto tlsCfg =
+	    options.getValue<std::string>("--tlsconfigfile", std::string(TlsSession::kNoFile));
+
+	ServerConnection connection(options.argument(0), options.argument(1), tlsCfg);
 	MetadataserverStatus s = MetadataserverStatusCommand::getStatus(connection);
 
 	if (options.isSet(kPorcelainMode)) {

--- a/src/admin/mount_info_list_command.cc
+++ b/src/admin/mount_info_list_command.cc
@@ -28,6 +28,10 @@ std::string MountInfoListCommand::name() const {
 	return "list-mount-info";
 }
 
+SaunaFsAdminCommand::SupportedOptions MountInfoListCommand::supportedOptions() const {
+	return {{kTlsMode, kTlsModeDescription}};
+}
+
 void MountInfoListCommand::usage() const {
 	std::cerr << name() << " <master ip> <master port>\n";
 	std::cerr << "    Lists mountpoint information from all currently open sessions\n";
@@ -37,7 +41,11 @@ void MountInfoListCommand::run(const Options& options) const {
 	if (options.arguments().size() != 2) {
 		throw WrongUsageException("Expected <master ip> and <master port> for " + name());
 	}
-	ServerConnection connection(options.argument(0), options.argument(1));
+
+	auto tlsCfg =
+	    options.getValue<std::string>("--tlsconfigfile", std::string(TlsSession::kNoFile));
+
+	ServerConnection connection(options.argument(0), options.argument(1), tlsCfg);
 	std::vector<MountInfoEntry> mountInfoList;
 
 	auto request = cltoma::mountInfoList::build();

--- a/src/admin/mount_info_list_command.h
+++ b/src/admin/mount_info_list_command.h
@@ -29,4 +29,5 @@ public:
 	std::string name() const override;
 	void usage() const override;
 	void run(const Options &options) const override;
+	SupportedOptions supportedOptions() const override;
 };

--- a/src/admin/promote_shadow_command.cc
+++ b/src/admin/promote_shadow_command.cc
@@ -31,6 +31,10 @@ std::string PromoteShadowCommand::name() const {
 	return "promote-shadow";
 }
 
+SaunaFsAdminCommand::SupportedOptions PromoteShadowCommand::supportedOptions() const {
+	return {{kTlsMode, kTlsModeDescription}};
+}
+
 void PromoteShadowCommand::usage() const {
 	std::cerr << name() << " <shadow ip> <shadow port>" << std::endl;
 	std::cerr << "    Promotes metadata server. Works only if personality 'ha-cluster-managed'"
@@ -43,7 +47,12 @@ void PromoteShadowCommand::run(const Options& options) const {
 		throw WrongUsageException("Expected <shadow ip> and <shadow port>"
 				" for " + name());
 	}
-	auto connection = RegisteredAdminConnection::create(options.argument(0), options.argument(1));
+
+	auto tlsCfg =
+	    options.getValue<std::string>("--tlsconfigfile", std::string(TlsSession::kNoFile));
+
+	auto connection =
+	    RegisteredAdminConnection::create(options.argument(0), options.argument(1), tlsCfg);
 	auto becomeMasterResponse = connection->sendAndReceive(
 			cltoma::adminBecomeMaster::build(), SAU_MATOCL_ADMIN_BECOME_MASTER);
 	uint8_t status;

--- a/src/admin/promote_shadow_command.h
+++ b/src/admin/promote_shadow_command.h
@@ -30,4 +30,5 @@ public:
 	std::string name() const override;
 	void usage() const override;
 	void run(const Options& options) const override;
+	SupportedOptions supportedOptions() const override;
 };

--- a/src/admin/ready_chunkservers_count_command.cc
+++ b/src/admin/ready_chunkservers_count_command.cc
@@ -25,9 +25,14 @@
 #include <vector>
 
 #include "admin/list_chunkservers_command.h"
+#include "common/tls_session.h"
 
 std::string ReadyChunkserversCountCommand::name() const {
 	return "ready-chunkservers-count";
+}
+
+SaunaFsAdminCommand::SupportedOptions ReadyChunkserversCountCommand::supportedOptions() const {
+	return {{kTlsMode, kTlsModeDescription}};
 }
 
 void ReadyChunkserversCountCommand::usage() const {
@@ -40,8 +45,12 @@ void ReadyChunkserversCountCommand::run(const Options& options) const {
 		throw WrongUsageException("Expected exactly two arguments for " + name());
 	}
 	uint32_t readyChunkservers = 0;
-	auto chunkservers = ListChunkserversCommand::getChunkserversList(
-			options.argument(0), options.argument(1));
+
+	auto tlsCfg =
+	    options.getValue<std::string>("--tlsconfigfile", std::string(TlsSession::kNoFile));
+
+	auto chunkservers = ListChunkserversCommand::getChunkserversList(options.argument(0),
+	                                                                 options.argument(1), tlsCfg);
 	for (const auto& cs : chunkservers) {
 		if (cs.totalspace > 0) {
 			++readyChunkservers;

--- a/src/admin/ready_chunkservers_count_command.h
+++ b/src/admin/ready_chunkservers_count_command.h
@@ -29,4 +29,5 @@ public:
 	virtual std::string name() const;
 	virtual void usage() const;
 	virtual void run(const Options& options) const;
+	virtual SupportedOptions supportedOptions() const;
 };

--- a/src/admin/registered_admin_connection.cc
+++ b/src/admin/registered_admin_connection.cc
@@ -64,10 +64,11 @@ std::string getPassword() {
 std::unique_ptr<RegisteredAdminConnection> RegisteredAdminConnection::create(
 		const std::string& host,
 		const std::string& port,
+		const std::string& tlsCfg,
 		int timeout) {
 	// Connect the master server
 	auto connection = std::unique_ptr<RegisteredAdminConnection>(
-			new RegisteredAdminConnection(host, port));
+			new RegisteredAdminConnection(host, port, tlsCfg));
 
 	connection->setTimeout(timeout);
 

--- a/src/admin/registered_admin_connection.h
+++ b/src/admin/registered_admin_connection.h
@@ -35,11 +35,12 @@ public:
 	static std::unique_ptr<RegisteredAdminConnection> create(
 			const std::string& host,
 			const std::string& port,
+			const std::string &tlsConfigFile = "",
 			int timeout = kDefaultTimeout);
 
 private:
 	/// Private constructor for ::create.
-	RegisteredAdminConnection(const std::string host, const std::string& port)
-		: KeptAliveServerConnection(host, port) {
-	}
+	RegisteredAdminConnection(const std::string host, const std::string &port,
+	                          const std::string &tlsConfigFile = "")
+	    : KeptAliveServerConnection(host, port, tlsConfigFile) {}
 };

--- a/src/admin/reload_config_command.cc
+++ b/src/admin/reload_config_command.cc
@@ -33,6 +33,10 @@ std::string ReloadConfigCommand::name() const {
 	return "reload-config";
 }
 
+SaunaFsAdminCommand::SupportedOptions ReloadConfigCommand::supportedOptions() const {
+	return {{kTlsMode, kTlsModeDescription}};
+}
+
 void ReloadConfigCommand::usage() const {
 	std::cerr << name() << " <master ip> <master port>" << std::endl;
 	std::cerr << "    Requests reloading configuration from the config file." << std::endl;
@@ -46,7 +50,11 @@ void ReloadConfigCommand::run(const Options& options) const {
 				"Expected <metadataserver ip> and <metadataserver port> for " + name());
 	}
 
-	auto connection = RegisteredAdminConnection::create(options.argument(0), options.argument(1));
+	auto tlsCfg =
+	    options.getValue<std::string>("--tlsconfigfile", std::string(TlsSession::kNoFile));
+
+	auto connection =
+	    RegisteredAdminConnection::create(options.argument(0), options.argument(1), tlsCfg);
 	auto adminReloadResponse =
 			connection->sendAndReceive(cltoma::adminReload::build(), SAU_MATOCL_ADMIN_RELOAD);
 	uint8_t status;

--- a/src/admin/reload_config_command.h
+++ b/src/admin/reload_config_command.h
@@ -29,4 +29,5 @@ public:
 	virtual std::string name() const override;
 	virtual void usage() const override;
 	virtual void run(const Options& options) const override;
+	SupportedOptions supportedOptions() const override;
 };

--- a/src/admin/saunafs_admin_command.cc
+++ b/src/admin/saunafs_admin_command.cc
@@ -25,3 +25,6 @@ const std::string SaunaFsAdminCommand::kPorcelainMode = "--porcelain";
 const std::string SaunaFsAdminCommand::kPorcelainModeDescription =
 		"Make the output parsing-friendly.";
 const std::string SaunaFsAdminCommand::kVerboseMode = "--verbose";
+const std::string SaunaFsAdminCommand::kTlsMode = "--tlsconfigfile=";
+const std::string SaunaFsAdminCommand::kTlsModeDescription =
+    "Specify a TLS config file to use TLS connection to metadata servers.";

--- a/src/admin/saunafs_admin_command.h
+++ b/src/admin/saunafs_admin_command.h
@@ -37,6 +37,8 @@ public:
 	static const std::string kPorcelainMode;
 	static const std::string kPorcelainModeDescription;
 	static const std::string kVerboseMode;
+	static const std::string kTlsMode;
+	static const std::string kTlsModeDescription;
 
 	virtual ~SaunaFsAdminCommand() {}
 	virtual std::string name() const = 0;

--- a/src/admin/save_metadata_command.cc
+++ b/src/admin/save_metadata_command.cc
@@ -41,7 +41,7 @@ void SaveMetadataCommand::usage() const {
 }
 
 SaunaFsAdminCommand::SupportedOptions SaveMetadataCommand::supportedOptions() const {
-	return { {"--async", "Don't wait for the task to finish."} };
+	return {{"--async", "Don't wait for the task to finish."}, {kTlsMode, kTlsModeDescription}};
 }
 
 void SaveMetadataCommand::run(const Options& options) const {
@@ -50,8 +50,12 @@ void SaveMetadataCommand::run(const Options& options) const {
 				"Expected <metadataserver ip> and <metadataserver port> for " + name());
 	}
 
+	auto tlsCfg =
+	    options.getValue<std::string>("--tlsconfigfile", std::string(TlsSession::kNoFile));
+
 	bool async = options.isSet("--async");
-	auto connection = RegisteredAdminConnection::create(options.argument(0), options.argument(1));
+	auto connection =
+	    RegisteredAdminConnection::create(options.argument(0), options.argument(1), tlsCfg);
 	auto request = cltoma::adminSaveMetadata::build(async);
 	auto response = connection->sendAndReceive(request, SAU_MATOCL_ADMIN_SAVE_METADATA);
 	uint8_t status;

--- a/src/admin/stop_master_without_saving_metadata.cc
+++ b/src/admin/stop_master_without_saving_metadata.cc
@@ -31,6 +31,11 @@ std::string MetadataserverStopWithoutSavingMetadataCommand::name() const {
 	return "stop-master-without-saving-metadata";
 }
 
+SaunaFsAdminCommand::SupportedOptions
+MetadataserverStopWithoutSavingMetadataCommand::supportedOptions() const {
+	return {{kTlsMode, kTlsModeDescription}};
+}
+
 void MetadataserverStopWithoutSavingMetadataCommand::usage() const {
 	std::cerr << name() << " <master ip> <master port>" << std::endl;
 	std::cerr << "    Stop the master server without saving metadata in the metadata.sfs file."
@@ -45,7 +50,12 @@ void MetadataserverStopWithoutSavingMetadataCommand::run(const Options& options)
 		throw WrongUsageException("Expected <metadataserver ip> and <metadataserver port>"
 				" for " + name());
 	}
-	auto connection = RegisteredAdminConnection::create(options.argument(0), options.argument(1));
+
+	auto tlsCfg =
+	    options.getValue<std::string>("--tlsconfigfile", std::string(TlsSession::kNoFile));
+
+	auto connection =
+	    RegisteredAdminConnection::create(options.argument(0), options.argument(1), tlsCfg);
 	auto adminStopWithoutMetadataDumpResponse = connection->sendAndReceive(
 			cltoma::adminStopWithoutMetadataDump::build(),
 			SAU_MATOCL_ADMIN_STOP_WITHOUT_METADATA_DUMP);

--- a/src/admin/stop_master_without_saving_metadata.h
+++ b/src/admin/stop_master_without_saving_metadata.h
@@ -30,4 +30,5 @@ public:
 	std::string name() const override;
 	void usage() const override;
 	void run(const Options& options) const override;
+	SupportedOptions supportedOptions() const override;
 };

--- a/src/admin/stop_task_command.cc
+++ b/src/admin/stop_task_command.cc
@@ -32,6 +32,10 @@ std::string StopTaskCommand::name() const {
 	return "stop-task";
 }
 
+SaunaFsAdminCommand::SupportedOptions StopTaskCommand::supportedOptions() const {
+	return {{kTlsMode, kTlsModeDescription}};
+}
+
 void StopTaskCommand::usage() const {
 	std::cerr << name() << " <master ip> <master port> <task id>" << std::endl;
 	std::cerr << "    Stop execution of task with the given id" << std::endl;
@@ -49,7 +53,12 @@ void StopTaskCommand::run(const Options& options) const {
 		std::cout << "Expected <task_id> as integer number" << std::endl;
 		return;
 	}
-	auto connection = RegisteredAdminConnection::create(options.argument(0), options.argument(1));
+
+	auto tlsCfg =
+	    options.getValue<std::string>("--tlsconfigfile", std::string(TlsSession::kNoFile));
+
+	auto connection =
+	    RegisteredAdminConnection::create(options.argument(0), options.argument(1), tlsCfg);
 	auto request = cltoma::stopTask::build(msgid, task_id);
 	auto response = connection->sendAndReceive(request, SAU_MATOCL_STOP_TASK);
 	uint8_t status;

--- a/src/admin/stop_task_command.h
+++ b/src/admin/stop_task_command.h
@@ -30,4 +30,5 @@ public:
 	std::string name() const override;
 	void usage() const override;
 	void run(const Options& options) const override;
+	SupportedOptions supportedOptions() const override;
 };

--- a/src/common/server_connection.cc
+++ b/src/common/server_connection.cc
@@ -21,9 +21,12 @@
 #include "common/platform.h"
 #include "common/server_connection.h"
 
+#include <csignal>
+
 #include "common/cwrap.h"
 #include "common/exceptions.h"
 #include "common/message_receive_buffer.h"
+#include "protocol/cltoma.h"
 #include "protocol/SFSCommunication.h"
 #include "errors/sfserr.h"
 #include "common/multi_buffer_writer.h"
@@ -33,24 +36,51 @@
 
 const int ServerConnection::kDefaultTimeout;
 
+constexpr size_t kMaxMessageSize = 4 * 1024 * 1024;
+
 namespace {
 
 /// Writes the \p request to the \p fd_ socket
-void sendRequestGeneric(int fd, const MessageBuffer& request, const Timeout& timeout) {
-	MultiBufferWriter writer;
-	writer.addBufferToSend(request.data(), request.size());
-	while (writer.hasDataToSend()) {
-		int status = tcptopoll(fd, POLLOUT, timeout.remaining_ms());
-		if (status == 0 || timeout.expired()) {
-			throw ConnectionException("Can't write data to socket: timeout");
-		} else if (status < 0) {
-			throw ConnectionException("Can't write data to socket: " +
-			                          errorString(tcpgetlasterror()));
+void sendRequestGeneric(int fd, const MessageBuffer &request, const Timeout &timeout,
+                        const TlsSession *tlsSession) {
+	if (tlsSession) {
+		size_t totalWritten = 0;
+		while (totalWritten < request.size()) {
+			int ret = SSL_write(tlsSession->session(), request.data() + totalWritten,
+			                    static_cast<int>(request.size() - totalWritten));
+			if (ret <= 0) {
+				int err = SSL_get_error(tlsSession->session(), ret);
+				if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) {
+					int pollEvents = (err == SSL_ERROR_WANT_WRITE) ? POLLOUT : POLLIN;
+					int status = tcptopoll(fd, pollEvents, timeout.remaining_ms());
+					if (status == 0 || timeout.expired()) {
+						throw ConnectionException("TLS write timeout");
+					} else if (status < 0) {
+						throw ConnectionException("TLS write poll failed: " +
+						                          errorString(tcpgetlasterror()));
+					}
+					continue;
+				}
+				throw ConnectionException("TLS write failed: " + opensslErrorString(err));
+			}
+			totalWritten += ret;
 		}
-		ssize_t bytesWritten = writer.writeTo(fd);
-		if (bytesWritten < 0) {
-			throw ConnectionException("Can't write data to socket: " +
-			                          errorString(tcpgetlasterror()));
+	} else {
+		MultiBufferWriter writer;
+		writer.addBufferToSend(request.data(), request.size());
+		while (writer.hasDataToSend()) {
+			int status = tcptopoll(fd, POLLOUT, timeout.remaining_ms());
+			if (status == 0 || timeout.expired()) {
+				throw ConnectionException("Can't write data to socket: timeout");
+			} else if (status < 0) {
+				throw ConnectionException("Can't write data to socket: " +
+				                          errorString(tcpgetlasterror()));
+			}
+			ssize_t bytesWritten = writer.writeTo(fd);
+			if (bytesWritten < 0) {
+				throw ConnectionException("Can't write data to socket: " +
+				                          errorString(tcpgetlasterror()));
+			}
 		}
 	}
 }
@@ -58,65 +88,136 @@ void sendRequestGeneric(int fd, const MessageBuffer& request, const Timeout& tim
 /// Reads a message from the \p socket
 /// Throws if its type is different than \p expectedType.
 /// Ignores NOP messages if \p receiveMode is ReceiveMode::kReceiveFirstNonNopMessage.
-MessageBuffer receiveRequestGeneric(
-		int fd,
-		PacketHeader::Type expectedType,
-		ServerConnection::ReceiveMode receiveMode,
-		const Timeout& timeout) {
-	MessageReceiveBuffer reader(4 * 1024 * 1024);
-	while (!reader.hasMessageData()) {
-		int status = tcptopoll(fd, POLLIN, timeout.remaining_ms());
-		if (status == 0 || timeout.expired()) {
-			throw ConnectionException("Can't read data from socket: timeout");
-		} else if (status < 0) {
-			throw ConnectionException(
-					"Can't read data from socket: " + errorString(tcpgetlasterror()));
-		}
-		ssize_t bytesRead = reader.readFrom(fd);
-		if (bytesRead == 0) {
-			throw ConnectionException("Can't read data from socket: connection reset by peer");
-		}
-		if (bytesRead < 0) {
-			throw ConnectionException(
-					"Can't read data from socket: " + errorString(tcpgetlasterror()));
-		}
-		if (reader.isMessageTooBig()) {
-			throw Exception("Receive buffer overflow");
-		}
-		while (reader.hasMessageData()
-				&& receiveMode == ServerConnection::ReceiveMode::kReceiveFirstNonNopMessage
-				&& reader.getMessageHeader().type == ANTOAN_NOP) {
-			// We have received a NOP message and were instructed to ignore it
-			reader.removeMessage();
-		}
-	}
+MessageBuffer receiveRequestGeneric(int fd, PacketHeader::Type expectedType,
+                                    ServerConnection::ReceiveMode receiveMode,
+                                    const Timeout &timeout, TlsSession *tlsSession) {
+	if (tlsSession) {
+		MessageBuffer buffer;
+		while (true) {
+			// Phase 1: Read the packet header
+			buffer.resize(PacketHeader::kSize);  // Resize buffer to hold only the header
+			size_t totalRead = 0;
+			while (totalRead < PacketHeader::kSize) {
+				int ret = SSL_read(tlsSession->session(), buffer.data() + totalRead,
+				                   static_cast<int>(PacketHeader::kSize - totalRead));
+				if (ret <= 0) {
+					int err = SSL_get_error(tlsSession->session(), ret);
+					if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) {
+						int pollEvents = (err == SSL_ERROR_WANT_WRITE) ? POLLOUT : POLLIN;
+						int status = tcptopoll(fd, pollEvents, timeout.remaining_ms());
+						if (status == 0 || timeout.expired()) {
+							throw ConnectionException("TLS read timeout");
+						} else if (status < 0) {
+							throw ConnectionException("TLS read poll failed: " +
+							                          errorString(tcpgetlasterror()));
+						}
+						continue;
+					}
+					throw ConnectionException("TLS read failed: " + opensslErrorString(err));
+				}
+				totalRead += ret;
+			}
 
-	if (reader.getMessageHeader().type != expectedType) {
-		throw Exception("Received unexpected message #" +
-				std::to_string(reader.getMessageHeader().type));
-	}
+			PacketHeader header;
+			deserialize(buffer, header);  // Deserialize header from the small buffer
+			// Validate payload length against a reasonable maximum to prevent excessive allocation
+			if (header.length > kMaxMessageSize - PacketHeader::kSize) {
+				throw Exception("Received message too large: " + std::to_string(header.length) +
+				                " bytes, exceeding maximum allowed.");
+			}
 
-	uint32_t length = reader.getMessageHeader().length;
-	return MessageBuffer(reader.getMessageData(), reader.getMessageData() + length);
+			// Phase 2: Resize buffer to hold the full message and read the remaining payload
+			buffer.resize(PacketHeader::kSize + header.length);
+			while (totalRead < PacketHeader::kSize + header.length) {
+				int ret =
+				    SSL_read(tlsSession->session(), buffer.data() + totalRead,
+				             static_cast<int>(PacketHeader::kSize + header.length - totalRead));
+				if (ret <= 0) {
+					int err = SSL_get_error(tlsSession->session(), ret);
+					if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) {
+						int pollEvents = (err == SSL_ERROR_WANT_WRITE) ? POLLOUT : POLLIN;
+						int status = tcptopoll(fd, pollEvents, timeout.remaining_ms());
+						if (status == 0 || timeout.expired()) {
+							throw ConnectionException("TLS read timeout");
+						} else if (status < 0) {
+							throw ConnectionException("TLS read poll failed: " +
+							                          errorString(tcpgetlasterror()));
+						}
+						continue;
+					}
+					throw ConnectionException("TLS read failed: " + opensslErrorString(err));
+				}
+				totalRead += ret;
+			}
+
+			if (receiveMode == ServerConnection::ReceiveMode::kReceiveFirstNonNopMessage &&
+			    header.type == ANTOAN_NOP) {
+				// We have received a NOP message and were instructed to ignore it
+				continue;
+			}
+
+			if (header.type != expectedType) {
+				throw Exception("Received unexpected message #" + std::to_string(header.type));
+			}
+
+			return MessageBuffer(buffer.data() + PacketHeader::kSize,
+			                     buffer.data() + PacketHeader::kSize + header.length);
+		}
+	} else {
+		MessageReceiveBuffer reader(kMaxMessageSize);
+		while (!reader.hasMessageData()) {
+			int status = tcptopoll(fd, POLLIN, timeout.remaining_ms());
+			if (status == 0 || timeout.expired()) {
+				throw ConnectionException("Can't read data from socket: timeout");
+			} else if (status < 0) {
+				throw ConnectionException("Can't read data from socket: " +
+				                          errorString(tcpgetlasterror()));
+			}
+			ssize_t bytesRead = reader.readFrom(fd);
+			if (bytesRead == 0) {
+				throw ConnectionException("Can't read data from socket: connection reset by peer");
+			}
+			if (bytesRead < 0) {
+				throw ConnectionException("Can't read data from socket: " +
+				                          errorString(tcpgetlasterror()));
+			}
+			if (reader.isMessageTooBig()) { throw Exception("Receive buffer overflow"); }
+			while (reader.hasMessageData() &&
+			       receiveMode == ServerConnection::ReceiveMode::kReceiveFirstNonNopMessage &&
+			       reader.getMessageHeader().type == ANTOAN_NOP) {
+				// We have received a NOP message and were instructed to ignore it
+				reader.removeMessage();
+			}
+		}
+
+		if (reader.getMessageHeader().type != expectedType) {
+			throw Exception("Received unexpected message #" +
+			                std::to_string(reader.getMessageHeader().type));
+		}
+
+		uint32_t length = reader.getMessageHeader().length;
+		return MessageBuffer(reader.getMessageData(), reader.getMessageData() + length);
+	}
 }
 
 } // anonymous namespace
 
-ServerConnection::ServerConnection(const std::string& host, const std::string& port) :
-		fd_(-1),
-		timeout_(kDefaultTimeout) {
+ServerConnection::ServerConnection(const std::string &host, const std::string &port,
+                                   const std::string &tlsConfigFile)
+    : fd_(-1), timeout_(kDefaultTimeout), tlsConfigFile_(tlsConfigFile) {
 	NetworkAddress server;
 	tcpresolve(host.c_str(), port.c_str(), &server.ip, &server.port, false);
 	connect(server);
 }
 
-ServerConnection::ServerConnection(const NetworkAddress& server) :
-		fd_(-1),
-		timeout_(kDefaultTimeout) {
+ServerConnection::ServerConnection(const NetworkAddress &server, const std::string &tlsConfigFile)
+    : fd_(-1), timeout_(kDefaultTimeout), tlsConfigFile_(tlsConfigFile) {
 	connect(server);
 }
 
 ServerConnection::~ServerConnection() {
+	if (tlsSession_ != nullptr) { tlsSession_.reset(); }
+
 	if (fd_ != -1) {
 		tcpclose(fd_);
 	}
@@ -126,7 +227,7 @@ MessageBuffer ServerConnection::sendAndReceive(
 		const MessageBuffer& request,
 		PacketHeader::Type expectedType,
 		ReceiveMode receiveMode) {
-	return ServerConnection::sendAndReceive(fd_, request, expectedType, receiveMode, timeout_);
+	return ServerConnection::sendAndReceive(fd_, request, expectedType, receiveMode, timeout_, tlsSession_.get());
 }
 
 MessageBuffer ServerConnection::sendAndReceive(
@@ -134,10 +235,10 @@ MessageBuffer ServerConnection::sendAndReceive(
 		const MessageBuffer& request,
 		PacketHeader::Type expectedType,
 		ReceiveMode receiveMode,
-		int tm) {
+		int tm, TlsSession* tlsSession) {
 	Timeout timeout{std::chrono::milliseconds(tm)};
-	sendRequestGeneric(fd, request, timeout);
-	return receiveRequestGeneric(fd, expectedType, receiveMode, timeout);
+	sendRequestGeneric(fd, request, timeout, tlsSession);
+	return receiveRequestGeneric(fd, expectedType, receiveMode, timeout, tlsSession);
 }
 
 void ServerConnection::connect(const NetworkAddress &server) {
@@ -155,6 +256,93 @@ void ServerConnection::connect(const NetworkAddress &server) {
 		throw ConnectionException("Can't connect to " + server.toString() + ": " +
 		                          strerr(tcpLastError));
 	}
+
+	if (tlsConfigFile_.empty()) {
+		return;
+	} else {
+		startTlsSession(server);
+	}
+}
+
+bool ServerConnection::performTlsHandshake() {
+	sassert(tlsSession_ != nullptr);
+
+#ifndef _WIN32
+	struct sigaction old_action, ignore_action;
+	ignore_action.sa_handler = SIG_IGN;
+	sigemptyset(&ignore_action.sa_mask);
+	ignore_action.sa_flags = 0;
+	sigaction(SIGPIPE, &ignore_action, &old_action);
+#endif
+
+	SSL *ssl = tlsSession_->session();
+	int ret;
+	Timeout timeout{std::chrono::milliseconds(timeout_)};
+	while (true) {
+		ret = SSL_connect(ssl);
+		if (ret == 1) {
+#ifndef _WIN32
+			sigaction(SIGPIPE, &old_action, nullptr);
+#endif
+			return true;
+		}
+
+		int err = SSL_get_error(ssl, ret);
+		lastHandshakeError_ = err;
+
+		if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) {
+			int pollEvents = (err == SSL_ERROR_WANT_WRITE) ? POLLOUT : POLLIN;
+			int status = tcptopoll(fd_, pollEvents, timeout.remaining_ms());
+			if (status == 0 || timeout.expired()) {
+#ifndef _WIN32
+				sigaction(SIGPIPE, &old_action, nullptr);
+#endif
+				return false;  // handshake timeout
+			} else if (status < 0) {
+#ifndef _WIN32
+				sigaction(SIGPIPE, &old_action, nullptr);
+#endif
+				return false;  // poll error
+			}
+			continue;
+		} else {
+			break;
+		}
+	}
+
+#ifndef _WIN32
+	sigaction(SIGPIPE, &old_action, nullptr);
+#endif
+
+	return false;
+}
+
+void ServerConnection::startTlsSession(const NetworkAddress &server) {
+	if (fd_ < 0 || tlsConfigFile_.empty()) {
+		throw ConnectionException("Can't start TLS session: no connection or TLS config file");
+	}
+
+	TlsSession::TlsConfig tlsCfg = TlsSession::TlsConfig::fromFile(tlsConfigFile_);
+
+	if (tlsCfg.expectedHostname.empty()) { tlsCfg.expectedHostname = std::to_string(server.ip); }
+
+	tlsSession_ = std::make_unique<TlsSession>(fd_, tlsCfg);
+
+	auto startTlsRequest = cltoma::startTls::build();
+	ssize_t ret = tcptowrite(fd_, startTlsRequest.data(), startTlsRequest.size(), timeout_);
+	if (ret < 0) {
+		throw ConnectionException("cannot transmit startTls request to metadata server: " +
+		                          errorString(tcpgetlasterror()));
+	} else if (ret != static_cast<int>(startTlsRequest.size())) {
+		throw ConnectionException("cannot transmit startTls request to metadata server: sent " +
+		                          std::to_string(ret) + " bytes instead of " +
+		                          std::to_string(startTlsRequest.size()));
+	}
+
+	if (!performTlsHandshake()) {
+		throw ConnectionException("TLS handshake failed with server: " + server.toString() +
+		                          ", error: " + opensslErrorString(lastHandshakeError_));
+	}
 }
 
 KeptAliveServerConnection::~KeptAliveServerConnection() {
@@ -170,9 +358,10 @@ MessageBuffer KeptAliveServerConnection::sendAndReceive(
 	Timeout timeout{std::chrono::milliseconds(timeout_)};
 	/* synchronized with nopThread_ */ {
 		std::unique_lock<std::mutex> lock(mutex_);
-		sendRequestGeneric(fd_, request, timeout);
+		sendRequestGeneric(fd_, request, timeout, tlsSession_.get());
 	}
-	return receiveRequestGeneric(fd_, expectedResponseType, receiveMode, timeout);
+	return receiveRequestGeneric(fd_, expectedResponseType, receiveMode, timeout,
+	                             tlsSession_.get());
 }
 
 void KeptAliveServerConnection::startNopThread() {
@@ -183,7 +372,7 @@ void KeptAliveServerConnection::startNopThread() {
 			if (threadCanRun_) {
 				// We have the lock, we can send something
 				Timeout timeout{std::chrono::milliseconds(timeout_)};
-				sendRequestGeneric(fd_, buildLegacyPacket(ANTOAN_NOP), timeout);
+				sendRequestGeneric(fd_, buildLegacyPacket(ANTOAN_NOP), timeout, tlsSession_.get());
 			}
 		}
 	};

--- a/src/common/server_connection.h
+++ b/src/common/server_connection.h
@@ -29,6 +29,7 @@
 #include <thread>
 
 #include "common/network_address.h"
+#include "common/tls_session.h"
 #include "protocol/packet.h"
 
 class ServerConnection {
@@ -40,8 +41,9 @@ public:
 
 	static const int kDefaultTimeout = 5000;
 
-	ServerConnection(const std::string& host, const std::string& port);
-	ServerConnection(const NetworkAddress& server);
+	ServerConnection(const std::string &host, const std::string &port,
+	                 const std::string &tlsConfigFile = "");
+	ServerConnection(const NetworkAddress &server, const std::string &tlsConfigFile = "");
 	virtual ~ServerConnection();
 
 	/// Sends a request and receives a response.
@@ -55,11 +57,9 @@ public:
 
 	/// A static method for those, who own a socket.
 	static MessageBuffer sendAndReceive(
-			int fd,
-			const MessageBuffer& request,
-			PacketHeader::Type expectedResponseType,
-			ReceiveMode receiveMode = ReceiveMode::kReceiveFirstNonNopMessage,
-			int timeout = kDefaultTimeout);
+	    int fd, const MessageBuffer &request, PacketHeader::Type expectedResponseType,
+	    ReceiveMode receiveMode = ReceiveMode::kReceiveFirstNonNopMessage,
+	    int timeout = kDefaultTimeout, TlsSession *tlsSession = nullptr);
 
 	void setTimeout(int timeout) {
 		timeout_ = timeout;
@@ -70,9 +70,23 @@ protected:
 	int fd_;
 	int timeout_;
 
+	/// Optional TLS session (present if tlsConfigFile_ was set and handshake succeeded)
+	std::unique_ptr<TlsSession> tlsSession_;
+	// Path to TLS client config file
+	std::string tlsConfigFile_;
+	int lastHandshakeError_{0};
+
 private:
 	/// Opens a connection and sets \p fd_
 	void connect(const NetworkAddress& server);
+
+	/// Starts a TLS connection request to target server and sets up TLS session if tlsConfigFile_
+	/// is not empty.
+	void startTlsSession(const NetworkAddress &server);
+
+	/// Performs a TLS handshake on the current fd_ and initializes tlsSession_ if tlsConfigFile_ is
+	/// not empty.
+	bool performTlsHandshake();
 };
 
 /// A special version of \p ServerConnection which sends \p ANTOAN_NOP every second.
@@ -80,16 +94,15 @@ private:
 class KeptAliveServerConnection : public ServerConnection {
 public:
 	/// Inherited constructor
-	KeptAliveServerConnection(const std::string& host, const std::string& port)
-			: ServerConnection(host, port),
-			  threadCanRun_(true) {
+	KeptAliveServerConnection(const std::string &host, const std::string &port,
+	                          const std::string &tlsConfigFile = "")
+	    : ServerConnection(host, port, tlsConfigFile), threadCanRun_(true) {
 		startNopThread();
 	}
 
 	/// Inherited constructor
-	KeptAliveServerConnection(const NetworkAddress& server)
-			: ServerConnection(server),
-			  threadCanRun_(true) {
+	KeptAliveServerConnection(const NetworkAddress &server, const std::string &tlsConfigFile = "")
+	    : ServerConnection(server, tlsConfigFile), threadCanRun_(true) {
 		startNopThread();
 	}
 

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -627,6 +627,14 @@ void matoclserv_tlshandshake(matoclserventry *eptr) {
 /// Initiate a TLS connection with the mount.
 /// @param eptr Pointer to the client connection in the master
 void matoclserv_starttls(matoclserventry *eptr) {
+	if (eptr->tlsSession != nullptr) {
+		safs::log_warn(
+		    "Attempted to start TLS session with client from {}:{}, but TLS session already exists",
+		    ipToString(eptr->peerIpAddress), eptr->peerPort);
+		eptr->mode = ClientConnectionMode::KILL;
+		return;
+	}
+
 	// Initialize a TLS session for the peer.
 	std::string keyFile = cfg_getstring("TLS_KEY_FILE", std::string(TlsSession::kNoFile));
 	std::string certFile = cfg_getstring("TLS_CERT_FILE", std::string(TlsSession::kNoFile));
@@ -5232,11 +5240,9 @@ void matoclserv_gotpacket(matoclserventry *eptr, uint32_t type, const uint8_t *d
 		return;
 	}
 
-	if (metadataserver::isMaster()) {
-		if (type == SAU_CLTOMA_STARTTLS) {
-			matoclserv_starttls(eptr);
-			return;
-		}
+	if (type == SAU_CLTOMA_STARTTLS) {
+		matoclserv_starttls(eptr);
+		return;
 	}
 
 	try {

--- a/tests/test_suites/ShortSystemTests/test_tls_master_admin_communication.sh
+++ b/tests/test_suites/ShortSystemTests/test_tls_master_admin_communication.sh
@@ -1,0 +1,77 @@
+timeout_set "2 minutes"
+assert_program_installed openssl
+
+# Parameters
+password="good-password"
+chunkservers=3
+mounts=2
+
+# Values to search for in dump-config
+master_config_value="NO_ATIME = 0"
+mount_config_value=sfscachemode=NEVER
+chunk_config_value="READ_AHEAD_KB = 1024"
+
+echo "Generating TLS certificates for master-client communication test..."
+TLS_CERTS_DIR="${TEMP_DIR}/testcerts"
+generate_certs "${TLS_CERTS_DIR}"
+
+# Create TLS client config file for saunafs-admin and mounts
+TLS_CFG_FILE="${TEMP_DIR}/sfstls.cfg"
+cat > "${TLS_CFG_FILE}" <<EOF
+tlscertfile=${TLS_CERTS_DIR}/client.crt
+tlskeyfile=${TLS_CERTS_DIR}/client.key
+tlsservercacertfile=${TLS_CERTS_DIR}/ca.crt
+tlsisserver=false
+tlsexpectedhostname=sfsmaster
+EOF
+
+# Configure master to use TLS certs
+master_tls_cfg="|TLS_CERT_FILE = ${TLS_CERTS_DIR}/server.crt"
+master_tls_cfg+="|TLS_KEY_FILE = ${TLS_CERTS_DIR}/server.key"
+master_tls_cfg+="|TLS_CA_CERT_FILE = ${TLS_CERTS_DIR}/ca.crt"
+
+# Bring up a local SaunaFS with TLS enabled on master and pass TLS config to mounts/admin
+CHUNKSERVERS="${chunkservers}" \
+  CHUNKSERVER_EXTRA_CONFIG="${chunk_config_value}" \
+  MASTER_EXTRA_CONFIG="${master_config_value}${master_tls_cfg}" \
+  MOUNT_EXTRA_CONFIG="tlsconfigfile=${TLS_CFG_FILE}|${mount_config_value}" \
+  MOUNTS="${mounts}" \
+  USE_RAMDISK="YES" \
+  ADMIN_PASSWORD="${password}" \
+  setup_local_empty_saunafs info
+
+# Read ports exported by setup
+master_port="${info[matocl]}"
+shadow_port="${info[masterauto_matocl]}"
+
+# 1) Verify saunafs-admin info works over TLS
+saunafs-admin info --porcelain localhost "${master_port}" --tlsconfigfile="${TLS_CFG_FILE}"
+
+# 2) Verify wrong password is rejected over TLS
+assert_failure saunafs-admin dump-config localhost "${master_port}" --tlsconfigfile="${TLS_CFG_FILE}" <<< "wrong-password"
+
+# 3) Verify correct password works over TLS and output contains expected entries
+config="$(saunafs-admin dump-config localhost "${master_port}" --tlsconfigfile="${TLS_CFG_FILE}" <<< "${password}")"
+printf "%s\n" "${config}"
+
+# Master option present once
+expect_equals 1 "$(grep "${master_config_value// = /: }" <<< "${config}" | wc -l)"
+
+# Expect chunkserver entries (one per chunkserver)
+expect_equals "${chunkservers}" "$(grep "${chunk_config_value// = /: }" <<< "${config}" | wc -l)"
+
+# Find mount entries
+expect_equals "${mounts}" "$(grep "${mount_config_value//=/: }" <<< "${config}" | wc -l)"
+
+# 4) Verify shadow works over TLS (subset of config)
+config="$(saunafs-admin dump-config localhost "${shadow_port}" --tlsconfigfile="${TLS_CFG_FILE}" <<< "${password}")"
+printf "%s\n" "${config}"
+expect_equals 1 "$(grep "${master_config_value// = /: }" <<< "${config}" | wc -l)"
+
+# 5) Verify defaults dump over TLS
+config="$(saunafs-admin dump-config --defaults localhost "${master_port}" --tlsconfigfile="${TLS_CFG_FILE}" <<< "${password}")"
+printf "%s\n" "${config}"
+# Spot-check a couple of defaults that should be stable
+expect_equals 1 "$(grep "GLOBALIOLIMITS_RENEGOTIATION_PERIOD_SECONDS: 0.1" <<< "${config}" | wc -l)"
+# This value may appear across multiple services, adjust expected count if needed
+expect_equals 3 "$(grep "REPLICATION_BANDWIDTH_LIMIT_KBPS: 0" <<< "${config}" | wc -l)"


### PR DESCRIPTION
This change introduces a TLS layer to encrypt traffic between the master and the saunafs-admin binary, protecting data in transit and mitigating on-path attacks. For that goal, an optional TLS configuration file path option has been added on all commands for saunafs-admin.

Also, this change allows the shadow metadata servers to start a TLS connection request, which is needed for some saunafs-admin binary to securely communicate to it.

**To the reviewers:**
- Notice the changes on `src/master/matoclserv.cc` which can be divided by two, one is the addition of a protection layer to avoid any possible protocol leak if a client tries to call an `*_STARTTLS` request if there is an already instantiated `tlsSession`; the goal of this idea is to force clients to first close their connection reference and then starting a new tls session request from scratch. The second change is that now not only masters can handle *_STARTTLS requests, but shadows can also do it; that change was needed to allowing other components communicating directly to shadow servers through TLS, to have a secure way to protect that communication, like for instance the `saunafs-admin` binary. 
- Also take a look on the way I exteded the src/common/server_connection.* related files in other to allow optional TLS communication through that connection and when performing any sending or receiving operation from the metadata server.
- Finally, validate the way I added the corresponding option for TLS related config file on each command of the `saunafs-admin`. The idea was to make it completely optional and ensuring that all server connection derived instances take it into account if present.