### PR TITLE
refactor(master): add per-operation FSNode arena

### DIFF
--- a/src/master/filesystem_node_arena.cc
+++ b/src/master/filesystem_node_arena.cc
@@ -1,0 +1,77 @@
+/*
+   Copyright 2026      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "common/platform.h"
+
+#include "master/filesystem_node_arena.h"
+
+#include <cassert>
+#include <utility>
+
+#include "master/filesystem_node_types.h"
+
+// Moves clear the source explicitly. A moved-from std::unordered_map is only "valid but
+// unspecified", so without the clear() the moved-from arena's destructor could still see
+// entries and destroy nodes that are now owned by the destination arena.
+FSNodeArena::FSNodeArena(FSNodeArena &&other) noexcept : nodes_(std::move(other.nodes_)) {
+	other.nodes_.clear();
+}
+
+FSNodeArena &FSNodeArena::operator=(FSNodeArena &&other) noexcept {
+	if (this != &other) {
+		destroyAll();
+		nodes_ = std::move(other.nodes_);
+		other.nodes_.clear();
+	}
+	return *this;
+}
+
+FSNodeArena::~FSNodeArena() { destroyAll(); }
+
+void FSNodeArena::destroyAll() {
+	for (auto &[_, node] : nodes_) {
+		if (node != nullptr) { FSNode::destroy(node); }
+	}
+	nodes_.clear();
+}
+
+std::optional<FSNode *> FSNodeArena::lookup(inode_t inode) const {
+	auto entryIt = nodes_.find(inode);
+	if (entryIt == nodes_.end()) { return std::nullopt; }
+	return entryIt->second;
+}
+
+FSNode *FSNodeArena::adopt(inode_t inode, FSNode *node) {
+	assert(node != nullptr);
+	// A mismatched key would pin/dedup/tombstone under the wrong inode, e.g. from a
+	// corrupt backend record whose serialized id disagrees with the key it was read from.
+	assert(node->id == inode);
+	auto [entryIt, inserted] = nodes_.emplace(inode, node);
+	if (!inserted) {
+		if (entryIt->second == nullptr) {
+			// Re-pin over a tombstone: the inode was deleted and recreated in this operation.
+			entryIt->second = node;
+		} else if (entryIt->second != node) {
+			// The inode is already pinned; keep that instance so existing borrows stay valid.
+			FSNode::destroy(node);
+		}
+	}
+	return entryIt->second;
+}
+
+void FSNodeArena::releaseAndTombstone(inode_t inode) { nodes_[inode] = nullptr; }

--- a/src/master/filesystem_node_arena.h
+++ b/src/master/filesystem_node_arena.h
@@ -1,0 +1,70 @@
+/*
+   Copyright 2026      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "common/platform.h"
+
+#include <optional>
+#include <unordered_map>
+
+#include "common/type_defs.h"
+
+class FSNode;
+
+/// Per-operation owner of FSNode objects materialized from a KV backend.
+///
+/// The node-resolution seam hands out borrowed FSNode pointers, valid for the current
+/// operation. In-memory builds back that borrow with gMetadata->nodeHash, which owns every
+/// node. KV builds materialize nodes from the database on demand instead; the arena is the
+/// owner behind their borrows: each materialized node is adopted here and destroyed when the
+/// owning FilesystemOperationContext is torn down. One instance per inode within the
+/// operation, so repeated resolves observe each other's mutations. In-memory builds never
+/// register anything and pay nothing.
+/// @see FilesystemOperationContext::nodeArena
+class FSNodeArena {
+public:
+	FSNodeArena() = default;
+	FSNodeArena(const FSNodeArena &) = delete;
+	FSNodeArena &operator=(const FSNodeArena &) = delete;
+	FSNodeArena(FSNodeArena &&other) noexcept;
+	FSNodeArena &operator=(FSNodeArena &&other) noexcept;
+
+	/// Destroys every owned node.
+	~FSNodeArena();
+
+	/// Entry for the inode: nullopt when unknown (caller materializes and adopts), the owned
+	/// instance when pinned, nullptr when tombstoned by releaseAndTombstone().
+	std::optional<FSNode *> lookup(inode_t inode) const;
+
+	/// Takes ownership of node and returns the arena's instance for the inode.
+	/// Callers must use the returned pointer: when the inode is already pinned, the incoming
+	/// node is destroyed and the pinned instance returned; adopting over a tombstone re-pins.
+	[[nodiscard]] FSNode *adopt(inode_t inode, FSNode *node);
+
+	/// Drops ownership without destroying the node and tombstones the inode, so a later
+	/// resolve in the same operation returns null instead of a dangling pointer.
+	/// For delete paths where the removal call destroys the node itself.
+	void releaseAndTombstone(inode_t inode);
+
+private:
+	void destroyAll();
+
+	/// Owned nodes by inode; a null value is a tombstone for a node deleted this operation.
+	std::unordered_map<inode_t, FSNode *> nodes_;
+};

--- a/src/master/filesystem_node_arena_unittest.cc
+++ b/src/master/filesystem_node_arena_unittest.cc
@@ -1,0 +1,131 @@
+/*
+   Copyright 2026      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "common/platform.h"
+
+#include "master/filesystem_node_arena.h"
+
+#include <gtest/gtest.h>
+#include <utility>
+
+#include "master/filesystem_node_types.h"
+#include "master/hstring_memstorage.h"
+
+class FSNodeArenaTest : public ::testing::Test {
+protected:
+	void SetUp() override { hstorage::Storage::reset(new hstorage::MemStorage()); }
+
+	// Nodes handed to adopt() are owned by the arena afterwards; leak and double-free
+	// violations in these tests are caught by the sanitizer jobs.
+	static FSNode *makeNode(inode_t inode) {
+		FSNode *node = FSNode::create(FSNodeType::kFile);
+		node->id = inode;
+		return node;
+	}
+};
+
+TEST_F(FSNodeArenaTest, LookupUnknownReturnsNullopt) {
+	FSNodeArena arena;
+	EXPECT_FALSE(arena.lookup(1).has_value());
+}
+
+TEST_F(FSNodeArenaTest, AdoptPinsAndLookupReturnsSameInstance) {
+	FSNodeArena arena;
+	FSNode *node = makeNode(7);
+	EXPECT_EQ(arena.adopt(7, node), node);
+	auto pinned = arena.lookup(7);
+	ASSERT_TRUE(pinned.has_value());
+	EXPECT_EQ(*pinned, node);
+}
+
+TEST_F(FSNodeArenaTest, AdoptDuplicateKeepsPinnedInstance) {
+	FSNodeArena arena;
+	FSNode *first = makeNode(7);
+	ASSERT_EQ(arena.adopt(7, first), first);
+	// The duplicate is destroyed by the arena; the pinned instance stays valid.
+	FSNode *returned = arena.adopt(7, makeNode(7));
+	EXPECT_EQ(returned, first);
+	auto pinned = arena.lookup(7);
+	ASSERT_TRUE(pinned.has_value());
+	EXPECT_EQ(*pinned, first);
+}
+
+TEST_F(FSNodeArenaTest, ReleaseAndTombstoneMakesLookupReturnNull) {
+	FSNodeArena arena;
+	FSNode *node = makeNode(7);
+	ASSERT_EQ(arena.adopt(7, node), node);
+	arena.releaseAndTombstone(7);
+	auto entry = arena.lookup(7);
+	ASSERT_TRUE(entry.has_value());
+	EXPECT_EQ(*entry, nullptr);
+	// The arena released ownership; the caller-side owner destroys the node
+	// (removeNode in production).
+	FSNode::destroy(node);
+}
+
+TEST_F(FSNodeArenaTest, TombstoneWithoutAdoptIsVisible) {
+	FSNodeArena arena;
+	arena.releaseAndTombstone(7);
+	auto entry = arena.lookup(7);
+	ASSERT_TRUE(entry.has_value());
+	EXPECT_EQ(*entry, nullptr);
+}
+
+TEST_F(FSNodeArenaTest, AdoptOverTombstoneRePins) {
+	FSNodeArena arena;
+	FSNode *first = makeNode(7);
+	ASSERT_EQ(arena.adopt(7, first), first);
+	arena.releaseAndTombstone(7);
+	FSNode::destroy(first);
+
+	FSNode *recreated = makeNode(7);
+	EXPECT_EQ(arena.adopt(7, recreated), recreated);
+	auto pinned = arena.lookup(7);
+	ASSERT_TRUE(pinned.has_value());
+	EXPECT_EQ(*pinned, recreated);
+}
+
+TEST_F(FSNodeArenaTest, MoveConstructorTransfersOwnershipAndEmptiesSource) {
+	FSNodeArena source;
+	FSNode *node = makeNode(7);
+	ASSERT_EQ(source.adopt(7, node), node);
+
+	FSNodeArena destination(std::move(source));
+	auto pinned = destination.lookup(7);
+	ASSERT_TRUE(pinned.has_value());
+	EXPECT_EQ(*pinned, node);
+	// The moved-from arena must be empty, or its destructor would double-free.
+	EXPECT_FALSE(source.lookup(7).has_value());
+}
+
+TEST_F(FSNodeArenaTest, MoveAssignmentReplacesOwnedNodesAndEmptiesSource) {
+	FSNodeArena source;
+	FSNode *kept = makeNode(7);
+	ASSERT_EQ(source.adopt(7, kept), kept);
+
+	FSNodeArena destination;
+	// The destination's prior node is destroyed by the assignment.
+	ASSERT_NE(destination.adopt(9, makeNode(9)), nullptr);
+
+	destination = std::move(source);
+	auto pinned = destination.lookup(7);
+	ASSERT_TRUE(pinned.has_value());
+	EXPECT_EQ(*pinned, kept);
+	EXPECT_FALSE(destination.lookup(9).has_value());
+	EXPECT_FALSE(source.lookup(7).has_value());
+}

--- a/src/master/filesystem_operation_context.h
+++ b/src/master/filesystem_operation_context.h
@@ -25,6 +25,7 @@
 #include "common/type_defs.h"
 #include "kv/itransaction.h"
 #include "kv/kv_types.h"
+#include "master/filesystem_node_arena.h"
 
 namespace kv {
 class IReadOnlyTransaction;
@@ -70,9 +71,10 @@ public:
 	FilesystemOperationContext &operator=(FilesystemOperationContext &&) = default;
 
 	/// Destructor.
-	/// Destroying the context only releases any owned transaction objects. It does not implicitly
-	/// commit or rollback transactions; callers must ensure that any required commit or rollback is
-	/// performed via the transaction interfaces before the context is destroyed.
+	/// Destroying the context releases any owned transaction objects and destroys the nodes
+	/// owned by the arena. It does not implicitly commit or rollback transactions; callers must
+	/// ensure that any required commit or rollback is performed via the transaction interfaces
+	/// before the context is destroyed.
 	~FilesystemOperationContext() = default;
 
 	/// Returns true if this context has an active transaction
@@ -90,6 +92,12 @@ public:
 	/// Get the transaction type hint
 	TransactionType getTransactionType() const { return transactionType_; }
 
+	/// Per-operation owner of KV-materialized nodes; stays empty on in-memory builds.
+	/// Accessible from const contexts: pinning is physical cache state shared through the
+	/// const resolution seam, not a logical filesystem mutation.
+	/// @see FSNodeArena
+	FSNodeArena &nodeArena() const { return nodeArena_; }
+
 private:
 	/// The active read-write transaction (if any)
 	std::unique_ptr<kv::IReadWriteTransaction> rwTransaction_ = nullptr;
@@ -99,4 +107,8 @@ private:
 
 	/// Hint about what transaction type to create if lazy initialization is needed
 	TransactionType transactionType_ = TransactionType::kNone;
+
+	/// Nodes materialized by a KV backend during this operation; freed on teardown.
+	/// Mutable so the const seam can pin; see nodeArena().
+	mutable FSNodeArena nodeArena_;
 };


### PR DESCRIPTION
The node resolution seam (idToNode, lookup, getRootNode) returns borrowed FSNode pointers. The in-memory backend backs every borrow with gMetadata->nodeHash, which owns all nodes, but KV backends materialize a fresh node on each resolve and had no owner behind the same pointer, leaking one node per resolution.

Add FSNodeArena, a per-operation owner and dedup map for KV-materialized nodes, carried as a mutable member of FilesystemOperationContext and freed in its existing teardown. Repeated resolves of one inode within an operation return the same instance, and delete paths can release ownership and tombstone the inode so later resolves in the same operation observe the deletion.

The in-memory backend registers nothing, so master behavior is unchanged. The context stays move-only and default-movable, and moves clear the source arena. The file is named
filesystem_node_arena.cc so the metarestore source glob picks it up.

Related to: LS-897