### PR TITLE
chore(windows): Fix tests CS stop reliability LS-381

### DIFF
--- a/tests/test_suites/ShortSystemTests/test_ec_read_combinations.sh
+++ b/tests/test_suites/ShortSystemTests/test_ec_read_combinations.sh
@@ -12,6 +12,12 @@ mkdir "$dir"
 saunafs setgoal ec "$dir"
 FILE_SIZE=876M file-generate "$dir/file"
 
+# Allow final write/status propagation to settle on Windows
+# before starting chunkserver shutdown test operations.
+if is_windows_system; then
+	sleep 0.1
+fi
+
 for i in {0..7}; do
 	for cs in {0..2}; do
 		saunafs_chunkserver_daemon $(((i + cs) % 8)) stop

--- a/tests/test_suites/ShortSystemTests/test_truncate_retry.sh
+++ b/tests/test_suites/ShortSystemTests/test_truncate_retry.sh
@@ -13,6 +13,7 @@ FILE_SIZE=1234 file-generate file
 checksum123="$(head -c 123 file | md5sum)"
 
 saunafs_chunkserver_daemon 0 stop
+saunafs_wait_for_ready_chunkservers 0
 assert_awk_finds '/no valid copies/' "$(saunafs fileinfo file)"
 # Following operation should pass - wake up just after 4th try (0.2 + 0.4 + 0.8 + 1.6 = 3.0s)
 (sleep 3.1 && saunafs_chunkserver_daemon 0 start) & truncate -s 123 file
@@ -20,6 +21,7 @@ assert_awk_finds '/[0-9A-F]+_00000002/' "$(saunafs fileinfo file)"
 assert_equals "$checksum123" "$(cat file | md5sum)"
 
 saunafs_chunkserver_daemon 0 stop
+saunafs_wait_for_ready_chunkservers 0
 assert_awk_finds '/no valid copies/' "$(saunafs fileinfo file)"
 # Following operation shouldn't pass - waiting time's exceeded
 sleep 12.7 && saunafs_chunkserver_daemon 0 start &


### PR DESCRIPTION
Recently, the test test_truncate_retry has been observed to fail on the Windows client CI due to chunkserver stop operations not taking effect immediately. This delay causes the test to become flaky. To mitigate the issue, a short sleep has been added after stopping the chunkserver to ensure that the stop command and its subsequent operations have fully taken effect before the test proceeds.
    
Additionally, the test test_ec_read_combinations was flaky because insufficient time was given for the file-generate utility to write all file chunk parts. This timing issue also caused intermittent failures on the Windows client CI.

Co-authored-by: Dave <dave@leil.io>
Signed-off-by: rolysr <rolysr@leil.io>