### PR TITLE
chore: update contact Leil emails LS-595

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -192,7 +192,7 @@ Currently, the preferred ways to indicate you want to contribute code are (in
 order):
 * Commenting on a specific Github issue
 * [Matrix](https://matrix.to/#/#leil:matrix.org),
-* [Email](mailto:contact@leil.io?subject=RFI),
+* [Email](mailto:hello@leil.io?subject=RFI),
 
 If you get an OK from us, please read below for more details.
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ file](src/nfs-ganesha/LICENSE) for more info.
 ### Other ways to contact us
 | Method                     | Link                                                          |
 |----------------------------|---------------------------------------------------------------|
-| :email: Email              | [contact@leil.io](mailto:contact@leil.io?subject=RFI) |
+| :email: Email              | [hello@leil.io](mailto:hello@leil.io?subject=RFI) |
 | :globe_with_meridians: Web | <https://leil.io>                                         |
 
 Thank you for your help.

--- a/cmake/Packing.cmake
+++ b/cmake/Packing.cmake
@@ -7,7 +7,7 @@ set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "SaunaFS - A distributed filesystem for th
         CACHE STRING "Summary of package description"
 )
 
-set(CPACK_PACKAGE_CONTACT "contact@saunafs.com"
+set(CPACK_PACKAGE_CONTACT "hello@leil.io"
         CACHE STRING "Contact email for package"
 )
 

--- a/src/cgi/help.html
+++ b/src/cgi/help.html
@@ -1,3 +1,3 @@
-Please, contact with contact@leil.io
+Please, contact with hello@leil.io
 <br/>
 

--- a/utils/update_news.sh
+++ b/utils/update_news.sh
@@ -47,7 +47,7 @@ while IFS= read -r line; do
     fi
 done < "$tmp_file"
 
-changelog_entry+="\n -- LeilFS Team <contact@leil.io>  ${current_date}\n"
+changelog_entry+="\n -- LeilFS Team <hello@leil.io>  ${current_date}\n"
 
 # Insert new NEWS entry after the first line
 {


### PR DESCRIPTION
This is part of [LS-573](https://linear.app/leil/issue/LS-573/substitute-contactleiliosaunafscom-helloleilio-and-supportsaunafscom) as the idea is to change all contact@leil.io emails by hello@leil.io