### PR TITLE
Rpm build from checkout ref

### DIFF
--- a/rpm/README.md
+++ b/rpm/README.md
@@ -30,6 +30,18 @@ sudo dnf install fedora-packager python3-specfile
 sudo ./build.sh
 ```
 
+The script creates the RPM source tarball from the current Git checkout by
+default. In CI, this means the `LEILFS_REF` used for checkout is also the source
+reference that gets packaged. To build a different local branch, tag, or commit
+from the same checkout, pass it explicitly:
+```bash
+sudo ./build.sh dev
+sudo ./build.sh v5.10.0
+sudo ./build.sh 1e9e026dc6fa536ebbc0708a58a9947741b8c2c0
+```
+Branch arguments may resolve through local refs or `origin/<branch>`, which
+matches Jenkins checkouts that leave the repository in detached `HEAD` state.
+
 ### Run the review script (takes around 25-30 minutes in CI)
 ```bash
 sudo ./review.sh

--- a/rpm/README.md
+++ b/rpm/README.md
@@ -30,17 +30,19 @@ sudo dnf install fedora-packager python3-specfile
 sudo ./build.sh
 ```
 
-The script creates the RPM source tarball from the current Git checkout by
-default. In CI, this means the `LEILFS_REF` used for checkout is also the source
-reference that gets packaged. To build a different local branch, tag, or commit
-from the same checkout, pass it explicitly:
+The script creates the RPM source tarball from the current Git checkout. In CI,
+this means the `LEILFS_REF` used for checkout is also the source reference that
+gets packaged. If Jenkins leaves the repository in detached `HEAD` state, pass
+the same checked-out branch, tag, or commit explicitly so the script can resolve
+and verify it:
 ```bash
 sudo ./build.sh dev
 sudo ./build.sh v5.10.0
 sudo ./build.sh 1e9e026dc6fa536ebbc0708a58a9947741b8c2c0
 ```
-Branch arguments may resolve through local refs or `origin/<branch>`, which
-matches Jenkins checkouts that leave the repository in detached `HEAD` state.
+Branch arguments may resolve through local refs or `origin/<branch>`, but the
+resolved ref must match the current checkout. To build another branch, tag, or
+commit, check it out first.
 
 ### Run the review script (takes around 25-30 minutes in CI)
 ```bash

--- a/rpm/build.sh
+++ b/rpm/build.sh
@@ -1,23 +1,67 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 # Builds the RPM package locally
 
 FILTERS=filters.toml
+SOURCE_REF=${1:-HEAD}
 
 read NAME VERSION RELEASE < <(rpmspec -q --qf "%{NAME} %{VERSION} %{RELEASE}\n" *.spec | head -1)
+SOURCE_TARBALL=v${VERSION}.tar.gz
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || true)
+
+resolve_source_ref() {
+    local ref=$1
+    local candidate
+
+    for candidate in \
+        "${ref}" \
+        "origin/${ref}" \
+        "refs/heads/${ref}" \
+        "refs/remotes/origin/${ref}" \
+        "refs/tags/${ref}"; do
+        if git -C "${REPO_ROOT}" rev-parse --verify --quiet "${candidate}^{commit}" >/dev/null; then
+            git -C "${REPO_ROOT}" rev-parse --verify "${candidate}^{commit}"
+            return
+        fi
+    done
+
+    echo "ERROR: Git reference not found: ${ref}" >&2
+    exit 1
+}
+
+create_source_tarball() {
+    local resolved_ref short_ref
+
+    if [ -z "${REPO_ROOT}" ]; then
+        echo "Getting source code tarball from spec..."
+        spectool -g ${NAME}.spec
+        return
+    fi
+
+    resolved_ref=$(resolve_source_ref "${SOURCE_REF}")
+    short_ref=$(git -C "${REPO_ROOT}" rev-parse --short "${resolved_ref}")
+
+    echo "Creating source code tarball from Git reference: ${SOURCE_REF} (${short_ref})"
+    git -C "${REPO_ROOT}" archive \
+        --format=tar.gz \
+        --prefix="${NAME}-${VERSION}/" \
+        --output="${PWD}/${SOURCE_TARBALL}" \
+        "${resolved_ref}"
+}
 
 echo "Packaging ${NAME} ${VERSION} ${RELEASE}..."
 
 echo "Cleaning old build artifacts and sources..."
 rm -f ${NAME}-${VERSION}-${RELEASE}.src.rpm
 rm -rf results_${NAME}
