### PR TITLE
feat(kv): add getSnapshot() for conflict-free reads on hot keys

### DIFF
--- a/src/fdb/fdb.cc
+++ b/src/fdb/fdb.cc
@@ -21,6 +21,7 @@
 #include "fdb/fdb.h"
 
 #include <cstdint>
+#include <iterator>
 
 #include <foundationdb/fdb_c_types.h>
 
@@ -73,40 +74,34 @@ fdb_error_t Transaction::setOption(FDBTransactionOption option, std::string_view
 std::optional<kv::Value> Transaction::get(const kv::Key &key, bool snapshot) {
 	if (!tr_) { return std::nullopt; }
 
-	FDBFuture *future =
-	    fdb_transaction_get(tr_.get(), key.data(), static_cast<int>(key.size()), snapshot);
+	UniqueFDBFuture future(
+	    fdb_transaction_get(tr_.get(), key.data(), static_cast<int>(key.size()), snapshot));
 
-	error_ = fdb_future_block_until_ready(future);
+	error_ = fdb_future_block_until_ready(future.get());
 
 	if (error_ != 0) {
 		safs::log_err("Transaction::get: fdb_future_block_until_ready: error: {}",
 		              fdb_get_error(error_));
 		return std::nullopt;
 	}
-	
+
 	fdb_bool_t valuePresent{};
 	const uint8_t *valueRead{};
 	int valueLength{};
 
-	error_ = fdb_future_get_value(future, &valuePresent, &valueRead, &valueLength);
+	error_ = fdb_future_get_value(future.get(), &valuePresent, &valueRead, &valueLength);
 
 	if (error_ != 0) {
 		safs::log_err("Transaction::get: fdb_future_get_value: error: {}", fdb_get_error(error_));
-		fdb_future_destroy(future);
 		return std::nullopt;
 	}
 
-	kv::Value value;
-
-	if (valuePresent != 0) {
-		value.assign(valueRead, valueRead + valueLength);
-	} else {
+	if (valuePresent == 0) {
 		safs::log_info("Transaction::get: key not found: {}", kv::keyToEscapedAscii(key));
-		value.clear();
 		return std::nullopt;
 	}
 
-	return value;
+	return kv::Value(valueRead, std::next(valueRead, valueLength));
 }
 
 std::unique_ptr<kv::IFuture> Transaction::getAsync(const kv::Key &key, bool snapshot) {
@@ -138,18 +133,17 @@ kv::GetRangeResult Transaction::getRange(
 	// FDB offsets are 1-based.
 	const int endOffset = 1 + end.getOffset();
 
-	FDBFuture *future = fdb_transaction_get_range(
+	UniqueFDBFuture future(fdb_transaction_get_range(
 	    tr_.get(), begin.getKey().data(), static_cast<int>(begin.getKey().size()), beginOrEqual,
 	    beginOffset, end.getKey().data(), static_cast<int>(end.getKey().size()), endOrEqual,
 	    endOffset, limit, kBytesLimit, streamingMode, iteration, static_cast<fdb_bool_t>(snapshot),
-	    static_cast<fdb_bool_t>(reverse));
+	    static_cast<fdb_bool_t>(reverse)));
 
-	auto error = fdb_future_block_until_ready(future);
+	auto error = fdb_future_block_until_ready(future.get());
 
 	if (error != 0) {
 		safs::log_err("Transaction::getRange: fdb_future_block_until_ready: error: {}",
 		              fdb_get_error(error));
-		fdb_future_destroy(future);
 		return {{}, false};
 	}
 
@@ -157,12 +151,11 @@ kv::GetRangeResult Transaction::getRange(
 	int count = 0;
 	fdb_bool_t more = 0;
 
-	error = fdb_future_get_keyvalue_array(future, &keyValues, &count, &more);
+	error = fdb_future_get_keyvalue_array(future.get(), &keyValues, &count, &more);
 
 	if (error != 0) {
 		safs::log_err("Transaction::getRange: fdb_future_get_keyvalue_array: error: {}",
 		              fdb_get_error(error));
-		fdb_future_destroy(future);
 		return {{}, false};
 	}
 
@@ -174,8 +167,6 @@ kv::GetRangeResult Transaction::getRange(
 		kv::Value value(keyValues[i].value, keyValues[i].value + keyValues[i].value_length);
 		pairs.emplace_back(std::move(key), std::move(value));
 	}
-
-	fdb_future_destroy(future);
 
 	if (pairs.empty()) {
 		safs::log_info("Transaction::getRange: no keys found in range: {} - {}",
@@ -218,23 +209,20 @@ void Transaction::removeRange(const kv::Key &start, const kv::Key &end) {
 bool Transaction::commit() {
 	if (!tr_) { return false; }
 
-	FDBFuture *future = fdb_transaction_commit(tr_.get());
+	UniqueFDBFuture future(fdb_transaction_commit(tr_.get()));
 
-	error_ = fdb_future_block_until_ready(future);
+	error_ = fdb_future_block_until_ready(future.get());
 
 	if (error_ != 0) {
 		safs::log_err("Transaction::commit: fdb_future_block_until_ready: error: {}",
 		              fdb_get_error(error_));
-		fdb_future_destroy(future);
 		return false;
 	}
 
 	// fdb_future_block_until_ready() only signals the future is ready; the
 	// actual commit outcome (e.g. conflict, transaction_too_old) is in the
 	// future itself and must be checked with fdb_future_get_error().
-	error_ = fdb_future_get_error(future);
-
-	fdb_future_destroy(future);
+	error_ = fdb_future_get_error(future.get());
 
 	if (error_ != 0) {
 		safs::log_err("Transaction::commit: commit failed: {}", fdb_get_error(error_));
@@ -247,6 +235,7 @@ bool Transaction::commit() {
 	if (versionError != 0) {
 		safs::log_err("Transaction::commit: fdb_transaction_get_committed_version: error: {}",
 		              fdb_get_error(versionError));
+		error_ = versionError;
 		return false;
 	}
 

--- a/src/fdb/fdb.cc
+++ b/src/fdb/fdb.cc
@@ -223,8 +223,21 @@ bool Transaction::commit() {
 	error_ = fdb_future_block_until_ready(future);
 
 	if (error_ != 0) {
-		safs::log_err("Transaction::commit: error: {}", fdb_get_error(error_));
+		safs::log_err("Transaction::commit: fdb_future_block_until_ready: error: {}",
+		              fdb_get_error(error_));
 		fdb_future_destroy(future);
+		return false;
+	}
+
+	// fdb_future_block_until_ready() only signals the future is ready; the
+	// actual commit outcome (e.g. conflict, transaction_too_old) is in the
+	// future itself and must be checked with fdb_future_get_error().
+	error_ = fdb_future_get_error(future);
+
+	fdb_future_destroy(future);
+
+	if (error_ != 0) {
+		safs::log_err("Transaction::commit: commit failed: {}", fdb_get_error(error_));
 		return false;
 	}
 
@@ -234,13 +247,10 @@ bool Transaction::commit() {
 	if (versionError != 0) {
 		safs::log_err("Transaction::commit: fdb_transaction_get_committed_version: error: {}",
 		              fdb_get_error(versionError));
-		fdb_future_destroy(future);
 		return false;
 	}
 
 	committedVersion_ = version;
-
-	fdb_future_destroy(future);
 
 	return true;
 }

--- a/src/fdb/fdb.h
+++ b/src/fdb/fdb.h
@@ -120,6 +120,17 @@ private:
 	fdb_error_t error_ = 1;  ///< The error code of the last operation.
 };
 
+/// Custom deleter for FDBFuture (C struct), to ensure proper cleanup.
+struct FDBFutureDeleter {
+	constexpr FDBFutureDeleter() noexcept = default;
+	void operator()(FDBFuture *fut) const {
+		if (fut != nullptr) { fdb_future_destroy(fut); }
+	}
+};
+
+/// Owning handle for an FDBFuture; automatically destroyed on scope exit.
+using UniqueFDBFuture = std::unique_ptr<FDBFuture, FDBFutureDeleter>;
+
 /// A class that wraps a FoundationDB transaction.
 /// Provides methods to perform read and write operations on the database.
 class Transaction {

--- a/src/fdb/fdb_transaction.cc
+++ b/src/fdb/fdb_transaction.cc
@@ -28,6 +28,12 @@ std::optional<kv::Value> FDBTransaction::get(const kv::Key &key) {
 	return tr_.get(key);
 }
 
+std::optional<kv::Value> FDBTransaction::getSnapshot(const kv::Key &key) {
+	if (!tr_) { return std::nullopt; }
+
+	return tr_.get(key, /*snapshot=*/true);
+}
+
 std::unique_ptr<kv::IFuture> FDBTransaction::getAsync(const kv::Key &key) {
 	if (!tr_) { return nullptr; }
 

--- a/src/fdb/fdb_transaction.h
+++ b/src/fdb/fdb_transaction.h
@@ -46,6 +46,15 @@ public:
 	/// @param key The key to retrieve the value for.
 	std::optional<kv::Value> get(const kv::Key &key) override;
 
+	/// Retrieves the value for a given key without adding it to the
+	/// transaction's read conflict range (snapshot read).
+	/// @warning Snapshot reads do not participate in conflict checking and
+	///          must not be used for correctness-critical read-modify-write
+	///          logic. They are intended for advisory reads (e.g. observing
+	///          a hot counter) where occasional anomalies are acceptable.
+	/// @param key The key to retrieve the value for.
+	std::optional<kv::Value> getSnapshot(const kv::Key &key) override;
+
 	/// Retrieves the value for a given key asynchronously.
 	/// @param key The key to retrieve the value for.
 	/// @return A future that will contain the value when ready.

--- a/src/fdb/fdb_unittest.cc
+++ b/src/fdb/fdb_unittest.cc
@@ -338,6 +338,103 @@ TEST_F(FDBKVEngineTest, AtomicAdd) {
 	safs::log_info("Atomic add successful: final value for 'count' is {}", finalValue);
 }
 
+TEST_F(FDBKVEngineTest, GetSnapshot) {
+	auto key = kv::toBytes("snapshot_key");
+	constexpr uint64_t initialValue = 42;
+
+	// Write the initial value.
+	{
+		auto transaction = kvEngine->createReadWriteTransaction();
+		transaction->set(key, kv::toBytesLE(initialValue));
+		ASSERT_TRUE(transaction->commit()) << "Failed to commit initial value for snapshot test.";
+	}
+
+	// getSnapshot returns the correct value when the key exists.
+	{
+		auto transaction = kvEngine->createReadWriteTransaction();
+		auto result = transaction->getSnapshot(key);
+		ASSERT_TRUE(result.has_value()) << "getSnapshot should return a value for an existing key.";
+		ASSERT_EQ(kv::fromBytesLE<uint64_t>(*result), initialValue)
+		    << "getSnapshot returned an unexpected value.";
+	}
+
+	// getSnapshot returns nullopt for a non-existent key.
+	{
+		auto transaction = kvEngine->createReadWriteTransaction();
+		auto result = transaction->getSnapshot(kv::toBytes("snapshot_key_missing"));
+		ASSERT_FALSE(result.has_value())
+		    << "getSnapshot should return nullopt for a non-existent key.";
+	}
+
+	// getSnapshot does not add the key to the read conflict range:
+	// a transaction that snapshot-reads a key can still commit even if
+	// another transaction modifies that key concurrently.
+	{
+		constexpr uint64_t kSideValue = 123U;
+		const auto sideKey = kv::toBytes("snapshot_side_key");
+
+		// Txn A: snapshot-read key and write to a different key.
+		auto txnA = kvEngine->createReadWriteTransaction();
+		auto snapResult = txnA->getSnapshot(key);
+		ASSERT_TRUE(snapResult.has_value())
+		    << "Snapshot read should return a value for existing key.";
+		txnA->set(sideKey, kv::toBytesLE(kSideValue));
+
+		// Txn B: concurrently modify key and commit.
+		auto txnB = kvEngine->createReadWriteTransaction();
+		txnB->atomicAdd(key, kv::toBytesLE(uint64_t{1}));
+		ASSERT_TRUE(txnB->commit()) << "Concurrent writer (Txn B) should commit successfully.";
+
+		// Txn A should still commit: snapshot read on key does not register
+		// a read conflict, so Txn B's write does not cause a conflict.
+		ASSERT_TRUE(txnA->commit())
+		    << "Transaction with only a snapshot read on key should commit "
+		       "despite a concurrent write to that key.";
+
+		// Verify sideKey was written by Txn A.
+		auto verifyTxn = kvEngine->createReadWriteTransaction();
+		auto sideVal = verifyTxn->get(sideKey);
+		ASSERT_TRUE(sideVal.has_value()) << "Side key written by Txn A should exist.";
+		ASSERT_EQ(kv::fromBytesLE<uint64_t>(*sideVal), kSideValue)
+		    << "Side key should contain the value written by Txn A.";
+	}
+
+	// By contrast, a regular get() participates in conflict detection and
+	// causes the transaction to fail if another transaction modifies the
+	// read key first.
+	{
+		constexpr uint64_t kSideValue = 456U;
+		const auto sideKey = kv::toBytes("snapshot_side_key_conflict");
+
+		// Txn A: regular read of key and write to a different key.
+		auto txnA = kvEngine->createReadWriteTransaction();
+		auto readResult = txnA->get(key);
+		ASSERT_TRUE(readResult.has_value())
+		    << "Regular read should return a value for existing key.";
+		txnA->set(sideKey, kv::toBytesLE(kSideValue));
+
+		// Txn B: modify key and commit.
+		auto txnB = kvEngine->createReadWriteTransaction();
+		txnB->atomicAdd(key, kv::toBytesLE(uint64_t{1}));
+		ASSERT_TRUE(txnB->commit()) << "Concurrent writer (Txn B) should commit successfully.";
+
+		// Txn A should fail: the regular read added key to the read conflict
+		// range, and Txn B's write causes a conflict.
+		ASSERT_FALSE(txnA->commit())
+		    << "Transaction with a regular read on key should fail to commit "
+		       "when another transaction modifies that key first.";
+	}
+
+	// Cleanup.
+	{
+		auto transaction = kvEngine->createReadWriteTransaction();
+		transaction->remove(key);
+		transaction->remove(kv::toBytes("snapshot_side_key"));
+		transaction->remove(kv::toBytes("snapshot_side_key_conflict"));
+		ASSERT_TRUE(transaction->commit()) << "Failed to clean up snapshot test keys.";
+	}
+}
+
 TEST_F(FDBKVEngineTest, GetAsync) {
 	std::string_view keyStr = "async_key";
 	std::string_view valueStr = "async_value";

--- a/src/kv/itransaction.h
+++ b/src/kv/itransaction.h
@@ -97,10 +97,12 @@ public:
 	/// transaction's read conflict range (snapshot/advisory read).
 	/// Use only when the read is advisory, for example, observing a
 	/// counter before a blind atomic write, to avoid unnecessary conflicts.
-	/// @warning Snapshot reads are not serializable and may observe stale
-	///          or internally inconsistent data relative to other reads in
-	///          the same transaction. Do not use for reads that must be
-	///          transactionally consistent; use get() instead.
+	/// @warning Snapshot reads do not add the key to the transaction's read
+	///          conflict set and therefore provide no serializable
+	///          guarantees. Decisions based on snapshot-read values can be
+	///          invalidated by concurrent writes without causing a commit
+	///          conflict. Use get() for reads that must be transactionally
+	///          consistent.
 	/// @param key The key to retrieve the value for.
 	virtual std::optional<Value> getSnapshot(const Key &key) = 0;
 

--- a/src/kv/itransaction.h
+++ b/src/kv/itransaction.h
@@ -93,6 +93,17 @@ public:
 	/// @param key The key to retrieve the value for.
 	virtual std::optional<Value> get(const Key &key) = 0;
 
+	/// Retrieves the value for a given key without adding it to the
+	/// transaction's read conflict range (snapshot/advisory read).
+	/// Use only when the read is advisory, for example, observing a
+	/// counter before a blind atomic write, to avoid unnecessary conflicts.
+	/// @warning Snapshot reads are not serializable and may observe stale
+	///          or internally inconsistent data relative to other reads in
+	///          the same transaction. Do not use for reads that must be
+	///          transactionally consistent; use get() instead.
+	/// @param key The key to retrieve the value for.
+	virtual std::optional<Value> getSnapshot(const Key &key) = 0;
+
 	/// Retrieves the value for a given key asynchronously.
 	/// @param key The key to retrieve the value for.
 	/// @return A future that will contain the value when ready.


### PR DESCRIPTION
Expose FDB snapshot reads through the kv::IReadOnlyTransaction interface
as a pure virtual getSnapshot(). The FDB implementation delegates to
fdb::Transaction::get(key, snapshot=true), which reads the value without
adding the key to the transaction's read conflict range.

This is needed for hot-key patterns where atomicAdd is combined with a
prior read of the same key: a normal get() would register the key as a
read conflict, causing spurious FDB transaction aborts under concurrent
metadata mutations.

**Additional fixes included in this PR:**

- **Commit conflict detection**: `Transaction::commit()` now calls
  `fdb_future_get_error()` to check the actual commit outcome. Previously,
  only `fdb_future_block_until_ready()` was checked, which returns 0 when
  the future is ready regardless of whether the commit succeeded — causing
  conflicts to be silently ignored and `commit()` to always return true.

- **FDBFuture RAII**: Introduced `FDBFutureDeleter` and `UniqueFDBFuture`
  (`std::unique_ptr` alias) in `fdb.h`, following the existing pattern for
  `FDBDatabase` and `FDBTransaction`. Applied to `get()`, `getRange()`, and
  `commit()`, eliminating all manual `fdb_future_destroy()` calls and the
  leak sites on early-exit paths.

- **Error propagation**: `Transaction::error()` now correctly reflects a
  failure when `fdb_transaction_get_committed_version()` fails (previously
  `error_` remained 0 after that code path).

Related to: LS-526