### PR TITLE
feat(monitoring): add GC stats to CS charts LS-344

### DIFF
--- a/src/cgi/sfs.cgi.in
+++ b/src/cgi/sfs.cgi.in
@@ -3235,6 +3235,7 @@ if "CC" in sectionset:
             (21, 'create', 'number of chunk creations per minute'),
             (22, 'delete', 'number of chunk deletions per minute'),
             (27, 'tests', 'number of chunk tests per minute'),
+            (31, 'gcpurge', 'number of chunk purges(.dat and .met) by GC per minute'),
         )
         servers = []
 

--- a/src/chunkserver/chartsdata.cc
+++ b/src/chunkserver/chartsdata.cc
@@ -75,8 +75,9 @@
 #define CHARTS_CHUNKIOJOBS 28
 #define CHARTS_CHUNKOPJOBS 29
 #define CHARTS_MEMORY 30
+#define CHARTS_GC_PURGE 31
 
-#define CHARTS_NUMBER 31
+#define CHARTS_NUMBER 32
 
 const unsigned long kLinuxMaxrssSize = 1024UL;
 
@@ -113,6 +114,7 @@ const unsigned long kLinuxMaxrssSize = 1024UL;
 	{"chunkiojobs"      ,CHARTS_MODE_MAX,0,CHARTS_SCALE_NONE ,   1, 1}, \
 	{"chunkopjobs"      ,CHARTS_MODE_MAX,0,CHARTS_SCALE_NONE ,   1, 1}, \
 	{"memory"           ,CHARTS_MODE_MAX,0,CHARTS_SCALE_NONE ,   1, 1}, \
+	{"gcpurge"          ,CHARTS_MODE_ADD,0,CHARTS_SCALE_NONE ,   1, 1}, \
 	{NULL               ,0              ,0,0                 ,   0, 0}  \
 };
 
