### PR TITLE
feat(kv,fdb): add async range reads

### DIFF
--- a/src/fdb/fdb.cc
+++ b/src/fdb/fdb.cc
@@ -18,24 +18,22 @@
 
 #include "common/platform.h"
 
-#include "fdb/fdb.h"
-
 #include <cstdint>
 #include <iterator>
+#include <memory>
 
 #include <foundationdb/fdb_c_types.h>
 
+#include "fdb/fdb.h"
 #include "fdb/fdb_future.h"
 #include "kv/kv_utils.h"
 #include "slogger/slogger.h"
 
 namespace fdb {
 
-const uint8_t *toU8(std::string_view str) {
-	return reinterpret_cast<const uint8_t *>(str.data());
-}
+const uint8_t *toU8(std::string_view str) { return reinterpret_cast<const uint8_t *>(str.data()); }
 
-//Static
+// Static
 
 fdb_error_t DB::selectAPIVersion(int version) { return fdb_select_api_version(version); }
 
@@ -108,7 +106,7 @@ std::unique_ptr<kv::IFuture> Transaction::getAsync(const kv::Key &key, bool snap
 	if (!tr_) { return nullptr; }
 
 	FDBFuture *future = fdb_transaction_get(tr_.get(), key.data(), static_cast<int>(key.size()),
-	                                         static_cast<fdb_bool_t>(snapshot));
+	                                        static_cast<fdb_bool_t>(snapshot));
 
 	return std::make_unique<FDBFutureValue>(future);
 }
