### PR TITLE
feat(master): conflict-free dir metadata and atime

### DIFF
--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -603,7 +603,9 @@ void FilesystemNodeOperationsBase::fillAttr(const FilesystemOperationContext &fs
 		put64bit(&ptr, static_cast<FSNodeFile *>(node)->length);
 		break;
 	case FSNodeType::kDirectory:
-		put32bit(&ptr, static_cast<FSNodeDirectory *>(node)->nlink);
+		// Served via getDirNlink so the KV backend can return 2 + persisted direct-subdir
+		// count; the in-memory master returns the node's own nlink field.
+		put32bit(&ptr, getDirNlink(fsOpContext, static_cast<FSNodeDirectory *>(node)));
 		// Rescale length to GB (reduces size to 32-bit length)
 		put64bit(&ptr, static_cast<FSNodeDirectory *>(node)->stats.length >> kGBBitShift);
 		break;
@@ -677,7 +679,10 @@ void FilesystemNodeOperationsBase::removeEdge(const FilesystemOperationContext &
 
 	parent->mtime = parent->ctime = timeStamp;
 
-	if (childNode->type == FSNodeType::kDirectory) { parent->nlink--; }
+	if (childNode->type == FSNodeType::kDirectory) {
+		parent->nlink--;
+		persistDirSubdirCountDelta(fsOpContext, parent, -1);
+	}
 
 	fsnodes_update_checksum(parent);
 	// Persist the parent's child-change time conflict-free; see link().
@@ -722,6 +727,17 @@ void FilesystemNodeOperationsBase::resetDirChildChangeTime(
 	// Default no-op: the in-memory master keeps a directory's mtime in the node itself.
 }
 
+void FilesystemNodeOperationsBase::persistDirSubdirCountDelta(
+    const FilesystemOperationContext & /*fsOpContext*/, FSNodeDirectory * /*dir*/,
+    int64_t /*delta*/) {
+	// Default no-op: the in-memory master keeps a directory's nlink in the node itself.
+}
+
+uint32_t FilesystemNodeOperationsBase::getDirNlink(
+    const FilesystemOperationContext & /*fsOpContext*/, const FSNodeDirectory *dir) {
+	return dir->nlink;
+}
+
 void FilesystemNodeOperationsBase::link(const FilesystemOperationContext &fsOpContext,
                                         uint32_t timeStamp, FSNodeDirectory *parent, FSNode *child,
                                         const HString &name) {
@@ -742,7 +758,10 @@ void FilesystemNodeOperationsBase::link(const FilesystemOperationContext &fsOpCo
 	// Implementation specific (virtual) edge preservation (in-memory, FDB, etc.)
 	preserveEdge(fsOpContext, parent, child, handlePtr);
 
-	if (child->type == FSNodeType::kDirectory) { parent->nlink++; }
+	if (child->type == FSNodeType::kDirectory) {
+		parent->nlink++;
+		persistDirSubdirCountDelta(fsOpContext, parent, 1);
+	}
 
 	StatsRecord childStats;
 	getStats(fsOpContext, child, &childStats);

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -718,8 +718,7 @@ void FilesystemNodeOperationsBase::removeEdge(const FilesystemOperationContext &
 void FilesystemNodeOperationsBase::persistDirChildChangeTime(
     const FilesystemOperationContext & /*fsOpContext*/, FSNodeDirectory * /*dir*/,
     uint32_t /*timeStamp*/) {
-	// Default no-op: the in-memory master persists a directory's mtime/ctime via the node
-	// itself (and the periodic metadata dump). The KV backend overrides this.
+	// Default no-op: the in-memory master keeps dir mtime/ctime in the node; the KV backend overrides.
 }
 
 uint32_t FilesystemNodeOperationsBase::getDirChildChangeTime(
@@ -728,7 +727,8 @@ uint32_t FilesystemNodeOperationsBase::getDirChildChangeTime(
 }
 
 void FilesystemNodeOperationsBase::resetDirChildChangeTime(
-    const FilesystemOperationContext & /*fsOpContext*/, FSNodeDirectory * /*dir*/) {
+    const FilesystemOperationContext & /*fsOpContext*/, FSNodeDirectory * /*dir*/,
+    uint32_t /*opTimeStamp*/) {
 	// Default no-op: the in-memory master keeps a directory's mtime in the node itself.
 }
 
@@ -745,9 +745,7 @@ uint32_t FilesystemNodeOperationsBase::getDirNlink(
 
 void FilesystemNodeOperationsBase::persistNodeAtime(
     const FilesystemOperationContext & /*fsOpContext*/, FSNode * /*node*/, uint32_t /*timeStamp*/) {
-	// Default no-op: the in-memory master persists a node's atime via the node itself (the
-	// caller, fs_update_atime, already bumped node->atime and logged ACCESS) and the periodic
-	// metadata dump. The KV backend overrides this with an FDB atomicMax on NODE_ATIME_.
+	// Default no-op: the in-memory master keeps atime in the node; the KV backend overrides.
 }
 
 uint32_t FilesystemNodeOperationsBase::getNodeAtime(

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -584,7 +584,12 @@ void FilesystemNodeOperationsBase::fillAttr(const FilesystemOperationContext &fs
 		if (childChange > mtime) { mtime = childChange; }
 		if (childChange > ctime) { ctime = childChange; }
 	}
-	put32bit(&ptr, node->atime);
+	// atime is reconciled with its conflict-free read-advance key: a read records
+	// atime via atomicMax on NODE_ATIME_ instead of rewriting the node, so node->atime can lag.
+	uint32_t atime = node->atime;
+	const uint32_t accessTime = getNodeAtime(fsOpContext, node);
+	if (accessTime > atime) { atime = accessTime; }
+	put32bit(&ptr, atime);
 	put32bit(&ptr, mtime);
 	put32bit(&ptr, ctime);
 
@@ -736,6 +741,23 @@ void FilesystemNodeOperationsBase::persistDirSubdirCountDelta(
 uint32_t FilesystemNodeOperationsBase::getDirNlink(
     const FilesystemOperationContext & /*fsOpContext*/, const FSNodeDirectory *dir) {
 	return dir->nlink;
+}
+
+void FilesystemNodeOperationsBase::persistNodeAtime(
+    const FilesystemOperationContext & /*fsOpContext*/, FSNode * /*node*/, uint32_t /*timeStamp*/) {
+	// Default no-op: the in-memory master persists a node's atime via the node itself (the
+	// caller, fs_update_atime, already bumped node->atime and logged ACCESS) and the periodic
+	// metadata dump. The KV backend overrides this with an FDB atomicMax on NODE_ATIME_.
+}
+
+uint32_t FilesystemNodeOperationsBase::getNodeAtime(
+    const FilesystemOperationContext & /*fsOpContext*/, const FSNode * /*node*/) {
+	return 0;
+}
+
+void FilesystemNodeOperationsBase::resetNodeAtime(
+    const FilesystemOperationContext & /*fsOpContext*/, FSNode * /*node*/) {
+	// Default no-op: the in-memory master keeps a node's atime in the node itself.
 }
 
 void FilesystemNodeOperationsBase::link(const FilesystemOperationContext &fsOpContext,

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -573,10 +573,20 @@ void FilesystemNodeOperationsBase::fillAttr(const FilesystemOperationContext &fs
 		}
 	}
 
-	// Timestamps
+	// Timestamps. A directory's mtime/ctime are reconciled with its conflict-free
+	// child-change time: a child create/remove records that key via atomicMax
+	// instead of rewriting the parent node, so the node's own mtime/ctime can lag behind.
+	uint32_t mtime = node->mtime;
+	uint32_t ctime = node->ctime;
+	if (node->type == FSNodeType::kDirectory) {
+		const uint32_t childChange =
+		    getDirChildChangeTime(fsOpContext, static_cast<FSNodeDirectory *>(node));
+		if (childChange > mtime) { mtime = childChange; }
+		if (childChange > ctime) { ctime = childChange; }
+	}
 	put32bit(&ptr, node->atime);
-	put32bit(&ptr, node->mtime);
-	put32bit(&ptr, node->ctime);
+	put32bit(&ptr, mtime);
+	put32bit(&ptr, ctime);
 
 	// Number of links
 	nlink = getNumberOfParents(fsOpContext, node);
@@ -670,6 +680,8 @@ void FilesystemNodeOperationsBase::removeEdge(const FilesystemOperationContext &
 	if (childNode->type == FSNodeType::kDirectory) { parent->nlink--; }
 
 	fsnodes_update_checksum(parent);
+	// Persist the parent's child-change time conflict-free; see link().
+	persistDirChildChangeTime(fsOpContext, parent, timeStamp);
 	HString currentName = childName;
 	if (parent->caseInsensitive) { currentName = HString::hstringToLowerCase(childName); }
 
@@ -691,6 +703,23 @@ void FilesystemNodeOperationsBase::removeEdge(const FilesystemOperationContext &
 	fsnodes_update_checksum(childNode);
 
 	gMetadata->edgeRemovedSignal.emit(parent->id, childName);
+}
+
+void FilesystemNodeOperationsBase::persistDirChildChangeTime(
+    const FilesystemOperationContext & /*fsOpContext*/, FSNodeDirectory * /*dir*/,
+    uint32_t /*timeStamp*/) {
+	// Default no-op: the in-memory master persists a directory's mtime/ctime via the node
+	// itself (and the periodic metadata dump). The KV backend overrides this.
+}
+
+uint32_t FilesystemNodeOperationsBase::getDirChildChangeTime(
+    const FilesystemOperationContext & /*fsOpContext*/, const FSNodeDirectory * /*dir*/) {
+	return 0;
+}
+
+void FilesystemNodeOperationsBase::resetDirChildChangeTime(
+    const FilesystemOperationContext & /*fsOpContext*/, FSNodeDirectory * /*dir*/) {
+	// Default no-op: the in-memory master keeps a directory's mtime in the node itself.
 }
 
 void FilesystemNodeOperationsBase::link(const FilesystemOperationContext &fsOpContext,
@@ -722,6 +751,9 @@ void FilesystemNodeOperationsBase::link(const FilesystemOperationContext &fsOpCo
 	if (timeStamp > 0) {
 		parent->mtime = parent->ctime = timeStamp;
 		fsnodes_update_checksum(parent);
+		// Persist the parent's child-change time conflict-free so it survives a
+		// reload without rewriting (and conflicting on) the whole parent node.
+		persistDirChildChangeTime(fsOpContext, parent, timeStamp);
 		assert(child->type != FSNodeType::kTrash);
 		child->ctime = timeStamp;
 		fsnodes_update_checksum(child);

--- a/src/master/filesystem_node.h
+++ b/src/master/filesystem_node.h
@@ -131,6 +131,26 @@ public:
 	uint64_t getNumberOfParents(const FilesystemOperationContext &fsOpContext,
 	                            const FSNode *node) override;
 
+	/// No-op: the in-memory master keeps a directory's mtime in the node itself.
+	/// @see IFilesystemNodeOperations::resetDirChildChangeTime
+	void resetDirChildChangeTime(const FilesystemOperationContext &fsOpContext,
+	                             FSNodeDirectory *dir) override;
+
+	/// Conflict-free persistence of a directory's child-change time: records
+	/// that an entry of `dir` was added or removed at `timeStamp` WITHOUT rewriting (and
+	/// conflicting on) the whole parent node. The default is a no-op: backends that persist
+	/// the directory node itself (the in-memory master) keep mtime/ctime in the node. The
+	/// KV backend overrides this with an FDB atomicMax on the DIR_CHILD_CHANGE_TIME_ key.
+	virtual void persistDirChildChangeTime(const FilesystemOperationContext &fsOpContext,
+	                                       FSNodeDirectory *dir, uint32_t timeStamp);
+
+	/// Returns the directory's persisted child-change time, or 0 if none. Used to reconcile
+	/// a directory's served mtime/ctime (max of the node field and this value) when a child
+	/// create/remove did not rewrite the node. Default 0: the node's own timestamps are
+	/// authoritative (in-memory master).
+	virtual uint32_t getDirChildChangeTime(const FilesystemOperationContext &fsOpContext,
+	                                       const FSNodeDirectory *dir);
+
 #ifndef METARESTORE
 	uint32_t getDirSize(const FSNodeDirectory *nodeDir, uint8_t withAttr) override;
 	void getDirData(const FilesystemOperationContext &fsOpContext, inode_t rootINode, uint32_t uid,

--- a/src/master/filesystem_node.h
+++ b/src/master/filesystem_node.h
@@ -131,6 +131,20 @@ public:
 	uint64_t getNumberOfParents(const FilesystemOperationContext &fsOpContext,
 	                            const FSNode *node) override;
 
+	/// No-op: the in-memory master stores atime in the node (the caller already bumped it).
+	/// @see IFilesystemNodeOperations::persistNodeAtime
+	void persistNodeAtime(const FilesystemOperationContext &fsOpContext, FSNode *node,
+	                      uint32_t timeStamp) override;
+
+	/// Returns 0: the in-memory master keeps a node's atime in the node itself.
+	/// @see IFilesystemNodeOperations::getNodeAtime
+	uint32_t getNodeAtime(const FilesystemOperationContext &fsOpContext,
+	                      const FSNode *node) override;
+
+	/// No-op: the in-memory master keeps a node's atime in the node itself.
+	/// @see IFilesystemNodeOperations::resetNodeAtime
+	void resetNodeAtime(const FilesystemOperationContext &fsOpContext, FSNode *node) override;
+
 	/// No-op: the in-memory master keeps a directory's mtime in the node itself.
 	/// @see IFilesystemNodeOperations::resetDirChildChangeTime
 	void resetDirChildChangeTime(const FilesystemOperationContext &fsOpContext,

--- a/src/master/filesystem_node.h
+++ b/src/master/filesystem_node.h
@@ -136,11 +136,6 @@ public:
 	void persistNodeAtime(const FilesystemOperationContext &fsOpContext, FSNode *node,
 	                      uint32_t timeStamp) override;
 
-	/// Returns 0: the in-memory master keeps a node's atime in the node itself.
-	/// @see IFilesystemNodeOperations::getNodeAtime
-	uint32_t getNodeAtime(const FilesystemOperationContext &fsOpContext,
-	                      const FSNode *node) override;
-
 	/// No-op: the in-memory master keeps a node's atime in the node itself.
 	/// @see IFilesystemNodeOperations::resetNodeAtime
 	void resetNodeAtime(const FilesystemOperationContext &fsOpContext, FSNode *node) override;
@@ -148,8 +143,9 @@ public:
 	/// No-op: the in-memory master keeps a directory's mtime in the node itself.
 	/// @see IFilesystemNodeOperations::resetDirChildChangeTime
 	void resetDirChildChangeTime(const FilesystemOperationContext &fsOpContext,
-	                             FSNodeDirectory *dir) override;
+	                             FSNodeDirectory *dir, uint32_t opTimeStamp) override;
 
+protected:
 	/// Conflict-free persistence of a directory's child-change time: records
 	/// that an entry of `dir` was added or removed at `timeStamp` WITHOUT rewriting (and
 	/// conflicting on) the whole parent node. The default is a no-op: backends that persist
@@ -179,6 +175,14 @@ public:
 	virtual uint32_t getDirNlink(const FilesystemOperationContext &fsOpContext,
 	                             const FSNodeDirectory *dir);
 
+	/// Returns a node's persisted access time, or 0 if none. Used to reconcile the served
+	/// atime (max of the node field and this value) when a read advanced atime without
+	/// rewriting the node. Default 0: the node's own atime is authoritative (in-memory master).
+	/// The KV backend overrides this with a read of the NODE_ATIME_ key.
+	virtual uint32_t getNodeAtime(const FilesystemOperationContext &fsOpContext,
+	                              const FSNode *node);
+
+public:
 #ifndef METARESTORE
 	uint32_t getDirSize(const FSNodeDirectory *nodeDir, uint8_t withAttr) override;
 	void getDirData(const FilesystemOperationContext &fsOpContext, inode_t rootINode, uint32_t uid,

--- a/src/master/filesystem_node.h
+++ b/src/master/filesystem_node.h
@@ -151,6 +151,20 @@ public:
 	virtual uint32_t getDirChildChangeTime(const FilesystemOperationContext &fsOpContext,
 	                                       const FSNodeDirectory *dir);
 
+	/// Conflict-free persistence of a directory's direct-subdirectory count delta:
+	/// records +1/-1 on every subdirectory link/unlink WITHOUT rewriting the parent
+	/// node, co-located with the in-memory FSNodeDirectory::nlink update. Default no-op: the
+	/// in-memory master keeps nlink in the node. The KV backend overrides with an FDB
+	/// atomicAdd on the DIR_SUBDIRS_ key.
+	virtual void persistDirSubdirCountDelta(const FilesystemOperationContext &fsOpContext,
+	                                        FSNodeDirectory *dir, int64_t delta);
+
+	/// Returns the directory's served link count. Default: the node's own nlink field (the
+	/// in-memory master). The KV backend overrides this to 2 + the persisted direct-subdir
+	/// count, so nlink survives a reload without rewriting the node per child create.
+	virtual uint32_t getDirNlink(const FilesystemOperationContext &fsOpContext,
+	                             const FSNodeDirectory *dir);
+
 #ifndef METARESTORE
 	uint32_t getDirSize(const FSNodeDirectory *nodeDir, uint8_t withAttr) override;
 	void getDirData(const FilesystemOperationContext &fsOpContext, inode_t rootINode, uint32_t uid,

--- a/src/master/filesystem_node_operations_interface.h
+++ b/src/master/filesystem_node_operations_interface.h
@@ -151,24 +151,19 @@ public:
 	virtual void persistNodeAtime(const FilesystemOperationContext &fsOpContext, FSNode *node,
 	                              uint32_t timeStamp) = 0;
 
-	/// Returns a node's persisted access time, or 0 if none. Used to reconcile the served
-	/// atime (max of the node field and this value) when a read advanced atime without
-	/// rewriting the node. In-memory backend: 0 (the node's own atime is authoritative).
-	virtual uint32_t getNodeAtime(const FilesystemOperationContext &fsOpContext,
-	                              const FSNode *node) = 0;
-
 	/// Resets the persisted access time to the node's current atime when atime is set
 	/// explicitly (utimes). atime can move backward, which the conflict-free
 	/// max-reconcile would otherwise mask; the KV backend overwrites the NODE_ATIME_
 	/// shadow so max(node->atime, shadow) == node->atime. In-memory backend: no-op.
 	virtual void resetNodeAtime(const FilesystemOperationContext &fsOpContext, FSNode *node) = 0;
 
-	/// Resets a directory's persisted child-change time to its current mtime when mtime is
-	/// set explicitly (utimes). Directory mtime can move backward after child changes, so the
-	/// KV backend overwrites the DIR_CHILD_CHANGE_TIME_ shadow to keep max-reconcile parity.
-	/// In-memory backend: no-op.
+	/// Resets a directory's persisted child-change time when mtime is set explicitly (utimes).
+	/// Directory mtime can move backward after child changes, so the KV backend overwrites the
+	/// DIR_CHILD_CHANGE_TIME_ shadow to keep max-reconcile parity. The shadow also reconciles
+	/// ctime, so it is clamped to opTimeStamp: an explicit future mtime must not drag the served
+	/// ctime past the time of the change. In-memory backend: no-op.
 	virtual void resetDirChildChangeTime(const FilesystemOperationContext &fsOpContext,
-	                                     FSNodeDirectory *dir) = 0;
+	                                     FSNodeDirectory *dir, uint32_t opTimeStamp) = 0;
 
 	/// Creates a hard link (directory entry) between a parent directory and an existing node.
 	///

--- a/src/master/filesystem_node_operations_interface.h
+++ b/src/master/filesystem_node_operations_interface.h
@@ -144,6 +144,13 @@ public:
 	/// @note KV backends: could schedule the set operation for later commit.
 	virtual void updateNode(const FilesystemOperationContext &fsOpContext, FSNode *node) = 0;
 
+	/// Resets a directory's persisted child-change time to its current mtime when mtime is
+	/// set explicitly (utimes). Directory mtime can move backward after child changes, so the
+	/// KV backend overwrites the DIR_CHILD_CHANGE_TIME_ shadow to keep max-reconcile parity.
+	/// In-memory backend: no-op.
+	virtual void resetDirChildChangeTime(const FilesystemOperationContext &fsOpContext,
+	                                     FSNodeDirectory *dir) = 0;
+
 	/// Creates a hard link (directory entry) between a parent directory and an existing node.
 	///
 	/// This method establishes a new edge from a parent directory to an existing child node,

--- a/src/master/filesystem_node_operations_interface.h
+++ b/src/master/filesystem_node_operations_interface.h
@@ -144,6 +144,25 @@ public:
 	/// @note KV backends: could schedule the set operation for later commit.
 	virtual void updateNode(const FilesystemOperationContext &fsOpContext, FSNode *node) = 0;
 
+	/// Persists a node's access-time advance recorded on a read. The caller
+	/// (fs_update_atime) has already bumped node->atime and logged ACCESS. In-memory backend:
+	/// no-op (the node itself is the store). KV backend: a conflict-free FDB atomicMax on the
+	/// NODE_ATIME_ key, WITHOUT rewriting (and conflicting on) the node. Read paths only.
+	virtual void persistNodeAtime(const FilesystemOperationContext &fsOpContext, FSNode *node,
+	                              uint32_t timeStamp) = 0;
+
+	/// Returns a node's persisted access time, or 0 if none. Used to reconcile the served
+	/// atime (max of the node field and this value) when a read advanced atime without
+	/// rewriting the node. In-memory backend: 0 (the node's own atime is authoritative).
+	virtual uint32_t getNodeAtime(const FilesystemOperationContext &fsOpContext,
+	                              const FSNode *node) = 0;
+
+	/// Resets the persisted access time to the node's current atime when atime is set
+	/// explicitly (utimes). atime can move backward, which the conflict-free
+	/// max-reconcile would otherwise mask; the KV backend overwrites the NODE_ATIME_
+	/// shadow so max(node->atime, shadow) == node->atime. In-memory backend: no-op.
+	virtual void resetNodeAtime(const FilesystemOperationContext &fsOpContext, FSNode *node) = 0;
+
 	/// Resets a directory's persisted child-change time to its current mtime when mtime is
 	/// set explicitly (utimes). Directory mtime can move backward after child changes, so the
 	/// KV backend overwrites the DIR_CHILD_CHANGE_TIME_ shadow to keep max-reconcile parity.

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -1598,8 +1598,12 @@ uint8_t FilesystemOperationsBase::setAttr(const FsContext &context,
 	}
 	if (setmask & SET_ATIME_NOW_FLAG) {
 		node->atime = timeStamp;
+		// Explicit set: overwrite the conflict-free atime shadow so a backward set is not
+		// masked by the max-reconcile. No-op on the in-memory master.
+		nodeOperations_->resetNodeAtime(fsOpContext, node);
 	} else if (setmask & SET_ATIME_FLAG) {
 		node->atime = attratime;
+		nodeOperations_->resetNodeAtime(fsOpContext, node);
 	}
 	if (setmask & SET_MTIME_NOW_FLAG) {
 		node->mtime = timeStamp;
@@ -1691,10 +1695,13 @@ static inline void fs_update_atime(const FilesystemOperationContext &fsOpContext
 		fsnodes_update_checksum(p);
 		gFSOperations->changeLog(fsOpContext, ts, "ACCESS(%" PRIiNode ")", p->id);
 
-		// Schedule the node update for KV backends.
-		if (fsOpContext.hasReadWriteTransaction()) {
-			gFSOperations->nodeOperations()->updateNode(fsOpContext, p);
-		}
+		// Persist the advance. The in-memory master needs nothing more (no-op); the
+		// KV backend records it with a conflict-free atomicMax on NODE_ATIME_ INSTEAD of the
+		// whole-node updateNode this used to do, so atime-on-read no longer conflicts with a
+		// concurrent writer on the node nor pays a whole-node write. fillAttr reconciles the
+		// served atime as max(node->atime, NODE_ATIME_), which also covers the case where the
+		// in-memory node->atime bump above is later lost (cache eviction or restart).
+		gFSOperations->nodeOperations()->persistNodeAtime(fsOpContext, p, ts);
 	}
 }
 

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -1609,13 +1609,13 @@ uint8_t FilesystemOperationsBase::setAttr(const FsContext &context,
 		node->mtime = timeStamp;
 		if (node->type == FSNodeType::kDirectory) {
 			nodeOperations_->resetDirChildChangeTime(fsOpContext,
-			                                        static_cast<FSNodeDirectory *>(node));
+			                                        static_cast<FSNodeDirectory *>(node), timeStamp);
 		}
 	} else if (setmask & SET_MTIME_FLAG) {
 		node->mtime = attrmtime;
 		if (node->type == FSNodeType::kDirectory) {
 			nodeOperations_->resetDirChildChangeTime(fsOpContext,
-			                                        static_cast<FSNodeDirectory *>(node));
+			                                        static_cast<FSNodeDirectory *>(node), timeStamp);
 		}
 	}
 	changeLog(fsOpContext, timeStamp,
@@ -1651,6 +1651,11 @@ uint8_t FilesystemOperationsBase::applyAttr(const FilesystemOperationContext &fs
 	}
 	node->atime = atime;
 	node->mtime = mtime;
+	// NOTE: unlike setAttr, this changelog-replay path does not reset the conflict-free
+	// atime / dir-child-change shadows. It is safe today: the in-memory master has no such
+	// shadows, and the KV MDS does not replay the changelog (emit-only). If changelog replay
+	// is ever enabled on a KV backend, mirror setAttr's resetNodeAtime / resetDirChildChangeTime
+	// here so a restored backward timestamp is not masked by the max-reconcile.
 	nodeOperations_->updateCTime(fsOpContext, node, timestamp);
 	fsnodes_update_checksum(node);
 	gMetadata->metadataVersion++;
@@ -1695,12 +1700,9 @@ static inline void fs_update_atime(const FilesystemOperationContext &fsOpContext
 		fsnodes_update_checksum(p);
 		gFSOperations->changeLog(fsOpContext, ts, "ACCESS(%" PRIiNode ")", p->id);
 
-		// Persist the advance. The in-memory master needs nothing more (no-op); the
-		// KV backend records it with a conflict-free atomicMax on NODE_ATIME_ INSTEAD of the
-		// whole-node updateNode this used to do, so atime-on-read no longer conflicts with a
-		// concurrent writer on the node nor pays a whole-node write. fillAttr reconciles the
-		// served atime as max(node->atime, NODE_ATIME_), which also covers the case where the
-		// in-memory node->atime bump above is later lost (cache eviction or restart).
+		// Persist the advance: no-op on the in-memory master; the KV backend records it with a
+		// conflict-free atomicMax on NODE_ATIME_ instead of a whole-node write. fillAttr serves
+		// max(node->atime, NODE_ATIME_), recovering the advance if the cached bump is lost.
 		gFSOperations->nodeOperations()->persistNodeAtime(fsOpContext, p, ts);
 	}
 }

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -1603,8 +1603,16 @@ uint8_t FilesystemOperationsBase::setAttr(const FsContext &context,
 	}
 	if (setmask & SET_MTIME_NOW_FLAG) {
 		node->mtime = timeStamp;
+		if (node->type == FSNodeType::kDirectory) {
+			nodeOperations_->resetDirChildChangeTime(fsOpContext,
+			                                        static_cast<FSNodeDirectory *>(node));
+		}
 	} else if (setmask & SET_MTIME_FLAG) {
 		node->mtime = attrmtime;
+		if (node->type == FSNodeType::kDirectory) {
+			nodeOperations_->resetDirChildChangeTime(fsOpContext,
+			                                        static_cast<FSNodeDirectory *>(node));
+		}
 	}
 	changeLog(fsOpContext, timeStamp,
 	          "ATTR(%" PRIiNode ",%d,%" PRIu32 ",%" PRIu32 ",%" PRIu32 ",%" PRIu32 ")", node->id,

--- a/src/master/kv_common_keys.h
+++ b/src/master/kv_common_keys.h
@@ -132,7 +132,8 @@ inline constexpr std::string_view kACLsKeyPrefix = "ACLS_";  // Section ACLS 1.2
 /// - OwnerId: inode_t serialized as Big Endian
 /// - Rigor: u8 (soft/hard/used)
 /// - Resource: u8 (inodes/size)
-/// - Value: u64 serialized as Big Endian
+/// - Value: u64. Soft/hard limits are big-endian; the used counter is little-endian
+///   (maintained by a conflict-free atomicAdd, so its readers decode little-endian).
 /// @note Numeric fields in the key are serialized as Big Endian to preserve numeric order in
 /// lexicographical sorting, enabling efficient scans by owner prefix and global quota prefix.
 inline constexpr std::string_view kQuotasKeyPrefix = "QUOT_";  // Section QUOT 1.1

--- a/src/master/kv_common_keys.h
+++ b/src/master/kv_common_keys.h
@@ -288,6 +288,16 @@ inline constexpr std::string_view kDirStatsPrefix = "DIR_STATS_";
 /// when no child change has been recorded.
 inline constexpr std::string_view kDirChildChangeTimePrefix = "DIR_CHILD_CHANGE_TIME_";
 
+/// Prefix for a directory's DIRECT subdirectory count.
+/// Format: DIR_SUBDIRS_<InodeId> -> <Count> (signed 64-bit little-endian)
+/// @note Maintained via a conflict-free FDB atomicAdd(+/-1) on every subdirectory
+/// link/unlink, co-located with the in-memory FSNodeDirectory::nlink update, so it is a
+/// persisted shadow of (nlink - 2). A directory's served nlink is 2 + this count (POSIX:
+/// 2 for "." and the parent entry, plus one per direct subdirectory). Distinct from the
+/// DIR_STATS Dirs counter, which is the RECURSIVE subtree directory count. An absent key
+/// counts as zero (an empty directory, nlink 2).
+inline constexpr std::string_view kDirSubdirCountPrefix = "DIR_SUBDIRS_";
+
 /// Suffix bytes for directory statistics fields.
 /// Used to differentiate the 8 stats keys per directory without string comparisons.
 enum class StatsSuffix : uint8_t {

--- a/src/master/kv_common_keys.h
+++ b/src/master/kv_common_keys.h
@@ -298,6 +298,17 @@ inline constexpr std::string_view kDirChildChangeTimePrefix = "DIR_CHILD_CHANGE_
 /// counts as zero (an empty directory, nlink 2).
 inline constexpr std::string_view kDirSubdirCountPrefix = "DIR_SUBDIRS_";
 
+/// Prefix for a node's access time.
+/// Format: NODE_ATIME_<InodeId> -> <TimeStamp> (32-bit little-endian)
+/// @note Advanced on a read via a conflict-free FDB atomicMax, so atime-on-read no longer
+/// rewrites (and conflicts on) the whole NODE_ blob. A node's served atime is reconciled as
+/// max(node field, this key). An absent key counts as zero, so the node's own atime stays
+/// authoritative when no read has advanced it. Applies to every node type (files via
+/// readChunk, symlinks via readlink, directories via readdir). On an explicit atime set
+/// (utimes), which may move atime BACKWARD, this key is overwritten (plain set) with the new
+/// value so the max-reconcile does not mask the set.
+inline constexpr std::string_view kNodeAtimeKeyPrefix = "NODE_ATIME_";
+
 /// Suffix bytes for directory statistics fields.
 /// Used to differentiate the 8 stats keys per directory without string comparisons.
 enum class StatsSuffix : uint8_t {

--- a/src/master/kv_common_keys.h
+++ b/src/master/kv_common_keys.h
@@ -275,6 +275,19 @@ inline constexpr std::string_view kDirNodesCountPrefix = "DIR_NODES_COUNT_";
 /// as children are added/removed, enabling efficient queries like 'saunafs dirinfo'.
 inline constexpr std::string_view kDirStatsPrefix = "DIR_STATS_";
 
+/// Prefix for a directory's child-change time.
+/// Format: DIR_CHILD_CHANGE_TIME_<InodeId> -> <TimeStamp> (32-bit little-endian)
+/// @note Updated via a conflict-free FDB atomicMax on every child link/unlink, so
+/// concurrent same-directory creates avoid colliding on (and need not rewrite) the whole
+/// parent node. A directory's served mtime and ctime are reconciled as max(node field,
+/// this key); since adding/removing an entry sets a directory's mtime and ctime to the
+/// same timestamp, one key covers both. Explicit directory mtime sets overwrite this
+/// key so backward mtime changes are not masked. Once present, this shadow remains
+/// authoritative during attribute reconciliation; whole-node writes do not fold it into
+/// NODE_. An absent key counts as zero, so the node's own timestamps remain authoritative
+/// when no child change has been recorded.
+inline constexpr std::string_view kDirChildChangeTimePrefix = "DIR_CHILD_CHANGE_TIME_";
+
 /// Suffix bytes for directory statistics fields.
 /// Used to differentiate the 8 stats keys per directory without string comparisons.
 enum class StatsSuffix : uint8_t {

--- a/tests/test_suites/ShortSystemTests/test_conflict_free_attrs.sh
+++ b/tests/test_suites/ShortSystemTests/test_conflict_free_attrs.sh
@@ -1,11 +1,8 @@
 timeout_set '2 minutes'
 
-# Exercises the attributes that the KV MDS persists conflict-free (directory link
-# count via DIR_SUBDIRS_, directory mtime via DIR_CHILD_CHANGE_TIME_, access time via NODE_ATIME_)
-# and reconciles on read as a function of the node field and a shadow key. The same
-# observable behaviour must hold on the in-memory Master (which keeps these in the node),
-# so this test is backend-agnostic and runs in both ShortSystemTests (Master) and FDBTests
-# (KV, via the test_short_ wrapper) to prove parity. Every check survives an MDS restart.
+# Conflict-free attributes (dir nlink via DIR_SUBDIRS_, dir mtime via DIR_CHILD_CHANGE_TIME_,
+# atime via NODE_ATIME_) must read back identically on the in-memory Master and the KV MDS, so
+# this test runs in both ShortSystemTests and FDBTests (test_short_ wrapper) and survives restart.
 
 USE_RAMDISK="YES" \
 	CHUNKSERVERS=1 \
@@ -13,7 +10,7 @@ USE_RAMDISK="YES" \
 	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER" \
 	setup_local_empty_saunafs info
 
-cd "${info[mount0]}"
+cd "${info[mount0]}" || exit 1
 
 # drop_caches before each stat: FUSE caches attributes, which would otherwise mask a
 # server-side timestamp/nlink change.
@@ -50,6 +47,14 @@ dir_past_mtime=$(( $(date +%s) - 100000 ))
 touch -m -d "@${dir_past_mtime}" d
 drop_caches
 assert_equals "${dir_past_mtime}" "$(stat -c %Y d)"
+
+# An explicit future dir mtime must not drag ctime forward: the child-change shadow (also used
+# to reconcile ctime) is clamped to the change time, so mtime follows the future value, ctime = now.
+dir_future_mtime=$(( $(date +%s) + 100000 ))
+touch -m -d "@${dir_future_mtime}" d
+drop_caches
+assert_equals "${dir_future_mtime}" "$(stat -c %Y d)"
+assert_less_than "$(stat -c %Z d)" "${dir_future_mtime}"
 
 # atime advances through the conflict-free read path.
 # Use a nonempty file so cat reaches persistNodeAtime and the atomicMax shadow.

--- a/tests/test_suites/ShortSystemTests/test_conflict_free_attrs.sh
+++ b/tests/test_suites/ShortSystemTests/test_conflict_free_attrs.sh
@@ -1,0 +1,86 @@
+timeout_set '2 minutes'
+
+# Exercises the attributes that the KV MDS persists conflict-free (directory link
+# count via DIR_SUBDIRS_, directory mtime via DIR_CHILD_CHANGE_TIME_, access time via NODE_ATIME_)
+# and reconciles on read as a function of the node field and a shadow key. The same
+# observable behaviour must hold on the in-memory Master (which keeps these in the node),
+# so this test is backend-agnostic and runs in both ShortSystemTests (Master) and FDBTests
+# (KV, via the test_short_ wrapper) to prove parity. Every check survives an MDS restart.
+
+USE_RAMDISK="YES" \
+	CHUNKSERVERS=1 \
+	MOUNTS=2 \
+	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER" \
+	setup_local_empty_saunafs info
+
+cd "${info[mount0]}"
+
+# drop_caches before each stat: FUSE caches attributes, which would otherwise mask a
+# server-side timestamp/nlink change.
+
+# Directory link count: POSIX 2 ("." + parent entry) + one per direct subdirectory
+mkdir d
+drop_caches
+assert_equals 2 "$(stat -c %h d)"
+
+mkdir d/sub1 d/sub2 d/sub3
+drop_caches
+assert_equals 5 "$(stat -c %h d)"
+
+# Plain files are not subdirectories: they must not change the link count.
+touch d/file1 d/file2
+drop_caches
+assert_equals 5 "$(stat -c %h d)"
+
+# Removing a subdirectory decrements it.
+rmdir d/sub3
+drop_caches
+assert_equals 4 "$(stat -c %h d)"
+
+# Directory mtime advances when a child is added (1s timestamp granularity)
+mtime_before=$(stat -c %Y d)
+sleep 1.2
+touch d/file3
+drop_caches
+mtime_after=$(stat -c %Y d)
+assert_less_than "${mtime_before}" "${mtime_after}"
+
+# Explicit directory mtime changes can move backward and must replace the max shadow.
+dir_past_mtime=$(( $(date +%s) - 100000 ))
+touch -m -d "@${dir_past_mtime}" d
+drop_caches
+assert_equals "${dir_past_mtime}" "$(stat -c %Y d)"
+
+# atime advances through the conflict-free read path.
+# Use a nonempty file so cat reaches persistNodeAtime and the atomicMax shadow.
+printf 'payload\n' > read_file
+read_past_atime=$(( $(date +%s) - 100000 ))
+touch -a -d "@${read_past_atime}" read_file
+drop_caches
+cat "${info[mount1]}/read_file" > /dev/null
+drop_caches
+read_advanced_atime=$(stat -c %X read_file)
+assert_less_than "${read_past_atime}" "${read_advanced_atime}"
+
+# Explicit atime changes can move backward and must replace the max shadow.
+touch reset_file
+future_atime=$(( $(date +%s) + 100000 ))
+reset_past_atime=$(( $(date +%s) - 100000 ))
+touch -a -d "@${future_atime}" reset_file
+touch -a -d "@${reset_past_atime}" reset_file
+drop_caches
+assert_equals "${reset_past_atime}" "$(stat -c %X reset_file)"
+
+# Everything survives one MDS restart. The KV backend reloads the shadows from FDB;
+# the in-memory Master reloads its metadata dump.
+dir_nlink=$(stat -c %h d)
+dir_mtime=$(stat -c %Y d)
+
+saunafs_master_daemon restart
+saunafs_wait_for_all_ready_chunkservers
+drop_caches
+
+assert_equals "${dir_nlink}" "$(stat -c %h d)"
+assert_equals "${dir_mtime}" "$(stat -c %Y d)"
+assert_equals "${read_advanced_atime}" "$(stat -c %X read_file)"
+assert_equals "${reset_past_atime}" "$(stat -c %X reset_file)"


### PR DESCRIPTION
## Summary

Adds Base node-operation hooks so a KV backend can persist a directory's
mtime/ctime, a directory's link count, and per-node atime as standalone,
commutatively-updated fields instead of rewriting the whole node on every
child create/remove or read. The served attribute is reconciled on read as a
function of the node field and the shadow value, so the in-memory Master keeps
its existing behavior through the defaults.

No behavior change for the in-memory Master: every new hook defaults to a
no-op (or returns the node's own field), and `fillAttr` reconciliation is a
max() that collapses to the node field when no shadow exists.

## What changed

- New virtual hooks on `IFilesystemNodeOperations` / `FilesystemNodeOperationsBase`:
  - `persistDirChildChangeTime` / `getDirChildChangeTime` / `resetDirChildChangeTime`
  - `persistDirSubdirCountDelta` / `getDirNlink`
  - `persistNodeAtime` / `getNodeAtime` / `resetNodeAtime`
- `fillAttr` serves a directory's mtime/ctime as `max(node, child-change shadow)`,
  its nlink via `getDirNlink`, and any node's atime as `max(node, atime shadow)`.
- `link` / `removeEdge` record the child-change time and subdir-count delta
  alongside the existing in-memory `nlink` update.
- `fs_update_atime` records the read-advance through `persistNodeAtime` rather
  than scheduling a whole-node update.
- `setAttr` overwrites the atime shadow (and, for directories, the child-change
  shadow) on an explicit `utimes` set so a backward set is not masked by the
  max-reconcile.
- Key prefixes documented in `kv_common_keys.h`; quota value-encoding doc
  clarified (used counter is little-endian).

## Backend parity

The new `ShortSystemTests/test_conflict_free_attrs` runs on the in-memory
Master here and on the KV backend (via the FDBTests wrapper in the companion
PR) to prove identical observable behavior: directory link count, directory
mtime (forward and explicit-backward), atime-on-read, explicit backward atime,
and survival across a metadata-server restart.

Related to LS-882
