### PR TITLE
feat(mount): add support for cgroup v2 io limiting

### DIFF
--- a/src/mount/io_limit_group.cc
+++ b/src/mount/io_limit_group.cc
@@ -19,58 +19,56 @@
  */
 
 #include "common/platform.h"
-#include "mount/io_limit_group.h"
 
 #include <fstream>
 #include <iostream>
 #include <sstream>
 #include <string>
 
-static void skipHierarchy(std::istream& is) {
-	char x;
-	do {
-		is >> x;
-	} while (x != ':');
-}
+#include "mount/io_limit_group.h"
 
-static bool searchSubsystems(std::istream& is, const std::string& subsystem) {
-	const int length = subsystem.length();
-	int matched = 0;
-	char x;
-	while (1) {
-		is >> x;
-		if (matched == length && (x == ',' || x == ':')) {
-			while (x != ':') {
-				is >> x;
-			}
+static bool searchSubsystems(const std::string& subsystems, const std::string& subsystem) {
+	std::stringstream ss(subsystems);
+	std::string sub;
+	while (std::getline(ss, sub, ',')) {
+		if (sub == subsystem) {
 			return true;
 		}
-		if (matched == length || x != subsystem[matched]) {
-			while (x != ',' && x != ':') {
-				is >> x;
-			}
-			if (x == ':') {
-				return false;
-			}
-			matched = 0;
-			continue;
-		}
-		matched++;
 	}
+	return false;
 }
 
 IoLimitGroupId getIoLimitGroupId(std::istream& input, const std::string& subsystem) {
+	std::string v2Path;
+	bool v2Found = false;
+
 	try {
 		for (std::string line; std::getline(input, line);) {
 			try {
 				std::stringstream ss(line);
-				ss.exceptions(std::stringstream::eofbit);
-				skipHierarchy(ss);
-				if (searchSubsystems(ss, subsystem)) {
-					ss.exceptions(std::stringstream::goodbit);
-					std::string groupId;
-					std::getline(ss, groupId);
-					return groupId;
+
+				std::string hierarchyIdStr;
+				if (!std::getline(ss, hierarchyIdStr, ':')) {
+					continue;
+				}
+
+				std::string subsystems;
+				if (!std::getline(ss, subsystems, ':')) {
+					continue;
+				}
+
+				std::string path;
+				if (!std::getline(ss, path)) {
+					continue;
+				}
+
+				if (hierarchyIdStr == "0" && subsystems.empty()) {
+					v2Path = path;
+					v2Found = true;
+				}
+
+				if (searchSubsystems(subsystems, subsystem)) {
+					return path;
 				}
 			} catch (std::ios_base::failure&) {
 				throw GetIoLimitGroupIdException("Parse error");
@@ -82,6 +80,10 @@ IoLimitGroupId getIoLimitGroupId(std::istream& input, const std::string& subsyst
 		if (!input.eof()) {
 			throw;
 		}
+	}
+
+	if (v2Found) {
+		return v2Path;
 	}
 
 	throw GetIoLimitGroupIdException("Can't find subsystem '" + subsystem + "'");

--- a/src/mount/io_limit_group_unittest.cc
+++ b/src/mount/io_limit_group_unittest.cc
@@ -19,10 +19,11 @@
  */
 
 #include "common/platform.h"
-#include "mount/io_limit_group.h"
 
-#include <sstream>
 #include <gtest/gtest.h>
+#include <sstream>
+
+#include "mount/io_limit_group.h"
 
 TEST(IoLimitGroupTests, Empty) {
 	std::stringstream input("");
@@ -57,4 +58,32 @@ TEST(IoLimitGroupTests, Commas) {
 TEST(IoLimitGroupTests, SecondLine) {
 	std::stringstream input("1:blah:/wrong\n:blkio:/test\n");
 	EXPECT_EQ(getIoLimitGroupId(input, "blkio"), "/test");
+}
+
+TEST(IoLimitGroupTests, CgroupV2) {
+	std::stringstream input("0::/test/path\n");
+	EXPECT_EQ(getIoLimitGroupId(input, "blkio"), "/test/path");
+}
+
+TEST(IoLimitGroupTests, CgroupV2AndV1) {
+	std::stringstream input("0::/v2/path\n1:blkio:/v1/path\n");
+	// V1 should take precedence
+	EXPECT_EQ(getIoLimitGroupId(input, "blkio"), "/v1/path");
+}
+
+TEST(IoLimitGroupTests, CgroupV2AndOtherV1) {
+	std::stringstream input("0::/v2/path\n1:cpu:/v1/cpu/path\n");
+	// V1 doesn't match requested, should fallback to v2
+	EXPECT_EQ(getIoLimitGroupId(input, "blkio"), "/v2/path");
+}
+
+TEST(IoLimitGroupTests, CgroupHybridReversed) {
+	std::stringstream input("1:blkio:/v1/path\n0::/v2/path\n");
+	// V1 should still take precedence if found first
+	EXPECT_EQ(getIoLimitGroupId(input, "blkio"), "/v1/path");
+}
+
+TEST(IoLimitGroupTests, MalformedLine) {
+	std::stringstream input("invalid_line\n0::/valid/v2\n");
+	EXPECT_EQ(getIoLimitGroupId(input, "blkio"), "/valid/v2");
 }


### PR DESCRIPTION
This PR adds support for cgroup v2 in the SaunaFS mount client's IO limiting logic.

The `getIoLimitGroupId` function has been updated to parse the cgroup v2 unified hierarchy format (`0::/path`) from `/proc/pid/cgroup`. It maintains backward compatibility with cgroup v1 by prioritizing the requested subsystem if found, but falls back to the v2 path otherwise.

Since SaunaFS uses the cgroup path as an internal identifier for its own token-bucket based throttling (and does not write to the kernel's blkio controller), this change is sufficient to enable IO limiting on systems that have migrated to cgroup v2 (such as Ubuntu 22.04+).

Changes:
- Refactored `src/mount/io_limit_group.cc` to support v2 and hybrid modes.
- Added test cases to `src/mount/io_limit_group_unittest.cc` to verify the new logic.
- Ensured compliance with project's include ordering and coding standards.

---
*PR created automatically by Jules for task [14541340734163373904](https://jules.google.com/task/14541340734163373904) started by @antuan96314*