### PR TITLE
refactor(master): allow quota ops in KV backends

### DIFF
--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -1408,12 +1408,13 @@ void FilesystemNodeOperationsBase::changeUidGid(const FilesystemOperationContext
 	int64_t size = 0;
 
 	// Decrease quota for old owner
-	quotaUpdate(fsOpContext, node, {{QuotaResource::kInodes, -1}});
-
 	if (node->type == FSNodeType::kFile || node->type == FSNodeType::kTrash ||
 	    node->type == FSNodeType::kReserved) {
 		size = getSize(fsOpContext, node);
-		quotaUpdate(fsOpContext, node, {{QuotaResource::kSize, -size}});
+		quotaUpdate(fsOpContext, node,
+		            {{QuotaResource::kInodes, -1}, {QuotaResource::kSize, -size}});
+	} else {
+		quotaUpdate(fsOpContext, node, {{QuotaResource::kInodes, -1}});
 	}
 
 	// Change ownership
@@ -1421,11 +1422,12 @@ void FilesystemNodeOperationsBase::changeUidGid(const FilesystemOperationContext
 	node->gid = gid;
 
 	// Increase quota for new owner
-	quotaUpdate(fsOpContext, node, {{QuotaResource::kInodes, +1}});
-
 	if (node->type == FSNodeType::kFile || node->type == FSNodeType::kTrash ||
 	    node->type == FSNodeType::kReserved) {
-		quotaUpdate(fsOpContext, node, {{QuotaResource::kSize, +size}});
+		quotaUpdate(fsOpContext, node,
+		            {{QuotaResource::kInodes, +1}, {QuotaResource::kSize, +size}});
+	} else {
+		quotaUpdate(fsOpContext, node, {{QuotaResource::kInodes, +1}});
 	}
 }
 
@@ -1451,7 +1453,6 @@ void FilesystemNodeOperationsBase::removeNode(const FilesystemOperationContext &
 
 	if (node->type == FSNodeType::kFile || node->type == FSNodeType::kTrash ||
 	    node->type == FSNodeType::kReserved) {
-		quotaUpdate(fsOpContext, node, {{QuotaResource::kSize, -getSize(fsOpContext, node)}});
 		gMetadata->fileNodes--;
 		for (uint32_t i = 0; i < static_cast<FSNodeFile*>(node)->chunks.size(); ++i) {
 			uint64_t chunkid = static_cast<FSNodeFile*>(node)->chunks[i];
@@ -1471,7 +1472,14 @@ void FilesystemNodeOperationsBase::removeNode(const FilesystemOperationContext &
 
 	gMetadata->inodePool.release(node->id, timeStamp, true);
 	xattr_removeinode(node->id);
-	quotaUpdate(fsOpContext, node, {{QuotaResource::kInodes, -1}});
+	if (node->type == FSNodeType::kFile || node->type == FSNodeType::kTrash ||
+	    node->type == FSNodeType::kReserved) {
+		quotaUpdate(
+		    fsOpContext, node,
+		    {{QuotaResource::kInodes, -1}, {QuotaResource::kSize, -getSize(fsOpContext, node)}});
+	} else {
+		quotaUpdate(fsOpContext, node, {{QuotaResource::kInodes, -1}});
+	}
 	quotaRemove(fsOpContext, QuotaOwnerType::kInode, node->id);
 #ifndef METARESTORE
 	fsnodes_periodic_remove(node->id);

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -195,13 +195,13 @@ void FilesystemNodeOperationsBase::preserveEdge(const FilesystemOperationContext
 	gMetadata->edgeChangedSignal.emit(parent, child, handlePtr);
 }
 
-void FilesystemNodeOperationsBase::quotaUpdate(
+void FilesystemNodeOperationsBase::nodeQuotaUpdate(
     [[maybe_unused]] const FilesystemOperationContext &fsOpContext, FSNode *node,
     const std::initializer_list<std::pair<QuotaResource, int64_t>> &resourceList) {
 	fsnodes_quota_update(node, resourceList);
 }
 
-void FilesystemNodeOperationsBase::quotaRemove(
+void FilesystemNodeOperationsBase::nodeQuotaRemove(
     [[maybe_unused]] const FilesystemOperationContext &fsOpContext, QuotaOwnerType ownerType,
     inode_t ownerId) {
 	fsnodes_quota_remove(ownerType, ownerId);
@@ -751,10 +751,10 @@ FSNode *FilesystemNodeOperationsBase::createNode(
 
 	fsnodes_update_checksum(node);
 	link(fsOpContext, timeStamp, parent, node, name);
-	quotaUpdate(fsOpContext, node, {{QuotaResource::kInodes, +1}});
+	nodeQuotaUpdate(fsOpContext, node, {{QuotaResource::kInodes, +1}});
 
 	if (type == FSNodeType::kFile) {
-		quotaUpdate(fsOpContext, node, {{QuotaResource::kSize, +getSize(fsOpContext, node)}});
+		nodeQuotaUpdate(fsOpContext, node, {{QuotaResource::kSize, +getSize(fsOpContext, node)}});
 	}
 
 	return node;
@@ -1304,8 +1304,8 @@ uint8_t FilesystemNodeOperationsBase::appendChunks(const FilesystemOperationCont
 	getStats(fsOpContext, destNodeFile, &newStats);
 
 	// Update quotas based on the change in file size
-	quotaUpdate(fsOpContext, destNodeFile,
-	            {{QuotaResource::kSize, newStats.size - previousStats.size}});
+	nodeQuotaUpdate(fsOpContext, destNodeFile,
+	                {{QuotaResource::kSize, newStats.size - previousStats.size}});
 
 	// Update stats for all parent directories
 	for (const auto &[parentId, _] : destNodeFile->parents) {
@@ -1392,7 +1392,8 @@ void FilesystemNodeOperationsBase::setLength(const FilesystemOperationContext &f
 
 	getStats(fsOpContext, nodeFile, &newStats);
 
-	quotaUpdate(fsOpContext, nodeFile, {{QuotaResource::kSize, newStats.size - previousStats.size}});
+	nodeQuotaUpdate(fsOpContext, nodeFile,
+	                {{QuotaResource::kSize, newStats.size - previousStats.size}});
 
 	updateParentStatsForNode(fsOpContext, nodeFile, &newStats, &previousStats);
 
@@ -1411,10 +1412,10 @@ void FilesystemNodeOperationsBase::changeUidGid(const FilesystemOperationContext
 	if (node->type == FSNodeType::kFile || node->type == FSNodeType::kTrash ||
 	    node->type == FSNodeType::kReserved) {
 		size = getSize(fsOpContext, node);
-		quotaUpdate(fsOpContext, node,
-		            {{QuotaResource::kInodes, -1}, {QuotaResource::kSize, -size}});
+		nodeQuotaUpdate(fsOpContext, node,
+		                {{QuotaResource::kInodes, -1}, {QuotaResource::kSize, -size}});
 	} else {
-		quotaUpdate(fsOpContext, node, {{QuotaResource::kInodes, -1}});
+		nodeQuotaUpdate(fsOpContext, node, {{QuotaResource::kInodes, -1}});
 	}
 
 	// Change ownership
@@ -1424,10 +1425,10 @@ void FilesystemNodeOperationsBase::changeUidGid(const FilesystemOperationContext
 	// Increase quota for new owner
 	if (node->type == FSNodeType::kFile || node->type == FSNodeType::kTrash ||
 	    node->type == FSNodeType::kReserved) {
-		quotaUpdate(fsOpContext, node,
-		            {{QuotaResource::kInodes, +1}, {QuotaResource::kSize, +size}});
+		nodeQuotaUpdate(fsOpContext, node,
+		                {{QuotaResource::kInodes, +1}, {QuotaResource::kSize, +size}});
 	} else {
-		quotaUpdate(fsOpContext, node, {{QuotaResource::kInodes, +1}});
+		nodeQuotaUpdate(fsOpContext, node, {{QuotaResource::kInodes, +1}});
 	}
 }
 
@@ -1474,13 +1475,13 @@ void FilesystemNodeOperationsBase::removeNode(const FilesystemOperationContext &
 	xattr_removeinode(node->id);
 	if (node->type == FSNodeType::kFile || node->type == FSNodeType::kTrash ||
 	    node->type == FSNodeType::kReserved) {
-		quotaUpdate(
+		nodeQuotaUpdate(
 		    fsOpContext, node,
 		    {{QuotaResource::kInodes, -1}, {QuotaResource::kSize, -getSize(fsOpContext, node)}});
 	} else {
-		quotaUpdate(fsOpContext, node, {{QuotaResource::kInodes, -1}});
+		nodeQuotaUpdate(fsOpContext, node, {{QuotaResource::kInodes, -1}});
 	}
-	quotaRemove(fsOpContext, QuotaOwnerType::kInode, node->id);
+	nodeQuotaRemove(fsOpContext, QuotaOwnerType::kInode, node->id);
 #ifndef METARESTORE
 	fsnodes_periodic_remove(node->id);
 	dcm_modify(node->id, 0);

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -203,7 +203,7 @@ void FilesystemNodeOperationsBase::quotaUpdate(
 
 void FilesystemNodeOperationsBase::quotaRemove(
     [[maybe_unused]] const FilesystemOperationContext &fsOpContext, QuotaOwnerType ownerType,
-    uint32_t ownerId) {
+    inode_t ownerId) {
 	fsnodes_quota_remove(ownerType, ownerId);
 }
 

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -195,6 +195,18 @@ void FilesystemNodeOperationsBase::preserveEdge(const FilesystemOperationContext
 	gMetadata->edgeChangedSignal.emit(parent, child, handlePtr);
 }
 
+void FilesystemNodeOperationsBase::quotaUpdate(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, FSNode *node,
+    const std::initializer_list<std::pair<QuotaResource, int64_t>> &resourceList) {
+	fsnodes_quota_update(node, resourceList);
+}
+
+void FilesystemNodeOperationsBase::quotaRemove(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, QuotaOwnerType ownerType,
+    uint32_t ownerId) {
+	fsnodes_quota_remove(ownerType, ownerId);
+}
+
 // Public methods
 
 FSNode *FilesystemNodeOperationsBase::lookup(
@@ -739,10 +751,10 @@ FSNode *FilesystemNodeOperationsBase::createNode(
 
 	fsnodes_update_checksum(node);
 	link(fsOpContext, timeStamp, parent, node, name);
-	fsnodes_quota_update(node, {{QuotaResource::kInodes, +1}});
+	quotaUpdate(fsOpContext, node, {{QuotaResource::kInodes, +1}});
 
 	if (type == FSNodeType::kFile) {
-		fsnodes_quota_update(node, {{QuotaResource::kSize, +getSize(fsOpContext, node)}});
+		quotaUpdate(fsOpContext, node, {{QuotaResource::kSize, +getSize(fsOpContext, node)}});
 	}
 
 	return node;
@@ -1292,8 +1304,8 @@ uint8_t FilesystemNodeOperationsBase::appendChunks(const FilesystemOperationCont
 	getStats(fsOpContext, destNodeFile, &newStats);
 
 	// Update quotas based on the change in file size
-	fsnodes_quota_update(destNodeFile,
-	                     {{QuotaResource::kSize, newStats.size - previousStats.size}});
+	quotaUpdate(fsOpContext, destNodeFile,
+	            {{QuotaResource::kSize, newStats.size - previousStats.size}});
 
 	// Update stats for all parent directories
 	for (const auto &[parentId, _] : destNodeFile->parents) {
@@ -1380,7 +1392,7 @@ void FilesystemNodeOperationsBase::setLength(const FilesystemOperationContext &f
 
 	getStats(fsOpContext, nodeFile, &newStats);
 
-	fsnodes_quota_update(nodeFile, {{QuotaResource::kSize, newStats.size - previousStats.size}});
+	quotaUpdate(fsOpContext, nodeFile, {{QuotaResource::kSize, newStats.size - previousStats.size}});
 
 	updateParentStatsForNode(fsOpContext, nodeFile, &newStats, &previousStats);
 
@@ -1396,12 +1408,12 @@ void FilesystemNodeOperationsBase::changeUidGid(const FilesystemOperationContext
 	int64_t size = 0;
 
 	// Decrease quota for old owner
-	fsnodes_quota_update(node, {{QuotaResource::kInodes, -1}});
+	quotaUpdate(fsOpContext, node, {{QuotaResource::kInodes, -1}});
 
 	if (node->type == FSNodeType::kFile || node->type == FSNodeType::kTrash ||
 	    node->type == FSNodeType::kReserved) {
 		size = getSize(fsOpContext, node);
-		fsnodes_quota_update(node, {{QuotaResource::kSize, -size}});
+		quotaUpdate(fsOpContext, node, {{QuotaResource::kSize, -size}});
 	}
 
 	// Change ownership
@@ -1409,11 +1421,11 @@ void FilesystemNodeOperationsBase::changeUidGid(const FilesystemOperationContext
 	node->gid = gid;
 
 	// Increase quota for new owner
-	fsnodes_quota_update(node, {{QuotaResource::kInodes, +1}});
+	quotaUpdate(fsOpContext, node, {{QuotaResource::kInodes, +1}});
 
 	if (node->type == FSNodeType::kFile || node->type == FSNodeType::kTrash ||
 	    node->type == FSNodeType::kReserved) {
-		fsnodes_quota_update(node, {{QuotaResource::kSize, +size}});
+		quotaUpdate(fsOpContext, node, {{QuotaResource::kSize, +size}});
 	}
 }
 
@@ -1439,7 +1451,7 @@ void FilesystemNodeOperationsBase::removeNode(const FilesystemOperationContext &
 
 	if (node->type == FSNodeType::kFile || node->type == FSNodeType::kTrash ||
 	    node->type == FSNodeType::kReserved) {
-		fsnodes_quota_update(node, {{QuotaResource::kSize, -getSize(fsOpContext, node)}});
+		quotaUpdate(fsOpContext, node, {{QuotaResource::kSize, -getSize(fsOpContext, node)}});
 		gMetadata->fileNodes--;
 		for (uint32_t i = 0; i < static_cast<FSNodeFile*>(node)->chunks.size(); ++i) {
 			uint64_t chunkid = static_cast<FSNodeFile*>(node)->chunks[i];
@@ -1459,8 +1471,8 @@ void FilesystemNodeOperationsBase::removeNode(const FilesystemOperationContext &
 
 	gMetadata->inodePool.release(node->id, timeStamp, true);
 	xattr_removeinode(node->id);
-	fsnodes_quota_update(node, {{QuotaResource::kInodes, -1}});
-	fsnodes_quota_remove(QuotaOwnerType::kInode, node->id);
+	quotaUpdate(fsOpContext, node, {{QuotaResource::kInodes, -1}});
+	quotaRemove(fsOpContext, QuotaOwnerType::kInode, node->id);
 #ifndef METARESTORE
 	fsnodes_periodic_remove(node->id);
 	dcm_modify(node->id, 0);

--- a/src/master/filesystem_node.h
+++ b/src/master/filesystem_node.h
@@ -22,6 +22,7 @@
 
 #include "common/platform.h"
 
+#include <initializer_list>
 #include <optional>
 
 #include "master/filesystem_node_operations_interface.h"
@@ -30,6 +31,7 @@
 #include "protocol/directory_entry.h"
 #include "protocol/handle_inode_entry.h"
 #include "protocol/named_inode_entry.h"
+#include "protocol/quota.h"
 
 /// Base class for filesystem node operations extensibility.
 ///
@@ -290,6 +292,19 @@ protected:
 	/// @see IFilesystemNodeOperations::preserveEdge
 	void preserveEdge(const FilesystemOperationContext &fsOpContext, FSNodeDirectory *parent,
 	                  FSNode *child, hstorage::Handle *handlePtr) override;
+
+	/// Updates owner quota usage for node mutations.
+	/// In-memory backend applies updates directly to quota structures.
+	/// KV backend can override to persist counters in the active transaction.
+	virtual void quotaUpdate(
+	    const FilesystemOperationContext &fsOpContext, FSNode *node,
+	    const std::initializer_list<std::pair<QuotaResource, int64_t>> &resourceList);
+
+	/// Removes all quota tuples for a specific owner.
+	/// In-memory backend removes from quota database.
+	/// KV backend can override to remove owner keys from persistent storage.
+	virtual void quotaRemove(const FilesystemOperationContext &fsOpContext,
+	                         QuotaOwnerType ownerType, uint32_t ownerId);
 
 private:
 	// Private helpers

--- a/src/master/filesystem_node.h
+++ b/src/master/filesystem_node.h
@@ -296,15 +296,15 @@ protected:
 	/// Updates owner quota usage for node mutations.
 	/// In-memory backend applies updates directly to quota structures.
 	/// KV backend can override to persist counters in the active transaction.
-	virtual void quotaUpdate(
+	virtual void nodeQuotaUpdate(
 	    const FilesystemOperationContext &fsOpContext, FSNode *node,
 	    const std::initializer_list<std::pair<QuotaResource, int64_t>> &resourceList);
 
 	/// Removes all quota tuples for a specific owner.
 	/// In-memory backend removes from quota database.
 	/// KV backend can override to remove owner keys from persistent storage.
-	virtual void quotaRemove(const FilesystemOperationContext &fsOpContext,
-	                         QuotaOwnerType ownerType, inode_t ownerId);
+	virtual void nodeQuotaRemove(const FilesystemOperationContext &fsOpContext,
+	                             QuotaOwnerType ownerType, inode_t ownerId);
 
 private:
 	// Private helpers

--- a/src/master/filesystem_node.h
+++ b/src/master/filesystem_node.h
@@ -304,7 +304,7 @@ protected:
 	/// In-memory backend removes from quota database.
 	/// KV backend can override to remove owner keys from persistent storage.
 	virtual void quotaRemove(const FilesystemOperationContext &fsOpContext,
-	                         QuotaOwnerType ownerType, uint32_t ownerId);
+	                         QuotaOwnerType ownerType, inode_t ownerId);
 
 private:
 	// Private helpers

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -3648,7 +3648,7 @@ void FilesystemOperationsBase::quotaUpdate(
 
 void FilesystemOperationsBase::quotaRemove(
     [[maybe_unused]] const FilesystemOperationContext &fsOpContext, QuotaOwnerType ownerType,
-    uint32_t ownerId) {
+    inode_t ownerId) {
 	fsnodes_quota_remove(ownerType, ownerId);
 }
 

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -64,19 +64,6 @@ inline bool isDepletedSpace() {
 
 static const int kInitialTaskBatchSize = 1000;
 
-template <class T>
-bool decodeChar(const char *keys, const std::vector<T> values, char key, T &value) {
-	const uint32_t count = strlen(keys);
-	sassert(values.size() == count);
-	for (uint32_t i = 0; i < count; i++) {
-		if (key == keys[i]) {
-			value = values[i];
-			return true;
-		}
-	}
-	return false;
-}
-
 FilesystemOperationsBase::FilesystemOperationsBase(
     std::unique_ptr<IFilesystemNodeOperations> _nodeOps)
     : nodeOperations_(std::move(_nodeOps)) {}

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -723,7 +723,8 @@ uint8_t FilesystemOperationsBase::trySetLength(const FsContext &context,
 				denyTruncatingParity = denyTruncatingParity && (length < node_file->length);
 				status = chunk_multi_truncate(
 				    ochunkid, lockId, (length & SFSCHUNKMASK), p->goal, denyTruncatingParity,
-				    fsnodes_quota_exceeded(p, {{QuotaResource::kSize, 1}}), &nchunkid);
+				    quotaExceeded(fsOpContext, p, {{QuotaResource::kSize, 1}}),
+				    &nchunkid);
 				if (status != SAUNAFS_STATUS_OK) {
 					return status;
 				}
@@ -1194,8 +1195,9 @@ uint8_t FilesystemOperationsBase::symlink(const FsContext &context,
 	}
 
 	if (context.isPersonalityMaster() &&
-	    (fsnodes_quota_exceeded_ug(context.uid(), context.gid(), {{QuotaResource::kInodes, 1}}) ||
-	     fsnodes_quota_exceeded_dir(workDir, {{QuotaResource::kInodes, 1}}))) {
+	    (quotaExceededUg(fsOpContext, context.uid(), context.gid(),
+	                     {{QuotaResource::kInodes, 1}}) ||
+	     quotaExceededDir(fsOpContext, workDir, {{QuotaResource::kInodes, 1}}))) {
 		return SAUNAFS_ERROR_QUOTA;
 	}
 
@@ -1280,8 +1282,9 @@ uint8_t FilesystemOperationsBase::mknod(const FsContext &context,
 	}
 
 	// Quota verification
-	if (fsnodes_quota_exceeded_ug(context.uid(), context.gid(), {{QuotaResource::kInodes, 1}}) ||
-	    fsnodes_quota_exceeded_dir(parentNode, {{QuotaResource::kInodes, 1}})) {
+	if (quotaExceededUg(fsOpContext, context.uid(), context.gid(),
+	                    {{QuotaResource::kInodes, 1}}) ||
+	    quotaExceededDir(fsOpContext, parentNode, {{QuotaResource::kInodes, 1}})) {
 		return SAUNAFS_ERROR_QUOTA;
 	}
 
@@ -1344,8 +1347,9 @@ uint8_t FilesystemOperationsBase::mkdir(const FsContext &context,
 		return SAUNAFS_ERROR_EEXIST;
 	}
 
-	if (fsnodes_quota_exceeded_ug(context.uid(), context.gid(), {{QuotaResource::kInodes, 1}}) ||
-	    fsnodes_quota_exceeded_dir(workNode, {{QuotaResource::kInodes, 1}})) {
+	if (quotaExceededUg(fsOpContext, context.uid(), context.gid(),
+	                    {{QuotaResource::kInodes, 1}}) ||
+	    quotaExceededDir(fsOpContext, workNode, {{QuotaResource::kInodes, 1}})) {
 		return SAUNAFS_ERROR_QUOTA;
 	}
 
@@ -1702,8 +1706,8 @@ uint8_t FilesystemOperationsBase::rename(const FsContext &context,
 		}
 	}
 
-	if (fsnodes_quota_exceeded_dir(
-	        destWorkDir, sourceWorkDir,
+	if (quotaExceededDirMove(
+	        fsOpContext, destWorkDir, sourceWorkDir,
 	        {{QuotaResource::kInodes, quota_delta[(int)QuotaResource::kInodes]},
 	         {QuotaResource::kSize, quota_delta[(int)QuotaResource::kSize]}})) {
 		return SAUNAFS_ERROR_QUOTA;
@@ -1819,7 +1823,8 @@ uint8_t FilesystemOperationsBase::append(const FsContext &context,
 
 	if (status != SAUNAFS_STATUS_OK) { return status; }
 
-	if (context.isPersonalityMaster() && fsnodes_quota_exceeded(p, {{QuotaResource::kSize, 1}})) {
+	if (context.isPersonalityMaster() &&
+	    quotaExceeded(fsOpContext, p, {{QuotaResource::kSize, 1}})) {
 		return SAUNAFS_ERROR_QUOTA;
 	}
 	status = nodeOperations_->appendChunks(fsOpContext, context.ts(), static_cast<FSNodeFile *>(p),
@@ -2461,7 +2466,7 @@ uint8_t FilesystemOperationsBase::writeChunk(const FsContext &context,
 	}
 #endif
 
-	const bool quota_exceeded = fsnodes_quota_exceeded(fileNode, {{QuotaResource::kSize, 1}});
+	const bool quota_exceeded = quotaExceeded(fsOpContext, fileNode, {{QuotaResource::kSize, 1}});
 
 	// Cache original stats for quota and parent update
 	StatsRecord originalStats;
@@ -2517,7 +2522,7 @@ uint8_t FilesystemOperationsBase::writeChunk(const FsContext &context,
 	nodeOperations_->getStats(fsOpContext, fileNode, &newStats);
 	nodeOperations_->updateParentStatsForNode(fsOpContext, fileNode, &newStats, &originalStats);
 
-	fsnodes_quota_update(fileNode, {{QuotaResource::kSize, newStats.size - originalStats.size}});
+	quotaUpdate(fsOpContext, fileNode, {{QuotaResource::kSize, newStats.size - originalStats.size}});
 	if (length) {
 		*length = fileNode->length;
 	}
@@ -2644,7 +2649,7 @@ uint8_t FilesystemOperationsBase::removeChunkFromFile(const FsContext &context,
 		auto *parent = nodeOperations_->idToNodeVerify<FSNodeDirectory>(fsOpContext, parentId);
 		nodeOperations_->addSubStats(fsOpContext, parent, &nsr, &psr);
 	}
-	fsnodes_quota_update(p, {{QuotaResource::kSize, nsr.size - psr.size}});
+	quotaUpdate(fsOpContext, p, {{QuotaResource::kSize, nsr.size - psr.size}});
 	fsnodes_update_checksum(p);
 	return SAUNAFS_STATUS_OK;
 }
@@ -2700,7 +2705,7 @@ uint8_t FilesystemOperationsBase::repair(const FsContext &context, inode_t inode
 		auto *parent = nodeOperations_->idToNodeVerify<FSNodeDirectory>(fsOpContext, parentId);
 		nodeOperations_->addSubStats(fsOpContext, parent, &nsr, &psr);
 	}
-	fsnodes_quota_update(p, {{QuotaResource::kSize, nsr.size - psr.size}});
+	quotaUpdate(fsOpContext, p, {{QuotaResource::kSize, nsr.size - psr.size}});
 	fsnodes_update_checksum(p);
 	return SAUNAFS_STATUS_OK;
 }
@@ -2754,7 +2759,7 @@ uint8_t FilesystemOperationsBase::applyRepair(const FilesystemOperationContext &
 		nodeOperations_->addSubStats(fsOpContext, parent, &nsr, &psr);
 	}
 
-	fsnodes_quota_update(p, {{QuotaResource::kSize, nsr.size - psr.size}});
+	quotaUpdate(fsOpContext, p, {{QuotaResource::kSize, nsr.size - psr.size}});
 
 	gMetadata->metadataVersion++;
 	p->mtime = timestamp;
@@ -3521,8 +3526,9 @@ uint64_t FilesystemOperationsBase::getMetadataVersion() {
 	return gMetadata->metadataVersion;
 }
 
-uint8_t FilesystemOperationsBase::applySetQuota(char rigor, char resource, char ownerType,
-                                                inode_t ownerId, uint64_t limit) {
+uint8_t FilesystemOperationsBase::applySetQuota(
+    const FilesystemOperationContext & /*fsOpContext*/, char rigor, char resource, char ownerType,
+    inode_t ownerId, uint64_t limit) {
 	return quotas::fs_apply_setquota(rigor, resource, ownerType, ownerId, limit);
 }
 
@@ -3607,6 +3613,46 @@ uint8_t FilesystemOperationsBase::getChunksInfo(const FsContext &context, uint32
 	return SAUNAFS_STATUS_OK;
 }
 
+#endif
+
+bool FilesystemOperationsBase::quotaExceededUg(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, uint32_t uid, uint32_t gid,
+    const std::initializer_list<std::pair<QuotaResource, int64_t>> &resourceList) {
+	return fsnodes_quota_exceeded_ug(uid, gid, resourceList);
+}
+
+bool FilesystemOperationsBase::quotaExceededDir(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, FSNode *node,
+    const std::initializer_list<std::pair<QuotaResource, int64_t>> &resourceList) {
+	return fsnodes_quota_exceeded_dir(node, resourceList);
+}
+
+bool FilesystemOperationsBase::quotaExceededDirMove(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, FSNodeDirectory *node,
+    FSNodeDirectory *prevNode,
+    const std::initializer_list<std::pair<QuotaResource, int64_t>> &resourceList) {
+	return fsnodes_quota_exceeded_dir(node, prevNode, resourceList);
+}
+
+bool FilesystemOperationsBase::quotaExceeded(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, FSNode *node,
+    const std::initializer_list<std::pair<QuotaResource, int64_t>> &resourceList) {
+	return fsnodes_quota_exceeded(node, resourceList);
+}
+
+void FilesystemOperationsBase::quotaUpdate(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, FSNode *node,
+    const std::initializer_list<std::pair<QuotaResource, int64_t>> &resourceList) {
+	fsnodes_quota_update(node, resourceList);
+}
+
+void FilesystemOperationsBase::quotaRemove(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, QuotaOwnerType ownerType,
+    uint32_t ownerId) {
+	fsnodes_quota_remove(ownerType, ownerId);
+}
+
+#ifndef METARESTORE
 uint8_t FilesystemOperationsBase::quotaGetAll(const FsContext &context,
                                               std::vector<QuotaEntry> &results) {
 	return quotas::fs_quota_get_all(context, results);
@@ -3618,8 +3664,9 @@ uint8_t FilesystemOperationsBase::quotaGet(const FsContext &context,
 	return quotas::fs_quota_get(context, owners, results);
 }
 
-uint8_t FilesystemOperationsBase::quotaSet(const FsContext &context,
-                                           const std::vector<QuotaEntry> &entries) {
+uint8_t FilesystemOperationsBase::quotaSet(
+    const FsContext &context, [[maybe_unused]] const FilesystemOperationContext &fsOpContext,
+    const std::vector<QuotaEntry> &entries) {
 	return quotas::fs_quota_set(context, entries);
 }
 
@@ -3628,7 +3675,9 @@ uint8_t FilesystemOperationsBase::quotaGetInfo(const FsContext &context,
                                                std::vector<std::string> &result) {
 	return quotas::fs_quota_get_info(context, entries, result);
 }
+#endif
 
+#ifndef METARESTORE
 uint8_t FilesystemOperationsBase::startChecksumRecalculation() {
 	return checksum::fs_start_checksum_recalculation();
 }

--- a/src/master/filesystem_operations.h
+++ b/src/master/filesystem_operations.h
@@ -330,13 +330,64 @@ public:
 	uint8_t fullPathByInode(const FsContext &context, inode_t inode,
 	                        std::string &fullPath) override;
 	std::string fullPathByInode(inode_t initialInode) override;
+#endif
 
 	// QUOTAS
 
+	/// Checks hard user/group quota limits for resource deltas.
+	/// @see IFilesystemOperations::quotaExceededUg
+	bool quotaExceededUg(
+	    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, uint32_t uid, uint32_t gid,
+	    const std::initializer_list<std::pair<QuotaResource, int64_t>> &resourceList) override;
+
+	/// Checks hard directory-owner quota limits for a node context.
+	/// @see IFilesystemOperations::quotaExceededDir
+	bool quotaExceededDir(
+	    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, FSNode *node,
+	    const std::initializer_list<std::pair<QuotaResource, int64_t>> &resourceList) override;
+
+	/// Checks destination-side hard directory quota limits for move/rename.
+	/// @see IFilesystemOperations::quotaExceededDirMove
+	bool quotaExceededDirMove(
+	    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, FSNodeDirectory *node,
+	    FSNodeDirectory *prevNode,
+	    const std::initializer_list<std::pair<QuotaResource, int64_t>> &resourceList) override;
+
+	/// Performs combined user/group and directory hard quota checks.
+	/// @see IFilesystemOperations::quotaExceeded
+	bool quotaExceeded(
+	    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, FSNode *node,
+	    const std::initializer_list<std::pair<QuotaResource, int64_t>> &resourceList) override;
+
+	/// Applies quota usage deltas for successful node mutations.
+	/// @see IFilesystemOperations::quotaUpdate
+	void quotaUpdate(
+	    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, FSNode *node,
+	    const std::initializer_list<std::pair<QuotaResource, int64_t>> &resourceList) override;
+
+	/// Removes all quota tuples for one owner.
+	/// @see IFilesystemOperations::quotaRemove
+	void quotaRemove([[maybe_unused]] const FilesystemOperationContext &fsOpContext,
+	                 QuotaOwnerType ownerType, uint32_t ownerId) override;
+
+#ifndef METARESTORE
+	/// Returns all quota entries visible to the caller.
+	/// @see IFilesystemOperations::quotaGetAll
 	uint8_t quotaGetAll(const FsContext &context, std::vector<QuotaEntry> &results) override;
+
+	/// Returns quota entries for selected owners.
+	/// @see IFilesystemOperations::quotaGet
 	uint8_t quotaGet(const FsContext &context, const std::vector<QuotaOwner> &owners,
 	                 std::vector<QuotaEntry> &results) override;
-	uint8_t quotaSet(const FsContext &context, const std::vector<QuotaEntry> &entries) override;
+
+	/// Sets quota tuples and emits SETQUOTA changelog entries.
+	/// @see IFilesystemOperations::quotaSet
+	uint8_t quotaSet(const FsContext &context,
+	                 [[maybe_unused]] const FilesystemOperationContext &fsOpContext,
+	                 const std::vector<QuotaEntry> &entries) override;
+
+	/// Builds display information for quota entries.
+	/// @see IFilesystemOperations::quotaGetInfo
 	uint8_t quotaGetInfo(const FsContext &context, const std::vector<QuotaEntry> &entries,
 	                     std::vector<std::string> &result) override;
 
@@ -345,7 +396,6 @@ public:
 	/// Starts recalculating metadata checksum in background.
 	/// @see IFilesystemOperations::fs_start_checksum_recalculation.
 	uint8_t startChecksumRecalculation() override;
-
 #endif
 	void addFilesToChunks(bool isMetadataLoading = true) override;
 
@@ -384,8 +434,10 @@ public:
 	uint8_t applyTrunc(uint32_t timestamp, inode_t inode, uint32_t indx, uint64_t chunkid,
 	                   uint32_t lockid) override;
 
-	uint8_t applySetQuota(char rigor, char resource, char ownerType, inode_t ownerId,
-	                      uint64_t limit) override;
+	/// Replays a SETQUOTA changelog tuple update.
+	/// @see IFilesystemOperations::applySetQuota
+	uint8_t applySetQuota(const FilesystemOperationContext &fsOpContext, char rigor, char resource,
+	                      char ownerType, inode_t ownerId, uint64_t limit) override;
 
 	// CHECKSUM
 

--- a/src/master/filesystem_operations.h
+++ b/src/master/filesystem_operations.h
@@ -368,7 +368,7 @@ public:
 	/// Removes all quota tuples for one owner.
 	/// @see IFilesystemOperations::quotaRemove
 	void quotaRemove([[maybe_unused]] const FilesystemOperationContext &fsOpContext,
-	                 QuotaOwnerType ownerType, uint32_t ownerId) override;
+	                 QuotaOwnerType ownerType, inode_t ownerId) override;
 
 #ifndef METARESTORE
 	/// Returns all quota entries visible to the caller.

--- a/src/master/filesystem_operations_interface.h
+++ b/src/master/filesystem_operations_interface.h
@@ -20,6 +20,7 @@
 
 #include "common/platform.h"
 
+#include <initializer_list>
 #include <map>
 #include <memory>
 #include <vector>
@@ -34,6 +35,7 @@
 #include "master/locks.h"
 #include "master/setgoal_task.h"
 #include "master/settrashtime_task.h"
+#include "protocol/quota.h"
 
 class HString;
 class AccessControlList;
@@ -1063,12 +1065,134 @@ public:
 	                                std::string &fullPath) = 0;
 	virtual std::string fullPathByInode(inode_t initialInode) = 0;
 
+#endif
+
 	// QUOTAS
 
+	/// Checks whether applying @p resourceList would exceed hard user/group limits.
+	///
+	/// In the in-memory implementation, only hard limits are enforced; soft limits are stored and
+	/// reported but do not reject operations. A limit value of 0 means "unlimited".
+	///
+	/// @param fsOpContext Filesystem operation context carrying backend transaction state.
+	/// @param uid User owner id used for user quota checks.
+	/// @param gid Group owner id used for group quota checks.
+	/// @param resourceList Resource deltas to validate (typically inodes and/or size).
+	/// @return true if either user or group hard quota would be exceeded.
+	virtual bool quotaExceededUg(
+	    const FilesystemOperationContext &fsOpContext, uint32_t uid, uint32_t gid,
+	    const std::initializer_list<std::pair<QuotaResource, int64_t>> &resourceList) = 0;
+
+	/// Checks whether applying @p resourceList would exceed hard directory-owner limits.
+	///
+	/// The check is performed for the node's directory owner (when applicable) and ancestor
+	/// directories according to the quota traversal rules used by rename/create/write paths.
+	///
+	/// @param fsOpContext Filesystem operation context carrying backend transaction state.
+	/// @param node Node whose directory context is validated.
+	/// @param resourceList Resource deltas to validate (typically inodes and/or size).
+	/// @return true if any checked directory hard quota would be exceeded.
+	virtual bool quotaExceededDir(
+	    const FilesystemOperationContext &fsOpContext, FSNode *node,
+	    const std::initializer_list<std::pair<QuotaResource, int64_t>> &resourceList) = 0;
+
+	/// Checks destination-side directory hard limits for move/rename operations.
+	///
+	/// Implementations compare destination and previous ancestry and stop checks at the common
+	/// ancestor, matching existing in-memory rename quota semantics.
+	///
+	/// @param fsOpContext Filesystem operation context carrying backend transaction state.
+	/// @param node Destination directory.
+	/// @param prevNode Previous/source directory.
+	/// @param resourceList Resource deltas to validate for the move.
+	/// @return true if destination-side hard quotas would be exceeded.
+	virtual bool quotaExceededDirMove(
+	    const FilesystemOperationContext &fsOpContext, FSNodeDirectory *node,
+	    FSNodeDirectory *prevNode,
+	    const std::initializer_list<std::pair<QuotaResource, int64_t>> &resourceList) = 0;
+
+	/// Checks both user/group and directory hard quotas for @p node.
+	///
+	/// This is the combined helper used by operations that need both checks in one call.
+	///
+	/// @param fsOpContext Filesystem operation context carrying backend transaction state.
+	/// @param node Node whose owner and directory quotas are validated.
+	/// @param resourceList Resource deltas to validate.
+	/// @return true if any relevant hard quota would be exceeded.
+	virtual bool quotaExceeded(
+	    const FilesystemOperationContext &fsOpContext, FSNode *node,
+	    const std::initializer_list<std::pair<QuotaResource, int64_t>> &resourceList) = 0;
+
+	/// Applies quota usage deltas after a successful metadata mutation.
+	///
+	/// In the in-memory implementation, this updates only user/group `used` counters
+	/// incrementally. Inode-owner `used` values are derived from directory stats for reads.
+	///
+	/// @param fsOpContext Filesystem operation context carrying backend transaction state.
+	/// @param node Mutated node whose owner usage must be updated.
+	/// @param resourceList Resource deltas to apply.
+	virtual void quotaUpdate(
+	    const FilesystemOperationContext &fsOpContext, FSNode *node,
+	    const std::initializer_list<std::pair<QuotaResource, int64_t>> &resourceList) = 0;
+
+	/// Removes all quota tuples for a single owner.
+	///
+	/// Used by inode-owner cleanup paths when an inode is removed.
+	///
+	/// @param fsOpContext Filesystem operation context carrying backend transaction state.
+	/// @param ownerType Owner namespace (user/group/inode).
+	/// @param ownerId Owner identifier.
+	virtual void quotaRemove(const FilesystemOperationContext &fsOpContext,
+	                         QuotaOwnerType ownerType, uint32_t ownerId) = 0;
+
+#ifndef METARESTORE
+	/// Returns all quota entries visible to @p context.
+	///
+	/// Non-privileged sessions require quota-management permission flags. Inode-owner visibility is
+	/// filtered by session root and inode `used` is reported using directory stats semantics.
+	/// In the in-memory implementation this returns only resources with at least one non-zero
+	/// soft/hard limit, plus the matching `used` entry for each returned resource.
+	///
+	/// @param context Session context used for permission and visibility checks.
+	/// @param[out] results Collected quota entries.
+	/// @return SAUNAFS_STATUS_OK on success or a permission error.
 	virtual uint8_t quotaGetAll(const FsContext &context, std::vector<QuotaEntry> &results) = 0;
+
+	/// Returns quota entries for selected owners.
+	///
+	/// Owner access is validated per owner type (user/group/inode). For each existing owner in the
+	/// in-memory implementation, all rigor/resource tuples are returned (including zero-valued ones),
+	/// except inode-owner `used`, which is derived from current directory stats.
+	///
+	/// @param context Session context used for permission and visibility checks.
+	/// @param owners Owners to query.
+	/// @param[out] results Collected quota entries.
+	/// @return SAUNAFS_STATUS_OK on success or an access/validation error.
 	virtual uint8_t quotaGet(const FsContext &context, const std::vector<QuotaOwner> &owners,
 	                         std::vector<QuotaEntry> &results) = 0;
-	virtual uint8_t quotaSet(const FsContext &context, const std::vector<QuotaEntry> &entries) = 0;
+
+	/// Sets quota entries and writes corresponding SETQUOTA changelog records.
+	///
+	/// The caller provides a read-write operation context so backend-specific quota writes can be
+	/// applied within the same operation scope.
+	///
+	/// @param context Session context used for permission checks.
+	/// @param fsOpContext Filesystem operation context carrying a read-write transaction.
+	/// @param entries Quota entries to set.
+	/// @return SAUNAFS_STATUS_OK on success or an access/validation/storage error.
+	virtual uint8_t quotaSet(const FsContext &context,
+	                         const FilesystemOperationContext &fsOpContext,
+	                         const std::vector<QuotaEntry> &entries) = 0;
+
+	/// Returns display information strings for quota entries.
+	///
+	/// For inode owners this is a resolved path when the inode exists; for other owner types it is
+	/// an empty string.
+	///
+	/// @param context Session context used for path resolution scope.
+	/// @param entries Quota entries for which to generate info.
+	/// @param[out] result Display strings aligned with @p entries.
+	/// @return SAUNAFS_STATUS_OK on success.
 	virtual uint8_t quotaGetInfo(const FsContext &context, const std::vector<QuotaEntry> &entries,
 	                             std::vector<std::string> &result) = 0;
 
@@ -1137,7 +1261,20 @@ public:
 	virtual uint8_t applyTrunc(uint32_t timestamp, inode_t inode, uint32_t indx, uint64_t chunkid,
 	                           uint32_t lockid) = 0;
 
-	virtual uint8_t applySetQuota(char rigor, char resource, char ownerType, inode_t ownerId,
+	/// Replays a SETQUOTA changelog entry during metadata restore.
+	///
+	/// Decodes single-character tuple selectors (rigor/resource/ownerType), applies one quota tuple
+	/// update, and advances metadata version on success.
+	///
+	/// @param fsOpContext The operation context carrying a read-write transaction in KV backends.
+	/// @param rigor Quota rigor selector ('S' or 'H').
+	/// @param resource Quota resource selector ('S' for size, 'I' for inodes).
+	/// @param ownerType Quota owner selector ('U', 'G', or 'I').
+	/// @param ownerId Owner identifier.
+	/// @param limit New tuple value.
+	/// @return SAUNAFS_STATUS_OK on success, SAUNAFS_ERROR_EINVAL on decode/validation errors.
+	virtual uint8_t applySetQuota(const FilesystemOperationContext &fsOpContext, char rigor,
+	                              char resource, char ownerType, inode_t ownerId,
 	                              uint64_t limit) = 0;
 
 	// CHECKSUM

--- a/src/master/filesystem_operations_interface.h
+++ b/src/master/filesystem_operations_interface.h
@@ -1143,7 +1143,7 @@ public:
 	/// @param ownerType Owner namespace (user/group/inode).
 	/// @param ownerId Owner identifier.
 	virtual void quotaRemove(const FilesystemOperationContext &fsOpContext,
-	                         QuotaOwnerType ownerType, uint32_t ownerId) = 0;
+	                         QuotaOwnerType ownerType, inode_t ownerId) = 0;
 
 #ifndef METARESTORE
 	/// Returns all quota entries visible to @p context.

--- a/src/master/filesystem_quota.cc
+++ b/src/master/filesystem_quota.cc
@@ -29,19 +29,6 @@
 #include "master/filesystem_metadata.h"
 #include "master/filesystem_operations_interface.h"
 
-template <class T>
-bool decodeChar(const char *keys, const std::vector<T> values, char key, T &value) {
-	const uint32_t count = strlen(keys);
-	sassert(values.size() == count);
-	for (uint32_t i = 0; i < count; i++) {
-		if (key == keys[i]) {
-			value = values[i];
-			return true;
-		}
-	}
-	return false;
-}
-
 #ifndef METARESTORE
 /*! \brief Remove entries that are not descendants of \param root_inode. */
 static void fs_remove_invisible_quota_entries(inode_t root_inode, std::vector<QuotaEntry> &results) {

--- a/src/master/filesystem_quota.cc
+++ b/src/master/filesystem_quota.cc
@@ -478,7 +478,7 @@ void fsnodes_quota_update(FSNode *node,
 	}
 }
 
-void fsnodes_quota_remove(QuotaOwnerType owner_type, uint32_t owner_id) {
+void fsnodes_quota_remove(QuotaOwnerType owner_type, inode_t owner_id) {
 	gMetadata->quotaDatabase.remove(owner_type, owner_id);
 	gMetadata->quotaChecksum = gMetadata->quotaDatabase.checksum();
 }

--- a/src/master/filesystem_quota.h
+++ b/src/master/filesystem_quota.h
@@ -21,13 +21,39 @@
 #include "common/platform.h"
 
 #include <cstdint>
+#include <cstring>
 #include <initializer_list>
 #include <utility>
+#include <vector>
 
+#include "common/massert.h"
 #include "common/quota_database.h"
 #include "master/filesystem_freenode.h"
 #include "master/filesystem_node_types.h"
 #include "protocol/quota.h"
+
+/// Decodes a single-character selector into a typed value.
+///
+/// Used by applySetQuota replay paths to decode SETQUOTA changelog fields
+/// (rigor, resource, ownerType) from their single-character representations.
+///
+/// @param keys  Null-terminated string of valid selector characters.
+/// @param values Parallel vector of typed values matching @p keys.
+/// @param key   Character to decode.
+/// @param[out] value Decoded typed value on success.
+/// @return true if @p key was found in @p keys.
+template <class T>
+inline bool decodeChar(const char *keys, const std::vector<T> &values, char key, T &value) {
+	const uint32_t count = strlen(keys);
+	sassert(values.size() == count);
+	for (uint32_t i = 0; i < count; i++) {
+		if (key == keys[i]) {
+			value = values[i];
+			return true;
+		}
+	}
+	return false;
+}
 
 class FsContext;
 

--- a/src/master/filesystem_quota.h
+++ b/src/master/filesystem_quota.h
@@ -85,10 +85,10 @@ void fsnodes_quota_update(FSNode *node,
 	const std::initializer_list<std::pair<QuotaResource, int64_t>> &resource_list);
 
 /*! \brief Remove quota.
- * \param owner_type Owner type (user, group, inode(directory)).
+ * \param owner_type Owner type (user, group, inode (directory)).
  * \param owner_id Owner id.
  */
-void fsnodes_quota_remove(QuotaOwnerType owner_type, uint32_t owner_id);
+void fsnodes_quota_remove(QuotaOwnerType owner_type, inode_t owner_id);
 
 /*! \brief Adjust reported free/total space based on quota information.
  * \param node Pointer to root node in directory tree that we should adjust space for.

--- a/src/master/kv_common_keys.h
+++ b/src/master/kv_common_keys.h
@@ -87,6 +87,16 @@ inline constexpr std::string_view kXAttrKeyPrefix = "XATR_";   // Section XATR 1
 /// @note InodeId is serialized as Big Endian to maintain numeric order in lexicographical sorting,
 /// enabling efficient range queries.
 inline constexpr std::string_view kACLsKeyPrefix = "ACLS_";    // Section ACLS 1.2
+
+/// Prefix for quotas
+/// Format: QUOT_<OwnerType><OwnerId><Rigor><Resource>:<Value>
+/// - OwnerType: u8 (user/group/inode)
+/// - OwnerId: inode_t serialized as Big Endian
+/// - Rigor: u8 (soft/hard/used)
+/// - Resource: u8 (inodes/size)
+/// - Value: u64 serialized as Big Endian
+/// @note Numeric fields in the key are serialized as Big Endian to preserve numeric order in
+/// lexicographical sorting, enabling efficient scans by owner prefix and global quota prefix.
 inline constexpr std::string_view kQuotasKeyPrefix = "QUOT_";  // Section QUOT 1.1
 inline constexpr std::string_view kLocksKeyPrefix = "FLCK_";   // Section FLCK 1.0
 

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -4817,7 +4817,17 @@ void matoclserv_fuse_setquota(matoclserventry *eptr, const uint8_t *data, uint32
 	uint8_t status = matoclserv_check_group_cache(eptr, gid);
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = gFSOperations->quotaSet(context, entries);
+		auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+		    FilesystemOperationContext::TransactionType::kReadWrite);
+
+		status = gFSOperations->quotaSet(context, fsOpContext, entries);
+
+		if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
+			if (!fsOpContext.getReadWriteTransaction()->commit()) {
+				safs::log_err("{}: transaction failed to commit for setquota", __func__);
+				status = SAUNAFS_ERROR_IO;
+			}
+		}
 	}
 
 	MessageBuffer reply;

--- a/src/master/restore.cc
+++ b/src/master/restore.cc
@@ -865,7 +865,21 @@ int do_setquota(const char *filename, uint64_t lv, uint32_t /*ts*/, const char *
 	GETU64(limit, ptr);
 	EAT(ptr, filename, lv, ')');
 
-	return gFSOperations->applySetQuota(rigor, resource, ownerType, ownerId, limit);
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
+	int status = gFSOperations->applySetQuota(fsOpContext, rigor, resource, ownerType, ownerId,
+	                                          limit);
+
+	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
+		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+			safs::log_err("{}: transaction failed to commit: ownerType {}, ownerId {}", __func__,
+			              ownerType, ownerId);
+			return SAUNAFS_ERROR_IO;
+		}
+	}
+
+	return status;
 }
 
 int do_snapshot(const char* /*filename*/, uint64_t /*lv*/, uint32_t /*ts*/, const char* /*ptr*/) {

--- a/src/master/snapshot_task.cc
+++ b/src/master/snapshot_task.cc
@@ -26,18 +26,23 @@
 #include "master/filesystem_metadata.h"
 #include "master/filesystem_operation_context.h"
 #include "master/filesystem_operations_interface.h"
-#include "master/filesystem_quota.h"
 
-int SnapshotTask::cloneNodeTest(FSNode *src_node, FSNode *dst_node, FSNodeDirectory *dst_parent) {
-	if (fsnodes_quota_exceeded_ug(src_node, {{QuotaResource::kInodes, 1}}) ||
-	    fsnodes_quota_exceeded_dir(dst_parent, {{QuotaResource::kInodes, 1}})) {
+int SnapshotTask::cloneNodeTest(const FilesystemOperationContext &fsOpContext, FSNode *src_node,
+                                FSNode *dst_node, FSNodeDirectory *dst_parent) {
+	if (gFSOperations->quotaExceededUg(fsOpContext, src_node->uid, src_node->gid,
+	                                   {{QuotaResource::kInodes, 1}}) ||
+	    gFSOperations->quotaExceededDir(fsOpContext, dst_parent,
+	                                    {{QuotaResource::kInodes, 1}})) {
 		return SAUNAFS_ERROR_QUOTA;
 	}
 	if (src_node->type == FSNodeType::kFile &&
-	    (fsnodes_quota_exceeded_ug(src_node, {{QuotaResource::kSize, 1}}) ||
-	     fsnodes_quota_exceeded_dir(dst_parent, {{QuotaResource::kSize, 1}}))) {
+	    (gFSOperations->quotaExceededUg(fsOpContext, src_node->uid, src_node->gid,
+	                                    {{QuotaResource::kSize, 1}}) ||
+	     gFSOperations->quotaExceededDir(fsOpContext, dst_parent,
+	                                    {{QuotaResource::kSize, 1}}))) {
 		return SAUNAFS_ERROR_QUOTA;
 	}
+
 	if (dst_node) {
 		if (orig_inode_ != 0 && dst_node->id == orig_inode_) {
 			return SAUNAFS_ERROR_EINVAL;
@@ -173,7 +178,8 @@ void SnapshotTask::cloneChunkData(const FilesystemOperationContext &fsOpContext,
 
 	gFSOperations->nodeOperations()->getStats(fsOpContext, dst_node, &nsr);
 	gFSOperations->nodeOperations()->addSubStats(fsOpContext, dst_parent, &nsr, &psr);
-	fsnodes_quota_update(dst_node, {{QuotaResource::kSize, nsr.size - psr.size}});
+	gFSOperations->quotaUpdate(fsOpContext, dst_node,
+	                           {{QuotaResource::kSize, nsr.size - psr.size}});
 }
 
 void SnapshotTask::cloneDirectoryData(const FSNodeDirectory *src_node, FSNodeDirectory *dst_node) {
@@ -239,7 +245,7 @@ int SnapshotTask::cloneNode(uint32_t ts) {
 	FSNode *dst_node =
 	    gFSOperations->nodeOperations()->lookup(fsOpContext, dst_parent, current_subtask_->second);
 
-	int status = cloneNodeTest(src_node, dst_node, dst_parent);
+	int status = cloneNodeTest(fsOpContext, src_node, dst_node, dst_parent);
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}

--- a/src/master/snapshot_task.h
+++ b/src/master/snapshot_task.h
@@ -87,7 +87,8 @@ public:
 
 protected:
 	/*! \brief Test if node can be cloned. */
-	int cloneNodeTest(FSNode *src_node, FSNode *dst_node, FSNodeDirectory *dst_parent);
+	int cloneNodeTest(const FilesystemOperationContext &fsOpContext, FSNode *src_node,
+	                  FSNode *dst_node, FSNodeDirectory *dst_parent);
 	FSNode *cloneToExistingNode(const FilesystemOperationContext &fsOpContext, uint32_t ts,
 	                            FSNode *src_node, FSNodeDirectory *dst_parent, FSNode *dst_node);
 	FSNode *cloneToNewNode(const FilesystemOperationContext &fsOpContext, uint32_t ts,


### PR DESCRIPTION
Thread FilesystemOperationContext through quota APIs (quotaExceeded*, quotaUpdate, quotaRemove, quotaSet, and applySetQuota) so KV backends can execute checks and updates inside the active read-write transaction.

Move setquota transaction ownership to callers:
matoclserv_fuse_setquota and restore::do_setquota now create and commit the transaction around the full op.

Introduce virtual quota hooks in FilesystemNodeOperationsBase (quotaUpdate, quotaRemove). The default implementation still delegates to fsnodes_quota_* helpers, preserving in-memory behavior.

Switch mutation and snapshot quota call sites to
gFSOperations/nodeOperations hooks, keeping backend-specific logic out of filesystem_quota.{h,cc}.

Add QUOT_ key format docs and extend quota interface comments.

Related to: LS-71