### PR TITLE
refactor(master): allow setgoal ops in KV

### DIFF
--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -1268,6 +1268,18 @@ void FilesystemNodeOperationsBase::checkFile(FSNodeFile *nodeFile, ChunkCountArr
 }
 #endif
 
+std::vector<inode_t> FilesystemNodeOperationsBase::getDirectoryChildInodes(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext,
+    const FSNodeDirectory *nodeDir) {
+	std::vector<inode_t> childInodes;
+	if (nodeDir == nullptr) { return childInodes; }
+
+	childInodes.reserve(nodeDir->entries.size());
+	for (const auto &entry : nodeDir->entries) { childInodes.push_back(entry.second->id); }
+
+	return childInodes;
+}
+
 uint8_t FilesystemNodeOperationsBase::appendChunks(const FilesystemOperationContext &fsOpContext,
                                                    uint32_t timeStamp, FSNodeFile *destNodeFile,
                                                    FSNodeFile *srcNodeFile) {
@@ -1362,7 +1374,7 @@ void FilesystemNodeOperationsBase::changeFileGoal(const FilesystemOperationConte
 
 	fsnodes_update_checksum(nodeFile);
 
-	gMetadata->nodeChangedSignal.emit(nodeFile);
+	if (!fsOpContext.hasReadWriteTransaction()) { gMetadata->nodeChangedSignal.emit(nodeFile); }
 }
 
 void FilesystemNodeOperationsBase::setLength(const FilesystemOperationContext &fsOpContext,
@@ -1821,6 +1833,8 @@ void FilesystemNodeOperationsBase::setgoalRecursive(const FilesystemOperationCon
                                                     inode_t *modifiedINodesOut,
                                                     inode_t *unchangedINodesOut,
                                                     inode_t *permissionDeniedINodesOut) {
+	bool nodeChanged = false;
+
 	if (node->type == FSNodeType::kFile || node->type == FSNodeType::kDirectory ||
 	    node->type == FSNodeType::kTrash || node->type == FSNodeType::kReserved) {
 		if ((node->mode & (EATTR_NOOWNER << EATTR_BIT_OFFSET)) == 0 && uid != 0 &&
@@ -1833,12 +1847,15 @@ void FilesystemNodeOperationsBase::setgoalRecursive(const FilesystemOperationCon
 					(*modifiedINodesOut)++;
 				} else {
 					node->goal = goal;
-					gMetadata->nodeChangedSignal.emit(node);
+					if (!fsOpContext.hasReadWriteTransaction()) {
+						gMetadata->nodeChangedSignal.emit(node);
+					}
 					(*modifiedINodesOut)++;
 				}
 
 				updateCTime(node, timeStamp);
 				fsnodes_update_checksum(node);
+				nodeChanged = true;
 			} else {
 				(*unchangedINodesOut)++;
 			}
@@ -1851,6 +1868,8 @@ void FilesystemNodeOperationsBase::setgoalRecursive(const FilesystemOperationCon
 			}
 		}
 	}
+
+	if (nodeChanged && fsOpContext.hasReadWriteTransaction()) { updateNode(fsOpContext, node); }
 }
 
 void FilesystemNodeOperationsBase::setTrashTimeRecursive(FSNode *node, uint32_t timeStamp,

--- a/src/master/filesystem_node.h
+++ b/src/master/filesystem_node.h
@@ -144,6 +144,12 @@ public:
 	            FSNodeDirectory *nodeDir, uint64_t firstEntry, uint64_t numberOfEntries,
 	            std::vector<DirectoryEntry> &dirEntriesOut) override;
 #endif
+
+	/// Returns direct child inode IDs for a directory.
+	/// @see IFilesystemNodeOperations::getDirectoryChildInodes
+	std::vector<inode_t> getDirectoryChildInodes(const FilesystemOperationContext &fsOpContext,
+	                                             const FSNodeDirectory *nodeDir) override;
+
 	/// Checks if a name is already used in the given directory.
 	/// @see IFilesystemNodeOperations::isNameUsed
 	bool isNameUsed(const FilesystemOperationContext &fsOpContext, FSNodeDirectory *node,

--- a/src/master/filesystem_node_operations_interface.h
+++ b/src/master/filesystem_node_operations_interface.h
@@ -403,6 +403,22 @@ public:
 	                    FSNodeDirectory *nodeDir, uint64_t firstEntry, uint64_t numberOfEntries,
 	                    std::vector<DirectoryEntry> &dirEntriesOut) = 0;
 #endif
+
+	/// Returns direct child inode IDs for a directory.
+	///
+	/// Used by recursive operations (for example setgoal tasks) to enqueue one subtree level.
+	///
+	/// Backend expectations:
+	/// - in-memory metadata implementation reads children from `nodeDir->entries`,
+	/// - KV/FDB implementation enumerates children from persistent EDGE_* records and must not
+	///   depend on `nodeDir->entries` being populated.
+	///
+	/// @param fsOpContext The filesystem operation context (transaction).
+	/// @param nodeDir Directory whose direct child inode IDs should be returned.
+	/// @return Direct child inode IDs (excluding "." and "..").
+	virtual std::vector<inode_t> getDirectoryChildInodes(
+	    const FilesystemOperationContext &fsOpContext, const FSNodeDirectory *nodeDir) = 0;
+
 	/// Checks if a name is already used in the given directory.
 	///
 	/// Determines whether a directory entry with the specified name exists in the given

--- a/src/master/setgoal_task.cc
+++ b/src/master/setgoal_task.cc
@@ -25,6 +25,7 @@
 #include "master/filesystem_checksum.h"
 #include "master/filesystem_metadata.h"
 #include "master/filesystem_operations_interface.h"
+#include "slogger/slogger.h"
 
 int SetGoalTask::execute(uint32_t ts, intrusive_list<Task> &work_queue) {
 	assert(current_inode_ != inode_list_.end());
@@ -42,15 +43,13 @@ int SetGoalTask::execute(uint32_t ts, intrusive_list<Task> &work_queue) {
 	uint8_t result = setGoal(fsOpContext, node, ts);
 
 	if (result != kNoAction) {
-		if (node->type == FSNodeType::kDirectory && (smode_ & SMODE_RMASK) &&
-		    !static_cast<const FSNodeDirectory *>(node)->entries.empty()) {
-			std::vector<inode_t> inode_list;
-			inode_list.reserve(static_cast<const FSNodeDirectory *>(node)->entries.size());
-			for (const auto &entry : static_cast<const FSNodeDirectory *>(node)->entries) {
-				inode_list.push_back(entry.second->id);
+		if (node->type == FSNodeType::kDirectory && (smode_ & SMODE_RMASK)) {
+			auto inode_list = gFSOperations->nodeOperations()->getDirectoryChildInodes(
+			    fsOpContext, static_cast<const FSNodeDirectory *>(node));
+			if (!inode_list.empty()) {
+				auto *task = new SetGoalTask(std::move(inode_list), uid_, goal_, smode_, stats_);
+				work_queue.push_front(*task);
 			}
-			auto task = new SetGoalTask(std::move(inode_list), uid_, goal_, smode_, stats_);
-			work_queue.push_front(*task);
 		}
 
 		if ((smode_ & SMODE_RMASK) == 0 && result == kNotPermitted) {
@@ -60,6 +59,14 @@ int SetGoalTask::execute(uint32_t ts, intrusive_list<Task> &work_queue) {
 		if (result == kChanged) {
 			gFSOperations->changeLog(ts, "SETGOAL(%" PRIiNode ",%" PRIu32 ",%" PRIu8 ",%" PRIu8 ")",
 			                         inode, uid_, goal_, smode_);
+		}
+	}
+
+	if (result == kChanged && fsOpContext.hasReadWriteTransaction()) {
+		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+			safs::log_err("{}: transaction failed to commit: inode {}, goal {}, smode {}", __func__,
+			              inode, static_cast<uint32_t>(goal_), static_cast<uint32_t>(smode_));
+			return SAUNAFS_ERROR_IO;
 		}
 	}
 
@@ -84,10 +91,17 @@ uint8_t SetGoalTask::setGoal(const FilesystemOperationContext &fsOpContext, FSNo
 					    fsOpContext, static_cast<FSNodeFile *>(node), goal_);
 				} else {
 					node->goal = goal_;
-					gMetadata->nodeChangedSignal.emit(node);
+					if (!fsOpContext.hasReadWriteTransaction()) {
+						gMetadata->nodeChangedSignal.emit(node);
+					}
 				}
 				gFSOperations->nodeOperations()->updateCTime(node, ts);
 				fsnodes_update_checksum(node);
+
+				// Make goal updates persistent for KV backends.
+				if (fsOpContext.hasReadWriteTransaction()) {
+					gFSOperations->nodeOperations()->updateNode(fsOpContext, node);
+				}
 				return SetGoalTask::kChanged;
 			} else {
 				return SetGoalTask::kNotChanged;


### PR DESCRIPTION
Introduce getDirectoryChildInodes() in node operations for backend-aware child enumeration.
Use it in SetGoalTask recursion instead of reading directory entries directly.

Persist goal updates via updateNode() when running with a RW transaction and commit the SetGoalTask transaction explicitly. Also persist node changes in setgoalRecursive() for KV backends.

Related to: LS-472