### PR TITLE
refactor(master): allow session management in KV

### DIFF
--- a/src/master/README.md
+++ b/src/master/README.md
@@ -161,6 +161,147 @@ The master communicates with five types of peers. The naming convention
 | `matontserv`   | Notifier clients | Broadcasts changelog events for inotify-like functionality. |
 | `masterconn`   | Active master   | Used only when running in **Shadow** personality. Receives changelogs and metadata from the active master. |
 
+## Client Sessions
+
+Client session state is split across a manager-owned in-memory view and a
+metadata-backed per-file view:
+
+- the session manager owns `Session` objects and handles creation, lookup,
+  timeout, persistence, and startup reconstruction,
+- each `Session` keeps mount-level session state plus an in-memory set of
+  currently open file inodes,
+- each `FSNodeFile` keeps the reverse mapping, `sessionIds`, inside filesystem
+  metadata.
+
+This split is intentional: some code needs to answer "what files does this
+session hold open?", while other code needs to answer "what sessions still
+hold this file open?". The manager layer isolates lifecycle logic from
+persistence, so different backends can keep the same session semantics while
+storing the durable state differently.
+
+The manager is attached during startup:
+
+- The master init sequence attaches the session manager before session state is
+  loaded.
+
+`matoclserv_sessions.cc` is a thin dispatcher layer: session-related wrappers
+forward to the active session manager with `sassert(...)` guards. Any
+dispatcher call before the backend is attached fails an assertion instead of
+falling back silently.
+
+### Session Data Model
+
+`Session` represents one client mount or meta-session known to the master.
+Its durable data is the information needed to recognize and restore a
+reconnectable mount: session identity, peer identity, mount root and access
+limits, UID/GID remapping, and hourly operation stats. Runtime-only state
+includes live connection state, transient connection details, caches, and the
+in-memory open-file set.
+
+`newSession` is not serialized directly. Instead, persistence treats
+reconnectable sessions as the durable subset, and loaded sessions are
+recreated in that reconnectable state.
+
+The lifecycle-related fields have distinct roles:
+
+- `newSession` acts as a small state flag used both to decide whether the
+  session is persisted and to select timeout policy.
+- `connections` is the in-memory connection counter updated by registration,
+  reconnect, and disconnect handling.
+- `disconnectedTimestamp` is cleared on reconnect/use, set when the last
+  connection drops, and initialized to `eventloop_time()` for sessions restored
+  from `sessions.sfs`.
+
+### Session ID Allocation and Changelog
+
+Session IDs come from a metadata-owned counter rather than from `sessions.sfs`.
+Allocating a new session consumes the current counter value, records the
+allocation in the changelog, and advances the counter. Because the same
+logical event is replayed during restore/shadow processing, session ID
+assignment stays consistent across snapshots and changelog replay.
+
+### Client Lifecycle
+
+The client lifecycle is:
+
+- **Create** -- Reconnectable sessions are allocated, filled with their stored
+  identity and limits, and persisted.
+- **Reconnect** -- An existing session record is reused, its disconnected
+  state is cleared, and its connection count is incremented.
+- **Disconnect** -- The connection count is decremented; once the last
+  connection drops, the session becomes eligible for timeout-based cleanup.
+- **Explicit delete / timeout cleanup** -- Both trigger teardown of the
+  session's open files and locks. Timeout cleanup also reaps expired session
+  records.
+
+The session file is not rewritten on every open or close. It is updated when
+reconnectable sessions are created and when periodic stats persistence runs.
+
+### Two Open-File Indexes
+
+The implementation keeps two synchronized indexes because different subsystems
+need opposite lookup directions:
+
+- `Session::openFilesSet` is the in-memory, per-session view of currently open
+  files.
+- `FSNodeFile::sessionIds` is the durable, per-file view of which sessions
+  still hold that file open.
+
+Normal open, close, and session-teardown paths update both sides. In the
+normal master open path, file-side membership is updated first and the
+in-memory session set is updated only on success. The file-side index is the
+durable one: it survives restart, drives reserved/trash file lifetime, and is
+used to rebuild the in-memory per-session view during startup.
+
+### `acquire()` / `release()` Semantics
+
+At the file-operation level, acquire adds session membership to the file node,
+while release removes it. If a reserved file no longer has any recorded
+openers, it can be deleted immediately. Lock cleanup is tied to session
+teardown rather than to a standalone release.
+
+Because reserved-file deletion is keyed off `FSNodeFile::sessionIds.empty()`,
+reserved-file lifetime depends on the file-side index, not on the session file
+alone.
+
+### Persistence and Restart
+
+The current master path spreads durable session-related state across two
+stores:
+
+- **`metadata.sfs`** stores `gMetadata->nextSessionId()` and the per-file
+  `FSNodeFile::sessionIds` vectors.
+- **`sessions.sfs`** stores reconnectable session metadata and hourly stats.
+
+`sessions.sfs` intentionally does **not** store:
+
+- `openFilesSet`
+- lock state
+- `connections`
+- `disconnectedTimestamp`
+- `groupsCache`
+- file-side `sessionIds`
+- transient connection details such as the current live socket attachment
+
+Startup reconstruction happens in two stages:
+
+1. Reconnectable sessions are loaded from `sessions.sfs` and start in a
+   disconnected state.
+2. Metadata loading rebuilds each session's in-memory open-file set from the
+   persisted file-side opener membership, creating compatibility-only
+   synthetic sessions if file-side membership exists without a matching session
+   record.
+
+This split answers the key restart questions:
+
+- **How does reconnect survive restart?**
+  Session identity and mount-level access limits come back from `sessions.sfs`.
+- **How does open-file state survive restart?**
+  File opener membership comes back from `FSNodeFile::sessionIds` in metadata.
+- **Why do reserved files depend on session state?**
+  Reserved/trash lifecycle logic consults the file-side `sessionIds` vector to
+  decide whether a detached file must stay alive.
+
 ## Metadata Persistence
 
 Metadata durability is achieved through two complementary mechanisms:

--- a/src/master/README.md
+++ b/src/master/README.md
@@ -163,144 +163,43 @@ The master communicates with five types of peers. The naming convention
 
 ## Client Sessions
 
-Client session state is split across a manager-owned in-memory view and a
-metadata-backed per-file view:
+Client session lifecycle is routed through `ISessionManager`. The file-backed
+master binds `SessionManagerFile`; KV/MDS builds can bind a different manager
+without changing the shared `Session` runtime object or the `matoclserv`
+protocol handlers.
 
-- the session manager owns `Session` objects and handles creation, lookup,
-  timeout, persistence, and startup reconstruction,
-- each `Session` keeps mount-level session state plus an in-memory set of
-  currently open file inodes,
-- each `FSNodeFile` keeps the reverse mapping, `sessionIds`, inside filesystem
-  metadata.
+`matoclserv_sessions.cc` is the dispatcher layer. Its wrappers forward to the
+active manager and assert if they are called before startup attaches one.
 
-This split is intentional: some code needs to answer "what files does this
-session hold open?", while other code needs to answer "what sessions still
-hold this file open?". The manager layer isolates lifecycle logic from
-persistence, so different backends can keep the same session semantics while
-storing the durable state differently.
+For the file-backed master, `SessionManagerFile` keeps the complete in-memory
+session catalog and persists reconnectable session records to `sessions.sfs`.
+The loader accepts the current session-file header only; old `MFS`-branded and
+pre-1.6.4 session files are rejected at startup instead of being interpreted by
+compatibility branches. `storeSessions()` continues to write the current format.
 
-The manager is attached during startup:
+Session durability is split between the session file and metadata:
 
-- The master init sequence attaches the session manager before session state is
-  loaded.
+- `sessions.sfs` stores reconnectable mount identity, access limits, UID/GID
+  mapping, and hourly operation stats.
+- `metadata.sfs` stores the session-id counter and each file's
+  `FSNodeFile::sessionIds` list.
+- `Session::openFilesSet` is an in-memory, per-session index rebuilt on startup
+  from the file-side `sessionIds` metadata.
 
-`matoclserv_sessions.cc` is a thin dispatcher layer: session-related wrappers
-forward to the active session manager with `sassert(...)` guards. Any
-dispatcher call before the backend is attached fails an assertion instead of
-falling back silently.
+That split gives the master both lookup directions: "which files does this
+session hold?" through `openFilesSet`, and "which sessions hold this file?"
+through `FSNodeFile::sessionIds`. The file-side list is the durable authority
+for reserved-file lifetime and purge decisions.
 
-### Session Data Model
+The lifecycle remains the traditional master lifecycle: create, reconnect,
+disconnect, explicit delete, and timeout cleanup. Session ids are still
+allocated through `gFSOperations->newSessionId()`, which records the allocation
+in the changelog for the file-backed master path.
 
-`Session` represents one client mount or meta-session known to the master.
-Its durable data is the information needed to recognize and restore a
-reconnectable mount: session identity, peer identity, mount root and access
-limits, UID/GID remapping, and hourly operation stats. Runtime-only state
-includes live connection state, transient connection details, caches, and the
-in-memory open-file set.
-
-`newSession` is not serialized directly. Instead, persistence treats
-reconnectable sessions as the durable subset, and loaded sessions are
-recreated in that reconnectable state.
-
-The lifecycle-related fields have distinct roles:
-
-- `newSession` acts as a small state flag used both to decide whether the
-  session is persisted and to select timeout policy.
-- `connections` is the in-memory connection counter updated by registration,
-  reconnect, and disconnect handling.
-- `disconnectedTimestamp` is cleared on reconnect/use, set when the last
-  connection drops, and initialized to `eventloop_time()` for sessions restored
-  from `sessions.sfs`.
-
-### Session ID Allocation and Changelog
-
-Session IDs come from a metadata-owned counter rather than from `sessions.sfs`.
-Allocating a new session consumes the current counter value, records the
-allocation in the changelog, and advances the counter. Because the same
-logical event is replayed during restore/shadow processing, session ID
-assignment stays consistent across snapshots and changelog replay.
-
-### Client Lifecycle
-
-The client lifecycle is:
-
-- **Create** -- Reconnectable sessions are allocated, filled with their stored
-  identity and limits, and persisted.
-- **Reconnect** -- An existing session record is reused, its disconnected
-  state is cleared, and its connection count is incremented.
-- **Disconnect** -- The connection count is decremented; once the last
-  connection drops, the session becomes eligible for timeout-based cleanup.
-- **Explicit delete / timeout cleanup** -- Both trigger teardown of the
-  session's open files and locks. Timeout cleanup also reaps expired session
-  records.
-
-The session file is not rewritten on every open or close. It is updated when
-reconnectable sessions are created and when periodic stats persistence runs.
-
-### Two Open-File Indexes
-
-The implementation keeps two synchronized indexes because different subsystems
-need opposite lookup directions:
-
-- `Session::openFilesSet` is the in-memory, per-session view of currently open
-  files.
-- `FSNodeFile::sessionIds` is the durable, per-file view of which sessions
-  still hold that file open.
-
-Normal open, close, and session-teardown paths update both sides. In the
-normal master open path, file-side membership is updated first and the
-in-memory session set is updated only on success. The file-side index is the
-durable one: it survives restart, drives reserved/trash file lifetime, and is
-used to rebuild the in-memory per-session view during startup.
-
-### `acquire()` / `release()` Semantics
-
-At the file-operation level, acquire adds session membership to the file node,
-while release removes it. If a reserved file no longer has any recorded
-openers, it can be deleted immediately. Lock cleanup is tied to session
-teardown rather than to a standalone release.
-
-Because reserved-file deletion is keyed off `FSNodeFile::sessionIds.empty()`,
-reserved-file lifetime depends on the file-side index, not on the session file
-alone.
-
-### Persistence and Restart
-
-The current master path spreads durable session-related state across two
-stores:
-
-- **`metadata.sfs`** stores `gMetadata->nextSessionId()` and the per-file
-  `FSNodeFile::sessionIds` vectors.
-- **`sessions.sfs`** stores reconnectable session metadata and hourly stats.
-
-`sessions.sfs` intentionally does **not** store:
-
-- `openFilesSet`
-- lock state
-- `connections`
-- `disconnectedTimestamp`
-- `groupsCache`
-- file-side `sessionIds`
-- transient connection details such as the current live socket attachment
-
-Startup reconstruction happens in two stages:
-
-1. Reconnectable sessions are loaded from `sessions.sfs` and start in a
-   disconnected state.
-2. Metadata loading rebuilds each session's in-memory open-file set from the
-   persisted file-side opener membership, creating compatibility-only
-   synthetic sessions if file-side membership exists without a matching session
-   record.
-
-This split answers the key restart questions:
-
-- **How does reconnect survive restart?**
-  Session identity and mount-level access limits come back from `sessions.sfs`.
-- **How does open-file state survive restart?**
-  File opener membership comes back from `FSNodeFile::sessionIds` in metadata.
-- **Why do reserved files depend on session state?**
-  Reserved/trash lifecycle logic consults the file-side `sessionIds` vector to
-  decide whether a detached file must stay alive.
+Explicit delete and timeout cleanup both call `matocl_close_files()` to release
+open files and locks. The helper reports whether teardown completed; timeout
+cleanup erases a session only after successful teardown, so a failed transactional
+backend commit can keep the session managed for a later retry.
 
 ## Metadata Persistence
 

--- a/src/master/filesystem_metadata.h
+++ b/src/master/filesystem_metadata.h
@@ -162,6 +162,10 @@ extern bool gDisableEmptyFoldersMetadataOnFullDisk;
 
 inline std::unique_ptr<IIdGenerator<inode_t>> gInodeIdGenerator = nullptr;
 
+// Session IDs are allocated by gSessionIdGenerator in the KV-backed path, so
+// gMetadata->nextSessionId() is no longer the source of truth for MDS.
+inline std::unique_ptr<IIdGenerator<uint32_t>> gSessionIdGenerator = nullptr;
+
 #ifndef METARESTORE
 extern std::map<int, Goal> gGoalDefinitions;
 extern bool gAtimeDisabled;

--- a/src/master/init.h
+++ b/src/master/init.h
@@ -42,6 +42,7 @@
 #include "master/metadata_backend_file.h"
 #include "master/metadata_backend_interface.h"
 #include "master/personality.h"
+#include "master/session_manager.h"
 #include "master/topology.h"
 #include "metrics/metrics.h"
 
@@ -73,6 +74,11 @@ inline int metadata_backend_init() {
 	return 0;
 }
 
+inline int session_manager_init() {
+	matoclserv_set_session_manager(std::make_unique<SessionManagerFile>());
+	return 0;
+}
+
 /// Functions to call before normal startup
 inline const std::vector<RunTab> earlyRunTabs = {
     RunTab{.function = metadataserver::personality_validate, .name = "validate personality"}};
