### PR TITLE
chore(kv): add prefixEnd utility

### DIFF
--- a/src/kv/kv_utils.h
+++ b/src/kv/kv_utils.h
@@ -40,6 +40,25 @@ inline void appendStr(Bytes &destination, std::string_view str) {
 	destination.insert(destination.end(), str.begin(), str.end());
 }
 
+/// Returns the exclusive upper bound for a prefix range scan.
+///
+/// This is equivalent to FoundationDB's `strinc` helper: the smallest key strictly greater
+/// than all keys that begin with @p prefix.
+///
+/// @throws std::invalid_argument if @p prefix is empty or all 0xFF bytes and has no finite upper
+/// bound.
+inline Key prefixEnd(Key prefix) {
+	for (size_t i = prefix.size(); i > 0; --i) {
+		if (prefix[i - 1] != 0xFF) {
+			++prefix[i - 1];
+			prefix.resize(i);
+			return prefix;
+		}
+	}
+
+	throw std::invalid_argument("Prefix has no finite upper bound");
+}
+
 /// Converts integral types to a vector of uint8_t encoded in little-endian order.
 template <typename T>
     requires(std::is_integral_v<T>)

--- a/src/kv/kv_utils_unittest.cc
+++ b/src/kv/kv_utils_unittest.cc
@@ -44,6 +44,54 @@ TEST(KVUtilsTest, ToBytes) {
 	EXPECT_EQ(result, expected);
 }
 
+TEST(KVUtilsTest, PrefixEnd) {
+	// Normal case: last byte incremented, length preserved
+	{
+		kv::Key prefix = {0x01, 0x02};
+		kv::Key expected = {0x01, 0x03};
+		EXPECT_EQ(kv::prefixEnd(prefix), expected);
+	}
+
+	// Last byte is 0xFF: carry into previous byte and truncate
+	{
+		kv::Key prefix = {0x01, 0xFF};
+		kv::Key expected = {0x02};
+		EXPECT_EQ(kv::prefixEnd(prefix), expected);
+	}
+
+	// Multiple trailing 0xFF bytes: carry and truncate all of them
+	{
+		kv::Key prefix = {0x01, 0xFF, 0xFF};
+		kv::Key expected = {0x02};
+		EXPECT_EQ(kv::prefixEnd(prefix), expected);
+	}
+
+	// Single byte, not 0xFF: just increment
+	{
+		kv::Key prefix = {0x42};
+		kv::Key expected = {0x43};
+		EXPECT_EQ(kv::prefixEnd(prefix), expected);
+	}
+
+	// All 0xFF bytes: no finite upper bound, must throw
+	{
+		kv::Key prefix = {0xFF, 0xFF};
+		EXPECT_THROW(kv::prefixEnd(prefix), std::invalid_argument);
+	}
+
+	// Single 0xFF byte: no finite upper bound, must throw
+	{
+		kv::Key prefix = {0xFF};
+		EXPECT_THROW(kv::prefixEnd(prefix), std::invalid_argument);
+	}
+
+	// Empty prefix: no finite upper bound, must throw
+	{
+		kv::Key prefix = {};
+		EXPECT_THROW(kv::prefixEnd(prefix), std::invalid_argument);
+	}
+}
+
 TEST(KVUtilsTest, ToBytesLE) {
 	// Test uint8_t (single byte - endianness doesn't matter)
 	{


### PR DESCRIPTION
Add `prefixEnd` helper to kv_utils.h, equivalent to FoundationDB's `strinc`: computes the smallest key strictly greater than all keys with a given prefix by scanning from the rightmost byte, incrementing the first non-0xFF byte, and truncating the rest. Throws `std::invalid_argument` for all-0xFF inputs.

Add unit tests covering: normal increment, single/multiple trailing 0xFF bytes with carry and truncation, single-byte input, and the all-0xFF throw case.

Related to: LS-71