### PR TITLE
perf(cs): make inputBuffer size progressive

### DIFF
--- a/src/chunkserver/chunk_high_level_ops.cc
+++ b/src/chunkserver/chunk_high_level_ops.cc
@@ -466,7 +466,10 @@ void WriteHighLevelOp::prepareInputBufferForWrite(bool isForward) {
 	if (inputBuffer_ == nullptr) {
 		inputBuffer_ = getWriteInputBufferPool().get(
 		    isForward ? kSauWriteDataPrefixSizeForward : kSauWriteDataPrefixSize,
-		    maxBlocksPerHddWriteJob_);
+		    nextInputBufferBlockCount_);
+
+		nextInputBufferBlockCount_ =
+		    std::min<uint16_t>(nextInputBufferBlockCount_ * 2, maxBlocksPerHddWriteJob_);
 	}
 
 	inputBuffer_->addNewWriteOperation();
@@ -573,6 +576,8 @@ void WriteHighLevelOp::cleanup() {
 	partiallyCompletedWrites_.clear();
 	chunkId_ = 0;
 	chunkVersion_ = 0;
+	nextInputBufferBlockCount_ =
+	    std::min(kDefaultInitialNextInputBufferBlockCount, maxBlocksPerHddWriteJob_);
 	chunkType_ = slice_traits::standard::ChunkPartType();
 }
 

--- a/src/chunkserver/chunk_high_level_ops.h
+++ b/src/chunkserver/chunk_high_level_ops.h
@@ -207,8 +207,15 @@ protected:
 /// @brief High-level operation for writing data to a chunk.
 class WriteHighLevelOp : public HighLevelOp {
 public:
+	/// @brief Default initial number of blocks for the next input buffer, which can be adjusted
+	/// based on the max blocks per HDD write job.
+	constexpr static uint16_t kDefaultInitialNextInputBufferBlockCount = 4;
+
 	WriteHighLevelOp(ChunkserverEntry *parent, uint16_t maxBlocksPerHddWriteJob)
-	    : HighLevelOp(parent), maxBlocksPerHddWriteJob_(maxBlocksPerHddWriteJob) {}
+	    : HighLevelOp(parent),
+	      maxBlocksPerHddWriteJob_(maxBlocksPerHddWriteJob),
+	      nextInputBufferBlockCount_(
+	          std::min(kDefaultInitialNextInputBufferBlockCount, maxBlocksPerHddWriteJob)) {}
 
 	/// Sets up and starts the write high level operation.
 	/// Enqueues a job_open for the chunk.
@@ -299,9 +306,12 @@ protected:
 
 	/// Prepares the input buffer for a write operation.
 	void prepareInputBufferForWrite(bool isForward);
-
-	///< Number of blocks to write to the device in one write job.
+	
+	/// Number of blocks to write to the device in one write job.
 	uint16_t maxBlocksPerHddWriteJob_;
+
+	/// Size in blocks of the next input buffer.
+	uint16_t nextInputBufferBlockCount_;
 
 	/// Indicates if the chunk is locked for writing. If true, master will be waiting for the lock
 	/// to be released when the write operation finishes.


### PR DESCRIPTION
The current implementation of the WriteHighLevelOp class always asks
for maxBlocksPerHddWriteJob_ blocks for its next inputBuffer_, i.e the
structure to land the upcoming data blocks to be written to the drive.
This can became a significant waste of memory when the write high level
operation only writes 1 block, but asks for 32, if the
MAX_BLOCKS_PER_HDD_WRITE_JOB is set to that number, for instance.

The change proposed targets asking for smaller initial input buffers,
to limit the memory wasted. Considering the previous case, the
write high level operation will ask for 4, 8, 16, 32 and continue
asking for input buffers of 32 blocks.

The main downside is a possible increase in the number of drive
operations in certain scenarios.

Signed-off-by: Dave <dave@leil.io>