### PR TITLE
perf(mount): set cachePerInodePercentage to 100 LS-423

### DIFF
--- a/doc/sfsmount.1.adoc
+++ b/doc/sfsmount.1.adoc
@@ -134,7 +134,7 @@ Set timeout for executing each wave of a write operation in milliseconds (defaul
 Specify what part of the write cache non occupied by other inodes can a single
 inode occupy (measured in %). E.g. When N=75 and the inode X uses 10 MiB, and
 all other inodes use 20 MiB out of 100 MiB cache, X can use 50 MiB more (since
-75% of 80 MiB is 60 MiB). Default: 25.
+75% of 80 MiB is 60 MiB). Default: 100.
 
 *-o sfschunkserverreadto=*'MSEC'::
 Set timeout for whole communication with a chunkserver during read operation in

--- a/src/mount/sauna_client.h
+++ b/src/mount/sauna_client.h
@@ -106,7 +106,7 @@ struct FsInitParams {
 #endif
 	static constexpr unsigned kDefaultMaxChunksWrittenInParallelPerInode = 0;
 	static constexpr unsigned kDefaultWriteCacheSize = 128;
-	static constexpr unsigned kDefaultCachePerInodePercentage = 25;
+	static constexpr unsigned kDefaultCachePerInodePercentage = 100;
 	static constexpr unsigned kDefaultWriteWorkers = 10;
 	static constexpr unsigned kDefaultWriteWindowSize = 15;
 	static constexpr unsigned kDefaultSymlinkCacheTimeout = 3600;


### PR DESCRIPTION
Set the default value of cachePerInodePercentage to 100 to improve write bandwidth under low concurrency (1–3 jobs), where the previous limit could underutilize available cache capacity.

Tests ensure that latency under higher concurrency workloads is not significantly degraded.

Closes LS-423