@@ -87,6 +93,8 @@ inline const std::vector<RunTab> runTabs = {
     RunTab{.function = rnd_init, .name = "random generator"},
     // has to be before 'fs_init' and 'matoclserv_networkinit'
     RunTab{.function = dcm_init, .name = "data cache manager"},
+    // must run before 'matoclserv_sessions_init' so the dispatcher has a backing manager.
+    RunTab{.function = session_manager_init, .name = "attach session manager"},
     // has to be before 'fs_init'
     RunTab{.function = matoclserv_sessions_init, .name = "load stored sessions"},
     RunTab{.function = exports_init, .name = "exports manager"},

--- a/src/master/kv_common_keys.h
+++ b/src/master/kv_common_keys.h
@@ -26,8 +26,6 @@
 inline constexpr std::string_view kMetaFormatKey = "META_FORMAT";
 inline constexpr std::string_view kMetaVersionKey = "META_VERSION";
 
-inline constexpr std::string_view kMetaNextSessionKey = "META_NEXT_SESSION";
-
 /// Prefix for persisted session records.
 /// Format: SESS_REC_<SessionId>:<SerializedSessionRecord>
 /// - SessionId: uint32_t serialized as Big Endian
@@ -47,8 +45,25 @@ inline constexpr std::string_view kSessionKeyPrefix = "SESS_REC_";
 /// @note Value is empty; key presence encodes membership in the open-file set.
 inline constexpr std::string_view kSessionOpenKeyPrefix = "SESS_OPEN_";
 
+/// Prefix for per-session runtime ownership state.
+/// Format: SESS_STATE_<SessionId>:<SerializedSessionState>
+/// - SessionId: uint32_t serialized as Big Endian
+/// - Value: versioned runtime state used by the FDB session manager.
+/// @note This row is intentionally separate from @c SESS_REC_ so the stable
+///       session record schema can remain unchanged while MDS-local ownership
+///       and disconnect state evolves.
+inline constexpr std::string_view kSessionStateKeyPrefix = "SESS_STATE_";
+
 inline constexpr std::string_view kInodeRangeStartKey = "META_NEXT_INODE_RANGE";
 inline constexpr std::string_view kChunkRangeStartKey = "META_NEXT_CHUNK_RANGE";
+inline constexpr std::string_view kSessionRangeStartKey = "META_NEXT_SESSION_RANGE";
+
+/// Cluster-wide counter used to allocate stable mds_id values.
+/// Format: META_NEXT_MDS_ID : <uint32_t LE>
+/// Each MDS bootstrap does atomicAdd(+1) on this key then reads the
+/// post-increment value as its assigned mds_id. Value 0 means "no mds_id
+/// has ever been allocated"; allocated ids start at 1.
+inline constexpr std::string_view kMetaNextMdsIdKey = "META_NEXT_MDS_ID";
 
 // Keys for filesystem statistics
 inline constexpr std::string_view kMetaNodesKey = "META_NODES";

--- a/src/master/kv_common_keys.h
+++ b/src/master/kv_common_keys.h
@@ -28,6 +28,25 @@ inline constexpr std::string_view kMetaVersionKey = "META_VERSION";
 
 inline constexpr std::string_view kMetaNextSessionKey = "META_NEXT_SESSION";
 
+/// Prefix for persisted session records.
+/// Format: SESS_REC_<SessionId>:<SerializedSessionRecord>
+/// - SessionId: uint32_t serialized as Big Endian
+/// - Value: versioned serialized Session record (kSessionRecordVersion + payload)
+/// @note SessionId is Big Endian to preserve numeric ordering in lexicographical
+/// scans by the SESS_REC_ prefix.
+/// @note This must stay disjoint from per-session secondary-index prefixes such as
+/// kSessionOpenKeyPrefix because session records are loaded by prefix scan.
+inline constexpr std::string_view kSessionKeyPrefix = "SESS_REC_";
+
+/// Prefix for the per-session open-file index.
+/// Format: SESS_OPEN_<SessionId><InodeId>:<EmptyValue>
+/// - SessionId: uint32_t serialized as Big Endian
+/// - InodeId: inode_t serialized as Big Endian
+/// @note The (SessionId, InodeId) key layout enables efficient per-session scans
+/// and range deletion of all open-file rows for a session.
+/// @note Value is empty; key presence encodes membership in the open-file set.
+inline constexpr std::string_view kSessionOpenKeyPrefix = "SESS_OPEN_";
+
 inline constexpr std::string_view kInodeRangeStartKey = "META_NEXT_INODE_RANGE";
 inline constexpr std::string_view kChunkRangeStartKey = "META_NEXT_CHUNK_RANGE";
 

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -5284,6 +5284,7 @@ bool matocl_close_files(Session *currentSession) {
 
 	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
 	    FilesystemOperationContext::TransactionType::kReadWrite);
+	const bool contextHasTransaction = fsOpContext.hasReadWriteTransaction();
 
 	// Teardown must preserve backend correctness across partial failures.
 	//
@@ -5302,67 +5303,59 @@ bool matocl_close_files(Session *currentSession) {
 	// session-management or timeout-driven cleanup can retry them.
 	std::vector<inode_t> pendingBatch;
 	std::vector<inode_t> committed;
-	pendingBatch.reserve(kTransactionBatchSize);
-	committed.reserve(currentSession->openFilesSet.size());
+	if (contextHasTransaction) { pendingBatch.reserve(kTransactionBatchSize); }
 
-	// Commits one pending batch for transactional backends, or marks it as completed immediately
-	// for synchronous backends.
+	// Commits one pending batch for transactional backends.
 	auto flushBatch = [&](bool isFinal) -> bool {
-		if (pendingBatch.empty()) { return true; }
-
-		if (!fsOpContext.hasReadWriteTransaction()) {
-			// File backend applies release() synchronously; nothing to commit.
-			committed.insert(committed.end(), pendingBatch.begin(), pendingBatch.end());
-			pendingBatch.clear();
-			return true;
-		}
-
 		if (!fsOpContext.getReadWriteTransaction()->commit()) { return false; }
 
-		committed.insert(committed.end(), pendingBatch.begin(), pendingBatch.end());
+		if (!isFinal) {
+			committed.insert(committed.end(), pendingBatch.begin(), pendingBatch.end());
+		}
+
 		pendingBatch.clear();
+
 		if (!isFinal) {
 			fsOpContext = gFSOperations->createFilesystemOperationContext(
 			    FilesystemOperationContext::TransactionType::kReadWrite);
 		}
+
 		return true;
 	};
 
 	bool anyFailure = false;
+	size_t pendingOperations = currentSession->openFilesSet.size();
 
 	for (inode_t openFileInode : currentSession->openFilesSet) {
 		gFSOperations->release(context, fsOpContext, openFileInode, currentSession->sessionId);
 		matocl_locks_release(context, fsOpContext, openFileInode, currentSession->sessionId);
-		pendingBatch.push_back(openFileInode);
 
-		if (pendingBatch.size() >= kTransactionBatchSize) {
-			if (!flushBatch(/*isFinal=*/false)) {
+		if (contextHasTransaction) {
+			pendingOperations--;
+			pendingBatch.push_back(openFileInode);
+
+			const bool shouldFlush =
+			    pendingBatch.size() >= kTransactionBatchSize || pendingOperations == 0;
+
+			if (shouldFlush && !flushBatch(/*isFinal=*/pendingOperations == 0)) {
 				safs::log_err(
 				    "{}: batch commit failed while closing files for session {}; "
-				    "leaving {} inode(s) from this batch plus any un-started "
+				    "leaving {} inode(s) from this batch plus {} un-started "
 				    "inodes in openFilesSet for callers that can retry later",
-				    __func__, currentSession->sessionId, pendingBatch.size());
+				    __func__, currentSession->sessionId, pendingBatch.size(), pendingOperations);
 				anyFailure = true;
 				break;
 			}
 		}
 	}
 
-	bool finalCommitSucceeded = true;
-	if (!anyFailure && !flushBatch(/*isFinal=*/true)) {
-		safs::log_err(
-		    "{}: final commit failed while closing files for session {}; "
-		    "leaving {} inode(s) in openFilesSet for callers that can retry later",
-		    __func__, currentSession->sessionId, pendingBatch.size());
-		finalCommitSucceeded = false;
-	}
-
-	if (!anyFailure && finalCommitSucceeded) {
+	if (!anyFailure) {
 		currentSession->openFilesSet.clear();
 	} else {
 		for (inode_t inode : committed) { currentSession->openFilesSet.erase(inode); }
 	}
-	return !anyFailure && finalCommitSucceeded && currentSession->openFilesSet.empty();
+
+	return !anyFailure;
 }
 
 void matoclserv_session_files(matoclserventry *eptr, [[maybe_unused]] const uint8_t *data,

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -5158,11 +5158,11 @@ void matoclserv_admin_reload(matoclserventry* eptr, const uint8_t* data, uint32_
 std::string get_client_configs() {
 	std::map<std::string, std::string> client_configs;
 
-	for (const auto& sessionPtr : gSessionsVector) {
-		if (sessionPtr->config.empty()) { continue; }
-		NetworkAddress addr(sessionPtr->peerIpAddress, sessionPtr->peerPort);
-		client_configs[addr.toString()] = sessionPtr->config;
-	}
+	matoclserv_for_each_session([&client_configs](const Session &session) {
+		if (session.config.empty()) { return; }
+		NetworkAddress addr(session.peerIpAddress, session.peerPort);
+		client_configs[addr.toString()] = session.config;
+	});
 
 	return cfg_yaml_list("clients", client_configs);
 }
@@ -5376,21 +5376,8 @@ void matoclserv_session_delete(matoclserventry *eptr, const uint8_t *data, uint3
 }
 
 void matocl_session_check() {
-	uint32_t now = eventloop_time();
-
-	for (auto sessionIt = gSessionsVector.begin(); sessionIt != gSessionsVector.end();) {
-		auto& sessionPtr = *sessionIt;
-		if (sessionPtr->connections == 0 &&
-		    ((sessionPtr->newSession > 1 && sessionPtr->disconnectedTimestamp < now) ||
-		     (sessionPtr->newSession == 1 &&
-		      sessionPtr->disconnectedTimestamp + gSessionSustainTime < now) ||
-		     (sessionPtr->newSession == 0 && sessionPtr->disconnectedTimestamp + 7200 < now))) {
-			matocl_session_timedout(sessionPtr.get());
-			sessionIt = gSessionsVector.erase(sessionIt);
-		} else {
-			++sessionIt;
-		}
-	}
+	matoclserv_remove_timed_out_sessions(
+	    [](Session *currentSession) { matocl_session_timedout(currentSession); });
 }
 
 void matocl_before_disconnect(matoclserventry *eptr) {

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -1426,7 +1426,7 @@ void matoclserv_fuse_register(matoclserventry *eptr, const uint8_t *data, uint32
 				    (path != nullptr) ? reinterpret_cast<const char *>(path) : "unknown path",
 				    ipToString(eptr->peerIpAddress), eptr->peerPort);
 
-				matoclserv_store_sessions();
+				matoclserv_persist_session(eptr->sessionData);
 			}
 
 			// answer
@@ -1531,7 +1531,7 @@ void matoclserv_fuse_register(matoclserventry *eptr, const uint8_t *data, uint32
 				    !eptr->sessionData->info.empty() ? eptr->sessionData->info : "unknown info",
 				    ipToString(eptr->peerIpAddress), eptr->peerPort);
 
-				matoclserv_store_sessions();
+				matoclserv_persist_session(eptr->sessionData);
 			}
 
 			// answer
@@ -5279,67 +5279,118 @@ void matocl_locks_release(const FsContext &context, const FilesystemOperationCon
 	}
 }
 
-void matocl_close_files(Session *currentSession) {
+bool matocl_close_files(Session *currentSession) {
 	FsContext context = FsContext::getForMaster(eventloop_time());
 
 	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
 	    FilesystemOperationContext::TransactionType::kReadWrite);
 
-	size_t operationCount = 0;
+	// Teardown must preserve backend correctness across partial failures.
+	//
+	// File-backed backends apply release() synchronously, so every processed inode can be erased
+	// from openFilesSet immediately.
+	//
+	// Transactional KV backends may batch many release() calls into one commit. If a batch commit
+	// fails, the backend state for that batch is rolled back, so those inodes must remain in
+	// openFilesSet. Callers that keep the session managed can retry them later. Only inodes from
+	// successfully committed batches are erased here.
+	//
+	// We intentionally do not retry failed batches in-function: release() may emit side effects
+	// outside the backend transaction, so retrying could duplicate those effects without a matching
+	// backend state change.
+	std::vector<inode_t> toProcess(currentSession->openFilesSet.begin(),
+	                               currentSession->openFilesSet.end());
+	std::vector<inode_t> pendingBatch;
+	std::vector<inode_t> committed;
+	pendingBatch.reserve(kTransactionBatchSize);
+	committed.reserve(toProcess.size());
 
-	for (const auto &openFileInode : currentSession->openFilesSet) {
+	// Commits one pending batch for transactional backends, or marks it as completed immediately
+	// for synchronous backends.
+	auto flushBatch = [&](bool isFinal) -> bool {
+		if (pendingBatch.empty()) { return true; }
+
+		if (!fsOpContext.hasReadWriteTransaction()) {
+			// File backend applies release() synchronously; nothing to commit.
+			committed.insert(committed.end(), pendingBatch.begin(), pendingBatch.end());
+			pendingBatch.clear();
+			return true;
+		}
+
+		if (!fsOpContext.getReadWriteTransaction()->commit()) { return false; }
+
+		committed.insert(committed.end(), pendingBatch.begin(), pendingBatch.end());
+		pendingBatch.clear();
+		if (!isFinal) {
+			fsOpContext = gFSOperations->createFilesystemOperationContext(
+			    FilesystemOperationContext::TransactionType::kReadWrite);
+		}
+		return true;
+	};
+
+	bool anyFailure = false;
+
+	for (inode_t openFileInode : toProcess) {
 		gFSOperations->release(context, fsOpContext, openFileInode, currentSession->sessionId);
 		matocl_locks_release(context, fsOpContext, openFileInode, currentSession->sessionId);
-		operationCount++;
+		pendingBatch.push_back(openFileInode);
 
-		if (fsOpContext.hasReadWriteTransaction() && operationCount >= kTransactionBatchSize) {
-			if (!commitTransactionBatch(fsOpContext, operationCount)) {
+		if (pendingBatch.size() >= kTransactionBatchSize) {
+			if (!flushBatch(/*isFinal=*/false)) {
 				safs::log_err(
-				    "{}: failed to commit transaction batch while closing files for session {}",
-				    __func__, currentSession->sessionId);
-				// KV-backends: Continue for now until the transaction retry strategy is implemented
+				    "{}: batch commit failed while closing files for session {}; "
+				    "leaving {} inode(s) from this batch plus any un-started "
+				    "inodes in openFilesSet for callers that can retry later",
+				    __func__, currentSession->sessionId, pendingBatch.size());
+				anyFailure = true;
+				break;
 			}
 		}
 	}
 
-	// Commit the final batch for KV backends
-	if (fsOpContext.hasReadWriteTransaction() && operationCount > 0) {
-		if (!fsOpContext.getReadWriteTransaction()->commit()) {
-			safs::log_err(
-			    "{}: failed to commit final transaction while closing files for session {}",
-			    __func__, currentSession->sessionId);
-		}
+	bool finalCommitSucceeded = true;
+	if (!anyFailure && !flushBatch(/*isFinal=*/true)) {
+		safs::log_err(
+		    "{}: final commit failed while closing files for session {}; "
+		    "leaving {} inode(s) in openFilesSet for callers that can retry later",
+		    __func__, currentSession->sessionId, pendingBatch.size());
+		finalCommitSucceeded = false;
 	}
 
-	currentSession->openFilesSet.clear();
+	for (inode_t inode : committed) { currentSession->openFilesSet.erase(inode); }
+	return !anyFailure && finalCommitSucceeded && currentSession->openFilesSet.empty();
 }
 
-void matoclserv_session_files(matoclserventry *eptr,
-                              [[maybe_unused]] const uint8_t *data,
+void matoclserv_session_files(matoclserventry *eptr, [[maybe_unused]] const uint8_t *data,
                               [[maybe_unused]] uint32_t length) {
 	std::vector<SessionFiles> sessions;
 	MessageBuffer reply;
 
-	for (const auto &eaptr : matoclservList) {
-		if (eaptr->mode == ClientConnectionMode::KILL || !eaptr->sessionData ||
-		    eaptr->registered != ClientState::kRegistered) {
-			continue;
-		}
+	// File-backed sessions report the local live-connection view. KV-backed managers may provide a
+	// backend-derived catalog instead, such as a broader session view that is not limited to
+	// currently connected local clients.
+	if (matoclserv_uses_backend_session_list()) {
+		sessions = matoclserv_list_sessions();
+	} else {
+		for (const auto &eaptr : matoclservList) {
+			if (eaptr->mode == ClientConnectionMode::KILL || !eaptr->sessionData ||
+			    eaptr->registered != ClientState::kRegistered) {
+				continue;
+			}
 
-		SessionFiles session;
-		session.sessionId = eaptr->sessionData->sessionId;
-		session.peerIp = eaptr->sessionData->peerIpAddress;
-		session.filesNumber = session_number_of_files(eaptr->sessionData);
-		sessions.push_back(session);
+			SessionFiles session;
+			session.sessionId = eaptr->sessionData->sessionId;
+			session.peerIp = eaptr->sessionData->peerIpAddress;
+			session.filesNumber = session_number_of_files(eaptr->sessionData);
+			sessions.push_back(session);
+		}
 	}
 
 	matocl::listSessions::serialize(reply, sessions);
 	matoclserv_createpacket(eptr, std::move(reply));
 }
 
-void matocl_session_timedout(Session *currentSession) {
-	matocl_close_files(currentSession);
-}
+bool matocl_session_timedout(Session *currentSession) { return matocl_close_files(currentSession); }
 
 void matoclserv_session_delete(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	uint8_t status = SAUNAFS_STATUS_OK;
@@ -5377,7 +5428,7 @@ void matoclserv_session_delete(matoclserventry *eptr, const uint8_t *data, uint3
 
 void matocl_session_check() {
 	matoclserv_remove_timed_out_sessions(
-	    [](Session *currentSession) { matocl_session_timedout(currentSession); });
+	    [](Session *currentSession) { return matocl_session_timedout(currentSession); });
 }
 
 void matocl_before_disconnect(matoclserventry *eptr) {
@@ -5410,6 +5461,8 @@ void matocl_before_disconnect(matoclserventry *eptr) {
 		if (eptr->sessionData->connections == 0) {
 			eptr->sessionData->disconnectedTimestamp = eventloop_time();
 		}
+
+		matoclserv_session_disconnected(eptr->sessionData);
 	}
 
 	matoclserv_remove_entry_from_unlock_list(eptr);

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -5295,15 +5295,15 @@ bool matocl_close_files(Session *currentSession) {
 	// openFilesSet. Callers that keep the session managed can retry them later. Only inodes from
 	// successfully committed batches are erased here.
 	//
-	// We intentionally do not retry failed batches in-function: release() may emit side effects
-	// outside the backend transaction, so retrying could duplicate those effects without a matching
-	// backend state change.
-	std::vector<inode_t> toProcess(currentSession->openFilesSet.begin(),
-	                               currentSession->openFilesSet.end());
+	// We intentionally do not perform immediate retries for failed batches in
+	// this function: release() may emit side effects outside the backend
+	// transaction, so retrying here could duplicate those effects without a
+	// matching backend state change. Failed inodes stay in openFilesSet so later
+	// session-management or timeout-driven cleanup can retry them.
 	std::vector<inode_t> pendingBatch;
 	std::vector<inode_t> committed;
 	pendingBatch.reserve(kTransactionBatchSize);
-	committed.reserve(toProcess.size());
+	committed.reserve(currentSession->openFilesSet.size());
 
 	// Commits one pending batch for transactional backends, or marks it as completed immediately
 	// for synchronous backends.
@@ -5330,7 +5330,7 @@ bool matocl_close_files(Session *currentSession) {
 
 	bool anyFailure = false;
 
-	for (inode_t openFileInode : toProcess) {
+	for (inode_t openFileInode : currentSession->openFilesSet) {
 		gFSOperations->release(context, fsOpContext, openFileInode, currentSession->sessionId);
 		matocl_locks_release(context, fsOpContext, openFileInode, currentSession->sessionId);
 		pendingBatch.push_back(openFileInode);
@@ -5357,7 +5357,11 @@ bool matocl_close_files(Session *currentSession) {
 		finalCommitSucceeded = false;
 	}
 
-	for (inode_t inode : committed) { currentSession->openFilesSet.erase(inode); }
+	if (!anyFailure && finalCommitSucceeded) {
+		currentSession->openFilesSet.clear();
+	} else {
+		for (inode_t inode : committed) { currentSession->openFilesSet.erase(inode); }
+	}
 	return !anyFailure && finalCommitSucceeded && currentSession->openFilesSet.empty();
 }
 
@@ -6295,19 +6299,7 @@ void matoclserv_reload() {
 		}
 	}
 
-	gSessionSustainTime = cfg_getuint32("SESSION_SUSTAIN_TIME", 86400);
-
-	if (gSessionSustainTime > 7 * 86400) {
-		gSessionSustainTime = 7 * 86400;
-		safs::log_warn(
-		    "SESSION_SUSTAIN_TIME too big (more than week) - setting this value to one week");
-	}
-
-	if (gSessionSustainTime < 60) {
-		gSessionSustainTime = 60;
-		safs::log_warn(
-		    "SESSION_SUSTAIN_TIME too low (less than minute) - setting this value to one minute");
-	}
+	matoclserv_configure_session_sustain_time();
 
 	matoclserv_iolimits_reload();
 

--- a/src/master/matoclserv_sessions.cc
+++ b/src/master/matoclserv_sessions.cc
@@ -32,7 +32,9 @@ namespace {
 
 std::unique_ptr<ISessionManager> gSessionManager;
 
-void configureSessionSustainTime() {
+}  // namespace
+
+void matoclserv_configure_session_sustain_time() {
 	gSessionSustainTime = cfg_getuint32("SESSION_SUSTAIN_TIME", 86400);
 
 	if (gSessionSustainTime > 7 * 86400) {
@@ -48,9 +50,8 @@ void configureSessionSustainTime() {
 	}
 }
 
-}  // namespace
-
 void matoclserv_set_session_manager(std::unique_ptr<ISessionManager> manager) {
+	sassert(manager != nullptr);
 	if (gSessionManager != nullptr) { gSessionManager->unload(); }
 	gSessionManager = std::move(manager);
 }
@@ -145,7 +146,7 @@ void matocl_session_stats_rotate() {
 int matoclserv_sessions_init() {
 	sassert(gSessionManager != nullptr);
 	int status = gSessionManager->initialize();
-	configureSessionSustainTime();
+	matoclserv_configure_session_sustain_time();
 	return status;
 }
 

--- a/src/master/matoclserv_sessions.cc
+++ b/src/master/matoclserv_sessions.cc
@@ -60,6 +60,18 @@ void matoclserv_store_sessions() {
 	gSessionManager->storeSessions();
 }
 
+void matoclserv_persist_session(Session *session) {
+	sassert(gSessionManager != nullptr);
+	if (session == nullptr) { return; }
+	gSessionManager->persistSession(*session);
+}
+
+void matoclserv_session_disconnected(Session *session) {
+	sassert(gSessionManager != nullptr);
+	if (session == nullptr) { return; }
+	gSessionManager->sessionDisconnected(*session);
+}
+
 int matoclserv_load_sessions() {
 	sassert(gSessionManager != nullptr);
 	return gSessionManager->loadSessions();
@@ -90,7 +102,17 @@ void matoclserv_for_each_session(const std::function<void(const Session &)> &vis
 	gSessionManager->forEachSession(visitor);
 }
 
-void matoclserv_remove_timed_out_sessions(const std::function<void(Session *)> &onTimedOut) {
+std::vector<SessionFiles> matoclserv_list_sessions() {
+	sassert(gSessionManager != nullptr);
+	return gSessionManager->listSessions();
+}
+
+bool matoclserv_uses_backend_session_list() {
+	sassert(gSessionManager != nullptr);
+	return gSessionManager->usesBackendSessionList();
+}
+
+void matoclserv_remove_timed_out_sessions(const std::function<bool(Session *)> &onTimedOut) {
 	sassert(gSessionManager != nullptr);
 	gSessionManager->removeTimedOutSessions(eventloop_time(), gSessionSustainTime, onTimedOut);
 }

--- a/src/master/matoclserv_sessions.cc
+++ b/src/master/matoclserv_sessions.cc
@@ -22,401 +22,17 @@
 
 #include "master/matoclserv_sessions.h"
 
-#include "common/cwrap.h"
-#include "common/datapack.h"
 #include "common/event_loop.h"
 #include "common/massert.h"
-#include "common/type_defs.h"
 #include "config/cfg.h"
-#include "master/filesystem_operation_context.h"
-#include "master/filesystem_operations_interface.h"
-#include "master/metadata_backend_common.h"
-#include "protocol/SFSCommunication.h"
+#include "master/session_manager.h"
 #include "slogger/slogger.h"
 
-Session *matoclserv_new_session(uint8_t newSession, uint8_t noNewId) {
-	auto sessionPtr = std::make_unique<Session>();
-	passert(sessionPtr.get());
+namespace {
 
-	auto newSessionIdNotNeeded = (newSession == 0 && noNewId);
-	sessionPtr->sessionId = (newSessionIdNotNeeded) ? 0 : gFSOperations->newSessionId();
-	sessionPtr->newSession = newSession;
-	sessionPtr->connections = 1;
-	gSessionsVector.push_back(std::move(sessionPtr));
-	return gSessionsVector.back().get();
-}
+std::unique_ptr<ISessionManager> gSessionManager;
 
-Session* matoclserv_find_session(uint32_t sessionId) {
-	if (sessionId == 0) { return nullptr; }
-
-	for (const auto& sessionPtr : gSessionsVector) {
-		if (sessionPtr->sessionId == sessionId) {
-			if (sessionPtr->newSession >= 2) {
-				sessionPtr->newSession -= 2;
-			}
-			sessionPtr->connections++;
-			sessionPtr->disconnectedTimestamp = 0;
-			return sessionPtr.get();
-		}
-	}
-	return nullptr;
-}
-
-void matoclserv_close_session(uint32_t sessionId) {
-	if (sessionId == 0) { return; }
-
-	for (const auto& sessionPtr : gSessionsVector) {
-		if (sessionPtr->sessionId == sessionId) {
-			if (sessionPtr->connections == 1 && sessionPtr->newSession < 2) {
-				sessionPtr->newSession += 2;
-			}
-		}
-	}
-}
-
-void matoclserv_store_sessions() {
-	uint32_t sessionInfoLength;
-	constexpr uint32_t kSessionSerializedSize =
-	    sizeof(Session::sessionId) + sizeof(sessionInfoLength) + sizeof(Session::peerIpAddress) +
-	    sizeof(Session::rootInode) + sizeof(Session::flags) + sizeof(Session::minGoal) +
-	    sizeof(Session::maxGoal) + sizeof(Session::minTrashTime) + sizeof(Session::maxTrashTime) +
-	    sizeof(Session::rootUid) + sizeof(Session::rootGid) + sizeof(Session::mapAllUid) +
-	    sizeof(Session::mapAllGid);
-	constexpr uint32_t kBufferSize = kSessionSerializedSize + (SESSION_STATS * 8);
-	std::vector<uint8_t> fsesrecord(kBufferSize); // 4+4+4+4+1+1+1+4+4+4+4+4+4+SESSION_STATS*4+SESSION_STATS*4
-
-	FILE *fd = fopen(kSessionsTmpFilename, "w");
-	if (fd == nullptr) {
-		safs_silent_errlog(LOG_WARNING,"can't store sessions, open error");
-		return;
-	}
-
-	memcpy(fsesrecord.data(), SFSSIGNATURE "S \001\006\004", 8);
-	uint8_t *ptr = fsesrecord.data() + 8;
-	put16bit(&ptr,SESSION_STATS);
-
-	if (fwrite(fsesrecord.data(), 10, 1, fd) != 1) {
-		safs_pretty_syslog(LOG_WARNING,"can't store sessions, fwrite error");
-		fclose(fd);
-		return;
-	}
-
-	for (const auto& sessionPtr : gSessionsVector) {
-		if (sessionPtr->newSession == 1) {
-			ptr = fsesrecord.data();
-			sessionInfoLength = sessionPtr->info.size();
-
-			put32bit(&ptr, sessionPtr->sessionId);
-			put32bit(&ptr, sessionInfoLength);
-			put32bit(&ptr, sessionPtr->peerIpAddress);
-			putINode(&ptr, sessionPtr->rootInode);
-			put8bit(&ptr, sessionPtr->flags);
-			put8bit(&ptr, sessionPtr->minGoal);
-			put8bit(&ptr, sessionPtr->maxGoal);
-			put32bit(&ptr, sessionPtr->minTrashTime);
-			put32bit(&ptr, sessionPtr->maxTrashTime);
-			put32bit(&ptr, sessionPtr->rootUid);
-			put32bit(&ptr, sessionPtr->rootGid);
-			put32bit(&ptr, sessionPtr->mapAllUid);
-			put32bit(&ptr, sessionPtr->mapAllGid);
-
-			for (auto i = 0; i < SESSION_STATS; i++) {
-				put32bit(&ptr, sessionPtr->currHourOperationsStats[i]);
-			}
-
-			for (auto i = 0; i < SESSION_STATS; i++) {
-				put32bit(&ptr, sessionPtr->prevHourOperationsStats[i]);
-			}
-
-			if (fwrite(fsesrecord.data(), kBufferSize, 1, fd) != 1) {
-				safs::log_warn("can't store sessions, fwrite error");
-				fclose(fd);
-				return;
-			}
-
-			if (sessionInfoLength > 0) {
-				if (fwrite(sessionPtr->info.data(), sessionInfoLength, 1, fd) != 1) {
-					safs::log_warn("can't store sessions, fwrite error");
-					fclose(fd);
-					return;
-				}
-			}
-		}
-	}
-
-	if (fclose(fd) != 0) {
-		safs_silent_errlog(LOG_WARNING,"can't store sessions, fclose error");
-		return;
-	}
-
-	if (rename(kSessionsTmpFilename, kSessionsFilename) < 0) {
-		safs_silent_errlog(LOG_WARNING, "can't store sessions, rename error");
-	}
-}
-
-#define MFSSIGNATURE "MFS"
-
-int matoclserv_load_sessions() {
-	uint32_t sessionInfoLength;
-	uint8_t headerBuffer[8];  // for signature and version. e.g. "SFS" " S 1.5"
-	std::vector<uint8_t> sessionBuffer;
-	const uint8_t *ptr;
-	uint8_t mapAllData;
-	uint8_t goalTrashData;
-	uint32_t statsInFile;
-	int bytesRead;
-
-	FILE *fd = fopen(kSessionsFilename, "r");
-
-	if (fd == nullptr) {
-		safs_silent_errlog(LOG_WARNING, "can't load sessions, fopen error");
-		if (errno == ENOENT) {  // it's ok if file does not exist
-			return 0;
-		}
-
-		return -1;
-	}
-
-	const size_t kSessionsHeaderSize = strlen(SFSSIGNATURE) + 5;
-
-	if (fread(headerBuffer, kSessionsHeaderSize, 1, fd) != 1) {
-		safs::log_warn("can't load sessions, fread error");
-		fclose(fd);
-		return -1;
-	}
-
-	// Guillex: Only "S \001\006\004" (last option) is expected
-	if (memcmp(headerBuffer, SFSSIGNATURE "S 1.5", kSessionsHeaderSize) == 0 ||
-	    memcmp(headerBuffer, MFSSIGNATURE "S 1.5", kSessionsHeaderSize) == 0) {
-		mapAllData = 0;
-		goalTrashData = 0;
-		statsInFile = 16;
-	} else if (memcmp(headerBuffer, SFSSIGNATURE "S \001\006\001", kSessionsHeaderSize) == 0 ||
-	           memcmp(headerBuffer, MFSSIGNATURE "S \001\006\001", kSessionsHeaderSize) == 0) {
-		mapAllData = 1;
-		goalTrashData = 0;
-		statsInFile = 16;
-	} else if (memcmp(headerBuffer, SFSSIGNATURE "S \001\006\002", kSessionsHeaderSize) == 0 ||
-	           memcmp(headerBuffer, MFSSIGNATURE "S \001\006\002", kSessionsHeaderSize) == 0) {
-		mapAllData = 1;
-		goalTrashData = 0;
-		statsInFile = 21;
-	} else if (memcmp(headerBuffer, SFSSIGNATURE "S \001\006\003", kSessionsHeaderSize) == 0 ||
-	           memcmp(headerBuffer, MFSSIGNATURE "S \001\006\003", kSessionsHeaderSize) == 0) {
-		mapAllData = 1;
-		goalTrashData = 0;
-		if (fread(headerBuffer, 2, 1, fd) != 1) {
-			safs::log_warn("can't load sessions, fread error");
-			fclose(fd);
-			return -1;
-		}
-		ptr = headerBuffer;
-		statsInFile = get16bit(&ptr);
-	} else if (memcmp(headerBuffer, SFSSIGNATURE "S \001\006\004", kSessionsHeaderSize) == 0 ||
-	           memcmp(headerBuffer, MFSSIGNATURE "S \001\006\004", kSessionsHeaderSize) == 0) {
-		mapAllData = 1;
-		goalTrashData = 1;
-		if (fread(headerBuffer, sizeof(uint16_t), 1, fd) != 1) {
-			safs::log_warn("can't load sessions, fread error");
-			fclose(fd);
-			return -1;
-		}
-		ptr = headerBuffer;
-		statsInFile = get16bit(&ptr);
-	} else {
-		safs::log_warn("can't load sessions, bad header");
-		fclose(fd);
-		return -1;
-	}
-
-	// Compile time constants
-	constexpr uint8_t kStatEntrySize =
-	    sizeof(std::remove_extent<decltype(Session::currHourOperationsStats)>::type::value_type) +
-	    sizeof(std::remove_extent<decltype(Session::prevHourOperationsStats)>::type::value_type);
-
-	constexpr uint32_t kCommonSize = sizeof(Session::sessionId) + sizeof(sessionInfoLength) +
-	                                 sizeof(Session::peerIpAddress) + sizeof(Session::rootInode) +
-	                                 sizeof(Session::flags) + sizeof(Session::rootUid) +
-	                                 sizeof(Session::rootGid);
-	constexpr uint32_t kExtraSizeWithMapAll =
-	    sizeof(Session::mapAllUid) + sizeof(Session::mapAllGid);
-	constexpr uint32_t kExtraSizeWithGoalTrash =
-	    sizeof(Session::minGoal) + sizeof(Session::maxGoal) + sizeof(Session::minTrashTime) +
-	    sizeof(Session::maxTrashTime);
-
-	// statsInFile is unknown at compile time, we need to use a runtime constant
-	const uint32_t kStatsSize = statsInFile * kStatEntrySize;
-
-	if (mapAllData == 0) {
-		sessionBuffer.resize(kCommonSize + kStatsSize);
-	} else if (goalTrashData == 0) {
-		sessionBuffer.resize(kCommonSize + kExtraSizeWithMapAll + kStatsSize);
-	} else {
-		sessionBuffer.resize(kCommonSize + kExtraSizeWithMapAll + kExtraSizeWithGoalTrash +
-		                  kStatsSize);
-	}
-
-	while (!feof(fd)) {
-		bytesRead = fread(sessionBuffer.data(), sessionBuffer.size(), 1, fd);
-
-		if (bytesRead == 1) {
-			ptr = sessionBuffer.data();
-			auto sessionPtr = std::make_unique<Session>();
-			passert(sessionPtr);
-			get32bit(&ptr, sessionPtr->sessionId);
-			get32bit(&ptr, sessionInfoLength);
-			get32bit(&ptr, sessionPtr->peerIpAddress);
-			getINode(&ptr, sessionPtr->rootInode);
-			sessionPtr->flags = get8bit(&ptr);
-			if (goalTrashData) {
-				sessionPtr->minGoal = get8bit(&ptr);
-				sessionPtr->maxGoal = get8bit(&ptr);
-				get32bit(&ptr, sessionPtr->minTrashTime);
-				get32bit(&ptr, sessionPtr->maxTrashTime);
-			}
-			get32bit(&ptr, sessionPtr->rootUid);
-			get32bit(&ptr, sessionPtr->rootGid);
-			if (mapAllData) {
-				get32bit(&ptr, sessionPtr->mapAllUid);
-				get32bit(&ptr, sessionPtr->mapAllGid);
-			}
-			sessionPtr->newSession = 1;
-			sessionPtr->disconnectedTimestamp = eventloop_time();
-			for (uint32_t i = 0; i < SESSION_STATS; i++) {
-				if (i < statsInFile) {
-					get32bit(&ptr, sessionPtr->currHourOperationsStats[i]);
-				} else {
-					sessionPtr->currHourOperationsStats[i] = 0;
-				}
-			}
-
-			if (statsInFile > SESSION_STATS) {
-				ptr += 4 * (statsInFile - SESSION_STATS);
-			}
-
-			for (uint32_t i = 0; i < SESSION_STATS; i++) {
-				if (i < statsInFile) {
-					get32bit(&ptr, sessionPtr->prevHourOperationsStats[i]);
-				} else {
-					sessionPtr->prevHourOperationsStats[i] = 0;
-				}
-			}
-
-			if (sessionInfoLength > 0) {
-				sessionPtr->info.resize(sessionInfoLength);
-				if (fread(sessionPtr->info.data(), sessionInfoLength, 1, fd) != 1) {
-					sessionPtr.reset();
-					safs::log_warn("can't load sessions, fread error");
-					fclose(fd);
-					return -1;
-				}
-			}
-
-			gSessionsVector.push_back(std::move(sessionPtr));
-		}
-
-		if (ferror(fd)) {
-			safs::log_warn("can't load sessions, fread error");
-			fclose(fd);
-			return -1;
-		}
-	}
-
-	safs::log_info("sessions have been loaded");
-	fclose(fd);
-	return 1;
-}
-#undef MFSSIGNATURE
-
-int matoclserv_insert_open_file(const FilesystemOperationContext &fsOpContext,
-                                Session *currentSession, inode_t inode) {
-	if (currentSession->openFilesSet.contains(inode)) {
-		return SAUNAFS_STATUS_OK;  // file already acquired - nothing to do
-	}
-
-	int status = gFSOperations->acquire(FsContext::getForMaster(eventloop_time()), fsOpContext,
-	                                    inode, currentSession->sessionId);
-
-	if (status == SAUNAFS_STATUS_OK) { currentSession->openFilesSet.insert(inode); }
-
-	return status;
-}
-
-void matoclserv_add_open_file(uint32_t sessionId, inode_t inode) {
-	for (const auto& sessionPtr : gSessionsVector) {
-		if (sessionPtr->sessionId == sessionId) {
-			if (!sessionPtr->openFilesSet.contains(inode)) {
-				sessionPtr->openFilesSet.insert(inode);
-			}
-			return;
-		}
-	}
-
-	// If session does not exist, create a new one
-	auto sessionPtr = std::make_unique<Session>();
-	passert(sessionPtr.get());
-	sessionPtr->sessionId = sessionId;
-	/* session created by filesystem - only for old clients (pre 1.5.13) */
-	sessionPtr->disconnectedTimestamp = eventloop_time();
-	sessionPtr->openFilesSet.insert(inode);
-	gSessionsVector.push_back(std::move(sessionPtr));
-}
-
-void matoclserv_remove_open_file(uint32_t sessionId, inode_t inode) {
-	for (const auto& sessionPtr : gSessionsVector) {
-		if (sessionPtr->sessionId == sessionId) {
-			if (sessionPtr->openFilesSet.contains(inode)) {
-				sessionPtr->openFilesSet.erase(inode);
-			}
-			return;
-		}
-	}
-
-	safs::log_err("sessions file is corrupted");
-}
-
-/// Resets the session timeouts for all sessions.
-void matoclserv_reset_session_timeouts() {
-	uint32_t now = eventloop_time();
-
-	for (auto& sessionPtr : gSessionsVector) {
-		sessionPtr->disconnectedTimestamp = now;
-	}
-}
-
-uint32_t session_number_of_files(Session *currentSession) {
-	return currentSession->openFilesSet.size();
-}
-
-void matocl_session_stats_rotate() {
-	for (auto& sessionPtr : gSessionsVector) {
-		sessionPtr->prevHourOperationsStats = sessionPtr->currHourOperationsStats;
-		sessionPtr->currHourOperationsStats.fill(0);
-	}
-	matoclserv_store_sessions();
-}
-
-int matoclserv_sessions_init() {
-	gSessionsVector.clear();
-
-	switch (matoclserv_load_sessions()) {
-		case 0: // no file
-		    safs::log_warn(
-		        "sessions file {}/{} not found; if it is not a fresh installation "
-		        "you have to restart all active mounts",
-		        fs::getCurrentWorkingDirectoryNoThrow().c_str(), kSessionsFilename);
-		    matoclserv_store_sessions();
-			break;
-		case 1: // file loaded
-		    safs::log_info("initialized sessions from file {}/{}",
-		                   fs::getCurrentWorkingDirectoryNoThrow().c_str(), kSessionsFilename);
-		    break;
-		default:
-		    safs::log_err("due to missing sessions ({}/{}) you have to restart all active mounts",
-		                  fs::getCurrentWorkingDirectoryNoThrow().c_str(), kSessionsFilename);
-		    break;
-	}
-
+void configureSessionSustainTime() {
 	gSessionSustainTime = cfg_getuint32("SESSION_SUSTAIN_TIME", 86400);
 
 	if (gSessionSustainTime > 7 * 86400) {
@@ -430,14 +46,87 @@ int matoclserv_sessions_init() {
 		safs::log_warn(
 		    "SESSION_SUSTAIN_TIME too low (less than minute) - setting this value to one minute");
 	}
+}
 
-	return 0;
+}  // namespace
+
+void matoclserv_set_session_manager(std::unique_ptr<ISessionManager> manager) {
+	if (gSessionManager != nullptr) { gSessionManager->unload(); }
+	gSessionManager = std::move(manager);
+}
+
+void matoclserv_store_sessions() {
+	sassert(gSessionManager != nullptr);
+	gSessionManager->storeSessions();
+}
+
+int matoclserv_load_sessions() {
+	sassert(gSessionManager != nullptr);
+	return gSessionManager->loadSessions();
+}
+
+Session *matoclserv_new_session(uint8_t newSession, uint8_t noNewId) {
+	sassert(gSessionManager != nullptr);
+	return gSessionManager->newSession(newSession, noNewId);
+}
+
+Session *matoclserv_find_session(uint32_t sessionId) {
+	sassert(gSessionManager != nullptr);
+	return gSessionManager->findSession(sessionId);
+}
+
+void matoclserv_close_session(uint32_t sessionId) {
+	sassert(gSessionManager != nullptr);
+	gSessionManager->closeSession(sessionId);
+}
+
+void matoclserv_reset_session_timeouts() {
+	sassert(gSessionManager != nullptr);
+	gSessionManager->resetSessionTimeouts();
+}
+
+void matoclserv_for_each_session(const std::function<void(const Session &)> &visitor) {
+	sassert(gSessionManager != nullptr);
+	gSessionManager->forEachSession(visitor);
+}
+
+void matoclserv_remove_timed_out_sessions(const std::function<void(Session *)> &onTimedOut) {
+	sassert(gSessionManager != nullptr);
+	gSessionManager->removeTimedOutSessions(eventloop_time(), gSessionSustainTime, onTimedOut);
+}
+
+int matoclserv_insert_open_file(const FilesystemOperationContext &fsOpContext,
+                                Session *currentSession, inode_t inode) {
+	sassert(gSessionManager != nullptr);
+	return gSessionManager->insertOpenFile(fsOpContext, currentSession, inode);
+}
+
+void matoclserv_add_open_file(uint32_t sessionId, inode_t inode) {
+	sassert(gSessionManager != nullptr);
+	gSessionManager->addOpenFile(sessionId, inode);
+}
+
+void matoclserv_remove_open_file(uint32_t sessionId, inode_t inode) {
+	sassert(gSessionManager != nullptr);
+	gSessionManager->removeOpenFile(sessionId, inode);
+}
+
+uint32_t session_number_of_files(Session *currentSession) {
+	return currentSession->openFilesSet.size();
+}
+
+void matocl_session_stats_rotate() {
+	sassert(gSessionManager != nullptr);
+	gSessionManager->rotateStats();
+}
+
+int matoclserv_sessions_init() {
+	sassert(gSessionManager != nullptr);
+	int status = gSessionManager->initialize();
+	configureSessionSustainTime();
+	return status;
 }
 
 void matoclserv_session_unload() {
-	for (const auto& sessionPtr : gSessionsVector) {
-		sessionPtr->openFilesSet.clear();
-	}
-
-	gSessionsVector.clear();
+	if (gSessionManager != nullptr) { gSessionManager->unload(); }
 }

--- a/src/master/matoclserv_sessions.h
+++ b/src/master/matoclserv_sessions.h
@@ -23,85 +23,25 @@
 #include "common/platform.h"
 
 #include <cstdint>
-#include <set>
-#include <string>
+#include <functional>
+#include <memory>
 
-#include "common/generic_lru_cache.h"
-#include "common/goal.h"
-#include "common/type_defs.h"
-#include "master/fs_context.h"
-
-#define SESSION_STATS 16
+#include "master/session.h"
 
 // From configuration
 inline uint32_t gSessionSustainTime;
 
 class FilesystemOperationContext;
+class ISessionManager;
 
-struct Session {
-	using GroupCache = GenericLruCache<uint32_t, FsContext::GroupsContainer, 1024>;
-	using OpenFilesSet = std::set<inode_t>;
+/// Overrides the active session manager implementation.
+void matoclserv_set_session_manager(std::unique_ptr<ISessionManager> manager);
 
-	uint32_t sessionId;      ///< Session ID
-	std::string info;        ///< Mount point path
-	std::string mountInfo;   ///< Mount information shown in the CGI, e.g., arguments, mount options
-	std::string config;      ///< Session configuration
-	uint32_t peerIpAddress;  ///< Peer IP address
-	uint16_t peerPort{};     ///< Peer port
-	uint8_t newSession;      ///< Indicates if this is a new session (1) or a reconnect (0)
-	uint8_t flags;           ///< Session flags. See more details in SFSCommunication.h
-	uint8_t minGoal;         ///< Minimum goal allowed for this session
-	uint8_t maxGoal;         ///< Maximum goal allowed for this session
-	uint32_t minTrashTime;   ///< Minimum time in seconds to keep files in trash
-	uint32_t maxTrashTime;   ///< Maximum time in seconds to keep files in trash
-	uint32_t rootUid;        ///< Remapped UID of the user who created the session
-	uint32_t rootGid;        ///< Remapped GID of the user who created the session
-	uint32_t mapAllUid;  ///< UID to map all non-root users to when the session has SESFLAG_MAPALL
-	                     ///< flag set)
-	uint32_t mapAllGid;  ///< GID to map all non-root users to when the session has SESFLAG_MAPALL
-	                     ///< flag set)
-	inode_t rootInode;   ///< Special Root Inode with value = 1
-	uint32_t disconnectedTimestamp;  ///< Last connected timestamp for this session
-	                                 ///< A value = 0 means a client is connected
-	                                 ///< A value > 0 means the last disconnection timestamp
-	uint32_t connections;  ///< Number of active connections. A value of 0 means no connections
-	std::array<uint32_t, SESSION_STATS> currHourOperationsStats;  ///< Current hour operations stats
-	std::array<uint32_t, SESSION_STATS>
-	    prevHourOperationsStats;  ///< Previous hour operations stats
-	GroupCache groupsCache;       ///< Cache for groups ID for this session
-	OpenFilesSet openFilesSet;    ///< Set of open files for this session
-
-	Session()
-	    : sessionId(),
-	      info(),
-	      peerIpAddress(),
-	      newSession(),
-	      flags(),
-	      minGoal(GoalId::kMin),
-	      maxGoal(GoalId::kMax),
-	      minTrashTime(),
-	      maxTrashTime(std::numeric_limits<uint32_t>::max()),
-	      rootUid(),
-	      rootGid(),
-	      mapAllUid(),
-	      mapAllGid(),
-	      rootInode(SPECIAL_INODE_ROOT),
-	      disconnectedTimestamp(),
-	      connections(),
-	      currHourOperationsStats(),
-	      prevHourOperationsStats(),
-	      groupsCache(),
-	      openFilesSet() {}
-};
-
-/// Vector storing all sessions.
-inline std::vector<std::unique_ptr<Session>> gSessionsVector;
-
-/// Stores all sessions to a file.
+/// Persists all sessions through the active session manager.
 void matoclserv_store_sessions();
 
-/// Loads all sessions from a file.
-/// @return 0 on success, -1 on error
+/// Loads all sessions from the active session manager's backing store.
+/// @return The active session manager's backend-defined load status.
 int matoclserv_load_sessions();
 
 /// Creates a new session.
@@ -115,20 +55,26 @@ Session *matoclserv_new_session(uint8_t newSession, uint8_t noNewId);
 /// @return Pointer to the session if found, nullptr otherwise
 Session *matoclserv_find_session(uint32_t sessionId);
 
-/// Closes a session by its ID.
-/// @param sessionId The session ID to close
+/// Marks a session as explicitly closed in manager state.
+/// @param sessionId The session ID to mark as closed
 void matoclserv_close_session(uint32_t sessionId);
 
 /// Returns the number of open files for a given session.
 /// @param currentSession Pointer to the session
 uint32_t session_number_of_files(Session *currentSession);
 
-/// Rotates the statistics for all sessions (current hour / previous hour) and stores all sessions
-/// to a file.
+/// Rotates the statistics for all sessions (current hour / previous hour) and
+/// persists them through the active session manager.
 void matocl_session_stats_rotate();
 
 /// Resets the session timeouts for all sessions.
 void matoclserv_reset_session_timeouts();
+
+/// Iterates over all sessions currently owned by the session manager.
+void matoclserv_for_each_session(const std::function<void(const Session &)> &visitor);
+
+/// Removes timed out sessions and invokes the callback before erasing each entry.
+void matoclserv_remove_timed_out_sessions(const std::function<void(Session *)> &onTimedOut);
 
 /// Inserts an open file to the list of open files for a given session.
 /// @param currentSession Pointer to the session
@@ -147,8 +93,8 @@ void matoclserv_add_open_file(uint32_t sessionId, inode_t inode);
 /// @param inode The inode of the open file to remove
 void matoclserv_remove_open_file(uint32_t sessionId, inode_t inode);
 
-/// Loads and initializes the sessions.
+/// Initializes the active session manager and configures SESSION_SUSTAIN_TIME.
 int matoclserv_sessions_init();
 
-/// Clears the sessions.
+/// Clears in-memory session state held by the active session manager.
 void matoclserv_session_unload();

--- a/src/master/matoclserv_sessions.h
+++ b/src/master/matoclserv_sessions.h
@@ -25,7 +25,9 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <vector>
 
+#include "common/sessions_file.h"
 #include "master/session.h"
 
 // From configuration
@@ -39,6 +41,12 @@ void matoclserv_set_session_manager(std::unique_ptr<ISessionManager> manager);
 
 /// Persists all sessions through the active session manager.
 void matoclserv_store_sessions();
+
+/// Persists one session through the active session manager.
+void matoclserv_persist_session(Session *session);
+
+/// Persists or observes session runtime state after a connection disconnects.
+void matoclserv_session_disconnected(Session *session);
 
 /// Loads all sessions from the active session manager's backing store.
 /// @return The active session manager's backend-defined load status.
@@ -73,8 +81,14 @@ void matoclserv_reset_session_timeouts();
 /// Iterates over all sessions currently owned by the session manager.
 void matoclserv_for_each_session(const std::function<void(const Session &)> &visitor);
 
-/// Removes timed out sessions and invokes the callback before erasing each entry.
-void matoclserv_remove_timed_out_sessions(const std::function<void(Session *)> &onTimedOut);
+/// Returns session summaries for the admin list-sessions command.
+std::vector<SessionFiles> matoclserv_list_sessions();
+
+/// Returns true when the active backend provides the admin list-sessions view.
+bool matoclserv_uses_backend_session_list();
+
+/// Removes timed out sessions whose callback confirms teardown completed.
+void matoclserv_remove_timed_out_sessions(const std::function<bool(Session *)> &onTimedOut);
 
 /// Inserts an open file to the list of open files for a given session.
 /// @param currentSession Pointer to the session

--- a/src/master/matoclserv_sessions.h
+++ b/src/master/matoclserv_sessions.h
@@ -110,5 +110,9 @@ void matoclserv_remove_open_file(uint32_t sessionId, inode_t inode);
 /// Initializes the active session manager and configures SESSION_SUSTAIN_TIME.
 int matoclserv_sessions_init();
 
+/// Reads SESSION_SUSTAIN_TIME from config and clamps it into the allowed range.
+/// Shared between session init and reload so both paths stay in sync.
+void matoclserv_configure_session_sustain_time();
+
 /// Clears in-memory session state held by the active session manager.
 void matoclserv_session_unload();

--- a/src/master/session.h
+++ b/src/master/session.h
@@ -1,0 +1,100 @@
+/*
+   Copyright 2005-2010 Jakub Kruszona-Zawadzki, Gemius SA
+   Copyright 2013-2014 EditShare
+   Copyright 2013-2015 Skytechnology sp. z o.o.
+   Copyright 2023      Leil Storage OÜ
+
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "common/platform.h"
+
+#include <array>
+#include <cstdint>
+#include <limits>
+#include <set>
+#include <string>
+
+#include "common/generic_lru_cache.h"
+#include "common/goal.h"
+#include "common/type_defs.h"
+#include "master/fs_context.h"
+
+/// Number of per-hour operation counters tracked in each Session.
+#define SESSION_STATS 16
+
+/// Shared in-memory representation of one client session.
+///
+/// This is a shared runtime type used by the session-manager layer, the
+/// compatibility wrappers around the legacy session API, and any
+/// backend-specific session-manager implementation.
+///
+/// The active session manager owns `Session` objects and returns raw pointers
+/// that remain valid for the session lifetime. `matoclserv` keeps those raw
+/// pointers in connection state and updates selected fields during register,
+/// reconnect, disconnect, and teardown.
+///
+/// Persistence is split between backend-defined durable fields and runtime-only
+/// fields. Values such as `connections`, `disconnectedTimestamp`,
+/// `groupsCache`, and `openFilesSet` are rebuilt or repopulated at runtime.
+///
+/// `openFilesSet` is the per-session view of open files. It complements the
+/// per-file `FSNodeFile::sessionIds` index used by filesystem metadata: the two
+/// indexes answer opposite lookup directions and are kept in sync by the open,
+/// release, and session-teardown paths.
+struct Session {
+	/// Cache mapping uid to supplementary groups used when building FsContext.
+	using GroupCache = GenericLruCache<uint32_t, FsContext::GroupsContainer, 1024>;
+
+	/// In-memory per-session set of currently open file inodes.
+	using OpenFilesSet = std::set<inode_t>;
+
+	uint32_t sessionId{};  ///< Session ID.
+	std::string info;      ///< Mount point path.
+	/// Mount information shown in the CGI, such as arguments and mount options.
+	std::string mountInfo;
+	std::string config;        ///< Session configuration.
+	uint32_t peerIpAddress{};  ///< Peer IP address.
+	uint16_t peerPort{};       ///< Peer port.
+	/// Registration and teardown lifecycle flag used by reconnect and timeout logic.
+	uint8_t newSession{};
+	/// Session flags. See the `SESFLAG_*` protocol definitions for details.
+	uint8_t flags{};
+	uint8_t minGoal{GoalId::kMin};  ///< Minimum goal allowed for this session.
+	uint8_t maxGoal{GoalId::kMax};  ///< Maximum goal allowed for this session.
+	/// Minimum time, in seconds, to keep files in trash.
+	uint32_t minTrashTime{};
+	/// Maximum time in seconds to keep files in trash.
+	uint32_t maxTrashTime{std::numeric_limits<uint32_t>::max()};
+	uint32_t rootUid{};  ///< Remapped UID of the user who created the session.
+	uint32_t rootGid{};  ///< Remapped GID of the user who created the session.
+	/// UID to map all non-root users to when `SESFLAG_MAPALL` is set.
+	uint32_t mapAllUid{};
+	/// GID to map all non-root users to when `SESFLAG_MAPALL` is set.
+	uint32_t mapAllGid{};
+	/// Session root inode. Defaults to the global root.
+	inode_t rootInode{SPECIAL_INODE_ROOT};
+	/// Last disconnection timestamp. Zero means a client is currently connected.
+	uint32_t disconnectedTimestamp{};
+	/// Active connection count. Zero means the session is currently disconnected.
+	uint32_t connections{};
+	/// Current hour operation counters.
+	std::array<uint32_t, SESSION_STATS> currHourOperationsStats{};
+	/// Previous hour operation counters.
+	std::array<uint32_t, SESSION_STATS> prevHourOperationsStats{};
+	GroupCache groupsCache;     ///< Cache of supplementary groups for this session.
+	OpenFilesSet openFilesSet;  ///< Set of currently open file inodes.
+};

--- a/src/master/session.h
+++ b/src/master/session.h
@@ -4,6 +4,7 @@
    Copyright 2013-2015 Skytechnology sp. z o.o.
    Copyright 2023      Leil Storage OÜ
 
+   This file is part of SaunaFS.
 
    SaunaFS is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/src/master/session_manager.cc
+++ b/src/master/session_manager.cc
@@ -152,6 +152,12 @@ void SessionManagerBase::rotateStats() {
 	storeSessions();
 }
 
+void SessionManagerBase::persistSession([[maybe_unused]] const Session &session) {
+	storeSessions();
+}
+
+void SessionManagerBase::sessionDisconnected([[maybe_unused]] const Session &session) {}
+
 void SessionManagerBase::unload() {
 	for (const auto &sessionPtr : sessions_) { sessionPtr->openFilesSet.clear(); }
 	sessions_.clear();
@@ -161,8 +167,26 @@ void SessionManagerBase::forEachSession(const std::function<void(const Session &
 	for (const auto &sessionPtr : sessions_) { visitor(*sessionPtr); }
 }
 
+std::vector<SessionFiles> SessionManagerBase::listSessions() const {
+	std::vector<SessionFiles> summaries;
+
+	for (const auto &sessionPtr : sessions_) {
+		if (sessionPtr->connections == 0) { continue; }
+
+		SessionFiles summary;
+		summary.sessionId = sessionPtr->sessionId;
+		summary.peerIp = sessionPtr->peerIpAddress;
+		summary.filesNumber = sessionPtr->openFilesSet.size();
+		summaries.push_back(summary);
+	}
+
+	return summaries;
+}
+
+bool SessionManagerBase::usesBackendSessionList() const { return false; }
+
 void SessionManagerBase::removeTimedOutSessions(uint32_t now, uint32_t sessionSustainTime,
-                                                const std::function<void(Session *)> &onTimedOut) {
+                                                const std::function<bool(Session *)> &onTimedOut) {
 	for (auto sessionIt = sessions_.begin(); sessionIt != sessions_.end();) {
 		auto &sessionPtr = *sessionIt;
 		if (!isTimedOut(*sessionPtr, now, sessionSustainTime)) {
@@ -170,7 +194,11 @@ void SessionManagerBase::removeTimedOutSessions(uint32_t now, uint32_t sessionSu
 			continue;
 		}
 
-		onTimedOut(sessionPtr.get());
+		if (!onTimedOut(sessionPtr.get())) {
+			++sessionIt;
+			continue;
+		}
+
 		onSessionRemoved(*sessionPtr);
 		sessionIt = sessions_.erase(sessionIt);
 	}

--- a/src/master/session_manager.cc
+++ b/src/master/session_manager.cc
@@ -1,0 +1,451 @@
+/*
+   Copyright 2005-2017 Jakub Kruszona-Zawadzki, Gemius SA
+   Copyright 2013-2014 EditShare
+   Copyright 2013-2017 Skytechnology sp. z o.o.
+   Copyright 2023      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "common/platform.h"
+
+#include "master/session_manager.h"
+
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
+#include <type_traits>
+
+#include "common/cwrap.h"
+#include "common/datapack.h"
+#include "common/event_loop.h"
+#include "common/massert.h"
+#include "master/filesystem_operation_context.h"
+#include "master/filesystem_operations_interface.h"
+#include "master/metadata_backend_common.h"
+#include "protocol/SFSCommunication.h"
+#include "slogger/slogger.h"
+
+Session *SessionManagerBase::addSession(std::unique_ptr<Session> sessionPtr) {
+	passert(sessionPtr.get());
+	sessions_.push_back(std::move(sessionPtr));
+	return sessions_.back().get();
+}
+
+Session *SessionManagerBase::findSessionEntry(uint32_t sessionId) {
+	if (sessionId == 0) { return nullptr; }
+
+	for (const auto &sessionPtr : sessions_) {
+		if (sessionPtr->sessionId == sessionId) { return sessionPtr.get(); }
+	}
+
+	return nullptr;
+}
+
+const Session *SessionManagerBase::findSessionEntry(uint32_t sessionId) const {
+	if (sessionId == 0) { return nullptr; }
+
+	for (const auto &sessionPtr : sessions_) {
+		if (sessionPtr->sessionId == sessionId) { return sessionPtr.get(); }
+	}
+
+	return nullptr;
+}
+
+Session *SessionManagerBase::newSession(uint8_t newSession, uint8_t noNewId) {
+	auto sessionPtr = std::make_unique<Session>();
+	auto newSessionIdNotNeeded = (newSession == 0 && noNewId);
+	if (newSessionIdNotNeeded) {
+		sessionPtr->sessionId = 0;
+	} else {
+		sessionPtr->sessionId = gFSOperations->newSessionId();
+		if (sessionPtr->sessionId == 0) {
+			safs::log_err("Refusing to register client: session id allocation failed");
+			return nullptr;
+		}
+	}
+	sessionPtr->newSession = newSession;
+	sessionPtr->connections = 1;
+	return addSession(std::move(sessionPtr));
+}
+
+Session *SessionManagerBase::findSession(uint32_t sessionId) {
+	auto *session = findSessionEntry(sessionId);
+	if (session == nullptr) { return nullptr; }
+
+	if (session->newSession >= 2) { session->newSession -= 2; }
+
+	session->connections++;
+	session->disconnectedTimestamp = 0;
+	return session;
+}
+
+void SessionManagerBase::closeSession(uint32_t sessionId) {
+	auto *session = findSessionEntry(sessionId);
+	if (session == nullptr) { return; }
+
+	if (session->connections == 1 && session->newSession < 2) { session->newSession += 2; }
+}
+
+int SessionManagerBase::insertOpenFile(const FilesystemOperationContext &fsOpContext,
+                                       Session *currentSession, inode_t inode) {
+	if (currentSession->openFilesSet.contains(inode)) {
+		return SAUNAFS_STATUS_OK;  // file already acquired - nothing to do
+	}
+
+	int status = gFSOperations->acquire(FsContext::getForMaster(eventloop_time()), fsOpContext,
+	                                    inode, currentSession->sessionId);
+	if (status == SAUNAFS_STATUS_OK) { currentSession->openFilesSet.insert(inode); }
+
+	return status;
+}
+
+void SessionManagerBase::addOpenFile(uint32_t sessionId, inode_t inode) {
+	auto *session = findSessionEntry(sessionId);
+	if (session != nullptr) {
+		session->openFilesSet.insert(inode);
+		return;
+	}
+
+	auto syntheticSession = std::make_unique<Session>();
+	syntheticSession->sessionId = sessionId;
+	// Session created by filesystem - only for old clients (pre 1.5.13).
+	syntheticSession->disconnectedTimestamp = eventloop_time();
+	syntheticSession->openFilesSet.insert(inode);
+	addSession(std::move(syntheticSession));
+}
+
+void SessionManagerBase::removeOpenFile(uint32_t sessionId, inode_t inode) {
+	auto *session = findSessionEntry(sessionId);
+	if (session == nullptr) {
+		safs::log_warn("{}: session {} not found for inode {}", __func__, sessionId, inode);
+		return;
+	}
+
+	if (session->openFilesSet.contains(inode)) { session->openFilesSet.erase(inode); }
+}
+
+void SessionManagerBase::resetSessionTimeouts() {
+	uint32_t now = eventloop_time();
+
+	for (auto &sessionPtr : sessions_) { sessionPtr->disconnectedTimestamp = now; }
+}
+
+void SessionManagerBase::rotateStats() {
+	for (auto &sessionPtr : sessions_) {
+		sessionPtr->prevHourOperationsStats = sessionPtr->currHourOperationsStats;
+		sessionPtr->currHourOperationsStats.fill(0);
+	}
+
+	storeSessions();
+}
+
+void SessionManagerBase::unload() {
+	for (const auto &sessionPtr : sessions_) { sessionPtr->openFilesSet.clear(); }
+	sessions_.clear();
+}
+
+void SessionManagerBase::forEachSession(const std::function<void(const Session &)> &visitor) const {
+	for (const auto &sessionPtr : sessions_) { visitor(*sessionPtr); }
+}
+
+void SessionManagerBase::removeTimedOutSessions(uint32_t now, uint32_t sessionSustainTime,
+                                                const std::function<void(Session *)> &onTimedOut) {
+	for (auto sessionIt = sessions_.begin(); sessionIt != sessions_.end();) {
+		auto &sessionPtr = *sessionIt;
+		if (!isTimedOut(*sessionPtr, now, sessionSustainTime)) {
+			++sessionIt;
+			continue;
+		}
+
+		onTimedOut(sessionPtr.get());
+		onSessionRemoved(*sessionPtr);
+		sessionIt = sessions_.erase(sessionIt);
+	}
+}
+
+void SessionManagerBase::onSessionRemoved([[maybe_unused]] const Session &session) {}
+
+bool SessionManagerBase::isTimedOut(const Session &session, uint32_t now,
+                                    uint32_t sessionSustainTime) {
+	if (session.connections != 0) { return false; }
+
+	return ((session.newSession > 1 && session.disconnectedTimestamp < now) ||
+	        (session.newSession == 1 && session.disconnectedTimestamp + sessionSustainTime < now) ||
+	        (session.newSession == 0 && session.disconnectedTimestamp + 7200 < now));
+}
+
+int SessionManagerFile::initialize() {
+	unload();
+
+	switch (loadSessions()) {
+	case 0:
+		safs::log_warn(
+		    "sessions file {}/{} not found; if it is not a fresh installation you have to restart all active mounts",
+		    fs::getCurrentWorkingDirectoryNoThrow(), kSessionsFilename);
+		storeSessions();
+		break;
+	case 1:
+		safs::log_info("initialized sessions from file {}/{}",
+		               fs::getCurrentWorkingDirectoryNoThrow(), kSessionsFilename);
+		break;
+	default:
+		safs::log_err("due to missing sessions ({}/{}) you have to restart all active mounts",
+		              fs::getCurrentWorkingDirectoryNoThrow(), kSessionsFilename);
+		break;
+	}
+
+	return 0;
+}
+
+void SessionManagerFile::storeSessions() {
+	uint32_t sessionInfoLength;
+	constexpr uint32_t kSessionSerializedSize =
+	    sizeof(Session::sessionId) + sizeof(sessionInfoLength) + sizeof(Session::peerIpAddress) +
+	    sizeof(Session::rootInode) + sizeof(Session::flags) + sizeof(Session::minGoal) +
+	    sizeof(Session::maxGoal) + sizeof(Session::minTrashTime) + sizeof(Session::maxTrashTime) +
+	    sizeof(Session::rootUid) + sizeof(Session::rootGid) + sizeof(Session::mapAllUid) +
+	    sizeof(Session::mapAllGid);
+	constexpr uint32_t kBufferSize = kSessionSerializedSize + (SESSION_STATS * 8);
+	std::vector<uint8_t> fsesrecord(kBufferSize);
+
+	FILE *fd = fopen(kSessionsTmpFilename, "w");
+	if (fd == nullptr) {
+		safs_silent_errlog(LOG_WARNING, "can't store sessions, open error");
+		return;
+	}
+
+	memcpy(fsesrecord.data(), SFSSIGNATURE "S \001\006\004", 8);
+	uint8_t *ptr = fsesrecord.data() + 8;
+	put16bit(&ptr, SESSION_STATS);
+
+	if (fwrite(fsesrecord.data(), 10, 1, fd) != 1) {
+		safs_pretty_syslog(LOG_WARNING, "can't store sessions, fwrite error");
+		fclose(fd);
+		return;
+	}
+
+	for (const auto &sessionPtr : sessions_) {
+		if (sessionPtr->newSession != 1) { continue; }
+
+		ptr = fsesrecord.data();
+		sessionInfoLength = sessionPtr->info.size();
+
+		put32bit(&ptr, sessionPtr->sessionId);
+		put32bit(&ptr, sessionInfoLength);
+		put32bit(&ptr, sessionPtr->peerIpAddress);
+		putINode(&ptr, sessionPtr->rootInode);
+		put8bit(&ptr, sessionPtr->flags);
+		put8bit(&ptr, sessionPtr->minGoal);
+		put8bit(&ptr, sessionPtr->maxGoal);
+		put32bit(&ptr, sessionPtr->minTrashTime);
+		put32bit(&ptr, sessionPtr->maxTrashTime);
+		put32bit(&ptr, sessionPtr->rootUid);
+		put32bit(&ptr, sessionPtr->rootGid);
+		put32bit(&ptr, sessionPtr->mapAllUid);
+		put32bit(&ptr, sessionPtr->mapAllGid);
+
+		for (int i = 0; i < SESSION_STATS; ++i) {
+			put32bit(&ptr, sessionPtr->currHourOperationsStats[i]);
+		}
+
+		for (int i = 0; i < SESSION_STATS; ++i) {
+			put32bit(&ptr, sessionPtr->prevHourOperationsStats[i]);
+		}
+
+		if (fwrite(fsesrecord.data(), kBufferSize, 1, fd) != 1) {
+			safs::log_warn("can't store sessions, fwrite error");
+			fclose(fd);
+			return;
+		}
+
+		if (sessionInfoLength > 0 &&
+		    fwrite(sessionPtr->info.data(), sessionInfoLength, 1, fd) != 1) {
+			safs::log_warn("can't store sessions, fwrite error");
+			fclose(fd);
+			return;
+		}
+	}
+
+	if (fclose(fd) != 0) {
+		safs_silent_errlog(LOG_WARNING, "can't store sessions, fclose error");
+		return;
+	}
+
+	if (rename(kSessionsTmpFilename, kSessionsFilename) < 0) {
+		safs_silent_errlog(LOG_WARNING, "can't store sessions, rename error");
+	}
+}
+
+#define MFSSIGNATURE "MFS"
+
+int SessionManagerFile::loadSessions() {
+	uint32_t sessionInfoLength;
+	uint8_t headerBuffer[8];
+	std::vector<uint8_t> sessionBuffer;
+	const uint8_t *ptr;
+	uint8_t mapAllData;
+	uint8_t goalTrashData;
+	uint32_t statsInFile;
+	int bytesRead;
+
+	FILE *fd = fopen(kSessionsFilename, "r");
+	if (fd == nullptr) {
+		safs_silent_errlog(LOG_WARNING, "can't load sessions, fopen error");
+		if (errno == ENOENT) { return 0; }
+		return -1;
+	}
+
+	const size_t kSessionsHeaderSize = strlen(SFSSIGNATURE) + 5;
+	if (fread(headerBuffer, kSessionsHeaderSize, 1, fd) != 1) {
+		safs::log_warn("can't load sessions, fread error");
+		fclose(fd);
+		return -1;
+	}
+
+	if (memcmp(headerBuffer, SFSSIGNATURE "S 1.5", kSessionsHeaderSize) == 0 ||
+	    memcmp(headerBuffer, MFSSIGNATURE "S 1.5", kSessionsHeaderSize) == 0) {
+		mapAllData = 0;
+		goalTrashData = 0;
+		statsInFile = 16;
+	} else if (memcmp(headerBuffer, SFSSIGNATURE "S \001\006\001", kSessionsHeaderSize) == 0 ||
+	           memcmp(headerBuffer, MFSSIGNATURE "S \001\006\001", kSessionsHeaderSize) == 0) {
+		mapAllData = 1;
+		goalTrashData = 0;
+		statsInFile = 16;
+	} else if (memcmp(headerBuffer, SFSSIGNATURE "S \001\006\002", kSessionsHeaderSize) == 0 ||
+	           memcmp(headerBuffer, MFSSIGNATURE "S \001\006\002", kSessionsHeaderSize) == 0) {
+		mapAllData = 1;
+		goalTrashData = 0;
+		statsInFile = 21;
+	} else if (memcmp(headerBuffer, SFSSIGNATURE "S \001\006\003", kSessionsHeaderSize) == 0 ||
+	           memcmp(headerBuffer, MFSSIGNATURE "S \001\006\003", kSessionsHeaderSize) == 0) {
+		mapAllData = 1;
+		goalTrashData = 0;
+		if (fread(headerBuffer, 2, 1, fd) != 1) {
+			safs::log_warn("can't load sessions, fread error");
+			fclose(fd);
+			return -1;
+		}
+		ptr = headerBuffer;
+		statsInFile = get16bit(&ptr);
+	} else if (memcmp(headerBuffer, SFSSIGNATURE "S \001\006\004", kSessionsHeaderSize) == 0 ||
+	           memcmp(headerBuffer, MFSSIGNATURE "S \001\006\004", kSessionsHeaderSize) == 0) {
+		mapAllData = 1;
+		goalTrashData = 1;
+		if (fread(headerBuffer, sizeof(uint16_t), 1, fd) != 1) {
+			safs::log_warn("can't load sessions, fread error");
+			fclose(fd);
+			return -1;
+		}
+		ptr = headerBuffer;
+		statsInFile = get16bit(&ptr);
+	} else {
+		safs::log_warn("can't load sessions, bad header");
+		fclose(fd);
+		return -1;
+	}
+
+	constexpr uint8_t kStatEntrySize =
+	    sizeof(std::remove_extent<decltype(Session::currHourOperationsStats)>::type::value_type) +
+	    sizeof(std::remove_extent<decltype(Session::prevHourOperationsStats)>::type::value_type);
+	constexpr uint32_t kCommonSize = sizeof(Session::sessionId) + sizeof(sessionInfoLength) +
+	                                 sizeof(Session::peerIpAddress) + sizeof(Session::rootInode) +
+	                                 sizeof(Session::flags) + sizeof(Session::rootUid) +
+	                                 sizeof(Session::rootGid);
+	constexpr uint32_t kExtraSizeWithMapAll =
+	    sizeof(Session::mapAllUid) + sizeof(Session::mapAllGid);
+	constexpr uint32_t kExtraSizeWithGoalTrash =
+	    sizeof(Session::minGoal) + sizeof(Session::maxGoal) + sizeof(Session::minTrashTime) +
+	    sizeof(Session::maxTrashTime);
+	const uint32_t kStatsSize = statsInFile * kStatEntrySize;
+
+	if (mapAllData == 0) {
+		sessionBuffer.resize(kCommonSize + kStatsSize);
+	} else if (goalTrashData == 0) {
+		sessionBuffer.resize(kCommonSize + kExtraSizeWithMapAll + kStatsSize);
+	} else {
+		sessionBuffer.resize(kCommonSize + kExtraSizeWithMapAll + kExtraSizeWithGoalTrash +
+		                     kStatsSize);
+	}
+
+	while (!feof(fd)) {
+		bytesRead = fread(sessionBuffer.data(), sessionBuffer.size(), 1, fd);
+		if (bytesRead == 1) {
+			ptr = sessionBuffer.data();
+			auto sessionPtr = std::make_unique<Session>();
+			get32bit(&ptr, sessionPtr->sessionId);
+			get32bit(&ptr, sessionInfoLength);
+			get32bit(&ptr, sessionPtr->peerIpAddress);
+			getINode(&ptr, sessionPtr->rootInode);
+			sessionPtr->flags = get8bit(&ptr);
+			if (goalTrashData) {
+				sessionPtr->minGoal = get8bit(&ptr);
+				sessionPtr->maxGoal = get8bit(&ptr);
+				get32bit(&ptr, sessionPtr->minTrashTime);
+				get32bit(&ptr, sessionPtr->maxTrashTime);
+			}
+			get32bit(&ptr, sessionPtr->rootUid);
+			get32bit(&ptr, sessionPtr->rootGid);
+			if (mapAllData) {
+				get32bit(&ptr, sessionPtr->mapAllUid);
+				get32bit(&ptr, sessionPtr->mapAllGid);
+			}
+
+			sessionPtr->newSession = 1;
+			sessionPtr->disconnectedTimestamp = eventloop_time();
+			for (uint32_t i = 0; i < SESSION_STATS; ++i) {
+				if (i < statsInFile) {
+					get32bit(&ptr, sessionPtr->currHourOperationsStats[i]);
+				} else {
+					sessionPtr->currHourOperationsStats[i] = 0;
+				}
+			}
+
+			if (statsInFile > SESSION_STATS) { ptr += 4 * (statsInFile - SESSION_STATS); }
+
+			for (uint32_t i = 0; i < SESSION_STATS; ++i) {
+				if (i < statsInFile) {
+					get32bit(&ptr, sessionPtr->prevHourOperationsStats[i]);
+				} else {
+					sessionPtr->prevHourOperationsStats[i] = 0;
+				}
+			}
+
+			if (sessionInfoLength > 0) {
+				sessionPtr->info.resize(sessionInfoLength);
+				if (fread(sessionPtr->info.data(), sessionInfoLength, 1, fd) != 1) {
+					safs::log_warn("can't load sessions, fread error");
+					fclose(fd);
+					return -1;
+				}
+			}
+
+			addSession(std::move(sessionPtr));
+		}
+
+		if (ferror(fd)) {
+			safs::log_warn("can't load sessions, fread error");
+			fclose(fd);
+			return -1;
+		}
+	}
+
+	safs::log_info("sessions have been loaded");
+	fclose(fd);
+	return 1;
+}
+
+#undef MFSSIGNATURE

--- a/src/master/session_manager.cc
+++ b/src/master/session_manager.cc
@@ -176,7 +176,7 @@ std::vector<SessionFiles> SessionManagerBase::listSessions() const {
 		SessionFiles summary;
 		summary.sessionId = sessionPtr->sessionId;
 		summary.peerIp = sessionPtr->peerIpAddress;
-		summary.filesNumber = sessionPtr->openFilesSet.size();
+		summary.filesNumber = static_cast<uint32_t>(sessionPtr->openFilesSet.size());
 		summaries.push_back(summary);
 	}
 
@@ -199,12 +199,16 @@ void SessionManagerBase::removeTimedOutSessions(uint32_t now, uint32_t sessionSu
 			continue;
 		}
 
-		onSessionRemoved(*sessionPtr);
+		if (!onSessionRemoved(*sessionPtr)) {
+			++sessionIt;
+			continue;
+		}
+
 		sessionIt = sessions_.erase(sessionIt);
 	}
 }
 
-void SessionManagerBase::onSessionRemoved([[maybe_unused]] const Session &session) {}
+bool SessionManagerBase::onSessionRemoved([[maybe_unused]] const Session &session) { return true; }
 
 bool SessionManagerBase::isTimedOut(const Session &session, uint32_t now,
                                     uint32_t sessionSustainTime) {

--- a/src/master/session_manager.cc
+++ b/src/master/session_manager.cc
@@ -317,15 +317,11 @@ void SessionManagerFile::storeSessions() {
 	}
 }
 
-#define MFSSIGNATURE "MFS"
-
 int SessionManagerFile::loadSessions() {
 	uint32_t sessionInfoLength;
 	uint8_t headerBuffer[8];
 	std::vector<uint8_t> sessionBuffer;
 	const uint8_t *ptr;
-	uint8_t mapAllData;
-	uint8_t goalTrashData;
 	uint32_t statsInFile;
 	int bytesRead;
 
@@ -343,71 +339,31 @@ int SessionManagerFile::loadSessions() {
 		return -1;
 	}
 
-	if (memcmp(headerBuffer, SFSSIGNATURE "S 1.5", kSessionsHeaderSize) == 0 ||
-	    memcmp(headerBuffer, MFSSIGNATURE "S 1.5", kSessionsHeaderSize) == 0) {
-		mapAllData = 0;
-		goalTrashData = 0;
-		statsInFile = 16;
-	} else if (memcmp(headerBuffer, SFSSIGNATURE "S \001\006\001", kSessionsHeaderSize) == 0 ||
-	           memcmp(headerBuffer, MFSSIGNATURE "S \001\006\001", kSessionsHeaderSize) == 0) {
-		mapAllData = 1;
-		goalTrashData = 0;
-		statsInFile = 16;
-	} else if (memcmp(headerBuffer, SFSSIGNATURE "S \001\006\002", kSessionsHeaderSize) == 0 ||
-	           memcmp(headerBuffer, MFSSIGNATURE "S \001\006\002", kSessionsHeaderSize) == 0) {
-		mapAllData = 1;
-		goalTrashData = 0;
-		statsInFile = 21;
-	} else if (memcmp(headerBuffer, SFSSIGNATURE "S \001\006\003", kSessionsHeaderSize) == 0 ||
-	           memcmp(headerBuffer, MFSSIGNATURE "S \001\006\003", kSessionsHeaderSize) == 0) {
-		mapAllData = 1;
-		goalTrashData = 0;
-		if (fread(headerBuffer, 2, 1, fd) != 1) {
-			safs::log_warn("can't load sessions, fread error");
-			fclose(fd);
-			return -1;
-		}
-		ptr = headerBuffer;
-		statsInFile = get16bit(&ptr);
-	} else if (memcmp(headerBuffer, SFSSIGNATURE "S \001\006\004", kSessionsHeaderSize) == 0 ||
-	           memcmp(headerBuffer, MFSSIGNATURE "S \001\006\004", kSessionsHeaderSize) == 0) {
-		mapAllData = 1;
-		goalTrashData = 1;
-		if (fread(headerBuffer, sizeof(uint16_t), 1, fd) != 1) {
-			safs::log_warn("can't load sessions, fread error");
-			fclose(fd);
-			return -1;
-		}
-		ptr = headerBuffer;
-		statsInFile = get16bit(&ptr);
-	} else {
+	if (memcmp(headerBuffer, SFSSIGNATURE "S \001\006\004", kSessionsHeaderSize) != 0) {
 		safs::log_warn("can't load sessions, bad header");
 		fclose(fd);
 		return -1;
 	}
 
+	if (fread(headerBuffer, sizeof(uint16_t), 1, fd) != 1) {
+		safs::log_warn("can't load sessions, fread error");
+		fclose(fd);
+		return -1;
+	}
+	ptr = headerBuffer;
+	statsInFile = get16bit(&ptr);
+
 	constexpr uint8_t kStatEntrySize =
 	    sizeof(std::remove_extent<decltype(Session::currHourOperationsStats)>::type::value_type) +
 	    sizeof(std::remove_extent<decltype(Session::prevHourOperationsStats)>::type::value_type);
-	constexpr uint32_t kCommonSize = sizeof(Session::sessionId) + sizeof(sessionInfoLength) +
-	                                 sizeof(Session::peerIpAddress) + sizeof(Session::rootInode) +
-	                                 sizeof(Session::flags) + sizeof(Session::rootUid) +
-	                                 sizeof(Session::rootGid);
-	constexpr uint32_t kExtraSizeWithMapAll =
-	    sizeof(Session::mapAllUid) + sizeof(Session::mapAllGid);
-	constexpr uint32_t kExtraSizeWithGoalTrash =
+	constexpr uint32_t kSessionSerializedSize =
+	    sizeof(Session::sessionId) + sizeof(sessionInfoLength) + sizeof(Session::peerIpAddress) +
+	    sizeof(Session::rootInode) + sizeof(Session::flags) +
 	    sizeof(Session::minGoal) + sizeof(Session::maxGoal) + sizeof(Session::minTrashTime) +
-	    sizeof(Session::maxTrashTime);
+	    sizeof(Session::maxTrashTime) + sizeof(Session::rootUid) + sizeof(Session::rootGid) +
+	    sizeof(Session::mapAllUid) + sizeof(Session::mapAllGid);
 	const uint32_t kStatsSize = statsInFile * kStatEntrySize;
-
-	if (mapAllData == 0) {
-		sessionBuffer.resize(kCommonSize + kStatsSize);
-	} else if (goalTrashData == 0) {
-		sessionBuffer.resize(kCommonSize + kExtraSizeWithMapAll + kStatsSize);
-	} else {
-		sessionBuffer.resize(kCommonSize + kExtraSizeWithMapAll + kExtraSizeWithGoalTrash +
-		                     kStatsSize);
-	}
+	sessionBuffer.resize(kSessionSerializedSize + kStatsSize);
 
 	while (!feof(fd)) {
 		bytesRead = fread(sessionBuffer.data(), sessionBuffer.size(), 1, fd);
@@ -419,18 +375,14 @@ int SessionManagerFile::loadSessions() {
 			get32bit(&ptr, sessionPtr->peerIpAddress);
 			getINode(&ptr, sessionPtr->rootInode);
 			sessionPtr->flags = get8bit(&ptr);
-			if (goalTrashData) {
-				sessionPtr->minGoal = get8bit(&ptr);
-				sessionPtr->maxGoal = get8bit(&ptr);
-				get32bit(&ptr, sessionPtr->minTrashTime);
-				get32bit(&ptr, sessionPtr->maxTrashTime);
-			}
+			sessionPtr->minGoal = get8bit(&ptr);
+			sessionPtr->maxGoal = get8bit(&ptr);
+			get32bit(&ptr, sessionPtr->minTrashTime);
+			get32bit(&ptr, sessionPtr->maxTrashTime);
 			get32bit(&ptr, sessionPtr->rootUid);
 			get32bit(&ptr, sessionPtr->rootGid);
-			if (mapAllData) {
-				get32bit(&ptr, sessionPtr->mapAllUid);
-				get32bit(&ptr, sessionPtr->mapAllGid);
-			}
+			get32bit(&ptr, sessionPtr->mapAllUid);
+			get32bit(&ptr, sessionPtr->mapAllGid);
 
 			sessionPtr->newSession = 1;
 			sessionPtr->disconnectedTimestamp = eventloop_time();
@@ -475,5 +427,3 @@ int SessionManagerFile::loadSessions() {
 	fclose(fd);
 	return 1;
 }
-
-#undef MFSSIGNATURE

--- a/src/master/session_manager.h
+++ b/src/master/session_manager.h
@@ -231,7 +231,7 @@ protected:
 /// open-files bookkeeping, and the timeout-reaping loop. Concrete subclasses
 /// only need to supply the persistence side: initialize(), loadSessions(),
 /// storeSessions(), plus, optionally, onSessionRemoved() to tear down any
-/// backend-specific per-session state.
+/// backend-specific per-session state and report whether removal can finish.
 ///
 /// Newly derived classes should prefer extending this base rather than
 /// implementing ISessionManager from scratch, so different backends keep the
@@ -292,9 +292,9 @@ public:
 	bool usesBackendSessionList() const override;
 
 	/// @copydoc ISessionManager::removeTimedOutSessions
-	/// @note Calls @p onTimedOut first. On success, calls onSessionRemoved()
-	///       (the derived class hook for backend cleanup), then erases the
-	///       entry. On failure, keeps the session for a later retry.
+	/// @note Calls @p onTimedOut first. If teardown and onSessionRemoved()
+	///       both succeed, erases the entry. Otherwise keeps the session for a
+	///       later retry.
 	void removeTimedOutSessions(uint32_t now, uint32_t sessionSustainTime,
 	                            const std::function<bool(Session *)> &onTimedOut) override;
 
@@ -318,10 +318,11 @@ protected:
 	/// Hook invoked after timed-out session teardown succeeds and before the
 	/// session is erased from the in-memory vector.
 	///
-	/// The default implementation is empty — it is used by the file backend
-	/// where persistence is driven by storeSessions(). KV backends override
-	/// this to drop the session record and its open-file index rows.
-	virtual void onSessionRemoved(const Session &session);
+	/// The default implementation returns true, it is used by the file
+	/// backend where persistence is driven by storeSessions(). KV backends
+	/// override this to drop the session record and its open-file index rows,
+	/// and return false if durable cleanup failed.
+	virtual bool onSessionRemoved(const Session &session);
 
 	/// Returns true when @p session is eligible for reaping under the tri-level
 	/// threshold (freshly-registered pending, normal, and legacy pre-1.5.13).

--- a/src/master/session_manager.h
+++ b/src/master/session_manager.h
@@ -1,0 +1,313 @@
+/*
+   Copyright 2005-2010 Jakub Kruszona-Zawadzki, Gemius SA
+   Copyright 2013-2014 EditShare
+   Copyright 2013-2015 Skytechnology sp. z o.o.
+   Copyright 2023      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "common/platform.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <vector>
+
+#include "master/session.h"
+
+class FilesystemOperationContext;
+
+/// Interface for session management.
+///
+/// Classes implementing this interface own the lifecycle of every client session
+/// served by the master: creation, lookup, timeout handling, persistence, and
+/// the per-session open-files index. It is the integration point between the
+/// network layer in `matoclserv` and the selected metadata backend. The
+/// master-side session dispatcher forwards every session call through the
+/// single active implementation, which is selected at startup by the backend
+/// wiring.
+///
+/// Implementations must be safe to call from the master event loop; they are not
+/// expected to be thread-safe across arbitrary threads at this point.
+class ISessionManager {
+public:
+	/// Default constructor.
+	ISessionManager() = default;
+
+	/// Unneeded copy/assign/move constructors and operators.
+	ISessionManager(const ISessionManager &) = delete;
+	ISessionManager &operator=(const ISessionManager &) = delete;
+	ISessionManager(ISessionManager &&) = delete;
+	ISessionManager &operator=(ISessionManager &&) = delete;
+
+	/// Virtual destructor.
+	virtual ~ISessionManager() = default;
+
+	/// Prepares the backing store and primes the in-memory session set.
+	///
+	/// Called exactly once from matoclserv_sessions_init(), after a concrete
+	/// session-manager implementation has been attached. The exact startup point
+	/// is backend-specific. Typical implementations invoke loadSessions() and
+	/// react to its outcome (missing store, loaded, error).
+	///
+	/// @return An implementation-defined startup status. The dispatcher
+	///         propagates this value to the RunTab. Implementations may log
+	///         loadSessions() failures and still return 0 to preserve legacy
+	///         startup behaviour.
+	virtual int initialize() = 0;
+
+	/// Loads all persisted sessions from the backing store into memory.
+	///
+	/// @return A backend-defined load status. Callers should treat this as an
+	///         implementation detail, apart from the conventional success/error
+	///         distinction used by initialize().
+	virtual int loadSessions() = 0;
+
+	/// Persists all sessions to the backing store.
+	///
+	/// Only sessions with @c newSession==1 are written. The exact persistence
+	/// semantics are backend-specific.
+	virtual void storeSessions() = 0;
+
+	/// Creates a new session and appends it to the managed set.
+	///
+	/// @param newSession Value copied into Session::newSession. Current
+	///                   registration paths pass 1 for both regular and meta
+	///                   sessions. The combination (@p newSession == 0 &&
+	///                   @p noNewId != 0) is a compatibility mode for
+	///                   session-id-less synthetic entries.
+	/// @param noNewId When non-zero together with @p newSession==0, the returned
+	///                session keeps sessionId=0 and no id is allocated from the
+	///                backend. Otherwise a fresh id is drawn from
+	///                IFilesystemOperations::newSessionId().
+	///
+	/// @return A pointer to the newly-added Session owned by this manager, or
+	///         nullptr if id allocation failed.
+	virtual Session *newSession(uint8_t newSession, uint8_t noNewId) = 0;
+
+	/// Returns the session matching @p sessionId, preparing it for reuse.
+	///
+	/// On hit, this increments @c connections, clears @c disconnectedTimestamp,
+	/// and clears the closed-session marker in Session::newSession when present
+	/// (subtracts 2 if @c newSession >= 2).
+	///
+	/// @return A pointer to the matching Session owned by this manager, or
+	///         nullptr if no session has the given id.
+	virtual Session *findSession(uint32_t sessionId) = 0;
+
+	/// Marks the session identified by @p sessionId as explicitly closed.
+	///
+	/// This only updates Session::newSession when the session exists, has exactly
+	/// one active connection, and is not already marked. It does not decrement
+	/// @c connections or set @c disconnectedTimestamp; that is done by
+	/// matocl_before_disconnect(). Timeout-based reaping is handled by
+	/// removeTimedOutSessions(). If @p sessionId is 0 or unknown this is a no-op.
+	virtual void closeSession(uint32_t sessionId) = 0;
+
+	/// Registers @p inode as open on @p currentSession, delegating the
+	/// persistent portion of the acquisition to the metadata backend.
+	///
+	/// If the session already tracks @p inode this returns immediately without
+	/// calling into the backend. Otherwise it invokes
+	/// IFilesystemOperations::acquire() inside the provided context; on
+	/// SAUNAFS_STATUS_OK it inserts @p inode into Session::openFilesSet.
+	///
+	/// @param fsOpContext The filesystem operation context (transaction).
+	/// @param currentSession Session that owns the opened file. Must be non-null.
+	/// @param inode The inode number of the file being acquired.
+	///
+	/// @return SAUNAFS_STATUS_OK on success, otherwise the status returned by
+	///         IFilesystemOperations::acquire().
+	virtual int insertOpenFile(const FilesystemOperationContext &fsOpContext,
+	                           Session *currentSession, inode_t inode) = 0;
+
+	/// Adds @p inode to Session::openFilesSet for the session @p sessionId.
+	///
+	/// Used during startup reconstruction, restore/shadow replay, and similar
+	/// paths where the file-side acquisition is already persisted and only the
+	/// in-memory index needs to be rebuilt. If no session with @p sessionId
+	/// exists, a synthetic placeholder session is created with
+	/// @c disconnectedTimestamp set to "now". This path preserves legacy
+	/// behaviour for pre-1.5.13 clients.
+	virtual void addOpenFile(uint32_t sessionId, inode_t inode) = 0;
+
+	/// Removes @p inode from Session::openFilesSet for the session @p sessionId.
+	///
+	/// Mirror of addOpenFile(). If no session is found the manager logs a
+	/// warning with the missing session id and inode but does not abort. This is
+	/// safe to call when the inode is absent from the set.
+	virtual void removeOpenFile(uint32_t sessionId, inode_t inode) = 0;
+
+	/// Refreshes disconnectedTimestamp for every managed session to "now".
+	///
+	/// Currently used when the process becomes active master again, to avoid
+	/// immediate timeout of sessions restored from a previously passive role.
+	virtual void resetSessionTimeouts() = 0;
+
+	/// Rolls per-session operation stats from current-hour into previous-hour
+	/// and zeroes the current-hour counters, then persists the result.
+	virtual void rotateStats() = 0;
+
+	/// Drops all in-memory session state without touching the backing store.
+	///
+	/// Used both at shutdown and as the first step of initialize()/re-load.
+	virtual void unload() = 0;
+
+	/// Invokes @p visitor on every managed session, in insertion order.
+	///
+	/// The visitor receives a @c const reference; modifying session state from
+	/// here is not supported.
+	virtual void forEachSession(const std::function<void(const Session &)> &visitor) const = 0;
+
+	/// Reaps sessions whose disconnect-timeout has elapsed.
+	///
+	/// For each session whose disconnect deadline is in the past, the manager
+	/// first invokes @p onTimedOut (so the network layer can close any lingering
+	/// open files) and then erases the entry — giving backend-specific
+	/// implementations a hook point to remove persistent rows.
+	///
+	/// @param now Current wall-clock time (seconds since epoch), typically from
+	///            eventloop_time().
+	/// @param sessionSustainTime How long a disconnected session is kept alive
+	///                           before it is eligible for reaping. Clamped by
+	///                           configuration on the dispatcher side.
+	/// @param onTimedOut Invoked exactly once per reaped session, before removal.
+	virtual void removeTimedOutSessions(uint32_t now, uint32_t sessionSustainTime,
+	                                    const std::function<void(Session *)> &onTimedOut) = 0;
+
+protected:
+	/// Guard against construction from a null reference; kept to mirror the
+	/// IFilesystemOperations pattern and prevent surprising coercions.
+	ISessionManager(const std::nullptr_t &) = delete;
+};
+
+/// Base implementation of ISessionManager shared by every backend.
+///
+/// Provides the in-memory session vector, the common id-allocation and
+/// open-files bookkeeping, and the timeout-reaping loop. Concrete subclasses
+/// only need to supply the persistence side: initialize(), loadSessions(),
+/// storeSessions(), plus, optionally, onSessionRemoved() to tear down any
+/// backend-specific per-session state.
+///
+/// Newly derived classes should prefer extending this base rather than
+/// implementing ISessionManager from scratch, so different backends keep the
+/// same in-memory semantics.
+class SessionManagerBase : public ISessionManager {
+public:
+	/// Default constructor.
+	SessionManagerBase() = default;
+
+	/// @copydoc ISessionManager::newSession
+	/// @note Delegates id allocation to IFilesystemOperations::newSessionId().
+	///       Returns nullptr when the allocator returns 0.
+	Session *newSession(uint8_t newSession, uint8_t noNewId) override;
+
+	/// @copydoc ISessionManager::findSession
+	Session *findSession(uint32_t sessionId) override;
+
+	/// @copydoc ISessionManager::closeSession
+	void closeSession(uint32_t sessionId) override;
+
+	/// @copydoc ISessionManager::insertOpenFile
+	int insertOpenFile(const FilesystemOperationContext &fsOpContext, Session *currentSession,
+	                   inode_t inode) override;
+
+	/// @copydoc ISessionManager::addOpenFile
+	void addOpenFile(uint32_t sessionId, inode_t inode) override;
+
+	/// @copydoc ISessionManager::removeOpenFile
+	void removeOpenFile(uint32_t sessionId, inode_t inode) override;
+
+	/// @copydoc ISessionManager::resetSessionTimeouts
+	void resetSessionTimeouts() override;
+
+	/// @copydoc ISessionManager::rotateStats
+	/// @note The final step persists via the derived storeSessions() override.
+	void rotateStats() override;
+
+	/// @copydoc ISessionManager::unload
+	void unload() override;
+
+	/// @copydoc ISessionManager::forEachSession
+	void forEachSession(const std::function<void(const Session &)> &visitor) const override;
+
+	/// @copydoc ISessionManager::removeTimedOutSessions
+	/// @note Calls @p onTimedOut first, then onSessionRemoved() (the derived
+	///       class hook for backend cleanup), then erases the entry.
+	void removeTimedOutSessions(uint32_t now, uint32_t sessionSustainTime,
+	                            const std::function<void(Session *)> &onTimedOut) override;
+
+	/// Appends @p sessionPtr to the managed vector and returns a non-owning
+	/// pointer to the stored Session. @p sessionPtr must be non-null.
+	///
+	/// Primary callers in production code are newSession() and the synthetic
+	/// addOpenFile() recovery path. Exposed publicly so that tests (and other
+	/// out-of-tree extensions) can populate the manager without going through
+	/// newSession(), which requires gFSOperations.
+	Session *addSession(std::unique_ptr<Session> sessionPtr);
+
+protected:
+	/// Looks up the session with @p sessionId without touching any fields.
+	/// Returns nullptr for sessionId==0 or when the id is unknown.
+	Session *findSessionEntry(uint32_t sessionId);
+
+	/// @copydoc SessionManagerBase::findSessionEntry(uint32_t)
+	const Session *findSessionEntry(uint32_t sessionId) const;
+
+	/// Hook invoked after a session has been reaped by removeTimedOutSessions()
+	/// and before it is erased from the in-memory vector.
+	///
+	/// The default implementation is empty — it is used by the file backend
+	/// where persistence is driven by storeSessions(). KV backends override
+	/// this to drop the session record and its open-file index rows.
+	virtual void onSessionRemoved(const Session &session);
+
+private:
+	/// Returns true when @p session is eligible for reaping under the tri-level
+	/// threshold (freshly-registered pending, normal, and legacy pre-1.5.13).
+	static bool isTimedOut(const Session &session, uint32_t now, uint32_t sessionSustainTime);
+
+protected:
+	/// The owned, insertion-ordered set of sessions.
+	std::vector<std::unique_ptr<Session>> sessions_;
+};
+
+/// File-backed session manager used by the classic master personality.
+///
+/// Persists sessions to @c sessions.sfs (see @c kSessionsFilename) next to the
+/// metadata image, using the SFSSIGNATURE "S \001\006\004" format and a legacy
+/// "MFS" accept list for upgrades. There is no per-session open-file index on
+/// disk. After restart, Session::openFilesSet is rebuilt from
+/// FSNodeFile::sessionIds during metadata loading, and the base-class
+/// onSessionRemoved() hook is intentionally a no-op.
+class SessionManagerFile final : public SessionManagerBase {
+public:
+	/// @copydoc ISessionManager::initialize
+	/// @note On fresh installs (sessions file missing) this logs a warning and
+	///       writes an empty file so subsequent runs find it.
+	int initialize() override;
+
+	/// @copydoc ISessionManager::loadSessions
+	int loadSessions() override;
+
+	/// @copydoc ISessionManager::storeSessions
+	/// @note Atomic rename from the ".tmp" companion. Partial write failures
+	///       leave the existing sessions file untouched.
+	void storeSessions() override;
+};

--- a/src/master/session_manager.h
+++ b/src/master/session_manager.h
@@ -29,6 +29,7 @@
 #include <memory>
 #include <vector>
 
+#include "common/sessions_file.h"
 #include "master/session.h"
 
 class FilesystemOperationContext;
@@ -84,6 +85,21 @@ public:
 	/// Only sessions with @c newSession==1 are written. The exact persistence
 	/// semantics are backend-specific.
 	virtual void storeSessions() = 0;
+
+	/// Persists one session through the active backend.
+	///
+	/// Backends that only support full-catalog rewrites may forward this to
+	/// storeSessions(). Backends with row-level persistence can upsert just the
+	/// requested session.
+	virtual void persistSession(const Session &session) = 0;
+
+	/// Persists or observes runtime state after an active connection disconnects.
+	///
+	/// The file backend keeps this as a no-op because its restart semantics are
+	/// driven by the persisted session catalog. KV backends may use this to
+	/// persist runtime ownership/disconnect state separately from the stable
+	/// session record.
+	virtual void sessionDisconnected(const Session &session) = 0;
 
 	/// Creates a new session and appends it to the managed set.
 	///
@@ -175,21 +191,33 @@ public:
 	/// here is not supported.
 	virtual void forEachSession(const std::function<void(const Session &)> &visitor) const = 0;
 
+	/// Returns session summaries for the admin list-sessions command.
+	///
+	/// Backends may choose whether this is local-process or cluster-wide. The
+	/// file backend exposes the current local in-memory view; KV backends could
+	/// expose the full cluster view (implementation dependent).
+	virtual std::vector<SessionFiles> listSessions() const = 0;
+
+	/// Returns true when listSessions() should replace matoclserv's local
+	/// connection-list walk for admin list-sessions.
+	virtual bool usesBackendSessionList() const = 0;
+
 	/// Reaps sessions whose disconnect-timeout has elapsed.
 	///
 	/// For each session whose disconnect deadline is in the past, the manager
 	/// first invokes @p onTimedOut (so the network layer can close any lingering
-	/// open files) and then erases the entry — giving backend-specific
-	/// implementations a hook point to remove persistent rows.
+	/// open files). If the callback returns true, the entry is removed. If it
+	/// returns false, the session stays managed so a later sweep can retry.
 	///
 	/// @param now Current wall-clock time (seconds since epoch), typically from
 	///            eventloop_time().
 	/// @param sessionSustainTime How long a disconnected session is kept alive
 	///                           before it is eligible for reaping. Clamped by
 	///                           configuration on the dispatcher side.
-	/// @param onTimedOut Invoked exactly once per reaped session, before removal.
+	/// @param onTimedOut Invoked for every timed-out session. Return true when
+	///                   teardown completed and the session may be removed.
 	virtual void removeTimedOutSessions(uint32_t now, uint32_t sessionSustainTime,
-	                                    const std::function<void(Session *)> &onTimedOut) = 0;
+	                                    const std::function<bool(Session *)> &onTimedOut) = 0;
 
 protected:
 	/// Guard against construction from a null reference; kept to mirror the
@@ -238,8 +266,18 @@ public:
 	void resetSessionTimeouts() override;
 
 	/// @copydoc ISessionManager::rotateStats
-	/// @note The final step persists via the derived storeSessions() override.
+	/// @note The default implementation preserves legacy behavior by calling
+	///       storeSessions() after rotating the in-memory counters. Backends
+	///       with row-level persistence may override this.
 	void rotateStats() override;
+
+	/// @copydoc ISessionManager::persistSession
+	/// @note Defaults to storeSessions() to preserve the file-backed contract.
+	void persistSession(const Session &session) override;
+
+	/// @copydoc ISessionManager::sessionDisconnected
+	/// @note Defaults to a no-op to preserve the file-backed contract.
+	void sessionDisconnected(const Session &session) override;
 
 	/// @copydoc ISessionManager::unload
 	void unload() override;
@@ -247,11 +285,18 @@ public:
 	/// @copydoc ISessionManager::forEachSession
 	void forEachSession(const std::function<void(const Session &)> &visitor) const override;
 
+	/// @copydoc ISessionManager::listSessions
+	std::vector<SessionFiles> listSessions() const override;
+
+	/// @copydoc ISessionManager::usesBackendSessionList
+	bool usesBackendSessionList() const override;
+
 	/// @copydoc ISessionManager::removeTimedOutSessions
-	/// @note Calls @p onTimedOut first, then onSessionRemoved() (the derived
-	///       class hook for backend cleanup), then erases the entry.
+	/// @note Calls @p onTimedOut first. On success, calls onSessionRemoved()
+	///       (the derived class hook for backend cleanup), then erases the
+	///       entry. On failure, keeps the session for a later retry.
 	void removeTimedOutSessions(uint32_t now, uint32_t sessionSustainTime,
-	                            const std::function<void(Session *)> &onTimedOut) override;
+	                            const std::function<bool(Session *)> &onTimedOut) override;
 
 	/// Appends @p sessionPtr to the managed vector and returns a non-owning
 	/// pointer to the stored Session. @p sessionPtr must be non-null.
@@ -270,15 +315,14 @@ protected:
 	/// @copydoc SessionManagerBase::findSessionEntry(uint32_t)
 	const Session *findSessionEntry(uint32_t sessionId) const;
 
-	/// Hook invoked after a session has been reaped by removeTimedOutSessions()
-	/// and before it is erased from the in-memory vector.
+	/// Hook invoked after timed-out session teardown succeeds and before the
+	/// session is erased from the in-memory vector.
 	///
 	/// The default implementation is empty — it is used by the file backend
 	/// where persistence is driven by storeSessions(). KV backends override
 	/// this to drop the session record and its open-file index rows.
 	virtual void onSessionRemoved(const Session &session);
 
-private:
 	/// Returns true when @p session is eligible for reaping under the tri-level
 	/// threshold (freshly-registered pending, normal, and legacy pre-1.5.13).
 	static bool isTimedOut(const Session &session, uint32_t now, uint32_t sessionSustainTime);

--- a/src/master/session_manager.h
+++ b/src/master/session_manager.h
@@ -335,11 +335,10 @@ protected:
 /// File-backed session manager used by the classic master personality.
 ///
 /// Persists sessions to @c sessions.sfs (see @c kSessionsFilename) next to the
-/// metadata image, using the SFSSIGNATURE "S \001\006\004" format and a legacy
-/// "MFS" accept list for upgrades. There is no per-session open-file index on
-/// disk. After restart, Session::openFilesSet is rebuilt from
-/// FSNodeFile::sessionIds during metadata loading, and the base-class
-/// onSessionRemoved() hook is intentionally a no-op.
+/// metadata image, using the SFSSIGNATURE "S \001\006\004" format. There is no
+/// per-session open-file index on disk. After restart, Session::openFilesSet is
+/// rebuilt from FSNodeFile::sessionIds during metadata loading, and the
+/// base-class onSessionRemoved() hook is intentionally a no-op.
 class SessionManagerFile final : public SessionManagerBase {
 public:
 	/// @copydoc ISessionManager::initialize

--- a/src/master/session_manager_unittest.cc
+++ b/src/master/session_manager_unittest.cc
@@ -58,7 +58,9 @@ public:
 	}
 
 	~ScopedCurrentDirectory() {
-		if (!previousPath_.empty()) { chdir(previousPath_.c_str()); }
+		if (!previousPath_.empty() && chdir(previousPath_.c_str()) != 0) {
+			ADD_FAILURE() << "failed to restore current working directory";
+		}
 	}
 
 	ScopedCurrentDirectory(const ScopedCurrentDirectory &) = delete;
@@ -82,13 +84,15 @@ public:
 	using SessionManagerBase::findSessionEntry;
 
 	int storeSessionsCallCount = 0;
+	bool removeHookResult = true;
 	std::vector<uint32_t> removedSessionIds;
 	std::vector<std::string> hookEvents;
 
 protected:
-	void onSessionRemoved(const Session &session) override {
+	bool onSessionRemoved(const Session &session) override {
 		removedSessionIds.push_back(session.sessionId);
 		hookEvents.push_back("removed:" + std::to_string(session.sessionId));
+		return removeHookResult;
 	}
 };
 
@@ -475,6 +479,26 @@ TEST(SessionManagerBaseTests, RemoveTimedOutKeepsSessionWhenTeardownFails) {
 
 	EXPECT_EQ(timedOut, std::vector<uint32_t>{1});
 	EXPECT_TRUE(manager.removedSessionIds.empty());
+	EXPECT_NE(manager.findSessionEntry(1), nullptr);
+}
+
+TEST(SessionManagerBaseTests, RemoveTimedOutKeepsSessionWhenRemovalHookFails) {
+	TestSessionManager manager;
+	manager.removeHookResult = false;
+	auto session = makeSession(1);
+	session->newSession = 1;
+	session->connections = 0;
+	session->disconnectedTimestamp = 100;
+	manager.addSession(std::move(session));
+
+	std::vector<uint32_t> timedOut;
+	manager.removeTimedOutSessions(200, 50, [&](Session *timedOutSession) {
+		timedOut.push_back(timedOutSession->sessionId);
+		return true;
+	});
+
+	EXPECT_EQ(timedOut, std::vector<uint32_t>{1});
+	EXPECT_EQ(manager.removedSessionIds, std::vector<uint32_t>{1});
 	EXPECT_NE(manager.findSessionEntry(1), nullptr);
 }
 

--- a/src/master/session_manager_unittest.cc
+++ b/src/master/session_manager_unittest.cc
@@ -201,6 +201,7 @@ TEST(SessionManagerBaseTests, RemoveTimedOutSkipsActiveSessions) {
 	std::vector<uint32_t> timedOut;
 	manager.removeTimedOutSessions(1'000'000, 60, [&](Session *timedOutSession) {
 		timedOut.push_back(timedOutSession->sessionId);
+		return true;
 	});
 
 	EXPECT_TRUE(timedOut.empty());
@@ -219,6 +220,7 @@ TEST(SessionManagerBaseTests, RemoveTimedOutReapsPendingCloseSession) {
 	std::vector<uint32_t> timedOut;
 	manager.removeTimedOutSessions(101, 100'000, [&](Session *timedOutSession) {
 		timedOut.push_back(timedOutSession->sessionId);
+		return true;
 	});
 
 	EXPECT_EQ(timedOut, std::vector<uint32_t>{1});
@@ -238,14 +240,18 @@ TEST(SessionManagerBaseTests, RemoveTimedOutHonorsStrictLessThanSustainBoundary)
 
 	// isTimedOut for newSession==1 uses dts + sustain < now (strict <).
 	// now == dts + sustain => NOT timed out.
-	manager.removeTimedOutSessions(
-	    150, 50, [&](Session *timedOutSession) { timedOut.push_back(timedOutSession->sessionId); });
+	manager.removeTimedOutSessions(150, 50, [&](Session *timedOutSession) {
+		timedOut.push_back(timedOutSession->sessionId);
+		return true;
+	});
 	EXPECT_TRUE(timedOut.empty());
 	EXPECT_NE(manager.findSessionEntry(1), nullptr);
 
 	// now == dts + sustain + 1 => timed out.
-	manager.removeTimedOutSessions(
-	    151, 50, [&](Session *timedOutSession) { timedOut.push_back(timedOutSession->sessionId); });
+	manager.removeTimedOutSessions(151, 50, [&](Session *timedOutSession) {
+		timedOut.push_back(timedOutSession->sessionId);
+		return true;
+	});
 	EXPECT_EQ(timedOut, std::vector<uint32_t>{1});
 	EXPECT_EQ(manager.findSessionEntry(1), nullptr);
 }
@@ -262,7 +268,10 @@ TEST(SessionManagerBaseTests, RemoveTimedOutUsesLegacyThresholdForOldClients) {
 	manager.addSession(std::move(session));
 
 	std::vector<uint32_t> timedOut;
-	auto record = [&](Session *timedOutSession) { timedOut.push_back(timedOutSession->sessionId); };
+	auto record = [&](Session *timedOutSession) {
+		timedOut.push_back(timedOutSession->sessionId);
+		return true;
+	};
 
 	// Legacy path uses kLegacyClientTimeoutSeconds and ignores sessionSustainTime.
 	// dts + kLegacyClientTimeoutSeconds == now => NOT timed out.
@@ -288,6 +297,7 @@ TEST(SessionManagerBaseTests, RemoveTimedOutInvokesOnTimedOutBeforeOnSessionRemo
 
 	manager.removeTimedOutSessions(200, 50, [&](Session *timedOutSession) {
 		manager.hookEvents.push_back("timedOut:" + std::to_string(timedOutSession->sessionId));
+		return true;
 	});
 
 	ASSERT_EQ(manager.hookEvents.size(), 2U);
@@ -316,6 +326,7 @@ TEST(SessionManagerBaseTests, RemoveTimedOutProcessesMixedSetCorrectly) {
 	std::vector<uint32_t> timedOut;
 	manager.removeTimedOutSessions(200, 100, [&](Session *timedOutSession) {
 		timedOut.push_back(timedOutSession->sessionId);
+		return true;
 	});
 
 	EXPECT_EQ(timedOut, std::vector<uint32_t>{3});
@@ -323,6 +334,51 @@ TEST(SessionManagerBaseTests, RemoveTimedOutProcessesMixedSetCorrectly) {
 	EXPECT_NE(manager.findSessionEntry(1), nullptr);
 	EXPECT_NE(manager.findSessionEntry(2), nullptr);
 	EXPECT_EQ(manager.findSessionEntry(3), nullptr);
+}
+
+TEST(SessionManagerBaseTests, RemoveTimedOutKeepsSessionWhenTeardownFails) {
+	TestSessionManager manager;
+	auto session = makeSession(1);
+	session->newSession = 1;
+	session->connections = 0;
+	session->disconnectedTimestamp = 100;
+	manager.addSession(std::move(session));
+
+	std::vector<uint32_t> timedOut;
+	manager.removeTimedOutSessions(200, 50, [&](Session *timedOutSession) {
+		timedOut.push_back(timedOutSession->sessionId);
+		return false;
+	});
+
+	EXPECT_EQ(timedOut, std::vector<uint32_t>{1});
+	EXPECT_TRUE(manager.removedSessionIds.empty());
+	EXPECT_NE(manager.findSessionEntry(1), nullptr);
+}
+
+TEST(SessionManagerBaseTests, RemoveTimedOutKeepsOnlyFailedTeardownSessions) {
+	TestSessionManager manager;
+	auto failed = makeSession(1);
+	failed->newSession = 1;
+	failed->connections = 0;
+	failed->disconnectedTimestamp = 100;
+	manager.addSession(std::move(failed));
+
+	auto completed = makeSession(2);
+	completed->newSession = 1;
+	completed->connections = 0;
+	completed->disconnectedTimestamp = 100;
+	manager.addSession(std::move(completed));
+
+	std::vector<uint32_t> timedOut;
+	manager.removeTimedOutSessions(200, 50, [&](Session *timedOutSession) {
+		timedOut.push_back(timedOutSession->sessionId);
+		return timedOutSession->sessionId != 1;
+	});
+
+	EXPECT_EQ(timedOut, (std::vector<uint32_t>{1, 2}));
+	EXPECT_EQ(manager.removedSessionIds, std::vector<uint32_t>{2});
+	EXPECT_NE(manager.findSessionEntry(1), nullptr);
+	EXPECT_EQ(manager.findSessionEntry(2), nullptr);
 }
 
 // ---------------------------------------------------------------------------
@@ -346,6 +402,15 @@ TEST(SessionManagerBaseTests, RotateStatsMovesCurrentToPrevAndZeroesCurrent) {
 	EXPECT_EQ(stored->prevHourOperationsStats[5], 42U);
 	EXPECT_EQ(stored->currHourOperationsStats[0], 0U);
 	EXPECT_EQ(stored->currHourOperationsStats[5], 0U);
+	EXPECT_EQ(manager.storeSessionsCallCount, 1);
+}
+
+TEST(SessionManagerBaseTests, PersistSessionDefaultsToStoreSessions) {
+	TestSessionManager manager;
+	const Session *stored = manager.addSession(makeSession(1));
+
+	manager.persistSession(*stored);
+
 	EXPECT_EQ(manager.storeSessionsCallCount, 1);
 }
 
@@ -419,4 +484,25 @@ TEST(SessionManagerBaseTests, ForEachSessionVisitsInInsertionOrder) {
 	manager.forEachSession([&](const Session &session) { visited.push_back(session.sessionId); });
 
 	EXPECT_EQ(visited, (std::vector<uint32_t>{10, 20, 30}));
+}
+
+TEST(SessionManagerBaseTests, ListSessionsReturnsActiveSessionSummaries) {
+	TestSessionManager manager;
+	auto disconnected = makeSession(10);
+	disconnected->connections = 0;
+	disconnected->openFilesSet.insert(100);
+	manager.addSession(std::move(disconnected));
+
+	auto active = makeSession(20);
+	active->peerIpAddress = 0x7F000001;
+	active->openFilesSet.insert(200);
+	active->openFilesSet.insert(300);
+	manager.addSession(std::move(active));
+
+	auto summaries = manager.listSessions();
+
+	ASSERT_EQ(summaries.size(), 1U);
+	EXPECT_EQ(summaries[0].sessionId, 20U);
+	EXPECT_EQ(summaries[0].peerIp, 0x7F000001U);
+	EXPECT_EQ(summaries[0].filesNumber, 2U);
 }

--- a/src/master/session_manager_unittest.cc
+++ b/src/master/session_manager_unittest.cc
@@ -22,18 +22,51 @@
 
 #include <gtest/gtest.h>
 
+#include <limits.h>
+#include <unistd.h>
+
+#include <array>
 #include <cstdint>
+#include <fstream>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
+#include "master/metadata_backend_common.h"
 #include "master/session.h"
+#include "unittests/TemporaryDirectory.h"
 
 namespace {
 
 /// Fixed timeout window applied to legacy pre-1.5.13 clients (newSession==0).
 /// Must stay in sync with the literal in SessionManagerBase::isTimedOut().
 constexpr uint32_t kLegacyClientTimeoutSeconds = 7200;
+
+class ScopedCurrentDirectory {
+public:
+	explicit ScopedCurrentDirectory(const std::string &path) {
+		std::array<char, PATH_MAX> buffer{};
+		if (getcwd(buffer.data(), buffer.size()) == nullptr) {
+			throw std::runtime_error("failed to read current working directory");
+		}
+
+		previousPath_ = buffer.data();
+		if (chdir(path.c_str()) != 0) {
+			throw std::runtime_error("failed to change current working directory");
+		}
+	}
+
+	~ScopedCurrentDirectory() {
+		if (!previousPath_.empty()) { chdir(previousPath_.c_str()); }
+	}
+
+	ScopedCurrentDirectory(const ScopedCurrentDirectory &) = delete;
+	ScopedCurrentDirectory &operator=(const ScopedCurrentDirectory &) = delete;
+
+private:
+	std::string previousPath_;
+};
 
 /// Concrete SessionManagerBase used by these tests.
 ///
@@ -68,7 +101,97 @@ std::unique_ptr<Session> makeSession(uint32_t sessionId) {
 	return session;
 }
 
+void writeRawSessionsFile(const std::vector<uint8_t> &contents) {
+	std::ofstream file(kSessionsFilename, std::ios::binary);
+	ASSERT_TRUE(file) << "Cannot open " << kSessionsFilename << " for writing";
+	file.write(reinterpret_cast<const char *>(contents.data()), contents.size());
+	ASSERT_TRUE(file.good()) << "Cannot write " << kSessionsFilename;
+}
+
 }  // namespace
+
+// ---------------------------------------------------------------------------
+// SessionManagerFile loader
+// ---------------------------------------------------------------------------
+
+TEST(SessionManagerFileTests, LoadSessionsReturnsZeroWhenSessionsFileIsMissing) {
+	TemporaryDirectory temp("/tmp", "session-file-missing");
+	ScopedCurrentDirectory cwd(temp.name());
+
+	SessionManagerFile manager;
+
+	EXPECT_EQ(manager.loadSessions(), 0);
+}
+
+TEST(SessionManagerFileTests, CurrentFormatRoundTripsThroughStoreAndLoad) {
+	TemporaryDirectory temp("/tmp", "session-file-current");
+	ScopedCurrentDirectory cwd(temp.name());
+
+	auto session = makeSession(42);
+	session->info = "mount-info";
+	session->peerIpAddress = 0x7F000001;
+	session->rootInode = 7;
+	session->flags = 3;
+	session->minGoal = 2;
+	session->maxGoal = 5;
+	session->minTrashTime = 60;
+	session->maxTrashTime = 3600;
+	session->rootUid = 1000;
+	session->rootGid = 1001;
+	session->mapAllUid = 2000;
+	session->mapAllGid = 2001;
+	session->currHourOperationsStats[0] = 11;
+	session->prevHourOperationsStats[0] = 22;
+
+	SessionManagerFile writer;
+	writer.addSession(std::move(session));
+	writer.storeSessions();
+
+	SessionManagerFile reader;
+	ASSERT_EQ(reader.loadSessions(), 1);
+
+	int visited = 0;
+	reader.forEachSession([&](const Session &loaded) {
+		++visited;
+		EXPECT_EQ(loaded.sessionId, 42U);
+		EXPECT_EQ(loaded.info, "mount-info");
+		EXPECT_EQ(loaded.peerIpAddress, 0x7F000001U);
+		EXPECT_EQ(loaded.rootInode, 7U);
+		EXPECT_EQ(loaded.flags, 3U);
+		EXPECT_EQ(loaded.minGoal, 2U);
+		EXPECT_EQ(loaded.maxGoal, 5U);
+		EXPECT_EQ(loaded.minTrashTime, 60U);
+		EXPECT_EQ(loaded.maxTrashTime, 3600U);
+		EXPECT_EQ(loaded.rootUid, 1000U);
+		EXPECT_EQ(loaded.rootGid, 1001U);
+		EXPECT_EQ(loaded.mapAllUid, 2000U);
+		EXPECT_EQ(loaded.mapAllGid, 2001U);
+		EXPECT_EQ(loaded.currHourOperationsStats[0], 11U);
+		EXPECT_EQ(loaded.prevHourOperationsStats[0], 22U);
+		EXPECT_EQ(loaded.newSession, 1U);
+	});
+	EXPECT_EQ(visited, 1);
+}
+
+TEST(SessionManagerFileTests, OldSfsSessionHeaderIsRejected) {
+	TemporaryDirectory temp("/tmp", "session-file-old-sfs");
+	ScopedCurrentDirectory cwd(temp.name());
+	writeRawSessionsFile({'S', 'F', 'S', 'S', ' ', 1, 6, 3});
+
+	SessionManagerFile manager;
+
+	EXPECT_EQ(manager.loadSessions(), -1);
+}
+
+TEST(SessionManagerFileTests, MfsSessionHeaderIsRejected) {
+	TemporaryDirectory temp("/tmp", "session-file-mfs");
+	ScopedCurrentDirectory cwd(temp.name());
+	writeRawSessionsFile({'M', 'F', 'S', 'S', ' ', 1, 6, 4});
+
+	SessionManagerFile manager;
+
+	EXPECT_EQ(manager.loadSessions(), -1);
+}
 
 // ---------------------------------------------------------------------------
 // findSession()

--- a/src/master/session_manager_unittest.cc
+++ b/src/master/session_manager_unittest.cc
@@ -1,0 +1,422 @@
+/*
+   Copyright 2026      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "common/platform.h"
+
+#include "master/session_manager.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "master/session.h"
+
+namespace {
+
+/// Fixed timeout window applied to legacy pre-1.5.13 clients (newSession==0).
+/// Must stay in sync with the literal in SessionManagerBase::isTimedOut().
+constexpr uint32_t kLegacyClientTimeoutSeconds = 7200;
+
+/// Concrete SessionManagerBase used by these tests.
+///
+/// Stubs the pure-virtual persistence hooks so the class is instantiable, and
+/// records onSessionRemoved() invocations so tests can assert on reaping hook
+/// behavior without touching any backend.
+class TestSessionManager : public SessionManagerBase {
+public:
+	int initialize() override { return 0; }
+	int loadSessions() override { return 0; }
+	void storeSessions() override { ++storeSessionsCallCount; }
+
+	using SessionManagerBase::findSessionEntry;
+
+	int storeSessionsCallCount = 0;
+	std::vector<uint32_t> removedSessionIds;
+	std::vector<std::string> hookEvents;
+
+protected:
+	void onSessionRemoved(const Session &session) override {
+		removedSessionIds.push_back(session.sessionId);
+		hookEvents.push_back("removed:" + std::to_string(session.sessionId));
+	}
+};
+
+std::unique_ptr<Session> makeSession(uint32_t sessionId) {
+	auto session = std::make_unique<Session>();
+	session->sessionId = sessionId;
+	session->newSession = 1;
+	session->connections = 1;
+	session->disconnectedTimestamp = 0;
+	return session;
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// findSession()
+// ---------------------------------------------------------------------------
+
+TEST(SessionManagerBaseTests, FindSessionReturnsNullForUnknownId) {
+	TestSessionManager manager;
+	manager.addSession(makeSession(100));
+	EXPECT_EQ(manager.findSession(999), nullptr);
+}
+
+TEST(SessionManagerBaseTests, FindSessionRejectsIdZero) {
+	TestSessionManager manager;
+	manager.addSession(makeSession(0));
+	EXPECT_EQ(manager.findSession(0), nullptr);
+}
+
+TEST(SessionManagerBaseTests, FindSessionRevivesDisconnectedSession) {
+	TestSessionManager manager;
+	auto session = makeSession(42);
+	session->connections = 0;
+	session->disconnectedTimestamp = 12345;
+	const Session *stored = manager.addSession(std::move(session));
+
+	Session *found = manager.findSession(42);
+
+	ASSERT_EQ(found, stored);
+	EXPECT_EQ(found->connections, 1U);
+	EXPECT_EQ(found->disconnectedTimestamp, 0U);
+}
+
+TEST(SessionManagerBaseTests, FindSessionClearsPendingCloseMarker) {
+	TestSessionManager manager;
+	auto session = makeSession(42);
+	// newSession == 3 means "regular session (1)" with the pending-close marker
+	// (bit 1) set by a prior closeSession() call.
+	session->newSession = 3;
+	session->connections = 0;
+	manager.addSession(std::move(session));
+
+	Session *found = manager.findSession(42);
+
+	ASSERT_NE(found, nullptr);
+	EXPECT_EQ(found->newSession, 1U);
+	EXPECT_EQ(found->connections, 1U);
+}
+
+TEST(SessionManagerBaseTests, FindSessionLeavesRegularNewSessionUntouched) {
+	TestSessionManager manager;
+	auto session = makeSession(42);
+	session->newSession = 1;
+	session->connections = 1;
+	manager.addSession(std::move(session));
+
+	Session *found = manager.findSession(42);
+
+	ASSERT_NE(found, nullptr);
+	EXPECT_EQ(found->newSession, 1U);
+	EXPECT_EQ(found->connections, 2U);
+}
+
+// ---------------------------------------------------------------------------
+// closeSession()
+// ---------------------------------------------------------------------------
+
+TEST(SessionManagerBaseTests, CloseSessionSetsMarkerOnLastConnection) {
+	TestSessionManager manager;
+	auto session = makeSession(42);
+	session->newSession = 1;
+	session->connections = 1;
+	manager.addSession(std::move(session));
+
+	manager.closeSession(42);
+
+	ASSERT_NE(manager.findSessionEntry(42), nullptr);
+	EXPECT_EQ(manager.findSessionEntry(42)->newSession, 3U);
+}
+
+TEST(SessionManagerBaseTests, CloseSessionIsNoOpWithMultipleConnections) {
+	TestSessionManager manager;
+	auto session = makeSession(42);
+	session->newSession = 1;
+	session->connections = 2;
+	manager.addSession(std::move(session));
+
+	manager.closeSession(42);
+
+	EXPECT_EQ(manager.findSessionEntry(42)->newSession, 1U);
+}
+
+TEST(SessionManagerBaseTests, CloseSessionDoesNotReapplyMarker) {
+	TestSessionManager manager;
+	auto session = makeSession(42);
+	session->newSession = 3;  // already marked
+	session->connections = 1;
+	manager.addSession(std::move(session));
+
+	manager.closeSession(42);
+
+	EXPECT_EQ(manager.findSessionEntry(42)->newSession, 3U);
+}
+
+TEST(SessionManagerBaseTests, CloseSessionOnUnknownIdIsNoOp) {
+	TestSessionManager manager;
+	manager.addSession(makeSession(42));
+
+	manager.closeSession(999);
+
+	ASSERT_NE(manager.findSessionEntry(42), nullptr);
+	EXPECT_EQ(manager.findSessionEntry(42)->newSession, 1U);
+}
+
+// ---------------------------------------------------------------------------
+// removeTimedOutSessions() — tri-level threshold + hook ordering.
+//
+// isTimedOut():
+//   connections != 0                                    => not timed out
+//   newSession > 1 && dts < now                         => timed out (pending close)
+//   newSession == 1 && dts + sustain < now              => timed out (regular)
+//   newSession == 0 && dts + 7200 < now                 => timed out (legacy)
+// ---------------------------------------------------------------------------
+
+TEST(SessionManagerBaseTests, RemoveTimedOutSkipsActiveSessions) {
+	TestSessionManager manager;
+	auto session = makeSession(1);
+	session->connections = 1;
+	session->disconnectedTimestamp = 0;
+	manager.addSession(std::move(session));
+
+	std::vector<uint32_t> timedOut;
+	manager.removeTimedOutSessions(1'000'000, 60, [&](Session *timedOutSession) {
+		timedOut.push_back(timedOutSession->sessionId);
+	});
+
+	EXPECT_TRUE(timedOut.empty());
+	EXPECT_TRUE(manager.removedSessionIds.empty());
+	EXPECT_NE(manager.findSessionEntry(1), nullptr);
+}
+
+TEST(SessionManagerBaseTests, RemoveTimedOutReapsPendingCloseSession) {
+	TestSessionManager manager;
+	auto session = makeSession(1);
+	session->newSession = 3;  // pending close
+	session->connections = 0;
+	session->disconnectedTimestamp = 100;
+	manager.addSession(std::move(session));
+
+	std::vector<uint32_t> timedOut;
+	manager.removeTimedOutSessions(101, 100'000, [&](Session *timedOutSession) {
+		timedOut.push_back(timedOutSession->sessionId);
+	});
+
+	EXPECT_EQ(timedOut, std::vector<uint32_t>{1});
+	EXPECT_EQ(manager.removedSessionIds, std::vector<uint32_t>{1});
+	EXPECT_EQ(manager.findSessionEntry(1), nullptr);
+}
+
+TEST(SessionManagerBaseTests, RemoveTimedOutHonorsStrictLessThanSustainBoundary) {
+	TestSessionManager manager;
+	auto session = makeSession(1);
+	session->newSession = 1;
+	session->connections = 0;
+	session->disconnectedTimestamp = 100;
+	manager.addSession(std::move(session));
+
+	std::vector<uint32_t> timedOut;
+
+	// isTimedOut for newSession==1 uses dts + sustain < now (strict <).
+	// now == dts + sustain => NOT timed out.
+	manager.removeTimedOutSessions(
+	    150, 50, [&](Session *timedOutSession) { timedOut.push_back(timedOutSession->sessionId); });
+	EXPECT_TRUE(timedOut.empty());
+	EXPECT_NE(manager.findSessionEntry(1), nullptr);
+
+	// now == dts + sustain + 1 => timed out.
+	manager.removeTimedOutSessions(
+	    151, 50, [&](Session *timedOutSession) { timedOut.push_back(timedOutSession->sessionId); });
+	EXPECT_EQ(timedOut, std::vector<uint32_t>{1});
+	EXPECT_EQ(manager.findSessionEntry(1), nullptr);
+}
+
+TEST(SessionManagerBaseTests, RemoveTimedOutUsesLegacyThresholdForOldClients) {
+	constexpr uint32_t kDisconnectedAt = 100;
+	constexpr uint32_t kIgnoredSustain = 50;
+
+	TestSessionManager manager;
+	auto session = makeSession(1);
+	session->newSession = 0;  // legacy pre-1.5.13 client
+	session->connections = 0;
+	session->disconnectedTimestamp = kDisconnectedAt;
+	manager.addSession(std::move(session));
+
+	std::vector<uint32_t> timedOut;
+	auto record = [&](Session *timedOutSession) { timedOut.push_back(timedOutSession->sessionId); };
+
+	// Legacy path uses kLegacyClientTimeoutSeconds and ignores sessionSustainTime.
+	// dts + kLegacyClientTimeoutSeconds == now => NOT timed out.
+	manager.removeTimedOutSessions(kDisconnectedAt + kLegacyClientTimeoutSeconds, kIgnoredSustain,
+	                               record);
+	EXPECT_TRUE(timedOut.empty());
+	EXPECT_NE(manager.findSessionEntry(1), nullptr);
+
+	// dts + kLegacyClientTimeoutSeconds < now => timed out.
+	manager.removeTimedOutSessions(kDisconnectedAt + kLegacyClientTimeoutSeconds + 1,
+	                               kIgnoredSustain, record);
+	EXPECT_EQ(timedOut, std::vector<uint32_t>{1});
+	EXPECT_EQ(manager.findSessionEntry(1), nullptr);
+}
+
+TEST(SessionManagerBaseTests, RemoveTimedOutInvokesOnTimedOutBeforeOnSessionRemoved) {
+	TestSessionManager manager;
+	auto session = makeSession(1);
+	session->newSession = 1;
+	session->connections = 0;
+	session->disconnectedTimestamp = 100;
+	manager.addSession(std::move(session));
+
+	manager.removeTimedOutSessions(200, 50, [&](Session *timedOutSession) {
+		manager.hookEvents.push_back("timedOut:" + std::to_string(timedOutSession->sessionId));
+	});
+
+	ASSERT_EQ(manager.hookEvents.size(), 2U);
+	EXPECT_EQ(manager.hookEvents[0], "timedOut:1");
+	EXPECT_EQ(manager.hookEvents[1], "removed:1");
+	EXPECT_EQ(manager.findSessionEntry(1), nullptr);
+}
+
+TEST(SessionManagerBaseTests, RemoveTimedOutProcessesMixedSetCorrectly) {
+	TestSessionManager manager;
+
+	auto active = makeSession(1);  // active — skip
+	active->connections = 1;
+	manager.addSession(std::move(active));
+
+	auto fresh = makeSession(2);  // disconnected within sustain — skip
+	fresh->connections = 0;
+	fresh->disconnectedTimestamp = 150;
+	manager.addSession(std::move(fresh));
+
+	auto stale = makeSession(3);  // disconnected past sustain — reap
+	stale->connections = 0;
+	stale->disconnectedTimestamp = 10;
+	manager.addSession(std::move(stale));
+
+	std::vector<uint32_t> timedOut;
+	manager.removeTimedOutSessions(200, 100, [&](Session *timedOutSession) {
+		timedOut.push_back(timedOutSession->sessionId);
+	});
+
+	EXPECT_EQ(timedOut, std::vector<uint32_t>{3});
+	EXPECT_EQ(manager.removedSessionIds, std::vector<uint32_t>{3});
+	EXPECT_NE(manager.findSessionEntry(1), nullptr);
+	EXPECT_NE(manager.findSessionEntry(2), nullptr);
+	EXPECT_EQ(manager.findSessionEntry(3), nullptr);
+}
+
+// ---------------------------------------------------------------------------
+// rotateStats()
+// ---------------------------------------------------------------------------
+
+TEST(SessionManagerBaseTests, RotateStatsMovesCurrentToPrevAndZeroesCurrent) {
+	TestSessionManager manager;
+	auto session = makeSession(1);
+	session->currHourOperationsStats.fill(0);
+	session->currHourOperationsStats[0] = 7;
+	session->currHourOperationsStats[5] = 42;
+	session->prevHourOperationsStats.fill(99);
+	manager.addSession(std::move(session));
+
+	manager.rotateStats();
+
+	const Session *stored = manager.findSessionEntry(1);
+	ASSERT_NE(stored, nullptr);
+	EXPECT_EQ(stored->prevHourOperationsStats[0], 7U);
+	EXPECT_EQ(stored->prevHourOperationsStats[5], 42U);
+	EXPECT_EQ(stored->currHourOperationsStats[0], 0U);
+	EXPECT_EQ(stored->currHourOperationsStats[5], 0U);
+	EXPECT_EQ(manager.storeSessionsCallCount, 1);
+}
+
+// ---------------------------------------------------------------------------
+// removeOpenFile()
+// ---------------------------------------------------------------------------
+
+TEST(SessionManagerBaseTests, RemoveOpenFileErasesInodeFromSet) {
+	TestSessionManager manager;
+	auto session = makeSession(1);
+	session->openFilesSet.insert(100);
+	session->openFilesSet.insert(200);
+	manager.addSession(std::move(session));
+
+	manager.removeOpenFile(1, 100);
+
+	const Session *stored = manager.findSessionEntry(1);
+	ASSERT_NE(stored, nullptr);
+	EXPECT_FALSE(stored->openFilesSet.contains(100));
+	EXPECT_TRUE(stored->openFilesSet.contains(200));
+}
+
+TEST(SessionManagerBaseTests, RemoveOpenFileIsNoOpForUnknownInode) {
+	TestSessionManager manager;
+	auto session = makeSession(1);
+	session->openFilesSet.insert(100);
+	manager.addSession(std::move(session));
+
+	manager.removeOpenFile(1, 999);
+
+	EXPECT_TRUE(manager.findSessionEntry(1)->openFilesSet.contains(100));
+}
+
+TEST(SessionManagerBaseTests, RemoveOpenFileOnUnknownSessionIsNoOp) {
+	TestSessionManager manager;
+	auto session = makeSession(1);
+	session->openFilesSet.insert(100);
+	manager.addSession(std::move(session));
+
+	manager.removeOpenFile(999, 100);
+
+	const Session *stored = manager.findSessionEntry(1);
+	ASSERT_NE(stored, nullptr);
+	EXPECT_TRUE(stored->openFilesSet.contains(100));
+}
+
+// ---------------------------------------------------------------------------
+// unload() / forEachSession()
+// ---------------------------------------------------------------------------
+
+TEST(SessionManagerBaseTests, UnloadClearsAllSessions) {
+	TestSessionManager manager;
+	auto session = makeSession(1);
+	session->openFilesSet.insert(100);
+	manager.addSession(std::move(session));
+	manager.addSession(makeSession(2));
+
+	manager.unload();
+
+	EXPECT_EQ(manager.findSessionEntry(1), nullptr);
+	EXPECT_EQ(manager.findSessionEntry(2), nullptr);
+}
+
+TEST(SessionManagerBaseTests, ForEachSessionVisitsInInsertionOrder) {
+	TestSessionManager manager;
+	manager.addSession(makeSession(10));
+	manager.addSession(makeSession(20));
+	manager.addSession(makeSession(30));
+
+	std::vector<uint32_t> visited;
+	manager.forEachSession([&](const Session &session) { visited.push_back(session.sessionId); });
+
+	EXPECT_EQ(visited, (std::vector<uint32_t>{10, 20, 30}));
+}


### PR DESCRIPTION
Introduce and extend the shared session-manager seam so master-side session
lifecycle can stay behavior-compatible for the file-backed master while KV
backends can persist session state at finer granularity.

## What changed

- Added `ISessionManager` and moved shared session catalog ownership behind the
  manager interface.
- Extracted the existing file-backed behavior into `SessionManagerFile`.
- Kept `matoclserv_sessions.*` as compatibility dispatchers to the active
  manager.
- Kept the file-backed master behavior model intact:
  - `sessions.sfs` remains the persistence format
  - session ids still come through `gFSOperations->newSessionId()`
  - the existing metadata/changelog replay path remains the source of truth
- Added row-level manager hooks needed by KV backends:
  - single-session persistence
  - disconnect/runtime-state persistence
  - backend-provided session listing
- Made timeout cleanup conditional on open-file teardown success, so failed
  teardown keeps the session managed for a later retry.
- Dropped ancient `sessions.sfs` loader compatibility for old `MFS` and
  pre-1.6.4 headers. The writer already emits only the current format.
- Condensed the master README session section so it documents the shared/base
  behavior without duplicating MDS-specific details.

## Scope

This PR is focused on the shared master/session infrastructure and the
file-backed implementation. It does not change the normal file-backed session
lifecycle, reconnect/disconnect behavior, open-file tracking, or
`SessionManagerFile::storeSessions()` format.

The intentional behavior change is limited to startup parsing of very old
session files: unsupported old headers are now rejected through the existing
bad-header path.

Related to: LS-624