### PR TITLE
perf: improve write batching

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ if(ENABLE_CCACHE AND CCACHE_FOUND)
   message(STATUS "Using ccache")
 endif()
 
-set(DEFAULT_MIN_VERSION "5.10.0")
+set(DEFAULT_MIN_VERSION "5.11.0")
 
 include(GNUInstallDirs)
 

--- a/doc/sfsmount.1.adoc
+++ b/doc/sfsmount.1.adoc
@@ -193,7 +193,8 @@ Try to change nice level to specified value on startup (default: -19).
 Define number of write workers (default: 10).
 
 *-o sfswritewindowsize=*'N'::
-Define write window size (in blocks) for each chunk (default: 15).
+Define write window size (in blocks) for each chunk. Can be updated via
+tweaks hidden file (default: 15).
 
 *-o sfsmemlock*::
 Try to lock memory (must be enabled at build time).
@@ -227,6 +228,12 @@ Equivalent to *--nonempty* option for use in fstab.
 *-o sfsmaxchunkswritteninparallelperinode=*'N'::
 Define the maximum number of chunks that can be written in parallel per inode.
 0 stands for unlimited (default: 0).
+
+*-o sfsusewriteflushpacket=*'0|1'::
+When set to 1, suggests the chunkserver to flush the packets received every
+window size blocks  (option sfswritewindowsize) or when a write needs to finish
+(e.g. when flush() is called on the inode or when enough time has passed). Can
+be updated via tweaks hidden file (default: 0).
 
 *-o sfsdirectio=*'0|1'::
 Whether to use FUSE DirectIO. This may improve performance when reading large

