### PR TITLE
sfsmount does not work with default in fstab

### DIFF
--- a/doc/leil-mount.1.adoc
+++ b/doc/leil-mount.1.adoc
@@ -348,7 +348,7 @@ like 'chmod ug-s', and therefore can't be controlled by SFS as 'chown'
 
 You can define your `/etc/fstab` LeilFS share like this:
 
-    leil-master:/ /mnt/leil safs default 0 0
+    leil-master:/ /mnt/leil safs rw 0 0
 
 == REPORTING BUGS
 


### PR DESCRIPTION
through trial and error I found `rw` works. with `default` I got:
```console
butonic@khal:/mnt$ sudo mount leilfs/
sfsmaster accepted connection with parameters: read-write ; root mapped to root:root
05/05/26 16:19:41.945 [info] [85447:85459] : Received IO limits configuration update from master
[2026-05-05 16:19:41.945] [info] Received IO limits configuration update from master
fuse: unknown option(s): `-o default'
error in fuse_session_new
05/05/26 16:19:43.946 [warning] [85447:85459] : master: connection lost
[2026-05-05 16:19:43.946] [warning] master: connection lost
05/05/26 16:19:43.946 [warning] [85447:85459] : master: disconnected
[2026-05-05 16:19:43.946] [warning] master: disconnected
```