### PR TITLE
feat(admin): Add default TLS for dump-config LS-380

### DIFF
--- a/src/admin/dump_config_command.cc
+++ b/src/admin/dump_config_command.cc
@@ -135,6 +135,9 @@ const static std::unordered_map<std::string, std::string> defaultOptionsMaster =
     {"PRIORITIZE_DATA_PARTS", "1"},
     {"USE_CHUNKSERVER_SIDE_CHUNK_LOCK", "0"},
     {"CREATE_EMPTY_FOLDERS_WHEN_SPACE_DEPLETED", "1"},
+    {"TLS_CERT_FILE", ""},
+    {"TLS_KEY_FILE", ""},
+    {"TLS_CA_CERT_FILE", ""},
 };
 
 const static std::unordered_map<std::string, std::string> defaultOptionsShadow = {
@@ -143,6 +146,9 @@ const static std::unordered_map<std::string, std::string> defaultOptionsShadow =
     {"MASTER_RECONNECTION_DELAY", "1"},
 	{"MASTER_TIMEOUT", "60"},
     {"LOAD_FACTOR_PENALTY", "0.0"},
+    {"TLS_CERT_FILE", ""},
+    {"TLS_KEY_FILE", ""},
+    {"TLS_CA_CERT_FILE", ""},
 };
 
 const static std::unordered_map<std::string, std::string> defaultOptionsCS = {
@@ -188,6 +194,9 @@ const static std::unordered_map<std::string, std::string> defaultOptionsCS = {
     {"CHUNK_TRASH_FREE_SPACE_THRESHOLD_GB", "0"},
     {"CHUNK_TRASH_GC_BATCH_SIZE", "1000"},
     {"CHUNK_TRASH_GC_SPACE_RECOVERY_BATCH_SIZE", "100"},
+    {"TLS_CERT_FILE", ""},
+    {"TLS_KEY_FILE", ""},
+    {"TLS_CA_CERT_FILE", ""},
 };
 
 const static std::unordered_map<std::string, std::string> defaultOptionsMeta = {
@@ -203,6 +212,9 @@ const static std::unordered_map<std::string, std::string> defaultOptionsMeta = {
     {"MASTER_HOST", "sfsmaster"},
     {"MASTER_PORT", "9419"},
     {"MASTER_RECONNECTION_DELAY", "1"},
+    {"TLS_CERT_FILE", ""},
+    {"TLS_KEY_FILE", ""},
+    {"TLS_CA_CERT_FILE", ""},
 };
 // clang-format on
 

--- a/tests/test_suites/ShortSystemTests/test_tls_master_admin_communication.sh
+++ b/tests/test_suites/ShortSystemTests/test_tls_master_admin_communication.sh
@@ -73,5 +73,8 @@ config="$(saunafs-admin dump-config --defaults localhost "${master_port}" --tlsc
 printf "%s\n" "${config}"
 # Spot-check a couple of defaults that should be stable
 expect_equals 1 "$(grep "GLOBALIOLIMITS_RENEGOTIATION_PERIOD_SECONDS: 0.1" <<< "${config}" | wc -l)"
-# This value may appear across multiple services, adjust expected count if needed
+# These values may appear across multiple services, adjust expected count if needed
 expect_equals 3 "$(grep "REPLICATION_BANDWIDTH_LIMIT_KBPS: 0" <<< "${config}" | wc -l)"
+expect_equals 3 "$(grep "TLS_CERT_FILE: \"\"" <<< "${config}" | wc -l)"
+expect_equals 3 "$(grep "TLS_KEY_FILE: \"\"" <<< "${config}" | wc -l)"
+expect_equals 3 "$(grep "TLS_CA_CERT_FILE: \"\"" <<< "${config}" | wc -l)"


### PR DESCRIPTION
Recent changes enabled TLS related configs on metadata servers, chunkservers and metaloggers, but corresponding dump-config function on saunafs-admin binary was not properly updated for handling defaults for these option values when being used. This commit adds those defaults values to be dumped to corresponding binaries for making TLS config addition more consistent.