### PR TITLE
perf(mount): reduce reads while writing

### DIFF
--- a/src/mount/chunk_writer.cc
+++ b/src/mount/chunk_writer.cc
@@ -53,18 +53,14 @@ static uint32_t gcd(uint32_t a, uint32_t b) {
 	}
 }
 
-ChunkWriter::Operation::Operation() : unfinishedWrites(0), offsetOfEnd(0) {}
-
 bool ChunkWriter::Operation::isExpandPossible(JournalPosition newPosition, uint32_t stripeSize) {
 	// If the operation is not empty, the new JournalPosition has to be compatible with
 	// the previous elements of the operation, ie. we can only expand by a new block
-	// of the same stripe and the same (from, to) range
-	for (const JournalPosition& position : journalPositions) {
+	// of the same stripe
+	for (const JournalPosition &position : journalPositions) {
 		sassert(newPosition->chunkIndex == position->chunkIndex);
-		if (newPosition->from != position->from
-				|| newPosition->to != position->to
-				|| (newPosition->blockIndex / stripeSize) != (position->blockIndex / stripeSize)
-				|| newPosition->blockIndex == position->blockIndex) {
+		if (newPosition->blockIndex == position->blockIndex ||
+		    (newPosition->blockIndex / stripeSize) != (position->blockIndex / stripeSize)) {
 			return false;
 		}
 	}
@@ -74,25 +70,27 @@ bool ChunkWriter::Operation::isExpandPossible(JournalPosition newPosition, uint3
 void ChunkWriter::Operation::expand(JournalPosition newPosition) {
 	sassert(newPosition->type != WriteCacheBlock::kParityBlock);
 	uint64_t newOffsetOfEnd = newPosition->offsetInFile() + newPosition->size();
-	if (newPosition->type != WriteCacheBlock::kReadBlock && newOffsetOfEnd > offsetOfEnd) {
-		offsetOfEnd = newOffsetOfEnd;
+	if (newPosition->type != WriteCacheBlock::kReadBlock) {
+		offsetOfEnd = std::max(offsetOfEnd, newOffsetOfEnd);
+		minimumModifiedOffset = std::min(minimumModifiedOffset, newPosition->from);
+		maximumModifiedOffset = std::max(maximumModifiedOffset, newPosition->to);
 	}
 	journalPositions.push_back(newPosition);
 }
 
-bool ChunkWriter::Operation::collidesWith(const Operation& operation) const {
-	for (const auto& position1 : journalPositions) {
-		for (const auto& position2 : operation.journalPositions) {
-			sassert(position1->chunkIndex == position2->chunkIndex);
-			if (position1->blockIndex != position2->blockIndex
-					|| position1->from >= position2->to
-					|| position1->to <= position2->from) {
-				continue;
-			}
-			return true;
-		}
+bool ChunkWriter::Operation::collidesWith(const Operation &operation, uint32_t stripeSize) const {
+	if (journalPositions.empty() || operation.journalPositions.empty()) { return false; }
+	sassert(journalPositions.front()->chunkIndex == operation.journalPositions.front()->chunkIndex);
+
+	if ((journalPositions.front()->blockIndex / stripeSize) !=
+	    (operation.journalPositions.front()->blockIndex / stripeSize)) {
+		// Different stripes, no collision
+		return false;
 	}
-	return false;
+
+	// Same chunk, same stripe - check if the modified parts of blocks overlap
+	return !(maximumModifiedOffset <= operation.minimumModifiedOffset ||
+	         minimumModifiedOffset >= operation.maximumModifiedOffset);
 }
 
 bool ChunkWriter::Operation::isFullStripe(uint32_t stripeSize) const {
@@ -347,7 +345,7 @@ bool ChunkWriter::canStartOperation(const Operation& operation) {
 	// Starting them may result in reading old version of data when calculating new parity.
 	for (const auto& writeIdAndOperation : pendingOperations_) {
 		const auto& pendingOperation = writeIdAndOperation.second;
-		if (operation.collidesWith(pendingOperation)) {
+		if (operation.collidesWith(pendingOperation, combinedStripeSize_)) {
 			return false;
 		}
 	}
@@ -414,8 +412,8 @@ void ChunkWriter::fillOperation(Operation &operation, int first_block, int first
 	if (size == 0) {
 		return;
 	}
-	int block_from = operation.journalPositions.front()->from;
-	int block_to = operation.journalPositions.front()->to;
+	int block_from = operation.minimumModifiedOffset;
+	int block_to = operation.maximumModifiedOffset;
 
 	std::vector<WriteCacheBlock> blocks;
 	blocks.reserve(size);
@@ -423,11 +421,26 @@ void ChunkWriter::fillOperation(Operation &operation, int first_block, int first
 	assert(blocks.size() == (size_t)size);
 
 	for (int index = 0; index < size; ++index) {
-		// Insert the new block into the journal just after the last block of the operation
-		auto position = journal_.insert(operation.journalPositions.back(), std::move(blocks[index]));
-		operation.journalPositions.push_back(position);
+		bool isBlockInOperation = false;
+		JournalPosition position;
+		// Check if the block is already in the journal, because it could be the case that the write
+		// operation on this block does not cover the whole interval the operation does.
+		for (const auto& journalPosition : operation.journalPositions) {
+			if (journalPosition->blockIndex == blocks[index].blockIndex) {
+				journalPosition->overwriteWithReadBlock(blocks[index]);
+				position = journalPosition;
+				isBlockInOperation = true;
+				break;
+			}
+		}
+		// If the block is not in the journal, insert it
+		if (!isBlockInOperation) {
+			// Insert the new block into the journal just after the last block of the operation
+			position = journal_.insert(operation.journalPositions.back(), std::move(blocks[index]));
+			operation.journalPositions.push_back(position);
+		}
 
-		stripe_element[first_index + index] = position->data();
+		stripe_element[first_index + index] = position->rawData(block_from);
 	}
 }
 
@@ -446,8 +459,8 @@ void ChunkWriter::fillNotExisting(Operation &operation, int first_block,
 	if (blocks_number == 0) {
 		return;
 	}
-	int block_from = operation.journalPositions.front()->from;
-	int block_to = operation.journalPositions.front()->to;
+	int block_from = operation.minimumModifiedOffset;
+	int block_to = operation.maximumModifiedOffset;
 	int beyond_start = first_block + first_index;
 
 	std::vector<WriteCacheBlock> blocks;
@@ -455,8 +468,7 @@ void ChunkWriter::fillNotExisting(Operation &operation, int first_block,
 	// Fills not existing blocks with zeroes
 	for (int index = beyond_start; index < beyond_start + blocks_number;
 	     ++index) {
-		WriteCacheBlock block(locator_->chunkIndex(), index,
-		                      WriteCacheBlock::kReadBlock);
+		WriteCacheBlock block(locator_->chunkIndex(), index, WriteCacheBlock::kReadBlock);
 		memset(block.data(), 0, SFSBLOCKSIZE);
 		block.from = block_from;
 		block.to = block_to;
@@ -481,10 +493,16 @@ void ChunkWriter::fillNotExisting(Operation &operation, int first_block,
  */
 void ChunkWriter::fillStripe(Operation &operation, int first_block, std::vector<uint8_t *> &stripe_element) {
 	for (const auto &position : operation.journalPositions) {
-		assert((position->blockIndex % combinedStripeSize_) == (position->blockIndex - first_block));
+		assert((position->blockIndex % combinedStripeSize_) ==
+		       (position->blockIndex - first_block));
 		assert(((int)position->blockIndex - first_block) < combinedStripeSize_);
-		assert(position->to == operation.journalPositions.front()->to);
-		assert(position->from == operation.journalPositions.front()->from);
+		assert(position->to <= operation.maximumModifiedOffset);
+		assert(position->from >= operation.minimumModifiedOffset);
+		if (position->from != operation.minimumModifiedOffset ||
+		    position->to != operation.maximumModifiedOffset) {
+			// This block is not fully covered by the operation, so we need to read it
+			continue;
+		}
 		stripe_element[position->blockIndex - first_block] = position->data();
 	}
 
@@ -492,21 +510,25 @@ void ChunkWriter::fillStripe(Operation &operation, int first_block, std::vector<
 	int hole_size = 0;
 	int range_end = std::min(combinedStripeSize_, SFSBLOCKSINCHUNK - first_block);
 	for (int i = 0; i < range_end; ++i) {
+		// If the block is beyond file size, it is not a hole, but it also doesn't need to be read
 		if (first_block + i >= chunkSizeInBlocks_) {
+			// Check if previous blocks were holes and fill them before filling not existing blocks
 			if (hole_size > 0) {
 				fillOperation(operation, first_block, hole_start, hole_size,
 				              stripe_element);
 				hole_size = 0;
 			}
 			if (stripe_element[i] == nullptr) {
+				// Fill not existing blocks with zeroes, so they can be used for parity calculation
 				fillNotExisting(operation, first_block, i, 1, stripe_element);
 			}
 			continue;
 		}
+
 		if (stripe_element[i] == nullptr) {
-			if (hole_size == 0) {
-				hole_start = i;
-			}
+			// This block is a hole, or it is not fully covered by the operation, so we need to read
+			// it.
+			if (hole_size == 0) { hole_start = i; }
 			hole_size++;
 		} else if (hole_size > 0) {
 			fillOperation(operation, first_block, hole_start, hole_size, stripe_element);
@@ -529,9 +551,9 @@ void ChunkWriter::startOperation(Operation operation) {
 	LOG_AVG_TILL_END_OF_SCOPE0("ChunkWriter::startOperation");
 	// If the operation is a partial-stripe write, read all the missing blocks first
 	int first_block = combinedStripeSize_ * (operation.journalPositions.front()->blockIndex / combinedStripeSize_);
-	int block_size = operation.journalPositions.front()->size();
-	int block_from = operation.journalPositions.front()->from;
-	int block_to = operation.journalPositions.front()->to;
+	int block_from = operation.minimumModifiedOffset;
+	int block_to = operation.maximumModifiedOffset;
+	int block_size = block_to - block_from;
 
 	std::vector<uint8_t *> stripe_element(combinedStripeSize_, nullptr);
 	fillStripe(operation, first_block, stripe_element);
@@ -650,9 +672,9 @@ void ChunkWriter::readBlocks(int block_index, int size, int block_from, int bloc
 	locator_->locationInfo().chunkId, locator_->locationInfo().version, std::move(plan));
 
 	assert(buffer.size() == 0);
-	executor.executePlan(buffer, chunk_type_locations, connector_,
-			read_data_get_connect_timeout_ms(), read_data_get_wave_read_timeout_ms(),
-			Timeout{std::chrono::milliseconds(read_data_get_wave_read_timeout_ms())});
+	executor.executePlan(buffer, chunk_type_locations, read_data_get_chunk_connector(),
+	                     read_data_get_connect_timeout_ms(), read_data_get_wave_read_timeout_ms(),
+	                     Timeout{std::chrono::milliseconds(read_data_get_wave_read_timeout_ms())});
 
 	int offset = 0;
 	for (int index = block_index; index < block_index + size; ++index) {

--- a/src/mount/chunk_writer.h
+++ b/src/mount/chunk_writer.h
@@ -142,10 +142,14 @@ private:
 	public:
 		std::vector<JournalPosition> journalPositions;  // stripe in the written journal
 		std::list<WriteCacheBlock> parityBuffers;       // memory for parity blocks
-		uint32_t unfinishedWrites;                      // number of write request sent
-		uint64_t offsetOfEnd;                           // offset in the file
+		uint32_t unfinishedWrites{0};                   // number of write request sent
+		uint64_t offsetOfEnd{0};                        // offset in the file
+		// minimum modified offset in each block of the operation
+		uint32_t minimumModifiedOffset{SFSBLOCKSIZE};
+		// maximum modified offset in each block of the operation
+		uint32_t maximumModifiedOffset{0};
 
-		Operation();
+		Operation() = default;
 		Operation(Operation&&) = default;
 		Operation(const Operation&) = delete;
 		Operation& operator=(const Operation&) = delete;
@@ -165,7 +169,7 @@ private:
 		 * Returns true if two operations write the same place in a file.
 		 * One of these operations have to be complete, ie. contain a full stripe
 		 */
-		bool collidesWith(const Operation& operation) const;
+		bool collidesWith(const Operation& operation, uint32_t stripeSize) const;
 
 		/*
 		 * Returns true if the operation is not a partial-stripe write operation

--- a/src/mount/readdata.cc
+++ b/src/mount/readdata.cc
@@ -506,6 +506,10 @@ bool read_data_get_prefetchxorstripes() {
 	return gPrefetchXorStripes;
 }
 
+ChunkConnector& read_data_get_chunk_connector() {
+	return gChunkConnector;
+}
+
 inline void clear_read_records() {
 	std::unique_lock gMutexLock(gMutex);
 

--- a/src/mount/readdata.h
+++ b/src/mount/readdata.h
@@ -404,6 +404,7 @@ uint32_t read_data_get_wave_read_timeout_ms();
 uint32_t read_data_get_connect_timeout_ms();
 uint32_t read_data_get_total_read_timeout_ms();
 bool read_data_get_prefetchxorstripes();
+ChunkConnector& read_data_get_chunk_connector();
 
 void read_inode_ops(inode_t inode);
 void read_inode_reconnect_and_clear_cache(inode_t inode, uint32_t chunkIndex);

--- a/src/mount/write_cache_block.cc
+++ b/src/mount/write_cache_block.cc
@@ -95,3 +95,26 @@ const uint8_t* WriteCacheBlock::data() const {
 uint8_t* WriteCacheBlock::data() {
 	return blockData.data() + from;
 }
+
+uint8_t* WriteCacheBlock::rawData(uint32_t offset) {
+	assert(offset < SFSBLOCKSIZE);
+	return blockData.data() + offset;
+}
+
+void WriteCacheBlock::overwriteWithReadBlock(const WriteCacheBlock& readBlock) {
+	assert(readBlock.type == kReadBlock);
+	assert(chunkIndex == readBlock.chunkIndex);
+	assert(blockIndex == readBlock.blockIndex);
+	assert(from >= readBlock.from);
+	assert(to <= readBlock.to);
+	assert(readBlock.to <= SFSBLOCKSIZE);
+
+	if (from > readBlock.from) {
+		auto copySize = from - readBlock.from;
+		memcpy(blockData.data() + readBlock.from, readBlock.data(), copySize);
+	}
+	if (to < readBlock.to) {
+		auto copySize = readBlock.to - to;
+		memcpy(blockData.data() + to, readBlock.blockData.data() + to, copySize);
+	}
+}

--- a/src/mount/write_cache_block.h
+++ b/src/mount/write_cache_block.h
@@ -52,4 +52,6 @@ public:
 	uint32_t size() const;
 	const uint8_t* data() const;
 	uint8_t* data();
+	uint8_t* rawData(uint32_t offset);
+	void overwriteWithReadBlock(const WriteCacheBlock& readBlock);
 };

--- a/tests/test_suites/ShortSystemTests/test_randwrite_same_stripe.sh
+++ b/tests/test_suites/ShortSystemTests/test_randwrite_same_stripe.sh
@@ -1,0 +1,29 @@
+timeout_set 30 seconds
+
+# Let's use a very high write window size to make sure all operations are sent to the chunkservers
+# immediately, while also disable write buffering on the chunkservers.
+
+CHUNKSERVERS=8 \
+	USE_RAMDISK=YES \
+	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER,sfswritewindowsize=384" \
+	CHUNKSERVER_EXTRA_CONFIG="WRITE_BUFFERING_SIZE_MB=0" \
+	MASTER_CUSTOM_GOALS="8 ec62: \$ec(6,2)"
+	setup_local_empty_saunafs info
+
+cd ${info[mount0]}
+
+mkdir dir_ec
+saunafs setgoal -r ec62 dir_ec
+cd dir_ec
+
+assert_success fio --name=fio_randwrite_test --size=384K --rw=randwrite --numjobs=1 --ioengine=libaio \
+	--group_reporting --bs=16K --verify=crc32
+
+assert_success fio --name=fio_randwrite_test --size=384K --rw=randwrite --numjobs=1 --ioengine=libaio \
+	--group_reporting --bs=1K --verify=md5 --verify_pattern=%o --do_verify=0
+
+saunafs_chunkserver_daemon 0 stop
+saunafs_chunkserver_daemon 1 stop
+
+assert_success fio --name=fio_randwrite_test --size=384K --rw=randwrite --numjobs=1 --ioengine=libaio \
+	--group_reporting --bs=1K --verify=md5 --verify_pattern=%o --verify_only


### PR DESCRIPTION
The goal of this change is to reduce the reads needed to perform write operations. This can significantly improve the speed of creation of small files when its sizes are not aligned to the SaunaFS block size and some other types of writes, such as random writes but in a less significant manner.

The current implementation restricts the consolidation of several WriteCacheBlock's into a single ChunkWriter::Operation (from now on operation) with the following conditions:
- the chunk must be the same as the one in the operation.
- the stripe must be the same as the one in the operation.
- the interval of the block to be modified must be the same as the ones the operation has.

If a cache block cannot be added to an operation, it must be put into a separate one and possibly wait for the completion of the one it was trying to attach.

The proposed changes remove the last constraint by making the operations to keep track of the interval it is going to modify and changing the logic that computes the parity parts. The result is that write cache blocks from actual client writes inside a single operation do not need to modify the same interval, at the expense of having to write the interval in the parities that covers them and possibly reading more in each of the data parts blocks to read the interval that covers them.

The chunk connector used while reading the missing parts to recalculate
the parity was changed to the ones always used in the reads to comply
with assumptions made in the chunkserver.

Signed-off-by: Dave <dave@leil.io>