### PR TITLE
fix(master): adopt chunk lock id after restart

### DIFF
--- a/src/master/chunks.cc
+++ b/src/master/chunks.cc
@@ -1455,15 +1455,22 @@ uint8_t chunk_modify(uint64_t currentChunkId, uint32_t *lockId, uint8_t goal, bo
 	Chunk *currentChunk = chunk_find(currentChunkId);
 	if (currentChunk == nullptr) { return SAUNAFS_ERROR_NOCHUNK; }
 
-	// Next check if the chunk is locked and if the lockid matches
+	// Next check if the chunk is locked and if the lockid matches.
 	if (*lockId != 0 && *lockId != currentChunk->lockid) {
-		if (currentChunk->lockid == 0 || currentChunk->lockedto == 0) {
-			// Lock was removed by some chunk operation or by a different client
-			return SAUNAFS_ERROR_NOTLOCKED;
+		// Adopt a client-presented lock id only for chunks restored without any live lock.
+		// `lockedto == 0` alone is not enough: writeEnd clears it while chunkserver-side
+		// writes may still be tracked by beingWritten, which is covered by isLocked().
+		const bool restartRestoredNoLock = currentChunk->lockid == 0 &&
+		                                   currentChunk->lockedto == 0 &&
+		                                   !currentChunk->isLocked();
+		if (!restartRestoredNoLock) {
+			if (currentChunk->lockid == 0 || currentChunk->lockedto == 0) {
+				// Lock was removed by some chunk operation or by a different client
+				return SAUNAFS_ERROR_NOTLOCKED;
+			}
+			// Case *lockId != currentChunk->lockid
+			return SAUNAFS_ERROR_WRONGLOCKID;
 		}
-
-		// Case *lockid != currentChunk->lockid
-		return SAUNAFS_ERROR_WRONGLOCKID;
 	}
 	if (*lockId == 0 && currentChunk->isLocked()) {
 		*targetChunkId = currentChunkId;


### PR DESCRIPTION
In a transactional KV-backed metadata backend, chunk_modify() could return SAUNAFS_ERROR_NOTLOCKED for a resuming write. Such a backend rebuilds chunk records from chunkserver reports rather than from a persisted lock, so a chunk re-materialized after a restart holds no lock (lockid == 0 && lockedto == 0). A client resuming a write it started before the chunk was reloaded still >

When a chunk currently holds no live lock, adopt the client-presented lock id rather than rejecting it: there is no lock holder to conflict with, and chunk_multi_modify() re-stamps lockid/lockedto right after. The guard is lockid == 0 && lockedto == 0 && !isLocked(); the isLocked() term keeps the path closed during the writeEnd/beingWritten window so a second concurrent writer c>

Existing master behavior is unchanged for every other case: a chunk that still holds a live lock keeps returning WRONGLOCKID on a mismatch, and a request with lockId == 0 is handled exactly as before. The only requests whose outcome changes are those that previously got NOTLOCKED on a chunk with no holder and no live lock state. If currentChunk->isLocked() is true, behavior is u>

Related to LS-817