### PR TITLE
feat(admin): add save-metadata --timeout option

### DIFF
--- a/doc/saunafs-admin.8.adoc
+++ b/doc/saunafs-admin.8.adoc
@@ -134,6 +134,10 @@ chunks with number of copies specified in the label to replicate/delete. +
   Authentication with the admin password is required. +
   --async +
     Don't wait for the task to finish. +
+  --timeout <seconds> +
+    Seconds to wait for the operation to finish (default: 5). A synchronous
+    save-metadata blocks until the dump completes, so raise this when dumping
+    large metadata. +
 
 *stop-task* __<master ip> <master port> <task id>__::
     Stop execution of task with the given id

--- a/src/admin/save_metadata_command.cc
+++ b/src/admin/save_metadata_command.cc
@@ -22,6 +22,7 @@
 #include "admin/save_metadata_command.h"
 
 #include <iostream>
+#include <limits>
 
 #include "admin/registered_admin_connection.h"
 #include "protocol/cltoma.h"
@@ -37,11 +38,14 @@ void SaveMetadataCommand::usage() const {
 			"    With --async fail if the process cannot be started, e.g. because the process\n"
 			"    is already in progress. Without --async, fails if either the process cannot be\n"
 			"    started or if it finishes with an error (i.e., no metadata file is created).\n"
+			"    With --timeout <seconds> set how long to wait for the operation (default: 5).\n"
 			"    Authentication with the admin password is required." << std::endl;
 }
 
 SaunaFsAdminCommand::SupportedOptions SaveMetadataCommand::supportedOptions() const {
-	return {{"--async", "Don't wait for the task to finish."}, {kTlsMode, kTlsModeDescription}};
+	return {{"--async", "Don't wait for the task to finish."},
+	        {"--timeout=", "Operation timeout"},
+	        {kTlsMode, kTlsModeDescription}};
 }
 
 void SaveMetadataCommand::run(const Options& options) const {
@@ -54,8 +58,23 @@ void SaveMetadataCommand::run(const Options& options) const {
 	    options.getValue<std::string>("--tlsconfigfile", std::string(TlsSession::kNoFile));
 
 	bool async = options.isSet("--async");
+	int timeout = ServerConnection::kDefaultTimeout;
+	if (options.isSet("--timeout")) {
+		// getValue<int> throws on non-numeric or out-of-int-range input; treat any such
+		// failure as out of range so it is rejected by the single check below.
+		int seconds = -1;
+		try {
+			seconds = options.getValue<int>("--timeout");
+		} catch (const std::exception &) {
+			// fall through with seconds == -1
+		}
+		if (seconds <= 0 || seconds > std::numeric_limits<int>::max() / 1000) {
+			throw WrongUsageException("--timeout must be between 1 and 2147483 seconds");
+		}
+		timeout = seconds * 1000;
+	}
 	auto connection =
-	    RegisteredAdminConnection::create(options.argument(0), options.argument(1), tlsCfg);
+	    RegisteredAdminConnection::create(options.argument(0), options.argument(1), tlsCfg, timeout);
 	auto request = cltoma::adminSaveMetadata::build(async);
 	auto response = connection->sendAndReceive(request, SAU_MATOCL_ADMIN_SAVE_METADATA);
 	uint8_t status;

--- a/tests/test_suites/ShortSystemTests/test_admin_save_metadata.sh
+++ b/tests/test_suites/ShortSystemTests/test_admin_save_metadata.sh
@@ -10,6 +10,11 @@ CHUNKSERVERS=1 \
 	setup_local_empty_saunafs info
 port=${saunafs_info_[matocl]}
 
+# A synchronous 'save-metadata' blocks the admin client until the dump finishes. The dump here is
+# deliberately slowed (see metarestore.sh below), so give the client a generous, machine-scaled
+# timeout to avoid tripping the 5s default on a loaded host.
+admin_timeout="--timeout=$(timeout_rescale_seconds 60)"
+
 # Instead of real sfsmetarestore, provide a program which hangs forever to slow down metadata dumps
 cat > "$TEMP_DIR/metarestore.sh" << END
 #!/usr/bin/env bash
@@ -36,7 +41,7 @@ assert_file_not_exists "$TEMP_DIR/dump_started"
 # Verify if the command without --async blocks us until metadata is created
 touch "${info[mount0]}/file2"  # To make changelog not empty for metarestore
 rm -f "$TEMP_DIR"/dump_*
-assert_success saunafs_admin_command save-metadata localhost "$port" <<< "pass"
+assert_success saunafs_admin_command save-metadata localhost "$port" ${admin_timeout} <<< "pass"
 assert_file_exists "$TEMP_DIR/dump_finished"
 assert_equals 3 $(count_metadata_files)
 
@@ -64,7 +69,7 @@ chmod +w "${info[master_data_path]}"  # Fix data dir
 # Verify if save-metadata properly reports status of the operation (using fork)
 sed -i -re "s/(MAGIC_PREFER_BACKGROUND_DUMP).*/\1 = 0/" "${info[master_cfg]}"
 saunafs_admin_master reload-config
-assert_success saunafs_admin_command save-metadata localhost "$port" <<< "pass"
+assert_success saunafs_admin_command save-metadata localhost "$port" ${admin_timeout} <<< "pass"
 chmod -w "${info[master_data_path]}"  # Make it impossible to save metadata
 assert_failure saunafs_admin_command save-metadata localhost "$port" <<< "pass"
 chmod +w "${info[master_data_path]}"  # Fix data dir

--- a/tests/test_suites/ShortSystemTests/test_metadata_dump.sh
+++ b/tests/test_suites/ShortSystemTests/test_metadata_dump.sh
@@ -11,6 +11,11 @@ CHUNKSERVERS=3 \
 	MASTER_EXTRA_CONFIG=$master_extra_config \
 	setup_local_empty_saunafs info
 
+# A synchronous 'save-metadata' blocks the admin client until the dump finishes. Under the heavy
+# workload below a dump can take a while on a loaded host, so give the client a generous,
+# machine-scaled timeout to avoid tripping the 5s default.
+admin_timeout="--timeout=$(timeout_rescale_seconds 60)"
+
 # 'metaout_tmp' is used to ensure 'metaout' is complete when "created"
 cat > $TEMP_DIR/metarestore_ok.sh << END
 #!/usr/bin/env bash
@@ -62,7 +67,7 @@ function check() {
 	assert_file_exists "changelog.sfs"
 	assert_file_exists "metadata.sfs"
 	if [[ $2 == OK ]]; then
-		assert_success saunafs_admin_master save-metadata
+		assert_success saunafs_admin_master save-metadata ${admin_timeout}
 	else
 		assert_failure saunafs_admin_master save-metadata
 	fi


### PR DESCRIPTION
A synchronous 'saunafs-admin save-metadata' blocks the admin client until the metadata dump finishes, but the client capped that wait at the 5s default (kDefaultTimeout). A dump that legitimately takes longer (large metadata, a loaded host, the niced dump child) makes the command abort with a non-zero exit and an empty stderr, even though the dump itself succeeds.

Add a --timeout option to save-metadata, mirroring magic-recalculate-metadata-checksum, so the wait can be raised. The default is unchanged (5s), so behavior is identical unless the option is passed. Document it in the saunafs-admin man page.

This surfaced as recurring flakiness in test_admin_save_metadata and test_metadata_dump on busy CI: both drive a deliberately slowed dump and then assert on a synchronous save-metadata, so the 5s wait would intermittently trip and fail the assertion. Pass --timeout on those synchronous calls, scaled by the test timeout multiplier.