### PR TITLE
perf(master): apply optimizations during chunks processing

### DIFF
--- a/src/common/observable_property.h
+++ b/src/common/observable_property.h
@@ -68,6 +68,9 @@ public:
 	/// Returns the number of connected slots.
 	size_t size() const { return slots_.size(); }
 
+	/// Returns true if no slots are connected.
+	bool empty() const { return slots_.empty(); }
+
 private:
 	/// List of connected slots (observers)
 	std::vector<SlotType> slots_;

--- a/src/master/chunks.cc
+++ b/src/master/chunks.cc
@@ -784,7 +784,9 @@ static void chunk_recalculate_checksum() {
 }
 
 static inline void emit_chunk_changed(const Chunk *c) {
-	gChunkChangedSignal.emit(c->chunkid, c->version, c->lockedto, c->lockid);
+	if (!gChunkChangedSignal.empty()) {
+		gChunkChangedSignal.emit(c->chunkid, c->version, c->lockedto, c->lockid);
+	}
 }
 
 uint64_t chunk_checksum(ChecksumMode mode) {

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -97,7 +97,7 @@ void FilesystemOperationsBase::changeLog(
 	changelog(version, entry);
 	getChangelogSignal().emit({.version = version, .entry = entry});
 	matomlserv_broadcast_logstring(version, (uint8_t *)entry, tsLength + entryLength);
-	matontserv_broadcast_message(version, std::string(entry, tsLength + entryLength));
+	matontserv_broadcast_message(version, std::string_view(entry, tsLength + entryLength));
 #endif
 }
 

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -95,7 +95,11 @@ void FilesystemOperationsBase::changeLog(
 
 	uint64_t version = increaseMetadataVersion(fsOpContext);
 	changelog(version, entry);
-	getChangelogSignal().emit({.version = version, .entry = entry});
+
+	if (!getChangelogSignal().empty()) {
+		getChangelogSignal().emit({.version = version, .entry = entry});
+	}
+
 	matomlserv_broadcast_logstring(version, (uint8_t *)entry, tsLength + entryLength);
 	matontserv_broadcast_message(version, std::string_view(entry, tsLength + entryLength));
 #endif

--- a/src/master/matontserv.cc
+++ b/src/master/matontserv.cc
@@ -147,7 +147,7 @@ uint8_t *matontserv_addpacket(MatontservEntry *eptr, uint32_t type, uint32_t siz
 	return eptr->outputPackets.back().packet.data() + kPacketHeaderSize;
 }
 
-void matontserv_broadcast_message(uint64_t version, std::string message) {
+void matontserv_broadcast_message(uint64_t version, std::string_view message) {
 	uint8_t *data;
 
 	for (auto &entry : matontservList) {
@@ -156,7 +156,7 @@ void matontserv_broadcast_message(uint64_t version, std::string message) {
 		                            1 + sizeof(version) + message.size());
 		put8bit(&data, 0xFF);
 		put64bit(&data, version);
-		memcpy(data, message.c_str(), message.size());
+		memcpy(data, message.data(), message.size());
 	}
 }
 

--- a/src/master/matontserv.h
+++ b/src/master/matontserv.h
@@ -20,10 +20,11 @@
 #include "common/platform.h"
 
 #include <cstdint>
+#include <string_view>
 
 #include "common/inotifier_list_entry.h"
 
-void matontserv_broadcast_message(uint64_t version, std::string message);
+void matontserv_broadcast_message(uint64_t version, std::string_view message);
 
 int matontserv_init(void);
 


### PR DESCRIPTION
This PR is intended to apply some optimizations to reduce the overhead introduced during chunk processing.

**Key relevant changes:**
- Remove string allocations in `FilesystemOperationsBase::changeLog()`.
- Skip signal emissions for `gChunkChangedSignal` and `getChangelogSignal()` when not slots are connected.

Related to LS-540.

Signed-off-by: Crash <crash@leil.io>