### PR TITLE
chore(fdb): drop per-miss key-not-found log in get

### DIFF
--- a/src/fdb/fdb.cc
+++ b/src/fdb/fdb.cc
@@ -27,7 +27,6 @@
 
 #include "fdb/fdb.h"
 #include "fdb/fdb_future.h"
-#include "kv/kv_utils.h"
 #include "slogger/slogger.h"
 
 namespace fdb {
@@ -150,7 +149,7 @@ std::optional<kv::Value> Transaction::get(const kv::Key &key, bool snapshot) {
 	}
 
 	if (valuePresent == 0) {
-		safs::log_info("Transaction::get: key not found: {}", kv::keyToEscapedAscii(key));
+		// Missing key is normal control flow; callers should handle the empty optional.
 		return std::nullopt;
 	}
 


### PR DESCRIPTION
A missing key is normal control flow in FDB. Transaction::get already signals it via an empty optional, and callers handle it. Logging every absent point read at info level flooded syslog. The file-test loop, for instance, scans inode ranges, with roughly two absent reads per inode, causing excessive unneeded logs.

Remove the log and the now-unused kv/kv_utils.h include. keyToEscapedAscii was its only user.

Related to: LS-817