### PR TITLE
fix(master): add FoundationDB transaction timeout

### DIFF
--- a/src/master/kv_connector_fdb.cc
+++ b/src/master/kv_connector_fdb.cc
@@ -18,6 +18,8 @@
 
 #include "common/platform.h"
 
+#include <limits>
+
 #include "master/kv_connector_fdb.h"
 
 #include "common/serialization.h"
@@ -51,6 +53,32 @@ bool KVConnectorFDB::init() {
 	if (!fdbDB) {
 		safs::log_err("Failed to get FoundationDB database instance");
 		return false;
+	}
+
+	// Bound every FDB transaction so a stuck op (e.g. an unreachable cluster) fails instead of
+	// blocking the single-threaded master loop forever; ~5s matches FDB's per-transaction
+	// server limit. The option's valid range is [0, INT_MAX] ms (0 disables), so read int64
+	// and reject out-of-range values, which FDB would otherwise truncate, wrap, or disable.
+	static constexpr int64_t kDefaultTxnTimeoutMs = 5000;
+	const auto timeoutMs = cfg_getint64("FDB_TRANSACTION_TIMEOUT_MS", kDefaultTxnTimeoutMs);
+	if (timeoutMs < 0 || timeoutMs > std::numeric_limits<int32_t>::max()) {
+		safs::log_err("FDB_TRANSACTION_TIMEOUT_MS must be in [0, {}] ms (0 disables), got {}",
+		              std::numeric_limits<int32_t>::max(), timeoutMs);
+		return false;
+	}
+	if (timeoutMs > 0) {
+		const auto encoded = kv::toBytesLE<int64_t>(timeoutMs);  // FDB Int option = 8-byte LE
+		const auto err = fdbDB->setOption(
+		    FDB_DB_OPTION_TRANSACTION_TIMEOUT,
+		    std::string_view(reinterpret_cast<const char *>(encoded.data()), encoded.size()));
+		if (err != 0) {
+			// A non-zero timeout was requested but could not be applied; fail fast instead of
+			// running unbounded, which would reintroduce the hang this guard prevents.
+			safs::log_err("Failed to set FDB transaction timeout ({} ms): {}", timeoutMs,
+			              fdb::DB::errorMsg(err));
+			return false;
+		}
+		safs::log_info("FDB transaction timeout set to {} ms", timeoutMs);
 	}
 
 	kvEngine_ = std::make_shared<fdb::FDBKVEngine>(fdbDB);


### PR DESCRIPTION
The FoundationDB connector created every transaction with default options, so an operation that never completes (for example against an unreachable cluster) blocked indefinitely and stalled the single-threaded master event loop, leaving clients unable to register.

Set a database-level transaction timeout when the connector opens the database, so every transaction it creates is bounded. The default is 5000 ms, at or under FoundationDB's own transaction lifetime, and is configurable via FDB_TRANSACTION_TIMEOUT_MS (0 disables). A stuck operation now fails instead of hanging, and the caller retries on its next cycle.

Related to LS-817