### PR TITLE
chore: improve AI agent instructions setup

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,13 +5,11 @@ applyTo: '**/*'
 # Language-specific instructions
 
 Use specific instructions for C and C++ files from
-[`./instructions/cpp.instructions.md`](./instructions/cpp.instructions.md).
-
-More language-specific instructions will be added in separate files as needed.
+[`instructions/cpp.instructions.md`](instructions/cpp.instructions.md).
 
 # Building and testing during development
 
-If the file `./copilot-user-instructions.md` exists, see it for environment-specific build and test commands.
+If the file `copilot-user.instructions.md` exists, see it for environment-specific build and test commands.
 
 # Commit messages
 

--- a/.gitignore
+++ b/.gitignore
@@ -114,4 +114,4 @@ CMakeUserPresets.json
 
 # Copilot user instructions #
 ##############
-.github/copilot-user-instructions.md
+.github/copilot-user.instructions.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# Instructions location
+
+Instructions for AI AGENTS are located in ./.github/copilot-instructions.md


### PR DESCRIPTION
- Add AGENTS.md as entry point for non-Copilot agents
  (e.g. Codex CLI, Claude) pointing to copilot-instructions.md
- Fix paths in copilot-instructions.md to be relative to
  the file's own directory inside .github/
- Remove human-facing filler note from copilot-instructions.md
- Update .gitignore to match renamed copilot-user.instructions.md

Reviewers:
According to local Codex, Claude and Copilot, these instructions were better to understand/follow by them.