### PR TITLE
perf: multi-buffer write batching

### DIFF
--- a/src/chunkserver/bgjobs.cc
+++ b/src/chunkserver/bgjobs.cc
@@ -665,10 +665,17 @@ uint32_t job_prefetch(ClientJobPool &jobPool, uint64_t chunkId, ChunkPartType ch
 }
 
 uint32_t job_write(ClientJobPool &jobPool, JobPool::JobCallback callback, uint64_t chunkId,
-                   uint32_t chunkVersion, ChunkPartType chunkType, InputBuffer *inputBuffer,
-                   uint32_t listenerId) {
+                   uint32_t chunkVersion, ChunkPartType chunkType,
+                   std::vector<InputBuffer *> inputBuffers, uint32_t listenerId) {
 	JobPool::ProcessJobCallback processJob = [=]() -> uint8_t {
-		auto writeOperations = inputBuffer->getWriteOperations();
+		if (inputBuffers.empty()) {
+			safs::log_warn("job_write: No input buffers found for chunk id {}", chunkId);
+			return SAUNAFS_STATUS_OK;
+		}
+
+		uint32_t totalBlocks = 0;
+		auto writeOperations = InputBuffer::getWriteOperations(inputBuffers, totalBlocks);
+
 		if (writeOperations.empty()) {
 			safs::log_warn("job_write: No write operations found for chunk id {}", chunkId);
 			return SAUNAFS_STATUS_OK;
@@ -685,20 +692,24 @@ uint32_t job_write(ClientJobPool &jobPool, JobPool::JobCallback callback, uint64
 
 			if (op.offset == 0 && op.size == SFSBLOCKSIZE) {
 				// Full blocks write
-				if (op.startBlock > op.endBlock) {
-					safs::log_warn(
-					    "job_write: startBlock {} > endBlock {} for chunk id {}. This is not "
-					    "supported.",
-					    op.startBlock, op.endBlock, chunkId);
+				uint32_t numBlocks = 0;
+				for (auto blocks : op.blocksPerBuffer) { numBlocks += blocks; }
+
+				// Make sure numBlocks does not exceed uint16_t max, as that's the maximum we can
+				// handle in one write
+				if (numBlocks > std::numeric_limits<uint16_t>::max()) {
+					safs::log_err(
+					    "job_write: Too many blocks ({}) in write operation for chunk id {}",
+					    numBlocks, chunkId);
 					statuses.push_back(SAUNAFS_ERROR_EINVAL);
 					break;
 				}
 
-				auto numBlocks = op.endBlock - op.startBlock + 1;
-				auto bytesWritten = hddChunkWriteFullBlocks(
-				    chunkId, chunkVersion, chunkType, op.startBlock, numBlocks, op.crcs, op.buffer);
+				auto bytesWritten =
+				    hddChunkWriteFullBlocks(chunkId, chunkVersion, chunkType, op.startBlock,
+				                            numBlocks, op.crcs, op.blocksPerBuffer, op.buffers);
 
-				if (bytesWritten != numBlocks * SFSBLOCKSIZE) {
+				if (bytesWritten != static_cast<int>(numBlocks * SFSBLOCKSIZE)) {
 					if (bytesWritten < 0) {
 						statuses.push_back(-bytesWritten);
 						break;
@@ -717,32 +728,32 @@ uint32_t job_write(ClientJobPool &jobPool, JobPool::JobCallback callback, uint64
 					}
 				} else {
 					// All blocks written successfully
-					for (uint16_t i = 0; i < numBlocks; ++i) {
+					for (uint32_t i = 0; i < numBlocks; ++i) {
 						statuses.push_back(SAUNAFS_STATUS_OK);
 					}
 				}
 			} else {
-				// Not a full block write
-				if (op.startBlock != op.endBlock) {
-					safs::log_warn(
-					    "job_write: startBlock {} != endBlock {} for chunk id {} when not full "
-					    "blocks. This is not supported, doing first block only.",
-					    op.startBlock, op.endBlock, chunkId);
-				}
-
 				statuses.push_back(hddChunkWriteBlock(chunkId, chunkVersion, chunkType,
 				                                      op.startBlock, op.offset, op.size, op.crcs[0],
-				                                      op.buffer));
+				                                      op.buffers[0]));
 
 				if (statuses.back() != SAUNAFS_STATUS_OK) { break; }
 			}
 		}
 
-		inputBuffer->applyStatuses(statuses);
+		if (statuses.empty()) {
+			safs::log_warn("job_write: No write operations were processed for chunk id {}", chunkId);
+			return SAUNAFS_STATUS_OK;
+		}
+
+		if (statuses.size() < totalBlocks) { statuses.resize(totalBlocks, statuses.back()); }
+		assert(statuses.size() == totalBlocks);
+
+		InputBuffer::applyStatuses(inputBuffers, statuses);
 
 		if (!statuses.empty() && statuses.back() != SAUNAFS_STATUS_OK) {
-			safs::log_err("Failed to write chunk id {}: {}", chunkId,
-			              saunafs_error_string(statuses.back()));
+			safs::log_warn("Failed to write chunk id {}: {}", chunkId,
+			               saunafs_error_string(statuses.back()));
 		}
 
 		return statuses.empty() ? static_cast<uint8_t>(SAUNAFS_STATUS_OK) : statuses.back();

--- a/src/chunkserver/bgjobs.h
+++ b/src/chunkserver/bgjobs.h
@@ -543,16 +543,13 @@ uint32_t job_prefetch(ClientJobPool &jobPool, uint64_t chunkId, ChunkPartType ch
 /// @param chunkId The ID of the chunk.
 /// @param chunkVersion The version of the chunk.
 /// @param chunkType The type of the chunk.
-/// @param blockNum The block number to write.
-/// @param offset The offset to write to.
-/// @param size The size to write.
-/// @param crc The CRC of the data.
-/// @param buffer The data buffer to write.
+/// @param inputBuffers The input buffers containing the data, offsets, block indexes and CRCs to be
+/// written.
 /// @param listenerId The ID of the listener associated with the job.
 /// @return The ID of the added job.
 uint32_t job_write(ClientJobPool &jobPool, JobPool::JobCallback callback, uint64_t chunkId,
-                   uint32_t chunkVersion, ChunkPartType chunkType, InputBuffer *inputBuffer,
-                   uint32_t listenerId = 0);
+                   uint32_t chunkVersion, ChunkPartType chunkType,
+                   std::vector<InputBuffer *> inputBuffers, uint32_t listenerId = 0);
 
 /// @brief Adds a get blocks job to the ClientJobPool.
 ///

--- a/src/chunkserver/chunk_file_creator.cc
+++ b/src/chunkserver/chunk_file_creator.cc
@@ -74,8 +74,10 @@ void ChunkFileCreator::write(const uint8_t *buffer, uint16_t startBlock, uint16_
                              std::vector<uint32_t> &crc) {
 	assert(is_open_ && !is_commited_ && chunk_);
 	auto *crcData = gOpenChunks.getResource(chunk_->metaFD()).crcData();
+	std::vector<uint16_t> blocksPerBuffer = {numBlocks};
+	std::vector<const uint8_t *> buffers = {buffer};
 	int writtenBytes = chunk_->owner()->writeChunkBlocks(chunk_, 0, startBlock, numBlocks, crc,
-	                                                     crcData, buffer, true);
+	                                                     crcData, blocksPerBuffer, buffers, true);
 	if (writtenBytes != static_cast<int>(numBlocks * SFSBLOCKSIZE)) {
 		if (writtenBytes < 0) {
 			int status = -writtenBytes;

--- a/src/chunkserver/chunk_high_level_ops.cc
+++ b/src/chunkserver/chunk_high_level_ops.cc
@@ -406,10 +406,12 @@ void WriteHighLevelOp::startNextWriteJob() {
 
 	/// Start the next write job: it is always the first write data buffer
 	writeJobWriteId_ = writeDataBuffers_.front()->getLastWriteId();
+	enqueuedInputBuffers_ = 1;
+	std::vector<InputBuffer *> inputBuffers = {writeDataBuffers_.front().get()};
 	writeJobId_ = job_write(
 	    *workerJobPool(),
 	    [this](uint8_t status, void *entry) { this->writeFinishedCallback(status, entry); },
-	    chunkId_, chunkVersion_, chunkType_, writeDataBuffers_.front().get());
+	    chunkId_, chunkVersion_, chunkType_, inputBuffers);
 }
 
 void WriteHighLevelOp::writeCurrentInputPacket() {
@@ -440,32 +442,29 @@ void WriteHighLevelOp::writeFinishedCallback(uint8_t status, void * /*entry*/) {
 	}
 	setNoWriteJobBeingProcessed();
 
-	if (writeDataBuffers_.empty()) {
-		// This should not happen, but if it does, we can just log and continue.
-		// The write job should not have been started if there were no buffers, so this is an
-		// inconsistent state.
-		safs::log_err(
-		    "({}) No write data buffers available after write finished for chunkId {:016X}.",
-		    __func__, chunkId_);
+	std::vector<std::pair<uint8_t, uint32_t>> statusWithWriteIdToReply;
+	uint16_t alreadyRepliedBlocks = 0;
+	while (enqueuedInputBuffers_ > 0) {
+		assert(!writeDataBuffers_.empty());
 
-		if (inDelayedClose_) {
-			decreasePendingWriteJobsToCheckAndApplyClosedOnParent();
+		auto statusWithWriteIdToReplyCurrentBuffer = writeDataBuffers_.front()->getStatuses();
+		statusWithWriteIdToReply.insert(statusWithWriteIdToReply.end(),
+		                                statusWithWriteIdToReplyCurrentBuffer.begin(),
+		                                statusWithWriteIdToReplyCurrentBuffer.end());
+		uint16_t alreadyRepliedBlocksBuffer = writeDataBuffers_.front()->repliedBlocks;
+		alreadyRepliedBlocks += alreadyRepliedBlocksBuffer;
+
+		if (alreadyRepliedBlocksBuffer > 0) {
+			// This means that this write data buffer has already been replied to for some blocks,
+			// so we need to remove the input buffer from the container that patches read
+			// operations.
+			hddRemoveAlreadyRepliedInputBuffer(chunkId_, chunkType_, writeDataBuffers_.front());
 		}
 
-		return;
+		getWriteInputBufferPool().put(std::move(writeDataBuffers_.front()));
+		writeDataBuffers_.pop_front();
+		enqueuedInputBuffers_--;
 	}
-
-	auto statusWithWriteIdToReply = writeDataBuffers_.front()->getStatuses();
-	uint16_t alreadyRepliedBlocks = writeDataBuffers_.front()->repliedBlocks;
-
-	if (alreadyRepliedBlocks > 0) {
-		// This means that this write data buffer has already been replied to for some blocks, so we
-		// need to remove the input buffer from the container that patches read operations.
-		hddRemoveAlreadyRepliedInputBuffer(chunkId_, chunkType_, writeDataBuffers_.front());
-	}
-
-	getWriteInputBufferPool().put(std::move(writeDataBuffers_.front()));
-	writeDataBuffers_.pop_front();
 
 	for (const auto &[status, writeId] : statusWithWriteIdToReply) {
 		if (alreadyRepliedBlocks == 0) {
@@ -652,8 +651,9 @@ void WriteHighLevelOp::delayedClose() {
 	// Input buffer now is null
 	assert(inputBuffer_ == nullptr);
 
-	// Drop write data buffers with no replied blocks
-	while (writeDataBuffers_.size() > (isWriteJobBeingProcessed() ? 1 : 0) &&
+	// Drop write data buffers with no replied blocks, and keep at least the amount input buffers
+	// that are currently enqueued in write jobs
+	while (writeDataBuffers_.size() > enqueuedInputBuffers_ &&
 	       writeDataBuffers_.back()->repliedBlocks == 0) {
 		getWriteInputBufferPool().put(std::move(writeDataBuffers_.back()));
 		writeDataBuffers_.pop_back();
@@ -683,6 +683,7 @@ void WriteHighLevelOp::cleanup() {
 		getWriteInputBufferPool().put(std::move(writeDataBuffers_.front()));
 		writeDataBuffers_.pop_front();
 	}
+	enqueuedInputBuffers_ = 0;
 
 	if (inputBuffer_ != nullptr) {
 		/// Drop the input buffer, it won't be used anymore

--- a/src/chunkserver/chunk_high_level_ops.h
+++ b/src/chunkserver/chunk_high_level_ops.h
@@ -353,6 +353,8 @@ protected:
 	uint8_t untoldStatus_ = SAUNAFS_STATUS_OK;  ///< Untold status to be sent to master at cleanup.
 	uint32_t writeJobId_ = 0;                   ///< ID of the current write job being processed
 	uint32_t writeJobWriteId_ = 0;              ///< Specific write operation from client
+	/// Number of input buffers currently enqueued in write jobs
+	uint16_t enqueuedInputBuffers_ = 0;
 	std::shared_ptr<InputBuffer> inputBuffer_ = nullptr;  ///< Buffer for the current write job
 	/// writeJobWriteId's which:
 	/// - have been completed by our worker, but need ack from the next

--- a/src/chunkserver/chunkserver-common/cmr_disk.cc
+++ b/src/chunkserver/chunkserver-common/cmr_disk.cc
@@ -25,6 +25,7 @@
 #include <linux/falloc.h>
 #include <sys/stat.h>
 #include <sys/statvfs.h>
+#include <sys/uio.h>
 #include <filesystem>
 
 #include "chunkserver-common/chunk_interface.h"
@@ -367,31 +368,68 @@ int CmrDisk::writePartialBlockAndCrc(IChunk *chunk, const uint8_t *buffer,
 	return size;
 }
 
-int CmrDisk::writeFullBlocksAndCrcs(IChunk *chunk, const uint8_t *buffer, uint16_t startBlock,
-                                    uint16_t numBlocks, const uint8_t *crcBuff, uint8_t *crcData,
+int CmrDisk::writeFullBlocksAndCrcs(IChunk *chunk, const std::vector<uint16_t> &blocksPerBuffer,
+                                    const std::vector<const uint8_t *> &buffers,
+                                    uint16_t startBlock, const uint8_t *crcBuff, uint8_t *crcData,
                                     bool areNewBlocks, const char *errorMsg) {
 	(void)areNewBlocks;
+	assert(blocksPerBuffer.size() == buffers.size());
 
-	uint32_t size = numBlocks * SFSBLOCKSIZE;
-	{
-		DiskWriteStatsUpdater updater(chunk->owner(), size);
+	constexpr size_t kMaxIovecsPerCall = 16;
+	std::array<struct iovec, kMaxIovecsPerCall> ioVectors{};
 
-		auto ret = pwrite(chunk->dataFD(), buffer, size, chunk->getBlockOffset(startBlock));
-
-		if (ret != size) {
-			hddAddErrorAndPreserveErrno(chunk);
-			safs::log_warn("{}: file:{} - write error", errorMsg, chunk->fullDataFilename());
-			hddReportDamagedChunk(chunk->id(), chunk->type());
-			updater.markWriteAsFailed();
-			return -1;
+	size_t buffersWritten = 0;
+	uint16_t blockCursor = startBlock;
+	uint32_t committedBytes = 0;
+	while (buffersWritten < buffers.size()) {
+		const size_t batchEnd = std::min(buffersWritten + kMaxIovecsPerCall, buffers.size());
+		size_t size = 0;
+		for (size_t j = buffersWritten; j < batchEnd; ++j) {
+			// const_cast is needed because POSIX struct iovec is not const-correct for write-style
+			// syscalls.
+			ioVectors[j - buffersWritten].iov_base = const_cast<uint8_t *>(buffers[j]);
+			ioVectors[j - buffersWritten].iov_len =
+			    static_cast<size_t>(blocksPerBuffer[j]) * SFSBLOCKSIZE;
+			size += ioVectors[j - buffersWritten].iov_len;
 		}
+
+		const off_t offset = chunk->getBlockOffset(blockCursor);
+		{
+			DiskWriteStatsUpdater updater(chunk->owner(), size);
+
+			ssize_t ret = 0;
+			do {
+				ret = pwritev(chunk->dataFD(), ioVectors.data(), batchEnd - buffersWritten, offset);
+			} while (ret < 0 && errno == EINTR);
+
+			if (ret != static_cast<ssize_t>(size)) {
+				hddAddErrorAndPreserveErrno(chunk);
+				safs::log_warn("{}: file:{} - write error", errorMsg, chunk->fullDataFilename());
+				hddReportDamagedChunk(chunk->id(), chunk->type());
+				updater.markWriteAsFailed();
+				return -1;  // damaged chunk, caller should handle it
+			}
+		}
+		// Successfully written the batch, now punch holes in the blocks that are fully zero and
+		// update CRCs
+		uint16_t blocksWritten = size / SFSBLOCKSIZE;
+
+		uint16_t blockCursorPunchHoles = blockCursor;
+		for (size_t i = 0; i < batchEnd - buffersWritten; ++i) {
+			punchHoles(chunk, static_cast<const uint8_t *>(ioVectors[i].iov_base),
+			           chunk->getBlockOffset(blockCursorPunchHoles), ioVectors[i].iov_len);
+			blockCursorPunchHoles += blocksPerBuffer[buffersWritten + i];
+		}
+
+		memcpy(crcData + blockCursor * kCrcSize, crcBuff + (blockCursor - startBlock) * kCrcSize,
+		       kCrcSize * blocksWritten);
+
+		blockCursor += blocksWritten;
+		buffersWritten = batchEnd;
+		committedBytes += size;
 	}
 
-	punchHoles(chunk, buffer, chunk->getBlockOffset(startBlock), size);
-
-	memcpy(crcData + startBlock * kCrcSize, crcBuff, kCrcSize * numBlocks);
-
-	return size;
+	return committedBytes;
 }
 
 void CmrDisk::punchHoles(IChunk *chunk, const uint8_t *buffer, uint32_t offset,
@@ -597,8 +635,10 @@ int CmrDisk::writeChunkBlock(IChunk *chunk, uint32_t version, uint16_t blocknum,
 
 int CmrDisk::writeChunkBlocks(IChunk *chunk, uint32_t version, uint16_t startBlock,
                               uint16_t numBlocks, std::vector<uint32_t> &crc, uint8_t *crcData,
-                              const uint8_t *buffer, bool isFromReplication) {
+                              const std::vector<uint16_t> &blocksPerBuffer,
+                              const std::vector<const uint8_t *> &buffers, bool isFromReplication) {
 	assert(chunk);
+	assert(blocksPerBuffer.size() == buffers.size());
 	LOG_AVG_TILL_END_OF_SCOPE0("writeChunkBlocks");
 	TRACETHIS3(chunk->id(), startBlock, numBlocks);
 
@@ -613,9 +653,15 @@ int CmrDisk::writeChunkBlocks(IChunk *chunk, uint32_t version, uint16_t startBlo
 	}
 
 	if (gCheckCrcWhenWriting && !isFromReplication) {
-		for (uint16_t i = 0; i < numBlocks; ++i) {
-			if (crc[i] != mycrc32(0, buffer + i * SFSBLOCKSIZE, SFSBLOCKSIZE)) {
-				return -SAUNAFS_ERROR_CRC;
+		uint16_t crcIndex = 0;
+		for (size_t bufferIndex = 0; bufferIndex < buffers.size(); ++bufferIndex) {
+			uint16_t blocksInBuffer = blocksPerBuffer[bufferIndex];
+			const uint8_t *buffer = buffers[bufferIndex];
+			for (uint16_t i = 0; i < blocksInBuffer; ++i) {
+				if (crc[crcIndex] != mycrc32(0, buffer + i * SFSBLOCKSIZE, SFSBLOCKSIZE)) {
+					return -SAUNAFS_ERROR_CRC;
+				}
+				crcIndex++;
 			}
 		}
 	}
@@ -643,11 +689,11 @@ int CmrDisk::writeChunkBlocks(IChunk *chunk, uint32_t version, uint16_t startBlo
 		areNewBlocks = true;
 	}
 
-	int written = writeFullBlocksAndCrcs(chunk, buffer, startBlock, numBlocks, crcBuff.data(),
-	                                     crcData, areNewBlocks, "writeChunkBlocks");
+	int written = writeFullBlocksAndCrcs(chunk, blocksPerBuffer, buffers, startBlock,
+	                                     crcBuff.data(), crcData, areNewBlocks, "writeChunkBlocks");
 	if (written < 0) { return -SAUNAFS_ERROR_IO; }
 
-	return numBlocks * SFSBLOCKSIZE;
+	return written;
 }
 
 int CmrDisk::writeChunkData(IChunk *chunk, uint8_t *blockBuffer,

--- a/src/chunkserver/chunkserver-common/cmr_disk.h
+++ b/src/chunkserver/chunkserver-common/cmr_disk.h
@@ -130,9 +130,10 @@ public:
 	                            uint16_t blockNum, bool isNewBlock,
 	                            const char *errorMsg) override;
 	/// Writes the data and the CRC for a number of full blocks
-	int writeFullBlocksAndCrcs(IChunk *chunk, const uint8_t *buffer, uint16_t startBlock,
-	                           uint16_t numBlocks, const uint8_t *crcBuff, uint8_t *crcData,
-	                           bool areNewBlocks, const char *errorMsg) override;
+	int writeFullBlocksAndCrcs(IChunk *chunk, const std::vector<uint16_t> &blocksPerBuffer,
+	                           const std::vector<const uint8_t *> &buffers, uint16_t startBlock,
+	                           const uint8_t *crcBuff, uint8_t *crcData, bool areNewBlocks,
+	                           const char *errorMsg) override;
 
 	/// If supported, deallocates space (creates a hole) in the byte range
 	/// starting at offset and continuing for size bytes.
@@ -148,8 +149,10 @@ public:
 	                    bool isFromReplication = false) override;
 	/// Writes `numBlocks` full Chunk blocks
 	int writeChunkBlocks(IChunk *chunk, uint32_t version, uint16_t startBlock, uint16_t numBlocks,
-	                     std::vector<uint32_t> &crc, uint8_t *crcData, const uint8_t *buffer,
-	                    bool isFromReplication = false) override;
+	                     std::vector<uint32_t> &crc, uint8_t *crcData,
+	                     const std::vector<uint16_t> &blocksPerBuffer,
+	                     const std::vector<const uint8_t *> &buffers,
+	                     bool isFromReplication = false) override;
 
 	/// Writes to device custom blockSize from blockBuffer
 	int writeChunkData(IChunk *chunk, uint8_t *blockBuffer, int32_t blockSize,

--- a/src/chunkserver/chunkserver-common/disk_interface.h
+++ b/src/chunkserver/chunkserver-common/disk_interface.h
@@ -212,9 +212,11 @@ public:
 	/// Writes the data and the CRC for a number of full blocks
 	/// \returns number of written bytes on success or the negative of the error code on failure.
 	/// If the written bytes are less than expected, it is IO error.
-	virtual int writeFullBlocksAndCrcs(IChunk *chunk, const uint8_t *buffer, uint16_t startBlock,
-	                                   uint16_t numBlocks, const uint8_t *crcBuff, uint8_t *crcData,
-	                                   bool areNewBlocks, const char *errorMsg) = 0;
+	virtual int writeFullBlocksAndCrcs(IChunk *chunk, const std::vector<uint16_t> &blocksPerBuffer,
+	                                   const std::vector<const uint8_t *> &buffers,
+	                                   uint16_t startBlock, const uint8_t *crcBuff,
+	                                   uint8_t *crcData, bool areNewBlocks,
+	                                   const char *errorMsg) = 0;
 
 	/// Writes a Chunk block
 	/// \return SAUNAFS_STATUS_OK on success or specific SAUNAFS_ error code
@@ -226,8 +228,10 @@ public:
 	/// \returns number of written bytes on success or the negative of the error code on failure.
 	/// If the written bytes are less than expected, it is IO error.
 	virtual int writeChunkBlocks(IChunk *chunk, uint32_t version, uint16_t startBlock,
-	                            uint16_t numBlocks, std::vector<uint32_t> &crc, uint8_t *crcData,
-	                            const uint8_t *buffer, bool isFromReplication = false) = 0;
+	                             uint16_t numBlocks, std::vector<uint32_t> &crc, uint8_t *crcData,
+	                             const std::vector<uint16_t> &blocksPerBuffer,
+	                             const std::vector<const uint8_t *> &buffers,
+	                             bool isFromReplication = false) = 0;
 
 	/// Writes the Chunk header into the device
 	///

--- a/src/chunkserver/hddspacemgr.cc
+++ b/src/chunkserver/hddspacemgr.cc
@@ -1094,7 +1094,8 @@ int hddChunkWriteBlock(uint64_t chunkId, uint32_t version,
 
 int hddChunkWriteFullBlocks(uint64_t chunkId, uint32_t version, ChunkPartType chunkType,
                             uint16_t startBlock, uint16_t numBlocks, std::vector<uint32_t> &crcList,
-                            const uint8_t *buffer) {
+                            std::vector<uint16_t> &blocksPerBuffer,
+                            std::vector<const uint8_t *> &buffers) {
 	auto *chunk = hddChunkFindAndLock(chunkId, chunkType);
 
 	if (chunk == ChunkNotFound) {
@@ -1105,7 +1106,7 @@ int hddChunkWriteFullBlocks(uint64_t chunkId, uint32_t version, ChunkPartType ch
 
 	auto *crcData = gOpenChunks.getResource(chunk->metaFD()).crcData();
 	int status = chunk->owner()->writeChunkBlocks(chunk, version, startBlock, numBlocks, crcList,
-	                                              crcData, buffer);
+	                                              crcData, blocksPerBuffer, buffers);
 	hddChunkRelease(chunk);
 
 	return status;

--- a/src/chunkserver/hddspacemgr.h
+++ b/src/chunkserver/hddspacemgr.h
@@ -80,7 +80,8 @@ int hddChunkWriteBlock(uint64_t chunkId, uint32_t version,
                        const uint8_t *buffer);
 int hddChunkWriteFullBlocks(uint64_t chunkId, uint32_t version, ChunkPartType chunkType,
                             uint16_t startBlock, uint16_t numBlocks, std::vector<uint32_t> &crcList,
-                            const uint8_t *buffer);
+                            std::vector<uint16_t> &blocksPerBuffer,
+                            std::vector<const uint8_t *> &buffers);
 
 /* chunk info */
 int hddChunkGetNumberOfBlocks(uint64_t chunkId, ChunkPartType chunkType,

--- a/src/chunkserver/io_buffers.cc
+++ b/src/chunkserver/io_buffers.cc
@@ -338,46 +338,91 @@ void InputBuffer::setupLastWriteOperation(uint16_t blockNum, uint32_t offset, ui
 	isBeingUpdated_ = false;
 }
 
-std::vector<WriteOperation> InputBuffer::getWriteOperations() const {
+std::vector<WriteOperation> InputBuffer::getWriteOperations(
+    const std::vector<InputBuffer *> &inputBuffers, uint32_t &totalBlocks) {
 	std::vector<WriteOperation> operations;
+	totalBlocks = 0;
 
-	auto isMergeable = [](const WriteOperation &wp, const WriteInfo &info) {
+	uint16_t endBlock = 0;
+	auto isMergeable = [&endBlock](const WriteOperation &wp, const WriteInfo &info) {
 		// If the operation and the info refer to full block writes and the info is the next block
 		// after the operation, we can merge them.
-		return wp.endBlock + 1 == info.blockNum && wp.offset == 0 && wp.size == SFSBLOCKSIZE &&
+		return endBlock + 1 == info.blockNum && wp.offset == 0 && wp.size == SFSBLOCKSIZE &&
 		       info.offset == 0 && info.size == SFSBLOCKSIZE;
 	};
 
-	for (uint32_t i = 0; i < writeInfo_.size(); ++i) {
-		const auto &info = writeInfo_[i];
+	for (auto *inputBuffer : inputBuffers) {
+		const auto &writeInfos = inputBuffer->getWriteInfoVector();
+		for (uint32_t i = 0; i < writeInfos.size(); ++i) {
+			totalBlocks++;
+			const auto &info = writeInfos[i];
 
-		if (!operations.empty() && isMergeable(operations.back(), info)) {
-			operations.back().endBlock++;
-			operations.back().crcs.push_back(crcData_[i]);
-			continue;
+			auto [blockData, crc] = inputBuffer->getBlockDataAndCrc(i);
+			if (!operations.empty() && isMergeable(operations.back(), info)) {
+				endBlock++;
+				operations.back().crcs.push_back(crc);
+
+				if (i > 0) {
+					operations.back().blocksPerBuffer.back()++;
+				} else {
+					// if i == 0, it means the block data is not contiguous (in memory) with the
+					// previous block data in the block buffer, so we need to add a new buffer for
+					// it.
+					operations.back().buffers.push_back(blockData);
+					operations.back().blocksPerBuffer.push_back(1);
+				}
+				continue;
+			}
+
+			// New operation that cannot be merged with the previous one, we need to create a new
+			// WriteOperation.
+			WriteOperation op;
+			op.startBlock = info.blockNum;
+			endBlock = info.blockNum;
+			op.blocksPerBuffer = {1};
+			op.buffers = {blockData};
+			op.offset = info.offset;
+			op.size = info.size;
+			op.crcs.push_back(crc);
+			operations.push_back(op);
 		}
-
-		WriteOperation op;
-		op.startBlock = info.blockNum;
-		op.endBlock = info.blockNum;
-		op.buffer = blockBuffer_.paddedIndex(i * SFSBLOCKSIZE);
-		op.offset = info.offset;
-		op.size = info.size;
-		op.crcs.push_back(crcData_[i]);
-		operations.push_back(op);
 	}
 
 	return operations;
 }
 
-void InputBuffer::applyStatuses(std::vector<uint8_t> &statuses) {
-	if (statuses.size() > writeInfo_.size()) {
-		safs::log_warn("({}) Called with more statuses than writeInfo_. Truncating the statuses.",
-		               __func__);
-		statuses.resize(writeInfo_.size());
+std::pair<const uint8_t *, size_t> InputBuffer::getBlockDataAndCrc(uint16_t index) const {
+	if (index >= writeInfo_.size()) {
+		safs::log_warn("({}) Invalid block index: {}", __func__, index);
+		return {nullptr, 0};
 	}
 
-	for (uint32_t i = 0; i < statuses.size(); ++i) { writeInfo_[i].status = statuses[i]; }
+	return {blockBuffer_.paddedIndex(index * SFSBLOCKSIZE), crcData_[index]};
+}
+
+void InputBuffer::applyStatuses(const std::vector<InputBuffer *> &inputBuffers,
+                                std::vector<uint8_t> &statuses) {
+	uint32_t blockCursor = 0;
+	for (const auto &inputBuffer : inputBuffers) {
+		if (blockCursor + inputBuffer->currentBlocks() > statuses.size()) {
+			safs::log_warn(
+			    "({}) Not enough statuses provided for the input buffers. Stopping "
+			    "the application of statuses.",
+			    __func__);
+			return;
+		}
+
+		auto currentInputBufferStatuses =
+		    std::vector<uint8_t>(statuses.begin() + blockCursor,
+		                         statuses.begin() + blockCursor + inputBuffer->currentBlocks());
+		assert(currentInputBufferStatuses.size() == inputBuffer->currentBlocks());
+		assert(inputBuffer->currentBlocks() == inputBuffer->writeInfo_.size());
+
+		for (uint32_t i = 0; i < inputBuffer->currentBlocks(); ++i) {
+			inputBuffer->writeInfo_[i].status = currentInputBufferStatuses[i];
+		}
+		blockCursor += inputBuffer->currentBlocks();
+	}
 }
 
 std::vector<std::pair<uint8_t, uint32_t>> InputBuffer::getStatuses() const {

--- a/src/chunkserver/io_buffers.h
+++ b/src/chunkserver/io_buffers.h
@@ -351,12 +351,14 @@ struct WriteInfo {
 ///
 /// The operation consists of a possibly condensed set of blocks to be written
 /// to the disk. The blocks are written in the same order as they were received
-/// from the client. A set of full blocks can be written in one write operation and
-/// the partial blocks are written one-by-one.
+/// from the client. A set of full blocks, not necessarily contiguous in memory, can be written in
+/// one write operation and the partial blocks are written one-by-one.
 struct WriteOperation {
 	uint16_t startBlock;         ///< The start block number in the chunk.
-	uint16_t endBlock;           ///< The end block number in the chunk.
-	const uint8_t *buffer;       ///< The pointer to the data to be written.
+	/// The number of blocks to be written from each buffer.
+	std::vector<uint16_t> blocksPerBuffer;
+	/// The pointers to the buffers containing the block data.
+	std::vector<const uint8_t *> buffers;
 	uint32_t offset;             ///< The offset in the block where the data starts.
 	uint32_t size;               ///< The size of the data to be written.
 	std::vector<uint32_t> crcs;  ///< The CRCs of the blocks to be written.
@@ -459,11 +461,18 @@ public:
 	/// It merges the write operations if contiguous full blocks.
 	/// The write operations are returned in the order they were received from the client.
 	/// @return The vector of write operations.
-	std::vector<WriteOperation> getWriteOperations() const;
+	static std::vector<WriteOperation> getWriteOperations(
+	    const std::vector<InputBuffer *> &inputBuffers, uint32_t &totalBlocks);
 
-	/// @brief Sets the statuses of the write operations in the buffer.
+	/// @brief Returns the pointer to the block data and CRC for the given block index.
+	/// If the block index is out of range, it returns nullptr and logs a warning.
+	std::pair<const uint8_t *, size_t> getBlockDataAndCrc(uint16_t index) const;
+
+	/// @brief Sets the statuses of the write operations to the provided buffers.
+	/// @param inputBuffers The vector of input buffers to set the statuses for.
 	/// @param statuses The vector of statuses to set.
-	void applyStatuses(std::vector<uint8_t> &statuses);
+	static void applyStatuses(const std::vector<InputBuffer *> &inputBuffers,
+	                          std::vector<uint8_t> &statuses);
 
 	/// @brief Returns the statuses,ID pair of the write operations in the buffer.
 	/// @return The vector of statuses along with write IDs.

--- a/src/chunkserver/io_buffers_unittest.cc
+++ b/src/chunkserver/io_buffers_unittest.cc
@@ -231,6 +231,19 @@ public:
 	InputBufferTests() : InputBuffer(testHeaderSize, testNumBlocks) {}
 };
 
+void checkWriteOperation(std::vector<WriteOperation> &writeOperations,
+                         std::vector<WriteOperation> &expectedWriteOperations) {
+	ASSERT_EQ(writeOperations.size(), expectedWriteOperations.size());
+	for (size_t i = 0; i < writeOperations.size(); i++) {
+		ASSERT_EQ(writeOperations[i].startBlock, expectedWriteOperations[i].startBlock);
+		ASSERT_EQ(writeOperations[i].blocksPerBuffer, expectedWriteOperations[i].blocksPerBuffer);
+		ASSERT_EQ(writeOperations[i].offset, expectedWriteOperations[i].offset);
+		ASSERT_EQ(writeOperations[i].size, expectedWriteOperations[i].size);
+		ASSERT_EQ(writeOperations[i].buffers, expectedWriteOperations[i].buffers);
+		ASSERT_EQ(writeOperations[i].crcs, expectedWriteOperations[i].crcs);
+	}
+}
+
 // InputBuffer tests
 
 TEST(InputBufferTests, inputBufferBasicWriteToSocketTest) {
@@ -326,149 +339,202 @@ TEST(InputBufferTests, inputBufferBasicReadFromSocketTest) {
 	close(auxPipeFileDescriptors[1]);
 }
 
-TEST(InputBufferTests, inputBufferAddSetupGetWriteOperationsTest) {
+TEST(InputBufferTests, inputBufferAddSetupGetWriteOperationsSingleBufferTest) {
 	InputBufferTests inputBuffer;
+	std::vector<InputBuffer *> inputBuffers{&inputBuffer};
+	uint32_t totalBlocks = 12345;
+	constexpr uint32_t dummyWriteId = 0;
 
-	auto checkWriteOperation = [](std::vector<WriteOperation> &writeOperations,
-	                              std::vector<WriteOperation> &expectedWriteOperations) {
-		ASSERT_EQ(writeOperations.size(), expectedWriteOperations.size());
-		for (size_t i = 0; i < writeOperations.size(); i++) {
-			ASSERT_EQ(writeOperations[i].startBlock, expectedWriteOperations[i].startBlock);
-			ASSERT_EQ(writeOperations[i].endBlock, expectedWriteOperations[i].endBlock);
-			ASSERT_EQ(writeOperations[i].offset, expectedWriteOperations[i].offset);
-			ASSERT_EQ(writeOperations[i].size, expectedWriteOperations[i].size);
-			ASSERT_EQ(writeOperations[i].buffer, expectedWriteOperations[i].buffer);
-			ASSERT_EQ(writeOperations[i].crcs, expectedWriteOperations[i].crcs);
-		}
-	};
-
+	// Test contiguous full blocks
 	inputBuffer.addNewWriteOperation();
-	inputBuffer.setupLastWriteOperation(0, 0, SFSBLOCKSIZE, 1, 1);
+	inputBuffer.setupLastWriteOperation(0, 0, SFSBLOCKSIZE, dummyWriteId, 1);
 	inputBuffer.addNewWriteOperation();
-	inputBuffer.setupLastWriteOperation(1, 0, SFSBLOCKSIZE, 2, 666);
+	inputBuffer.setupLastWriteOperation(1, 0, SFSBLOCKSIZE, dummyWriteId, 666);
 	inputBuffer.addNewWriteOperation();
-	inputBuffer.setupLastWriteOperation(2, 0, SFSBLOCKSIZE, 3, 555);
+	inputBuffer.setupLastWriteOperation(2, 0, SFSBLOCKSIZE, dummyWriteId, 555);
 	inputBuffer.addNewWriteOperation();
-	inputBuffer.setupLastWriteOperation(3, 0, SFSBLOCKSIZE, 4, 444);
-	std::vector<WriteOperation> writeOperations = inputBuffer.getWriteOperations();
+	inputBuffer.setupLastWriteOperation(3, 0, SFSBLOCKSIZE, dummyWriteId, 444);
+	std::vector<WriteOperation> writeOperations =
+	    InputBuffer::getWriteOperations(inputBuffers, totalBlocks);
 	std::vector<WriteOperation> expectedWriteOperations = {
 	    {.startBlock = 0,
-	     .endBlock = 3,
-	     .buffer = inputBuffer.rawData(InputBuffer::BufferType::Block),
+	     .blocksPerBuffer = {4},
+	     .buffers = {inputBuffer.rawData(InputBuffer::BufferType::Block)},
 	     .offset = 0,
 	     .size = SFSBLOCKSIZE,
 	     .crcs = {1, 666, 555, 444}}};
 	checkWriteOperation(writeOperations, expectedWriteOperations);
+	ASSERT_EQ(totalBlocks, 4u);
 
+	// Test non-contiguous blocks and non-full block
 	inputBuffer.clear();
 	inputBuffer.addNewWriteOperation();
-	inputBuffer.setupLastWriteOperation(5, 0, SFSBLOCKSIZE, 5, 123);
+	inputBuffer.setupLastWriteOperation(5, 0, SFSBLOCKSIZE, dummyWriteId, 123);
 	inputBuffer.addNewWriteOperation();
-	inputBuffer.setupLastWriteOperation(7, 0, SFSBLOCKSIZE, 6, 456);
+	inputBuffer.setupLastWriteOperation(7, 0, SFSBLOCKSIZE, dummyWriteId, 456);
 	inputBuffer.addNewWriteOperation();
-	inputBuffer.setupLastWriteOperation(8, 0, 12345, 7, 789);
+	inputBuffer.setupLastWriteOperation(8, 0, 12345, dummyWriteId, 789);
 	inputBuffer.addNewWriteOperation();
-	inputBuffer.setupLastWriteOperation(9, 0, SFSBLOCKSIZE, 8, 901);
-	writeOperations = inputBuffer.getWriteOperations();
+	inputBuffer.setupLastWriteOperation(9, 0, SFSBLOCKSIZE, dummyWriteId, 901);
+	totalBlocks = 12345;
+	writeOperations = InputBuffer::getWriteOperations(inputBuffers, totalBlocks);
 	expectedWriteOperations = {
 	    {.startBlock = 5,
-	     .endBlock = 5,
-	     .buffer = inputBuffer.rawData(InputBuffer::BufferType::Block),
+	     .blocksPerBuffer = {1},
+	     .buffers = {inputBuffer.rawData(InputBuffer::BufferType::Block)},
 	     .offset = 0,
 	     .size = SFSBLOCKSIZE,
 	     .crcs = {123}},
 	    {.startBlock = 7,
-	     .endBlock = 7,
-	     .buffer = inputBuffer.rawData(InputBuffer::BufferType::Block) + SFSBLOCKSIZE,
+	     .blocksPerBuffer = {1},
+	     .buffers = {inputBuffer.rawData(InputBuffer::BufferType::Block) + SFSBLOCKSIZE},
 	     .offset = 0,
 	     .size = SFSBLOCKSIZE,
 	     .crcs = {456}},
 	    {.startBlock = 8,
-	     .endBlock = 8,
-	     .buffer = inputBuffer.rawData(InputBuffer::BufferType::Block) + 2 * SFSBLOCKSIZE,
+	     .blocksPerBuffer = {1},
+	     .buffers = {inputBuffer.rawData(InputBuffer::BufferType::Block) + 2 * SFSBLOCKSIZE},
 	     .offset = 0,
 	     .size = 12345,
 	     .crcs = {789}},
 	    {.startBlock = 9,
-	     .endBlock = 9,
-	     .buffer = inputBuffer.rawData(InputBuffer::BufferType::Block) + 3 * SFSBLOCKSIZE,
+	     .blocksPerBuffer = {1},
+	     .buffers = {inputBuffer.rawData(InputBuffer::BufferType::Block) + 3 * SFSBLOCKSIZE},
 	     .offset = 0,
 	     .size = SFSBLOCKSIZE,
 	     .crcs = {901}}};
 	checkWriteOperation(writeOperations, expectedWriteOperations);
+	ASSERT_EQ(totalBlocks, 4u);
 
+	// Test apparently contiguous data which start in non-full block, and test block overwrite
 	inputBuffer.clear();
 	inputBuffer.addNewWriteOperation();
-	inputBuffer.setupLastWriteOperation(10, 12345, SFSBLOCKSIZE, 9, 111);
+	inputBuffer.setupLastWriteOperation(10, 12345, SFSBLOCKSIZE - 12345, dummyWriteId, 111);
 	inputBuffer.addNewWriteOperation();
-	inputBuffer.setupLastWriteOperation(11, 0, SFSBLOCKSIZE, 10, 222);
+	inputBuffer.setupLastWriteOperation(11, 0, SFSBLOCKSIZE, dummyWriteId, 222);
 	inputBuffer.addNewWriteOperation();
-	inputBuffer.setupLastWriteOperation(12, 0, SFSBLOCKSIZE, 11, 333);
+	inputBuffer.setupLastWriteOperation(12, 0, SFSBLOCKSIZE, dummyWriteId, 333);
 	inputBuffer.addNewWriteOperation();
-	inputBuffer.setupLastWriteOperation(12, 0, SFSBLOCKSIZE, 12, 444);
-	writeOperations = inputBuffer.getWriteOperations();
+	inputBuffer.setupLastWriteOperation(12, 0, SFSBLOCKSIZE, dummyWriteId, 444);
+	totalBlocks = 12345;
+	writeOperations = InputBuffer::getWriteOperations(inputBuffers, totalBlocks);
 	expectedWriteOperations = {
 	    {.startBlock = 10,
-	     .endBlock = 10,
-	     .buffer = inputBuffer.rawData(InputBuffer::BufferType::Block),
+	     .blocksPerBuffer = {1},
+	     .buffers = {inputBuffer.rawData(InputBuffer::BufferType::Block)},
 	     .offset = 12345,
-	     .size = SFSBLOCKSIZE,
+	     .size = SFSBLOCKSIZE - 12345,
 	     .crcs = {111}},
 	    {.startBlock = 11,
-	     .endBlock = 12,
-	     .buffer = inputBuffer.rawData(InputBuffer::BufferType::Block) + SFSBLOCKSIZE,
+	     .blocksPerBuffer = {2},
+	     .buffers = {inputBuffer.rawData(InputBuffer::BufferType::Block) + SFSBLOCKSIZE},
 	     .offset = 0,
 	     .size = SFSBLOCKSIZE,
 	     .crcs = {222, 333}},
 	    {.startBlock = 12,
-	     .endBlock = 12,
-	     .buffer = inputBuffer.rawData(InputBuffer::BufferType::Block) + 3 * SFSBLOCKSIZE,
+	     .blocksPerBuffer = {1},
+	     .buffers = {inputBuffer.rawData(InputBuffer::BufferType::Block) + 3 * SFSBLOCKSIZE},
 	     .offset = 0,
 	     .size = SFSBLOCKSIZE,
 	     .crcs = {444}}};
 	checkWriteOperation(writeOperations, expectedWriteOperations);
+	ASSERT_EQ(totalBlocks, 4u);
 
+	// Test extreme block indexes, last before SFSBLOCKSINCHUNK, 0 and a couple of contiguous full
+	// blocks far beyond the current SFSBLOCKSINCHUNK, which are mergeable.
 	inputBuffer.clear();
 	inputBuffer.addNewWriteOperation();
-	inputBuffer.setupLastWriteOperation(1023, 12345, SFSBLOCKSIZE, 13, 555);
+	inputBuffer.setupLastWriteOperation(1023, 12345, SFSBLOCKSIZE, dummyWriteId, 555);
 	inputBuffer.addNewWriteOperation();
-	inputBuffer.setupLastWriteOperation(0, 0, 12345, 14, 666);
+	inputBuffer.setupLastWriteOperation(0, 0, 12345, dummyWriteId, 666);
 	inputBuffer.addNewWriteOperation();
-	inputBuffer.setupLastWriteOperation(9999, 0, SFSBLOCKSIZE, 15, 777);
+	inputBuffer.setupLastWriteOperation(9999, 0, SFSBLOCKSIZE, dummyWriteId, 777);
 	inputBuffer.addNewWriteOperation();
-	inputBuffer.setupLastWriteOperation(10000, 0, SFSBLOCKSIZE, 16, 888);
-	writeOperations = inputBuffer.getWriteOperations();
+	inputBuffer.setupLastWriteOperation(10000, 0, SFSBLOCKSIZE, dummyWriteId, 888);
+	totalBlocks = 12345;
+	writeOperations = InputBuffer::getWriteOperations(inputBuffers, totalBlocks);
 	expectedWriteOperations = {
 	    {.startBlock = 1023,
-	     .endBlock = 1023,
-	     .buffer = inputBuffer.rawData(InputBuffer::BufferType::Block),
+	     .blocksPerBuffer = {1},
+	     .buffers = {inputBuffer.rawData(InputBuffer::BufferType::Block)},
 	     .offset = 12345,
 	     .size = SFSBLOCKSIZE,
 	     .crcs = {555}},
 	    {.startBlock = 0,
-	     .endBlock = 0,
-	     .buffer = inputBuffer.rawData(InputBuffer::BufferType::Block) + SFSBLOCKSIZE,
+	     .blocksPerBuffer = {1},
+	     .buffers = {inputBuffer.rawData(InputBuffer::BufferType::Block) + SFSBLOCKSIZE},
 	     .offset = 0,
 	     .size = 12345,
 	     .crcs = {666}},
 	    {.startBlock = 9999,
-	     .endBlock = 10000,
-	     .buffer = inputBuffer.rawData(InputBuffer::BufferType::Block) + 2 * SFSBLOCKSIZE,
+	     .blocksPerBuffer = {2},
+	     .buffers = {inputBuffer.rawData(InputBuffer::BufferType::Block) + 2 * SFSBLOCKSIZE},
 	     .offset = 0,
 	     .size = SFSBLOCKSIZE,
 	     .crcs = {777, 888}}};
 	checkWriteOperation(writeOperations, expectedWriteOperations);
+	ASSERT_EQ(totalBlocks, 4u);
 
 	std::vector<uint8_t> statuses = {SAUNAFS_STATUS_OK, SAUNAFS_ERROR_WRONGSIZE, SAUNAFS_ERROR_IO,
 	                                 SAUNAFS_ERROR_IO};
-	inputBuffer.applyStatuses(statuses);
+	InputBuffer::applyStatuses({&inputBuffer}, statuses);
 	auto statusesWriteIdPairs = inputBuffer.getStatuses();
 
-	std::vector<std::pair<uint8_t, uint32_t>> expectedStatuses = {{SAUNAFS_STATUS_OK, 13},
-	                                                              {SAUNAFS_ERROR_WRONGSIZE, 14},
-	                                                              {SAUNAFS_ERROR_IO, 15},
-	                                                              {SAUNAFS_ERROR_IO, 16}};
+	std::vector<std::pair<uint8_t, uint32_t>> expectedStatuses = {
+	    {SAUNAFS_STATUS_OK, dummyWriteId},
+	    {SAUNAFS_ERROR_WRONGSIZE, dummyWriteId},
+	    {SAUNAFS_ERROR_IO, dummyWriteId},
+	    {SAUNAFS_ERROR_IO, dummyWriteId}};
 	ASSERT_EQ(statusesWriteIdPairs, expectedStatuses);
+}
+
+TEST(InputBufferTests, inputBufferAddSetupGetWriteOperationsMultiBufferTest) {
+	constexpr uint32_t dummyWriteId = 0;
+	InputBufferTests inputBuffer1;  // blocks 0,1,2,3
+	InputBufferTests inputBuffer2;  // blocks 4,5,6,7
+	InputBufferTests inputBuffer3;  // blocks 8,9,10,11
+	InputBufferTests inputBuffer4;  // blocks 12, part of 13
+	std::vector<InputBuffer *> inputBuffers{&inputBuffer1, &inputBuffer2, &inputBuffer3,
+	                                        &inputBuffer4};
+	std::vector<uint32_t> crcs;
+	uint32_t totalBlocks = 12345;
+
+	// Test contiguous blocks from multiple buffers, and split the last input buffer
+	for (int i = 0; i < 3; i++) {
+		for (int j = 0; j < 4; j++) {
+			uint32_t blockIndex = j + 4 * i;
+			inputBuffers[i]->addNewWriteOperation();
+			inputBuffers[i]->setupLastWriteOperation(blockIndex, 0, SFSBLOCKSIZE, dummyWriteId,
+			                                         blockIndex * 111);
+			crcs.push_back(blockIndex * 111);
+		}
+	}
+	inputBuffer4.addNewWriteOperation();
+	inputBuffer4.setupLastWriteOperation(12, 0, SFSBLOCKSIZE, dummyWriteId, 12 * 111);
+	crcs.push_back(12 * 111);
+	inputBuffer4.addNewWriteOperation();
+	inputBuffer4.setupLastWriteOperation(13, 0, 12345, dummyWriteId, 13 * 111);
+
+	std::vector<WriteOperation> writeOperations =
+	    InputBuffer::getWriteOperations(inputBuffers, totalBlocks);
+	std::vector<WriteOperation> expectedWriteOperations = {
+	    {.startBlock = 0,
+	     .blocksPerBuffer = {4, 4, 4, 1},
+	     .buffers = {inputBuffer1.rawData(InputBuffer::BufferType::Block),
+	                 inputBuffer2.rawData(InputBuffer::BufferType::Block),
+	                 inputBuffer3.rawData(InputBuffer::BufferType::Block),
+	                 inputBuffer4.rawData(InputBuffer::BufferType::Block)},
+	     .offset = 0,
+	     .size = SFSBLOCKSIZE,
+	     .crcs = crcs},
+	    {.startBlock = 13,
+	     .blocksPerBuffer = {1},
+	     .buffers = {inputBuffer4.rawData(InputBuffer::BufferType::Block) + SFSBLOCKSIZE},
+	     .offset = 0,
+	     .size = 12345,
+	     .crcs = {13 * 111}}};
+	checkWriteOperation(writeOperations, expectedWriteOperations);
+	ASSERT_EQ(totalBlocks, 14u);
 }
 
 TEST(InputBufferTests, inputBufferGeneralTest) {
@@ -513,7 +579,7 @@ TEST(InputBufferTests, inputBufferGeneralTest) {
 		}
 
 		std::vector<uint8_t> statuses(dataSizes.size(), SAUNAFS_ERROR_IO);
-		inputBuffer.applyStatuses(statuses);
+		InputBuffer::applyStatuses({&inputBuffer}, statuses);
 	});
 
 	// Make sure the consumer thread is waiting for the wake up call

--- a/utils/chunk_operations_eio.c
+++ b/utils/chunk_operations_eio.c
@@ -2,15 +2,17 @@
 #define _GNU_SOURCE
 #endif
 #include <dlfcn.h>
-#include <stdio.h>
-#include <unistd.h>
-#include <stdlib.h>
-#include <fcntl.h>
-#include <string.h>
 #include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/uio.h>
+#include <unistd.h>
 
 typedef ssize_t (*pread_t)(int, void *, size_t, off_t);
 typedef ssize_t (*pwrite_t)(int, const void *, size_t, off_t);
+typedef ssize_t (*pwritev_t)(int, const struct iovec *, int, off_t);
 typedef int (*close_t)(int);
 typedef int (*fsync_t)(int);
 
@@ -124,6 +126,21 @@ ssize_t pwrite(int fd, const void *buf, size_t count, off_t offset) {
 		_pwrite = (pwrite_t)dlsym(RTLD_NEXT, "pwrite");
 	}
 	return _pwrite(fd, buf, count, offset);
+}
+
+ssize_t pwritev(int fd, const struct iovec *iov, int iovcnt, off_t offset) {
+	size_t total = 0;
+	for (int i = 0; i < iovcnt; ++i) total += iov[i].iov_len;
+
+	int err = err_on_operation(fd, "pwrite", offset, total);
+	if (err) {
+		errno = err;
+		return -1;
+	}
+
+	static pwritev_t _pwritev = NULL;
+	if (!_pwritev) { _pwritev = (pwritev_t)dlsym(RTLD_NEXT, "pwritev"); }
+	return _pwritev(fd, iov, iovcnt, offset);
 }
 
 int close(int fd) {


### PR DESCRIPTION
This change targets paving the way to improve the write batching in the chunkserver. The main difference in the current changes is the use of pwritev instead of pwrite for syncing the data to the drives. The pwritev allows the write of several iov structures in a single call, which in the future can be used to flush data from several InputBuffers at the same time.

The proposed changes keep most of the previous logic, with several enhancements to make easier next changes:
- the InputBuffer::getWriteOperations was changed the way it accepts a vector of inputBuffers. The list of write operations that is built there can contain operations whose data buffers belong to different inputBuffers. The use of it remains nearly the same because only one buffer is going to be passed in a single call.
- the WriteHighLevelOp now keeps track of the number of enqueued inputBuffers and reacts accordingly at the write job callback. Only one InputBuffer is going to be enqueed at a time in the proposed changes, keeping the same logic as before.

A unittest was added to check the expected behavior of getWriteOperations. The chunk_operations_eio library was enhanced to catch the pwritev calls and test them as well.

Signed-off-by: Dave <dave@leil.io>