### PR TITLE
refactor(master): return QuotaCheckResult in quota checks

### DIFF
--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -1762,12 +1762,8 @@ uint8_t FilesystemOperationsBase::symlink(const FsContext &context,
 	}
 
 	if (context.isPersonalityMaster()) {
-		uint8_t quotaStatus = statusFromQuotaCheck(quotaExceededUg(
-		    fsOpContext, context.uid(), context.gid(), {{QuotaResource::kInodes, 1}}));
-		if (quotaStatus != SAUNAFS_STATUS_OK) { return quotaStatus; }
-
-		quotaStatus = statusFromQuotaCheck(
-		    quotaExceededDir(fsOpContext, workDir, {{QuotaResource::kInodes, 1}}));
+		uint8_t quotaStatus = checkQuotaUgDir(
+		    fsOpContext, context.uid(), context.gid(), workDir, {{QuotaResource::kInodes, 1}});
 		if (quotaStatus != SAUNAFS_STATUS_OK) { return quotaStatus; }
 	}
 
@@ -1853,12 +1849,8 @@ uint8_t FilesystemOperationsBase::mknod(const FsContext &context,
 	}
 
 	// Quota verification
-	uint8_t quotaStatus = statusFromQuotaCheck(
-	    quotaExceededUg(fsOpContext, context.uid(), context.gid(), {{QuotaResource::kInodes, 1}}));
-	if (quotaStatus != SAUNAFS_STATUS_OK) { return quotaStatus; }
-
-	quotaStatus = statusFromQuotaCheck(
-	    quotaExceededDir(fsOpContext, parentNode, {{QuotaResource::kInodes, 1}}));
+	uint8_t quotaStatus = checkQuotaUgDir(
+	    fsOpContext, context.uid(), context.gid(), parentNode, {{QuotaResource::kInodes, 1}});
 	if (quotaStatus != SAUNAFS_STATUS_OK) { return quotaStatus; }
 
 	static_cast<FSNodeDirectory *>(parentNode)->caseInsensitive = isCaseInsensitive;
@@ -1920,12 +1912,8 @@ uint8_t FilesystemOperationsBase::mkdir(const FsContext &context,
 		return SAUNAFS_ERROR_EEXIST;
 	}
 
