### PR TITLE
ci(legal): add CAA workflow for contributors LS-591

### DIFF
--- a/.github/workflows/caa.yml
+++ b/.github/workflows/caa.yml
@@ -1,0 +1,15 @@
+name: "CAA Check"
+
+on:
+  push:
+    branches: [dev]
+  pull_request:
+    branches: [dev]
+
+permissions:
+  contents: read
+
+jobs:
+  caa:
+    uses: leil-io/legal/.github/workflows/caa-assistant.yml@main
+


### PR DESCRIPTION
- Integrates CLA Assistant Lite to enforce Contributor Copyright
Assignment (CAA)
- References centralized CAA.md in leil-io/legal repository
- Uses PAT-based storage for signature tracking via GitHub Actions