### PR TITLE
test: Add specific preset for WSL1 builds LS-545

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -128,6 +128,13 @@
         {
             "name": "test-vcpkg",
             "inherits": ["test", "vcpkg"]
+        },
+        {
+            "name": "wsl1-test-vcpkg",
+            "inherits": ["test-vcpkg"],
+            "cacheVariables": {
+                "ENABLE_FOUNDATIONDB": "OFF"
+            }
         }
     ],
     "buildPresets": [
@@ -178,6 +185,11 @@
         {
             "name": "test-vcpkg",
             "configurePreset": "test-vcpkg",
+            "inherits": ["default"]
+        },
+        {
+            "name": "wsl1-test-vcpkg",
+            "configurePreset": "wsl1-test-vcpkg",
             "inherits": ["default"]
         }
     ],
@@ -304,6 +316,19 @@
                 {
                     "type": "build",
                     "name": "test-vcpkg"
+                }
+            ]
+        },
+        {
+            "name": "wsl1-test-vcpkg",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "wsl1-test-vcpkg"
+                },
+                {
+                    "type": "build",
+                    "name": "wsl1-test-vcpkg"
                 }
             ]
         }


### PR DESCRIPTION
Previously, building the project on WSL1 as part of the Windows client CI pipeline could fail because FoundationDB is not well supported on WSL1. Additionally, changes related to MDS code could also cause build failures on WSL1. This commit introduces a dedicated CMake preset for WSL1, allowing the project to build successfully in that environment without requiring manual updates to the Windows CI configuration.