### PR TITLE
refactor(master): allow ACL ops in KV backends

### DIFF
--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -1938,7 +1938,9 @@ void FilesystemNodeOperationsBase::setExtraAttrRecursive(FSNode *node, uint32_t 
 	fsnodes_update_checksum(node);
 }
 
-uint8_t FilesystemNodeOperationsBase::deleteAcl(FSNode *node, AclType type, uint32_t timeStamp) {
+uint8_t FilesystemNodeOperationsBase::deleteAcl(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, FSNode *node, AclType type,
+    uint32_t timeStamp) {
 	if (type == AclType::kRichACL) {
 		gMetadata->aclStorage.erase(node->id);
 	} else if (type == AclType::kDefault) {
@@ -1979,7 +1981,8 @@ uint8_t FilesystemNodeOperationsBase::deleteAcl(FSNode *node, AclType type, uint
 }
 
 #ifndef METARESTORE
-uint8_t FilesystemNodeOperationsBase::getAcl(FSNode *node, RichACL &acl) {
+uint8_t FilesystemNodeOperationsBase::getAcl(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, FSNode *node, RichACL &acl) {
 	const RichACL *richAcl = gMetadata->aclStorage.get(node->id);
 
 	if (!richAcl) { return SAUNAFS_ERROR_ENOATTR; }
@@ -1991,7 +1994,9 @@ uint8_t FilesystemNodeOperationsBase::getAcl(FSNode *node, RichACL &acl) {
 }
 #endif
 
-uint8_t FilesystemNodeOperationsBase::setAcl(FSNode *node, const RichACL &acl, uint32_t timeStamp) {
+uint8_t FilesystemNodeOperationsBase::setAcl(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, FSNode *node,
+    const RichACL &acl, uint32_t timeStamp) {
 	if (!acl.checkInheritFlags(node->type == FSNodeType::kDirectory)) {
 		return SAUNAFS_ERROR_ENOTSUP;
 	}
@@ -2021,8 +2026,9 @@ uint8_t FilesystemNodeOperationsBase::setAcl(FSNode *node, const RichACL &acl, u
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t FilesystemNodeOperationsBase::setAcl(FSNode *node, AclType type,
-                                             const AccessControlList &acl, uint32_t timeStamp) {
+uint8_t FilesystemNodeOperationsBase::setAcl(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, FSNode *node, AclType type,
+    const AccessControlList &acl, uint32_t timeStamp) {
 	if (type != AclType::kDefault && type != AclType::kAccess) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
@@ -2076,12 +2082,21 @@ int FilesystemNodeOperationsBase::nameCheck(const std::string &name) {
 	return 0;
 }
 
-int FilesystemNodeOperationsBase::access(const FsContext &context, FSNode *node, uint8_t modeMask) {
+const RichACL *FilesystemNodeOperationsBase::getAclForAccess(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, FSNode *node,
+    [[maybe_unused]] std::optional<RichACL> &scratch) {
+	return gMetadata->aclStorage.get(node->id);
+}
+
+int FilesystemNodeOperationsBase::access(const FsContext &context,
+                                         const FilesystemOperationContext &fsOpContext,
+                                         FSNode *node, uint8_t modeMask) {
 	if ((context.sesflags() & SESFLAG_NOMASTERPERMCHECK) || context.uid() == 0) {
 		return 1;  // super user or no permission check
 	}
 
-	const RichACL *nodeAcl = gMetadata->aclStorage.get(node->id);
+	std::optional<RichACL> aclScratch;  // not constructed here; KV backends emplace() as needed
+	const RichACL *nodeAcl = getAclForAccess(fsOpContext, node, aclScratch);
 
 	// If ACLs are present, use it for permission checking
 	if (nodeAcl != nullptr) {
@@ -2238,7 +2253,7 @@ uint8_t FilesystemNodeOperationsBase::getNodeForOperation(
 		return SAUNAFS_ERROR_EPERM;
 	}
 
-	if (context.canCheckPermissions() && !access(context, candidateNode, modeMask)) {
+	if (context.canCheckPermissions() && !access(context, fsOpContext, candidateNode, modeMask)) {
 		return SAUNAFS_ERROR_EACCES;
 	}
 

--- a/src/master/filesystem_node.h
+++ b/src/master/filesystem_node.h
@@ -22,6 +22,8 @@
 
 #include "common/platform.h"
 
+#include <optional>
+
 #include "master/filesystem_node_operations_interface.h"
 #include "master/filesystem_node_types.h"
 #include "master/fs_context.h"
@@ -174,13 +176,28 @@ public:
 	std::string escapeName(const std::string &name) override;
 
 	// ACL operations
-	uint8_t setAcl(FSNode *node, const RichACL &acl, uint32_t timeStamp) override;
-	uint8_t setAcl(FSNode *node, AclType type, const AccessControlList &acl,
-	               uint32_t timeStamp) override;
+
+	/// Stores a RichACL on a node, replacing any previously stored ACL.
+	/// @see IFilesystemNodeOperations::setAcl
+	uint8_t setAcl(const FilesystemOperationContext &fsOpContext, FSNode *node,
+	               const RichACL &acl, uint32_t timeStamp) override;
+
+	/// Merges a POSIX ACL into the node's stored RichACL.
+	/// @see IFilesystemNodeOperations::setAcl
+	uint8_t setAcl(const FilesystemOperationContext &fsOpContext, FSNode *node, AclType type,
+	               const AccessControlList &acl, uint32_t timeStamp) override;
+
 #ifndef METARESTORE
-	uint8_t getAcl(FSNode *node, RichACL &acl) override;
+	/// Retrieves the stored RichACL for a node.
+	/// @see IFilesystemNodeOperations::getAcl
+	uint8_t getAcl(const FilesystemOperationContext &fsOpContext, FSNode *node,
+	               RichACL &acl) override;
 #endif  // METARESTORE
-	uint8_t deleteAcl(FSNode *node, AclType type, uint32_t timeStamp) override;
+
+	/// Removes or prunes the ACL stored on a node according to the ACL type.
+	/// @see IFilesystemNodeOperations::deleteAcl
+	uint8_t deleteAcl(const FilesystemOperationContext &fsOpContext, FSNode *node, AclType type,
+	                  uint32_t timeStamp) override;
 
 	// Recursive operations
 #ifndef METARESTORE
@@ -208,7 +225,18 @@ public:
 	                           inode_t *permissionDeniedINodesOut) override;
 
 	// Access control operations
-	int access(const FsContext &context, FSNode *node, uint8_t modeMask) override;
+	int access(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	           FSNode *node, uint8_t modeMask) override;
+
+protected:
+	/// Returns the stored RichACL for @p node, or nullptr if none is present.
+	/// @p scratch is an optional caller-supplied buffer; implementations that need
+	/// to materialise a temporary ACL (e.g. KV backends) emplace into @p scratch
+	/// and return &scratch->value(), while the default in-memory implementation
+	/// leaves @p scratch empty and returns a pointer into aclStorage directly.
+	/// The caller avoids constructing a RichACL when it is not needed.
+	virtual const RichACL *getAclForAccess(const FilesystemOperationContext &fsOpContext,
+	                                       FSNode *node, std::optional<RichACL> &scratch);
 	int stickyAccess(FSNode *parent, FSNode *node, uint32_t uid) override;
 	int nameCheck(const std::string &name) override;
 	uint8_t verifySession(const FsContext &context, OperationMode operationMode,

--- a/src/master/filesystem_node_operations_interface.h
+++ b/src/master/filesystem_node_operations_interface.h
@@ -466,13 +466,78 @@ public:
 	virtual std::string escapeName(const std::string &name) = 0;
 
 	// ACL operations
-	virtual uint8_t setAcl(FSNode *node, const RichACL &acl, uint32_t timeStamp) = 0;
-	virtual uint8_t setAcl(FSNode *node, AclType type, const AccessControlList &acl,
-	                       uint32_t timeStamp) = 0;
+
+	/// Stores a RichACL on a node, replacing any previously stored ACL.
+	///
+	/// If the ACL is equivalent to the node's POSIX mode bits (RichACL::equivMode returns true),
+	/// the stored ACL is erased and only the mode bits are updated. Otherwise the ACL is written
+	/// to storage after resolving the auto-set-mode flag: if kAutoSetMode is set, the flag is
+	/// cleared and the ACL's mode is derived from the node's current mode bits before storing.
+	/// In both cases node->mode is updated to reflect the new permission bits, and the node's
+	/// ctime and checksum are updated.
+	///
+	/// @param fsOpContext The filesystem operation context (transaction).
+	/// @param node The node on which to set the ACL.
+	/// @param acl The RichACL to store.
+	/// @param timeStamp The timestamp used to update the node's ctime.
+	/// @return SAUNAFS_STATUS_OK on success, SAUNAFS_ERROR_ENOTSUP if the ACL's inherit flags
+	///         are invalid for the node type.
+	virtual uint8_t setAcl(const FilesystemOperationContext &fsOpContext, FSNode *node,
+	                       const RichACL &acl, uint32_t timeStamp) = 0;
+
+	/// Merges a POSIX ACL into the node's stored RichACL.
+	///
+	/// Reads the current RichACL (if any), calls createExplicitInheritance() and
+	/// removeInheritOnly() to normalise inheritance, then appends the POSIX ACL entries:
+	/// - kDefault: calls appendDefaultPosixACL() and refreshes the mode bits from the node.
+	/// - kAccess:  calls appendPosixACL() and updates node->mode from the resulting RichACL.
+	/// The merged ACL is always written back to storage.  node->ctime and checksum are updated.
+	///
+	/// @param fsOpContext The filesystem operation context (transaction).
+	/// @param node The node on which to set the ACL.
+	/// @param type Must be AclType::kAccess or AclType::kDefault.
+	/// @param acl The POSIX ACL entries to merge in.
+	/// @param timeStamp The timestamp used to update the node's ctime.
+	/// @return SAUNAFS_STATUS_OK on success.
+	///         SAUNAFS_ERROR_EINVAL  if type is neither kAccess nor kDefault.
+	///         SAUNAFS_ERROR_ENOTSUP if type is kDefault and node is not a directory.
+	virtual uint8_t setAcl(const FilesystemOperationContext &fsOpContext, FSNode *node,
+	                       AclType type, const AccessControlList &acl, uint32_t timeStamp) = 0;
+
 #ifndef METARESTORE
-	virtual uint8_t getAcl(FSNode *node, RichACL &acl) = 0;
+	/// Retrieves the stored RichACL for a node.
+	///
+	/// Looks up the ACL in storage. If no ACL is stored for the node (i.e. permissions are
+	/// fully described by the mode bits alone), returns SAUNAFS_ERROR_ENOATTR. Otherwise
+	/// copies the stored ACL into @p acl and asserts that node->mode matches the ACL's mode.
+	///
+	/// @param fsOpContext The filesystem operation context (transaction).
+	/// @param node The node whose ACL to retrieve.
+	/// @param[out] acl Receives the stored RichACL.
+	/// @return SAUNAFS_STATUS_OK on success, SAUNAFS_ERROR_ENOATTR if no ACL is stored.
+	virtual uint8_t getAcl(const FilesystemOperationContext &fsOpContext, FSNode *node,
+	                       RichACL &acl) = 0;
 #endif  // METARESTORE
-	virtual uint8_t deleteAcl(FSNode *node, AclType type, uint32_t timeStamp) = 0;
+
+	/// Removes or prunes the ACL stored on a node according to the ACL type.
+	///
+	/// - kRichACL: removes the entire stored ACL unconditionally.
+	/// - kDefault: only valid on directories; reads the current ACL, calls
+	///   createExplicitInheritance() and removeInheritOnly(true) to strip default
+	///   (inherit-only) entries, then erases the ACL if empty or writes back the pruned ACL.
+	/// - kAccess:  reads the current ACL, calls createExplicitInheritance() and
+	///   removeInheritOnly(false) to strip access entries, then erases or writes back.
+	/// In all cases node->ctime and checksum are updated.
+	///
+	/// @param fsOpContext The filesystem operation context (transaction).
+	/// @param node The node whose ACL to delete or prune.
+	/// @param type The ACL type to remove (kRichACL, kDefault, or kAccess).
+	/// @param timeStamp The timestamp used to update the node's ctime.
+	/// @return SAUNAFS_STATUS_OK on success.
+	///         SAUNAFS_ERROR_ENOTSUP if type is kDefault and node is not a directory.
+	///         SAUNAFS_ERROR_EINVAL  if type is not kRichACL, kDefault, or kAccess.
+	virtual uint8_t deleteAcl(const FilesystemOperationContext &fsOpContext, FSNode *node,
+	                          AclType type, uint32_t timeStamp) = 0;
 
 	// Recursive operations
 #ifndef METARESTORE
@@ -501,7 +566,8 @@ public:
 	                                   inode_t *permissionDeniedINodesOut) = 0;
 
 	// Access control operations
-	virtual int access(const FsContext &context, FSNode *node, uint8_t modeMask) = 0;
+	virtual int access(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                   FSNode *node, uint8_t modeMask) = 0;
 	virtual int stickyAccess(FSNode *parent, FSNode *node, uint32_t uid) = 0;
 	virtual int nameCheck(const std::string &name) = 0;
 	virtual uint8_t verifySession(const FsContext &context, OperationMode operationMode,

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -957,7 +957,7 @@ uint8_t FilesystemOperationsBase::setAttr(const FsContext &context,
 			return SAUNAFS_ERROR_EPERM;
 		}
 		if ((setmask & (SET_ATIME_NOW_FLAG | SET_MTIME_NOW_FLAG)) &&
-		    !nodeOperations_->access(context, p, MODE_MASK_W)) {
+		    !nodeOperations_->access(context, fsOpContext, p, MODE_MASK_W)) {
 			return SAUNAFS_ERROR_EACCES;
 		}
 	}
@@ -2256,7 +2256,9 @@ uint8_t FilesystemOperationsBase::openCheck(const FsContext &context,
 		if (flags & WANT_WRITE) {
 			modemask |= MODE_MASK_W;
 		}
-		if (!nodeOperations_->access(context, p, modemask)) { return SAUNAFS_ERROR_EACCES; }
+		if (!nodeOperations_->access(context, fsOpContext, p, modemask)) {
+			return SAUNAFS_ERROR_EACCES;
+		}
 	}
 	nodeOperations_->fillAttr(fsOpContext, p, NULL, context.uid(), context.gid(), context.auid(),
 	                          context.agid(), context.sesflags(), attr);
@@ -3234,7 +3236,9 @@ uint8_t FilesystemOperationsBase::applySetXAttr(const FilesystemOperationContext
 	return status;
 }
 
-uint8_t FilesystemOperationsBase::deleteAcl(const FsContext &context, inode_t inode, AclType type) {
+uint8_t FilesystemOperationsBase::deleteAcl(const FsContext &context,
+                                            const FilesystemOperationContext &fsOpContext,
+                                            inode_t inode, AclType type) {
 	ChecksumUpdater cu(context.ts());
 	FSNode *p;
 	uint8_t status =
@@ -3243,15 +3247,11 @@ uint8_t FilesystemOperationsBase::deleteAcl(const FsContext &context, inode_t in
 		return status;
 	}
 
-	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
-	    FilesystemOperationContext::TransactionType::kReadWrite);
-
 	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kAny,
 	                                              MODE_MASK_EMPTY, inode, &p);
-
 	if (status != SAUNAFS_STATUS_OK) { return status; }
 
-	status = nodeOperations_->deleteAcl(p, type, context.ts());
+	status = nodeOperations_->deleteAcl(fsOpContext, p, type, context.ts());
 
 	if (context.isPersonalityMaster()) {
 		if (status == SAUNAFS_STATUS_OK) {
@@ -3272,8 +3272,9 @@ uint8_t FilesystemOperationsBase::deleteAcl(const FsContext &context, inode_t in
 
 #ifndef METARESTORE
 
-uint8_t FilesystemOperationsBase::setAcl(const FsContext &context, inode_t inode,
-                                         const RichACL &acl) {
+uint8_t FilesystemOperationsBase::setAcl(const FsContext &context,
+                                         const FilesystemOperationContext &fsOpContext,
+                                         inode_t inode, const RichACL &acl) {
 	ChecksumUpdater cu(context.ts());
 	FSNode *p;
 	uint8_t status =
@@ -3282,16 +3283,13 @@ uint8_t FilesystemOperationsBase::setAcl(const FsContext &context, inode_t inode
 		return status;
 	}
 
-	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
-	    FilesystemOperationContext::TransactionType::kReadWrite);
-
 	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kAny,
 	                                              MODE_MASK_EMPTY, inode, &p);
-
 	if (status != SAUNAFS_STATUS_OK) { return status; }
 
 	std::string acl_string = acl.toString();
-	status = nodeOperations_->setAcl(p, acl, context.ts());
+	status = nodeOperations_->setAcl(fsOpContext, p, acl, context.ts());
+
 	if (context.isPersonalityMaster()) {
 		if (status == SAUNAFS_STATUS_OK) {
 			changeLog(context.ts(), "SETRICHACL(%" PRIiNode ",%s)", p->id, acl_string.c_str());
@@ -3302,7 +3300,9 @@ uint8_t FilesystemOperationsBase::setAcl(const FsContext &context, inode_t inode
 	return status;
 }
 
-uint8_t FilesystemOperationsBase::setAcl(const FsContext &context, inode_t inode, AclType type,
+uint8_t FilesystemOperationsBase::setAcl(const FsContext &context,
+                                         const FilesystemOperationContext &fsOpContext,
+                                         inode_t inode, AclType type,
                                          const AccessControlList &acl) {
 	ChecksumUpdater cu(context.ts());
 	FSNode *p;
@@ -3312,16 +3312,13 @@ uint8_t FilesystemOperationsBase::setAcl(const FsContext &context, inode_t inode
 		return status;
 	}
 
-	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
-	    FilesystemOperationContext::TransactionType::kReadWrite);
-
 	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kAny,
 	                                              MODE_MASK_EMPTY, inode, &p);
-
 	if (status != SAUNAFS_STATUS_OK) { return status; }
 
 	std::string acl_string = acl.toString();
-	status = nodeOperations_->setAcl(p, type, acl, context.ts());
+	status = nodeOperations_->setAcl(fsOpContext, p, type, acl, context.ts());
+
 	if (context.isPersonalityMaster()) {
 		if (status == SAUNAFS_STATUS_OK) {
 			changeLog(context.ts(), "SETACL(%" PRIiNode ",%c,%s)", p->id,
@@ -3331,11 +3328,11 @@ uint8_t FilesystemOperationsBase::setAcl(const FsContext &context, inode_t inode
 		gMetadata->metadataVersion++;
 	}
 	return status;
-
-	return SAUNAFS_ERROR_EINVAL;
 }
 
-uint8_t FilesystemOperationsBase::getAcl(const FsContext &context, inode_t inode, RichACL &acl) {
+uint8_t FilesystemOperationsBase::getAcl(const FsContext &context,
+                                         const FilesystemOperationContext &fsOpContext,
+                                         inode_t inode, RichACL &acl) {
 	FSNode *p;
 	uint8_t status =
 	    nodeOperations_->verifySession(context, OperationMode::kReadOnly, SessionType::kAny);
@@ -3343,20 +3340,17 @@ uint8_t FilesystemOperationsBase::getAcl(const FsContext &context, inode_t inode
 		return status;
 	}
 
-	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
-	    FilesystemOperationContext::TransactionType::kReadOnly);
-
 	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kAny,
 	                                              MODE_MASK_EMPTY, inode, &p);
-
 	if (status != SAUNAFS_STATUS_OK) { return status; }
 
-	return nodeOperations_->getAcl(p, acl);
+	return nodeOperations_->getAcl(fsOpContext, p, acl);
 }
 
 #endif /* #ifndef METARESTORE */
 
-uint8_t FilesystemOperationsBase::applySetAcl(uint32_t timestamp, inode_t inode, char aclType,
+uint8_t FilesystemOperationsBase::applySetAcl(const FilesystemOperationContext &fsOpContext,
+                                              uint32_t timestamp, inode_t inode, char aclType,
                                               const char *aclString) {
 	AccessControlList acl;
 	try {
@@ -3372,14 +3366,16 @@ uint8_t FilesystemOperationsBase::applySetAcl(uint32_t timestamp, inode_t inode,
 	if (!decodeChar("da", {AclType::kDefault, AclType::kAccess}, aclType, aclTypeEnum)) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
-	uint8_t status = nodeOperations_->setAcl(p, aclTypeEnum, std::move(acl), timestamp);
-	if (status == SAUNAFS_STATUS_OK) {
-		gMetadata->metadataVersion++;
-	}
-	return status;
+
+	uint8_t status = nodeOperations_->setAcl(fsOpContext, p, aclTypeEnum, acl, timestamp);
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+
+	gMetadata->metadataVersion++;
+	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t FilesystemOperationsBase::applySetRichAcl(uint32_t timestamp, inode_t inode,
+uint8_t FilesystemOperationsBase::applySetRichAcl(const FilesystemOperationContext &fsOpContext,
+                                                  uint32_t timestamp, inode_t inode,
                                                   const std::string &acl_string) {
 	RichACL acl;
 	try {
@@ -3391,11 +3387,12 @@ uint8_t FilesystemOperationsBase::applySetRichAcl(uint32_t timestamp, inode_t in
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
-	uint8_t status = nodeOperations_->setAcl(p, std::move(acl), timestamp);
-	if (status == SAUNAFS_STATUS_OK) {
-		gMetadata->metadataVersion++;
-	}
-	return status;
+
+	uint8_t status = nodeOperations_->setAcl(fsOpContext, p, acl, timestamp);
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+
+	gMetadata->metadataVersion++;
+	return SAUNAFS_STATUS_OK;
 }
 
 #ifndef METARESTORE

--- a/src/master/filesystem_operations.h
+++ b/src/master/filesystem_operations.h
@@ -86,7 +86,11 @@ public:
 
 	uint8_t append(const FsContext &context, const FilesystemOperationContext &fsOpContext,
 	               inode_t inode, inode_t inode_src) override;
-	uint8_t deleteAcl(const FsContext &context, inode_t inode, AclType type) override;
+
+	/// Removes or prunes the ACL stored on a node, given its inode.
+	/// @see IFilesystemOperations::deleteAcl
+	uint8_t deleteAcl(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                  inode_t inode, AclType type) override;
 
 	/// Creates a hard link to an existing file in a destination directory.
 	/// @see IFilesystemOperations::link
@@ -256,10 +260,21 @@ public:
 	                      std::vector<ChunkWithAddressAndLabel> &chunks) override;
 	uint8_t getTrashTimePrepare(const FsContext &context, inode_t inode, uint8_t gmode,
 	                            TrashtimeMap &fileTrashtimes, TrashtimeMap &dirTrashtimes) override;
-	uint8_t setAcl(const FsContext &context, inode_t inode, AclType type,
-	               const AccessControlList &acl) override;
-	uint8_t setAcl(const FsContext &context, inode_t inode, const RichACL &acl) override;
-	uint8_t getAcl(const FsContext &context, inode_t inode, RichACL &acl) override;
+
+	/// Merges a POSIX ACL (kAccess or kDefault) into the node's stored RichACL.
+	/// @see IFilesystemOperations::setAcl
+	uint8_t setAcl(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	               inode_t inode, AclType type, const AccessControlList &acl) override;
+
+	/// Stores a RichACL directly on a node, replacing any previously stored ACL.
+	/// @see IFilesystemOperations::setAcl
+	uint8_t setAcl(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	               inode_t inode, const RichACL &acl) override;
+
+	/// Retrieves the stored RichACL for a node, given its inode.
+	/// @see IFilesystemOperations::getAcl
+	uint8_t getAcl(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	               inode_t inode, RichACL &acl) override;
 
 	// Functions which modify metadata or return some information.
 	// To be used by the master server with personality == kMaster
@@ -352,10 +367,17 @@ public:
 	uint8_t applySetXAttr(const FilesystemOperationContext &fsOpContext, uint32_t timestamp,
 	                      inode_t inode, uint32_t anleng, const uint8_t *attrname, uint32_t avleng,
 	                      const uint8_t *attrvalue, uint32_t mode) override;
-	uint8_t applySetAcl(uint32_t timestamp, inode_t inode, char aclType,
-	                    const char *aclString) override;
-	uint8_t applySetRichAcl(uint32_t timestamp, inode_t inode,
-	                        const std::string &acl_string) override;
+
+	/// Replays a SETACL changelog entry during metadata restore.
+	/// @see IFilesystemOperations::applySetAcl
+	uint8_t applySetAcl(const FilesystemOperationContext &fsOpContext, uint32_t timestamp,
+	                    inode_t inode, char aclType, const char *aclString) override;
+
+	/// Replays a SETRICHACL changelog entry during metadata restore.
+	/// @see IFilesystemOperations::applySetRichAcl
+	uint8_t applySetRichAcl(const FilesystemOperationContext &fsOpContext, uint32_t timestamp,
+	                        inode_t inode, const std::string &acl_string) override;
+
 	uint8_t applyUnlink(uint32_t timestamp, inode_t parent, const HString &name,
 	                    inode_t inode) override;
 	uint8_t applyUnlock(uint64_t chunkid) override;

--- a/src/master/filesystem_operations_interface.h
+++ b/src/master/filesystem_operations_interface.h
@@ -165,7 +165,23 @@ public:
 
 	virtual uint8_t append(const FsContext &context, const FilesystemOperationContext &fsOpContext,
 	                       inode_t inode, inode_t inode_src) = 0;
-	virtual uint8_t deleteAcl(const FsContext &context, inode_t inode, AclType type) = 0;
+
+	/// Removes or prunes the ACL stored on a node, given its inode.
+	///
+	/// Verifies the session (read-write, non-meta) and resolves the inode to a node, then
+	/// delegates to IFilesystemNodeOperations::deleteAcl. On success, writes a
+	/// DELETEACL(inode, type_char) entry to the changelog (master personality) or
+	/// increments the metadata version (shadow personality).
+	///
+	/// @param context The FS operation context (user credentials, session flags, timestamp).
+	/// @param fsOpContext The operation context carrying a read-write transaction in KV backends.
+	/// @param inode The inode of the node whose ACL to delete or prune.
+	/// @param type The ACL type to remove: kRichACL removes the entire ACL; kDefault removes
+	///             default (inherit-only) entries; kAccess removes access entries.
+	/// @return SAUNAFS_STATUS_OK on success, or a session/permission/node-lookup error.
+	virtual uint8_t deleteAcl(const FsContext &context,
+	                          const FilesystemOperationContext &fsOpContext, inode_t inode,
+	                          AclType type) = 0;
 
 	/// Creates a hard link to an existing file in a destination directory.
 	///
@@ -943,10 +959,53 @@ public:
 	virtual uint8_t getTrashTimePrepare(const FsContext &context, inode_t inode, uint8_t gmode,
 	                                    TrashtimeMap &fileTrashtimes,
 	                                    TrashtimeMap &dirTrashtimes) = 0;
-	virtual uint8_t setAcl(const FsContext &context, inode_t inode, AclType type,
-	                       const AccessControlList &acl) = 0;
-	virtual uint8_t setAcl(const FsContext &context, inode_t inode, const RichACL &acl) = 0;
-	virtual uint8_t getAcl(const FsContext &context, inode_t inode, RichACL &acl) = 0;
+
+	/// Merges a POSIX ACL (kAccess or kDefault) into the node's stored RichACL.
+	///
+	/// Verifies the session (read-write, non-meta), resolves the inode, then delegates to
+	/// IFilesystemNodeOperations::setAcl(AclType, AccessControlList). On success, writes a
+	/// SETACL(inode, 'a'|'d', acl_string) entry to the changelog (master personality) or
+	/// increments the metadata version (shadow personality).
+	///
+	/// @param context The FS operation context (user credentials, session flags, timestamp).
+	/// @param fsOpContext The operation context carrying a read-write transaction in KV backends.
+	/// @param inode The inode of the node on which to set the ACL.
+	/// @param type Must be AclType::kAccess or AclType::kDefault.
+	/// @param acl The POSIX ACL entries to merge in.
+	/// @return SAUNAFS_STATUS_OK on success, or a session/permission/node-lookup error.
+	virtual uint8_t setAcl(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                       inode_t inode, AclType type, const AccessControlList &acl) = 0;
+
+	/// Stores a RichACL directly on a node, replacing any previously stored ACL.
+	///
+	/// Verifies the session (read-write, non-meta), resolves the inode, calls
+	/// acl.toString() to produce the changelog representation, then delegates to
+	/// IFilesystemNodeOperations::setAcl(RichACL). On success, writes a
+	/// SETRICHACL(inode, acl_string) entry to the changelog (master personality) or
+	/// increments the metadata version (shadow personality).
+	///
+	/// @param context The FS operation context (user credentials, session flags, timestamp).
+	/// @param fsOpContext The operation context carrying a read-write transaction in KV backends.
+	/// @param inode The inode of the node on which to set the ACL.
+	/// @param acl The RichACL to store.
+	/// @return SAUNAFS_STATUS_OK on success, or a session/permission/node-lookup error.
+	virtual uint8_t setAcl(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                       inode_t inode, const RichACL &acl) = 0;
+
+	/// Retrieves the stored RichACL for a node, given its inode.
+	///
+	/// Verifies the session (read-only, any session type), resolves the inode, then delegates
+	/// to IFilesystemNodeOperations::getAcl. Does not write to the changelog and does not
+	/// need a read-write transaction.
+	///
+	/// @param context The FS operation context (user credentials, session flags, timestamp).
+	/// @param fsOpContext The operation context carrying a read-only transaction in KV backends.
+	/// @param inode The inode of the node whose ACL to retrieve.
+	/// @param[out] acl Receives the stored RichACL.
+	/// @return SAUNAFS_STATUS_OK on success, SAUNAFS_ERROR_ENOATTR if no ACL is stored,
+	///         or a session/permission/node-lookup error.
+	virtual uint8_t getAcl(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                       inode_t inode, RichACL &acl) = 0;
 
 	// Functions which modify metadata or return some information.
 	// To be used by the master server with personality == kMaster
@@ -1039,10 +1098,39 @@ public:
 	virtual uint8_t applySetXAttr(const FilesystemOperationContext &fsOpContext, uint32_t timestamp,
 	                              inode_t inode, uint32_t anleng, const uint8_t *attrname,
 	                              uint32_t avleng, const uint8_t *attrvalue, uint32_t mode) = 0;
-	virtual uint8_t applySetAcl(uint32_t timestamp, inode_t inode, char aclType,
-	                            const char *aclString) = 0;
-	virtual uint8_t applySetRichAcl(uint32_t timestamp, inode_t inode,
+
+	/// Replays a SETACL changelog entry during metadata restore.
+	///
+	/// Parses @p aclString via AccessControlList::fromString, resolves the inode, decodes
+	/// @p aclType ('d' -> kDefault, 'a' -> kAccess) via decodeChar, then calls
+	/// IFilesystemNodeOperations::setAcl(AclType, AccessControlList). On success, increments
+	/// the metadata version.
+	///
+	/// @param fsOpContext The operation context carrying a read-write transaction in KV backends.
+	/// @param timestamp The timestamp from the changelog entry, used to update the node's ctime.
+	/// @param inode The inode of the node on which to set the ACL.
+	/// @param aclType Single character encoding the ACL type: 'd' for kDefault, 'a' for kAccess.
+	/// @param aclString The serialized POSIX ACL string as written by AccessControlList::toString.
+	/// @return SAUNAFS_STATUS_OK on success, SAUNAFS_ERROR_EINVAL if parsing or type decoding
+	///         fails, SAUNAFS_ERROR_ENOENT if the inode does not exist.
+	virtual uint8_t applySetAcl(const FilesystemOperationContext &fsOpContext, uint32_t timestamp,
+	                            inode_t inode, char aclType, const char *aclString) = 0;
+
+	/// Replays a SETRICHACL changelog entry during metadata restore.
+	///
+	/// Parses @p acl_string via RichACL::fromString, resolves the inode, then calls
+	/// IFilesystemNodeOperations::setAcl(RichACL). On success, increments the metadata version.
+	///
+	/// @param fsOpContext The operation context carrying a read-write transaction in KV backends.
+	/// @param timestamp The timestamp from the changelog entry, used to update the node's ctime.
+	/// @param inode The inode of the node on which to set the ACL.
+	/// @param acl_string The serialized RichACL string as written by RichACL::toString.
+	/// @return SAUNAFS_STATUS_OK on success, SAUNAFS_ERROR_EINVAL if parsing fails,
+	///         SAUNAFS_ERROR_ENOENT if the inode does not exist.
+	virtual uint8_t applySetRichAcl(const FilesystemOperationContext &fsOpContext,
+	                                uint32_t timestamp, inode_t inode,
 	                                const std::string &acl_string) = 0;
+
 	virtual uint8_t applyUnlink(uint32_t timestamp, inode_t parent, const HString &name,
 	                            inode_t inode) = 0;
 	virtual uint8_t applyUnlock(uint64_t chunkid) = 0;

--- a/src/master/kv_common_keys.h
+++ b/src/master/kv_common_keys.h
@@ -81,7 +81,11 @@ inline constexpr std::string_view kChunkKeyPrefix = "CHNK_";   // Section CHNK 1
 /// enabling efficient range queries for all xattrs of a specific inode.
 inline constexpr std::string_view kXAttrKeyPrefix = "XATR_";   // Section XATR 1.0
 
-// Reserved for future use
+/// Prefix for Access Control Lists (ACLs)
+/// Format: ACLS_<InodeId>:<binary RichACL>
+/// e.g.: ACLS_1999:<binary data>
+/// @note InodeId is serialized as Big Endian to maintain numeric order in lexicographical sorting,
+/// enabling efficient range queries.
 inline constexpr std::string_view kACLsKeyPrefix = "ACLS_";    // Section ACLS 1.2
 inline constexpr std::string_view kQuotasKeyPrefix = "QUOT_";  // Section QUOT 1.1
 inline constexpr std::string_view kLocksKeyPrefix = "FLCK_";   // Section FLCK 1.0

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -4337,10 +4337,22 @@ void matoclserv_fuse_deleteacl(matoclserventry *eptr, const uint8_t *data, uint3
 	cltoma::fuseDeleteAcl::deserialize(data, length, messageId, inode, uid, gid, type);
 
 	uint8_t status = matoclserv_check_group_cache(eptr, gid);
+
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = gFSOperations->deleteAcl(context, inode, type);
+		auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+		    FilesystemOperationContext::TransactionType::kReadWrite);
+
+		status = gFSOperations->deleteAcl(context, fsOpContext, inode, type);
+
+		if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
+			if (!fsOpContext.getReadWriteTransaction()->commit()) {
+				safs::log_err("{}: transaction failed to commit: inode {}", __func__, inode);
+				status = SAUNAFS_ERROR_IO;
+			}
+		}
 	}
+
 	matoclserv_createpacket(eptr, matocl::fuseDeleteAcl::build(messageId, status));
 }
 
@@ -4358,32 +4370,35 @@ void matoclserv_fuse_getacl(matoclserventry *eptr, const uint8_t *data, uint32_t
 
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = gFSOperations->getAcl(context, inode, acl);
-	}
+		auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+		    FilesystemOperationContext::TransactionType::kReadOnly);
 
-	if (status == SAUNAFS_STATUS_OK) {
-		if (eptr->version >= kRichACLVersion) {
-			FSNode *node = gFSOperations->nodeOperations()->idToNode(inode);
-			uint32_t owner_id = node ? node->uid : RichACL::Ace::kInvalidId;
-			matocl::fuseGetAcl::serialize(reply, messageId, owner_id, acl);
-		} else {
-			std::pair<bool, AccessControlList> posix_acl;
-			if (type == AclType::kDefault) {
-				posix_acl = acl.convertToDefaultPosixACL();
+		status = gFSOperations->getAcl(context, fsOpContext, inode, acl);
+
+		if (status == SAUNAFS_STATUS_OK) {
+			if (eptr->version >= kRichACLVersion) {
+				FSNode *node = gFSOperations->nodeOperations()->idToNode(fsOpContext, inode);
+				uint32_t owner_id = node ? node->uid : RichACL::Ace::kInvalidId;
+				matocl::fuseGetAcl::serialize(reply, messageId, owner_id, acl);
 			} else {
-				// default behavior for unknown acl type.
-				posix_acl = acl.convertToPosixACL();
-			}
-
-			if (posix_acl.first) {
-				if (eptr->version >= kACL11Version) {
-					matocl::fuseGetAcl::serialize(reply, messageId, posix_acl.second);
+				std::pair<bool, AccessControlList> posix_acl;
+				if (type == AclType::kDefault) {
+					posix_acl = acl.convertToDefaultPosixACL();
 				} else {
-					legacy::AccessControlList legacy_acl = posix_acl.second;
-					matocl::fuseGetAcl::serialize(reply, messageId, legacy_acl);
+					// default behavior for unknown acl type.
+					posix_acl = acl.convertToPosixACL();
 				}
-			} else {
-				status = SAUNAFS_ERROR_ENOATTR;
+
+				if (posix_acl.first) {
+					if (eptr->version >= kACL11Version) {
+						matocl::fuseGetAcl::serialize(reply, messageId, posix_acl.second);
+					} else {
+						legacy::AccessControlList legacy_acl = posix_acl.second;
+						matocl::fuseGetAcl::serialize(reply, messageId, legacy_acl);
+					}
+				} else {
+					status = SAUNAFS_ERROR_ENOATTR;
+				}
 			}
 		}
 	}
@@ -4771,14 +4786,26 @@ void matoclserv_fuse_setacl(matoclserventry *eptr, const uint8_t *data, uint32_t
 	}
 
 	uint8_t status = matoclserv_check_group_cache(eptr, gid);
+
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
+		auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+		    FilesystemOperationContext::TransactionType::kReadWrite);
+
 		if (use_posix) {
-			status = gFSOperations->setAcl(context, inode, type, posix_acl);
+			status = gFSOperations->setAcl(context, fsOpContext, inode, type, posix_acl);
 		} else {
-			status = gFSOperations->setAcl(context, inode, rich_acl);
+			status = gFSOperations->setAcl(context, fsOpContext, inode, rich_acl);
+		}
+
+		if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
+			if (!fsOpContext.getReadWriteTransaction()->commit()) {
+				safs::log_err("{}: transaction failed to commit: inode {}", __func__, inode);
+				status = SAUNAFS_ERROR_IO;
+			}
 		}
 	}
+
 	matoclserv_createpacket(eptr, matocl::fuseSetAcl::build(messageId, status));
 }
 

--- a/src/master/recursive_remove_task.cc
+++ b/src/master/recursive_remove_task.cc
@@ -34,7 +34,7 @@ int RemoveTask::retrieveNodes(const FilesystemOperationContext &fsOpContext, FSN
 	if (!wd_tmp) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
-	if (!gFSOperations->nodeOperations()->access(*context_, wd_tmp, MODE_MASK_W)) {
+	if (!gFSOperations->nodeOperations()->access(*context_, fsOpContext, wd_tmp, MODE_MASK_W)) {
 		return SAUNAFS_ERROR_EACCES;
 	}
 	wd = static_cast<FSNodeDirectory*>(wd_tmp);

--- a/src/master/restore.cc
+++ b/src/master/restore.cc
@@ -772,7 +772,22 @@ int do_deleteacl(const char *filename, uint64_t lv, uint32_t ts, const char *ptr
 		safs_pretty_syslog(LOG_ERR, "%s:%" PRIu64 ": corrupted ACL type", filename, lv);
 		return -1;
 	}
-	return gFSOperations->deleteAcl(FsContext::getForRestore(ts), inode, aclType);
+
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
+	int status =
+	    gFSOperations->deleteAcl(FsContext::getForRestore(ts), fsOpContext, inode, aclType);
+
+	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
+		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+			safs::log_err("{}: transaction failed to commit: inode {}, ACL type {}", __func__,
+			              inode, aclTypeRaw);
+			return SAUNAFS_ERROR_IO;
+		}
+	}
+
+	return status;
 }
 
 int do_setacl(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -789,8 +804,21 @@ int do_setacl(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
 	GETPATH(aclString, aclSize, ptr, filename, lv, ')');
 	EAT(ptr, filename, lv, ')');
 
-	return gFSOperations->applySetAcl(ts, inode, aclType,
-	                                  reinterpret_cast<const char *>(aclString));
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
+	int status = gFSOperations->applySetAcl(fsOpContext, ts, inode, aclType,
+	                                        reinterpret_cast<const char *>(aclString));
+
+	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
+		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+			safs::log_err("{}: transaction failed to commit: inode {}, ACL type {}", __func__,
+			              inode, aclType);
+			return SAUNAFS_ERROR_IO;
+		}
+	}
+
+	return status;
 }
 
 int do_setrichacl(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -804,10 +832,23 @@ int do_setrichacl(const char *filename, uint64_t lv, uint32_t ts, const char *pt
 	GETPATH(acl_string, acl_size, ptr, filename, lv, ')');
 	EAT(ptr, filename, lv, ')');
 
-	return gFSOperations->applySetRichAcl(ts, inode, reinterpret_cast<const char *>(acl_string));
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
+	int status = gFSOperations->applySetRichAcl(fsOpContext, ts, inode,
+	                                            reinterpret_cast<const char *>(acl_string));
+
+	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
+		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+			safs::log_err("{}: transaction failed to commit: inode {}", __func__, inode);
+			return SAUNAFS_ERROR_IO;
+		}
+	}
+
+	return status;
 }
 
-int do_setquota(const char *filename, uint64_t lv, uint32_t, const char *ptr) {
+int do_setquota(const char *filename, uint64_t lv, uint32_t /*ts*/, const char *ptr) {
 	char rigor = '\0', resource = '\0', ownerType = '\0';
 	inode_t ownerId;
 	uint64_t limit;


### PR DESCRIPTION
Thread FilesystemOperationContext through all ACL methods (deleteAcl, setAcl, getAcl, applySetAcl, applySetRichAcl) in both IFilesystemNodeOperations and IFilesystemOperations, removing the internal transaction creation that was hardcoded inside each FilesystemOperationsBase method body.

Callers (matoclserv, restore) now own the transaction lifecycle, enabling KV backends to participate in ACL operations as part of a single coordinated transaction.

Introduce a protected virtual `getAclForAccess()` method to abstract ACL retrieval inside `access()`. The default in-memory implementation reads from `aclStorage`; KV backends can override it to materialise the ACL from the key-value store.

Pass `FilesystemOperationContext` through `access()` at all call sites so the new virtual hook receives the context it needs. A caller-supplied `RichACL scratch` buffer is provided so temporary ACLs can be returned without extra allocation.

The in-memory base implementation is not affected by the changes.

Also document all affected interface declarations according to their implementations.

Related to: LS-70