### PR TITLE
fix(mount): fix malloc trim thread naming

### DIFF
--- a/src/mount/sauna_client.cc
+++ b/src/mount/sauna_client.cc
@@ -122,10 +122,11 @@ struct ReaddirSession {
 std::jthread gMallocTrimThread;
 
 void mallocTrimThread(const std::stop_token& stop, unsigned mallocTrimePeriod_ms) {
-	if (pthread_setname_np(pthread_self(), "mallocTrimThread") != 0) {
+	int setname_result = pthread_setname_np(pthread_self(), "mallocTrimTh");
+	if (setname_result != 0) {
 		// If thread name was not set, log a warning
 		// This is not a fatal error, so we just log it
-		safs::log_warn("Failed to set malloc trim thread name: {}", strerror(errno));
+		safs::log_warn("Failed to set malloc trim thread name: {}", strerror(setname_result));
 	}
 
 	while (!stop.stop_requested()) {


### PR DESCRIPTION
The malloc trim thread naming was always failing due to be longer than the allowed length. This change fixes it by reducing the length below the allowed limit while preserving the meaning.

Signed-off-by: Dave <dave@leil.io>