### PR TITLE
refactor(master): vectorize chunk metadata

### DIFF
--- a/src/master/chunks.cc
+++ b/src/master/chunks.cc
@@ -38,6 +38,7 @@
 #include <random>
 #include <unordered_map>
 #include <utility>
+#include <vector>
 
 #include "common/chunk_copies_calculator.h"
 #include "common/chunk_version_with_todel_flag.h"
@@ -565,7 +566,7 @@ struct ChunksMetadata {
 	// chunks
 	chunk_bucket *cbhead;
 	Chunk *chfreehead;
-	Chunk *chunkhash[kChunkHashSize];
+	std::vector<Chunk *> chunkhash[kChunkHashSize];
 	uint64_t lastchunkid;
 	Chunk *lastchunkptr;
 
@@ -619,6 +620,7 @@ static ChunksMetadata *gChunksMetadata;
 #ifndef METARESTORE
 
 static Chunk *gCurrentChunkInZombieLoop = nullptr;
+static size_t gCurrentChunkInZombieLoopIndex = 0;
 
 class ReplicationDelayInfo {
 public:
@@ -753,9 +755,9 @@ ChecksumRecalculationStatus chunks_update_checksum_a_bit(uint32_t speedLimit) {
 	}
 	uint32_t recalculated = 0;
 	while (gChunksMetadata->checksumRecalculationPosition < kChunkHashSize) {
-		Chunk *c;
-		for (c = gChunksMetadata->chunkhash[gChunksMetadata->checksumRecalculationPosition]; c; c=c->next) {
-			chunk_checksum_add_to_background(c);
+		for (Chunk *chunk :
+		     gChunksMetadata->chunkhash[gChunksMetadata->checksumRecalculationPosition]) {
+			chunk_checksum_add_to_background(chunk);
 			++recalculated;
 		}
 		++gChunksMetadata->checksumRecalculationPosition;
@@ -776,9 +778,9 @@ ChecksumRecalculationStatus chunks_update_checksum_a_bit(uint32_t speedLimit) {
 static void chunk_recalculate_checksum() {
 	gChunksMetadata->chunksChecksum = CHECKSUMSEED;
 	for (int i = 0; i < kChunkHashSize; ++i) {
-		for (Chunk *ch = gChunksMetadata->chunkhash[i]; ch; ch = ch->next) {
-			ch->checksum = chunk_checksum(ch);
-			addToChecksum(gChunksMetadata->chunksChecksum, ch->checksum);
+		for (Chunk *chunk : gChunksMetadata->chunkhash[i]) {
+			chunk->checksum = chunk_checksum(chunk);
+			addToChecksum(gChunksMetadata->chunksChecksum, chunk->checksum);
 		}
 	}
 }
@@ -832,8 +834,7 @@ Chunk *chunk_new(uint64_t chunkid, uint32_t chunkversion) {
 	uint32_t chunkpos = chunkHashPos(chunkid);
 	Chunk *newchunk;
 	newchunk = chunk_malloc();
-	newchunk->next = gChunksMetadata->chunkhash[chunkpos];
-	gChunksMetadata->chunkhash[chunkpos] = newchunk;
+	gChunksMetadata->chunkhash[chunkpos].push_back(newchunk);
 	newchunk->chunkid = chunkid;
 	newchunk->version = chunkversion;
 	gChunksMetadata->lastchunkid = chunkid;
@@ -959,11 +960,10 @@ void chunk_handle_disconnected_copies(Chunk *c) {
 
 Chunk *chunk_find(uint64_t chunkid) {
 	uint32_t chunkpos = chunkHashPos(chunkid);
-	Chunk *chunkit;
 	if (gChunksMetadata->lastchunkid==chunkid) {
 		return gChunksMetadata->lastchunkptr;
 	}
-	for (chunkit = gChunksMetadata->chunkhash[chunkpos] ; chunkit ; chunkit = chunkit->next) {
+	for (Chunk *chunkit : gChunksMetadata->chunkhash[chunkpos]) {
 		if (chunkit->chunkid == chunkid) {
 			gChunksMetadata->lastchunkid = chunkid;
 			gChunksMetadata->lastchunkptr = chunkit;
@@ -973,7 +973,7 @@ Chunk *chunk_find(uint64_t chunkid) {
 			return chunkit;
 		}
 	}
-	return NULL;
+	return nullptr;
 }
 
 #ifndef METARESTORE
@@ -2027,6 +2027,15 @@ void chunk_server_label_changed(const MediaLabel &previousLabel, const MediaLabe
 	}
 }
 
+static Chunk *getCurrentChunkInBucket(uint32_t currentBucket, size_t currentBucketIndex) {
+	if (currentBucket >= kChunkHashSize) { return nullptr; }
+
+	const auto &bucket = gChunksMetadata->chunkhash[currentBucket];
+	if (currentBucketIndex >= bucket.size()) { return nullptr; }
+
+	return bucket[currentBucketIndex];
+}
+
 /*
  * A function that is called in every main loop iteration, that cleans chunk structs
  */
@@ -2040,7 +2049,9 @@ void chunk_clean_zombie_servers_a_bit() {
 
 	watchdog.start();
 	while (current_position < kChunkHashSize) {
-		for (; gCurrentChunkInZombieLoop; gCurrentChunkInZombieLoop = gCurrentChunkInZombieLoop->next) {
+		const auto &bucket = gChunksMetadata->chunkhash[current_position];
+		while (gCurrentChunkInZombieLoopIndex < bucket.size()) {
+			gCurrentChunkInZombieLoop = bucket[gCurrentChunkInZombieLoopIndex++];
 			chunk_handle_disconnected_copies(gCurrentChunkInZombieLoop);
 			if (watchdog.expired()) {
 				eventloop_make_next_poll_nonblocking();
@@ -2049,13 +2060,17 @@ void chunk_clean_zombie_servers_a_bit() {
 		}
 		++current_position;
 		if (current_position < kChunkHashSize) {
-			gCurrentChunkInZombieLoop = gChunksMetadata->chunkhash[current_position];
+			gCurrentChunkInZombieLoopIndex = 0;
+			gCurrentChunkInZombieLoop =
+			    getCurrentChunkInBucket(current_position, gCurrentChunkInZombieLoopIndex);
 		}
 	}
 	if (current_position >= kChunkHashSize) {
 		--gDisconnectedCounter;
 		current_position = 0;
-		gCurrentChunkInZombieLoop = gChunksMetadata->chunkhash[0];
+		gCurrentChunkInZombieLoopIndex = 0;
+		gCurrentChunkInZombieLoop =
+		    getCurrentChunkInBucket(current_position, gCurrentChunkInZombieLoopIndex);
 	}
 	eventloop_make_next_poll_nonblocking();
 }
@@ -2300,12 +2315,12 @@ private:
 
 	struct MainLoopStack {
 		uint32_t current_bucket;
+		size_t current_bucket_index;
 		uint16_t usable_server_count;
 		uint32_t chunks_done_count;
 		uint32_t buckets_done_count;
 		std::size_t endangered_to_serve;
-		Chunk* node;
-		Chunk* prev;
+		Chunk *node;
 		ActiveLoopWatchdog work_limit;
 		ActiveLoopWatchdog watchdog;
 	};
@@ -2346,6 +2361,7 @@ ChunkWorker::ChunkWorker()
 		  deleteLoopCount_(0) {
 	memset(&inforec_,0,sizeof(loop_info));
 	stack_.current_bucket = 0;
+	stack_.current_bucket_index = 0;
 }
 
 void ChunkWorker::doEveryLoopTasks() {
@@ -2972,34 +2988,26 @@ void ChunkWorker::doChunkJobs(Chunk *c, uint16_t serverCount) {
 bool ChunkWorker::deleteUnusedChunks() {
 	while (stack_.node != nullptr) {
 		chunk_handle_disconnected_copies(stack_.node);
+		auto &bucket = gChunksMetadata->chunkhash[stack_.current_bucket];
 		if (stack_.node->fileCount() == 0 && stack_.node->parts.empty()) {
-			// If current chunk in zombie loop is to be deleted, it must be updated
-			// to the next chunk
-			if (stack_.node == gCurrentChunkInZombieLoop) {
-				gCurrentChunkInZombieLoop = gCurrentChunkInZombieLoop->next;
-			}
-			// Something could be inserted between prev and node (when we yielded)
-			// so we need to make prev valid.
-			while (stack_.prev && stack_.prev->next != stack_.node) {
-				stack_.prev = stack_.prev->next;
-			}
+			assert(stack_.current_bucket_index < bucket.size());
+			assert(bucket[stack_.current_bucket_index] == stack_.node);
 
-			assert((!stack_.prev && gChunksMetadata->chunkhash[stack_.current_bucket] == stack_.node) ||
-			       (stack_.prev && stack_.prev->next == stack_.node));
+			if (stack_.node == gCurrentChunkInZombieLoop) { gCurrentChunkInZombieLoop = nullptr; }
 
-			if (stack_.prev) {
-				stack_.prev->next = stack_.node->next;
-			} else {
-				gChunksMetadata->chunkhash[stack_.current_bucket] =
-				        stack_.node->next;
+			Chunk *toDelete = bucket[stack_.current_bucket_index];
+			if (stack_.current_bucket_index + 1 < bucket.size()) {
+				std::swap(bucket[stack_.current_bucket_index], bucket.back());
 			}
+			bucket.pop_back();
+			chunk_delete(toDelete);
 
-			Chunk *tmp = stack_.node->next;
-			chunk_delete(stack_.node);
-			stack_.node = tmp;
+			stack_.node =
+			    getCurrentChunkInBucket(stack_.current_bucket, stack_.current_bucket_index);
 		} else {
-			stack_.prev = stack_.node;
-			stack_.node = stack_.node->next;
+			++stack_.current_bucket_index;
+			stack_.node =
+			    getCurrentChunkInBucket(stack_.current_bucket, stack_.current_bucket_index);
 		}
 
 		if (stack_.watchdog.expired()) {
@@ -3074,8 +3082,9 @@ void ChunkWorker::mainLoop() {
 			}
 
 			// delete unused chunks
-			stack_.prev = nullptr;
-			stack_.node = gChunksMetadata->chunkhash[stack_.current_bucket];
+			stack_.current_bucket_index = 0;
+			stack_.node =
+			    getCurrentChunkInBucket(stack_.current_bucket, stack_.current_bucket_index);
 			while (!deleteUnusedChunks()) {
 				yield;
 				stack_.watchdog.start();
@@ -3086,11 +3095,15 @@ void ChunkWorker::mainLoop() {
 			                           nullptr);
 			updateSortedServersIfNeeded();
 
-			stack_.node = gChunksMetadata->chunkhash[stack_.current_bucket];
+			stack_.current_bucket_index = 0;
+			stack_.node =
+			    getCurrentChunkInBucket(stack_.current_bucket, stack_.current_bucket_index);
 			while (stack_.node) {
 				doChunkJobs(stack_.node, stack_.usable_server_count);
 				++stack_.chunks_done_count;
-				stack_.node = stack_.node->next;
+				++stack_.current_bucket_index;
+				stack_.node =
+				    getCurrentChunkInBucket(stack_.current_bucket, stack_.current_bucket_index);
 
 				if (stack_.watchdog.expired()) {
 					yield;
@@ -3141,12 +3154,12 @@ constexpr uint32_t kSerializedChunkSizeWithLockId = 20;
 #ifdef METARESTORE
 
 void chunk_dump(void) {
-	Chunk *c;
 	uint32_t i;
 
-	for (i=0 ; i<kChunkHashSize ; i++) {
-		for (c=gChunksMetadata->chunkhash[i] ; c ; c=c->next) {
-			printf("*|i:%016" PRIX64 "|v:%08" PRIX32 "|g:%" PRIu8 "|t:%10" PRIu32 "\n",c->chunkid,c->version,c->highestIdGoal(),c->lockedto);
+	for (i = 0; i < kChunkHashSize; i++) {
+		for (Chunk *chunk : gChunksMetadata->chunkhash[i]) {
+			printf("*|i:%016" PRIX64 "|v:%08" PRIX32 "|g:%" PRIu8 "|t:%10" PRIu32 "\n",
+			       chunk->chunkid, chunk->version, chunk->highestIdGoal(), chunk->lockedto);
 		}
 	}
 }
@@ -3196,9 +3209,8 @@ void chunk_store(FILE *fd) {
 	uint8_t hdr[8];
 	uint8_t storebuff[kSerializedChunkSizeWithLockId * CHUNKCNT];
 	uint8_t *ptr;
-	uint32_t i,j;
-	Chunk *c;
-// chunkdata
+	uint32_t i, j;
+	// chunkdata
 	uint64_t chunkid;
 	uint32_t version;
 	uint32_t lockedto, lockid;
@@ -3210,7 +3222,7 @@ void chunk_store(FILE *fd) {
 	j=0;
 	ptr = storebuff;
 	for (i=0 ; i<kChunkHashSize ; i++) {
-		for (c=gChunksMetadata->chunkhash[i] ; c ; c=c->next) {
+		for (Chunk *c : gChunksMetadata->chunkhash[i]) {
 #ifndef METARESTORE
 			chunk_handle_disconnected_copies(c);
 #endif

--- a/src/master/chunks.cc
+++ b/src/master/chunks.cc
@@ -28,6 +28,7 @@
 #include <syslog.h>
 #include <unistd.h>
 #include <algorithm>
+#include <array>
 #include <cinttypes>
 #include <cstdint>
 #include <cstdio>
@@ -553,44 +554,28 @@ uint64_t Chunk::allFullChunkCopies[CHUNK_MATRIX_SIZE][CHUNK_MATRIX_SIZE];
 #endif
 
 #define CHUNK_BUCKET_SIZE 20000
-struct chunk_bucket {
-	Chunk bucket[CHUNK_BUCKET_SIZE];
-	uint32_t firstfree;
-	chunk_bucket *next;
+struct ChunkBucket {
+	std::array<Chunk, CHUNK_BUCKET_SIZE> bucket;
+	uint32_t firstAvailableChunk{};
 };
 
 namespace {
 struct ChunksMetadata {
 	// chunks
-	chunk_bucket *cbhead;
+	std::vector<std::unique_ptr<ChunkBucket>> chunkBuckets;
 	std::vector<Chunk *> availableChunks;
-	std::vector<Chunk *> chunkhash[kChunkHashSize];
-	uint64_t lastchunkid;
-	Chunk *lastchunkptr;
+	std::vector<Chunk *> chunkhash[kChunkHashSize]{};
+	uint64_t lastchunkid{};
+	Chunk *lastchunkptr{};
 
 	// other chunks metadata information
-	uint64_t chunksChecksum;
-	uint64_t chunksChecksumRecalculated;
-	uint32_t checksumRecalculationPosition;
+	uint64_t chunksChecksum{};
+	uint64_t chunksChecksumRecalculated{};
+	uint32_t checksumRecalculationPosition{};
 
-	ChunksMetadata() :
-			cbhead{},
-			availableChunks{},
-			chunkhash{},
-			lastchunkid{},
-			lastchunkptr{},
-			chunksChecksum{},
-			chunksChecksumRecalculated{},
-			checksumRecalculationPosition{0} {
-	}
+	ChunksMetadata() = default;
 
-	~ChunksMetadata() {
-		chunk_bucket *cbn;
-		for (chunk_bucket *cb = cbhead; cb; cb = cbn) {
-			cbn = cb->next;
-			delete cb;
-		}
-	}
+	~ChunksMetadata() = default;
 
 	/// Gets the id that will be assigned to the next created chunk without incrementing it.
 	static uint64_t getNextChunkId() {
@@ -800,7 +785,6 @@ uint64_t chunk_checksum(ChecksumMode mode) {
 }
 
 static inline Chunk *chunk_malloc() {
-	chunk_bucket *cb;
 	Chunk *ret;
 	if (!gChunksMetadata->availableChunks.empty()) {
 		ret = gChunksMetadata->availableChunks.back();
@@ -808,14 +792,17 @@ static inline Chunk *chunk_malloc() {
 		ret->clear();
 		return ret;
 	}
-	if (gChunksMetadata->cbhead==NULL || gChunksMetadata->cbhead->firstfree==CHUNK_BUCKET_SIZE) {
-		cb = new chunk_bucket;
-		cb->next = gChunksMetadata->cbhead;
-		cb->firstfree = 0;
-		gChunksMetadata->cbhead = cb;
+
+	if (gChunksMetadata->chunkBuckets.empty() ||
+	    gChunksMetadata->chunkBuckets.back()->firstAvailableChunk == CHUNK_BUCKET_SIZE) {
+		auto chunkBucket = std::make_unique<ChunkBucket>();
+		chunkBucket->firstAvailableChunk = 0;
+		gChunksMetadata->chunkBuckets.push_back(std::move(chunkBucket));
 	}
-	ret = (gChunksMetadata->cbhead->bucket)+(gChunksMetadata->cbhead->firstfree);
-	gChunksMetadata->cbhead->firstfree++;
+
+	auto &currentBucket = gChunksMetadata->chunkBuckets.back();
+	ret = &(currentBucket->bucket[currentBucket->firstAvailableChunk]);
+	currentBucket->firstAvailableChunk++;
 	ret->clear();
 	return ret;
 }

--- a/src/master/chunks.cc
+++ b/src/master/chunks.cc
@@ -603,6 +603,7 @@ static ChunksMetadata *gChunksMetadata;
 #ifndef METARESTORE
 
 static Chunk *gCurrentChunkInZombieLoop = nullptr;
+static uint32_t gCurrentChunkInZombieLoopBucket = kChunkHashSize;
 static size_t gCurrentChunkInZombieLoopIndex = 0;
 
 class ReplicationDelayInfo {
@@ -2033,6 +2034,7 @@ void chunk_clean_zombie_servers_a_bit() {
 
 	watchdog.start();
 	while (current_position < kChunkHashSize) {
+		gCurrentChunkInZombieLoopBucket = current_position;
 		const auto &bucket = gChunksMetadata->chunkhash[current_position];
 		while (gCurrentChunkInZombieLoopIndex < bucket.size()) {
 			gCurrentChunkInZombieLoop = bucket[gCurrentChunkInZombieLoopIndex++];
@@ -2052,6 +2054,7 @@ void chunk_clean_zombie_servers_a_bit() {
 	if (current_position >= kChunkHashSize) {
 		--gDisconnectedCounter;
 		current_position = 0;
+		gCurrentChunkInZombieLoopBucket = current_position;
 		gCurrentChunkInZombieLoopIndex = 0;
 		gCurrentChunkInZombieLoop =
 		    getCurrentChunkInBucket(current_position, gCurrentChunkInZombieLoopIndex);
@@ -2977,13 +2980,14 @@ bool ChunkWorker::deleteUnusedChunks() {
 			assert(stack_.current_bucket_index < bucket.size());
 			assert(bucket[stack_.current_bucket_index] == stack_.node);
 
+			if (stack_.current_bucket == gCurrentChunkInZombieLoopBucket &&
+			    stack_.current_bucket_index < gCurrentChunkInZombieLoopIndex) {
+				--gCurrentChunkInZombieLoopIndex;
+			}
 			if (stack_.node == gCurrentChunkInZombieLoop) { gCurrentChunkInZombieLoop = nullptr; }
 
 			Chunk *toDelete = bucket[stack_.current_bucket_index];
-			if (stack_.current_bucket_index + 1 < bucket.size()) {
-				std::swap(bucket[stack_.current_bucket_index], bucket.back());
-			}
-			bucket.pop_back();
+			bucket.erase(bucket.begin() + static_cast<std::ptrdiff_t>(stack_.current_bucket_index));
 			chunk_delete(toDelete);
 
 			stack_.node =

--- a/src/master/chunks.cc
+++ b/src/master/chunks.cc
@@ -602,8 +602,13 @@ static ChunksMetadata *gChunksMetadata;
 
 #ifndef METARESTORE
 
+// Last chunk processed by the zombie loop
 static Chunk *gCurrentChunkInZombieLoop = nullptr;
-static uint32_t gCurrentChunkInZombieLoopBucket = kChunkHashSize;
+// Hash bucket currently being scanned
+static uint32_t gCurrentChunkInZombieLoopBucket = 0;
+// Outer iteration index over chunkhash
+static uint32_t gCurrentChunkInZombieLoopPosition = 0;
+// Index within the current bucket's vector
 static size_t gCurrentChunkInZombieLoopIndex = 0;
 
 class ReplicationDelayInfo {
@@ -1989,8 +1994,13 @@ void chunk_server_disconnected(matocsserventry */*ptr*/, const MediaLabel &label
 		replicationDelayInfoForLabel[label].serverDisconnected();
 	}
 	// If chunkserver disconnects, we can assure it was processed by zombie server loop
-	// only if the loop was executed at least twice.
+	// only if the loop was executed at least twice. Reset the scan position so the
+	// next call starts from the beginning, ensuring both passes cover all chunks.
 	gDisconnectedCounter = 2;
+	gCurrentChunkInZombieLoopPosition = 0;
+	gCurrentChunkInZombieLoopBucket = 0;
+	gCurrentChunkInZombieLoopIndex = 0;
+	gCurrentChunkInZombieLoop = nullptr;
 	eventloop_make_next_poll_nonblocking();
 	fs_cs_disconnected();
 	gChunksMetadata->lastchunkid = 0;
@@ -2026,16 +2036,15 @@ static Chunk *getCurrentChunkInBucket(uint32_t currentBucket, size_t currentBuck
  */
 void chunk_clean_zombie_servers_a_bit() {
 	SignalLoopWatchdog watchdog;
-	static uint32_t current_position = kChunkHashSize;
 
 	if (gDisconnectedCounter == 0) {
 		return;
 	}
 
 	watchdog.start();
-	while (current_position < kChunkHashSize) {
-		gCurrentChunkInZombieLoopBucket = current_position;
-		const auto &bucket = gChunksMetadata->chunkhash[current_position];
+	while (gCurrentChunkInZombieLoopPosition < kChunkHashSize) {
+		gCurrentChunkInZombieLoopBucket = gCurrentChunkInZombieLoopPosition;
+		const auto &bucket = gChunksMetadata->chunkhash[gCurrentChunkInZombieLoopPosition];
 		while (gCurrentChunkInZombieLoopIndex < bucket.size()) {
 			gCurrentChunkInZombieLoop = bucket[gCurrentChunkInZombieLoopIndex++];
 			chunk_handle_disconnected_copies(gCurrentChunkInZombieLoop);
@@ -2044,21 +2053,19 @@ void chunk_clean_zombie_servers_a_bit() {
 				return;
 			}
 		}
-		++current_position;
-		if (current_position < kChunkHashSize) {
+		++gCurrentChunkInZombieLoopPosition;
+		if (gCurrentChunkInZombieLoopPosition < kChunkHashSize) {
 			gCurrentChunkInZombieLoopIndex = 0;
-			gCurrentChunkInZombieLoop =
-			    getCurrentChunkInBucket(current_position, gCurrentChunkInZombieLoopIndex);
+			gCurrentChunkInZombieLoop = getCurrentChunkInBucket(gCurrentChunkInZombieLoopPosition,
+			                                                    gCurrentChunkInZombieLoopIndex);
 		}
 	}
-	if (current_position >= kChunkHashSize) {
-		--gDisconnectedCounter;
-		current_position = 0;
-		gCurrentChunkInZombieLoopBucket = current_position;
-		gCurrentChunkInZombieLoopIndex = 0;
-		gCurrentChunkInZombieLoop =
-		    getCurrentChunkInBucket(current_position, gCurrentChunkInZombieLoopIndex);
-	}
+	--gDisconnectedCounter;
+	gCurrentChunkInZombieLoopPosition = 0;
+	gCurrentChunkInZombieLoopBucket = 0;
+	gCurrentChunkInZombieLoopIndex = 0;
+	gCurrentChunkInZombieLoop =
+	    getCurrentChunkInBucket(gCurrentChunkInZombieLoopPosition, gCurrentChunkInZombieLoopIndex);
 	eventloop_make_next_poll_nonblocking();
 }
 

--- a/src/master/chunks.cc
+++ b/src/master/chunks.cc
@@ -256,7 +256,6 @@ public:
 
 	uint64_t chunkid;
 	uint64_t checksum;
-	Chunk *next;
 #ifndef METARESTORE
 	compact_vector<ChunkPart> parts;
 #endif
@@ -301,7 +300,6 @@ public:
 
 	void clear() {
 		goalCounters_.clear();
-		next = nullptr;
 		chunkid = 0;
 		version = 0;
 		lockid = 0;
@@ -565,7 +563,7 @@ namespace {
 struct ChunksMetadata {
 	// chunks
 	chunk_bucket *cbhead;
-	Chunk *chfreehead;
+	std::vector<Chunk *> availableChunks;
 	std::vector<Chunk *> chunkhash[kChunkHashSize];
 	uint64_t lastchunkid;
 	Chunk *lastchunkptr;
@@ -577,7 +575,7 @@ struct ChunksMetadata {
 
 	ChunksMetadata() :
 			cbhead{},
-			chfreehead{},
+			availableChunks{},
 			chunkhash{},
 			lastchunkid{},
 			lastchunkptr{},
@@ -804,9 +802,9 @@ uint64_t chunk_checksum(ChecksumMode mode) {
 static inline Chunk *chunk_malloc() {
 	chunk_bucket *cb;
 	Chunk *ret;
-	if (gChunksMetadata->chfreehead) {
-		ret = gChunksMetadata->chfreehead;
-		gChunksMetadata->chfreehead = ret->next;
+	if (!gChunksMetadata->availableChunks.empty()) {
+		ret = gChunksMetadata->availableChunks.back();
+		gChunksMetadata->availableChunks.pop_back();
 		ret->clear();
 		return ret;
 	}
@@ -824,8 +822,7 @@ static inline Chunk *chunk_malloc() {
 
 #ifndef METARESTORE
 static inline void chunk_free(Chunk *p) {
-	p->next = gChunksMetadata->chfreehead;
-	gChunksMetadata->chfreehead = p;
+	gChunksMetadata->availableChunks.push_back(p);
 	p->inEndangeredQueue = 0;
 }
 #endif /* METARESTORE */

--- a/src/master/chunks.cc
+++ b/src/master/chunks.cc
@@ -564,7 +564,7 @@ struct ChunksMetadata {
 	// chunks
 	std::vector<std::unique_ptr<ChunkBucket>> chunkBuckets;
 	std::vector<Chunk *> availableChunks;
-	std::vector<Chunk *> chunkhash[kChunkHashSize]{};
+	compact_vector<Chunk *> chunkhash[kChunkHashSize]{};
 	uint64_t lastchunkid{};
 	Chunk *lastchunkptr{};
 

--- a/src/master/chunks.cc
+++ b/src/master/chunks.cc
@@ -602,12 +602,8 @@ static ChunksMetadata *gChunksMetadata;
 
 #ifndef METARESTORE
 
-// Last chunk processed by the zombie loop
-static Chunk *gCurrentChunkInZombieLoop = nullptr;
-// Hash bucket currently being scanned
-static uint32_t gCurrentChunkInZombieLoopBucket = 0;
 // Outer iteration index over chunkhash
-static uint32_t gCurrentChunkInZombieLoopPosition = 0;
+static uint32_t gCurrentBucketInZombieLoop = 0;
 // Index within the current bucket's vector
 static size_t gCurrentChunkInZombieLoopIndex = 0;
 
@@ -953,14 +949,14 @@ Chunk *chunk_find(uint64_t chunkid) {
 	if (gChunksMetadata->lastchunkid==chunkid) {
 		return gChunksMetadata->lastchunkptr;
 	}
-	for (Chunk *chunkit : gChunksMetadata->chunkhash[chunkpos]) {
-		if (chunkit->chunkid == chunkid) {
+	for (Chunk *chunk : gChunksMetadata->chunkhash[chunkpos]) {
+		if (chunk->chunkid == chunkid) {
 			gChunksMetadata->lastchunkid = chunkid;
-			gChunksMetadata->lastchunkptr = chunkit;
+			gChunksMetadata->lastchunkptr = chunk;
 #ifndef METARESTORE
-			chunk_handle_disconnected_copies(chunkit);
+			chunk_handle_disconnected_copies(chunk);
 #endif // METARESTORE
-			return chunkit;
+			return chunk;
 		}
 	}
 	return nullptr;
@@ -1997,10 +1993,8 @@ void chunk_server_disconnected(matocsserventry */*ptr*/, const MediaLabel &label
 	// only if the loop was executed at least twice. Reset the scan position so the
 	// next call starts from the beginning, ensuring both passes cover all chunks.
 	gDisconnectedCounter = 2;
-	gCurrentChunkInZombieLoopPosition = 0;
-	gCurrentChunkInZombieLoopBucket = 0;
+	gCurrentBucketInZombieLoop = 0;
 	gCurrentChunkInZombieLoopIndex = 0;
-	gCurrentChunkInZombieLoop = nullptr;
 	eventloop_make_next_poll_nonblocking();
 	fs_cs_disconnected();
 	gChunksMetadata->lastchunkid = 0;
@@ -2037,35 +2031,31 @@ static Chunk *getCurrentChunkInBucket(uint32_t currentBucket, size_t currentBuck
 void chunk_clean_zombie_servers_a_bit() {
 	SignalLoopWatchdog watchdog;
 
-	if (gDisconnectedCounter == 0) {
-		return;
-	}
+	if (gDisconnectedCounter == 0) { return; }
 
 	watchdog.start();
-	while (gCurrentChunkInZombieLoopPosition < kChunkHashSize) {
-		gCurrentChunkInZombieLoopBucket = gCurrentChunkInZombieLoopPosition;
-		const auto &bucket = gChunksMetadata->chunkhash[gCurrentChunkInZombieLoopPosition];
+
+	while (gCurrentBucketInZombieLoop < kChunkHashSize) {
+		const auto &bucket = gChunksMetadata->chunkhash[gCurrentBucketInZombieLoop];
+
 		while (gCurrentChunkInZombieLoopIndex < bucket.size()) {
-			gCurrentChunkInZombieLoop = bucket[gCurrentChunkInZombieLoopIndex++];
-			chunk_handle_disconnected_copies(gCurrentChunkInZombieLoop);
+			chunk_handle_disconnected_copies(bucket[gCurrentChunkInZombieLoopIndex++]);
+
 			if (watchdog.expired()) {
 				eventloop_make_next_poll_nonblocking();
 				return;
 			}
 		}
-		++gCurrentChunkInZombieLoopPosition;
-		if (gCurrentChunkInZombieLoopPosition < kChunkHashSize) {
-			gCurrentChunkInZombieLoopIndex = 0;
-			gCurrentChunkInZombieLoop = getCurrentChunkInBucket(gCurrentChunkInZombieLoopPosition,
-			                                                    gCurrentChunkInZombieLoopIndex);
-		}
+
+		++gCurrentBucketInZombieLoop;
+
+		if (gCurrentBucketInZombieLoop < kChunkHashSize) { gCurrentChunkInZombieLoopIndex = 0; }
 	}
+
 	--gDisconnectedCounter;
-	gCurrentChunkInZombieLoopPosition = 0;
-	gCurrentChunkInZombieLoopBucket = 0;
+	gCurrentBucketInZombieLoop = 0;
 	gCurrentChunkInZombieLoopIndex = 0;
-	gCurrentChunkInZombieLoop =
-	    getCurrentChunkInBucket(gCurrentChunkInZombieLoopPosition, gCurrentChunkInZombieLoopIndex);
+
 	eventloop_make_next_poll_nonblocking();
 }
 
@@ -2987,11 +2977,10 @@ bool ChunkWorker::deleteUnusedChunks() {
 			assert(stack_.current_bucket_index < bucket.size());
 			assert(bucket[stack_.current_bucket_index] == stack_.node);
 
-			if (stack_.current_bucket == gCurrentChunkInZombieLoopBucket &&
+			if (stack_.current_bucket == gCurrentBucketInZombieLoop &&
 			    stack_.current_bucket_index < gCurrentChunkInZombieLoopIndex) {
 				--gCurrentChunkInZombieLoopIndex;
 			}
-			if (stack_.node == gCurrentChunkInZombieLoop) { gCurrentChunkInZombieLoop = nullptr; }
 
 			Chunk *toDelete = bucket[stack_.current_bucket_index];
 			bucket.erase(bucket.begin() + static_cast<std::ptrdiff_t>(stack_.current_bucket_index));


### PR DESCRIPTION
Port the chunk metadata container refactor from
refactor-chunks-metadata.

Replace linked chunk-hash traversal with compact_vector<Chunk *> iteration
across lookup, checksum, zombie cleanup, worker loops, and METARESTORE
dump/store paths.

Remove the remaining Chunk::next reuse path by tracking reusable chunks in
ChunksMetadata::availableChunks.

Replace the bucket chain with
std::vector<std::unique_ptr<ChunkBucket>> and simplify
ChunksMetadata initialization with default member initializers and a
defaulted constructor.

LS-564