### PR TITLE
refactor(master): allow lock ops in KV backends

### DIFF
--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -1827,7 +1827,9 @@ uint8_t FilesystemOperationsBase::append(const FsContext &context,
 	return status;
 }
 
-static int fsnodes_check_lock_permissions(const FsContext &context, inode_t inode, uint16_t op) {
+int FilesystemOperationsBase::checkLockPermissions(const FsContext &context,
+                                                   const FilesystemOperationContext &fsOpContext,
+                                                   inode_t inode, uint16_t op) {
 	FSNode *dummy;
 	uint8_t modemask = MODE_MASK_EMPTY;
 
@@ -1837,27 +1839,24 @@ static int fsnodes_check_lock_permissions(const FsContext &context, inode_t inod
 		modemask = MODE_MASK_R;
 	}
 
-	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
-	    FilesystemOperationContext::TransactionType::kReadOnly);
-
 	return gFSOperations->nodeOperations()->getNodeForOperation(
 	    context, fsOpContext, ExpectedNodeType::kAny, modemask, inode, &dummy);
 }
 
-int FilesystemOperationsBase::posixLockProbe(const FsContext &context, inode_t inode,
-                                             uint64_t start, uint64_t end, uint64_t owner,
-                                             uint32_t sessionid, uint32_t reqid, uint32_t msgid,
-                                             uint16_t oper, safs_locks::FlockWrapper &info) {
-	uint8_t status;
-
+int FilesystemOperationsBase::posixLockProbe(const FsContext &context,
+                                             const FilesystemOperationContext &fsOpContext,
+                                             inode_t inode, uint64_t start, uint64_t end,
+                                             uint64_t owner, uint32_t sessionid, uint32_t reqid,
+                                             uint32_t msgid, uint16_t oper,
+                                             safs_locks::FlockWrapper &info) {
 	if (oper != safs_locks::kShared && oper != safs_locks::kExclusive &&
 	    oper != safs_locks::kUnlock) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
 
-	if ((status = fsnodes_check_lock_permissions(context, inode, oper)) != SAUNAFS_STATUS_OK) {
-		return status;
-	}
+	uint8_t status = checkLockPermissions(context, fsOpContext, inode, oper);
+
+	if (status != SAUNAFS_STATUS_OK) { return status; }
 
 	FileLocks &locks = gMetadata->posixLocks;
 	const FileLocks::Lock *collision;
@@ -1877,16 +1876,13 @@ int FilesystemOperationsBase::posixLockProbe(const FsContext &context, inode_t i
 	}
 }
 
-int FilesystemOperationsBase::lockOperation(const FsContext &context, FileLocks &locks,
-                                            inode_t inode, uint64_t start, uint64_t end,
-                                            uint64_t owner, uint32_t sessionid, uint32_t reqid,
-                                            uint32_t msgid, uint16_t oper, bool nonblocking,
-                                            std::vector<FileLocks::Owner> &applied) {
-	uint8_t status;
+int FilesystemOperationsBase::lockOperation(
+    const FsContext &context, const FilesystemOperationContext &fsOpContext, FileLocks &locks,
+    inode_t inode, uint64_t start, uint64_t end, uint64_t owner, uint32_t sessionid, uint32_t reqid,
+    uint32_t msgid, uint16_t oper, bool nonblocking, std::vector<FileLocks::Owner> &applied) {
+	uint8_t status = checkLockPermissions(context, fsOpContext, inode, oper);
 
-	if ((status = fsnodes_check_lock_permissions(context, inode, oper)) != SAUNAFS_STATUS_OK) {
-		return status;
-	}
+	if (status != SAUNAFS_STATUS_OK) { return status; }
 
 	FileLocks::LockQueue queue;
 	bool success = false;
@@ -1936,13 +1932,15 @@ int FilesystemOperationsBase::lockOperation(const FsContext &context, FileLocks 
 	return status;
 }
 
-int FilesystemOperationsBase::flockOperation(const FsContext &context, inode_t inode,
-                                             uint64_t owner, uint32_t sessionid, uint32_t reqid,
-                                             uint32_t msgid, uint16_t oper, bool nonblocking,
+int FilesystemOperationsBase::flockOperation(const FsContext &context,
+                                             const FilesystemOperationContext &fsOpContext,
+                                             inode_t inode, uint64_t owner, uint32_t sessionid,
+                                             uint32_t reqid, uint32_t msgid, uint16_t oper,
+                                             bool nonblocking,
                                              std::vector<FileLocks::Owner> &applied) {
 	ChecksumUpdater cu(context.ts());
-	int ret = lockOperation(context, gMetadata->flockLocks, inode, 0, 1, owner, sessionid, reqid,
-	                        msgid, oper, nonblocking, applied);
+	int ret = lockOperation(context, fsOpContext, gMetadata->flockLocks, inode, 0, 1, owner,
+	                        sessionid, reqid, msgid, oper, nonblocking, applied);
 	if (context.isPersonalityMaster()) {
 		changeLog(context.ts(),
 		          "FLCK(%" PRIu8 ",%" PRIiNode ",0,1,%" PRIu64 ",%" PRIu32 ",%" PRIu16 ")",
@@ -1954,14 +1952,15 @@ int FilesystemOperationsBase::flockOperation(const FsContext &context, inode_t i
 	return ret;
 }
 
-int FilesystemOperationsBase::posixLockOperation(const FsContext &context, inode_t inode,
-                                                 uint64_t start, uint64_t end, uint64_t owner,
-                                                 uint32_t sessionid, uint32_t reqid, uint32_t msgid,
-                                                 uint16_t oper, bool nonblocking,
+int FilesystemOperationsBase::posixLockOperation(const FsContext &context,
+                                                 const FilesystemOperationContext &fsOpContext,
+                                                 inode_t inode, uint64_t start, uint64_t end,
+                                                 uint64_t owner, uint32_t sessionid, uint32_t reqid,
+                                                 uint32_t msgid, uint16_t oper, bool nonblocking,
                                                  std::vector<FileLocks::Owner> &applied) {
 	ChecksumUpdater cu(context.ts());
-	int ret = lockOperation(context, gMetadata->posixLocks, inode, start, end, owner, sessionid,
-	                        reqid, msgid, oper, nonblocking, applied);
+	int ret = lockOperation(context, fsOpContext, gMetadata->posixLocks, inode, start, end, owner,
+	                        sessionid, reqid, msgid, oper, nonblocking, applied);
 	if (context.isPersonalityMaster()) {
 		changeLog(context.ts(),
 		          "FLCK(%" PRIu8 ",%" PRIiNode ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu32
@@ -1973,9 +1972,9 @@ int FilesystemOperationsBase::posixLockOperation(const FsContext &context, inode
 	return ret;
 }
 
-int FilesystemOperationsBase::locksClearSession(const FsContext &context, uint8_t type,
-                                                inode_t inode, uint32_t sessionid,
-                                                std::vector<FileLocks::Owner> &applied) {
+int FilesystemOperationsBase::locksClearSession(
+    const FsContext &context, [[maybe_unused]] const FilesystemOperationContext &fsOpContext,
+    uint8_t type, inode_t inode, uint32_t sessionid, std::vector<FileLocks::Owner> &applied) {
 	if (type != (uint8_t)safs_locks::Type::kFlock && type != (uint8_t)safs_locks::Type::kPosix) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
@@ -2010,10 +2009,10 @@ int FilesystemOperationsBase::locksClearSession(const FsContext &context, uint8_
 	return SAUNAFS_STATUS_OK;
 }
 
-int FilesystemOperationsBase::locksListAll(const FsContext &context, uint8_t type, bool pending,
-                                           uint64_t start, uint64_t max,
-                                           std::vector<safs_locks::Info> &outLocks) {
-	(void)context;
+int FilesystemOperationsBase::locksListAll(
+    [[maybe_unused]] const FsContext &context,
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, uint8_t type, bool pending,
+    uint64_t start, uint64_t max, std::vector<safs_locks::Info> &outLocks) {
 	FileLocks *locks;
 	if (type == (uint8_t)safs_locks::Type::kFlock) {
 		locks = &gMetadata->flockLocks;
@@ -2032,10 +2031,10 @@ int FilesystemOperationsBase::locksListAll(const FsContext &context, uint8_t typ
 	return SAUNAFS_STATUS_OK;
 }
 
-int FilesystemOperationsBase::locksListInode(const FsContext &context, uint8_t type, bool pending,
-                                             inode_t inode, uint64_t start, uint64_t max,
-                                             std::vector<safs_locks::Info> &outLocks) {
-	(void)context;
+int FilesystemOperationsBase::locksListInode(
+    [[maybe_unused]] const FsContext &context,
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, uint8_t type, bool pending,
+    inode_t inode, uint64_t start, uint64_t max, std::vector<safs_locks::Info> &outLocks) {
 	FileLocks *locks;
 
 	if (type == (uint8_t)safs_locks::Type::kFlock) {
@@ -2067,9 +2066,9 @@ void FilesystemOperationsBase::manageLockTryLockPending(FileLocks &locks, inode_
 	}
 }
 
-int FilesystemOperationsBase::locksUnlockInode(const FsContext &context, uint8_t type,
-                                               inode_t inode,
-                                               std::vector<FileLocks::Owner> &applied) {
+int FilesystemOperationsBase::locksUnlockInode(
+    const FsContext &context, [[maybe_unused]] const FilesystemOperationContext &fsOpContext,
+    uint8_t type, inode_t inode, std::vector<FileLocks::Owner> &applied) {
 	ChecksumUpdater cu(context.ts());
 
 	if (type == (uint8_t)safs_locks::Type::kFlock) {
@@ -2092,9 +2091,9 @@ int FilesystemOperationsBase::locksUnlockInode(const FsContext &context, uint8_t
 	return SAUNAFS_STATUS_OK;
 }
 
-int FilesystemOperationsBase::locksRemovePending(const FsContext &context, uint8_t type,
-                                                 uint64_t ownerid, uint32_t sessionid,
-                                                 inode_t inode, uint64_t reqid) {
+int FilesystemOperationsBase::locksRemovePending(
+    const FsContext &context, [[maybe_unused]] const FilesystemOperationContext &fsOpContext,
+    uint8_t type, uint64_t ownerid, uint32_t sessionid, inode_t inode, uint64_t reqid) {
 	ChecksumUpdater cu(context.ts());
 
 	FileLocks *locks;

--- a/src/master/filesystem_operations.h
+++ b/src/master/filesystem_operations.h
@@ -447,49 +447,55 @@ public:
 	// Locks
 
 	/// Perform a flock operation on filesystem.
-	/// @see IFilesystemOperations::fs_flock_op.
-	int flockOperation(const FsContext &context, inode_t inode, uint64_t owner, uint32_t sessionid,
-	                   uint32_t reqid, uint32_t msgid, uint16_t oper, bool nonblocking,
+	/// @see IFilesystemOperations::flockOperation.
+	int flockOperation(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                   inode_t inode, uint64_t owner, uint32_t sessionid, uint32_t reqid,
+	                   uint32_t msgid, uint16_t oper, bool nonblocking,
 	                   std::vector<FileLocks::Owner> &applied) override;
 
 	/// Perform a posix lock operation on filesystem.
-	/// @see IFilesystemOperations::fs_posixlock_op.
-	int posixLockOperation(const FsContext &context, inode_t inode, uint64_t start, uint64_t end,
-	                       uint64_t owner, uint32_t sessionid, uint32_t reqid, uint32_t msgid,
-	                       uint16_t oper, bool nonblocking,
-	                       std::vector<FileLocks::Owner> &applied) override;
+	/// @see IFilesystemOperations::posixLockOperation.
+	int posixLockOperation(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                       inode_t inode, uint64_t start, uint64_t end, uint64_t owner,
+	                       uint32_t sessionid, uint32_t reqid, uint32_t msgid, uint16_t oper,
+	                       bool nonblocking, std::vector<FileLocks::Owner> &applied) override;
 
 	/// Perform a POSIX lock probe on filesystem.
-	/// @see IFilesystemOperations::fs_posixlock_probe.
-	int posixLockProbe(const FsContext &context, inode_t inode, uint64_t start, uint64_t end,
-	                   uint64_t owner, uint32_t sessionid, uint32_t reqid, uint32_t msgid,
-	                   uint16_t oper, safs_locks::FlockWrapper &info) override;
+	/// @see IFilesystemOperations::posixLockProbe.
+	int posixLockProbe(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                   inode_t inode, uint64_t start, uint64_t end, uint64_t owner,
+	                   uint32_t sessionid, uint32_t reqid, uint32_t msgid, uint16_t oper,
+	                   safs_locks::FlockWrapper &info) override;
 
 	/// Release (unlock + unqueue) all locks from a given session.
-	/// @see IFilesystemOperations::fs_locks_clear_session.
-	int locksClearSession(const FsContext &context, uint8_t type, inode_t inode, uint32_t sessionid,
+	/// @see IFilesystemOperations::locksClearSession.
+	int locksClearSession(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                      uint8_t type, inode_t inode, uint32_t sessionid,
 	                      std::vector<FileLocks::Owner> &applied) override;
 
 	/// List locks in the filesystem.
-	/// @see IFilesystemOperations::fs_locks_list_all.
-	int locksListAll(const FsContext &context, uint8_t type, bool pending, uint64_t start,
-	                 uint64_t max, std::vector<safs_locks::Info> &outLocks) override;
+	/// @see IFilesystemOperations::locksListAll.
+	int locksListAll(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                 uint8_t type, bool pending, uint64_t start, uint64_t max,
+	                 std::vector<safs_locks::Info> &outLocks) override;
 
 	/// List locks for a specific inode.
-	/// @see IFilesystemOperations::fs_locks_list_inode.
-	int locksListInode(const FsContext &context, uint8_t type, bool pending, inode_t inode,
-	                   uint64_t start, uint64_t max,
+	/// @see IFilesystemOperations::locksListInode.
+	int locksListInode(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                   uint8_t type, bool pending, inode_t inode, uint64_t start, uint64_t max,
 	                   std::vector<safs_locks::Info> &outLocks) override;
 
 	/// Unlocks the matching locks on the specified inode and tries to apply pending locks.
-	/// @see IFilesystemOperations::fs_locks_unlock_inode.
-	int locksUnlockInode(const FsContext &context, uint8_t type, inode_t inode,
+	/// @see IFilesystemOperations::locksUnlockInode.
+	int locksUnlockInode(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                     uint8_t type, inode_t inode,
 	                     std::vector<FileLocks::Owner> &applied) override;
 
 	/// Removes a pending lock matching the provided parameters.
-	/// @see IFilesystemOperations::fs_locks_remove_pending.
-	int locksRemovePending(const FsContext &context, uint8_t type, uint64_t ownerid,
-	                       uint32_t sessionid, inode_t inode, uint64_t reqid) override;
+	/// @see IFilesystemOperations::locksRemovePending.
+	int locksRemovePending(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                       uint8_t type, uint64_t ownerid, uint32_t sessionid, inode_t inode,
+	                       uint64_t reqid) override;
 
 protected:
 	/// Backend-specific hook for retrieving an xattr value.
@@ -527,17 +533,27 @@ protected:
 	    uint8_t anleng, const uint8_t *attrname, uint32_t avleng, const uint8_t *attrvalue,
 	    uint32_t mode);
 
+	/// Permission check for lock operations.
+	/// Validates that the caller has appropriate read/write access for the
+	/// requested lock type. Shared by posixLockProbe and lockOperation.
+	static int checkLockPermissions(const FsContext &context,
+	                                const FilesystemOperationContext &fsOpContext, inode_t inode,
+	                                uint16_t op);
+
+	/// Core lock operation logic shared by flockOperation and posixLockOperation.
+	/// Operates on the given FileLocks reference, enabling KV overrides to pass
+	/// a temporary FileLocks loaded from FDB instead of gMetadata.
+	int lockOperation(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                  FileLocks &locks, inode_t inode, uint64_t start, uint64_t end, uint64_t owner,
+	                  uint32_t sessionid, uint32_t reqid, uint32_t msgid, uint16_t oper,
+	                  bool nonblocking, std::vector<FileLocks::Owner> &applied);
+
+	/// Try applying pending locks after an unlock.
+	/// Operates on the given FileLocks reference for the same reason as lockOperation.
+	void manageLockTryLockPending(FileLocks &locks, inode_t inode, uint64_t start, uint64_t end,
+	                              std::vector<FileLocks::Owner> &applied);
+
 private:
-	/// Helper function used internally by `fs_flock_op` and `fs_posixlock_op`.
-	static int lockOperation(const FsContext &context, FileLocks &locks, inode_t inode,
-	                         uint64_t start, uint64_t end, uint64_t owner, uint32_t sessionid,
-	                         uint32_t reqid, uint32_t msgid, uint16_t oper, bool nonblocking,
-	                         std::vector<FileLocks::Owner> &applied);
-
-	/// Helper function used internally by `fs_locks_unlock_inode`.
-	static void manageLockTryLockPending(FileLocks &locks, inode_t inode, uint64_t start,
-	                                     uint64_t end, std::vector<FileLocks::Owner> &applied);
-
 	/// Node operations object
 	std::unique_ptr<IFilesystemNodeOperations> nodeOperations_;
 };

--- a/src/master/filesystem_operations_interface.h
+++ b/src/master/filesystem_operations_interface.h
@@ -1289,6 +1289,7 @@ public:
 	/// Supports placing and removing whole-file shared/exclusive advisory locks, removing pending
 	/// requests and handling interruptible requests.
 	/// @param context Filesystem context.
+	/// @param fsOpContext The operation context carrying a transaction in KV backends.
 	/// @param inode Target inode for the flock operation.
 	/// @param owner Owner identifier provided by the client.
 	/// @param sessionid Session id of the requesting client.
@@ -1302,15 +1303,18 @@ public:
 	/// @return `SAUNAFS_STATUS_OK` on success, `SAUNAFS_ERROR_WAITING` if the request
 	///         cannot be granted immediately, `SAUNAFS_ERROR_EINVAL` for invalid args,
 	///         or other filesystem-specific error codes (permission, quota, etc.).
-	virtual int flockOperation(const FsContext &context, inode_t inode, uint64_t owner,
-	                           uint32_t sessionid, uint32_t reqid, uint32_t msgid, uint16_t oper,
-	                           bool nonblocking, std::vector<FileLocks::Owner> &applied) = 0;
+	virtual int flockOperation(const FsContext &context,
+	                           const FilesystemOperationContext &fsOpContext, inode_t inode,
+	                           uint64_t owner, uint32_t sessionid, uint32_t reqid, uint32_t msgid,
+	                           uint16_t oper, bool nonblocking,
+	                           std::vector<FileLocks::Owner> &applied) = 0;
 
 	/// Perform a POSIX byte-range (fcntl) lock operation on the filesystem.
 	///
 	/// Handles POSIX (fcntl) style byte-range locks: place shared/exclusive locks,
 	/// release ranges, enqueue pending requests and handle interruptible requests.
 	/// @param context Filesystem context (permissions, timestamp, personality, ...).
+	/// @param fsOpContext The operation context carrying a transaction in KV backends.
 	/// @param inode Target inode on which the byte-range lock is requested.
 	/// @param start Start offset of the range (inclusive).
 	/// @param end End offset of the range (exclusive).
@@ -1326,15 +1330,17 @@ public:
 	/// @return `SAUNAFS_STATUS_OK` on success, `SAUNAFS_ERROR_WAITING` if the request
 	///         cannot be granted immediately, `SAUNAFS_ERROR_EINVAL` for invalid args,
 	///         or other filesystem-specific error codes (permission, quota, etc.).
-	virtual int posixLockOperation(const FsContext &context, inode_t inode, uint64_t start,
-	                               uint64_t end, uint64_t owner, uint32_t sessionid, uint32_t reqid,
-	                               uint32_t msgid, uint16_t oper, bool nonblocking,
+	virtual int posixLockOperation(const FsContext &context,
+	                               const FilesystemOperationContext &fsOpContext, inode_t inode,
+	                               uint64_t start, uint64_t end, uint64_t owner, uint32_t sessionid,
+	                               uint32_t reqid, uint32_t msgid, uint16_t oper, bool nonblocking,
 	                               std::vector<FileLocks::Owner> &applied) = 0;
 
 	/// Perform a POSIX lock probe on filesystem.
 	/// A POSIX probe checks whether a lock request (shared/exclusive) would be blocked
 	/// by existing locks without placing a lock.
 	/// @param context Filesystem context.
+	/// @param fsOpContext The operation context carrying a transaction in KV backends.
 	/// @param inode Inode number on which to probe locks.
 	/// @param start Start of the range to probe.
 	/// @param end End of the range to probe.
@@ -1349,59 +1355,74 @@ public:
 	/// @return SAUNAFS_STATUS_OK if no conflicting lock was found (info.l_type set to kUnlock),
 	///         SAUNAFS_ERROR_WAITING if a conflicting lock was found (info filled),
 	///         SAUNAFS_ERROR_EINVAL for invalid parameters.
-	virtual int posixLockProbe(const FsContext &context, inode_t inode, uint64_t start,
-	                           uint64_t end, uint64_t owner, uint32_t sessionid, uint32_t reqid,
-	                           uint32_t msgid, uint16_t oper, safs_locks::FlockWrapper &info) = 0;
+	virtual int posixLockProbe(const FsContext &context,
+	                           const FilesystemOperationContext &fsOpContext, inode_t inode,
+	                           uint64_t start, uint64_t end, uint64_t owner, uint32_t sessionid,
+	                           uint32_t reqid, uint32_t msgid, uint16_t oper,
+	                           safs_locks::FlockWrapper &info) = 0;
 
 	/// Release (unlock + unqueue) all locks from a given session.
 	/// @param context Filesystem context.
+	/// @param fsOpContext The operation context carrying a transaction in KV backends.
 	/// @param type Type of locks to clear (kFlock, kPosix).
 	/// @param inode inode number on which to clear locks.
 	/// @param sessionid Session id whose locks are to be cleared.
 	/// @param applied Vector to be filled with the owners of the cleared locks.
-	virtual int locksClearSession(const FsContext &context, uint8_t type, inode_t inode,
-	                              uint32_t sessionid, std::vector<FileLocks::Owner> &applied) = 0;
+	virtual int locksClearSession(const FsContext &context,
+	                              const FilesystemOperationContext &fsOpContext, uint8_t type,
+	                              inode_t inode, uint32_t sessionid,
+	                              std::vector<FileLocks::Owner> &applied) = 0;
 
 	/// List locks in the filesystem.
 	/// Fills outLocks with locks matching the type and pending parameters.
 	/// @param context Filesystem context (could be ignored in some implementations).
+	/// @param fsOpContext The operation context carrying a transaction in KV backends.
 	/// @param type Type of locks to list (kFlock, kPosix).
 	/// @param pending If true, lists pending locks, otherwise lists active locks.
 	/// @param start Start index for listing.
 	/// @param max Maximum number of locks to list.
 	/// @param outLocks Vector to be filled with the listed locks.
-	virtual int locksListAll(const FsContext &context, uint8_t type, bool pending, uint64_t start,
-	                         uint64_t max, std::vector<safs_locks::Info> &outLocks) = 0;
+	virtual int locksListAll(const FsContext &context,
+	                         const FilesystemOperationContext &fsOpContext, uint8_t type,
+	                         bool pending, uint64_t start, uint64_t max,
+	                         std::vector<safs_locks::Info> &outLocks) = 0;
 
 	/// List locks for a specific inode.
 	/// @param context Filesystem context (could be ignored in some implementations).
+	/// @param fsOpContext The operation context carrying a transaction in KV backends.
 	/// @param type Type of locks to list (kFlock, kPosix).
 	/// @param pending If true, lists pending locks, otherwise lists active locks.
 	/// @param inode inode number on which to list locks.
 	/// @param start Start index for listing.
 	/// @param max Maximum number of locks to list.
 	/// @param outLocks Vector to be filled with the listed locks.
-	virtual int locksListInode(const FsContext &context, uint8_t type, bool pending, inode_t inode,
-	                           uint64_t start, uint64_t max,
+	virtual int locksListInode(const FsContext &context,
+	                           const FilesystemOperationContext &fsOpContext, uint8_t type,
+	                           bool pending, inode_t inode, uint64_t start, uint64_t max,
 	                           std::vector<safs_locks::Info> &outLocks) = 0;
 
 	/// Unlocks the matching locks on the specified inode and tries to apply pending locks.
 	/// @param context Filesystem context.
+	/// @param fsOpContext The operation context carrying a transaction in KV backends.
 	/// @param type Type of locks to unlock (kFlock, kPosix).
 	/// @param inode inode number on which to unlock locks.
 	/// @param applied Vector to be filled with the owners of the unlocked locks.
-	virtual int locksUnlockInode(const FsContext &context, uint8_t type, inode_t inode,
-	                             std::vector<FileLocks::Owner> &applied) = 0;
+	virtual int locksUnlockInode(const FsContext &context,
+	                             const FilesystemOperationContext &fsOpContext, uint8_t type,
+	                             inode_t inode, std::vector<FileLocks::Owner> &applied) = 0;
 
 	/// Removes a pending lock matching the provided parameters.
 	/// @param context Filesystem context.
+	/// @param fsOpContext The operation context carrying a transaction in KV backends.
 	/// @param type Type of lock to operate on (kFlock, kPosix).
 	/// @param ownerid Owner identifier provided by the client (FUSE owner typically).
 	/// @param sessionid Session id of the client that enqueued the lock.
 	/// @param inode Inode number on which the pending lock was queued.
 	/// @param reqid Request id (used to identify interruptible requests).
-	virtual int locksRemovePending(const FsContext &context, uint8_t type, uint64_t ownerid,
-	                               uint32_t sessionid, inode_t inode, uint64_t reqid) = 0;
+	virtual int locksRemovePending(const FsContext &context,
+	                               const FilesystemOperationContext &fsOpContext, uint8_t type,
+	                               uint64_t ownerid, uint32_t sessionid, inode_t inode,
+	                               uint64_t reqid) = 0;
 };
 
 // Global filesystem operations instance.

--- a/src/master/kv_common_keys.h
+++ b/src/master/kv_common_keys.h
@@ -98,6 +98,17 @@ inline constexpr std::string_view kACLsKeyPrefix = "ACLS_";    // Section ACLS 1
 /// @note Numeric fields in the key are serialized as Big Endian to preserve numeric order in
 /// lexicographical sorting, enabling efficient scans by owner prefix and global quota prefix.
 inline constexpr std::string_view kQuotasKeyPrefix = "QUOT_";  // Section QUOT 1.1
+
+/// Prefix for locks
+/// Format: FLCK_<InodeId:BE><Type:u8><Status:u8> → serialized lock entries
+/// - InodeId: inode_t serialized as Big Endian (enables per-inode prefix scan)
+/// - Type: u8 (safs_locks::Type – kFlock or kPosix)
+/// - Status: u8 (0 = active, 1 = pending)
+/// @note Inode-first key layout allows efficient per-inode scans using
+/// prefix FLCK_<InodeId>. Numeric fields in the key are serialized as
+/// Big Endian to preserve numeric order in lexicographical sorting.
+/// The value contains all lock entries for the given (inode, type, status)
+/// tuple, serialized as a contiguous sequence via FileLocks serialization.
 inline constexpr std::string_view kLocksKeyPrefix = "FLCK_";   // Section FLCK 1.0
 
 // Case-insensitive directory support

--- a/src/master/locks.h
+++ b/src/master/locks.h
@@ -23,6 +23,7 @@
 #include "common/platform.h"
 
 #include <unordered_map>
+#include <utility>
 
 #include "common/compact_vector.h"
 #include "common/memory_mapped_file.h"
@@ -343,6 +344,27 @@ public:
 
 	/*! \brief Removes all locks from the class. */
 	void clear();
+
+	/// Inserts a lock directly into the active set (for restoring from KV).
+	void insertActive(inode_t inode, Lock lock) { active_locks_[inode].insert(lock); }
+
+	/// Inserts a lock directly into the pending queue (for restoring from KV).
+	void insertPending(inode_t inode, Lock lock) {
+		LockQueue &queue = pending_locks_[inode];
+		queue.insert(std::lower_bound(queue.begin(), queue.end(), lock), std::move(lock));
+	}
+
+	/// Returns the active lock set for a given inode, or nullptr if none.
+	const Locks *getActiveLocks(inode_t inode) const {
+		auto iter = active_locks_.find(inode);
+		return iter != active_locks_.end() ? &iter->second : nullptr;
+	}
+
+	/// Returns the pending lock queue for a given inode, or nullptr if none.
+	const LockQueue *getPendingLocks(inode_t inode) const {
+		auto iter = pending_locks_.find(inode);
+		return iter != pending_locks_.end() ? &iter->second : nullptr;
+	}
 
 	FileLocks(const FileLocks &other) = delete;
 	FileLocks(FileLocks &&other) = delete;

--- a/src/master/locks_unittest.cc
+++ b/src/master/locks_unittest.cc
@@ -323,3 +323,63 @@ TEST(LocksTest, Unqueue) {
 
 	locks.clear();
 }
+
+// KV restore API tests (insertActive / insertPending / getActiveLocks / getPendingLocks)
+
+TEST(LocksTest, GettersReturnNullptrForMissingInode) {
+	FileLocks locks;
+
+	EXPECT_EQ(nullptr, locks.getActiveLocks(99));
+	EXPECT_EQ(nullptr, locks.getPendingLocks(99));
+}
+
+TEST(LocksTest, InsertActiveMakesLockQueryable) {
+	FileLocks locks;
+	const inode_t inode = 7;
+
+	EXPECT_EQ(nullptr, locks.getActiveLocks(inode));
+
+	FileLocks::Lock lock(LockRange::Type::kExclusive, 0, 10, owners[0]);
+	locks.insertActive(inode, lock);
+
+	const FileLocks::Locks *active = locks.getActiveLocks(inode);
+	ASSERT_NE(nullptr, active);
+	EXPECT_EQ(1U, active->size());
+
+	// Another owner must collide with the inserted active lock
+	const FileLocks::Lock *collision =
+	    locks.findCollision(inode, LockRange::Type::kExclusive, 0, 10, owners[1]);
+	ASSERT_NE(nullptr, collision);
+	EXPECT_EQ(0U, collision->start);
+	EXPECT_EQ(10U, collision->end);
+
+	locks.clear();
+}
+
+TEST(LocksTest, InsertPendingPreservesSortOrder) {
+	FileLocks locks;
+	const inode_t inode = 42;
+
+	EXPECT_EQ(nullptr, locks.getPendingLocks(inode));
+
+	// Insert out of order: [50,60), [10,20), [30,40)
+	locks.insertPending(inode, FileLocks::Lock(LockRange::Type::kExclusive, 50, 60, owners[0]));
+	locks.insertPending(inode, FileLocks::Lock(LockRange::Type::kExclusive, 10, 20, owners[1]));
+	locks.insertPending(inode, FileLocks::Lock(LockRange::Type::kExclusive, 30, 40, owners[2]));
+
+	// Queue must be sorted by start position regardless of insertion order
+	const FileLocks::LockQueue *queue = locks.getPendingLocks(inode);
+	ASSERT_NE(nullptr, queue);
+	ASSERT_EQ(3U, queue->size());
+	EXPECT_EQ(10U, (*queue)[0].start);
+	EXPECT_EQ(30U, (*queue)[1].start);
+	EXPECT_EQ(50U, (*queue)[2].start);
+
+	// gatherCandidates must correctly identify locks that overlap [25, 35):
+	// [10,20) is a predecessor candidate (first-- logic) and [30,40) overlaps.
+	FileLocks::LockQueue candidates;
+	locks.gatherCandidates(inode, 25, 35, candidates);
+	EXPECT_EQ(2U, candidates.size());
+
+	locks.clear();
+}

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -4469,8 +4469,21 @@ void matoclserv_fuse_flock(matoclserventry *eptr, const uint8_t *data, uint32_t 
 	}
 
 	std::vector<FileLocks::Owner> applied;
-	status = gFSOperations->flockOperation(context, inode, owner, eptr->sessionData->sessionId,
-	                                       requestId, messageId, op, nonblocking, applied);
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
+	status = gFSOperations->flockOperation(context, fsOpContext, inode, owner,
+	                                       eptr->sessionData->sessionId, requestId, messageId, op,
+	                                       nonblocking, applied);
+
+	if ((status == SAUNAFS_STATUS_OK || status == SAUNAFS_ERROR_WAITING) &&
+	    fsOpContext.hasReadWriteTransaction()) {
+		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+			safs::log_err("{}: transaction failed to commit: inode {}", __func__, inode);
+			status = SAUNAFS_ERROR_IO;
+			applied.clear();
+		}
+	}
 
 	matoclserv_lock_wake_up(applied, safs_locks::Type::kFlock);
 
@@ -4510,8 +4523,11 @@ void matoclserv_fuse_getlk(matoclserventry *eptr, const uint8_t *data, uint32_t 
 		lock_end = (uint64_t)lock_info.l_start + (uint64_t)lock_info.l_len;
 	}
 
-	status = gFSOperations->posixLockProbe(context, inode, lock_info.l_start, lock_end, owner,
-	                                       eptr->sessionData->sessionId, 0, message_id,
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadOnly);
+
+	status = gFSOperations->posixLockProbe(context, fsOpContext, inode, lock_info.l_start, lock_end,
+	                                       owner, eptr->sessionData->sessionId, 0, message_id,
 	                                       lock_info.l_type, lock_info);
 
 	// Standard states that lock of length 0 is a lock till EOF
@@ -4564,9 +4580,21 @@ void matoclserv_fuse_setlk(matoclserventry *eptr, const uint8_t *data, uint32_t 
 	}
 
 	std::vector<FileLocks::Owner> applied;
-	status = gFSOperations->posixLockOperation(context, inode, lock_info.l_start, lock_end, owner,
-	                                           eptr->sessionData->sessionId, request_id, message_id,
-	                                           op, nonblocking, applied);
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
+	status = gFSOperations->posixLockOperation(context, fsOpContext, inode, lock_info.l_start,
+	                                           lock_end, owner, eptr->sessionData->sessionId,
+	                                           request_id, message_id, op, nonblocking, applied);
+
+	if ((status == SAUNAFS_STATUS_OK || status == SAUNAFS_ERROR_WAITING) &&
+	    fsOpContext.hasReadWriteTransaction()) {
+		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+			safs::log_err("{}: transaction failed to commit: inode {}", __func__, inode);
+			status = SAUNAFS_ERROR_IO;
+			applied.clear();
+		}
+	}
 
 	matoclserv_lock_wake_up(applied, safs_locks::Type::kPosix);
 
@@ -4611,15 +4639,19 @@ void matoclserv_manage_locks_list(matoclserventry *eptr, const uint8_t *data, ui
 
 	deserializePacketVersionNoHeader(data, length, version);
 
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadOnly);
+
 	if (version == cltoma::manageLocksList::kAll) {
 		cltoma::manageLocksList::deserialize(data, length, type, pending, start, max);
 		max = std::min(max, SAU_CLTOMA_MANAGE_LOCKS_LIST_LIMIT);
-		status = gFSOperations->locksListAll(context, (uint8_t)type, pending, start, max, locks);
+		status = gFSOperations->locksListAll(context, fsOpContext, (uint8_t)type, pending, start,
+		                                     max, locks);
 	} else if (version == cltoma::manageLocksList::kInode) {
 		cltoma::manageLocksList::deserialize(data, length, inode, type, pending, start, max);
 		max = std::min(max, SAU_CLTOMA_MANAGE_LOCKS_LIST_LIMIT);
-		status = gFSOperations->locksListInode(context, (uint8_t)type, pending, inode, start, max,
-		                                       locks);
+		status = gFSOperations->locksListInode(context, fsOpContext, (uint8_t)type, pending, inode,
+		                                       start, max, locks);
 	} else {
 		throw IncorrectDeserializationException(
 				"Unknown SAU_CLTOMA_MANAGE_LOCKS_LIST version: " + std::to_string(version));
@@ -4656,6 +4688,9 @@ void matoclserv_manage_locks_unlock(matoclserventry *eptr, const uint8_t *data, 
 
 	deserializePacketVersionNoHeader(data, length, version);
 
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
 	if (version == cltoma::manageLocksUnlock::kSingle) {
 		cltoma::manageLocksUnlock::deserialize(data, length, type, inode, sessionid, owner, start,
 		                                       end);
@@ -4664,29 +4699,38 @@ void matoclserv_manage_locks_unlock(matoclserventry *eptr, const uint8_t *data, 
 			end = std::numeric_limits<decltype(end)>::max();
 		}
 		if (type == safs_locks::Type::kAll || type == safs_locks::Type::kFlock) {
-			status = gFSOperations->flockOperation(context, inode, owner, sessionid, 0, 0,
-			                                       safs_locks::kUnlock, true, flocks_applied);
+			status = gFSOperations->flockOperation(context, fsOpContext, inode, owner, sessionid, 0,
+			                                       0, safs_locks::kUnlock, true, flocks_applied);
 		}
 		if (status == SAUNAFS_STATUS_OK &&
 		    (type == safs_locks::Type::kAll || type == safs_locks::Type::kPosix)) {
-			status =
-			    gFSOperations->posixLockOperation(context, inode, start, end, owner, sessionid, 0,
-			                                      0, safs_locks::kUnlock, true, posix_applied);
+			status = gFSOperations->posixLockOperation(context, fsOpContext, inode, start, end,
+			                                           owner, sessionid, 0, 0, safs_locks::kUnlock,
+			                                           true, posix_applied);
 		}
 	} else if (version == cltoma::manageLocksUnlock::kInode) {
 		cltoma::manageLocksUnlock::deserialize(data, length, type, inode);
 		if (type == safs_locks::Type::kAll || type == safs_locks::Type::kFlock) {
-			status = gFSOperations->locksUnlockInode(context, (uint8_t)safs_locks::Type::kFlock,
-			                                         inode, flocks_applied);
+			status = gFSOperations->locksUnlockInode(
+			    context, fsOpContext, (uint8_t)safs_locks::Type::kFlock, inode, flocks_applied);
 		}
 		if (status == SAUNAFS_STATUS_OK &&
 		    (type == safs_locks::Type::kAll || type == safs_locks::Type::kPosix)) {
-			status = gFSOperations->locksUnlockInode(context, (uint8_t)safs_locks::Type::kPosix,
-			                                         inode, posix_applied);
+			status = gFSOperations->locksUnlockInode(
+			    context, fsOpContext, (uint8_t)safs_locks::Type::kPosix, inode, posix_applied);
 		}
 	} else {
 		throw IncorrectDeserializationException("Unknown SAU_CLTOMA_MANAGE_LOCKS_UNLOCK version: " +
 		                                        std::to_string(version));
+	}
+
+	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
+		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+			safs::log_err("{}: transaction failed to commit: inode {}", __func__, inode);
+			status = SAUNAFS_ERROR_IO;
+			flocks_applied.clear();
+			posix_applied.clear();
+		}
 	}
 
 	for (auto sessionAndMsg : flocks_applied) {
@@ -4732,10 +4776,20 @@ void matoclserv_fuse_locks_interrupt(matoclserventry *eptr, const uint8_t *data,
 
 	cltoma::fuseFlock::deserialize(data, length, messageId, interruptData);
 
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
 	// we do not reply, so there is not need for checking status of this fs_operation
-	gFSOperations->locksRemovePending(context, type, interruptData.owner,
+	gFSOperations->locksRemovePending(context, fsOpContext, type, interruptData.owner,
 	                                  eptr->sessionData->sessionId, interruptData.ino,
 	                                  interruptData.reqid);
+
+	if (fsOpContext.hasReadWriteTransaction()) {
+		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+			safs::log_err("{}: transaction failed to commit: inode {}", __func__,
+			              interruptData.ino);
+		}
+	}
 }
 
 void matoclserv_update_credentials(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
@@ -5121,19 +5175,20 @@ void matoclserv_broadcast_metadata_checksum_recalculated(uint8_t status) {
 	}
 }
 
-void matocl_locks_release(const FsContext &context, inode_t inode, uint32_t sessionId) {
+void matocl_locks_release(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+                          inode_t inode, uint32_t sessionId) {
 	std::vector<FileLocks::Owner> applied;
 
-	gFSOperations->locksClearSession(context, (uint8_t)safs_locks::Type::kFlock, inode, sessionId,
-	                                 applied);
+	gFSOperations->locksClearSession(context, fsOpContext, (uint8_t)safs_locks::Type::kFlock, inode,
+	                                 sessionId, applied);
 
 	for (auto candidate : applied) {
 		matoclserv_lock_wake_up(candidate.sessionid, candidate.msgid, safs_locks::Type::kFlock);
 	}
 
 	applied.clear();
-	gFSOperations->locksClearSession(context, (uint8_t)safs_locks::Type::kPosix, inode, sessionId,
-	                                 applied);
+	gFSOperations->locksClearSession(context, fsOpContext, (uint8_t)safs_locks::Type::kPosix, inode,
+	                                 sessionId, applied);
 
 	for (auto candidate : applied) {
 		matoclserv_lock_wake_up(candidate.sessionid, candidate.msgid, safs_locks::Type::kPosix);
@@ -5150,7 +5205,7 @@ void matocl_close_files(Session *currentSession) {
 
 	for (const auto &openFileInode : currentSession->openFilesSet) {
 		gFSOperations->release(context, fsOpContext, openFileInode, currentSession->sessionId);
-		matocl_locks_release(context, openFileInode, currentSession->sessionId);
+		matocl_locks_release(context, fsOpContext, openFileInode, currentSession->sessionId);
 		operationCount++;
 
 		if (fsOpContext.hasReadWriteTransaction() && operationCount >= kTransactionBatchSize) {

--- a/src/master/restore.cc
+++ b/src/master/restore.cc
@@ -480,19 +480,31 @@ int do_lock_op(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) 
 
 	int status = SAUNAFS_STATUS_OK;
 
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
 	switch (static_cast<safs_locks::Type>(lock_type)) {
 	case safs_locks::Type::kFlock:
-		status = gFSOperations->flockOperation(FsContext::getForRestore(ts), inode, owner,
-		                                       sessionid, 0, 0, op, nonblocking, dummy_applied);
+		status =
+		    gFSOperations->flockOperation(FsContext::getForRestore(ts), fsOpContext, inode, owner,
+		                                  sessionid, 0, 0, op, nonblocking, dummy_applied);
 		break;
 	case safs_locks::Type::kPosix:
-		status = gFSOperations->posixLockOperation(FsContext::getForRestore(ts), inode, start, end,
-		                                           owner, sessionid, 0, 0, op, nonblocking,
-		                                           dummy_applied);
+		status = gFSOperations->posixLockOperation(FsContext::getForRestore(ts), fsOpContext, inode,
+		                                           start, end, owner, sessionid, 0, 0, op,
+		                                           nonblocking, dummy_applied);
 		break;
 	default:
 		safs_pretty_syslog(LOG_ERR, "Invalid lock type passed to restore: %u", lock_type);
 		return SAUNAFS_ERROR_EINVAL;
+	}
+
+	if ((status == SAUNAFS_STATUS_OK || status == SAUNAFS_ERROR_WAITING) &&
+	    fsOpContext.hasReadWriteTransaction()) {
+		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+			safs::log_err("{}: transaction failed to commit: inode {}", __func__, inode);
+			status = SAUNAFS_ERROR_IO;
+		}
 	}
 
 	if (status==SAUNAFS_ERROR_WAITING) {
@@ -520,8 +532,20 @@ int do_remove_pending_op(const char *filename, uint64_t lv, uint32_t ts, const c
 	GETU64(reqid, ptr);
 	EAT(ptr,filename,lv,')');
 
-	return gFSOperations->locksRemovePending(FsContext::getForRestore(ts), lock_type, ownerid,
-	                                         sessionid, inode, reqid);
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
+	int status = gFSOperations->locksRemovePending(FsContext::getForRestore(ts), fsOpContext,
+	                                               lock_type, ownerid, sessionid, inode, reqid);
+
+	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
+		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+			safs::log_err("{}: transaction failed to commit: inode {}", __func__, inode);
+			status = SAUNAFS_ERROR_IO;
+		}
+	}
+
+	return status;
 }
 
 int do_lock_clear_session(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -537,8 +561,20 @@ int do_lock_clear_session(const char *filename, uint64_t lv, uint32_t ts, const 
 	GETU32(sessionid, ptr);
 	EAT(ptr, filename, lv, ')');
 
-	return gFSOperations->locksClearSession(FsContext::getForRestore(ts), lock_type, inode,
-	                                        sessionid, applied);
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
+	int status = gFSOperations->locksClearSession(FsContext::getForRestore(ts), fsOpContext,
+	                                              lock_type, inode, sessionid, applied);
+
+	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
+		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+			safs::log_err("{}: transaction failed to commit: inode {}", __func__, inode);
+			status = SAUNAFS_ERROR_IO;
+		}
+	}
+
+	return status;
 }
 
 int do_lock_unlock_inode(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -552,7 +588,20 @@ int do_lock_unlock_inode(const char *filename, uint64_t lv, uint32_t ts, const c
 	GETINODE(inode, ptr);
 	EAT(ptr, filename, lv, ')');
 
-	return gFSOperations->locksUnlockInode(FsContext::getForRestore(ts), lock_type, inode, applied);
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
+	int status = gFSOperations->locksUnlockInode(FsContext::getForRestore(ts), fsOpContext,
+	                                             lock_type, inode, applied);
+
+	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
+		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+			safs::log_err("{}: transaction failed to commit: inode {}", __func__, inode);
+			status = SAUNAFS_ERROR_IO;
+		}
+	}
+
+	return status;
 }
 
 int do_purge(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {


### PR DESCRIPTION
Add virtual lock API to FilesystemOperationsInterface so KV backends can override flock, posix lock, probe, clear-session, remove-pending, unlock-inode, and list operations with FDB-first persistence.

Expose lockOperation, manageLockTryLockPending, and checkLockPermissions as protected members so KV
overrides reuse base logic instead of duplicating it.

Define FLCK 1.0 inode-first key format in kv_common_keys.h.

Related to: LS-72

Co-authored-by: Crash <crash@leil.io>