### PR TITLE
docs(master): improve FS operations docs

### DIFF
--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -3406,11 +3406,11 @@ uint8_t FilesystemOperationsBase::applySetRichAcl(const FilesystemOperationConte
 #ifndef METARESTORE
 uint32_t FilesystemOperationsBase::getDirPathSize(const FilesystemOperationContext &fsOpContext,
                                                   inode_t inode) {
-	FSNode *node;
-	node = nodeOperations_->idToNode(fsOpContext, inode);
+	FSNode *node = nodeOperations_->idToNode(fsOpContext, inode);
+
 	if (node) {
 		if (node->type != FSNodeType::kDirectory) {
-			return 15;  // "(not directory)"
+			return kDirPathNotDirectory.size();
 		} else {
 			FSNodeDirectory *parent = nullptr;
 			if (!node->parents.empty()) {
@@ -3420,19 +3420,20 @@ uint32_t FilesystemOperationsBase::getDirPathSize(const FilesystemOperationConte
 			return 1 + nodeOperations_->getPathSize(fsOpContext, parent, node);
 		}
 	} else {
-		return 11;  // "(not found)"
+		return kDirPathNotFound.size();
 	}
+
 	return 0;  // unreachable
 }
 
 void FilesystemOperationsBase::getDirPathData(const FilesystemOperationContext &fsOpContext,
                                               inode_t inode, uint8_t *buff, uint32_t size) {
-	FSNode *node;
-	node = nodeOperations_->idToNode(fsOpContext, inode);
+	FSNode *node = nodeOperations_->idToNode(fsOpContext, inode);
+
 	if (node) {
 		if (node->type != FSNodeType::kDirectory) {
-			if (size >= 15) {
-				memcpy(buff, "(not directory)", 15);
+			if (size >= kDirPathNotDirectory.size()) {
+				memcpy(buff, kDirPathNotDirectory.data(), kDirPathNotDirectory.size());
 				return;
 			}
 		} else {
@@ -3449,8 +3450,8 @@ void FilesystemOperationsBase::getDirPathData(const FilesystemOperationContext &
 			}
 		}
 	} else {
-		if (size >= 11) {
-			memcpy(buff, "(not found)", 11);
+		if (size >= kDirPathNotFound.size()) {
+			memcpy(buff, kDirPathNotFound.data(), kDirPathNotFound.size());
 			return;
 		}
 	}

--- a/src/master/filesystem_operations.h
+++ b/src/master/filesystem_operations.h
@@ -111,17 +111,34 @@ public:
 	               inode_t parent_src, const HString &name_src, inode_t parent_dst,
 	               const HString &name_dst, inode_t *inode, Attributes *attr) override;
 
+	/// Updates extra-attribute flags on a node (optionally recursively).
+	/// @see IFilesystemOperations::setExtraAttr
 	uint8_t setExtraAttr(const FsContext &context, inode_t inode, uint8_t eattr, uint8_t smode,
 	                     inode_t *sinodes, inode_t *ncinodes, inode_t *nsinodes) override;
+
+	/// Schedules setting a storage goal on a node (optionally recursively).
+	/// @see IFilesystemOperations::setGoal
 	uint8_t setGoal(const FsContext &context, inode_t inode, uint8_t goal, uint8_t smode,
 	                std::shared_ptr<SetGoalTask::StatsArray> setgoal_stats,
 	                const std::function<void(int)> &callback) override;
+
+	/// Applies a single-node goal update during shadow/restore replay and verifies consistency.
+	/// @see IFilesystemOperations::applySetGoal
 	uint8_t applySetGoal(const FsContext &context, inode_t inode, uint8_t goal, uint8_t smode,
 	                     uint32_t master_result) override;
+
+	/// Updates the stored path string of a trash inode.
+	/// @see IFilesystemOperations::setTrashPath
 	uint8_t setTrashPath(const FsContext &context, inode_t inode, const std::string &path) override;
+
+	/// Schedules setting trash-time on a node (optionally recursively).
+	/// @see IFilesystemOperations::setTrashTime
 	uint8_t setTrashTime(const FsContext &context, inode_t inode, uint32_t trashtime, uint8_t smode,
 	                     std::shared_ptr<SetTrashtimeTask::StatsArray> settrashtime_stats,
 	                     const std::function<void(int)> &callback) override;
+
+	/// Applies a single-node trash-time update on shadow/restore replay and verifies consistency.
+	/// @see IFilesystemOperations::applySetTrashTime
 	uint8_t applySetTrashTime(const FsContext &context, inode_t inode, uint32_t trashtime,
 	                          uint8_t smode, uint32_t master_result) override;
 

--- a/src/master/filesystem_operations.h
+++ b/src/master/filesystem_operations.h
@@ -84,6 +84,8 @@ public:
 	uint8_t release(const FsContext &context, const FilesystemOperationContext &fsOpContext,
 	                inode_t inode, uint32_t sessionid) override;
 
+	/// Appends the contents of one file to another.
+	/// @see IFilesystemOperations::append
 	uint8_t append(const FsContext &context, const FilesystemOperationContext &fsOpContext,
 	               inode_t inode, inode_t inode_src) override;
 
@@ -98,6 +100,8 @@ public:
 	             inode_t inode_src, inode_t parent_dst, const HString &name_dst, inode_t *inode,
 	             Attributes *attr) override;
 
+	/// Purges a trash node from metadata.
+	/// @see IFilesystemOperations::purge
 	uint8_t purge(const FsContext &context, const FilesystemOperationContext &fsOpContext,
 	              inode_t inode) override;
 
@@ -279,6 +283,8 @@ public:
 	// Functions which modify metadata or return some information.
 	// To be used by the master server with personality == kMaster
 
+	/// Retrieves filesystem-wide capacity and object counters.
+	/// @see IFilesystemOperations::getFSStats
 	void getFSStats(uint64_t *totalSpace, uint64_t *availableSpace, uint64_t *trashSpace,
 	                inode_t *trashNodes, uint64_t *reservedSpace, inode_t *reservedNodes,
 	                inode_t *inodes, inode_t *directoryNodes, inode_t *fileNodes,
@@ -293,7 +299,10 @@ public:
 	void getDirPathData(const FilesystemOperationContext &fsOpContext, inode_t inode, uint8_t *buff,
 	                    uint32_t size) override;
 
+	/// Resolves a filesystem path to a directory inode, starting from the root.
+	/// @see IFilesystemOperations::getRootInode
 	uint8_t getRootInode(inode_t *rootinode, const uint8_t *path) override;
+
 	uint8_t readChunk(const FilesystemOperationContext &fsOpContext, inode_t inode, uint32_t indx,
 	                  uint64_t *chunkid, uint64_t *length) override;
 	uint8_t writeEnd(const FilesystemOperationContext &fsOpContext, inode_t inode, uint64_t length,

--- a/src/master/filesystem_operations.h
+++ b/src/master/filesystem_operations.h
@@ -283,9 +283,16 @@ public:
 	                inode_t *trashNodes, uint64_t *reservedSpace, inode_t *reservedNodes,
 	                inode_t *inodes, inode_t *directoryNodes, inode_t *fileNodes,
 	                inode_t *linkNodes) override;
+
+	/// Returns the byte length of the full path string for a directory node.
+	/// @see IFilesystemOperations::getDirPathSize
 	uint32_t getDirPathSize(const FilesystemOperationContext &fsOpContext, inode_t inode) override;
+
+	/// Writes the full path string for a directory node into a caller-supplied buffer.
+	/// @see IFilesystemOperations::getDirPathData
 	void getDirPathData(const FilesystemOperationContext &fsOpContext, inode_t inode, uint8_t *buff,
 	                    uint32_t size) override;
+
 	uint8_t getRootInode(inode_t *rootinode, const uint8_t *path) override;
 	uint8_t readChunk(const FilesystemOperationContext &fsOpContext, inode_t inode, uint32_t indx,
 	                  uint64_t *chunkid, uint64_t *length) override;

--- a/src/master/filesystem_operations_interface.h
+++ b/src/master/filesystem_operations_interface.h
@@ -23,6 +23,7 @@
 #include <initializer_list>
 #include <map>
 #include <memory>
+#include <string_view>
 #include <vector>
 
 #include "common/attributes.h"
@@ -51,6 +52,10 @@ struct NamedInodeEntry;
 struct HandleInodeEntry;
 
 inline constexpr char kAclXattrs[] = "system.richacl";
+
+// Sentinel strings written by getDirPathData() for error cases
+inline constexpr std::string_view kDirPathNotFound = "(not found)";
+inline constexpr std::string_view kDirPathNotDirectory = "(not directory)";
 
 /// Result of a getXAttr operation. Owns the attribute value bytes.
 struct XAttrGetResult {
@@ -1016,10 +1021,47 @@ public:
 	                        inode_t *trashNodes, uint64_t *reservedSpace, inode_t *reservedNodes,
 	                        inode_t *inodes, inode_t *directoryNodes, inode_t *fileNodes,
 	                        inode_t *linkNodes) = 0;
+
+	/// Returns the byte length of the directory-path representation for `inode`.
+	///
+	/// Return value:
+	/// - If the inode is not found: `kDirPathNotFound.size()`.
+	/// - If the node is not a directory: `kDirPathNotDirectory.size()`.
+	/// - If the node is a directory: full absolute path length in bytes, including leading `/`.
+	///
+	/// Use this value to pre-allocate the buffer passed to `getDirPathData()` for an
+	/// untruncated result.
+	///
+	/// @param fsOpContext The operation context (used for node lookups in KV backends).
+	/// @param inode The inode of the directory node to measure.
+	/// @return The number of bytes required for `getDirPathData()` to produce an
+	///         untruncated result for this inode.
 	virtual uint32_t getDirPathSize(const FilesystemOperationContext &fsOpContext,
 	                                inode_t inode) = 0;
+
+	/// Writes the directory-path representation for `inode` into a caller-supplied buffer.
+	///
+	/// Resolves `inode` to a node and writes into `buff` (up to `size` bytes):
+	/// - If the inode is not found and `size >= kDirPathNotFound.size()`: writes
+	///   `kDirPathNotFound` into `buff`; writes nothing if `size` is smaller.
+	/// - If the node is not a directory and `size >= kDirPathNotDirectory.size()`: writes
+	///   `kDirPathNotDirectory` into `buff`; writes nothing if `size` is smaller.
+	/// - If the node is a valid directory:
+	///   - If `size == 0`, nothing is written.
+	///   - If `size > 0`, `buff[0]` is always `'/'` and the remaining bytes are filled with path
+	///     data. If the buffer is too small for the full path, output is truncated: `buff[0]`
+	///     remains `'/'` and the remaining bytes contain a right-aligned tail of the path.
+	///
+	/// The buffer is not null-terminated. Callers should use `getDirPathSize()` first to
+	/// obtain the exact buffer size needed for an untruncated result.
+	///
+	/// @param fsOpContext The operation context (used for node lookups in KV backends).
+	/// @param inode The inode of the directory node whose path to write.
+	/// @param buff Pointer to the output buffer.
+	/// @param size The size of the output buffer in bytes.
 	virtual void getDirPathData(const FilesystemOperationContext &fsOpContext, inode_t inode,
 	                            uint8_t *buff, uint32_t size) = 0;
+
 	virtual uint8_t getRootInode(inode_t *rootinode, const uint8_t *path) = 0;
 	virtual uint8_t readChunk(const FilesystemOperationContext &fsOpContext, inode_t inode,
 	                          uint32_t indx, uint64_t *chunkid, uint64_t *length) = 0;

--- a/src/master/filesystem_operations_interface.h
+++ b/src/master/filesystem_operations_interface.h
@@ -23,6 +23,7 @@
 #include <initializer_list>
 #include <map>
 #include <memory>
+#include <string>
 #include <string_view>
 #include <vector>
 
@@ -324,20 +325,160 @@ public:
 	                       inode_t parent_src, const HString &name_src, inode_t parent_dst,
 	                       const HString &name_dst, inode_t *inode, Attributes *attr) = 0;
 
+	/// Updates extra-attribute flags on a node (optionally recursively).
+	///
+	/// Applies `eattr` using `smode` semantics (set/increase/decrease, with optional recursion).
+	/// Valid bits in `eattr` are: `EATTR_NOOWNER`, `EATTR_NOACACHE`, `EATTR_NOECACHE`,
+	/// and `EATTR_NODATACACHE`.
+	///
+	/// Counter parameters:
+	/// - On master, outputs the number of changed (`sinodes`), unchanged (`ncinodes`),
+	///   and permission-denied (`nsinodes`) inodes.
+	/// - On shadow/restore replay, inputs are expected counts from changelog replay and
+	///   are validated against the locally computed values.
+	///
+	/// @param context The FS operation context (credentials/session/timestamp).
+	/// @param inode Root inode for the operation.
+	/// @param eattr Extra-attribute bitmask to apply.
+	/// @param smode Mode controlling set/increase/decrease and recursion.
+	/// @param[in,out] sinodes Changed count (output on master; expected input on shadow/restore).
+	/// @param[in,out] ncinodes Unchanged count (output on master; expected input on
+	/// shadow/restore).
+	/// @param[in,out] nsinodes Permission-denied count (output on master; expected input on
+	/// shadow/restore).
+	///
+	/// @return SAUNAFS_STATUS_OK on success.
+	/// @return SAUNAFS_ERROR_EINVAL if `smode` or `eattr` is invalid.
+	/// @return SAUNAFS_ERROR_EROFS if the session is read-only.
+	/// @return SAUNAFS_ERROR_ENOENT if the inode cannot be resolved or the session context
+	///         is invalid for this non-meta operation.
+	/// @return SAUNAFS_ERROR_EPERM if the target is outside the session-visible namespace, or
+	///         (non-recursive mode) no change is permitted due to ownership checks.
+	/// @return SAUNAFS_ERROR_MISMATCH on shadow/restore replay if expected counters differ.
 	virtual uint8_t setExtraAttr(const FsContext &context, inode_t inode, uint8_t eattr,
 	                             uint8_t smode, inode_t *sinodes, inode_t *ncinodes,
 	                             inode_t *nsinodes) = 0;
+
+	/// Schedules setting a storage goal on a node (optionally recursively).
+	///
+	/// Accepted `smode` values are `SMODE_SET` and `SMODE_RSET` only.
+	/// `setgoal_stats` accumulates changed/not-changed/not-permitted counters.
+	///
+	/// If the operation is not finished in the initial batch, returns
+	/// `SAUNAFS_ERROR_WAITING`; in that case `callback` is invoked on completion with the
+	/// final status. If it finishes immediately, `callback` is not invoked.
+	///
+	/// @param context The FS operation context (credentials/session/timestamp).
+	/// @param inode Root inode for the operation.
+	/// @param goal Target goal id.
+	/// @param smode Set mode (`SMODE_SET` or `SMODE_RSET`).
+	/// @param setgoal_stats Shared counters for changed/not-changed/not-permitted inodes.
+	/// @param callback Completion callback used when asynchronous processing is required.
+	///
+	/// @return SAUNAFS_STATUS_OK on immediate success.
+	/// @return SAUNAFS_ERROR_WAITING if accepted for asynchronous completion.
+	/// @return SAUNAFS_ERROR_EINVAL if `goal` or `smode` is invalid.
+	/// @return SAUNAFS_ERROR_EROFS if the session is read-only.
+	/// @return SAUNAFS_ERROR_ENOENT if the inode cannot be resolved.
+	/// @return SAUNAFS_ERROR_EPERM if the target type is unsupported (not a directory,
+	///         file, trash, or reserved node), the target is outside the session-visible
+	///         namespace, or (non-recursive mode) a single-node owner check fails and the
+	///         initial batch completes immediately. In recursive mode, owner-based denials
+	///         are accumulated in `setgoal_stats` counters instead.
 	virtual uint8_t setGoal(const FsContext &context, inode_t inode, uint8_t goal, uint8_t smode,
 	                        std::shared_ptr<SetGoalTask::StatsArray> setgoal_stats,
 	                        const std::function<void(int)> &callback) = 0;
+
+	/// Applies a single-node goal update during shadow/restore replay and verifies consistency.
+	///
+	/// Computes the local per-node set-goal result for `inode` and compares it with
+	/// `master_result` (expected `SetGoalTask::k*` result code).
+	///
+	/// @param context The FS operation context (typically shadow/restore replay context).
+	/// @param inode The inode to update.
+	/// @param goal Target goal id.
+	/// @param smode Set mode (`SMODE_SET` or `SMODE_RSET`).
+	/// @param master_result Expected per-node result code from master changelog replay.
+	///
+	/// @return SAUNAFS_STATUS_OK on success.
+	/// @return SAUNAFS_ERROR_EINVAL if `goal` or `smode` is invalid.
+	/// @return SAUNAFS_ERROR_EROFS if the session is read-only.
+	/// @return SAUNAFS_ERROR_ENOENT if the inode cannot be resolved.
+	/// @return SAUNAFS_ERROR_EPERM if the target type is unsupported (not a directory,
+	///         file, trash, or reserved node) or the target is outside the session-visible
+	///         namespace.
+	/// @return SAUNAFS_ERROR_MISMATCH if local result differs from `master_result`.
 	virtual uint8_t applySetGoal(const FsContext &context, inode_t inode, uint8_t goal,
 	                             uint8_t smode, uint32_t master_result) = 0;
+
+	/// Updates the stored path string of a trash inode.
+	///
+	/// For contexts with session data, this operation requires a meta session.
+	/// `path` must be non-empty and must not contain embedded `'\0'` bytes.
+	///
+	/// @param context The FS operation context (credentials/session/timestamp).
+	/// @param inode Inode expected to be in trash.
+	/// @param path New stored trash path.
+	///
+	/// @return SAUNAFS_STATUS_OK on success.
+	/// @return SAUNAFS_ERROR_EINVAL if `path` is empty or contains `'\0'`.
+	/// @return SAUNAFS_ERROR_EROFS if the session is read-only.
+	/// @return SAUNAFS_ERROR_EPERM if the session is not a meta session, or inode is outside
+	///         the session-visible namespace.
+	/// @return SAUNAFS_ERROR_ENOENT if inode cannot be resolved as a trash node.
 	virtual uint8_t setTrashPath(const FsContext &context, inode_t inode,
 	                             const std::string &path) = 0;
+
+	/// Schedules setting trash-time on a node (optionally recursively).
+	///
+	/// `smode` controls set/increase/decrease semantics and optional recursion.
+	/// `settrashtime_stats` accumulates changed/not-changed/not-permitted counters.
+	///
+	/// If the operation is not finished in the initial batch, returns
+	/// `SAUNAFS_ERROR_WAITING`; in that case `callback` is invoked on completion with the
+	/// final status. If it finishes immediately, `callback` is not invoked.
+	///
+	/// @param context The FS operation context (credentials/session/timestamp).
+	/// @param inode Root inode for the operation.
+	/// @param trashtime Target trash-time value.
+	/// @param smode Mode controlling set/increase/decrease and recursion.
+	/// @param settrashtime_stats Shared counters for changed/not-changed/not-permitted inodes.
+	/// @param callback Completion callback used when asynchronous processing is required.
+	///
+	/// @return SAUNAFS_STATUS_OK on immediate success.
+	/// @return SAUNAFS_ERROR_WAITING if accepted for asynchronous completion.
+	/// @return SAUNAFS_ERROR_EINVAL if `smode` is invalid.
+	/// @return SAUNAFS_ERROR_EROFS if the session is read-only.
+	/// @return SAUNAFS_ERROR_ENOENT if the inode cannot be resolved.
+	/// @return SAUNAFS_ERROR_EPERM if the target type is unsupported (not a directory,
+	///         file, trash, or reserved node), the target is outside the session-visible
+	///         namespace, or (non-recursive mode) a single-node owner check fails and the
+	///         initial batch completes immediately. In recursive mode, owner-based denials
+	///         are accumulated in `settrashtime_stats` counters instead.
 	virtual uint8_t setTrashTime(const FsContext &context, inode_t inode, uint32_t trashtime,
 	                             uint8_t smode,
 	                             std::shared_ptr<SetTrashtimeTask::StatsArray> settrashtime_stats,
 	                             const std::function<void(int)> &callback) = 0;
+
+	/// Applies a single-node trash-time update on shadow/restore replay and verifies consistency.
+	///
+	/// Computes the local per-node set-trashtime result for `inode` and compares it with
+	/// `master_result` (expected `SetTrashtimeTask::k*` result code).
+	///
+	/// @param context The FS operation context (typically shadow/restore replay context).
+	/// @param inode The inode to update.
+	/// @param trashtime Target trash-time value.
+	/// @param smode Mode controlling set/increase/decrease and recursion.
+	/// @param master_result Expected per-node result code from master changelog replay.
+	///
+	/// @return SAUNAFS_STATUS_OK on success.
+	/// @return SAUNAFS_ERROR_EINVAL if `smode` is invalid.
+	/// @return SAUNAFS_ERROR_EROFS if the session is read-only.
+	/// @return SAUNAFS_ERROR_ENOENT if the inode cannot be resolved.
+	/// @return SAUNAFS_ERROR_EPERM if the target type is unsupported (not a directory,
+	///         file, trash, or reserved node) or the target is outside the session-visible
+	///         namespace.
+	/// @return SAUNAFS_ERROR_MISMATCH if local result differs from `master_result`.
 	virtual uint8_t applySetTrashTime(const FsContext &context, inode_t inode, uint32_t trashtime,
 	                                  uint8_t smode, uint32_t master_result) = 0;
 

--- a/src/master/filesystem_operations_interface.h
+++ b/src/master/filesystem_operations_interface.h
@@ -170,6 +170,29 @@ public:
 	virtual uint8_t release(const FsContext &context, const FilesystemOperationContext &fsOpContext,
 	                        inode_t inode, uint32_t sessionid) = 0;
 
+	/// Appends the contents of one file to another.
+	///
+	/// Interprets `inode` as destination and `inode_src` as source.
+	/// On success, destination file data is extended by the source file data in order.
+	/// If the source file has no chunks, no data is copied, but all preceding validations
+	/// (session, permissions, quota) still apply.
+	///
+	/// @param context The FS operation context containing user credentials, session info,
+	///                and timestamp.
+	/// @param fsOpContext The filesystem operation context (transaction).
+	/// @param inode Destination inode (must be writable in the current session context).
+	/// @param inode_src Source inode (must be readable in the current session context).
+	///
+	/// @return SAUNAFS_STATUS_OK on success.
+	/// @return SAUNAFS_ERROR_EINVAL if `inode == inode_src`.
+	/// @return SAUNAFS_ERROR_EROFS if the session is read-only.
+	/// @return SAUNAFS_ERROR_ENOENT if the session is invalid for this operation or an inode
+	///         cannot be resolved.
+	/// @return SAUNAFS_ERROR_EPERM if an inode is outside the session-visible subtree or is not
+	///         a file-like node.
+	/// @return SAUNAFS_ERROR_EACCES if read/write permissions are insufficient.
+	/// @return SAUNAFS_ERROR_QUOTA if appending would exceed quota (master personality).
+	/// @return SAUNAFS_ERROR_INDEXTOOBIG if the resulting chunk index range would overflow.
 	virtual uint8_t append(const FsContext &context, const FilesystemOperationContext &fsOpContext,
 	                       inode_t inode, inode_t inode_src) = 0;
 
@@ -236,6 +259,25 @@ public:
 	                     inode_t inode_src, inode_t parent_dst, const HString &name_dst,
 	                     inode_t *inode, Attributes *attr) = 0;
 
+	/// Purges a trash node from metadata.
+	///
+	/// The inode must resolve to a trash-type node; otherwise the call fails.
+	/// For contexts with session data, this operation requires a meta session.
+	///
+	/// On success, the trash entry is removed. If the node still has active file sessions,
+	/// it is moved to reserved instead of being removed immediately, while still reporting
+	/// success.
+	///
+	/// @param context The FS operation context containing user credentials, session info,
+	///                and timestamp.
+	/// @param fsOpContext The filesystem operation context (transaction).
+	/// @param inode The inode of the trash node to purge.
+	///
+	/// @return SAUNAFS_STATUS_OK on success.
+	/// @return SAUNAFS_ERROR_EROFS if the session is read-only.
+	/// @return SAUNAFS_ERROR_EPERM if the session is not a meta session, or the inode
+	///         resolves to a node that is inaccessible from a meta session.
+	/// @return SAUNAFS_ERROR_ENOENT if the inode does not exist or is not a trash-type node.
 	virtual uint8_t purge(const FsContext &context, const FilesystemOperationContext &fsOpContext,
 	                      inode_t inode) = 0;
 
@@ -1017,6 +1059,24 @@ public:
 	// Functions which modify metadata or return some information.
 	// To be used by the master server with personality == kMaster
 
+	/// Retrieves filesystem-wide capacity and object counters.
+	///
+	/// This method fills all output parameters with the current master-side values used by
+	/// `CLTOMA_INFO`/`MATOCL_INFO` (`SaunaFsStatistics`):
+	/// - `totalSpace` and `availableSpace` come from `matocsserv_getspace()`.
+	/// - All remaining parameters reflect the current metadata counters, sourced from the
+	///   backend used by the active implementation (in-memory or KV store).
+	///
+	/// @param[out] totalSpace Receives total chunkserver space in bytes.
+	/// @param[out] availableSpace Receives currently available chunkserver space in bytes.
+	/// @param[out] trashSpace Receives total size in bytes of files in trash.
+	/// @param[out] trashNodes Receives number of files in trash.
+	/// @param[out] reservedSpace Receives total size in bytes of files in reserved.
+	/// @param[out] reservedNodes Receives number of files in reserved.
+	/// @param[out] inodes Receives total number of metadata nodes.
+	/// @param[out] directoryNodes Receives number of directory nodes.
+	/// @param[out] fileNodes Receives number of file-type nodes.
+	/// @param[out] linkNodes Receives number of symbolic-link nodes.
 	virtual void getFSStats(uint64_t *totalSpace, uint64_t *availableSpace, uint64_t *trashSpace,
 	                        inode_t *trashNodes, uint64_t *reservedSpace, inode_t *reservedNodes,
 	                        inode_t *inodes, inode_t *directoryNodes, inode_t *fileNodes,
@@ -1062,7 +1122,24 @@ public:
 	virtual void getDirPathData(const FilesystemOperationContext &fsOpContext, inode_t inode,
 	                            uint8_t *buff, uint32_t size) = 0;
 
+	/// Resolves a filesystem path to a directory inode, starting from the root.
+	///
+	/// Walks each `/`-separated component of `path` from the filesystem root directory.
+	/// Multiple consecutive `/` characters are treated as a single separator.
+	/// An empty path or a path consisting only of `/` characters resolves to the root inode.
+	/// On success, writes the inode of the resolved directory to `*rootinode`.
+	///
+	/// @note Primarily used during FUSE session registration to resolve the mount subpath
+	///       into the inode that becomes the session's visible filesystem root.
+	///
+	/// @param[out] rootinode Receives the inode of the directory at `path`.
+	/// @param path Null-terminated path to resolve (e.g. `"subvol/dir"`).
+	/// @return `SAUNAFS_STATUS_OK` on success.
+	/// @return `SAUNAFS_ERROR_ENOENT` if any path component is not found.
+	/// @return `SAUNAFS_ERROR_ENOTDIR` if any resolved path component is not a directory.
+	/// @return `SAUNAFS_ERROR_EINVAL` if a path component name is invalid.
 	virtual uint8_t getRootInode(inode_t *rootinode, const uint8_t *path) = 0;
+
 	virtual uint8_t readChunk(const FilesystemOperationContext &fsOpContext, inode_t inode,
 	                          uint32_t indx, uint64_t *chunkid, uint64_t *length) = 0;
 	virtual uint8_t writeEnd(const FilesystemOperationContext &fsOpContext, inode_t inode,


### PR DESCRIPTION
Adds a gradual improvement to the documentation comments for some filesystem operations and tiny refactoring to reduce magic numbers on the related functions.

Related to: LS-417

