### PR TITLE
test: reduce flakiness of admin list-mount-info test

### DIFF
--- a/tests/test_suites/ShortSystemTests/test_admin_list_mount_info.sh
+++ b/tests/test_suites/ShortSystemTests/test_admin_list_mount_info.sh
@@ -2,8 +2,20 @@ MOUNTS=4 \
 	USE_RAMDISK=YES \
 	setup_local_empty_saunafs info
 
+# Mounts report their info to the master asynchronously after connecting, so right after
+# mounting or after a master restart the admin command can return blocks containing only
+# the "Session ID:" header. Poll until every session has a complete mount info block
+# instead of sleeping a fixed time, which is not enough on loaded machines.
+mount_infos_are_complete() {
+	local expected_count=$1
+	local mounts
+	mounts=$(saunafs_admin_command list-mount-info localhost "${info[matocl]}") || return 1
+	[[ $(grep -c "^Session ID:" <<<"${mounts}") -eq ${expected_count} ]] || return 1
+	[[ $(grep -c "^SAUNAFS CLIENT MOUNT INFO:" <<<"${mounts}") -eq ${expected_count} ]] || return 1
+}
+
 # wait for master server to populate mount info for each mountpoint
-sleep 3
+assert_eventually 'mount_infos_are_complete 4' "30 seconds"
 
 check_mount_infos() {
 	declare -A expected_map
@@ -59,6 +71,8 @@ check_mount_infos
 assert_success saunafs_master_daemon stop
 sleep 5
 assert_success saunafs_master_daemon start
-sleep 3
+
+# wait for the mounts to reconnect and report their info to the restarted master
+assert_eventually 'mount_infos_are_complete 4' "30 seconds"
 
 check_mount_infos


### PR DESCRIPTION
The test compares the mount info reported by each mount against the master's list-mount-info output. Mounts send their info to the master asynchronously after connecting, so on a loaded machine the fixed 3 second sleep is not always enough and the admin command returns a block containing only the "Session ID:" header (seen in Jenkins PR-895 build 10).

Replace both fixed sleeps with polling until the master returns a complete info block for all 4 sessions.

Reproduced locally under 3x CPU oversubscription with 1-CPU test containers: 1/30 runs failed with the old script, 30/30 passed with the polling version.