### PR TITLE
refactor(master): node-operations backend seams

### DIFF
--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -1305,6 +1305,19 @@ std::vector<inode_t> FilesystemNodeOperationsBase::getDirectoryChildInodes(
 	return childInodes;
 }
 
+std::vector<std::pair<HString, inode_t>> FilesystemNodeOperationsBase::getDirectoryChildEdges(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, const FSNodeDirectory *nodeDir) {
+	std::vector<std::pair<HString, inode_t>> childEdges;
+	if (nodeDir == nullptr) { return childEdges; }
+
+	childEdges.reserve(nodeDir->entries.size());
+	for (const auto &entry : nodeDir->entries) {
+		childEdges.emplace_back(HString(*entry.first), entry.second->id);
+	}
+
+	return childEdges;
+}
+
 uint8_t FilesystemNodeOperationsBase::appendChunks(const FilesystemOperationContext &fsOpContext,
                                                    uint32_t timeStamp, FSNodeFile *destNodeFile,
                                                    FSNodeFile *srcNodeFile) {

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -762,14 +762,15 @@ FSNode *FilesystemNodeOperationsBase::createNode(
 	}
 
 	// If desired, node inherits permissions from parent's default ACL
+	std::optional<RichACL> parentAclScratch;
 	const RichACL *parentAcl = (inheritAcl == AclInheritance::kInheritAcl)
-	                               ? gMetadata->aclStorage.get(parent->id)
+	                               ? getAclForAccess(fsOpContext, parent, parentAclScratch)
 	                               : nullptr;
 	if (parentAcl != nullptr) {
 		RichACL acl;
 		uint16_t mode = node->mode;
 		if (RichACL::inheritInode(*parentAcl, mode, acl, umask, type == FSNodeType::kDirectory)) {
-			gMetadata->aclStorage.set(node->id, std::move(acl));
+			storeInheritedAcl(fsOpContext, node, std::move(acl));
 		}
 		// Set effective permissions as the intersection of mode and ACL
 		node->mode &= mode | ~kStandardPermissionsMask;
@@ -2180,6 +2181,11 @@ const RichACL *FilesystemNodeOperationsBase::getAclForAccess(
     [[maybe_unused]] const FilesystemOperationContext &fsOpContext, FSNode *node,
     [[maybe_unused]] std::optional<RichACL> &scratch) {
 	return gMetadata->aclStorage.get(node->id);
+}
+
+void FilesystemNodeOperationsBase::storeInheritedAcl(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, FSNode *node, RichACL &&acl) {
+	gMetadata->aclStorage.set(node->id, std::move(acl));
 }
 
 int FilesystemNodeOperationsBase::access(const FsContext &context,

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -1318,6 +1318,13 @@ std::vector<std::pair<HString, inode_t>> FilesystemNodeOperationsBase::getDirect
 	return childEdges;
 }
 
+std::string FilesystemNodeOperationsBase::getBaseStoredChildName(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, FSNodeDirectory *nodeDir,
+    const HString &anyCaseName) {
+	if (nodeDir == nullptr) { return {}; }
+	return nodeDir->getBaseStoredChildName(anyCaseName);
+}
+
 uint8_t FilesystemNodeOperationsBase::appendChunks(const FilesystemOperationContext &fsOpContext,
                                                    uint32_t timeStamp, FSNodeFile *destNodeFile,
                                                    FSNodeFile *srcNodeFile) {

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -1301,7 +1301,9 @@ std::vector<inode_t> FilesystemNodeOperationsBase::getDirectoryChildInodes(
 	if (nodeDir == nullptr) { return childInodes; }
 
 	childInodes.reserve(nodeDir->entries.size());
-	for (const auto &entry : nodeDir->entries) { childInodes.push_back(entry.second->id); }
+	for (const auto &entry : nodeDir->entries) {
+		if (entry.second != nullptr) { childInodes.push_back(entry.second->id); }
+	}
 
 	return childInodes;
 }
@@ -1313,7 +1315,9 @@ std::vector<std::pair<HString, inode_t>> FilesystemNodeOperationsBase::getDirect
 
 	childEdges.reserve(nodeDir->entries.size());
 	for (const auto &entry : nodeDir->entries) {
-		childEdges.emplace_back(HString(*entry.first), entry.second->id);
+		if (entry.second != nullptr) {
+			childEdges.emplace_back(HString(*entry.first), entry.second->id);
+		}
 	}
 
 	return childEdges;

--- a/src/master/filesystem_node.h
+++ b/src/master/filesystem_node.h
@@ -161,6 +161,12 @@ public:
 	std::vector<std::pair<HString, inode_t>> getDirectoryChildEdges(
 	    const FilesystemOperationContext &fsOpContext, const FSNodeDirectory *nodeDir) override;
 
+	/// Resolves the stored-case child name via the directory's in-memory lowercase index.
+	/// @see IFilesystemNodeOperations::getBaseStoredChildName
+	std::string getBaseStoredChildName(const FilesystemOperationContext &fsOpContext,
+	                                   FSNodeDirectory *nodeDir,
+	                                   const HString &anyCaseName) override;
+
 	/// Checks if a name is already used in the given directory.
 	/// @see IFilesystemNodeOperations::isNameUsed
 	bool isNameUsed(const FilesystemOperationContext &fsOpContext, FSNodeDirectory *node,

--- a/src/master/filesystem_node.h
+++ b/src/master/filesystem_node.h
@@ -156,6 +156,11 @@ public:
 	std::vector<inode_t> getDirectoryChildInodes(const FilesystemOperationContext &fsOpContext,
 	                                             const FSNodeDirectory *nodeDir) override;
 
+	/// Returns direct child (name, inode) edges for a directory.
+	/// @see IFilesystemNodeOperations::getDirectoryChildEdges
+	std::vector<std::pair<HString, inode_t>> getDirectoryChildEdges(
+	    const FilesystemOperationContext &fsOpContext, const FSNodeDirectory *nodeDir) override;
+
 	/// Checks if a name is already used in the given directory.
 	/// @see IFilesystemNodeOperations::isNameUsed
 	bool isNameUsed(const FilesystemOperationContext &fsOpContext, FSNodeDirectory *node,

--- a/src/master/filesystem_node.h
+++ b/src/master/filesystem_node.h
@@ -275,6 +275,13 @@ protected:
 	/// The caller avoids constructing a RichACL when it is not needed.
 	virtual const RichACL *getAclForAccess(const FilesystemOperationContext &fsOpContext,
 	                                       FSNode *node, std::optional<RichACL> &scratch);
+
+	/// Persists the ACL a freshly created @p node inherits from its parent's default ACL.
+	/// The default in-memory implementation stores into aclStorage; backends that keep ACLs
+	/// elsewhere (e.g. KV) override to persist there. @p acl is consumed.
+	virtual void storeInheritedAcl(const FilesystemOperationContext &fsOpContext, FSNode *node,
+	                               RichACL &&acl);
+
 	int stickyAccess(FSNode *parent, FSNode *node, uint32_t uid) override;
 	int nameCheck(const std::string &name) override;
 	uint8_t verifySession(const FsContext &context, OperationMode operationMode,

--- a/src/master/filesystem_node_operations_interface.h
+++ b/src/master/filesystem_node_operations_interface.h
@@ -450,6 +450,24 @@ public:
 	virtual std::vector<std::pair<HString, inode_t>> getDirectoryChildEdges(
 	    const FilesystemOperationContext &fsOpContext, const FSNodeDirectory *nodeDir) = 0;
 
+	/// Returns the original stored-case name under which `nodeDir`'s child matching `anyCaseName`
+	/// is recorded, resolving case-insensitively (any-case input maps to the stored casing).
+	/// Returns an empty string if no matching child exists. Used to canonicalize names under
+	/// case-insensitive directories (e.g. a symlink target).
+	///
+	/// Backend expectations:
+	/// - in-memory implementation resolves via the directory's in-memory lowercase index,
+	/// - KV/FDB implementation resolves via persisted edge indices and must not depend on
+	///   `nodeDir->entries`/`lowerCaseEntries` being populated.
+	///
+	/// @param fsOpContext The filesystem operation context (transaction).
+	/// @param nodeDir Case-insensitive directory to resolve the child name in.
+	/// @param anyCaseName Any-case child name to canonicalize.
+	/// @return The original stored-case child name, or empty if not found.
+	virtual std::string getBaseStoredChildName(const FilesystemOperationContext &fsOpContext,
+	                                           FSNodeDirectory *nodeDir,
+	                                           const HString &anyCaseName) = 0;
+
 	/// Checks if a name is already used in the given directory.
 	///
 	/// Determines whether a directory entry with the specified name exists in the given

--- a/src/master/filesystem_node_operations_interface.h
+++ b/src/master/filesystem_node_operations_interface.h
@@ -433,6 +433,23 @@ public:
 	virtual std::vector<inode_t> getDirectoryChildInodes(
 	    const FilesystemOperationContext &fsOpContext, const FSNodeDirectory *nodeDir) = 0;
 
+	/// Returns direct child (name, inode) edges for a directory.
+	///
+	/// Like getDirectoryChildInodes but also carries the edge name, for recursive
+	/// operations that must recreate the edges in a destination (for example snapshot
+	/// cloning).
+	///
+	/// Backend expectations:
+	/// - in-memory metadata implementation reads children from `nodeDir->entries`,
+	/// - KV/FDB implementation enumerates children from persistent EDGE_* records and must not
+	///   depend on `nodeDir->entries` being populated.
+	///
+	/// @param fsOpContext The filesystem operation context (transaction).
+	/// @param nodeDir Directory whose direct child (name, inode) edges should be returned.
+	/// @return Direct child (name, inode) edges (excluding "." and "..").
+	virtual std::vector<std::pair<HString, inode_t>> getDirectoryChildEdges(
+	    const FilesystemOperationContext &fsOpContext, const FSNodeDirectory *nodeDir) = 0;
+
 	/// Checks if a name is already used in the given directory.
 	///
 	/// Determines whether a directory entry with the specified name exists in the given

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -1333,10 +1333,11 @@ uint8_t FilesystemOperationsBase::getCanonicalPath(const FsContext &context,
 				dir->updateLowerCaseEntries();
 			}
 
-			// Case-insensitive: resolve canonical casing using getBaseStoredChildName
+			// Canonicalize to the stored-case child name, so a stored symlink target still
+			// resolves after case-insensitivity is later turned off.
 			std::string baseName;
 			if (caseInsensitiveFS) {
-				baseName = dir->getBaseStoredChildName(name);
+				baseName = nodeOperations_->getBaseStoredChildName(fsOpContext, dir, name);
 				if (baseName.empty()) { return SAUNAFS_ERROR_ENOENT; }
 			} else {
 				baseName = name;

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -1777,6 +1777,12 @@ uint8_t FilesystemOperationsBase::symlink(const FsContext &context,
 
 	fsnodes_update_checksum(newNode);
 
+	// Re-persist: createNode() stored the node before the symlink target was set above
+	// (no-op on the in-memory backend).
+	if (fsOpContext.hasReadWriteTransaction()) {
+		nodeOperations_->updateNode(fsOpContext, newNode);
+	}
+
 	StatsRecord statsRecord;
 	memset(&statsRecord, 0, sizeof(StatsRecord));
 	statsRecord.length = basePath.length();

--- a/src/master/snapshot_task.cc
+++ b/src/master/snapshot_task.cc
@@ -61,7 +61,7 @@ FSNode *SnapshotTask::cloneToExistingNode(const FilesystemOperationContext &fsOp
 
 	switch (src_node->type) {
 	case FSNodeType::kDirectory:
-		cloneDirectoryData(static_cast<const FSNodeDirectory *>(src_node),
+		cloneDirectoryData(fsOpContext, static_cast<const FSNodeDirectory *>(src_node),
 		                   static_cast<FSNodeDirectory *>(dst_node));
 		break;
 	case FSNodeType::kFile:
@@ -105,7 +105,7 @@ FSNode *SnapshotTask::cloneToNewNode(const FilesystemOperationContext &fsOpConte
 
 	switch (src_node->type) {
 	case FSNodeType::kDirectory:
-		cloneDirectoryData(static_cast<const FSNodeDirectory *>(src_node),
+		cloneDirectoryData(fsOpContext, static_cast<const FSNodeDirectory *>(src_node),
 		                   static_cast<FSNodeDirectory *>(dst_node));
 		break;
 	case FSNodeType::kFile:
@@ -180,15 +180,17 @@ void SnapshotTask::cloneChunkData(const FilesystemOperationContext &fsOpContext,
 	                           {{QuotaResource::kSize, nsr.size - psr.size}});
 }
 
-void SnapshotTask::cloneDirectoryData(const FSNodeDirectory *src_node, FSNodeDirectory *dst_node) {
+void SnapshotTask::cloneDirectoryData(const FilesystemOperationContext &fsOpContext,
+                                      const FSNodeDirectory *src_node, FSNodeDirectory *dst_node) {
 	if (!enqueue_work_) {
 		return;
 	}
 	SubtaskContainer data;
-	data.reserve(src_node->entries.size());
-	for (const auto &entry : src_node->entries) {
-		auto local_id = entry.second->id;
-		data.emplace_back(std::move(local_id), (HString)(*entry.first));
+	// Enumerate children through the backend-agnostic edge seam: the in-memory backend
+	// reads `src_node->entries`, the KV backend scans EDGE_* rows (entries is not populated).
+	for (auto &[name, childId] :
+	     gFSOperations->nodeOperations()->getDirectoryChildEdges(fsOpContext, src_node)) {
+		data.emplace_back(childId, std::move(name));
 	}
 	if (!data.empty()) {
 		auto task = new SnapshotTask(std::move(data), orig_inode_, dst_node->id, 0, can_overwrite_,

--- a/src/master/snapshot_task.cc
+++ b/src/master/snapshot_task.cc
@@ -188,8 +188,9 @@ void SnapshotTask::cloneDirectoryData(const FilesystemOperationContext &fsOpCont
 	SubtaskContainer data;
 	// Enumerate children through the backend-agnostic edge seam: the in-memory backend
 	// reads `src_node->entries`, the KV backend scans EDGE_* rows (entries is not populated).
-	for (auto &[name, childId] :
-	     gFSOperations->nodeOperations()->getDirectoryChildEdges(fsOpContext, src_node)) {
+	auto childEdges = gFSOperations->nodeOperations()->getDirectoryChildEdges(fsOpContext, src_node);
+	data.reserve(childEdges.size());
+	for (auto &[name, childId] : childEdges) {
 		data.emplace_back(childId, std::move(name));
 	}
 	if (!data.empty()) {

--- a/src/master/snapshot_task.h
+++ b/src/master/snapshot_task.h
@@ -98,8 +98,8 @@ protected:
 	                                    FSNodeFile *dst_node);
 	void cloneChunkData(const FilesystemOperationContext &fsOpContext, const FSNodeFile *src_node,
 	                    FSNodeFile *dst_node, FSNodeDirectory *dst_parent);
-	void cloneDirectoryData(const FSNodeDirectory *src_node, FSNodeDirectory *dst_node);
-	void cloneDirectoryData(FSNodeDirectory *src_node, FSNodeDirectory *dst_node);
+	void cloneDirectoryData(const FilesystemOperationContext &fsOpContext,
+	                        const FSNodeDirectory *src_node, FSNodeDirectory *dst_node);
 	void cloneSymlinkData(const FilesystemOperationContext &fsOpContext, FSNodeSymlink *src_node,
 	                      FSNodeSymlink *dst_node, FSNodeDirectory *dst_parent);
 


### PR DESCRIPTION
Adds extension seams to the node-operations interface so a backend that
does not hold the namespace and ACLs in memory can override how directory
children, canonical child names, and inherited ACLs are read and written.
Every change is behavior-neutral for the in-memory backend: each new
virtual ships a default implementation that preserves the existing
in-memory code path.

What changes

* getDirectoryChildEdges seam. Snapshot directory recursion enumerated
  children straight from FSNodeDirectory::entries. It now goes through a
  name-bearing enumerator seam (the sibling of the existing
  getDirectoryChildInodes), so a backend that populates entries lazily
  can enumerate from its own records. The operation context is threaded
  through cloneDirectoryData.

* getBaseStoredChildName seam. getCanonicalPath resolved a
  case-insensitive directory's stored-case child name via the in-memory
  directory index. That resolution is now a seam; the base class keeps
  the in-memory implementation.

* Symlink re-persist. createNode persists a symlink node before its
  target path is assigned. The node is now re-persisted after the target
  is set, so a backend that persists on updateNode stores the target.
  No-op on the in-memory backend, where updateNode does nothing.

* storeInheritedAcl seam. Create-time inherited-ACL writes are routed
  through a seam, and the parent default-ACL read reuses the existing
  getAclForAccess seam. The default implementation stores into
  aclStorage, unchanged from before.

Why

These operations read FSNode structures (entries, the lowercase index,
aclStorage) directly. A backend that keeps that state out of memory
cannot override the behavior without a seam. The seams keep the
in-memory backend on its existing fast path while letting alternative
backends plug in.

Compatibility

No behavior change for the in-memory backend. Default implementations
reproduce the previous code exactly, and the symlink re-persist is a
no-op there. Covered by the existing master test suite.

Related to LS-817