@@ -165,7 +167,7 @@ void chartsdata_refresh(void) {
 	uint64_t bytesIn, bytesOut, totalBytesRead, totalBytesWrite;
 	uint32_t opsRead, opsWrite, totalOpsRead, totalOpsWrite, replications = 0;
 	uint32_t opsCreate, opsDelete, opsUpdateVersion, opsDuplicate, opsTruncate;
-	uint32_t opsDupTrunc, opsTest;
+	uint32_t opsDupTrunc, opsTest, opsGCPurge;
 	uint32_t maxChunkServerJobsCount, maxMasterJobsCount;
 
 	// Timer runs only when the process is executing.
@@ -245,9 +247,8 @@ void chartsdata_refresh(void) {
 	data[CHARTS_TOTAL_LLOPW] = totalOpsWrite;
 	data[CHARTS_REPL] = replications + gReplicator.getStats();
 
-	HddStats::operationStats(&opsCreate, &opsDelete, &opsUpdateVersion,
-	                         &opsDuplicate, &opsTruncate, &opsDupTrunc,
-	                         &opsTest);
+	HddStats::operationStats(&opsCreate, &opsDelete, &opsUpdateVersion, &opsDuplicate, &opsTruncate,
+	                         &opsDupTrunc, &opsTest, &opsGCPurge);
 	data[CHARTS_CREATE] = opsCreate;
 	data[CHARTS_DELETE] = opsDelete;
 	data[CHARTS_VERSION] = opsUpdateVersion;
@@ -255,6 +256,7 @@ void chartsdata_refresh(void) {
 	data[CHARTS_TRUNCATE] = opsTruncate;
 	data[CHARTS_DUPTRUNC] = opsDupTrunc;
 	data[CHARTS_TEST] = opsTest;
+	data[CHARTS_GC_PURGE] = opsGCPurge;
 
 	charts_add(data, eventloop_time() - SECONDS_IN_ONE_MINUTE);
 }

--- a/src/chunkserver/chunkserver-common/chunk_trash_manager_impl.cc
+++ b/src/chunkserver/chunkserver-common/chunk_trash_manager_impl.cc
@@ -25,6 +25,7 @@
 #include "chunkserver-common/chunk_trash_manager_impl.h"
 #include "config/cfg.h"
 #include "errors/saunafs_error_codes.h"
+#include "hdd_stats.h"
 #include "slogger/slogger.h"
 
 namespace fs = std::filesystem;
@@ -161,6 +162,7 @@ void ChunkTrashManagerImpl::removeTrashFiles(
 	for (const auto &[diskPath, fileEntries] : filesToRemove) {
 		for (const auto &fileEntry : fileEntries) {
 			if (removeFileFromTrash(fileEntry.second) != SAUNAFS_STATUS_OK) { continue; }
+			HddStats::gStatsOperationsGCPurge++;
 			getTrashIndex().remove(fileEntry.first, fileEntry.second, diskPath);
 		}
 	}

--- a/src/chunkserver/chunkserver-common/hdd_stats.cc
+++ b/src/chunkserver/chunkserver-common/hdd_stats.cc
@@ -19,6 +19,7 @@
 #include "common/platform.h"
 
 #include "chunkserver-common/hdd_stats.h"
+#include <cstdint>
 
 #include "chunkserver-common/disk_interface.h"
 #include "devtools/TracePrinter.h"
@@ -83,10 +84,9 @@ void stats(statsReport report) {
 	*report.totalWriteTime = gStatsTotalTimeWrite.exchange(0);
 }
 
-void operationStats(uint32_t *opsCreate, uint32_t *opsDelete,
-                    uint32_t *opsUpdateVersion, uint32_t *opsDuplicate,
-                    uint32_t *opsTruncate, uint32_t *opsDupTrunc,
-                    uint32_t *opsTest) {
+void operationStats(uint32_t *opsCreate, uint32_t *opsDelete, uint32_t *opsUpdateVersion,
+                    uint32_t *opsDuplicate, uint32_t *opsTruncate, uint32_t *opsDupTrunc,
+                    uint32_t *opsTest, uint32_t *opsGCPurge) {
 	TRACETHIS();
 	*opsCreate = gStatsOperationsCreate.exchange(0);
 	*opsDelete = gStatsOperationsDelete.exchange(0);
@@ -95,6 +95,7 @@ void operationStats(uint32_t *opsCreate, uint32_t *opsDelete,
 	*opsDuplicate = gStatsOperationsDuplicate.exchange(0);
 	*opsTruncate = gStatsOperationsTruncate.exchange(0);
 	*opsDupTrunc = gStatsOperationsDupTrunc.exchange(0);
+	*opsGCPurge = gStatsOperationsGCPurge.exchange(0);
 }
 
 void overheadRead(uint32_t size) {

--- a/src/chunkserver/chunkserver-common/hdd_stats.h
+++ b/src/chunkserver/chunkserver-common/hdd_stats.h
@@ -56,6 +56,8 @@ inline std::atomic<uint32_t> gStatsOperationsDuplicate(0);
 inline std::atomic<uint32_t> gStatsOperationsTruncate(0);
 inline std::atomic<uint32_t> gStatsOperationsDupTrunc(0);
 
+inline std::atomic<uint32_t> gStatsOperationsGCPurge(0);
+
 struct statsReport {
 	statsReport(uint64_t *overBytesRead, uint64_t *overBytesWrite,
 	            uint32_t *overOpsRead, uint32_t *overOpsWrite,
@@ -99,7 +101,7 @@ void stats(statsReport report);
 void operationStats(uint32_t *opsCreate, uint32_t *opsDelete,
                     uint32_t *opsUpdateVersion, uint32_t *opsDuplicate,
                     uint32_t *opsTruncate, uint32_t *opsDupTrunc,
-                    uint32_t *opsTest);
+                    uint32_t *opsTest, uint32_t *opsGCPurge);
 
 void overheadRead(uint32_t size);
 void overheadWrite(uint32_t size);


### PR DESCRIPTION
This commit introduces a chunkserver-side feature to display Garbage Collector(GC) deletions per minute in the CGI chart of the chunkserver(CS).

When a chunk is moved to the .trash.bin directory(if Garbage Collector is ENABLED) the chunk is marked as deleted and added to chunks deleted stats in the chunkserver.  Tracking when the chunk is actually deleted(purged) by the GC is needed for better testing of this feature and more precise information. 