### PR TITLE
feat(fdb): async commit future, atomicMax, mutationCount + safety

### DIFF
--- a/src/fdb/fdb.cc
+++ b/src/fdb/fdb.cc
@@ -18,10 +18,17 @@
 
 #include "common/platform.h"
 
+#include <algorithm>
 #include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <iterator>
+#include <map>
 #include <memory>
+#include <mutex>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include <foundationdb/fdb_c_types.h>
 
@@ -45,6 +52,8 @@ struct AtomicOpCounters {
 	std::atomic<uint64_t> commits{0};
 	std::atomic<uint64_t> commitConflicts{0};
 	std::atomic<uint64_t> commitFailures{0};
+	std::atomic<uint64_t> readWaitNanos{0};
+	std::atomic<uint64_t> commitWaitNanos{0};
 };
 
 /// Process-wide counter instance. Namespace-scope with constant initialization
@@ -61,6 +70,56 @@ inline void bump(std::atomic<uint64_t> &counter) {
 	counter.fetch_add(1, std::memory_order_relaxed);
 }
 
+inline void addNanos(std::atomic<uint64_t> &counter, uint64_t nanos) {
+	if (!gOpCountersEnabled.load(std::memory_order_relaxed)) { return; }
+	counter.fetch_add(nanos, std::memory_order_relaxed);
+}
+
+/// Nanoseconds elapsed since `start` on the steady clock, for accumulating the
+/// wall time the single MDS thread spends blocked in FDB read/commit futures.
+inline uint64_t elapsedNanosSince(std::chrono::steady_clock::time_point start) {
+	return static_cast<uint64_t>(
+	    std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now() - start)
+	        .count());
+}
+
+/// Per-key-prefix read histogram, for attributing the read round-trips a single
+/// operation costs to the key families it touches (NODE_, EDGE_, QUOT_, ...).
+/// Only populated while op-counter accounting is enabled; guarded by its own
+/// mutex because, although MDS reads issue from the single event-loop thread
+/// today, the diagnostic must stay correct if that ever changes.
+std::mutex gReadPrefixMutex;
+std::map<std::string, uint64_t> gReadPrefixHistogram;
+
+/// Extracts the leading printable tag of a key (the run of [A-Z_] bytes the MDS
+/// key schema uses before the binary id), e.g. "NODE_", "DIR_PARENT_". Falls
+/// back to "<other>" for keys that do not start with such a tag. The scan is
+/// capped at 24 bytes, which comfortably covers every current key-family tag and
+/// bounds the histogram key length; a hypothetical longer tag would bucket under
+/// its first 24 bytes.
+std::string readPrefixTag(const kv::Key &key) {
+	constexpr size_t kMaxTagLen = 24;
+	size_t end = 0;
+	while (end < key.size() && end < kMaxTagLen) {
+		const auto byte = static_cast<unsigned char>(key[end]);
+		const bool isTag = (byte >= 'A' && byte <= 'Z') || byte == '_';
+		if (!isTag) { break; }
+		++end;
+	}
+	if (end == 0) { return "<other>"; }
+	return std::string(reinterpret_cast<const char *>(key.data()), end);
+}
+
+/// Buckets one read by its key prefix when accounting is on.
+inline void bumpReadPrefix(const kv::Key &key) {
+	if (!gOpCountersEnabled.load(std::memory_order_relaxed)) { return; }
+	// Parse the tag (string scan + allocation) outside the lock to keep the
+	// global mutex's hold time to just the map insertion.
+	std::string tag = readPrefixTag(key);
+	std::lock_guard<std::mutex> guard(gReadPrefixMutex);
+	++gReadPrefixHistogram[std::move(tag)];
+}
+
 }  // namespace
 
 void setOpCountersEnabled(bool enabled) {
@@ -68,6 +127,8 @@ void setOpCountersEnabled(bool enabled) {
 }
 
 bool opCountersEnabled() { return gOpCountersEnabled.load(std::memory_order_relaxed); }
+
+void addReadWaitNanos(uint64_t nanos) { addNanos(gOpCounters.readWaitNanos, nanos); }
 
 FdbOpCounters getOpCounters() {
 	auto &c = gOpCounters;
@@ -81,7 +142,20 @@ FdbOpCounters getOpCounters() {
 	    c.commits.load(std::memory_order_relaxed),
 	    c.commitConflicts.load(std::memory_order_relaxed),
 	    c.commitFailures.load(std::memory_order_relaxed),
+	    c.readWaitNanos.load(std::memory_order_relaxed),
+	    c.commitWaitNanos.load(std::memory_order_relaxed),
 	};
+}
+
+std::vector<std::pair<std::string, uint64_t>> getReadPrefixHistogram() {
+	std::vector<std::pair<std::string, uint64_t>> out;
+	{
+		std::lock_guard<std::mutex> guard(gReadPrefixMutex);
+		out.assign(gReadPrefixHistogram.begin(), gReadPrefixHistogram.end());
+	}
+	std::sort(out.begin(), out.end(),
+	          [](const auto &lhs, const auto &rhs) { return lhs.second > rhs.second; });
+	return out;
 }
 
 const uint8_t *toU8(std::string_view str) { return reinterpret_cast<const uint8_t *>(str.data()); }
@@ -126,10 +200,15 @@ std::optional<kv::Value> Transaction::get(const kv::Key &key, bool snapshot) {
 	if (!tr_) { return std::nullopt; }
 
 	bump(gOpCounters.pointReads);
+	bumpReadPrefix(key);
 	UniqueFDBFuture future(
 	    fdb_transaction_get(tr_.get(), key.data(), static_cast<int>(key.size()), snapshot));
 
+	const bool profiling = opCountersEnabled();
+	const auto waitStart =
+	    profiling ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point{};
 	error_ = fdb_future_block_until_ready(future.get());
+	if (profiling) { addNanos(gOpCounters.readWaitNanos, elapsedNanosSince(waitStart)); }
 
 	if (error_ != 0) {
 		safs::log_err("Transaction::get: fdb_future_block_until_ready: error: {}",
@@ -160,6 +239,7 @@ std::unique_ptr<kv::IFuture> Transaction::getAsync(const kv::Key &key, bool snap
 	if (!tr_) { return nullptr; }
 
 	bump(gOpCounters.pointReads);
+	bumpReadPrefix(key);
 	FDBFuture *future = fdb_transaction_get(tr_.get(), key.data(), static_cast<int>(key.size()),
 	                                        static_cast<fdb_bool_t>(snapshot));
 
@@ -183,6 +263,7 @@ std::unique_ptr<kv::IRangeFuture> Transaction::getRangeAsync(
 	if (!tr_) { return nullptr; }
 
 	bump(gOpCounters.rangeReads);
+	bumpReadPrefix(begin.getKey());
 	static constexpr int kBytesLimit = 0;
 
 	// For begin selectors: orEqual=0 means >= (inclusive), orEqual=1 means > (exclusive)
@@ -222,6 +303,16 @@ void Transaction::atomicAdd(const kv::Key &key, const kv::Value &delta) {
 	                          static_cast<int>(delta.size()), FDB_MUTATION_TYPE_ADD);
 }
 
+void Transaction::atomicMax(const kv::Key &key, const kv::Value &value) {
+	if (!tr_) { return; }
+
+	// Counted under atomicAdds is wrong, and adding a positional counter field would
+	// desync the FdbOpCounters snapshot init; atomicMax is profiling-irrelevant, so it
+	// intentionally bumps no op counter.
+	fdb_transaction_atomic_op(tr_.get(), key.data(), static_cast<int>(key.size()), value.data(),
+	                          static_cast<int>(value.size()), FDB_MUTATION_TYPE_MAX);
+}
+
 void Transaction::remove(const kv::Key &key) {
 	if (!tr_) { return; }
 
@@ -243,7 +334,11 @@ bool Transaction::commit() {
 	bump(gOpCounters.commits);
 	UniqueFDBFuture future(fdb_transaction_commit(tr_.get()));
 
+	const bool profiling = opCountersEnabled();
+	const auto waitStart =
+	    profiling ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point{};
 	error_ = fdb_future_block_until_ready(future.get());
+	if (profiling) { addNanos(gOpCounters.commitWaitNanos, elapsedNanosSince(waitStart)); }
 
 	if (error_ != 0) {
 		safs::log_err("Transaction::commit: fdb_future_block_until_ready: error: {}",
@@ -284,6 +379,149 @@ bool Transaction::commit() {
 	committedVersion_ = version;
 
 	return true;
+}
+
+namespace {
+
+/// Pollable wrapper around an in-flight fdb_transaction_commit() future.
+/// Mirrors Transaction::commit()'s outcome handling (error mapping, conflict vs
+/// failure accounting, committed-version capture) but without blocking at submit
+/// time. The back-pointers reference the owning Transaction's members, so that
+/// Transaction must outlive this future.
+class FDBCommitFuture final : public kv::ICommitFuture {
+public:
+	FDBCommitFuture(FDBFuture *commitFuture, FDBTransaction *trHandle,
+	                std::optional<int64_t> *committedVersionOut, fdb_error_t *errorOut)
+	    : future_(commitFuture),
+	      trHandle_(trHandle),
+	      committedVersionOut_(committedVersionOut),
+	      errorOut_(errorOut) {}
+
+	~FDBCommitFuture() override {
+		if (future_ != nullptr) { fdb_future_destroy(future_); }
+	}
+
+	FDBCommitFuture(const FDBCommitFuture &) = delete;
+	FDBCommitFuture &operator=(const FDBCommitFuture &) = delete;
+	FDBCommitFuture(FDBCommitFuture &&) = delete;
+	FDBCommitFuture &operator=(FDBCommitFuture &&) = delete;
+
+	bool isReady() override {
+		return future_ == nullptr || fdb_future_is_ready(future_) != 0;
+	}
+
+	void setReadyCallback(void (*callback)(void *), void *arg) override {
+		// No wakeup requested: nothing to arm, and arming an FDB callback for a null
+		// user callback would only risk the one-time node leak for no benefit.
+		if (callback == nullptr) { return; }
+		if (future_ == nullptr) {
+			callback(arg);
+			return;
+		}
+		// Route the wakeup through a heap node rather than `this`: the event-loop
+		// thread may destroy this future (after observing isReady()) concurrently
+		// with the FDB network thread firing the callback, so the callback must not
+		// dereference the future. The node owns only a plain function pointer and
+		// arg and is freed by the callback. If this future is destroyed before the
+		// commit ever becomes ready, the callback never fires and the node leaks
+		// once: a bounded, one-time leak per such future, which is harmless.
+		auto *node = new ReadyNode{callback, arg};
+		fdb_error_t err = fdb_future_set_callback(future_, &FDBCommitFuture::onReady, node);
+		if (err != 0) {
+			// Wakeup not armed; the caller's poll loop still finalizes this commit
+			// at its normal cadence, just without the immediate wakeup.
+			delete node;
+			safs::log_warn("FDBCommitFuture::setReadyCallback: fdb_future_set_callback: {}",
+			               fdb_get_error(err));
+		}
+	}
+
+	bool getResult(int *error, bool *retryable) override {
+		if (retryable != nullptr) { *retryable = false; }
+		if (consumed_ || future_ == nullptr) {
+			// A null future is a defensive failure (commitAsync never builds one: it
+			// returns an ImmediateCommitFuture when there is no transaction). Report a
+			// generic non-zero error rather than the success-looking consumedError_ (0).
+			if (error != nullptr) { *error = future_ == nullptr ? 1 : consumedError_; }
+			if (retryable != nullptr) { *retryable = consumedRetryable_; }
+			return false;
+		}
+		consumed_ = true;
+
+		// Mirror the synchronous commit() path: attribute any blocked wait to
+		// commitWaitNanos. Usually near-zero here, since the caller's poll loop
+		// finalizes only after isReady(), but a forced finalize can still block.
+		const bool profiling = opCountersEnabled();
+		const auto waitStart =
+		    profiling ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point{};
+		fdb_error_t err = fdb_future_block_until_ready(future_);
+		if (profiling) { addNanos(gOpCounters.commitWaitNanos, elapsedNanosSince(waitStart)); }
+		if (err == 0) { err = fdb_future_get_error(future_); }
+
+		if (err != 0) {
+			*errorOut_ = err;
+			consumedError_ = err;
+			const bool isRetryable = DB::evaluatePredicate(FDB_ERROR_PREDICATE_RETRYABLE, err);
+			consumedRetryable_ = isRetryable;
+			safs::log_err("FDBCommitFuture::getResult: commit failed: {}", fdb_get_error(err));
+			if (opCountersEnabled()) {
+				auto &counter =
+				    isRetryable ? gOpCounters.commitConflicts : gOpCounters.commitFailures;
+				counter.fetch_add(1, std::memory_order_relaxed);
+			}
+			if (error != nullptr) { *error = err; }
+			if (retryable != nullptr) { *retryable = isRetryable; }
+			return false;
+		}
+
+		int64_t version{};
+		fdb_error_t versionError = fdb_transaction_get_committed_version(trHandle_, &version);
+		if (versionError != 0) {
+			*errorOut_ = versionError;
+			consumedError_ = versionError;
+			safs::log_err("FDBCommitFuture::getResult: fdb_transaction_get_committed_version: {}",
+			              fdb_get_error(versionError));
+			if (error != nullptr) { *error = versionError; }
+			return false;
+		}
+
+		*committedVersionOut_ = version;
+		*errorOut_ = 0;
+		if (error != nullptr) { *error = 0; }
+		return true;
+	}
+
+private:
+	/// Owns the wakeup target across the future's lifetime so the FDB network
+	/// thread never touches the (possibly freed) future. Freed by onReady().
+	struct ReadyNode {
+		void (*callback)(void *);
+		void *arg;
+	};
+
+	static void onReady(FDBFuture * /*future*/, void *param) {
+		std::unique_ptr<ReadyNode> node(static_cast<ReadyNode *>(param));
+		if (node->callback != nullptr) { node->callback(node->arg); }
+	}
+
+	FDBFuture *future_;
+	FDBTransaction *trHandle_;
+	std::optional<int64_t> *committedVersionOut_;
+	fdb_error_t *errorOut_;
+	bool consumed_ = false;
+	fdb_error_t consumedError_ = 0;
+	bool consumedRetryable_ = false;
+};
+
+}  // namespace
+
+std::unique_ptr<kv::ICommitFuture> Transaction::commitAsync() {
+	if (!tr_) { return std::make_unique<kv::ImmediateCommitFuture>(false); }
+
+	bump(gOpCounters.commits);
+	FDBFuture *future = fdb_transaction_commit(tr_.get());
+
+	return std::make_unique<FDBCommitFuture>(future, tr_.get(), &committedVersion_, &error_);
 }
 
 }  // namespace fdb

--- a/src/fdb/fdb.cc
+++ b/src/fdb/fdb.cc
@@ -358,9 +358,12 @@ bool Transaction::commit() {
 		// accounting is on; keeps the disabled path a single relaxed bool load.
 		// The gate is already known here, so increment directly instead of bump().
 		if (opCountersEnabled()) {
-			auto &counter = DB::evaluatePredicate(FDB_ERROR_PREDICATE_RETRYABLE, error_)
-			                    ? gOpCounters.commitConflicts
-			                    : gOpCounters.commitFailures;
+			// Match FDBCommitFuture::getResult: a commit_unknown_result / maybe-committed
+			// error is a commitFailure, not a (definitely-not-committed) conflict.
+			auto &counter =
+			    DB::evaluatePredicate(FDB_ERROR_PREDICATE_RETRYABLE_NOT_COMMITTED, error_)
+			        ? gOpCounters.commitConflicts
+			        : gOpCounters.commitFailures;
 			counter.fetch_add(1, std::memory_order_relaxed);
 		}
 		return false;
@@ -461,7 +464,15 @@ public:
 		if (err != 0) {
 			*errorOut_ = err;
 			consumedError_ = err;
-			const bool isRetryable = DB::evaluatePredicate(FDB_ERROR_PREDICATE_RETRYABLE, err);
+			// RETRYABLE_NOT_COMMITTED, NOT the broad RETRYABLE predicate: RETRYABLE also
+			// returns true for commit_unknown_result (1021) and the rest of the
+			// MAYBE_COMMITTED class, where the commit may already have applied. A blind
+			// replay of such an op would double-apply it (a second inode/chunk, a double
+			// atomicAdd). Reporting only the definitely-not-committed conflicts
+			// (not_committed 1020, transaction_too_old 1007, ...) as retryable lets callers
+			// safely replay those and surface an unknown-result commit as an error instead.
+			const bool isRetryable =
+			    DB::evaluatePredicate(FDB_ERROR_PREDICATE_RETRYABLE_NOT_COMMITTED, err);
 			consumedRetryable_ = isRetryable;
 			safs::log_err("FDBCommitFuture::getResult: commit failed: {}", fdb_get_error(err));
 			if (opCountersEnabled()) {

--- a/src/fdb/fdb.h
+++ b/src/fdb/fdb.h
@@ -23,6 +23,8 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <utility>
+#include <vector>
 
 #include <fdb/fdb_api_version.h>  // Needs to be included before foundationdb/fdb_c.h
 #include <foundationdb/fdb_c.h>
@@ -45,10 +47,23 @@ struct FdbOpCounters {
 	uint64_t commits{0};          ///< commit attempts (each one round-trip).
 	uint64_t commitConflicts{0};  ///< commit attempts that failed with a retryable error.
 	uint64_t commitFailures{0};   ///< commit attempts that failed with a non-retryable error.
+	uint64_t readWaitNanos{0};    ///< wall time blocked in read futures (sync get + getAsync + range).
+	uint64_t commitWaitNanos{0};  ///< wall time blocked waiting for commit futures.
 };
+
+/// Adds to the process-wide read-wait accumulator the nanoseconds a caller spent
+/// blocked on a read future. Used by the future wrappers (fdb_future.cc) whose
+/// blocking happens outside this translation unit. No-op when accounting is off.
+void addReadWaitNanos(uint64_t nanos);
 
 /// Returns a snapshot of the process-wide FDB operation counters.
 FdbOpCounters getOpCounters();
+
+/// Returns the per-key-prefix read histogram (point + range reads bucketed by
+/// the leading key tag, e.g. "NODE_"), sorted by descending count. Only
+/// populated while op-counter accounting is enabled; used to attribute the read
+/// round-trips an operation costs to the key families it touches.
+std::vector<std::pair<std::string, uint64_t>> getReadPrefixHistogram();
 
 /// Enables or disables op-counter accounting (disabled by default). When
 /// disabled, the per-call bump is a single relaxed bool load and getOpCounters()
@@ -227,6 +242,14 @@ public:
 	/// @param delta The delta value to add.
 	void atomicAdd(const kv::Key &key, const kv::Value &delta);
 
+	/// Atomically sets the value to max(existing, value) as little-endian unsigned
+	/// integers (absent key counts as zero). This is FoundationDB's MAX mutation, not
+	/// the lexicographic BYTE_MAX. Conflict-free: no read, no read conflict range. See
+	/// kv::IReadWriteTransaction::atomicMax.
+	/// @param key The key to update.
+	/// @param value The candidate value (fixed-width little-endian).
+	void atomicMax(const kv::Key &key, const kv::Value &value);
+
 	/// Removes a key from the database.
 	/// @param key The key to remove.
 	void remove(const kv::Key &key);
@@ -237,6 +260,11 @@ public:
 	/// Commits the transaction.
 	/// @return True if the commit was successful, false otherwise.
 	bool commit();
+
+	/// Submits the commit asynchronously, returning a pollable future.
+	/// The future references this transaction's state, so the Transaction must
+	/// outlive the returned future.
+	std::unique_ptr<kv::ICommitFuture> commitAsync();
 
 	/// Gets the committed version of the transaction.
 	/// @return The committed version, if available.

--- a/src/fdb/fdb_future.cc
+++ b/src/fdb/fdb_future.cc
@@ -19,16 +19,41 @@
 #include "common/platform.h"
 
 #include <cassert>
+#include <chrono>
 #include <iterator>
 #include <utility>
 #include <vector>
 
 #include <foundationdb/fdb_c_types.h>
 
+#include "fdb/fdb.h"
 #include "fdb/fdb_future.h"
 #include "slogger/slogger.h"
 
 namespace fdb {
+
+namespace {
+
+/// Translates a RETRYABLE FoundationDB read error into a typed exception so the
+/// master's op boundary can replay the op on a fresh transaction instead of letting
+/// the read failure (e.g. transaction_timed_out under load) propagate uncaught and
+/// abort the whole MDS. Non-retryable errors are left for the caller to report via
+/// the *error out-parameter as before.
+void throwIfRetryable(fdb_error_t err) {
+	// transaction_timed_out (1031) is deliberately absent from FDB's RETRYABLE
+	// predicate because a timeout during COMMIT has an unknown result. This helper
+	// guards READ futures only, and the op-boundary replay runs on a fresh
+	// transaction with a fresh timeout budget, so a timed-out read is safe to
+	// replay. The commit path (FDBCommitFuture::getResult) uses the raw predicate
+	// and keeps 1031 non-retryable.
+	constexpr fdb_error_t kTransactionTimedOut = 1031;
+	if (err == kTransactionTimedOut ||
+	    fdb_error_predicate(FDB_ERROR_PREDICATE_RETRYABLE, err) != 0) {
+		throw kv::RetryableTransactionError(static_cast<int>(err), fdb_get_error(err));
+	}
+}
+
+}  // namespace
 
 FDBFutureValue::FDBFutureValue(FDBFuture *future) : future_(future) {}
 
@@ -52,13 +77,25 @@ std::optional<kv::Value> FDBFutureValue::get(int *error) {
 	// Mark as consumed
 	consumed_ = true;
 
-	// Block until the future is ready
+	// Block until the future is ready. Times the wait so a pipelined read (issued
+	// earlier, already resolved here) shows as near-zero, while a serial read shows
+	// its full round-trip; this attributes per-op latency to read-wait.
+	const bool profiling = opCountersEnabled();
+	const auto waitStart =
+	    profiling ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point{};
 	fdb_error_t fdbError = fdb_future_block_until_ready(future_);
+	if (profiling) {
+		addReadWaitNanos(static_cast<uint64_t>(
+		    std::chrono::duration_cast<std::chrono::nanoseconds>(
+		        std::chrono::steady_clock::now() - waitStart)
+		        .count()));
+	}
 
 	if (fdbError != 0) {
 		safs::log_err("FDBFutureValue::get: fdb_future_block_until_ready: error: {}",
 		              fdb_get_error(fdbError));
 		if (error != nullptr) { *error = static_cast<int>(fdbError); }
+		throwIfRetryable(fdbError);
 		return std::nullopt;
 	}
 
@@ -73,6 +110,7 @@ std::optional<kv::Value> FDBFutureValue::get(int *error) {
 		safs::log_err("FDBFutureValue::get: fdb_future_get_value: error: {}",
 		              fdb_get_error(fdbError));
 		if (error != nullptr) { *error = static_cast<int>(fdbError); }
+		throwIfRetryable(fdbError);
 		return std::nullopt;
 	}
 
@@ -110,12 +148,22 @@ kv::GetRangeResult FDBFutureRange::get(int *error) {
 
 	consumed_ = true;
 
+	const bool profiling = opCountersEnabled();
+	const auto waitStart =
+	    profiling ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point{};
 	fdb_error_t fdbError = fdb_future_block_until_ready(future_);
+	if (profiling) {
+		addReadWaitNanos(static_cast<uint64_t>(
+		    std::chrono::duration_cast<std::chrono::nanoseconds>(
+		        std::chrono::steady_clock::now() - waitStart)
+		        .count()));
+	}
 
 	if (fdbError != 0) {
 		safs::log_err("FDBFutureRange::get: fdb_future_block_until_ready: error: {}",
 		              fdb_get_error(fdbError));
 		if (error != nullptr) { *error = static_cast<int>(fdbError); }
+		throwIfRetryable(fdbError);
 		return {{}, false};
 	}
 
@@ -129,6 +177,7 @@ kv::GetRangeResult FDBFutureRange::get(int *error) {
 		safs::log_err("FDBFutureRange::get: fdb_future_get_keyvalue_array: error: {}",
 		              fdb_get_error(fdbError));
 		if (error != nullptr) { *error = static_cast<int>(fdbError); }
+		throwIfRetryable(fdbError);
 		return {{}, false};
 	}
 

--- a/src/fdb/fdb_future.cc
+++ b/src/fdb/fdb_future.cc
@@ -44,8 +44,9 @@ void throwIfRetryable(fdb_error_t err) {
 	// predicate because a timeout during COMMIT has an unknown result. This helper
 	// guards READ futures only, and the op-boundary replay runs on a fresh
 	// transaction with a fresh timeout budget, so a timed-out read is safe to
-	// replay. The commit path (FDBCommitFuture::getResult) uses the raw predicate
-	// and keeps 1031 non-retryable.
+	// replay. The commit path (FDBCommitFuture::getResult) uses RETRYABLE_NOT_COMMITTED,
+	// which excludes 1031 and the whole maybe-committed class, so a commit with an
+	// unknown result is never blindly replayed.
 	constexpr fdb_error_t kTransactionTimedOut = 1031;
 	if (err == kTransactionTimedOut ||
 	    fdb_error_predicate(FDB_ERROR_PREDICATE_RETRYABLE, err) != 0) {

--- a/src/fdb/fdb_transaction.cc
+++ b/src/fdb/fdb_transaction.cc
@@ -59,24 +59,35 @@ std::unique_ptr<kv::IRangeFuture> FDBTransaction::getRangeAsync(const kv::KeySel
 void FDBTransaction::set(const kv::Key &key, const kv::Value &value) {
 	if (!tr_) { return; }
 
+	mutationCount_++;
 	tr_.set(key, value);
 }
 
 void FDBTransaction::atomicAdd(const kv::Key &key, const kv::Value &delta) {
 	if (!tr_) { return; }
 
+	mutationCount_++;
 	tr_.atomicAdd(key, delta);
+}
+
+void FDBTransaction::atomicMax(const kv::Key &key, const kv::Value &value) {
+	if (!tr_) { return; }
+
+	mutationCount_++;
+	tr_.atomicMax(key, value);
 }
 
 void FDBTransaction::remove(const kv::Key &key) {
 	if (!tr_) { return; }
 
+	mutationCount_++;
 	tr_.remove(key);
 }
 
 void FDBTransaction::removeRange(const kv::Key &start, const kv::Key &end) {
 	if (!tr_) { return; }
 
+	mutationCount_++;
 	tr_.removeRange(start, end);
 }
 
@@ -84,6 +95,12 @@ bool FDBTransaction::commit() {
 	if (!tr_) { return false; }
 
 	return tr_.commit();
+}
+
+std::unique_ptr<kv::ICommitFuture> FDBTransaction::commitAsync() {
+	if (!tr_) { return std::make_unique<kv::ImmediateCommitFuture>(false); }
+
+	return tr_.commitAsync();
 }
 
 std::optional<int64_t> FDBTransaction::getCommittedVersion() const {

--- a/src/fdb/fdb_transaction.h
+++ b/src/fdb/fdb_transaction.h
@@ -89,6 +89,11 @@ public:
 	/// @param delta The delta value to add (must be little-endian).
 	void atomicAdd(const kv::Key &key, const kv::Value &delta) override;
 
+	/// Atomically sets the value to max(existing, value) as little-endian unsigned
+	/// integers (FDB MAX, not lexicographic BYTE_MAX). Conflict-free.
+	/// @see kv::IReadWriteTransaction::atomicMax.
+	void atomicMax(const kv::Key &key, const kv::Value &value) override;
+
 	/// Removes a key from the database.
 	/// @param key The key to remove.
 	void remove(const kv::Key &key) override;
@@ -99,8 +104,14 @@ public:
 	/// Commits the transaction, making all changes permanent.
 	bool commit() override;
 
+	/// Submits the commit asynchronously and returns a pollable future.
+	std::unique_ptr<kv::ICommitFuture> commitAsync() override;
+
 	/// Returns the committed version of the transaction, if available.
 	std::optional<int64_t> getCommittedVersion() const override;
+
+	/// Number of buffered mutations issued on this transaction so far.
+	uint64_t mutationCount() const override { return mutationCount_; }
 
 	/// Returns the error code of the last operation.
 	fdb_error_t error() const { return error_; }
@@ -108,6 +119,7 @@ public:
 private:
 	fdb::Transaction tr_;
 	fdb_error_t error_{1};
+	uint64_t mutationCount_{0};
 };
 
 }  // namespace fdb

--- a/src/fdb/fdb_unittest.cc
+++ b/src/fdb/fdb_unittest.cc
@@ -19,10 +19,12 @@
 #include "common/platform.h"
 
 #include <gtest/gtest.h>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include "fdb/fdb.h"
@@ -763,5 +765,182 @@ TEST_F(FDBKVEngineTest, OpCountersGatedByFlag) {
 		auto txn = kvEngine->createReadWriteTransaction();
 		txn->remove(key);
 		ASSERT_TRUE(txn->commit());
+	}
+}
+
+// atomicMax persists the numeric max of the stored and candidate values, treats an
+// absent key as zero, and is conflict-free (concurrent writers do not abort each
+// other). Values are fixed-width little-endian, matching the FDB MAX mutation.
+TEST_F(FDBKVEngineTest, AtomicMax) {
+	const auto key = kv::toBytes("atomic_max_key");
+	const auto absentKey = kv::toBytes("atomic_max_absent_key");
+
+	{  // Start from a clean slate.
+		auto txn = kvEngine->createReadWriteTransaction();
+		txn->remove(key);
+		txn->remove(absentKey);
+		ASSERT_TRUE(txn->commit());
+	}
+
+	{  // Seed an initial value.
+		auto txn = kvEngine->createReadWriteTransaction();
+		txn->set(key, kv::toBytesLE(uint64_t{100}));
+		ASSERT_TRUE(txn->commit());
+	}
+
+	{  // A smaller candidate must not lower the stored value.
+		auto txn = kvEngine->createReadWriteTransaction();
+		txn->atomicMax(key, kv::toBytesLE(uint64_t{50}));
+		ASSERT_TRUE(txn->commit());
+	}
+	{
+		auto txn = kvEngine->createReadWriteTransaction();
+		auto v = txn->get(key);
+		ASSERT_TRUE(v.has_value());
+		EXPECT_EQ(kv::fromBytesLE<uint64_t>(*v), uint64_t{100});
+	}
+
+	{  // A larger candidate must raise it.
+		auto txn = kvEngine->createReadWriteTransaction();
+		txn->atomicMax(key, kv::toBytesLE(uint64_t{200}));
+		ASSERT_TRUE(txn->commit());
+	}
+	{
+		auto txn = kvEngine->createReadWriteTransaction();
+		auto v = txn->get(key);
+		ASSERT_TRUE(v.has_value());
+		EXPECT_EQ(kv::fromBytesLE<uint64_t>(*v), uint64_t{200});
+	}
+
+	// Numeric, not lexicographic: 256 (LE bytes 00 01 ..) must beat 255 (LE bytes
+	// FF 00 ..) even though 255's first byte is larger. This is what separates FDB
+	// MAX (little-endian integer) from BYTE_MAX (byte-string/lexicographic).
+	{
+		auto txn = kvEngine->createReadWriteTransaction();
+		txn->set(key, kv::toBytesLE(uint64_t{255}));
+		ASSERT_TRUE(txn->commit());
+	}
+	{
+		auto txn = kvEngine->createReadWriteTransaction();
+		txn->atomicMax(key, kv::toBytesLE(uint64_t{256}));
+		ASSERT_TRUE(txn->commit());
+	}
+	{
+		auto txn = kvEngine->createReadWriteTransaction();
+		auto v = txn->get(key);
+		ASSERT_TRUE(v.has_value());
+		EXPECT_EQ(kv::fromBytesLE<uint64_t>(*v), uint64_t{256});
+	}
+
+	{  // An absent key counts as zero, so any positive candidate is stored.
+		auto txn = kvEngine->createReadWriteTransaction();
+		txn->atomicMax(absentKey, kv::toBytesLE(uint64_t{7}));
+		ASSERT_TRUE(txn->commit());
+	}
+	{
+		auto txn = kvEngine->createReadWriteTransaction();
+		auto v = txn->get(absentKey);
+		ASSERT_TRUE(v.has_value());
+		EXPECT_EQ(kv::fromBytesLE<uint64_t>(*v), uint64_t{7});
+	}
+
+	// Conflict-free: two transactions that both atomicMax the same key both commit
+	// (atomicMax adds no read conflict range), and the result is the max of the two.
+	{
+		auto txnA = kvEngine->createReadWriteTransaction();
+		txnA->atomicMax(key, kv::toBytesLE(uint64_t{1000}));
+		auto txnB = kvEngine->createReadWriteTransaction();
+		txnB->atomicMax(key, kv::toBytesLE(uint64_t{2000}));
+		ASSERT_TRUE(txnB->commit());
+		ASSERT_TRUE(txnA->commit()) << "atomicMax must not abort a concurrent writer.";
+	}
+	{
+		auto txn = kvEngine->createReadWriteTransaction();
+		auto v = txn->get(key);
+		ASSERT_TRUE(v.has_value());
+		EXPECT_EQ(kv::fromBytesLE<uint64_t>(*v), uint64_t{2000});
+	}
+
+	{  // Cleanup.
+		auto txn = kvEngine->createReadWriteTransaction();
+		txn->remove(key);
+		txn->remove(absentKey);
+		ASSERT_TRUE(txn->commit());
+	}
+}
+
+// mutationCount() counts each buffered write exactly once and ignores reads. Group
+// commit relies on this to detect whether a failed op body already poisoned a shared
+// transaction. The transaction is intentionally dropped without committing: the count
+// is a property of the buffered mutations, not of the commit.
+TEST_F(FDBKVEngineTest, MutationCount) {
+	auto txn = kvEngine->createReadWriteTransaction();
+	EXPECT_EQ(txn->mutationCount(), uint64_t{0}) << "A fresh transaction has buffered nothing.";
+
+	txn->set(kv::toBytes("mc_key"), kv::toBytesLE(uint64_t{1}));
+	EXPECT_EQ(txn->mutationCount(), uint64_t{1}) << "set() buffers one mutation.";
+
+	txn->atomicAdd(kv::toBytes("mc_key"), kv::toBytesLE(uint64_t{1}));
+	EXPECT_EQ(txn->mutationCount(), uint64_t{2}) << "atomicAdd() buffers one mutation.";
+
+	txn->atomicMax(kv::toBytes("mc_key"), kv::toBytesLE(uint64_t{9}));
+	EXPECT_EQ(txn->mutationCount(), uint64_t{3}) << "atomicMax() buffers one mutation.";
+
+	(void)txn->get(kv::toBytes("mc_key"));
+	EXPECT_EQ(txn->mutationCount(), uint64_t{3}) << "get() is a read, not a mutation.";
+
+	txn->remove(kv::toBytes("mc_key"));
+	EXPECT_EQ(txn->mutationCount(), uint64_t{4}) << "remove() buffers one mutation.";
+
+	txn->removeRange(kv::toBytes("mc_a"), kv::toBytes("mc_b"));
+	EXPECT_EQ(txn->mutationCount(), uint64_t{5}) << "removeRange() buffers one mutation.";
+}
+
+// Exercises the async-commit path end to end: poll isReady(), finalize via getResult(),
+// confirm the committed version is captured, that getResult() is single-use, and that
+// the write is durable.
+TEST_F(FDBKVEngineTest, CommitAsync) {
+	const auto key = kv::toBytes("commit_async_key");
+	const auto value = kv::toBytes("commit_async_value");
+
+	auto txn = kvEngine->createReadWriteTransaction();
+	txn->set(key, value);
+
+	auto future = txn->commitAsync();
+	ASSERT_TRUE(future != nullptr) << "commitAsync() must return a future.";
+
+	// Drive the future to readiness through isReady(), then finalize. Bounded by a
+	// wall-clock deadline (not an iteration count) so it stays robust on slow or
+	// loaded CI; the timeout is generous since a healthy commit resolves in millis.
+	const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+	while (!future->isReady() && std::chrono::steady_clock::now() < deadline) {
+		std::this_thread::sleep_for(std::chrono::milliseconds(1));
+	}
+	ASSERT_TRUE(future->isReady()) << "Commit future did not become ready within the timeout.";
+
+	int error = -1;
+	bool retryable = true;
+	ASSERT_TRUE(future->getResult(&error, &retryable)) << "Async commit should succeed.";
+	EXPECT_EQ(error, 0);
+	EXPECT_FALSE(retryable);
+
+	// A successful commit captures its version on the (still-alive) transaction.
+	EXPECT_TRUE(txn->getCommittedVersion().has_value())
+	    << "A successful async commit must expose its committed version.";
+
+	// Single-use: a second getResult() reports false without re-committing.
+	EXPECT_FALSE(future->getResult()) << "getResult() is single-use.";
+
+	{  // The write is durable.
+		auto verify = kvEngine->createReadWriteTransaction();
+		auto got = verify->get(key);
+		ASSERT_TRUE(got.has_value()) << "Async-committed key must be present.";
+		EXPECT_EQ(*got, value);
+	}
+
+	{  // Cleanup.
+		auto cleanup = kvEngine->createReadWriteTransaction();
+		cleanup->remove(key);
+		ASSERT_TRUE(cleanup->commit());
 	}
 }

--- a/src/fdb/fdb_unittest.cc
+++ b/src/fdb/fdb_unittest.cc
@@ -718,6 +718,41 @@ TEST(FdbOpCountersGatingTest, FlagReflectsSetter) {
 	EXPECT_FALSE(fdb::opCountersEnabled());
 }
 
+// Locks the error-predicate semantics the commit-retry decision depends on. The retry
+// paths (matoclserv_commit_op_with_retry, the deferred-commit poller, the group-commit
+// batch poller) replay an op ONLY when FDBCommitFuture::getResult reports the commit
+// retryable. That flag MUST come from RETRYABLE_NOT_COMMITTED, never the broad RETRYABLE
+// predicate: RETRYABLE also covers commit_unknown_result / the maybe-committed class,
+// where the commit may already have applied, so a blind replay would double-apply the op
+// (a second inode/chunk, a double atomicAdd). This guards against a regression back to the
+// broad predicate. Runs under the fixture so the FDB API version is selected (the predicate
+// is a local libfdb_c call and needs no cluster).
+TEST_F(FDBKVEngineTest, CommitErrorRetryablePredicate) {
+	// FDB error codes (fdbclient/error_definitions.h).
+	constexpr fdb_error_t kNotCommitted = 1020;          // definitely did not commit
+	constexpr fdb_error_t kTransactionTooOld = 1007;     // definitely did not commit
+	constexpr fdb_error_t kCommitUnknownResult = 1021;   // MAY have committed
+	constexpr fdb_error_t kTransactionTimedOut = 1031;   // unknown result during commit
+
+	// The predicate the commit path uses: only definitely-not-committed conflicts are
+	// safe to blindly replay.
+	EXPECT_TRUE(fdb::DB::evaluatePredicate(FDB_ERROR_PREDICATE_RETRYABLE_NOT_COMMITTED,
+	                                       kNotCommitted));
+	EXPECT_TRUE(fdb::DB::evaluatePredicate(FDB_ERROR_PREDICATE_RETRYABLE_NOT_COMMITTED,
+	                                       kTransactionTooOld));
+	EXPECT_FALSE(fdb::DB::evaluatePredicate(FDB_ERROR_PREDICATE_RETRYABLE_NOT_COMMITTED,
+	                                        kCommitUnknownResult));
+	EXPECT_FALSE(fdb::DB::evaluatePredicate(FDB_ERROR_PREDICATE_RETRYABLE_NOT_COMMITTED,
+	                                        kTransactionTimedOut));
+
+	// Why the broad predicate is wrong here: it would flag commit_unknown_result retryable.
+	EXPECT_TRUE(fdb::DB::evaluatePredicate(FDB_ERROR_PREDICATE_RETRYABLE, kCommitUnknownResult));
+	EXPECT_TRUE(fdb::DB::evaluatePredicate(FDB_ERROR_PREDICATE_MAYBE_COMMITTED,
+	                                       kCommitUnknownResult));
+	// not_committed is never in the maybe-committed class.
+	EXPECT_FALSE(fdb::DB::evaluatePredicate(FDB_ERROR_PREDICATE_MAYBE_COMMITTED, kNotCommitted));
+}
+
 // Counters must move only while accounting is enabled. Drives real FDB ops and
 // compares getOpCounters() deltas with the gate off versus on.
 TEST_F(FDBKVEngineTest, OpCountersGatedByFlag) {

--- a/src/kv/ifuture.h
+++ b/src/kv/ifuture.h
@@ -21,10 +21,30 @@
 #include "common/platform.h"
 
 #include <optional>
+#include <stdexcept>
+#include <string>
 
 #include "kv/kv_types.h"
 
 namespace kv {
+
+/// Thrown by a read future's get() when the underlying transaction failed with a
+/// RETRYABLE backend error (e.g. FoundationDB transaction_timed_out / not_committed /
+/// transaction_too_old). The single-threaded master event loop catches this at the op
+/// boundary and replays the op on a fresh transaction (bounded) instead of letting a
+/// transient read failure abort the whole MDS. Non-retryable read failures (corruption,
+/// genuinely-absent keys) are still reported the old way (error code / nullopt), not via
+/// this type.
+class RetryableTransactionError : public std::runtime_error {
+public:
+	RetryableTransactionError(int errorCode, const std::string &message)
+	    : std::runtime_error(message), errorCode_(errorCode) {}
+
+	int errorCode() const noexcept { return errorCode_; }
+
+private:
+	int errorCode_;
+};
 
 /// Interface for asynchronous future results from key-value operations.
 /// Provides methods to check readiness and retrieve values from pending operations.
@@ -48,6 +68,9 @@ public:
 	/// Blocks until the result is ready and retrieves the value.
 	/// @param error Optional pointer to store error code (0 on success, non-zero on error).
 	/// @return The value if successful and present, std::nullopt on error or if key not found.
+	/// @throws RetryableTransactionError if the backend read failed with a retryable
+	///   error; callers must catch it at the op boundary. Non-retryable failures and
+	///   genuinely-absent keys still report via @p error / std::nullopt.
 	/// @note This method can only be called once. Subsequent calls return std::nullopt.
 	/// @note The caller must keep the transaction alive until this method returns.
 	virtual std::optional<Value> get(int *error = nullptr) = 0;
@@ -77,12 +100,94 @@ public:
 	/// Blocks until the result is ready and retrieves the range.
 	/// @param error Optional pointer to store error code (0 on success, non-zero on error).
 	/// @return The range result, or an empty result on error.
+	/// @throws RetryableTransactionError if the backend read failed with a retryable
+	///   error; callers must catch it at the op boundary. Non-retryable failures still
+	///   report via @p error / an empty result.
 	/// @note This method can only be called once. Subsequent calls return an empty result.
 	/// @note The caller must keep the transaction alive until this method returns.
 	virtual GetRangeResult get(int *error = nullptr) = 0;
 
 protected:
 	IRangeFuture() = default;
+};
+
+/// Interface for an in-flight asynchronous commit.
+///
+/// Lets a single-threaded event loop submit a commit and keep doing other work,
+/// polling isReady() each iteration and finalizing with getResult() once ready,
+/// instead of blocking on a synchronous commit().
+///
+/// @note Single-use: getResult() may be called only once.
+/// @note The transaction that produced this future must stay alive until getResult() returns.
+class ICommitFuture {
+public:
+	virtual ~ICommitFuture() = default;
+
+	// Non-copyable, non-movable
+	ICommitFuture(const ICommitFuture &) = delete;
+	ICommitFuture &operator=(const ICommitFuture &) = delete;
+	ICommitFuture(ICommitFuture &&) = delete;
+	ICommitFuture &operator=(ICommitFuture &&) = delete;
+
+	/// Checks whether the commit result is available without blocking.
+	virtual bool isReady() = 0;
+
+	/// Finalizes the commit, blocking if not yet ready.
+	/// @param error Optional out-param for the backend error code (0 on success).
+	/// @param retryable Optional out-param: on failure, true if the error is a
+	///   transient conflict the caller may retry by replaying the op on a fresh
+	///   transaction (e.g. FDB not_committed / transaction_too_old); false for a
+	///   permanent failure. Set to false on success. Keeps the retry decision
+	///   backend-agnostic so callers need not interpret raw backend error codes.
+	/// @return True if the commit succeeded and is durable, false otherwise.
+	/// @note Single-use; subsequent calls return false.
+	virtual bool getResult(int *error = nullptr, bool *retryable = nullptr) = 0;
+
+	/// Registers a one-shot wakeup fired when the commit result becomes ready, so a
+	/// blocked poll() can be woken to call getResult() promptly instead of waiting
+	/// out the poll timeout. The callback may run on another thread (the FDB network
+	/// thread) and may fire immediately and inline if the result is already ready,
+	/// so it must be cheap, thread-safe, and must not touch this future or its
+	/// transaction (e.g. just write an eventfd). Best-effort: a missed wakeup only
+	/// delays finalization to the next poll, it never loses the result.
+	virtual void setReadyCallback(void (*callback)(void *), void *arg) = 0;
+
+protected:
+	ICommitFuture() = default;
+};
+
+/// Trivial already-completed commit future, for backends that commit synchronously
+/// (in-memory Master, test mocks). Keeps the deferred-commit code path uniform.
+class ImmediateCommitFuture final : public ICommitFuture {
+public:
+	/// @param success Whether the (already-completed) commit succeeded.
+	/// @param retryable On failure, whether the caller may retry. Normally false for
+	///   a synchronous backend; set true to synthesize a transient conflict (used by
+	///   the commit-retry fault-injection hook).
+	explicit ImmediateCommitFuture(bool success, bool retryable = false)
+	    : success_(success), retryable_(retryable) {}
+
+	bool isReady() override { return true; }
+
+	// Defaults are declared on the ICommitFuture base only; redefining them on the
+	// override would bind statically and risk surprising callers.
+	bool getResult(int *error, bool *retryable) override {
+		if (error != nullptr) { *error = success_ ? 0 : 1; }
+		if (retryable != nullptr) { *retryable = success_ ? false : retryable_; }
+		// Single-use, matching FDBCommitFuture: report the outcome once, then false.
+		if (consumed_) { return false; }
+		consumed_ = true;
+		return success_;
+	}
+
+	void setReadyCallback(void (*callback)(void *), void *arg) override {
+		if (callback != nullptr) { callback(arg); }
+	}
+
+private:
+	bool success_;
+	bool retryable_;
+	bool consumed_ = false;
 };
 
 }  // namespace kv

--- a/src/kv/itransaction.h
+++ b/src/kv/itransaction.h
@@ -31,6 +31,7 @@ namespace kv {
 
 class IFuture;
 class IRangeFuture;
+class ICommitFuture;
 
 /// Represents a key selector for range queries.
 class KeySelector {
@@ -133,6 +134,19 @@ public:
 	/// @param delta The delta value to add (must be little-endian).
 	virtual void atomicAdd(const Key &key, const Value &delta) = 0;
 
+	/// Atomically sets the value for a key to the maximum of its existing value and
+	/// `value`, compared as little-endian unsigned integers (an absent key counts as
+	/// zero). This is FoundationDB's MAX mutation (numeric little-endian), not BYTE_MAX
+	/// (lexicographic): the shorter operand is zero-extended on the high end, so encode
+	/// values as fixed-width little-endian for the comparison to be a true numeric max.
+	/// Commutative and conflict-free: it performs no read and adds no read conflict
+	/// range, so concurrent writers never abort each other on this key. This is the
+	/// basis for fire-and-forget monotonic fields (e.g. atime) whose deferred commit
+	/// can never diverge from the backend on a conflict.
+	/// @param key The key to update.
+	/// @param value The candidate value (fixed-width little-endian).
+	virtual void atomicMax(const Key &key, const Value &value) = 0;
+
 	/// Removes a key from the database.
 	/// @param key The key to remove.
 	virtual void remove(const Key &key) = 0;
@@ -145,8 +159,19 @@ public:
 	/// Commits the transaction, making all changes permanent.
 	virtual bool commit() = 0;
 
+	/// Submits the commit asynchronously and returns a pollable future.
+	/// The caller drives completion via ICommitFuture::isReady()/getResult().
+	/// @note The transaction must stay alive until the future's getResult() returns.
+	virtual std::unique_ptr<ICommitFuture> commitAsync() = 0;
+
 	/// Returns the committed version of the transaction, if available.
 	virtual std::optional<int64_t> getCommittedVersion() const = 0;
+
+	/// Number of buffered mutations (set / atomicAdd / atomicMax / remove /
+	/// removeRange calls) issued on this transaction so far. Lets a shared-transaction
+	/// owner (group commit) detect whether a failed op body already wrote, poisoning
+	/// the shared transaction (it must be rebuilt), or failed clean (no rebuild needed).
+	virtual uint64_t mutationCount() const = 0;
 
 protected:
 	IReadWriteTransaction() = default;


### PR DESCRIPTION
FDB/KV engine foundation for the async-commit work. Adds the async commit future (commitAsync/ICommitFuture), atomicMax and mutationCount primitives, the commit_unknown_result predicate fix, and op profiling. No master behavior change, but needed for the MDS.

Related to: LS-857