### PR TITLE
refactor(master): delegate periodic ops to backends

### DIFF
--- a/src/admin/list_defective_files_command.cc
+++ b/src/admin/list_defective_files_command.cc
@@ -29,13 +29,6 @@
 
 static const uint64_t kDefaultEntriesLimit = 1000;
 
-enum NodeErrorFlag {
-	kChunkUnavailable = 1,
-	kChunkUnderGoal   = 2,
-	kStructureError   = 4,
-	kAllNodeErrors    = 7
-};
-
 std::string ListDefectiveFilesCommand::name() const {
 	return "list-defective-files";
 }

--- a/src/common/defective_file_info.h
+++ b/src/common/defective_file_info.h
@@ -22,7 +22,17 @@
 #pragma once
 
 #include "common/platform.h"
+
+#include <cstdint>
+
 #include "common/serialization_macros.h"
+
+enum NodeErrorFlag : uint8_t {
+	kChunkUnavailable = 1,
+	kChunkUnderGoal   = 2,
+	kStructureError   = 4,
+	kAllNodeErrors    = kChunkUnavailable | kChunkUnderGoal | kStructureError,
+};
 
 SAUNAFS_DEFINE_SERIALIZABLE_CLASS(DefectiveFileInfo,
 		std::string, file_name,

--- a/src/master/README.md
+++ b/src/master/README.md
@@ -273,14 +273,32 @@ Jobs support cancellation and completion callbacks.
 Several maintenance routines run on timer-driven or per-loop schedules,
 registered in `fs_periodic_master_init()` (see `filesystem_periodic.cc`):
 
-| Operation | Schedule | Purpose |
-|-----------|----------|---------|
-| **File integrity test** (`fs_periodic_file_test` / `fs_background_file_test`) | Every second (timer) + every loop (background) | Scans the entire node hash table in a configurable cycle time (`FILE_TEST_LOOP_MIN_TIME`, default 3600s). For each file node, checks chunk availability and copy counts. For each directory, validates parent-child pointer consistency. Builds a `gDefectiveNodes` map of inodes with unavailable chunks, under-goal chunks, or structural errors. |
-| **Background task processing** (`fs_background_task_manager_work`) | Every loop | Drives the `TaskManager`, processing a batch of tasks (snapshots, recursive removes, goal/trashtime changes) per iteration. |
-| **Checksum recalculation** (`fs_background_checksum_recalculation_a_bit`) | Every loop | Incrementally recalculates metadata checksums (nodes, xattrs, chunks) in the background, progressing through steps at a speed limit per iteration. |
-| **Trash cleanup** (`fs_periodic_emptytrash`) | Every 100ms | Purges expired trash entries whose deletion timestamp has passed. |
-| **Reserved file cleanup** (`fs_periodic_emptyreserved`) | Configurable period in ms (`EMPTY_RESERVED_FILES_PERIOD_MSECONDS`); `0` disables | Force-releases reserved files (deleted-but-still-open files) from all owning sessions, even if sessions are still active; enabling it can disrupt clients that still hold those files. |
-| **Chunk maintenance** (in `chunks.cc`) | Periodic | Handles chunk replication, deletion of excess copies, and rebalancing across chunkservers. |
+- **File integrity test** (`fs_periodic_file_test` / `fs_background_file_test`):
+  runs every second (timer) and every loop (background). Scans the entire node
+  hash table in a configurable cycle time (`FILE_TEST_LOOP_MIN_TIME`, default
+  3600s). For each file node, checks chunk availability and copy counts. For
+  each directory, validates parent-child pointer consistency. Builds a
+  `gDefectiveNodes` map of inodes with unavailable chunks, under-goal chunks,
+  or structural errors.
+- **Background task processing** (`fs_background_task_manager_work`):
+  runs every loop. Drives the `TaskManager`, processing a batch of tasks
+  (snapshots, recursive removes, goal/trashtime changes) per iteration.
+- **Checksum recalculation** (`fs_background_checksum_recalculation_a_bit`):
+  runs every loop. Incrementally recalculates metadata checksums (nodes,
+  xattrs, chunks) in the background, progressing through steps at a speed
+  limit per iteration.
+- **Trash cleanup** (`fs_periodic_emptytrash`):
+  runs every 100ms. Purges expired trash entries whose deletion timestamp has
+  passed.
+- **Reserved file cleanup** (`fs_periodic_emptyreserved`):
+  runs on a configurable period in ms
+  (`EMPTY_RESERVED_FILES_PERIOD_MSECONDS`), where `0` disables it.
+  Force-releases reserved files (deleted-but-still-open files) from all owning
+  sessions, even if sessions are still active; enabling it can disrupt clients
+  that still hold those files.
+- **Chunk maintenance** (in `chunks.cc`):
+  runs periodically. Handles chunk replication, deletion of excess copies, and
+  rebalancing across chunkservers.
 
 ## Initialization Sequence
 

--- a/src/master/filesystem.cc
+++ b/src/master/filesystem.cc
@@ -451,15 +451,15 @@ void fs_unload() {
 }
 
 int fs_init(bool doLoad) {
+	// Initialize the concrete filesystem operations before any FS call
+	initFSOperations();
+
 	try {
 		fs_read_config_file();
 	} catch (Exception &ex) {
 		safs::log_err("Error in configuration: {}", ex.what());
 		throw;
 	}
-
-	// Initialize the concrete filesystem operations before any FS call
-	initFSOperations();
 
 	if (!gMetadataLockfile) {
 		gMetadataLockfile = std::make_unique<Lockfile>(kMetadataFilename + std::string(".lock"));

--- a/src/master/filesystem_checksum_updater.h
+++ b/src/master/filesystem_checksum_updater.h
@@ -52,7 +52,8 @@ public:
 protected:
 	static void writeToChangelog(uint32_t ts) {
 		lastEntry_ = gMetadata->metadataVersion;
-		if (metadataserver::isMaster() && !gChecksumBackgroundUpdater.inProgress()) {
+		if (metadataserver::isMaster() && gFSOperations->metadataChecksumSupported() &&
+		    !gChecksumBackgroundUpdater.inProgress()) {
 			// The checksum updater is not used by KV/MDS backends, which do not rely on
 			// changelog-based checksumming. The fsOpContext here is a placeholder to satisfy
 			// the updated changeLog() signature; no transaction commit is needed.

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -1560,7 +1560,7 @@ void FilesystemNodeOperationsBase::removeNode(const FilesystemOperationContext &
 	}
 	nodeQuotaRemove(fsOpContext, QuotaOwnerType::kInode, node->id);
 #ifndef METARESTORE
-	fsnodes_periodic_remove(node->id);
+	fsnodes_periodic_remove(fsOpContext, node->id);
 	dcm_modify(node->id, 0);
 #endif
 

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -23,12 +23,19 @@
 
 #include "master/filesystem_operations.h"
 
+#include <algorithm>
 #include <cstdarg>
 #include <cstdint>
+#include <sstream>
 #include <string_view>
 
 #include "common/attributes.h"
 #include "common/event_loop.h"
+#if defined(SAUNAFS_HAVE_64BIT_JUDY) && !defined(DISABLE_JUDY_FOR_DEFECTIVENODESMAP)
+#include "common/judy_map.h"
+#else
+#include "common/flat_map.h"
+#endif
 #include "common/loop_watchdog.h"
 #include "errors/saunafs_error_codes.h"
 #include "master/changelog.h"
@@ -44,6 +51,7 @@
 #include "master/filesystem_stats.h"
 #include "master/fs_context.h"
 #include "master/locks.h"
+#include "master/matoclserv.h"
 #include "master/matoclserv_sessions.h"
 #include "master/matocsserv.h"
 #include "master/matomlserv.h"
@@ -103,6 +111,11 @@ void FilesystemOperationsBase::changeLog(
 }
 
 #ifndef METARESTORE
+
+// ---------------------------------------------------------------------------
+// Periodic trash/reserved cleanup (in-memory backend)
+// ---------------------------------------------------------------------------
+
 void FilesystemOperationsBase::doEmptyTrash(uint32_t timeStamp) {
 	SignalLoopWatchdog watchdog;
 
@@ -192,6 +205,459 @@ void FilesystemOperationsBase::doEmptyReserved(uint32_t timeStamp) {
 
 		reservedIter = gMetadata->reserved.begin();
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Periodic file-test scanner helpers (in-memory backend)
+// ---------------------------------------------------------------------------
+
+namespace {
+
+constexpr int kDefaultFileTestLoopTime = 300;
+constexpr int kErrorsLogMax = 500;
+
+static inode_t fsinfo_files = 0;
+static inode_t fsinfo_ugfiles = 0;
+static inode_t fsinfo_mfiles = 0;
+static uint32_t fsinfo_chunks = 0;
+static uint32_t fsinfo_ugchunks = 0;
+static uint32_t fsinfo_mchunks = 0;
+static uint32_t fsinfo_loopstart = 0;
+static uint32_t fsinfo_loopend = 0;
+static uint32_t fsinfo_notfoundchunks = 0;
+static uint32_t fsinfo_unavailchunks = 0;
+static inode_t fsinfo_unavailfiles = 0;
+static inode_t fsinfo_unavailtrashfiles = 0;
+static inode_t fsinfo_unavailreservedfiles = 0;
+
+static uint32_t gFileTestLoopTime = kDefaultFileTestLoopTime;
+static int gFileTestLoopIndex = 0;
+static unsigned gFileTestLoopBucketLimit = 0;
+
+enum NodeErrorFlag {
+	kChunkUnavailable = 1,
+	kChunkUnderGoal = 2,
+	kStructureError = 4,
+	kAllNodeErrors = 7
+};
+
+#if defined(SAUNAFS_HAVE_64BIT_JUDY) && !defined(DISABLE_JUDY_FOR_DEFECTIVENODESMAP)
+using DefectiveNodesMap = judy_map<inode_t, uint8_t>;
+#else
+using DefectiveNodesMap = flat_map<inode_t, uint8_t>;
+#endif
+
+constexpr size_t kMaxNodeEntries = 1000000;
+static DefectiveNodesMap gDefectiveNodes;
+
+std::string getDetachedNodePath(IFilesystemOperations &operations,
+                                const FilesystemOperationContext &fsOpContext, const FSNode *node) {
+	return operations.getDetachedPath(fsOpContext, node).value_or("");
+}
+
+std::string getNodeInfo(IFilesystemOperations &operations,
+                        const FilesystemOperationContext &fsOpContext, FSNode *node) {
+	std::string name;
+	if (node == nullptr) { return name; }
+
+	if (node->type == FSNodeType::kTrash) {
+		name = "file in trash " + std::to_string(node->id) + ": " +
+		       getDetachedNodePath(operations, fsOpContext, node);
+	} else if (node->type == FSNodeType::kReserved) {
+		name = "reserved file " + std::to_string(node->id) + ": " +
+		       getDetachedNodePath(operations, fsOpContext, node);
+	} else if (node->type == FSNodeType::kFile) {
+		name = "file " + std::to_string(node->id) + ": ";
+		bool first = true;
+		for (const auto &[parentId, _] : node->parents) {
+			std::string path;
+			auto *parent =
+			    operations.nodeOperations()->idToNodeVerify<FSNodeDirectory>(fsOpContext, parentId);
+			operations.nodeOperations()->getPath(fsOpContext, parent, node, path);
+			if (!first) {
+				name += "|" + path;
+			} else {
+				name += path;
+			}
+			first = false;
+		}
+	} else if (node->type == FSNodeType::kDirectory) {
+		name = "directory " + std::to_string(node->id) + ": ";
+		std::string path;
+		FSNodeDirectory *parent = nullptr;
+		if (!node->parents.empty()) {
+			parent = operations.nodeOperations()->idToNodeVerify<FSNodeDirectory>(
+			    fsOpContext, node->parents.front().first);
+		}
+		operations.nodeOperations()->getPath(fsOpContext, parent, node, path);
+		name += path;
+	}
+
+	return operations.nodeOperations()->escapeName(name);
+}
+
+void processFileTest(FilesystemOperationsBase &operations) {
+	uint32_t k;
+	uint8_t vc, node_error_flag;
+	ActiveLoopWatchdog watchdog;
+	auto fsOpContext = operations.createFilesystemOperationContext(
+	    FilesystemOperationContext::TransactionType::kReadOnly);
+
+	static inode_t files = 0;
+	static inode_t ugfiles = 0;
+	static inode_t mfiles = 0;
+	static uint32_t chunks = 0;
+	static uint32_t ugchunks = 0;
+	static uint32_t mchunks = 0;
+	static uint32_t notfoundchunks = 0;
+	static uint32_t unavailchunks = 0;
+	static inode_t unavailfiles = 0;
+	static inode_t unavailtrashfiles = 0;
+	static inode_t unavailreservedfiles = 0;
+
+	if (gFileTestLoopIndex == 0) {
+		if (unavailfiles > 0) { safs::log_err("Currently unavailable files: {}", unavailfiles); }
+		if (unavailchunks > 0) { safs::log_err("Currently unavailable chunks: {}", unavailchunks); }
+		if (unavailreservedfiles > 0) {
+			safs::log_err("Currently unavailable reserved files: {}", unavailreservedfiles);
+		}
+		if (unavailtrashfiles > 0) {
+			safs::log_warn("Currently unavailable trash files: {}", unavailtrashfiles);
+		}
+
+		fsinfo_files = files;
+		fsinfo_ugfiles = ugfiles;
+		fsinfo_mfiles = mfiles;
+		fsinfo_chunks = chunks;
+		fsinfo_ugchunks = ugchunks;
+		fsinfo_mchunks = mchunks;
+		fsinfo_loopstart = fsinfo_loopend;
+		fsinfo_loopend = eventloop_time();
+		fsinfo_notfoundchunks = notfoundchunks;
+		fsinfo_unavailchunks = unavailchunks;
+		fsinfo_unavailfiles = unavailfiles;
+		fsinfo_unavailtrashfiles = unavailtrashfiles;
+		fsinfo_unavailreservedfiles = unavailreservedfiles;
+
+		files = 0;
+		ugfiles = 0;
+		mfiles = 0;
+		chunks = 0;
+		ugchunks = 0;
+		mchunks = 0;
+		notfoundchunks = 0;
+		unavailchunks = 0;
+		unavailfiles = 0;
+		unavailtrashfiles = 0;
+		unavailreservedfiles = 0;
+	}
+
+	watchdog.start();
+	for (k = 0; k < gFileTestLoopBucketLimit && gFileTestLoopIndex < NODEHASHSIZE;
+	     k++, gFileTestLoopIndex++) {
+		if (k > 0 && watchdog.expired()) {
+			gFileTestLoopBucketLimit -= k;
+			return;
+		}
+
+		for (const auto &node : gMetadata->nodeHash[gFileTestLoopIndex]) {
+			node_error_flag = 0;
+
+			if (node->type == FSNodeType::kFile || node->type == FSNodeType::kTrash ||
+			    node->type == FSNodeType::kReserved) {
+				for (const auto &chunkid : static_cast<FSNodeFile *>(node)->chunks) {
+					if (chunkid == 0) { continue; }
+
+					if (chunk_get_fullcopies(chunkid, &vc) != SAUNAFS_STATUS_OK) {
+						node_error_flag |= static_cast<int>(kChunkUnavailable);
+						notfoundchunks++;
+						mchunks++;
+					} else if (vc == 0) {
+						node_error_flag |= static_cast<int>(kChunkUnavailable);
+						unavailchunks++;
+						mchunks++;
+					} else {
+						int recover, remove;
+						chunk_get_partstomodify(chunkid, recover, remove);
+						if (recover > 0) {
+							node_error_flag |= static_cast<int>(kChunkUnderGoal);
+							ugchunks++;
+						}
+					}
+					chunks++;
+				}
+			}
+
+			if (node->type == FSNodeType::kDirectory) {
+				for (const auto &entry : static_cast<FSNodeDirectory *>(node)->entries) {
+					FSNode *childNode = entry.second;
+
+					if (!childNode) {
+						node_error_flag |= static_cast<int>(kStructureError);
+					} else {
+						auto parentInChildPtr = std::find_if(
+						    childNode->parents.begin(), childNode->parents.end(),
+						    [node](const std::pair<inode_t, const hstorage::Handle *> &p) {
+							    return p.first == node->id;
+						    });
+						if (parentInChildPtr == childNode->parents.end()) {
+							node_error_flag |= static_cast<int>(kStructureError);
+						}
+					}
+				}
+			}
+
+			if (node_error_flag == 0) {
+				auto it = gDefectiveNodes.find(node->id);
+				if (it != gDefectiveNodes.end()) { gDefectiveNodes.erase(it); }
+				continue;
+			}
+
+			if (node_error_flag & kChunkUnavailable) {
+				if (node->type == FSNodeType::kTrash) {
+					unavailtrashfiles++;
+				} else if (node->type == FSNodeType::kReserved) {
+					unavailreservedfiles++;
+				} else {
+					unavailfiles += node->parents.size();
+				}
+
+				auto it = gDefectiveNodes.find(node->id);
+				if (it == gDefectiveNodes.end()) {
+					std::string name = getNodeInfo(operations, fsOpContext, node);
+					safs::log_trace("Chunks unavailable in {}", name);
+				}
+			}
+			if (node_error_flag & kChunkUnderGoal) { ugfiles++; }
+			if (node_error_flag & kStructureError) {
+				auto it = gDefectiveNodes.find(node->id);
+				if (it == gDefectiveNodes.end()) {
+					std::string name = getNodeInfo(operations, fsOpContext, node);
+					safs_pretty_syslog(LOG_ERR, "Structure error in %s", name.c_str());
+				}
+			}
+
+			if (gDefectiveNodes.size() < kMaxNodeEntries) {
+				gDefectiveNodes[node->id] = node_error_flag;
+			} else {
+				auto it = gDefectiveNodes.find(node->id);
+				if (it != gDefectiveNodes.end()) { (*it).second = node_error_flag; }
+			}
+		}
+	}
+
+	gFileTestLoopBucketLimit -= k;
+	if (gFileTestLoopIndex >= NODEHASHSIZE) { gFileTestLoopIndex = 0; }
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Periodic file-test scanner hooks (in-memory backend)
+// ---------------------------------------------------------------------------
+
+void FilesystemOperationsBase::setFileTestLoopTime(uint32_t loopTime) {
+	gFileTestLoopTime = loopTime;
+}
+
+uint32_t FilesystemOperationsBase::fileTestLoopTime() { return gFileTestLoopTime; }
+
+void FilesystemOperationsBase::fsTestPeriodicTick(uint32_t timeStamp) {
+	if (timeStamp <= gTestStartTime) {
+		gFileTestLoopBucketLimit = 0;
+		return;
+	}
+
+	if (gFileTestLoopBucketLimit == 0) {
+		gFileTestLoopBucketLimit = NODEHASHSIZE / gFileTestLoopTime;
+		processFileTest(*this);
+	}
+}
+
+void FilesystemOperationsBase::fsTestBackgroundStep() {
+	if (gFileTestLoopBucketLimit > 0) {
+		processFileTest(*this);
+		if (gFileTestLoopBucketLimit > 0) { eventloop_make_next_poll_nonblocking(); }
+	}
+}
+
+void FilesystemOperationsBase::fsTestGetData(FsTestReport &out) {
+	auto fsOpContext =
+	    createFilesystemOperationContext(FilesystemOperationContext::TransactionType::kReadOnly);
+	std::stringstream report;
+	int errors = 0;
+
+	for (const auto &entry : gDefectiveNodes) {
+		if (errors >= kErrorsLogMax) { break; }
+
+		FSNode *node = nodeOperations()->idToNode<FSNode>(fsOpContext, entry.first);
+		if (!node) {
+			report << "Structure error in defective list, entry " << std::to_string(entry.first)
+			       << "\n";
+			errors++;
+			continue;
+		}
+
+		if (node->type == FSNodeType::kFile || node->type == FSNodeType::kTrash ||
+		    node->type == FSNodeType::kReserved) {
+			FSNodeFile *fileNode = static_cast<FSNodeFile *>(node);
+			for (std::size_t j = 0; j < fileNode->chunks.size(); ++j) {
+				auto chunkid = fileNode->chunks[j];
+				if (chunkid == 0) { continue; }
+
+				uint8_t vc;
+				if (chunk_get_fullcopies(chunkid, &vc) != SAUNAFS_STATUS_OK) {
+					report << "structure error - chunk " << chunkid
+					       << " not found (inode: " << fileNode->id << " ; index: " << j << ")\n";
+					errors++;
+				} else if (vc == 0) {
+					report << "currently unavailable chunk " << chunkid
+					       << " (inode: " << fileNode->id << " ; index: " << j << ")\n";
+					errors++;
+				}
+			}
+		}
+
+		if (errors >= kErrorsLogMax) { break; }
+
+		if (entry.second & kChunkUnavailable) {
+			assert(node->type == FSNodeType::kFile || node->type == FSNodeType::kTrash ||
+			       node->type == FSNodeType::kReserved);
+			std::string name = getNodeInfo(*this, fsOpContext, node);
+			if (node->type == FSNodeType::kTrash) {
+				report << "-";
+			} else if (node->type == FSNodeType::kReserved) {
+				report << "+";
+			} else {
+				report << "*";
+			}
+			report << " currently unavailable " << name << "\n";
+			errors++;
+		}
+
+		if (errors >= kErrorsLogMax) { break; }
+
+		if (entry.second & kStructureError) {
+			std::string name = getNodeInfo(*this, fsOpContext, node);
+			report << "Structure error in " << name << "\n";
+			errors++;
+		}
+
+		if (errors >= kErrorsLogMax) { break; }
+	}
+
+	if (errors >= kErrorsLogMax) {
+		report << "only first " << errors << " errors (unavailable chunks/files) were logged\n";
+	}
+
+	if (fsinfo_notfoundchunks > 0) {
+		report << "unknown chunks: " << fsinfo_notfoundchunks << "\n";
+	}
+
+	if (fsinfo_unavailchunks > 0) {
+		report << "unavailable chunks: " << fsinfo_unavailchunks << "\n";
+	}
+
+	if (fsinfo_unavailtrashfiles > 0) {
+		report << "unavailable trash files: " << fsinfo_unavailtrashfiles << "\n";
+	}
+
+	if (fsinfo_unavailreservedfiles > 0) {
+		report << "unavailable reserved files: " << fsinfo_unavailreservedfiles << "\n";
+	}
+
+	if (fsinfo_unavailfiles > 0) { report << "unavailable files: " << fsinfo_unavailfiles << "\n"; }
+
+	out.report = report.str();
+	out.files = fsinfo_files;
+	out.underGoalFiles = fsinfo_ugfiles;
+	out.missingFiles = fsinfo_mfiles;
+	out.chunks = fsinfo_chunks;
+	out.underGoalChunks = fsinfo_ugchunks;
+	out.missingChunks = fsinfo_mchunks;
+	out.loopStart = fsinfo_loopstart;
+	out.loopEnd = fsinfo_loopend;
+}
+
+std::vector<DefectiveFileInfo> FilesystemOperationsBase::fsTestGetDefectiveNodes(
+    uint8_t requestedFlags, uint64_t maxEntries, uint64_t &cursor) {
+	auto fsOpContext =
+	    createFilesystemOperationContext(FilesystemOperationContext::TransactionType::kReadOnly);
+	std::vector<DefectiveFileInfo> defectiveNodesInfo;
+	ActiveLoopWatchdog watchdog;
+	defectiveNodesInfo.reserve(maxEntries);
+	auto it = gDefectiveNodes.find_nth(cursor);
+	watchdog.start();
+	for (uint64_t i = 0; i < maxEntries && it != gDefectiveNodes.end(); ++it) {
+		if (((*it).second & requestedFlags) != 0) {
+			FSNode *node = nodeOperations()->idToNode<FSNode>(fsOpContext, (*it).first);
+			std::string info = getNodeInfo(*this, fsOpContext, node);
+			defectiveNodesInfo.emplace_back(std::move(info), (*it).second);
+			++i;
+		}
+		++cursor;
+		if (watchdog.expired()) { return defectiveNodesInfo; }
+	}
+	cursor = 0;
+	return defectiveNodesInfo;
+}
+
+void FilesystemOperationsBase::fsTestOnNodeRemoved(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, inode_t inode) {
+	auto it = gDefectiveNodes.find(inode);
+	if (it != gDefectiveNodes.end()) { gDefectiveNodes.erase(it); }
+}
+
+// ---------------------------------------------------------------------------
+// Periodic checksum recalculation (in-memory backend)
+// ---------------------------------------------------------------------------
+
+void FilesystemOperationsBase::backgroundChecksumStep() {
+	uint32_t recalculated = 0;
+
+	switch (gChecksumBackgroundUpdater.getStep()) {
+	case ChecksumRecalculatingStep::kNone:
+		return;
+	case ChecksumRecalculatingStep::kNodes:
+		while (gChecksumBackgroundUpdater.getPosition() < NODEHASHSIZE) {
+			auto checkSumPosition = gChecksumBackgroundUpdater.getPosition();
+			for (const auto &node : gMetadata->nodeHash[checkSumPosition]) {
+				fsnodes_checksum_add_to_background(node);
+				++recalculated;
+			}
+			gChecksumBackgroundUpdater.incPosition();
+			if (recalculated >= gChecksumBackgroundUpdater.getSpeedLimit()) { break; }
+		}
+		if (gChecksumBackgroundUpdater.getPosition() == NODEHASHSIZE) {
+			gChecksumBackgroundUpdater.incStep();
+		}
+		break;
+	case ChecksumRecalculatingStep::kXattrs:
+		while (gChecksumBackgroundUpdater.getPosition() < XATTR_DATA_HASH_SIZE) {
+			auto checksumPosition = gChecksumBackgroundUpdater.getPosition();
+			for (const auto &xde : gMetadata->xattrDataHash[checksumPosition]) {
+				xattr_checksum_add_to_background(xde.get());
+				++recalculated;
+			}
+			gChecksumBackgroundUpdater.incPosition();
+			if (recalculated >= gChecksumBackgroundUpdater.getSpeedLimit()) { break; }
+		}
+		if (gChecksumBackgroundUpdater.getPosition() == XATTR_DATA_HASH_SIZE) {
+			gChecksumBackgroundUpdater.incStep();
+		}
+		break;
+	case ChecksumRecalculatingStep::kChunks:
+		if (chunks_update_checksum_a_bit(gChecksumBackgroundUpdater.getSpeedLimit()) ==
+		    ChecksumRecalculationStatus::kDone) {
+			gChecksumBackgroundUpdater.incStep();
+		}
+		break;
+	case ChecksumRecalculatingStep::kDone:
+		gChecksumBackgroundUpdater.end();
+		matoclserv_broadcast_metadata_checksum_recalculated(SAUNAFS_STATUS_OK);
+		return;
+	}
+	eventloop_make_next_poll_nonblocking();
 }
 
 uint8_t FilesystemOperationsBase::readReservedSize(inode_t rootinode,

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -234,13 +234,6 @@ static uint32_t gFileTestLoopTime = kDefaultFileTestLoopTime;
 static int gFileTestLoopIndex = 0;
 static unsigned gFileTestLoopBucketLimit = 0;
 
-enum NodeErrorFlag {
-	kChunkUnavailable = 1,
-	kChunkUnderGoal = 2,
-	kStructureError = 4,
-	kAllNodeErrors = 7
-};
-
 #if defined(SAUNAFS_HAVE_64BIT_JUDY) && !defined(DISABLE_JUDY_FOR_DEFECTIVENODESMAP)
 using DefectiveNodesMap = judy_map<inode_t, uint8_t>;
 #else

--- a/src/master/filesystem_operations.h
+++ b/src/master/filesystem_operations.h
@@ -166,6 +166,12 @@ public:
 	                         const std::string &inputPath, std::string &canonicalPath) override;
 
 #ifndef METARESTORE
+	/// Updates the configured duration of one full file-test pass.
+	static void setFileTestLoopTime(uint32_t loopTime);
+
+	/// Returns the configured duration of one full file-test pass.
+	static uint32_t fileTestLoopTime();
+
 	/// Returns a map with all defined goals.
 	const std::map<int, Goal> &getAllGoalDefinitions() const override;
 
@@ -460,6 +466,36 @@ public:
 	/// Starts recalculating metadata checksum in background.
 	/// @see IFilesystemOperations::fs_start_checksum_recalculation.
 	uint8_t startChecksumRecalculation() override;
+
+	/// Runs the once-per-second file-test scheduler tick.
+	/// @see IFilesystemOperations::fsTestPeriodicTick
+	void fsTestPeriodicTick(uint32_t timeStamp) override;
+
+	/// Runs one background file-test step from the event loop.
+	/// @see IFilesystemOperations::fsTestBackgroundStep
+	void fsTestBackgroundStep() override;
+
+	/// Returns the last published file-test report.
+	/// @see IFilesystemOperations::fsTestGetData
+	void fsTestGetData(FsTestReport &out) override;
+
+	/// Returns a paginated list of defective files.
+	/// @see IFilesystemOperations::fsTestGetDefectiveNodes
+	std::vector<DefectiveFileInfo> fsTestGetDefectiveNodes(uint8_t requestedFlags,
+	                                                       uint64_t maxEntries,
+	                                                       uint64_t &cursor) override;
+
+	/// Removes file-test state for a deleted node.
+	/// @see IFilesystemOperations::fsTestOnNodeRemoved
+	void fsTestOnNodeRemoved(const FilesystemOperationContext &fsOpContext, inode_t inode) override;
+
+	/// Runs one background metadata-checksum recalculation step.
+	/// @see IFilesystemOperations::backgroundChecksumStep
+	void backgroundChecksumStep() override;
+
+	/// In-memory backend has no backend-specific periodic options.
+	/// @see IFilesystemOperations::readBackendPeriodicConfig
+	void readBackendPeriodicConfig() override {}
 #endif
 	void addFilesToChunks(bool isMetadataLoading = true) override;
 
@@ -509,6 +545,10 @@ public:
 
 	/// Returns checksum of the loaded metadata.
 	uint64_t metadataChecksum(ChecksumMode mode) override;
+
+	/// In-memory backend supports Master-Shadow metadata checksums.
+	/// @see IFilesystemOperations::metadataChecksumSupported
+	bool metadataChecksumSupported() const override { return true; }
 
 	// Locks
 

--- a/src/master/filesystem_operations_interface.h
+++ b/src/master/filesystem_operations_interface.h
@@ -29,6 +29,7 @@
 #include <vector>
 
 #include "common/attributes.h"
+#include "common/defective_file_info.h"
 #include "common/goal.h"
 #include "master/checksum.h"
 #include "master/filesystem_node_operations_interface.h"
@@ -69,6 +70,19 @@ struct XAttrListResult {
 	/// Serialized xattr names: each name is followed by a '\0' byte.
 	/// Does NOT include the always-present kAclXattrs prefix.
 	std::vector<uint8_t> data;
+};
+
+/// Internal carrier for file-test status returned by fs_test_getdata().
+struct FsTestReport {
+	uint32_t loopStart = 0;
+	uint32_t loopEnd = 0;
+	inode_t files = 0;
+	inode_t underGoalFiles = 0;
+	inode_t missingFiles = 0;
+	uint32_t chunks = 0;
+	uint32_t underGoalChunks = 0;
+	uint32_t missingChunks = 0;
+	std::string report;
 };
 
 /// Interface for filesystem operations extensibility.
@@ -1535,6 +1549,66 @@ public:
 	/// Starts recalculating metadata checksum in background.
 	/// @return SAUNAFS_STATUS_OK if dump started successfully, otherwise cause of the failure.
 	virtual uint8_t startChecksumRecalculation() = 0;
+
+	/// Runs the once-per-second file-test scheduler tick.
+	///
+	/// The in-memory implementation preserves the node-hash scan timing and counters.
+	/// KV implementations may acquire backend-specific scanner ownership and publish their
+	/// result state elsewhere.
+	///
+	/// @param timeStamp Event-loop timestamp for this scheduler tick.
+	virtual void fsTestPeriodicTick(uint32_t timeStamp) = 0;
+
+	/// Runs one background file-test step from the event loop.
+	///
+	/// The in-memory implementation preserves the watchdog/yield behavior. KV implementations may
+	/// use backend-specific page transactions and cooperative leases.
+	virtual void fsTestBackgroundStep() = 0;
+
+	/// Returns the last published file-test report.
+	///
+	/// The in-memory implementation builds the report from gDefectiveNodes. KV implementations may
+	/// return a previously rendered report from shared backend storage.
+	///
+	/// @param[out] out File-test report populated from the latest published scan results.
+	virtual void fsTestGetData(FsTestReport &out) = 0;
+
+	/// Returns a paginated list of defective files matching @p requestedFlags.
+	///
+	/// The cursor is opaque to callers; pass 0 to start from the beginning. The in-memory
+	/// implementation keeps the hash-map position semantics; KV implementations use it
+	/// as an inode-ordered scan position into FILETEST_DEFECTIVE_ rows.
+	///
+	/// @param requestedFlags NodeErrorFlag bits used to filter defective files.
+	/// @param maxEntries Maximum number of entries to return.
+	/// @param[in,out] cursor Opaque scan cursor; set to 0 to start a new scan.
+	/// @return Defective file entries matching @p requestedFlags.
+	virtual std::vector<DefectiveFileInfo> fsTestGetDefectiveNodes(uint8_t requestedFlags,
+	                                                               uint64_t maxEntries,
+	                                                               uint64_t &cursor) = 0;
+
+	/// Removes backend-specific file-test state for a node that is being deleted.
+	///
+	/// KV implementations may use @p fsOpContext to clear state in the same transaction as the
+	/// node removal. The in-memory implementation only erases from gDefectiveNodes.
+	///
+	/// @param fsOpContext Filesystem operation context carrying backend transaction state.
+	/// @param inode Removed inode whose file-test state must be cleared.
+	virtual void fsTestOnNodeRemoved(const FilesystemOperationContext &fsOpContext,
+	                                 inode_t inode) = 0;
+
+	/// Runs one background metadata-checksum recalculation step.
+	///
+	/// The in-memory implementation preserves the checksum updater behavior. KV implementations may
+	/// no-op because metadata checksums are not meaningful for native KV metadata.
+	virtual void backgroundChecksumStep() = 0;
+
+	/// Reads backend-specific options from configuration.
+	///
+	/// Called from `fs_read_periodic_config_file()` after the master-side options are loaded,
+	/// so backends can read their own keys without the master code referencing them.
+	/// Implementations with no backend-specific periodic options should override as a no-op.
+	virtual void readBackendPeriodicConfig() = 0;
 #endif
 	virtual void addFilesToChunks(bool isMetadataLoading = true) = 0;
 
@@ -1616,6 +1690,9 @@ public:
 
 	/// Returns checksum of the loaded metadata.
 	virtual uint64_t metadataChecksum(ChecksumMode mode) = 0;
+
+	/// Returns whether this backend computes meaningful Master-Shadow metadata checksums.
+	virtual bool metadataChecksumSupported() const = 0;
 
 	// Lock operations
 

--- a/src/master/filesystem_periodic.cc
+++ b/src/master/filesystem_periodic.cc
@@ -23,65 +23,22 @@
 #include "master/filesystem_periodic.h"
 
 #include <cstdint>
+#include <string>
+#include <utility>
 
-#include "config/cfg.h"
 #include "common/event_loop.h"
-#if defined(SAUNAFS_HAVE_64BIT_JUDY) && !defined(DISABLE_JUDY_FOR_DEFECTIVENODESMAP)
-#  include "common/judy_map.h"
-#else
-#  include "common/flat_map.h"
-#endif
-#include "common/loop_watchdog.h"
-#include "master/chunks.h"
-#include "master/filesystem_checksum.h"
+#include "config/cfg.h"
 #include "master/filesystem_checksum_updater.h"
 #include "master/filesystem_metadata.h"
 #include "master/filesystem_operations.h"
 #include "master/filesystem_operations_interface.h"
-#include "master/matoclserv.h"
 
-#define MSGBUFFSIZE 1000000
-#define ERRORS_LOG_MAX 500
 #define FILETESTSMINLOOPTIME 1
 #define FILETESTSMAXLOOPTIME 7200
 
 #ifndef METARESTORE
 
-static inode_t fsinfo_files = 0;
-static inode_t fsinfo_ugfiles = 0;
-static inode_t fsinfo_mfiles = 0;
-static uint32_t fsinfo_chunks = 0;
-static uint32_t fsinfo_ugchunks = 0;
-static uint32_t fsinfo_mchunks = 0;
-static uint32_t fsinfo_loopstart = 0;
-static uint32_t fsinfo_loopend = 0;
-static uint32_t fsinfo_notfoundchunks = 0;
-static uint32_t fsinfo_unavailchunks = 0;
-static inode_t fsinfo_unavailfiles = 0;
-static inode_t fsinfo_unavailtrashfiles = 0;
-static inode_t fsinfo_unavailreservedfiles = 0;
-
 static int gTasksBatchSize = 1000;
-
-static int gFileTestLoopTime = 300;
-static int gFileTestLoopIndex = 0;
-static unsigned gFileTestLoopBucketLimit = 0;
-
-enum NodeErrorFlag {
-	kChunkUnavailable = 1,
-	kChunkUnderGoal   = 2,
-	kStructureError   = 4,
-	kAllNodeErrors    = 7
-};
-
-#if defined(SAUNAFS_HAVE_64BIT_JUDY) && !defined(DISABLE_JUDY_FOR_DEFECTIVENODESMAP)
-	using DefectiveNodesMap = judy_map<inode_t, uint8_t>;
-#else
-	using DefectiveNodesMap = flat_map<inode_t, uint8_t>;
-#endif
-
-static const size_t kMaxNodeEntries = 1000000;
-static DefectiveNodesMap gDefectiveNodes;
 
 void fs_background_task_manager_work() {
 	if (gMetadata->taskManager.workAvailable()) {
@@ -94,454 +51,39 @@ void fs_background_task_manager_work() {
 	}
 }
 
-static std::string get_detached_node_path(const FilesystemOperationContext &fsOpContext,
-                                          const FSNode *node) {
-	return gFSOperations->getDetachedPath(fsOpContext, node).value_or("");
-}
-
-static std::string get_node_info(const FilesystemOperationContext &fsOpContext, FSNode *node) {
-	std::string name;
-	if (node == nullptr) {
-		return name;
-	}
-
-	if (node->type == FSNodeType::kTrash) {
-		name = "file in trash " + std::to_string(node->id) + ": " +
-		       get_detached_node_path(fsOpContext, node);
-	} else if (node->type == FSNodeType::kReserved) {
-		name = "reserved file " + std::to_string(node->id) + ": " +
-		       get_detached_node_path(fsOpContext, node);
-	} else if (node->type == FSNodeType::kFile) {
-		name = "file " + std::to_string(node->id) + ": ";
-		bool first = true;
-		for (const auto &[parentId, _] : node->parents) {
-			std::string path;
-			auto *parent = gFSOperations->nodeOperations()->idToNodeVerify<FSNodeDirectory>(
-			    fsOpContext, parentId);
-			gFSOperations->nodeOperations()->getPath(fsOpContext, parent, node, path);
-			if (!first) {
-				name += "|" + path;
-			} else {
-				name += path;
-			}
-			first = false;
-		}
-	} else if (node->type == FSNodeType::kDirectory) {
-		name = "directory " + std::to_string(node->id) + ": ";
-		std::string path;
-		FSNodeDirectory *parent = nullptr;
-		if (!node->parents.empty()) {
-			parent = gFSOperations->nodeOperations()->idToNodeVerify<FSNodeDirectory>(
-			    fsOpContext, node->parents.front().first);
-		}
-		gFSOperations->nodeOperations()->getPath(fsOpContext, parent, node, path);
-		name += path;
-	}
-
-	return gFSOperations->nodeOperations()->escapeName(name);
-}
-
-std::vector<DefectiveFileInfo> fs_get_defective_nodes_info(uint8_t requested_flags, uint64_t max_entries,
-	                                                   uint64_t &entry_index) {
-	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
-	    FilesystemOperationContext::TransactionType::kReadOnly);
-	FSNode *node;
-	std::vector<DefectiveFileInfo> defective_nodes_info;
-	ActiveLoopWatchdog watchdog;
-	defective_nodes_info.reserve(max_entries);
-	auto it = gDefectiveNodes.find_nth(entry_index);
-	watchdog.start();
-	for (uint64_t i = 0; i < max_entries && it != gDefectiveNodes.end(); ++it) {
-		if (((*it).second & requested_flags) != 0) {
-			node = gFSOperations->nodeOperations()->idToNode<FSNode>(fsOpContext, (*it).first);
-			std::string info = get_node_info(fsOpContext, node);
-			defective_nodes_info.emplace_back(std::move(info), (*it).second);
-			++i;
-		}
-		++entry_index;
-		if (watchdog.expired()) {
-			return defective_nodes_info;
-		}
-	}
-	entry_index = 0;
-	return defective_nodes_info;
+std::vector<DefectiveFileInfo> fs_get_defective_nodes_info(uint8_t requested_flags,
+                                                           uint64_t max_entries,
+                                                           uint64_t &entry_index) {
+	return gFSOperations->fsTestGetDefectiveNodes(requested_flags, max_entries, entry_index);
 }
 
 void fs_test_getdata(uint32_t &loopstart, uint32_t &loopend, inode_t &files, inode_t &ugfiles,
                      inode_t &mfiles, uint32_t &chunks, uint32_t &ugchunks, uint32_t &mchunks,
                      std::string &result) {
-	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
-	    FilesystemOperationContext::TransactionType::kReadOnly);
-	std::stringstream report;
-	int errors = 0;
+	FsTestReport report;
+	gFSOperations->fsTestGetData(report);
 
-	for (const auto &entry : gDefectiveNodes) {
-		if (errors >= ERRORS_LOG_MAX) {
-			break;
-		}
-
-		FSNode *node = gFSOperations->nodeOperations()->idToNode<FSNode>(fsOpContext, entry.first);
-		if (!node) {
-			report << "Structure error in defective list, entry " << std::to_string(entry.first) << "\n";
-			errors++;
-			continue;
-		}
-
-		if (node->type == FSNodeType::kFile || node->type == FSNodeType::kTrash ||
-		    node->type == FSNodeType::kReserved) {
-			FSNodeFile *file_node = static_cast<FSNodeFile *>(node);
-			for (std::size_t j = 0; j < file_node->chunks.size(); ++j) {
-				auto chunkid = file_node->chunks[j];
-				if (chunkid == 0) {
-					continue;
-				}
-
-				uint8_t vc;
-				if (chunk_get_fullcopies(chunkid, &vc) != SAUNAFS_STATUS_OK) {
-					report << "structure error - chunk " << chunkid
-					       << " not found (inode: " << file_node->id
-					       << " ; index: " << j << ")\n";
-					errors++;
-				} else if (vc == 0) {
-					report << "currently unavailable chunk " << chunkid
-					       << " (inode: " << file_node->id << " ; index: " << j
-					       << ")\n";
-					errors++;
-				}
-			}
-		}
-
-		if (errors >= ERRORS_LOG_MAX) {
-			break;
-		}
-
-		if (entry.second & kChunkUnavailable) {
-			assert(node->type == FSNodeType::kFile || node->type == FSNodeType::kTrash ||
-			       node->type == FSNodeType::kReserved);
-			std::string name = get_node_info(fsOpContext, node);
-			if (node->type == FSNodeType::kTrash) {
-				report << "-";
-			} else if (node->type == FSNodeType::kReserved) {
-				report << "+";
-			} else {
-				report << "*";
-			}
-			report << " currently unavailable " << name << "\n";
-			errors++;
-		}
-
-		if (errors >= ERRORS_LOG_MAX) {
-			break;
-		}
-
-		if (entry.second & kStructureError) {
-			std::string name = get_node_info(fsOpContext, node);
-			report << "Structure error in " << name << "\n";
-			errors++;
-		}
-
-		if (errors >= ERRORS_LOG_MAX) {
-			break;
-		}
-	}
-
-	if (errors >= ERRORS_LOG_MAX) {
-		report << "only first " << errors
-		       << " errors (unavailable chunks/files) were logged\n";
-	}
-	if (fsinfo_notfoundchunks > 0) {
-		report << "unknown chunks: " << fsinfo_notfoundchunks << "\n";
-	}
-	if (fsinfo_unavailchunks > 0) {
-		report << "unavailable chunks: " << fsinfo_unavailchunks << "\n";
-	}
-	if (fsinfo_unavailtrashfiles > 0) {
-		report << "unavailable trash files: " << fsinfo_unavailtrashfiles << "\n";
-	}
-	if (fsinfo_unavailreservedfiles > 0) {
-		report << "unavailable reserved files: " << fsinfo_unavailreservedfiles << "\n";
-	}
-	if (fsinfo_unavailfiles > 0) {
-		report << "unavailable files: " << fsinfo_unavailfiles << "\n";
-	}
-	result = report.str();
-
-	files = fsinfo_files;
-	ugfiles = fsinfo_ugfiles;
-	mfiles = fsinfo_mfiles;
-	chunks = fsinfo_chunks;
-	ugchunks = fsinfo_ugchunks;
-	mchunks = fsinfo_mchunks;
-	loopstart = fsinfo_loopstart;
-	loopend = fsinfo_loopend;
+	loopstart = report.loopStart;
+	loopend = report.loopEnd;
+	files = report.files;
+	ugfiles = report.underGoalFiles;
+	mfiles = report.missingFiles;
+	chunks = report.chunks;
+	ugchunks = report.underGoalChunks;
+	mchunks = report.missingChunks;
+	result = std::move(report.report);
 }
 
-void fs_background_checksum_recalculation_a_bit() {
-	uint32_t recalculated = 0;
+void fs_background_checksum_recalculation_a_bit() { gFSOperations->backgroundChecksumStep(); }
 
-	switch (gChecksumBackgroundUpdater.getStep()) {
-	case ChecksumRecalculatingStep::kNone:  // Recalculation not in progress.
-		return;
-	case ChecksumRecalculatingStep::kNodes:
-		// Nodes are in a hashtable, therefore they can be recalculated in multiple steps.
-		while (gChecksumBackgroundUpdater.getPosition() < NODEHASHSIZE) {
-			auto checkSumPosition = gChecksumBackgroundUpdater.getPosition();
-			for (const auto &node : gMetadata->nodeHash[checkSumPosition]) {
-				fsnodes_checksum_add_to_background(node);
-				++recalculated;
-			}
-			gChecksumBackgroundUpdater.incPosition();
-			if (recalculated >= gChecksumBackgroundUpdater.getSpeedLimit()) {
-				break;
-			}
-		}
-		if (gChecksumBackgroundUpdater.getPosition() == NODEHASHSIZE) {
-			gChecksumBackgroundUpdater.incStep();
-		}
-		break;
-	case ChecksumRecalculatingStep::kXattrs:
-		// Xattrs are in a hashtable, therefore they can be recalculated in multiple steps.
-		while (gChecksumBackgroundUpdater.getPosition() < XATTR_DATA_HASH_SIZE) {
-			auto checksumPosition = gChecksumBackgroundUpdater.getPosition();
-			for (const auto &xde : gMetadata->xattrDataHash[checksumPosition]) {
-				xattr_checksum_add_to_background(xde.get());
-				++recalculated;
-			}
-			gChecksumBackgroundUpdater.incPosition();
-			if (recalculated >= gChecksumBackgroundUpdater.getSpeedLimit()) {
-				break;
-			}
-		}
-		if (gChecksumBackgroundUpdater.getPosition() == XATTR_DATA_HASH_SIZE) {
-			gChecksumBackgroundUpdater.incStep();
-		}
-		break;
-	case ChecksumRecalculatingStep::kChunks:
-		// Chunks can be processed in multiple steps.
-		if (chunks_update_checksum_a_bit(gChecksumBackgroundUpdater.getSpeedLimit()) ==
-		    ChecksumRecalculationStatus::kDone) {
-			gChecksumBackgroundUpdater.incStep();
-		}
-		break;
-	case ChecksumRecalculatingStep::kDone:
-		gChecksumBackgroundUpdater.end();
-		matoclserv_broadcast_metadata_checksum_recalculated(SAUNAFS_STATUS_OK);
-		return;
-	}
-	eventloop_make_next_poll_nonblocking();
+void fs_periodic_file_test() { gFSOperations->fsTestPeriodicTick(eventloop_time()); }
+
+void fs_background_file_test(void) { gFSOperations->fsTestBackgroundStep(); }
+
+void fsnodes_periodic_remove(const FilesystemOperationContext &fsOpContext, inode_t inode) {
+	gFSOperations->fsTestOnNodeRemoved(fsOpContext, inode);
 }
 
-void fs_process_file_test() {
-	uint32_t k;
-	uint8_t vc, node_error_flag;
-	ActiveLoopWatchdog watchdog;
-	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
-	    FilesystemOperationContext::TransactionType::kReadOnly);
-
-	static inode_t files = 0;
-	static inode_t ugfiles = 0;
-	static inode_t mfiles = 0;
-	static uint32_t chunks = 0;
-	static uint32_t ugchunks = 0;
-	static uint32_t mchunks = 0;
-	static uint32_t notfoundchunks = 0;
-	static uint32_t unavailchunks = 0;
-	static inode_t unavailfiles = 0;
-	static inode_t unavailtrashfiles = 0;
-	static inode_t unavailreservedfiles = 0;
-
-	if (gFileTestLoopIndex == 0) {
-		if (unavailfiles > 0) {
-			safs::log_err("Currently unavailable files: {}", unavailfiles);
-		}
-		if (unavailchunks > 0) {
-			safs::log_err("Currently unavailable chunks: {}", unavailchunks);
-		}
-		if (unavailreservedfiles > 0) {
-			safs::log_err("Currently unavailable reserved files: {}", unavailreservedfiles);
-		}
-		if (unavailtrashfiles > 0) {
-			safs::log_warn("Currently unavailable trash files: {}", unavailtrashfiles);
-		}
-
-		fsinfo_files = files;
-		fsinfo_ugfiles = ugfiles;
-		fsinfo_mfiles = mfiles;
-		fsinfo_chunks = chunks;
-		fsinfo_ugchunks = ugchunks;
-		fsinfo_mchunks = mchunks;
-		fsinfo_loopstart = fsinfo_loopend;
-		fsinfo_loopend = eventloop_time();
-		fsinfo_notfoundchunks = notfoundchunks;
-		fsinfo_unavailchunks = unavailchunks;
-		fsinfo_unavailfiles = unavailfiles;
-		fsinfo_unavailtrashfiles = unavailtrashfiles;
-		fsinfo_unavailreservedfiles = unavailreservedfiles;
-
-		files = 0;
-		ugfiles = 0;
-		mfiles = 0;
-		chunks = 0;
-		ugchunks = 0;
-		mchunks = 0;
-		notfoundchunks = 0;
-		unavailchunks = 0;
-		unavailfiles = 0;
-		unavailtrashfiles = 0;
-		unavailreservedfiles = 0;
-	}
-
-	watchdog.start();
-	for (k = 0; k < gFileTestLoopBucketLimit && gFileTestLoopIndex < NODEHASHSIZE;
-	     k++, gFileTestLoopIndex++) {
-		if (k > 0 && watchdog.expired()) {
-			gFileTestLoopBucketLimit -= k;
-			return;
-		}
-
-		for (const auto &node : gMetadata->nodeHash[gFileTestLoopIndex]) {
-			node_error_flag = 0;
-
-			if (node->type == FSNodeType::kFile || node->type == FSNodeType::kTrash ||
-			    node->type == FSNodeType::kReserved) {
-				for (const auto &chunkid : static_cast<FSNodeFile *>(node)->chunks) {
-					if (chunkid == 0) {
-						continue;
-					}
-
-					if (chunk_get_fullcopies(chunkid, &vc) !=
-					    SAUNAFS_STATUS_OK) {
-						node_error_flag |=
-						        static_cast<int>(kChunkUnavailable);
-						notfoundchunks++;
-						mchunks++;
-					} else if (vc == 0) {
-						node_error_flag |=
-						        static_cast<int>(kChunkUnavailable);
-						unavailchunks++;
-						mchunks++;
-					} else {
-						int recover, remove;
-						chunk_get_partstomodify(chunkid, recover, remove);
-						if (recover > 0) {
-							node_error_flag |=
-							        static_cast<int>(kChunkUnderGoal);
-							ugchunks++;
-						}
-					}
-					chunks++;
-				}
-			}
-
-			if (node->type == FSNodeType::kDirectory) {
-				for (const auto &entry : static_cast<FSNodeDirectory *>(node)->entries) {
-					FSNode *childNode = entry.second;
-
-					if (!childNode) {
-						// the node points to invalid memory
-						node_error_flag |= static_cast<int>(kStructureError);
-					} else {
-						auto parentInChildPtr = std::find_if(
-						    childNode->parents.begin(), childNode->parents.end(),
-						    [node](const std::pair<inode_t, const hstorage::Handle *> &p) {
-							    return p.first == node->id;
-						    });
-						// the node doesn't have a parent entry pointing to the current directory
-						if (parentInChildPtr == childNode->parents.end()) {
-							node_error_flag |= static_cast<int>(kStructureError);
-						}
-					}
-				}
-			}
-
-			if (node_error_flag == 0) {
-				auto it = gDefectiveNodes.find(node->id);
-				if (it != gDefectiveNodes.end()) {
-					gDefectiveNodes.erase(it);
-				}
-				continue;
-			}
-
-			if (node_error_flag & kChunkUnavailable) {
-				if (node->type == FSNodeType::kTrash) {
-					unavailtrashfiles++;
-				} else if (node->type == FSNodeType::kReserved) {
-					unavailreservedfiles++;
-				} else {
-					unavailfiles += node->parents.size();
-				}
-
-				auto it = gDefectiveNodes.find(node->id);
-				if (it == gDefectiveNodes.end()) {
-					std::string name = get_node_info(fsOpContext, node);
-					safs::log_trace("Chunks unavailable in {}",
-					                   name);
-				}
-			}
-			if (node_error_flag & kChunkUnderGoal) {
-				ugfiles++;
-			}
-			if (node_error_flag & kStructureError) {
-				auto it = gDefectiveNodes.find(node->id);
-				if (it == gDefectiveNodes.end()) {
-					std::string name = get_node_info(fsOpContext, node);
-					safs_pretty_syslog(LOG_ERR, "Structure error in %s",
-					                   name.c_str());
-				}
-			}
-
-			if (gDefectiveNodes.size() < kMaxNodeEntries) {
-				gDefectiveNodes[node->id] = node_error_flag;
-			} else {
-				auto it = gDefectiveNodes.find(node->id);
-				if (it != gDefectiveNodes.end()) {
-					(*it).second = node_error_flag;
-				}
-			}
-		}
-	}
-
-	gFileTestLoopBucketLimit -= k;
-	if (gFileTestLoopIndex >= NODEHASHSIZE) {
-		gFileTestLoopIndex = 0;
-	}
-}
-
-void fs_periodic_file_test() {
-	if (eventloop_time() <= gTestStartTime) {
-		gFileTestLoopBucketLimit = 0;
-		return;
-	}
-
-	if (gFileTestLoopBucketLimit == 0) {
-		gFileTestLoopBucketLimit = NODEHASHSIZE / gFileTestLoopTime;
-		fs_process_file_test();
-	}
-}
-
-void fs_background_file_test(void) {
-	if (gFileTestLoopBucketLimit > 0) {
-		fs_process_file_test();
-		if (gFileTestLoopBucketLimit > 0) {
-			eventloop_make_next_poll_nonblocking();
-		}
-	}
-}
-
-void fsnodes_periodic_remove(inode_t inode) {
-	auto it = gDefectiveNodes.find(inode);
-	if (it != gDefectiveNodes.end()) {
-		gDefectiveNodes.erase(it);
-	}
-}
-#endif
-
-struct InodeInfo {
-	inode_t free;
-	inode_t reserved;
-};
-
-#ifndef METARESTORE
 void fs_periodic_emptytrash(void) {
 	gFSOperations->doEmptyTrash(eventloop_time());
 }
@@ -551,7 +93,9 @@ void fs_periodic_emptyreserved(void) {
 }
 
 void fs_read_periodic_config_file() {
-	gFileTestLoopTime = cfg_get_minmaxvalue<uint32_t>("FILE_TEST_LOOP_MIN_TIME", 3600, FILETESTSMINLOOPTIME, FILETESTSMAXLOOPTIME);
+	FilesystemOperationsBase::setFileTestLoopTime(cfg_get_minmaxvalue<uint32_t>(
+	    "FILE_TEST_LOOP_MIN_TIME", 3600, FILETESTSMINLOOPTIME, FILETESTSMAXLOOPTIME));
+	gFSOperations->readBackendPeriodicConfig();
 }
 
 void fs_periodic_master_init() {

--- a/src/master/filesystem_periodic.h
+++ b/src/master/filesystem_periodic.h
@@ -24,6 +24,7 @@
 
 #include "common/defective_file_info.h"
 #include "common/type_defs.h"
+#include "master/filesystem_operation_context.h"
 
 inline uint32_t gEmptyReservedFilesPeriod = 0;
 
@@ -37,4 +38,4 @@ void fs_periodic_master_init();
 void fs_test_getdata(uint32_t &loopstart, uint32_t &loopend, inode_t &files, inode_t &ugfiles,
                      inode_t &mfiles, uint32_t &chunks, uint32_t &ugchunks, uint32_t &mchunks,
                      std::string &report);
-void fsnodes_periodic_remove(inode_t inode);
+void fsnodes_periodic_remove(const FilesystemOperationContext &fsOpContext, inode_t inode);

--- a/src/master/kv_common_keys.h
+++ b/src/master/kv_common_keys.h
@@ -81,7 +81,7 @@ inline constexpr std::string_view kMetaLinkNodesKey = "META_LINK_NODES";
 /// Format: NODE_<InodeId>:<SerializedFSNodeData>
 /// @note InodeId is serialized as Big Endian to maintain numeric order in lexicographical sorting
 /// enabling efficient range queries for all nodes or specific inode ranges.
-inline constexpr std::string_view kNodeKeyPrefix = "NODE_";    // Section NODE 1.0
+inline constexpr std::string_view kNodeKeyPrefix = "NODE_";  // Section NODE 1.0
 
 /// Prefix for edges (directory entries)
 /// Format: EDGE_<ParentId><Name>:<ChildId>
@@ -94,33 +94,33 @@ inline constexpr std::string_view kNodeKeyPrefix = "NODE_";    // Section NODE 1
 /// which are stored as separate keys with their own prefixes (e.g., DIR_PARENT_, PARENT_).
 /// @see kEdgeLowerKeyPrefix, kDirParentKeyPrefix, kParentKeyPrefix, kDirNodesCountPrefix,
 /// kDirStatsPrefix
-inline constexpr std::string_view kEdgeKeyPrefix = "EDGE_";    // Section EDGE 1.0
+inline constexpr std::string_view kEdgeKeyPrefix = "EDGE_";  // Section EDGE 1.0
 
 /// Prefix for free/reusable inode ids
 /// Format: FREE_<InodeId>:<TimeStamp>
 /// @note InodeId is serialized as Big Endian. TimeStamp is a 32-bit Big Endian value indicating
 /// when the inode was freed.
-inline constexpr std::string_view kFreeKeyPrefix = "FREE_";    // Section FREE 1.0
+inline constexpr std::string_view kFreeKeyPrefix = "FREE_";  // Section FREE 1.0
 
 /// Prefix for chunk entries (mostly used for chunk locking)
 /// Format: CHNK_<ChunkId><ChunkVersion>:<LockedTo><LockId>
 /// @note ChunkId (64-bit) and ChunkVersion (32-bit) are serialized as Big Endian in the key.
 /// LockedTo and LockId (both 32-bit) are also Big Endian.
-inline constexpr std::string_view kChunkKeyPrefix = "CHNK_";   // Section CHNK 1.0
+inline constexpr std::string_view kChunkKeyPrefix = "CHNK_";  // Section CHNK 1.0
 
 /// Prefix for extended attributes (xattrs)
 /// Format: XATR_<InodeId><AttributeName>:<AttributeValue>
 /// e.g.: XATR_1999UserAttr:UserValue
 /// @note InodeId is serialized as Big Endian to maintain numeric order in lexicographical sorting,
 /// enabling efficient range queries for all xattrs of a specific inode.
-inline constexpr std::string_view kXAttrKeyPrefix = "XATR_";   // Section XATR 1.0
+inline constexpr std::string_view kXAttrKeyPrefix = "XATR_";  // Section XATR 1.0
 
 /// Prefix for Access Control Lists (ACLs)
 /// Format: ACLS_<InodeId>:<binary RichACL>
 /// e.g.: ACLS_1999:<binary data>
 /// @note InodeId is serialized as Big Endian to maintain numeric order in lexicographical sorting,
 /// enabling efficient range queries.
-inline constexpr std::string_view kACLsKeyPrefix = "ACLS_";    // Section ACLS 1.2
+inline constexpr std::string_view kACLsKeyPrefix = "ACLS_";  // Section ACLS 1.2
 
 /// Prefix for quotas
 /// Format: QUOT_<OwnerType><OwnerId><Rigor><Resource>:<Value>
@@ -152,6 +152,73 @@ inline constexpr std::string_view kTrashPathKeyPrefix = "TRSH_PATH_";  // Sectio
 /// Deleted/Purged when all sessions pointing to the file release it.
 inline constexpr std::string_view kReservedPathKeyPrefix = "RSVD_PATH_";  // Section RSVD 1.0
 
+/// File-test scanner lease.
+/// Format: FILETEST_LEASE:<OwnerMdsId><ExpiryTime><LeaseEpoch><ActiveScanGeneration>
+/// - OwnerMdsId: uint32_t serialized as Big Endian
+/// - ExpiryTime: uint32_t Unix timestamp serialized as Big Endian
+/// - LeaseEpoch: uint64_t serialized as Big Endian
+/// - ActiveScanGeneration: uint64_t serialized as Big Endian
+inline constexpr std::string_view kFileTestLeaseKey = "FILETEST_LEASE";
+
+/// Last-committed NODE_ key from the in-progress scan; the next page resumes after it.
+/// Absent when no scan is in progress or at cycle start.
+/// Format: FILETEST_CURSOR:<LastCommittedNodeKey>
+/// - LastCommittedNodeKey: raw NODE_<InodeId> key bytes
+/// @note InodeId inside LastCommittedNodeKey is serialized as Big Endian.
+inline constexpr std::string_view kFileTestCursorKey = "FILETEST_CURSOR";
+
+/// Running counters for the in-progress scan cycle; written by the lease owner each committed page.
+/// Reset to a fresh Stats with the new generation when a cycle completes or a new one begins.
+/// Format: FILETEST_ACTIVE_STATS:<ScanGeneration><LoopStart><LoopEnd><Files>
+///                               <UnderGoalFiles><MissingFiles><Chunks>
+///                               <UnderGoalChunks><MissingChunks><NotFoundChunks>
+///                               <UnavailableChunks><UnavailableFiles>
+///                               <UnavailableTrashFiles><UnavailableReservedFiles>
+/// - ScanGeneration: uint64_t serialized as Big Endian
+/// - LoopStart, LoopEnd: uint32_t Unix timestamps serialized as Big Endian
+/// - Files, UnderGoalFiles, MissingFiles: inode_t serialized as Big Endian
+/// - Chunks, UnderGoalChunks, MissingChunks, NotFoundChunks, UnavailableChunks:
+///   uint32_t serialized as Big Endian
+/// - UnavailableFiles, UnavailableTrashFiles, UnavailableReservedFiles:
+///   inode_t serialized as Big Endian
+inline constexpr std::string_view kFileTestActiveStatsKey = "FILETEST_ACTIVE_STATS";
+
+/// Completed-cycle counters swapped atomically from FILETEST_ACTIVE_STATS at end-of-cycle.
+/// Read by FSTEST_INFO and as the generation anchor for list-defective-files scans.
+/// Format: FILETEST_PUBLISHED_STATS:<ScanGeneration><LoopStart><LoopEnd><Files>
+///                                  <UnderGoalFiles><MissingFiles><Chunks>
+///                                  <UnderGoalChunks><MissingChunks><NotFoundChunks>
+///                                  <UnavailableChunks><UnavailableFiles>
+///                                  <UnavailableTrashFiles><UnavailableReservedFiles>
+/// @see kFileTestActiveStatsKey for field types and order.
+inline constexpr std::string_view kFileTestPublishedStatsKey = "FILETEST_PUBLISHED_STATS";
+
+/// Rendered human-readable report swapped atomically alongside FILETEST_PUBLISHED_STATS.
+/// Built from the completed generation's FILETEST_REPORT_ rows; capped below FDB's value limit.
+/// Format: FILETEST_PUBLISHED_REPORT:<ReportText>
+/// - ReportText: raw bytes of the rendered report string with no length prefix
+inline constexpr std::string_view kFileTestPublishedReportKey = "FILETEST_PUBLISHED_REPORT";
+
+/// Prefix for per-defective-inode file-test rows.
+/// Format: FILETEST_DEFECTIVE_<InodeId>:<ScanGeneration><Flags>
+/// - InodeId: inode_t serialized as Big Endian
+/// - ScanGeneration: uint64_t serialized as Big Endian
+/// - Flags: uint8_t NodeErrorFlag bitmask
+/// @note InodeId is encoded in the key to preserve numeric ordering for scans.
+inline constexpr std::string_view kFileTestDefectiveKeyPrefix = "FILETEST_DEFECTIVE_";
+
+/// Prefix for per-inode pre-rendered report fragments used to build FILETEST_PUBLISHED_REPORT.
+/// Generation-scoped so publish can range-scan only the completed cycle and ignore stale rows.
+/// Only inodes with visible FSTEST_INFO lines have a row; under-goal-only inodes are omitted
+/// (Master also produces no report text for them, this is an intentional parity).
+/// Format: FILETEST_REPORT_<KeyScanGeneration><InodeId>:<ScanGeneration><Errors><Text>
+/// - KeyScanGeneration: uint64_t serialized as Big Endian
+/// - InodeId: inode_t serialized as Big Endian
+/// - ScanGeneration: uint64_t serialized as Big Endian
+/// - Errors: uint32_t serialized as Big Endian
+/// - Text: raw bytes of the pre-rendered report fragment with no length prefix
+inline constexpr std::string_view kFileTestReportKeyPrefix = "FILETEST_REPORT_";
+
 /// Prefix for locks
 /// Format: FLCK_<InodeId:BE><Type:u8><Status:u8> → serialized lock entries
 /// - InodeId: inode_t serialized as Big Endian (enables per-inode prefix scan)
@@ -162,7 +229,7 @@ inline constexpr std::string_view kReservedPathKeyPrefix = "RSVD_PATH_";  // Sec
 /// Big Endian to preserve numeric order in lexicographical sorting.
 /// The value contains all lock entries for the given (inode, type, status)
 /// tuple, serialized as a contiguous sequence via FileLocks serialization.
-inline constexpr std::string_view kLocksKeyPrefix = "FLCK_";   // Section FLCK 1.0
+inline constexpr std::string_view kLocksKeyPrefix = "FLCK_";  // Section FLCK 1.0
 
 // Case-insensitive directory support
 


### PR DESCRIPTION
This PR delegates the remaining master periodic operations to filesystem
backends through `IFilesystemOperations`.

It adds backend hooks for:

- `fsTestPeriodicTick`
- `fsTestBackgroundStep`
- `fsTestGetData`
- `fsTestGetDefectiveNodes`
- `fsTestOnNodeRemoved`
- `backgroundChecksumStep`
- `readBackendPeriodicConfig`
- `metadataChecksumSupported`

The in-memory file-test scanner state, scan loop, defective-node map, report
rendering, and remove-node cleanup are moved from `filesystem_periodic.cc` into
`FilesystemOperationsBase`. `filesystem_periodic.cc` is now scheduler glue that
keeps the existing public C-style entry points used by `matoclserv.cc` and
`filesystem_node.cc`, but routes them through `gFSOperations`.

The per-loop metadata checksum recalculation body is also moved behind
`backgroundChecksumStep`, matching the existing backend hook for starting
checksum recalculation. `ChecksumUpdater` now gates checksum changelog emission
on `metadataChecksumSupported()` so backends without meaningful Master/Shadow
metadata checksums do not emit `CHECKSUM(...):0` entries.

This PR also adds shared `FILETEST_*` key constants in `kv_common_keys.h` for
the KV file-test scanner state:

- `FILETEST_LEASE`
- `FILETEST_CURSOR`
- `FILETEST_ACTIVE_STATS`
- `FILETEST_PUBLISHED_STATS`
- `FILETEST_PUBLISHED_REPORT`
- `FILETEST_DEFECTIVE_<inode>`
- `FILETEST_REPORT_<scan_generation><inode>`

These are only the master-side seams and shared key names; the FDB scanner
behavior itself is implemented in the MDS repository.

Review Note:

The code ported from `filesystem_periodic.cc` was intentionally kept close to
the original structure to make the move easy to review and verify mechanically.
It has not been refactored to match the destination style yet. Follow-up changes
will clean up that implementation once this backend seam is in place.

Related to: LS-672

Signed-off-by: guillex <guillex@leil.io>