### PR TITLE
refactor(master): make ancestry and root lookups KV-compatible

### DIFF
--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -401,6 +401,18 @@ std::vector<inode_t> FilesystemNodeOperationsBase::getParentIds(
 	return parentIds;
 }
 
+std::string FilesystemNodeOperationsBase::getChildNameByParentId(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, inode_t parentId,
+    FSNode *node) {
+	if (node == nullptr) { return {}; }
+	for (const auto &[storedParentId, nameHandle] : node->parents) {
+		if (storedParentId != parentId) { continue; }
+		if (nameHandle == nullptr) { return {}; }
+		return static_cast<std::string>(*nameHandle);
+	}
+	return {};
+}
+
 void FilesystemNodeOperationsBase::subStats(const FilesystemOperationContext &fsOpContext,
                                             FSNodeDirectory *parent, StatsRecord *stats) {
 	if (parent != nullptr) {

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -403,7 +403,7 @@ std::vector<inode_t> FilesystemNodeOperationsBase::getParentIds(
 
 std::string FilesystemNodeOperationsBase::getChildNameByParentId(
     [[maybe_unused]] const FilesystemOperationContext &fsOpContext, inode_t parentId,
-    FSNode *node) {
+    const FSNode *node) {
 	if (node == nullptr) { return {}; }
 	for (const auto &[storedParentId, nameHandle] : node->parents) {
 		if (storedParentId != parentId) { continue; }

--- a/src/master/filesystem_node.h
+++ b/src/master/filesystem_node.h
@@ -293,7 +293,7 @@ protected:
 	/// Returns the edge name that links parentId -> node.
 	/// @see IFilesystemNodeOperations::getChildNameByParentId
 	std::string getChildNameByParentId(const FilesystemOperationContext &fsOpContext,
-	                                   inode_t parentId, FSNode *node) override;
+	                                   inode_t parentId, const FSNode *node) override;
 
 	/// Internal node lookup operation with context - override in subclasses for custom storage.
 	/// @see IFilesystemNodeOperations::idToNodeInternal

--- a/src/master/filesystem_node.h
+++ b/src/master/filesystem_node.h
@@ -290,6 +290,11 @@ protected:
 	std::vector<inode_t> getParentIds(
 	    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, FSNode *node) override;
 
+	/// Returns the edge name that links parentId -> node.
+	/// @see IFilesystemNodeOperations::getChildNameByParentId
+	std::string getChildNameByParentId(const FilesystemOperationContext &fsOpContext,
+	                                   inode_t parentId, FSNode *node) override;
+
 	/// Internal node lookup operation with context - override in subclasses for custom storage.
 	/// @see IFilesystemNodeOperations::idToNodeInternal
 	FSNode *idToNodeInternal(const FilesystemOperationContext &fsOpContext,

--- a/src/master/filesystem_node_operations_interface.h
+++ b/src/master/filesystem_node_operations_interface.h
@@ -665,9 +665,10 @@ public:
 	/// @param fsOpContext The filesystem operation context potentially containing a transaction.
 	/// @param parentId Parent inode id.
 	/// @param node Child node.
-	/// @return Edge name or empty string if not found.
+	/// @return Edge name, or empty string if the edge is not found, @p node is null, or
+	///         @p parentId is 0.
 	virtual std::string getChildNameByParentId(const FilesystemOperationContext &fsOpContext,
-	                                           inode_t parentId, FSNode *node) = 0;
+	                                           inode_t parentId, const FSNode *node) = 0;
 
 protected:
 	/// Core node lookup operation with context - override in subclasses for custom storage.

--- a/src/master/filesystem_node_operations_interface.h
+++ b/src/master/filesystem_node_operations_interface.h
@@ -661,6 +661,14 @@ public:
 	virtual std::vector<inode_t> getParentIds(const FilesystemOperationContext &fsOpContext,
 	                                          FSNode *node) = 0;
 
+	/// Returns the edge name that links parentId -> node.
+	/// @param fsOpContext The filesystem operation context potentially containing a transaction.
+	/// @param parentId Parent inode id.
+	/// @param node Child node.
+	/// @return Edge name or empty string if not found.
+	virtual std::string getChildNameByParentId(const FilesystemOperationContext &fsOpContext,
+	                                           inode_t parentId, FSNode *node) = 0;
+
 protected:
 	/// Core node lookup operation with context - override in subclasses for custom storage.
 	/// @param context The FS context for the operation, potentially carrying a transaction.

--- a/src/master/filesystem_node_types.h
+++ b/src/master/filesystem_node_types.h
@@ -496,7 +496,7 @@ public:
 	 */
 	std::string getChildName(const FSNode *node) const {
 		for (const auto &[parentId, hstring] : node->parents) {
-			if (parentId == this->id) { return hstring->get(); }
+			if (parentId == this->id) { return hstring ? hstring->get() : std::string{}; }
 		}
 		return {};
 	}

--- a/src/master/filesystem_node_types.h
+++ b/src/master/filesystem_node_types.h
@@ -538,8 +538,10 @@ public:
 				FSNode *child = (*lowerIt).second;
 				if (!child) { return {}; }
 				// ORIGINAL name from parents vector (first stored casing).
-				for (const auto &[parentId, hstring] : child->parents) {
-					if (parentId == this->id) { return std::string(hstring->get()); }
+				for (const auto &[parentId, nameHandle] : child->parents) {
+					if (parentId != this->id) { continue; }
+					if (nameHandle == nullptr) { return {}; }
+					return static_cast<std::string>(*nameHandle);
 				}
 
 				// Fallback: scan entries for pointer equality (should rarely be needed).

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -482,13 +482,12 @@ uint8_t FilesystemOperationsBase::lookup(const FsContext &context,
 				                          context.gid(), context.auid(), context.agid(),
 				                          context.sesflags(), attr);
 			} else {
-				if (!workDir->parents.empty()) {
-					if (workDir->parents[0].first == context.rootinode()) {
-						*inode = SPECIAL_INODE_ROOT;
-					} else {
-						*inode = workDir->parents[0].first;
-					}
-					FSNode *pp = nodeOperations_->idToNode(fsOpContext, workDir->parents[0].first);
+				inode_t firstParentId = nodeOperations_->getFirstParentId(fsOpContext, workDir);
+				if (firstParentId != 0) {
+					FSNode *pp = nodeOperations_->idToNode(fsOpContext, firstParentId);
+					if (pp == nullptr) { return SAUNAFS_ERROR_ENOENT; }
+					*inode =
+					    (firstParentId == context.rootinode()) ? SPECIAL_INODE_ROOT : firstParentId;
 					nodeOperations_->fillAttr(fsOpContext, pp, workDir, context.uid(),
 					                          context.gid(), context.auid(), context.agid(),
 					                          context.sesflags(), attr);
@@ -580,9 +579,12 @@ uint8_t FilesystemOperationsBase::fullPathByInode(const FsContext &context, inod
 	}
 
 	while (current_inode != context.rootinode()) {
-		if (!current_node || current_node->parents.empty()) {
-			if (current_node->parents.empty() && (current_node->type == FSNodeType::kReserved ||
-			                                     current_node->type == FSNodeType::kTrash)) {
+		inode_t parentId =
+		    current_node ? nodeOperations_->getFirstParentId(fsOpContext, current_node) : 0;
+		if (!current_node || parentId == 0) {
+			if (current_node && parentId == 0 &&
+			    (current_node->type == FSNodeType::kReserved ||
+			     current_node->type == FSNodeType::kTrash)) {
 				current_name =
 				    current_node->type == FSNodeType::kTrash
 				        ? gMetadata->trash.at(TrashPathKey(current_node)).get() + " (trash)"
@@ -592,12 +594,11 @@ uint8_t FilesystemOperationsBase::fullPathByInode(const FsContext &context, inod
 			}
 			return SAUNAFS_ERROR_ENOENT;
 		}
-		auto [parentId, nameHandle] = current_node->parents[0];
-		if (!nameHandle) { return SAUNAFS_ERROR_ENOENT; }
 		status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kAny,
 		                                              MODE_MASK_R, parentId, &parent_node);
 		if (status != SAUNAFS_STATUS_OK) { return status; }
-		current_name = nameHandle->get();
+		current_name = static_cast<FSNodeDirectory *>(parent_node)->getChildName(current_node);
+		if (current_name.empty()) { return SAUNAFS_ERROR_ENOENT; }
 		fullPath = current_inode == initial_inode
 		               ? current_name
 		               : current_name + "/" + fullPath;
@@ -616,9 +617,9 @@ std::string FilesystemOperationsBase::fullPathByInode(const FilesystemOperationC
 	std::string currentName = "";
 
 	while (currentInode != SPECIAL_INODE_ROOT) {
-		if (!currentNode) {
-			return "";
-		} else if (currentNode->parents.empty()) {
+		if (!currentNode) { return ""; }
+		inode_t parent = nodeOperations_->getFirstParentId(fsOpContext, currentNode);
+		if (parent == 0) {
 			if (currentNode->type == FSNodeType::kReserved ||
 			    currentNode->type == FSNodeType::kTrash) {
 				std::string pathFromTrashOrReserved;
@@ -637,7 +638,6 @@ std::string FilesystemOperationsBase::fullPathByInode(const FilesystemOperationC
 			break;
 		}
 
-		auto parent = currentNode->parents[0].first;
 		auto parentNode = nodeOperations_->idToNode<FSNodeDirectory>(fsOpContext, parent);
 		if (!parentNode) { return ""; }
 		currentName = parentNode->getChildName(currentNode);
@@ -2652,10 +2652,7 @@ uint8_t FilesystemOperationsBase::removeChunkFromFile(const FsContext &context,
 	changeLog(ts, "REPAIR(%" PRIiNode ",%" PRIu32 "):%" PRIu32, inode, indx, nversion);
 
 	nodeOperations_->getStats(fsOpContext, p, &nsr);
-	for (const auto &[parentId, _] : p->parents) {
-		auto *parent = nodeOperations_->idToNodeVerify<FSNodeDirectory>(fsOpContext, parentId);
-		nodeOperations_->addSubStats(fsOpContext, parent, &nsr, &psr);
-	}
+	nodeOperations_->updateParentStatsForNode(fsOpContext, p, &nsr, &psr);
 	quotaUpdate(fsOpContext, p, {{QuotaResource::kSize, nsr.size - psr.size}});
 	fsnodes_update_checksum(p);
 	return SAUNAFS_STATUS_OK;
@@ -2708,10 +2705,7 @@ uint8_t FilesystemOperationsBase::repair(const FsContext &context, inode_t inode
 		}
 	}
 	nodeOperations_->getStats(fsOpContext, p, &nsr);
-	for (const auto &[parentId, _] : p->parents) {
-		auto *parent = nodeOperations_->idToNodeVerify<FSNodeDirectory>(fsOpContext, parentId);
-		nodeOperations_->addSubStats(fsOpContext, parent, &nsr, &psr);
-	}
+	nodeOperations_->updateParentStatsForNode(fsOpContext, p, &nsr, &psr);
 	quotaUpdate(fsOpContext, p, {{QuotaResource::kSize, nsr.size - psr.size}});
 	fsnodes_update_checksum(p);
 	return SAUNAFS_STATUS_OK;
@@ -2761,10 +2755,7 @@ uint8_t FilesystemOperationsBase::applyRepair(const FilesystemOperationContext &
 
 	nodeOperations_->getStats(fsOpContext, p, &nsr);
 
-	for (const auto &[parentId, _] : p->parents) {
-		auto *parent = nodeOperations_->idToNodeVerify<FSNodeDirectory>(fsOpContext, parentId);
-		nodeOperations_->addSubStats(fsOpContext, parent, &nsr, &psr);
-	}
+	nodeOperations_->updateParentStatsForNode(fsOpContext, p, &nsr, &psr);
 
 	quotaUpdate(fsOpContext, p, {{QuotaResource::kSize, nsr.size - psr.size}});
 

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -371,7 +371,7 @@ void FilesystemOperationsBase::statfs(const FsContext &context,
 	if (context.rootinode() == SPECIAL_INODE_ROOT) {
 		*trspace = gMetadata->trashSpace;
 		*respace = gMetadata->reservedSpace;
-		rn = gMetadata->root;
+		rn = nodeOperations_->getRootNode(fsOpContext);
 	} else {
 		*trspace = 0;
 		*respace = 0;

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -597,7 +597,7 @@ uint8_t FilesystemOperationsBase::fullPathByInode(const FsContext &context, inod
 		status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kAny,
 		                                              MODE_MASK_R, parentId, &parent_node);
 		if (status != SAUNAFS_STATUS_OK) { return status; }
-		current_name = static_cast<FSNodeDirectory *>(parent_node)->getChildName(current_node);
+		current_name = nodeOperations_->getChildNameByParentId(fsOpContext, parentId, current_node);
 		if (current_name.empty()) { return SAUNAFS_ERROR_ENOENT; }
 		fullPath = current_inode == initial_inode
 		               ? current_name
@@ -640,7 +640,8 @@ std::string FilesystemOperationsBase::fullPathByInode(const FilesystemOperationC
 
 		auto parentNode = nodeOperations_->idToNode<FSNodeDirectory>(fsOpContext, parent);
 		if (!parentNode) { return ""; }
-		currentName = parentNode->getChildName(currentNode);
+		currentName = nodeOperations_->getChildNameByParentId(fsOpContext, parent, currentNode);
+		if (currentName.empty()) { return ""; }
 		fullPath = currentInode == initialInode ? currentName : currentName + "/" + fullPath;
 		currentInode = parent;
 		currentNode = parentNode;


### PR DESCRIPTION
This PR reduces the remaining direct in-memory metadata access from master filesystem operations and routes those paths through nodeOperations_ instead. The goal is to keep these operations compatible with KV/FDB-backed metadata, where callers should not depend on FSNode::parents or gMetadata->root directly.

Changes:
- Replace direct node->parents access in lookup(".."), fullPathByInode, removeChunkFromFile, repair, and applyRepair with nodeOperations_ ancestry helpers.
- Add getChildNameByParentId() to the node-operations interface so fullPathByInode can resolve edge names without relying on in-memory parent handles.
- Make fullPathByInode fail fast when the parent edge name is missing, returning ENOENT or an empty path instead of building a malformed partial path.
- Use nodeOperations_->getRootNode() in statfs instead of gMetadata->root.
- Guard FSNodeDirectory::getChildName() against null edge-name handles.

No behavior change is expected for valid in-memory metadata. The only intentional tightening is that missing or corrupted parent edge names now cause path resolution to fail cleanly instead of producing malformed output.

Related to: LS-417

Note: stopping asking Copilot for review, it is just repeating itself.