### PR TITLE
sfsmount: add WAN tuning options for metadata and chunkserver selection

### DIFF
--- a/doc/sfsmount.1.adoc
+++ b/doc/sfsmount.1.adoc
@@ -89,6 +89,10 @@ Path to the TLS configuration file for client-side TLS settings.
 Connection with master is done in background - with this option mount can be
 run without network (good for being run from fstab / init scripts etc.).
 
+*-o wan*::
+Apply WAN-tuned mount settings:
+`sfschunkserverlatencysort=1,sfsacl=0,sfsxattrs=0,sfsdirentrycacheto=60,sfsdirentrycachesize=10000000`.
+
 *-o sfsacl=*'0|1'::
 Enable or disable ACL xattr handling. Use `-o sfsacl=0` to disable it
 (default: 1).

--- a/doc/sfsmount.1.adoc
+++ b/doc/sfsmount.1.adoc
@@ -89,14 +89,24 @@ Path to the TLS configuration file for client-side TLS settings.
 Connection with master is done in background - with this option mount can be
 run without network (good for being run from fstab / init scripts etc.).
 
-*-o sfsacl*::
-Enable ACL support (disabled by default).
+*-o sfsacl=*'0|1'::
+Enable or disable ACL xattr handling. Use `-o sfsacl=0` to disable it
+(default: 1).
+
+*-o sfsxattrs=*'0|1'::
+Enable or disable xattr handling (default: 1).
 
 *-o sfsaclcacheto=*'SEC'::
 Set ACL cache timeout in seconds (default: 1.0).
 
 *-o sfsaclcachesize=*'N'::
 Define ACL cache size in number of entries (0: no cache; default: 1000).
