### PR TITLE
refactor(master): clean up filesystem operations

### DIFF
--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -208,13 +208,13 @@ uint8_t FilesystemOperationsBase::setTrashPath(const FsContext &context, inode_t
 	    FilesystemOperationContext::TransactionType::kReadWrite);
 	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kAny,
 	                                              MODE_MASK_EMPTY, inode, &node);
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	} else if (node->type != FSNodeType::kTrash) {
-		return SAUNAFS_ERROR_ENOENT;
-	} else if (path.length() == 0) {
-		return SAUNAFS_ERROR_EINVAL;
-	}
+
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+
+	if (node->type != FSNodeType::kTrash) { return SAUNAFS_ERROR_ENOENT; }
+
+	if (path.length() == 0) { return SAUNAFS_ERROR_EINVAL; }
+
 	for (uint32_t i = 0; i < path.length(); i++) {
 		if (path[i] == 0) { return SAUNAFS_ERROR_EINVAL; }
 	}
@@ -242,11 +242,10 @@ uint8_t FilesystemOperationsBase::undel(const FsContext &context, inode_t inode)
 	    FilesystemOperationContext::TransactionType::kReadWrite);
 	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kAny,
 	                                              MODE_MASK_EMPTY, inode, &node);
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	} else if (node->type != FSNodeType::kTrash) {
-		return SAUNAFS_ERROR_ENOENT;
-	}
+
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+
+	if (node->type != FSNodeType::kTrash) { return SAUNAFS_ERROR_ENOENT; }
 
 	status = nodeOperations_->undel(fsOpContext, context.ts(), static_cast<FSNodeFile *>(node));
 	if (context.isPersonalityMaster()) {
@@ -270,11 +269,11 @@ uint8_t FilesystemOperationsBase::purge(const FsContext &context,
 
 	status = nodeOperations_->getNodeForOperation(context, fsOpContext, ExpectedNodeType::kAny,
 	                                              MODE_MASK_EMPTY, inode, &node);
-	if (status != SAUNAFS_STATUS_OK) {
-		return status;
-	} else if (node->type != FSNodeType::kTrash) {
-		return SAUNAFS_ERROR_ENOENT;
-	}
+
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+
+	if (node->type != FSNodeType::kTrash) { return SAUNAFS_ERROR_ENOENT; }
+
 	// This should be equal to inode, because `node` is not a directory
 	inode_t purged_inode = node->id;
 	nodeOperations_->purge(fsOpContext, context.ts(), node);
@@ -1813,13 +1812,14 @@ int FilesystemOperationsBase::posixLockProbe(const FsContext &context,
 	if (collision == nullptr) {
 		info.l_type = safs_locks::kUnlock;
 		return SAUNAFS_STATUS_OK;
-	} else {
-		info.l_type = static_cast<int>(collision->type);
-		info.l_start = collision->start;
-		info.l_len = std::min<uint64_t>(collision->end - collision->start,
-		                                std::numeric_limits<int64_t>::max());
-		return SAUNAFS_ERROR_WAITING;
 	}
+
+	info.l_type = static_cast<int>(collision->type);
+	info.l_start = collision->start;
+	info.l_len =
+	    std::min<uint64_t>(collision->end - collision->start, std::numeric_limits<int64_t>::max());
+
+	return SAUNAFS_ERROR_WAITING;
 }
 
 int FilesystemOperationsBase::lockOperation(
@@ -3257,21 +3257,19 @@ uint32_t FilesystemOperationsBase::getDirPathSize(const FilesystemOperationConte
 	FSNode *node = nodeOperations_->idToNode(fsOpContext, inode);
 
 	if (node) {
-		if (node->type != FSNodeType::kDirectory) {
-			return kDirPathNotDirectory.size();
-		} else {
-			FSNodeDirectory *parent = nullptr;
-			const inode_t parentId = nodeOperations_->getFirstParentId(fsOpContext, node);
-			if (parentId != 0) {
-				parent = nodeOperations_->idToNodeVerify<FSNodeDirectory>(fsOpContext, parentId);
-			}
-			return 1 + nodeOperations_->getPathSize(fsOpContext, parent, node);
+		if (node->type != FSNodeType::kDirectory) { return kDirPathNotDirectory.size(); }
+
+		FSNodeDirectory *parent = nullptr;
+		const inode_t parentId = nodeOperations_->getFirstParentId(fsOpContext, node);
+
+		if (parentId != 0) {
+			parent = nodeOperations_->idToNodeVerify<FSNodeDirectory>(fsOpContext, parentId);
 		}
-	} else {
-		return kDirPathNotFound.size();
+
+		return 1 + nodeOperations_->getPathSize(fsOpContext, parent, node);
 	}
 
-	return 0;  // unreachable
+	return kDirPathNotFound.size();
 }
 
 void FilesystemOperationsBase::getDirPathData(const FilesystemOperationContext &fsOpContext,
@@ -3403,11 +3401,8 @@ std::vector<JobInfo> FilesystemOperationsBase::getCurrentTasksInfo() {
 }
 
 uint8_t FilesystemOperationsBase::cancelJob(uint32_t job_id) {
-	if (gMetadata->taskManager.cancelJob(job_id)) {
-		return SAUNAFS_STATUS_OK;
-	} else {
-		return SAUNAFS_ERROR_EINVAL;
-	}
+	if (gMetadata->taskManager.cancelJob(job_id)) { return SAUNAFS_STATUS_OK; }
+	return SAUNAFS_ERROR_EINVAL;
 }
 
 uint32_t FilesystemOperationsBase::reserveJobId() { return gMetadata->taskManager.reserveJobId(); }

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -180,8 +180,8 @@ uint8_t FilesystemOperationsBase::getDetachedAttr(const FilesystemOperationConte
 		return SAUNAFS_ERROR_ENOENT;
 	}
 
-	nodeOperations_->fillAttr(fsOpContext, node, NULL, node->uid, node->gid, node->uid, node->gid,
-	                          sesflags, attr);
+	nodeOperations_->fillAttr(fsOpContext, node, nullptr, node->uid, node->gid, node->uid,
+	                          node->gid, sesflags, attr);
 
 	return SAUNAFS_STATUS_OK;
 }
@@ -624,8 +624,8 @@ uint8_t FilesystemOperationsBase::getAttr(const FsContext &context,
 	                                              MODE_MASK_EMPTY, inode, &node);
 	if (status != SAUNAFS_STATUS_OK) { return status; }
 
-	nodeOperations_->fillAttr(fsOpContext, node, NULL, context.uid(), context.gid(), context.auid(),
-	                          context.agid(), context.sesflags(), attr);
+	nodeOperations_->fillAttr(fsOpContext, node, nullptr, context.uid(), context.gid(),
+	                          context.auid(), context.agid(), context.sesflags(), attr);
 
 	incrementFSStat(FsStats::Getattr);
 	metrics::Counter::increment(metrics::Counter::Master::FS_GETATTR);
@@ -683,8 +683,8 @@ uint8_t FilesystemOperationsBase::trySetLength(const FsContext &context,
 			}
 		}
 	}
-	nodeOperations_->fillAttr(fsOpContext, node, NULL, context.uid(), context.gid(), context.auid(),
-	                          context.agid(), context.sesflags(), attr);
+	nodeOperations_->fillAttr(fsOpContext, node, nullptr, context.uid(), context.gid(),
+	                          context.auid(), context.agid(), context.sesflags(), attr);
 	incrementFSStat(FsStats::Setattr);
 	metrics::Counter::increment(metrics::Counter::Master::FS_SETATTR);
 	return SAUNAFS_STATUS_OK;
@@ -849,8 +849,8 @@ uint8_t FilesystemOperationsBase::doSetLength(const FsContext &context,
 	node->mtime = timeStamp;
 	nodeOperations_->updateCTime(node, timeStamp);
 	fsnodes_update_checksum(node);
-	nodeOperations_->fillAttr(fsOpContext, node, NULL, context.uid(), context.gid(), context.auid(),
-	                          context.agid(), context.sesflags(), attr);
+	nodeOperations_->fillAttr(fsOpContext, node, nullptr, context.uid(), context.gid(),
+	                          context.auid(), context.agid(), context.sesflags(), attr);
 
 	// Make the change persistent for KV backends
 	if (fsOpContext.hasReadWriteTransaction()) { nodeOperations_->updateNode(fsOpContext, node); }
@@ -990,8 +990,8 @@ uint8_t FilesystemOperationsBase::setAttr(const FsContext &context,
 	          "ATTR(%" PRIiNode ",%d,%" PRIu32 ",%" PRIu32 ",%" PRIu32 ",%" PRIu32 ")", node->id,
 	          node->mode & 07777, node->uid, node->gid, node->atime, node->mtime);
 	nodeOperations_->updateCTime(node, timeStamp);
-	nodeOperations_->fillAttr(fsOpContext, node, NULL, context.uid(), context.gid(), context.auid(),
-	                          context.agid(), context.sesflags(), attr);
+	nodeOperations_->fillAttr(fsOpContext, node, nullptr, context.uid(), context.gid(),
+	                          context.auid(), context.agid(), context.sesflags(), attr);
 	fsnodes_update_checksum(node);
 
 	// Make persistent the changes on KV backends
@@ -1160,7 +1160,9 @@ uint8_t FilesystemOperationsBase::symlink(const FsContext &context,
 	statsRecord.length = basePath.length();
 	nodeOperations_->addStats(fsOpContext, workDir, &statsRecord);
 
-	if (attr != NULL) { nodeOperations_->fillAttr(context, fsOpContext, newNode, workDir, *attr); }
+	if (attr != nullptr) {
+		nodeOperations_->fillAttr(context, fsOpContext, newNode, workDir, *attr);
+	}
 
 	if (context.isPersonalityMaster()) {
 		assert(*inode == 0);
@@ -2071,7 +2073,7 @@ int FilesystemOperationsBase::locksRemovePending(
 uint8_t FilesystemOperationsBase::readdirSize(const FsContext &context, inode_t inode,
                                               uint8_t flags, void **dnode, uint32_t *dbuffsize) {
 	FSNode *node;
-	*dnode = NULL;
+	*dnode = nullptr;
 	*dbuffsize = 0;
 
 	uint8_t status =
@@ -2183,8 +2185,8 @@ uint8_t FilesystemOperationsBase::openCheck(const FsContext &context,
 			return SAUNAFS_ERROR_EACCES;
 		}
 	}
-	nodeOperations_->fillAttr(fsOpContext, node, NULL, context.uid(), context.gid(), context.auid(),
-	                          context.agid(), context.sesflags(), attr);
+	nodeOperations_->fillAttr(fsOpContext, node, nullptr, context.uid(), context.gid(),
+	                          context.auid(), context.agid(), context.sesflags(), attr);
 	incrementFSStat(FsStats::Open);
 	metrics::Counter::increment(metrics::Counter::Master::FS_OPEN);
 	return SAUNAFS_STATUS_OK;

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -24,7 +24,6 @@
 #include "master/filesystem_operations.h"
 
 #include <cstdarg>
-#include <cstddef>
 #include <cstdint>
 
 #include "common/attributes.h"
@@ -36,7 +35,6 @@
 #include "master/filesystem_checksum.h"
 #include "master/filesystem_checksum_updater.h"
 #include "master/filesystem_metadata.h"
-#include "master/filesystem_node.h"
 #include "master/filesystem_node_types.h"
 #include "master/filesystem_operation_context.h"
 #include "master/filesystem_operations_interface.h"
@@ -44,7 +42,6 @@
 #include "master/filesystem_stats.h"
 #include "master/fs_context.h"
 #include "master/locks.h"
-#include "master/matoclserv.h"
 #include "master/matoclserv_sessions.h"
 #include "master/matocsserv.h"
 #include "master/matomlserv.h"
@@ -52,7 +49,6 @@
 #include "master/recursive_remove_task.h"
 #include "master/task_manager.h"
 #include "metrics/metrics.h"
-#include "protocol/matocl.h"
 #include "slogger/slogger.h"
 
 inline bool isDepletedSpace() {

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -77,9 +77,8 @@ void FilesystemOperationsBase::changeLog(
 
 	// Then append the entry to the buffer
 	va_list argList;
-	uint32_t entryLength;
 	va_start(argList, format);
-	entryLength = vsnprintf(entry + tsLength, kMaxEntrySize, format, argList);
+	uint32_t entryLength = vsnprintf(entry + tsLength, kMaxEntrySize, format, argList);
 	va_end(argList);
 
 	if (entryLength >= kMaxEntrySize) {
@@ -159,12 +158,11 @@ void FilesystemOperationsBase::readTrash(const FilesystemOperationContext &fsOpC
 uint8_t FilesystemOperationsBase::getDetachedAttr(const FilesystemOperationContext &fsOpContext,
                                                   inode_t rootinode, uint8_t sesflags,
                                                   inode_t inode, Attributes &attr, uint8_t dtype) {
-	FSNode *node;
 	attr.fill(0);
 	if (rootinode != 0) { return SAUNAFS_ERROR_EPERM; }
 	(void)sesflags;
 	if (!DTYPE_ISVALID(dtype)) { return SAUNAFS_ERROR_EINVAL; }
-	node = nodeOperations_->idToNode(fsOpContext, inode);
+	FSNode *node = nodeOperations_->idToNode(fsOpContext, inode);
 	if (!node) { return SAUNAFS_ERROR_ENOENT; }
 	if (node->type != FSNodeType::kTrash && node->type != FSNodeType::kReserved) {
 		return SAUNAFS_ERROR_ENOENT;
@@ -185,10 +183,9 @@ uint8_t FilesystemOperationsBase::getDetachedAttr(const FilesystemOperationConte
 uint8_t FilesystemOperationsBase::getTrashPath(const FilesystemOperationContext &fsOpContext,
                                                inode_t rootinode, uint8_t sesflags, inode_t inode,
                                                std::string &path) {
-	FSNode *node;
 	if (rootinode != 0) { return SAUNAFS_ERROR_EPERM; }
 	(void)sesflags;
-	node = nodeOperations_->idToNode(fsOpContext, inode);
+	FSNode *node = nodeOperations_->idToNode(fsOpContext, inode);
 	if (!node) { return SAUNAFS_ERROR_ENOENT; }
 	if (node->type != FSNodeType::kTrash) { return SAUNAFS_ERROR_ENOENT; }
 	path = (std::string)gMetadata->trash.at(TrashPathKey(node));
@@ -373,8 +370,7 @@ uint8_t FilesystemOperationsBase::applyChecksum(const std::string &version, uint
 
 uint8_t FilesystemOperationsBase::applyAccess(const FilesystemOperationContext &fsOpContext,
                                               uint32_t timestamp, inode_t inode) {
-	FSNode *node;
-	node = nodeOperations_->idToNode(fsOpContext, inode);
+	FSNode *node = nodeOperations_->idToNode(fsOpContext, inode);
 	if (!node) { return SAUNAFS_ERROR_ENOENT; }
 	node->atime = timestamp;
 	fsnodes_update_checksum(node);
@@ -1804,10 +1800,9 @@ int FilesystemOperationsBase::posixLockProbe(const FsContext &context,
 	if (status != SAUNAFS_STATUS_OK) { return status; }
 
 	FileLocks &locks = gMetadata->posixLocks;
-	const FileLocks::Lock *collision;
-
-	collision = locks.findCollision(inode, static_cast<FileLocks::Lock::Type>(oper), start, end,
-	                                FileLocks::Owner{owner, sessionid, reqid, msgid});
+	const FileLocks::Lock *collision =
+	    locks.findCollision(inode, static_cast<FileLocks::Lock::Type>(oper), start, end,
+	                        FileLocks::Owner{owner, sessionid, reqid, msgid});
 
 	if (collision == nullptr) {
 		info.l_type = safs_locks::kUnlock;
@@ -2328,11 +2323,10 @@ uint8_t FilesystemOperationsBase::readChunk(const FilesystemOperationContext &fs
                                             uint64_t *length) {
 	uint32_t timeStamp = eventloop_time();
 	ChecksumUpdater checksumUpdater(timeStamp);
-	FSNodeFile *nodeFile;
 
 	*chunkid = 0;
 	*length = 0;
-	nodeFile = nodeOperations_->idToNode<FSNodeFile>(fsOpContext, inode);
+	FSNodeFile *nodeFile = nodeOperations_->idToNode<FSNodeFile>(fsOpContext, inode);
 	if (!nodeFile) { return SAUNAFS_ERROR_ENOENT; }
 	if (nodeFile->type != FSNodeType::kFile && nodeFile->type != FSNodeType::kTrash &&
 	    nodeFile->type != FSNodeType::kReserved) {


### PR DESCRIPTION
Refactors `src/master/filesystem_operations.cc`.

Improve readability and static-analysis results without changing
behavior.

Initialize variables at declaration, flatten return paths, remove
unused includes, and replace `NULL` with `nullptr`.

No runtime behavior changes are intended.

Related to: LS-473

Notes:
- Pausing here to keep short the incremental refactor. Other PRs will complement it.
- AI code reviewers, please focus on the goal of each commit, I am aware that there are missing steps, that will be covered in next commits/PRs.
