### PR TITLE
fix(build): fix chunkserver-common_pic link deps

### DIFF
--- a/src/chunkserver/chunkserver-common/CMakeLists.txt
+++ b/src/chunkserver/chunkserver-common/CMakeLists.txt
@@ -2,8 +2,11 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 collect_sources(CHUNKSERVER_PLUGINS)
 shared_add_library(chunkserver-common ${CHUNKSERVER_PLUGINS_SOURCES})
-target_link_libraries(chunkserver-common safsprotocol sfscommon
-        ${Boost_LIBRARIES} ${ADDITIONAL_LIBS})
+shared_target_link_libraries(chunkserver-common
+        safsprotocol
+        sfscommon
+        ${Boost_LIBRARIES}
+        ${ADDITIONAL_LIBS})
 
 shared_target_link_libraries(chunkserver-common STATIC sfserr SHARED sfserr_pic)
 


### PR DESCRIPTION
`chunkserver-common` is created via `shared_add_library`, which produces both `chunkserver-common` and `chunkserver-common_pic`. `target_link_libraries` only applied dependencies to the non-PIC target.

Use `shared_target_link_libraries` so both variants get the same dependency set. This fixes GCC link failures in some plugins' unit tests with missing `ProducerConsumerQueueWithPriority::*` symbols.