+
+*-o sfsxattrcacheto=*'SEC'::
+Set xattr cache timeout in seconds (default: 30.0).
+
+*-o sfsxattrcachesize=*'N'::
+Define xattr cache size in number of entries (0: no cache; default: 10000).
 
 *-o sfsrwlock=*'0|1'::
 When set to 1, parallel reads from the same descriptor are performed (default:

--- a/src/common/chunk_connector.cc
+++ b/src/common/chunk_connector.cc
@@ -23,6 +23,7 @@
 #include <errno.h>
 #include <algorithm>
 
+#include "common/chunkserver_stats.h"
 #include "common/exceptions.h"
 #include "errors/sfserr.h"
 #include "common/sockets.h"
@@ -32,7 +33,8 @@ static int64_t timeoutTime(int64_t rtt, uint8_t tryCounter) {
 	return rtt * (1 << (tryCounter / 2)) * 3 / (tryCounter % 2 == 0 ? 3 : 2);
 }
 
-ChunkConnector::ChunkConnector(uint32_t sourceIp) : roundTripTime_ms_(20), sourceIp_(sourceIp) {
+ChunkConnector::ChunkConnector(uint32_t sourceIp)
+		: roundTripTime_ms_(20), sourceIp_(sourceIp), chunkserverStats_(nullptr) {
 }
 
 int ChunkConnector::startUsingConnection(const NetworkAddress& server,
@@ -60,11 +62,16 @@ int ChunkConnector::startUsingConnection(const NetworkAddress& server,
 				timeoutTime(roundTripTime_ms_, retries),
 				timeout.remaining_ms());
 		connectTimeout = std::max(int64_t(1), connectTimeout); // tcpnumtoconnect doesn't like 0
+		Timer connectTimer;
 		if (tcpnumtoconnect(fd, server.ip, server.port, connectTimeout) < 0) {
 			err = tcpgetlasterror();
 			tcpclose(fd);
 			fd = -1;
 		} else {
+			if (chunkserverStats_) {
+				chunkserverStats_->updateRoundTripTime(server,
+						static_cast<uint32_t>(std::max<int64_t>(1, connectTimer.elapsed_ms())));
+			}
 			break;
 		}
 		retries++;

--- a/src/common/chunk_connector.h
+++ b/src/common/chunk_connector.h
@@ -25,6 +25,8 @@
 #include "common/sockets.h"
 #include "common/time_utils.h"
 
+class ChunkserverStats;
+
 class ChunkConnector {
 public:
 	ChunkConnector(uint32_t sourceIp = 0);
@@ -42,12 +44,20 @@ public:
 		sourceIp_ = sourceIp;
 	}
 
+	/// A setter.
+	void setChunkserverStats(ChunkserverStats* chunkserverStats) {
+		chunkserverStats_ = chunkserverStats;
+	}
+
 private:
 	/// Time after which SYN packet will be considered lost during the first retry of tcptoconnect.
 	uint32_t roundTripTime_ms_;
 
 	/// IP address to bind to when connecting chunkservers.
 	uint32_t sourceIp_;
+
+	/// Optional statistics sink for per-chunkserver RTT observations.
+	ChunkserverStats* chunkserverStats_;
 };
 
 class Connection {

--- a/src/common/chunkserver_stats.cc
+++ b/src/common/chunkserver_stats.cc
@@ -20,15 +20,20 @@
 #include "common/platform.h"
 #include "common/chunkserver_stats.h"
 
+#include <algorithm>
 #include <mutex>
 #include <unordered_map>
 
 // ChunkserverEntry implementation
 
 constexpr int ChunkserverStats::ChunkserverEntry::defectiveTimeout_ms;
+constexpr uint32_t ChunkserverStats::ChunkserverEntry::kReferenceRoundTripTime_ms;
+constexpr float ChunkserverStats::ChunkserverEntry::kLatencyInfluence;
+constexpr uint32_t ChunkserverStats::ChunkserverEntry::kRoundTripTimeSmoothingFactor;
 
 ChunkserverStats::ChunkserverEntry::ChunkserverEntry(): pendingReads_(0), pendingWrites_(0),
-		defects_(0), defectiveTimeout_(std::chrono::milliseconds(defectiveTimeout_ms)) {
+		defects_(0), roundTripTime_ms_(0), hasRoundTripTime_(false),
+		defectiveTimeout_(std::chrono::milliseconds(defectiveTimeout_ms)) {
 }
 
 // ChunkserverStats implementation
@@ -36,7 +41,12 @@ ChunkserverStats::ChunkserverEntry::ChunkserverEntry(): pendingReads_(0), pendin
 const ChunkserverStats::ChunkserverEntry ChunkserverStats::getStatisticsFor(
 		const NetworkAddress& address) {
 	std::unique_lock<std::mutex> lock(mutex_);
-	return chunkserverEntries_[address];
+	ChunkserverEntry chunkserver = chunkserverEntries_[address];
+	if (!useRoundTripTime_.load()) {
+		chunkserver.hasRoundTripTime_ = false;
+		chunkserver.roundTripTime_ms_ = 0;
+	}
+	return chunkserver;
 }
 
 void ChunkserverStats::registerReadOperation(const NetworkAddress& address) {
@@ -59,6 +69,30 @@ void ChunkserverStats::unregisterWriteOperation(const NetworkAddress& address) {
 	chunkserverEntries_[address].pendingWrites_--;
 }
 
+void ChunkserverStats::setUseRoundTripTime(bool useRoundTripTime) {
+	useRoundTripTime_.store(useRoundTripTime);
+}
+
+bool ChunkserverStats::useRoundTripTime() const {
+	return useRoundTripTime_.load();
+}
+
+void ChunkserverStats::updateRoundTripTime(const NetworkAddress& address, uint32_t roundTripTime_ms) {
+	std::unique_lock<std::mutex> lock(mutex_);
+	ChunkserverEntry &chunkserver = chunkserverEntries_[address];
+	roundTripTime_ms = std::max<uint32_t>(1, roundTripTime_ms);
+	if (!chunkserver.hasRoundTripTime_) {
+		chunkserver.roundTripTime_ms_ = roundTripTime_ms;
+		chunkserver.hasRoundTripTime_ = true;
+		return;
+	}
+
+	chunkserver.roundTripTime_ms_ =
+	    ((chunkserver.roundTripTime_ms_ * (ChunkserverEntry::kRoundTripTimeSmoothingFactor - 1))
+	     + roundTripTime_ms) / ChunkserverEntry::kRoundTripTimeSmoothingFactor;
+	chunkserver.roundTripTime_ms_ = std::max<uint32_t>(1, chunkserver.roundTripTime_ms_);
+}
+
 void ChunkserverStats::markWorking(const NetworkAddress& address) {
 	std::unique_lock<std::mutex> lock(mutex_);
 	chunkserverEntries_[address].defects_ = 0;
@@ -74,10 +108,19 @@ void ChunkserverStats::markDefective(const NetworkAddress& address) {
 }
 
 float ChunkserverStats::ChunkserverEntry::score() const {
+	float latencyAdjustment = 0.f;
+	if (hasRoundTripTime_) {
+		float reference = static_cast<float>(kReferenceRoundTripTime_ms);
+		float rtt = static_cast<float>(roundTripTime_ms_);
+		latencyAdjustment = (reference - rtt) / (reference + rtt);
+		latencyAdjustment = std::max(-1.f, std::min(1.f, latencyAdjustment));
+	}
+
 	if (defects_ > 0 && !defectiveTimeout_.expired()) {
-		return 1. / (defects_ + 1);
+		float healthPenalty = 1.f / (defects_ + 1);
+		return healthPenalty * (1.f + kLatencyInfluence * latencyAdjustment);
 	} else {
-		return 1;
+		return 1.f + kLatencyInfluence * latencyAdjustment;
 	}
 }
 
@@ -114,6 +157,11 @@ void ChunkserverStatsProxy::registerWriteOperation(const NetworkAddress& address
 void ChunkserverStatsProxy::unregisterWriteOperation(const NetworkAddress& address) {
 	stats_.unregisterWriteOperation(address);
 	writeOperations_[address]--;
+}
+
+void ChunkserverStatsProxy::updateRoundTripTime(const NetworkAddress& address,
+		uint32_t roundTripTime_ms) {
+	stats_.updateRoundTripTime(address, roundTripTime_ms);
 }
 
 void ChunkserverStatsProxy::markDefective(const NetworkAddress& address) {

--- a/src/common/chunkserver_stats.h
+++ b/src/common/chunkserver_stats.h
@@ -78,7 +78,7 @@ public:
 	private:
 		static constexpr int defectiveTimeout_ms = 2000;
 		static constexpr uint32_t kReferenceRoundTripTime_ms = 100;
-		static constexpr float kLatencyInfluence = 0.49f;
+		static constexpr float kLatencyInfluence = 0.3f;
 		static constexpr uint32_t kRoundTripTimeSmoothingFactor = 8;
 
 		uint32_t pendingReads_;

--- a/src/common/chunkserver_stats.h
+++ b/src/common/chunkserver_stats.h
@@ -21,7 +21,9 @@
 
 #include "common/platform.h"
 
+#include <atomic>
 #include <chrono>
+#include <cstdint>
 #include <mutex>
 #include <unordered_map>
 
@@ -34,8 +36,8 @@
 // Code which uses chunkservers to perform read/write operations should register and unregister
 // these operations with the global ChunkserverStats instance.
 //
-// If there is a choice between multiple chunkservers capable of performing some operation, the
-// chunkserver with lowest pending operation count should be chosen.
+// If there is a choice between multiple chunkservers capable of performing some operation, prefer
+// healthy chunkservers with lower observed latency.
 //
 // Code that determines a chunkserver to be defective should call markDefective(). Others should
 // prefer to use chunkservers not marked as defective, if possible. The defective flag is cleared
@@ -63,14 +65,27 @@ public:
 			return pendingWrites_;
 		}
 
+		bool hasRoundTripTime() const {
+			return hasRoundTripTime_;
+		}
+
+		uint32_t roundTripTime_ms() const {
+			return roundTripTime_ms_;
+		}
+
 		float score() const;
 
 	private:
 		static constexpr int defectiveTimeout_ms = 2000;
+		static constexpr uint32_t kReferenceRoundTripTime_ms = 100;
+		static constexpr float kLatencyInfluence = 0.49f;
+		static constexpr uint32_t kRoundTripTimeSmoothingFactor = 8;
 
 		uint32_t pendingReads_;
 		uint32_t pendingWrites_;
 		uint32_t defects_;
+		uint32_t roundTripTime_ms_;
+		bool hasRoundTripTime_;
 		Timeout defectiveTimeout_;
 
 		friend class ChunkserverStats;
@@ -86,11 +101,15 @@ public:
 	void registerWriteOperation(const NetworkAddress& address);
 	void unregisterWriteOperation(const NetworkAddress& address);
 
+	void setUseRoundTripTime(bool useRoundTripTime);
+	bool useRoundTripTime() const;
+	void updateRoundTripTime(const NetworkAddress& address, uint32_t roundTripTime_ms);
 	void markDefective(const NetworkAddress& address);
 	void markWorking(const NetworkAddress& address);
 
 private:
 	std::mutex mutex_;
+	std::atomic<bool> useRoundTripTime_{false};
 	std::unordered_map<NetworkAddress, ChunkserverEntry> chunkserverEntries_;
 };
 
@@ -120,6 +139,7 @@ public:
 	void registerWriteOperation(const NetworkAddress& address);
 	void unregisterWriteOperation(const NetworkAddress& address);
 
+	void updateRoundTripTime(const NetworkAddress& address, uint32_t roundTripTime_ms);
 	void markDefective(const NetworkAddress& address);
 	void markWorking(const NetworkAddress& address);
 

--- a/src/common/chunkserver_stats_unittest.cc
+++ b/src/common/chunkserver_stats_unittest.cc
@@ -77,12 +77,59 @@ TEST(ChunkserverStatsTests, ChunkserverStatsDefectTracking) {
 	EXPECT_EQ(stats.getStatisticsFor(server1).score(), 1.);
 }
 
+TEST(ChunkserverStatsTests, ChunkserverStatsRoundTripTimeTracking) {
+	ChunkserverStats stats;
+	NetworkAddress server1(1111, 11);
+	NetworkAddress server2(2222, 22);
+
+	stats.setUseRoundTripTime(true);
+	stats.updateRoundTripTime(server1, 200);
+	stats.updateRoundTripTime(server2, 20);
+
+	EXPECT_TRUE(stats.getStatisticsFor(server1).hasRoundTripTime());
+	EXPECT_EQ(200u, stats.getStatisticsFor(server1).roundTripTime_ms());
+	EXPECT_GT(stats.getStatisticsFor(server2).score(), stats.getStatisticsFor(server1).score());
+
+	stats.updateRoundTripTime(server1, 40);
+	EXPECT_LT(stats.getStatisticsFor(server1).roundTripTime_ms(), 200u);
+	EXPECT_GT(stats.getStatisticsFor(server1).roundTripTime_ms(), 40u);
+}
+
+TEST(ChunkserverStatsTests, ChunkserverStatsRoundTripTimeDisabled) {
+	ChunkserverStats stats;
+	NetworkAddress server1(1111, 11);
+	NetworkAddress server2(2222, 22);
+
+	stats.updateRoundTripTime(server1, 200);
+	stats.updateRoundTripTime(server2, 20);
+
+	EXPECT_FALSE(stats.getStatisticsFor(server1).hasRoundTripTime());
+	EXPECT_FALSE(stats.getStatisticsFor(server2).hasRoundTripTime());
+	EXPECT_EQ(stats.getStatisticsFor(server1).score(), 1.);
+	EXPECT_EQ(stats.getStatisticsFor(server2).score(), 1.);
+}
+
+TEST(ChunkserverStatsTests, ChunkserverStatsDefectPenaltyOutweighsLatency) {
+	ChunkserverStats stats;
+	NetworkAddress fastServer(1111, 11);
+	NetworkAddress slowServer(2222, 22);
+
+	stats.setUseRoundTripTime(true);
+	stats.updateRoundTripTime(fastServer, 5);
+	stats.updateRoundTripTime(slowServer, 500);
+	stats.markDefective(fastServer);
+
+	EXPECT_LT(stats.getStatisticsFor(fastServer).score(),
+	          stats.getStatisticsFor(slowServer).score());
+}
+
 TEST(ChunkserverStatsTests, ChunkserverStatsProxy) {
 	ChunkserverStats stats;
 	NetworkAddress server1(1111, 11);
 
 	{
 		ChunkserverStatsProxy proxy(stats);
+		stats.setUseRoundTripTime(true);
 
 		proxy.registerReadOperation(server1);
 		proxy.registerReadOperation(server1);
@@ -97,6 +144,9 @@ TEST(ChunkserverStatsTests, ChunkserverStatsProxy) {
 
 		proxy.unregisterWriteOperation(server1);
 		EXPECT_EQ(1u, stats.getStatisticsFor(server1).pendingWrites());
+
+		proxy.updateRoundTripTime(server1, 25);
+		EXPECT_TRUE(stats.getStatisticsFor(server1).hasRoundTripTime());
 	}
 	EXPECT_EQ(0u, stats.getStatisticsFor(server1).pendingReads());
 	EXPECT_EQ(0u, stats.getStatisticsFor(server1).pendingWrites());

--- a/src/mount/client/saunafs_c_api.cc
+++ b/src/mount/client/saunafs_c_api.cc
@@ -50,6 +50,7 @@ void sau_set_default_init_params(struct sau_init_params *params,
 	params->report_reserved_period = SaunaClient::FsInitParams::kDefaultReportReservedPeriod;
 
 	params->io_retries = SaunaClient::FsInitParams::kDefaultIoRetries;
+	params->chunkserver_latency_sort = SaunaClient::FsInitParams::kDefaultChunkserverLatencySort;
 	params->chunkserver_round_time_ms = SaunaClient::FsInitParams::kDefaultRoundTime;
 	params->chunkserver_connect_timeout_ms = SaunaClient::FsInitParams::kDefaultChunkserverConnectTo;
 	params->chunkserver_wave_read_timeout_ms = SaunaClient::FsInitParams::kDefaultChunkserverWaveReadTo;
@@ -235,6 +236,7 @@ sau_t *sau_init_with_params(struct sau_init_params *params) {
 	COPY_PARAM(delayed_init);
 	COPY_PARAM(report_reserved_period);
 	COPY_PARAM(io_retries);
+	COPY_PARAM(chunkserver_latency_sort);
 	COPY_PARAM(chunkserver_round_time_ms);
 	COPY_PARAM(chunkserver_connect_timeout_ms);
 	COPY_PARAM(chunkserver_wave_read_timeout_ms);

--- a/src/mount/client/saunafs_c_api.h
+++ b/src/mount/client/saunafs_c_api.h
@@ -52,6 +52,7 @@ typedef struct sau_init_params {
 	unsigned report_reserved_period;
 
 	unsigned io_retries;
+	bool chunkserver_latency_sort;
 	unsigned chunkserver_round_time_ms;
 	unsigned chunkserver_connect_timeout_ms;
 	unsigned chunkserver_wave_read_timeout_ms;

--- a/src/mount/fuse/main.cc
+++ b/src/mount/fuse/main.cc
@@ -237,6 +237,7 @@ static int mainloop(struct fuse_args *args, struct fuse_cmdline_opts *fuse_opts,
 	params.io_retries = gMountOptions.ioretries;
 	params.io_limits_config_file = gMountOptions.iolimits ? gMountOptions.iolimits : "";
 	params.bandwidth_overuse = gMountOptions.bandwidthoveruse;
+	params.chunkserver_latency_sort = gMountOptions.chunkserverlatencysort;
 	params.chunkserver_round_time_ms = gMountOptions.chunkserverrtt;
 	params.chunkserver_connect_timeout_ms = gMountOptions.chunkserverconnectreadto;
 	params.chunkserver_wave_read_timeout_ms = gMountOptions.chunkserverwavereadto;

--- a/src/mount/fuse/main.cc
+++ b/src/mount/fuse/main.cc
@@ -122,7 +122,11 @@ static void sfs_fsinit(void *userdata, struct fuse_conn_info *conn) {
 
 	fuse_conn_info_opts *conn_opts = (fuse_conn_info_opts *)userdata;
 	fuse_apply_conn_info_opts(conn_opts, conn);
-	conn->want |= FUSE_CAP_POSIX_ACL;
+	if (gMountOptions.acl && gMountOptions.xattrs) {
+		conn->want |= FUSE_CAP_POSIX_ACL;
+	} else {
+		conn->want &= ~FUSE_CAP_POSIX_ACL;
+	}
 	conn->want &= ~FUSE_CAP_ATOMIC_O_TRUNC;
 
 	daemonize_return_status(0);
@@ -261,8 +265,12 @@ static int mainloop(struct fuse_args *args, struct fuse_cmdline_opts *fuse_opts,
 	params.mkdir_copy_sgid = gMountOptions.mkdircopysgid;
 	params.sugid_clear_mode = gMountOptions.sugidclearmode;
 	params.use_rw_lock = gMountOptions.rwlock;
+	params.enable_acl = gMountOptions.acl && gMountOptions.xattrs;
+	params.enable_xattrs = gMountOptions.xattrs;
 	params.acl_cache_timeout = gMountOptions.aclcacheto;
 	params.acl_cache_size = gMountOptions.aclcachesize;
+	params.xattr_cache_timeout = gMountOptions.xattrcacheto;
+	params.xattr_cache_size = gMountOptions.xattrcachesize;
 	params.debug_mode = gMountOptions.debug;
 	params.direct_io = gMountOptions.directio;
 	params.max_chunks_written_in_parallel_per_inode =
@@ -701,10 +709,20 @@ int main(int argc, char *argv[]) try {
 	if (!gMountOptions.nostdmountoptions)
 		fuse_opt_add_arg(&args, "-o" DEFAULT_OPTIONS);
 
+	if (gMountOptions.acl && !gMountOptions.xattrs) {
+		fprintf(stderr, "ACL support requires xattrs - disabling ACL support\n");
+	}
+
 	if (gMountOptions.aclcachesize > 1000 * 1000) {
 		fprintf(stderr, "acl cache size too big (%u) - decreased to "
 				"1000000\n", gMountOptions.aclcachesize);
 		gMountOptions.aclcachesize = 1000 * 1000;
+	}
+
+	if (gMountOptions.xattrcachesize > 1000 * 1000) {
+		fprintf(stderr, "xattr cache size too big (%u) - decreased to "
+				"1000000\n", gMountOptions.xattrcachesize);
+		gMountOptions.xattrcachesize = 1000 * 1000;
 	}
 
 	if (gMountOptions.direntrycachesize > 10000000) {

--- a/src/mount/fuse/mount_config.cc
+++ b/src/mount/fuse/mount_config.cc
@@ -59,6 +59,7 @@ struct fuse_opt gSfsOptsStage2[] = {
 	SFS_OPT("sfswritecachesize=%u", writecachesize, 0),
 	SFS_OPT("sfschunkserverwavewriteto=%u", chunkserverwavewriteto, 0),
 	SFS_OPT("sfsaclcachesize=%u", aclcachesize, 0),
+	SFS_OPT("sfsxattrcachesize=%u", xattrcachesize, 0),
 	SFS_OPT("sfscacheperinodepercentage=%u", cachePerInodePercentage, 0),
 	SFS_OPT("sfswriteworkers=%u", writeworkers, 0),
 	SFS_OPT("sfsioretries=%u", ioretries, 0),
@@ -67,6 +68,9 @@ struct fuse_opt gSfsOptsStage2[] = {
 	SFS_OPT("sfsmeta", meta, 1),
 	SFS_OPT("sfsdelayedinit", delayedinit, 1),
 	SFS_OPT("sfsacl", acl, 1),
+	SFS_OPT("sfsacl=%d", acl, 0),
+	SFS_OPT("sfsxattrs", xattrs, 1),
+	SFS_OPT("sfsxattrs=%d", xattrs, 0),
 	SFS_OPT("sfsrwlock=%d", rwlock, 0),
 	SFS_OPT("sfsdonotrememberpassword", donotrememberpassword, 1),
 	SFS_OPT("sfscachemode=%s", cachemode, 0),
@@ -79,6 +83,7 @@ struct fuse_opt gSfsOptsStage2[] = {
 	SFS_OPT("sfsnegativecachetimeout=%u", negativecachetimeout, 0),
 	SFS_OPT("sfsnegativecachesize=%u", negativecachesize, 0),
 	SFS_OPT("sfsaclcacheto=%lf", aclcacheto, 0),
+	SFS_OPT("sfsxattrcacheto=%lf", xattrcacheto, 0),
 	SFS_OPT("sfsreportreservedperiod=%u", reportreservedperiod, 0),
 	SFS_OPT("sfsiolimits=%s", iolimits, 0),
 	SFS_OPT("sfschunkserverrtt=%d", chunkserverrtt, 0),
@@ -148,6 +153,7 @@ void initialize_opts_name_values() {
 #endif
 	gOptsNameValues["sfswritecachesize"] = std::to_string(gMountOptions.writecachesize);
 	gOptsNameValues["sfsaclcachesize"] = std::to_string(gMountOptions.aclcachesize);
+	gOptsNameValues["sfsxattrcachesize"] = std::to_string(gMountOptions.xattrcachesize);
 	gOptsNameValues["sfscacheperinodepercentage"] =
 	    std::to_string(gMountOptions.cachePerInodePercentage);
 	gOptsNameValues["sfswriteworkers"] = std::to_string(gMountOptions.writeworkers);
@@ -164,6 +170,7 @@ void initialize_opts_name_values() {
 	gOptsNameValues["sfsmeta"] = std::to_string(gMountOptions.meta);
 	gOptsNameValues["sfsdelayedinit"] = std::to_string(gMountOptions.delayedinit);
 	gOptsNameValues["sfsacl"] = std::to_string(gMountOptions.acl);
+	gOptsNameValues["sfsxattrs"] = std::to_string(gMountOptions.xattrs);
 	gOptsNameValues["sfsrwlock"] = std::to_string(gMountOptions.rwlock);
 	gOptsNameValues["sfsdonotrememberpassword"] =
 	    std::to_string(gMountOptions.donotrememberpassword);
@@ -181,6 +188,7 @@ void initialize_opts_name_values() {
 	gOptsNameValues["sfsnegativecachetimeout"] = std::to_string(gMountOptions.negativecachetimeout);
 	gOptsNameValues["sfsnegativecachesize"] = std::to_string(gMountOptions.negativecachesize);
 	gOptsNameValues["sfsaclcacheto"] = std::to_string(gMountOptions.aclcacheto);
+	gOptsNameValues["sfsxattrcacheto"] = std::to_string(gMountOptions.xattrcacheto);
 	gOptsNameValues["sfsreportreservedperiod"] = std::to_string(gMountOptions.reportreservedperiod);
 	gOptsNameValues["sfsiolimits"] =
 	    gMountOptions.iolimits ? std::string(gMountOptions.iolimits) : "";
@@ -311,8 +319,8 @@ void usage(const char *progname) {
 				"- with this option mount can be run without "
 				"network (good for being run from fstab/init "
 				"scripts etc.)\n"
-"    -o sfsacl                   DEPRECATED, used to enable/disable ACL "
-				"support, ignored now\n"
+"    -o sfsacl=0|1              enable/disable ACL xattr handling (default: %d)\n"
+"    -o sfsxattrs=0|1           enable/disable xattr handling (default: %d)\n"
 "    -o sfsrwlock=0|1            when set to 1, parallel reads from the same "
 				"descriptor are performed (default: %d)\n"
 "    -o sfsmkdircopysgid=N       sgid bit should be copied during mkdir "
@@ -337,6 +345,7 @@ void usage(const char *progname) {
 				"When equal to 0 disabled for both internal and Linux kernel-level negative caching. "
 				"If changed in .saunafs_tweaks clears the whole cache (default: %u)\n"
 "    -o sfsaclcacheto=SEC        set ACL cache timeout in seconds (default: %.2f)\n"
+"    -o sfsxattrcacheto=SEC      set xattr cache timeout in seconds (default: %.2f)\n"
 "    -o sfsreportreservedperiod=SEC  set reporting reserved inodes interval in "
 				"seconds (default: %u)\n"
 "    -o sfschunkserverrtt=MSEC   set timeout after which SYN packet is "
@@ -350,6 +359,8 @@ void usage(const char *progname) {
 "    -o sfsmemlock               try to lock memory\n"
 #endif
 "    -o sfsaclcachesize=N        define ACL cache size in number of entries "
+				"(0: no cache; default: %u)\n"
+"    -o sfsxattrcachesize=N      define xattr cache size in number of entries "
 				"(0: no cache; default: %u)\n"
 "    -o sfsioretries=N           define number of retries before I/O error is "
 				"returned (default: %u)\n"
@@ -403,6 +414,8 @@ void usage(const char *progname) {
 		SaunaClient::FsInitParams::kDefaultWriteWorkers,
 		SaunaClient::FsInitParams::kDefaultWriteWindowSize,
 		SaunaClient::FsInitParams::kDefaultMaxChunksWrittenInParallelPerInode,
+		SaunaClient::FsInitParams::kDefaultEnableAcl,
+		SaunaClient::FsInitParams::kDefaultEnableXattrs,
 		SaunaClient::FsInitParams::kDefaultUseRwLock,
 		SaunaClient::FsInitParams::kDefaultMkdirCopySgid,
 		sugidClearModeString(SaunaClient::FsInitParams::kDefaultSugidClearMode),
@@ -413,10 +426,12 @@ void usage(const char *progname) {
 		SaunaClient::FsInitParams::kDefaultNegativeCacheTo,
 		SaunaClient::FsInitParams::kDefaultNegativeCacheSize,
 		SaunaClient::FsInitParams::kDefaultAclCacheTimeout,
+		SaunaClient::FsInitParams::kDefaultXattrCacheTimeout,
 		SaunaClient::FsInitParams::kDefaultReportReservedPeriod,
 		SaunaClient::FsInitParams::kDefaultRoundTime,
 		SaunaClient::FsInitParams::kDefaultChunkserverWaveReadTo,
 		SaunaClient::FsInitParams::kDefaultAclCacheSize,
+		SaunaClient::FsInitParams::kDefaultXattrCacheSize,
 		SaunaClient::FsInitParams::kDefaultIoRetries,
 		SaunaClient::FsInitParams::kDefaultSymlinkCacheTimeout,
 		SaunaClient::FsInitParams::kDefaultSubfolder,

--- a/src/mount/fuse/mount_config.cc
+++ b/src/mount/fuse/mount_config.cc
@@ -30,6 +30,22 @@
 
 #define SFS_OPT(t, p, v) { t, offsetof(struct sfsopts_, p), v }
 
+namespace {
+
+constexpr double kWanDirentryCacheTimeout = 60.0;
+constexpr unsigned kWanDirentryCacheSize = 10000000;
+
+void enable_wan_preset() {
+	gMountOptions.wan = 1;
+	gMountOptions.chunkserverlatencysort = 1;
+	gMountOptions.acl = 0;
+	gMountOptions.xattrs = 0;
+	gMountOptions.direntrycacheto = kWanDirentryCacheTimeout;
+	gMountOptions.direntrycachesize = kWanDirentryCacheSize;
+}
+
+}  // namespace
+
 sfsopts_ gMountOptions;
 std::map<std::string, std::string> gOptsNameValues;
 
@@ -134,6 +150,10 @@ struct fuse_opt gSfsOptsStage2[] = {
 	FUSE_OPT_KEY("-n",             KEY_NOSTDMOUNTOPTIONS),
 	FUSE_OPT_KEY("--nostdopts",    KEY_NOSTDMOUNTOPTIONS),
 	FUSE_OPT_KEY("--nonempty",     KEY_NONEMPTY),
+	FUSE_OPT_KEY("wan",            KEY_WAN),
+	FUSE_OPT_KEY("wan=1",          KEY_WAN),
+	FUSE_OPT_KEY("sfswan",         KEY_WAN),
+	FUSE_OPT_KEY("sfswan=1",       KEY_WAN),
 	FUSE_OPT_END
 };
 
@@ -171,6 +191,7 @@ void initialize_opts_name_values() {
 	gOptsNameValues["sfsdebug"] = std::to_string(gMountOptions.debug);
 	gOptsNameValues["sfsmeta"] = std::to_string(gMountOptions.meta);
 	gOptsNameValues["sfsdelayedinit"] = std::to_string(gMountOptions.delayedinit);
+	gOptsNameValues["wan"] = std::to_string(gMountOptions.wan);
 	gOptsNameValues["sfsacl"] = std::to_string(gMountOptions.acl);
 	gOptsNameValues["sfsxattrs"] = std::to_string(gMountOptions.xattrs);
 	gOptsNameValues["sfsrwlock"] = std::to_string(gMountOptions.rwlock);
@@ -323,6 +344,9 @@ void usage(const char *progname) {
 				"- with this option mount can be run without "
 				"network (good for being run from fstab/init "
 				"scripts etc.)\n"
+"    -o wan                      shortcut for WAN-tuned settings: "
+				"sfschunkserverlatencysort=1,sfsacl=0,sfsxattrs=0,"
+				"sfsdirentrycacheto=60,sfsdirentrycachesize=10000000\n"
 "    -o sfsacl=0|1              enable/disable ACL xattr handling (default: %d)\n"
 "    -o sfsxattrs=0|1           enable/disable xattr handling (default: %d)\n"
 "    -o sfsrwlock=0|1            when set to 1, parallel reads from the same "
@@ -670,6 +694,9 @@ int sfs_opt_proc_stage2(void *data, const char *arg, int key, struct fuse_args *
 		return 0;
 	case KEY_NONEMPTY:
 		gMountOptions.nonemptymount = 1;
+		return 0;
+	case KEY_WAN:
+		enable_wan_preset();
 		return 0;
 	default:
 		fprintf(stderr, "internal error\n");

--- a/src/mount/fuse/mount_config.cc
+++ b/src/mount/fuse/mount_config.cc
@@ -86,6 +86,8 @@ struct fuse_opt gSfsOptsStage2[] = {
 	SFS_OPT("sfsxattrcacheto=%lf", xattrcacheto, 0),
 	SFS_OPT("sfsreportreservedperiod=%u", reportreservedperiod, 0),
 	SFS_OPT("sfsiolimits=%s", iolimits, 0),
+	SFS_OPT("sfschunkserverlatencysort", chunkserverlatencysort, 1),
+	SFS_OPT("sfschunkserverlatencysort=%d", chunkserverlatencysort, 0),
 	SFS_OPT("sfschunkserverrtt=%d", chunkserverrtt, 0),
 	SFS_OPT("sfschunkserverconnectreadto=%d", chunkserverconnectreadto, 0),
 	SFS_OPT("sfschunkserverwavereadto=%d", chunkserverwavereadto, 0),
@@ -192,6 +194,8 @@ void initialize_opts_name_values() {
 	gOptsNameValues["sfsreportreservedperiod"] = std::to_string(gMountOptions.reportreservedperiod);
 	gOptsNameValues["sfsiolimits"] =
 	    gMountOptions.iolimits ? std::string(gMountOptions.iolimits) : "";
+	gOptsNameValues["sfschunkserverlatencysort"] =
+	    std::to_string(gMountOptions.chunkserverlatencysort);
 	gOptsNameValues["sfschunkserverrtt"] = std::to_string(gMountOptions.chunkserverrtt);
 	gOptsNameValues["sfschunkserverconnectreadto"] =
 	    std::to_string(gMountOptions.chunkserverconnectreadto);
@@ -348,6 +352,8 @@ void usage(const char *progname) {
 "    -o sfsxattrcacheto=SEC      set xattr cache timeout in seconds (default: %.2f)\n"
 "    -o sfsreportreservedperiod=SEC  set reporting reserved inodes interval in "
 				"seconds (default: %u)\n"
+"    -o sfschunkserverlatencysort=0|1  prefer lower-latency chunkservers when "
+				"choosing read/write targets (default: %d)\n"
 "    -o sfschunkserverrtt=MSEC   set timeout after which SYN packet is "
 				"considered lost during the first retry of "
 				"connecting a chunkserver (default: %u)\n"
@@ -428,6 +434,7 @@ void usage(const char *progname) {
 		SaunaClient::FsInitParams::kDefaultAclCacheTimeout,
 		SaunaClient::FsInitParams::kDefaultXattrCacheTimeout,
 		SaunaClient::FsInitParams::kDefaultReportReservedPeriod,
+		SaunaClient::FsInitParams::kDefaultChunkserverLatencySort,
 		SaunaClient::FsInitParams::kDefaultRoundTime,
 		SaunaClient::FsInitParams::kDefaultChunkserverWaveReadTo,
 		SaunaClient::FsInitParams::kDefaultAclCacheSize,

--- a/src/mount/fuse/mount_config.h
+++ b/src/mount/fuse/mount_config.h
@@ -55,6 +55,7 @@ enum {
 	KEY_PASSWORDASK,
 	KEY_NOSTDMOUNTOPTIONS,
 	KEY_NONEMPTY,
+	KEY_WAN,
 	KEY_HELP,
 	KEY_VERSION
 };
@@ -76,6 +77,7 @@ struct sfsopts_ {
 	int meta;
 	int debug;
 	int delayedinit;
+	int wan;
 	int acl;
 	int xattrs;
 	double aclcacheto;
@@ -150,6 +152,7 @@ struct sfsopts_ {
 		meta(0),
 		debug(SaunaClient::FsInitParams::kDefaultDebugMode),
 		delayedinit(SaunaClient::FsInitParams::kDefaultDelayedInit),
+		wan(0),
 		acl(SaunaClient::FsInitParams::kDefaultEnableAcl),
 		xattrs(SaunaClient::FsInitParams::kDefaultEnableXattrs),
 		aclcacheto(SaunaClient::FsInitParams::kDefaultAclCacheTimeout),

--- a/src/mount/fuse/mount_config.h
+++ b/src/mount/fuse/mount_config.h
@@ -104,6 +104,7 @@ struct sfsopts_ {
 	unsigned negativecachesize;
 	unsigned reportreservedperiod;
 	char *iolimits;
+	int chunkserverlatencysort;
 	int chunkserverrtt;
 	int chunkserverconnectreadto;
 	int chunkserverwavereadto;
@@ -177,6 +178,7 @@ struct sfsopts_ {
 		negativecachesize(SaunaClient::FsInitParams::kDefaultNegativeCacheSize),
 		reportreservedperiod(SaunaClient::FsInitParams::kDefaultReportReservedPeriod),
 		iolimits(NULL),
+		chunkserverlatencysort(SaunaClient::FsInitParams::kDefaultChunkserverLatencySort),
 		chunkserverrtt(SaunaClient::FsInitParams::kDefaultRoundTime),
 		chunkserverconnectreadto(SaunaClient::FsInitParams::kDefaultChunkserverConnectTo),
 		chunkserverwavereadto(SaunaClient::FsInitParams::kDefaultChunkserverWaveReadTo),

--- a/src/mount/fuse/mount_config.h
+++ b/src/mount/fuse/mount_config.h
@@ -77,8 +77,11 @@ struct sfsopts_ {
 	int debug;
 	int delayedinit;
 	int acl;
+	int xattrs;
 	double aclcacheto;
 	unsigned aclcachesize;
+	double xattrcacheto;
+	unsigned xattrcachesize;
 	int rwlock;
 	int mkdircopysgid;
 	char *sugidclearmodestr;
@@ -146,9 +149,12 @@ struct sfsopts_ {
 		meta(0),
 		debug(SaunaClient::FsInitParams::kDefaultDebugMode),
 		delayedinit(SaunaClient::FsInitParams::kDefaultDelayedInit),
-		acl(), // deprecated
+		acl(SaunaClient::FsInitParams::kDefaultEnableAcl),
+		xattrs(SaunaClient::FsInitParams::kDefaultEnableXattrs),
 		aclcacheto(SaunaClient::FsInitParams::kDefaultAclCacheTimeout),
 		aclcachesize(SaunaClient::FsInitParams::kDefaultAclCacheSize),
+		xattrcacheto(SaunaClient::FsInitParams::kDefaultXattrCacheTimeout),
+		xattrcachesize(SaunaClient::FsInitParams::kDefaultXattrCacheSize),
 		rwlock(SaunaClient::FsInitParams::kDefaultUseRwLock),
 		mkdircopysgid(SaunaClient::FsInitParams::kDefaultMkdirCopySgid),
 		sugidclearmodestr(NULL),

--- a/src/mount/readdata.cc
+++ b/src/mount/readdata.cc
@@ -38,6 +38,7 @@
 #include "common/read_plan_executor.h"
 #include "common/time_utils.h"
 #include "mount/chunk_reader.h"
+#include "mount/global_chunkserver_stats.h"
 #include "mount/mastercomm.h"
 #include "mount/memory_info.h"
 #include "mount/mount_info.h"
@@ -753,6 +754,7 @@ void read_data_end(ReadRecord *rrec) {
 }
 
 void read_data_init(uint32_t retries,
+		bool chunkserverLatencySort,
 		uint32_t chunkserverRoundTripTime_ms,
 		uint32_t chunkserverConnectTimeout_ms,
 		uint32_t chunkServerWaveReadTimeout_ms,
@@ -791,7 +793,10 @@ void read_data_init(uint32_t retries,
 	gMaxReadaheadRequests = max_readahead_requests;
 	gPrefetchXorStripes = prefetchXorStripes;
 	gBandwidthOveruse = bandwidth_overuse;
+	globalChunkserverStats.setUseRoundTripTime(chunkserverLatencySort);
 	gChunkConnector.setRoundTripTime(chunkserverRoundTripTime_ms);
+	gChunkConnector.setChunkserverStats(
+	    chunkserverLatencySort ? &globalChunkserverStats : nullptr);
 	gChunkConnector.setSourceIp(fs_getsrcip());
 	pthread_attr_init(&thattr);
 	pthread_attr_setstacksize(&thattr,0x100000);

--- a/src/mount/readdata.h
+++ b/src/mount/readdata.h
@@ -416,7 +416,8 @@ int read_to_buffer(ReadRecord *rrec, uint64_t current_offset,
                    std::unique_lock<std::mutex> &entryLock);
 int read_data(ReadRecord *rr, off_t fuseOffset, size_t fuseSize,
               uint64_t offset, uint32_t size, ReadCache::Result &ret);
-void read_data_init(uint32_t retries, uint32_t chunkserverRoundTripTime_ms,
+void read_data_init(uint32_t retries, bool chunkserverLatencySort,
+                    uint32_t chunkserverRoundTripTime_ms,
                     uint32_t chunkserverConnectTimeout_ms,
                     uint32_t chunkServerWaveReadTimeout_ms,
                     uint32_t chunkserverTotalReadTimeout_ms,

--- a/src/mount/sauna_client.cc
+++ b/src/mount/sauna_client.cc
@@ -251,6 +251,8 @@ static double attr_cache_timeout = 0.1;
 static int mkdir_copy_sgid = 0;
 static int sugid_clear_mode = 0;
 bool use_rwlock = 0;
+static std::atomic<bool> gEnableAcl = true;
+static std::atomic<bool> gEnableXattrs = true;
 static std::atomic<bool> gDirectIo(false);
 
 // lock_request_counter shared by flock and setlk
@@ -337,6 +339,22 @@ void patch_uid_gid_fields(AttrReply &e) { patch_uid_gid_fields(e.attr); }
 
 static std::unique_ptr<AclCache> acl_cache;
 
+struct XattrCacheRecord {
+	uint8_t status;
+	std::vector<uint8_t> value;
+};
+
+typedef std::shared_ptr<XattrCacheRecord> XattrCacheEntry;
+typedef LruCache<
+		LruCacheOption::UseTreeMap,
+		LruCacheOption::Reentrant,
+		XattrCacheEntry,
+		inode_t, uint32_t, uint32_t, std::string> XattrCache;
+
+static std::unique_ptr<XattrCache> xattr_cache;
+static SteadyClock gXattrCacheClock;
+static const std::string kListXattrCacheKey;
+
 void update_readdir_session(uint64_t sessId, uint64_t entryIno) {
 	std::lock_guard<std::mutex> sessions_lock(gReaddirMutex);
 	gReaddirSessions[sessId].lastReadIno = entryIno;
@@ -392,6 +410,9 @@ static uint8_t updateNextReaddirEntryIndexIfMasterRestarted(ReaddirSession &read
 void masterDisconnectedCallback() {
 	gGroupCache.reset();
 	gDirEntryCache.clear();
+	if (xattr_cache) {
+		xattr_cache->clear();
+	}
 	std::lock_guard<std::mutex> sessions_lock(gReaddirMutex);
 	for (auto& rs : gReaddirSessions) {
 		rs.second.restarted = true;
@@ -402,6 +423,15 @@ inline void eraseAclCache(inode_t inode) {
 	acl_cache->erase(
 			inode    , 0, 0,
 			inode + 1, 0, 0);
+}
+
+inline void eraseXattrCache(inode_t inode) {
+	if (!xattr_cache) {
+		return;
+	}
+	xattr_cache->erase(
+			inode    , 0, 0, std::string(),
+			inode + 1, 0, 0, std::string());
 }
 
 // TODO consider making oplog_printf asynchronous
@@ -1924,7 +1954,7 @@ std::vector<DirEntry> readdir(Context &ctx, uint64_t fh, inode_t ino, off_t off,
 
 		struct stat stats;
 		attr_to_stat(it->inode,it->attr,&stats);
-		result.emplace_back(it->name, stats, entry_index); // nextEntryOffset = entry_index
+		result.emplace_back(it->name, stats, entry_index);
 	}
 
 	if (max_entries == 0) {
@@ -2663,6 +2693,83 @@ void fsync(Context &ctx, inode_t ino, int datasync, FileInfo* fi) {
 
 namespace {
 
+bool isAclXattrName(const char *name) {
+	return strcmp(name, "system.posix_acl_access") == 0 ||
+			strcmp(name, "system.posix_acl_default") == 0 ||
+			strcmp(name, "system.nfs4_acl") == 0 ||
+			strcmp(name, "system.richacl") == 0
+#ifdef __APPLE__
+			|| strcmp(name, "com.apple.system.Security") == 0
+#endif
+			;
+}
+
+std::vector<uint8_t> filterVisibleXattrs(const uint8_t *buff, uint32_t valueLength) {
+	std::vector<uint8_t> filtered;
+	if (valueLength == 0) {
+		return filtered;
+	}
+	if (!gEnableXattrs.load()) {
+		return filtered;
+	}
+	if (gEnableAcl.load()) {
+		filtered.assign(buff, buff + valueLength);
+		return filtered;
+	}
+
+	const uint8_t *current = buff;
+	const uint8_t *end = buff + valueLength;
+	while (current < end) {
+		const uint8_t *terminator = (const uint8_t*)memchr(current, '\0', end - current);
+		if (!terminator) {
+			break;
+		}
+		if (!isAclXattrName((const char*)current)) {
+			filtered.insert(filtered.end(), current, terminator + 1);
+		}
+		current = terminator + 1;
+	}
+	return filtered;
+}
+
+XattrCacheEntry loadListXattrCacheEntry(Context& ctx, inode_t ino, uint32_t uid, uint32_t gid,
+		const std::string&) {
+	const uint8_t *buff = nullptr;
+	uint32_t valueLength = 0;
+	uint8_t status;
+	RETRY_ON_ERROR_WITH_UPDATED_CREDENTIALS(status, ctx,
+		fs_listxattr(ino, 0, uid, gid, XATTR_GMODE_GET_DATA, &buff, &valueLength));
+	if (status != SAUNAFS_STATUS_OK) {
+		throw RequestException(status);
+	}
+
+	XattrCacheEntry entry(new XattrCacheRecord());
+	entry->status = status;
+	entry->value = filterVisibleXattrs(buff, valueLength);
+	return entry;
+}
+
+XattrCacheEntry loadPlainXattrCacheEntry(Context& ctx, inode_t ino, uint32_t uid, uint32_t gid,
+		const std::string &name) {
+	const uint8_t *buff = nullptr;
+	uint32_t valueLength = 0;
+	uint8_t status;
+	RETRY_ON_ERROR_WITH_UPDATED_CREDENTIALS(status, ctx,
+		fs_getxattr(ino, 0, uid, gid, (uint8_t)name.length(), (const uint8_t*)name.c_str(),
+			XATTR_GMODE_GET_DATA, &buff, &valueLength));
+	if (status != SAUNAFS_STATUS_OK && status != SAUNAFS_ERROR_ENOATTR &&
+			status != SAUNAFS_ERROR_ENODATA) {
+		throw RequestException(status);
+	}
+
+	XattrCacheEntry entry(new XattrCacheRecord());
+	entry->status = status;
+	if (status == SAUNAFS_STATUS_OK) {
+		entry->value.assign(buff, buff + valueLength);
+	}
+	return entry;
+}
+
 class XattrHandler {
 public:
 	virtual ~XattrHandler() {}
@@ -2701,6 +2808,9 @@ public:
 		RETRY_ON_ERROR_WITH_UPDATED_CREDENTIALS(status, ctx,
 			fs_setxattr(ino, 0, ctx.uid, ctx.gid, nleng, (const uint8_t*)name,
 				(uint32_t)size, (const uint8_t*)value, mode));
+		if (status == SAUNAFS_STATUS_OK) {
+			eraseXattrCache(ino);
+		}
 		return status;
 	}
 
@@ -2722,6 +2832,9 @@ public:
 		uint8_t status;
 		RETRY_ON_ERROR_WITH_UPDATED_CREDENTIALS(status, ctx,
 			fs_removexattr(ino, 0, ctx.uid, ctx.gid, nleng, (const uint8_t*)name));
+		if (status == SAUNAFS_STATUS_OK) {
+			eraseXattrCache(ino);
+		}
 		return status;
 	}
 };
@@ -2770,6 +2883,7 @@ public:
 		RETRY_ON_ERROR_WITH_UPDATED_CREDENTIALS(status, ctx,
 			fs_setacl(ino, ctx.uid, ctx.gid, type_, posix_acl));
 		eraseAclCache(ino);
+		eraseXattrCache(ino);
 		gDirEntryCache.lockAndInvalidateInode(ino);
 		return status;
 	}
@@ -2809,6 +2923,7 @@ public:
 		RETRY_ON_ERROR_WITH_UPDATED_CREDENTIALS(status, ctx,
 			fs_deletacl(ino, ctx.uid, ctx.gid, type_));
 		eraseAclCache(ino);
+		eraseXattrCache(ino);
 		return status;
 	}
 
@@ -2829,6 +2944,7 @@ public:
 		RETRY_ON_ERROR_WITH_UPDATED_CREDENTIALS(status, ctx,
 			fs_setacl(ino, ctx.uid, ctx.gid, acl));
 		eraseAclCache(ino);
+		eraseXattrCache(ino);
 		gDirEntryCache.lockAndInvalidateInode(ino);
 		return status;
 	}
@@ -2865,6 +2981,7 @@ public:
 		RETRY_ON_ERROR_WITH_UPDATED_CREDENTIALS(status, ctx,
 			fs_deletacl(ino, ctx.uid, ctx.gid, AclType::kRichACL));
 		eraseAclCache(ino);
+		eraseXattrCache(ino);
 		return status;
 	}
 private:
@@ -2883,6 +3000,7 @@ public:
 		RETRY_ON_ERROR_WITH_UPDATED_CREDENTIALS(status, ctx,
 			fs_setacl(ino, ctx.uid, ctx.gid, acl));
 		eraseAclCache(ino);
+		eraseXattrCache(ino);
 		gDirEntryCache.lockAndInvalidateInode(ino);
 		return status;
 	}
@@ -2919,6 +3037,7 @@ public:
 		RETRY_ON_ERROR_WITH_UPDATED_CREDENTIALS(status, ctx,
 			fs_deletacl(ino, ctx.uid, ctx.gid, AclType::kRichACL));
 		eraseAclCache(ino);
+		eraseXattrCache(ino);
 		return status;
 	}
 private:
@@ -2949,6 +3068,7 @@ public:
 		RETRY_ON_ERROR_WITH_UPDATED_CREDENTIALS(status, ctx,
 			fs_setacl(ino, ctx.uid, ctx.gid, result));
 		eraseAclCache(ino);
+		eraseXattrCache(ino);
 		gDirEntryCache.lockAndInvalidateInode(ino);
 		return status;
 	}
@@ -2983,6 +3103,7 @@ public:
 		RETRY_ON_ERROR_WITH_UPDATED_CREDENTIALS(status, ctx,
 			fs_deletacl(ino, ctx.uid, ctx.gid, AclType::kRichACL));
 		eraseAclCache(ino);
+		eraseXattrCache(ino);
 		return status;
 	}
 
@@ -3017,6 +3138,12 @@ static std::map<std::string, XattrHandler*> xattr_handlers = {
 };
 
 static XattrHandler* choose_xattr_handler(const char *name) {
+	if (!gEnableXattrs.load()) {
+		return &enotsupXattrHandler;
+	}
+	if (!gEnableAcl.load() && isAclXattrName(name)) {
+		return &enotsupXattrHandler;
+	}
 	try {
 		return xattr_handlers.at(name);
 	} catch (std::out_of_range&) {
@@ -3098,6 +3225,15 @@ void setxattr(Context &ctx, inode_t ino, const char *name, const char *value,
 				saunafs_error_string(SAUNAFS_ERROR_EINVAL));
 		throw RequestException(SAUNAFS_ERROR_EINVAL);
 	}
+	if (!gEnableXattrs.load()) {
+		oplog_printf(ctx, "setxattr (%" PRIiNode ",%s,%" PRIu64 ",%d): %s",
+				ino,
+				name,
+				(uint64_t)size,
+				flags,
+				saunafs_error_string(SAUNAFS_ERROR_ENOTSUP));
+		throw RequestException(SAUNAFS_ERROR_ENOTSUP);
+	}
 	if (strcmp(name,"security.capability")==0) {
 		oplog_printf(ctx, "setxattr (%" PRIiNode ",%s,%" PRIu64 ",%d): %s",
 				ino,
@@ -3146,6 +3282,7 @@ XattrReply getxattr(Context &ctx, inode_t ino, const char *name, size_t size, ui
 	std::vector<uint8_t> buffer;
 	const uint8_t *buff;
 	uint32_t leng;
+	XattrHandler *handler;
 
 
 	stats_inc(OP_GETXATTR);
@@ -3190,6 +3327,14 @@ XattrReply getxattr(Context &ctx, inode_t ino, const char *name, size_t size, ui
 				saunafs_error_string(SAUNAFS_ERROR_EINVAL));
 		throw RequestException(SAUNAFS_ERROR_EINVAL);
 	}
+	if (!gEnableXattrs.load()) {
+		oplog_printf(ctx, "getxattr (%" PRIiNode ",%s,%" PRIu64 "): %s",
+				ino,
+				name,
+				(uint64_t)size,
+				saunafs_error_string(SAUNAFS_ERROR_ENOTSUP));
+		throw RequestException(SAUNAFS_ERROR_ENOTSUP);
+	}
 	if (strcmp(name,"security.capability")==0) {
 		oplog_printf(ctx, "getxattr (%" PRIiNode ",%s,%" PRIu64 "): %s",
 				ino,
@@ -3204,7 +3349,25 @@ XattrReply getxattr(Context &ctx, inode_t ino, const char *name, size_t size, ui
 		mode = XATTR_GMODE_GET_DATA;
 	}
 	(void)position;
-	RETRY_ON_ERROR_WITH_UPDATED_CREDENTIALS(status, ctx, choose_xattr_handler(name)->getxattr(ctx, ino, name, nleng, mode, leng, buffer)) 
+	handler = choose_xattr_handler(name);
+	if (handler == &plainXattrHandler && xattr_cache) {
+		try {
+			auto cache_entry = xattr_cache->get(gXattrCacheClock.now(), ino, ctx.uid, ctx.gid,
+					std::string(name),
+					[&ctx](inode_t cache_ino, uint32_t uid, uint32_t gid,
+							const std::string &cache_name) {
+						return loadPlainXattrCacheEntry(ctx, cache_ino, uid, gid, cache_name);
+					});
+			status = cache_entry->status;
+			buffer = cache_entry->value;
+			leng = buffer.size();
+		} catch (RequestException &e) {
+			status = e.saunafs_error_code;
+		}
+	} else {
+		RETRY_ON_ERROR_WITH_UPDATED_CREDENTIALS(status, ctx,
+			handler->getxattr(ctx, ino, name, nleng, mode, leng, buffer));
+	}
 	buff = buffer.data();
 	if (status != SAUNAFS_STATUS_OK) {
 		oplog_printf(ctx, "getxattr (%" PRIiNode ",%s,%" PRIu64 "): %s",
@@ -3243,10 +3406,10 @@ XattrReply getxattr(Context &ctx, inode_t ino, const char *name, size_t size, ui
 }
 
 XattrReply listxattr(Context &ctx, inode_t ino, size_t size) {
+	std::vector<uint8_t> buffer;
 	const uint8_t *buff;
 	uint32_t leng;
 	int status;
-	uint8_t mode;
 
 	stats_inc(OP_LISTXATTR);
 	if (debug_mode) {
@@ -3261,13 +3424,36 @@ XattrReply listxattr(Context &ctx, inode_t ino, size_t size) {
 				saunafs_error_string(SAUNAFS_ERROR_EPERM));
 		throw RequestException(SAUNAFS_ERROR_EPERM);
 	}
-	if (size==0) {
-		mode = XATTR_GMODE_LENGTH_ONLY;
-	} else {
-		mode = XATTR_GMODE_GET_DATA;
+	if (!gEnableXattrs.load()) {
+		oplog_printf(ctx, "listxattr (%" PRIiNode ",%" PRIu64 "): OK (0)",
+				ino,
+				(uint64_t)size);
+		return XattrReply{0, {}};
 	}
-	RETRY_ON_ERROR_WITH_UPDATED_CREDENTIALS(status, ctx,
-		fs_listxattr(ino,0,ctx.uid,ctx.gid,mode,&buff,&leng));
+	if (xattr_cache) {
+		try {
+			auto cache_entry = xattr_cache->get(gXattrCacheClock.now(), ino, ctx.uid, ctx.gid,
+					kListXattrCacheKey,
+					[&ctx](inode_t cache_ino, uint32_t uid, uint32_t gid,
+							const std::string &cache_name) {
+						return loadListXattrCacheEntry(ctx, cache_ino, uid, gid, cache_name);
+					});
+			status = cache_entry->status;
+			buffer = cache_entry->value;
+			leng = buffer.size();
+		} catch (RequestException &e) {
+			status = e.saunafs_error_code;
+		}
+	} else {
+		uint8_t listMode = (size == 0 && gEnableAcl.load()) ? XATTR_GMODE_LENGTH_ONLY :
+				XATTR_GMODE_GET_DATA;
+		RETRY_ON_ERROR_WITH_UPDATED_CREDENTIALS(status, ctx,
+			fs_listxattr(ino, 0, ctx.uid, ctx.gid, listMode, &buff, &leng));
+		if (status == SAUNAFS_STATUS_OK && listMode == XATTR_GMODE_GET_DATA) {
+			buffer = filterVisibleXattrs(buff, leng);
+			leng = buffer.size();
+		}
+	}
 	if (status != SAUNAFS_STATUS_OK) {
 		oplog_printf(ctx, "listxattr (%" PRIiNode ",%" PRIu64 "): %s",
 				ino,
@@ -3282,6 +3468,7 @@ XattrReply listxattr(Context &ctx, inode_t ino, size_t size) {
 				leng);
 		return XattrReply{leng, {}};
 	} else {
+		buff = buffer.data();
 		if (leng>size) {
 			oplog_printf(ctx, "listxattr (%" PRIiNode ",%" PRIu64 "): %s",
 					ino,
@@ -3338,6 +3525,13 @@ void removexattr(Context &ctx, inode_t ino, const char *name) {
 				name,
 				saunafs_error_string(SAUNAFS_ERROR_EINVAL));
 		throw RequestException(SAUNAFS_ERROR_EINVAL);
+	}
+	if (!gEnableXattrs.load()) {
+		oplog_printf(ctx, "removexattr (%" PRIiNode ",%s): %s",
+				ino,
+				name,
+				saunafs_error_string(SAUNAFS_ERROR_ENOTSUP));
+		throw RequestException(SAUNAFS_ERROR_ENOTSUP);
 	}
 	status = choose_xattr_handler(name)->removexattr(ctx, ino, name, nleng);
 	if (status != SAUNAFS_STATUS_OK) {
@@ -3567,8 +3761,10 @@ std::vector<ChunkserverListEntry> getchunkservers() {
 void init(int debug_mode_, int keep_cache_, double direntry_cache_timeout_, unsigned direntry_cache_size_,
 		unsigned negative_cache_timeout_, unsigned negative_cache_size_,
 		double entry_cache_timeout_, double attr_cache_timeout_, int mkdir_copy_sgid_,
-		SugidClearMode sugid_clear_mode_, bool use_rwlock_,
-		double acl_cache_timeout_, unsigned acl_cache_size_, bool direct_io,
+		SugidClearMode sugid_clear_mode_, bool use_rwlock_, bool enable_acl_,
+		bool enable_xattrs_,
+		double acl_cache_timeout_, unsigned acl_cache_size_,
+		double xattr_cache_timeout_, unsigned xattr_cache_size_, bool direct_io,
 #ifdef _WIN32
 		int mounting_uid_, int mounting_gid_, std::unordered_set<uint32_t> &allowed_users_,
 		bool ignore_utimens_update_, unsigned acquired_files_cleanup_period_,
@@ -3601,6 +3797,8 @@ void init(int debug_mode_, int keep_cache_, double direntry_cache_timeout_, unsi
 	mkdir_copy_sgid = mkdir_copy_sgid_;
 	sugid_clear_mode = static_cast<decltype (sugid_clear_mode)>(sugid_clear_mode_);
 	use_rwlock = use_rwlock_;
+	gEnableXattrs = enable_xattrs_;
+	gEnableAcl = enable_acl_ && gEnableXattrs.load();
 	uint64_t timeout = (uint64_t)(direntry_cache_timeout * 1000000);
 	gDirEntryCache.setTimeout(timeout);
 	gDirEntryCacheMaxSize = direntry_cache_size_;
@@ -3613,15 +3811,30 @@ void init(int debug_mode_, int keep_cache_, double direntry_cache_timeout_, unsi
 		safs::log_debug("mkdir copy sgid={} sugid clear mode={}",
 		                mkdir_copy_sgid_, sugidClearModeString(sugid_clear_mode_));
 		safs::log_debug("RW lock {}", use_rwlock ? "enabled" : "disabled");
+		safs::log_debug("ACL support {}", gEnableAcl.load() ? "enabled" : "disabled");
+		safs::log_debug("XATTR support {}", gEnableXattrs.load() ? "enabled" : "disabled");
 		safs::log_debug("ACL acl_cache_timeout={:.2f}, acl_cache_size={}\n",
 		                acl_cache_timeout_, acl_cache_size_);
+		safs::log_debug("XATTR xattr_cache_timeout={:.2f}, xattr_cache_size={}\n",
+		                xattr_cache_timeout_, xattr_cache_size_);
 	}
 	statsptr_init();
 
-	acl_cache.reset(new AclCache(
-			std::chrono::milliseconds((int)(1000 * acl_cache_timeout_)),
-			acl_cache_size_,
-			getAcl));
+	if (gEnableAcl.load() && acl_cache_timeout_ > 0.0 && acl_cache_size_ > 0) {
+		acl_cache.reset(new AclCache(
+				std::chrono::milliseconds((int)(1000 * acl_cache_timeout_)),
+				acl_cache_size_,
+				getAcl));
+	} else {
+		acl_cache.reset();
+	}
+	if (gEnableXattrs.load() && xattr_cache_timeout_ > 0.0 && xattr_cache_size_ > 0) {
+		xattr_cache.reset(new XattrCache(
+				std::chrono::milliseconds((int)(1000 * xattr_cache_timeout_)),
+				xattr_cache_size_));
+	} else {
+		xattr_cache.reset();
+	}
 
 #ifdef __linux__
 	if (malloc_trim_period_ > 0) {
@@ -3631,6 +3844,8 @@ void init(int debug_mode_, int keep_cache_, double direntry_cache_timeout_, unsi
 
 	std::lock_guard lock(gMountInfoMtx);
 	gTweaks.registerVariable("DirectIO", gDirectIo, "sfsdirectio");
+	gTweaks.registerVariable("EnableAcl", gEnableAcl, "sfsacl");
+	gTweaks.registerVariable("EnableXattrs", gEnableXattrs, "sfsxattrs");
 	gTweaks.registerVariable("NegativeCacheTimeout", gNegativeCacheTimeoutMs, "sfsnegativecachetimeout");
 	gTweaks.registerVariable("NegativeCacheMaxSize", gNegativeCacheMaxSize, "sfsnegativecachesize");
 	gTweaks.registerVariable("StatfsCacheTimeout", gStatfsCacheTimeout, "statfscachetimeout");
@@ -3642,10 +3857,18 @@ void init(int debug_mode_, int keep_cache_, double direntry_cache_timeout_, unsi
 	gTweaks.registerVariable("AcquiredFilesCleanupTimeout", gCleanAcquiredFilesTimeout,
 	                         "sfscleanacquiredfilestimeout");
 #endif
-	gTweaks.registerVariable("AclCacheMaxTime", acl_cache->maxTime_ms, "aclcacheto");
-	gTweaks.registerVariable("AclCacheHit", acl_cache->cacheHit);
-	gTweaks.registerVariable("AclCacheExpired", acl_cache->cacheExpired);
-	gTweaks.registerVariable("AclCacheMiss", acl_cache->cacheMiss);
+	if (acl_cache) {
+		gTweaks.registerVariable("AclCacheMaxTime", acl_cache->maxTime_ms, "aclcacheto");
+		gTweaks.registerVariable("AclCacheHit", acl_cache->cacheHit);
+		gTweaks.registerVariable("AclCacheExpired", acl_cache->cacheExpired);
+		gTweaks.registerVariable("AclCacheMiss", acl_cache->cacheMiss);
+	}
+	if (xattr_cache) {
+		gTweaks.registerVariable("XattrCacheMaxTime", xattr_cache->maxTime_ms, "xattrcacheto");
+		gTweaks.registerVariable("XattrCacheHit", xattr_cache->cacheHit);
+		gTweaks.registerVariable("XattrCacheExpired", xattr_cache->cacheExpired);
+		gTweaks.registerVariable("XattrCacheMiss", xattr_cache->cacheMiss);
+	}
 }
 
 void fs_init(FsInitParams &params) {
@@ -3732,8 +3955,9 @@ void fs_init(FsInitParams &params) {
 	init(params.debug_mode, params.keep_cache, params.direntry_cache_timeout, params.direntry_cache_size,
 		params.negative_cache_timeout, params.negative_cache_size,
 		params.entry_cache_timeout, params.attr_cache_timeout, params.mkdir_copy_sgid,
-		params.sugid_clear_mode, params.use_rw_lock,
-		params.acl_cache_timeout, params.acl_cache_size, params.direct_io,
+		params.sugid_clear_mode, params.use_rw_lock, params.enable_acl, params.enable_xattrs,
+		params.acl_cache_timeout, params.acl_cache_size,
+		params.xattr_cache_timeout, params.xattr_cache_size, params.direct_io,
 #ifdef _WIN32
 		params.mounting_uid, params.mounting_gid, params.allowed_users,
 		params.ignore_utimens_update, params.clean_acquired_files_period,

--- a/src/mount/sauna_client.cc
+++ b/src/mount/sauna_client.cc
@@ -420,6 +420,9 @@ void masterDisconnectedCallback() {
 }
 
 inline void eraseAclCache(inode_t inode) {
+	if (!acl_cache) {
+		return;
+	}
 	acl_cache->erase(
 			inode    , 0, 0,
 			inode + 1, 0, 0);

--- a/src/mount/sauna_client.cc
+++ b/src/mount/sauna_client.cc
@@ -3913,6 +3913,7 @@ void fs_init(FsInitParams &params) {
 	}
 
 	read_data_init(params.io_retries,
+			params.chunkserver_latency_sort,
 			params.chunkserver_round_time_ms,
 			params.chunkserver_connect_timeout_ms,
 			params.chunkserver_wave_read_timeout_ms,

--- a/src/mount/sauna_client.h
+++ b/src/mount/sauna_client.h
@@ -138,6 +138,7 @@ struct FsInitParams {
 	static constexpr unsigned kDefaultXattrCacheSize = 10000;
 	static constexpr bool     kDefaultVerbose = false;
 	static constexpr bool     kDirectIO = false;
+	static constexpr bool     kDefaultChunkserverLatencySort = false;
 
 	// TLS related parameters
 	static constexpr std::string_view kDefaultTlsConfigFile = TlsSession::kNoFile;
@@ -148,6 +149,7 @@ struct FsInitParams {
 	             do_not_remember_password(kDefaultDoNotRememberPassword), delayed_init(kDefaultDelayedInit),
 	             report_reserved_period(kDefaultReportReservedPeriod),
 	             io_retries(kDefaultIoRetries),
+	             chunkserver_latency_sort(kDefaultChunkserverLatencySort),
 	             chunkserver_round_time_ms(kDefaultRoundTime),
 	             chunkserver_connect_timeout_ms(kDefaultChunkserverConnectTo),
 	             chunkserver_wave_read_timeout_ms(kDefaultChunkserverWaveReadTo),
@@ -200,6 +202,7 @@ struct FsInitParams {
 	             do_not_remember_password(kDefaultDoNotRememberPassword), delayed_init(kDefaultDelayedInit),
 	             report_reserved_period(kDefaultReportReservedPeriod),
 	             io_retries(kDefaultIoRetries),
+	             chunkserver_latency_sort(kDefaultChunkserverLatencySort),
 	             chunkserver_round_time_ms(kDefaultRoundTime),
 	             chunkserver_connect_timeout_ms(kDefaultChunkserverConnectTo),
 	             chunkserver_wave_read_timeout_ms(kDefaultChunkserverWaveReadTo),
@@ -259,6 +262,7 @@ struct FsInitParams {
 	unsigned report_reserved_period;
 
 	unsigned io_retries;
+	bool chunkserver_latency_sort;
 	unsigned chunkserver_round_time_ms;
 	unsigned chunkserver_connect_timeout_ms;
 	unsigned chunkserver_wave_read_timeout_ms;

--- a/src/mount/sauna_client.h
+++ b/src/mount/sauna_client.h
@@ -130,8 +130,12 @@ struct FsInitParams {
 	static constexpr SugidClearMode kDefaultSugidClearMode = SugidClearMode::kNever;
 #endif
 	static constexpr bool     kDefaultUseRwLock = true;
+	static constexpr bool     kDefaultEnableAcl = true;
+	static constexpr bool     kDefaultEnableXattrs = true;
 	static constexpr double   kDefaultAclCacheTimeout = 1.0;
 	static constexpr unsigned kDefaultAclCacheSize = 1000;
+	static constexpr double   kDefaultXattrCacheTimeout = 30.0;
+	static constexpr unsigned kDefaultXattrCacheSize = 10000;
 	static constexpr bool     kDefaultVerbose = false;
 	static constexpr bool     kDirectIO = false;
 
@@ -168,7 +172,9 @@ struct FsInitParams {
 	             entry_cache_timeout(kDefaultEntryCacheTimeout), attr_cache_timeout(kDefaultAttrCacheTimeout),
 	             mkdir_copy_sgid(kDefaultMkdirCopySgid), sugid_clear_mode(kDefaultSugidClearMode),
 	             use_rw_lock(kDefaultUseRwLock),
+	             enable_acl(kDefaultEnableAcl), enable_xattrs(kDefaultEnableXattrs),
 	             acl_cache_timeout(kDefaultAclCacheTimeout), acl_cache_size(kDefaultAclCacheSize),
+	             xattr_cache_timeout(kDefaultXattrCacheTimeout), xattr_cache_size(kDefaultXattrCacheSize),
 #ifdef _WIN32
 	             mounting_uid(USE_LOCAL_ID), mounting_gid(USE_LOCAL_ID),
 	             clean_acquired_files_period(kDefaultCleanAcquiredFilesPeriod),
@@ -218,7 +224,9 @@ struct FsInitParams {
 	             entry_cache_timeout(kDefaultEntryCacheTimeout), attr_cache_timeout(kDefaultAttrCacheTimeout),
 	             mkdir_copy_sgid(kDefaultMkdirCopySgid), sugid_clear_mode(kDefaultSugidClearMode),
 	             use_rw_lock(kDefaultUseRwLock),
+	             enable_acl(kDefaultEnableAcl), enable_xattrs(kDefaultEnableXattrs),
 	             acl_cache_timeout(kDefaultAclCacheTimeout), acl_cache_size(kDefaultAclCacheSize),
+	             xattr_cache_timeout(kDefaultXattrCacheTimeout), xattr_cache_size(kDefaultXattrCacheSize),
 #ifdef _WIN32
 	             mounting_uid(USE_LOCAL_ID), mounting_gid(USE_LOCAL_ID),
 	             clean_acquired_files_period(kDefaultCleanAcquiredFilesPeriod),
@@ -284,8 +292,12 @@ struct FsInitParams {
 	bool mkdir_copy_sgid;
 	SugidClearMode sugid_clear_mode;
 	bool use_rw_lock;
+	bool enable_acl;
+	bool enable_xattrs;
 	double acl_cache_timeout;
 	unsigned acl_cache_size;
+	double xattr_cache_timeout;
+	unsigned xattr_cache_size;
 #ifdef _WIN32
 	int mounting_uid;
 	int mounting_gid;

--- a/src/mount/writedata.cc
+++ b/src/mount/writedata.cc
@@ -978,11 +978,15 @@ void *write_worker(void *) {
 void write_data_init(uint32_t cachesize, uint32_t retries, uint32_t workers,
                      uint32_t writewindowsize, uint32_t chunkserverTimeout_ms,
                      uint32_t cachePerInodePercentage, uint32_t waveTimeout,
-                     uint32_t maxChunksWrittenInParallelPerInode) {
+                     uint32_t maxChunksWrittenInParallelPerInode,
+                     bool chunkserverLatencySort) {
 	uint64_t cachebytecount = uint64_t(cachesize) * 1024 * 1024;
 	uint64_t cacheblockcount = (cachebytecount / SFSBLOCKSIZE);
 	pthread_attr_t thattr;
 
+	globalChunkserverStats.setUseRoundTripTime(chunkserverLatencySort);
+	gChunkConnector.setChunkserverStats(
+	    chunkserverLatencySort ? &globalChunkserverStats : nullptr);
 	gChunkConnector.setSourceIp(fs_getsrcip());
 	gWriteWindowSize = writewindowsize;
 	gChunkserverTimeout_ms = chunkserverTimeout_ms;

--- a/src/mount/writedata.h
+++ b/src/mount/writedata.h
@@ -33,7 +33,8 @@ namespace WriteAlgorithm {
 void write_data_init(uint32_t cachesize, uint32_t retries, uint32_t workers,
                      uint32_t writewindowsize, uint32_t chunkserverTimeout_ms,
                      uint32_t cachePerInodePercentage, uint32_t waveTimeout,
-                     uint32_t maxChunksWrittenInParallelPerInode);
+                     uint32_t maxChunksWrittenInParallelPerInode,
+                     bool chunkserverLatencySort);
 void write_data_term(void);
 void *write_data_new(inode_t inode);
 int write_data_end(void *vid);


### PR DESCRIPTION
This PR adds three related sfsmount changes aimed at improving behavior on high-latency links.

It introduces mount controls for ACL/XATTR handling, adds optional latency-aware chunkserver selection, and provides a -o wan preset that enables a practical WAN-oriented configuration.

Included changes:

restore sfsacl=0|1
add sfsxattrs=0|1
add caching for listxattr() / getxattr() on the mount side
add sfschunkserverlatencysort=0|1
make latency-based chunkserver selection opt-in and keep health/failure state as the stronger signal
add -o wan as shorthand for:
sfschunkserverlatencysort=1,sfsacl=0,sfsxattrs=0,sfsdirentrycacheto=60,sfsdirentrycachesize=10000000
update sfsmount help and manpage documentation
These are client/mount-side changes only. No master or protocol changes are required.

The `-o wan` option makes Saunafs actually more responsive than NFS when the server is behind a WAN VPN wall. We saw improvements in multiple applications, including launching software that resides in Saunafs storage launching and responding faster than the same software residing in a NFS storage.  