--- a/src/chunkserver/chunk_high_level_ops.cc
+++ b/src/chunkserver/chunk_high_level_ops.cc
@@ -338,6 +338,10 @@ bool WriteHighLevelOp::isWriteJobBeingProcessed() const { return writeJobId_ != 
 
 void WriteHighLevelOp::setNoWriteJobBeingProcessed() { writeJobId_ = 0; }
 
+bool WriteHighLevelOp::isInputBufferFreezable() const {
+	return inputBuffer_ != nullptr && !inputBuffer_->isBeingUpdated();
+}
+
 void WriteHighLevelOp::startOpenWriteJob() {
 	writeJobWriteId_ = 0;
 	writeJobId_ = job_open(
@@ -389,55 +393,135 @@ void WriteHighLevelOp::delayedCloseCallback(uint8_t status, void * /*entry*/) {
 	decreasePendingWriteJobsToCheckAndApplyClosedOnParent();
 }
 
+// ---------------------------------------------------------------------------
+// Differentiating hooks. Each `WriteHighLevelOp` base implementation is
+// immediately followed by the matching `WriteHighLevelOpExpectFlush` override
+// for easy side-by-side comparison.
+// ---------------------------------------------------------------------------
+
+bool WriteHighLevelOp::canStartWriteJobNow() const {
+	return !writeDataBuffers_.empty() && !isWriteJobBeingProcessed();
+}
+
+bool WriteHighLevelOpExpectFlush::canStartWriteJobNow() const {
+	if (!expectsWriteFlush_) { return WriteHighLevelOp::canStartWriteJobNow(); }
+	return !writeDataBuffers_.empty() && !isWriteJobBeingProcessed() &&
+	       !inputBuffersForNextFlush_.empty();
+}
+
+bool WriteHighLevelOp::shouldWriteCurrentInputBuffer() const {
+	return isInputBufferFreezable() && (inputBuffer_->isFull() || !isWriteJobBeingProcessed());
+}
+
+bool WriteHighLevelOpExpectFlush::shouldWriteCurrentInputBuffer() const {
+	if (!expectsWriteFlush_) { return WriteHighLevelOp::shouldWriteCurrentInputBuffer(); }
+	return isInputBufferFreezable() && inputBuffer_->isFull();
+}
+
+void WriteHighLevelOp::freezeCurrentInputBuffer() {
+	writeDataBuffers_.emplace_back(std::move(inputBuffer_));
+}
+
+void WriteHighLevelOpExpectFlush::freezeCurrentInputBuffer() {
+	WriteHighLevelOp::freezeCurrentInputBuffer();
+	if (expectsWriteFlush_) { ++inputBuffersReadySinceLastFlush_; }
+}
+
+void WriteHighLevelOp::collectInputBuffersForNextJob(std::vector<InputBuffer *> &inputBuffers) {
+	if (writeDataBuffers_.front()->currentBlocks() == 0) {
+		safs::log_warn("({}) Called with no blocks in front InputBuffer.", __func__);
+	}
+
+	enqueuedInputBuffers_ = 1;
+	inputBuffers.push_back(writeDataBuffers_.front().get());
+}
+
+void WriteHighLevelOpExpectFlush::collectInputBuffersForNextJob(
+    std::vector<InputBuffer *> &inputBuffers) {
+	if (!expectsWriteFlush_) {
+		WriteHighLevelOp::collectInputBuffersForNextJob(inputBuffers);
+		return;
+	}
+
+	enqueuedInputBuffers_ = inputBuffersForNextFlush_.front();
+	inputBuffersForNextFlush_.pop();
+
+	if (writeDataBuffers_.size() < enqueuedInputBuffers_) {
+		safs::log_err("({}) Fewer available write data buffers than expected ({} < {}).", __func__,
+		              writeDataBuffers_.size(), enqueuedInputBuffers_);
+		enqueuedInputBuffers_ = writeDataBuffers_.size();
+	}
+
+	auto inputBuffersIt = writeDataBuffers_.begin();
+	for (uint32_t i = 0; i < enqueuedInputBuffers_; i++) {
+		if (inputBuffersIt->get()->currentBlocks() == 0) {
+			safs::log_warn("({}) Called with no blocks in front InputBuffer.", __func__);
+		}
+
+		inputBuffers.push_back(inputBuffersIt->get());
+		inputBuffersIt++;
+	}
+}
+
+bool WriteHighLevelOp::shouldDeferInstantReply(bool /*fromFlushDataCall*/) const { return false; }
+
+bool WriteHighLevelOpExpectFlush::shouldDeferInstantReply(bool fromFlushDataCall) const {
+	return expectsWriteFlush_ && !fromFlushDataCall;
+}
+
+void WriteHighLevelOp::onSwitchingToEagerWriteOnDelayedClose() {}
+
+void WriteHighLevelOpExpectFlush::onSwitchingToEagerWriteOnDelayedClose() {
+	expectsWriteFlush_ = false;
+}
+
+void WriteHighLevelOp::resetFlushBatchingState() {}
+
+void WriteHighLevelOpExpectFlush::resetFlushBatchingState() {
+	inputBuffersReadySinceLastFlush_ = 0;
+	inputBuffersForNextFlush_ = std::queue<uint32_t>();
+}
+
+void WriteHighLevelOp::flushData() {
+	safs::log_warn("({}) Called flushData on a write operation that does not expect write flush.",
+	               __func__);
+}
+
+void WriteHighLevelOpExpectFlush::flushData() {
+	tryInstantReply(true);
+
+	if (inputBuffer_ != nullptr && inputBuffer_->currentBlocks() > 0 &&
+	    !inputBuffer_->isBeingUpdated()) {
+		freezeCurrentInputBuffer();
+	}
+
+	if (inputBuffersReadySinceLastFlush_ > 0) {
+		inputBuffersForNextFlush_.push(inputBuffersReadySinceLastFlush_);
+		inputBuffersReadySinceLastFlush_ = 0;
+
+		if (canStartWriteJobNow()) { startNextWriteJob(); }
+	} else {
+		// This can happen if the connection is created but very little data is sent, which implies
+		// some WriteHighLevelOp receive no write data packets.
+		safs::log_debug("({}) Called flushData with no input buffers ready to be flushed.",
+		                __func__);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// End of differentiating hooks.
+// ---------------------------------------------------------------------------
+
 void WriteHighLevelOp::startNextWriteJob() {
-	if (writeDataBuffers_.empty()) {
-		safs::log_warn("({}) Called with no write data buffers.", __func__);
-		return;
-	}
-
-	if (isWriteJobBeingProcessed()) {
-		safs::log_warn("({}) Called with write job already in progress.", __func__);
-		return;
-	}
-
-	if (expectWriteFlush_ && inputBuffersForNextFlush_.empty()) {
-		safs::log_warn(
-		    "({}) Called with no input buffers ready to be flushed while expecting write flush.",
-		    __func__);
+	if (!canStartWriteJobNow()) {
+		safs::log_warn("({}) Called when not ready to start a write job.", __func__);
 		return;
 	}
 
 	/// Start the next write job: it is always the first write data buffer
 	writeJobWriteId_ = writeDataBuffers_.front()->getLastWriteId();
 	std::vector<InputBuffer *> inputBuffers;
-
-	if (expectWriteFlush_) {
-		enqueuedInputBuffers_ = inputBuffersForNextFlush_.front();
-		inputBuffersForNextFlush_.pop();
-
-		if (writeDataBuffers_.size() < enqueuedInputBuffers_) {
-			safs::log_err("({}) Fewer available write data buffers than expected ({} < {}).",
-			              __func__, writeDataBuffers_.size(), enqueuedInputBuffers_);
-			enqueuedInputBuffers_ = writeDataBuffers_.size();
-		}
-
-		auto inputBuffersIt = writeDataBuffers_.begin();
-		for (uint32_t i = 0; i < enqueuedInputBuffers_; i++) {
-			if (inputBuffersIt->get()->currentBlocks() == 0) {
-				safs::log_warn("({}) Called with no blocks in front InputBuffer.", __func__);
-			}
-
-			inputBuffers.push_back(inputBuffersIt->get());
-			inputBuffersIt++;
-		}
-	} else {
-		if (writeDataBuffers_.front()->currentBlocks() == 0) {
-			safs::log_warn("({}) Called with no blocks in front InputBuffer.", __func__);
-		}
-
-		enqueuedInputBuffers_ = 1;
-		inputBuffers.push_back(writeDataBuffers_.front().get());
-	}
+	collectInputBuffersForNextJob(inputBuffers);
 
 	writeJobId_ = job_write(
 	    *workerJobPool(),
@@ -445,54 +529,23 @@ void WriteHighLevelOp::startNextWriteJob() {
 	    chunkId_, chunkVersion_, chunkType_, inputBuffers);
 }
 
-void WriteHighLevelOp::writeCurrentInputPacket() {
-	writeDataBuffers_.emplace_back(std::move(inputBuffer_));
-	inputBuffersReadySinceLastFlush_++;
-	if (!isWriteJobBeingProcessed() && !expectWriteFlush_) { startNextWriteJob(); }
+void WriteHighLevelOp::writeCurrentInputBuffer() {
+	freezeCurrentInputBuffer();
+	if (canStartWriteJobNow()) { startNextWriteJob(); }
 }
 
 void WriteHighLevelOp::continueWritingIfPossible() {
 	tryInstantReply();
 	// There should not be any write jobs being processed.
 
-	if (!writeDataBuffers_.empty() && (!expectWriteFlush_ || !inputBuffersForNextFlush_.empty())) {
-		// There is a write buffer ready to be written and either we do not expect write flushes (so
-		// we can write it immediately) or we expect write flushes but there are already scheduled
-		// flushes from previous flushData calls, so we can write it immediately.
+	if (canStartWriteJobNow()) {
 		startNextWriteJob();
 		return;
 	}
 
-	if (!expectWriteFlush_ && inputBuffer_ != nullptr && !inputBuffer_->isBeingUpdated()) {
+	if (shouldWriteCurrentInputBuffer()) {
 		assert(inputBuffer_->currentBlocks() > 0);
-		writeCurrentInputPacket();
-	}
-}
-
-void WriteHighLevelOp::flushData() {
-	if (!expectWriteFlush_) {
-		safs::log_warn("({}) Called flushData on a write operation that does not expect write flush.",
-		               __func__);
-	}
-
-	tryInstantReply(true);
-
-	if (inputBuffer_ != nullptr && inputBuffer_->currentBlocks() > 0 && !inputBuffer_->isBeingUpdated()) {
-		writeDataBuffers_.emplace_back(std::move(inputBuffer_));
-		inputBuffersReadySinceLastFlush_++;
-	}
-
-	if (inputBuffersReadySinceLastFlush_ > 0) {
-		inputBuffersForNextFlush_.push(inputBuffersReadySinceLastFlush_);
-		inputBuffersReadySinceLastFlush_ = 0;
-	
-		if (!isWriteJobBeingProcessed() && !writeDataBuffers_.empty()) {
-			startNextWriteJob();
-		}
-	} else {
-		// This can happen if the connection is created but very little data is sent, which implies
-		// some WriteHighLevelOp receive no write data packets.
-		safs::log_debug("({}) Called flushData with no input buffers ready to be flushed.", __func__);
+		writeCurrentInputBuffer();
 	}
 }
 
@@ -571,7 +624,7 @@ void WriteHighLevelOp::prepareInputBufferForWrite(bool isForward) {
 	if (inputBuffer_ != nullptr && inputBuffer_->isFull()) {
 		safs::log_warn("({}) Called with full inputBuffer, isForward: {}. Writing existing buffer.",
 		               __func__, isForward);
-		writeCurrentInputPacket();
+		writeCurrentInputBuffer();
 	}
 
 	if (inputBuffer_ == nullptr) {
@@ -586,14 +639,12 @@ void WriteHighLevelOp::prepareInputBufferForWrite(bool isForward) {
 	inputBuffer_->addNewWriteOperation();
 }
 
-void WriteHighLevelOp::setup(uint64_t chunkId, uint32_t chunkVersion, ChunkPartType chunkType,
-                             bool expectWriteFlush) {
+void WriteHighLevelOp::setup(uint64_t chunkId, uint32_t chunkVersion, ChunkPartType chunkType) {
 	stats_hlopw++;
 
 	chunkId_ = chunkId;
 	chunkVersion_ = chunkVersion;
 	chunkType_ = chunkType;
-	expectWriteFlush_ = expectWriteFlush;
 
 	isChunkLocked_ = masterconn_get_job_pool()->enforceChunkLock(chunkId_, chunkType_);
 	startOpenWriteJob();
@@ -613,10 +664,9 @@ void WriteHighLevelOp::processWriteDataBlock(uint16_t blocknum, uint32_t opOffse
 	inputBuffer_->setupLastWriteOperation(blocknum, opOffset, opSize, writeId, crc);
 	tryInstantReply();
 
-	// No write jobs in progress or current input buffer is full - write it
-	if (inputBuffer_->isFull() || (!isWriteJobBeingProcessed() && !expectWriteFlush_)) {
+	if (shouldWriteCurrentInputBuffer()) {
 		assert(inputBuffer_->currentBlocks() > 0);
-		writeCurrentInputPacket();
+		writeCurrentInputBuffer();
 	}
 }
 
@@ -660,7 +710,7 @@ bool WriteHighLevelOp::trySeal() {
 		// There is an input buffer, all its data has been processed and replied
 		// so we can write it out to complete the operation
 		assert(inputBuffer_->currentBlocks() > 0);
-		writeCurrentInputPacket();
+		writeCurrentInputBuffer();
 	} else {
 		// There is no input buffer, we can only seal if all write data buffers have been replied
 		for (const auto &buffer : writeDataBuffers_) {
@@ -724,7 +774,7 @@ void WriteHighLevelOp::delayedClose() {
 
 	// We do not expect write flush anymore, so all the remaining buffers should be written out, but
 	// one-by-one
-	expectWriteFlush_ = false;
+	onSwitchingToEagerWriteOnDelayedClose();
 	if (!isWriteJobBeingProcessed() && !writeDataBuffers_.empty()) {
 		// No write job in progress, start one to trigger the processing of the remaining buffers,
 		// which will be replied in writeFinishedCallback
@@ -752,8 +802,7 @@ void WriteHighLevelOp::cleanup() {
 		writeDataBuffers_.pop_front();
 	}
 	enqueuedInputBuffers_ = 0;
-	inputBuffersReadySinceLastFlush_ = 0;
-	inputBuffersForNextFlush_ = std::queue<uint32_t>();
+	resetFlushBatchingState();
 	nextInputBufferBlockCount_ =
 	    std::min(kDefaultInitialNextInputBufferBlockCount, maxBlocksPerHddWriteJob_);
 
@@ -794,7 +843,7 @@ void WriteHighLevelOp::tryInstantReply(bool fromFlushDataCall) {
 		return;
 	}
 
-	if (expectWriteFlush_ && !fromFlushDataCall) {
+	if (shouldDeferInstantReply(fromFlushDataCall)) {
 		// If we expect write flushes, we only try instant reply when flushData is called, because
 		// that's the only time when we know that there won't be more data to be flushed for the
 		// current write operation.

--- a/src/chunkserver/chunk_high_level_ops.cc
+++ b/src/chunkserver/chunk_high_level_ops.cc
@@ -394,20 +394,51 @@ void WriteHighLevelOp::startNextWriteJob() {
 		safs::log_warn("({}) Called with no write data buffers.", __func__);
 		return;
 	}
-	if (writeDataBuffers_.front()->currentBlocks() == 0) {
-		safs::log_warn("({}) Called with no blocks in front InputBuffer.", __func__);
-		return;
-	}
 
 	if (isWriteJobBeingProcessed()) {
 		safs::log_warn("({}) Called with write job already in progress.", __func__);
 		return;
 	}
 
+	if (expectWriteFlush_ && inputBuffersForNextFlush_.empty()) {
+		safs::log_warn(
+		    "({}) Called with no input buffers ready to be flushed while expecting write flush.",
+		    __func__);
+		return;
+	}
+
 	/// Start the next write job: it is always the first write data buffer
 	writeJobWriteId_ = writeDataBuffers_.front()->getLastWriteId();
-	enqueuedInputBuffers_ = 1;
-	std::vector<InputBuffer *> inputBuffers = {writeDataBuffers_.front().get()};
+	std::vector<InputBuffer *> inputBuffers;
+
+	if (expectWriteFlush_) {
+		enqueuedInputBuffers_ = inputBuffersForNextFlush_.front();
+		inputBuffersForNextFlush_.pop();
+
+		if (writeDataBuffers_.size() < enqueuedInputBuffers_) {
+			safs::log_err("({}) Fewer available write data buffers than expected ({} < {}).",
+			              __func__, writeDataBuffers_.size(), enqueuedInputBuffers_);
+			enqueuedInputBuffers_ = writeDataBuffers_.size();
+		}
+
+		auto inputBuffersIt = writeDataBuffers_.begin();
+		for (uint32_t i = 0; i < enqueuedInputBuffers_; i++) {
+			if (inputBuffersIt->get()->currentBlocks() == 0) {
+				safs::log_warn("({}) Called with no blocks in front InputBuffer.", __func__);
+			}
+
+			inputBuffers.push_back(inputBuffersIt->get());
+			inputBuffersIt++;
+		}
+	} else {
+		if (writeDataBuffers_.front()->currentBlocks() == 0) {
+			safs::log_warn("({}) Called with no blocks in front InputBuffer.", __func__);
+		}
+
+		enqueuedInputBuffers_ = 1;
+		inputBuffers.push_back(writeDataBuffers_.front().get());
+	}
+
 	writeJobId_ = job_write(
 	    *workerJobPool(),
 	    [this](uint8_t status, void *entry) { this->writeFinishedCallback(status, entry); },
@@ -416,22 +447,52 @@ void WriteHighLevelOp::startNextWriteJob() {
 
 void WriteHighLevelOp::writeCurrentInputPacket() {
 	writeDataBuffers_.emplace_back(std::move(inputBuffer_));
-	if (!isWriteJobBeingProcessed()) { startNextWriteJob(); }
+	inputBuffersReadySinceLastFlush_++;
+	if (!isWriteJobBeingProcessed() && !expectWriteFlush_) { startNextWriteJob(); }
 }
 
 void WriteHighLevelOp::continueWritingIfPossible() {
 	tryInstantReply();
+	// There should not be any write jobs being processed.
 
-	if (!writeDataBuffers_.empty()) {
-		// there is a write buffer ready to be written, there should not be any
-		// write jobs being processed.
+	if (!writeDataBuffers_.empty() && (!expectWriteFlush_ || !inputBuffersForNextFlush_.empty())) {
+		// There is a write buffer ready to be written and either we do not expect write flushes (so
+		// we can write it immediately) or we expect write flushes but there are already scheduled
+		// flushes from previous flushData calls, so we can write it immediately.
 		startNextWriteJob();
 		return;
 	}
 
-	if (inputBuffer_ != nullptr && !inputBuffer_->isBeingUpdated()) {
+	if (!expectWriteFlush_ && inputBuffer_ != nullptr && !inputBuffer_->isBeingUpdated()) {
 		assert(inputBuffer_->currentBlocks() > 0);
 		writeCurrentInputPacket();
+	}
+}
+
+void WriteHighLevelOp::flushData() {
+	if (!expectWriteFlush_) {
+		safs::log_warn("({}) Called flushData on a write operation that does not expect write flush.",
+		               __func__);
+	}
+
+	tryInstantReply(true);
+
+	if (inputBuffer_ != nullptr && inputBuffer_->currentBlocks() > 0 && !inputBuffer_->isBeingUpdated()) {
+		writeDataBuffers_.emplace_back(std::move(inputBuffer_));
+		inputBuffersReadySinceLastFlush_++;
+	}
+
+	if (inputBuffersReadySinceLastFlush_ > 0) {
+		inputBuffersForNextFlush_.push(inputBuffersReadySinceLastFlush_);
+		inputBuffersReadySinceLastFlush_ = 0;
+	
+		if (!isWriteJobBeingProcessed() && !writeDataBuffers_.empty()) {
+			startNextWriteJob();
+		}
+	} else {
+		// This can happen if the connection is created but very little data is sent, which implies
+		// some WriteHighLevelOp receive no write data packets.
+		safs::log_debug("({}) Called flushData with no input buffers ready to be flushed.", __func__);
 	}
 }
 
@@ -525,12 +586,14 @@ void WriteHighLevelOp::prepareInputBufferForWrite(bool isForward) {
 	inputBuffer_->addNewWriteOperation();
 }
 
-void WriteHighLevelOp::setup(uint64_t chunkId, uint32_t chunkVersion, ChunkPartType chunkType) {
+void WriteHighLevelOp::setup(uint64_t chunkId, uint32_t chunkVersion, ChunkPartType chunkType,
+                             bool expectWriteFlush) {
 	stats_hlopw++;
 
 	chunkId_ = chunkId;
 	chunkVersion_ = chunkVersion;
 	chunkType_ = chunkType;
+	expectWriteFlush_ = expectWriteFlush;
 
 	isChunkLocked_ = masterconn_get_job_pool()->enforceChunkLock(chunkId_, chunkType_);
 	startOpenWriteJob();
@@ -551,7 +614,7 @@ void WriteHighLevelOp::processWriteDataBlock(uint16_t blocknum, uint32_t opOffse
 	tryInstantReply();
 
 	// No write jobs in progress or current input buffer is full - write it
-	if (!isWriteJobBeingProcessed() || inputBuffer_->isFull()) {
+	if (inputBuffer_->isFull() || (!isWriteJobBeingProcessed() && !expectWriteFlush_)) {
 		assert(inputBuffer_->currentBlocks() > 0);
 		writeCurrentInputPacket();
 	}
@@ -659,6 +722,9 @@ void WriteHighLevelOp::delayedClose() {
 		writeDataBuffers_.pop_back();
 	}
 
+	// We do not expect write flush anymore, so all the remaining buffers should be written out, but
+	// one-by-one
+	expectWriteFlush_ = false;
 	if (!isWriteJobBeingProcessed() && !writeDataBuffers_.empty()) {
 		// No write job in progress, start one to trigger the processing of the remaining buffers,
 		// which will be replied in writeFinishedCallback
@@ -667,7 +733,9 @@ void WriteHighLevelOp::delayedClose() {
 
 	// Pending write jobs will be handled in writeFinishedCallback, they need to write out the
 	// buffers
-	parentPendingWriteJobs() += writeDataBuffers_.size();
+	if (!writeDataBuffers_.empty()) {
+		parentPendingWriteJobs() += writeDataBuffers_.size() - enqueuedInputBuffers_ + 1;
+	}
 }
 
 void WriteHighLevelOp::cleanup() {
@@ -684,6 +752,10 @@ void WriteHighLevelOp::cleanup() {
 		writeDataBuffers_.pop_front();
 	}
 	enqueuedInputBuffers_ = 0;
+	inputBuffersReadySinceLastFlush_ = 0;
+	inputBuffersForNextFlush_ = std::queue<uint32_t>();
+	nextInputBufferBlockCount_ =
+	    std::min(kDefaultInitialNextInputBufferBlockCount, maxBlocksPerHddWriteJob_);
 
 	if (inputBuffer_ != nullptr) {
 		/// Drop the input buffer, it won't be used anymore
@@ -707,7 +779,7 @@ void WriteHighLevelOp::cleanup() {
 	}
 }
 
-void WriteHighLevelOp::tryInstantReply() {
+void WriteHighLevelOp::tryInstantReply(bool fromFlushDataCall) {
 	// No need to try instant reply if:
 	// - sealed: everything has been replied already.
 	// - in delayed close: we won't accept new write data and we will reply to pending ones in
@@ -719,6 +791,13 @@ void WriteHighLevelOp::tryInstantReply() {
 	//   standard slice we may lost data due to a single IO error.
 	if (isSealed_ || inDelayedClose_ || isOpenWriteJobBeingProcessed() || !isChunkLocked_ ||
 	    chunkType_ == slice_traits::standard::ChunkPartType()) {
+		return;
+	}
+
+	if (expectWriteFlush_ && !fromFlushDataCall) {
+		// If we expect write flushes, we only try instant reply when flushData is called, because
+		// that's the only time when we know that there won't be more data to be flushed for the
+		// current write operation.
 		return;
 	}
 
@@ -742,13 +821,21 @@ void WriteHighLevelOp::tryInstantReply() {
 	};
 
 	// Try for write data buffers, in the expected order of reply
+	uint32_t inputBufferCount = 0;
 	for (auto &buff : writeDataBuffers_) {
 		// Everything replied
+		inputBufferCount++;
 		if (buff->repliedBlocks == buff->currentBlocks()) { continue; }
 
 		if (getAvailableWriteBufferingBlocks() + static_cast<int32_t>(buff->repliedBlocks) <
 		    static_cast<int32_t>(buff->currentBlocks())) {
 			// Cannot reply the remaining blocks
+			return;
+		}
+
+		if (inputBufferCount <= enqueuedInputBuffers_) {
+			// We can only reply buffers that are not already enqueued in write jobs, because for
+			// enqueued ones the access to the status fields is not thread safe.
 			return;
 		}
 

--- a/src/chunkserver/chunk_high_level_ops.h
+++ b/src/chunkserver/chunk_high_level_ops.h
@@ -228,7 +228,9 @@ public:
 	/// @param chunkId ID of the chunk.
 	/// @param chunkVersion Version of the chunk.
 	/// @param chunkType Type of the chunk.
-	void setup(uint64_t chunkId, uint32_t chunkVersion, ChunkPartType chunkType);
+	/// @param expectWriteFlush Indicates if the write operation expects a write flush packet.
+	void setup(uint64_t chunkId, uint32_t chunkVersion, ChunkPartType chunkType,
+	           bool expectWriteFlush = false);
 
 	/// Prepares for new write data to be added to the input buffer.
 	/// @param mustForward Indicates if the data must be forwarded to another chunkserver.
@@ -293,8 +295,12 @@ public:
 	/// being processed or the chunk is not locked for writing.
 	/// Does not violates the order of replies for the write data blocks received from the client,
 	/// neither the amount of write buffering blocks available.
-	void tryInstantReply();
+	/// @param fromFlushDataCall Indicates if the function is called from flushData.
+	void tryInstantReply(bool fromFlushDataCall = false);
 
+	/// Makes the current input buffer available for write jobs. Starts write jobs if not running one
+	/// or schedules the write job to run ASAP.
+	void flushData();
 protected:
 	/// Decreases the pending write jobs in the parent ChunkserverEntry to check and apply closed on
 	/// parent. This is used while in delayed close mode whenever a callback is processed.
@@ -332,12 +338,18 @@ protected:
 
 	/// Prepares the input buffer for a write operation.
 	void prepareInputBufferForWrite(bool isForward);
-	
+
 	/// Number of blocks to write to the device in one write job.
 	uint16_t maxBlocksPerHddWriteJob_;
 
 	/// Size in blocks of the next input buffer.
 	uint16_t nextInputBufferBlockCount_;
+	/// Indicates if the write operation expects a write flush packet.
+	bool expectWriteFlush_ = false;
+	/// Queue of number of input buffers waiting to be flushed.
+	std::queue<uint32_t> inputBuffersForNextFlush_;
+	///< Number of input buffers that are ready to be flushed since the last flush.
+	uint32_t inputBuffersReadySinceLastFlush_ = 0;
 
 	/// Indicates if the operation is in delayed close:
 	/// - no new replies issued

--- a/src/chunkserver/chunk_high_level_ops.h
+++ b/src/chunkserver/chunk_high_level_ops.h
@@ -211,6 +211,18 @@ protected:
 };
 
 /// @brief High-level operation for writing data to a chunk.
+///
+/// Contains the core write-path logic and state for all write variants. In its default form it
+/// implements the standard, "eager" write path: write jobs are started as soon as a buffer is
+/// ready (no client-side WRITE_FLUSH is expected).
+///
+/// One concrete derivation exists:
+/// - `WriteHighLevelOpExpectFlush`: batched mode. Write jobs are deferred until the client sends
+///   an explicit WRITE_FLUSH packet, at which point `flushData()` releases a batch of buffered
+///   input packets for writing.
+///
+/// The differentiating behavior is expressed through a small set of virtual hooks (see the
+/// `protected` section). Default implementations match the no-flush (eager) variant.
 class WriteHighLevelOp : public HighLevelOp {
 public:
 	/// @brief Default initial number of blocks for the next input buffer, which can be adjusted
@@ -223,14 +235,14 @@ public:
 	      nextInputBufferBlockCount_(
 	          std::min(kDefaultInitialNextInputBufferBlockCount, maxBlocksPerHddWriteJob)) {}
 
+	virtual ~WriteHighLevelOp() = default;
+
 	/// Sets up and starts the write high level operation.
 	/// Enqueues a job_open for the chunk.
 	/// @param chunkId ID of the chunk.
 	/// @param chunkVersion Version of the chunk.
 	/// @param chunkType Type of the chunk.
-	/// @param expectWriteFlush Indicates if the write operation expects a write flush packet.
-	void setup(uint64_t chunkId, uint32_t chunkVersion, ChunkPartType chunkType,
-	           bool expectWriteFlush = false);
+	void setup(uint64_t chunkId, uint32_t chunkVersion, ChunkPartType chunkType);
 
 	/// Prepares for new write data to be added to the input buffer.
 	/// @param mustForward Indicates if the data must be forwarded to another chunkserver.
@@ -293,15 +305,66 @@ public:
 	/// the write operation and the amount of write buffering blocks available.
 	/// Does not work if the operation is sealed, in delayed close, the open write job is still
 	/// being processed or the chunk is not locked for writing.
-	/// Does not violates the order of replies for the write data blocks received from the client,
+	/// Does not violate the order of replies for the write data blocks received from the client,
 	/// neither the amount of write buffering blocks available.
 	/// @param fromFlushDataCall Indicates if the function is called from flushData.
 	void tryInstantReply(bool fromFlushDataCall = false);
 
-	/// Makes the current input buffer available for write jobs. Starts write jobs if not running one
-	/// or schedules the write job to run ASAP.
-	void flushData();
+	/// Makes the current input buffer available for write jobs. Starts write jobs if not running
+	/// one or schedules the write job to run ASAP.
+	/// Default (no-flush) behavior logs a warning and drains the current input buffer
+	/// opportunistically. The expect-flush variant overrides this with the real batching logic.
+	virtual void flushData();
+
 protected:
+	// ---------------------------------------------------------------------------
+	// Differentiating hooks. Defaults implement the no-flush ("eager") behavior.
+	// Implementations live in chunk_high_level_ops.cc, paired with the matching
+	// `WriteHighLevelOpExpectFlush` overrides for easy side-by-side comparison.
+	// ---------------------------------------------------------------------------
+
+	/// Whether a write job may be started right now. Encapsulates the full precondition set used
+	/// by `writeCurrentInputBuffer()` and `continueWritingIfPossible()` to decide whether to launch the
+	/// next job from queued buffers: there must be at least one queued buffer in
+	/// `writeDataBuffers_` and no write job currently in flight. The expect-flush variant adds the
+	/// extra requirement that a flush trigger has been received (unless batching has been turned
+	/// off after a delayed close).
+	virtual bool canStartWriteJobNow() const;
+
+	/// Populates `inputBuffers` and sets `enqueuedInputBuffers_` for the next write job.
+	/// Default takes only the first front buffer (single-buffer write).
+	virtual void collectInputBuffersForNextJob(std::vector<InputBuffer *> &inputBuffers);
+
+	/// Whether `processWriteDataBlock()` should freeze the current input buffer onto
+	/// `writeDataBuffers_` (and possibly start a write job) immediately after appending the just-
+	/// received block. Encapsulates the full precondition set: there must be a current input
+	/// buffer (`inputBuffer_ != nullptr`) that is not still being updated. Default (eager) policy:
+	/// freeze as soon as the buffer is full, or whenever there is no in-flight write job that
+	/// would naturally drain it later.
+	virtual bool shouldWriteCurrentInputBuffer() const;
+
+	/// Whether `tryInstantReply()` should defer (no-op) the reply. Used by the expect-flush
+	/// variant to delay instant replies until an explicit `flushData()` trigger.
+	virtual bool shouldDeferInstantReply(bool fromFlushDataCall) const;
+
+	/// Hook called from `delayedClose()` right before re-evaluating whether to start a write job.
+	/// Derived classes use this to switch off flush batching and fall back to eager behavior, so
+	/// that any remaining buffered data is drained one-by-one.
+	virtual void onSwitchingToEagerWriteOnDelayedClose();
+
+	/// Hook called from `cleanup()` to reset any flush-batching state.
+	virtual void resetFlushBatchingState();
+
+	/// Moves the current `inputBuffer_` onto `writeDataBuffers_`. Unlike `writeCurrentInputBuffer()`,
+	/// this does NOT start a new write job; callers are responsible for triggering one if
+	/// appropriate. Derived classes may override to perform additional bookkeeping (e.g. updating
+	/// flush-batching counters).
+	virtual void freezeCurrentInputBuffer();
+
+	// ---------------------------------------------------------------------------
+	// Shared protected methods.
+	// ---------------------------------------------------------------------------
+
 	/// Decreases the pending write jobs in the parent ChunkserverEntry to check and apply closed on
 	/// parent. This is used while in delayed close mode whenever a callback is processed.
 	void decreasePendingWriteJobsToCheckAndApplyClosedOnParent();
@@ -311,6 +374,9 @@ protected:
 
 	/// Sets that no write job is being processed.
 	void setNoWriteJobBeingProcessed();
+
+	/// Checks whether the current input buffer can be frozen
+	bool isInputBufferFreezable() const;
 
 	/// Starts an open write job for the current chunk.
 	void startOpenWriteJob();
@@ -325,7 +391,7 @@ protected:
 	/// Preserves the inputPacket buffer into writePackets (to avoid copying it).
 	/// Creates a new write if no running write job.
 	/// Used for write operations, where the data comes from the network.
-	void writeCurrentInputPacket();
+	void writeCurrentInputBuffer();
 
 	/// Checks and processes the next packet in the input buffer.
 	void continueWritingIfPossible();
@@ -339,17 +405,15 @@ protected:
 	/// Prepares the input buffer for a write operation.
 	void prepareInputBufferForWrite(bool isForward);
 
+	// ---------------------------------------------------------------------------
+	// Shared protected state.
+	// ---------------------------------------------------------------------------
+
 	/// Number of blocks to write to the device in one write job.
 	uint16_t maxBlocksPerHddWriteJob_;
 
 	/// Size in blocks of the next input buffer.
 	uint16_t nextInputBufferBlockCount_;
-	/// Indicates if the write operation expects a write flush packet.
-	bool expectWriteFlush_ = false;
-	/// Queue of number of input buffers waiting to be flushed.
-	std::queue<uint32_t> inputBuffersForNextFlush_;
-	///< Number of input buffers that are ready to be flushed since the last flush.
-	uint32_t inputBuffersReadySinceLastFlush_ = 0;
 
 	/// Indicates if the operation is in delayed close:
 	/// - no new replies issued
@@ -376,6 +440,40 @@ protected:
 	std::set<uint32_t> partiallyCompletedWrites_;
 	/// List of write data buffers waiting to be written to the chunk.
 	std::list<std::shared_ptr<InputBuffer>> writeDataBuffers_;
+};
+
+/// @brief Concrete write high-level operation that batches writes until a WRITE_FLUSH arrives.
+///
+/// While `expectsWriteFlush_` is true, input packets accumulate in `writeDataBuffers_` without
+/// triggering a write job. The client signals batch boundaries via WRITE_FLUSH, which translates
+/// to `flushData()` calls that release a batch of buffers to a single `job_write`. Instant replies
+/// are also deferred to flush points.
+///
+/// On `delayedClose()`, the variant switches off flush batching (`expectsWriteFlush_ = false`) so
+/// any remaining buffered data is drained one-by-one, matching the base eager behavior.
+class WriteHighLevelOpExpectFlush : public WriteHighLevelOp {
+public:
+	using WriteHighLevelOp::WriteHighLevelOp;
+
+	void flushData() override;
+
+protected:
+	bool canStartWriteJobNow() const override;
+	void collectInputBuffersForNextJob(std::vector<InputBuffer *> &inputBuffers) override;
+	void freezeCurrentInputBuffer() override;
+	bool shouldWriteCurrentInputBuffer() const override;
+	bool shouldDeferInstantReply(bool fromFlushDataCall) const override;
+	void onSwitchingToEagerWriteOnDelayedClose() override;
+	void resetFlushBatchingState() override;
+
+private:
+	/// Indicates whether the operation is still in flush-batching mode. Cleared by
+	/// `delayedClose()` so the remaining buffered data is drained using the base (eager) behavior.
+	bool expectsWriteFlush_ = true;
+	/// Queue of number of input buffers per pending flush batch.
+	std::queue<uint32_t> inputBuffersForNextFlush_;
+	/// Number of input buffers that became ready since the last flush.
+	uint32_t inputBuffersReadySinceLastFlush_ = 0;
 };
 
 /// @brief Creates a callback function for closing a write operation.

--- a/src/chunkserver/chunkserver_entry.cc
+++ b/src/chunkserver/chunkserver_entry.cc
@@ -334,13 +334,20 @@ void ChunkserverEntry::writeInit(const uint8_t *data, PacketHeader::Type type,
 	std::vector<ChunkTypeWithAddress> chain;
 
 	sassert(type == SAU_CLTOCS_WRITE_INIT);
+	bool expectWriteFlush = false;
 	try {
 		PacketVersion v;
 		deserializePacketVersionNoHeader(data, length, v);
-		sassert(v == cltocs::writeInit::kECChunks);
-		cltocs::writeInit::deserialize(data, length, chunkId, chunkVersion, chunkType, chain);
-	} catch (Exception &) {
-		safs::log_info("Received malformed WRITE_INIT message (length: {})", length);
+		if (v == cltocs::writeInit::kECChunks) {
+			cltocs::writeInit::deserialize(data, length, chunkId, chunkVersion, chunkType, chain);
+		} else if (v == cltocs::writeInit::kECChunksWithWriteFlush) {
+			cltocs::writeInit::deserialize(data, length, chunkId, chunkVersion, chunkType,
+			                               expectWriteFlush, chain);
+		} else {
+			throw IncorrectDeserializationException("Unexpected packet version");
+		}
+	} catch (Exception &ex) {
+		safs::log_info("Received malformed WRITE_INIT message (length: {}): {}", length, ex.what());
 		state = State::Close;
 		return;
 	}
@@ -349,7 +356,12 @@ void ChunkserverEntry::writeInit(const uint8_t *data, PacketHeader::Type type,
 		// Create a chain -- connect to the next chunkserver
 		fwdServer = chain[0].address;
 		chain.erase(chain.begin());
-		cltocs::writeInit::serialize(fwdInitPacket, chunkId, chunkVersion, chunkType, chain);
+		if (expectWriteFlush) {
+			cltocs::writeInit::serialize(fwdInitPacket, chunkId, chunkVersion, chunkType,
+			                             expectWriteFlush, chain);
+		} else {
+			cltocs::writeInit::serialize(fwdInitPacket, chunkId, chunkVersion, chunkType, chain);
+		}
 		fwdOutputPacket.startPtr = fwdInitPacket.data();
 		fwdOutputPacket.bytesLeft = fwdInitPacket.size();
 		connectRetryCounter = 0;
@@ -365,7 +377,7 @@ void ChunkserverEntry::writeInit(const uint8_t *data, PacketHeader::Type type,
 
 	// Setup write HLO
 	writeHLOs_.emplace_back(std::make_unique<WriteHighLevelOp>(this, maxBlocksPerHddWriteJob_));
-	writeHLOs_.back()->setup(chunkId, chunkVersion, chunkType);
+	writeHLOs_.back()->setup(chunkId, chunkVersion, chunkType, expectWriteFlush);
 }
 
 void ChunkserverEntry::writeData(const uint8_t *data, PacketHeader::Type type,
@@ -444,6 +456,36 @@ void ChunkserverEntry::writeStatus(const uint8_t *data, PacketHeader::Type type,
 	}
 
 	writeHLOs_.back()->updateUsingWriteStatusAndReply(status, writeId);
+}
+
+void ChunkserverEntry::writeFlush(const uint8_t *data, uint32_t length) {
+	TRACETHIS();
+	uint64_t opChunkId;
+
+	try {
+		cltocs::writeFlush::deserialize(data, length, opChunkId);
+	} catch (IncorrectDeserializationException &ex) {
+		safs::log_info("Received malformed WRITE_FLUSH message (length: {}): {}", length,
+		               ex.what());
+		state = State::IOFinish;
+		return;
+	}
+	if (opChunkId != chunkId) {
+		safs::log_info(
+		    "Received malformed WRITE_FLUSH message (got chunkId={:016X}, expected {:016X})",
+		    opChunkId, chunkId);
+		state = State::IOFinish;
+		return;
+	}
+
+	if (writeHLOs_.empty()) {
+		safs::log_warn("Received WRITE_FLUSH message without prior WRITE_INIT (chunkId={:016X})",
+		               opChunkId);
+		state = State::Close;
+		return;
+	}
+
+	writeHLOs_.back()->flushData();
 }
 
 void ChunkserverEntry::writeEnd(const uint8_t *data, uint32_t length) {
@@ -739,6 +781,9 @@ void ChunkserverEntry::gotPacket(uint32_t type, const uint8_t *data,
 		case SAU_CLTOCS_WRITE_DATA:
 			writeData(data, type, length);
 			break;
+		case SAU_CLTOCS_WRITE_FLUSH:
+			writeFlush(data, length);
+			break;
 		case SAU_CLTOCS_WRITE_END:
 			writeEnd(data, length);
 			break;
@@ -751,6 +796,9 @@ void ChunkserverEntry::gotPacket(uint32_t type, const uint8_t *data,
 		switch (type) {
 		case SAU_CLTOCS_WRITE_DATA:
 			writeData(data, type, length);
+			break;
+		case SAU_CLTOCS_WRITE_FLUSH:
+			writeFlush(data, length);
 			break;
 		case SAU_CSTOCL_WRITE_STATUS:
 			writeStatus(data, type, length);
@@ -766,6 +814,7 @@ void ChunkserverEntry::gotPacket(uint32_t type, const uint8_t *data,
 	} else if (state == State::IOFinish) {
 		switch (type) {
 		case SAU_CLTOCS_WRITE_DATA:
+		case SAU_CLTOCS_WRITE_FLUSH:
 		case SAU_CLTOCS_WRITE_END:
 			return;
 		default:
@@ -773,7 +822,8 @@ void ChunkserverEntry::gotPacket(uint32_t type, const uint8_t *data,
 			state = State::Close;
 		}
 	} else {
-		safs::log_info("Got invalid message (type:{})", type);
+		safs::log_info("Got invalid message (current state: {}) (type:{})", static_cast<int>(state),
+		               type);
 		state = State::Close;
 	}
 }
@@ -868,7 +918,8 @@ bool ChunkserverEntry::readHeader(int socket, PacketStruct &packet, uint8_t *hea
 	}
 	packet.bytesLeft = length;
 
-	if (mustForward && (type == SAU_CLTOCS_WRITE_DATA || type == SAU_CLTOCS_WRITE_END)) {
+	if (mustForward && (type == SAU_CLTOCS_WRITE_DATA || type == SAU_CLTOCS_WRITE_END ||
+	                    type == SAU_CLTOCS_WRITE_FLUSH)) {
 		fwdOutputPacket.bytesLeft = PacketHeader::kSize;
 		// Use the correct buffer for forwarding
 		if (type == SAU_CLTOCS_WRITE_DATA) {

--- a/src/chunkserver/chunkserver_entry.cc
+++ b/src/chunkserver/chunkserver_entry.cc
@@ -376,8 +376,13 @@ void ChunkserverEntry::writeInit(const uint8_t *data, PacketHeader::Type type,
 	}
 
 	// Setup write HLO
-	writeHLOs_.emplace_back(std::make_unique<WriteHighLevelOp>(this, maxBlocksPerHddWriteJob_));
-	writeHLOs_.back()->setup(chunkId, chunkVersion, chunkType, expectWriteFlush);
+	if (expectWriteFlush) {
+		writeHLOs_.emplace_back(
+		    std::make_unique<WriteHighLevelOpExpectFlush>(this, maxBlocksPerHddWriteJob_));
+	} else {
+		writeHLOs_.emplace_back(std::make_unique<WriteHighLevelOp>(this, maxBlocksPerHddWriteJob_));
+	}
+	writeHLOs_.back()->setup(chunkId, chunkVersion, chunkType);
 }
 
 void ChunkserverEntry::writeData(const uint8_t *data, PacketHeader::Type type,

--- a/src/chunkserver/chunkserver_entry.h
+++ b/src/chunkserver/chunkserver_entry.h
@@ -338,6 +338,9 @@ struct ChunkserverEntry {
 	void writeData(const uint8_t *data, PacketHeader::Type type,
 	               PacketHeader::Length length);
 
+	/// Flushes the written data to the drives.
+	void writeFlush(const uint8_t *data, uint32_t length);
+
 	/// Finalizes a write operation and closes the chunk and connection.
 	void writeEnd(const uint8_t *data, uint32_t length);
 

--- a/src/common/saunafs_version.h
+++ b/src/common/saunafs_version.h
@@ -55,4 +55,4 @@ constexpr uint32_t kFirstVersionWithClusterId = saunafsVersion(5, 0, 0);
 constexpr uint32_t kFirstVersionWithReadTrashReservedByHandleOffset = saunafsVersion(5, 3, 0);
 constexpr uint32_t kFirstVersionWithUnlockChunkNotice = saunafsVersion(5, 8, 0);
 constexpr uint32_t kFirstVersionWithChunkserverSideChunkLock = saunafsVersion(5, 8, 0);
-constexpr uint32_t kFirstVersionWithWriteFlushPacket = saunafsVersion(5, 10, 0);
+constexpr uint32_t kFirstVersionWithWriteFlushPacket = saunafsVersion(5, 11, 0);

--- a/src/common/saunafs_version.h
+++ b/src/common/saunafs_version.h
@@ -55,3 +55,4 @@ constexpr uint32_t kFirstVersionWithClusterId = saunafsVersion(5, 0, 0);
 constexpr uint32_t kFirstVersionWithReadTrashReservedByHandleOffset = saunafsVersion(5, 3, 0);
 constexpr uint32_t kFirstVersionWithUnlockChunkNotice = saunafsVersion(5, 8, 0);
 constexpr uint32_t kFirstVersionWithChunkserverSideChunkLock = saunafsVersion(5, 8, 0);
+constexpr uint32_t kFirstVersionWithWriteFlushPacket = saunafsVersion(5, 10, 0);

--- a/src/common/write_executor.cc
+++ b/src/common/write_executor.cc
@@ -34,9 +34,10 @@
 
 const uint32_t kReceiveBufferSize = 1024;
 
-WriteExecutor::WriteExecutor(ChunkserverStats& chunkserverStats,
-		const NetworkAddress& headAddress, uint32_t chunkserver_version, int headFd,
-		uint32_t responseTimeout_ms, uint64_t chunkId, uint32_t chunkVersion, ChunkPartType chunkType)
+WriteExecutor::WriteExecutor(ChunkserverStats &chunkserverStats, const NetworkAddress &headAddress,
+                             uint32_t chunkserver_version, int headFd, uint32_t responseTimeout_ms,
+                             uint64_t chunkId, uint32_t chunkVersion, ChunkPartType chunkType,
+                             uint32_t writeWindowSize, bool useWriteFlushPacket)
 		: chunkserverStats_(chunkserverStats),
 		  isRunning_(false),
 		  chunkId_(chunkId),
@@ -46,6 +47,8 @@ WriteExecutor::WriteExecutor(ChunkserverStats& chunkserverStats,
 		  chunkserver_version_(chunkserver_version),
 		  chainHeadFd_(headFd),
 		  receiveBuffer_(kReceiveBufferSize),
+		  writeWindowSize_(writeWindowSize),
+		  useWriteFlushPacket_(useWriteFlushPacket),
 		  unconfirmedPackets_(0),
 		  responseTimeout_(std::chrono::milliseconds(responseTimeout_ms)) {
 	chunkserverStats_.registerWriteOperation(chainHead_);
@@ -74,9 +77,20 @@ void WriteExecutor::addInitPacket() {
 			return first.chunkserver_version > second.chunkserver_version;
 	});
 
-	sassert((!chain_.empty() && chain_.front().chunkserver_version >= kFirstECVersion) ||
-	        chunkserver_version_ >= kFirstECVersion);
-	cltocs::writeInit::serialize(buffer, chunkId_, chunkVersion_, chunkType_, chain_);
+	auto minChunkserverVersion = chunkserver_version_;
+	if (!chain_.empty()) {
+		minChunkserverVersion = std::min(minChunkserverVersion, chain_.back().chunkserver_version);
+	}
+	sassert(minChunkserverVersion >= kFirstECVersion);
+
+	if (minChunkserverVersion < kFirstVersionWithWriteFlushPacket) {
+		// Some chunkserver in the chain doesn't support write flush packet
+		cltocs::writeInit::serialize(buffer, chunkId_, chunkVersion_, chunkType_, chain_);
+		useWriteFlushPacket_ = false;
+	} else {
+		cltocs::writeInit::serialize(buffer, chunkId_, chunkVersion_, chunkType_,
+		                             useWriteFlushPacket_, chain_);
+	}
 
 	increaseUnconfirmedPacketCount();
 	isRunning_ = true;
@@ -97,11 +111,35 @@ void WriteExecutor::addDataPacket(uint32_t writeId,
 	packet.data = data;
 	packet.dataSize = size;
 
+	writeDataPacketsSinceLastFlush_++;
+	if (writeDataPacketsSinceLastFlush_ >= writeWindowSize_) {
+		addFlushPacket();
+	}
+
 	increaseUnconfirmedPacketCount();
+}
+
+void WriteExecutor::addFlushPacket() {
+	sassert(isRunning_);
+	if (writeDataPacketsSinceLastFlush_ == 0 || !useWriteFlushPacket_) {
+		// No need to flush if we haven't sent any data packets since last flush
+		// or not using flush packets or chunkserver doesn't support flush packets.
+		return;
+	}
+
+	pendingPackets_.push_back(Packet());
+	Packet& packet = pendingPackets_.back();
+	cltocs::writeFlush::serialize(packet.buffer, chunkId_);
+	writeDataPacketsSinceLastFlush_ = 0;
 }
 
 void WriteExecutor::addEndPacket() {
 	sassert(isRunning_);
+
+	// For cases when the write ends prematurely due to write buffering.
+	// Won't do anything if it was already sent.
+	addFlushPacket();
+
 	pendingPackets_.push_back(Packet());
 	std::vector<uint8_t>& buffer = pendingPackets_.back().buffer;
 	cltocs::writeEnd::serialize(buffer, chunkId_);

--- a/src/common/write_executor.h
+++ b/src/common/write_executor.h
@@ -54,11 +54,16 @@ public:
 	 * \param chunkId - a chunk that will be written to
 	 * \param chunkVersion - a chunk that will be written to
 	 * \param chunkType - a chunk that will be written to
+	 * \param writeWindowSize - the maximum number of write operations that can be in progress at
+	 * the same time
+	 * \param useWriteFlushPacket - if true, flush packet will be used to trigger flush of the data to
+	 * chunkservers when the number of pending operations reaches writeWindowSize or when the
+	 * ChunkWriter stops accepting new operations -> client called flush on inode.
 	 */
 	WriteExecutor(ChunkserverStats& chunkserverStats,
 			const NetworkAddress& headAddress, uint32_t chunkserver_version, int headFd,
 			uint32_t responseTimeout_ms, uint64_t chunkId, uint32_t chunkVersion,
-			ChunkPartType chunkType);
+			ChunkPartType chunkType, uint32_t writeWindowSize, bool useWriteFlushPacket);
 	WriteExecutor(const WriteExecutor&) = delete;
 	~WriteExecutor();
 	WriteExecutor& operator=(const WriteExecutor&) = delete;
@@ -66,6 +71,7 @@ public:
 	void addInitPacket();
 	void addDataPacket(uint32_t writeId,
 			uint16_t block, uint32_t offset, uint32_t size, const uint8_t* data);
+	void addFlushPacket();
 	void addEndPacket();
 	void sendData();
 	std::vector<Status> receiveData();
@@ -116,6 +122,9 @@ private:
 	std::list<Packet> pendingPackets_;
 	MultiBufferWriter bufferWriter_;
 	MessageReceiveBuffer receiveBuffer_;
+	uint32_t writeDataPacketsSinceLastFlush_{0};
+	const uint32_t writeWindowSize_;
+	bool useWriteFlushPacket_;
 
 	/// Number of WRITE_STATUS messages that are expected to be received from the chunkserver
 	uint32_t unconfirmedPackets_;

--- a/src/mount/chunk_writer.cc
+++ b/src/mount/chunk_writer.cc
@@ -106,11 +106,13 @@ bool ChunkWriter::Operation::isFullStripe(uint32_t stripeSize) const {
 	return (journalPositions.size() == elementsInStripe);
 }
 
-ChunkWriter::ChunkWriter(ChunkserverStats &chunkserverStats,
-                         ChunkConnector &connector, int dataChainFd)
+ChunkWriter::ChunkWriter(ChunkserverStats &chunkserverStats, ChunkConnector &connector,
+                         int dataChainFd, uint32_t writeWindowSize, bool useWriteFlushPacket)
     : chunkserverStats_(chunkserverStats),
       connector_(connector),
-      dataChainFd_(dataChainFd) {}
+      dataChainFd_(dataChainFd),
+      writeWindowSize_(writeWindowSize),
+      useWriteFlushPacket_(useWriteFlushPacket) {}
 
 ChunkWriter::~ChunkWriter() {
 	try {
@@ -155,7 +157,7 @@ void ChunkWriter::init(WriteChunkLocator* locator, uint32_t chunkserverTimeout_m
 		std::unique_ptr<WriteExecutor> executor(new WriteExecutor(
 				chunkserverStats_, location.address, location.chunkserver_version, fd,
 				chunkserverTimeout_ms, locator_->locationInfo().chunkId, locator_->locationInfo().version,
-				location.chunk_type));
+				location.chunk_type, writeWindowSize_, useWriteFlushPacket_));
 		executors_.insert(std::make_pair(fd, std::move(executor)));
 	}
 
@@ -170,11 +172,14 @@ uint32_t ChunkWriter::getMinimumBlockCountWorthWriting() {
 	return combinedStripeSize_;
 }
 
-uint32_t ChunkWriter::startNewOperations(bool can_expect_next_block) {
+uint32_t ChunkWriter::startNewOperations(bool can_expect_next_block,
+                                         bool wasLastBlockRecentlyWritten) {
 	LOG_AVG_TILL_END_OF_SCOPE0("ChunkWriter::startNewOperations");
 	uint32_t operationsStarted = 0;
 	// Start all possible operations. Break at the first operation that can't be started, because
 	// we have to preserve the order of operations in order to ensure the files contain proper data
+
+	bool cannotStartNextNewOperation = false;
 	for (auto i = newOperations_.begin(); i != newOperations_.end(); i = newOperations_.erase(i)) {
 		Operation& operation = *i;
 		// Don't start partial-stripe writes if they can be extended in the future.
@@ -185,11 +190,26 @@ uint32_t ChunkWriter::startNewOperations(bool can_expect_next_block) {
 				&& can_expect_next_block) {
 			break;
 		}
+
+		// Check collisions
 		if (!canStartOperation(operation)) {
+			cannotStartNextNewOperation = true;
 			break;
 		}
+
 		startOperation(std::move(operation));
 		++operationsStarted;
+	}
+
+	if (cannotStartNextNewOperation || !wasLastBlockRecentlyWritten ||
+	    (!acceptsNewOperations_ && newOperations_.empty())) {
+		// If we can't start the next operation due to collision of the writes, we have to flush
+		// the data to chunkservers in order to finish the pending operations and be able to start
+		// the next ones. We can also be in flush mode -- finish all the operations as soon as
+		// possible.
+
+		// Won't do anything if flush packet is disabled or last packet was already a flush packet
+		for (auto &executorPair : executors_) { executorPair.second->addFlushPacket(); }
 	}
 	return operationsStarted;
 }
@@ -264,6 +284,10 @@ void ChunkWriter::processOperations(uint32_t msTimeout) {
 
 uint32_t ChunkWriter::getUnfinishedOperationsCount() {
 	return pendingOperations_.size() + newOperations_.size();
+}
+
+bool ChunkWriter::isWaitingForData() {
+	return getUnfinishedOperationsCount() <= writeWindowSize_;
 }
 
 uint32_t ChunkWriter::getPendingOperationsCount() {

--- a/src/mount/chunk_writer.h
+++ b/src/mount/chunk_writer.h
@@ -45,9 +45,16 @@ public:
 	 *        to write to them and read from them
 	 * \param dataChainFd - end of pipe; if anything is written to it, ChunkWriter will break its
 	 *        poll call and look for some new data in write cache for the currently written chunk
+	 * \param writeWindowSize - limit how many operations may be in flight; the writer may
+	 *        intentionally allow up to writeWindowSize + 1 unfinished operations to keep at least
+	 *        writeWindowSize writes in progress in common cases. When the limit is reached, it may
+	 *        trigger a flush of the data to chunkservers if the flush packet is enabled.
+	 * \param useWriteFlushPacket - if true, flush packet will be used to trigger flush of the data
+	 *        to chunkservers when the number of pending operations reaches writeWindowSize or when
+	 *        the ChunkWriter stops accepting new operations -> client called flush on inode.
 	 */
-	ChunkWriter(ChunkserverStats &stats, ChunkConnector &connector,
-	            int dataChainFd);
+	ChunkWriter(ChunkserverStats &stats, ChunkConnector &connector, int dataChainFd,
+	            uint32_t writeWindowSize, bool useWriteFlushPacket);
 	ChunkWriter(const ChunkWriter&) = delete;
 	~ChunkWriter();
 	ChunkWriter& operator=(const ChunkWriter&) = delete;
@@ -79,8 +86,10 @@ public:
 	/*!
 	 * Starts these added operations, which are worth starting right now.
 	 * Returns number of operations started.
+	 * \param can_expect_next_block - indicates if the next block is expected
+	 * \param wasLastBlockRecentlyWritten - indicates if the last block was recently written
 	 */
-	uint32_t startNewOperations(bool can_expect_next_block);
+	uint32_t startNewOperations(bool can_expect_next_block, bool wasLastBlockRecentlyWritten);
 
 	/*!
 	 * Processes all started operations for at most specified time (0 - asap)
@@ -91,6 +100,12 @@ public:
 	 * \return number of new and pending write operations.
 	 */
 	uint32_t getUnfinishedOperationsCount();
+
+	/*!
+	 * \return true if the ChunkWriter is waiting for more data to write, i.e. if the number of
+	 * unfinished operations is less than writeWindowSize + 1.
+	 */
+	bool isWaitingForData();
 
 	/*!
 	 * \return number of pending write operations.
@@ -185,6 +200,8 @@ private:
 	bool acceptsNewOperations_ = true;
 	int combinedStripeSize_ = 0;
 	int dataChainFd_;
+	uint32_t writeWindowSize_ = 0;
+	bool useWriteFlushPacket_ = false;
 	int chunkSizeInBlocks_;
 
 	std::map<int, std::unique_ptr<WriteExecutor>> executors_;

--- a/src/mount/fuse/main.cc
+++ b/src/mount/fuse/main.cc
@@ -267,6 +267,7 @@ static int mainloop(struct fuse_args *args, struct fuse_cmdline_opts *fuse_opts,
 	params.direct_io = gMountOptions.directio;
 	params.max_chunks_written_in_parallel_per_inode =
 	    gMountOptions.maxchunkswritteninparallelperinode;
+	params.use_write_flush_packet = gMountOptions.usewriteflushpacket;
 	params.malloc_trim_period = gMountOptions.malloctrimperiod;
 	params.log_notifications_area = gMountOptions.lognotificationarea;
 	params.message_suppression_period = gMountOptions.messagesuppressionperiod;

--- a/src/mount/fuse/mount_config.cc
+++ b/src/mount/fuse/mount_config.cc
@@ -98,6 +98,7 @@ struct fuse_opt gSfsOptsStage2[] = {
 	SFS_OPT("sfsdirentrycachesize=%u", direntrycachesize, 0),
 	SFS_OPT("nostdmountoptions", nostdmountoptions, 1),
 	SFS_OPT("sfsmaxchunkswritteninparallelperinode=%u", maxchunkswritteninparallelperinode, 0),
+	SFS_OPT("sfsusewriteflushpacket=%d", usewriteflushpacket, 0),
 	SFS_OPT("limitglibcmallocarenas=%d", limitglibcmallocarenas, 0),
 	SFS_OPT("malloctrimperiod=%d", malloctrimperiod, 0),
 	SFS_OPT("sfslognotificationarea=%d", lognotificationarea, 0),
@@ -157,6 +158,7 @@ void initialize_opts_name_values() {
 	}
 	gOptsNameValues["sfsmaxchunkswritteninparallelperinode"] =
 	    std::to_string(gMountOptions.maxchunkswritteninparallelperinode);
+	gOptsNameValues["sfsusewriteflushpacket"] = std::to_string(gMountOptions.usewriteflushpacket);
 	gOptsNameValues["sfsioretries (read)"] = std::to_string(gMountOptions.ioretries);
 	gOptsNameValues["sfsioretries (write)"] = std::to_string(gMountOptions.ioretries);
 	gOptsNameValues["sfswritewindowsize"] = std::to_string(gMountOptions.writewindowsize);
@@ -296,6 +298,9 @@ void usage(const char *progname) {
 "    -o sfsmaxchunkswritteninparallelperinode=N  define the maximum number of chunks "
 				"that can be written in parallel per inode. 0 stands for unlimited "
 				"(default: %u)\n"
+"    -o sfsusewriteflushpacket=0|1  when set to 1, suggests the chunkserver to flush "
+"				the packets received every window size blocks or when write needs to "
+"				finish (default: %d)\n"
 "\n"
 "Other options:\n"
 "    -m   --meta                 equivalent to '-o sfsmeta'\n"
@@ -403,6 +408,7 @@ void usage(const char *progname) {
 		SaunaClient::FsInitParams::kDefaultWriteWorkers,
 		SaunaClient::FsInitParams::kDefaultWriteWindowSize,
 		SaunaClient::FsInitParams::kDefaultMaxChunksWrittenInParallelPerInode,
+		SaunaClient::FsInitParams::kDefaultUseWriteFlushPacket,
 		SaunaClient::FsInitParams::kDefaultUseRwLock,
 		SaunaClient::FsInitParams::kDefaultMkdirCopySgid,
 		sugidClearModeString(SaunaClient::FsInitParams::kDefaultSugidClearMode),

--- a/src/mount/fuse/mount_config.h
+++ b/src/mount/fuse/mount_config.h
@@ -119,6 +119,7 @@ struct sfsopts_ {
 	bool directio;
 	int useinodebasedwritealgorithm;
 	unsigned maxchunkswritteninparallelperinode;
+	bool usewriteflushpacket;
 	int ignoreflush;
 	unsigned limitglibcmallocarenas;
 	unsigned malloctrimperiod;
@@ -189,6 +190,7 @@ struct sfsopts_ {
 		directio(SaunaClient::FsInitParams::kDirectIO),
 		useinodebasedwritealgorithm(0), // deprecated
 		maxchunkswritteninparallelperinode(SaunaClient::FsInitParams::kDefaultMaxChunksWrittenInParallelPerInode),
+		usewriteflushpacket(SaunaClient::FsInitParams::kDefaultUseWriteFlushPacket),
 		ignoreflush(0), // deprecated
 		limitglibcmallocarenas(SaunaClient::FsInitParams::kDefaultLimitGlibcMallocArenas),
 		malloctrimperiod(SaunaClient::FsInitParams::kDefaultMallocTrimPeriod),

--- a/src/mount/sauna_client.cc
+++ b/src/mount/sauna_client.cc
@@ -3707,7 +3707,8 @@ void fs_init(FsInitParams &params) {
 	WriteAlgorithm::write_data_init(
 	    params.write_cache_size, params.io_retries, params.write_workers, params.write_window_size,
 	    params.chunkserver_write_timeout_ms, params.cache_per_inode_percentage,
-	    params.write_wave_timeout_ms, params.max_chunks_written_in_parallel_per_inode);
+	    params.write_wave_timeout_ms, params.max_chunks_written_in_parallel_per_inode,
+	    params.use_write_flush_packet);
 #ifdef _WIN32
 	set_debug_mode(params.debug_mode);
 #endif

--- a/src/mount/sauna_client.h
+++ b/src/mount/sauna_client.h
@@ -105,6 +105,7 @@ struct FsInitParams {
 	static constexpr unsigned kDefaultWriteWaveTo = 50;
 #endif
 	static constexpr unsigned kDefaultMaxChunksWrittenInParallelPerInode = 0;
+	static constexpr bool     kDefaultUseWriteFlushPacket = false;
 	static constexpr unsigned kDefaultWriteCacheSize = 128;
 	static constexpr unsigned kDefaultCachePerInodePercentage = 100;
 	static constexpr unsigned kDefaultWriteWorkers = 10;
@@ -179,6 +180,7 @@ struct FsInitParams {
 	             malloc_trim_period(kDefaultMallocTrimPeriod),
 #endif
 	             max_chunks_written_in_parallel_per_inode(kDefaultMaxChunksWrittenInParallelPerInode),
+	             use_write_flush_packet(kDefaultUseWriteFlushPacket),
 	             statfs_cache_timeout(kDefaultStatfsCacheTo),
 	             use_quota_in_volume_size(kDefaultUseQuotaInVolumeSize),
 	             max_wait_retry_time(kDefaultMaxWaitRetryTime),
@@ -229,6 +231,7 @@ struct FsInitParams {
 	             malloc_trim_period(kDefaultMallocTrimPeriod),
 #endif
 	             max_chunks_written_in_parallel_per_inode(kDefaultMaxChunksWrittenInParallelPerInode),
+	             use_write_flush_packet(kDefaultUseWriteFlushPacket),
 	             statfs_cache_timeout(kDefaultStatfsCacheTo),
 	             use_quota_in_volume_size(kDefaultUseQuotaInVolumeSize),
 	             max_wait_retry_time(kDefaultMaxWaitRetryTime),
@@ -299,6 +302,7 @@ struct FsInitParams {
 #endif
 
 	unsigned max_chunks_written_in_parallel_per_inode;
+	bool use_write_flush_packet;
 	unsigned statfs_cache_timeout;
 	bool use_quota_in_volume_size;
 	unsigned max_wait_retry_time;

--- a/src/mount/writedata.cc
+++ b/src/mount/writedata.cc
@@ -173,8 +173,19 @@ struct inodedata {
 	std::atomic_bool emptyChunkDataList = true;
 	std::atomic<uint64_t> totalCachedBlocks = 0;
 	std::mutex mutex;
-	Timer lastWriteToDataChain;     // inodeLock
-	Timer lastWriteToChunkservers;  // inodeLock
+	ChunkData *lastChunkDataWritten = nullptr;   // inodeLock
+	// Steady-clock timestamps in ms; stored as atomic integers because
+	// std::atomic<Timer> is ill-formed (Timer is not trivially copyable).
+	std::atomic<int64_t> lastWriteToDataChainMs{nowSteadyMs()};
+	std::atomic<int64_t> lastWriteToChunkserversMs{nowSteadyMs()};
+
+	static int64_t nowSteadyMs() {
+		return std::chrono::duration_cast<std::chrono::milliseconds>(
+		           SteadyClock::now().time_since_epoch())
+		    .count();
+	}
+
+	static int64_t elapsedMsSince(int64_t timestampMs) { return nowSteadyMs() - timestampMs; }
 
 	inodedata(inode_t inode) : inode(inode) {}
 
@@ -188,12 +199,14 @@ struct inodedata {
 	 */
 	bool requiresFlushing() {
 		return (flushwaiting > 0 ||
-		        lastWriteToDataChain.elapsed_ms() >= kMaximumTimeInDataChainSinceLastWrite_ms ||
-		        lastWriteToChunkservers.elapsed_ms() >= kMaximumTimeInDataChainSinceLastFlush_ms);
+		        elapsedMsSince(lastWriteToDataChainMs.load()) >=
+		            kMaximumTimeInDataChainSinceLastWrite_ms ||
+		        elapsedMsSince(lastWriteToChunkserversMs.load(std::memory_order_relaxed)) >=
+		            kMaximumTimeInDataChainSinceLastFlush_ms);
 	}
 
 	bool wasLastBlockRecentlyWritten() const {
-		return lastWriteToDataChain.elapsed_ms() < kVeryRecentWrite_ms;
+		return elapsedMsSince(lastWriteToDataChainMs.load()) < kVeryRecentWrite_ms;
 	}
 
 private:
@@ -215,7 +228,7 @@ private:
 	 * This is used to avoid writing a partial stripe to chunkservers when last block was full and
 	 * next one has not even started.
 	 */
-	static const uint32_t kVeryRecentWrite_ms = 5;
+	static const uint32_t kVeryRecentWrite_ms = 100;
 };
 
 using InodeDataPtr = std::unique_ptr<inodedata>;
@@ -227,8 +240,10 @@ struct ChunkData {
 	uint32_t minimumBlocksToWrite = 1;
 	std::list<WriteCacheBlock> dataChain;
 	std::atomic_bool recentlyUnlockNoticeReceived = false;
-	bool inQueue =
-	    false;  // true if this chunk is waiting in one of the queues or is being processed
+	// true if this chunk is waiting in the delayed queue
+	std::atomic<bool> inDelayedQueue = false;
+	// true if this chunk is waiting in one of the queues or is being processed
+	bool inQueue = false;
 	bool workerWaitingForData = false;
 	std::unique_ptr<WriteChunkLocator> locator;
 	std::atomic<int> writesCount = 0;
@@ -442,6 +457,7 @@ void write_free_chunkdata(ChunkData *fChunkData, UniqueLock &) {
 	if (chunkDataListIt != id->chunkDataList.end()) {
 		id->chunkDataList.erase(chunkDataListIt);
 		id->emptyChunkDataList = id->chunkDataList.empty();
+		if (id->lastChunkDataWritten == fChunkData) { id->lastChunkDataWritten = nullptr; }
 	}
 }
 
@@ -451,6 +467,7 @@ void write_free_chunkdata(ChunkData *fChunkData, UniqueLock &) {
 static void delayed_queue_put(ChunkData *chunkData, uint32_t seconds, UniqueLock &) {
 	delayedQueue.emplace_back(
 	    DelayedQueueEntry(chunkData, seconds * DelayedQueueEntry::kTicksPerSecond));
+	if (chunkData != kNoChunkData) { chunkData->inDelayedQueue.store(true); }
 }
 
 /* globalLock: LOCKED*/
@@ -458,6 +475,7 @@ static bool delayed_queue_remove(ChunkData *chunkData, UniqueLock &) {
 	for (auto it = delayedQueue.begin(); it != delayedQueue.end(); ++it) {
 		if (it->chunkData == chunkData) {
 			delayedQueue.erase(it);
+			chunkData->inDelayedQueue.store(false);
 			return true;
 		}
 	}
@@ -468,15 +486,16 @@ static bool delayed_queue_remove(ChunkData *chunkData, UniqueLock &) {
 static std::vector<ChunkData *> delayed_queue_remove(inodedata *id, UniqueLock &) {
 	std::vector<ChunkData *> removedChunkData;
 
-	auto it = std::remove_if(delayedQueue.begin(), delayedQueue.end(),
-	                         [&](const DelayedQueueEntry &entry) {
-		                         if (entry.chunkData->getParent() == id) {
-			                         removedChunkData.push_back(entry.chunkData);
-			                         return true;
-		                         }
-		                         return false;
-	                         });
+	auto it = std::remove_if(
+	    delayedQueue.begin(), delayedQueue.end(), [&](const DelayedQueueEntry &entry) {
+		    if (entry.chunkData != kNoChunkData && entry.chunkData->getParent() == id) {
+			    removedChunkData.push_back(entry.chunkData);
+			    return true;
+		    }
+		    return false;
+	    });
 
+	for (auto *chunkData : removedChunkData) { chunkData->inDelayedQueue.store(false); }
 	delayedQueue.erase(it, delayedQueue.end());
 	return removedChunkData;
 }
@@ -496,6 +515,7 @@ void *delayed_queue_worker(void *) {
 			if (--it->ticksLeft <= 0) {
 				auto *data = reinterpret_cast<uint8_t *>(it->chunkData);
 				jobsQueue->put(0, 0, data, 1);
+				it->chunkData->inDelayedQueue.store(false);
 				it = delayedQueue.erase(it);
 			} else {
 				++it;
@@ -778,13 +798,20 @@ void ChunkJobWriter::processJob(ChunkData *chunkData) {
 				chunkData_->tryCounter = 1;
 			}
 			// Keep the lock
+			auto chunkId = locator->locationInfo().chunkId;
 			chunkData_->locator = std::move(locator);
 			// Move data left in the journal into front of the write cache
 			returnJournalToDataChain(writer.releaseJournal(), inodeLock);
 			inodeLock.unlock();
 
-			safs::log_warn("write file error, inode: {}, index: {} - {}", parent->inode,
-			               chunkIndex_, errorString.c_str());
+			if (e.status() != SAUNAFS_ERROR_LOCKED) {
+				safs::log_warn("write file error, inode: {}, index: {}, chunkId: {} - {}",
+				               parent->inode, chunkIndex_, chunkId, errorString.c_str());
+			} else {
+				safs::log_info("write file error, inode: {}, index: {}, chunkId: {} - {}",
+				               parent->inode, chunkIndex_, chunkId, errorString.c_str());
+			}
+
 			if (chunkData_->tryCounter >= maxretries && e.status() != SAUNAFS_ERROR_LOCKED) {
 				// Convert error to an unrecoverable error
 				throw UnrecoverableWriteException(e.message(), e.status());
@@ -858,17 +885,22 @@ void ChunkJobWriter::processDataChain(ChunkWriter &writer) {
 		    writer.acceptsNewOperations()) {
 			UniqueLock inodeLock(parent->mutex);
 			// While there is any block worth sending, we add new write operation
+			int blocksPut = 0;
 			while (haveBlockWorthWriting(writer.getUnfinishedOperationsCount())) {
 				// Remove block from cache and pass it to the writer
 				writer.addOperation(std::move(chunkData_->dataChain.front()));
 				chunkData_->popFromChain();
+				blocksPut++;
+			}
+			if (blocksPut > 0) {
 				inodeLock.unlock();
 
-				write_cb_release_blocks(1);
+				write_cb_release_blocks(blocksPut);
 
 				inodeLock.lock();
 			}
-			if (chunkData_->requiresFlushing() && !haveAnyBlockInCurrentChunk()) {
+			if ((chunkData_->requiresFlushing() || chunkData_ != parent->lastChunkDataWritten) &&
+			    !haveAnyBlockInCurrentChunk()) {
 				// No more data and some flushing is needed or required, so flush everything
 				writer.startFlushMode();
 			}
@@ -900,9 +932,8 @@ void ChunkJobWriter::processDataChain(ChunkWriter &writer) {
 		    std::min(parent->maxfleng - chunkIndex_ * SFSCHUNKSIZE, (uint64_t)SFSCHUNKSIZE));
 		inodeLock.unlock();
 		if (writer.startNewOperations(can_expect_next_block) > 0) {
-			inodeLock.lock();
-			parent->lastWriteToChunkservers.reset();
-			inodeLock.unlock();
+			parent->lastWriteToChunkserversMs.store(inodedata::nowSteadyMs(),
+			                                        std::memory_order_relaxed);
 		}
 		if (writer.getPendingOperationsCount() == 0) {
 			return;
@@ -1039,7 +1070,8 @@ void write_data_term(void) {
 int write_block(ChunkData *chunkData, uint16_t pos, uint32_t from, uint32_t to, const uint8_t *data,
                 UniqueLock &inodeLock) {
 	inodedata *parent = chunkData->getParent();
-	parent->lastWriteToDataChain.reset();
+	parent->lastWriteToDataChainMs.store(inodedata::nowSteadyMs());
+	parent->lastChunkDataWritten = chunkData;
 
 	// Try to expand the last block
 	if (!chunkData->dataChain.empty()) {
@@ -1066,7 +1098,8 @@ int write_block(ChunkData *chunkData, uint16_t pos, uint32_t from, uint32_t to, 
 		// - there is a lot of blocks in the write chain
 		// - there are at least two chunks in the write chain
 		if (chunkData->tryCounter == 0 &&
-		    (chunkData->dataChain.size() > chunkData->minimumBlocksToWrite)) {
+		    chunkData->dataChain.size() > chunkData->minimumBlocksToWrite &&
+		    chunkData->inDelayedQueue.load()) {
 			inodeLock.unlock();
 
 			globalLock.lock();

--- a/src/mount/writedata.cc
+++ b/src/mount/writedata.cc
@@ -205,8 +205,13 @@ struct inodedata {
 		            kMaximumTimeInDataChainSinceLastFlush_ms);
 	}
 
-	bool wasLastBlockRecentlyWritten() const {
+	bool wasLastBlockVeryRecentlyWritten() const {
 		return elapsedMsSince(lastWriteToDataChainMs.load()) < kVeryRecentWrite_ms;
+	}
+
+	bool wasLastBlockRecentlyWritten() const {
+		return elapsedMsSince(lastWriteToDataChainMs.load(std::memory_order_relaxed)) <
+		       kRecentWrite_ms;
 	}
 
 private:
@@ -228,7 +233,12 @@ private:
 	 * This is used to avoid writing a partial stripe to chunkservers when last block was full and
 	 * next one has not even started.
 	 */
-	static const uint32_t kVeryRecentWrite_ms = 100;
+	static const uint32_t kVeryRecentWrite_ms = 5;
+
+	/*! Limit for triggering the send of a write flush packet when the last write to chunkservers
+	 * was not very recent.
+	 */
+	static const uint32_t kRecentWrite_ms = 100;
 };
 
 using InodeDataPtr = std::unique_ptr<inodedata>;
@@ -352,7 +362,8 @@ static InodeDataMap inodedataMap;
 using TruncateLocatorsDataMap = std::map<inode_t, std::pair<uint64_t, uint64_t>>;
 static std::mutex truncateLocatorsDataMutex;
 static TruncateLocatorsDataMap truncateLocatorsData;
-static uint32_t gWriteWindowSize;
+static std::atomic<uint32_t> gWriteWindowSize;
+static std::atomic<bool> gUseWriteFlushPacket;
 static uint32_t gChunkserverTimeout_ms;
 
 // percentage of the free cache (1% - 100%) which can be used by one inode
@@ -717,7 +728,7 @@ private:
 	 * These can be taken only if we are close to run out of tasks to do.
 	 * inodeLock: LOCKED
 	 */
-	bool haveBlockWorthWriting(uint32_t unfinishedOperationCount);
+	bool haveBlockWorthWriting(bool isWaitingForData);
 	ChunkData *chunkData_ = kNoChunkData;
 	uint32_t chunkIndex_ = 0;
 	Timer wholeOperationTimer;
@@ -739,7 +750,8 @@ void ChunkJobWriter::processJob(ChunkData *chunkData) {
 	inodedata *parent = chunkData_->getParent();
 
 	/*  Process the job */
-	ChunkWriter writer(globalChunkserverStats, gChunkConnector, chunkData_->newDataInChainPipe[0]);
+	ChunkWriter writer(globalChunkserverStats, gChunkConnector, chunkData_->newDataInChainPipe[0],
+	                   gWriteWindowSize.load(), gUseWriteFlushPacket.load());
 	wholeOperationTimer.reset();
 	std::unique_ptr<WriteChunkLocator> locator = std::move(chunkData_->locator);
 	if (!locator) { locator.reset(new WriteChunkLocator()); }
@@ -886,7 +898,7 @@ void ChunkJobWriter::processDataChain(ChunkWriter &writer) {
 			UniqueLock inodeLock(parent->mutex);
 			// While there is any block worth sending, we add new write operation
 			int blocksPut = 0;
-			while (haveBlockWorthWriting(writer.getUnfinishedOperationsCount())) {
+			while (haveBlockWorthWriting(writer.isWaitingForData())) {
 				// Remove block from cache and pass it to the writer
 				writer.addOperation(std::move(chunkData_->dataChain.front()));
 				chunkData_->popFromChain();
@@ -904,12 +916,12 @@ void ChunkJobWriter::processDataChain(ChunkWriter &writer) {
 				// No more data and some flushing is needed or required, so flush everything
 				writer.startFlushMode();
 			}
-			if (writer.getUnfinishedOperationsCount() < gWriteWindowSize) {
+			if (writer.isWaitingForData()) {
 				chunkData_->workerWaitingForData = true;
 			}
 			can_expect_next_block =
 			    haveAnyBlockInCurrentChunk() ||
-			    (parent->wasLastBlockRecentlyWritten() && chunkData_->dataChain.empty());
+			    (parent->wasLastBlockVeryRecentlyWritten() && chunkData_->dataChain.empty());
 		} else if (writer.acceptsNewOperations()) {
 			// We are running out of time...
 			UniqueLock inodeLock(parent->mutex);
@@ -924,14 +936,15 @@ void ChunkJobWriter::processDataChain(ChunkWriter &writer) {
 			}
 			can_expect_next_block =
 			    haveAnyBlockInCurrentChunk() ||
-			    (parent->wasLastBlockRecentlyWritten() && chunkData_->dataChain.empty());
+			    (parent->wasLastBlockVeryRecentlyWritten() && chunkData_->dataChain.empty());
 		}
 
 		UniqueLock inodeLock(parent->mutex);
 		writer.setChunkSizeInBlocks(
 		    std::min(parent->maxfleng - chunkIndex_ * SFSCHUNKSIZE, (uint64_t)SFSCHUNKSIZE));
 		inodeLock.unlock();
-		if (writer.startNewOperations(can_expect_next_block) > 0) {
+		if (writer.startNewOperations(can_expect_next_block,
+		                              parent->wasLastBlockRecentlyWritten()) > 0) {
 			parent->lastWriteToChunkserversMs.store(inodedata::nowSteadyMs(),
 			                                        std::memory_order_relaxed);
 		}
@@ -961,21 +974,21 @@ void ChunkJobWriter::returnJournalToDataChain(std::list<WriteCacheBlock> &&journ
 
 bool ChunkJobWriter::haveAnyBlockInCurrentChunk() { return !chunkData_->dataChain.empty(); }
 
-bool ChunkJobWriter::haveBlockWorthWriting(uint32_t unfinishedOperationCount) {
+bool ChunkJobWriter::haveBlockWorthWriting(bool isWaitingForData) {
 	if (!haveAnyBlockInCurrentChunk()) { return false; }
 	const auto &block = chunkData_->dataChain.front();
 	if (block.type != WriteCacheBlock::kWritableBlock) {
 		// Always write data, that was previously written
 		return true;
-	} else if (unfinishedOperationCount >= gWriteWindowSize) {
-		// Don't start new operations if there is already a lot of pending writes
+	} else if (!isWaitingForData) {
+		// Don't start new operations if we have enough data in progress
 		return false;
-	} else {
-		// Always start full blocks; start partial blocks only if we have to flush the data
-		// or the block won't be expanded (only the last one can be) to a full block
-		return (block.size() == SFSBLOCKSIZE || chunkData_->requiresFlushing() ||
-		        chunkData_->dataChain.size() > 1);
 	}
+
+	// Always start full blocks; start partial blocks only if we have to flush the data
+	// or the block won't be expanded (only the last one can be) to a full block
+	return (block.size() == SFSBLOCKSIZE || chunkData_->requiresFlushing() ||
+	        chunkData_->dataChain.size() > 1);
 }
 
 /* main working thread | globalLock:UNLOCKED */
@@ -1009,13 +1022,14 @@ void *write_worker(void *) {
 void write_data_init(uint32_t cachesize, uint32_t retries, uint32_t workers,
                      uint32_t writewindowsize, uint32_t chunkserverTimeout_ms,
                      uint32_t cachePerInodePercentage, uint32_t waveTimeout,
-                     uint32_t maxChunksWrittenInParallelPerInode) {
+                     uint32_t maxChunksWrittenInParallelPerInode, bool useWriteFlushPacket) {
 	uint64_t cachebytecount = uint64_t(cachesize) * 1024 * 1024;
 	uint64_t cacheblockcount = (cachebytecount / SFSBLOCKSIZE);
 	pthread_attr_t thattr;
 
 	gChunkConnector.setSourceIp(fs_getsrcip());
 	gWriteWindowSize = writewindowsize;
+	gUseWriteFlushPacket = useWriteFlushPacket;
 	gChunkserverTimeout_ms = chunkserverTimeout_ms;
 	maxretries = retries;
 	gWriteWaveTimeout = waveTimeout;
@@ -1040,6 +1054,8 @@ void write_data_init(uint32_t cachesize, uint32_t retries, uint32_t workers,
 
 	std::lock_guard mountInfoLock(gMountInfoMtx);
 	gTweaks.registerVariable("WriteMaxRetries", maxretries, "sfsioretries (write)");
+	gTweaks.registerVariable("WriteWindowSize", gWriteWindowSize, "sfswritewindowsize");
+	gTweaks.registerVariable("UseWriteFlushPacket", gUseWriteFlushPacket, "sfsusewriteflushpacket");
 	gTweaks.registerVariable("WriteWaveTimeout", gWriteWaveTimeout, "sfschunkserverwavewriteto");
 	gTweaks.registerVariable("MaxChunksWrittenInParallelPerInode",
 	                         gMaxChunksWrittenInParallelPerInode,

--- a/src/mount/writedata.h
+++ b/src/mount/writedata.h
@@ -33,7 +33,7 @@ namespace WriteAlgorithm {
 void write_data_init(uint32_t cachesize, uint32_t retries, uint32_t workers,
                      uint32_t writewindowsize, uint32_t chunkserverTimeout_ms,
                      uint32_t cachePerInodePercentage, uint32_t waveTimeout,
-                     uint32_t maxChunksWrittenInParallelPerInode);
+                     uint32_t maxChunksWrittenInParallelPerInode, bool useWriteFlushPacket);
 void write_data_term(void);
 void *write_data_new(inode_t inode);
 int write_data_end(void *vid);

--- a/src/protocol/SFSCommunication.h
+++ b/src/protocol/SFSCommunication.h
@@ -570,7 +570,8 @@ enum class SugidClearMode : uint8_t {
 // 0x04BA
 #define SAU_CLTOCS_WRITE_INIT (1000U + 210U)
 /// version==0 chunkid:64 chunkversion:32 chunktype:8 chain:(N * [ip:32 port:16])
-/// version==1 chunkid:64 chunkversion:32 chunktype:16 chain:(N * [ip:32 port:16])
+/// version==1 chunkid:64 chunkversion:32 chunktype:16 chain:(N * [ip:32 port:16 chunktype:16 chunkserver_version:32])
+/// version==2 chunkid:64 chunkversion:32 chunktype:16 expectwriteflush:8 chain:(N * [ip:32 port:16 chunktype:16 chunkserver_version:32])
 
 // 0x04BB
 #define SAU_CSTOCL_WRITE_STATUS (1000U + 211U)
@@ -579,6 +580,10 @@ enum class SugidClearMode : uint8_t {
 // 0x04BC
 #define SAU_CLTOCS_WRITE_DATA (1000U + 212U)
 /// chunkid:64 writeid:32 blocknum:16 offset:32 size:32 crc:32 data:BYTES[size]
+
+// 0x04C0
+#define SAU_CLTOCS_WRITE_FLUSH (1000U + 216U)
+/// chunkid:64
 
 // 0x04BD
 #define SAU_CLTOCS_WRITE_END (1000U + 213U)

--- a/src/protocol/cltocs.h
+++ b/src/protocol/cltocs.h
@@ -79,23 +79,8 @@ inline void deserialize(const uint8_t* source, uint32_t sourceSize,
 
 namespace writeInit {
 
-const PacketVersion kStandardAndXorChunks = 0;
 const PacketVersion kECChunks = 1;
-
-inline void serialize(std::vector<uint8_t>& destination,
-		uint64_t chunkId, uint32_t chunkVersion, legacy::ChunkPartType chunkType,
-		const std::vector<NetworkAddress>& chain) {
-	serializePacket(destination, SAU_CLTOCS_WRITE_INIT, kStandardAndXorChunks,
-			chunkId, chunkVersion, chunkType, chain);
-}
-
-inline void deserialize(const uint8_t* source, uint32_t sourceSize,
-		uint64_t& chunkId, uint32_t& chunkVersion, legacy::ChunkPartType& chunkType,
-		std::vector<NetworkAddress>& chain) {
-	verifyPacketVersionNoHeader(source, sourceSize, kStandardAndXorChunks);
-	deserializeAllPacketDataNoHeader(source, sourceSize,
-			chunkId, chunkVersion, chunkType, chain);
-}
+const PacketVersion kECChunksWithWriteFlush = 2;
 
 inline void serialize(std::vector<uint8_t>& destination,
 		uint64_t chunkId, uint32_t chunkVersion, ChunkPartType chunkType,
@@ -110,6 +95,21 @@ inline void deserialize(const uint8_t* source, uint32_t sourceSize,
 	verifyPacketVersionNoHeader(source, sourceSize, kECChunks);
 	deserializeAllPacketDataNoHeader(source, sourceSize,
 			chunkId, chunkVersion, chunkType, chain);
+}
+
+inline void serialize(std::vector<uint8_t> &destination, uint64_t chunkId, uint32_t chunkVersion,
+                      ChunkPartType chunkType, bool expectWriteFlush,
+                      const std::vector<ChunkTypeWithAddress> &chain) {
+	serializePacket(destination, SAU_CLTOCS_WRITE_INIT, kECChunksWithWriteFlush,
+			chunkId, chunkVersion, chunkType, expectWriteFlush, chain);
+}
+
+inline void deserialize(const uint8_t *source, uint32_t sourceSize, uint64_t &chunkId,
+                        uint32_t &chunkVersion, ChunkPartType &chunkType, bool &expectWriteFlush,
+                        std::vector<ChunkTypeWithAddress> &chain) {
+	verifyPacketVersionNoHeader(source, sourceSize, kECChunksWithWriteFlush);
+	deserializeAllPacketDataNoHeader(source, sourceSize,
+			chunkId, chunkVersion, chunkType, expectWriteFlush, chain);
 }
 
 } // namespace writeInit
@@ -136,6 +136,25 @@ inline void deserializePrefix(const uint8_t* source, uint32_t sourceSize,
 static const uint32_t kPrefixSize = 4 + 8 + 4 + 2 + 4 + 4 + 4;
 
 } // namespace writeData
+
+namespace writeFlush {
+
+const PacketVersion kInitial = 0;
+
+inline void serialize(std::vector<uint8_t> &destination, uint64_t chunkId) {
+	serializePacket(destination, SAU_CLTOCS_WRITE_FLUSH, kInitial, chunkId);
+}
+
+inline void deserialize(const uint8_t *source, uint32_t sourceSize, uint64_t &chunkId) {
+	verifyPacketVersionNoHeader(source, sourceSize, kInitial);
+	deserializePacketDataNoHeader(source, sourceSize, chunkId);
+}
+
+// kPrefixSize is equal to:
+// version:u32 chunkId:u64
+static const uint32_t kPrefixSize = 4 + 8;
+
+} // namespace writeFlush
 
 namespace writeEnd {
 

--- a/src/protocol/cltocs_unittest.cc
+++ b/src/protocol/cltocs_unittest.cc
@@ -74,6 +74,32 @@ TEST(CltocsCommunicationTests, WriteInit) {
 	SAUNAFS_VERIFY_INOUT_PAIR(chain);
 }
 
+TEST(CltocsCommunicationTests, WriteInitWithWriteFlush) {
+	SAUNAFS_DEFINE_INOUT_PAIR(uint64_t, chunkId,  0x987654321, 0);
+	SAUNAFS_DEFINE_INOUT_PAIR(uint32_t, chunkVersion, 0x01234567, 0);
+	SAUNAFS_DEFINE_INOUT_PAIR(ChunkPartType, chunkType, xor_p_of_7, standard);
+	SAUNAFS_DEFINE_INOUT_PAIR(bool, expectWriteFlush, true, false);
+	SAUNAFS_DEFINE_INOUT_VECTOR_PAIR(ChunkTypeWithAddress, chain) = {
+			ChunkTypeWithAddress(NetworkAddress(0x0A000001, 12388), slice_traits::standard::ChunkPartType(), kStdVersion),
+			ChunkTypeWithAddress(NetworkAddress(0x0A000002, 12389), slice_traits::standard::ChunkPartType(), kStdVersion),
+	};
+
+	std::vector<uint8_t> buffer;
+	ASSERT_NO_THROW(cltocs::writeInit::serialize(buffer,
+			chunkIdIn, chunkVersionIn, chunkTypeIn, expectWriteFlushIn, chainIn));
+
+	verifyHeader(buffer, SAU_CLTOCS_WRITE_INIT);
+	removeHeaderInPlace(buffer);
+	ASSERT_NO_THROW(cltocs::writeInit::deserialize(buffer.data(), buffer.size(),
+			chunkIdOut, chunkVersionOut, chunkTypeOut, expectWriteFlushOut, chainOut));
+
+	SAUNAFS_VERIFY_INOUT_PAIR(chunkId);
+	SAUNAFS_VERIFY_INOUT_PAIR(chunkVersion);
+	SAUNAFS_VERIFY_INOUT_PAIR(chunkType);
+	SAUNAFS_VERIFY_INOUT_PAIR(expectWriteFlush);
+	SAUNAFS_VERIFY_INOUT_PAIR(chain);
+}
+
 TEST(CltocsCommunicationTests, WriteData) {
 	SAUNAFS_DEFINE_INOUT_PAIR(uint64_t, chunkId,  0x987654321, 0);
 	SAUNAFS_DEFINE_INOUT_PAIR(uint32_t, writeId,  0x12345,     0);
@@ -98,6 +124,19 @@ TEST(CltocsCommunicationTests, WriteData) {
 	SAUNAFS_VERIFY_INOUT_PAIR(offset);
 	SAUNAFS_VERIFY_INOUT_PAIR(size);
 	SAUNAFS_VERIFY_INOUT_PAIR(crc);
+}
+
+TEST(CltocsCommunicationTests, WriteFlush) {
+	SAUNAFS_DEFINE_INOUT_PAIR(uint64_t, chunkId, 0x987654321, 0);
+
+	std::vector<uint8_t> buffer;
+	ASSERT_NO_THROW(cltocs::writeFlush::serialize(buffer, chunkIdIn));
+
+	verifyHeader(buffer, SAU_CLTOCS_WRITE_FLUSH);
+	removeHeaderInPlace(buffer);
+	ASSERT_NO_THROW(cltocs::writeFlush::deserialize(buffer.data(), buffer.size(), chunkIdOut));
+
+	SAUNAFS_VERIFY_INOUT_PAIR(chunkId);
 }
 
 TEST(CltocsCommunicationTests, WriteEnd) {

--- a/tests/test_suites/SanityChecks/test_mount_tweaks.sh
+++ b/tests/test_suites/SanityChecks/test_mount_tweaks.sh
@@ -14,8 +14,12 @@ expect_equals "false" "$(cat ${info[mount0]}/.saunafs_tweaks | grep -i directio 
 expect_equals "true" "$(cat ${info[mount1]}/.saunafs_tweaks | grep -i directio | awk '{print $2}')"
 
 # Modify the options on the fly from tweaks file
+echo "WriteWindowSize=50" | sudo tee ${info[mount0]}/.saunafs_tweaks
+echo "UseWriteFlushPacket=true" | sudo tee ${info[mount0]}/.saunafs_tweaks
 echo "DirectIO=true" | sudo tee ${info[mount0]}/.saunafs_tweaks
 echo "DirectIO=false" | sudo tee ${info[mount1]}/.saunafs_tweaks
 
+expect_equals "50" "$(cat ${info[mount0]}/.saunafs_tweaks | grep -i WriteWindowSize | awk '{print $2}')"
+expect_equals "true" "$(cat ${info[mount0]}/.saunafs_tweaks | grep -i UseWriteFlushPacket | awk '{print $2}')"
 expect_equals "true" "$(cat ${info[mount0]}/.saunafs_tweaks | grep -i directio | awk '{print $2}')"
 expect_equals "false" "$(cat ${info[mount1]}/.saunafs_tweaks | grep -i directio | awk '{print $2}')"

--- a/tests/test_suites/ShortSystemTests/test_concurrent_random_writes_on_chunk.sh
+++ b/tests/test_suites/ShortSystemTests/test_concurrent_random_writes_on_chunk.sh
@@ -19,6 +19,7 @@ FILE_SIZE=$(( times_to_repeat * 4 * 1024 )) file-generate ${TEMP_DIR}/original_f
 # written in random order and with many concurrent writes.
 
 master_reloading_loop_file=${TEMP_DIR}/master_reloading_loop_file
+client_tweaking_loop_file=${TEMP_DIR}/client_tweaking_loop_file
 switch_use_chunkserver_side_chunk_lock_thread() {
 	touch ${master_reloading_loop_file}
 	while true; do
@@ -34,12 +35,41 @@ switch_use_chunkserver_side_chunk_lock_thread() {
 	echo "switch_use_chunkserver_side_chunk_lock_thread stopped"
 }
 
+switch_use_write_flush_packet_thread() {
+	touch ${client_tweaking_loop_file}
+	while true; do
+		if [ ! -e ${client_tweaking_loop_file} ]; then
+			break
+		fi
+		# Make the test more robust by switching write flush packet usage on the fly on the
+		# client side, which can cause more interleaving of operations and increase chances of
+		# catching concurrency issues.
+		sleep 0.23
+		for mount in $(seq 0 3); do
+			current=$(cat ${info[mount${mount}]}/.saunafs_tweaks | grep -i UseWriteFlushPacket \
+				| awk '{print $2}')
+			case ${current} in
+				true)  new_value=false ;;
+				*)     new_value=true  ;;
+			esac
+			echo "UseWriteFlushPacket=${new_value}" | sudo tee ${info[mount${mount}]}/.saunafs_tweaks
+		done
+	done
+	echo "switch_write_flush_packet_thread stopped"
+}
+
 stop_switch_use_chunkserver_side_chunk_lock_thread() {
 	rm -f ${master_reloading_loop_file}
 }
 
+stop_switch_use_write_flush_packet_thread() {
+	rm -f ${client_tweaking_loop_file}
+}
+
 switch_use_chunkserver_side_chunk_lock_thread &
 switch_use_chunkserver_side_chunk_lock_thread_pid=$!
+switch_use_write_flush_packet_thread &
+switch_use_write_flush_packet_thread_pid=$!
 
 for i in $(seq 0 $((times_to_repeat - 1))); do
 	shuffled_seq=($(shuf -e $(seq 0 3)))
@@ -58,5 +88,6 @@ for i in $(seq 0 $((times_to_repeat - 1))); do
 done
 
 stop_switch_use_chunkserver_side_chunk_lock_thread
+stop_switch_use_write_flush_packet_thread
 
 MESSAGE="Validating file after concurrent random writes" expect_success file-validate dir/file

--- a/tests/test_suites/TestTemplates/test_ec_parallel_writing.inc
+++ b/tests/test_suites/TestTemplates/test_ec_parallel_writing.inc
@@ -4,8 +4,21 @@ else
 	timeout_set $(( (FILE_SIZE_MB / 25) * 3)) minutes
 fi
 
+# Have 4 mounts to use flush packet, 4 that are not going to use it and 2 that might use it.
+
+random_seed=$RANDOM
+RANDOM=$random_seed
+echo "Using random seed for setup: $random_seed"
+
 CHUNKSERVERS=4 \
 	MOUNTS=10 \
+	MOUNT_USE_WRITE_FLUSH_PACKET=1 \
+	MOUNT_0_EXTRA_CONFIG="sfsusewriteflushpacket=0" \
+	MOUNT_1_EXTRA_CONFIG="sfsusewriteflushpacket=0" \
+	MOUNT_2_EXTRA_CONFIG="sfsusewriteflushpacket=0" \
+	MOUNT_3_EXTRA_CONFIG="sfsusewriteflushpacket=0" \
+	MOUNT_4_EXTRA_CONFIG="sfsusewriteflushpacket=$((RANDOM % 2))" \
+	MOUNT_5_EXTRA_CONFIG="sfsusewriteflushpacket=$((RANDOM % 2))" \
 	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER,readbuffersexpirationtime=100,maxreadaheadrequests=1,readworkers=10" \
 	MASTER_CUSTOM_GOALS="10 ec_3_1: \$ec(3,1)" \
 	USE_RAMDISK=YES \

--- a/tests/tools/saunafs.sh
+++ b/tests/tools/saunafs.sh
@@ -34,6 +34,11 @@ setup_local_empty_saunafs() {
 	saunafs_info_[chunkserver_count]=$number_of_chunkservers
 	saunafs_info_[admin_password]=${ADMIN_PASSWORD:-password}
 	saunafs_info_[metadata_backend]="${metadata_backend}"
+	saunafs_info_[mount_use_write_flush_packet]=${MOUNT_USE_WRITE_FLUSH_PACKET:-NOT_SET}
+
+	local random_seed=${RANDOM_SEED:-$RANDOM}
+	RANDOM=$random_seed
+	echo "Using random seed: $random_seed"
 
 	declare -g mds_command="sfsmaster"
 
@@ -747,14 +752,25 @@ function validate_and_append_fuse_options() {
 create_sfsmount_cfg_() {
 	local this_mount_cfg_variable="MOUNT_${1}_EXTRA_CONFIG"
 	local this_mount_exports_variable="MOUNT_${1}_EXTRA_EXPORTS"
+
+	# Make the tests more robust by randomizing write flush packet usage if not set by the test.
+	if [[ ${saunafs_info_[mount_use_write_flush_packet]} == NOT_SET ]]; then
+		echo "sfsusewriteflushpacket=$((RANDOM % 2))"
+	else
+		echo "sfsusewriteflushpacket=${saunafs_info_[mount_use_write_flush_packet]}"
+	fi
+
+	# General config for all mounts
 	echo "sfsmaster=$ip_address"
 	echo "sfsport=${saunafs_info_[matocl]}"
+	echo "${MOUNT_EXTRA_CONFIG-}" | tr '|' '\n'
+
+	# Mount specific config and exports
+	echo "${!this_mount_cfg_variable-}" | tr '|' '\n'
 	if [[ ${!this_mount_exports_variable-} ]]; then
 		# we want custom exports options, so we need to identify with a password
 		echo "sfspassword=${1}"
 	fi
-	echo "${MOUNT_EXTRA_CONFIG-}" | tr '|' '\n'
-	echo "${!this_mount_cfg_variable-}" | tr '|' '\n'
 }
 
 windows_do_mount_() {

--- a/utils/chunk_operations_eio.c
+++ b/utils/chunk_operations_eio.c
@@ -75,7 +75,8 @@ static int err_on_operation(int fd, const char* opname, size_t offset, size_t si
 	// TODO: remove fixed pattern for SMRs after the basic support
 	if (strstr(filename, always_eio_trigger) || strstr(filename, "sauna_nullb0")) {
 		return EIO;
-	} else if (strstr(filename, far_eio_trigger) && offset > FAR_OFFSET_THRESHOLD) {
+	} else if (strstr(filename, far_eio_trigger) &&
+	           (offset > FAR_OFFSET_THRESHOLD || size > FAR_OFFSET_THRESHOLD - offset)) {
 		return EIO;
 	} else if (strstr(filename, slow_and_one_eio_trigger)) {
 		// sleep for a while to simulate a slow operation


### PR DESCRIPTION
This PR introduces a way for the client to suggest the chunkserver
it is writing to wait up to a point, which is for the new write flush
packet.

The new option in the client sfsusewriteflushpacket is updateable via
the tweaks hidden file and the option sfswritewindowsize was also made
updateable via tweaks hidden file. The triggers to send a write flush
packet are the following:
- write window size packets were sent to the peer chunkserver.
- write end packet is going to be sent to the peer chunkserver.
- new operations collide with some of the previously sent operations.
- the last write to the chunkservers of that ChunkWriter was at least
100ms ago.
- the chunk writer is in flush mode, i.e either a flush was called on
the inode, the chunk is not the last one written in the inode or a lot
of time passed, and there are no new operations.

Please note these changes make the whole behavior of the chunk writer
to depend on the instantiation parameters passed (writeWindowSize and
useWriteFlushPacket), this way encapsulating the logic and allowing
those parameters to be updated via tweaks hidden file. Beside the
previous conditions the implementation of the write flush packet
only sends it if at least one previous block of data was sent and the
peer chunkserver supports it. The new packets are tested with new unittests.

In the chunkserver side the idea revolves around having a
WriteHighLevelOp that depending on the new parameter expectWriteFlush
heavily changes its behavior. The write flush packet also works for the
replication goals (state WriteForward).

This is the comparison of the main behavior changes that depends on
expectWriteFlush parameter:
- expectWriteFlush=0: Prior behavior. Every job_write flushes a single
InputBuffer. The conditions to start a write are that no job is in
progress and there are InputBuffers already freezed (in
writeDataBuffers_) ready to be flushed. The condition to freeze the
current inputBuffer_ is that it is full or there is no job in progress.
- expectWriteFlush=1: New behavior. Every job_write flushes some
InputBuffers that depends on the number of freezed ones between each
write flush packet received (inputBuffersForNextFlush_). The conditions
to start a write are that this queue (inputBuffersForNextFlush_) is not
empty and no write job is in progress. The condition to freeze the
current inputBuffer_ is that it is full or a write flush packet has
arrived.

A new WriteHighLevelOpExpectFlush was created to extract the logic
coming from the new behavior implemented and making the whole
code more readable.

As a side change, the effective write window size was increased by 1.
The unfinished-operations cap counted the trailing newOperations_
entry, which is usually held back to complete a stripe. That left
in-flight pending operations bounded by writeWindowSize_ - 1 in many
cases. Adjust the check so at least writeWindowSize_ operations are
kept in flight in a broader set of cases, without changing the meaning
of the write window size option.

Some of the changes also target reducing the amount of locking/unlocking of the
main mutexes synchronizing the write algorithm in the client side.

Changes include:
- making lastWriteToDataChain and lastWriteToChunkservers atomic the
way locking to protect them is not necessary.
- maintaining an atomic inDelayedQueue member of the ChunkData
structure so the write_block function does not perform extra
lock()/unlock() calls on the inode and global locks for unnecessary
cases.
- consolidate the releasing of blocks while moving them to the writer
journal so even when several blocks are moved, the inode lock is open
and closed once.

Side changes:
- log the chunkId in the case some write error happens. Change the log
level of the SAUNAFS_ERROR_LOCKED errors to log_info.
- maintain lastChunkDataWritten and use it as another condition to
trigger flush mode in the writer.

The PR also introduces changes in the testing framework that randomly enables/disables the sfsusewriteflushpacket option for every mountpoint independently. Also the tweaking ability of the WriteWindowSize and UseWriteFlushPacket options were tested.

The far_eio_trigger case in the chunk_operations_eio library was
extended the way it considers now the end offset of the request instead
of the begining. The reason is that mounts using write flush packet
usually compose a single write operation at offset 0 if not much data
is sent, and it was not triggering the errors as expected in the tests.

Includes the bump of the main CMake version to v5.11.0.

Signed-off-by: Dave <dave@leil.io>