### PR TITLE
test: reduce flakiness of io limiting tests

### DIFF
--- a/tests/test_suites/ShortSystemTests/test_global_io_limiting_many_clients.sh
+++ b/tests/test_suites/ShortSystemTests/test_global_io_limiting_many_clients.sh
@@ -6,14 +6,16 @@ echo "limit unclassified 1024" > "$iolimits"
 
 # number of mounts
 N=5
-# tolerated relative error (in %)
+# Tolerated relative error (in %) for the strict fast side.
 E=11
 if is_windows_system; then
 	E=15
 fi
-if valgrind_enabled; then
-	E=$((5 * E))
-fi
+# Slow-side tolerance (in %): loose, reads can stall on busy CI machines.
+E_SLOW=$((50 * $(timeout_get_total_multiplier)))
+# Fast-side absolute grace (in ns) for the limiter's token bucket bursts.
+# Larger here: the sequential reader start-up gives the bucket more time to refill.
+FAST_GRACE=$((500 * 1000 * 1000))
 
 CHUNKSERVERS=3 \
 	MOUNTS=$N \
@@ -48,6 +50,7 @@ start_readers | while [ $(head -c1M |wc -c) = $((1024 * 1024)) ]; do
 	abserr=$((time - expected))
 	relerr=$((100 * abserr / expected))
 	echo $expected $time $abserr $relerr
-	assert_near 0 $relerr $E
+	assert_less_or_equal $((expected * (100 - E) / 100 - FAST_GRACE)) ${time}
+	assert_less_or_equal ${time} $((expected * (100 + E_SLOW) / 100))
 	i=$((i+1))
 done

--- a/tests/test_suites/ShortSystemTests/test_global_io_limiting_read_write.sh
+++ b/tests/test_suites/ShortSystemTests/test_global_io_limiting_read_write.sh
@@ -4,13 +4,15 @@ timeout_set 1 minute
 iolimits="$TEMP_DIR/iolimits.cfg"
 echo "limit unclassified 1024" > "$iolimits"
 
+# Tolerated relative error (in %) for the strict fast side.
 E=11
 if is_windows_system; then
 	E=15
 fi
-if valgrind_enabled; then
-	E=$((5 * E))
-fi
+# Slow-side tolerance (in %): loose, reads can stall on busy CI machines.
+E_SLOW=$((100 * $(timeout_get_total_multiplier)))
+# Fast-side absolute grace (in ns) for the limiter's token bucket bursts.
+FAST_GRACE=$((250 * 1000 * 1000))
 
 CHUNKSERVERS=3 \
 	MOUNTS=2 \
@@ -35,4 +37,5 @@ time=$((end - start))
 abserr=$((time - expected))
 relerr=$((100 * abserr / expected))
 echo $expected $time $abserr $relerr
-assert_near 0 $relerr $E
+assert_less_or_equal $((expected * (100 - E) / 100 - FAST_GRACE)) ${time}
+assert_less_or_equal ${time} $((expected * (100 + E_SLOW) / 100))

--- a/tests/test_suites/ShortSystemTests/test_global_io_limiting_reconfiguration.sh
+++ b/tests/test_suites/ShortSystemTests/test_global_io_limiting_reconfiguration.sh
@@ -4,13 +4,15 @@ timeout_set 1 minute
 iolimits="$TEMP_DIR/iolimits.cfg"
 echo "limit unclassified 1024" > "$iolimits"
 
+# Tolerated relative error (in %) for the strict fast side.
 E=11
 if is_windows_system; then
 	E=15
 fi
-if valgrind_enabled; then
-	E=$((5 * E))
-fi
+# Slow-side tolerance (in %): loose, reads can stall on busy CI machines.
+E_SLOW=$((100 * $(timeout_get_total_multiplier)))
+# Fast-side absolute grace (in ns) for the limiter's token bucket bursts.
+FAST_GRACE=$((250 * 1000 * 1000))
 
 CHUNKSERVERS=3 \
 	USE_RAMDISK=YES \
@@ -40,4 +42,5 @@ time=$((end - start))
 abserr=$((time - expected))
 relerr=$((100 * abserr / expected))
 echo $expected $time $abserr $relerr
-assert_near 0 $relerr $E
+assert_less_or_equal $((expected * (100 - E) / 100 - FAST_GRACE)) ${time}
+assert_less_or_equal ${time} $((expected * (100 + E_SLOW) / 100))

--- a/tests/test_suites/ShortSystemTests/test_global_io_limiting_transition.sh
+++ b/tests/test_suites/ShortSystemTests/test_global_io_limiting_transition.sh
@@ -8,14 +8,15 @@ echo "limit unclassified 10240" > "$iolimits"
 N=5
 # number of rounds
 R=3
-# tolerated relative error (in %)
+# Tolerated relative error (in %) for the strict fast side.
 E=11
 if is_windows_system; then
 	E=15
 fi
