### PR TITLE
fix(ci): update workflow install prefix to leilfs

### DIFF
--- a/.github/workflows/run-unit-and-ganesha-tests.yml
+++ b/.github/workflows/run-unit-and-ganesha-tests.yml
@@ -154,7 +154,7 @@ jobs:
                   -DENABLE_URAFT=ON \
                   -DGSH_CAN_HOST_LOCAL_FS=ON \
                   -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-                  -DCMAKE_INSTALL_PREFIX="${GITHUB_WORKSPACE}/install/saunafs/" \
+                  -DCMAKE_INSTALL_PREFIX="${GITHUB_WORKSPACE}/install/leilfs/" \
                   -DENABLE_TESTS=ON \
                   -DCODE_COVERAGE=OFF \
                   -DSAUNAFS_TEST_POINTER_OBFUSCATION=ON \


### PR DESCRIPTION
The workflow was installing to the old 'saunafs' directory path while test scripts (updated in #816) were looking for binaries in 'leilfs'. Update the CMAKE_INSTALL_PREFIX to use the correct 'leilfs' path.