### PR TITLE
refactor(master): support extraattr ops on KV

### DIFF
--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -1912,11 +1912,12 @@ void FilesystemNodeOperationsBase::setTrashTimeRecursive(FSNode *node, uint32_t 
 	}
 }
 
-void FilesystemNodeOperationsBase::setExtraAttrRecursive(FSNode *node, uint32_t timeStamp,
-                                                         uint32_t uid, uint8_t eattr, uint8_t smode,
-                                                         inode_t *modifiedINodesOut,
-                                                         inode_t *unchangedINodesOut,
-                                                         inode_t *permissionDeniedINodesOut) {
+void FilesystemNodeOperationsBase::setExtraAttrRecursive(
+    const FilesystemOperationContext &fsOpContext, FSNode *node, uint32_t timeStamp, uint32_t uid,
+    uint8_t eattr, uint8_t smode, inode_t *modifiedINodesOut, inode_t *unchangedINodesOut,
+    inode_t *permissionDeniedINodesOut) {
+	bool nodeChanged = false;
+
 	// Check permission
 	if ((node->mode & (EATTR_NOOWNER << EATTR_BIT_OFFSET)) == 0 && uid != 0 && node->uid != uid) {
 		(*permissionDeniedINodesOut)++;
@@ -1924,8 +1925,10 @@ void FilesystemNodeOperationsBase::setExtraAttrRecursive(FSNode *node, uint32_t 
 		// Sanitize attributes: remove NOECACHE flag for non-directory nodes
 		uint8_t adjustedExtraAttr = eattr;
 		if (node->type != FSNodeType::kDirectory) {
+			const uint16_t oldMode = node->mode;
 			node->mode &= ~(EATTR_NOECACHE << EATTR_BIT_OFFSET);
 			adjustedExtraAttr &= ~(EATTR_NOECACHE);
+			if (node->mode != oldMode) { nodeChanged = true; }
 		}
 
 		// Compute new extra attributes based on smode
@@ -1956,6 +1959,7 @@ void FilesystemNodeOperationsBase::setExtraAttrRecursive(FSNode *node, uint32_t 
 
 			(*modifiedINodesOut)++;
 			updateCTime(node, timeStamp);
+			nodeChanged = true;
 		} else {
 			(*unchangedINodesOut)++;
 		}
@@ -1966,12 +1970,15 @@ void FilesystemNodeOperationsBase::setExtraAttrRecursive(FSNode *node, uint32_t 
 		const auto *dirNode = static_cast<const FSNodeDirectory *>(node);
 
 		for (const auto &entry : dirNode->entries) {
-			setExtraAttrRecursive(entry.second, timeStamp, uid, eattr, smode, modifiedINodesOut,
-			                  unchangedINodesOut, permissionDeniedINodesOut);
+			setExtraAttrRecursive(fsOpContext, entry.second, timeStamp, uid, eattr, smode,
+			                      modifiedINodesOut, unchangedINodesOut, permissionDeniedINodesOut);
 		}
 	}
 
 	fsnodes_update_checksum(node);
+
+	// Make the change persistent for KV backends
+	if (nodeChanged && fsOpContext.hasReadWriteTransaction()) { updateNode(fsOpContext, node); }
 }
 
 uint8_t FilesystemNodeOperationsBase::deleteAcl(

--- a/src/master/filesystem_node.h
+++ b/src/master/filesystem_node.h
@@ -212,6 +212,9 @@ public:
 	                      GoalStatistics &dirGoalsTab) override;
 	void getTrashTimeRecursive(FSNode *node, uint8_t gmode, TrashtimeMap &fileTrashtimes,
 	                           TrashtimeMap &dirTrashtimes) override;
+
+	/// Aggregates extra-attribute histogram counters for a node or subtree.
+	/// @see IFilesystemNodeOperations::getExtraAttrRecursive
 	void getExtraAttrRecursive(FSNode *node, uint8_t gmode, ExtraAttributesArray &fileEAttrTab,
 	                           ExtraAttributesArray &dirEAttrTab) override;
 #endif  // METARESTORE
@@ -225,9 +228,11 @@ public:
 	                           inode_t *unchangedINodesOut,
 	                           inode_t *permissionDeniedINodesOut) override;
 
-	void setExtraAttrRecursive(FSNode *node, uint32_t timeStamp, uint32_t uid, uint8_t eattr,
-	                           uint8_t smode, inode_t *modifiedINodesOut,
-	                           inode_t *unchangedINodesOut,
+	/// Applies extra-attribute updates on a node or subtree and tracks outcomes.
+	/// @see IFilesystemNodeOperations::setExtraAttrRecursive
+	void setExtraAttrRecursive(const FilesystemOperationContext &fsOpContext, FSNode *node,
+	                           uint32_t timeStamp, uint32_t uid, uint8_t eattr, uint8_t smode,
+	                           inode_t *modifiedINodesOut, inode_t *unchangedINodesOut,
 	                           inode_t *permissionDeniedINodesOut) override;
 
 	// Access control operations

--- a/src/master/filesystem_node_operations_interface.h
+++ b/src/master/filesystem_node_operations_interface.h
@@ -535,6 +535,19 @@ public:
 	                              GoalStatistics &dirGoalsTab) = 0;
 	virtual void getTrashTimeRecursive(FSNode *node, uint8_t gmode, TrashtimeMap &fileTrashtimes,
 	                                   TrashtimeMap &dirTrashtimes) = 0;
+
+	/// Aggregates extra-attribute histogram counters for a node or subtree.
+	///
+	/// Traverses `node` according to `gmode`. For non-directory nodes, increments
+	/// `fileEAttrTab` using a mask of file-relevant flags
+	/// (`EATTR_NOOWNER | EATTR_NOACACHE | EATTR_NODATACACHE`).
+	/// For directories, increments `dirEAttrTab` using the full extra-attribute nibble
+	/// (including `EATTR_NOECACHE`).
+	///
+	/// @param node Root node for traversal.
+	/// @param gmode Traversal mode (`GMODE_NORMAL` or `GMODE_RECURSIVE`).
+	/// @param[in,out] fileEAttrTab Histogram for non-directory nodes.
+	/// @param[in,out] dirEAttrTab Histogram for directory nodes.
 	virtual void getExtraAttrRecursive(FSNode *node, uint8_t gmode,
 	                                   ExtraAttributesArray &fileEAttrTab,
 	                                   ExtraAttributesArray &dirEAttrTab) = 0;
@@ -549,8 +562,31 @@ public:
 	                                   inode_t *modifiedINodesOut, inode_t *unchangedINodesOut,
 	                                   inode_t *permissionDeniedINodesOut) = 0;
 
-	virtual void setExtraAttrRecursive(FSNode *node, uint32_t timeStamp, uint32_t uid,
-	                                   uint8_t eattr, uint8_t smode, inode_t *modifiedINodesOut,
+	/// Applies extra-attribute updates on a node or subtree and tracks outcomes.
+	///
+	/// Applies `eattr` according to `smode` (set/increase/decrease, optional recursion).
+	/// Permission is denied when `uid` is neither root nor owner and `EATTR_NOOWNER` is
+	/// not set on the target node; denied nodes increment `permissionDeniedINodesOut`.
+	/// For non-directory nodes, `EATTR_NOECACHE` is cleared/ignored.
+	///
+	/// Nodes with changed extra attributes:
+	/// - have mode (extraattr bits) updated,
+	/// - propagate mode to stored ACL metadata (if present),
+	/// - update ctime/checksum,
+	/// - are persisted via updateNode() when a read-write transaction is present.
+	///
+	/// @param fsOpContext The filesystem operation context (transaction).
+	/// @param node Root node for update traversal.
+	/// @param timeStamp Timestamp used for ctime updates.
+	/// @param uid Requesting uid used for ownership checks.
+	/// @param eattr Requested extra-attribute bitmask.
+	/// @param smode Update mode flags (`SMODE_*`, including optional recursion).
+	/// @param[in,out] modifiedINodesOut Count of nodes whose extra attributes changed.
+	/// @param[in,out] unchangedINodesOut Count of nodes visited without effective changes.
+	/// @param[in,out] permissionDeniedINodesOut Count of nodes rejected by ownership checks.
+	virtual void setExtraAttrRecursive(const FilesystemOperationContext &fsOpContext, FSNode *node,
+	                                   uint32_t timeStamp, uint32_t uid, uint8_t eattr,
+	                                   uint8_t smode, inode_t *modifiedINodesOut,
 	                                   inode_t *unchangedINodesOut,
 	                                   inode_t *permissionDeniedINodesOut) = 0;
 

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -3050,9 +3050,11 @@ uint8_t FilesystemOperationsBase::applySetTrashTime(const FsContext &context, in
 	return SAUNAFS_STATUS_OK;
 }
 
-uint8_t FilesystemOperationsBase::setExtraAttr(const FsContext &context, inode_t inode,
-                                               uint8_t eattr, uint8_t smode, inode_t *sinodes,
-                                               inode_t *ncinodes, inode_t *nsinodes) {
+uint8_t FilesystemOperationsBase::setExtraAttr(const FsContext &context,
+                                               const FilesystemOperationContext &fsOpContext,
+                                               inode_t inode, uint8_t eattr, uint8_t smode,
+                                               inode_t *sinodes, inode_t *ncinodes,
+                                               inode_t *nsinodes) {
 	ChecksumUpdater cu(context.ts());
 	if (!SMODE_ISVALID(smode) ||
 	    (eattr & (~(EATTR_NOOWNER | EATTR_NOACACHE | EATTR_NOECACHE | EATTR_NODATACACHE)))) {
@@ -3064,9 +3066,6 @@ uint8_t FilesystemOperationsBase::setExtraAttr(const FsContext &context, inode_t
 		return status;
 	}
 
-	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
-	    FilesystemOperationContext::TransactionType::kReadWrite);
-
 	FSNode *p;
 	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kAny,
 	                                              MODE_MASK_EMPTY, inode, &p);
@@ -3077,8 +3076,8 @@ uint8_t FilesystemOperationsBase::setExtraAttr(const FsContext &context, inode_t
 	inode_t nci = 0;
 	inode_t nsi = 0;
 	sassert(context.hasUidGidData());
-	nodeOperations_->setExtraAttrRecursive(p, context.ts(), context.uid(), eattr, smode, &si, &nci,
-	                                       &nsi);
+	nodeOperations_->setExtraAttrRecursive(fsOpContext, p, context.ts(), context.uid(), eattr,
+	                                       smode, &si, &nci, &nsi);
 	if (context.isPersonalityMaster()) {
 		if ((smode & SMODE_RMASK) == 0 && nsi > 0 && si == 0 && nci == 0) {
 			return SAUNAFS_ERROR_EPERM;

--- a/src/master/filesystem_operations.h
+++ b/src/master/filesystem_operations.h
@@ -113,8 +113,9 @@ public:
 
 	/// Updates extra-attribute flags on a node (optionally recursively).
 	/// @see IFilesystemOperations::setExtraAttr
-	uint8_t setExtraAttr(const FsContext &context, inode_t inode, uint8_t eattr, uint8_t smode,
-	                     inode_t *sinodes, inode_t *ncinodes, inode_t *nsinodes) override;
+	uint8_t setExtraAttr(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                     inode_t inode, uint8_t eattr, uint8_t smode, inode_t *sinodes,
+	                     inode_t *ncinodes, inode_t *nsinodes) override;
 
 	/// Schedules setting a storage goal on a node (optionally recursively).
 	/// @see IFilesystemOperations::setGoal
@@ -249,6 +250,9 @@ public:
 	uint8_t getGoal(const FsContext &context, const FilesystemOperationContext &fsOpContext,
 	                inode_t inode, uint8_t gmode, GoalStatistics &fgtab,
 	                GoalStatistics &dgtab) override;
+
+	/// Retrieves aggregated extra-attribute statistics for a node or subtree.
+	/// @see IFilesystemOperations::getExtraAttr
 	uint8_t getExtraAttr(const FsContext &context, inode_t inode, uint8_t gmode,
 	                     ExtraAttributesArray &fileEAttrTab,
 	                     ExtraAttributesArray &dirEAttrTab) override;

--- a/src/master/filesystem_operations_interface.h
+++ b/src/master/filesystem_operations_interface.h
@@ -338,6 +338,7 @@ public:
 	///   are validated against the locally computed values.
 	///
 	/// @param context The FS operation context (credentials/session/timestamp).
+	/// @param fsOpContext The operation context carrying a read-write transaction in KV backends.
 	/// @param inode Root inode for the operation.
 	/// @param eattr Extra-attribute bitmask to apply.
 	/// @param smode Mode controlling set/increase/decrease and recursion.
@@ -355,8 +356,9 @@ public:
 	/// @return SAUNAFS_ERROR_EPERM if the target is outside the session-visible namespace, or
 	///         (non-recursive mode) no change is permitted due to ownership checks.
 	/// @return SAUNAFS_ERROR_MISMATCH on shadow/restore replay if expected counters differ.
-	virtual uint8_t setExtraAttr(const FsContext &context, inode_t inode, uint8_t eattr,
-	                             uint8_t smode, inode_t *sinodes, inode_t *ncinodes,
+	virtual uint8_t setExtraAttr(const FsContext &context,
+	                             const FilesystemOperationContext &fsOpContext, inode_t inode,
+	                             uint8_t eattr, uint8_t smode, inode_t *sinodes, inode_t *ncinodes,
 	                             inode_t *nsinodes) = 0;
 
 	/// Schedules setting a storage goal on a node (optionally recursively).
@@ -1022,6 +1024,29 @@ public:
 	virtual uint8_t getGoal(const FsContext &context, const FilesystemOperationContext &fsOpContext,
 	                        inode_t inode, uint8_t gmode, GoalStatistics &fgtab,
 	                        GoalStatistics &dgtab) = 0;
+
+	/// Retrieves aggregated extra-attribute statistics for a node or subtree.
+	///
+	/// Resolves `inode` in the caller session and aggregates counts of extra-attribute
+	/// combinations into separate histograms for non-directory nodes and directory nodes.
+	/// Traversal depth is controlled by `gmode` (`GMODE_NORMAL` for one node,
+	/// `GMODE_RECURSIVE` for subtree).
+	///
+	/// Histogram semantics:
+	/// - `fileEAttrTab` indexes are built from non-directory extraattr bits
+	///   `EATTR_NOOWNER | EATTR_NOACACHE | EATTR_NODATACACHE`.
+	/// - `dirEAttrTab` indexes are built from directory extraattr bits (full extraattr nibble).
+	///
+	/// @param context The FS operation context (credentials/session/timestamp).
+	/// @param inode Root inode for the query.
+	/// @param gmode Traversal mode (`GMODE_NORMAL` or `GMODE_RECURSIVE`).
+	/// @param[out] fileEAttrTab Histogram for non-directory nodes.
+	/// @param[out] dirEAttrTab Histogram for directory nodes.
+	///
+	/// @return SAUNAFS_STATUS_OK on success.
+	/// @return SAUNAFS_ERROR_EINVAL if `gmode` is invalid.
+	/// @return Session/visibility errors returned by verifySession/getNodeForOperation
+	///         (for example SAUNAFS_ERROR_ENOENT, SAUNAFS_ERROR_EPERM, SAUNAFS_ERROR_EROFS).
 	virtual uint8_t getExtraAttr(const FsContext &context, inode_t inode, uint8_t gmode,
 	                             ExtraAttributesArray &fileEAttrTab,
 	                             ExtraAttributesArray &dirEAttrTab) = 0;

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -3619,8 +3619,20 @@ void matoclserv_fuse_seteattr(matoclserventry *eptr, const uint8_t *data, uint32
 	eattr = get8bit(&data);
 	smode = get8bit(&data);
 
-	status = gFSOperations->setExtraAttr(matoclserv_get_context(eptr, uid, 0), inode, eattr, smode,
-	                                     &changed, &notchanged, &notpermitted);
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
+	status = gFSOperations->setExtraAttr(matoclserv_get_context(eptr, uid, 0), fsOpContext, inode,
+	                                     eattr, smode, &changed, &notchanged, &notpermitted);
+
+	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
+		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+			safs::log_err("{}: transaction failed to commit: inode {}, eattr {}, smode {}",
+			              __func__, inode, static_cast<uint32_t>(eattr),
+			              static_cast<uint32_t>(smode));
+			status = SAUNAFS_ERROR_IO;
+		}
+	}
 
 	constexpr uint32_t kFailedSize = sizeof(msgid) + sizeof(status);
 	constexpr uint32_t kSuccessSize =

--- a/src/master/restore.cc
+++ b/src/master/restore.cc
@@ -726,8 +726,23 @@ int do_seteattr(const char* filename, uint64_t lv, uint32_t ts, const char* ptr)
 	GETINODE(nci,ptr);
 	EAT(ptr,filename,lv,',');
 	GETINODE(npi,ptr);
-	return gFSOperations->setExtraAttr(FsContext::getForRestoreWithUidGid(ts, uid, 0), inode, eattr,
-	                                   smode, &ci, &nci, &npi);
+
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
+	int status = gFSOperations->setExtraAttr(FsContext::getForRestoreWithUidGid(ts, uid, 0),
+	                                         fsOpContext, inode, eattr, smode, &ci, &nci, &npi);
+
+	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
+		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+			safs::log_err("{}: transaction failed to commit: inode {}, uid {}, eattr {}, smode {}",
+			              __func__, inode, uid, static_cast<uint32_t>(eattr),
+			              static_cast<uint32_t>(smode));
+			status = SAUNAFS_ERROR_IO;
+		}
+	}
+
+	return status;
 }
 
 int do_setgoal(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {


### PR DESCRIPTION
Move setExtraAttr transaction ownership to callers. Pass FilesystemOperationContext through setExtraAttr and recursive node operations, and commit in matoclserv/restore callers. Persist changed nodes in setExtraAttrRecursive with updateNode() when a read-write transaction exists.

Extend extraattr API docs in interfaces and add brief @see comments in concrete headers.

Related to: LS-417