### PR TITLE
doc: delete lazy flag from rremove manpage

### DIFF
--- a/doc/saunafs-rremove.1.adoc
+++ b/doc/saunafs-rremove.1.adoc
@@ -8,7 +8,7 @@ saunafs-rremove - remove recursively
 == SYNOPSIS
 
 [verse]
-*saunafs-rremove* [*-l*] 'OBJECT'...
+*saunafs-rremove* 'OBJECT'...
 
 == DESCRIPTION
 

--- a/doc/saunafs.1.adoc
+++ b/doc/saunafs.1.adoc
@@ -55,7 +55,7 @@ saunafs - open prompt to perform SaunaFS-specific operations
 *saunafs makesnapshot* [*-o*] 'SOURCE'... 'DESTINATION'
 
 [verse]
-*saunafs rremove* [*-l*] 'OBJECT'...
+*saunafs rremove* 'OBJECT'...
 
 == DESCRIPTION
 


### PR DESCRIPTION
As lazy option was removed from v5.0.0, it is not needed to reference it on manpages from current tools binaries. This commits fixes that issue for rremove manpages references.

Fixes inconsistency detected on rremove manpages on: https://github.com/leil-io/leilfs/issues/830