### PR TITLE
test: reduce flakiness of deferred metadata test

### DIFF
--- a/tests/test_suites/ShortSystemTests/test_deferred_metadata_dump.sh
+++ b/tests/test_suites/ShortSystemTests/test_deferred_metadata_dump.sh
@@ -39,6 +39,10 @@ echo "test_data" > test_dir/test_file.txt
 echo "Starting test with deferred metadata dump..."
 
 echo "Stopping primary master to simulate failover..."
+# Step off the mount while the master is down: with the cwd on the mount, every bash fork
+# stats "." through FUSE and blocks uninterruptibly for the mount's full retry budget
+# (longer than the test timeout) until the client reconnects to a master.
+cd "${TEMP_DIR}"
 assert_success saunafs_master_daemon_ha stop
 
 # Verify that starting sfsmaster with default values does not trigger a deferred metadata dump
@@ -62,7 +66,10 @@ assert_success saunafs_master_daemon_ha start -o initial-personality=master \
 saunafs_wait_for_all_ready_chunkservers
 
 echo "Testing filesystem functionality during metadata dump..."
-assert_eventually 'echo "additional_data_during_dump" > test_dir/during_dump_file.txt' "60 seconds"
+assert_eventually 'echo "additional_data_during_dump" > "${info[mount0]}/test_dir/during_dump_file.txt"' "60 seconds"
+
+# The write above confirms the client session is back, it is safe to work on the mount again.
+cd "${info[mount0]}"
 
 assert_equals "test_data" "$(cat test_dir/test_file.txt)"
 assert_equals "additional_data_during_dump" "$(cat test_dir/during_dump_file.txt)"


### PR DESCRIPTION
When the CI machine is overloaded, this test can freeze between the master stop and restart until the whole run times out.

With the mount disconnected from the Master, Bash stats "." in every forked child before exec. The test keeps its cwd on the mount while the master is down, so once the kernel attribute cache lapses, the first command substitution after the stop blocks in uninterruptible sleep until the mount exhausts its operation retries, which takes longer than the test timeout. On an idle machine the cache is refreshed by the stop command itself and the window is rarely hit, which is why the test only fails under load.

Step off the mount before stopping the master and return after the restart once chunkservers are ready.

Verified locally: with the cwd on the mount, the first fork after the stop blocks deterministically once the attribute cache lapses; with the fix, repeated stop/start cycling under a concurrent writer never blocks and the full test passes reliably.

Related to: LS-879