### PR TITLE
fix(master): avoid crash of nodes in trash

### DIFF
--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -251,6 +251,14 @@ void FilesystemNodeOperationsBase::updateCTime(
 	}
 }
 
+void FilesystemNodeOperationsBase::updateCTimeForTrashNode(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, FSNode *node, uint32_t newCtime,
+    uint32_t oldTrashtime) {
+	TrashPathKey oldKey(node->id, node->ctime, oldTrashtime);
+	node->ctime = newCtime;
+	updateTrashFromOldEntry(gMetadata->trash, node, oldKey);
+}
+
 std::string FilesystemNodeOperationsBase::escapeName(const std::string &name) {
 	constexpr std::array<char, 16> hexDigits = {
 	    {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'}};

--- a/src/master/filesystem_node.h
+++ b/src/master/filesystem_node.h
@@ -75,6 +75,11 @@ public:
 	void updateCTime([[maybe_unused]] const FilesystemOperationContext &fsOpContext, FSNode *node,
 	                 uint32_t ctime) override;
 
+	/// Updates ctime on a trash node whose trashtime has just changed.
+	/// @see IFilesystemNodeOperations::updateCTimeForTrashNode
+	void updateCTimeForTrashNode([[maybe_unused]] const FilesystemOperationContext &fsOpContext,
+	                             FSNode *node, uint32_t newCtime, uint32_t oldTrashtime) override;
+
 	void fillAttr(const FilesystemOperationContext &fsOpContext, FSNode *node, FSNode *parent,
 	              uint32_t uid, uint32_t gid, uint32_t auid, uint32_t agid, uint8_t sesflags,
 	              Attributes &attr) override;

--- a/src/master/filesystem_node_operations_interface.h
+++ b/src/master/filesystem_node_operations_interface.h
@@ -213,6 +213,19 @@ public:
 	virtual void updateCTime(const FilesystemOperationContext &fsOpContext, FSNode *node,
 	                         uint32_t ctime) = 0;
 
+	/// Updates ctime on a trash node whose trashtime has just changed, keeping the TrashPathKey
+	/// ordering and/or the backend expiry index consistent.
+	/// Must be called with the old trashtime captured before that field is mutated.
+	///
+	/// @param fsOpContext The filesystem operation context (transaction).
+	/// @param node The trash node whose ctime and trashtime are being updated.
+	/// @param newCtime The new ctime value to set on the node.
+	/// @param oldTrashtime The old trashtime value before the update, used for locating the
+	///                     existing TrashPathKey.
+	virtual void updateCTimeForTrashNode(const FilesystemOperationContext &fsOpContext,
+	                                     FSNode *node, uint32_t newCtime,
+	                                     uint32_t oldTrashtime) = 0;
+
 	virtual void fillAttr(const FilesystemOperationContext &fsOpContext, FSNode *node,
 	                      FSNode *parent, uint32_t uid, uint32_t gid, uint32_t auid, uint32_t agid,
 	                      uint8_t sesflags, Attributes &attr) = 0;

--- a/src/master/filesystem_trash_reserved_files.h
+++ b/src/master/filesystem_trash_reserved_files.h
@@ -60,6 +60,18 @@ struct TrashPathKey {
 	{
 	}
 
+	TrashPathKey(uint32_t nodeId, uint32_t ctime, uint32_t trashtime)
+	    :
+#ifdef WORDS_BIGENDIAN
+	      timestamp(std::min((uint64_t)ctime + trashtime, (uint64_t)UINT32_MAX)),
+	      id(nodeId)
+#else
+	      id(nodeId),
+	      timestamp(std::min((uint64_t)ctime + trashtime, (uint64_t)UINT32_MAX))
+#endif
+	{
+	}
+
 	bool operator<(const TrashPathKey &other) const {
 		return std::make_pair(timestamp, id) < std::make_pair(other.timestamp, other.id);
 	}

--- a/src/master/settrashtime_task.cc
+++ b/src/master/settrashtime_task.cc
@@ -90,6 +90,7 @@ uint8_t SetTrashtimeTask::setTrashtime(const FilesystemOperationContext &fsOpCon
 			return SetTrashtimeTask::kNotPermitted;
 		} else {
 			set = 0;
+			const uint32_t oldTrashtime = node->trashtime;
 			switch (smode_ & SMODE_TMASK) {
 			case SMODE_SET:
 				if (node->trashtime != trashtime_) {
@@ -111,7 +112,12 @@ uint8_t SetTrashtimeTask::setTrashtime(const FilesystemOperationContext &fsOpCon
 				break;
 			}
 			if (set) {
-				gFSOperations->nodeOperations()->updateCTime(fsOpContext, node, ts);
+				if (node->type == FSNodeType::kTrash) {
+					gFSOperations->nodeOperations()->updateCTimeForTrashNode(fsOpContext, node, ts,
+					                                                         oldTrashtime);
+				} else {
+					gFSOperations->nodeOperations()->updateCTime(fsOpContext, node, ts);
+				}
 				fsnodes_update_checksum(node);
 				return SetTrashtimeTask::kChanged;
 			} else {

--- a/tests/test_suites/ShortSystemTests/test_trash_settrashtime_on_trash_node.sh
+++ b/tests/test_suites/ShortSystemTests/test_trash_settrashtime_on_trash_node.sh
@@ -1,0 +1,40 @@
+timeout_set 1 minute
+
+# Regression test for a master crash triggered by calling settrashtime on a file that is
+# already resident in the trash.
+
+MOUNTS=2 \
+	CHUNKSERVERS=1 \
+	USE_RAMDISK=YES \
+	SFSEXPORTS_META_EXTRA_OPTIONS="nonrootmeta" \
+	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER" \
+	MOUNT_1_EXTRA_CONFIG="sfsmeta" \
+	setup_local_empty_saunafs info
+
+trash="${info[mount1]}/trash"
+regular="${info[mount0]}"
+
+# Create a file with a long trashtime so it stays in trash for the duration of the test.
+cd "${regular}"
+echo "content" > testfile
+oneDayInseconds=$((24 * 60 * 60))
+saunafs settrashtime ${oneDayInseconds} testfile
+rm testfile
+
+# Wait for the deleted file to appear in the trash via the meta mount.
+assert_eventually 'test "$(ls "${trash}" | grep -v undel | wc -l)" -eq 1'
+
+file_in_trash="${trash}/$(ls "${trash}" | grep -v undel | head -1)"
+
+# Change the trashtime of the file while it is already inside the trash.
+assert_success saunafs settrashtime 7200 "${file_in_trash}"
+
+# ls the trash directory to trigger the master to read the node with the updated trashtime.
+assert_success ls "${trash}"
+
+# Confirm the master is still alive.
+assert_success saunafs_master_daemon isalive
+
+# undel the file and check it is there
+assert_success mv "${file_in_trash}" "${trash}/undel"
+assert_success test -f "${regular}/testfile"


### PR DESCRIPTION
Fix a crash triggered when changing trashtime of a node already in trash. When trashtime changes, rekey trash metadata using the old and new expiry.
Add a regression test covering settrashtime on nodes already in trash.

Related to: LS-644

Co-authored-by: Dave <dave@leil.io>
Co-authored-by: GigaCronos <jorge.cabrera@leil.io>
Signed-off-by: guillex <guillex@leil.io>