### PR TITLE
refactor(master): use virtual parent lookup for dir paths

### DIFF
--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -382,6 +382,15 @@ FSNodeDirectory *FilesystemNodeOperationsBase::getFirstParent(
 	return gMetadata->root;
 }
 
+inode_t FilesystemNodeOperationsBase::getFirstParentId(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, FSNode *node) {
+	assert(node);
+
+	if (!node->parents.empty()) { return node->parents[0].first; }
+
+	return 0;
+}
+
 std::vector<inode_t> FilesystemNodeOperationsBase::getParentIds(
     [[maybe_unused]] const FilesystemOperationContext &fsOpContext, FSNode *node) {
 	assert(node);

--- a/src/master/filesystem_node.h
+++ b/src/master/filesystem_node.h
@@ -270,6 +270,10 @@ protected:
 	FSNodeDirectory *getFirstParent(const FilesystemOperationContext &fsOpContext,
 	                                FSNode *node) override;
 
+	/// @see IFilesystemNodeOperations::getFirstParentId
+	inode_t getFirstParentId([[maybe_unused]] const FilesystemOperationContext &fsOpContext,
+	                         FSNode *node) override;
+
 	/// Returns the IDs of all parents of the given node.
 	/// @see IFilesystemNodeOperations::getParentIds
 	std::vector<inode_t> getParentIds(

--- a/src/master/filesystem_node_operations_interface.h
+++ b/src/master/filesystem_node_operations_interface.h
@@ -593,6 +593,15 @@ public:
 	virtual FSNodeDirectory *getFirstParent(const FilesystemOperationContext &fsOpContext,
 	                                        FSNode *node) = 0;
 
+	/// Returns the inode id of the first parent of the given node, or 0 if the node has no parents.
+	/// @param fsOpContext The filesystem operation context potentially containing a transaction.
+	/// @param node The node whose first parent id is to be retrieved.
+	/// @return The inode id of the first parent, or 0 if the node has no parents.
+	/// @note Prefer this over getParentIds() when only the first parent is needed, as it avoids
+	///       building the full parent vector (relevant for KV backends).
+	virtual inode_t getFirstParentId(const FilesystemOperationContext &fsOpContext,
+	                                 FSNode *node) = 0;
+
 	/// Returns all parent ids of the given node.
 	/// @param fsOpContext The filesystem operation context potentially containing a transaction.
 	/// @param node The node whose parents are to be retrieved.

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -3413,9 +3413,10 @@ uint32_t FilesystemOperationsBase::getDirPathSize(const FilesystemOperationConte
 			return kDirPathNotDirectory.size();
 		} else {
 			FSNodeDirectory *parent = nullptr;
-			if (!node->parents.empty()) {
-				parent = nodeOperations_->idToNodeVerify<FSNodeDirectory>(fsOpContext,
-				                                                          node->parents[0].first);
+			auto parentIds = nodeOperations_->getParentIds(fsOpContext, node);
+			if (!parentIds.empty()) {
+				parent =
+				    nodeOperations_->idToNodeVerify<FSNodeDirectory>(fsOpContext, parentIds[0]);
 			}
 			return 1 + nodeOperations_->getPathSize(fsOpContext, parent, node);
 		}
@@ -3439,9 +3440,10 @@ void FilesystemOperationsBase::getDirPathData(const FilesystemOperationContext &
 		} else {
 			if (size > 0) {
 				FSNodeDirectory *parent = nullptr;
-				if (!node->parents.empty()) {
-					parent = nodeOperations_->idToNodeVerify<FSNodeDirectory>(
-					    fsOpContext, node->parents[0].first);
+				auto parentIds = nodeOperations_->getParentIds(fsOpContext, node);
+				if (!parentIds.empty()) {
+					parent =
+					    nodeOperations_->idToNodeVerify<FSNodeDirectory>(fsOpContext, parentIds[0]);
 				}
 
 				buff[0] = '/';

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -329,14 +329,11 @@ void FilesystemOperationsBase::getFSStats(uint64_t *totalSpace, uint64_t *availa
 uint8_t FilesystemOperationsBase::getRootInode(inode_t *rootinode, const uint8_t *path) {
 	HString hname;
 	uint32_t nleng;
-	const uint8_t *name;
-	FSNodeDirectory *parent;
-
-	name = path;
-	parent = gMetadata->root;
+	const uint8_t *name = path;
 
 	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
 	    FilesystemOperationContext::TransactionType::kReadOnly);
+	FSNodeDirectory *parent = nodeOperations_->getRootNode(fsOpContext);
 
 	for (;;) {
 		while (*name == '/') {

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -3410,10 +3410,9 @@ uint32_t FilesystemOperationsBase::getDirPathSize(const FilesystemOperationConte
 			return kDirPathNotDirectory.size();
 		} else {
 			FSNodeDirectory *parent = nullptr;
-			auto parentIds = nodeOperations_->getParentIds(fsOpContext, node);
-			if (!parentIds.empty()) {
-				parent =
-				    nodeOperations_->idToNodeVerify<FSNodeDirectory>(fsOpContext, parentIds[0]);
+			const inode_t parentId = nodeOperations_->getFirstParentId(fsOpContext, node);
+			if (parentId != 0) {
+				parent = nodeOperations_->idToNodeVerify<FSNodeDirectory>(fsOpContext, parentId);
 			}
 			return 1 + nodeOperations_->getPathSize(fsOpContext, parent, node);
 		}
@@ -3437,10 +3436,10 @@ void FilesystemOperationsBase::getDirPathData(const FilesystemOperationContext &
 		} else {
 			if (size > 0) {
 				FSNodeDirectory *parent = nullptr;
-				auto parentIds = nodeOperations_->getParentIds(fsOpContext, node);
-				if (!parentIds.empty()) {
+				const inode_t parentId = nodeOperations_->getFirstParentId(fsOpContext, node);
+				if (parentId != 0) {
 					parent =
-					    nodeOperations_->idToNodeVerify<FSNodeDirectory>(fsOpContext, parentIds[0]);
+					    nodeOperations_->idToNodeVerify<FSNodeDirectory>(fsOpContext, parentId);
 				}
 
 				buff[0] = '/';


### PR DESCRIPTION
This PR refactors shared master path logic to rely on backend-aware node operations instead of direct in-memory metadata access.
It is intended to be behavior-preserving while making dirpath/root resolution compatible with KV/FDB backends.

Related to: LS-434