### PR TITLE
chore(wsl1): Fix consistent FDB deps install LS-379

### DIFF
--- a/tests/ci_build/install-foundationdb.sh
+++ b/tests/ci_build/install-foundationdb.sh
@@ -74,25 +74,29 @@ sha256sum -c "${server_pkg}${hash_suffix}" || die "Server package verification f
 cd - || die "Failed to change back to previous directory"
 
 # Install the packages
-echo "Installing FoundationDB packages..."
-dpkg -i "${workspace}/${client_pkg}" "${workspace}/${server_pkg}" || die "Failed to install FoundationDB packages"
-
-# Fix any missing dependencies
-echo "Fixing missing dependencies..."
-apt-get install -f -y || die "Failed to fix missing dependencies"
-
-# Verify the installation
-echo "Verifying FoundationDB installation..."
-if command -v fdbcli &> /dev/null; then
-	echo "FoundationDB CLI installed successfully."
-	fdbcli --version
+if grep -q Microsoft /proc/version && ! grep -q microsoft-standard /proc/version; then
+	echo "Running on WSL1: skipping FoundationDB installation."
 else
-	echo "FoundationDB CLI installation failed."
-	exit 1
+	echo "Installing FoundationDB packages..."
+	dpkg -i "${workspace}/${client_pkg}" "${workspace}/${server_pkg}" || die "Failed to install FoundationDB packages"
+
+	# Fix any missing dependencies
+	echo "Fixing missing dependencies..."
+	apt-get install -f -y || die "Failed to fix missing dependencies"
+
+	# Verify the installation
+	echo "Verifying FoundationDB installation..."
+	if command -v fdbcli &> /dev/null; then
+		echo "FoundationDB CLI installed successfully."
+		fdbcli --version
+	else
+		echo "FoundationDB CLI installation failed."
+		exit 1
+	fi
+
+	# Clean up temporary workspace
+	echo "Removing temporary workspace..."
+	rm -r "${workspace:?}"
+
+	echo "FoundationDB installation completed successfully."
 fi
-
-# Clean up temporary workspace
-echo "Removing temporary workspace..."
-rm -r "${workspace:?}"
-
-echo "FoundationDB installation completed successfully."

--- a/tests/setup_machine.sh
+++ b/tests/setup_machine.sh
@@ -195,11 +195,7 @@ if [ ! -f /etc/sudoers.d/saunafstest ] || ! grep -q '# FoundationDB' /etc/sudoer
 fi
 
 echo ; echo 'Install FoundationDB'
-if grep -q Microsoft /proc/version && ! grep -q microsoft-standard /proc/version; then
-	echo "Running on WSL1: skipping FoundationDB installation."
-else
-	"$script_dir/ci_build/install-foundationdb.sh"
-fi
+"$script_dir/ci_build/install-foundationdb.sh"
 
 echo ; echo 'Fixing GIDs of users'
 for name in saunafstest saunafstest_{0..9}; do


### PR DESCRIPTION
Previously, the installation of FoundationDB was skipped on WSL1, which led to the need of manually installing packages dependencies for project compilation on WSL1, due to no complete header files being present. This commit fixes that issue by ensuring only FDB related libraries and header files are available on WSL1.