### PR TITLE
fix(tests): stop daemons before FDB teardown

### DIFF
--- a/tests/tools/foundationdb.sh
+++ b/tests/tools/foundationdb.sh
@@ -57,9 +57,9 @@ function check_cluster_status() {
 function cleanup_fdb_cluster() {
 	# Kill fdbmonitor (runs as root); escalate to SIGKILL if SIGTERM does not
 	# stop it within the grace period.
-	sudo pkill -f "${fdbmonitor_pattern}" 2>/dev/null || true
+	sudo -n pkill -f "${fdbmonitor_pattern}" 2>/dev/null || true
 	if ! wait_until_processes_stop "${fdbmonitor_pattern}" 5; then
-		sudo pkill -9 -f "${fdbmonitor_pattern}" 2>/dev/null || true
+		sudo -n pkill -9 -f "${fdbmonitor_pattern}" 2>/dev/null || true
 		wait_until_processes_stop "${fdbmonitor_pattern}" 2 || true
 	fi
 

--- a/tests/tools/test.sh
+++ b/tests/tools/test.sh
@@ -69,8 +69,10 @@ test_end() {
 		remove_all_emulated_zoned_disks
 	fi
 
-	# Clean up FDB cluster if one was started for this test.
+	# Clean up FDB cluster if one was started for this test. LeilFS processes
+	# must be stopped first: killing FDB under a live MDS wedges teardown.
 	if [[ ${fdb_cluster_started:-} ]]; then
+		terminate_fs_processes
 		cleanup_fdb_cluster
 	fi
 
@@ -180,6 +182,27 @@ unix_unmount_fs() {
 			break
 		fi
 	done
+}
+
+# Stop mounts first (no FUSE op may hang on a dying MDS), then daemons:
+# SIGTERM, bounded wait, SIGKILL. Run before cleanup_fdb_cluster -- FDB
+# must never die under a live MDS or teardown wedges. On Windows only the
+# client mount runs locally; unmount it and leave the rest to the caller.
+terminate_fs_processes() {
+	if is_windows_system; then
+		windows_unmount_fs
+		return
+	fi
+	local pattern='sfs|saunafs-polo|polonaise-'
+	unix_unmount_fs
+	pkill -TERM -u saunafstest "$pattern" || true
+	for i in {1..25}; do
+		if ! pgrep -u saunafstest "$pattern" >/dev/null; then
+			return
+		fi
+		sleep 0.2
+	done
+	pkill -KILL -u saunafstest "$pattern" || true
 }
 
 # Do not use directly

--- a/tests/tools/timeout.sh
+++ b/tests/tools/timeout.sh
@@ -49,6 +49,12 @@ timeout_killer_thread() {
 
 			test_add_failure "$test_timeout_message"
 			test_freeze_result
+			# Stop LeilFS and FDB before the sweep. fdb_cluster_started is set
+			# after this subshell forks, so cleanup_fdb_cluster runs
+			# unconditionally (safe no-op without a cluster). killall stays
+			# last: it kills this shell too.
+			terminate_fs_processes
+			cleanup_fdb_cluster
 			killall -9 -u $(whoami)
 		fi
 	done


### PR DESCRIPTION
On the failure path, test_end killed the FoundationDB cluster while the MDS, chunkservers and FUSE mounts were still running. The MDS then blocks or errors on the dead cluster and FUSE operations hang, so teardown never completes and the test container never exits, hanging the whole CI build.

On the timeout path, FDB cleanup never ran at all: the watchdog's killall -9 kills its own shell first, so test_end is never reached. The root fdbmonitor survived and kept respawning fdbservers every 60 seconds (restart-delay), leaving the workspace behind.

Add terminate_fs_processes, which unmounts FUSE mounts first so no new operation can hang against a dying MDS, then SIGTERMs all LeilFS daemons with a bounded wait and a SIGKILL escalation. Call it before cleanup_fdb_cluster in test_end (guarded by fdb_cluster_started, so non-FDB suites are unaffected) and in the timeout watchdog before the final killall. The watchdog calls cleanup_fdb_cluster unconditionally because fdb_cluster_started is set after the watchdog subshell forks and is never visible there; the function is a safe no-op without a cluster.

Verified in the docker runner: failure-path and timeout-path probe tests leave no LeilFS or FDB processes and no workspace behind, and their containers exit promptly; the MDS log shows a graceful terminate before the FDB kill.

Related to: LS-817