### PR TITLE
Revert "chore: Remove DCO requirement (#787)"

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -1,0 +1,11 @@
+name: Conventional Commits
+on:
+  pull_request:
+    branches: [ dev ]
+jobs:
+  build:
+    name: Conventional Commits
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: webiny/action-conventional-commits@v1.3.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -296,14 +296,51 @@ must be satisfied before it is considered for peer review:
 - All automated tests must pass.
 - The build job must be in a healthy state. <!-- omit in toc -->
 
-### Copyright assignment/licensing
+### Developer Certificate of Origin
 
-Before we accept your PR, we will need your permission to license code however
-we wish, either as a copyright assignment or as a Contributor License Agreement
-(CLA). This is not yet done, so please write to us on
-[Matrix](https://matrix.to/#/#leil:matrix.org) if you wish to submit your code
-to us. Some contributions (e.g., simple typo or bug fixes) can be waived from this requirement, but this is at the discretion of the developers.
+Before we accept your PR, we want you to sign-off your commit(s) with a valid
+GPG key. See the git manual for more info. This indicates that you accept the
+text below.
 
+```
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```
 
 ## Attribution
 


### PR DESCRIPTION
This reverts commit ff9610d6147a471299cef8e097a45ca6b80888b2.

As final decision, the project will continue under a DCO (Developer Certificate of Origin) model and will not adopt a CLA/CAA or any form of copyright assignment or relicensing agreement.

Related to: LS-645