### PR TITLE
fix(mount): clear read cache on truncate

### DIFF
--- a/src/mount/readdata.cc
+++ b/src/mount/readdata.cc
@@ -841,10 +841,16 @@ void read_data_term(void) {
 void read_inode_ops(inode_t inode) { // attributes of inode have been changed - force reconnect and clear cache
 	std::unique_lock gMutexLock(gMutex);
 
-	ReadRecordRange range = gActiveReadRecords.equal_range(inode);
+	for (ReadRecords *records : {&gActiveReadRecords, &gInactiveReadRecords}) {
+		ReadRecordRange range = records->equal_range(inode);
 
-	for (auto it = range.first; it != range.second; ++it) {
-		it->second->refreshCounter = REFRESHTICKS; // force reconnect on forthcoming access
+		for (auto it = range.first; it != range.second; ++it) {
+			it->second->refreshCounter = REFRESHTICKS;  // force reconnect on forthcoming access
+			if (!it->second->expired) {
+				std::unique_lock inodeLock(it->second->mutex);
+				it->second->cache.clear();
+			}
+		}
 	}
 }
 

--- a/tests/test_suites/ShortSystemTests/test_truncate_invalidates_read_cache.sh
+++ b/tests/test_suites/ShortSystemTests/test_truncate_invalidates_read_cache.sh
@@ -1,0 +1,53 @@
+timeout_set 1 minute
+
+# Reproduces stale reads served from the mount-side read cache after truncate.
+# The read cache is populated through an open descriptor, then the file is
+# truncated (shrunk and sparsely re-grown, so its correct content is zeros).
+# A pread on the same descriptor must not return the pre-truncate content.
+# cacheexpirationtime (24h) far exceeds any scaled test timeout, so cache
+# entries cannot expire mid-test and mask the regression with a silent pass.
+
+CHUNKSERVERS=1 \
+	USE_RAMDISK=YES \
+	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER | cacheexpirationtime=86400000" \
+	setup_local_empty_saunafs info
+
+cd "${info[mount0]}"
+
+FILE_SIZE=262144 file-generate file
+
+cat > "$TEMP_DIR/stale_read_check.py" << 'END'
+import os
+import sys
+
+path = sys.argv[1]
+size = int(sys.argv[2])
+
+fd = os.open(path, os.O_RDONLY)
+
+before = os.pread(fd, size, 0)
+if len(before) != size:
+    print(f"SETUP FAILURE: initial read returned {len(before)} bytes, expected {size}")
+    sys.exit(1)
+
+os.truncate(path, 0)
+os.truncate(path, size)  # sparse re-grow: correct content is all zeros
+
+after = os.pread(fd, size, 0)
+os.close(fd)
+
+if after == b"\0" * size:
+    sys.exit(0)
+
+if len(after) != size:
+    print(f"SHORT READ: pread returned {len(after)} bytes, expected {size}")
+elif after == before:
+    print("STALE READ: pread returned the pre-truncate content")
+else:
+    zeros = sum(b == 0 for b in after)
+    print(f"CORRUPT READ: {zeros}/{size} bytes zero, "
+          "neither all-zeros nor the pre-truncate content")
+sys.exit(1)
+END
+
+assert_success python3 "$TEMP_DIR/stale_read_check.py" "$(realpath file)" 262144


### PR DESCRIPTION
read_inode_ops() claimed to force reconnect and clear cache but only
reset refreshCounter, which cache hits never consult. Reads through a
descriptor opened before a truncate kept returning pre-truncate data
for up to cacheexpirationtime (default 1 s). The write path has cleared
the cache since https://github.com/leil-io/leilfs/pull/337; the truncate path never did.

Sweep both active and inactive read records, matching the write-path
locking. Add a regression test that fails without the fix
(LongSystemTests.test_sqlite_stress_several_goals hit this as
"database disk image is malformed" under concurrent truncates).

Add a regression test that fails without the fix.

Related to: LS-879