@@ -117,7 +115,17 @@ kv::GetRangeResult Transaction::getRange(
     const kv::KeySelector &begin, const kv::KeySelector &end, int limit, int iteration /* = 0 */,
     bool snapshot /* = false */, bool reverse /* = false */,
     FDBStreamingMode streamingMode /* = FDB_STREAMING_MODE_SERIAL */) {
-	if (!tr_) { return {{}, false}; }
+	auto future = getRangeAsync(begin, end, limit, iteration, snapshot, reverse, streamingMode);
+	if (!future) { return {{}, false}; }
+
+	return future->get();
+}
+
+std::unique_ptr<kv::IRangeFuture> Transaction::getRangeAsync(
+    const kv::KeySelector &begin, const kv::KeySelector &end, int limit, int iteration /* = 0 */,
+    bool snapshot /* = false */, bool reverse /* = false */,
+    FDBStreamingMode streamingMode /* = FDB_STREAMING_MODE_SERIAL */) {
+	if (!tr_) { return nullptr; }
 
 	static constexpr int kBytesLimit = 0;
 
@@ -133,50 +141,13 @@ kv::GetRangeResult Transaction::getRange(
 	// FDB offsets are 1-based.
 	const int endOffset = 1 + end.getOffset();
 
-	UniqueFDBFuture future(fdb_transaction_get_range(
+	FDBFuture *future = fdb_transaction_get_range(
 	    tr_.get(), begin.getKey().data(), static_cast<int>(begin.getKey().size()), beginOrEqual,
 	    beginOffset, end.getKey().data(), static_cast<int>(end.getKey().size()), endOrEqual,
 	    endOffset, limit, kBytesLimit, streamingMode, iteration, static_cast<fdb_bool_t>(snapshot),
-	    static_cast<fdb_bool_t>(reverse)));
+	    static_cast<fdb_bool_t>(reverse));
 
-	auto error = fdb_future_block_until_ready(future.get());
-
-	if (error != 0) {
-		safs::log_err("Transaction::getRange: fdb_future_block_until_ready: error: {}",
-		              fdb_get_error(error));
-		return {{}, false};
-	}
-
-	const FDBKeyValue *keyValues;
-	int count = 0;
-	fdb_bool_t more = 0;
-
-	error = fdb_future_get_keyvalue_array(future.get(), &keyValues, &count, &more);
-
-	if (error != 0) {
-		safs::log_err("Transaction::getRange: fdb_future_get_keyvalue_array: error: {}",
-		              fdb_get_error(error));
-		return {{}, false};
-	}
-
-	std::vector<kv::KeyValuePair> pairs;
-	pairs.reserve(count);
-
-	for (int i = 0; i < count; ++i) {
-		kv::Key key(keyValues[i].key, keyValues[i].key + keyValues[i].key_length);
-		kv::Value value(keyValues[i].value, keyValues[i].value + keyValues[i].value_length);
-		pairs.emplace_back(std::move(key), std::move(value));
-	}
-
-	if (pairs.empty()) {
-		safs::log_info("Transaction::getRange: no keys found in range: {} - {}",
-		               kv::keyToEscapedAscii(begin.getKey()), kv::keyToEscapedAscii(end.getKey()));
-		return {{}, false};
-	}
-
-	kv::GetRangeResult result(std::move(pairs), more != 0);
-
-	return result;
+	return std::make_unique<FDBFutureRange>(future);
 }
 
 void Transaction::set(const kv::Key &key, const kv::Value &value) {

--- a/src/fdb/fdb.h
+++ b/src/fdb/fdb.h
@@ -171,10 +171,24 @@ public:
 	/// @param streamingMode The streaming mode to use for the range query.
 	/// @return GetRangeResult with key-value pairs and whether more results are available.
 	/// @note If the transaction is not valid, it returns an empty GetRangeResult
-	kv::GetRangeResult getRange(const kv::KeySelector &begin, const kv::KeySelector &end,
-	                            int limit, int iteration = 0, bool snapshot = false,
-	                            bool reverse = false,
+	kv::GetRangeResult getRange(const kv::KeySelector &begin, const kv::KeySelector &end, int limit,
+	                            int iteration = 0, bool snapshot = false, bool reverse = false,
 	                            FDBStreamingMode streamingMode = FDB_STREAMING_MODE_SERIAL);
+
+	/// Gets a range of keys and values asynchronously.
+	/// @param begin The starting key for the range.
+	/// @param end The ending key for the range.
+	/// @param limit The maximum number of key-value pairs to retrieve.
+	/// @param iteration The iteration number for streaming mode.
+	/// @param snapshot Whether to use a snapshot for the transaction.
+	/// @param reverse Whether to retrieve the range in reverse order.
+	/// @param streamingMode The streaming mode to use for the range query.
+	/// @return A future that will contain the range when ready.
+	/// @note The transaction must remain alive until the future's get() method is called.
+	std::unique_ptr<kv::IRangeFuture> getRangeAsync(
+	    const kv::KeySelector &begin, const kv::KeySelector &end, int limit, int iteration = 0,
+	    bool snapshot = false, bool reverse = false,
+	    FDBStreamingMode streamingMode = FDB_STREAMING_MODE_SERIAL);
 
 	/// Sets a value for a given key.
 	/// @param key The key to set the value for.

--- a/src/fdb/fdb_future.cc
+++ b/src/fdb/fdb_future.cc
@@ -18,8 +18,14 @@
 
 #include "common/platform.h"
 
-#include "fdb/fdb_future.h"
+#include <cassert>
+#include <iterator>
+#include <utility>
+#include <vector>
 
+#include <foundationdb/fdb_c_types.h>
+
+#include "fdb/fdb_future.h"
 #include "slogger/slogger.h"
 
 namespace fdb {
@@ -81,6 +87,68 @@ std::optional<kv::Value> FDBFutureValue::get(int *error) {
 
 	// Key not found
 	return std::nullopt;
+}
+
+FDBFutureRange::FDBFutureRange(FDBFuture *future) : future_(future) {}
+
+FDBFutureRange::~FDBFutureRange() {
+	if (future_ != nullptr) { fdb_future_destroy(future_); }
+}
+
+bool FDBFutureRange::isReady() {
+	if (future_ == nullptr) { return false; }
+
+	return fdb_future_is_ready(future_) != 0;
+}
+
+kv::GetRangeResult FDBFutureRange::get(int *error) {
+	// Return an empty result if already consumed or invalid.
+	if (consumed_ || future_ == nullptr) {
+		if (error != nullptr) { *error = 1; }
+		return {{}, false};
+	}
+
+	consumed_ = true;
+
+	fdb_error_t fdbError = fdb_future_block_until_ready(future_);
+
+	if (fdbError != 0) {
+		safs::log_err("FDBFutureRange::get: fdb_future_block_until_ready: error: {}",
+		              fdb_get_error(fdbError));
+		if (error != nullptr) { *error = static_cast<int>(fdbError); }
+		return {{}, false};
+	}
+
+	const FDBKeyValue *keyValues = nullptr;
+	int count = 0;
+	fdb_bool_t more = 0;
+
+	fdbError = fdb_future_get_keyvalue_array(future_, &keyValues, &count, &more);
+
+	if (fdbError != 0) {
+		safs::log_err("FDBFutureRange::get: fdb_future_get_keyvalue_array: error: {}",
+		              fdb_get_error(fdbError));
+		if (error != nullptr) { *error = static_cast<int>(fdbError); }
+		return {{}, false};
+	}
+
+	std::vector<kv::KeyValuePair> pairs;
+	pairs.reserve(count);
+
+	for (int i = 0; i < count; ++i) {
+		assert(keyValues[i].key != nullptr || keyValues[i].key_length == 0);
+		const auto *keyData = static_cast<const uint8_t *>(keyValues[i].key);
+		kv::Key key(keyData, keyData + keyValues[i].key_length);
+
+		assert(keyValues[i].value != nullptr || keyValues[i].value_length == 0);
+		const auto *valueData = static_cast<const uint8_t *>(keyValues[i].value);
+		kv::Value value(valueData, valueData + keyValues[i].value_length);
+
+		pairs.emplace_back(std::move(key), std::move(value));
+	}
+
+	if (error != nullptr) { *error = 0; }
+	return {std::move(pairs), more != 0};
 }
 
 }  // namespace fdb

--- a/src/fdb/fdb_future.h
+++ b/src/fdb/fdb_future.h
@@ -33,7 +33,7 @@ namespace fdb {
 /// Implements the kv::IFuture interface for asynchronous get operations.
 ///
 /// @note The transaction that created this future must remain alive until get() is called.
-/// @note This future is single-use: get() can only be called once successfully.
+/// @note This future is single-use: get() can only be called once.
 class FDBFutureValue final : public kv::IFuture {
 public:
 	/// Constructs a FDBFutureValue wrapping the given FDBFuture*.
@@ -58,6 +58,41 @@ public:
 	/// @return The value if successful and present, std::nullopt on error or if key not found.
 	/// @note This method can only be called once. Subsequent calls return std::nullopt.
 	std::optional<kv::Value> get(int *error = nullptr) override;
+
+private:
+	FDBFuture *future_;
+	bool consumed_ = false;
+};
+
+/// Wraps a FoundationDB range future (FDBFuture*) with RAII semantics.
+/// Implements the kv::IRangeFuture interface for asynchronous get_range operations.
+///
+/// @note The transaction that created this future must remain alive until get() is called.
+/// @note This future is single-use: get() can only be called once.
+class FDBFutureRange final : public kv::IRangeFuture {
+public:
+	/// Constructs a FDBFutureRange wrapping the given FDBFuture*.
+	/// @param future The FDB future to wrap. Takes ownership.
+	explicit FDBFutureRange(FDBFuture *future);
+
+	/// Destructor. Destroys the wrapped FDB future.
+	~FDBFutureRange() override;
+
+	// Non-copyable, non-movable
+	FDBFutureRange(const FDBFutureRange &) = delete;
+	FDBFutureRange &operator=(const FDBFutureRange &) = delete;
+	FDBFutureRange(FDBFutureRange &&) = delete;
+	FDBFutureRange &operator=(FDBFutureRange &&) = delete;
+
+	/// Checks if the future result is ready without blocking.
+	/// @return True if the result is ready, false otherwise.
+	bool isReady() override;
+
+	/// Blocks until the result is ready and retrieves the range.
+	/// @param error Optional pointer to store error code (0 on success, non-zero on error).
+	/// @return The range result, or an empty result on error.
+	/// @note This method can only be called once. Subsequent calls return an empty result.
+	kv::GetRangeResult get(int *error = nullptr) override;
 
 private:
 	FDBFuture *future_;

--- a/src/fdb/fdb_transaction.cc
+++ b/src/fdb/fdb_transaction.cc
@@ -16,8 +16,9 @@
    along with SaunaFS  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "fdb/fdb_transaction.h"
+#include "common/platform.h"
 
+#include "fdb/fdb_transaction.h"
 #include "kv/ifuture.h"
 
 namespace fdb {
@@ -45,6 +46,14 @@ kv::GetRangeResult FDBTransaction::getRange(const kv::KeySelector &start,
 	if (!tr_) { return {{}, false}; }
 
 	return tr_.getRange(start, end, limit);
+}
+
+std::unique_ptr<kv::IRangeFuture> FDBTransaction::getRangeAsync(const kv::KeySelector &start,
+                                                                const kv::KeySelector &end,
+                                                                int limit) {
+	if (!tr_) { return nullptr; }
+
+	return tr_.getRangeAsync(start, end, limit);
 }
 
 void FDBTransaction::set(const kv::Key &key, const kv::Value &value) {

--- a/src/fdb/fdb_transaction.h
+++ b/src/fdb/fdb_transaction.h
@@ -18,9 +18,10 @@
 
 #pragma once
 
-#include "kv/itransaction.h"
+#include "common/platform.h"
 
 #include "fdb/fdb.h"
+#include "kv/itransaction.h"
 
 namespace fdb {
 
@@ -67,6 +68,16 @@ public:
 	/// @param limit The maximum number of key-value pairs to retrieve.
 	kv::GetRangeResult getRange(const kv::KeySelector &start, const kv::KeySelector &end,
 	                            int limit = kv::kDefaultGetRangeLimit) override;
+
+	/// Retrieves a range of keys and values asynchronously.
+	/// @param start The starting key for the range.
+	/// @param end The ending key for the range.
+	/// @param limit The maximum number of key-value pairs to retrieve.
+	/// @return A future that will contain the range when ready.
+	/// @note The transaction must remain alive until the future's get() method is called.
+	std::unique_ptr<kv::IRangeFuture> getRangeAsync(const kv::KeySelector &start,
+	                                                const kv::KeySelector &end,
+	                                                int limit = kv::kDefaultGetRangeLimit) override;
 
 	/// Sets a value for a given key.
 	/// @param key The key to set the value for.

--- a/src/fdb/fdb_unittest.cc
+++ b/src/fdb/fdb_unittest.cc
@@ -18,17 +18,19 @@
 
 #include "common/platform.h"
 
+#include <gtest/gtest.h>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "fdb/fdb.h"
 #include "fdb/fdb_context.h"
 #include "fdb/fdb_kv_engine.h"
 #include "kv/ifuture.h"
 #include "kv/itransaction.h"
 #include "kv/kv_utils.h"
-
-#include <gtest/gtest.h>
-#include <cstddef>
-#include <cstdint>
-#include <vector>
 
 /// Fixture for testing the FDBKVEngine.
 /// Initializes the FoundationDB context and database connection before running tests.
@@ -231,6 +233,103 @@ TEST_F(FDBKVEngineTest, GetRangeWithOffsets) {
 	ASSERT_EQ(elementsWithOffsets.size(), kExpectedNumberOfElements);
 	ASSERT_EQ(elementsWithOffsets.front(), "key_13");  // Lexicographical order
 	ASSERT_EQ(elementsWithOffsets.back(), "key_17");
+}
+
+TEST_F(FDBKVEngineTest, GetRangeAsync) {
+	const auto prefix = kv::toBytes("async_range_key_");
+	const auto end = kv::prefixEnd(prefix);
+	kv::KeySelector startSelector(prefix, true, 0);
+	kv::KeySelector endSelector(end, true, 0);
+
+	constexpr size_t kNumKeys = 6;
+
+	{
+		auto transaction = kvEngine->createReadWriteTransaction();
+		transaction->removeRange(prefix, end);
+		ASSERT_TRUE(transaction->commit()) << "Failed to clear async range test keys.";
+	}
+
+	{
+		auto transaction = kvEngine->createReadWriteTransaction();
+		for (size_t i = 0; i < kNumKeys; ++i) {
+			std::string key = "async_range_key_" + std::to_string(i);
+			std::string value = "async_range_value_" + std::to_string(i);
+			transaction->set(kv::toBytes(key), kv::toBytes(value));
+		}
+		ASSERT_TRUE(transaction->commit()) << "Failed to seed async range test keys.";
+	}
+
+	{
+		auto transaction = kvEngine->createReadWriteTransaction();
+		auto syncResult = transaction->getRange(startSelector, endSelector, kNumKeys);
+		auto future = transaction->getRangeAsync(startSelector, endSelector, kNumKeys);
+		ASSERT_TRUE(future != nullptr) << "Failed to create async range future.";
+
+		int error = -1;
+		auto asyncResult = future->get(&error);
+		ASSERT_EQ(error, 0);
+		ASSERT_EQ(asyncResult.getPairs().size(), syncResult.getPairs().size());
+		ASSERT_EQ(asyncResult.hasMore(), syncResult.hasMore());
+		for (size_t i = 0; i < syncResult.getPairs().size(); ++i) {
+			ASSERT_EQ(asyncResult.getPairs()[i].key, syncResult.getPairs()[i].key);
+			ASSERT_EQ(asyncResult.getPairs()[i].value, syncResult.getPairs()[i].value);
+		}
+	}
+
+	{
+		auto transaction = kvEngine->createReadWriteTransaction();
+		auto future = transaction->getRangeAsync(startSelector, endSelector, 2);
+		ASSERT_TRUE(future != nullptr) << "Failed to create paginated async range future.";
+
+		int error = -1;
+		auto rangeResult = future->get(&error);
+		ASSERT_EQ(error, 0);
+		ASSERT_EQ(rangeResult.getPairs().size(), 2U);
+		ASSERT_TRUE(rangeResult.hasMore());
+
+		error = 0;
+		auto secondRead = future->get(&error);
+		ASSERT_NE(error, 0);
+		ASSERT_TRUE(secondRead.getPairs().empty());
+		ASSERT_FALSE(secondRead.hasMore());
+	}
+
+	{
+		auto transaction = kvEngine->createReadWriteTransaction();
+		kv::KeySelector secondPageStart(kv::toBytes("async_range_key_2"), true, 0);
+
+		auto firstFuture = transaction->getRangeAsync(startSelector, endSelector, 2);
+		auto secondFuture = transaction->getRangeAsync(secondPageStart, endSelector, 2);
+		ASSERT_TRUE(firstFuture != nullptr && secondFuture != nullptr)
+		    << "Failed to create multiple async range futures.";
+
+		int firstError = -1;
+		int secondError = -1;
+		auto firstResult = firstFuture->get(&firstError);
+		auto secondResult = secondFuture->get(&secondError);
+
+		ASSERT_EQ(firstError, 0);
+		ASSERT_EQ(secondError, 0);
+		ASSERT_EQ(firstResult.getPairs().size(), 2U);
+		ASSERT_EQ(secondResult.getPairs().size(), 2U);
+		ASSERT_EQ(firstResult.getPairs().front().key, kv::toBytes("async_range_key_0"));
+		ASSERT_EQ(secondResult.getPairs().front().key, kv::toBytes("async_range_key_2"));
+	}
+
+	{
+		auto transaction = kvEngine->createReadWriteTransaction();
+		auto missingPrefix = kv::toBytes("async_range_missing_");
+		auto future =
+		    transaction->getRangeAsync(kv::KeySelector(missingPrefix, true, 0),
+		                               kv::KeySelector(kv::prefixEnd(missingPrefix), true, 0));
+		ASSERT_TRUE(future != nullptr) << "Failed to create empty async range future.";
+
+		int error = -1;
+		auto rangeResult = future->get(&error);
+		ASSERT_EQ(error, 0);
+		ASSERT_TRUE(rangeResult.getPairs().empty());
+		ASSERT_FALSE(rangeResult.hasMore());
+	}
 }
 
 TEST_F(FDBKVEngineTest, RemoveRange) {

--- a/src/kv/ifuture.h
+++ b/src/kv/ifuture.h
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include "common/platform.h"
+
 #include <optional>
 
 #include "kv/kv_types.h"
@@ -27,7 +29,7 @@ namespace kv {
 /// Interface for asynchronous future results from key-value operations.
 /// Provides methods to check readiness and retrieve values from pending operations.
 ///
-/// @note This future is single-use: get() can only be called once successfully.
+/// @note This future is single-use: get() can only be called once.
 /// @note The transaction that created this future must remain alive until get() is called.
 class IFuture {
 public:
@@ -52,6 +54,35 @@ public:
 
 protected:
 	IFuture() = default;
+};
+
+/// Interface for asynchronous future results from key-value range operations.
+///
+/// @note This future is single-use: get() can only be called once.
+/// @note The transaction that created this future must remain alive until get() is called.
+class IRangeFuture {
+public:
+	virtual ~IRangeFuture() = default;
+
+	// Non-copyable, non-movable
+	IRangeFuture(const IRangeFuture &) = delete;
+	IRangeFuture &operator=(const IRangeFuture &) = delete;
+	IRangeFuture(IRangeFuture &&) = delete;
+	IRangeFuture &operator=(IRangeFuture &&) = delete;
+
+	/// Checks if the future result is ready without blocking.
+	/// @return True if the result is ready, false otherwise.
+	virtual bool isReady() = 0;
+
+	/// Blocks until the result is ready and retrieves the range.
+	/// @param error Optional pointer to store error code (0 on success, non-zero on error).
+	/// @return The range result, or an empty result on error.
+	/// @note This method can only be called once. Subsequent calls return an empty result.
+	/// @note The caller must keep the transaction alive until this method returns.
+	virtual GetRangeResult get(int *error = nullptr) = 0;
+
+protected:
+	IRangeFuture() = default;
 };
 
 }  // namespace kv

--- a/src/kv/itransaction.h
+++ b/src/kv/itransaction.h
@@ -18,24 +18,19 @@
 
 #pragma once
 
+#include "common/platform.h"
+
 #include <cstdint>
 #include <cstring>
 #include <memory>
 #include <optional>
-#include <vector>
 
-#include "kv/kv_utils.h"
+#include "kv/kv_types.h"
 
 namespace kv {
 
 class IFuture;
-
-/// Represents a key-value pair in the key-value store.
-/// Keys and values are stored as vectors of bytes.
-struct KeyValuePair {
-	Key key;
-	Value value;
-};
+class IRangeFuture;
 
 /// Represents a key selector for range queries.
 class KeySelector {
@@ -56,23 +51,6 @@ private:
 	Key key_;         ///< The key for this selector.
 	bool inclusive_;  ///< Whether the key is inclusive in the range.
 	int offset_;      ///< Offset for the key selector, used for pagination in range queries.
-};
-
-/// Result of a range query with information if there are more results available.
-class GetRangeResult {
-public:
-	GetRangeResult(std::vector<KeyValuePair> pairs, bool hasMore)
-	    : pairs_(std::move(pairs)), hasMore_(hasMore) {}
-
-	/// Returns the key-value pairs in the result.
-	const std::vector<KeyValuePair> &getPairs() const { return pairs_; }
-
-	/// Returns whether there are more results available.
-	bool hasMore() const { return hasMore_; }
-
-private:
-	std::vector<KeyValuePair> pairs_;  ///< The key-value pairs retrieved in the range query.
-	bool hasMore_{false};              ///< True if more results are available beyond this range.
 };
 
 constexpr int kDefaultGetRangeLimit = 1000;
@@ -118,6 +96,16 @@ public:
 	/// @param limit The maximum number of key-value pairs to retrieve.
 	virtual GetRangeResult getRange(const KeySelector &start, const KeySelector &end,
 	                                int limit = kDefaultGetRangeLimit) = 0;
+
+	/// Retrieves a range of keys and values asynchronously.
+	/// @param start The starting key for the range.
+	/// @param end The ending key for the range.
+	/// @param limit The maximum number of key-value pairs to retrieve.
+	/// @return A future that will contain the range when ready.
+	/// @note The transaction must remain alive until the future's get() method is called.
+	virtual std::unique_ptr<IRangeFuture> getRangeAsync(const KeySelector &start,
+	                                                    const KeySelector &end,
+	                                                    int limit = kDefaultGetRangeLimit) = 0;
 
 protected:
 	IReadOnlyTransaction() = default;

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -21,6 +21,7 @@
 #include "common/platform.h"
 
 #include <cstdint>
+#include <utility>
 #include <vector>
 
 namespace kv {
@@ -28,5 +29,29 @@ namespace kv {
 using Bytes = std::vector<uint8_t>;
 using Key = Bytes;
 using Value = Bytes;
+
+/// Represents a key-value pair in the key-value store.
+/// Keys and values are stored as vectors of bytes.
+struct KeyValuePair {
+	Key key;
+	Value value;
+};
+
+/// Result of a range query with information if there are more results available.
+class GetRangeResult {
+public:
+	GetRangeResult(std::vector<KeyValuePair> pairs, bool hasMore)
+	    : pairs_(std::move(pairs)), hasMore_(hasMore) {}
+
+	/// Returns the key-value pairs in the result.
+	const std::vector<KeyValuePair> &getPairs() const { return pairs_; }
+
+	/// Returns whether there are more results available.
+	bool hasMore() const { return hasMore_; }
+
+private:
+	std::vector<KeyValuePair> pairs_;  ///< The key-value pairs retrieved in the range query.
+	bool hasMore_{false};              ///< True if more results are available beyond this range.
+};
 
 }  // namespace kv


### PR DESCRIPTION
Move range result types into kv_types and add IRangeFuture to the KV transaction interface. Implement FDB range futures and route the synchronous FDB getRange path through the async implementation.

Add FDB coverage for normal, empty, paginated, multiple-pending, and single-use async range reads.

Related to: LS-672

Signed-off-by: guillex <guillex@leil.io>