### PR TITLE
fix(master): fix session id init and test wait

### DIFF
--- a/src/master/filesystem.cc
+++ b/src/master/filesystem.cc
@@ -295,6 +295,7 @@ int fs_loadall(bool isFromInit = true) {
 
 	gChunkIdGenerator->initialize();
 	gInodeIdGenerator->initialize();
+	if (gSessionIdGenerator) { gSessionIdGenerator->initialize(); }
 
 	{
 		auto scopedTimer = util::ScopedTimer("metadata load time");

--- a/tests/tools/foundationdb.sh
+++ b/tests/tools/foundationdb.sh
@@ -95,8 +95,9 @@ function start_fdb_cluster() {
 
 	create_config_file
 
-	# Start FoundationDB with required sudo privileges
-	sudo /usr/lib/foundationdb/fdbmonitor --conffile "${workspace}/conf/foundationdb.conf" &
+	# Start FoundationDB with required sudo privileges. Detach via a subshell so the
+	# test shell's bare `wait` does not block on this long-running daemon.
+	( sudo /usr/lib/foundationdb/fdbmonitor --conffile "${workspace}/conf/foundationdb.conf" & )
 
 	# Ensure cluster is configured
 	fdbcli --exec "configure new single memory" --cluster-file "${workspace}/conf/fdb.cluster"


### PR DESCRIPTION
Two independent fixes that together unblock three SanityChecks sourced for FDB
in the MDS (libsaunafs_client_example, oplog_gid, read_cache_consistency).

Related to: LS-720

Signed-off-by: guillex <guillex@leil.io>