### PR TITLE
docs(master): clarify reserved cleanup behavior

### DIFF
--- a/src/master/README.md
+++ b/src/master/README.md
@@ -279,7 +279,7 @@ registered in `fs_periodic_master_init()` (see `filesystem_periodic.cc`):
 | **Background task processing** (`fs_background_task_manager_work`) | Every loop | Drives the `TaskManager`, processing a batch of tasks (snapshots, recursive removes, goal/trashtime changes) per iteration. |
 | **Checksum recalculation** (`fs_background_checksum_recalculation_a_bit`) | Every loop | Incrementally recalculates metadata checksums (nodes, xattrs, chunks) in the background, progressing through steps at a speed limit per iteration. |
 | **Trash cleanup** (`fs_periodic_emptytrash`) | Every 100ms | Purges expired trash entries whose deletion timestamp has passed. |
-| **Reserved file cleanup** (`fs_periodic_emptyreserved`) | Configurable period | Releases reserved files (deleted-but-still-open files) whose sessions are no longer active. |
+| **Reserved file cleanup** (`fs_periodic_emptyreserved`) | Configurable period in ms (`EMPTY_RESERVED_FILES_PERIOD_MSECONDS`); `0` disables | Force-releases reserved files (deleted-but-still-open files) from all owning sessions, even if sessions are still active; enabling it can disrupt clients that still hold those files. |
 | **Chunk maintenance** (in `chunks.cc`) | Periodic | Handles chunk replication, deletion of excess copies, and rebalancing across chunkservers. |
 
 ## Initialization Sequence

--- a/src/master/filesystem_operations.h
+++ b/src/master/filesystem_operations.h
@@ -390,7 +390,8 @@ public:
 	/// @see IFilesystemOperations::doEmptyTrash
 	void doEmptyTrash(uint32_t timeStamp) override;
 
-	/// Releases all reserved files whose sessions have expired (no active openers).
+	/// Forcefully releases every reserved file from each of its owning sessions, regardless
+	/// of whether those sessions are still active.
 	/// @see IFilesystemOperations::doEmptyReserved
 	void doEmptyReserved(uint32_t timeStamp) override;
 #endif

--- a/src/master/filesystem_operations_interface.h
+++ b/src/master/filesystem_operations_interface.h
@@ -1518,10 +1518,14 @@ public:
 	///                  expiryTs < timeStamp are eligible for purge.
 	virtual void doEmptyTrash(uint32_t timeStamp) = 0;
 
-	/// Releases all reserved files whose sessions have expired (no active openers).
+	/// Forcefully releases every reserved file from each of its owning sessions, regardless
+	/// of whether those sessions are still active.
 	///
-	/// Default implementation iterates gMetadata->reserved. KV backends override this to scan
-	/// RSVD_PATH_ entries directly from FDB.
+	/// Disabled by default (EMPTY_RESERVED_FILES_PERIOD_MSECONDS = 0). When enabled it
+	/// can disrupt clients that still hold reserved files they have not yet released.
+	///
+	/// Default implementation iterates the in-memory reserved map. KV backends override
+	/// this to scan reserved entries directly from FDB.
 	///
 	/// @param timeStamp Current wall-clock time (seconds since epoch).
 	virtual void doEmptyReserved(uint32_t timeStamp) = 0;


### PR DESCRIPTION
Document that periodic reserved cleanup force-releases all owning sessions, is disabled by default, and can disrupt active clients. Update README and API comments to reflect doEmptyReserved semantics.

No functional code changes.

Related to: LS-624