### PR TITLE
refactor(master): route trash/reserved via ops

### DIFF
--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -202,6 +202,20 @@ void FilesystemNodeOperationsBase::nodeQuotaRemove(
 	fsnodes_quota_remove(ownerType, ownerId);
 }
 
+void FilesystemNodeOperationsBase::updateDetachedSpaceUsage(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, const FSNodeFile *nodeFile,
+    uint64_t previousLength, uint64_t newLength) {
+	if (previousLength == newLength) { return; }
+
+	if (nodeFile->type == FSNodeType::kTrash) {
+		gMetadata->trashSpace -= previousLength;
+		gMetadata->trashSpace += newLength;
+	} else if (nodeFile->type == FSNodeType::kReserved) {
+		gMetadata->reservedSpace -= previousLength;
+		gMetadata->reservedSpace += newLength;
+	}
+}
+
 // Public methods
 
 FSNode *FilesystemNodeOperationsBase::lookup(
@@ -223,7 +237,8 @@ FSNode *FilesystemNodeOperationsBase::lookup(
 	return nullptr;
 }
 
-void FilesystemNodeOperationsBase::updateCTime(FSNode *node, uint32_t ctime) {
+void FilesystemNodeOperationsBase::updateCTime(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, FSNode *node, uint32_t ctime) {
 	if (node->type == FSNodeType::kTrash && node->ctime != ctime) {
 		auto oldKey = TrashPathKey(node);
 		node->ctime = ctime;
@@ -1315,17 +1330,12 @@ uint8_t FilesystemNodeOperationsBase::appendChunks(const FilesystemOperationCont
 		}
 	}
 
+	uint64_t previousLength = destNodeFile->length;
+
 	// Calculate the new total length after appending
 	uint64_t length = (static_cast<uint64_t>(dstChunks) << SFSCHUNKBITS) + srcNodeFile->length;
 
-	// Update trash or reserved space counters if the destination is in trash or reserved
-	if (destNodeFile->type == FSNodeType::kTrash) {
-		gMetadata->trashSpace -= destNodeFile->length;
-		gMetadata->trashSpace += length;
-	} else if (destNodeFile->type == FSNodeType::kReserved) {
-		gMetadata->reservedSpace -= destNodeFile->length;
-		gMetadata->reservedSpace += length;
-	}
+	updateDetachedSpaceUsage(fsOpContext, destNodeFile, previousLength, length);
 
 	destNodeFile->length = length;
 	getStats(fsOpContext, destNodeFile, &newStats);
@@ -1384,15 +1394,10 @@ void FilesystemNodeOperationsBase::setLength(const FilesystemOperationContext &f
 	uint32_t chunks = 0;
 	StatsRecord previousStats;
 	StatsRecord newStats;
+	uint64_t previousLength = nodeFile->length;
 	getStats(fsOpContext, nodeFile, &previousStats);
 
-	if (nodeFile->type == FSNodeType::kTrash) {
-		gMetadata->trashSpace -= nodeFile->length;
-		gMetadata->trashSpace += length;
-	} else if (nodeFile->type == FSNodeType::kReserved) {
-		gMetadata->reservedSpace -= nodeFile->length;
-		gMetadata->reservedSpace += length;
-	}
+	updateDetachedSpaceUsage(fsOpContext, nodeFile, previousLength, length);
 
 	nodeFile->length = length;
 
@@ -1455,6 +1460,51 @@ void FilesystemNodeOperationsBase::changeUidGid(const FilesystemOperationContext
 	} else {
 		nodeQuotaUpdate(fsOpContext, node, {{QuotaResource::kInodes, +1}});
 	}
+}
+
+namespace {
+
+/// Returns true when a path segment of the given length consisting entirely of dots is a
+/// dot-only name (".") or dot-dot name (".."), which are invalid in trash paths.
+bool isDotOnlySegment(uint32_t segmentLength, uint32_t dotCount) {
+	return segmentLength == dotCount && segmentLength <= 2;
+}
+
+}  // namespace
+
+uint8_t FilesystemNodeOperationsBase::validateTrashPath(const std::string &pathStr) {
+	if (pathStr.empty()) { return SAUNAFS_ERROR_CANTCREATEPATH; }
+
+	// Skip leading slashes
+	size_t start = pathStr.find_first_not_of('/');
+	if (start == std::string::npos) { return SAUNAFS_ERROR_CANTCREATEPATH; }
+
+	std::string_view path(pathStr);
+	path.remove_prefix(start);
+
+	uint32_t partLength = 0;
+	uint32_t dots = 0;
+
+	for (char chr : path) {
+		if (chr == '\0') { return SAUNAFS_ERROR_CANTCREATEPATH; }
+
+		if (chr == '/') {
+			if (partLength == 0) { return SAUNAFS_ERROR_CANTCREATEPATH; }  // "//"
+			if (isDotOnlySegment(partLength, dots)) { return SAUNAFS_ERROR_CANTCREATEPATH; }
+			partLength = 0;
+			dots = 0;
+		} else {
+			if (chr == '.') { dots++; }
+			partLength++;
+			if (partLength > kMaxFileNameLength) { return SAUNAFS_ERROR_CANTCREATEPATH; }
+		}
+	}
+
+	// Last segment must be non-empty and not a dot-only name
+	if (partLength == 0) { return SAUNAFS_ERROR_CANTCREATEPATH; }
+	if (isDotOnlySegment(partLength, dots)) { return SAUNAFS_ERROR_CANTCREATEPATH; }
+
+	return SAUNAFS_STATUS_OK;
 }
 
 void FilesystemNodeOperationsBase::removeNode(const FilesystemOperationContext &fsOpContext,
@@ -1630,52 +1680,19 @@ uint8_t FilesystemNodeOperationsBase::undel(const FilesystemOperationContext &fs
 		pathStr = (std::string)gMetadata->reserved.at(node->id);
 	}
 
-	const char *path = pathStr.c_str();
-	unsigned pathLength = pathStr.length();
+	uint8_t validationStatus = validateTrashPath(pathStr);
+	if (validationStatus != SAUNAFS_STATUS_OK) { return validationStatus; }
 
-	if (pathStr.empty()) { return SAUNAFS_ERROR_CANTCREATEPATH; }
-
-	while (*path == '/' && pathLength > 0) {
-		path++;
-		pathLength--;
-	}
-
-	if (pathLength == 0) { return SAUNAFS_ERROR_CANTCREATEPATH; }
-
-	uint32_t partLength = 0;
-	uint32_t dots = 0;
-
-	for (uint32_t i = 0; i < pathLength; i++) {
-		if (path[i] == 0) {  // incorrect name character
-			return SAUNAFS_ERROR_CANTCREATEPATH;
-		}
-
-		if (path[i] == '/') {
-			if (partLength == 0) {  // "//" in path
-				return SAUNAFS_ERROR_CANTCREATEPATH;
-			}
-			if (partLength == dots && partLength <= 2) {  // '.' or '..' in path
-				return SAUNAFS_ERROR_CANTCREATEPATH;
-			}
-			partLength = 0;
-			dots = 0;
-		} else {
-			if (path[i] == '.') { dots++; }
-			partLength++;
-			if (partLength > kMaxFileNameLength) { return SAUNAFS_ERROR_CANTCREATEPATH; }
-		}
-	}
-
-	if (partLength == 0) {  // last part cannot be empty - it's the name of undeleted file
-		return SAUNAFS_ERROR_CANTCREATEPATH;
-	}
-
-	if (partLength == dots && partLength <= 2) {  // '.' or '..' in path
-		return SAUNAFS_ERROR_CANTCREATEPATH;
-	}
+	// Strip leading slashes for path reconstruction
+	std::string_view pathView = pathStr;
+	const size_t firstNonSlash = pathView.find_first_not_of('/');
+	if (firstNonSlash != std::string_view::npos) { pathView.remove_prefix(firstNonSlash); }
+	const char *path = pathView.data();
+	auto pathLength = static_cast<unsigned>(pathView.size());
 
 	// Path reconstruction
 
+	uint32_t partLength = 0;
 	FSNode *currentNode = nullptr;
 	FSNodeDirectory *currentParent = gMetadata->root;
 
@@ -1844,7 +1861,7 @@ void FilesystemNodeOperationsBase::setgoalRecursive(const FilesystemOperationCon
 					(*modifiedINodesOut)++;
 				}
 
-				updateCTime(node, timeStamp);
+				updateCTime(fsOpContext, node, timeStamp);
 				fsnodes_update_checksum(node);
 				nodeChanged = true;
 			} else {
@@ -1968,7 +1985,7 @@ void FilesystemNodeOperationsBase::setExtraAttrRecursive(
 			}
 
 			(*modifiedINodesOut)++;
-			updateCTime(node, timeStamp);
+			updateCTime(fsOpContext, node, timeStamp);
 			nodeChanged = true;
 		} else {
 			(*unchangedINodesOut)++;
@@ -2027,7 +2044,7 @@ uint8_t FilesystemNodeOperationsBase::deleteAcl(
 		return SAUNAFS_ERROR_EINVAL;
 	}
 
-	updateCTime(node, timeStamp);
+	updateCTime(fsOpContext, node, timeStamp);
 	fsnodes_update_checksum(node);
 
 	return SAUNAFS_STATUS_OK;
@@ -2074,7 +2091,7 @@ uint8_t FilesystemNodeOperationsBase::setAcl(
 		gMetadata->aclStorage.set(node->id, std::move(newAcl));
 	}
 
-	updateCTime(node, timeStamp);
+	updateCTime(fsOpContext, node, timeStamp);
 	fsnodes_update_checksum(node);
 	return SAUNAFS_STATUS_OK;
 }
@@ -2107,7 +2124,7 @@ uint8_t FilesystemNodeOperationsBase::setAcl(
 	}
 	gMetadata->aclStorage.set(node->id, std::move(newAcl));
 
-	updateCTime(node, timeStamp);
+	updateCTime(fsOpContext, node, timeStamp);
 	fsnodes_update_checksum(node);
 	return SAUNAFS_STATUS_OK;
 }

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -1467,7 +1467,7 @@ namespace {
 /// Returns true when a path segment of the given length consisting entirely of dots is a
 /// dot-only name (".") or dot-dot name (".."), which are invalid in trash paths.
 bool isDotOnlySegment(uint32_t segmentLength, uint32_t dotCount) {
-	return segmentLength == dotCount && segmentLength <= 2;
+	return segmentLength > 0 && segmentLength == dotCount && segmentLength <= 2;
 }
 
 }  // namespace

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -27,6 +27,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
+#include <string_view>
 #include <type_traits>
 
 #include "common/attributes.h"
@@ -206,13 +207,12 @@ void FilesystemNodeOperationsBase::updateDetachedSpaceUsage(
     [[maybe_unused]] const FilesystemOperationContext &fsOpContext, const FSNodeFile *nodeFile,
     uint64_t previousLength, uint64_t newLength) {
 	if (previousLength == newLength) { return; }
+	const uint64_t diffLength = newLength - previousLength;
 
 	if (nodeFile->type == FSNodeType::kTrash) {
-		gMetadata->trashSpace -= previousLength;
-		gMetadata->trashSpace += newLength;
+		gMetadata->trashSpace += diffLength;
 	} else if (nodeFile->type == FSNodeType::kReserved) {
-		gMetadata->reservedSpace -= previousLength;
-		gMetadata->reservedSpace += newLength;
+		gMetadata->reservedSpace += diffLength;
 	}
 }
 

--- a/src/master/filesystem_node.h
+++ b/src/master/filesystem_node.h
@@ -72,7 +72,8 @@ public:
 	void removeEdge(const FilesystemOperationContext &fsOpContext, uint32_t timeStamp,
 	                FSNodeDirectory *parent, const HString &childName, FSNode *childNode) override;
 
-	void updateCTime(FSNode *node, uint32_t ctime) override;
+	void updateCTime([[maybe_unused]] const FilesystemOperationContext &fsOpContext, FSNode *node,
+	                 uint32_t ctime) override;
 
 	void fillAttr(const FilesystemOperationContext &fsOpContext, FSNode *node, FSNode *parent,
 	              uint32_t uid, uint32_t gid, uint32_t auid, uint32_t agid, uint8_t sesflags,
@@ -328,12 +329,32 @@ protected:
 	virtual void nodeQuotaRemove(const FilesystemOperationContext &fsOpContext,
 	                             QuotaOwnerType ownerType, inode_t ownerId);
 
-private:
-	// Private helpers
+	/// Updates detached trash/reserved space counters for a file size mutation.
+	/// In-memory backend updates `gMetadata->trashSpace` / `gMetadata->reservedSpace`.
+	/// KV backends can override to persist the delta in the active transaction.
+	virtual void updateDetachedSpaceUsage(const FilesystemOperationContext &fsOpContext,
+	                                      const FSNodeFile *nodeFile, uint64_t previousLength,
+	                                      uint64_t newLength);
 
+	/// Validates a trash/reserved path string for use with undel().
+	///
+	/// Checks that the path is non-empty, contains no NUL bytes, has no "//" sequences,
+	/// no "." or ".." components, and that all name segments fit within kMaxFileNameLength.
+	///
+	/// @param pathStr  The full path string as stored in trash/reserved (leading '/' is stripped).
+	/// @return SAUNAFS_STATUS_OK if the path is valid; SAUNAFS_ERROR_CANTCREATEPATH otherwise.
+	static uint8_t validateTrashPath(const std::string &pathStr);
+
+	/// Frees a node and performs all associated in-memory and KV cleanup.
+	///
+	/// Caller is responsible for removing the NODE_ key from KV and decrementing the
+	/// kMetaNodesKey / kMetaFileNodesKey counters (via atomicAdd) BEFORE calling this.
+	/// This method deletes chunks, releases the inode, cleans up xattrs, quota, and
+	/// node hash, then destroys the node object.
 	void removeNode(const FilesystemOperationContext &fsOpContext, uint32_t timeStamp,
 	                FSNode *node);
 
+private:
 	/// Number of blocks in the last chunk before EOF
 	static uint32_t lastChunkBlocks(FSNodeFile *node);
 

--- a/src/master/filesystem_node_operations_interface.h
+++ b/src/master/filesystem_node_operations_interface.h
@@ -210,7 +210,8 @@ public:
 	                        FSNodeDirectory *parent, const HString &childName,
 	                        FSNode *childNode) = 0;
 
-	virtual void updateCTime(FSNode *node, uint32_t ctime) = 0;
+	virtual void updateCTime(const FilesystemOperationContext &fsOpContext, FSNode *node,
+	                         uint32_t ctime) = 0;
 
 	virtual void fillAttr(const FilesystemOperationContext &fsOpContext, FSNode *node,
 	                      FSNode *parent, uint32_t uid, uint32_t gid, uint32_t auid, uint32_t agid,

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -28,6 +28,7 @@
 
 #include "common/attributes.h"
 #include "common/event_loop.h"
+#include "common/loop_watchdog.h"
 #include "errors/saunafs_error_codes.h"
 #include "master/changelog.h"
 #include "master/chunks.h"
@@ -101,6 +102,96 @@ void FilesystemOperationsBase::changeLog(
 }
 
 #ifndef METARESTORE
+void FilesystemOperationsBase::doEmptyTrash(uint32_t timeStamp) {
+	SignalLoopWatchdog watchdog;
+
+	auto trashIter = gMetadata->trash.begin();
+
+	// This function is reimplemented in KV backends, so fsOpContext is here only to satisfy the
+	// interface. It does not need to be committed.
+	auto fsOpContext =
+	    createFilesystemOperationContext(FilesystemOperationContext::TransactionType::kReadWrite);
+
+	watchdog.start();
+
+	while (trashIter != gMetadata->trash.end() && ((*trashIter).first.timestamp < timeStamp)) {
+		auto *node =
+		    nodeOperations()->idToNodeVerify<FSNodeFile>(fsOpContext, (*trashIter).first.id);
+
+		if (node == kNodeNotFound) {
+			removeTrashEntry(gMetadata->trash, gMetadata->trashHandlesIndex,
+			                 gMetadata->trashReservedToId, node);
+			trashIter = gMetadata->trash.begin();
+			continue;
+		}
+
+		assert(node->type == FSNodeType::kTrash);
+
+		auto nodeId = node->id;
+		nodeOperations()->purge(fsOpContext, timeStamp, node);
+
+		// Purge operation should be performed anyway - if it fails, inode will be reserved
+		changeLog(fsOpContext, timeStamp, "PURGE(%" PRIiNode ")", nodeId);
+
+		trashIter = gMetadata->trash.begin();
+
+		if (watchdog.expired()) { break; }
+	}
+}
+
+void FilesystemOperationsBase::doEmptyReserved(uint32_t timeStamp) {
+	SignalLoopWatchdog watchdog;
+
+	auto reservedIter = gMetadata->reserved.begin();
+
+	// This function is reimplemented in KV backends, so fsOpContext is here only to satisfy the
+	// interface. It does not need to be committed.
+	auto fsOpContext =
+	    createFilesystemOperationContext(FilesystemOperationContext::TransactionType::kReadWrite);
+
+	watchdog.start();
+
+	while (reservedIter != gMetadata->reserved.end()) {
+		if (watchdog.expired()) { break; }
+
+		auto *node =
+		    nodeOperations()->idToNodeVerify<FSNodeFile>(fsOpContext, (*reservedIter).first);
+
+		if (node == kNodeNotFound) {
+			removeReservedEntry(gMetadata->reserved, gMetadata->reservedHandlesIndex,
+			                    gMetadata->trashReservedToId, (*reservedIter).first);
+			reservedIter = gMetadata->reserved.begin();
+			continue;
+		}
+
+		assert(node->type == FSNodeType::kReserved);
+
+		auto nodeId = node->id;
+		FsContext context = FsContext::getForMaster(timeStamp);
+
+		assert(!node->sessionIds.empty());
+
+		auto sessionIds = node->sessionIds;
+
+		if (!sessionIds.empty()) {
+			for (auto &sessionId : sessionIds) {
+				uint8_t status = release(context, fsOpContext, nodeId, sessionId);
+				if (status != SAUNAFS_STATUS_OK) {
+					safs::log_err(
+					    "Failed to release from periodic cleaning reserved file: {}, session: {}, status: {}",
+					    nodeId, sessionId, status);
+				}
+			}
+		} else {
+			safs::log_critical(
+			    "Failed to release from periodic cleaning reserved file: {}, no session associated with the file",
+			    nodeId);
+		}
+
+		reservedIter = gMetadata->reserved.begin();
+	}
+}
+
 uint8_t FilesystemOperationsBase::readReservedSize(inode_t rootinode,
                                                    [[maybe_unused]] uint8_t sesflags,
                                                    uint32_t *dbuffsize) {
@@ -199,7 +290,27 @@ uint8_t FilesystemOperationsBase::getTrashPath(const FilesystemOperationContext 
 
 	return SAUNAFS_STATUS_OK;
 }
+
 #endif
+
+std::optional<std::string> FilesystemOperationsBase::getDetachedPath(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, const FSNode *node) {
+	if (node == nullptr) { return std::nullopt; }
+
+	if (node->type == FSNodeType::kTrash) {
+		auto iter = gMetadata->trash.find(TrashPathKey(node));
+		if (iter == gMetadata->trash.end()) { return std::nullopt; }
+		return (std::string)(*iter).second;
+	}
+
+	if (node->type == FSNodeType::kReserved) {
+		auto iter = gMetadata->reserved.find(node->id);
+		if (iter == gMetadata->reserved.end()) { return std::nullopt; }
+		return (std::string)(*iter).second;
+	}
+
+	return std::nullopt;
+}
 
 uint8_t FilesystemOperationsBase::setTrashPath(const FsContext &context, inode_t inode,
                                                const std::string &path) {
@@ -260,6 +371,14 @@ uint8_t FilesystemOperationsBase::undel(const FsContext &context, inode_t inode)
 	} else {
 		gMetadata->metadataVersion++;
 	}
+
+	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
+		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+			safs::log_err("undel: failed to commit transaction for inode {}", inode);
+			status = SAUNAFS_ERROR_IO;
+		}
+	}
+
 	return status;
 }
 
@@ -546,10 +665,11 @@ uint8_t FilesystemOperationsBase::fullPathByInode(const FsContext &context, inod
 			if (currentNode != kNodeNotFound && parentId == 0 &&
 			    (currentNode->type == FSNodeType::kReserved ||
 			     currentNode->type == FSNodeType::kTrash)) {
+				auto detachedPath = getDetachedPath(fsOpContext, currentNode);
+				if (!detachedPath.has_value()) { return SAUNAFS_ERROR_ENOENT; }
 				currentName =
-				    currentNode->type == FSNodeType::kTrash
-				        ? gMetadata->trash.at(TrashPathKey(currentNode)).get() + " (trash)"
-				        : gMetadata->reserved.at(currentInode).get() + " (reserved)";
+				    *detachedPath +
+				    (currentNode->type == FSNodeType::kTrash ? " (trash)" : " (reserved)");
 				fullPath = currentName;
 				return SAUNAFS_STATUS_OK;
 			}
@@ -587,19 +707,10 @@ std::string FilesystemOperationsBase::fullPathByInode(const FilesystemOperationC
 		if (parent == 0) {
 			if (currentNode->type == FSNodeType::kReserved ||
 			    currentNode->type == FSNodeType::kTrash) {
-				std::string pathFromTrashOrReserved;
-				if (currentNode->type == FSNodeType::kTrash) {
-					const auto key = TrashPathKey(currentNode);
-					auto iter = gMetadata->trash.find(key);
-					if (iter == gMetadata->trash.end()) { return ""; }
-					pathFromTrashOrReserved = (*iter).second.get() + " (trash)";
-				} else {
-					auto iter = gMetadata->reserved.find(currentInode);
-					if (iter == gMetadata->reserved.end()) { return ""; }
-					pathFromTrashOrReserved = (*iter).second.get() + " (reserved)";
-				}
-
-				return "/" + pathFromTrashOrReserved;
+				auto detachedPath = getDetachedPath(fsOpContext, currentNode);
+				if (!detachedPath.has_value()) { return ""; }
+				return "/" + *detachedPath +
+				       (currentNode->type == FSNodeType::kTrash ? " (trash)" : " (reserved)");
 			}
 			break;
 		}
@@ -859,7 +970,7 @@ uint8_t FilesystemOperationsBase::doSetLength(const FsContext &context,
 	changeLog(fsOpContext, timeStamp, "LENGTH(%" PRIiNode ",%" PRIu64 ",%" PRIu32 ")", inode,
 	          static_cast<FSNodeFile *>(node)->length, static_cast<uint32_t>(eraseFurtherChunks));
 	node->mtime = timeStamp;
-	nodeOperations_->updateCTime(node, timeStamp);
+	nodeOperations_->updateCTime(fsOpContext, node, timeStamp);
 	fsnodes_update_checksum(node);
 	nodeOperations_->fillAttr(fsOpContext, node, nullptr, context.uid(), context.gid(),
 	                          context.auid(), context.agid(), context.sesflags(), attr);
@@ -1001,7 +1112,7 @@ uint8_t FilesystemOperationsBase::setAttr(const FsContext &context,
 	changeLog(fsOpContext, timeStamp,
 	          "ATTR(%" PRIiNode ",%d,%" PRIu32 ",%" PRIu32 ",%" PRIu32 ",%" PRIu32 ")", node->id,
 	          node->mode & 07777, node->uid, node->gid, node->atime, node->mtime);
-	nodeOperations_->updateCTime(node, timeStamp);
+	nodeOperations_->updateCTime(fsOpContext, node, timeStamp);
 	nodeOperations_->fillAttr(fsOpContext, node, nullptr, context.uid(), context.gid(),
 	                          context.auid(), context.agid(), context.sesflags(), attr);
 	fsnodes_update_checksum(node);
@@ -1031,7 +1142,7 @@ uint8_t FilesystemOperationsBase::applyAttr(const FilesystemOperationContext &fs
 	}
 	node->atime = atime;
 	node->mtime = mtime;
-	nodeOperations_->updateCTime(node, timestamp);
+	nodeOperations_->updateCTime(fsOpContext, node, timestamp);
 	fsnodes_update_checksum(node);
 	gMetadata->metadataVersion++;
 
@@ -1054,7 +1165,7 @@ uint8_t FilesystemOperationsBase::applyLength(const FilesystemOperationContext &
 	nodeOperations_->setLength(fsOpContext, static_cast<FSNodeFile *>(node), length,
 	                           eraseFurtherChunks);
 	node->mtime = timestamp;
-	nodeOperations_->updateCTime(node, timestamp);
+	nodeOperations_->updateCTime(fsOpContext, node, timestamp);
 	fsnodes_update_checksum(node);
 	gMetadata->metadataVersion++;
 
@@ -2463,7 +2574,7 @@ uint8_t FilesystemOperationsBase::writeChunk(const FsContext &context,
 	}
 
 	fileNode->mtime = context.ts();
-	nodeOperations_->updateCTime(fileNode, context.ts());
+	nodeOperations_->updateCTime(fsOpContext, fileNode, context.ts());
 	fsnodes_update_checksum(fileNode);
 
 	// Make the change persistent for KV backends
@@ -2504,7 +2615,7 @@ uint8_t FilesystemOperationsBase::writeEnd(const FilesystemOperationContext &fsO
 			bool eraseFurtherChunks = false;
 			nodeOperations_->setLength(fsOpContext, nodeFile, length, eraseFurtherChunks);
 			nodeFile->mtime = timeStamp;
-			nodeOperations_->updateCTime(nodeFile, timeStamp);
+			nodeOperations_->updateCTime(fsOpContext, nodeFile, timeStamp);
 			fsnodes_update_checksum(nodeFile);
 
 			// Make the change persistent for KV backends
@@ -2569,7 +2680,7 @@ uint8_t FilesystemOperationsBase::removeChunkFromFile(const FsContext &context,
 
 	fileNode->chunks[chunkIndex] = 0;
 	nodeFile->mtime = timeStamp;
-	nodeOperations_->updateCTime(nodeFile, timeStamp);
+	nodeOperations_->updateCTime(fsOpContext, nodeFile, timeStamp);
 
 	// Log the repair operation with new version 0 (indicating deletion)
 	uint32_t newVersion = 0;
@@ -2620,7 +2731,7 @@ uint8_t FilesystemOperationsBase::repair(const FsContext &context, inode_t inode
 			changeLog(fsOpContext, timeStamp, "REPAIR(%" PRIiNode ",%" PRIu32 "):%" PRIu32, inode,
 			          chunkIndex, newVersion);
 			node->mtime = timeStamp;
-			nodeOperations_->updateCTime(node, timeStamp);
+			nodeOperations_->updateCTime(fsOpContext, node, timeStamp);
 			if (newVersion > 0) {
 				(*repaired)++;
 			} else {
@@ -2686,7 +2797,7 @@ uint8_t FilesystemOperationsBase::applyRepair(const FilesystemOperationContext &
 
 	gMetadata->metadataVersion++;
 	nodeFile->mtime = timestamp;
-	nodeOperations_->updateCTime(nodeFile, timestamp);
+	nodeOperations_->updateCTime(fsOpContext, nodeFile, timestamp);
 
 	fsnodes_update_checksum(nodeFile);
 
@@ -2932,10 +3043,14 @@ uint8_t FilesystemOperationsBase::applySetTrashTime(const FsContext &context, in
 	sassert(context.hasUidGidData());
 
 	SetTrashtimeTask task(context.uid(), trashtime, smode);
-	uint32_t myResult = task.setTrashtime(node, context.ts());
+	uint32_t myResult = task.setTrashtime(fsOpContext, node, context.ts());
 
 	gMetadata->metadataVersion++;
 	if (master_result != myResult) { return SAUNAFS_ERROR_MISMATCH; }
+	if (myResult == SetTrashtimeTask::kChanged && fsOpContext.hasReadWriteTransaction()) {
+		nodeOperations_->updateNode(fsOpContext, node);
+		if (!fsOpContext.getReadWriteTransaction()->commit()) { return SAUNAFS_ERROR_IO; }
+	}
 
 	return SAUNAFS_STATUS_OK;
 }
@@ -3056,7 +3171,7 @@ uint8_t FilesystemOperationsBase::setXAttr(const FsContext &context,
 	if (mode > XATTR_SMODE_REMOVE) { return SAUNAFS_ERROR_EINVAL; }
 	status = doConcreteSetXAttr(fsOpContext, node->id, anleng, attrname, avleng, attrvalue, mode);
 	if (status != SAUNAFS_STATUS_OK) { return status; }
-	nodeOperations_->updateCTime(node, timeStamp);
+	nodeOperations_->updateCTime(fsOpContext, node, timeStamp);
 	fsnodes_update_checksum(node);
 	changeLog(fsOpContext, timeStamp, "SETXATTR(%" PRIiNode ",%s,%s,%" PRIu8 ")", node->id,
 	          nodeOperations_->escapeName(std::string((const char *)attrname, anleng)).c_str(),
@@ -3125,7 +3240,7 @@ uint8_t FilesystemOperationsBase::applySetXAttr(const FilesystemOperationContext
 	                            attrvalue, mode);
 
 	if (status != SAUNAFS_STATUS_OK) { return status; }
-	nodeOperations_->updateCTime(node, timestamp);
+	nodeOperations_->updateCTime(fsOpContext, node, timestamp);
 	gMetadata->metadataVersion++;
 	fsnodes_update_checksum(node);
 	return status;

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -25,6 +25,7 @@
 
 #include <cstdarg>
 #include <cstdint>
+#include <string_view>
 
 #include "common/attributes.h"
 #include "common/event_loop.h"
@@ -119,8 +120,9 @@ void FilesystemOperationsBase::doEmptyTrash(uint32_t timeStamp) {
 		    nodeOperations()->idToNodeVerify<FSNodeFile>(fsOpContext, (*trashIter).first.id);
 
 		if (node == kNodeNotFound) {
-			removeTrashEntry(gMetadata->trash, gMetadata->trashHandlesIndex,
-			                 gMetadata->trashReservedToId, node);
+			const TrashPathKey trashKey = (*trashIter).first;
+			removeTrashEntryByKey(gMetadata->trash, gMetadata->trashHandlesIndex,
+			                      gMetadata->trashReservedToId, trashKey);
 			trashIter = gMetadata->trash.begin();
 			continue;
 		}

--- a/src/master/filesystem_operations.h
+++ b/src/master/filesystem_operations.h
@@ -23,6 +23,7 @@
 #include "common/platform.h"
 
 #include <map>
+#include <optional>
 
 #include "common/goal.h"
 #include "common/type_defs.h"
@@ -384,6 +385,14 @@ public:
 	                        std::string &fullPath) override;
 	std::string fullPathByInode(const FilesystemOperationContext &fsOpContext,
 	                            inode_t initialInode) override;
+
+	/// Purges expired trash entries whose expiry timestamp is before @p timeStamp.
+	/// @see IFilesystemOperations::doEmptyTrash
+	void doEmptyTrash(uint32_t timeStamp) override;
+
+	/// Releases all reserved files whose sessions have expired (no active openers).
+	/// @see IFilesystemOperations::doEmptyReserved
+	void doEmptyReserved(uint32_t timeStamp) override;
 #endif
 
 	// QUOTAS
@@ -588,6 +597,14 @@ protected:
 	    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, inode_t inode,
 	    uint8_t anleng, const uint8_t *attrname, uint32_t avleng, const uint8_t *attrvalue,
 	    uint32_t mode);
+
+	/// Backend-specific hook for retrieving a detached trash/reserved path.
+	/// Default implementation reads from in-memory trash/reserved containers.
+	/// @param fsOpContext Operation context (provides transaction for KV backends).
+	/// @param node Detached trash/reserved node whose stored path should be retrieved.
+	/// @return Stored detached path without leading slash or suffix, or std::nullopt if absent.
+	virtual std::optional<std::string> getDetachedPath(
+	    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, const FSNode *node);
 
 	/// Permission check for lock operations.
 	/// Validates that the caller has appropriate read/write access for the

--- a/src/master/filesystem_operations.h
+++ b/src/master/filesystem_operations.h
@@ -604,7 +604,8 @@ protected:
 	/// @param node Detached trash/reserved node whose stored path should be retrieved.
 	/// @return Stored detached path without leading slash or suffix, or std::nullopt if absent.
 	virtual std::optional<std::string> getDetachedPath(
-	    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, const FSNode *node);
+	    [[maybe_unused]] const FilesystemOperationContext &fsOpContext,
+	    const FSNode *node) override;
 
 	/// Permission check for lock operations.
 	/// Validates that the caller has appropriate read/write access for the

--- a/src/master/filesystem_operations_interface.h
+++ b/src/master/filesystem_operations_interface.h
@@ -23,6 +23,7 @@
 #include <initializer_list>
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -111,6 +112,11 @@ public:
 	virtual void changeLog(const FilesystemOperationContext &fsOpContext, uint32_t ts,
 	                       const char *format, ...)
 	    __attribute__((__format__(__printf__, 4, 5))) = 0;
+
+	/// Retrieves the stored path for a detached trash/reserved node.
+	/// Implementations may override this to load detached paths from backend-specific storage.
+	virtual std::optional<std::string> getDetachedPath(
+	    const FilesystemOperationContext &fsOpContext, const FSNode *node) = 0;
 
 	// Functions which create/apply (depending on the given context) changes to the metadata.
 	// Common for metarestore and master server (both personalities)

--- a/src/master/filesystem_operations_interface.h
+++ b/src/master/filesystem_operations_interface.h
@@ -1503,6 +1503,23 @@ public:
 	virtual uint8_t quotaGetInfo(const FsContext &context, const std::vector<QuotaEntry> &entries,
 	                             std::vector<std::string> &result) = 0;
 
+	/// Purges expired trash entries whose expiry timestamp is before @p timeStamp.
+	///
+	/// Default implementation iterates gMetadata->trash. KV backends override this to scan
+	/// TRSH_TIME_ entries directly from FDB.
+	///
+	/// @param timeStamp Current wall-clock time (seconds since epoch). Entries with
+	///                  expiryTs < timeStamp are eligible for purge.
+	virtual void doEmptyTrash(uint32_t timeStamp) = 0;
+
+	/// Releases all reserved files whose sessions have expired (no active openers).
+	///
+	/// Default implementation iterates gMetadata->reserved. KV backends override this to scan
+	/// RSVD_PATH_ entries directly from FDB.
+	///
+	/// @param timeStamp Current wall-clock time (seconds since epoch).
+	virtual void doEmptyReserved(uint32_t timeStamp) = 0;
+
 	// CHECKSUM
 
 	/// Starts recalculating metadata checksum in background.

--- a/src/master/filesystem_periodic.cc
+++ b/src/master/filesystem_periodic.cc
@@ -36,6 +36,7 @@
 #include "master/filesystem_checksum.h"
 #include "master/filesystem_checksum_updater.h"
 #include "master/filesystem_metadata.h"
+#include "master/filesystem_operations.h"
 #include "master/filesystem_operations_interface.h"
 #include "master/matoclserv.h"
 
@@ -93,6 +94,13 @@ void fs_background_task_manager_work() {
 	}
 }
 
+static std::string get_detached_node_path(const FilesystemOperationContext &fsOpContext,
+                                          const FSNode *node) {
+	std::string path = gFSOperations->fullPathByInode(fsOpContext, node->id);
+	if (!path.empty() && path.front() == '/') { path.erase(path.begin()); }
+	return path;
+}
+
 static std::string get_node_info(const FilesystemOperationContext &fsOpContext, FSNode *node) {
 	std::string name;
 	if (node == nullptr) {
@@ -101,10 +109,10 @@ static std::string get_node_info(const FilesystemOperationContext &fsOpContext, 
 
 	if (node->type == FSNodeType::kTrash) {
 		name = "file in trash " + std::to_string(node->id) + ": " +
-		       (std::string)gMetadata->trash.at(TrashPathKey(node));
+		       get_detached_node_path(fsOpContext, node);
 	} else if (node->type == FSNodeType::kReserved) {
 		name = "reserved file " + std::to_string(node->id) + ": " +
-		       (std::string)gMetadata->reserved.at(node->id);
+		       get_detached_node_path(fsOpContext, node);
 	} else if (node->type == FSNodeType::kFile) {
 		name = "file " + std::to_string(node->id) + ": ";
 		bool first = true;
@@ -536,95 +544,12 @@ struct InodeInfo {
 };
 
 #ifndef METARESTORE
-static void fs_do_emptytrash(uint32_t ts) {
-	SignalLoopWatchdog watchdog;
-
-	auto it = gMetadata->trash.begin();
-	watchdog.start();
-	while (it != gMetadata->trash.end() && ((*it).first.timestamp < ts)) {
-		auto fsOpContext = gFSOperations->createFilesystemOperationContext(
-		    FilesystemOperationContext::TransactionType::kReadWrite);
-		FSNodeFile *node = gFSOperations->nodeOperations()->idToNodeVerify<FSNodeFile>(
-		    fsOpContext, (*it).first.id);
-
-		if (!node) {
-			std::string pathName = (*it).second.get();
-			removeTrashEntry(gMetadata->trash, gMetadata->trashHandlesIndex,
-			                 gMetadata->trashReservedToId, node);
-			it = gMetadata->trash.begin();
-			continue;
-		}
-
-		assert(node->type == FSNodeType::kTrash);
-
-		auto node_id = node->id;
-		gFSOperations->nodeOperations()->purge(fsOpContext, ts, node);
-
-		// Purge operation should be performed anyway - if it fails, inode will be reserved
-		gFSOperations->changeLog(fsOpContext, ts, "PURGE(%" PRIiNode ")", node_id);
-
-		it = gMetadata->trash.begin();
-
-		if (watchdog.expired()) {
-			break;
-		}
-	}
-}
-
 void fs_periodic_emptytrash(void) {
-	uint32_t ts = eventloop_time();
-	fs_do_emptytrash(ts);
-}
-
-static void fs_do_emptyreserved(uint32_t ts) {
-	SignalLoopWatchdog watchdog;
-
-	auto it = gMetadata->reserved.begin();
-	watchdog.start();
-	while (it != gMetadata->reserved.end()) {
-		if (watchdog.expired()) { break; }
-
-		auto fsOpContext = gFSOperations->createFilesystemOperationContext(
-		    FilesystemOperationContext::TransactionType::kReadWrite);
-		auto *node =
-		    gFSOperations->nodeOperations()->idToNodeVerify<FSNodeFile>(fsOpContext, (*it).first);
-
-		if (!node) {
-			removeReservedEntry(gMetadata->reserved, gMetadata->reservedHandlesIndex,
-			                    gMetadata->trashReservedToId, (*it).first);
-			it = gMetadata->reserved.begin();
-			continue;
-		}
-
-		assert(node->type == FSNodeType::kReserved);
-
-		auto node_id = node->id;
-		FsContext context = FsContext::getForMaster(ts);
-
-		assert(!node->sessionIds.empty());
-		auto sessionIds = node->sessionIds;
-		if (!sessionIds.empty()) {
-			for (auto &sessionId : sessionIds) {
-				uint8_t status = gFSOperations->release(context, fsOpContext, node_id, sessionId);
-				if (status != SAUNAFS_STATUS_OK) {
-					safs::log_err(
-					    "Failed to release from periodic cleaning reserved file: {}, session: {}, status: {}",
-					    node_id, sessionId, status);
-				}
-			}
-		} else {
-			safs::log_critical(
-			    "Failed to release from periodic cleaning reserved file: {}, no session associated with the file",
-			    node_id);
-		}
-
-		it = gMetadata->reserved.begin();
-	}
+	gFSOperations->doEmptyTrash(eventloop_time());
 }
 
 void fs_periodic_emptyreserved(void) {
-	uint32_t ts = eventloop_time();
-	fs_do_emptyreserved(ts);
+	gFSOperations->doEmptyReserved(eventloop_time());
 }
 
 void fs_read_periodic_config_file() {

--- a/src/master/filesystem_periodic.cc
+++ b/src/master/filesystem_periodic.cc
@@ -96,9 +96,7 @@ void fs_background_task_manager_work() {
 
 static std::string get_detached_node_path(const FilesystemOperationContext &fsOpContext,
                                           const FSNode *node) {
-	std::string path = gFSOperations->fullPathByInode(fsOpContext, node->id);
-	if (!path.empty() && path.front() == '/') { path.erase(path.begin()); }
-	return path;
+	return gFSOperations->getDetachedPath(fsOpContext, node).value_or("");
 }
 
 static std::string get_node_info(const FilesystemOperationContext &fsOpContext, FSNode *node) {

--- a/src/master/filesystem_trash_reserved_files.h
+++ b/src/master/filesystem_trash_reserved_files.h
@@ -144,6 +144,23 @@ inline void addTrashEntry(TrashPathContainer &trash, HandleIndexContainer &trash
 	trashHandlesIndex.insert({HandleIndexKey(pathId), node->id});
 }
 
+inline void removeTrashEntryByKey(TrashPathContainer &trash,
+                                  HandleIndexContainer &trashHandlesIndex,
+                                  TrashReservedToIdContainer &trashReservedToId,
+                                  const TrashPathKey &key) {
+	auto trashIt = trash.find(key);
+	if (trashIt == trash.end()) { return; }
+
+	uint64_t handleHash = (*trashIt).second.data();
+	auto pathIdIt = trashReservedToId.nameToId.find(handleHash);
+	if (pathIdIt != trashReservedToId.nameToId.end()) {
+		uint64_t pathId = pathIdIt->second;
+		trashHandlesIndex.erase(HandleIndexKey(pathId));
+		trashReservedToId.erase(handleHash);
+	}
+	trash.erase(trashIt);
+}
+
 inline void removeTrashEntry(TrashPathContainer &trash, HandleIndexContainer &trashHandlesIndex,
                              TrashReservedToIdContainer &trashReservedToId, FSNode *node) {
 	TrashPathKey key(node);

--- a/src/master/filesystem_trash_reserved_files_unittest.cc
+++ b/src/master/filesystem_trash_reserved_files_unittest.cc
@@ -20,10 +20,80 @@
 
 #include <gtest/gtest.h>
 
+#include "master/filesystem_node.h"
+#include "master/filesystem_node_operations_interface.h"
 #include "master/filesystem_trash_reserved_files.h"
 #include "master/hstring_memstorage.h"
+#include "protocol/SFSCommunication.h"
 
 using namespace hstorage;
+
+struct TrashPathValidator : FilesystemNodeOperationsBase {
+	static uint8_t validate(const std::string &path) { return validateTrashPath(path); }
+};
+
+class ValidateTrashPathTest : public ::testing::Test {
+protected:
+	void SetUp() override { Storage::reset(new MemStorage()); }
+
+	static uint8_t validate(const std::string &path) { return TrashPathValidator::validate(path); }
+};
+
+TEST_F(ValidateTrashPathTest, EmptyPathIsRejected) { EXPECT_NE(validate(""), SAUNAFS_STATUS_OK); }
+
+TEST_F(ValidateTrashPathTest, AllSlashesAreRejected) {
+	EXPECT_NE(validate("/"), SAUNAFS_STATUS_OK);
+	EXPECT_NE(validate("///"), SAUNAFS_STATUS_OK);
+}
+
+TEST_F(ValidateTrashPathTest, DotSegmentsAreRejected) {
+	EXPECT_NE(validate("."), SAUNAFS_STATUS_OK);
+	EXPECT_NE(validate(".."), SAUNAFS_STATUS_OK);
+	EXPECT_NE(validate("a/."), SAUNAFS_STATUS_OK);
+	EXPECT_NE(validate("a/.."), SAUNAFS_STATUS_OK);
+	EXPECT_NE(validate("./b"), SAUNAFS_STATUS_OK);
+	EXPECT_NE(validate("../b"), SAUNAFS_STATUS_OK);
+}
+
+TEST_F(ValidateTrashPathTest, TripleDotSegmentIsAccepted) {
+	// "..." is not "." or ".." so it is a valid segment
+	EXPECT_EQ(validate("..."), SAUNAFS_STATUS_OK);
+	EXPECT_EQ(validate("a/..."), SAUNAFS_STATUS_OK);
+}
+
+TEST_F(ValidateTrashPathTest, ConsecutiveSlashesAreRejected) {
+	EXPECT_NE(validate("a//b"), SAUNAFS_STATUS_OK);
+}
+
+TEST_F(ValidateTrashPathTest, EmbeddedNullByteIsRejected) {
+	std::string pathWithNull = std::string("a/") + '\0' + "b";
+	EXPECT_NE(validate(pathWithNull), SAUNAFS_STATUS_OK);
+}
+
+TEST_F(ValidateTrashPathTest, SegmentExceedingMaxLengthIsRejected) {
+	std::string longSegment(kMaxFileNameLength + 1, 'x');
+	EXPECT_NE(validate(longSegment), SAUNAFS_STATUS_OK);
+	EXPECT_NE(validate("a/" + longSegment), SAUNAFS_STATUS_OK);
+}
+
+TEST_F(ValidateTrashPathTest, MaxLengthSegmentIsAccepted) {
+	std::string maxSegment(kMaxFileNameLength, 'x');
+	EXPECT_EQ(validate(maxSegment), SAUNAFS_STATUS_OK);
+}
+
+TEST_F(ValidateTrashPathTest, ValidSingleSegmentIsAccepted) {
+	EXPECT_EQ(validate("file"), SAUNAFS_STATUS_OK);
+	EXPECT_EQ(validate("/file"), SAUNAFS_STATUS_OK);
+}
+
+TEST_F(ValidateTrashPathTest, ValidMultiSegmentPathIsAccepted) {
+	EXPECT_EQ(validate("a/b/c"), SAUNAFS_STATUS_OK);
+	EXPECT_EQ(validate("/a/b/c"), SAUNAFS_STATUS_OK);
+}
+
+TEST_F(ValidateTrashPathTest, TrailingSlashIsRejected) {
+	EXPECT_NE(validate("a/b/"), SAUNAFS_STATUS_OK);
+}
 
 class FilesystemTrashReservedTests : public ::testing::Test {
 protected:

--- a/src/master/filesystem_trash_reserved_files_unittest.cc
+++ b/src/master/filesystem_trash_reserved_files_unittest.cc
@@ -81,6 +81,30 @@ TEST_F(FilesystemTrashReservedTests, AddAndRemoveTrashEntryFromContainers) {
 	FSNode::destroy(node);
 }
 
+TEST_F(FilesystemTrashReservedTests, RemoveTrashEntryByKeyWithoutNode) {
+	TrashPathContainer trash;
+	HandleIndexContainer trashHandlesIndex;
+	TrashReservedToIdContainer trashReservedToId;
+	FSNode *node = createFSNode(1, FSNodeType::kFile);
+
+	std::string path = "/path/to/file";
+
+	addTrashEntry(trash, trashHandlesIndex, trashReservedToId, node, path);
+
+	ASSERT_EQ(trash.size(), 1U);
+	ASSERT_EQ(trashHandlesIndex.size(), 1U);
+	ASSERT_EQ(trashReservedToId.counter, 1U);
+
+	TrashPathKey key(node);
+	FSNode::destroy(node);
+
+	removeTrashEntryByKey(trash, trashHandlesIndex, trashReservedToId, key);
+
+	ASSERT_EQ(trash.size(), 0U);
+	ASSERT_EQ(trashHandlesIndex.size(), 0U);
+	ASSERT_EQ(trashReservedToId.counter, 1U);
+}
+
 TEST_F(FilesystemTrashReservedTests, AddAndRemoveReservedEntryFromContainers) {
 	ReservedPathContainer reserved;
 	HandleIndexContainer reservedHandlesIndex;

--- a/src/master/kv_common_keys.h
+++ b/src/master/kv_common_keys.h
@@ -115,7 +115,7 @@ inline constexpr std::string_view kTrashPathKeyPrefix = "TRSH_PATH_";  // Sectio
 /// Prefix for reserved path entries (path lookup by inode)
 /// Format: RSVD_PATH_<InodeId>:<PathString>
 /// @note Written when a file enters the reserved list (unlinked with active sessions).
-/// Deleted when all sessions are released.
+/// Deleted/Purged when all sessions pointing to the file release it.
 inline constexpr std::string_view kReservedPathKeyPrefix = "RSVD_PATH_";  // Section RSVD 1.0
 
 /// Prefix for locks

--- a/src/master/kv_common_keys.h
+++ b/src/master/kv_common_keys.h
@@ -99,6 +99,25 @@ inline constexpr std::string_view kACLsKeyPrefix = "ACLS_";    // Section ACLS 1
 /// lexicographical sorting, enabling efficient scans by owner prefix and global quota prefix.
 inline constexpr std::string_view kQuotasKeyPrefix = "QUOT_";  // Section QUOT 1.1
 
+/// Prefix for trash time-ordered entries (for periodic expiry scans)
+/// Format: TRSH_TIME_<ExpiryTimestamp><InodeId>:<empty>
+/// - ExpiryTimestamp: ctime + trashtime, 32-bit Big Endian
+/// - InodeId: inode_t Big Endian (sizeof(inode_t) bytes)
+/// @note Lexicographic order matches expiry time order, enabling efficient scan up to a deadline.
+/// @note Value is empty; the key itself encodes all information needed for expiry scans.
+inline constexpr std::string_view kTrashTimeKeyPrefix = "TRSH_TIME_";  // Section TRSH 1.0
+
+/// Prefix for trash path entries (path lookup by inode)
+/// Format: TRSH_PATH_<InodeId>:<PathString>
+/// @note Written when a file enters trash; deleted on undel or purge.
+inline constexpr std::string_view kTrashPathKeyPrefix = "TRSH_PATH_";  // Section TRSH 1.0
+
+/// Prefix for reserved path entries (path lookup by inode)
+/// Format: RSVD_PATH_<InodeId>:<PathString>
+/// @note Written when a file enters the reserved list (unlinked with active sessions).
+/// Deleted when all sessions are released.
+inline constexpr std::string_view kReservedPathKeyPrefix = "RSVD_PATH_";  // Section RSVD 1.0
+
 /// Prefix for locks
 /// Format: FLCK_<InodeId:BE><Type:u8><Status:u8> → serialized lock entries
 /// - InodeId: inode_t serialized as Big Endian (enables per-inode prefix scan)

--- a/src/master/setgoal_task.cc
+++ b/src/master/setgoal_task.cc
@@ -96,7 +96,7 @@ uint8_t SetGoalTask::setGoal(const FilesystemOperationContext &fsOpContext, FSNo
 						gMetadata->nodeChangedSignal.emit(node);
 					}
 				}
-				gFSOperations->nodeOperations()->updateCTime(node, ts);
+				gFSOperations->nodeOperations()->updateCTime(fsOpContext, node, ts);
 				fsnodes_update_checksum(node);
 
 				// Make goal updates persistent for KV backends.

--- a/src/master/settrashtime_task.cc
+++ b/src/master/settrashtime_task.cc
@@ -23,7 +23,6 @@
 #include "master/settrashtime_task.h"
 
 #include "master/filesystem_checksum.h"
-#include "master/filesystem_metadata.h"
 #include "master/filesystem_operations_interface.h"
 
 int SetTrashtimeTask::execute(uint32_t ts, intrusive_list<Task> &work_queue) {
@@ -36,19 +35,17 @@ int SetTrashtimeTask::execute(uint32_t ts, intrusive_list<Task> &work_queue) {
 	FSNode *node = gFSOperations->nodeOperations()->idToNode(fsOpContext, inode);
 	if (!node) { return SAUNAFS_ERROR_EINVAL; }
 
-	uint8_t result = setTrashtime(node, ts);
+	uint8_t result = setTrashtime(fsOpContext, node, ts);
 
 	if (result != kNoAction) {
-		if (node->type == FSNodeType::kDirectory && (smode_ & SMODE_RMASK) &&
-		    !static_cast<const FSNodeDirectory *>(node)->entries.empty()) {
-			std::vector<inode_t> inode_list;
-			inode_list.reserve(static_cast<const FSNodeDirectory *>(node)->entries.size());
-			for (const auto &entry : static_cast<const FSNodeDirectory *>(node)->entries) {
-				inode_list.push_back(entry.second->id);
+		if (node->type == FSNodeType::kDirectory && (smode_ & SMODE_RMASK)) {
+			auto inode_list = gFSOperations->nodeOperations()->getDirectoryChildInodes(
+			    fsOpContext, static_cast<const FSNodeDirectory *>(node));
+			if (!inode_list.empty()) {
+				auto *task =
+				    new SetTrashtimeTask(std::move(inode_list), uid_, trashtime_, smode_, stats_);
+				work_queue.push_front(*task);
 			}
-			auto task = new SetTrashtimeTask(std::move(inode_list), uid_,
-			                                              trashtime_, smode_, stats_);
-			work_queue.push_front(*task);
 		}
 
 		if ((smode_ & SMODE_RMASK) == 0 && result == kNotPermitted) {
@@ -82,7 +79,8 @@ bool SetTrashtimeTask::isFinished() const {
 	return current_inode_ == inode_list_.end();
 }
 
-uint8_t SetTrashtimeTask::setTrashtime(FSNode *node, uint32_t ts) {
+uint8_t SetTrashtimeTask::setTrashtime(const FilesystemOperationContext &fsOpContext, FSNode *node,
+                                       uint32_t ts) {
 	uint8_t set;
 
 	if (node->type == FSNodeType::kFile || node->type == FSNodeType::kDirectory ||
@@ -92,7 +90,6 @@ uint8_t SetTrashtimeTask::setTrashtime(FSNode *node, uint32_t ts) {
 			return SetTrashtimeTask::kNotPermitted;
 		} else {
 			set = 0;
-			auto old_trash_key = TrashPathKey(node);
 			switch (smode_ & SMODE_TMASK) {
 			case SMODE_SET:
 				if (node->trashtime != trashtime_) {
@@ -114,10 +111,7 @@ uint8_t SetTrashtimeTask::setTrashtime(FSNode *node, uint32_t ts) {
 				break;
 			}
 			if (set) {
-				node->ctime = ts;
-				if (node->type == FSNodeType::kTrash) {
-					updateTrashFromOldEntry(gMetadata->trash, node, old_trash_key);
-				}
+				gFSOperations->nodeOperations()->updateCTime(fsOpContext, node, ts);
 				fsnodes_update_checksum(node);
 				return SetTrashtimeTask::kChanged;
 			} else {

--- a/src/master/settrashtime_task.h
+++ b/src/master/settrashtime_task.h
@@ -25,6 +25,8 @@
 #include "master/filesystem_trash_reserved_files.h"
 #include "master/task_manager.h"
 
+class FilesystemOperationContext;
+
 class SetTrashtimeTask : public TaskManager::Task {
 public:
 	enum {
@@ -68,7 +70,7 @@ public:
 		return "Setting trashtime (" + std::to_string(trashtime) + "): " + target;
 	}
 
-	uint8_t setTrashtime(FSNode *node, uint32_t ts);
+	uint8_t setTrashtime(const FilesystemOperationContext &fsOpContext, FSNode *node, uint32_t ts);
 
 private:
 	std::vector<inode_t> inode_list_;


### PR DESCRIPTION
Move periodic trash and reserved cleanup behind filesystem operations dispatch so backends can provide their own implementation.

Add detached-path lookup hooks and route ctime updates through operation context so KV backends can persist trash expiry changes and detached path resolution.

Make recursive settrashtime traverse children through node operations and keep detached space accounting backend-overridable.

Related to: LS-611
Related to: LS-612

Notes:
- Tests and re-implementation for KV is in the MDS repository (all passing).