-rm -f v${VERSION}.tar.gz
+rm -f ${SOURCE_TARBALL}
 
 echo "Running rpmlint on ${NAME}.spec..."
 if rpmlint -c ${FILTERS} ${NAME}.spec; then
     echo "${NAME}.spec check successful."
-    echo "Getting source code tarball..."
-    spectool -g ${NAME}.spec
+    create_source_tarball
     echo "Building packages..."
     # If BuildRequires was changed - reinstall every BuildRequires
     echo "Running local mockbuild..."

--- a/rpm/build.sh
+++ b/rpm/build.sh
@@ -7,13 +7,24 @@ set -euo pipefail
 FILTERS=filters.toml
 SOURCE_REF=${1:-HEAD}
 
-read NAME VERSION RELEASE < <(rpmspec -q --qf "%{NAME} %{VERSION} %{RELEASE}\n" *.spec | head -1)
-SOURCE_TARBALL=v${VERSION}.tar.gz
-REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || true)
+if ! read NAME VERSION RELEASE < <(rpmspec -q --qf "%{NAME} %{VERSION} %{RELEASE}\n" *.spec | head -1); then
+    echo "ERROR: Failed to parse NAME, VERSION, or RELEASE from spec file." >&2
+    exit 1
+fi
+if [ -z "${NAME:-}" ] || [ -z "${VERSION:-}" ] || [ -z "${RELEASE:-}" ]; then
+    echo "ERROR: Failed to parse NAME, VERSION, or RELEASE from spec file." >&2
+    exit 1
+fi
+
+SOURCE_TARBALL="v${VERSION}.tar.gz"
+REPO_ROOT_ERROR=$(mktemp)
+trap 'rm -f "${REPO_ROOT_ERROR}"' EXIT
+REPO_ROOT=$(git rev-parse --show-toplevel 2>"${REPO_ROOT_ERROR}" || true)
 
 resolve_source_ref() {
     local ref=$1
     local candidate
+    local resolved
 
     for candidate in \
         "${ref}" \
@@ -21,26 +32,42 @@ resolve_source_ref() {
         "refs/heads/${ref}" \
         "refs/remotes/origin/${ref}" \
         "refs/tags/${ref}"; do
-        if git -C "${REPO_ROOT}" rev-parse --verify --quiet "${candidate}^{commit}" >/dev/null; then
-            git -C "${REPO_ROOT}" rev-parse --verify "${candidate}^{commit}"
-            return
+        if resolved=$(git -C "${REPO_ROOT}" rev-parse --verify --quiet "${candidate}^{commit}" 2>/dev/null); then
+            echo "${resolved}"
+            return 0
         fi
     done
 
     echo "ERROR: Git reference not found: ${ref}" >&2
-    exit 1
+    return 1
 }
 
 create_source_tarball() {
     local resolved_ref short_ref
 
     if [ -z "${REPO_ROOT}" ]; then
-        echo "Getting source code tarball from spec..."
-        spectool -g ${NAME}.spec
+        if grep -qi "dubious ownership" "${REPO_ROOT_ERROR}"; then
+            echo "ERROR: Git refused this checkout due to dubious ownership." >&2
+            echo "Run the build without sudo or configure Git safe.directory for this checkout." >&2
+            exit 1
+        fi
+
+        if [ "${SOURCE_REF}" != "HEAD" ]; then
+            echo "ERROR: ${SOURCE_REF} requested but not inside a Git checkout." >&2
+            exit 1
+        fi
+
+        echo "WARNING: not inside a Git checkout; downloading source tarball from spec." >&2
+        spectool -g "${NAME}.spec"
         return
     fi
 
     resolved_ref=$(resolve_source_ref "${SOURCE_REF}")
+    if [ "${resolved_ref}" != "$(git -C "${REPO_ROOT}" rev-parse HEAD)" ]; then
+        echo "ERROR: ${SOURCE_REF} does not match the current checkout; please check out that ref or run ./build.sh without an argument." >&2
+        exit 1
+    fi
+
     short_ref=$(git -C "${REPO_ROOT}" rev-parse --short "${resolved_ref}")
 
     echo "Creating source code tarball from Git reference: ${SOURCE_REF} (${short_ref})"
@@ -54,12 +81,12 @@ create_source_tarball() {
 echo "Packaging ${NAME} ${VERSION} ${RELEASE}..."
 
 echo "Cleaning old build artifacts and sources..."
-rm -f ${NAME}-${VERSION}-${RELEASE}.src.rpm
-rm -rf results_${NAME}
-rm -f ${SOURCE_TARBALL}
+rm -f "${NAME}-${VERSION}-${RELEASE}.src.rpm"
+rm -rf "results_${NAME}"
+rm -f "${SOURCE_TARBALL}"
 
 echo "Running rpmlint on ${NAME}.spec..."
-if rpmlint -c ${FILTERS} ${NAME}.spec; then
+if rpmlint -c "${FILTERS}" "${NAME}.spec"; then
     echo "${NAME}.spec check successful."
     create_source_tarball
     echo "Building packages..."
@@ -67,7 +94,7 @@ if rpmlint -c ${FILTERS} ${NAME}.spec; then
     echo "Running local mockbuild..."
     fedpkg mockbuild -- --clean -v
     echo "Running rpmlint in results_${NAME}/${VERSION}/${RELEASE}/..."
-    if rpmlint -c ${FILTERS} results_${NAME}/${VERSION}/${RELEASE}/*.x86_64.rpm; then
+    if rpmlint -c "${FILTERS}" "results_${NAME}/${VERSION}/${RELEASE}"/*.x86_64.rpm; then
         echo "Build finished successfully."
     else
         echo "ERROR: Build finished unsuccessfully"

--- a/rpm/leilfs.spec
+++ b/rpm/leilfs.spec
@@ -471,6 +471,9 @@ rm -f %{buildroot}%{_libdir}/libsaunafsmount_shared.so
 %{_datadir}/leil-cgi/leil.css
 %{_datadir}/leil-cgi/leil.cgi
 %{_datadir}/leil-cgi/chart.cgi
+%{_datadir}/leil-cgi/sfs.css
+%{_datadir}/leil-cgi/sfs.cgi
+%{_datadir}/sfscgi
 
 # Files - CGI server
 ############################################################

--- a/rpm/review.sh
+++ b/rpm/review.sh
@@ -1,28 +1,43 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 # Uses built RPM packages in results_*/ to generate a review in
 # review-*/review.txt
 
-read NAME VERSION RELEASE < <(rpmspec -q --qf "%{NAME} %{VERSION}\n" *.spec | head -1)
+read NAME VERSION < <(rpmspec -q --qf "%{NAME} %{VERSION}\n" *.spec | head -1)
+REVIEW_DIR="review-${NAME}"
+REVIEW_WORKDIR=$(mktemp -d -t "${NAME}-review.XXXXXX")
+
+cleanup() {
+    rm -rf "${REVIEW_WORKDIR}"
+}
+trap cleanup EXIT
 
 echo "Cleaning old review results..."
-rm -rf review-${NAME}
+rm -rf "${REVIEW_DIR}"
 
-RELEASE_DIR=$(find results_${NAME}/${VERSION}/ -maxdepth 1 -mindepth 1 -type d | head -1)
+RELEASE_DIR=$(find "results_${NAME}/${VERSION}/" -maxdepth 1 -mindepth 1 -type d | head -1)
 
-if [ -z "$RELEASE_DIR" ]; then
+if [ -z "${RELEASE_DIR}" ]; then
     echo "ERROR: No build results found in results_${NAME}/${VERSION}/"
     exit 1
 fi
 
 echo "Found build results in: ${RELEASE_DIR}"
-echo "Copying resulting source and rpm packages..."
-cp -f ${RELEASE_DIR}/*.src.rpm .
-find ${RELEASE_DIR}/ -name "*.rpm" ! -name "*debug*" -exec cp -f {} . \;
+echo "Copying resulting source and rpm packages to ${REVIEW_WORKDIR}..."
+cp -f "${RELEASE_DIR}"/*.src.rpm "${REVIEW_WORKDIR}/"
+find "${RELEASE_DIR}/" -name "*.rpm" ! -name "*debug*" -exec cp -f {} "${REVIEW_WORKDIR}/" \;
+cp -f "${NAME}.spec" "${REVIEW_WORKDIR}/"
 
 echo "Running Fedora Review..."
-fedora-review -n ${NAME} -p -v
+(
+    cd "${REVIEW_WORKDIR}"
+    fedora-review -n "${NAME}" -p -v
+)
 
-echo "Review concluded, removing source and rpm packages..."
-rm -f *.src.rpm
-rm -f *.rpm
+if [ -d "${REVIEW_WORKDIR}/${REVIEW_DIR}" ]; then
+    cp -a "${REVIEW_WORKDIR}/${REVIEW_DIR}" .
+fi
+
+echo "Review concluded."

--- a/rpm/review.sh
+++ b/rpm/review.sh
@@ -5,39 +5,57 @@ set -euo pipefail
 # Uses built RPM packages in results_*/ to generate a review in
 # review-*/review.txt
 
-read NAME VERSION < <(rpmspec -q --qf "%{NAME} %{VERSION}\n" *.spec | head -1)
+if ! read NAME VERSION < <(rpmspec -q --qf "%{NAME} %{VERSION}\n" *.spec | head -1); then
+    echo "ERROR: Failed to parse NAME or VERSION from spec file." >&2
+    exit 1
+fi
+if [ -z "${NAME:-}" ] || [ -z "${VERSION:-}" ]; then
+    echo "ERROR: Failed to parse NAME or VERSION from spec file." >&2
+    exit 1
+fi
+
 REVIEW_DIR="review-${NAME}"
-REVIEW_WORKDIR=$(mktemp -d -t "${NAME}-review.XXXXXX")
+REVIEW_WORKDIR=""
 
 cleanup() {
-    rm -rf "${REVIEW_WORKDIR}"
+    if [ -n "${REVIEW_WORKDIR}" ]; then
+        rm -rf "${REVIEW_WORKDIR}"
+    fi
 }
 trap cleanup EXIT
+
+REVIEW_WORKDIR=$(mktemp -d --tmpdir "${NAME}-review.XXXXXX")
 
 echo "Cleaning old review results..."
 rm -rf "${REVIEW_DIR}"
 
-RELEASE_DIR=$(find "results_${NAME}/${VERSION}/" -maxdepth 1 -mindepth 1 -type d | head -1)
+RESULTS_DIR="results_${NAME}/${VERSION}"
+RELEASE_DIR=$(find "${RESULTS_DIR}/" -maxdepth 1 -mindepth 1 -type d -print -quit 2>/dev/null || true)
 
 if [ -z "${RELEASE_DIR}" ]; then
-    echo "ERROR: No build results found in results_${NAME}/${VERSION}/"
+    echo "ERROR: No build results found in ${RESULTS_DIR}/"
     exit 1
 fi
 
 echo "Found build results in: ${RELEASE_DIR}"
 echo "Copying resulting source and rpm packages to ${REVIEW_WORKDIR}..."
-cp -f "${RELEASE_DIR}"/*.src.rpm "${REVIEW_WORKDIR}/"
 find "${RELEASE_DIR}/" -name "*.rpm" ! -name "*debug*" -exec cp -f {} "${REVIEW_WORKDIR}/" \;
 cp -f "${NAME}.spec" "${REVIEW_WORKDIR}/"
 
 echo "Running Fedora Review..."
+fedora_review_status=0
 (
     cd "${REVIEW_WORKDIR}"
     fedora-review -n "${NAME}" -p -v
-)
+) || fedora_review_status=$?
 
 if [ -d "${REVIEW_WORKDIR}/${REVIEW_DIR}" ]; then
     cp -a "${REVIEW_WORKDIR}/${REVIEW_DIR}" .
+fi
+
+if [ "${fedora_review_status}" -ne 0 ]; then
+    echo "ERROR: Fedora Review failed with exit code ${fedora_review_status}"
+    exit "${fedora_review_status}"
 fi
 
 echo "Review concluded."


### PR DESCRIPTION
This PR updates the rpm folder for related Fedora packaging build, introducing fixes needed due to rebranding plus adapting build.sh and review.sh scripts to work on a Jenkins pipeline.

Related to: LS-844