### PR TITLE
feat(chunkserver): add plugin reload mechanism 

### DIFF
--- a/src/chunkserver/chunkserver-common/iplugin.h
+++ b/src/chunkserver/chunkserver-common/iplugin.h
@@ -38,6 +38,9 @@ public:
 	/// needed.
 	virtual bool initialize() = 0;
 
+	/// Called on chunkserver reload to refresh plugin configuration parameters.
+	virtual void reload() = 0;
+
 	/// Returns the plugin name
 	virtual std::string name() = 0;
 	/// Returns the plugin version

--- a/src/chunkserver/chunkserver-common/plugin_manager.cc
+++ b/src/chunkserver/chunkserver-common/plugin_manager.cc
@@ -118,6 +118,15 @@ bool PluginManager::checkVersion(IPlugin *plugin) {
 	return false;
 }
 
+void PluginManager::reloadPlugins() {
+	for (auto &[name, plugin] : diskPlugins_) {
+		if (plugin) {
+			safs::log_info("Reloading plugin {}", plugin->toString());
+			plugin->reload();
+		}
+	}
+}
+
 void PluginManager::cleanupPlugins() {
 	for (auto &[name, plugin] : diskPlugins_) {
 		if (plugin) {

--- a/src/chunkserver/chunkserver-common/plugin_manager.h
+++ b/src/chunkserver/chunkserver-common/plugin_manager.h
@@ -49,6 +49,9 @@ public:
 	/// True if this plugin manager can handle the plugin based on the version.
 	bool checkVersion(IPlugin *plugin);
 
+	/// Reload plugins options for all the needed plugins.
+	void reloadPlugins();
+
 	/// Cleanup resources for all the needed plugins.
 	void cleanupPlugins();
 

--- a/src/chunkserver/hddspacemgr.cc
+++ b/src/chunkserver/hddspacemgr.cc
@@ -2845,6 +2845,9 @@ void hddReload(void) {
 	} catch (const Exception& ex) {
 		safs_pretty_syslog(LOG_ERR, "%s", ex.what());
 	}
+
+	// Request plugins to reload
+	pluginManager.reloadPlugins();
 }
 
 int hddLateInit() {


### PR DESCRIPTION
This PR introduces a plugin-wide reload mechanism, allowing disk plugins to
reconfigure themselves at runtime without requiring a chunkserver restart.

### What changed

- Added a new pure virtual method `reload()` to `DiskPlugin`, making reload
  a first-class lifecycle operation alongside initialization and cleanup.
- Extended `PluginManager` with `reloadPlugins()`, which iterates over all
  registered disk plugins and invokes their reload logic, including logging
  for observability.
- Integrated plugin reload into the chunkserver reload flow by calling
  `pluginManager.reloadPlugins()` from `hddReload()`.

### Why

Previously, plugin configuration was only applied during initialization,
requiring a full restart to reflect any changes. This limitation made runtime
tuning difficult, especially for components sensitive to configuration changes.

With this change, plugins can dynamically adapt to updated configuration,
enabling more flexible operation and reducing downtime.

### Impact

- Establishes a consistent mechanism for runtime reconfiguration across all
  disk plugins.
- Enables components such as the ZoneFS garbage collector to react to config
  changes (e.g., frequency, enable/disable) without restart.
- Improves operational agility and simplifies testing and tuning workflows.

Related to LS-566