### PR TITLE
fix(cs): fix CS crash on writes delayed close

### DIFF
--- a/src/chunkserver/buffers_pool.h
+++ b/src/chunkserver/buffers_pool.h
@@ -86,9 +86,12 @@ public:
 	 * @param buffer The buffer to put back.
 	 */
 	void put(std::shared_ptr<T> &&buffer) {
+		// Move into a local so the caller's shared_ptr is always nulled,
+		// even if the pool is full and we end up discarding the buffer.
+		auto localBuffer = std::move(buffer);
 		std::unique_lock lock(mutex_);
 
-		auto [headerSize, numBlocks] = buffer->type();
+		auto [headerSize, numBlocks] = localBuffer->type();
 		auto &buffers = buffersMap_[{headerSize, numBlocks}];
 
 		if (operationsSinceLastLog_ == kLogAfterEveryXTimes) {
@@ -100,8 +103,8 @@ public:
 		operationsSinceLastLog_++;
 
 		if (currentNumberOfBlocks_ + numBlocks <= maxNumberOfBlocks_) {
-			buffer->clear();
-			buffers.emplace(std::move(buffer));
+			localBuffer->clear();
+			buffers.emplace(std::move(localBuffer));
 			currentNumberOfBlocks_ += numBlocks;
 		}
 		// To make sure the deallocation is not done under the lock.

--- a/tests/test_suites/ShortSystemTests/test_cs_failure_during_xor_write_default.sh
+++ b/tests/test_suites/ShortSystemTests/test_cs_failure_during_xor_write_default.sh
@@ -1,0 +1,2 @@
+CUSTOM_CS_EXTRA_CONFIG="MAX_BUFFERS_POOL_SIZE_MB=64|WRITE_BUFFERING_SIZE_MB=512"
+	source test_suites/TestTemplates/test_cs_failure_during_xor_write.inc

--- a/tests/test_suites/ShortSystemTests/test_cs_failure_during_xor_write_no_buffers.sh
+++ b/tests/test_suites/ShortSystemTests/test_cs_failure_during_xor_write_no_buffers.sh
@@ -1,0 +1,2 @@
+CUSTOM_CS_EXTRA_CONFIG="MAX_BUFFERS_POOL_SIZE_MB=0|WRITE_BUFFERING_SIZE_MB=0"
+	source test_suites/TestTemplates/test_cs_failure_during_xor_write.inc

--- a/tests/test_suites/TestTemplates/test_cs_failure_during_xor_write.inc
+++ b/tests/test_suites/TestTemplates/test_cs_failure_during_xor_write.inc
@@ -26,6 +26,7 @@ assert_program_installed socat
 CHUNKSERVERS=4 \
 	MOUNTS=10 \
 	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER" \
+	CHUNKSERVER_EXTRA_CONFIG="${CUSTOM_CS_EXTRA_CONFIG}" \
 	USE_RAMDISK=YES \
 	setup_local_empty_saunafs info
 


### PR DESCRIPTION
The chunkserver can crash during a delayed close of a write high level
operation if the inputBuffer_ is non-null and has not replied any
blocks. The code path goes through putting the inputBuffer_ into the
InputBuffer's pool and asserting that the inputBuffer_ is null
afterwards. If the InputBuffer's pool is full and cannot accept the one
tried to be put, it is leaving it alive (rvalue reference) which causes
the assert to fail.

The fix consists in moving buffer into a local variable at the start of
BuffersPool::put, before any pool-capacity check. This ensures the
caller's shared_ptr is always nulled (ownership transferred) even when
the pool is full and the buffer is discarded, while keeping the
rvalue-reference API to enforce explicit std::move() at call sites.

A new test was added from a previous one that reproduced the issue
previously described.

Signed-off-by: Dave <dave@leil.io>