### PR TITLE
build: fix bash completion path for rpm packages

### DIFF
--- a/src/data/CMakeLists.txt
+++ b/src/data/CMakeLists.txt
@@ -24,7 +24,7 @@ if(EXISTS ${CMAKE_CURRENT_BINARY_DIR}/sfsmds.cfg)
   install(FILES ${CMAKE_CURRENT_BINARY_DIR}/sfsmds.cfg       DESTINATION ${SFSMDS_EXAMPLES_SUBDIR})
 endif()
 
-install(FILES saunafs.completion DESTINATION etc/bash_completion.d RENAME saunafs COMPONENT client)
+install(FILES saunafs.completion DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/bash_completion.d RENAME saunafs COMPONENT client)
 
 if(BUILD_TESTS)
   # Create a mock include dir.


### PR DESCRIPTION
Previously, the bash completion file was installed using the relative destination `etc/bash_completion.d`. CMake's install() prepends CMAKE_INSTALL_PREFIX to relative paths, which caused incorrect installation paths for some package formats.

- Debian packages: CMAKE_INSTALL_PREFIX defaults to `/usr`, but dpkg installs files relative to `/`, so the file ended up in the expected `/etc/bash_completion.d`.

- RPM packages via CPack: the same relative path became `/usr/etc/bash_completion.d`, which is incorrect.

This commit fixes the installation path by using the absolute destination derived from `CMAKE_INSTALL_FULL_SYSCONFDIR`, ensuring the completion file is installed under `/etc/bash_completion.d` regardless of the CMAKE_INSTALL_PREFIX or packaging backend.

Fixes LS-419.

IMPORTANT: This PR depends on PR #788 and should be merged after.