### PR TITLE
tests: remove pidof usage from Ganesha helper

### DIFF
--- a/tests/tools/ganesha.sh
+++ b/tests/tools/ganesha.sh
@@ -40,13 +40,8 @@ check_and_recover_rpc_service() {
 		return 0
 	fi
 
-	rpcbind_pid=$(pidof rpcbind)
-
-	# Check if rpcbind is running and restart it
-	if [ -n "$rpcbind_pid" ]; then
-		echo "RPC service is unavailable"
-		sudo pkill -HUP rpcbind
-	fi
+	echo "RPC service is unavailable"
+	sudo pkill -x -HUP rpcbind 2>/dev/null || true
 
 	return 1
 }


### PR DESCRIPTION
The pidof call was only used to determine whether rpcbind was running before issuing a HUP signal. Since pkill is already used for the signal operation, the additional check is redundant.

Remove the pidof usage to avoid introducing a dependency on procps as requested by Debian bug [#1136582](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1136582).
Related to: LS-820
Reported-by: Gioele Barabucci <gioele@debian.org>