### PR TITLE
refactor(master): route ACL mode sync through node ops

### DIFF
--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -1985,12 +1985,7 @@ void FilesystemNodeOperationsBase::setExtraAttrRecursive(
 		if (newExtraAttr != (node->mode >> EATTR_BIT_OFFSET)) {
 			node->mode =
 			    (node->mode & kPermissionsMask) | (((uint16_t)newExtraAttr) << EATTR_BIT_OFFSET);
-			const RichACL *nodeAcl = gMetadata->aclStorage.get(node->id);
-
-			if (nodeAcl != nullptr) {
-				gMetadata->aclStorage.setMode(node->id, node->mode,
-				                              node->type == FSNodeType::kDirectory);
-			}
+			syncAclWithMode(fsOpContext, node);
 
 			(*modifiedINodesOut)++;
 			updateCTime(fsOpContext, node, timeStamp);
@@ -2056,6 +2051,11 @@ uint8_t FilesystemNodeOperationsBase::deleteAcl(
 	fsnodes_update_checksum(node);
 
 	return SAUNAFS_STATUS_OK;
+}
+
+void FilesystemNodeOperationsBase::syncAclWithMode(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, FSNode *node) {
+	gMetadata->aclStorage.setMode(node->id, node->mode, node->type == FSNodeType::kDirectory);
 }
 
 #ifndef METARESTORE

--- a/src/master/filesystem_node.h
+++ b/src/master/filesystem_node.h
@@ -217,6 +217,10 @@ public:
 	uint8_t deleteAcl(const FilesystemOperationContext &fsOpContext, FSNode *node, AclType type,
 	                  uint32_t timeStamp) override;
 
+	/// Re-aligns a node's stored ACL with the standard permission bits in node->mode.
+	/// @see IFilesystemNodeOperations::syncAclWithMode
+	void syncAclWithMode(const FilesystemOperationContext &fsOpContext, FSNode *node) override;
+
 	// Recursive operations
 #ifndef METARESTORE
 	void getGoalRecursive(const FilesystemOperationContext &fsOpContext, FSNode *node,

--- a/src/master/filesystem_node_operations_interface.h
+++ b/src/master/filesystem_node_operations_interface.h
@@ -558,6 +558,17 @@ public:
 	virtual uint8_t deleteAcl(const FilesystemOperationContext &fsOpContext, FSNode *node,
 	                          AclType type, uint32_t timeStamp) = 0;
 
+	/// Re-aligns a node's stored ACL with the standard permission bits in node->mode.
+	///
+	/// Ensures the (node->mode & kStandardPermissionsMask) == acl.getMode() invariant
+	/// holds after a mode change. No-op when the node has no stored ACL.
+	///
+	/// @param fsOpContext The filesystem operation context (transaction).
+	/// @param node The node whose stored ACL must be re-aligned with node->mode.
+	/// @note In-memory backend: updates the in-process AclStorage cache.
+	/// @note KV backends: read-modify-write the persisted ACL in the same transaction.
+	virtual void syncAclWithMode(const FilesystemOperationContext &fsOpContext, FSNode *node) = 0;
+
 	// Recursive operations
 #ifndef METARESTORE
 	virtual void getGoalRecursive(const FilesystemOperationContext &fsOpContext, FSNode *node,

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -1583,7 +1583,7 @@ uint8_t FilesystemOperationsBase::setAttr(const FsContext &context,
 	}
 	if (setmask & SET_MODE_FLAG) {
 		node->mode = (attrmode & 07777) | (node->mode & 0xF000);
-		gMetadata->aclStorage.setMode(node->id, node->mode, node->type == FSNodeType::kDirectory);
+		nodeOperations_->syncAclWithMode(fsOpContext, node);
 	}
 	if (setmask & (SET_UID_FLAG | SET_GID_FLAG)) {
 		nodeOperations_->changeUidGid(fsOpContext, node,
@@ -1627,7 +1627,7 @@ uint8_t FilesystemOperationsBase::applyAttr(const FilesystemOperationContext &fs
 	if (mode > 07777) { return SAUNAFS_ERROR_EINVAL; }
 
 	node->mode = mode | (node->mode & 0xF000);
-	gMetadata->aclStorage.setMode(node->id, node->mode, node->type == FSNodeType::kDirectory);
+	nodeOperations_->syncAclWithMode(fsOpContext, node);
 	if (node->uid != uid || node->gid != gid) {
 		nodeOperations_->changeUidGid(fsOpContext, node, uid, gid);
 	}


### PR DESCRIPTION
Let metadata backends handle ACL updates after mode changes so KV backends can preserve the mode/ACL invariant.

Related to: LS-720

Signed-off-by: guillex <guillex@leil.io>