### PR TITLE
ci: Fix Jenkins unable to delete root files from workspace

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -228,7 +228,6 @@ pipeline {
                                     export PATH="/usr/lib/ccache:$PATH"
                                     cd build
                                     sudo nice make -j\$((\$(nproc) / 2)) install
-                                    sudo chown \$(id -u):\$(id -g) . -R
                                     saunafs-tests --gtest_filter="RebalancingTests*" --gtest_output="xml:./rebalance_test_detail.xml" || true
                                 """
                                 publishJunit("build/*test_detail.xml")
@@ -241,6 +240,11 @@ pipeline {
                                 "Unit tests failed on ${BRANCH_NAME}",
                                 "Unit tests failed on branch ${BRANCH_NAME}, build number ${BUILD_NUMBER}"
                             )
+                        }
+                        cleanup {
+                            sh """
+                                sudo chown \$(id -u):\$(id -g) $WORKSPACE -R
+                            """
                         }
                     }
                 }


### PR DESCRIPTION
A previous commit already attempted to solve this. However, if the pipeline was cancelled in the middle of a build (before it chown the directory), it would still leave the files owned partially by root, which would mean that Jenkins would not be able to clean the directory.

This fixes that by moving the chown into the post cleanup stage.