### PR TITLE
chore: update cgi symlinks not being created

### DIFF
--- a/src/cgi/CMakeLists.txt
+++ b/src/cgi/CMakeLists.txt
@@ -3,9 +3,12 @@ configure_file(chart.cgi.in    chart.cgi)
 configure_file(leil.cgi.in      leil.cgi)
 
 add_custom_target(saunafs-cgiserver-symlink ALL
-  COMMAND ln -sf leil-cgiserver saunafs-cgiserver
+  COMMAND ${CMAKE_COMMAND} -E create_symlink leil-cgiserver saunafs-cgiserver
+  COMMAND ${CMAKE_COMMAND} -E create_symlink leil.cgi sfs.cgi
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-  DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/leil-cgiserver)
+  DEPENDS
+    ${CMAKE_CURRENT_BINARY_DIR}/leil-cgiserver
+    ${CMAKE_CURRENT_BINARY_DIR}/leil.cgi)
 
 set(CGI_FILES err.gif favicon.ico favicon.svg index.html logomini.svg logomini.png leil.css)
 set(CGI_SCRIPTS
@@ -13,7 +16,22 @@ set(CGI_SCRIPTS
   ${CMAKE_CURRENT_BINARY_DIR}/chart.cgi)
 set(CGI_SERVERS ${CMAKE_CURRENT_BINARY_DIR}/leil-cgiserver)
 
+function(install_symlink target link_name destination)
+  install(CODE "
+    execute_process(
+      COMMAND \"${CMAKE_COMMAND}\" -E create_symlink
+        \"${target}\"
+        \"\$ENV{DESTDIR}${destination}/${link_name}\")
+  ")
+endfunction()
+
 install(FILES ${CGI_FILES} DESTINATION ${CGI_SUBDIR})
 install(PROGRAMS ${CGI_SCRIPTS} DESTINATION ${CGI_SUBDIR})
+
+# Create symlinks for legacy CGI compatibility.
+install_symlink(leil.cgi sfs.cgi ${CGI_SUBDIR})
+install_symlink(leil.css sfs.css ${CGI_SUBDIR})
+install_symlink(leil-cgi sfscgi ${CMAKE_INSTALL_FULL_DATAROOTDIR})
+
 install(PROGRAMS ${CGI_SERVERS} DESTINATION ${SBIN_SUBDIR})
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/saunafs-cgiserver DESTINATION ${SBIN_SUBDIR})
+install_symlink(leil-cgiserver saunafs-cgiserver ${SBIN_SUBDIR})


### PR DESCRIPTION
As part of initial rebranding efforts to LeilFS, it was need to keep symlinks with older SaunaFS related names pointing to new LeilFS bins, in order to keep backward compatibility and make smooth upgrades for customers. Due to this, only sfscgi old name was pending to be added as a symlink. This commit fixes that issue.

Related to: LS-830