### PR TITLE
chore: add windows-no-intaller CMake preset

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -78,6 +78,13 @@
             }
         },
         {
+            "name": "windows-no-installer",
+            "inherits": ["windows"],
+            "cacheVariables": {
+                "BUILD_WINCLIENT_INSTALLER": "OFF"
+            }
+        },
+        {
             "name": "debug",
             "binaryDir": "${sourceDir}/build/leilfs/debug",
             "installDir": "${sourceDir}/install/leilfs/",
@@ -145,6 +152,11 @@
         {
             "name": "windows",
             "configurePreset": "windows",
+            "inherits": ["default"]
+        },
+        {
+            "name": "windows-no-installer",
+            "configurePreset": "windows-no-installer",
             "inherits": ["default"]
         },
         {
@@ -217,6 +229,19 @@
                 {
                     "type": "build",
                     "name": "windows"
+                }
+            ]
+        },
+        {
+            "name": "windows-no-installer",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "windows-no-installer"
+                },
+                {
+                    "type": "build",
+                    "name": "windows-no-installer"
                 }
             ]
         },


### PR DESCRIPTION
This commit adds a new Windows client specific compilation preset that will be need for development process only of the Windows client without including the installer building part.