### PR TITLE
refactor(CS): remove defragmentOrMoveChunk from IDisk

### DIFF
--- a/src/chunkserver/chunkserver-common/cmr_disk.cc
+++ b/src/chunkserver/chunkserver-common/cmr_disk.cc
@@ -187,12 +187,6 @@ void CmrDisk::setChunkBlocks(IChunk *chunk, uint16_t originalBlocks,
 	chunk->setBlocks(newBlocks);
 }
 
-int CmrDisk::defragmentOrMoveChunk(IChunk *chunk, uint8_t *crcData) {
-	(void)chunk;
-	(void)crcData;
-	return SAUNAFS_STATUS_OK;
-}
-
 void CmrDisk::updateAfterScan() {
 	// Nothing to do, but we need the function in the interface
 }

--- a/src/chunkserver/chunkserver-common/cmr_disk.h
+++ b/src/chunkserver/chunkserver-common/cmr_disk.h
@@ -86,8 +86,6 @@ public:
 	void setChunkBlocks(IChunk *chunk, uint16_t originalBlocks,
 	                    uint16_t newBlocks) override;
 
-	int defragmentOrMoveChunk(IChunk *chunk, uint8_t *crcData) override;
-
 	void updateAfterScan() override;
 
 	// IO

--- a/src/chunkserver/chunkserver-common/disk_interface.h
+++ b/src/chunkserver/chunkserver-common/disk_interface.h
@@ -145,11 +145,6 @@ public:
 	virtual void setChunkBlocks(IChunk *chunk, uint16_t originalBlocks,
 	                            uint16_t newBlocks) = 0;
 
-	/// Defragments or moves the given Chunk if needed.
-	/// If this type of this does not support Chunk fragmentation, an empty
-	/// implementation is enough.
-	virtual int defragmentOrMoveChunk(IChunk *chunk, uint8_t *crcData) = 0;
-
 	/// Updates this disk attributes after a scan.
 	/// Useful for SMR drives, for instance, to update the zones state after
 	/// knowing all the Chunks.


### PR DESCRIPTION
Removes defragmentOrMoveChunk function from disk interface, now only needed in ZoneFSDisk, also removed crcData parameter.

The function was also removed from cmrDisk implementation.

Related to LS-538