-	uint8_t quotaStatus = statusFromQuotaCheck(
-	    quotaExceededUg(fsOpContext, context.uid(), context.gid(), {{QuotaResource::kInodes, 1}}));
-	if (quotaStatus != SAUNAFS_STATUS_OK) { return quotaStatus; }
-
-	quotaStatus = statusFromQuotaCheck(
-	    quotaExceededDir(fsOpContext, workNode, {{QuotaResource::kInodes, 1}}));
+	uint8_t quotaStatus = checkQuotaUgDir(
+	    fsOpContext, context.uid(), context.gid(), workNode, {{QuotaResource::kInodes, 1}});
 	if (quotaStatus != SAUNAFS_STATUS_OK) { return quotaStatus; }
 
 	if (gDisableEmptyFoldersMetadataOnFullDisk) {
@@ -4146,6 +4134,14 @@ QuotaCheckResult FilesystemOperationsBase::quotaExceeded(
     const FilesystemOperationContext &fsOpContext, FSNode *node,
     const std::initializer_list<std::pair<QuotaResource, int64_t>> &resourceList) {
 	return {.exceeded = fsnodes_quota_exceeded(fsOpContext, node, resourceList)};
+}
+
+uint8_t FilesystemOperationsBase::checkQuotaUgDir(
+    const FilesystemOperationContext &fsOpContext, uint32_t uid, uint32_t gid, FSNode *dir,
+    const std::initializer_list<std::pair<QuotaResource, int64_t>> &resourceList) {
+	uint8_t status = statusFromQuotaCheck(quotaExceededUg(fsOpContext, uid, gid, resourceList));
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+	return statusFromQuotaCheck(quotaExceededDir(fsOpContext, dir, resourceList));
 }
 
 void FilesystemOperationsBase::quotaUpdate(

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -1277,10 +1277,12 @@ uint8_t FilesystemOperationsBase::trySetLength(const FsContext &context,
 				uint64_t newChunkId;
 				// We deny truncating parity only if truncating down
 				denyTruncatingParity = denyTruncatingParity && (length < fileNode->length);
+				const auto quotaCheck =
+				    quotaExceeded(fsOpContext, node, {{QuotaResource::kSize, 1}});
+				if (quotaCheck.status != SAUNAFS_STATUS_OK) { return quotaCheck.status; }
 				status = gChunkOperations->multiTruncate(
 				    fsOpContext, oldChunkId, lockId, (length & SFSCHUNKMASK), node->goal,
-				    denyTruncatingParity,
-				    quotaExceeded(fsOpContext, node, {{QuotaResource::kSize, 1}}), &newChunkId);
+				    denyTruncatingParity, quotaCheck.exceeded, &newChunkId);
 				if (status != SAUNAFS_STATUS_OK) { return status; }
 				fileNode->chunks[chunkIndex] = newChunkId;
 				*chunkid = newChunkId;
@@ -1759,11 +1761,14 @@ uint8_t FilesystemOperationsBase::symlink(const FsContext &context,
 		return SAUNAFS_ERROR_EEXIST;
 	}
 
-	if (context.isPersonalityMaster() &&
-	    (quotaExceededUg(fsOpContext, context.uid(), context.gid(),
-	                     {{QuotaResource::kInodes, 1}}) ||
-	     quotaExceededDir(fsOpContext, workDir, {{QuotaResource::kInodes, 1}}))) {
-		return SAUNAFS_ERROR_QUOTA;
+	if (context.isPersonalityMaster()) {
+		uint8_t quotaStatus = statusFromQuotaCheck(quotaExceededUg(
+		    fsOpContext, context.uid(), context.gid(), {{QuotaResource::kInodes, 1}}));
+		if (quotaStatus != SAUNAFS_STATUS_OK) { return quotaStatus; }
+
+		quotaStatus = statusFromQuotaCheck(
+		    quotaExceededDir(fsOpContext, workDir, {{QuotaResource::kInodes, 1}}));
+		if (quotaStatus != SAUNAFS_STATUS_OK) { return quotaStatus; }
 	}
 
 	auto *newNode = static_cast<FSNodeSymlink *>(nodeOperations_->createNode(
@@ -1848,10 +1853,13 @@ uint8_t FilesystemOperationsBase::mknod(const FsContext &context,
 	}
 
 	// Quota verification
-	if (quotaExceededUg(fsOpContext, context.uid(), context.gid(), {{QuotaResource::kInodes, 1}}) ||
-	    quotaExceededDir(fsOpContext, parentNode, {{QuotaResource::kInodes, 1}})) {
-		return SAUNAFS_ERROR_QUOTA;
-	}
+	uint8_t quotaStatus = statusFromQuotaCheck(
+	    quotaExceededUg(fsOpContext, context.uid(), context.gid(), {{QuotaResource::kInodes, 1}}));
+	if (quotaStatus != SAUNAFS_STATUS_OK) { return quotaStatus; }
+
+	quotaStatus = statusFromQuotaCheck(
+	    quotaExceededDir(fsOpContext, parentNode, {{QuotaResource::kInodes, 1}}));
+	if (quotaStatus != SAUNAFS_STATUS_OK) { return quotaStatus; }
 
 	static_cast<FSNodeDirectory *>(parentNode)->caseInsensitive = isCaseInsensitive;
 
@@ -1912,10 +1920,13 @@ uint8_t FilesystemOperationsBase::mkdir(const FsContext &context,
 		return SAUNAFS_ERROR_EEXIST;
 	}
 
-	if (quotaExceededUg(fsOpContext, context.uid(), context.gid(), {{QuotaResource::kInodes, 1}}) ||
-	    quotaExceededDir(fsOpContext, workNode, {{QuotaResource::kInodes, 1}})) {
-		return SAUNAFS_ERROR_QUOTA;
-	}
+	uint8_t quotaStatus = statusFromQuotaCheck(
+	    quotaExceededUg(fsOpContext, context.uid(), context.gid(), {{QuotaResource::kInodes, 1}}));
+	if (quotaStatus != SAUNAFS_STATUS_OK) { return quotaStatus; }
+
+	quotaStatus = statusFromQuotaCheck(
+	    quotaExceededDir(fsOpContext, workNode, {{QuotaResource::kInodes, 1}}));
+	if (quotaStatus != SAUNAFS_STATUS_OK) { return quotaStatus; }
 
 	if (gDisableEmptyFoldersMetadataOnFullDisk) {
 		if (isDepletedSpace()) {
@@ -2252,11 +2263,11 @@ uint8_t FilesystemOperationsBase::rename(const FsContext &context,
 		}
 	}
 
-	if (quotaExceededDirMove(fsOpContext, destWorkDir, sourceWorkDir,
+	uint8_t quotaStatus = statusFromQuotaCheck(
+	    quotaExceededDirMove(fsOpContext, destWorkDir, sourceWorkDir,
 	                         {{QuotaResource::kInodes, quotaDelta[(int)QuotaResource::kInodes]},
-	                          {QuotaResource::kSize, quotaDelta[(int)QuotaResource::kSize]}})) {
-		return SAUNAFS_ERROR_QUOTA;
-	}
+	                          {QuotaResource::kSize, quotaDelta[(int)QuotaResource::kSize]}}));
+	if (quotaStatus != SAUNAFS_STATUS_OK) { return quotaStatus; }
 
 	if (destinationChildNode != kNodeNotFound) {
 		nodeOperations_->unlink(fsOpContext, context.ts(), destWorkDir, baseNameDst,
@@ -2370,9 +2381,10 @@ uint8_t FilesystemOperationsBase::append(const FsContext &context,
 
 	if (status != SAUNAFS_STATUS_OK) { return status; }
 
-	if (context.isPersonalityMaster() &&
-	    quotaExceeded(fsOpContext, targetNode, {{QuotaResource::kSize, 1}})) {
-		return SAUNAFS_ERROR_QUOTA;
+	if (context.isPersonalityMaster()) {
+		uint8_t quotaStatus = statusFromQuotaCheck(
+		    quotaExceeded(fsOpContext, targetNode, {{QuotaResource::kSize, 1}}));
+		if (quotaStatus != SAUNAFS_STATUS_OK) { return quotaStatus; }
 	}
 	status = nodeOperations_->appendChunks(fsOpContext, context.ts(),
 	                                       static_cast<FSNodeFile *>(targetNode),
@@ -3002,7 +3014,9 @@ uint8_t FilesystemOperationsBase::writeChunk(const FsContext &context,
 	}
 #endif
 
-	const bool isQuotaExceeded = quotaExceeded(fsOpContext, fileNode, {{QuotaResource::kSize, 1}});
+	const auto quotaCheck = quotaExceeded(fsOpContext, fileNode, {{QuotaResource::kSize, 1}});
+	if (quotaCheck.status != SAUNAFS_STATUS_OK) { return quotaCheck.status; }
+	const bool isQuotaExceeded = quotaCheck.exceeded;
 
 	// Cache original stats for quota and parent update
 	StatsRecord originalStats;
@@ -4110,28 +4124,28 @@ uint8_t FilesystemOperationsBase::getChunksInfo(const FsContext &context, uint32
 
 #endif
 
-bool FilesystemOperationsBase::quotaExceededUg(
+QuotaCheckResult FilesystemOperationsBase::quotaExceededUg(
     [[maybe_unused]] const FilesystemOperationContext &fsOpContext, uint32_t uid, uint32_t gid,
     const std::initializer_list<std::pair<QuotaResource, int64_t>> &resourceList) {
-	return fsnodes_quota_exceeded_ug(uid, gid, resourceList);
+	return {.exceeded = fsnodes_quota_exceeded_ug(uid, gid, resourceList)};
 }
 
-bool FilesystemOperationsBase::quotaExceededDir(
+QuotaCheckResult FilesystemOperationsBase::quotaExceededDir(
     const FilesystemOperationContext &fsOpContext, FSNode *node,
     const std::initializer_list<std::pair<QuotaResource, int64_t>> &resourceList) {
-	return fsnodes_quota_exceeded_dir(fsOpContext, node, resourceList);
+	return {.exceeded = fsnodes_quota_exceeded_dir(fsOpContext, node, resourceList)};
 }
 
-bool FilesystemOperationsBase::quotaExceededDirMove(
+QuotaCheckResult FilesystemOperationsBase::quotaExceededDirMove(
     const FilesystemOperationContext &fsOpContext, FSNodeDirectory *node, FSNodeDirectory *prevNode,
     const std::initializer_list<std::pair<QuotaResource, int64_t>> &resourceList) {
-	return fsnodes_quota_exceeded_dir(fsOpContext, node, prevNode, resourceList);
+	return {.exceeded = fsnodes_quota_exceeded_dir(fsOpContext, node, prevNode, resourceList)};
 }
 
-bool FilesystemOperationsBase::quotaExceeded(
+QuotaCheckResult FilesystemOperationsBase::quotaExceeded(
     const FilesystemOperationContext &fsOpContext, FSNode *node,
     const std::initializer_list<std::pair<QuotaResource, int64_t>> &resourceList) {
-	return fsnodes_quota_exceeded(fsOpContext, node, resourceList);
+	return {.exceeded = fsnodes_quota_exceeded(fsOpContext, node, resourceList)};
 }
 
 void FilesystemOperationsBase::quotaUpdate(

--- a/src/master/filesystem_operations.h
+++ b/src/master/filesystem_operations.h
@@ -464,6 +464,12 @@ public:
 	    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, FSNode *node,
 	    const std::initializer_list<std::pair<QuotaResource, int64_t>> &resourceList) override;
 
+	/// Runs user/group then directory hard quota checks, propagating read-failure status.
+	/// @see IFilesystemOperations::checkQuotaUgDir
+	uint8_t checkQuotaUgDir(
+	    const FilesystemOperationContext &fsOpContext, uint32_t uid, uint32_t gid, FSNode *dir,
+	    const std::initializer_list<std::pair<QuotaResource, int64_t>> &resourceList) override;
+
 	/// Applies quota usage deltas for successful node mutations.
 	/// @see IFilesystemOperations::quotaUpdate
 	void quotaUpdate(

--- a/src/master/filesystem_operations.h
+++ b/src/master/filesystem_operations.h
@@ -441,26 +441,26 @@ public:
 
 	/// Checks hard user/group quota limits for resource deltas.
 	/// @see IFilesystemOperations::quotaExceededUg
-	bool quotaExceededUg(
+	QuotaCheckResult quotaExceededUg(
 	    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, uint32_t uid, uint32_t gid,
 	    const std::initializer_list<std::pair<QuotaResource, int64_t>> &resourceList) override;
 
 	/// Checks hard directory-owner quota limits for a node context.
 	/// @see IFilesystemOperations::quotaExceededDir
-	bool quotaExceededDir(
+	QuotaCheckResult quotaExceededDir(
 	    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, FSNode *node,
 	    const std::initializer_list<std::pair<QuotaResource, int64_t>> &resourceList) override;
 
 	/// Checks destination-side hard directory quota limits for move/rename.
 	/// @see IFilesystemOperations::quotaExceededDirMove
-	bool quotaExceededDirMove(
+	QuotaCheckResult quotaExceededDirMove(
 	    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, FSNodeDirectory *node,
 	    FSNodeDirectory *prevNode,
 	    const std::initializer_list<std::pair<QuotaResource, int64_t>> &resourceList) override;
 
 	/// Performs combined user/group and directory hard quota checks.
 	/// @see IFilesystemOperations::quotaExceeded
-	bool quotaExceeded(
+	QuotaCheckResult quotaExceeded(
 	    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, FSNode *node,
 	    const std::initializer_list<std::pair<QuotaResource, int64_t>> &resourceList) override;
 

--- a/src/master/filesystem_operations_interface.h
+++ b/src/master/filesystem_operations_interface.h
@@ -1739,6 +1739,32 @@ public:
 	    const FilesystemOperationContext &fsOpContext, FSNode *node,
 	    const std::initializer_list<std::pair<QuotaResource, int64_t>> &resourceList) = 0;
 
+	/// Runs the user/group then directory hard-quota checks for a create-style operation,
+	/// returning the final operation status directly.
+	///
+	/// Unlike quotaExceeded(), which derives the owner and directory context from a single
+	/// existing node, this takes the owner (@p uid / @p gid) and the target @p dir explicitly.
+	/// That is required on paths where the node does not exist yet (symlink, mknod, mkdir,
+	/// snapshot clone): the owner is the creating caller's context and the directory is the
+	/// intended parent.
+	///
+	/// It returns a status rather than a QuotaCheckResult because every caller folds the result
+	/// the same way and never inspects `exceeded` on its own; folding it here keeps each call
+	/// site to a single check. The user/group check is evaluated first and its status (including
+	/// a backend read failure) is propagated before the directory check runs.
+	///
+	/// @param fsOpContext Filesystem operation context carrying backend transaction state.
+	/// @param uid User owner id used for the user/group quota check.
+	/// @param gid Group owner id used for the user/group quota check.
+	/// @param dir Parent directory node whose owner/ancestor quotas are validated.
+	/// @param resourceList Resource deltas to validate (typically inodes and/or size).
+	/// @return SAUNAFS_STATUS_OK when neither check is exceeded and both reads succeed,
+	///         SAUNAFS_ERROR_QUOTA when a hard limit would be exceeded, or the backend status
+	///         on a quota read failure.
+	virtual uint8_t checkQuotaUgDir(
+	    const FilesystemOperationContext &fsOpContext, uint32_t uid, uint32_t gid, FSNode *dir,
+	    const std::initializer_list<std::pair<QuotaResource, int64_t>> &resourceList) = 0;
+
 	/// Applies quota usage deltas after a successful metadata mutation.
 	///
 	/// In the in-memory implementation, this updates only user/group `used` counters

--- a/src/master/filesystem_operations_interface.h
+++ b/src/master/filesystem_operations_interface.h
@@ -31,6 +31,7 @@
 #include "common/attributes.h"
 #include "common/defective_file_info.h"
 #include "common/goal.h"
+#include "errors/saunafs_error_codes.h"
 #include "master/checksum.h"
 #include "master/filesystem_node_operations_interface.h"
 #include "master/filesystem_node_types.h"
@@ -50,6 +51,18 @@ struct ChunkWithAddressAndLabel;
 
 struct QuotaEntry;
 struct QuotaOwner;
+
+/// Result of a quota enforcement check. Fallible backends must report quota read failures
+/// through status, because a KV backend read error may not reliably fail the later commit.
+struct QuotaCheckResult {
+	uint8_t status = SAUNAFS_STATUS_OK;
+	bool exceeded = false;
+};
+
+inline uint8_t statusFromQuotaCheck(const QuotaCheckResult &result) {
+	if (result.status != SAUNAFS_STATUS_OK) { return result.status; }
+	return result.exceeded ? SAUNAFS_ERROR_QUOTA : SAUNAFS_STATUS_OK;
+}
 
 struct NamedInodeEntry;
 struct HandleInodeEntry;
@@ -1681,8 +1694,8 @@ public:
 	/// @param uid User owner id used for user quota checks.
 	/// @param gid Group owner id used for group quota checks.
 	/// @param resourceList Resource deltas to validate (typically inodes and/or size).
-	/// @return true if either user or group hard quota would be exceeded.
-	virtual bool quotaExceededUg(
+	/// @return status plus whether either user or group hard quota would be exceeded.
+	virtual QuotaCheckResult quotaExceededUg(
 	    const FilesystemOperationContext &fsOpContext, uint32_t uid, uint32_t gid,
 	    const std::initializer_list<std::pair<QuotaResource, int64_t>> &resourceList) = 0;
 
@@ -1694,8 +1707,8 @@ public:
 	/// @param fsOpContext Filesystem operation context carrying backend transaction state.
 	/// @param node Node whose directory context is validated.
 	/// @param resourceList Resource deltas to validate (typically inodes and/or size).
-	/// @return true if any checked directory hard quota would be exceeded.
-	virtual bool quotaExceededDir(
+	/// @return status plus whether any checked directory hard quota would be exceeded.
+	virtual QuotaCheckResult quotaExceededDir(
 	    const FilesystemOperationContext &fsOpContext, FSNode *node,
 	    const std::initializer_list<std::pair<QuotaResource, int64_t>> &resourceList) = 0;
 
@@ -1708,8 +1721,8 @@ public:
 	/// @param node Destination directory.
 	/// @param prevNode Previous/source directory.
 	/// @param resourceList Resource deltas to validate for the move.
-	/// @return true if destination-side hard quotas would be exceeded.
-	virtual bool quotaExceededDirMove(
+	/// @return status plus whether destination-side hard quotas would be exceeded.
+	virtual QuotaCheckResult quotaExceededDirMove(
 	    const FilesystemOperationContext &fsOpContext, FSNodeDirectory *node,
 	    FSNodeDirectory *prevNode,
 	    const std::initializer_list<std::pair<QuotaResource, int64_t>> &resourceList) = 0;
@@ -1721,8 +1734,8 @@ public:
 	/// @param fsOpContext Filesystem operation context carrying backend transaction state.
 	/// @param node Node whose owner and directory quotas are validated.
 	/// @param resourceList Resource deltas to validate.
-	/// @return true if any relevant hard quota would be exceeded.
-	virtual bool quotaExceeded(
+	/// @return status plus whether any relevant hard quota would be exceeded.
+	virtual QuotaCheckResult quotaExceeded(
 	    const FilesystemOperationContext &fsOpContext, FSNode *node,
 	    const std::initializer_list<std::pair<QuotaResource, int64_t>> &resourceList) = 0;
 

--- a/src/master/snapshot_task.cc
+++ b/src/master/snapshot_task.cc
@@ -30,18 +30,22 @@
 
 int SnapshotTask::cloneNodeTest(const FilesystemOperationContext &fsOpContext, FSNode *src_node,
                                 FSNode *dst_node, FSNodeDirectory *dst_parent) {
-	if (gFSOperations->quotaExceededUg(fsOpContext, src_node->uid, src_node->gid,
-	                                   {{QuotaResource::kInodes, 1}}) ||
-	    gFSOperations->quotaExceededDir(fsOpContext, dst_parent,
-	                                    {{QuotaResource::kInodes, 1}})) {
-		return SAUNAFS_ERROR_QUOTA;
-	}
-	if (src_node->type == FSNodeType::kFile &&
-	    (gFSOperations->quotaExceededUg(fsOpContext, src_node->uid, src_node->gid,
-	                                    {{QuotaResource::kSize, 1}}) ||
-	     gFSOperations->quotaExceededDir(fsOpContext, dst_parent,
-	                                    {{QuotaResource::kSize, 1}}))) {
-		return SAUNAFS_ERROR_QUOTA;
+	int quotaStatus = statusFromQuotaCheck(gFSOperations->quotaExceededUg(
+	    fsOpContext, src_node->uid, src_node->gid, {{QuotaResource::kInodes, 1}}));
+	if (quotaStatus != SAUNAFS_STATUS_OK) { return quotaStatus; }
+
+	quotaStatus = statusFromQuotaCheck(
+	    gFSOperations->quotaExceededDir(fsOpContext, dst_parent, {{QuotaResource::kInodes, 1}}));
+	if (quotaStatus != SAUNAFS_STATUS_OK) { return quotaStatus; }
+
+	if (src_node->type == FSNodeType::kFile) {
+		quotaStatus = statusFromQuotaCheck(gFSOperations->quotaExceededUg(
+		    fsOpContext, src_node->uid, src_node->gid, {{QuotaResource::kSize, 1}}));
+		if (quotaStatus != SAUNAFS_STATUS_OK) { return quotaStatus; }
+
+		quotaStatus = statusFromQuotaCheck(
+		    gFSOperations->quotaExceededDir(fsOpContext, dst_parent, {{QuotaResource::kSize, 1}}));
+		if (quotaStatus != SAUNAFS_STATUS_OK) { return quotaStatus; }
 	}
 
 	if (dst_node) {

--- a/src/master/snapshot_task.cc
+++ b/src/master/snapshot_task.cc
@@ -30,21 +30,13 @@
 
 int SnapshotTask::cloneNodeTest(const FilesystemOperationContext &fsOpContext, FSNode *src_node,
                                 FSNode *dst_node, FSNodeDirectory *dst_parent) {
-	int quotaStatus = statusFromQuotaCheck(gFSOperations->quotaExceededUg(
-	    fsOpContext, src_node->uid, src_node->gid, {{QuotaResource::kInodes, 1}}));
-	if (quotaStatus != SAUNAFS_STATUS_OK) { return quotaStatus; }
-
-	quotaStatus = statusFromQuotaCheck(
-	    gFSOperations->quotaExceededDir(fsOpContext, dst_parent, {{QuotaResource::kInodes, 1}}));
+	int quotaStatus = gFSOperations->checkQuotaUgDir(
+	    fsOpContext, src_node->uid, src_node->gid, dst_parent, {{QuotaResource::kInodes, 1}});
 	if (quotaStatus != SAUNAFS_STATUS_OK) { return quotaStatus; }
 
 	if (src_node->type == FSNodeType::kFile) {
-		quotaStatus = statusFromQuotaCheck(gFSOperations->quotaExceededUg(
-		    fsOpContext, src_node->uid, src_node->gid, {{QuotaResource::kSize, 1}}));
-		if (quotaStatus != SAUNAFS_STATUS_OK) { return quotaStatus; }
-
-		quotaStatus = statusFromQuotaCheck(
-		    gFSOperations->quotaExceededDir(fsOpContext, dst_parent, {{QuotaResource::kSize, 1}}));
+		quotaStatus = gFSOperations->checkQuotaUgDir(
+		    fsOpContext, src_node->uid, src_node->gid, dst_parent, {{QuotaResource::kSize, 1}});
 		if (quotaStatus != SAUNAFS_STATUS_OK) { return quotaStatus; }
 	}
 


### PR DESCRIPTION
The quota check virtuals returned bool, which conflates two distinct outcomes: "a hard quota would be exceeded" and "the backend could not read the quota state". That is fine for the in-memory backend, where reading quota state cannot fail. It is not fine for alternative KV backends: a quota read there can fail, and such a read failure does not reliably fail the later metadata commit. Folding a failed read into "not exceeded" lets a metadata mutation commit without an enforced quota check (fail-open).

Widen the contract to QuotaCheckResult{status, exceeded} so a backend can surface a read failure as a status instead of a silent false. Add statusFromQuotaCheck, which maps {OK, true} to SAUNAFS_ERROR_QUOTA and propagates any non-OK status before exceeded is inspected. Update quotaExceeded, quotaExceededUg, quotaExceededDir, and quotaExceededDirMove plus their call sites (trySetLength, symlink, mknod, mkdir, rename, append, writeChunk, and snapshot cloneNodeTest) to check status before acting on exceeded.

The in-memory base returns SAUNAFS_STATUS_OK unconditionally, so its behavior is unchanged. This commit lands only the public contract and the call-site propagation; the KV-backed implementation that reports read failures as SAUNAFS_ERROR_IO lives in an alternative backend.

Related to: LS-756, LS-759