### PR TITLE
fix(cs): fix flaky test_helgrind_basic

### DIFF
--- a/src/chunkserver/network_worker_thread.cc
+++ b/src/chunkserver/network_worker_thread.cc
@@ -122,6 +122,11 @@ void NetworkWorkerThread::operator()() {
 }
 
 bool NetworkWorkerThread::updateAndCheckTerminationStatus() {
+	// Don't even check the rest if we already know we can terminate.
+	if (canTerminate_.load()) {
+		return true;
+	}
+
 	std::lock_guard lock(csservheadLock);
 	bool canTerminate =
 	    doTerminate.load() && ((csservEntries.empty() &&

--- a/tests/test_suites/SingleMachineTests/test_helgrind_basic.sh
+++ b/tests/test_suites/SingleMachineTests/test_helgrind_basic.sh
@@ -53,3 +53,5 @@ generateFiles
 # finishes validating files and sometimes it gets stuck
 # drop_caches
 # validateFiles
+
+saunafs_chunkserver_daemon 0 stop


### PR DESCRIPTION
This change targets improving the stability of the test_helgrind_basic. The test was failing due missing protection of the bgJobPool member of the network worker class when stopping the chunkserver. The solution proposed is to avoid accessing that member when it is no longer needed.

The test_helgrind_basic was modified to explicitly test the stop mechanism.

Signed-off-by: Dave <dave@leil.io>