### PR TITLE
refactor(master): allow xattr ops in KV backends

### DIFF
--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -55,8 +55,6 @@
 #include "protocol/matocl.h"
 #include "slogger/slogger.h"
 
-[[maybe_unused]] static const char kAclXattrs[] = "system.richacl";
-
 inline bool isDepletedSpace() {
 	uint64_t totalSpace = 0;
 	uint64_t availableSpace = 0;
@@ -3089,10 +3087,10 @@ uint8_t FilesystemOperationsBase::setExtraAttr(const FsContext &context, inode_t
 
 #ifndef METARESTORE
 
-uint8_t FilesystemOperationsBase::listXAttrLeng(const FsContext &context,
-                                                const FilesystemOperationContext &fsOpContext,
-                                                inode_t inode, uint8_t opened, void **xanode,
-                                                uint32_t *xasize) {
+uint8_t FilesystemOperationsBase::listXAttr(const FsContext &context,
+                                            const FilesystemOperationContext &fsOpContext,
+                                            inode_t inode, uint8_t opened, XAttrListResult &result,
+                                            uint32_t *xasize) {
 	FSNode *p;
 
 	uint8_t status =
@@ -3108,15 +3106,32 @@ uint8_t FilesystemOperationsBase::listXAttrLeng(const FsContext &context,
 	if (status != SAUNAFS_STATUS_OK) { return status; }
 
 	*xasize = sizeof(kAclXattrs);
-	return get_xattrs_length_for_inode(p->id, xanode, xasize);
+	return doConcreteListXAttr(fsOpContext, p->id, result, xasize);
 }
 
-void FilesystemOperationsBase::listXAttrData(void *xanode, uint8_t *xabuff) {
-	memcpy(xabuff, kAclXattrs, sizeof(kAclXattrs));
-	xattr_listattr_data(xanode, xabuff + sizeof(kAclXattrs));
+uint8_t FilesystemOperationsBase::getXAttr(const FsContext &context,
+                                           const FilesystemOperationContext &fsOpContext,
+                                           inode_t inode, uint8_t opened, uint8_t anleng,
+                                           const uint8_t *attrname, XAttrGetResult &result) {
+	FSNode *p;
+
+	uint8_t status =
+	    nodeOperations_->verifySession(context, OperationMode::kReadOnly, SessionType::kNotMeta);
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+
+	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kAny,
+	                                              opened == 0 ? MODE_MASK_R : MODE_MASK_EMPTY,
+	                                              inode, &p);
+
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+
+	if (xattr_namecheck(anleng, attrname) < 0) { return SAUNAFS_ERROR_EINVAL; }
+	return doConcreteGetXAttr(fsOpContext, p->id, anleng, attrname, result);
 }
 
-uint8_t FilesystemOperationsBase::setXAttr(const FsContext &context, inode_t inode, uint8_t opened,
+uint8_t FilesystemOperationsBase::setXAttr(const FsContext &context,
+                                           const FilesystemOperationContext &fsOpContext,
+                                           inode_t inode, uint8_t opened,
                                            uint8_t anleng, const uint8_t *attrname, uint32_t avleng,
                                            const uint8_t *attrvalue, uint8_t mode) {
 	uint32_t ts = eventloop_time();
@@ -3130,9 +3145,6 @@ uint8_t FilesystemOperationsBase::setXAttr(const FsContext &context, inode_t ino
 		return status;
 	}
 
-	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
-	    FilesystemOperationContext::TransactionType::kReadWrite);
-
 	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kAny,
 	                                              opened == 0 ? MODE_MASK_W : MODE_MASK_EMPTY,
 	                                              inode, &p);
@@ -3145,7 +3157,7 @@ uint8_t FilesystemOperationsBase::setXAttr(const FsContext &context, inode_t ino
 	if (mode > XATTR_SMODE_REMOVE) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
-	status = xattr_setattr(p->id, anleng, attrname, avleng, attrvalue, mode);
+	status = doConcreteSetXAttr(fsOpContext, p->id, anleng, attrname, avleng, attrvalue, mode);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
@@ -3158,34 +3170,50 @@ uint8_t FilesystemOperationsBase::setXAttr(const FsContext &context, inode_t ino
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t FilesystemOperationsBase::getXAttr(const FsContext &context,
-                                           const FilesystemOperationContext &fsOpContext,
-                                           inode_t inode, uint8_t opened, uint8_t anleng,
-                                           const uint8_t *attrname, uint32_t *avleng,
-                                           uint8_t **attrvalue) {
-	FSNode *p;
+#endif /* #ifndef METARESTORE */
 
-	uint8_t status =
-	    nodeOperations_->verifySession(context, OperationMode::kReadOnly, SessionType::kNotMeta);
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	}
+uint8_t FilesystemOperationsBase::doConcreteGetXAttr(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, inode_t inode, uint8_t anleng,
+    const uint8_t *attrname, XAttrGetResult &result) {
+	uint32_t avleng = 0;
+	uint8_t *attrvalue = nullptr;  // Assigned by xattr_getattr
 
-	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kAny,
-	                                              opened == 0 ? MODE_MASK_R : MODE_MASK_EMPTY,
-	                                              inode, &p);
+	uint8_t status = xattr_getattr(inode, anleng, attrname, &avleng, &attrvalue);
 
 	if (status != SAUNAFS_STATUS_OK) { return status; }
 
-	if (xattr_namecheck(anleng, attrname) < 0) {
-		return SAUNAFS_ERROR_EINVAL;
-	}
-	return xattr_getattr(p->id, anleng, attrname, avleng, attrvalue);
+	result.value.assign(attrvalue, attrvalue + avleng);
+
+	return SAUNAFS_STATUS_OK;
 }
 
-#endif /* #ifndef METARESTORE */
+uint8_t FilesystemOperationsBase::doConcreteListXAttr(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, inode_t inode,
+    XAttrListResult &result, uint32_t *xasize) {
+	void *xanode = nullptr;  // Assigned by get_xattrs_length_for_inode
 
-uint8_t FilesystemOperationsBase::applySetXAttr(uint32_t timestamp, inode_t inode, uint32_t anleng,
+	uint8_t status = get_xattrs_length_for_inode(inode, &xanode, xasize);
+
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+
+	uint32_t nameDataSize = *xasize - sizeof(kAclXattrs);
+
+	if (nameDataSize > 0 && xanode != nullptr) {
+		result.data.resize(nameDataSize);
+		xattr_listattr_data(xanode, result.data.data());
+	}
+
+	return SAUNAFS_STATUS_OK;
+}
+
+uint8_t FilesystemOperationsBase::doConcreteSetXAttr(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, inode_t inode, uint8_t anleng,
+    const uint8_t *attrname, uint32_t avleng, const uint8_t *attrvalue, uint32_t mode) {
+	return xattr_setattr(inode, anleng, attrname, avleng, attrvalue, mode);
+}
+
+uint8_t FilesystemOperationsBase::applySetXAttr(const FilesystemOperationContext &fsOpContext,
+                                                uint32_t timestamp, inode_t inode, uint32_t anleng,
                                                 const uint8_t *attrname, uint32_t avleng,
                                                 const uint8_t *attrvalue, uint32_t mode) {
 	FSNode *p;
@@ -3195,14 +3223,11 @@ uint8_t FilesystemOperationsBase::applySetXAttr(uint32_t timestamp, inode_t inod
 		return SAUNAFS_ERROR_EINVAL;
 	}
 	p = nodeOperations_->idToNode(inode);
-	if (!p) {
-		return SAUNAFS_ERROR_ENOENT;
-	}
-	status = xattr_setattr(inode, anleng, attrname, avleng, attrvalue, mode);
+	if (!p) { return SAUNAFS_ERROR_ENOENT; }
+	status = doConcreteSetXAttr(fsOpContext, inode, static_cast<uint8_t>(anleng), attrname, avleng,
+	                            attrvalue, mode);
 
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	}
+	if (status != SAUNAFS_STATUS_OK) { return status; }
 	nodeOperations_->updateCTime(p, timestamp);
 	gMetadata->metadataVersion++;
 	fsnodes_update_checksum(p);

--- a/src/master/filesystem_operations.h
+++ b/src/master/filesystem_operations.h
@@ -224,18 +224,27 @@ public:
 	uint8_t getGoal(const FsContext &context, const FilesystemOperationContext &fsOpContext,
 	                inode_t inode, uint8_t gmode, GoalStatistics &fgtab,
 	                GoalStatistics &dgtab) override;
-	uint8_t getXAttr(const FsContext &context, const FilesystemOperationContext &fsOpContext,
-	                 inode_t inode, uint8_t opened, uint8_t anleng, const uint8_t *attrname,
-	                 uint32_t *avleng, uint8_t **attrvalue) override;
 	uint8_t getExtraAttr(const FsContext &context, inode_t inode, uint8_t gmode,
 	                     ExtraAttributesArray &fileEAttrTab,
 	                     ExtraAttributesArray &dirEAttrTab) override;
-	uint8_t listXAttrLeng(const FsContext &context,
-	                      const FilesystemOperationContext &fsOpContext, inode_t inode,
-	                      uint8_t opened, void **xanode, uint32_t *xasize) override;
-	uint8_t setXAttr(const FsContext &context, inode_t inode, uint8_t opened, uint8_t anleng,
-	                 const uint8_t *attrname, uint32_t avleng, const uint8_t *attrvalue,
-	                 uint8_t mode) override;
+
+	/// Lists extended attribute names for an inode.
+	/// @see IFilesystemOperations::listXAttr
+	uint8_t listXAttr(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                  inode_t inode, uint8_t opened, XAttrListResult &result,
+	                  uint32_t *xasize) override;
+
+	/// Retrieves the value of a single extended attribute.
+	/// @see IFilesystemOperations::getXAttr
+	uint8_t getXAttr(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                 inode_t inode, uint8_t opened, uint8_t anleng, const uint8_t *attrname,
+	                 XAttrGetResult &result) override;
+
+	/// Sets, replaces, or removes an extended attribute on an inode.
+	/// @see IFilesystemOperations::setXAttr
+	uint8_t setXAttr(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                 inode_t inode, uint8_t opened, uint8_t anleng, const uint8_t *attrname,
+	                 uint32_t avleng, const uint8_t *attrvalue, uint8_t mode) override;
 
 	/// Removes (unlinks) a file or non-directory node from the filesystem.
 	/// @see IFilesystemOperations::unlink
@@ -267,7 +276,6 @@ public:
 	                 uint64_t chunkid, uint32_t lockid) override;
 	void getTrashTimeStore(TrashtimeMap &fileTrashtimes, TrashtimeMap &dirTrashtimes,
 	                       uint8_t *buff) override;
-	void listXAttrData(void *xanode, uint8_t *xabuff) override;
 
 	uint32_t newSessionId() override;
 
@@ -341,9 +349,9 @@ public:
 	                    inode_t inode, uint64_t length, bool eraseFurtherChunks) override;
 	uint8_t applyRepair(const FilesystemOperationContext &fsOpContext, uint32_t timestamp,
 	                    inode_t inode, uint32_t indx, uint32_t nversion) override;
-	uint8_t applySetXAttr(uint32_t timestamp, inode_t inode, uint32_t anleng,
-	                      const uint8_t *attrname, uint32_t avleng, const uint8_t *attrvalue,
-	                      uint32_t mode) override;
+	uint8_t applySetXAttr(const FilesystemOperationContext &fsOpContext, uint32_t timestamp,
+	                      inode_t inode, uint32_t anleng, const uint8_t *attrname, uint32_t avleng,
+	                      const uint8_t *attrvalue, uint32_t mode) override;
 	uint8_t applySetAcl(uint32_t timestamp, inode_t inode, char aclType,
 	                    const char *aclString) override;
 	uint8_t applySetRichAcl(uint32_t timestamp, inode_t inode,
@@ -408,6 +416,42 @@ public:
 	/// @see IFilesystemOperations::fs_locks_remove_pending.
 	int locksRemovePending(const FsContext &context, uint8_t type, uint64_t ownerid,
 	                       uint32_t sessionid, inode_t inode, uint64_t reqid) override;
+
+protected:
+	/// Backend-specific hook for retrieving an xattr value.
+	/// Default implementation reads from in-memory hash tables.
+	/// @param fsOpContext Operation context (provides transaction for KV backends).
+	/// @param inode The inode to retrieve the attribute from.
+	/// @param anleng Length of the attribute name.
+	/// @param attrname The attribute name bytes.
+	/// @param[out] result Populated with an owned copy of the attribute value.
+	virtual uint8_t doConcreteGetXAttr(
+	    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, inode_t inode,
+	    uint8_t anleng, const uint8_t *attrname, XAttrGetResult &result);
+
+	/// Backend-specific hook for listing xattr names for an inode.
+	/// Default implementation reads from in-memory hash tables.
+	/// @param fsOpContext Operation context (provides transaction for KV backends).
+	/// @param inode The inode to list attributes for.
+	/// @param[out] result Populated with serialized xattr name data.
+	/// @param[in,out] xasize Pre-initialized with sizeof(kAclXattrs); add name sizes here.
+	virtual uint8_t doConcreteListXAttr(
+	    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, inode_t inode,
+	    XAttrListResult &result, uint32_t *xasize);
+
+	/// Backend-specific hook for setting/removing an xattr.
+	/// Default implementation modifies in-memory hash tables.
+	/// @param fsOpContext Operation context (provides transaction for KV backends).
+	/// @param inode The inode to set/remove the attribute on.
+	/// @param anleng Length of the attribute name.
+	/// @param attrname The attribute name bytes.
+	/// @param avleng Length of the attribute value.
+	/// @param attrvalue The attribute value bytes.
+	/// @param mode One of XATTR_SMODE_* (create, replace, remove, etc.).
+	virtual uint8_t doConcreteSetXAttr(
+	    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, inode_t inode,
+	    uint8_t anleng, const uint8_t *attrname, uint32_t avleng, const uint8_t *attrvalue,
+	    uint32_t mode);
 
 private:
 	/// Helper function used internally by `fs_flock_op` and `fs_posixlock_op`.

--- a/src/master/filesystem_operations_interface.h
+++ b/src/master/filesystem_operations_interface.h
@@ -22,6 +22,7 @@
 
 #include <map>
 #include <memory>
+#include <vector>
 
 #include "common/attributes.h"
 #include "common/goal.h"
@@ -46,6 +47,20 @@ struct QuotaOwner;
 
 struct NamedInodeEntry;
 struct HandleInodeEntry;
+
+inline constexpr char kAclXattrs[] = "system.richacl";
+
+/// Result of a getXAttr operation. Owns the attribute value bytes.
+struct XAttrGetResult {
+	std::vector<uint8_t> value;
+};
+
+/// Result of a listXAttr operation. Owns the serialized name list.
+struct XAttrListResult {
+	/// Serialized xattr names: each name is followed by a '\0' byte.
+	/// Does NOT include the always-present kAclXattrs prefix.
+	std::vector<uint8_t> data;
+};
 
 /// Interface for filesystem operations extensibility.
 /// Classes implementing this interface can be used to override default filesystem behavior.
@@ -804,16 +819,89 @@ public:
 	virtual uint8_t getExtraAttr(const FsContext &context, inode_t inode, uint8_t gmode,
 	                             ExtraAttributesArray &fileEAttrTab,
 	                             ExtraAttributesArray &dirEAttrTab) = 0;
-	virtual uint8_t listXAttrLeng(const FsContext &context,
-	                              const FilesystemOperationContext &fsOpContext, inode_t inode,
-	                              uint8_t opened, void **xanode, uint32_t *xasize) = 0;
+
+	/// Lists extended attribute names for an inode.
+	///
+	/// Verifies the session (read-only, non-meta) and resolves the inode with
+	/// read permission check (or no permission check if the file is already opened).
+	/// On success, returns the total serialized size of all xattr names (including
+	/// the always-present "system.richacl\0" prefix) and an owned result containing
+	/// the serialized user-defined attribute names.
+	///
+	/// @param context The FS operation context containing user credentials and session info.
+	/// @param fsOpContext The operation context carrying a transaction in KV backends.
+	/// @param inode The inode to list attributes for.
+	/// @param opened Non-zero if the file is already opened (skips permission check).
+	/// @param[out] result Populated with the serialized xattr name data (excluding the
+	///                    kAclXattrs prefix, which the caller must prepend).
+	/// @param[out] xasize Total byte size of the serialized xattr name list, including
+	///                    the "system.richacl\0" prefix and a trailing '\0' per name.
+	///
+	/// @return SAUNAFS_STATUS_OK on success, or one of the following error codes:
+	///         - Session or permission errors from verifySession/getNodeForOperation
+	///         - SAUNAFS_ERROR_ERANGE if the total xattr name list exceeds SFS_XATTR_LIST_MAX
+	virtual uint8_t listXAttr(const FsContext &context,
+	                          const FilesystemOperationContext &fsOpContext, inode_t inode,
+	                          uint8_t opened, XAttrListResult &result, uint32_t *xasize) = 0;
+
+	/// Retrieves the value of a single extended attribute.
+	///
+	/// Verifies the session (read-only, non-meta), resolves the inode with read
+	/// permission check (or no check if already opened), and validates the attribute
+	/// name (must not contain null bytes). Then looks up the named attribute and
+	/// returns an owned copy of its value.
+	///
+	/// @param context The FS operation context containing user credentials and session info.
+	/// @param fsOpContext The operation context carrying a transaction in KV backends.
+	/// @param inode The inode to retrieve the attribute from.
+	/// @param opened Non-zero if the file is already opened (skips permission check).
+	/// @param anleng Length of the attribute name in bytes.
+	/// @param attrname The attribute name bytes (not null-terminated).
+	/// @param[out] result Populated with an owned copy of the attribute value on success.
+	///
+	/// @return SAUNAFS_STATUS_OK on success, or one of the following error codes:
+	///         - Session or permission errors from verifySession/getNodeForOperation
+	///         - SAUNAFS_ERROR_EINVAL if the attribute name contains null bytes
+	///         - SAUNAFS_ERROR_ENOATTR if the attribute does not exist
+	///         - SAUNAFS_ERROR_ERANGE if the stored value exceeds SFS_XATTR_SIZE_MAX
 	virtual uint8_t getXAttr(const FsContext &context,
 	                         const FilesystemOperationContext &fsOpContext, inode_t inode,
 	                         uint8_t opened, uint8_t anleng, const uint8_t *attrname,
-	                         uint32_t *avleng, uint8_t **attrvalue) = 0;
-	virtual uint8_t setXAttr(const FsContext &context, inode_t inode, uint8_t opened,
-	                         uint8_t anleng, const uint8_t *attrname, uint32_t avleng,
-	                         const uint8_t *attrvalue, uint8_t mode) = 0;
+	                         XAttrGetResult &result) = 0;
+
+	/// Sets, replaces, or removes an extended attribute on an inode.
+	///
+	/// Verifies the session (read-write, non-meta), resolves the inode with write
+	/// permission check (or no check if already opened), and validates the attribute
+	/// name and mode. Depending on the mode, the attribute is created, replaced, or
+	/// removed. On success, updates the inode's ctime, its checksum, and writes
+	/// a SETXATTR entry to the changelog.
+	///
+	/// @param context The FS operation context containing user credentials and session info.
+	/// @param fsOpContext The operation context carrying a read-write transaction in KV backends.
+	/// @param inode The inode to set/remove the attribute on.
+	/// @param opened Non-zero if the file is already opened (skips permission check).
+	/// @param anleng Length of the attribute name in bytes.
+	/// @param attrname The attribute name bytes (not null-terminated).
+	/// @param avleng Length of the attribute value in bytes. Not applied to storage for REMOVE,
+	///              but still referenced in changelog logging; pass 0 for REMOVE.
+	/// @param attrvalue The attribute value bytes. Not applied to storage for REMOVE,
+	///                  but still referenced in changelog logging; pass a valid pointer for REMOVE.
+	/// @param mode One of XATTR_SMODE_CREATE_OR_REPLACE, XATTR_SMODE_CREATE_ONLY,
+	///             XATTR_SMODE_REPLACE_ONLY, or XATTR_SMODE_REMOVE.
+	///
+	/// @return SAUNAFS_STATUS_OK on success, or one of the following error codes:
+	///         - Session or permission errors from verifySession/getNodeForOperation
+	///         - SAUNAFS_ERROR_EINVAL if the attribute name is empty or contains null bytes,
+	///           or mode is invalid
+	///         - SAUNAFS_ERROR_EEXIST if mode is CREATE_ONLY and the attribute already exists
+	///         - SAUNAFS_ERROR_ENOATTR if mode is REPLACE_ONLY or REMOVE and the attribute
+	///           does not exist
+	///         - SAUNAFS_ERROR_ERANGE if the value or total name list size exceeds limits
+	virtual uint8_t setXAttr(const FsContext &context,
+	                         const FilesystemOperationContext &fsOpContext, inode_t inode,
+	                         uint8_t opened, uint8_t anleng, const uint8_t *attrname,
+	                         uint32_t avleng, const uint8_t *attrvalue, uint8_t mode) = 0;
 
 	/// Removes (unlinks) a file or non-directory node from the filesystem.
 	///
@@ -876,7 +964,6 @@ public:
 	                         uint64_t length, uint64_t chunkid, uint32_t lockid) = 0;
 	virtual void getTrashTimeStore(TrashtimeMap &fileTrashtimes, TrashtimeMap &dirTrashtimes,
 	                               uint8_t *buff) = 0;
-	virtual void listXAttrData(void *xanode, uint8_t *xabuff) = 0;
 
 	virtual uint32_t newSessionId() = 0;
 
@@ -949,9 +1036,9 @@ public:
 	                            inode_t inode, uint64_t length, bool eraseFurtherChunks) = 0;
 	virtual uint8_t applyRepair(const FilesystemOperationContext &fsOpContext, uint32_t timestamp,
 	                            inode_t inode, uint32_t indx, uint32_t nversion) = 0;
-	virtual uint8_t applySetXAttr(uint32_t timestamp, inode_t inode, uint32_t anleng,
-	                              const uint8_t *attrname, uint32_t avleng,
-	                              const uint8_t *attrvalue, uint32_t mode) = 0;
+	virtual uint8_t applySetXAttr(const FilesystemOperationContext &fsOpContext, uint32_t timestamp,
+	                              inode_t inode, uint32_t anleng, const uint8_t *attrname,
+	                              uint32_t avleng, const uint8_t *attrvalue, uint32_t mode) = 0;
 	virtual uint8_t applySetAcl(uint32_t timestamp, inode_t inode, char aclType,
 	                            const char *aclString) = 0;
 	virtual uint8_t applySetRichAcl(uint32_t timestamp, inode_t inode,

--- a/src/master/filesystem_xattr.cc
+++ b/src/master/filesystem_xattr.cc
@@ -115,12 +115,14 @@ void xattr_recalculate_checksum() {
 
 void xattr_removeinode(inode_t inode) {
 	XAttributeInodeEntry *xattrInodeEntry = nullptr;
+	bool hadEntries = false;
 
 	auto hash = get_xattr_inode_hash(inode);
 	auto &bucket = gMetadata->xattrInodeHash[hash];
 	for (auto attributeIterator = bucket.begin(); attributeIterator != bucket.end();) {
 		xattrInodeEntry = attributeIterator->get();
 		if (xattrInodeEntry->inode == inode) {
+			hadEntries = true;
 			while (!xattrInodeEntry->xattrDataEntries.empty()) {
 				xattr_removeentry(xattrInodeEntry, xattrInodeEntry->xattrDataEntries.front());
 			}
@@ -128,6 +130,10 @@ void xattr_removeinode(inode_t inode) {
 		} else {
 			++attributeIterator;
 		}
+	}
+
+	if (hadEntries) {
+		gXAttrInodeRemovedSignal.emit(inode);
 	}
 }
 

--- a/src/master/filesystem_xattr.h
+++ b/src/master/filesystem_xattr.h
@@ -28,6 +28,7 @@
 #include <vector>
 
 #include "common/massert.h"
+#include "common/observable_property.h"
 #include "common/type_defs.h"
 
 #define XATTR_INODE_HASH_SIZE 65536
@@ -100,3 +101,6 @@ uint8_t get_xattrs_length_for_inode(inode_t inode, void **xattrInodePointer, uin
 uint8_t xattr_setattr(inode_t inode, uint8_t attributeNameLength, const uint8_t *attributeName,
                       uint32_t attributeValueLength, const uint8_t *attributeValueBuffer,
                       uint8_t mode);
+
+/// Signal emitted when all xattrs for an inode are removed (node deletion cleanup).
+inline Signal<inode_t> gXAttrInodeRemovedSignal;

--- a/src/master/kv_common_keys.h
+++ b/src/master/kv_common_keys.h
@@ -74,8 +74,14 @@ inline constexpr std::string_view kFreeKeyPrefix = "FREE_";    // Section FREE 1
 /// LockedTo and LockId (both 32-bit) are also Big Endian.
 inline constexpr std::string_view kChunkKeyPrefix = "CHNK_";   // Section CHNK 1.0
 
-// Reserved for future use
+/// Prefix for extended attributes (xattrs)
+/// Format: XATR_<InodeId><AttributeName>:<AttributeValue>
+/// e.g.: XATR_1999UserAttr:UserValue
+/// @note InodeId is serialized as Big Endian to maintain numeric order in lexicographical sorting,
+/// enabling efficient range queries for all xattrs of a specific inode.
 inline constexpr std::string_view kXAttrKeyPrefix = "XATR_";   // Section XATR 1.0
+
+// Reserved for future use
 inline constexpr std::string_view kACLsKeyPrefix = "ACLS_";    // Section ACLS 1.2
 inline constexpr std::string_view kQuotasKeyPrefix = "QUOT_";  // Section QUOT 1.1
 inline constexpr std::string_view kLocksKeyPrefix = "FLCK_";   // Section FLCK 1.0

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -3694,10 +3694,9 @@ void matoclserv_fuse_getxattr(matoclserventry *eptr, const uint8_t *data, uint32
 		put32bit(&ptr, msgid);
 		put8bit(&ptr, SAUNAFS_ERROR_EINVAL);
 	} else if (anleng == 0) {
-		void *xanode;
+		XAttrListResult listResult;
 		uint32_t xasize;
-		status =
-		    gFSOperations->listXAttrLeng(context, fsOpContext, inode, opened, &xanode, &xasize);
+		status = gFSOperations->listXAttr(context, fsOpContext, inode, opened, listResult, &xasize);
 		const uint32_t kSuccessSize =
 		    sizeof(msgid) + sizeof(xasize) + ((mode == XATTR_GMODE_GET_DATA) ? xasize : 0);
 		ptr = matoclserv_createpacket(eptr, MATOCL_FUSE_GETXATTR,
@@ -3710,14 +3709,18 @@ void matoclserv_fuse_getxattr(matoclserventry *eptr, const uint8_t *data, uint32
 		} else {
 			put32bit(&ptr, xasize);
 			if (mode == XATTR_GMODE_GET_DATA && xasize > 0) {
-				gFSOperations->listXAttrData(xanode, ptr);
+				memcpy(ptr, kAclXattrs, sizeof(kAclXattrs));
+				if (!listResult.data.empty()) {
+					memcpy(ptr + sizeof(kAclXattrs), listResult.data.data(),
+					       listResult.data.size());
+				}
 			}
 		}
 	} else {
-		uint8_t *attrvalue;
-		uint32_t avleng;
+		XAttrGetResult getResult;
 		status = gFSOperations->getXAttr(context, fsOpContext, inode, opened, anleng, attrname,
-		                                 &avleng, &attrvalue);
+		                                 getResult);
+		uint32_t avleng = static_cast<uint32_t>(getResult.value.size());
 		const uint32_t kSuccessSize =
 		    sizeof(msgid) + sizeof(avleng) + ((mode == XATTR_GMODE_GET_DATA) ? avleng : 0);
 		ptr = matoclserv_createpacket(eptr, MATOCL_FUSE_GETXATTR,
@@ -3729,7 +3732,9 @@ void matoclserv_fuse_getxattr(matoclserventry *eptr, const uint8_t *data, uint32
 			put8bit(&ptr, status);
 		} else {
 			put32bit(&ptr, avleng);
-			if (mode == XATTR_GMODE_GET_DATA && avleng > 0) { memcpy(ptr, attrvalue, avleng); }
+			if (mode == XATTR_GMODE_GET_DATA && avleng > 0) {
+				memcpy(ptr, getResult.value.data(), avleng);
+			}
 		}
 	}
 }
@@ -3794,8 +3799,20 @@ void matoclserv_fuse_setxattr(matoclserventry *eptr, const uint8_t *data, uint32
 
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = gFSOperations->setXAttr(context, inode, opened, anleng, attrname, avleng,
-		                                 attrvalue, mode);
+		auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+		    FilesystemOperationContext::TransactionType::kReadWrite);
+
+		status = gFSOperations->setXAttr(context, fsOpContext, inode, opened, anleng, attrname,
+		                                 avleng, attrvalue, mode);
+
+		if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
+			if (!fsOpContext.getReadWriteTransaction()->commit()) {
+				safs::log_err("{}: transaction failed to commit: inode {}, attrname {}", __func__,
+				              inode,
+				              std::string_view(reinterpret_cast<const char *>(attrname), anleng));
+				status = SAUNAFS_ERROR_IO;
+			}
+		}
 	}
 
 	ptr = matoclserv_createpacket(eptr, MATOCL_FUSE_SETXATTR, sizeof(msgid) + sizeof(status));

--- a/src/master/restore.cc
+++ b/src/master/restore.cc
@@ -735,8 +735,21 @@ int do_setxattr(const char* filename, uint64_t lv, uint32_t ts, const char* ptr)
 	EAT(ptr,filename,lv,',');
 	GETU32(mode,ptr);
 	EAT(ptr,filename,lv,')');
-	return gFSOperations->applySetXAttr(ts, inode, strlen((char *)name), name, valueleng, value,
-	                                    mode);
+
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
+	int status = gFSOperations->applySetXAttr(fsOpContext, ts, inode, strlen((char *)name), name,
+	                                          valueleng, value, mode);
+
+	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
+		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+			safs::log_err("{}: transaction failed to commit: inode {}", __func__, inode);
+			status = SAUNAFS_ERROR_IO;
+		}
+	}
+
+	return status;
 }
 
 int do_deleteacl(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {


### PR DESCRIPTION
Operations related to extended attributes now receive a FilesystemOperationContext (transaction handle) to allow KV backends to aggregate all changes in the same transaction.

To foster code reuse, three virtual hooks are introduced: doConcreteGetXAttr, doConcreteListXAttr and doConcreteSetXAttr. The default implementations delegate to the existing in-memory helpers, preserving behaviour.

A removal signal (gXAttrInodeRemovedSignal) was added so any listener can connect and react to it.

kAclXattrs was promoted from a file-local static to an inline constexpr in the interface header so all xattr implementations can reference it.

All changes are backward-compatible with the in-memory implementation.

Related to: LS-69