### PR TITLE
ci: update reference to leil-tests v0.8.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ REGISTRY_URL = "registry.ci.leil.io"
 def getLeilTestsRef() {
     def ref = params?.LEIL_TESTS_REF?.trim()
     if (!ref) {
-        return 'refs/tags/v0.7.0'
+        return 'refs/tags/v0.8.0'
     }
 
     if (ref.startsWith('refs/')) {
@@ -171,8 +171,8 @@ pipeline {
         )
         string(
             name: 'LEIL_TESTS_REF',
-            defaultValue: 'v0.7.0',
-            description: 'leil-tests ref: branch (dev, fix/foo), tag (v0.7.0), refs/*, or SHA'
+            defaultValue: 'v0.8.0',
+            description: 'leil-tests ref: branch (dev, fix/foo), tag (v0.8.0), refs/*, or SHA'
         )
     }
 


### PR DESCRIPTION
Bump the default leil-tests ref from v0.7.0 to v0.8.0 in the Jenkins pipeline: the getLeilTestsRef() fallback, the LEIL_TESTS_REF parameter default, and its description example. The v0.8.0 tag exists in leil-io/leil-tests. The LEIL_TESTS_REF override still allows pinning any branch, tag, or SHA per build.

Related to: LS-879