### PR TITLE
feat(fdb): introduce helper and support fdb features

### DIFF
--- a/src/fdb/fdb.cc
+++ b/src/fdb/fdb.cc
@@ -209,6 +209,13 @@ void Transaction::remove(const kv::Key &key) {
 	fdb_transaction_clear(tr_.get(), key.data(), static_cast<int>(key.size()));
 }
 
+void Transaction::removeRange(const kv::Key &start, const kv::Key &end) {
+	if (!tr_) { return; }
+
+	fdb_transaction_clear_range(tr_.get(), start.data(), static_cast<int>(start.size()), end.data(),
+	                            static_cast<int>(end.size()));
+}
+
 bool Transaction::commit() {
 	if (!tr_) { return false; }
 

--- a/src/fdb/fdb.cc
+++ b/src/fdb/fdb.cc
@@ -25,6 +25,7 @@
 #include <foundationdb/fdb_c_types.h>
 
 #include "fdb/fdb_future.h"
+#include "kv/kv_utils.h"
 #include "slogger/slogger.h"
 
 namespace fdb {
@@ -100,8 +101,7 @@ std::optional<kv::Value> Transaction::get(const kv::Key &key, bool snapshot) {
 	if (valuePresent != 0) {
 		value.assign(valueRead, valueRead + valueLength);
 	} else {
-		safs::log_info("Transaction::get: key not found: {}",
-		               std::string_view(reinterpret_cast<const char *>(key.data()), key.size()));
+		safs::log_info("Transaction::get: key not found: {}", kv::keyToEscapedAscii(key));
 		value.clear();
 		return std::nullopt;
 	}
@@ -179,8 +179,7 @@ kv::GetRangeResult Transaction::getRange(
 
 	if (pairs.empty()) {
 		safs::log_info("Transaction::getRange: no keys found in range: {} - {}",
-		               std::string(begin.getKey().begin(), begin.getKey().end()),
-		               std::string(end.getKey().begin(), end.getKey().end()));
+		               kv::keyToEscapedAscii(begin.getKey()), kv::keyToEscapedAscii(end.getKey()));
 		return {{}, false};
 	}
 

--- a/src/fdb/fdb.h
+++ b/src/fdb/fdb.h
@@ -179,6 +179,9 @@ public:
 	/// @param key The key to remove.
 	void remove(const kv::Key &key);
 
+	/// Removes a half-open key range [start, end) from the database.
+	void removeRange(const kv::Key &start, const kv::Key &end);
+
 	/// Commits the transaction.
 	/// @return True if the commit was successful, false otherwise.
 	bool commit();

--- a/src/fdb/fdb_transaction.cc
+++ b/src/fdb/fdb_transaction.cc
@@ -59,6 +59,12 @@ void FDBTransaction::remove(const kv::Key &key) {
 	tr_.remove(key);
 }
 
+void FDBTransaction::removeRange(const kv::Key &start, const kv::Key &end) {
+	if (!tr_) { return; }
+
+	tr_.removeRange(start, end);
+}
+
 bool FDBTransaction::commit() {
 	if (!tr_) { return false; }
 

--- a/src/fdb/fdb_transaction.h
+++ b/src/fdb/fdb_transaction.h
@@ -73,6 +73,9 @@ public:
 	/// @param key The key to remove.
 	void remove(const kv::Key &key) override;
 
+	/// Removes a half-open key range [start, end) from the database.
+	void removeRange(const kv::Key &start, const kv::Key &end) override;
+
 	/// Commits the transaction, making all changes permanent.
 	bool commit() override;
 

--- a/src/fdb/fdb_unittest.cc
+++ b/src/fdb/fdb_unittest.cc
@@ -233,6 +233,77 @@ TEST_F(FDBKVEngineTest, GetRangeWithOffsets) {
 	ASSERT_EQ(elementsWithOffsets.back(), "key_17");
 }
 
+TEST_F(FDBKVEngineTest, RemoveRange) {
+	constexpr size_t kNumKeys = 10;
+
+	{  // Initially insert keys key_0, key_1, ..., key_9 into the database
+		auto transaction = kvEngine->createReadWriteTransaction();
+		for (size_t i = 0; i < kNumKeys; ++i) {
+			std::string key = "key_" + std::to_string(i);
+			std::string value = "value_" + std::to_string(i);
+			transaction->set(kv::toBytes(key), kv::toBytes(value));
+		}
+		ASSERT_TRUE(transaction->commit());
+	}
+
+	{  // Remove the range [key_3, key_7), i.e. keys key_3, key_4, key_5 and key_6.
+		auto transaction = kvEngine->createReadWriteTransaction();
+		transaction->removeRange(kv::toBytes("key_3"), kv::toBytes("key_7"));
+		ASSERT_TRUE(transaction->commit());
+	}
+
+	{
+		auto transaction = kvEngine->createReadWriteTransaction();
+		for (size_t i = 0; i < kNumKeys; ++i) {
+			std::string key = "key_" + std::to_string(i);
+			auto value = transaction->get(kv::toBytes(key));
+			// Range of keys [key_3, key_7) should be removed, but the others should still be
+			// present.
+			if (i >= 3 && i < 7) {
+				ASSERT_FALSE(value.has_value()) << "Expected key missing: " << key;
+			} else {
+				ASSERT_TRUE(value.has_value()) << "Expected key present: " << key;
+			}
+		}
+	}
+
+	{  // Remove the range [key_0, key_2), i.e. keys key_0 and key_1.
+		auto transaction = kvEngine->createReadWriteTransaction();
+		transaction->removeRange(kv::toBytes("key_0"), kv::toBytes("key_2"));
+		ASSERT_TRUE(transaction->commit());
+	}
+
+	{  // Verify that key_0 and key_1 are removed, but key_2 is still present
+		auto transaction = kvEngine->createReadWriteTransaction();
+		ASSERT_FALSE(transaction->get(kv::toBytes("key_0")).has_value());
+		ASSERT_FALSE(transaction->get(kv::toBytes("key_1")).has_value());
+		ASSERT_TRUE(transaction->get(kv::toBytes("key_2")).has_value());
+	}
+
+	{  // Remove range with a single key: start key and end key are the same, but the range is
+	   // end-exclusive, so key_2 should not be removed.
+		auto transaction = kvEngine->createReadWriteTransaction();
+		transaction->removeRange(kv::toBytes("key_2"), kv::toBytes("key_2"));
+		ASSERT_TRUE(transaction->commit());
+	}
+
+	{  // Verify that key_2 is still present after calling removeRange() with a single key
+		auto transaction = kvEngine->createReadWriteTransaction();
+		ASSERT_TRUE(transaction->get(kv::toBytes("key_2")).has_value());
+	}
+
+	{  // Remove key_2 by calling removeRange() with a range that includes key_2
+		auto transaction = kvEngine->createReadWriteTransaction();
+		transaction->removeRange(kv::toBytes("key_2"), kv::toBytes("key_3"));
+		ASSERT_TRUE(transaction->commit());
+	}
+
+	{  // Verify that key_2 is removed
+		auto transaction = kvEngine->createReadWriteTransaction();
+		ASSERT_FALSE(transaction->get(kv::toBytes("key_2")).has_value());
+	}
+}
+
 TEST_F(FDBKVEngineTest, AtomicAdd) {
 	kv::Key key{'c', 'o', 'u', 'n', 't'};
 	constexpr int64_t initialValue = 10;

--- a/src/kv/itransaction.h
+++ b/src/kv/itransaction.h
@@ -136,6 +136,11 @@ public:
 	/// @param key The key to remove.
 	virtual void remove(const Key &key) = 0;
 
+	/// Removes a half-open key range [start, end) from the database.
+	/// @param start Inclusive start key.
+	/// @param end Exclusive end key.
+	virtual void removeRange(const Key &start, const Key &end) = 0;
+
 	/// Commits the transaction, making all changes permanent.
 	virtual bool commit() = 0;
 

--- a/src/kv/kv_utils.h
+++ b/src/kv/kv_utils.h
@@ -20,6 +20,7 @@
 
 #include "common/platform.h"
 
+#include <array>
 #include <bit>
 #include <cstring>
 #include <memory>
@@ -57,6 +58,53 @@ inline Key prefixEnd(Key prefix) {
 	}
 
 	throw std::invalid_argument("Prefix has no finite upper bound");
+}
+
+/// Returns true if @p byteValue is a plain printable ASCII character (0x20 - 0x7E).
+///
+/// Used to decide whether a byte can be emitted as-is or must be escaped.
+constexpr bool isPrintableAscii(uint8_t byteValue) noexcept {
+	// Keep logs simple and grep-safe: only plain printable ASCII.
+	constexpr auto kMinPrintable = 0x20;  // space
+	constexpr auto kMaxPrintable = 0x7e;  // tilde (~)
+	return byteValue >= kMinPrintable && byteValue <= kMaxPrintable;
+}
+
+/// Converts a raw byte buffer to a printable ASCII string with non-printable bytes escaped.
+///
+/// Each byte that passes isPrintableAscii() is emitted verbatim. All other bytes are
+/// rendered as `\xNN` (lowercase hex), making binary key data safe to include in log
+/// messages and easily grep-able.
+///
+/// @param data Pointer to the byte buffer to convert.
+/// @param size Number of bytes to process.
+/// @return A string where every byte is either a printable ASCII character or `\xNN`.
+inline std::string bytesToEscapedAscii(const uint8_t *data, size_t size) {
+	static constexpr std::array<char, 16> kHex = {'0', '1', '2', '3', '4', '5', '6', '7',
+	                                              '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
+	std::string out;
+	// Worst case every byte becomes "\xNN" (4 chars).
+	out.reserve(size * 4);
+	for (size_t i = 0; i < size; ++i) {
+		const uint8_t byteValue = data[i];
+		if (isPrintableAscii(byteValue)) {
+			out.push_back(static_cast<char>(byteValue));
+		} else {
+			out.append("\\x");
+			out.push_back(kHex[byteValue >> 4]);    // Upper 4 bits (0..15)
+			out.push_back(kHex[byteValue & 0x0f]);  // Lower 4 bits (0..15)
+		}
+	}
+	return out;
+}
+
+/// Converts a KV key to a printable ASCII string with non-printable bytes escaped.
+///
+/// Convenience wrapper around bytesToEscapedAscii() for kv::Key values.
+/// @param key The key to convert.
+/// @return A human-readable representation of the key suitable for logging.
+inline std::string keyToEscapedAscii(const kv::Key &key) {
+	return bytesToEscapedAscii(key.data(), key.size());
 }
 
 /// Converts integral types to a vector of uint8_t encoded in little-endian order.

--- a/src/kv/kv_utils_unittest.cc
+++ b/src/kv/kv_utils_unittest.cc
@@ -494,3 +494,120 @@ TEST(KVUtilsTest, EncodeKeyBE) {
 		EXPECT_EQ(result.size(), kPrefix.size() + sizeof(kValue));
 	}
 }
+
+TEST(KVUtilsTest, IsPrintableAscii) {
+	// Boundary: space (0x20) is the first printable character
+	EXPECT_TRUE(kv::isPrintableAscii(0x20));
+
+	// Boundary: tilde (0x7E) is the last printable character
+	EXPECT_TRUE(kv::isPrintableAscii(0x7E));
+
+	// Common printable characters
+	EXPECT_TRUE(kv::isPrintableAscii('A'));
+	EXPECT_TRUE(kv::isPrintableAscii('z'));
+	EXPECT_TRUE(kv::isPrintableAscii('0'));
+	EXPECT_TRUE(kv::isPrintableAscii('!'));
+
+	// Just below the printable range: control characters
+	EXPECT_FALSE(kv::isPrintableAscii(0x1F));  // US (unit separator)
+	EXPECT_FALSE(kv::isPrintableAscii(0x00));  // NUL
+	EXPECT_FALSE(kv::isPrintableAscii('\n'));   // newline (0x0A)
+	EXPECT_FALSE(kv::isPrintableAscii('\t'));   // tab (0x09)
+
+	// Just above the printable range: DEL and extended bytes
+	EXPECT_FALSE(kv::isPrintableAscii(0x7F));  // DEL
+	EXPECT_FALSE(kv::isPrintableAscii(0x80));  // first extended byte
+	EXPECT_FALSE(kv::isPrintableAscii(0xFF));  // max uint8_t
+}
+
+TEST(KVUtilsTest, BytesToEscapedAscii) {
+	// Empty input: empty output
+	{
+		std::string result = kv::bytesToEscapedAscii(nullptr, 0);
+		EXPECT_EQ(result, "");
+	}
+
+	// All printable ASCII: output equals input as string
+	{
+		const std::string kInput = "Hello, World!";
+		std::string result = kv::bytesToEscapedAscii(
+		    reinterpret_cast<const uint8_t *>(kInput.data()), kInput.size());
+		EXPECT_EQ(result, kInput);
+	}
+
+	// Single non-printable byte: rendered as \xNN
+	{
+		const uint8_t kInput[] = {0x01};
+		std::string result = kv::bytesToEscapedAscii(kInput, sizeof(kInput));
+		EXPECT_EQ(result, "\\x01");
+	}
+
+	// NUL byte
+	{
+		const uint8_t kInput[] = {0x00};
+		std::string result = kv::bytesToEscapedAscii(kInput, sizeof(kInput));
+		EXPECT_EQ(result, "\\x00");
+	}
+
+	// DEL (0x7F): just above the printable range
+	{
+		const uint8_t kInput[] = {0x7F};
+		std::string result = kv::bytesToEscapedAscii(kInput, sizeof(kInput));
+		EXPECT_EQ(result, "\\x7f");
+	}
+
+	// 0xFF: max byte value
+	{
+		const uint8_t kInput[] = {0xFF};
+		std::string result = kv::bytesToEscapedAscii(kInput, sizeof(kInput));
+		EXPECT_EQ(result, "\\xff");
+	}
+
+	// Mixed printable and non-printable bytes
+	{
+		const uint8_t kInput[] = {'A', 0x01, 'B', 0xFF};
+		std::string result = kv::bytesToEscapedAscii(kInput, sizeof(kInput));
+		EXPECT_EQ(result, "A\\x01B\\xff");
+	}
+
+	// Boundary bytes: space (0x20) and tilde (0x7E) are printable
+	{
+		const uint8_t kInput[] = {0x1F, 0x20, 0x7E, 0x7F};
+		std::string result = kv::bytesToEscapedAscii(kInput, sizeof(kInput));
+		EXPECT_EQ(result, "\\x1f ~\\x7f");
+	}
+
+	// Binary key-like data (prefix + big-endian uint32_t)
+	{
+		const uint8_t kInput[] = {'N', 0x00, 0x00, 0x00, 0x01};
+		std::string result = kv::bytesToEscapedAscii(kInput, sizeof(kInput));
+		EXPECT_EQ(result, "N\\x00\\x00\\x00\\x01");
+	}
+}
+
+TEST(KVUtilsTest, KeyToEscapedAscii) {
+	// Empty key: empty output
+	{
+		kv::Key key = {};
+		EXPECT_EQ(kv::keyToEscapedAscii(key), "");
+	}
+
+	// All printable ASCII key
+	{
+		kv::Key key = {'N', 'O', 'D', 'E', '_'};
+		EXPECT_EQ(kv::keyToEscapedAscii(key), "NODE_");
+	}
+
+	// Key with non-printable byte suffix (e.g. encodeKeyBE result)
+	{
+		kv::Key key = kv::encodeKeyBE("N", static_cast<uint32_t>(1));
+		// "N" + 0x00 0x00 0x00 0x01
+		EXPECT_EQ(kv::keyToEscapedAscii(key), "N\\x00\\x00\\x00\\x01");
+	}
+
+	// key consisting entirely of non-printable bytes
+	{
+		kv::Key key = {0x00, 0xFF, 0x1F};
+		EXPECT_EQ(kv::keyToEscapedAscii(key), "\\x00\\xff\\x1f");
+	}
+}

--- a/src/master/filesystem_metadata.h
+++ b/src/master/filesystem_metadata.h
@@ -93,6 +93,9 @@ public:
 	/// Signal emitted when a node changes (added, modified, but not removed)
 	Signal<FSNode *> nodeChangedSignal;
 
+	/// Signal emitted when a node is removed
+	Signal<inode_t> nodeRemovedSignal;
+
 	/// Signal emitted when an edge changes (added, modified, but not removed)
 	Signal<FSNodeDirectory *, FSNode *, hstorage::Handle *> edgeChangedSignal;
 

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -1492,13 +1492,14 @@ void FilesystemNodeOperationsBase::removeNode(const FilesystemOperationContext &
 	auto nodeIterator = std::find(gMetadata->nodeHash[nodeHashIndex].begin(),
 	                              gMetadata->nodeHash[nodeHashIndex].end(), node);
 
-	FSNode::destroy(node);
-
 	if (nodeIterator != gMetadata->nodeHash[nodeHashIndex].end()) {
 		auto lastElement = gMetadata->nodeHash[nodeHashIndex].end() - 1;
 		std::iter_swap(nodeIterator, lastElement); // Swap with last element to avoid erase: O(1)
 		gMetadata->nodeHash[nodeHashIndex].pop_back(); // Remove the last element: O(1)
+		gMetadata->nodeRemovedSignal.emit(node->id);
 	}
+
+	FSNode::destroy(node);
 }
 
 void FilesystemNodeOperationsBase::unlink(const FilesystemOperationContext &fsOpContext,


### PR DESCRIPTION
This PR introduces some features and helpers to support the fdb API used by the FDB-based backends.

The relevant changes are:
* Support key range deletes through the `removeRange()` function.
* Escape non-printable keys to keep the logs readable, grep-safe and robust when working with binary keyspaces.
* Introduce `nodeRemovedSignal()` to track metadata node removals in FDB-based backends.

Signed-off-by: Crash <<crash@leil.io>>