### PR TITLE
fix(master): fix xattr lookup with hash collisions

### DIFF
--- a/src/master/filesystem_xattr.cc
+++ b/src/master/filesystem_xattr.cc
@@ -26,6 +26,13 @@
 #include <master/filesystem_metadata.h>
 #include <master/filesystem_xattr.h>
 
+XAttributeInodeEntry *find_xattr_inode_entry(inode_t inode, uint32_t inodeHash) {
+	for (const auto &xattrEntry : gMetadata->xattrInodeHash[inodeHash]) {
+		if (xattrEntry->inode == inode) { return xattrEntry.get(); }
+	}
+	return nullptr;
+}
+
 static uint64_t xattr_checksum(const XAttributeDataEntry *xattrDataEntry) {
 	if (!xattrDataEntry) {
 		return 0;
@@ -153,12 +160,7 @@ uint8_t xattr_setattr(inode_t inode, uint8_t attributeNameLength, const uint8_t 
 	}
 
 	auto inodeHash = get_xattr_inode_hash(inode);
-	for (const auto &xattrEntry : gMetadata->xattrInodeHash[inodeHash]) {
-		xattrInodeEntry = xattrEntry.get();
-		if (xattrInodeEntry->inode == inode) {
-			break;
-		}
-	}
+	xattrInodeEntry = find_xattr_inode_entry(inode, inodeHash);
 
 	auto dataHash = get_xattr_data_hash(inode, attributeNameLength, attributeName);
 	for (const auto &xattrDataEntry : gMetadata->xattrDataHash[dataHash]) {
@@ -239,7 +241,7 @@ uint8_t xattr_setattr(inode_t inode, uint8_t attributeNameLength, const uint8_t 
 	gMetadata->xattrDataHash[dataHash].push_back(std::move(xattrDataEntry));
 	auto *xattrDataEntryPointer = gMetadata->xattrDataHash[dataHash].back().get();
 
-	if (xattrInodeEntry) {
+	if (xattrInodeEntry != nullptr) {
 		xattrInodeEntry->xattrDataEntries.push_back(xattrDataEntryPointer);
 		xattrInodeEntry->attributeNameLength += attributeNameLength + 1U;
 		xattrInodeEntry->attributeValueLength += attributeValueLength;

--- a/src/master/filesystem_xattr.h
+++ b/src/master/filesystem_xattr.h
@@ -84,9 +84,11 @@ static inline uint32_t get_xattr_data_hash(inode_t inode, uint8_t attributeNameL
 	return (hash & (XATTR_DATA_HASH_SIZE - 1));
 }
 
-static inline uint32_t get_xattr_inode_hash(inode_t inode) {
+static constexpr uint32_t get_xattr_inode_hash(inode_t inode) {
 	return ((inode * 0x72B5F387U) & (XATTR_INODE_HASH_SIZE - 1));
 }
+
+XAttributeInodeEntry *find_xattr_inode_entry(inode_t inode, uint32_t inodeHash);
 
 void xattr_checksum_add_to_background(XAttributeDataEntry *xattrDataEntry);
 void xattr_listattr_data(void *xattrInodeEntry, uint8_t *xattrDataBuffer);

--- a/src/master/filesystem_xattr_unittest.cc
+++ b/src/master/filesystem_xattr_unittest.cc
@@ -1,0 +1,163 @@
+/*
+   Copyright 2023      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "common/platform.h"
+
+#include <gtest/gtest.h>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "master/filesystem_metadata.h"
+#include "master/filesystem_xattr.h"
+
+// gMetadata is defined in filesystem.cc, which is linked into the master library used by the unit
+// test.
+
+class XAttrHashCollisionTest : public ::testing::Test {
+protected:
+	void SetUp() override { gMetadata = new FilesystemMetadata; }
+	void TearDown() override {
+		delete gMetadata;
+		gMetadata = nullptr;
+	}
+
+	static void setXAttr(inode_t inode, const std::string &name, const std::string &value) {
+		ASSERT_EQ(SAUNAFS_STATUS_OK, xattr_setattr(inode, static_cast<uint8_t>(name.size()),
+		                                           reinterpret_cast<const uint8_t *>(name.data()),
+		                                           static_cast<uint32_t>(value.size()),
+		                                           reinterpret_cast<const uint8_t *>(value.data()),
+		                                           XATTR_SMODE_CREATE_OR_REPLACE));
+	}
+
+	/// Retrieves the value of a single xattr by name. Returns empty string if not found.
+	static std::string getXAttr(inode_t inode, const std::string &name) {
+		uint32_t valueLength = 0;
+		uint8_t *valuePtr = nullptr;
+		uint8_t status =
+		    xattr_getattr(inode, static_cast<uint8_t>(name.size()),
+		                  reinterpret_cast<const uint8_t *>(name.data()), &valueLength, &valuePtr);
+		if (status != SAUNAFS_STATUS_OK) { return {}; }
+		if (valueLength == 0) { return {}; }
+		return {reinterpret_cast<const char *>(valuePtr), valueLength};
+	}
+
+	/// Returns the total attribute name list size for the inode via xattrInodeHash
+	static uint32_t listSize(inode_t inode) {
+		void *node = nullptr;
+		uint32_t size = 0;
+		EXPECT_EQ(SAUNAFS_STATUS_OK, get_xattrs_length_for_inode(inode, &node, &size));
+		return size;
+	}
+
+	/// Returns the set of attribute names listed for the inode via xattrInodeHash.
+	/// This exercises the same code path as `attr -ql` (listing xattrs).
+	static std::set<std::string> listNames(inode_t inode) {
+		void *node = nullptr;
+		uint32_t size = 0;
+
+		if (get_xattrs_length_for_inode(inode, &node, &size) != SAUNAFS_STATUS_OK ||
+		    node == nullptr || size == 0) {
+			return {};
+		}
+
+		std::vector<uint8_t> xattrBuffer(size);
+		xattr_listattr_data(node, xattrBuffer.data());
+
+		// The buffer contains NUL-separated names
+		std::set<std::string> names;
+		const char *xattrBufferPointer = reinterpret_cast<const char *>(xattrBuffer.data());
+		const char *end = xattrBufferPointer + size;
+
+		while (xattrBufferPointer < end) {
+			std::string name(xattrBufferPointer);
+			const auto nameLength = name.size();
+			if (nameLength > 0) { names.insert(std::move(name)); }
+			xattrBufferPointer += nameLength + 1;
+		}
+
+		return names;
+	}
+
+public:
+	// The two inodes are designed to collide in get_xattr_inode_hash:
+	//   (1      * 0x72B5F387) & 0xFFFF == 62343
+	//   (65537  * 0x72B5F387) & 0xFFFF == 62343
+	static constexpr inode_t kInodeA = 1;
+	static constexpr inode_t kInodeB = 65537;
+};
+
+// Confirms compile-time that the two inodes do collide.
+static_assert(get_xattr_inode_hash(XAttrHashCollisionTest::kInodeA) ==
+                  get_xattr_inode_hash(XAttrHashCollisionTest::kInodeB),
+              "Test inodes must collide in xattrInodeHash");
+
+TEST_F(XAttrHashCollisionTest, ListingIsCorrectForCollidingInodes) {
+	const std::string attributeNameA = "user.alpha";
+	const std::string attributeNameB = "user.beta";
+
+	setXAttr(kInodeA, attributeNameA, "val_a");
+	setXAttr(kInodeB, attributeNameB, "val_b");
+
+	// Each inode has exactly one attribute name (+1 for the NUL separator)
+	EXPECT_EQ(attributeNameA.size() + 1, listSize(kInodeA));
+	EXPECT_EQ(attributeNameB.size() + 1, listSize(kInodeB));
+
+	// Verify listed names are correct for each inode
+	EXPECT_EQ(std::set<std::string>({attributeNameA}), listNames(kInodeA));
+	EXPECT_EQ(std::set<std::string>({attributeNameB}), listNames(kInodeB));
+
+	// Verify values are retrievable and correct
+	EXPECT_EQ("val_a", getXAttr(kInodeA, attributeNameA));
+	EXPECT_EQ("val_b", getXAttr(kInodeB, attributeNameB));
+
+	// Cross-inode lookups must fail
+	EXPECT_EQ("", getXAttr(kInodeA, attributeNameB));
+	EXPECT_EQ("", getXAttr(kInodeB, attributeNameA));
+}
+
+TEST_F(XAttrHashCollisionTest, MultipleAttrsOnCollidingInodes) {
+	const std::string attributeNameA1 = "user.a1";
+	const std::string attributeNameA2 = "user.a2";
+	const std::string attributeNameB1 = "user.b1";
+
+	setXAttr(kInodeA, attributeNameA1, "x");
+	setXAttr(kInodeA, attributeNameA2, "y");
+	setXAttr(kInodeB, attributeNameB1, "z");
+
+	uint32_t expectedA = attributeNameA1.size() + 1 + attributeNameA2.size() + 1;
+	uint32_t expectedB = attributeNameB1.size() + 1;
+
+	EXPECT_EQ(expectedA, listSize(kInodeA));
+	EXPECT_EQ(expectedB, listSize(kInodeB));
+
+	// Verify listed names
+	EXPECT_EQ((std::set<std::string>({attributeNameA1, attributeNameA2})), listNames(kInodeA));
+	EXPECT_EQ(std::set<std::string>({attributeNameB1}), listNames(kInodeB));
+
+	// Verify values
+	EXPECT_EQ("x", getXAttr(kInodeA, attributeNameA1));
+	EXPECT_EQ("y", getXAttr(kInodeA, attributeNameA2));
+	EXPECT_EQ("z", getXAttr(kInodeB, attributeNameB1));
+
+	// Cross-inode must not return values
+	EXPECT_EQ("", getXAttr(kInodeA, attributeNameB1));
+	EXPECT_EQ("", getXAttr(kInodeB, attributeNameA1));
+	EXPECT_EQ("", getXAttr(kInodeB, attributeNameA2));
+}

--- a/src/master/metadata_backend_file.cc
+++ b/src/master/metadata_backend_file.cc
@@ -286,12 +286,7 @@ static bool xattr_load(MetadataLoader::Options options) {
 		}
 
 		auto inodeHash = get_xattr_inode_hash(inode);
-		for (const auto &xattrEntry : gMetadata->xattrInodeHash[inodeHash]) {
-			xattrInodeEntry = xattrEntry.get();
-			if (xattrInodeEntry->inode == inode) {
-				break;
-			}
-		}
+		xattrInodeEntry = find_xattr_inode_entry(inode, inodeHash);
 
 		if (xattrInodeEntry != nullptr &&
 		    xattrInodeEntry->attributeNameLength + attributeNameLength + 1 > SFS_XATTR_LIST_MAX) {

--- a/tests/test_suites/SanityChecks/test_xattr_persistence.sh
+++ b/tests/test_suites/SanityChecks/test_xattr_persistence.sh
@@ -1,0 +1,134 @@
+timeout_set 1 minute
+assert_program_installed attr
+
+CHUNKSERVERS=1 \
+	USE_RAMDISK=YES \
+	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER" \
+	setup_local_empty_saunafs info
+
+verify_batch_files() {
+	local prefix="$1"
+	for i in $(seq 1 500); do
+		listed=$(attr -ql "batch_$i")
+		if [[ "$listed" != "battr" ]]; then
+			test_add_failure "${prefix} listing mismatch on batch_$i: expected 'battr', got '$listed'"
+			break
+		fi
+		actual=$(attr -qg "battr" "batch_$i")
+		if [[ "$actual" != "bval_$i" ]]; then
+			test_add_failure "${prefix} value mismatch on batch_$i: expected 'bval_$i', got '$actual'"
+			break
+		fi
+	done
+}
+
+cd "${info[mount0]}"
+
+# --- Phase 1: Basic xattr persistence through master restart ---
+
+mkdir dir1
+echo "content_a" > file_a
+echo "content_b" > file_b
+echo "content_c" > dir1/file_c
+
+# Set multiple xattrs on file_a
+expect_success attr -qs "attr1" -V "value_a1" file_a
+expect_success attr -qs "attr2" -V "value_a2" file_a
+
+# Set single xattr on file_b and file_c
+expect_success attr -qs "attr1" -V "value_b1" file_b
+expect_success attr -qs "attr1" -V "value_c1" dir1/file_c
+
+# Set xattr on directory
+expect_success attr -qs "dir_attr" -V "dir_value" dir1
+
+# Verify listing (exercises xattrInodeHash lookup)
+expect_equals "$(echo -e "attr1\nattr2" | sort)" "$(attr -ql file_a | sort)"
+expect_equals "attr1" "$(attr -ql file_b)"
+expect_equals "attr1" "$(attr -ql dir1/file_c)"
+expect_equals "dir_attr" "$(attr -ql dir1)"
+
+# Verify getting (exercises xattrDataHash lookup)
+expect_equals "value_a1" "$(attr -qg attr1 file_a)"
+expect_equals "value_a2" "$(attr -qg attr2 file_a)"
+expect_equals "value_b1" "$(attr -qg attr1 file_b)"
+expect_equals "value_c1" "$(attr -qg attr1 dir1/file_c)"
+expect_equals "dir_value" "$(attr -qg dir_attr dir1)"
+
+# Non-existing xattr should fail
+expect_failure attr -qg "nonexistent" file_a
+expect_failure attr -qg "attr2" file_b
+
+for i in $(seq 1 500); do
+    echo "data" > "batch_$i"
+    expect_success attr -qs "battr" -V "bval_$i" "batch_$i"
+done
+
+# Verify listing and getting for all batch files before restart
+verify_batch_files "Pre-restart"
+
+# Restart master triggers metadata save + load cycle
+saunafs_master_daemon restart
+
+# Verify named files survived restart
+expect_equals "$(echo -e "attr1\nattr2" | sort)" "$(attr -ql file_a | sort)"
+expect_equals "attr1" "$(attr -ql file_b)"
+expect_equals "value_a1" "$(attr -qg attr1 file_a)"
+expect_equals "value_a2" "$(attr -qg attr2 file_a)"
+expect_equals "value_b1" "$(attr -qg attr1 file_b)"
+expect_equals "value_c1" "$(attr -qg attr1 dir1/file_c)"
+expect_equals "dir_value" "$(attr -qg dir_attr dir1)"
+expect_failure attr -qg "nonexistent" file_a
+
+# Verify batch files survived restart (listing + getting)
+verify_batch_files "Post-restart"
+
+# --- Phase 2: Remove all xattrs from a file ---
+
+expect_success attr -qr "attr1" file_a
+expect_success attr -qr "attr2" file_a
+
+# Xattrs should be gone from file_a
+expect_failure attr -qg "attr1" file_a
+expect_failure attr -qg "attr2" file_a
+
+# Other files should be unaffected
+expect_equals "value_b1" "$(attr -qg attr1 file_b)"
+expect_equals "value_c1" "$(attr -qg attr1 dir1/file_c)"
+expect_equals "dir_value" "$(attr -qg dir_attr dir1)"
+
+# Persist and verify
+saunafs_master_daemon restart
+
+expect_failure attr -qg "attr1" file_a
+expect_failure attr -qg "attr2" file_a
+expect_equals "value_b1" "$(attr -qg attr1 file_b)"
+expect_equals "value_c1" "$(attr -qg attr1 dir1/file_c)"
+expect_equals "dir_value" "$(attr -qg dir_attr dir1)"
+
+# --- Phase 3: Remove all files that have xattrs ---
+
+rm file_b
+rm dir1/file_c
+expect_success attr -qr "dir_attr" dir1
+
+# Persist and verify system stability
+saunafs_master_daemon restart
+
+# Deleted files should not exist
+expect_failure test -e file_b
+expect_failure test -e dir1/file_c
+# Directory xattr should be gone
+expect_failure attr -qg "dir_attr" dir1
+
+# --- Phase 4: New xattrs work after clearing everything ---
+
+echo "new" > fresh_file
+expect_success attr -qs "fresh_attr" -V "fresh_value" fresh_file
+expect_equals "fresh_attr" "$(attr -ql fresh_file)"
+expect_equals "fresh_value" "$(attr -qg fresh_attr fresh_file)"
+
+saunafs_master_daemon restart
+
+expect_equals "fresh_attr" "$(attr -ql fresh_file)"
+expect_equals "fresh_value" "$(attr -qg fresh_attr fresh_file)"


### PR DESCRIPTION
Previously, during a xattr lookup, the iteration assigned the entry pointer before verifying the inode, which could leave xattrInodeEntry pointing to the wrong inode when hash collisions occurred.

This commit fixes incorrect lookup of xattr entries when multiple inodes map to the same xattrInodeHash bucket. The lookup now checks the inode first and only assigns the entry when the correct inode is found.

Additional improvements:
- Mark get_xattr_inode_hash() as constexpr so collisions can be verified at compile time.
- Add unit tests validating correct behavior when inodes collide in xattrInodeHash.
- Add integration tests covering xattr persistence, listing, and deletion across master restarts.

Signed-off-by: Crash <<crash@leil.io>>