### PR TITLE
fix: fix logger load failure

### DIFF
--- a/src/chunkserver/chunkserver-common/disk_plugin.cc
+++ b/src/chunkserver/chunkserver-common/disk_plugin.cc
@@ -29,7 +29,9 @@ DiskPlugin::~DiskPlugin() {}
 bool DiskPlugin::initialize() {
 	// Needed after upgrading to c++23
 	// https://github.com/gabime/spdlog/wiki/How-to-use-spdlog-in-DLLs
-	initializeLogger();
+	if (!initializeLogger()) {
+		return false;
+	}
 
 	// Also needed after upgrading to c++23
 	initializeEmptyBlockCrcForDisks();
@@ -37,13 +39,30 @@ bool DiskPlugin::initialize() {
 	return true;
 }
 
-void DiskPlugin::initializeLogger() {
-		logger_ = spdlog::get("syslog");
+bool DiskPlugin::initializeLogger() {
+	logger_ = spdlog::get("syslog");
 
-		if (!logger_) {
+	if (!logger_) {
+		// spdlog's registry can be per-shared-library when used as a
+		// header-only lib, so `get` may return null even though another
+		// module already registered "syslog". Catch the duplicate-name
+		// exception and fall back to `get` in that case.
+		try {
 			logger_ = spdlog::syslog_logger_mt("syslog");
+		} catch (const spdlog::spdlog_ex &e) {
+			logger_ = spdlog::get("syslog");
+
+			if (!logger_) {
+				safs::log_warn(
+				    "Disk plugin: failed to create or obtain 'syslog' spdlog logger after exception: {}",
+				    e.what());
+				return false;
+			}
 		}
 	}
+
+	return true;
+}
 
 std::string DiskPlugin::toString() {
 	return name() + " v" + SAUNAFS_PACKAGE_VERSION;

--- a/src/chunkserver/chunkserver-common/disk_plugin.h
+++ b/src/chunkserver/chunkserver-common/disk_plugin.h
@@ -36,7 +36,10 @@ public:
 	bool initialize() override;
 
 	/// Initializes the logger for this plugin.
-	void initializeLogger();
+	/// Returns true when logger initialization succeeds.
+	/// Returns false when logger initialization fails and callers should
+	/// treat the plugin initialization as failed.
+	bool initializeLogger();
 
 	/// Matches the versioning system of the other packages.
 	/// Override this method if you need to change the version for testing.


### PR DESCRIPTION
When the CS founds several plugins, there is a chance that even though the spdlog::get fails to get the "syslog" logger another module already create it and the upcoming try to create it triggers an exception and the chunkserver initialization fails.

The proposed fix catches the exception in the case syslog_logger_mt fails and tries to the get the logger again. If no logger was found logs a warning and signals a failed initialization.

Signed-off-by: Dave <dave@leil.io>