### PR TITLE
fix(windows): Fix offset type issue in client lib LS-364

### DIFF
--- a/src/mount/sauna_client.cc
+++ b/src/mount/sauna_client.cc
@@ -1019,7 +1019,7 @@ EntryParam lookup(Context &ctx, inode_t parent, const char *name) {
 	attr_to_stat(inode, attr, &e.attr);
 	if (maxFileLen > static_cast<uint64_t>(e.attr.st_size)) {
 		update_attr_size(attr, maxFileLen);
-		e.attr.st_size = static_cast<__off_t>(maxFileLen);
+		e.attr.st_size = static_cast<off_t>(maxFileLen);
 	}
 
 	// If lookup succeeded and data did not come from cache, then cache it.


### PR DESCRIPTION
Due to changes introduced in commit 84c158a3, the Windows client related code was not compiling correctly because of an offset type issue. This commit addresses that issue by ensuring correct cross-platform compatibility for client base library.