### PR TITLE
test(windows): fix testing binaries path

### DIFF
--- a/tests/tools/config.sh
+++ b/tests/tools/config.sh
@@ -48,7 +48,7 @@ chmod 777 "$TEMP_DIR"
 # Prepare important environment variables
 export PATH="$SAUNAFS_ROOT/sbin:$SAUNAFS_ROOT/bin:$PATH"
 if is_windows_system; then
-	export PATH="$(get_windows_homepath)/SaunaFS:/mnt/c/Windows/System32:$PATH"
+	export PATH="$(get_windows_homepath)/LeilFS:/mnt/c/Windows/System32:$PATH"
 	export SAFS_MOUNT_COMMAND="sfsmount.exe"
 	export SAFS_ADMIN_COMMAND="saunafs-admin.exe"
 	export SAFS_SAUNAFS_COMMAND="saunafs.exe"


### PR DESCRIPTION
Due to recent changes related with rebranding process for LeilFS, it is also needed to consistently update the Windows client related testing framework to correctly point to testing binaries path, so that Windows client CI can work. This commit resolves that consistency issue.