### PR TITLE
fix(cs): avoid moved-from disk access on removal

### DIFF
--- a/src/chunkserver/hddspacemgr.cc
+++ b/src/chunkserver/hddspacemgr.cc
@@ -420,14 +420,15 @@ void hddCheckDisks() {
 	for (auto &diskToDelWithPendingChunks : gNewDisksToBeDeletedWithPendingChunks) {
 		for (auto it = gDisks.begin(); it != gDisks.end(); ++it) {
 			if (diskToDelWithPendingChunks.first == it->get()) {
-				if (!diskToDelWithPendingChunks.second.empty()) {
-					// Pending chunks
-					gDisksToBeDeletedWithPendingChunks.emplace_back(
-					    std::move(*it), std::move(diskToDelWithPendingChunks.second));
-				}
 				ChunkTrashManager::eraseDisk((*it)->metaPath());
 				if (!(*it)->isZonedDevice() && (*it)->metaPath() != (*it)->dataPath()) {
 					ChunkTrashManager::eraseDisk((*it)->dataPath());
+				}
+				if (!diskToDelWithPendingChunks.second.empty()) {
+					// Pending chunks; moving *it leaves a null unique_ptr in
+					// gDisks, so it must stay the last use of the disk.
+					gDisksToBeDeletedWithPendingChunks.emplace_back(
+					    std::move(*it), std::move(diskToDelWithPendingChunks.second));
 				}
 				gDisks.erase(it);
 				break;


### PR DESCRIPTION
hddCheckDisks moved the disk's unique_ptr out of gDisks into gDisksToBeDeletedWithPendingChunks and then dereferenced the same vector slot to unregister the disk paths from ChunkTrashManager. The slot holds nullptr after the move, so when a disk was removed from the config while chunks on it were still locked by workers (the only case where the pending chunks list is non empty), the disks thread crashed with a null dereference and took down the whole chunkserver.

Observed in CI as a flaky failure of
LongSystemTests.test_concurrent_replications: the chunkserver that lost a disk segfaulted right after logging "Disk ... successfully removed", never re-registered with the master, and the test timed out waiting for a file part to appear on it.

Unregister the trash manager paths before moving the pointer, and keep the move as the last use of the disk.

Related to: LS-879