### PR TITLE
refactor(master): allow metadata version updates in KV

### DIFF
--- a/src/master/chunks.cc
+++ b/src/master/chunks.cc
@@ -846,8 +846,22 @@ void chunk_increase_version_operation(Chunk *targetChunk, bool needsLocking);
 void chunk_emergency_increase_version(Chunk *c) {
 	chunk_increase_version_operation(c, false);
 	chunk_update_checksum(c);
-	gFSOperations->increaseChunkVersion(c->chunkid);
+
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
+	gFSOperations->increaseChunkVersion(fsOpContext, c->chunkid);
+
 	emit_chunk_changed(c);
+
+	// Commit the transaction under KV backends
+	if (fsOpContext.hasReadWriteTransaction()) {
+		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+			safs::log_critical(
+			    "{}: Failed to commit transaction for increasing version of chunk {}.", __func__,
+			    c->chunkid);
+		}
+	}
 }
 
 /// @brief This function should be called when an operation on a chunk fails (chunk not writable)

--- a/src/master/filesystem_checksum_updater.h
+++ b/src/master/filesystem_checksum_updater.h
@@ -53,9 +53,15 @@ protected:
 	static void writeToChangelog(uint32_t ts) {
 		lastEntry_ = gMetadata->metadataVersion;
 		if (metadataserver::isMaster() && !gChecksumBackgroundUpdater.inProgress()) {
+			// The checksum updater is not used by KV/MDS backends, which do not rely on
+			// changelog-based checksumming. The fsOpContext here is a placeholder to satisfy
+			// the updated changeLog() signature; no transaction commit is needed.
+			auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+			    FilesystemOperationContext::TransactionType::kReadWrite);
 			std::string versionString = saunafsVersionToString(SAUNAFS_VERSHEX);
 			uint64_t checksum = gFSOperations->metadataChecksum(ChecksumMode::kGetCurrent);
-			gFSOperations->changeLog(ts, "CHECKSUM(%s):%" PRIu64, versionString.c_str(), checksum);
+			gFSOperations->changeLog(fsOpContext, ts, "CHECKSUM(%s):%" PRIu64,
+			                         versionString.c_str(), checksum);
 		}
 	}
 

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -1731,7 +1731,7 @@ uint8_t FilesystemNodeOperationsBase::undel(const FilesystemOperationContext &fs
 #endif
 
 			gFSOperations->changeLog(
-			    timeStamp,
+			    fsOpContext, timeStamp,
 			    "CREATE(%" PRIiNode ",%s,%c,%d,%" PRIu32 ",%" PRIu32 ",%" PRIu32 "):%" PRIiNode,
 			    currentParent->id, escapeName(name).c_str(),
 			    static_cast<char>(FSNodeType::kDirectory), currentNode->mode & kPermissionsMask,

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -68,11 +68,10 @@ FilesystemOperationsBase::FilesystemOperationsBase(
     std::unique_ptr<IFilesystemNodeOperations> _nodeOps)
     : nodeOperations_(std::move(_nodeOps)) {}
 
-void FilesystemOperationsBase::changeLog(uint32_t ts, const char *format, ...) {
-#ifdef METARESTORE
-	(void)ts;
-	(void)format;
-#else
+void FilesystemOperationsBase::changeLog(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, [[maybe_unused]] uint32_t ts,
+    [[maybe_unused]] const char *format, ...) {
+#ifndef METARESTORE
 	const uint32_t kMaxTimestampSize = 20;
 	const uint32_t kMaxEntrySize = kMaxLogLineSize - kMaxTimestampSize;
 	static char entry[kMaxLogLineSize];
@@ -94,7 +93,7 @@ void FilesystemOperationsBase::changeLog(uint32_t ts, const char *format, ...) {
 		entryLength++;
 	}
 
-	uint64_t version = gMetadata->metadataVersion++;
+	uint64_t version = increaseMetadataVersion(fsOpContext);
 	changelog(version, entry);
 	getChangelogSignal().emit({.version = version, .entry = entry});
 	matomlserv_broadcast_logstring(version, (uint8_t *)entry, tsLength + entryLength);
@@ -219,7 +218,7 @@ uint8_t FilesystemOperationsBase::setTrashPath(const FsContext &context, inode_t
 	                     gMetadata->trashReservedToId, p, path);
 
 	if (context.isPersonalityMaster()) {
-		changeLog(context.ts(), "SETPATH(%" PRIiNode ",%s)", p->id,
+		changeLog(fsOpContext, context.ts(), "SETPATH(%" PRIiNode ",%s)", p->id,
 		          nodeOperations_->escapeName(path).c_str());
 	} else {
 		gMetadata->metadataVersion++;
@@ -246,7 +245,9 @@ uint8_t FilesystemOperationsBase::undel(const FsContext &context, inode_t inode)
 
 	status = nodeOperations_->undel(fsOpContext, context.ts(), static_cast<FSNodeFile *>(p));
 	if (context.isPersonalityMaster()) {
-		if (status == SAUNAFS_STATUS_OK) { changeLog(context.ts(), "UNDEL(%" PRIiNode ")", p->id); }
+		if (status == SAUNAFS_STATUS_OK) {
+			changeLog(fsOpContext, context.ts(), "UNDEL(%" PRIiNode ")", p->id);
+		}
 	} else {
 		gMetadata->metadataVersion++;
 	}
@@ -274,7 +275,7 @@ uint8_t FilesystemOperationsBase::purge(const FsContext &context,
 	nodeOperations_->purge(fsOpContext, context.ts(), p);
 
 	if (context.isPersonalityMaster()) {
-		changeLog(context.ts(), "PURGE(%" PRIiNode ")", purged_inode);
+		changeLog(fsOpContext, context.ts(), "PURGE(%" PRIiNode ")", purged_inode);
 	} else {
 		gMetadata->metadataVersion++;
 	}
@@ -659,8 +660,8 @@ uint8_t FilesystemOperationsBase::trySetLength(const FsContext &context,
 				if (status != SAUNAFS_STATUS_OK) { return status; }
 				node_file->chunks[indx] = nchunkid;
 				*chunkid = nchunkid;
-				changeLog(ts, "TRUNC(%" PRIiNode ",%" PRIu32 ",%" PRIu32 "):%" PRIu64, p->id, indx,
-				          lockId, nchunkid);
+				changeLog(fsOpContext, ts, "TRUNC(%" PRIiNode ",%" PRIu32 ",%" PRIu32 "):%" PRIu64,
+				          p->id, indx, lockId, nchunkid);
 				fsnodes_update_checksum(p);
 
 				// Make the change persistent for KV backends
@@ -777,7 +778,13 @@ uint8_t FilesystemOperationsBase::setNextChunkId(const FsContext &context, uint6
 	uint8_t status = chunk_set_next_chunkid(nextChunkId);
 	if (context.isPersonalityMaster()) {
 		if (status == SAUNAFS_STATUS_OK) {
-			changeLog(context.ts(), "NEXTCHUNKID(%" PRIu64 ")", nextChunkId);
+			// changeLog requires a FilesystemOperationContext, but this function is only reachable
+			// when gChunkIdGenerator->isStrictlyMonotonic() (non-KV), so no transaction commit is
+			// needed.
+			auto fsOpContext = createFilesystemOperationContext(
+			    FilesystemOperationContext::TransactionType::kReadWrite);
+
+			changeLog(fsOpContext, context.ts(), "NEXTCHUNKID(%" PRIu64 ")", nextChunkId);
 		}
 	} else {
 		gMetadata->metadataVersion++;
@@ -786,10 +793,11 @@ uint8_t FilesystemOperationsBase::setNextChunkId(const FsContext &context, uint6
 }
 
 #ifndef METARESTORE
-uint8_t FilesystemOperationsBase::endSetLength(uint64_t chunkid) {
+uint8_t FilesystemOperationsBase::endSetLength(const FilesystemOperationContext &fsOpContext,
+                                               uint64_t chunkid) {
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
-	changeLog(ts, "UNLOCK(%" PRIu64 ")", chunkid);
+	changeLog(fsOpContext, ts, "UNLOCK(%" PRIu64 ")", chunkid);
 	return chunk_unlock(chunkid);
 }
 #endif
@@ -824,7 +832,7 @@ uint8_t FilesystemOperationsBase::doSetLength(const FsContext &context,
 	bool eraseFurtherChunks = true;
 	nodeOperations_->setLength(fsOpContext, static_cast<FSNodeFile *>(p), length,
 	                           eraseFurtherChunks);
-	changeLog(ts, "LENGTH(%" PRIiNode ",%" PRIu64 ",%" PRIu32 ")", inode,
+	changeLog(fsOpContext, ts, "LENGTH(%" PRIiNode ",%" PRIu64 ",%" PRIu32 ")", inode,
 	          static_cast<FSNodeFile *>(p)->length, static_cast<uint32_t>(eraseFurtherChunks));
 	p->mtime = ts;
 	nodeOperations_->updateCTime(p, ts);
@@ -965,7 +973,8 @@ uint8_t FilesystemOperationsBase::setAttr(const FsContext &context,
 	} else if (setmask & SET_MTIME_FLAG) {
 		p->mtime = attrmtime;
 	}
-	changeLog(ts, "ATTR(%" PRIiNode ",%d,%" PRIu32 ",%" PRIu32 ",%" PRIu32 ",%" PRIu32 ")", p->id,
+	changeLog(fsOpContext, ts,
+	          "ATTR(%" PRIiNode ",%d,%" PRIu32 ",%" PRIu32 ",%" PRIu32 ",%" PRIu32 ")", p->id,
 	          p->mode & 07777, p->uid, p->gid, p->atime, p->mtime);
 	nodeOperations_->updateCTime(p, ts);
 	nodeOperations_->fillAttr(fsOpContext, p, NULL, context.uid(), context.gid(), context.auid(),
@@ -1029,16 +1038,23 @@ uint8_t FilesystemOperationsBase::applyLength(const FilesystemOperationContext &
 
 /// Update atime of the given node and generate a changelog entry.
 /// Doesn't do anything if NO_ATIME=1 is set in the config file.
-static inline void fs_update_atime(FSNode *p, uint32_t ts) {
+static inline void fs_update_atime(const FilesystemOperationContext &fsOpContext, FSNode *p,
+                                   uint32_t ts) {
 	if (!gAtimeDisabled && p->atime != ts) {
 		p->atime = ts;
 		fsnodes_update_checksum(p);
-		gFSOperations->changeLog(ts, "ACCESS(%" PRIiNode ")", p->id);
+		gFSOperations->changeLog(fsOpContext, ts, "ACCESS(%" PRIiNode ")", p->id);
+
+		// Schedule the node update for KV backends.
+		if (fsOpContext.hasReadWriteTransaction()) {
+			gFSOperations->nodeOperations()->updateNode(fsOpContext, p);
+		}
 	}
 }
 
-uint8_t FilesystemOperationsBase::readlink(const FsContext &context, inode_t inode,
-                                           std::string &path) {
+uint8_t FilesystemOperationsBase::readlink(const FsContext &context,
+                                           const FilesystemOperationContext &fsOpContext,
+                                           inode_t inode, std::string &path) {
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
 	FSNode *p = NULL;
@@ -1046,9 +1062,6 @@ uint8_t FilesystemOperationsBase::readlink(const FsContext &context, inode_t ino
 	uint8_t status =
 	    nodeOperations_->verifySession(context, OperationMode::kReadOnly, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) { return status; }
-
-	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
-	    FilesystemOperationContext::TransactionType::kReadOnly);
 
 	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kAny,
 	                                              MODE_MASK_EMPTY, inode, &p);
@@ -1058,7 +1071,7 @@ uint8_t FilesystemOperationsBase::readlink(const FsContext &context, inode_t ino
 	if (p->type != FSNodeType::kSymlink) { return SAUNAFS_ERROR_EINVAL; }
 
 	path = (std::string) static_cast<FSNodeSymlink *>(p)->path;
-	fs_update_atime(p, ts);
+	fs_update_atime(fsOpContext, p, ts);
 	incrementFSStat(FsStats::Readlink);
 	metrics::Counter::increment(metrics::Counter::Master::FS_READLINK);
 	return SAUNAFS_STATUS_OK;
@@ -1137,8 +1150,9 @@ uint8_t FilesystemOperationsBase::symlink(const FsContext &context,
 	if (context.isPersonalityMaster()) {
 		assert(*inode == 0);
 		*inode = newNode->id;
-		changeLog(context.ts(), "SYMLINK(%" PRIiNode ",%s,%s,%" PRIu32 ",%" PRIu32 "):%" PRIiNode,
-		          workNode->id, nodeOperations_->escapeName(name).c_str(),
+		changeLog(fsOpContext, context.ts(),
+		          "SYMLINK(%" PRIiNode ",%s,%s,%" PRIu32 ",%" PRIu32 "):%" PRIiNode, workNode->id,
+		          nodeOperations_->escapeName(name).c_str(),
 		          nodeOperations_->escapeName(basePath).c_str(), context.uid(), context.gid(),
 		          newNode->id);
 	} else {
@@ -1217,7 +1231,7 @@ uint8_t FilesystemOperationsBase::mknod(const FsContext &context,
 	nodeOperations_->fillAttr(fsOpContext, newNode, parentNode, context.uid(), context.gid(),
 	                          context.auid(), context.agid(), context.sesflags(), attr);
 
-	changeLog(timeStamp,
+	changeLog(fsOpContext, timeStamp,
 	          "CREATE(%" PRIiNode ",%s,%c,%d,%" PRIu32 ",%" PRIu32 ",%" PRIu32 "):%" PRIiNode,
 	          parentNode->id, nodeOperations_->escapeName(name).c_str(), static_cast<char>(type),
 	          newNode->mode & kPermissionsMask, context.uid(), context.gid(), rdev, newNode->id);
@@ -1282,7 +1296,7 @@ uint8_t FilesystemOperationsBase::mkdir(const FsContext &context,
 	nodeOperations_->fillAttr(fsOpContext, newNode, workDir, context.uid(), context.gid(),
 	                          context.auid(), context.agid(), context.sesflags(), attr);
 
-	changeLog(timeStamp,
+	changeLog(fsOpContext, timeStamp,
 	          "CREATE(%" PRIiNode ",%s,%c,%d,%" PRIu32 ",%" PRIu32 ",%" PRIu32 "):%" PRIiNode,
 	          workDir->id, nodeOperations_->escapeName(name).c_str(),
 	          static_cast<char>(FSNodeType::kDirectory), newNode->mode & kPermissionsMask,
@@ -1369,7 +1383,7 @@ uint8_t FilesystemOperationsBase::unlink(const FsContext &context,
 
 	if (child->type == FSNodeType::kDirectory) { return SAUNAFS_ERROR_EPERM; }
 
-	changeLog(timeStamp, "UNLINK(%" PRIiNode ",%s):%" PRIiNode, workDir->id,
+	changeLog(fsOpContext, timeStamp, "UNLINK(%" PRIiNode ",%s):%" PRIiNode, workDir->id,
 	          nodeOperations_->escapeName(baseName).c_str(), child->id);
 
 	nodeOperations_->unlink(fsOpContext, timeStamp, workDir, baseName, child);
@@ -1449,7 +1463,7 @@ uint8_t FilesystemOperationsBase::rmdir(const FsContext &context,
 		return SAUNAFS_ERROR_ENOTEMPTY;
 	}
 
-	changeLog(timeStamp, "UNLINK(%" PRIiNode ",%s):%" PRIiNode, workNode->id,
+	changeLog(fsOpContext, timeStamp, "UNLINK(%" PRIiNode ",%s):%" PRIiNode, workNode->id,
 	          nodeOperations_->escapeName(name).c_str(), child->id);
 
 	nodeOperations_->unlink(fsOpContext, timeStamp, workDir, name, child);
@@ -1623,7 +1637,7 @@ uint8_t FilesystemOperationsBase::rename(const FsContext &context,
 	}
 
 	if (context.isPersonalityMaster()) {
-		changeLog(context.ts(), "MOVE(%" PRIiNode ",%s,%" PRIiNode ",%s):%" PRIiNode,
+		changeLog(fsOpContext, context.ts(), "MOVE(%" PRIiNode ",%s,%" PRIiNode ",%s):%" PRIiNode,
 		          sourceWorkNode->id, nodeOperations_->escapeName(baseNameSrc).c_str(),
 		          destWorkNode->id, nodeOperations_->escapeName(baseNameDst).c_str(),
 		          sourceChildNode->id);
@@ -1681,8 +1695,8 @@ uint8_t FilesystemOperationsBase::link(const FsContext &context,
 	if (attr) { nodeOperations_->fillAttr(context, fsOpContext, sp, dwd, *attr); }
 
 	if (context.isPersonalityMaster()) {
-		changeLog(context.ts(), "LINK(%" PRIiNode ",%" PRIiNode ",%s)", sp->id, dwd->id,
-		          nodeOperations_->escapeName(name_dst).c_str());
+		changeLog(fsOpContext, context.ts(), "LINK(%" PRIiNode ",%" PRIiNode ",%s)", sp->id,
+		          dwd->id, nodeOperations_->escapeName(name_dst).c_str());
 	} else {
 		gMetadata->metadataVersion++;
 	}
@@ -1729,7 +1743,7 @@ uint8_t FilesystemOperationsBase::append(const FsContext &context,
 	}
 
 	if (context.isPersonalityMaster()) {
-		changeLog(context.ts(), "APPEND(%" PRIiNode ",%" PRIiNode ")", p->id, sp->id);
+		changeLog(fsOpContext, context.ts(), "APPEND(%" PRIiNode ",%" PRIiNode ")", p->id, sp->id);
 	} else {
 		gMetadata->metadataVersion++;
 	}
@@ -1848,7 +1862,7 @@ int FilesystemOperationsBase::flockOperation(const FsContext &context,
 	int ret = lockOperation(context, fsOpContext, gMetadata->flockLocks, inode, 0, 1, owner,
 	                        sessionid, reqid, msgid, oper, nonblocking, applied);
 	if (context.isPersonalityMaster()) {
-		changeLog(context.ts(),
+		changeLog(fsOpContext, context.ts(),
 		          "FLCK(%" PRIu8 ",%" PRIiNode ",0,1,%" PRIu64 ",%" PRIu32 ",%" PRIu16 ")",
 		          (uint8_t)safs_locks::Type::kFlock, inode, owner, sessionid, oper);
 	} else {
@@ -1868,7 +1882,7 @@ int FilesystemOperationsBase::posixLockOperation(const FsContext &context,
 	int ret = lockOperation(context, fsOpContext, gMetadata->posixLocks, inode, start, end, owner,
 	                        sessionid, reqid, msgid, oper, nonblocking, applied);
 	if (context.isPersonalityMaster()) {
-		changeLog(context.ts(),
+		changeLog(fsOpContext, context.ts(),
 		          "FLCK(%" PRIu8 ",%" PRIiNode ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu32
 		          ",%" PRIu16 ")",
 		          (uint8_t)safs_locks::Type::kPosix, inode, start, end, owner, sessionid, oper);
@@ -1905,8 +1919,8 @@ int FilesystemOperationsBase::locksClearSession(
 		}
 	}
 	if (context.isPersonalityMaster()) {
-		changeLog(context.ts(), "CLRLCK(%" PRIu8 ",%" PRIiNode ",%" PRIu32 ")", type, inode,
-		          sessionid);
+		changeLog(fsOpContext, context.ts(), "CLRLCK(%" PRIu8 ",%" PRIiNode ",%" PRIu32 ")", type,
+		          inode, sessionid);
 	} else {
 		gMetadata->metadataVersion++;
 	}
@@ -1988,7 +2002,7 @@ int FilesystemOperationsBase::locksUnlockInode(
 	}
 
 	if (context.isPersonalityMaster()) {
-		changeLog(context.ts(), "FLCKINODE(%" PRIu8 ",%" PRIiNode ")", type, inode);
+		changeLog(fsOpContext, context.ts(), "FLCKINODE(%" PRIu8 ",%" PRIiNode ")", type, inode);
 	} else {
 		gMetadata->metadataVersion++;
 	}
@@ -2017,7 +2031,7 @@ int FilesystemOperationsBase::locksRemovePending(
 	});
 
 	if (context.isPersonalityMaster()) {
-		changeLog(context.ts(),
+		changeLog(fsOpContext, context.ts(),
 		          "RMPLOCK(%" PRIu8 ",%" PRIu64 ",%" PRIu32 ",%" PRIiNode ",%" PRIu64 ")", type,
 		          ownerid, sessionid, inode, reqid);
 	} else {
@@ -2053,14 +2067,15 @@ uint8_t FilesystemOperationsBase::readdirSize(const FsContext &context, inode_t 
 	return SAUNAFS_STATUS_OK;
 }
 
-void FilesystemOperationsBase::readdirData(const FsContext &context, uint8_t flags, void *dnode,
-                                           uint8_t *dbuff) {
+void FilesystemOperationsBase::readdirData(const FsContext &context,
+                                           const FilesystemOperationContext &fsOpContext,
+                                           uint8_t flags, void *dnode, uint8_t *dbuff) {
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
 	FSNode *p = (FSNode *)dnode;
-	fs_update_atime(p, ts);
-	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
-	    FilesystemOperationContext::TransactionType::kReadOnly);
+
+	fs_update_atime(fsOpContext, p, ts);
+
 	nodeOperations_->getDirData(fsOpContext, context.rootinode(), context.uid(), context.gid(),
 	                            context.auid(), context.agid(), context.sesflags(),
 	                            static_cast<FSNodeDirectory *>(p), dbuff,
@@ -2069,15 +2084,14 @@ void FilesystemOperationsBase::readdirData(const FsContext &context, uint8_t fla
 	metrics::Counter::increment(metrics::Counter::Master::FS_READDIR);
 }
 
-uint8_t FilesystemOperationsBase::readdir(const FsContext &context, inode_t inode,
-                                          uint64_t first_entry, uint64_t number_of_entries,
+uint8_t FilesystemOperationsBase::readdir(const FsContext &context,
+                                          const FilesystemOperationContext &fsOpContext,
+                                          inode_t inode, uint64_t first_entry,
+                                          uint64_t number_of_entries,
                                           std::vector<DirectoryEntry> &dir_entries) {
 	uint8_t status =
 	    nodeOperations_->verifySession(context, OperationMode::kReadOnly, SessionType::kNotMeta);
 	if (status != SAUNAFS_STATUS_OK) { return status; }
-
-	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
-	    FilesystemOperationContext::TransactionType::kReadOnly);
 
 	FSNode *dir;
 	status = nodeOperations_->getNodeForOperation(
@@ -2088,7 +2102,7 @@ uint8_t FilesystemOperationsBase::readdir(const FsContext &context, inode_t inod
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
 
-	fs_update_atime(dir, ts);
+	fs_update_atime(fsOpContext, dir, ts);
 
 	nodeOperations_->getDir(fsOpContext, context.rootinode(), context.uid(), context.gid(),
 	                        context.auid(), context.agid(), context.sesflags(),
@@ -2182,7 +2196,8 @@ uint8_t FilesystemOperationsBase::acquire(const FsContext &context,
 	}
 
 	if (context.isPersonalityMaster()) {
-		changeLog(context.ts(), "ACQUIRE(%" PRIiNode ",%" PRIu32 ")", inode, sessionid);
+		changeLog(fsOpContext, context.ts(), "ACQUIRE(%" PRIiNode ",%" PRIu32 ")", inode,
+		          sessionid);
 	} else {
 		gMetadata->metadataVersion++;
 	}
@@ -2225,7 +2240,8 @@ uint8_t FilesystemOperationsBase::release(const FsContext &context,
 #endif /* #ifndef METARESTORE */
 
 		if (context.isPersonalityMaster()) {
-			changeLog(context.ts(), "RELEASE(%" PRIiNode ",%" PRIu32 ")", inode, sessionid);
+			changeLog(fsOpContext, context.ts(), "RELEASE(%" PRIiNode ",%" PRIu32 ")", inode,
+			          sessionid);
 		} else {
 			gMetadata->metadataVersion++;
 		}
@@ -2244,12 +2260,20 @@ uint8_t FilesystemOperationsBase::release(const FsContext &context,
 uint32_t FilesystemOperationsBase::newSessionId() {
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
+
 	const uint32_t current = gMetadata->nextSessionId().getValue();
-	changeLog(ts, "SESSION():%" PRIu32, current);
+
+	// Used so far only for the changeLog signature
+	auto fsOpContext =
+	    createFilesystemOperationContext(FilesystemOperationContext::TransactionType::kReadWrite);
+	changeLog(fsOpContext, ts, "SESSION():%" PRIu32, current);
+
 	gMetadata->nextSessionId().increment();
+
 	return current;
 }
 #endif
+
 uint8_t FilesystemOperationsBase::applySession(uint32_t sessionid) {
 	if (sessionid != gMetadata->nextSessionId().getValue()) { return SAUNAFS_ERROR_MISMATCH; }
 	gMetadata->metadataVersion++;
@@ -2297,7 +2321,7 @@ uint8_t FilesystemOperationsBase::readChunk(const FilesystemOperationContext &fs
 #endif
 	if (indx < p->chunks.size()) { *chunkid = p->chunks[indx]; }
 	*length = p->length;
-	fs_update_atime(p, ts);
+	fs_update_atime(fsOpContext, p, ts);
 	incrementFSStat(FsStats::Read);
 	metrics::Counter::increment(metrics::Counter::Master::FS_READ);
 	return SAUNAFS_STATUS_OK;
@@ -2392,9 +2416,9 @@ uint8_t FilesystemOperationsBase::writeChunk(const FsContext &context,
 	if (length) { *length = fileNode->length; }
 
 	if (context.isPersonalityMaster()) {
-		changeLog(context.ts(), "WRITE(%" PRIiNode ",%" PRIu32 ",%" PRIu8 ",%" PRIu32 "):%" PRIu64,
-		          inode, index, should_increase_chunk_version_on_modification(*opflag), *lockid,
-		          nchunkid);
+		changeLog(fsOpContext, context.ts(),
+		          "WRITE(%" PRIiNode ",%" PRIu32 ",%" PRIu8 ",%" PRIu32 "):%" PRIu64, inode, index,
+		          should_increase_chunk_version_on_modification(*opflag), *lockid, nchunkid);
 	} else {
 		gMetadata->metadataVersion++;
 	}
@@ -2446,19 +2470,20 @@ uint8_t FilesystemOperationsBase::writeEnd(const FilesystemOperationContext &fsO
 				nodeOperations_->updateNode(fsOpContext, p);
 			}
 
-			changeLog(ts, "LENGTH(%" PRIiNode ",%" PRIu64 ",%" PRIu32 ")", inode, length,
-			          static_cast<uint32_t>(eraseFurtherChunks));
+			changeLog(fsOpContext, ts, "LENGTH(%" PRIiNode ",%" PRIu64 ",%" PRIu32 ")", inode,
+			          length, static_cast<uint32_t>(eraseFurtherChunks));
 		}
 	}
 
-	changeLog(ts, "UNLOCK(%" PRIu64 ")", chunkid);
+	changeLog(fsOpContext, ts, "UNLOCK(%" PRIu64 ")", chunkid);
 	return chunk_unlock(chunkid);
 }
 
-void FilesystemOperationsBase::increaseChunkVersion(uint64_t chunkid) {
+void FilesystemOperationsBase::increaseChunkVersion(const FilesystemOperationContext &fsOpContext,
+                                                    uint64_t chunkid) {
 	uint32_t ts = eventloop_time();
 	ChecksumUpdater cu(ts);
-	changeLog(ts, "INCVERSION(%" PRIu64 ")", chunkid);
+	changeLog(fsOpContext, ts, "INCVERSION(%" PRIu64 ")", chunkid);
 }
 #endif
 
@@ -2504,7 +2529,7 @@ uint8_t FilesystemOperationsBase::removeChunkFromFile(const FsContext &context,
 
 	// Log the repair operation with new version 0 (indicating deletion)
 	uint32_t nversion = 0;
-	changeLog(ts, "REPAIR(%" PRIiNode ",%" PRIu32 "):%" PRIu32, inode, indx, nversion);
+	changeLog(fsOpContext, ts, "REPAIR(%" PRIiNode ",%" PRIu32 "):%" PRIu32, inode, indx, nversion);
 
 	nodeOperations_->getStats(fsOpContext, p, &nsr);
 	nodeOperations_->updateParentStatsForNode(fsOpContext, p, &nsr, &psr);
@@ -2544,7 +2569,8 @@ uint8_t FilesystemOperationsBase::repair(const FsContext &context, inode_t inode
 	nodeOperations_->getStats(fsOpContext, p, &psr);
 	for (indx = 0; indx < node_file->chunks.size(); indx++) {
 		if (chunk_repair(p->goal, node_file->chunks[indx], &nversion, correct_only)) {
-			changeLog(ts, "REPAIR(%" PRIiNode ",%" PRIu32 "):%" PRIu32, inode, indx, nversion);
+			changeLog(fsOpContext, ts, "REPAIR(%" PRIiNode ",%" PRIu32 "):%" PRIu32, inode, indx,
+			          nversion);
 			p->mtime = ts;
 			nodeOperations_->updateCTime(p, ts);
 			if (nversion > 0) {
@@ -2898,7 +2924,7 @@ uint8_t FilesystemOperationsBase::setExtraAttr(const FsContext &context,
 		*sinodes = si;
 		*ncinodes = nci;
 		*nsinodes = nsi;
-		changeLog(context.ts(),
+		changeLog(fsOpContext, context.ts(),
 		          "SETEATTR(%" PRIiNode ",%" PRIu32 ",%" PRIu8 ",%" PRIu8 "):%" PRIiNode
 		          ",%" PRIiNode ",%" PRIiNode,
 		          p->id, context.uid(), eattr, smode, si, nci, nsi);
@@ -2979,7 +3005,7 @@ uint8_t FilesystemOperationsBase::setXAttr(const FsContext &context,
 	if (status != SAUNAFS_STATUS_OK) { return status; }
 	nodeOperations_->updateCTime(p, ts);
 	fsnodes_update_checksum(p);
-	changeLog(ts, "SETXATTR(%" PRIiNode ",%s,%s,%" PRIu8 ")", p->id,
+	changeLog(fsOpContext, ts, "SETXATTR(%" PRIiNode ",%s,%s,%" PRIu8 ")", p->id,
 	          nodeOperations_->escapeName(std::string((const char *)attrname, anleng)).c_str(),
 	          nodeOperations_->escapeName(std::string((const char *)attrvalue, avleng)).c_str(),
 	          mode);
@@ -3073,7 +3099,7 @@ uint8_t FilesystemOperationsBase::deleteAcl(const FsContext &context,
 			static_assert((int)AclType::kDefault == 1, "fix acl_type table");
 			static_assert((int)AclType::kRichACL == 2, "fix acl_type table");
 
-			changeLog(context.ts(), "DELETEACL(%" PRIiNode ",%c)", p->id,
+			changeLog(fsOpContext, context.ts(), "DELETEACL(%" PRIiNode ",%c)", p->id,
 			          acl_type[std::min(3, (int)type)]);
 		}
 	} else {
@@ -3102,7 +3128,8 @@ uint8_t FilesystemOperationsBase::setAcl(const FsContext &context,
 
 	if (context.isPersonalityMaster()) {
 		if (status == SAUNAFS_STATUS_OK) {
-			changeLog(context.ts(), "SETRICHACL(%" PRIiNode ",%s)", p->id, acl_string.c_str());
+			changeLog(fsOpContext, context.ts(), "SETRICHACL(%" PRIiNode ",%s)", p->id,
+			          acl_string.c_str());
 		}
 	} else {
 		gMetadata->metadataVersion++;
@@ -3129,7 +3156,7 @@ uint8_t FilesystemOperationsBase::setAcl(const FsContext &context,
 
 	if (context.isPersonalityMaster()) {
 		if (status == SAUNAFS_STATUS_OK) {
-			changeLog(context.ts(), "SETACL(%" PRIiNode ",%c,%s)", p->id,
+			changeLog(fsOpContext, context.ts(), "SETACL(%" PRIiNode ",%c,%s)", p->id,
 			          (type == AclType::kAccess ? 'a' : 'd'), acl_string.c_str());
 		}
 	} else {
@@ -3314,6 +3341,11 @@ void FilesystemOperationsBase::addFilesToChunks(bool isMetadataLoading) {
 uint64_t FilesystemOperationsBase::getMetadataVersion() {
 	if (!gMetadata) { throw NoMetadataException(); }
 	return gMetadata->metadataVersion;
+}
+
+uint64_t FilesystemOperationsBase::increaseMetadataVersion(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext) {
+	return gMetadata->metadataVersion++;
 }
 
 uint8_t FilesystemOperationsBase::applySetQuota(const FilesystemOperationContext & /*fsOpContext*/,

--- a/src/master/filesystem_operations.h
+++ b/src/master/filesystem_operations.h
@@ -67,9 +67,14 @@ public:
 	/// Returns version of the loaded metadata.
 	uint64_t getMetadataVersion() override;
 
+	/// Increments the metadata version counter and returns the pre-increment value (the version of
+	/// this mutation).
+	/// @see IFilesystemOperations::increaseMetadataVersion
+	uint64_t increaseMetadataVersion(const FilesystemOperationContext &fsOpContext) override;
+
 	/// @see IFilesystemOperations::fs_changelog
-	void changeLog(uint32_t ts, const char *format, ...) override
-	    __attribute__((__format__(__printf__, 3, 4)));
+	void changeLog(const FilesystemOperationContext &fsOpContext, uint32_t ts, const char *format,
+	               ...) override __attribute__((__format__(__printf__, 4, 5)));
 
 	// Functions which create/apply (depending on the given context) changes to the metadata.
 	// Common for metarestore and master server (both personalities)
@@ -200,7 +205,7 @@ public:
 
 	/// Unlocks a chunk after a truncate operation completes (phase 1.5).
 	/// @see IFilesystemOperations::endSetLength
-	uint8_t endSetLength(uint64_t chunkid) override;
+	uint8_t endSetLength(const FilesystemOperationContext &fsOpContext, uint64_t chunkid) override;
 
 	/// Sets attributes for a filesystem node (file, directory, etc.).
 	/// @see IFilesystemOperations::setAttr
@@ -209,7 +214,8 @@ public:
 	                uint32_t attrgid, uint32_t attratime, uint32_t attrmtime,
 	                SugidClearMode sugidclearmode, Attributes &attr) override;
 
-	uint8_t readlink(const FsContext &context, inode_t inode, std::string &path) override;
+	uint8_t readlink(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                 inode_t inode, std::string &path) override;
 	void statfs(const FsContext &context, const FilesystemOperationContext &fsOpContext,
 	            uint64_t *totalspace, uint64_t *availspace, uint64_t *trashspace,
 	            uint64_t *reservedspace, inode_t *inodes) override;
@@ -236,12 +242,14 @@ public:
 	                        const std::function<void(int)> &callback, uint32_t job_id) override;
 	uint8_t readdirSize(const FsContext &context, inode_t inode, uint8_t flags, void **dnode,
 	                    uint32_t *dbuffsize) override;
-	void readdirData(const FsContext &context, uint8_t flags, void *dnode, uint8_t *dbuff) override;
+	void readdirData(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                 uint8_t flags, void *dnode, uint8_t *dbuff) override;
 
 	/// Reads a paginated list of entries from a directory.
 	/// @see IFilesystemOperations::readdir
-	uint8_t readdir(const FsContext &context, inode_t inode, uint64_t first_entry,
-	                uint64_t number_of_entries, std::vector<DirectoryEntry> &dir_entries) override;
+	uint8_t readdir(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                inode_t inode, uint64_t first_entry, uint64_t number_of_entries,
+	                std::vector<DirectoryEntry> &dir_entries) override;
 
 	uint8_t checkFile(const FsContext &context, inode_t inode,
 	                  ChunkCountArray &chunkCount) override;
@@ -364,7 +372,8 @@ public:
 	                   inode_t inode, uint32_t index, uint64_t *chunkid) override;
 
 	// SPECIAL - LOG EMERGENCY INCREASE VERSION FROM CHUNKS-MODULE
-	void increaseChunkVersion(uint64_t chunkid) override;
+	void increaseChunkVersion(const FilesystemOperationContext &fsOpContext,
+	                          uint64_t chunkid) override;
 
 	uint8_t fullPathByInode(const FsContext &context, inode_t inode,
 	                        std::string &fullPath) override;

--- a/src/master/filesystem_operations_interface.h
+++ b/src/master/filesystem_operations_interface.h
@@ -97,11 +97,20 @@ public:
 	/// Returns version of the loaded metadata.
 	virtual uint64_t getMetadataVersion() = 0;
 
+	/// Increments the metadata version counter and returns the pre-increment value (the version of
+	/// this mutation).
+	virtual uint64_t increaseMetadataVersion(const FilesystemOperationContext &fsOpContext) = 0;
+
 	/// Adds an entry to a changelog, updates filesystem.cc internal structures, prepends a
 	/// proper timestamp to changelog entry and broadcasts it to metaloggers and shadow masters.
-	/// The attribute is used to ensure printf-like format string checking by the compiler.
-	virtual void changeLog(uint32_t ts, const char *format, ...)
-	    __attribute__((__format__(__printf__, 3, 4))) = 0;
+	/// The __attribute__ is used to ensure printf-like format string checking by the compiler.
+	/// @param fsOpContext Operation context (provides transaction for KV backends).
+	/// @param ts Timestamp to add to the changelog entry.
+	/// @param format printf-like format string for the changelog entry.
+	/// @param ... Variable arguments for the format string.
+	virtual void changeLog(const FilesystemOperationContext &fsOpContext, uint32_t ts,
+	                       const char *format, ...)
+	    __attribute__((__format__(__printf__, 4, 5))) = 0;
 
 	// Functions which create/apply (depending on the given context) changes to the metadata.
 	// Common for metarestore and master server (both personalities)
@@ -818,6 +827,7 @@ public:
 	/// 2. When cleaning up after a failed truncate operation
 	///
 	/// @param chunkid The chunk ID to unlock (obtained from trySetLength's chunkid output).
+	/// @param fsOpContext The filesystem operation context (transaction).
 	///
 	/// @return SAUNAFS_STATUS_OK on success, or SAUNAFS_ERROR_NOCHUNK if the chunk doesn't exist.
 	///
@@ -830,7 +840,8 @@ public:
 	///       (SAUNAFS_ERROR_DELAYED) and client-performs truncate/end flows where
 	///       trySetLength() can return SAUNAFS_ERROR_NOTPOSSIBLE (e.g. FUSE_TRUNCATE_END).
 	/// @see trySetLength, doSetLength
-	virtual uint8_t endSetLength(uint64_t chunkid) = 0;
+	virtual uint8_t endSetLength(const FilesystemOperationContext &fsOpContext,
+	                             uint64_t chunkid) = 0;
 
 	/// Sets attributes for a filesystem node (file, directory, etc.).
 	///
@@ -889,7 +900,9 @@ public:
 	                        uint32_t attrgid, uint32_t attratime, uint32_t attrmtime,
 	                        SugidClearMode sugidclearmode, Attributes &attr) = 0;
 
-	virtual uint8_t readlink(const FsContext &context, inode_t inode, std::string &path) = 0;
+	virtual uint8_t readlink(const FsContext &context,
+	                         const FilesystemOperationContext &fsOpContext, inode_t inode,
+	                         std::string &path) = 0;
 	virtual void statfs(const FsContext &context, const FilesystemOperationContext &fsOpContext,
 	                    uint64_t *totalspace, uint64_t *availspace, uint64_t *trashspace,
 	                    uint64_t *reservedspace, inode_t *inodes) = 0;
@@ -995,8 +1008,9 @@ public:
 	                                const std::function<void(int)> &callback, uint32_t job_id) = 0;
 	virtual uint8_t readdirSize(const FsContext &context, inode_t inode, uint8_t flags,
 	                            void **dnode, uint32_t *dbuffsize) = 0;
-	virtual void readdirData(const FsContext &context, uint8_t flags, void *dnode,
-	                         uint8_t *dbuff) = 0;
+	virtual void readdirData(const FsContext &context,
+	                         const FilesystemOperationContext &fsOpContext, uint8_t flags,
+	                         void *dnode, uint8_t *dbuff) = 0;
 
 	/// Reads a paginated list of entries from a directory.
 	///
@@ -1006,6 +1020,7 @@ public:
 	///
 	/// @param context Session context containing user credentials (uid, gid), session
 	///                flags, and root inode information.
+	/// @param fsOpContext The filesystem operation context (transaction).
 	/// @param inode The inode number of the directory to read.
 	/// @param first_entry Starting index for pagination (offset into the directory listing).
 	/// @param number_of_entries Maximum number of entries to return.
@@ -1014,8 +1029,8 @@ public:
 	/// @return SAUNAFS_STATUS_OK on success, or an appropriate error code on failure
 	///         (e.g., SAUNAFS_ERROR_ENOENT if directory not found,
 	///         SAUNAFS_ERROR_EACCES if permission denied).
-	virtual uint8_t readdir(const FsContext &context, inode_t inode, uint64_t first_entry,
-	                        uint64_t number_of_entries,
+	virtual uint8_t readdir(const FsContext &context, const FilesystemOperationContext &fsOpContext,
+	                        inode_t inode, uint64_t first_entry, uint64_t number_of_entries,
 	                        std::vector<DirectoryEntry> &dir_entries) = 0;
 
 	virtual uint8_t checkFile(const FsContext &context, inode_t inode,
@@ -1349,7 +1364,8 @@ public:
 	                           uint32_t index, uint64_t *chunkid) = 0;
 
 	// SPECIAL - LOG EMERGENCY INCREASE VERSION FROM CHUNKS-MODULE
-	virtual void increaseChunkVersion(uint64_t chunkid) = 0;
+	virtual void increaseChunkVersion(const FilesystemOperationContext &fsOpContext,
+	                                  uint64_t chunkid) = 0;
 
 	virtual uint8_t fullPathByInode(const FsContext &context, inode_t inode,
 	                                std::string &fullPath) = 0;

--- a/src/master/filesystem_periodic.cc
+++ b/src/master/filesystem_periodic.cc
@@ -561,7 +561,7 @@ static void fs_do_emptytrash(uint32_t ts) {
 		gFSOperations->nodeOperations()->purge(fsOpContext, ts, node);
 
 		// Purge operation should be performed anyway - if it fails, inode will be reserved
-		gFSOperations->changeLog(ts, "PURGE(%" PRIiNode ")", node_id);
+		gFSOperations->changeLog(fsOpContext, ts, "PURGE(%" PRIiNode ")", node_id);
 
 		it = gMetadata->trash.begin();
 

--- a/src/master/filesystem_quota.cc
+++ b/src/master/filesystem_quota.cc
@@ -245,7 +245,7 @@ uint8_t fs_quota_set(const FsContext &context, const FilesystemOperationContext 
 		gMetadata->quotaDatabase.removeEmpty(owner.ownerType, owner.ownerId);
 		gMetadata->quotaChecksum = gMetadata->quotaDatabase.checksum();
 		gFSOperations->changeLog(
-		    ts, "SETQUOTA(%c,%c,%c,%" PRIiNode ",%" PRIu64 ")",
+		    fsOpContext, ts, "SETQUOTA(%c,%c,%c,%" PRIiNode ",%" PRIu64 ")",
 		    rigor_name[(int)entry.entryKey.rigor], resource_name[(int)entry.entryKey.resource],
 		    owner_name[(int)owner.ownerType], inode_t{owner.ownerId}, uint64_t{entry.limit});
 	}

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -568,8 +568,17 @@ void matoclserv_chunk_status(uint64_t chunkId, uint8_t status, bool isFailedCrea
 		return;
 	case FUSE_TRUNCATE:
 	case FUSE_TRUNCATE_END:
-		gFSOperations->endSetLength(chunkId);
+		gFSOperations->endSetLength(fsOpContext, chunkId);
 		if (status != SAUNAFS_STATUS_OK) {
+			// Commit endSetLength's unlock changelog even on error, so KV backends
+			// persist the unlock regardless of the chunk operation outcome.
+			if (fsOpContext.hasReadWriteTransaction()) {
+				if (!fsOpContext.getReadWriteTransaction()->commit()) {
+					safs::log_err(
+					    "{}: transaction failed to commit after endSetLength: inode {}, chunkId {}",
+					    __func__, inode, chunkId);
+				}
+			}
 			serializer->serializeFuseTruncate(reply, operationType, messageId, status);
 		} else {
 			Attributes attr;
@@ -2075,7 +2084,9 @@ void matoclserv_fuse_truncate(matoclserventry *eptr, PacketHeader header, const 
 
 				if (status == SAUNAFS_STATUS_OK) { status = chunk_can_unlock(chunkId, lockId); }
 
-				if (status == SAUNAFS_STATUS_OK) { gFSOperations->endSetLength(chunkId); }
+				if (status == SAUNAFS_STATUS_OK) {
+					gFSOperations->endSetLength(fsOpContext, chunkId);
+				}
 			}
 		}
 	} else {
@@ -2243,7 +2254,19 @@ void matoclserv_fuse_readlink(matoclserventry *eptr, const uint8_t *data, uint32
 	getINode(&data, inode);
 
 	FsContext context = matoclserv_get_context(eptr);
-	status = gFSOperations->readlink(context, inode, path);
+
+	// ReadWrite mode is needed to update atime of the symlink
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
+	status = gFSOperations->readlink(context, fsOpContext, inode, path);
+
+	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
+		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+			// Best-effort: atime update only, do not fail the readlink.
+			safs::log_err("{}: transaction failed to commit: inode {}", __func__, inode);
+		}
+	}
 
 	constexpr uint32_t kFailedAnswerSize = sizeof(msgid) + sizeof(status);
 	constexpr uint32_t kSuccessAnswerSize = sizeof(msgid) + sizeof(uint32_t);
@@ -2835,8 +2858,19 @@ void matoclserv_fuse_getdir(matoclserventry *eptr,const PacketHeader &header, co
 
 		if (packet_version == cltoma::fuseGetDir::kClientAbleToProcessDirentIndex) {
 			std::vector<DirectoryEntry> dir_entries;
-			status = gFSOperations->readdir(context, inode, first_entry, number_of_entries,
-			                                dir_entries);  //<DirectoryEntry>
+			auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+			    FilesystemOperationContext::TransactionType::kReadWrite);
+
+			status = gFSOperations->readdir(context, fsOpContext, inode, first_entry,
+			                                number_of_entries, dir_entries);
+
+			if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
+				if (!fsOpContext.getReadWriteTransaction()->commit()) {
+					// Best-effort: atime update only, do not fail the directory listing.
+					safs::log_err("{}: Failed to commit atime update for inode {}", __func__,
+					              inode);
+				}
+			}
 
 			if (status != SAUNAFS_STATUS_OK) {
 				matocl::fuseGetDir::serialize(buffer, message_id, status);
@@ -2910,7 +2944,17 @@ void matoclserv_fuse_getdir(matoclserventry *eptr, const uint8_t *data, uint32_t
 	if (status != SAUNAFS_STATUS_OK) {
 		put8bit(&ptr, status);
 	} else {
-		gFSOperations->readdirData(context, flags, custom, ptr);
+		auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+		    FilesystemOperationContext::TransactionType::kReadWrite);
+
+		gFSOperations->readdirData(context, fsOpContext, flags, custom, ptr);
+
+		// Best effort to update atime
+		if (fsOpContext.hasReadWriteTransaction()) {
+			if (!fsOpContext.getReadWriteTransaction()->commit()) {
+				safs::log_err("{}: Failed to commit atime update for inode {}", __func__, inode);
+			}
+		}
 	}
 
 	eptr->sessionData->currHourOperationsStats[12]++;
@@ -3001,9 +3045,12 @@ void matoclserv_fuse_read_chunk(matoclserventry *eptr, PacketHeader header, cons
 	std::vector<uint8_t> receivedData(data, data + header.length);
 	serializer->deserializeFuseReadChunk(receivedData, messageId, inode, index);
 
+	// ReadWrite transaction is needed to update atime inside readChunk
 	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
-	    FilesystemOperationContext::TransactionType::kReadOnly);
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
 	status = gFSOperations->readChunk(fsOpContext, inode, index, &chunkid, &fleng);
+
 	std::vector<ChunkTypeWithAddress> allChunkCopies;
 	if (status == SAUNAFS_STATUS_OK) {
 		if (chunkid > 0) {
@@ -3012,6 +3059,14 @@ void matoclserv_fuse_read_chunk(matoclserventry *eptr, PacketHeader header, cons
 			remove_unsupported_ec_parts(eptr->version, allChunkCopies);
 		} else {
 			version = 0;
+		}
+	}
+
+	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
+		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+			// Best-effort: atime update only, do not fail the chunk read.
+			safs::log_err("{}: transaction failed to commit: inode {}, chunk index {}", __func__,
+			              inode, index);
 		}
 	}
 
@@ -5339,9 +5394,23 @@ void matocl_session_check() {
 }
 
 void matocl_before_disconnect(matoclserventry *eptr) {
+	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadWrite);
+
 	// unlock locked chunks
 	for (const auto &operation : eptr->delayedChunkOperations) {
-		if (operation->type == FUSE_TRUNCATE) { gFSOperations->endSetLength(operation->chunkId); }
+		if (operation->type == FUSE_TRUNCATE) {
+			gFSOperations->endSetLength(fsOpContext, operation->chunkId);
+		}
+	}
+
+	// Commit the transaction for KV backends
+	if (fsOpContext.hasReadWriteTransaction()) {
+		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+			safs::log_critical(
+			    "{}: transaction failed to commit while unlocking chunks for session {}", __func__,
+			    eptr->sessionData ? eptr->sessionData->sessionId : 0);
+		}
 	}
 
 	eptr->delayedChunkOperations.clear();

--- a/src/master/recursive_remove_task.cc
+++ b/src/master/recursive_remove_task.cc
@@ -50,7 +50,7 @@ int RemoveTask::retrieveNodes(const FilesystemOperationContext &fsOpContext, FSN
 
 void RemoveTask::doUnlink(const FilesystemOperationContext &fsOpContext, uint32_t ts,
                           FSNodeDirectory *wd, FSNode *child) {
-	gFSOperations->changeLog(ts, "UNLINK(%" PRIiNode ",%s):%" PRIiNode, parent_,
+	gFSOperations->changeLog(fsOpContext, ts, "UNLINK(%" PRIiNode ",%s):%" PRIiNode, parent_,
 	                         gFSOperations->nodeOperations()->escapeName(*current_subtask_).c_str(),
 	                         child->id);
 

--- a/src/master/setgoal_task.cc
+++ b/src/master/setgoal_task.cc
@@ -57,7 +57,8 @@ int SetGoalTask::execute(uint32_t ts, intrusive_list<Task> &work_queue) {
 		}
 		(*stats_)[result] += 1;
 		if (result == kChanged) {
-			gFSOperations->changeLog(ts, "SETGOAL(%" PRIiNode ",%" PRIu32 ",%" PRIu8 ",%" PRIu8 ")",
+			gFSOperations->changeLog(fsOpContext, ts,
+			                         "SETGOAL(%" PRIiNode ",%" PRIu32 ",%" PRIu8 ",%" PRIu8 ")",
 			                         inode, uid_, goal_, smode_);
 		}
 	}

--- a/src/master/settrashtime_task.cc
+++ b/src/master/settrashtime_task.cc
@@ -57,10 +57,24 @@ int SetTrashtimeTask::execute(uint32_t ts, intrusive_list<Task> &work_queue) {
 		(*stats_)[result] += 1;
 		if (result == kChanged) {
 			gFSOperations->changeLog(
-			    ts, "SETTRASHTIME(%" PRIiNode ",%" PRIu32 ",%" PRIu32 ",%" PRIu8 ")", inode, uid_,
-			    trashtime_, smode_);
+			    fsOpContext, ts, "SETTRASHTIME(%" PRIiNode ",%" PRIu32 ",%" PRIu32 ",%" PRIu8 ")",
+			    inode, uid_, trashtime_, smode_);
+
+			// Schedule the node update for KV backends.
+			if (fsOpContext.hasReadWriteTransaction()) {
+				gFSOperations->nodeOperations()->updateNode(fsOpContext, node);
+			}
 		}
 	}
+
+	if (result == kChanged && fsOpContext.hasReadWriteTransaction()) {
+		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+			safs::log_err("{}: transaction failed to commit: inode {}, trashtime {}, smode {}",
+			              __func__, inode, trashtime_, static_cast<uint32_t>(smode_));
+			return SAUNAFS_ERROR_IO;
+		}
+	}
+
 	return SAUNAFS_STATUS_OK;
 }
 

--- a/src/master/snapshot_task.cc
+++ b/src/master/snapshot_task.cc
@@ -213,14 +213,15 @@ void SnapshotTask::cloneSymlinkData(const FilesystemOperationContext &fsOpContex
 	gFSOperations->nodeOperations()->addSubStats(fsOpContext, dst_parent, &nsr, &psr);
 }
 
-void SnapshotTask::emitChangelog(uint32_t ts, inode_t dst_inode) {
+void SnapshotTask::emitChangelog(const FilesystemOperationContext &fsOpContext, uint32_t ts,
+                                 inode_t dst_inode) {
 	if (!emit_changelog_) {
-		gMetadata->metadataVersion++;
+		gFSOperations->increaseMetadataVersion(fsOpContext);
 		return;
 	}
 
 	gFSOperations->changeLog(
-	    ts, "CLONE(%" PRIiNode ",%" PRIiNode ",%" PRIiNode ",%s,%" PRIu8 ")",
+	    fsOpContext, ts, "CLONE(%" PRIiNode ",%" PRIiNode ",%" PRIiNode ",%s,%" PRIu8 ")",
 	    current_subtask_->first, dst_parent_inode_, dst_inode,
 	    gFSOperations->nodeOperations()->escapeName(current_subtask_->second).c_str(),
 	    can_overwrite_);
@@ -259,7 +260,7 @@ int SnapshotTask::cloneNode(uint32_t ts) {
 	assert(dst_node);
 	fsnodes_update_checksum(dst_node);
 	fsnodes_update_checksum(dst_parent);
-	emitChangelog(ts, dst_node->id);
+	emitChangelog(fsOpContext, ts, dst_node->id);
 	if (dst_inode_ != 0 && dst_inode_ != dst_node->id) {
 		return SAUNAFS_ERROR_MISMATCH;
 	}

--- a/src/master/snapshot_task.h
+++ b/src/master/snapshot_task.h
@@ -108,7 +108,8 @@ protected:
 	 * The function (for master) emits metadata CLONE information. For shadow it updates
 	 * metadata version.
 	 */
-	void emitChangelog(uint32_t ts, inode_t dst_inode);
+	void emitChangelog(const FilesystemOperationContext &fsOpContext, uint32_t ts,
+	                   inode_t dst_inode);
 
 private:
 	SubtaskContainer subtask_; /*!< List of pairs (inode to be cloned, clone file name). */


### PR DESCRIPTION
Pass FilesystemOperationContext through `changeLog` and related helpers so metadata version updates can happen inside backend-managed transactions.

Use RW contexts for paths that update `atime` and for chunk unlock/version flows that also advance metadata.

Related to: LS-526

Notes:
- Most of the changes were driven by the addition of the transaction context to changeLog.
- Please notice that transactions are irrelevant for the Base (in-memory) implementation, but needed for KV backends, so the behavior for this repo is not affected.
- The integration test is in the MDS repo.