### PR TITLE
test: scale rescaled waits by the machine multiplier

### DIFF
--- a/tests/tools/timeout.sh
+++ b/tests/tools/timeout.sh
@@ -87,10 +87,23 @@ timeout_get_multiplier() {
 	cat "$test_timeout_multiplier_file"
 }
 
+# Total scaling applied to test timeouts: the framework multiplier (e.g. 15 under valgrind,
+# set via timeout_set_multiplier, and an extra 5x on Windows) combined with the machine
+# multiplier (SAUNAFS_TEST_TIMEOUT_MULTIPLIER, exported on slow or loaded CI machines). Both
+# model the same thing, an environment that runs uniformly slower, so rescaled waits track the
+# same total the hard test timeout uses (see timeout_killer_thread).
+timeout_get_total_multiplier() {
+	local framework_multiplier=$(timeout_get_multiplier)
+	if is_windows_system; then
+		framework_multiplier=$((5 * framework_multiplier))
+	fi
+	echo $((framework_multiplier * ${SAUNAFS_TEST_TIMEOUT_MULTIPLIER:-1}))
+}
+
 # takes as parameter timeout (e.g. '1 minute') and rescales it by multiplier
 # prints result in seconds to standard output (e.g. '900 seconds')
 timeout_rescale() {
-	local multiplier=$(timeout_get_multiplier)
+	local multiplier=$(timeout_get_total_multiplier)
 	local value=$(($(date +%s -d "$1") - $(date +%s)))
 	echo $((value * multiplier)) seconds
 }
@@ -98,6 +111,6 @@ timeout_rescale() {
 # takes as parameter timeout in seconds (e.g. '60') and rescales it by multiplier
 # prints result to standard output (e.g. '900')
 timeout_rescale_seconds() {
-	local multiplier=$(timeout_get_multiplier)
+	local multiplier=$(timeout_get_total_multiplier)
 	echo $(($1 * multiplier))
 }


### PR DESCRIPTION
The test framework has two independent timeout multipliers:

  - the framework multiplier (timeout_set_multiplier), which models a uniformly slower execution mode and is 15 under valgrind, 1 otherwise;
  - the machine multiplier (SAUNAFS_TEST_TIMEOUT_MULTIPLIER), which CI exports to model a slower or loaded machine.

timeout_killer_thread scales the hard per-test timeout by both (value x framework x machine), but timeout_rescale and timeout_rescale_seconds apply only the framework one. Those two functions back every assert_eventually window and every rescaled sleep, so per-operation waits get no extra time on a slow machine even though the overall test budget does.

This mainly affects CI: tests run concurrently on VMs that are slower per core and slower still under contention, so the operations they wait on (replication, metadata sync, daemons registering) genuinely take longer. A wait can expire while the operation is still in progress and the test flakes, while the hard timeout it would otherwise hit stays far from reached. test_concurrent_replications is a likely case: it waits a flat 180s for all EC parts of a file, while its 15 minute hard timeout, scaled to 75 minutes on CI, sits almost entirely unused.

Introduce timeout_get_total_multiplier (framework x machine) and use it in timeout_rescale and timeout_rescale_seconds, so rescaled waits scale the same way the hard timeout already does. The default machine multiplier is 1, so local runs are unchanged; only environments that export SAUNAFS_TEST_TIMEOUT_MULTIPLIER get the longer, proportional windows.