### PR TITLE
fix(tools): Fix help for rremove function LS-410

### DIFF
--- a/src/tools/recursive_remove.cc
+++ b/src/tools/recursive_remove.cc
@@ -146,14 +146,14 @@ static int recursive_remove(const char *file_name) {
 
 int recursive_remove_run(int argc, char **argv) {
 	int status = 0;
+	// Go past initial command
+	argc--;
+	argv++;
 
 	if (argc < 1) {
 		recursive_remove_usage();
 		return 1;
 	}
-	// Go past initial command
-	argc--;
-	argv++;
 
 	while (argc > 0) {
 		if (recursive_remove(*argv) < 0) {


### PR DESCRIPTION
From changes introduced on commit cbc53d7, there was a bug affecting the help printing logic for the rremove function from saunafs command tools. This commit fixes that issue.