### PR TITLE
fix: Add encoding detection to avoid crash

### DIFF
--- a/src/cgi/sfs.cgi.in
+++ b/src/cgi/sfs.cgi.in
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import chardet
 import os
 import re
 import socket
@@ -363,7 +364,9 @@ def deserialize_string(buffer):
     if len(buffer) < length or buffer[length - 1] != 0:
         raise RuntimeError("malformed message; cannot deserialize")
     if isinstance(buffer, (bytearray, bytes)):
-        ret = str(buffer[0:length - 1], 'utf-8')
+        detected = chardet.detect(buffer[0:length - 1])
+        encoding = detected['encoding'] or 'utf-8'
+        ret = str(buffer[0:length - 1], encoding)
     else:
         ret = str(buffer[0:length - 1])
     del buffer[0:length]


### PR DESCRIPTION
New implementation will try to detect encoding of received info before rendering instead of assuming 'utf-8' encoding which will cause crash when polish characters were not encoded using 'utf-8'.

Closes LS-416