### PR TITLE
refactor(master): require fsOpContext in lookups

### DIFF
--- a/src/master/filesystem_dump.cc
+++ b/src/master/filesystem_dump.cc
@@ -144,15 +144,19 @@ void fs_dumpedgelist(FSNodeDirectory *parent) {
 }
 
 void fs_dumpedgelist(const TrashPathContainer &data) {
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadOnly);
 	for (const auto &entry : data) {
-		FSNode *child = gFSOperations->nodeOperations()->idToNode(entry.first.id);
+		FSNode *child = gFSOperations->nodeOperations()->idToNode(fsOpContext, entry.first.id);
 		fs_dumpedge(nullptr, child, (std::string)entry.second);
 	}
 }
 
 void fs_dumpedgelist(const ReservedPathContainer &data) {
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadOnly);
 	for (const auto &entry : data) {
-		FSNode *child = gFSOperations->nodeOperations()->idToNode(entry.first);
+		FSNode *child = gFSOperations->nodeOperations()->idToNode(fsOpContext, entry.first);
 		fs_dumpedge(nullptr, child, (std::string)entry.second);
 	}
 }

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -142,7 +142,8 @@ uint64_t FilesystemNodeOperationsBase::fileRealSize(FSNodeFile *node, uint32_t n
 
 // Protected methods
 
-FSNode *FilesystemNodeOperationsBase::idToNodeInternal(inode_t inode) const {
+FSNode *FilesystemNodeOperationsBase::idToNodeInternal(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, inode_t inode) const {
 	// Find the node with the given id
 	uint32_t nodeHashIndex = NODEHASHPOS(inode);
 
@@ -151,12 +152,6 @@ FSNode *FilesystemNodeOperationsBase::idToNodeInternal(inode_t inode) const {
 	}
 
 	return nullptr;
-}
-
-FSNode *FilesystemNodeOperationsBase::idToNodeInternal(
-    const FilesystemOperationContext &fsOpContext, inode_t inode) const {
-	(void)fsOpContext;  // Unused parameter in this implementation
-	return idToNodeInternal(inode);
 }
 
 void FilesystemNodeOperationsBase::incrementNodeCounters(
@@ -286,9 +281,10 @@ bool FilesystemNodeOperationsBase::isNameUsed(const FilesystemOperationContext &
 	return lookup(fsOpContext, node, name, isCaseInsensitive) != nullptr;
 }
 
-bool FilesystemNodeOperationsBase::isAncestor(FSNodeDirectory *ancestor, FSNode *node) {
+bool FilesystemNodeOperationsBase::isAncestor(const FilesystemOperationContext &fsOpContext,
+                                              FSNodeDirectory *ancestor, FSNode *node) {
 	for (const auto &[parentId, _] : node->parents) {
-		auto *dirNode = idToNodeVerify<FSNodeDirectory>(parentId);
+		auto *dirNode = idToNodeVerify<FSNodeDirectory>(fsOpContext, parentId);
 
 		while (dirNode != nullptr) {
 			if (ancestor == dirNode) { return true; }
@@ -296,7 +292,7 @@ bool FilesystemNodeOperationsBase::isAncestor(FSNodeDirectory *ancestor, FSNode 
 			assert(dirNode->parents.size() <= 1);
 
 			if (!dirNode->parents.empty()) {
-				dirNode = idToNodeVerify<FSNodeDirectory>(dirNode->parents[0].first);
+				dirNode = idToNodeVerify<FSNodeDirectory>(fsOpContext, dirNode->parents[0].first);
 			} else {
 				dirNode = nullptr;
 			}
@@ -306,14 +302,14 @@ bool FilesystemNodeOperationsBase::isAncestor(FSNodeDirectory *ancestor, FSNode 
 	return false;
 }
 
-bool FilesystemNodeOperationsBase::isAncestorOrNodeReservedOrTrash(FSNodeDirectory *ancestor,
-                                                                   FSNode *node) {
+bool FilesystemNodeOperationsBase::isAncestorOrNodeReservedOrTrash(
+    const FilesystemOperationContext &fsOpContext, FSNodeDirectory *ancestor, FSNode *node) {
 	// Return true if file is reserved:
 	if (node && (node->type == FSNodeType::kReserved || node->type == FSNodeType::kTrash)) {
 		return true;
 	}
 	// Or if ancestor is ancestor of node
-	return isAncestor(ancestor, node);
+	return isAncestor(fsOpContext, ancestor, node);
 }
 
 // stats
@@ -375,10 +371,13 @@ uint64_t FilesystemNodeOperationsBase::getNumberOfParents(
 	return node->parents.size();
 }
 
-FSNodeDirectory *FilesystemNodeOperationsBase::getFirstParent(FSNode *node) {
+FSNodeDirectory *FilesystemNodeOperationsBase::getFirstParent(
+    const FilesystemOperationContext &fsOpContext, FSNode *node) {
 	assert(node);
 
-	if (!node->parents.empty()) { return idToNodeVerify<FSNodeDirectory>(node->parents[0].first); }
+	if (!node->parents.empty()) {
+		return idToNodeVerify<FSNodeDirectory>(fsOpContext, node->parents[0].first);
+	}
 
 	return gMetadata->root;
 }
@@ -765,7 +764,8 @@ void FilesystemNodeOperationsBase::updateNode(
 	// Default implementation does nothing, it is not needed for the in-memory backend
 }
 
-uint32_t FilesystemNodeOperationsBase::getPathSize(FSNodeDirectory *parent, FSNode *child) {
+uint32_t FilesystemNodeOperationsBase::getPathSize(const FilesystemOperationContext &fsOpContext,
+                                                   FSNodeDirectory *parent, FSNode *child) {
 	if (parent == nullptr || child == nullptr) {
 		return 0;
 	}
@@ -776,7 +776,7 @@ uint32_t FilesystemNodeOperationsBase::getPathSize(FSNodeDirectory *parent, FSNo
 	while (parent != gMetadata->root && !parent->parents.empty()) {
 		child = parent;
 		assert(child->parents.size() == 1);
-		parent = idToNodeVerify<FSNodeDirectory>(child->parents[0].first);
+		parent = idToNodeVerify<FSNodeDirectory>(fsOpContext, child->parents[0].first);
 		name = parent->getChildName(child);
 		size += name.length() + 1;
 	}
@@ -784,7 +784,8 @@ uint32_t FilesystemNodeOperationsBase::getPathSize(FSNodeDirectory *parent, FSNo
 	return size;
 }
 
-void FilesystemNodeOperationsBase::getPathData(FSNodeDirectory *parent, FSNode *child,
+void FilesystemNodeOperationsBase::getPathData(const FilesystemOperationContext &fsOpContext,
+                                               FSNodeDirectory *parent, FSNode *child,
                                                uint8_t *path, uint32_t size) {
 	if (parent == nullptr || child == nullptr) {
 		return;
@@ -807,7 +808,7 @@ void FilesystemNodeOperationsBase::getPathData(FSNodeDirectory *parent, FSNode *
 	while (parent != gMetadata->root && !parent->parents.empty()) {
 		child = parent;
 		assert(child->parents.size() == 1);
-		parent = idToNodeVerify<FSNodeDirectory>(child->parents[0].first);
+		parent = idToNodeVerify<FSNodeDirectory>(fsOpContext, child->parents[0].first);
 		name = parent->getChildName(child);
 
 		if (size >= name.length()) {
@@ -824,9 +825,10 @@ void FilesystemNodeOperationsBase::getPathData(FSNodeDirectory *parent, FSNode *
 	}
 }
 
-void FilesystemNodeOperationsBase::getPath(FSNodeDirectory *parent, FSNode *child,
+void FilesystemNodeOperationsBase::getPath(const FilesystemOperationContext &fsOpContext,
+                                           FSNodeDirectory *parent, FSNode *child,
                                            std::string &path) {
-	uint32_t size = getPathSize(parent, child);
+	uint32_t size = getPathSize(fsOpContext, parent, child);
 
 	if (size > FSNode::kEdgeNameMaxSize) {
 		safs::log_warn("path too long !!! - truncate");
@@ -835,7 +837,7 @@ void FilesystemNodeOperationsBase::getPath(FSNodeDirectory *parent, FSNode *chil
 
 	path.resize(size);
 
-	getPathData(parent, child, (uint8_t *)path.data(), size);
+	getPathData(fsOpContext, parent, child, (uint8_t *)path.data(), size);
 }
 
 #ifndef METARESTORE
@@ -1083,7 +1085,7 @@ void FilesystemNodeOperationsBase::getDirData(const FilesystemOperationContext &
 		// parent attributes
 		if (withAttr) {
 			if (!nodeDir->parents.empty()) {
-				auto *parent = idToNodeVerify<FSNode>(nodeDir->parents[0].first);
+				auto *parent = idToNodeVerify<FSNode>(fsOpContext, nodeDir->parents[0].first);
 				fillAttr(fsOpContext, parent, nodeDir, uid, gid, auid, agid, sesflags, attr);
 				::memcpy(outBuffer, attr.data(), attr.size());
 			} else {
@@ -1144,7 +1146,6 @@ void FilesystemNodeOperationsBase::getDir(const FilesystemOperationContext &fsOp
                                           FSNodeDirectory *nodeDir, uint64_t firstEntry,
                                           uint64_t numberOfEntries,
                                           std::vector<DirectoryEntry> &dirEntriesOut) {
-	(void)fsOpContext;  // unused in this implementation
 	sassert(!(firstEntry & kSignBit64));
 
 	FSNodeDirectory *parent;
@@ -1155,7 +1156,7 @@ void FilesystemNodeOperationsBase::getDir(const FilesystemOperationContext &fsOp
 	if (firstEntry == kDotEntryIndex && numberOfEntries >= 1) {
 		inode = nodeDir->id != rootINode ? nodeDir->id : SPECIAL_INODE_ROOT;
 		parent = idToNodeVerify<FSNodeDirectory>(
-		    nodeDir->parents.empty() ? SPECIAL_INODE_ROOT : nodeDir->parents[0].first);
+		    fsOpContext, nodeDir->parents.empty() ? SPECIAL_INODE_ROOT : nodeDir->parents[0].first);
 		fillAttr(fsOpContext, nodeDir, parent, uid, gid, auid, agid, sesflags, attr);
 		dirEntriesOut.emplace_back(kDotEntryIndex, kDotDotEntryIndex, inode, ".", attr);
 
@@ -1167,8 +1168,9 @@ void FilesystemNodeOperationsBase::getDir(const FilesystemOperationContext &fsOp
 	if (firstEntry == kDotDotEntryIndex && numberOfEntries >= 1) {
 		if (nodeDir->id == rootINode) {
 			inode = SPECIAL_INODE_ROOT;
-			parent = idToNodeVerify<FSNodeDirectory>(
-			    nodeDir->parents.empty() ? SPECIAL_INODE_ROOT : nodeDir->parents[0].first);
+			parent = idToNodeVerify<FSNodeDirectory>(fsOpContext, nodeDir->parents.empty()
+			                                                          ? SPECIAL_INODE_ROOT
+			                                                          : nodeDir->parents[0].first);
 			fillAttr(fsOpContext, nodeDir, parent, uid, gid, auid, agid, sesflags, attr);
 		} else {
 			if (!nodeDir->parents.empty() && nodeDir->parents[0].first != rootINode) {
@@ -1177,9 +1179,11 @@ void FilesystemNodeOperationsBase::getDir(const FilesystemOperationContext &fsOp
 				inode = SPECIAL_INODE_ROOT;
 			}
 
-			parent = idToNodeVerify<FSNodeDirectory>(
-			    nodeDir->parents.empty() ? SPECIAL_INODE_ROOT : nodeDir->parents[0].first);
+			parent = idToNodeVerify<FSNodeDirectory>(fsOpContext, nodeDir->parents.empty()
+			                                                          ? SPECIAL_INODE_ROOT
+			                                                          : nodeDir->parents[0].first);
 			auto *grandparent = idToNodeVerify<FSNodeDirectory>(
+			    fsOpContext,
 			    parent->parents.empty() ? SPECIAL_INODE_ROOT : parent->parents[0].first);
 			fillAttr(fsOpContext, parent, grandparent, uid, gid, auid, agid, sesflags, attr);
 		}
@@ -1513,7 +1517,7 @@ void FilesystemNodeOperationsBase::unlink(const FilesystemOperationContext &fsOp
 		if (childNode->type == FSNodeType::kFile &&
 		    (childNode->trashtime > 0 ||
 		     !static_cast<FSNodeFile *>(childNode)->sessionIds.empty())) {
-			getPath(parent, childNode, path);
+			getPath(fsOpContext, parent, childNode, path);
 		}
 	}
 
@@ -2243,7 +2247,7 @@ uint8_t FilesystemNodeOperationsBase::getNodeForOperation(
 
 			if (candidateNode == nullptr) { return SAUNAFS_ERROR_ENOENT; }
 
-			if (!isAncestorOrNodeReservedOrTrash(candidateRoot, candidateNode)) {
+			if (!isAncestorOrNodeReservedOrTrash(fsOpContext, candidateRoot, candidateNode)) {
 				return SAUNAFS_ERROR_EPERM;
 			}
 		}

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -1091,7 +1091,7 @@ void FilesystemNodeOperationsBase::getDirData(const FilesystemOperationContext &
 					         attr);
 					::memcpy(outBuffer, attr.data(), attr.size());
 				} else {
-					FSNode *foundRootNode = idToNode(rootINode);
+					FSNode *foundRootNode = idToNode(fsOpContext, rootINode);
 					if (foundRootNode) {  // it should be always true because it's checked
 						// before, but better check than sorry
 						fillAttr(fsOpContext, foundRootNode, nodeDir, uid, gid, auid, agid,

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -967,7 +967,8 @@ void FilesystemNodeOperationsBase::getDetachedData(const TrashPathContainer &dat
 	}
 }
 
-void FilesystemNodeOperationsBase::getDetachedData(const HandleIndexContainer &data,
+void FilesystemNodeOperationsBase::getDetachedData(const FilesystemOperationContext &fsOpContext,
+                                                   const HandleIndexContainer &data,
                                                    uint64_t handleOffset, uint32_t maxEntries,
                                                    std::vector<HandleInodeEntry> &entries,
                                                    bool fromTrash) {
@@ -982,7 +983,7 @@ void FilesystemNodeOperationsBase::getDetachedData(const HandleIndexContainer &d
 		std::string nameForClient;
 
 		if (fromTrash) {
-			FSNode *node = idToNode((*iter).second);
+			FSNode *node = idToNode(fsOpContext, (*iter).second);
 			nameForClient = gMetadata->trash.at(TrashPathKey(node)).get().c_str();
 		} else {
 			nameForClient = gMetadata->reserved.at((*iter).second).get().c_str();

--- a/src/master/filesystem_node.h
+++ b/src/master/filesystem_node.h
@@ -166,7 +166,8 @@ public:
 
 	/// Returns entries from a HandleIndexContainer starting at a given handleOffset.
 	/// @see IFilesystemNodeOperations::getDetachedData
-	void getDetachedData(const HandleIndexContainer &data, uint64_t handleOffset,
+	void getDetachedData(const FilesystemOperationContext &fsOpContext,
+	                     const HandleIndexContainer &data, uint64_t handleOffset,
 	                     uint32_t maxEntries, std::vector<HandleInodeEntry> &entries,
 	                     bool fromTrash) override;
 #endif

--- a/src/master/filesystem_node.h
+++ b/src/master/filesystem_node.h
@@ -173,9 +173,12 @@ public:
 #endif
 
 	// Path operations
-	void getPath(FSNodeDirectory *parent, FSNode *child, std::string &path) override;
-	uint32_t getPathSize(FSNodeDirectory *parent, FSNode *child) override;
-	void getPathData(FSNodeDirectory *parent, FSNode *child, uint8_t *path, uint32_t size) override;
+	void getPath(const FilesystemOperationContext &fsOpContext, FSNodeDirectory *parent,
+	             FSNode *child, std::string &path) override;
+	uint32_t getPathSize(const FilesystemOperationContext &fsOpContext, FSNodeDirectory *parent,
+	                     FSNode *child) override;
+	void getPathData(const FilesystemOperationContext &fsOpContext, FSNodeDirectory *parent,
+	                 FSNode *child, uint8_t *path, uint32_t size) override;
 	std::string escapeName(const std::string &name) override;
 
 	// ACL operations
@@ -256,23 +259,21 @@ protected:
 
 	/// Returns true if \a ancestor is ancestor of \a node.
 	/// @see IFilesystemNodeOperations::isAncestor
-	bool isAncestor(FSNodeDirectory *ancestor, FSNode *node) override;
+	bool isAncestor(const FilesystemOperationContext &fsOpContext,
+	                FSNodeDirectory *ancestor, FSNode *node) override;
 
 	/// Returns true if \a node is reserved or in trash or \a ancestor is ancestor of \a node.
 	/// @see IFilesystemNodeOperations::isAncestorOrNodeReservedOrTrash
-	bool isAncestorOrNodeReservedOrTrash(FSNodeDirectory *ancestor, FSNode *node) override;
+	bool isAncestorOrNodeReservedOrTrash(const FilesystemOperationContext &fsOpContext,
+	                                    FSNodeDirectory *ancestor, FSNode *node) override;
 
-	FSNodeDirectory *getFirstParent(FSNode *node) override;
+	FSNodeDirectory *getFirstParent(const FilesystemOperationContext &fsOpContext,
+	                                FSNode *node) override;
 
 	/// Returns the IDs of all parents of the given node.
 	/// @see IFilesystemNodeOperations::getParentIds
 	std::vector<inode_t> getParentIds(
 	    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, FSNode *node) override;
-
-protected:
-	/// Internal node lookup operation - override in subclasses for custom storage.
-	/// @see IFilesystemNodeOperations::idToNodeInternal
-	FSNode *idToNodeInternal(inode_t inode) const override;
 
 	/// Internal node lookup operation with context - override in subclasses for custom storage.
 	/// @see IFilesystemNodeOperations::idToNodeInternal

--- a/src/master/filesystem_node_operations_interface.h
+++ b/src/master/filesystem_node_operations_interface.h
@@ -96,14 +96,6 @@ public:
 
 	// Type-safe node lookup operations
 
-	/// Looks up a node by its inode and verifies its type.
-	template <class NodeType>
-	NodeType *idToNodeVerify(inode_t inode) {
-		auto *node = static_cast<NodeType *>(this->idToNodeInternal(inode));
-		this->checkNodeType(node);
-		return node;
-	}
-
 	/// Looks up a node by its inode and context, and verifies its type.
 	template <class NodeType>
 	NodeType *idToNodeVerify(const FilesystemOperationContext &fsOpContext, inode_t inode) {
@@ -454,10 +446,12 @@ public:
 #endif
 
 	// Path operations
-	virtual void getPath(FSNodeDirectory *parent, FSNode *child, std::string &path) = 0;
-	virtual uint32_t getPathSize(FSNodeDirectory *parent, FSNode *child) = 0;
-	virtual void getPathData(FSNodeDirectory *parent, FSNode *child, uint8_t *path,
-	                         uint32_t size) = 0;
+	virtual void getPath(const FilesystemOperationContext &fsOpContext, FSNodeDirectory *parent,
+	                     FSNode *child, std::string &path) = 0;
+	virtual uint32_t getPathSize(const FilesystemOperationContext &fsOpContext,
+	                             FSNodeDirectory *parent, FSNode *child) = 0;
+	virtual void getPathData(const FilesystemOperationContext &fsOpContext, FSNodeDirectory *parent,
+	                         FSNode *child, uint8_t *path, uint32_t size) = 0;
 	virtual std::string escapeName(const std::string &name) = 0;
 
 	// ACL operations
@@ -583,16 +577,21 @@ public:
 	// Ancestry operations
 
 	/// Returns true if \a ancestor is ancestor of \a node.
+	/// @param fsOpContext Filesystem operation context with a potential transaction.
 	/// @param ancestor potential ancestor node
 	/// @param node potential descendant node
-	virtual bool isAncestor(FSNodeDirectory *ancestor, FSNode *node) = 0;
+	virtual bool isAncestor(const FilesystemOperationContext &fsOpContext,
+	                        FSNodeDirectory *ancestor, FSNode *node) = 0;
 
 	/// Returns true if \a node is reserved or in trash or \a ancestor is ancestor of \a node.
+	/// @param fsOpContext Filesystem operation context with a potential transaction.
 	/// @param ancestor potential ancestor node
 	/// @param node potential reserved, trash or descendant node
-	virtual bool isAncestorOrNodeReservedOrTrash(FSNodeDirectory *ancestor, FSNode *node) = 0;
+	virtual bool isAncestorOrNodeReservedOrTrash(const FilesystemOperationContext &fsOpContext,
+	                                             FSNodeDirectory *ancestor, FSNode *node) = 0;
 
-	virtual FSNodeDirectory *getFirstParent(FSNode *node) = 0;
+	virtual FSNodeDirectory *getFirstParent(const FilesystemOperationContext &fsOpContext,
+	                                        FSNode *node) = 0;
 
 	/// Returns all parent ids of the given node.
 	/// @param fsOpContext The filesystem operation context potentially containing a transaction.
@@ -602,11 +601,6 @@ public:
 	                                          FSNode *node) = 0;
 
 protected:
-	/// Core node lookup operation - override in subclasses for custom storage.
-	/// @param inode The inode of the node to look up.
-	/// @return Pointer to the node if found, nullptr otherwise.
-	virtual FSNode *idToNodeInternal(inode_t inode) const = 0;
-
 	/// Core node lookup operation with context - override in subclasses for custom storage.
 	/// @param context The FS context for the operation, potentially carrying a transaction.
 	/// @param inode The inode of the node to look up.

--- a/src/master/filesystem_node_operations_interface.h
+++ b/src/master/filesystem_node_operations_interface.h
@@ -112,12 +112,6 @@ public:
 		return node;
 	}
 
-	/// Looks up a node by its inode.
-	template <class NodeType = FSNode>
-	NodeType *idToNode(inode_t inode) {
-		return static_cast<NodeType *>(this->idToNodeInternal(inode));
-	}
-
 	/// Looks up a node by its inode and context.
 	template <class NodeType = FSNode>
 	NodeType *idToNode(const FilesystemOperationContext &fsOpContext, inode_t inode) {
@@ -453,7 +447,8 @@ public:
 	/// The offset provided by the client (e.g., FUSE readdir) is always non-negative (sign bit 0).
 	/// Internally, the server may store offsets with the sign bit set (bit 63 = 1).
 	/// All lookups are enforced to be done ignoring the sign bit by setting it to 0.
-	virtual void getDetachedData(const HandleIndexContainer &data, uint64_t handleOffset,
+	virtual void getDetachedData(const FilesystemOperationContext &fsOpContext,
+	                             const HandleIndexContainer &data, uint64_t handleOffset,
 	                             uint32_t maxEntries, std::vector<HandleInodeEntry> &entries,
 	                             bool fromTrash) = 0;
 #endif

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -417,6 +417,10 @@ uint8_t FilesystemOperationsBase::applyAccess(const FilesystemOperationContext &
 	p->atime = timestamp;
 	fsnodes_update_checksum(p);
 	gMetadata->metadataVersion++;
+
+	// Make the change persistent for KV backends
+	if (fsOpContext.hasReadWriteTransaction()) { nodeOperations_->updateNode(fsOpContext, p); }
+
 	return SAUNAFS_STATUS_OK;
 }
 
@@ -834,6 +838,9 @@ uint8_t FilesystemOperationsBase::applyTrunc(const FilesystemOperationContext &f
 	gMetadata->metadataVersion++;
 	fsnodes_update_checksum(p);
 
+	// Make the change persistent for KV backends
+	if (fsOpContext.hasReadWriteTransaction()) { nodeOperations_->updateNode(fsOpContext, p); }
+
 	return SAUNAFS_STATUS_OK;
 }
 
@@ -1074,6 +1081,10 @@ uint8_t FilesystemOperationsBase::applyAttr(const FilesystemOperationContext &fs
 	nodeOperations_->updateCTime(p, timestamp);
 	fsnodes_update_checksum(p);
 	gMetadata->metadataVersion++;
+
+	// Make persistent the changes on KV backends
+	if (fsOpContext.hasReadWriteTransaction()) { nodeOperations_->updateNode(fsOpContext, p); }
+
 	return SAUNAFS_STATUS_OK;
 }
 
@@ -1094,6 +1105,10 @@ uint8_t FilesystemOperationsBase::applyLength(const FilesystemOperationContext &
 	nodeOperations_->updateCTime(p, timestamp);
 	fsnodes_update_checksum(p);
 	gMetadata->metadataVersion++;
+
+	// Make the change persistent for KV backends
+	if (fsOpContext.hasReadWriteTransaction()) { nodeOperations_->updateNode(fsOpContext, p); }
+
 	return SAUNAFS_STATUS_OK;
 }
 

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -1497,7 +1497,7 @@ uint8_t FilesystemOperationsBase::recursiveRemove(const FsContext &context, inod
 
 	std::string node_name;
 
-	nodeOperations_->getPath(static_cast<FSNodeDirectory *>(wd_tmp), child, node_name);
+	nodeOperations_->getPath(fsOpContext, static_cast<FSNodeDirectory *>(wd_tmp), child, node_name);
 	return gMetadata->taskManager.submitTask(job_id, context.ts(), kInitialTaskBatchSize, task,
 	                                         RemoveTask::generateDescription(node_name), callback);
 }
@@ -1651,7 +1651,8 @@ uint8_t FilesystemOperationsBase::rename(const FsContext &context,
 	std::array<int64_t, 2> quota_delta = {{1, 1}};
 
 	if (sourceChildNode->type == FSNodeType::kDirectory) {
-		if (nodeOperations_->isAncestor(static_cast<FSNodeDirectory *>(sourceChildNode),
+		if (nodeOperations_->isAncestor(fsOpContext,
+		                                static_cast<FSNodeDirectory *>(sourceChildNode),
 		                                destWorkDir)) {
 			return SAUNAFS_ERROR_EINVAL;
 		}
@@ -2892,8 +2893,8 @@ uint8_t FilesystemOperationsBase::setGoal(const FsContext &context, inode_t inod
 	auto task = new SetGoalTask({p->id}, context.uid(), goal,
 							  smode, setgoal_stats);
 	std::string node_name;
-	FSNodeDirectory *parent = nodeOperations_->getFirstParent(p);
-	nodeOperations_->getPath(parent, p, node_name);
+	FSNodeDirectory *parent = nodeOperations_->getFirstParent(fsOpContext, p);
+	nodeOperations_->getPath(fsOpContext, parent, p, node_name);
 
 	std::string goal_name;
 #ifndef METARESTORE
@@ -2983,8 +2984,8 @@ uint8_t FilesystemOperationsBase::setTrashTime(
 	auto task = new SetTrashtimeTask({p->id}, context.uid(), trashtime,
 							  smode, settrashtime_stats);
 	std::string node_name;
-	FSNodeDirectory *parent = nodeOperations_->getFirstParent(p);
-	nodeOperations_->getPath(parent, p, node_name);
+	FSNodeDirectory *parent = nodeOperations_->getFirstParent(fsOpContext, p);
+	nodeOperations_->getPath(fsOpContext, parent, p, node_name);
 	return gMetadata->taskManager.submitTask(context.ts(), kInitialTaskBatchSize,
 	                                          task, SetTrashtimeTask::generateDescription(node_name, trashtime),
 	                                          callback);
@@ -3398,9 +3399,10 @@ uint32_t FilesystemOperationsBase::getDirPathSize(const FilesystemOperationConte
 		} else {
 			FSNodeDirectory *parent = nullptr;
 			if (!node->parents.empty()) {
-				parent = nodeOperations_->idToNodeVerify<FSNodeDirectory>(node->parents[0].first);
+				parent = nodeOperations_->idToNodeVerify<FSNodeDirectory>(fsOpContext,
+				                                                          node->parents[0].first);
 			}
-			return 1 + nodeOperations_->getPathSize(parent, node);
+			return 1 + nodeOperations_->getPathSize(fsOpContext, parent, node);
 		}
 	} else {
 		return 11;  // "(not found)"
@@ -3422,12 +3424,12 @@ void FilesystemOperationsBase::getDirPathData(const FilesystemOperationContext &
 			if (size > 0) {
 				FSNodeDirectory *parent = nullptr;
 				if (!node->parents.empty()) {
-					parent =
-					    nodeOperations_->idToNodeVerify<FSNodeDirectory>(node->parents[0].first);
+					parent = nodeOperations_->idToNodeVerify<FSNodeDirectory>(
+					    fsOpContext, node->parents[0].first);
 				}
 
 				buff[0] = '/';
-				nodeOperations_->getPathData(parent, node, buff + 1, size - 1);
+				nodeOperations_->getPathData(fsOpContext, parent, node, buff + 1, size - 1);
 				return;
 			}
 		}
@@ -3611,22 +3613,21 @@ bool FilesystemOperationsBase::quotaExceededUg(
 }
 
 bool FilesystemOperationsBase::quotaExceededDir(
-    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, FSNode *node,
+    const FilesystemOperationContext &fsOpContext, FSNode *node,
     const std::initializer_list<std::pair<QuotaResource, int64_t>> &resourceList) {
-	return fsnodes_quota_exceeded_dir(node, resourceList);
+	return fsnodes_quota_exceeded_dir(fsOpContext, node, resourceList);
 }
 
 bool FilesystemOperationsBase::quotaExceededDirMove(
-    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, FSNodeDirectory *node,
-    FSNodeDirectory *prevNode,
+    const FilesystemOperationContext &fsOpContext, FSNodeDirectory *node, FSNodeDirectory *prevNode,
     const std::initializer_list<std::pair<QuotaResource, int64_t>> &resourceList) {
-	return fsnodes_quota_exceeded_dir(node, prevNode, resourceList);
+	return fsnodes_quota_exceeded_dir(fsOpContext, node, prevNode, resourceList);
 }
 
 bool FilesystemOperationsBase::quotaExceeded(
-    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, FSNode *node,
+    const FilesystemOperationContext &fsOpContext, FSNode *node,
     const std::initializer_list<std::pair<QuotaResource, int64_t>> &resourceList) {
-	return fsnodes_quota_exceeded(node, resourceList);
+	return fsnodes_quota_exceeded(fsOpContext, node, resourceList);
 }
 
 void FilesystemOperationsBase::quotaUpdate(
@@ -3653,10 +3654,10 @@ uint8_t FilesystemOperationsBase::quotaGet(const FsContext &context,
 	return quotas::fs_quota_get(context, owners, results);
 }
 
-uint8_t FilesystemOperationsBase::quotaSet(
-    const FsContext &context, [[maybe_unused]] const FilesystemOperationContext &fsOpContext,
-    const std::vector<QuotaEntry> &entries) {
-	return quotas::fs_quota_set(context, entries);
+uint8_t FilesystemOperationsBase::quotaSet(const FsContext &context,
+                                           const FilesystemOperationContext &fsOpContext,
+                                           const std::vector<QuotaEntry> &entries) {
+	return quotas::fs_quota_set(context, fsOpContext, entries);
 }
 
 uint8_t FilesystemOperationsBase::quotaGetInfo(const FsContext &context,

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -125,10 +125,11 @@ void FilesystemOperationsBase::readReserved(uint32_t off, uint32_t max_entries,
 	nodeOperations_->getDetachedData(gMetadata->reserved, off, max_entries, entries);
 }
 
-void FilesystemOperationsBase::readReserved(uint64_t handleOffset, uint32_t maxEntries,
+void FilesystemOperationsBase::readReserved(const FilesystemOperationContext &fsOpContext,
+                                            uint64_t handleOffset, uint32_t maxEntries,
                                             std::vector<HandleInodeEntry> &entries) {
-	nodeOperations_->getDetachedData(gMetadata->reservedHandlesIndex, handleOffset, maxEntries,
-	                                 entries, false);
+	nodeOperations_->getDetachedData(fsOpContext, gMetadata->reservedHandlesIndex, handleOffset,
+	                                 maxEntries, entries, false);
 }
 
 uint8_t FilesystemOperationsBase::readTrashSize(inode_t rootinode, uint8_t sesflags,
@@ -152,14 +153,16 @@ void FilesystemOperationsBase::readTrash(uint32_t off, uint32_t max_entries,
 	nodeOperations_->getDetachedData(gMetadata->trash, off, max_entries, entries);
 }
 
-void FilesystemOperationsBase::readTrash(uint64_t handleOffset, uint32_t maxEntries,
+void FilesystemOperationsBase::readTrash(const FilesystemOperationContext &fsOpContext,
+                                         uint64_t handleOffset, uint32_t maxEntries,
                                          std::vector<HandleInodeEntry> &entries) {
-	nodeOperations_->getDetachedData(gMetadata->trashHandlesIndex, handleOffset, maxEntries,
-	                                 entries, true);
+	nodeOperations_->getDetachedData(fsOpContext, gMetadata->trashHandlesIndex, handleOffset,
+	                                 maxEntries, entries, true);
 }
 
 /* common procedure for trash and reserved files */
-uint8_t FilesystemOperationsBase::getDetachedAttr(inode_t rootinode, uint8_t sesflags,
+uint8_t FilesystemOperationsBase::getDetachedAttr(const FilesystemOperationContext &fsOpContext,
+                                                  inode_t rootinode, uint8_t sesflags,
                                                   inode_t inode, Attributes &attr, uint8_t dtype) {
 	FSNode *p;
 	attr.fill(0);
@@ -170,7 +173,7 @@ uint8_t FilesystemOperationsBase::getDetachedAttr(inode_t rootinode, uint8_t ses
 	if (!DTYPE_ISVALID(dtype)) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
-	p = nodeOperations_->idToNode(inode);
+	p = nodeOperations_->idToNode(fsOpContext, inode);
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
@@ -184,22 +187,20 @@ uint8_t FilesystemOperationsBase::getDetachedAttr(inode_t rootinode, uint8_t ses
 		return SAUNAFS_ERROR_ENOENT;
 	}
 
-	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
-	    FilesystemOperationContext::TransactionType::kReadOnly);
-
 	nodeOperations_->fillAttr(fsOpContext, p, NULL, p->uid, p->gid, p->uid, p->gid, sesflags, attr);
 
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t FilesystemOperationsBase::getTrashPath(inode_t rootinode, uint8_t sesflags, inode_t inode,
+uint8_t FilesystemOperationsBase::getTrashPath(const FilesystemOperationContext &fsOpContext,
+                                               inode_t rootinode, uint8_t sesflags, inode_t inode,
                                                std::string &path) {
 	FSNode *p;
 	if (rootinode != 0) {
 		return SAUNAFS_ERROR_EPERM;
 	}
 	(void)sesflags;
-	p = nodeOperations_->idToNode(inode);
+	p = nodeOperations_->idToNode(fsOpContext, inode);
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
@@ -406,9 +407,10 @@ uint8_t FilesystemOperationsBase::applyChecksum(const std::string &version, uint
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t FilesystemOperationsBase::applyAccess(uint32_t timestamp, inode_t inode) {
+uint8_t FilesystemOperationsBase::applyAccess(const FilesystemOperationContext &fsOpContext,
+                                              uint32_t timestamp, inode_t inode) {
 	FSNode *p;
-	p = nodeOperations_->idToNode(inode);
+	p = nodeOperations_->idToNode(fsOpContext, inode);
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
@@ -605,10 +607,11 @@ uint8_t FilesystemOperationsBase::fullPathByInode(const FsContext &context, inod
 	return SAUNAFS_STATUS_OK;
 }
 
-std::string FilesystemOperationsBase::fullPathByInode(inode_t initialInode) {
+std::string FilesystemOperationsBase::fullPathByInode(const FilesystemOperationContext &fsOpContext,
+                                                      inode_t initialInode) {
 	std::string fullPath = "";
 	inode_t currentInode = initialInode;
-	FSNode *currentNode = nodeOperations_->idToNode(currentInode);
+	FSNode *currentNode = nodeOperations_->idToNode(fsOpContext, currentInode);
 	std::string currentName = "";
 
 	while (currentInode != SPECIAL_INODE_ROOT) {
@@ -634,7 +637,7 @@ std::string FilesystemOperationsBase::fullPathByInode(inode_t initialInode) {
 		}
 
 		auto parent = currentNode->parents[0].first;
-		auto parentNode = nodeOperations_->idToNode<FSNodeDirectory>(parent);
+		auto parentNode = nodeOperations_->idToNode<FSNodeDirectory>(fsOpContext, parent);
 		if (!parentNode) { return ""; }
 		currentName = parentNode->getChildName(currentNode);
 		fullPath = currentInode == initialInode ? currentName : currentName + "/" + fullPath;
@@ -788,11 +791,12 @@ uint8_t FilesystemOperationsBase::getCanonicalPath(const FsContext &context,
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t FilesystemOperationsBase::applyTrunc(uint32_t timestamp, inode_t inode, uint32_t indx,
+uint8_t FilesystemOperationsBase::applyTrunc(const FilesystemOperationContext &fsOpContext,
+                                             uint32_t timestamp, inode_t inode, uint32_t indx,
                                              uint64_t chunkid, uint32_t lockid) {
 	uint64_t ochunkid, nchunkid;
 	uint8_t status;
-	auto *p = nodeOperations_->idToNode<FSNodeFile>(inode);
+	auto *p = nodeOperations_->idToNode<FSNodeFile>(fsOpContext, inode);
 
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
@@ -1369,7 +1373,8 @@ uint8_t FilesystemOperationsBase::mkdir(const FsContext &context,
 }
 #endif
 
-uint8_t FilesystemOperationsBase::applyCreate(uint32_t timestamp, inode_t parent,
+uint8_t FilesystemOperationsBase::applyCreate(const FilesystemOperationContext &fsOpContext,
+                                              uint32_t timestamp, inode_t parent,
                                               const HString &name, FSNodeType type, uint32_t mode,
                                               uint32_t uid, uint32_t gid, uint32_t rdev,
                                               inode_t inode) {
@@ -1379,16 +1384,13 @@ uint8_t FilesystemOperationsBase::applyCreate(uint32_t timestamp, inode_t parent
 	    type != FSNodeType::kDirectory) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
-	wd = nodeOperations_->idToNode(parent);
+	wd = nodeOperations_->idToNode(fsOpContext, parent);
 	if (!wd) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
 	if (wd->type != FSNodeType::kDirectory) {
 		return SAUNAFS_ERROR_ENOTDIR;
 	}
-
-	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
-		FilesystemOperationContext::TransactionType::kReadWrite);
 
 	// For metadata restore operations, use default case-sensitive behavior
 	if (nodeOperations_->isNameUsed(fsOpContext, static_cast<FSNodeDirectory *>(wd), name)) {
@@ -1550,16 +1552,14 @@ uint8_t FilesystemOperationsBase::rmdir(const FsContext &context,
 }
 #endif
 
-uint8_t FilesystemOperationsBase::applyUnlink(uint32_t timestamp, inode_t parent,
+uint8_t FilesystemOperationsBase::applyUnlink(const FilesystemOperationContext &fsOpContext,
+                                              uint32_t timestamp, inode_t parent,
                                               const HString &name, inode_t inode) {
-	FSNode *workDir = nodeOperations_->idToNode(parent);
+	FSNode *workDir = nodeOperations_->idToNode(fsOpContext, parent);
 
 	if (!workDir) { return SAUNAFS_ERROR_ENOENT; }
 
 	if (workDir->type != FSNodeType::kDirectory) { return SAUNAFS_ERROR_ENOTDIR; }
-
-	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
-	    FilesystemOperationContext::TransactionType::kReadWrite);
 
 	FSNode *child =
 	    nodeOperations_->lookup(fsOpContext, static_cast<FSNodeDirectory *>(workDir), name);
@@ -2388,7 +2388,8 @@ uint8_t fs_auto_repair_if_needed(FSNodeFile *p, uint32_t chunkIndex) {
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t FilesystemOperationsBase::readChunk(inode_t inode, uint32_t indx, uint64_t *chunkid,
+uint8_t FilesystemOperationsBase::readChunk(const FilesystemOperationContext &fsOpContext,
+                                            inode_t inode, uint32_t indx, uint64_t *chunkid,
                                             uint64_t *length) {
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
@@ -2396,7 +2397,7 @@ uint8_t FilesystemOperationsBase::readChunk(inode_t inode, uint32_t indx, uint64
 
 	*chunkid = 0;
 	*length = 0;
-	p = nodeOperations_->idToNode<FSNodeFile>(inode);
+	p = nodeOperations_->idToNode<FSNodeFile>(fsOpContext, inode);
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
@@ -3387,9 +3388,10 @@ uint8_t FilesystemOperationsBase::applySetRichAcl(const FilesystemOperationConte
 }
 
 #ifndef METARESTORE
-uint32_t FilesystemOperationsBase::getDirPathSize(inode_t inode) {
+uint32_t FilesystemOperationsBase::getDirPathSize(const FilesystemOperationContext &fsOpContext,
+                                                  inode_t inode) {
 	FSNode *node;
-	node = nodeOperations_->idToNode(inode);
+	node = nodeOperations_->idToNode(fsOpContext, inode);
 	if (node) {
 		if (node->type != FSNodeType::kDirectory) {
 			return 15;  // "(not directory)"
@@ -3406,9 +3408,10 @@ uint32_t FilesystemOperationsBase::getDirPathSize(inode_t inode) {
 	return 0;  // unreachable
 }
 
-void FilesystemOperationsBase::getDirPathData(inode_t inode, uint8_t *buff, uint32_t size) {
+void FilesystemOperationsBase::getDirPathData(const FilesystemOperationContext &fsOpContext,
+                                              inode_t inode, uint8_t *buff, uint32_t size) {
 	FSNode *node;
-	node = nodeOperations_->idToNode(inode);
+	node = nodeOperations_->idToNode(fsOpContext, inode);
 	if (node) {
 		if (node->type != FSNodeType::kDirectory) {
 			if (size >= 15) {

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -377,7 +377,7 @@ void FilesystemOperationsBase::statfs(const FsContext &context,
 	} else {
 		*trspace = 0;
 		*respace = 0;
-		rn = nodeOperations_->idToNode(context.rootinode());
+		rn = nodeOperations_->idToNode(fsOpContext, context.rootinode());
 	}
 	if (!rn || rn->type != FSNodeType::kDirectory) {
 		*totalspace = 0;
@@ -485,7 +485,7 @@ uint8_t FilesystemOperationsBase::lookup(const FsContext &context,
 					} else {
 						*inode = workDir->parents[0].first;
 					}
-					FSNode *pp = nodeOperations_->idToNode(workDir->parents[0].first);
+					FSNode *pp = nodeOperations_->idToNode(fsOpContext, workDir->parents[0].first);
 					nodeOperations_->fillAttr(fsOpContext, pp, workDir, context.uid(),
 					                          context.gid(), context.auid(), context.agid(),
 					                          context.sesflags(), attr);
@@ -743,7 +743,7 @@ uint8_t FilesystemOperationsBase::getCanonicalPath(const FsContext &context,
                                                    const std::string &inputPath,
                                                    std::string &canonicalPath) {
 	bool caseInsensitiveFS = context.isCaseInsensitive();
-	FSNode *currentNode = nodeOperations_->idToNode(context.rootinode());
+	FSNode *currentNode = nodeOperations_->idToNode(fsOpContext, context.rootinode());
 	std::string resultPath;
 
 	if (!currentNode || currentNode->type != FSNodeType::kDirectory) {
@@ -1055,7 +1055,7 @@ uint8_t FilesystemOperationsBase::applyAttr(const FilesystemOperationContext &fs
                                             uint32_t timestamp, inode_t inode, uint32_t mode,
                                             uint32_t uid, uint32_t gid, uint32_t atime,
                                             uint32_t mtime) {
-	FSNode *p = nodeOperations_->idToNode(inode);
+	FSNode *p = nodeOperations_->idToNode(fsOpContext, inode);
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
@@ -1076,7 +1076,7 @@ uint8_t FilesystemOperationsBase::applyAttr(const FilesystemOperationContext &fs
 uint8_t FilesystemOperationsBase::applyLength(const FilesystemOperationContext &fsOpContext,
                                               uint32_t timestamp, inode_t inode, uint64_t length,
                                               bool eraseFurtherChunks) {
-	FSNode *p = nodeOperations_->idToNode(inode);
+	FSNode *p = nodeOperations_->idToNode(fsOpContext, inode);
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
@@ -3215,7 +3215,7 @@ uint8_t FilesystemOperationsBase::applySetXAttr(const FilesystemOperationContext
 	    mode > XATTR_SMODE_REMOVE) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
-	p = nodeOperations_->idToNode(inode);
+	p = nodeOperations_->idToNode(fsOpContext, inode);
 	if (!p) { return SAUNAFS_ERROR_ENOENT; }
 	status = doConcreteSetXAttr(fsOpContext, inode, static_cast<uint8_t>(anleng), attrname, avleng,
 	                            attrvalue, mode);
@@ -3349,7 +3349,7 @@ uint8_t FilesystemOperationsBase::applySetAcl(const FilesystemOperationContext &
 	} catch (Exception &) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
-	FSNode *p = nodeOperations_->idToNode(inode);
+	FSNode *p = nodeOperations_->idToNode(fsOpContext, inode);
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
@@ -3374,7 +3374,7 @@ uint8_t FilesystemOperationsBase::applySetRichAcl(const FilesystemOperationConte
 	} catch (Exception &) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
-	FSNode *p = nodeOperations_->idToNode(inode);
+	FSNode *p = nodeOperations_->idToNode(fsOpContext, inode);
 	if (!p) {
 		return SAUNAFS_ERROR_ENOENT;
 	}

--- a/src/master/filesystem_operations.h
+++ b/src/master/filesystem_operations.h
@@ -283,10 +283,12 @@ public:
 	                inode_t *trashNodes, uint64_t *reservedSpace, inode_t *reservedNodes,
 	                inode_t *inodes, inode_t *directoryNodes, inode_t *fileNodes,
 	                inode_t *linkNodes) override;
-	uint32_t getDirPathSize(inode_t inode) override;
-	void getDirPathData(inode_t inode, uint8_t *buff, uint32_t size) override;
+	uint32_t getDirPathSize(const FilesystemOperationContext &fsOpContext, inode_t inode) override;
+	void getDirPathData(const FilesystemOperationContext &fsOpContext, inode_t inode, uint8_t *buff,
+	                    uint32_t size) override;
 	uint8_t getRootInode(inode_t *rootinode, const uint8_t *path) override;
-	uint8_t readChunk(inode_t inode, uint32_t indx, uint64_t *chunkid, uint64_t *length) override;
+	uint8_t readChunk(const FilesystemOperationContext &fsOpContext, inode_t inode, uint32_t indx,
+	                  uint64_t *chunkid, uint64_t *length) override;
 	uint8_t writeEnd(const FilesystemOperationContext &fsOpContext, inode_t inode, uint64_t length,
 	                 uint64_t chunkid, uint32_t lockid) override;
 	void getTrashTimeStore(TrashtimeMap &fileTrashtimes, TrashtimeMap &dirTrashtimes,
@@ -299,21 +301,22 @@ public:
 	void readReservedData(inode_t rootinode, uint8_t sesflags, uint8_t *dbuff) override;
 	void readReserved(uint32_t off, uint32_t max_entries,
 	                  std::vector<NamedInodeEntry> &entries) override;
-	void readReserved(uint64_t handleOffset, uint32_t maxEntries,
-	                  std::vector<HandleInodeEntry> &entries) override;
+	void readReserved(const FilesystemOperationContext &fsOpContext, uint64_t handleOffset,
+	                  uint32_t maxEntries, std::vector<HandleInodeEntry> &entries) override;
 
 	// TRASH
 	uint8_t readTrashSize(inode_t rootinode, uint8_t sesflags, uint32_t *dbuffsize) override;
 	void readTrashData(inode_t rootinode, uint8_t sesflags, uint8_t *dbuff) override;
 	void readTrash(uint32_t off, uint32_t max_entries,
 	               std::vector<NamedInodeEntry> &entries) override;
-	void readTrash(uint64_t handleOffset, uint32_t maxEntries,
-	               std::vector<HandleInodeEntry> &entries) override;
-	uint8_t getTrashPath(inode_t rootinode, uint8_t sesflags, inode_t inode,
-	                     std::string &path) override;
+	void readTrash(const FilesystemOperationContext &fsOpContext, uint64_t handleOffset,
+	               uint32_t maxEntries, std::vector<HandleInodeEntry> &entries) override;
+	uint8_t getTrashPath(const FilesystemOperationContext &fsOpContext, inode_t rootinode,
+	                     uint8_t sesflags, inode_t inode, std::string &path) override;
 
 	// RESERVED+TRASH
-	uint8_t getDetachedAttr(inode_t rootinode, uint8_t sesflags, inode_t inode, Attributes &attr,
+	uint8_t getDetachedAttr(const FilesystemOperationContext &fsOpContext, inode_t rootinode,
+	                        uint8_t sesflags, inode_t inode, Attributes &attr,
 	                        uint8_t dtype) override;
 
 	// EXTRA
@@ -329,7 +332,8 @@ public:
 
 	uint8_t fullPathByInode(const FsContext &context, inode_t inode,
 	                        std::string &fullPath) override;
-	std::string fullPathByInode(inode_t initialInode) override;
+	std::string fullPathByInode(const FilesystemOperationContext &fsOpContext,
+	                            inode_t initialInode) override;
 #endif
 
 	// QUOTAS
@@ -401,10 +405,11 @@ public:
 
 	// Functions which apply changes from changelog, only for shadow master and metarestore
 	uint8_t applyChecksum(const std::string &version, uint64_t checksum) override;
-	uint8_t applyCreate(uint32_t timestamp, inode_t parent, const HString &name, FSNodeType type,
-	                    uint32_t mode, uint32_t uid, uint32_t gid, uint32_t rdev,
+	uint8_t applyCreate(const FilesystemOperationContext &fsOpContext, uint32_t timestamp,
+	                    inode_t parent, const HString &name, FSNodeType type, uint32_t mode,
+	                    uint32_t uid, uint32_t gid, uint32_t rdev, inode_t inode) override;
+	uint8_t applyAccess(const FilesystemOperationContext &fsOpContext, uint32_t timestamp,
 	                    inode_t inode) override;
-	uint8_t applyAccess(uint32_t timestamp, inode_t inode) override;
 	uint8_t applyAttr(const FilesystemOperationContext &fsOpContext, uint32_t timestamp,
 	                  inode_t inode, uint32_t mode, uint32_t uid, uint32_t gid, uint32_t atime,
 	                  uint32_t mtime) override;
@@ -428,11 +433,11 @@ public:
 	uint8_t applySetRichAcl(const FilesystemOperationContext &fsOpContext, uint32_t timestamp,
 	                        inode_t inode, const std::string &acl_string) override;
 
-	uint8_t applyUnlink(uint32_t timestamp, inode_t parent, const HString &name,
-	                    inode_t inode) override;
+	uint8_t applyUnlink(const FilesystemOperationContext &fsOpContext, uint32_t timestamp,
+	                    inode_t parent, const HString &name, inode_t inode) override;
 	uint8_t applyUnlock(uint64_t chunkid) override;
-	uint8_t applyTrunc(uint32_t timestamp, inode_t inode, uint32_t indx, uint64_t chunkid,
-	                   uint32_t lockid) override;
+	uint8_t applyTrunc(const FilesystemOperationContext &fsOpContext, uint32_t timestamp,
+	                   inode_t inode, uint32_t indx, uint64_t chunkid, uint32_t lockid) override;
 
 	/// Replays a SETQUOTA changelog tuple update.
 	/// @see IFilesystemOperations::applySetQuota

--- a/src/master/filesystem_operations_interface.h
+++ b/src/master/filesystem_operations_interface.h
@@ -1016,11 +1016,13 @@ public:
 	                        inode_t *trashNodes, uint64_t *reservedSpace, inode_t *reservedNodes,
 	                        inode_t *inodes, inode_t *directoryNodes, inode_t *fileNodes,
 	                        inode_t *linkNodes) = 0;
-	virtual uint32_t getDirPathSize(inode_t inode) = 0;
-	virtual void getDirPathData(inode_t inode, uint8_t *buff, uint32_t size) = 0;
+	virtual uint32_t getDirPathSize(const FilesystemOperationContext &fsOpContext,
+	                                inode_t inode) = 0;
+	virtual void getDirPathData(const FilesystemOperationContext &fsOpContext, inode_t inode,
+	                            uint8_t *buff, uint32_t size) = 0;
 	virtual uint8_t getRootInode(inode_t *rootinode, const uint8_t *path) = 0;
-	virtual uint8_t readChunk(inode_t inode, uint32_t indx, uint64_t *chunkid,
-	                          uint64_t *length) = 0;
+	virtual uint8_t readChunk(const FilesystemOperationContext &fsOpContext, inode_t inode,
+	                          uint32_t indx, uint64_t *chunkid, uint64_t *length) = 0;
 	virtual uint8_t writeEnd(const FilesystemOperationContext &fsOpContext, inode_t inode,
 	                         uint64_t length, uint64_t chunkid, uint32_t lockid) = 0;
 	virtual void getTrashTimeStore(TrashtimeMap &fileTrashtimes, TrashtimeMap &dirTrashtimes,
@@ -1033,21 +1035,22 @@ public:
 	virtual void readReservedData(inode_t rootinode, uint8_t sesflags, uint8_t *dbuff) = 0;
 	virtual void readReserved(uint32_t off, uint32_t max_entries,
 	                          std::vector<NamedInodeEntry> &entries) = 0;
-	virtual void readReserved(uint64_t handleOffset, uint32_t maxEntries,
-	                          std::vector<HandleInodeEntry> &entries) = 0;
+	virtual void readReserved(const FilesystemOperationContext &fsOpContext, uint64_t handleOffset,
+	                          uint32_t maxEntries, std::vector<HandleInodeEntry> &entries) = 0;
 
 	// TRASH
 	virtual uint8_t readTrashSize(inode_t rootinode, uint8_t sesflags, uint32_t *dbuffsize) = 0;
 	virtual void readTrashData(inode_t rootinode, uint8_t sesflags, uint8_t *dbuff) = 0;
 	virtual void readTrash(uint32_t off, uint32_t max_entries,
 	                       std::vector<NamedInodeEntry> &entries) = 0;
-	virtual void readTrash(uint64_t handleOffset, uint32_t maxEntries,
-	                       std::vector<HandleInodeEntry> &entries) = 0;
-	virtual uint8_t getTrashPath(inode_t rootinode, uint8_t sesflags, inode_t inode,
-	                             std::string &path) = 0;
+	virtual void readTrash(const FilesystemOperationContext &fsOpContext, uint64_t handleOffset,
+	                       uint32_t maxEntries, std::vector<HandleInodeEntry> &entries) = 0;
+	virtual uint8_t getTrashPath(const FilesystemOperationContext &fsOpContext, inode_t rootinode,
+	                             uint8_t sesflags, inode_t inode, std::string &path) = 0;
 
 	// RESERVED+TRASH
-	virtual uint8_t getDetachedAttr(inode_t rootinode, uint8_t sesflags, inode_t inode,
+	virtual uint8_t getDetachedAttr(const FilesystemOperationContext &fsOpContext,
+	                                inode_t rootinode, uint8_t sesflags, inode_t inode,
 	                                Attributes &attr, uint8_t dtype) = 0;
 
 	// EXTRA
@@ -1063,7 +1066,8 @@ public:
 
 	virtual uint8_t fullPathByInode(const FsContext &context, inode_t inode,
 	                                std::string &fullPath) = 0;
-	virtual std::string fullPathByInode(inode_t initialInode) = 0;
+	virtual std::string fullPathByInode(const FilesystemOperationContext &fsOpContext,
+	                                    inode_t initialInode) = 0;
 
 #endif
 
@@ -1206,10 +1210,11 @@ public:
 
 	// Functions which apply changes from changelog, only for shadow master and metarestore
 	virtual uint8_t applyChecksum(const std::string &version, uint64_t checksum) = 0;
-	virtual uint8_t applyCreate(uint32_t timestamp, inode_t parent, const HString &name,
-	                            FSNodeType type, uint32_t mode, uint32_t uid, uint32_t gid,
-	                            uint32_t rdev, inode_t inode) = 0;
-	virtual uint8_t applyAccess(uint32_t timestamp, inode_t inode) = 0;
+	virtual uint8_t applyCreate(const FilesystemOperationContext &fsOpContext, uint32_t timestamp,
+	                            inode_t parent, const HString &name, FSNodeType type, uint32_t mode,
+	                            uint32_t uid, uint32_t gid, uint32_t rdev, inode_t inode) = 0;
+	virtual uint8_t applyAccess(const FilesystemOperationContext &fsOpContext, uint32_t timestamp,
+	                            inode_t inode) = 0;
 	virtual uint8_t applyAttr(const FilesystemOperationContext &fsOpContext, uint32_t timestamp,
 	                          inode_t inode, uint32_t mode, uint32_t uid, uint32_t gid,
 	                          uint32_t atime, uint32_t mtime) = 0;
@@ -1255,11 +1260,11 @@ public:
 	                                uint32_t timestamp, inode_t inode,
 	                                const std::string &acl_string) = 0;
 
-	virtual uint8_t applyUnlink(uint32_t timestamp, inode_t parent, const HString &name,
-	                            inode_t inode) = 0;
+	virtual uint8_t applyUnlink(const FilesystemOperationContext &fsOpContext, uint32_t timestamp,
+	                            inode_t parent, const HString &name, inode_t inode) = 0;
 	virtual uint8_t applyUnlock(uint64_t chunkid) = 0;
-	virtual uint8_t applyTrunc(uint32_t timestamp, inode_t inode, uint32_t indx, uint64_t chunkid,
-	                           uint32_t lockid) = 0;
+	virtual uint8_t applyTrunc(const FilesystemOperationContext &fsOpContext, uint32_t timestamp,
+	                           inode_t inode, uint32_t indx, uint64_t chunkid, uint32_t lockid) = 0;
 
 	/// Replays a SETQUOTA changelog entry during metadata restore.
 	///

--- a/src/master/filesystem_periodic.cc
+++ b/src/master/filesystem_periodic.cc
@@ -136,6 +136,8 @@ static std::string get_node_info(FSNode *node) {
 
 std::vector<DefectiveFileInfo> fs_get_defective_nodes_info(uint8_t requested_flags, uint64_t max_entries,
 	                                                   uint64_t &entry_index) {
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadOnly);
 	FSNode *node;
 	std::vector<DefectiveFileInfo> defective_nodes_info;
 	ActiveLoopWatchdog watchdog;
@@ -144,7 +146,7 @@ std::vector<DefectiveFileInfo> fs_get_defective_nodes_info(uint8_t requested_fla
 	watchdog.start();
 	for (uint64_t i = 0; i < max_entries && it != gDefectiveNodes.end(); ++it) {
 		if (((*it).second & requested_flags) != 0) {
-			node = gFSOperations->nodeOperations()->idToNode<FSNode>((*it).first);
+			node = gFSOperations->nodeOperations()->idToNode<FSNode>(fsOpContext, (*it).first);
 			std::string info = get_node_info(node);
 			defective_nodes_info.emplace_back(std::move(info), (*it).second);
 			++i;
@@ -161,6 +163,8 @@ std::vector<DefectiveFileInfo> fs_get_defective_nodes_info(uint8_t requested_fla
 void fs_test_getdata(uint32_t &loopstart, uint32_t &loopend, inode_t &files, inode_t &ugfiles,
                      inode_t &mfiles, uint32_t &chunks, uint32_t &ugchunks, uint32_t &mchunks,
                      std::string &result) {
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadOnly);
 	std::stringstream report;
 	int errors = 0;
 
@@ -169,7 +173,7 @@ void fs_test_getdata(uint32_t &loopstart, uint32_t &loopend, inode_t &files, ino
 			break;
 		}
 
-		FSNode *node = gFSOperations->nodeOperations()->idToNode<FSNode>(entry.first);
+		FSNode *node = gFSOperations->nodeOperations()->idToNode<FSNode>(fsOpContext, entry.first);
 		if (!node) {
 			report << "Structure error in defective list, entry " << std::to_string(entry.first) << "\n";
 			errors++;

--- a/src/master/filesystem_periodic.cc
+++ b/src/master/filesystem_periodic.cc
@@ -93,11 +93,12 @@ void fs_background_task_manager_work() {
 	}
 }
 
-static std::string get_node_info(FSNode *node) {
+static std::string get_node_info(const FilesystemOperationContext &fsOpContext, FSNode *node) {
 	std::string name;
 	if (node == nullptr) {
 		return name;
 	}
+
 	if (node->type == FSNodeType::kTrash) {
 		name = "file in trash " + std::to_string(node->id) + ": " +
 		       (std::string)gMetadata->trash.at(TrashPathKey(node));
@@ -109,9 +110,9 @@ static std::string get_node_info(FSNode *node) {
 		bool first = true;
 		for (const auto &[parentId, _] : node->parents) {
 			std::string path;
-			auto *parent =
-			    gFSOperations->nodeOperations()->idToNodeVerify<FSNodeDirectory>(parentId);
-			gFSOperations->nodeOperations()->getPath(parent, node, path);
+			auto *parent = gFSOperations->nodeOperations()->idToNodeVerify<FSNodeDirectory>(
+			    fsOpContext, parentId);
+			gFSOperations->nodeOperations()->getPath(fsOpContext, parent, node, path);
 			if (!first) {
 				name += "|" + path;
 			} else {
@@ -125,9 +126,9 @@ static std::string get_node_info(FSNode *node) {
 		FSNodeDirectory *parent = nullptr;
 		if (!node->parents.empty()) {
 			parent = gFSOperations->nodeOperations()->idToNodeVerify<FSNodeDirectory>(
-			    node->parents.front().first);
+			    fsOpContext, node->parents.front().first);
 		}
-		gFSOperations->nodeOperations()->getPath(parent, node, path);
+		gFSOperations->nodeOperations()->getPath(fsOpContext, parent, node, path);
 		name += path;
 	}
 
@@ -147,7 +148,7 @@ std::vector<DefectiveFileInfo> fs_get_defective_nodes_info(uint8_t requested_fla
 	for (uint64_t i = 0; i < max_entries && it != gDefectiveNodes.end(); ++it) {
 		if (((*it).second & requested_flags) != 0) {
 			node = gFSOperations->nodeOperations()->idToNode<FSNode>(fsOpContext, (*it).first);
-			std::string info = get_node_info(node);
+			std::string info = get_node_info(fsOpContext, node);
 			defective_nodes_info.emplace_back(std::move(info), (*it).second);
 			++i;
 		}
@@ -211,7 +212,7 @@ void fs_test_getdata(uint32_t &loopstart, uint32_t &loopend, inode_t &files, ino
 		if (entry.second & kChunkUnavailable) {
 			assert(node->type == FSNodeType::kFile || node->type == FSNodeType::kTrash ||
 			       node->type == FSNodeType::kReserved);
-			std::string name = get_node_info(node);
+			std::string name = get_node_info(fsOpContext, node);
 			if (node->type == FSNodeType::kTrash) {
 				report << "-";
 			} else if (node->type == FSNodeType::kReserved) {
@@ -228,7 +229,7 @@ void fs_test_getdata(uint32_t &loopstart, uint32_t &loopend, inode_t &files, ino
 		}
 
 		if (entry.second & kStructureError) {
-			std::string name = get_node_info(node);
+			std::string name = get_node_info(fsOpContext, node);
 			report << "Structure error in " << name << "\n";
 			errors++;
 		}
@@ -328,6 +329,8 @@ void fs_process_file_test() {
 	uint32_t k;
 	uint8_t vc, node_error_flag;
 	ActiveLoopWatchdog watchdog;
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadOnly);
 
 	static inode_t files = 0;
 	static inode_t ugfiles = 0;
@@ -464,7 +467,7 @@ void fs_process_file_test() {
 
 				auto it = gDefectiveNodes.find(node->id);
 				if (it == gDefectiveNodes.end()) {
-					std::string name = get_node_info(node);
+					std::string name = get_node_info(fsOpContext, node);
 					safs::log_trace("Chunks unavailable in {}",
 					                   name);
 				}
@@ -475,7 +478,7 @@ void fs_process_file_test() {
 			if (node_error_flag & kStructureError) {
 				auto it = gDefectiveNodes.find(node->id);
 				if (it == gDefectiveNodes.end()) {
-					std::string name = get_node_info(node);
+					std::string name = get_node_info(fsOpContext, node);
 					safs_pretty_syslog(LOG_ERR, "Structure error in %s",
 					                   name.c_str());
 				}

--- a/src/master/filesystem_quota.cc
+++ b/src/master/filesystem_quota.cc
@@ -40,7 +40,7 @@ static void fs_remove_invisible_quota_entries(inode_t root_inode, std::vector<Qu
 	    FilesystemOperationContext::TransactionType::kReadOnly);
 
 	FSNodeDirectory *root_node =
-	    gFSOperations->nodeOperations()->idToNodeVerify<FSNodeDirectory>(root_inode);
+	    gFSOperations->nodeOperations()->idToNodeVerify<FSNodeDirectory>(fsOpContext, root_inode);
 
 	auto it = std::remove_if(
 	    results.begin(), results.end(), [&fsOpContext, root_node](const QuotaEntry &entry) {
@@ -49,14 +49,15 @@ static void fs_remove_invisible_quota_entries(inode_t root_inode, std::vector<Qu
 			        fsOpContext, entry.entryKey.owner.ownerId);
 			    if (!node) { return true; }
 			    if (root_node->id == entry.entryKey.owner.ownerId) { return false; }
-			    return !gFSOperations->nodeOperations()->isAncestor(root_node, node);
+			    return !gFSOperations->nodeOperations()->isAncestor(fsOpContext, root_node, node);
 		    }
 		    return false;
 	    });
 	results.erase(it, results.end());
 }
 
-static void fsnodes_getpath(inode_t root_inode, FSNode *node, std::string &ret) {
+static void fsnodes_getpath(const FilesystemOperationContext &fsOpContext, inode_t root_inode,
+                            FSNode *node, std::string &ret) {
 	std::string::size_type size;
 	FSNode *p;
 
@@ -69,8 +70,8 @@ static void fsnodes_getpath(inode_t root_inode, FSNode *node, std::string &ret) 
 	size = 0;
 	while (p != gMetadata->root && !p->parents.empty() && p->id != root_inode) {
 		// get first parent
-		auto *parent =
-		    gFSOperations->nodeOperations()->idToNodeVerify<FSNodeDirectory>(p->parents[0].first);
+		auto *parent = gFSOperations->nodeOperations()->idToNodeVerify<FSNodeDirectory>(
+		    fsOpContext, p->parents[0].first);
 		size += parent->getChildName(p).length() + 1;
 		p = parent;
 	}
@@ -83,8 +84,8 @@ static void fsnodes_getpath(inode_t root_inode, FSNode *node, std::string &ret) 
 
 	p = node;
 	while (p != gMetadata->root && !p->parents.empty()) {
-		auto *parent =
-		    gFSOperations->nodeOperations()->idToNodeVerify<FSNodeDirectory>(p->parents[0].first);
+		auto *parent = gFSOperations->nodeOperations()->idToNodeVerify<FSNodeDirectory>(
+		    fsOpContext, p->parents[0].first);
 		std::string name = parent->getChildName(p);
 		if (size >= name.length()) {
 			size -= name.length();
@@ -205,22 +206,18 @@ uint8_t fs_quota_get_info(const FsContext &context, const std::vector<QuotaEntry
 		if (entry.entryKey.owner.ownerType == QuotaOwnerType::kInode) {
 			FSNode *node = gFSOperations->nodeOperations()->idToNode(fsOpContext,
 			                                                         entry.entryKey.owner.ownerId);
-			if (node) {
-				fsnodes_getpath(context.rootinode(), node, info);
-			}
+			if (node) { fsnodes_getpath(fsOpContext, context.rootinode(), node, info); }
 		}
 		result.push_back(info);
 	}
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t fs_quota_set(const FsContext &context, const std::vector<QuotaEntry> &entries) {
+uint8_t fs_quota_set(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+                     const std::vector<QuotaEntry> &entries) {
 	static const char rigor_name[3] = {'S', 'H', 'U'};
 	static const char resource_name[2] = {'I', 'S'};
 	static const char owner_name[3] = {'U', 'G', 'I'};
-
-	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
-	    FilesystemOperationContext::TransactionType::kReadOnly);
 
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
@@ -282,11 +279,13 @@ uint8_t fs_apply_setquota(char rigor, char resource, char owner_type, inode_t ow
 }
 }  // namespace quotas
 
-static int fsnodes_find_depth(FSNodeDirectory *a) {
+static int fsnodes_find_depth(const FilesystemOperationContext &fsOpContext, FSNodeDirectory *a) {
 	assert(a);
+
 	int depth = 1;
 	while (!a->parents.empty()) {
-		a = gFSOperations->nodeOperations()->idToNodeVerify<FSNodeDirectory>(a->parents[0].first);
+		a = gFSOperations->nodeOperations()->idToNodeVerify<FSNodeDirectory>(fsOpContext,
+		                                                                     a->parents[0].first);
 		++depth;
 	}
 
@@ -300,27 +299,29 @@ static int fsnodes_find_depth(FSNodeDirectory *a) {
  * If the nodes are files with many hard links,
  * then it's possible that this function will fail.
  *
+ * \param fsOpContext Filesystem operation context with a potential transaction.
  *  \return Pointer to common ancestor.
  */
-static FSNode *fsnodes_find_common_ancestor(FSNodeDirectory *a, FSNodeDirectory *b) {
+static FSNode *fsnodes_find_common_ancestor(const FilesystemOperationContext &fsOpContext,
+                                            FSNodeDirectory *a, FSNodeDirectory *b) {
 	if (!a || !b) {
 		return nullptr;
 	}
 
-	int depth_a = fsnodes_find_depth(a);
-	int depth_b = fsnodes_find_depth(b);
+	int depth_a = fsnodes_find_depth(fsOpContext, a);
+	int depth_b = fsnodes_find_depth(fsOpContext, b);
 
 	if (depth_a > depth_b) {
 		for(;depth_a > depth_b;--depth_a) {
 			assert(a && !a->parents.empty());
 			a = gFSOperations->nodeOperations()->idToNodeVerify<FSNodeDirectory>(
-			    a->parents[0].first);
+			    fsOpContext, a->parents[0].first);
 		}
 	} else if (depth_b > depth_a) {
 		for(;depth_b > depth_a;--depth_b) {
 			assert(b && !b->parents.empty());
 			b = gFSOperations->nodeOperations()->idToNodeVerify<FSNodeDirectory>(
-			    b->parents[0].first);
+			    fsOpContext, b->parents[0].first);
 		}
 	}
 
@@ -331,8 +332,10 @@ static FSNode *fsnodes_find_common_ancestor(FSNodeDirectory *a, FSNodeDirectory 
 	while(!a->parents.empty()) {
 		assert(!b->parents.empty());
 
-		a = gFSOperations->nodeOperations()->idToNodeVerify<FSNodeDirectory>(a->parents[0].first);
-		b = gFSOperations->nodeOperations()->idToNodeVerify<FSNodeDirectory>(b->parents[0].first);
+		a = gFSOperations->nodeOperations()->idToNodeVerify<FSNodeDirectory>(fsOpContext,
+		                                                                     a->parents[0].first);
+		b = gFSOperations->nodeOperations()->idToNodeVerify<FSNodeDirectory>(fsOpContext,
+		                                                                     b->parents[0].first);
 
 		if (a == b) {
 			return a;
@@ -395,8 +398,9 @@ bool fsnodes_quota_exceeded_ug(FSNode *node,
 	return fsnodes_quota_exceeded_ug(node->uid, node->gid, resource_list);
 }
 
-bool fsnodes_quota_exceeded_dir(FSNode *node,
-		const std::initializer_list<std::pair<QuotaResource, int64_t>> &resource_list) {
+bool fsnodes_quota_exceeded_dir(
+    const FilesystemOperationContext &fsOpContext, FSNode *node,
+    const std::initializer_list<std::pair<QuotaResource, int64_t>> &resource_list) {
 	if (!node) {
 		return false;
 	}
@@ -409,7 +413,7 @@ bool fsnodes_quota_exceeded_dir(FSNode *node,
 		// Directory can have only one parent, so we get rid of recursion.
 		while(!node->parents.empty()) {
 			auto *parent = gFSOperations->nodeOperations()->idToNodeVerify<FSNodeDirectory>(
-			    node->parents[0].first);
+			    fsOpContext, node->parents[0].first);
 			if (fsnodes_test_dir_quota_noparents(parent, resource_list)) {
 				return true;
 			}
@@ -417,24 +421,22 @@ bool fsnodes_quota_exceeded_dir(FSNode *node,
 		}
 	} else {
 		for (const auto &[parentId, _] : node->parents) {
-			auto *parent =
-			    gFSOperations->nodeOperations()->idToNodeVerify<FSNodeDirectory>(parentId);
-			if (fsnodes_quota_exceeded_dir(parent, resource_list)) {
-				return true;
-			}
+			auto *parent = gFSOperations->nodeOperations()->idToNodeVerify<FSNodeDirectory>(
+			    fsOpContext, parentId);
+			if (fsnodes_quota_exceeded_dir(fsOpContext, parent, resource_list)) { return true; }
 		}
 	}
 
 	return false;
 }
 
-bool fsnodes_quota_exceeded_dir(FSNodeDirectory *node, FSNodeDirectory* prev_node,
-		const std::initializer_list<std::pair<QuotaResource, int64_t>> &resource_list) {
-	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
-	    FilesystemOperationContext::TransactionType::kReadOnly);
+bool fsnodes_quota_exceeded_dir(
+    const FilesystemOperationContext &fsOpContext, FSNodeDirectory *node,
+    FSNodeDirectory *prev_node,
+    const std::initializer_list<std::pair<QuotaResource, int64_t>> &resource_list) {
 	// Because nodes are directories fsnodes_find_common_ancestor
 	// is guaranteed to work properly.
-	FSNode *common = fsnodes_find_common_ancestor(prev_node, node);
+	FSNode *common = fsnodes_find_common_ancestor(fsOpContext, prev_node, node);
 	if (node == common) {
 		return false;
 	}
@@ -462,10 +464,11 @@ bool fsnodes_quota_exceeded_dir(FSNodeDirectory *node, FSNodeDirectory* prev_nod
 	return false;
 }
 
-bool fsnodes_quota_exceeded(FSNode *node,
-		const std::initializer_list<std::pair<QuotaResource, int64_t>> &resource_list) {
+bool fsnodes_quota_exceeded(
+    const FilesystemOperationContext &fsOpContext, FSNode *node,
+    const std::initializer_list<std::pair<QuotaResource, int64_t>> &resource_list) {
 	return fsnodes_quota_exceeded_ug(node, resource_list) ||
-	       fsnodes_quota_exceeded_dir(node, resource_list);
+	       fsnodes_quota_exceeded_dir(fsOpContext, node, resource_list);
 }
 
 void fsnodes_quota_update(FSNode *node,

--- a/src/master/filesystem_quota.cc
+++ b/src/master/filesystem_quota.cc
@@ -36,22 +36,23 @@ static void fs_remove_invisible_quota_entries(inode_t root_inode, std::vector<Qu
 		return;
 	}
 
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadOnly);
+
 	FSNodeDirectory *root_node =
 	    gFSOperations->nodeOperations()->idToNodeVerify<FSNodeDirectory>(root_inode);
 
-	auto it = std::remove_if(results.begin(), results.end(), [root_node](const QuotaEntry &entry) {
-		if (entry.entryKey.owner.ownerType == QuotaOwnerType::kInode) {
-			FSNode *node = gFSOperations->nodeOperations()->idToNode(entry.entryKey.owner.ownerId);
-			if (!node) {
-				return true;
-			}
-			if (root_node->id == entry.entryKey.owner.ownerId) {
-				return false;
-			}
-			return !gFSOperations->nodeOperations()->isAncestor(root_node, node);
-		}
-		return false;
-	});
+	auto it = std::remove_if(
+	    results.begin(), results.end(), [&fsOpContext, root_node](const QuotaEntry &entry) {
+		    if (entry.entryKey.owner.ownerType == QuotaOwnerType::kInode) {
+			    FSNode *node = gFSOperations->nodeOperations()->idToNode(
+			        fsOpContext, entry.entryKey.owner.ownerId);
+			    if (!node) { return true; }
+			    if (root_node->id == entry.entryKey.owner.ownerId) { return false; }
+			    return !gFSOperations->nodeOperations()->isAncestor(root_node, node);
+		    }
+		    return false;
+	    });
 	results.erase(it, results.end());
 }
 
@@ -108,6 +109,9 @@ uint8_t fs_quota_get_all(const FsContext &context, std::vector<QuotaEntry> &resu
 	}
 	results = gMetadata->quotaDatabase.getEntriesWithStats();
 
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadOnly);
+
 	for (auto &entry : results) {
 		if (entry.entryKey.owner.ownerType != QuotaOwnerType::kInode ||
 		    entry.entryKey.rigor != QuotaRigor::kUsed) {
@@ -115,7 +119,7 @@ uint8_t fs_quota_get_all(const FsContext &context, std::vector<QuotaEntry> &resu
 		}
 
 		FSNodeDirectory *node = gFSOperations->nodeOperations()->idToNode<FSNodeDirectory>(
-		    entry.entryKey.owner.ownerId);
+		    fsOpContext, entry.entryKey.owner.ownerId);
 		if (!node || node->type != FSNodeType::kDirectory) { continue; }
 
 		switch (entry.entryKey.resource) {
@@ -135,6 +139,8 @@ uint8_t fs_quota_get_all(const FsContext &context, std::vector<QuotaEntry> &resu
 
 uint8_t fs_quota_get(const FsContext &context, const std::vector<QuotaOwner> &owners,
                      std::vector<QuotaEntry> &results) {
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadOnly);
 	std::vector<QuotaEntry> tmp;
 	FSNodeDirectory *node;
 	for (const QuotaOwner &owner : owners) {
@@ -149,7 +155,8 @@ uint8_t fs_quota_get(const FsContext &context, const std::vector<QuotaOwner> &ow
 				}
 				break;
 			case QuotaOwnerType::kInode:
-				node = gFSOperations->nodeOperations()->idToNode<FSNodeDirectory>(owner.ownerId);
+				node = gFSOperations->nodeOperations()->idToNode<FSNodeDirectory>(fsOpContext,
+				                                                                  owner.ownerId);
 				if (!node || node->type != FSNodeType::kDirectory) { return SAUNAFS_ERROR_EINVAL; }
 				if (node->uid != context.uid() ||
 				    (node->gid != context.gid() && !(context.sesflags() & SESFLAG_IGNOREGID))) {
@@ -164,8 +171,8 @@ uint8_t fs_quota_get(const FsContext &context, const std::vector<QuotaOwner> &ow
 		if (result) {
 			for (auto rigor : {QuotaRigor::kSoft, QuotaRigor::kHard, QuotaRigor::kUsed}) {
 				if (owner.ownerType == QuotaOwnerType::kInode && rigor == QuotaRigor::kUsed) {
-					node =
-					    gFSOperations->nodeOperations()->idToNode<FSNodeDirectory>(owner.ownerId);
+					node = gFSOperations->nodeOperations()->idToNode<FSNodeDirectory>(
+					    fsOpContext, owner.ownerId);
 					assert(node);
 					tmp.push_back(
 					    {{owner, rigor, QuotaResource::kInodes}, (uint64_t)node->stats.inodes});
@@ -188,13 +195,16 @@ uint8_t fs_quota_get(const FsContext &context, const std::vector<QuotaOwner> &ow
 
 uint8_t fs_quota_get_info(const FsContext &context, const std::vector<QuotaEntry> &entries,
 		std::vector<std::string> &result) {
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadOnly);
 	std::string info;
 
 	result.clear();
 	for (const auto &entry : entries) {
 		info.clear();
 		if (entry.entryKey.owner.ownerType == QuotaOwnerType::kInode) {
-			FSNode *node = gFSOperations->nodeOperations()->idToNode(entry.entryKey.owner.ownerId);
+			FSNode *node = gFSOperations->nodeOperations()->idToNode(fsOpContext,
+			                                                         entry.entryKey.owner.ownerId);
 			if (node) {
 				fsnodes_getpath(context.rootinode(), node, info);
 			}
@@ -209,6 +219,9 @@ uint8_t fs_quota_set(const FsContext &context, const std::vector<QuotaEntry> &en
 	static const char resource_name[2] = {'I', 'S'};
 	static const char owner_name[3] = {'U', 'G', 'I'};
 
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadOnly);
+
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
 	if (context.sesflags() & SESFLAG_READONLY) {
@@ -221,7 +234,8 @@ uint8_t fs_quota_set(const FsContext &context, const std::vector<QuotaEntry> &en
 		if(entry.entryKey.owner.ownerType != QuotaOwnerType::kInode) {
 			continue;
 		}
-		FSNode *node = gFSOperations->nodeOperations()->idToNode(entry.entryKey.owner.ownerId);
+		FSNode *node =
+		    gFSOperations->nodeOperations()->idToNode(fsOpContext, entry.entryKey.owner.ownerId);
 		if(!node) {
 			return SAUNAFS_ERROR_EINVAL;
 		}
@@ -416,6 +430,8 @@ bool fsnodes_quota_exceeded_dir(FSNode *node,
 
 bool fsnodes_quota_exceeded_dir(FSNodeDirectory *node, FSNodeDirectory* prev_node,
 		const std::initializer_list<std::pair<QuotaResource, int64_t>> &resource_list) {
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadOnly);
 	// Because nodes are directories fsnodes_find_common_ancestor
 	// is guaranteed to work properly.
 	FSNode *common = fsnodes_find_common_ancestor(prev_node, node);
@@ -429,8 +445,8 @@ bool fsnodes_quota_exceeded_dir(FSNodeDirectory *node, FSNodeDirectory* prev_nod
 
 	// node is directory so it has only one parent.
 	while(!node->parents.empty()) {
-		auto *parent =
-		    gFSOperations->nodeOperations()->idToNode<FSNodeDirectory>(node->parents[0].first);
+		auto *parent = gFSOperations->nodeOperations()->idToNode<FSNodeDirectory>(
+		    fsOpContext, node->parents[0].first);
 
 		if (parent == common) {
 			return false;

--- a/src/master/filesystem_quota.h
+++ b/src/master/filesystem_quota.h
@@ -32,6 +32,8 @@
 #include "master/filesystem_node_types.h"
 #include "protocol/quota.h"
 
+class FilesystemOperationContext;
+
 /// Decodes a single-character selector into a typed value.
 ///
 /// Used by applySetQuota replay paths to decode SETQUOTA changelog fields
@@ -75,31 +77,37 @@ bool fsnodes_quota_exceeded_ug(FSNode *node,
 	const std::initializer_list<std::pair<QuotaResource, int64_t>> &resource_list);
 
 /*! \brief Test if resource change exceeds quota for directories.
+ * \param fsOpContext Filesystem operation context with a potential transaction.
  * \param node Pointer to node in directory tree to check quota for.
  * \param resource_list Required changes to resources.
  * \return true if quota is exceeded.
  */
-bool fsnodes_quota_exceeded_dir(FSNode *node,
-	const std::initializer_list<std::pair<QuotaResource, int64_t>> &resource_list);
+bool fsnodes_quota_exceeded_dir(
+    const FilesystemOperationContext &fsOpContext, FSNode *node,
+    const std::initializer_list<std::pair<QuotaResource, int64_t>> &resource_list);
 
 /*! \brief Test if moving node (moving resources from one parent to other) exceeds quota.
+ * \param fsOpContext Filesystem operation context with a potential transaction.
  * \param node Destination parent.
  * \param prev_node Source parent.
  * \param resource_list required changes to quota.
  * \return true if quota is exceeded.
  */
-bool fsnodes_quota_exceeded_dir(FSNodeDirectory *node, FSNodeDirectory* prev_node,
-	const std::initializer_list<std::pair<QuotaResource, int64_t>> &resource_list);
-
+bool fsnodes_quota_exceeded_dir(
+    const FilesystemOperationContext &fsOpContext, FSNodeDirectory *node,
+    FSNodeDirectory *prev_node,
+    const std::initializer_list<std::pair<QuotaResource, int64_t>> &resource_list);
 
 /*! \brief Test if resource change exceeds quota for user+groups and directories.
+ * \param fsOpContext Filesystem operation context with a potential transaction.
  * \param node Pointer to node in directory tree to check quota for. User id and group id is taken
  *             from node.
  * \param resource_list Required changes to resources.
  * \return true if quota is exceeded.
  */
-bool fsnodes_quota_exceeded(FSNode *node,
-	const std::initializer_list<std::pair<QuotaResource, int64_t>> &resource_list);
+bool fsnodes_quota_exceeded(
+    const FilesystemOperationContext &fsOpContext, FSNode *node,
+    const std::initializer_list<std::pair<QuotaResource, int64_t>> &resource_list);
 
 /*! \brief Update quota for both user+group and directory.
  * \param node Pointer to node in directory tree to update quota for. User id and group id is taken
@@ -127,7 +135,8 @@ namespace quotas {
 uint8_t fs_quota_get_all(const FsContext &context, std::vector<QuotaEntry> &results);
 uint8_t fs_quota_get(const FsContext &context, const std::vector<QuotaOwner> &owners,
                      std::vector<QuotaEntry> &results);
-uint8_t fs_quota_set(const FsContext &context, const std::vector<QuotaEntry> &entries);
+uint8_t fs_quota_set(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+                     const std::vector<QuotaEntry> &entries);
 uint8_t fs_quota_get_info(const FsContext &context, const std::vector<QuotaEntry> &entries,
                           std::vector<std::string> &result);
 

--- a/src/master/filesystem_snapshot.cc
+++ b/src/master/filesystem_snapshot.cc
@@ -62,8 +62,8 @@ uint8_t fs_snapshot(const FsContext &context, inode_t inode_src, inode_t parent_
 
 	if (src_node->type == FSNodeType::kDirectory) {
 		if (src_node == dst_parent_node ||
-		    gFSOperations->nodeOperations()->isAncestor(static_cast<FSNodeDirectory *>(src_node),
-		                                                dst_parent_node)) {
+		    gFSOperations->nodeOperations()->isAncestor(
+		        fsOpContext, static_cast<FSNodeDirectory *>(src_node), dst_parent_node)) {
 			return SAUNAFS_ERROR_EINVAL;
 		}
 	}
@@ -74,12 +74,14 @@ uint8_t fs_snapshot(const FsContext &context, inode_t inode_src, inode_t parent_
 	                                   static_cast<FSNodeDirectory *>(dst_parent_node)->id,
 	                                   0, can_overwrite, ignore_missing_src, true, true);
 	std::string src_path;
-	FSNodeDirectory *parent = gFSOperations->nodeOperations()->getFirstParent(src_node);
-	gFSOperations->nodeOperations()->getPath(parent, src_node, src_path);
+	FSNodeDirectory *parent =
+	    gFSOperations->nodeOperations()->getFirstParent(fsOpContext, src_node);
+	gFSOperations->nodeOperations()->getPath(fsOpContext, parent, src_node, src_path);
 
 	std::string dst_path;
-	FSNodeDirectory *grandparent = gFSOperations->nodeOperations()->getFirstParent(dst_parent_node);
-	gFSOperations->nodeOperations()->getPath(grandparent, dst_parent_node, dst_path);
+	FSNodeDirectory *grandparent =
+	    gFSOperations->nodeOperations()->getFirstParent(fsOpContext, dst_parent_node);
+	gFSOperations->nodeOperations()->getPath(fsOpContext, grandparent, dst_parent_node, dst_path);
 	if (dst_path.size() > 1) {
 		dst_path += "/";
 	}

--- a/src/master/filesystem_store_acl.cc
+++ b/src/master/filesystem_store_acl.cc
@@ -62,7 +62,8 @@ void fs_store_acls(FILE *fd) {
 	fs_store_marker(fd);
 }
 
-static int fs_load_posix_acl(const std::shared_ptr<MemoryMappedFile> &metadataFile,
+static int fs_load_posix_acl(const FilesystemOperationContext &fsOpContext,
+                             const std::shared_ptr<MemoryMappedFile> &metadataFile,
                              size_t& offsetBegin,
                              int ignoreFlag,
                              bool default_acl) {
@@ -106,7 +107,7 @@ static int fs_load_posix_acl(const std::shared_ptr<MemoryMappedFile> &metadataFi
 		AccessControlList posix_acl;
 		deserialize(ptr, size, inode, posix_acl);
 		offsetBegin += size;
-		FSNode *p = gFSOperations->nodeOperations()->idToNode(inode);
+		FSNode *p = gFSOperations->nodeOperations()->idToNode(fsOpContext, inode);
 		if (!p) {
 			throw Exception("unknown inode: " + std::to_string(inode));
 		}
@@ -137,7 +138,8 @@ static int fs_load_posix_acl(const std::shared_ptr<MemoryMappedFile> &metadataFi
 	return kSuccess;
 }
 
-static int fs_load_legacy_acl(const std::shared_ptr<MemoryMappedFile> &metadataFile,
+static int fs_load_legacy_acl(const FilesystemOperationContext &fsOpContext,
+                              const std::shared_ptr<MemoryMappedFile> &metadataFile,
                               size_t& offsetBegin,
                               int ignoreFlag) {
 	try {
@@ -176,7 +178,7 @@ static int fs_load_legacy_acl(const std::shared_ptr<MemoryMappedFile> &metadataF
 		std::unique_ptr<legacy::AccessControlList> default_acl;
 		deserialize(ptr, size, inode, extended_acl, default_acl);
 		offsetBegin += size;
-		FSNode *p = gFSOperations->nodeOperations()->idToNode(inode);
+		FSNode *p = gFSOperations->nodeOperations()->idToNode(fsOpContext, inode);
 		if (!p) {
 			throw Exception("unknown inode: " + std::to_string(inode));
 		}
@@ -205,10 +207,12 @@ static int fs_load_legacy_acl(const std::shared_ptr<MemoryMappedFile> &metadataF
 }
 
 bool fs_load_legacy_acls(MetadataLoader::Options options) {
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadOnly);
 	int status;
 
 	do {
-		status = fs_load_legacy_acl(options.metadataFile, options.offset,
+		status = fs_load_legacy_acl(fsOpContext, options.metadataFile, options.offset,
 		                            options.ignoreFlag);
 		if (status < 0) {
 			return false;
@@ -218,9 +222,11 @@ bool fs_load_legacy_acls(MetadataLoader::Options options) {
 }
 
 bool fs_load_posix_acls(MetadataLoader::Options options) {
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadOnly);
 	int status;
 	do {
-		status = fs_load_posix_acl(options.metadataFile, options.offset,
+		status = fs_load_posix_acl(fsOpContext, options.metadataFile, options.offset,
 		                           options.ignoreFlag, false);
 		if (status < 0) {
 			return false;
@@ -228,7 +234,7 @@ bool fs_load_posix_acls(MetadataLoader::Options options) {
 	} while (status == 0);
 
 	do {
-		status = fs_load_posix_acl(options.metadataFile, options.offset,
+		status = fs_load_posix_acl(fsOpContext, options.metadataFile, options.offset,
 		                           options.ignoreFlag, true);
 		if (status < 0) {
 			return false;
@@ -238,7 +244,8 @@ bool fs_load_posix_acls(MetadataLoader::Options options) {
 	return true;
 }
 
-int fs_load_acl(const std::shared_ptr<MemoryMappedFile> &metadataFile, size_t &offsetBegin,
+int fs_load_acl(const FilesystemOperationContext &fsOpContext,
+                const std::shared_ptr<MemoryMappedFile> &metadataFile, size_t &offsetBegin,
                 int ignoreFlag) {
 	try {
 		// Read size of the entry
@@ -275,7 +282,7 @@ int fs_load_acl(const std::shared_ptr<MemoryMappedFile> &metadataFile, size_t &o
 		RichACL acl;
 		deserialize(ptr, size, inode, acl);
 		offsetBegin += size;
-		FSNode *p = gFSOperations->nodeOperations()->idToNode(inode);
+		FSNode *p = gFSOperations->nodeOperations()->idToNode(fsOpContext, inode);
 		if (!p) {
 			throw Exception("unknown inode: " + std::to_string(inode));
 		}
@@ -291,10 +298,12 @@ int fs_load_acl(const std::shared_ptr<MemoryMappedFile> &metadataFile, size_t &o
 }
 
 bool fs_load_acls(MetadataLoader::Options options) {
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadOnly);
 	int s;
 
 	do {
-		s = fs_load_acl(options.metadataFile, options.offset,
+		s = fs_load_acl(fsOpContext, options.metadataFile, options.offset,
 		                options.ignoreFlag);
 		if (s < 0) { return false; }
 	} while (s == 0);

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -848,6 +848,9 @@ void matoclserv_session_list(matoclserventry *eptr, const uint8_t *data, uint32_
 		vmode = get8bit(&data);
 	}
 
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadOnly);
+
 	uint32_t size = sizeof(uint16_t);  // 2 bytes for SESSION_STATS
 
 	constexpr uint32_t kExtraVModeSize = sizeof(Session::minGoal) + sizeof(Session::maxGoal) +
@@ -877,7 +880,7 @@ void matoclserv_session_list(matoclserventry *eptr, const uint8_t *data, uint32_
 				size += 1;  // for '.'
 			} else {
 				size += sizeof(pathLength);
-				size += gFSOperations->getDirPathSize(eaptr->sessionData->rootInode);
+				size += gFSOperations->getDirPathSize(fsOpContext, eaptr->sessionData->rootInode);
 			}
 		}
 	}
@@ -906,10 +909,12 @@ void matoclserv_session_list(matoclserventry *eptr, const uint8_t *data, uint32_
 				putINode(&ptr, static_cast<inode_t>(1));
 				put8bit(&ptr, '.');
 			} else {
-				pathLength = gFSOperations->getDirPathSize(eaptr->sessionData->rootInode);
+				pathLength =
+				    gFSOperations->getDirPathSize(fsOpContext, eaptr->sessionData->rootInode);
 				put32bit(&ptr, pathLength);
 				if (pathLength > 0) {
-					gFSOperations->getDirPathData(eaptr->sessionData->rootInode, ptr, pathLength);
+					gFSOperations->getDirPathData(fsOpContext, eaptr->sessionData->rootInode, ptr,
+					                              pathLength);
 					ptr += pathLength;
 				}
 			}
@@ -2996,7 +3001,9 @@ void matoclserv_fuse_read_chunk(matoclserventry *eptr, PacketHeader header, cons
 	std::vector<uint8_t> receivedData(data, data + header.length);
 	serializer->deserializeFuseReadChunk(receivedData, messageId, inode, index);
 
-	status = gFSOperations->readChunk(inode, index, &chunkid, &fleng);
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadOnly);
+	status = gFSOperations->readChunk(fsOpContext, inode, index, &chunkid, &fleng);
 	std::vector<ChunkTypeWithAddress> allChunkCopies;
 	if (status == SAUNAFS_STATUS_OK) {
 		if (chunkid > 0) {
@@ -4064,8 +4071,11 @@ void matoclserv_fuse_gettrash(matoclserventry *eptr, const PacketHeader &header,
 		uint64_t off;
 		cltoma::fuseGetTrash::deserialize(data, header.length, msgId, off, maxEntries);
 		std::vector<HandleInodeEntry> entries;
+		auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+		    FilesystemOperationContext::TransactionType::kReadOnly);
 		gFSOperations->readTrash(
-		    off, std::min<uint32_t>(maxEntries, matocl::fuseGetDir::kMaxNumberOfDirectoryEntries),
+		    fsOpContext, off,
+		    std::min<uint32_t>(maxEntries, matocl::fuseGetDir::kMaxNumberOfDirectoryEntries),
 		    entries);
 		matoclserv_createpacket(eptr, matocl::fuseGetTrash::build(msgId, entries));
 	} else {
@@ -4100,8 +4110,10 @@ void matoclserv_fuse_getdetachedattr(matoclserventry *eptr, const uint8_t *data,
 		dtype = DTYPE_UNKNOWN;
 	}
 
-	status = gFSOperations->getDetachedAttr(eptr->sessionData->rootInode, eptr->sessionData->flags,
-	                                        inode, attr, dtype);
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadOnly);
+	status = gFSOperations->getDetachedAttr(fsOpContext, eptr->sessionData->rootInode,
+	                                        eptr->sessionData->flags, inode, attr, dtype);
 
 	constexpr uint32_t kFailedSize = sizeof(msgid) + sizeof(status);
 	constexpr uint32_t kSuccessSize = sizeof(msgid) + attr.size();
@@ -4138,8 +4150,10 @@ void matoclserv_fuse_gettrashpath(matoclserventry *eptr, const uint8_t *data, ui
 	get32bit(&data, msgid);
 	getINode(&data, inode);
 
-	status = gFSOperations->getTrashPath(eptr->sessionData->rootInode, eptr->sessionData->flags,
-	                                     inode, path);
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadOnly);
+	status = gFSOperations->getTrashPath(fsOpContext, eptr->sessionData->rootInode,
+	                                     eptr->sessionData->flags, inode, path);
 
 	constexpr uint32_t kFailedSize = sizeof(msgid) + sizeof(status);
 	const uint32_t kSuccessSize = sizeof(msgid) + sizeof(uint32_t) + path.length() + 1;
@@ -4320,8 +4334,11 @@ void matoclserv_fuse_getreserved(matoclserventry *eptr, const PacketHeader &head
 		uint64_t off;
 		cltoma::fuseGetReserved::deserialize(data, header.length, msgId, off, maxEntries);
 		std::vector<HandleInodeEntry> entries;
+		auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+		    FilesystemOperationContext::TransactionType::kReadOnly);
 		gFSOperations->readReserved(
-		    off, std::min<uint32_t>(maxEntries, matocl::fuseGetDir::kMaxNumberOfDirectoryEntries),
+		    fsOpContext, off,
+		    std::min<uint32_t>(maxEntries, matocl::fuseGetDir::kMaxNumberOfDirectoryEntries),
 		    entries);
 		matoclserv_createpacket(eptr, matocl::fuseGetReserved::build(msgId, entries));
 	} else {

--- a/src/master/matontserv.cc
+++ b/src/master/matontserv.cc
@@ -341,7 +341,10 @@ void matontserv_get_path_type_inode(MatontservEntry *eptr, const uint8_t *data, 
 
 	inode_t inode = static_cast<inode_t>(responseInode);
 	std::string pathByInode;
-	FSNode *node = invalidInode ? nullptr : gFSOperations->nodeOperations()->idToNode(inode);
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadOnly);
+	FSNode *node =
+	    invalidInode ? nullptr : gFSOperations->nodeOperations()->idToNode(fsOpContext, inode);
 	if (node == nullptr) {
 		safs::log_info("NTTOMA_GET_PATH_TYPE_INODE - inode {} not found", responseInode);
 		// Send back an empty path
@@ -353,7 +356,7 @@ void matontserv_get_path_type_inode(MatontservEntry *eptr, const uint8_t *data, 
 		return;
 	}
 
-	pathByInode = gFSOperations->fullPathByInode(inode);
+	pathByInode = gFSOperations->fullPathByInode(fsOpContext, inode);
 	responseData =
 	    matontserv_addpacket(eptr, MATONT_GET_PATH_TYPE_INODE,
 	                         sizeof(responseInode) + sizeof(node->type) + pathByInode.size() + 1);

--- a/src/master/metadata_backend_file.cc
+++ b/src/master/metadata_backend_file.cc
@@ -409,7 +409,7 @@ static int8_t fs_parseEdge(const FilesystemOperationContext &fsOpContext,
 
 	std::string name(pSrc, pSrc + edgeNameSize);
 	sectionOffset += edgeNameSize;
-	FSNode *child = gFSOperations->nodeOperations()->idToNode(childId);
+	FSNode *child = gFSOperations->nodeOperations()->idToNode(fsOpContext, childId);
 	if (!child) {
 		safs_pretty_syslog(
 		    LOG_ERR, "loading edge: %" PRIiNode ",%s->%" PRIiNode " error: child not found",
@@ -439,7 +439,8 @@ static int8_t fs_parseEdge(const FilesystemOperationContext &fsOpContext,
 	} else {
 		FSNodeDirectory *parent;
 		if (currentParentId != parentId){
-			parent = gFSOperations->nodeOperations()->idToNode<FSNodeDirectory>(parentId);
+			parent =
+			    gFSOperations->nodeOperations()->idToNode<FSNodeDirectory>(fsOpContext, parentId);
 			currentParentNode = parent;
 		} else {
 			parent = currentParentNode;
@@ -449,8 +450,8 @@ static int8_t fs_parseEdge(const FilesystemOperationContext &fsOpContext,
 			    LOG_ERR, "loading edge: %" PRIiNode ",%s->%" PRIiNode " error: parent not found",
 			    parentId, gFSOperations->nodeOperations()->escapeName(name).c_str(), childId);
 			if (ignoreFlag) {
-				parent =
-				    gFSOperations->nodeOperations()->idToNode<FSNodeDirectory>(SPECIAL_INODE_ROOT);
+				parent = gFSOperations->nodeOperations()->idToNode<FSNodeDirectory>(
+				    fsOpContext, SPECIAL_INODE_ROOT);
 				if (!parent || parent->type != FSNodeType::kDirectory) {
 					safs_pretty_syslog(
 					    LOG_ERR,
@@ -477,8 +478,8 @@ static int8_t fs_parseEdge(const FilesystemOperationContext &fsOpContext,
 			              gFSOperations->nodeOperations()->escapeName(name), childId,
 			              static_cast<char>(parent->type));
 			if (ignoreFlag) {
-				parent =
-				    gFSOperations->nodeOperations()->idToNode<FSNodeDirectory>(SPECIAL_INODE_ROOT);
+				parent = gFSOperations->nodeOperations()->idToNode<FSNodeDirectory>(
+				    fsOpContext, SPECIAL_INODE_ROOT);
 				if (!parent || parent->type != FSNodeType::kDirectory) {
 					safs_pretty_syslog(
 					    LOG_ERR,

--- a/src/master/metadata_backend_file.cc
+++ b/src/master/metadata_backend_file.cc
@@ -874,8 +874,11 @@ static int fs_load(const std::shared_ptr<MemoryMappedFile> &metadataFile, int ig
 
 	util::ScopedTimer timer("checking filesystem consistency of the metadata file took");
 
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadOnly);
+
 	gMetadata->root =
-	    gFSOperations->nodeOperations()->idToNode<FSNodeDirectory>(SPECIAL_INODE_ROOT);
+	    gFSOperations->nodeOperations()->idToNode<FSNodeDirectory>(fsOpContext, SPECIAL_INODE_ROOT);
 	if (gMetadata->root == nullptr) {
 		safs::log_err("error reading metadata (root node not found)");
 		return kOpFailure;
@@ -1137,15 +1140,19 @@ void MetadataBackendFile::storeedgelist(FSNodeDirectory *parent, FILE *fd) {
 }
 
 void MetadataBackendFile::storeedgelist(const TrashPathContainer &data, FILE *fd) {
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadOnly);
 	for (const auto &entry : data) {
-		FSNode *child = gFSOperations->nodeOperations()->idToNode(entry.first.id);
+		FSNode *child = gFSOperations->nodeOperations()->idToNode(fsOpContext, entry.first.id);
 		storeedge(nullptr, child, (std::string)entry.second, fd);
 	}
 }
 
 void MetadataBackendFile::storeedgelist(const ReservedPathContainer &data, FILE *fd) {
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadOnly);
 	for (const auto &entry : data) {
-		FSNode *child = gFSOperations->nodeOperations()->idToNode(entry.first);
+		FSNode *child = gFSOperations->nodeOperations()->idToNode(fsOpContext, entry.first);
 		storeedge(nullptr, child, (std::string)entry.second, fd);
 	}
 }

--- a/src/master/restore.cc
+++ b/src/master/restore.cc
@@ -208,7 +208,19 @@ int do_access(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
 	EAT(ptr,filename,lv,'(');
 	GETINODE(inode,ptr);
 	EAT(ptr,filename,lv,')');
-	return gFSOperations->applyAccess(ts, inode);
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
+	int status = gFSOperations->applyAccess(fsOpContext, ts, inode);
+
+	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
+		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+			safs::log_err("{}: transaction failed to commit: inode {}", __func__, inode);
+			status = SAUNAFS_ERROR_IO;
+		}
+	}
+
+	return status;
 }
 
 int do_append(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -329,8 +341,22 @@ int do_create(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
 	EAT(ptr,filename,lv,')');
 	EAT(ptr,filename,lv,':');
 	GETINODE(inode,ptr);
-	return gFSOperations->applyCreate(ts, parent, HString((const char *)name),
-	                                  static_cast<FSNodeType>(type), mode, uid, gid, rdev, inode);
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
+	int status = gFSOperations->applyCreate(fsOpContext, ts, parent, HString((const char *)name),
+	                                        static_cast<FSNodeType>(type), mode, uid, gid, rdev, inode);
+
+	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
+		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+			safs::log_err(
+			    "{}: transaction failed to commit: parent {}, type {}, inode {}",
+			    __func__, parent, type, inode);
+			status = SAUNAFS_ERROR_IO;
+		}
+	}
+
+	return status;
 }
 
 int do_session(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
@@ -1014,7 +1040,20 @@ int do_unlink(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
 	EAT(ptr,filename,lv,')');
 	EAT(ptr,filename,lv,':');
 	GETINODE(inode,ptr);
-	return gFSOperations->applyUnlink(ts, parent, HString((char *)name), inode);
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
+	int status = gFSOperations->applyUnlink(fsOpContext, ts, parent, HString((char *)name), inode);
+
+	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
+		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+			safs::log_err("{}: transaction failed to commit: parent {}, inode {}",
+			              __func__, parent, inode);
+			status = SAUNAFS_ERROR_IO;
+		}
+	}
+
+	return status;
 }
 
 int do_unlock(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
@@ -1053,7 +1092,20 @@ int do_trunc(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
 	EAT(ptr,filename,lv,')');
 	EAT(ptr,filename,lv,':');
 	GETU64(chunkid,ptr);
-	return gFSOperations->applyTrunc(ts, inode, indx, chunkid, lockid);
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
+	int status = gFSOperations->applyTrunc(fsOpContext, ts, inode, indx, chunkid, lockid);
+
+	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
+		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+			safs::log_err("{}: transaction failed to commit: inode {}, chunk index {}, chunkid {}",
+			              __func__, inode, indx, chunkid);
+			status = SAUNAFS_ERROR_IO;
+		}
+	}
+
+	return status;
 }
 
 int do_write(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {

--- a/src/master/settrashtime_task.cc
+++ b/src/master/settrashtime_task.cc
@@ -31,10 +31,10 @@ int SetTrashtimeTask::execute(uint32_t ts, intrusive_list<Task> &work_queue) {
 
 	inode_t inode = *current_inode_;
 	++current_inode_;
-	FSNode *node = gFSOperations->nodeOperations()->idToNode(inode);
-	if (!node) {
-		return SAUNAFS_ERROR_EINVAL;
-	}
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+	FSNode *node = gFSOperations->nodeOperations()->idToNode(fsOpContext, inode);
+	if (!node) { return SAUNAFS_ERROR_EINVAL; }
 
 	uint8_t result = setTrashtime(node, ts);
 


### PR DESCRIPTION
Propagate FilesystemOperationContext across master code paths and
remove context-less node lookup APIs.

- Pass existing fsOpContext to idToNode() call sites.
- Remove idToNode(inode_t), idToNodeVerify(inode_t), and
  idToNodeInternal(inode_t) overloads from node operation interfaces.
- Thread fsOpContext through path/ancestry helpers and detached
  data/attr APIs.
- Update callers in quota, periodic checks, snapshots, ACL/metadata
  load/store, matocl/matont handlers, and restore replay paths.
- Move restore-side transaction ownership for applyAccess/applyCreate/
  applyUnlink/applyTrunc and commit in caller scope.

No behavior change is intended for the in-memory backend.
For KV backends, this enforces transactional consistency and improves
batching by reusing a single operation context.

Related to: LS-417

Signed-off-by: guillex <guillex@leil.io>