### PR TITLE
fix(master): persist append in KV backend

### DIFF
--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -1321,8 +1321,8 @@ uint8_t FilesystemNodeOperationsBase::appendChunks(const FilesystemOperationCont
 	nodeQuotaUpdate(fsOpContext, destNodeFile,
 	                {{QuotaResource::kSize, newStats.size - previousStats.size}});
 
-	// Update stats for all parent directories
-	for (const auto &[parentId, _] : destNodeFile->parents) {
+	// Update stats for all parent directories via backend-specific parent lookup.
+	for (inode_t parentId : getParentIds(fsOpContext, destNodeFile)) {
 		auto *parentNode = idToNodeVerify<FSNodeDirectory>(fsOpContext, parentId);
 		addSubStats(fsOpContext, parentNode, &newStats, &previousStats);
 	}

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -1832,6 +1832,13 @@ uint8_t FilesystemOperationsBase::append(const FsContext &context,
 	if (status != SAUNAFS_STATUS_OK) {
 		return status;
 	}
+
+	// Make append changes persistent for KV backends.
+	if (fsOpContext.hasReadWriteTransaction()) {
+		nodeOperations_->updateNode(fsOpContext, p);
+		nodeOperations_->updateNode(fsOpContext, sp);
+	}
+
 	if (context.isPersonalityMaster()) {
 		changeLog(context.ts(), "APPEND(%" PRIiNode ",%" PRIiNode ")", p->id, sp->id);
 	} else {


### PR DESCRIPTION
Use backend-aware parent ID lookup in appendChunks. Persist source and destination node updates in append when a read-write transaction is active.

Related to: LS-417