### PR TITLE
feat: single-commit FUSE_CREATE RPC

### DIFF
--- a/src/common/saunafs_version.h
+++ b/src/common/saunafs_version.h
@@ -56,3 +56,4 @@ constexpr uint32_t kFirstVersionWithReadTrashReservedByHandleOffset = saunafsVer
 constexpr uint32_t kFirstVersionWithUnlockChunkNotice = saunafsVersion(5, 8, 0);
 constexpr uint32_t kFirstVersionWithChunkserverSideChunkLock = saunafsVersion(5, 8, 0);
 constexpr uint32_t kFirstVersionWithWriteFlushPacket = saunafsVersion(5, 11, 0);
+constexpr uint32_t kFirstVersionWithFusedCreate = saunafsVersion(5, 11, 0);

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -3084,6 +3084,101 @@ void matoclserv_fuse_mknod(matoclserventry *eptr, PacketHeader header, const uin
 	});
 }
 
+// Fused create+open: mknod a file and acquire it for the calling session in a single
+// transaction, so an empty-file create costs one durable commit instead of two (the
+// mknod + open round-trip pair). Version-gated on the client; old clients still send
+// the separate FUSE_MKNOD and FUSE_OPEN.
+void matoclserv_fuse_create(matoclserventry *eptr, PacketHeader header, const uint8_t *data) {
+	uint32_t messageId, uid, gid;
+	inode_t parentInode;
+	LegacyString<uint8_t> name;
+	uint16_t mode, umask;
+	uint8_t flags;
+
+	if (header.type == SAU_CLTOMA_FUSE_CREATE) {
+		cltoma::fuseCreate::deserialize(data, header.length, messageId, parentInode, name, mode,
+		                                umask, uid, gid, flags);
+	} else {
+		throw IncorrectDeserializationException(
+				"Unknown packet type for matoclserv_fuse_create: " + std::to_string(header.type));
+	}
+
+	// Reply data shared between the op body and the reply continuation; a retry
+	// refreshes it through the same struct.
+	auto replyData = std::make_shared<std::pair<inode_t, Attributes>>();
+	uint8_t status = matoclserv_check_group_cache(eptr, gid);
+
+	// Replayable op body: mknod + acquire the open file + openCheck, all in one
+	// transaction. On the KV backend the in-memory open-file record (Session::openFilesSet)
+	// is deliberately NOT done here; it is applied once on commit success (below) so a
+	// retry replays the persistent acquire on a fresh transaction without the already-open
+	// early-return skipping it. On the in-memory Master there is no transaction to roll
+	// back, so acquire+record are coupled here (matoclserv_insert_open_file): a later
+	// openCheck failure must not orphan an untracked acquire that disconnect cleanup would
+	// never release (mirrors matoclserv_fuse_open).
+	OpReplay runCreate = [eptr, uid, gid, parentInode, name, mode, umask, flags,
+	                      replyData](FilesystemOperationContext &ctx) -> uint8_t {
+		FsContext context = matoclserv_get_context(eptr, uid, gid);
+		uint8_t opStatus =
+		    gFSOperations->mknod(context, ctx, parentInode, HString(name), FSNodeType::kFile, mode,
+		                         umask, 0, &replyData->first, replyData->second);
+		if (opStatus == SAUNAFS_STATUS_OK) {
+			opStatus = ctx.getReadWriteTransaction() == nullptr
+			               ? matoclserv_insert_open_file(ctx, eptr->sessionData, replyData->first)
+			               : matoclserv_acquire_open_file_persist(ctx, eptr->sessionData,
+			                                                      replyData->first);
+		}
+		if (opStatus == SAUNAFS_STATUS_OK) {
+			opStatus = gFSOperations->openCheck(context, ctx, replyData->first,
+			                                    flags | AFTER_CREATE, replyData->second);
+		}
+		return opStatus;
+	};
+
+	if (eptr->sessionData) {
+		eptr->sessionData->currHourOperationsStats[8]++;
+	}
+
+	// Builds the reply (inode + attr) applying the same data-cache adjustment the
+	// FUSE_OPEN reply uses, since this op opens the file as well as creating it.
+	auto sendCreateReply = [eptr, messageId](uint8_t replyStatus, inode_t ino,
+	                                         Attributes replyAttr) {
+		MessageBuffer reply;
+		if (replyStatus == SAUNAFS_STATUS_OK) {
+			// When the data cache manager cannot keep this open coherent (dcm_open == 0), clear
+			// the ALLOWDATACACHE attribute bit so the client does not cache this file's data.
+			if (dcm_open(ino, eptr->sessionData->sessionId) == 0) {
+				replyAttr[1] &= (0xFF ^ (MATTR_ALLOWDATACACHE << 4));
+			}
+			matocl::fuseCreate::serialize(reply, messageId, ino, replyAttr);
+		} else {
+			matocl::fuseCreate::serialize(reply, messageId, replyStatus);
+		}
+		matoclserv_createpacket(eptr, std::move(reply));
+	};
+
+	if (status != SAUNAFS_STATUS_OK) {  // group-cache error: reply without running the op
+		sendCreateReply(status, replyData->first, replyData->second);
+		return;
+	}
+
+	// Reply continuation (dropped for a killed client) plus an onCommit hook that records the
+	// open file on commit success and runs even for a killed client, so the persisted acquire
+	// is tracked in openFilesSet for disconnect cleanup. On the in-memory Master the op body
+	// already recorded it (matoclserv_insert_open_file); the set insert there is an idempotent
+	// no-op. Mirrors matoclserv_fuse_open.
+	matoclserv_submit_op(
+	    eptr, std::move(runCreate),
+	    [sendCreateReply, replyData](uint8_t commitStatus) {
+		    sendCreateReply(commitStatus, replyData->first, replyData->second);
+	    },
+	    [eptr, replyData](uint8_t commitStatus) {
+		    if (commitStatus == SAUNAFS_STATUS_OK) {
+			    matoclserv_record_open_file(eptr->sessionData, replyData->first);
+		    }
+	    });
+}
+
 void matoclserv_fuse_mkdir(matoclserventry *eptr, PacketHeader header, const uint8_t *data) {
 	uint32_t messageId, uid, gid;
 	inode_t inode;
@@ -6408,6 +6503,9 @@ void matoclserv_gotpacket(matoclserventry *eptr, uint32_t type, const uint8_t *d
 				    break;
 				case SAU_CLTOMA_FUSE_MKNOD:
 					matoclserv_fuse_mknod(eptr, PacketHeader(type, length), data);
+					break;
+				case SAU_CLTOMA_FUSE_CREATE:
+					matoclserv_fuse_create(eptr, PacketHeader(type, length), data);
 					break;
 				case SAU_CLTOMA_FUSE_MKDIR:
 					matoclserv_fuse_mkdir(eptr, PacketHeader(type, length), data);

--- a/src/mount/mastercomm.cc
+++ b/src/mount/mastercomm.cc
@@ -2290,6 +2290,48 @@ uint8_t fs_mknod(inode_t parent, uint8_t nleng, const uint8_t *name, uint8_t typ
 	}
 }
 
+uint8_t fs_create(inode_t parent, uint8_t nleng, const uint8_t *name, uint16_t mode, uint16_t umask,
+                  uint32_t uid, uint32_t gid, uint8_t flags, inode_t &inode, Attributes &attr) {
+	threc* rec = fs_get_my_threc();
+	auto message = cltoma::fuseCreate::build(rec->packetId, parent,
+			LegacyString<uint8_t>(reinterpret_cast<const char*>(name), nleng),
+			mode, umask, uid, gid, flags);
+	if (!fs_saucreatepacket(rec, message)) {
+		return SAUNAFS_ERROR_IO;
+	}
+	if (!fs_sausendandreceive(rec, SAU_MATOCL_FUSE_CREATE, message)) {
+		return SAUNAFS_ERROR_IO;
+	}
+	try {
+		uint32_t messageId;
+		PacketVersion packetVersion;
+		deserializePacketVersionNoHeader(message, packetVersion);
+		if (packetVersion == matocl::fuseCreate::kStatusPacketVersion) {
+			uint8_t status;
+			matocl::fuseCreate::deserialize(message, messageId, status);
+			if (status == SAUNAFS_STATUS_OK) {
+				fs_got_inconsistent("SAU_MATOCL_FUSE_CREATE", message.size(),
+						"version 0 and SAUNAFS_STATUS_OK");
+				return SAUNAFS_ERROR_IO;
+			}
+			return status;
+		} else if (packetVersion == matocl::fuseCreate::kResponsePacketVersion) {
+			matocl::fuseCreate::deserialize(message, messageId, inode, attr);
+			// The fused create also opens the file; track the acquire client-side
+			// like fs_opencheck does, so it is reported via CLTOMA_FUSE_RESERVED_INODES.
+			fs_inc_acnt(inode);
+			return SAUNAFS_STATUS_OK;
+		} else {
+			fs_got_inconsistent("SAU_MATOCL_FUSE_CREATE", message.size(),
+					"unknown version " + std::to_string(packetVersion));
+			return SAUNAFS_ERROR_IO;
+		}
+	} catch (Exception& ex) {
+		fs_got_inconsistent("SAU_MATOCL_FUSE_CREATE", message.size(), ex.what());
+		return SAUNAFS_ERROR_IO;
+	}
+}
+
 uint8_t fs_mkdir(inode_t parent, uint8_t nleng, const uint8_t *name, uint16_t mode, uint16_t umask,
                  uint32_t uid, uint32_t gid, uint8_t copysgid, inode_t &inode, Attributes &attr) {
 	threc* rec = fs_get_my_threc();

--- a/src/mount/mastercomm.h
+++ b/src/mount/mastercomm.h
@@ -73,6 +73,8 @@ uint8_t fs_symlink(inode_t parent, uint8_t nleng, const uint8_t *name, const uin
 uint8_t fs_mknod(inode_t parent, uint8_t nleng, const uint8_t *name, uint8_t type, uint16_t mode,
                  uint16_t umask, uint32_t uid, uint32_t gid, uint32_t rdev, inode_t &inode,
                  Attributes &attr);
+uint8_t fs_create(inode_t parent, uint8_t nleng, const uint8_t *name, uint16_t mode, uint16_t umask,
+                  uint32_t uid, uint32_t gid, uint8_t flags, inode_t &inode, Attributes &attr);
 uint8_t fs_mkdir(inode_t parent, uint8_t nleng, const uint8_t *name, uint16_t mode, uint16_t umask,
                  uint32_t uid, uint32_t gid, uint8_t copysgid, inode_t &inode, Attributes &attr);
 uint8_t fs_unlink(inode_t parent, uint8_t nleng, const uint8_t *name, uint32_t uid, uint32_t gid);

--- a/src/mount/sauna_client.cc
+++ b/src/mount/sauna_client.cc
@@ -2207,29 +2207,46 @@ EntryParam create(Context &ctx, inode_t parent, const char *name, mode_t mode,
 		throw RequestException(SAUNAFS_ERROR_EINVAL);
 	}
 
-	RETRY_ON_ERROR_WITH_UPDATED_CREDENTIALS(status, ctx,
-		fs_mknod(parent,nleng,(const uint8_t*)name,TYPE_FILE,mode&07777,ctx.umask,ctx.uid,ctx.gid,0,inode,attr));
-	if (status != SAUNAFS_STATUS_OK) {
-		oplog_printf(ctx, "create (%" PRIiNode ",%s,-%s:0%04o) (mknod): %s",
-				parent,
-				name,
-				modestr+1,
-				(unsigned int)mode,
-				saunafs_error_string(status));
-		throw RequestException(status);
-	}
-	Attributes tmp_attr;
-	RETRY_ON_ERROR_WITH_UPDATED_CREDENTIALS(status, ctx,
-		fs_opencheck(inode,ctx.uid,ctx.gid,oflags,tmp_attr));
+	if (masterVersion.load() >= kFirstVersionWithFusedCreate) {
+		// Fused create+open: one FUSE_CREATE RPC instead of the separate FUSE_MKNOD
+		// and FUSE_OPEN round-trip pair.
+		RETRY_ON_ERROR_WITH_UPDATED_CREDENTIALS(status, ctx,
+			fs_create(parent, nleng, (const uint8_t*)name, mode & 07777, ctx.umask, ctx.uid,
+			          ctx.gid, oflags, inode, attr));
+		if (status != SAUNAFS_STATUS_OK) {
+			oplog_printf(ctx, "create (%" PRIiNode ",%s,-%s:0%04o): %s",
+					parent,
+					name,
+					modestr+1,
+					(unsigned int)mode,
+					saunafs_error_string(status));
+			throw RequestException(status);
+		}
+	} else {
+		RETRY_ON_ERROR_WITH_UPDATED_CREDENTIALS(status, ctx,
+			fs_mknod(parent,nleng,(const uint8_t*)name,TYPE_FILE,mode&07777,ctx.umask,ctx.uid,ctx.gid,0,inode,attr));
+		if (status != SAUNAFS_STATUS_OK) {
+			oplog_printf(ctx, "create (%" PRIiNode ",%s,-%s:0%04o) (mknod): %s",
+					parent,
+					name,
+					modestr+1,
+					(unsigned int)mode,
+					saunafs_error_string(status));
+			throw RequestException(status);
+		}
+		Attributes tmp_attr;
+		RETRY_ON_ERROR_WITH_UPDATED_CREDENTIALS(status, ctx,
+			fs_opencheck(inode,ctx.uid,ctx.gid,oflags,tmp_attr));
 
-	if (status != SAUNAFS_STATUS_OK) {
-		oplog_printf(ctx, "create (%" PRIiNode ",%s,-%s:0%04o) (open): %s",
-				parent,
-				name,
-				modestr+1,
-				(unsigned int)mode,
-				saunafs_error_string(status));
-		throw RequestException(status);
+		if (status != SAUNAFS_STATUS_OK) {
+			oplog_printf(ctx, "create (%" PRIiNode ",%s,-%s:0%04o) (open): %s",
+					parent,
+					name,
+					modestr+1,
+					(unsigned int)mode,
+					saunafs_error_string(status));
+			throw RequestException(status);
+		}
 	}
 
 	mattr = attr_get_mattr(attr);

--- a/src/protocol/SFSCommunication.h
+++ b/src/protocol/SFSCommunication.h
@@ -1629,6 +1629,17 @@ enum class SugidClearMode : uint8_t {
 #define SAU_MATOCL_DELETE_SESSION (1000U + 708U)
 /// status:8
 
+// 0x06AD
+#define SAU_CLTOMA_FUSE_CREATE (1000U + 709U)
+// msgid:32 inode:32 name:NAME mode:16 umask:16 uid:32 gid:32 flags:8
+// Fused create+open: combines mknod and open into one request, replacing the
+// FUSE_MKNOD + FUSE_OPEN round-trip pair.
+
+// 0x06AE
+#define SAU_MATOCL_FUSE_CREATE (1000U + 710U)
+// msgid:32 status:8
+// msgid:32 inode:32 attr:ATTR
+
 // 0x643
 #define SAU_CLTOMA_ADMIN_DUMP_CONFIG (1000U + 603U)
 /// -

--- a/src/protocol/cltoma.h
+++ b/src/protocol/cltoma.h
@@ -59,6 +59,13 @@ SAUNAFS_DEFINE_PACKET_SERIALIZATION(cltoma, fuseMknod, SAU_CLTOMA_FUSE_MKNOD, 0,
 		uint32_t, gid,
 		uint32_t, rdev)
 
+// Fused create+open: server does mknod (type file) + acquire for the session.
+// flags carries the open flags (WANT_READ/WANT_WRITE), matching fuseOpen.
+SAUNAFS_DEFINE_PACKET_SERIALIZATION(cltoma, fuseCreate, SAU_CLTOMA_FUSE_CREATE, 0, uint32_t,
+                                    messageId, inode_t, inode, LegacyString<uint8_t>, name,
+                                    uint16_t, mode, uint16_t, umask, uint32_t, uid, uint32_t, gid,
+                                    uint8_t, flags)
+
 SAUNAFS_DEFINE_PACKET_SERIALIZATION(cltoma, fuseMkdir, SAU_CLTOMA_FUSE_MKDIR, 0,
 		uint32_t, messageId,
 		inode_t, inode,

--- a/src/protocol/matocl.h
+++ b/src/protocol/matocl.h
@@ -68,6 +68,21 @@ SAUNAFS_DEFINE_PACKET_SERIALIZATION(
 		inode_t, inode,
 		Attributes, attributes)
 
+// SAU_MATOCL_FUSE_CREATE (fused create+open, mirrors fuseMknod's reply shape)
+SAUNAFS_DEFINE_PACKET_VERSION(matocl, fuseCreate, kStatusPacketVersion, 0)
+SAUNAFS_DEFINE_PACKET_VERSION(matocl, fuseCreate, kResponsePacketVersion, 1)
+
+SAUNAFS_DEFINE_PACKET_SERIALIZATION(
+		matocl, fuseCreate, SAU_MATOCL_FUSE_CREATE, kStatusPacketVersion,
+		uint32_t, messageId,
+		uint8_t, status)
+
+SAUNAFS_DEFINE_PACKET_SERIALIZATION(
+		matocl, fuseCreate, SAU_MATOCL_FUSE_CREATE, kResponsePacketVersion,
+		uint32_t, messageId,
+		inode_t, inode,
+		Attributes, attributes)
+
 // SAU_MATOCL_FUSE_MKDIR
 SAUNAFS_DEFINE_PACKET_VERSION(matocl, fuseMkdir, kStatusPacketVersion, 0)
 SAUNAFS_DEFINE_PACKET_VERSION(matocl, fuseMkdir, kResponsePacketVersion, 1)


### PR DESCRIPTION
Creating a file drives two client RPCs, FUSE_MKNOD then FUSE_OPEN, so a create costs two round trips to the master. On the KV backend each RPC also runs its own metadata transaction with its own durable commit, so an empty file pays two durable commits, and that commit is the dominant per-op cost capping file-create throughput.

Add a fused SAU_CLTOMA_FUSE_CREATE / SAU_MATOCL_FUSE_CREATE RPC that does mknod + acquire (open registration) in one transaction, one commit. The mount client sends it from the create path; matoclserv_fuse_create runs a replayable op body through the group commit pipeline and applies the in-memory open-file record once on commit success, so a retry replays the persistent acquire cleanly.

Master behavior is preserved. The traditional in-memory Master runs the same handler with no transaction to roll back, so acquire and the open-file record are coupled in the body via matoclserv_insert_open_file (mirroring matoclserv_fuse_open), and a later openCheck failure cannot orphan an untracked acquire. The emitted changelog is unchanged: the same CREATE then ACQUIRE entries, in the same order.

This is not a breaking change. The RPC is version gated on kFirstVersionWithFusedCreate (5.11.0): an older client keeps using the FUSE_MKNOD + FUSE_OPEN pair, and an older master never receives the new packet. No existing packet or on-disk format is altered.

Closes LS-891