### PR TITLE
feat(monitoring): add used space delta to chunkservers charts LS-456

### DIFF
--- a/src/cgi/sfs.cgi.in
+++ b/src/cgi/sfs.cgi.in
@@ -3239,6 +3239,8 @@ if "CC" in sectionset:
             (22, 'delete', 'number of chunk deletions per minute'),
             (27, 'tests', 'number of chunk tests per minute'),
             (31, 'gcpurge', 'number of chunk purges(.dat and .met) by GC per minute'),
+            (32, 'spacegrowth', 'positive disk usage delta - space growth (bytes/s)'),
+            (33, 'spacereclaimed', 'negative disk usage delta - space decrease (bytes/s)'),
         )
         servers = []
 

--- a/src/chunkserver/chartsdata.cc
+++ b/src/chunkserver/chartsdata.cc
@@ -27,6 +27,7 @@
 #include <sys/time.h>
 #include <syslog.h>
 #include <unistd.h>
+#include <algorithm>
 #include <cerrno>
 #include <csignal>
 #include <cstdio>
@@ -76,8 +77,10 @@
 #define CHARTS_CHUNKOPJOBS 29
 #define CHARTS_MEMORY 30
 #define CHARTS_GC_PURGE 31
+#define CHARTS_SPACE_GROWTH 32
+#define CHARTS_SPACE_RECLAIMED 33
 
-#define CHARTS_NUMBER 32
+#define CHARTS_NUMBER 34
 
 const unsigned long kLinuxMaxrssSize = 1024UL;
 
@@ -115,6 +118,8 @@ const unsigned long kLinuxMaxrssSize = 1024UL;
 	{"chunkopjobs"      ,CHARTS_MODE_MAX,0,CHARTS_SCALE_NONE ,   1, 1}, \
 	{"memory"           ,CHARTS_MODE_MAX,0,CHARTS_SCALE_NONE ,   1, 1}, \
 	{"gcpurge"          ,CHARTS_MODE_ADD,0,CHARTS_SCALE_NONE ,   1, 1}, \
+	{"spacegrowth"      ,CHARTS_MODE_ADD,0,CHARTS_SCALE_NONE ,   1,60}, \
+	{"spacereclaimed"   ,CHARTS_MODE_ADD,0,CHARTS_SCALE_NONE ,   1,60}, \
 	{NULL               ,0              ,0,0                 ,   0, 0}  \
 };
 
@@ -169,6 +174,7 @@ void chartsdata_refresh(void) {
 	uint32_t opsCreate, opsDelete, opsUpdateVersion, opsDuplicate, opsTruncate;
 	uint32_t opsDupTrunc, opsTest, opsGCPurge;
 	uint32_t maxChunkServerJobsCount, maxMasterJobsCount;
+	int64_t usedSpaceDelta;
 
 	// Timer runs only when the process is executing.
 	struct itimerval userTime;
@@ -257,6 +263,11 @@ void chartsdata_refresh(void) {
 	data[CHARTS_DUPTRUNC] = opsDupTrunc;
 	data[CHARTS_TEST] = opsTest;
 	data[CHARTS_GC_PURGE] = opsGCPurge;
+
+	HddStats::getSpaceDeltaStats(&usedSpaceDelta);
+
+	data[CHARTS_SPACE_GROWTH] = std::max(usedSpaceDelta, int64_t(0));
+	data[CHARTS_SPACE_RECLAIMED] = std::max(-usedSpaceDelta, int64_t(0));
 
 	charts_add(data, eventloop_time() - SECONDS_IN_ONE_MINUTE);
 }

--- a/src/chunkserver/chunkserver-common/hdd_stats.cc
+++ b/src/chunkserver/chunkserver-common/hdd_stats.cc
@@ -100,6 +100,15 @@ void operationStats(uint32_t *opsCreate, uint32_t *opsDelete, uint32_t *opsUpdat
 	*opsGCPurge = gStatsOperationsGCPurge.exchange(0);
 }
 
+void getSpaceDeltaStats(int64_t *spaceDelta) {
+	TRACETHIS();
+	const uint64_t lastReadUsedSpace = gStatsLastReadUsedSpace.load();
+	const uint64_t previousReadUsedSpace = gStatsPreviousReadUsedSpace.exchange(lastReadUsedSpace);
+	*spaceDelta = (previousReadUsedSpace == 0)
+	                  ? 0
+	                  : int64_t(lastReadUsedSpace) - int64_t(previousReadUsedSpace);
+}
+
 void overheadRead(uint32_t size) {
 	TRACETHIS();
 	gStatsOverheadOperationsRead++;

--- a/src/chunkserver/chunkserver-common/hdd_stats.h
+++ b/src/chunkserver/chunkserver-common/hdd_stats.h
@@ -58,6 +58,9 @@ inline std::atomic<uint32_t> gStatsOperationsDupTrunc(0);
 
 inline std::atomic<uint32_t> gStatsOperationsGCPurge(0);
 
+inline std::atomic<uint64_t> gStatsLastReadUsedSpace(0);
+inline std::atomic<uint64_t> gStatsPreviousReadUsedSpace(0);
+
 // This is for internal use of GarbageCollector
 inline std::atomic<uint64_t> gBytesWrittenSinceLastGCSweep(0);
 inline std::atomic<uint64_t> gBytesReadSinceLastGCSweep(0);
@@ -105,6 +108,10 @@ void stats(statsReport report);
 void operationStats(uint32_t *opsCreate, uint32_t *opsDelete, uint32_t *opsUpdateVersion,
                     uint32_t *opsDuplicate, uint32_t *opsTruncate, uint32_t *opsDupTrunc,
                     uint32_t *opsTest, uint32_t *opsGCPurge);
+
+/// Only called from chartsdata_refresh every minute
+/// The information is saved later (every hour) in the csstats file					
+void getSpaceDeltaStats(int64_t *spaceDelta) ;
 
 void overheadRead(uint32_t size);
 void overheadWrite(uint32_t size);

--- a/src/chunkserver/hddspacemgr.cc
+++ b/src/chunkserver/hddspacemgr.cc
@@ -586,6 +586,8 @@ void hddGetTotalSpace(uint64_t *usedSpace, uint64_t *totalSpace,
 	*toDelUsedSpace = toDelTotal - toDelAvailable;
 	*toDelTotalSpace = toDelTotal;
 	*toDelChunkCount = toDelChunks;
+
+	HddStats::gStatsLastReadUsedSpace = *usedSpace;
 }
 
 int hddGetLoadFactor() {


### PR DESCRIPTION
This commit introduces a chunkserver-side feature to display used space growth and used space decrease in bytes/second in the monitoring charts of chunkservers.

Needed to measure more precisely the space reclamation rate of the garbage collector.