### PR TITLE
fix: fix first version with chunk unlock notice

### DIFF
--- a/src/common/saunafs_version.h
+++ b/src/common/saunafs_version.h
@@ -53,5 +53,5 @@ constexpr uint32_t kFirstVersionWithMountInfoOnMonitoring = saunafsVersion(5, 0,
 constexpr uint32_t kFirstVersionWithChunkBasedWriteAlgorithm = saunafsVersion(5, 0, 0);
 constexpr uint32_t kFirstVersionWithClusterId = saunafsVersion(5, 0, 0);
 constexpr uint32_t kFirstVersionWithReadTrashReservedByHandleOffset = saunafsVersion(5, 3, 0);
-constexpr uint32_t kFirstVersionWithUnlockChunkNotice = saunafsVersion(5, 7, 0);
+constexpr uint32_t kFirstVersionWithUnlockChunkNotice = saunafsVersion(5, 8, 0);
 constexpr uint32_t kFirstVersionWithChunkserverSideChunkLock = saunafsVersion(5, 8, 0);


### PR DESCRIPTION
Since the changes introducing the unlock chunk notice packet were not included in the version 5.7.0, the required version for sending such packets from the master side must be bumped to the current one, which is 5.8.0.

Signed-off-by: Dave <dave@leil.io>