### PR TITLE
chore: add Claude config and update instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,6 @@ CMakeUserPresets.json
 # Copilot user instructions #
 ##############
 .github/copilot-user.instructions.md
+
+# CLAUDE #
+.claude

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,5 @@
 # Instructions location
 
-Instructions for AI AGENTS are located in ./.github/copilot-instructions.md
+Instructions for AI agents are located in:
+- `.github/copilot-instructions.md`
+- `.github/copilot-user.instructions.md` (if present; optional/local-only)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
Add .claude directory to .gitignore and symlink CLAUDE.md to AGENTS.md. Update AGENTS.md to list both instruction files.