### PR TITLE
fix(tests): exact key match in dirinfo/admin info

### DIFF
--- a/tests/tools/saunafs.sh
+++ b/tests/tools/saunafs.sh
@@ -1151,8 +1151,25 @@ sfschunkserver_check_no_buffer_in_use() {
 # The output lines from `dirinfo` and `admin info` are formatted as:
 # "key (possibly with spaces): value"
 # For example: "FS objects: 5"
+# Uses awk (instead of grep/cut) to match the label exactly in field 1.
+# This avoids collisions like "size" matching "realsize" and trims whitespace safely.
 function get_value_from_dirinfo_and_admin_info() {
 	local content="${1}"
 	local key="${2}"
-	echo "${content}" | grep "${key}:" | cut -d: -f2- | sed 's/^[[:space:]]*//; s/[[:space:]]*$//'
+	echo "${content}" | awk -F: -v key="${key}" '
+		/:/ {
+			label = $1
+			sub(/^[[:space:]]+/, "", label)
+			sub(/[[:space:]]+$/, "", label)
+
+			# Exact key match on label (left side of ":").
+			if (label == key) {
+				value = $0
+				sub(/^[^:]*:[[:space:]]*/, "", value)
+				sub(/[[:space:]]*$/, "", value)
+				print value
+				exit
+			}
+		}
+	'
 }


### PR DESCRIPTION
Replace grep/cut/sed pipeline with awk in
get_value_from_dirinfo_and_admin_info to perform exact label matching. The old grep-based approach would incorrectly match "size" against "realsize". The awk implementation trims leading whitespace from dirinfo labels and matches the key exactly, handling both tab-separated admin info and space-padded dirinfo output correctly.

Reviewers: the change does not affect this repo, but the function is extensively used in the MDS repo.