### PR TITLE
fix(master): persist snapshot mutations on KV

### DIFF
--- a/src/master/snapshot_task.cc
+++ b/src/master/snapshot_task.cc
@@ -260,7 +260,15 @@ int SnapshotTask::cloneNode(uint32_t ts) {
 	assert(dst_node);
 	fsnodes_update_checksum(dst_node);
 	fsnodes_update_checksum(dst_parent);
+
+	// Persist post-createNode in-memory mutations on KV backends.
+	if (fsOpContext.hasReadWriteTransaction()) {
+		gFSOperations->nodeOperations()->updateNode(fsOpContext, dst_node);
+		gFSOperations->nodeOperations()->updateNode(fsOpContext, dst_parent);
+	}
+
 	emitChangelog(fsOpContext, ts, dst_node->id);
+
 	if (dst_inode_ != 0 && dst_inode_ != dst_node->id) {
 		return SAUNAFS_ERROR_MISMATCH;
 	}


### PR DESCRIPTION
cloneNode mutates the destination node in memory after createNode (chunks, length, goal, trashtime, mode/uid/gid/times, symlink path, device rdev) but never flushed those changes. In-memory backends treat the mutation itself as persistence, so the legacy backend was unaffected. On KV backends the post-createNode mutations were discarded at commit, producing 0-byte snapshot files (chunks empty, length 0).

Call updateNode on dst_node and dst_parent at the end of cloneNode, gated on a real RW transaction (matching the existing commit guard). The base implementation is a no-op so legacy backends keep working.

Unblocks/fixes test FDBTests.test_san_snapshot in the MDS.

Related to: LS-720