-if valgrind_enabled; then
-	E=$((5 * E))
-fi
+# Slow-side tolerance (in %): loose, reads can stall on busy CI machines.
+E_SLOW=$((50 * $(timeout_get_total_multiplier)))
+# Fast-side absolute grace (in ns) for the limiter's token bucket bursts.
+FAST_GRACE=$((250 * 1000 * 1000))
 
 CHUNKSERVERS=3 \
 	MOUNTS=$N \
@@ -29,6 +30,8 @@ truncate -s10M "${info[mount0]}/file"
 # consume accumulated limit
 cat "${info[mount0]}/file" >/dev/null
 
+total_time=0
+total_expected=0
 for ((round=0; round < R; round++)); do
 	for ((mount=0; mount < N; mount++)); do
 		start=$(nanostamp)
@@ -39,6 +42,9 @@ for ((round=0; round < R; round++)); do
 		abserr=$((time - expected))
 		relerr=$((100 * abserr / expected))
 		echo $expected $time $abserr $relerr
-		assert_near 0 $relerr $E
+		assert_less_or_equal $((expected * (100 - E) / 100 - FAST_GRACE)) ${time}
+		total_time=$((total_time + time))
+		total_expected=$((total_expected + expected))
 	done
 done
+assert_less_or_equal ${total_time} $((total_expected * (100 + E_SLOW) / 100))

--- a/tests/test_suites/ShortSystemTests/test_io_limits.sh
+++ b/tests/test_suites/ShortSystemTests/test_io_limits.sh
@@ -8,6 +8,16 @@ echo "limit unclassified 1024" > "$iolimits"
 iolimits2="$TEMP_DIR/iolimits2.cfg"
 echo "limit unclassified 2048" > "$iolimits2"
 
+# Check the wall-clock time of a rate-limited operation. The slow tolerance is later
+# scaled by the machine multiplier to tolerate heavy workloads; the fast side stays strict.
+assert_limited_io_time() {
+	local expected_time_ms=$1
+	local actual_time_ms=$2
+	local slow_tolerance_ms=$(( (250 + expected_time_ms * 15 / 100) * $(timeout_get_total_multiplier) ))
+	assert_less_or_equal $((expected_time_ms - 250)) "${actual_time_ms}"
+	assert_less_or_equal "${actual_time_ms}" $((expected_time_ms + slow_tolerance_ms))
+}
+
 run_io_test() {
 	local limit_mbps=$1
 	local expected_time_divisor=$2
@@ -23,19 +33,19 @@ run_io_test() {
 		echo "$MESSAGE"
 		seconds=$("$time" -f %e file-generate "file_${mb}" 2>&1)
 		actual_time_ms=$(bc <<< "scale=0; $seconds * 1000 / 1")
-		assert_near "${expected_time_ms}" "${actual_time_ms}" "$(rescale_value 250)"
+		assert_limited_io_time "${expected_time_ms}" "${actual_time_ms}"
 
 		export MESSAGE="Reading $mb MB at $limit_mbps MB/s"
 		echo "$MESSAGE"
 		seconds=$("$time" -f %e file-validate "file_${mb}" 2>&1)
 		actual_time_ms=$(bc <<< "scale=0; $seconds * 1000 / 1")
-		assert_near "${expected_time_ms}" "${actual_time_ms}" "$(rescale_value 250)"
+		assert_limited_io_time "${expected_time_ms}" "${actual_time_ms}"
 
 		export MESSAGE="Reading + writing $mb MB at $limit_mbps MB/s"
 		echo "$MESSAGE"
 		seconds=$("$time" -f %e bash -c "file-validate file_${mb} & file-generate garbage & wait" 2>&1)
 		actual_time_ms=$(bc <<< "scale=0; $seconds * 1000 / 1")
-		assert_near "$((2 * expected_time_ms))" "${actual_time_ms}" "$(rescale_value 250)"
+		assert_limited_io_time "$((2 * expected_time_ms))" "${actual_time_ms}"
 	done
 }
 
@@ -45,15 +55,6 @@ CHUNKSERVERS=3 \
 	setup_local_empty_saunafs info
 
 cd "${info[mount0]}"
-
-rescale_value() {
-	if valgrind_enabled || [[ ${info[is_windows_system]} -eq 1 ]]; then
-		echo $((4 * $1))
-	else
-		echo "$1"
-	fi
-}
-
 
 run_io_test 1 1
 


### PR DESCRIPTION
When the CI machine is overloaded, the io limiting tests fail on wall clock overshoots (observed between +2% and +457%) although the limiter is healthy: the old asserts were symmetric, so a read stalled by the scheduler counted as a limiter error.

Only the fast side is a correctness property of a rate limiter, so keep it strict and unscaled. Bound the slow side scaled by the total timeout multiplier, consistent with how test timeouts already model slow machines, and in the transition test bound it on the aggregate of all reads so a single stalled read cannot fail the run alone. Replace the local rescale_value in test_io_limits, which ignored the machine multiplier, with a slow tolerance that has a relative component, and drop the valgrind branches since the multiplier already covers them.

Verified locally: pinning the whole cluster plus busy loops to a few cores reproduces the CI failures on all four tests before the change and passes afterwards, both with a declared timeout multiplier and unpinned; a limiter letting IO through too fast still fails.

Related to: LS-879