### PR TITLE
build: Fix compilation errors for boost 1.9

### DIFF
--- a/cmake/Libraries.cmake
+++ b/cmake/Libraries.cmake
@@ -70,7 +70,7 @@ else()
 endif()
 
 # Find Boost
-find_package(Boost CONFIG REQUIRED COMPONENTS filesystem iostreams program_options system)
+find_package(Boost CONFIG REQUIRED COMPONENTS filesystem iostreams program_options)
 
 # Find Thrift
 find_package(Thrift COMPONENTS library)

--- a/src/chunkserver/chunkserver-common/hdd_utils.h
+++ b/src/chunkserver/chunkserver-common/hdd_utils.h
@@ -20,6 +20,7 @@
 
 #include "common/platform.h"
 
+#include <boost/shared_ptr.hpp>
 #include <deque>
 
 #include "chunkserver-common/chunk_interface.h"

--- a/src/chunkserver/chunkserver-common/plugin_manager.h
+++ b/src/chunkserver/chunkserver-common/plugin_manager.h
@@ -25,6 +25,7 @@
 #include <boost/dll/import.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/function.hpp>
+#include <boost/shared_ptr.hpp>
 
 #include "chunkserver-common/disk_plugin.h"
 

--- a/src/uraft/uraft.cc
+++ b/src/uraft/uraft.cc
@@ -152,20 +152,20 @@ bool uRaft::validPacket(const uint8_t *data, size_t size) {
 void uRaft::startElectionTimer() {
 	int timeout = opt_.election_timeout_min +
 	              rand() % (opt_.election_timeout_max - opt_.election_timeout_min);
-	election_timer_.expires_from_now(boost::posix_time::millisec(timeout));
+	election_timer_.expires_after(std::chrono::milliseconds(timeout));
 	election_timer_.async_wait(boost::bind(&uRaft::electionTimeout, this,
 	                                       boost::asio::placeholders::error));
 }
 
 void uRaft::startHearbeatTimer() {
-	heartbeat_timer_.expires_from_now(boost::posix_time::millisec(opt_.heartbeat_period));
+	heartbeat_timer_.expires_after(std::chrono::milliseconds(opt_.heartbeat_period));
 	heartbeat_timer_.async_wait(boost::bind(&uRaft::heartbeat, this,
 	                                        boost::asio::placeholders::error));
 }
 
 void uRaft::signLoyaltyAgreement() {
 	state_.loyalty_agreement = true;
-	loyalty_agreement_timer_.expires_from_now(boost::posix_time::millisec(opt_.election_timeout_min));
+	loyalty_agreement_timer_.expires_after(std::chrono::milliseconds(opt_.election_timeout_min));
 	loyalty_agreement_timer_.async_wait([this](const boost::system::error_code & error) {
 		if (!error) {
 			state_.loyalty_agreement = false;

--- a/src/uraft/uraft.h
+++ b/src/uraft/uraft.h
@@ -4,6 +4,7 @@
 
 #include <boost/array.hpp>
 #include <boost/asio.hpp>
+#include <boost/asio/steady_timer.hpp>
 
 /*! \brief Implementation of modified Raft consensus algorithm.
  *
@@ -222,8 +223,8 @@ protected:
 protected:
 	boost::asio::io_context                 &io_service_;
 	boost::asio::ip::udp::socket            socket_;
-	boost::asio::deadline_timer             election_timer_,heartbeat_timer_;
-	boost::asio::deadline_timer             loyalty_agreement_timer_;
+	boost::asio::steady_timer             election_timer_,heartbeat_timer_;
+	boost::asio::steady_timer             loyalty_agreement_timer_;
 	boost::array<uint8_t,kMaxPacketLength>  packet_data_;
 	boost::asio::ip::udp::endpoint          sender_endpoint_;
 

--- a/src/uraft/uraftcontroller.cc
+++ b/src/uraft/uraftcontroller.cc
@@ -17,6 +17,7 @@
 #include <boost/bind.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/version.hpp>
+#include <boost/chrono.hpp>
 
 constexpr int kCommandTimeoutMs = 5000;  ///< Default command timeout in milliseconds.
 
@@ -57,11 +58,11 @@ void uRaftController::init() {
 		return;
 	}
 
-	check_cmd_status_timer_.expires_from_now(boost::posix_time::millisec(opt_.check_cmd_status_period));
+	check_cmd_status_timer_.expires_after(std::chrono::milliseconds(opt_.check_cmd_status_period));
 	check_cmd_status_timer_.async_wait(boost::bind(&uRaftController::checkCommandStatus, this,
 	                                   boost::asio::placeholders::error));
 
-	check_node_status_timer_.expires_from_now(boost::posix_time::millisec(opt_.check_node_status_period));
+	check_node_status_timer_.expires_after(std::chrono::milliseconds(opt_.check_node_status_period));
 	check_node_status_timer_.async_wait(boost::bind(&uRaftController::checkNodeStatus, this,
 	                                    boost::asio::placeholders::error));
 
@@ -249,7 +250,7 @@ void uRaftController::checkCommandStatus(const boost::system::error_code &error)
 		}
 	}
 
-	check_cmd_status_timer_.expires_from_now(boost::posix_time::millisec(opt_.check_cmd_status_period));
+	check_cmd_status_timer_.expires_after(std::chrono::milliseconds(opt_.check_cmd_status_period));
 	check_cmd_status_timer_.async_wait(boost::bind(&uRaftController::checkCommandStatus, this,
 	                                   boost::asio::placeholders::error));
 }
@@ -295,7 +296,7 @@ void uRaftController::checkNodeStatus(const boost::system::error_code &error) {
 		}
 	}
 
-	check_node_status_timer_.expires_from_now(boost::posix_time::millisec(opt_.check_node_status_period));
+	check_node_status_timer_.expires_after(std::chrono::milliseconds(opt_.check_node_status_period));
 	check_node_status_timer_.async_wait(boost::bind(&uRaftController::checkNodeStatus, this,
 	                                    boost::asio::placeholders::error));
 }
@@ -328,7 +329,7 @@ void uRaftController::scheduleDeadRecovery() {
 	if (dead_recovery_pending_) { return; }
 	dead_recovery_pending_ = true;
 
-	dead_recovery_timer_.expires_from_now(boost::posix_time::millisec(kDeadRecoveryDelayMs));
+	dead_recovery_timer_.expires_after(std::chrono::milliseconds(kDeadRecoveryDelayMs));
 	dead_recovery_timer_.async_wait([this](const boost::system::error_code &ec) {
 		if (ec) { return; }
 
@@ -353,7 +354,7 @@ void uRaftController::scheduleDeadRecovery() {
 }
 
 void uRaftController::setSlowCommandTimeout(int timeout) {
-	cmd_timeout_timer_.expires_from_now(boost::posix_time::millisec(timeout));
+	cmd_timeout_timer_.expires_after(std::chrono::milliseconds(timeout));
 	cmd_timeout_timer_.async_wait([this, timeout](const boost::system::error_code & error) {
 		if (!error) {
 			syslog(LOG_ERR, "Metadata server mode switching timeout after %d ms", timeout);
@@ -631,7 +632,7 @@ void uRaftController::startPromotionBackoff(bool reset) {
 	syslog(LOG_WARNING, "Promotion backoff enabled (%d ms), streak=%d", backoff_ms,
 	       promotion_failure_streak_);
 
-	promotion_backoff_timer_.expires_from_now(boost::posix_time::millisec(backoff_ms));
+	promotion_backoff_timer_.expires_after(std::chrono::milliseconds(backoff_ms));
 	promotion_backoff_timer_.async_wait([this](const boost::system::error_code &ec) {
 		if (ec) { return; }
 		promotion_backoff_active_ = false;

--- a/src/uraft/uraftcontroller.h
+++ b/src/uraft/uraftcontroller.h
@@ -153,12 +153,12 @@ private:
 	int computePromotionBackoffMs() const;
 
 protected:
-	boost::asio::deadline_timer check_cmd_status_timer_;
-	boost::asio::deadline_timer check_node_status_timer_;
-	boost::asio::deadline_timer cmd_timeout_timer_;
+	boost::asio::steady_timer check_cmd_status_timer_;
+	boost::asio::steady_timer check_node_status_timer_;
+	boost::asio::steady_timer cmd_timeout_timer_;
 
 	/// @brief Timer used to implement promotion backoff after failed promotions.
-	boost::asio::deadline_timer promotion_backoff_timer_;
+	boost::asio::steady_timer promotion_backoff_timer_;
 	/// @brief Number of consecutive promotion failures used to compute exponential backoff.
 	/// This value is reset on successful promotion.
 	int promotion_failure_streak_ = 0;
@@ -166,7 +166,7 @@ protected:
 	bool promotion_backoff_active_ = false;
 
 	/// @brief Timer used to schedule delayed recovery after detecting dead metadata.
-	boost::asio::deadline_timer dead_recovery_timer_;
+	boost::asio::steady_timer dead_recovery_timer_;
 	/// @brief True while a dead recovery timer is scheduled (prevents stacking retries).
 	bool dead_recovery_pending_ = false;
 


### PR DESCRIPTION
This also changes from posix_timer (which I think is system time) to steady_timer (monotonic time), which should help avoid bugs with system time.