### PR TITLE
refactor(master): KV parity for changelog, locks, and repair

### DIFF
--- a/src/master/chunks.cc
+++ b/src/master/chunks.cc
@@ -1088,15 +1088,26 @@ bool chunk_get_version_and_goal_counters(uint64_t chunkid, uint32_t &version,
 	return true;
 }
 
+bool chunk_get_lock_state(uint64_t chunkid, uint32_t &lockid, uint32_t &lockedto) {
+	Chunk *c = chunk_find(chunkid);
+	if (c == nullptr) { return false; }
+	lockid = c->lockid;
+	lockedto = c->lockedto;
+	return true;
+}
+
 bool chunk_exists(uint64_t chunkid) { return chunk_find(chunkid) != nullptr; }
 
 void chunk_create_with_goal_counters(uint64_t chunkid, uint32_t version,
-                                     const std::vector<ChunkGoalCounters::GoalCounter> &goals) {
+                                     const std::vector<ChunkGoalCounters::GoalCounter> &goals,
+                                     uint32_t lockid, uint32_t lockedto) {
 	if (chunk_find(chunkid) != nullptr) { return; }
 	Chunk *c = chunk_new(chunkid, version);
 	for (const auto &counter : goals) {
 		for (uint32_t i = 0; i < counter.count; ++i) { c->addFileWithGoal(counter.goal); }
 	}
+	c->lockid = lockid;
+	c->lockedto = lockedto;
 	chunk_update_checksum(c);
 }
 

--- a/src/master/chunks.h
+++ b/src/master/chunks.h
@@ -56,15 +56,18 @@ int chunk_unlock(uint64_t chunkid);
 bool chunk_get_version_and_goal_counters(uint64_t chunkid, uint32_t &version,
                                          ChunkGoalCounters &counters);
 
+/// Reads a chunk's write-lock state (lockid and lock expiry timestamp).
+/// Returns false if the chunk is unknown.
+bool chunk_get_lock_state(uint64_t chunkid, uint32_t &lockid, uint32_t &lockedto);
+
 /// Returns true if the chunk is present in the in-memory hash.
 bool chunk_exists(uint64_t chunkid);
 
-/// Creates an in-memory chunk with the given version and per-goal reference counts, unless it is
-/// already present. The counterpart to chunk_add_from_initial_metadata_load for callers that
-/// restore a chunk's reference counts on demand (e.g. when a chunkserver reports it after a
-/// restart) rather than from the metadata image.
+/// Restores an in-memory chunk from persisted version, refs and lock state.
+/// Used by on-demand restore paths when a chunk is not present in memory yet.
 void chunk_create_with_goal_counters(uint64_t chunkid, uint32_t version,
-                                     const std::vector<ChunkGoalCounters::GoalCounter> &goals);
+                                     const std::vector<ChunkGoalCounters::GoalCounter> &goals,
+                                     uint32_t lockid, uint32_t lockedto);
 
 uint8_t chunk_apply_modification(uint32_t ts, uint64_t oldChunkId, uint32_t lockid, uint8_t goal,
 		bool doIncreaseVersion, uint64_t *newChunkId);

--- a/src/master/filesystem_operation_context.h
+++ b/src/master/filesystem_operation_context.h
@@ -20,7 +20,11 @@
 
 #include "common/platform.h"
 
+#include <cassert>
 #include <memory>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "common/type_defs.h"
 #include "kv/itransaction.h"
@@ -75,7 +79,11 @@ public:
 	/// owned by the arena. It does not implicitly commit or rollback transactions; callers must
 	/// ensure that any required commit or rollback is performed via the transaction interfaces
 	/// before the context is destroyed.
-	~FilesystemOperationContext() = default;
+	/// Debug builds catch a committed context whose deferred changelog was not drained,
+	/// because dropping those entries would lose changelog, metalogger and notifier sinks.
+	~FilesystemOperationContext() {
+		assert(deferredChangelogEntries_.empty() || !commitConfirmed_);
+	}
 
 	/// Returns true if this context has an active transaction
 	bool hasTransaction() const;
@@ -98,6 +106,34 @@ public:
 	/// @see FSNodeArena
 	FSNodeArena &nodeArena() const { return nodeArena_; }
 
+	/// A changelog entry whose publication is held until the owning transaction commits.
+	struct DeferredChangelogEntry {
+		uint64_t version;
+		std::string entry;
+	};
+
+	/// Buffer changelog sinks until this context's transaction commits.
+	/// Needed for replayable KV commits: aborted attempts drop their buffers, and
+	/// consumers never see uncommitted entries.
+	void setDeferChangelog() { deferChangelog_ = true; }
+
+	/// Returns true when changelog entries must be buffered instead of published inline.
+	bool deferChangelog() const { return deferChangelog_; }
+
+	/// Buffer one changelog entry for post-commit publication.
+	void appendDeferredChangelogEntry(uint64_t version, std::string entry) const {
+		deferredChangelogEntries_.emplace_back(version, std::move(entry));
+	}
+
+	/// Drains buffered entries for post-commit publication.
+	/// Dropping an unconfirmed context without draining discards aborted/replayed entries.
+	std::vector<DeferredChangelogEntry> takeDeferredChangelogEntries() const {
+		return std::exchange(deferredChangelogEntries_, {});
+	}
+
+	/// Records that the transaction committed so the destructor catches an undrained buffer.
+	void confirmCommitted() const { commitConfirmed_ = true; }
+
 private:
 	/// The active read-write transaction (if any)
 	std::unique_ptr<kv::IReadWriteTransaction> rwTransaction_ = nullptr;
@@ -111,4 +147,13 @@ private:
 	/// Nodes materialized by a KV backend during this operation; freed on teardown.
 	/// Mutable so the const seam can pin; see nodeArena().
 	mutable FSNodeArena nodeArena_;
+
+	/// See setDeferChangelog().
+	bool deferChangelog_ = false;
+
+	/// Changelog entries buffered for post-commit publication; mutable like nodeArena_.
+	mutable std::vector<DeferredChangelogEntry> deferredChangelogEntries_;
+
+	/// See confirmCommitted(); mutable like the entry buffer it guards.
+	mutable bool commitConfirmed_ = false;
 };

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -108,6 +108,12 @@ void FilesystemOperationsBase::changeLog(
 		return;
 	}
 
+	if (fsOpContext.hasReadWriteTransaction()) {
+		// Direct KV commits still publish inline; sequence them with deferred publications
+		// so duplicate staged versions do not reach changelog consumers.
+		version = matoclserv_sequence_published_changelog_version(version);
+	}
+
 	changelog(version, entry);
 
 	if (!getChangelogSignal().empty()) {

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -114,14 +114,7 @@ void FilesystemOperationsBase::changeLog(
 		version = matoclserv_sequence_published_changelog_version(version);
 	}
 
-	changelog(version, entry);
-
-	if (!getChangelogSignal().empty()) {
-		getChangelogSignal().emit({.version = version, .entry = entry});
-	}
-
-	matomlserv_broadcast_logstring(version, (uint8_t *)entry, timeStampLength + entryLength);
-	matontserv_broadcast_message(version, std::string_view(entry, timeStampLength + entryLength));
+	matoclserv_emit_changelog_sinks(version, entry, timeStampLength + entryLength);
 #endif
 }
 

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -100,6 +100,14 @@ void FilesystemOperationsBase::changeLog(
 	}
 
 	uint64_t version = increaseMetadataVersion(fsOpContext);
+
+	if (fsOpContext.deferChangelog()) {
+		// Defer every sink (local log, signal, broadcasts) so replayed attempts publish nothing.
+		fsOpContext.appendDeferredChangelogEntry(version,
+		                                         std::string(entry, timeStampLength + entryLength));
+		return;
+	}
+
 	changelog(version, entry);
 
 	if (!getChangelogSignal().empty()) {

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -3278,6 +3278,11 @@ uint8_t FilesystemOperationsBase::repair(const FsContext &context, inode_t inode
 			(*notchanged)++;
 		}
 	}
+	if (*erased > 0 || *repaired > 0) {
+		// Chunk-table and mtime edits only touch the materialized node on KV.
+		// Persist them; in-memory backend already stores the node itself.
+		nodeOperations_->updateNode(fsOpContext, node);
+	}
 	nodeOperations_->getStats(fsOpContext, node, &newStats);
 	nodeOperations_->updateParentStatsForNode(fsOpContext, node, &newStats, &previousStats);
 	quotaUpdate(fsOpContext, node, {{QuotaResource::kSize, newStats.size - previousStats.size}});

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -5623,9 +5623,7 @@ void matoclserv_manage_locks_unlock(matoclserventry *eptr, const uint8_t *data, 
 
 	deserializePacketVersionNoHeader(data, length, version);
 
-	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
-	    FilesystemOperationContext::TransactionType::kReadWrite);
-
+	// Deserialize once; the packet does not change across retry attempts.
 	if (version == cltoma::manageLocksUnlock::kSingle) {
 		cltoma::manageLocksUnlock::deserialize(data, length, type, inode, sessionid, owner, start,
 		                                       end);
@@ -5633,39 +5631,54 @@ void matoclserv_manage_locks_unlock(matoclserventry *eptr, const uint8_t *data, 
 		if (end == 0) {
 			end = std::numeric_limits<decltype(end)>::max();
 		}
-		if (type == safs_locks::Type::kAll || type == safs_locks::Type::kFlock) {
-			status = gFSOperations->flockOperation(context, fsOpContext, inode, owner, sessionid, 0,
-			                                       0, safs_locks::kUnlock, true, flocks_applied);
-		}
-		if (status == SAUNAFS_STATUS_OK &&
-		    (type == safs_locks::Type::kAll || type == safs_locks::Type::kPosix)) {
-			status = gFSOperations->posixLockOperation(context, fsOpContext, inode, start, end,
-			                                           owner, sessionid, 0, 0, safs_locks::kUnlock,
-			                                           true, posix_applied);
-		}
 	} else if (version == cltoma::manageLocksUnlock::kInode) {
 		cltoma::manageLocksUnlock::deserialize(data, length, type, inode);
-		if (type == safs_locks::Type::kAll || type == safs_locks::Type::kFlock) {
-			status = gFSOperations->locksUnlockInode(
-			    context, fsOpContext, (uint8_t)safs_locks::Type::kFlock, inode, flocks_applied);
-		}
-		if (status == SAUNAFS_STATUS_OK &&
-		    (type == safs_locks::Type::kAll || type == safs_locks::Type::kPosix)) {
-			status = gFSOperations->locksUnlockInode(
-			    context, fsOpContext, (uint8_t)safs_locks::Type::kPosix, inode, posix_applied);
-		}
 	} else {
 		throw IncorrectDeserializationException("Unknown SAU_CLTOMA_MANAGE_LOCKS_UNLOCK version: " +
 		                                        std::to_string(version));
 	}
 
-	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
-		if (!fsOpContext.getReadWriteTransaction()->commit()) {
-			safs::log_err("{}: transaction failed to commit: inode {}", __func__, inode);
-			status = SAUNAFS_ERROR_IO;
-			flocks_applied.clear();
-			posix_applied.clear();
-		}
+	// Admin unlock shares lock records with FLOCK/SETLK, so routine KV conflicts
+	// must replay instead of returning EIO.
+	bool transactional = false;
+	status = matoclserv_commit_op_with_retry(
+	    [&](FilesystemOperationContext &fsOpContext) -> uint8_t {
+		    transactional = fsOpContext.hasReadWriteTransaction();
+		    flocks_applied.clear();  // reset per attempt so a replay cannot duplicate wake sets
+		    posix_applied.clear();
+		    uint8_t st = SAUNAFS_STATUS_OK;
+		    if (version == cltoma::manageLocksUnlock::kSingle) {
+			    if (type == safs_locks::Type::kAll || type == safs_locks::Type::kFlock) {
+				    st = gFSOperations->flockOperation(context, fsOpContext, inode, owner,
+				                                       sessionid, 0, 0, safs_locks::kUnlock, true,
+				                                       flocks_applied);
+			    }
+			    if (st == SAUNAFS_STATUS_OK &&
+			        (type == safs_locks::Type::kAll || type == safs_locks::Type::kPosix)) {
+				    st = gFSOperations->posixLockOperation(context, fsOpContext, inode, start, end,
+				                                           owner, sessionid, 0, 0,
+				                                           safs_locks::kUnlock, true, posix_applied);
+			    }
+		    } else {
+			    if (type == safs_locks::Type::kAll || type == safs_locks::Type::kFlock) {
+				    st = gFSOperations->locksUnlockInode(context, fsOpContext,
+				                                         (uint8_t)safs_locks::Type::kFlock, inode,
+				                                         flocks_applied);
+			    }
+			    if (st == SAUNAFS_STATUS_OK &&
+			        (type == safs_locks::Type::kAll || type == safs_locks::Type::kPosix)) {
+				    st = gFSOperations->locksUnlockInode(context, fsOpContext,
+				                                         (uint8_t)safs_locks::Type::kPosix, inode,
+				                                         posix_applied);
+			    }
+		    }
+		    return st;
+	    });
+
+	if (transactional && status != SAUNAFS_STATUS_OK) {
+		// KV rolled back the failed attempt, so wake no one; in-memory applied in place.
+		flocks_applied.clear();
+		posix_applied.clear();
 	}
 
 	for (auto sessionAndMsg : flocks_applied) {
@@ -5711,20 +5724,14 @@ void matoclserv_fuse_locks_interrupt(matoclserventry *eptr, const uint8_t *data,
 
 	cltoma::fuseFlock::deserialize(data, length, messageId, interruptData);
 
-	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
-	    FilesystemOperationContext::TransactionType::kReadWrite);
-
-	// we do not reply, so there is not need for checking status of this fs_operation
-	gFSOperations->locksRemovePending(context, fsOpContext, type, interruptData.owner,
-	                                  eptr->sessionData->sessionId, interruptData.ino,
-	                                  interruptData.reqid);
-
-	if (fsOpContext.hasReadWriteTransaction()) {
-		if (!fsOpContext.getReadWriteTransaction()->commit()) {
-			safs::log_err("{}: transaction failed to commit: inode {}", __func__,
-			              interruptData.ino);
-		}
-	}
+	// There is no reply, but pending-lock removal still needs KV conflict retry;
+	// otherwise a routine commit conflict can silently leave the pending lock behind.
+	matoclserv_commit_op_with_retry([&](FilesystemOperationContext &fsOpContext) -> uint8_t {
+		return gFSOperations->locksRemovePending(context, fsOpContext, type,
+		                                         interruptData.owner,
+		                                         eptr->sessionData->sessionId,
+		                                         interruptData.ino, interruptData.reqid);
+	});
 }
 
 void matoclserv_update_credentials(matoclserventry *eptr, const uint8_t *data, uint32_t length) {

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -322,6 +322,17 @@ uint64_t matoclserv_sequence_published_changelog_version(uint64_t stagedVersion)
 	return gLastPublishedChangelogVersion;
 }
 
+void matoclserv_emit_changelog_sinks(uint64_t version, char *entry, std::size_t size) {
+	// C-string sinks stop at the trailing NUL; broadcasts send it, matching the inline path.
+	changelog(version, entry);
+	if (!getChangelogSignal().empty()) {
+		getChangelogSignal().emit({.version = version, .entry = entry});
+	}
+	matomlserv_broadcast_logstring(version, reinterpret_cast<uint8_t *>(entry),
+	                               static_cast<uint32_t>(size));
+	matontserv_broadcast_message(version, std::string_view(entry, size));
+}
+
 /// Publishes buffered changelog sinks after a deferring transaction commits.
 /// Staged KV versions can collide, so this is the total-order point that reissues
 /// monotonically increasing versions for changelog, metaloggers and notifiers.
@@ -330,16 +341,8 @@ static void matoclserv_publish_deferred_changelog(const FilesystemOperationConte
 	auto entries = ctx.takeDeferredChangelogEntries();
 	for (auto &deferred : entries) {
 		deferred.version = matoclserv_sequence_published_changelog_version(deferred.version);
-		// C-string sinks stop at the trailing NUL; broadcasts send it, matching inline path.
-		changelog(deferred.version, deferred.entry.c_str());
-		if (!getChangelogSignal().empty()) {
-			getChangelogSignal().emit(
-			    {.version = deferred.version, .entry = deferred.entry.c_str()});
-		}
-		matomlserv_broadcast_logstring(deferred.version,
-		                               reinterpret_cast<uint8_t *>(deferred.entry.data()),
-		                               deferred.entry.size());
-		matontserv_broadcast_message(deferred.version, std::string_view(deferred.entry));
+		matoclserv_emit_changelog_sinks(deferred.version, deferred.entry.data(),
+		                                deferred.entry.size());
 	}
 }
 
@@ -5382,14 +5385,17 @@ static uint8_t matoclserv_run_lock_op(std::vector<FileLocks::Owner> &applied,
 		    if (lockStatus == SAUNAFS_ERROR_WAITING) { return SAUNAFS_STATUS_OK; }
 		    return lockStatus;
 	    });
+
 	if (lockStatus != SAUNAFS_STATUS_OK && lockStatus != SAUNAFS_ERROR_WAITING) {
 		applied.clear();  // op error, nothing committed: never wake owners for it
 		return lockStatus;
 	}
+
 	if (commitStatus != SAUNAFS_STATUS_OK) {  // conflict retries exhausted
 		applied.clear();
 		return SAUNAFS_ERROR_IO;
 	}
+
 	return lockStatus;
 }
 

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -312,11 +312,25 @@ static void matoclserv_commit_wakeup_serve(const std::vector<pollfd> &pdesc) {
 	}
 }
 
-/// Publishes all changelog sinks after a deferring transaction commits.
+/// Last changelog version handed to KV changelog sinks.
+/// In-memory master bypasses this; its inline version counter is already serialized.
+static uint64_t gLastPublishedChangelogVersion = 0;
+
+uint64_t matoclserv_sequence_published_changelog_version(uint64_t stagedVersion) {
+	gLastPublishedChangelogVersion =
+	    std::max(gLastPublishedChangelogVersion + 1, stagedVersion);
+	return gLastPublishedChangelogVersion;
+}
+
+/// Publishes buffered changelog sinks after a deferring transaction commits.
+/// Staged KV versions can collide, so this is the total-order point that reissues
+/// monotonically increasing versions for changelog, metaloggers and notifiers.
+/// Gaps are allowed; direct inline KV publications use the same sequencer.
 static void matoclserv_publish_deferred_changelog(const FilesystemOperationContext &ctx) {
 	auto entries = ctx.takeDeferredChangelogEntries();
 	for (auto &deferred : entries) {
-		// Preserve inline payload bytes, including the trailing NUL.
+		deferred.version = matoclserv_sequence_published_changelog_version(deferred.version);
+		// C-string sinks stop at the trailing NUL; broadcasts send it, matching inline path.
 		changelog(deferred.version, deferred.entry.c_str());
 		if (!getChangelogSignal().empty()) {
 			getChangelogSignal().emit(

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -336,29 +336,15 @@ static void matoclserv_commit_confirmed(const FilesystemOperationContext &ctx) {
 	matoclserv_publish_deferred_changelog(ctx);
 }
 
-/// Runs a replayable op body on a fresh read-write transaction and commits it
-/// SYNCHRONOUSLY, replaying the whole op (body + commit) on a fresh transaction on a
-/// retryable backend error -- either a read error thrown from the body
-/// (kv::RetryableTransactionError) or a retryable commit conflict (surfaced by
-/// getResult's retryable flag). Bounded by
-/// gMaxCommitRetries. Used by the few standalone post-durability cleanup commits that do
-/// not go through the group batch (e.g. the writeEnd cleanup in the write_chunk
-/// continuation), which still need conflict-retry because batch commits run concurrently
-/// and can conflict on a shared inode -- without it those sites reply EIO on every such
-/// conflict.
-///
-/// Returns the op status. A non-OK body status is returned WITHOUT committing (e.g.
-/// permission error, or SAUNAFS_ERROR_LOCKED from writeChunk). A non-retryable commit
-/// failure or retry exhaustion returns SAUNAFS_ERROR_IO. Commit is intentionally NOT
-/// retried on commit_unknown_result (non-retryable here): the commit may have applied,
-/// so a blind replay could double-apply (e.g. burn a second chunk).
-///
-/// The body must refresh any reply/out state it owns on EACH call (it may run more than
-/// once) and must NOT apply in-process persistent side effects -- do those only after
-/// this returns SAUNAFS_STATUS_OK. On the KV backend the body may only read, check, and
-/// stage backend writes; it must not mutate in-memory MDS structures, because a replay
-/// reruns it on a fresh transaction that does not roll those back. Returns OK with no
-/// commit when there is no read-write transaction (in-memory Master, applied in place).
+/// Runs a replayable op on a fresh read-write transaction and commits synchronously.
+/// Retryable body reads and retryable commit conflicts replay the whole body on a
+/// new transaction, bounded by gMaxCommitRetries. Non-OK body status returns without
+/// commit; non-retryable commit failure or retry exhaustion returns SAUNAFS_ERROR_IO.
+/// Unknown commit result is not replayed because it may have applied already; replay
+/// could double-apply. Used by standalone post-durability cleanups outside the group
+/// batch because they can conflict with batched commits on the same inode. The body
+/// must rebuild out state each attempt and defer persistent in-memory side effects
+/// until OK. Without a read-write transaction, the body has already applied in place.
 static uint8_t matoclserv_commit_op_with_retry(const OpReplay &body) {
 	for (uint32_t attempt = 0;; ++attempt) {
 		FilesystemOperationContext ctx = gFSOperations->createFilesystemOperationContext(
@@ -5368,6 +5354,31 @@ static void matoclserv_lock_wake_up(std::vector<FileLocks::Owner> &owners, safs_
 	}
 }
 
+/// Runs a lock mutation through commit retry and returns client-visible status.
+/// WAITING must commit because it persists a pending lock, so map it to OK for the
+/// harness and restore WAITING afterwards. `applied` is per-attempt wakeup state;
+/// non-committed outcomes clear it so callers can wake unconditionally.
+static uint8_t matoclserv_run_lock_op(std::vector<FileLocks::Owner> &applied,
+                                      const OpReplay &lockOp) {
+	uint8_t lockStatus = SAUNAFS_STATUS_OK;
+	uint8_t commitStatus =
+	    matoclserv_commit_op_with_retry([&](FilesystemOperationContext &fsOpContext) -> uint8_t {
+		    applied.clear();  // reset per attempt so a replay cannot duplicate the wake set
+		    lockStatus = lockOp(fsOpContext);
+		    if (lockStatus == SAUNAFS_ERROR_WAITING) { return SAUNAFS_STATUS_OK; }
+		    return lockStatus;
+	    });
+	if (lockStatus != SAUNAFS_STATUS_OK && lockStatus != SAUNAFS_ERROR_WAITING) {
+		applied.clear();  // op error, nothing committed: never wake owners for it
+		return lockStatus;
+	}
+	if (commitStatus != SAUNAFS_STATUS_OK) {  // conflict retries exhausted
+		applied.clear();
+		return SAUNAFS_ERROR_IO;
+	}
+	return lockStatus;
+}
+
 void matoclserv_fuse_flock(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	FsContext context = FsContext::getForMaster(eventloop_time());
 	uint32_t messageId;
@@ -5396,21 +5407,12 @@ void matoclserv_fuse_flock(matoclserventry *eptr, const uint8_t *data, uint32_t 
 	}
 
 	std::vector<FileLocks::Owner> applied;
-	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
-	    FilesystemOperationContext::TransactionType::kReadWrite);
-
-	status = gFSOperations->flockOperation(context, fsOpContext, inode, owner,
-	                                       eptr->sessionData->sessionId, requestId, messageId, op,
-	                                       nonblocking, applied);
-
-	if ((status == SAUNAFS_STATUS_OK || status == SAUNAFS_ERROR_WAITING) &&
-	    fsOpContext.hasReadWriteTransaction()) {
-		if (!fsOpContext.getReadWriteTransaction()->commit()) {
-			safs::log_err("{}: transaction failed to commit: inode {}", __func__, inode);
-			status = SAUNAFS_ERROR_IO;
-			applied.clear();
-		}
-	}
+	status = matoclserv_run_lock_op(
+	    applied, [&](FilesystemOperationContext &fsOpContext) -> uint8_t {
+		    return gFSOperations->flockOperation(context, fsOpContext, inode, owner,
+		                                         eptr->sessionData->sessionId, requestId,
+		                                         messageId, op, nonblocking, applied);
+	    });
 
 	matoclserv_lock_wake_up(applied, safs_locks::Type::kFlock);
 
@@ -5507,21 +5509,13 @@ void matoclserv_fuse_setlk(matoclserventry *eptr, const uint8_t *data, uint32_t 
 	}
 
 	std::vector<FileLocks::Owner> applied;
-	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
-	    FilesystemOperationContext::TransactionType::kReadWrite);
-
-	status = gFSOperations->posixLockOperation(context, fsOpContext, inode, lock_info.l_start,
-	                                           lock_end, owner, eptr->sessionData->sessionId,
-	                                           request_id, message_id, op, nonblocking, applied);
-
-	if ((status == SAUNAFS_STATUS_OK || status == SAUNAFS_ERROR_WAITING) &&
-	    fsOpContext.hasReadWriteTransaction()) {
-		if (!fsOpContext.getReadWriteTransaction()->commit()) {
-			safs::log_err("{}: transaction failed to commit: inode {}", __func__, inode);
-			status = SAUNAFS_ERROR_IO;
-			applied.clear();
-		}
-	}
+	status = matoclserv_run_lock_op(
+	    applied, [&](FilesystemOperationContext &fsOpContext) -> uint8_t {
+		    return gFSOperations->posixLockOperation(context, fsOpContext, inode,
+		                                             lock_info.l_start, lock_end, owner,
+		                                             eptr->sessionData->sessionId, request_id,
+		                                             message_id, op, nonblocking, applied);
+	    });
 
 	matoclserv_lock_wake_up(applied, safs_locks::Type::kPosix);
 

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -312,6 +312,30 @@ static void matoclserv_commit_wakeup_serve(const std::vector<pollfd> &pdesc) {
 	}
 }
 
+/// Publishes all changelog sinks after a deferring transaction commits.
+static void matoclserv_publish_deferred_changelog(const FilesystemOperationContext &ctx) {
+	auto entries = ctx.takeDeferredChangelogEntries();
+	for (auto &deferred : entries) {
+		// Preserve inline payload bytes, including the trailing NUL.
+		changelog(deferred.version, deferred.entry.c_str());
+		if (!getChangelogSignal().empty()) {
+			getChangelogSignal().emit(
+			    {.version = deferred.version, .entry = deferred.entry.c_str()});
+		}
+		matomlserv_broadcast_logstring(deferred.version,
+		                               reinterpret_cast<uint8_t *>(deferred.entry.data()),
+		                               deferred.entry.size());
+		matontserv_broadcast_message(deferred.version, std::string_view(deferred.entry));
+	}
+}
+
+/// Confirms a durable deferring commit and drains its changelog buffer.
+/// confirmCommitted() arms the destructor tripwire before publication drains entries.
+static void matoclserv_commit_confirmed(const FilesystemOperationContext &ctx) {
+	ctx.confirmCommitted();
+	matoclserv_publish_deferred_changelog(ctx);
+}
+
 /// Runs a replayable op body on a fresh read-write transaction and commits it
 /// SYNCHRONOUSLY, replaying the whole op (body + commit) on a fresh transaction on a
 /// retryable backend error -- either a read error thrown from the body
@@ -339,6 +363,7 @@ static uint8_t matoclserv_commit_op_with_retry(const OpReplay &body) {
 	for (uint32_t attempt = 0;; ++attempt) {
 		FilesystemOperationContext ctx = gFSOperations->createFilesystemOperationContext(
 		    FilesystemOperationContext::TransactionType::kReadWrite);
+		if (ctx.hasReadWriteTransaction()) { ctx.setDeferChangelog(); }
 		uint8_t status;
 		try {
 			if (attempt < gDebugInjectReadConflicts) {
@@ -367,6 +392,7 @@ static uint8_t matoclserv_commit_op_with_retry(const OpReplay &body) {
 		int commitError = 0;
 		bool retryable = false;
 		if (txn->commitAsync()->getResult(&commitError, &retryable)) {
+			matoclserv_commit_confirmed(ctx);
 			return SAUNAFS_STATUS_OK;  // durable
 		}
 		if (retryable && attempt < gMaxCommitRetries) {
@@ -519,15 +545,13 @@ static bool matoclserv_replay_members_iteration(std::vector<BatchMember> &member
 /// can no longer be used. Terminates: every restart either drops a member or
 /// consumes one member's bounded retry budget.
 ///
-/// Replaying a body re-runs its changeLog() call. This is safe for the KV backend:
-/// the metadata version is bumped inside the op transaction via a conflict-free
-/// atomicAdd (so it increments exactly once per durable commit), and metaloggers are
-/// not authoritative for the KV backend (the store is the source of truth), so a
-/// re-emitted changelog line is inert.
+/// Replayed bodies rerun changeLog(); discarded contexts drop their buffered entries.
+/// Only the durable context publishes, so each entry appears once after commit.
 static FilesystemOperationContext matoclserv_replay_members(std::vector<BatchMember> &members) {
 	for (;;) {
 		FilesystemOperationContext ctx = gFSOperations->createFilesystemOperationContext(
 		    FilesystemOperationContext::TransactionType::kReadWrite);
+		if (ctx.hasReadWriteTransaction()) { ctx.setDeferChangelog(); }
 		bool restart = false;
 		for (size_t idx = 0; idx < members.size() && !restart;) {
 			restart = matoclserv_replay_members_iteration(members, idx, ctx);
@@ -555,6 +579,11 @@ static void matoclserv_join_open_batch(BatchMember member) {
 	if (!gOpenBatch.hasContext) {
 		gOpenBatch.ctx = gFSOperations->createFilesystemOperationContext(
 		    FilesystemOperationContext::TransactionType::kReadWrite);
+		// Batched KV ops buffer changelog entries until commit, avoiding uncommitted
+		// publication and duplicate entries from replayed batches.
+		if (gOpenBatch.ctx.hasReadWriteTransaction()) {
+			gOpenBatch.ctx.setDeferChangelog();
+		}
 		gOpenBatch.hasContext = true;
 	}
 	auto *txn = gOpenBatch.ctx.getReadWriteTransaction();
@@ -626,6 +655,7 @@ static void matoclserv_poll_batch() {
 		const bool ok = gInFlightBatch->future->getResult(&commitError, &retryable);
 		if (ok) {
 			matoclserv_record_committed_batch(gInFlightBatch->members.size());
+			matoclserv_commit_confirmed(gInFlightBatch->ctx);
 			for (BatchMember &member : gInFlightBatch->members) {
 				matoclserv_finish_member(member, SAUNAFS_STATUS_OK);
 			}

--- a/src/master/matoclserv.h
+++ b/src/master/matoclserv.h
@@ -22,6 +22,7 @@
 
 #include "common/platform.h"
 
+#include <cstddef>
 #include <cstdint>
 
 #include "common/type_defs.h"
@@ -49,6 +50,11 @@ void matoclserv_notify_unlock_list(uint64_t chunkId);
 /// Reissues a staged KV changelog version into the strictly increasing published stream.
 /// In-memory master bypasses this; its inline versions are already serialized.
 uint64_t matoclserv_sequence_published_changelog_version(uint64_t stagedVersion);
+
+/// Fans one formatted changelog entry out to every sink: the changelog file/replay, the
+/// changelog signal, metaloggers, and notifiers. `entry` must be NUL-terminated for the
+/// C-string sinks; `size` counts the trailing NUL so broadcasts match the inline framing.
+void matoclserv_emit_changelog_sinks(uint64_t version, char *entry, std::size_t size);
 
 /// Initializes the network configuration and register the eventloop callbacks.
 /// @return 0 on success, negative value on error

--- a/src/master/matoclserv.h
+++ b/src/master/matoclserv.h
@@ -46,6 +46,10 @@ void matoclserv_chunk_status(uint64_t chunkId, uint8_t status,
 /// @param chunkId The ID of the chunk that has been unlocked
 void matoclserv_notify_unlock_list(uint64_t chunkId);
 
+/// Reissues a staged KV changelog version into the strictly increasing published stream.
+/// In-memory master bypasses this; its inline versions are already serialized.
+uint64_t matoclserv_sequence_published_changelog_version(uint64_t stagedVersion);
+
 /// Initializes the network configuration and register the eventloop callbacks.
 /// @return 0 on success, negative value on error
 int matoclserv_network_init();

--- a/tests/test_suites/ShortSystemTests/test_file_locks_ping_pong.sh
+++ b/tests/test_suites/ShortSystemTests/test_file_locks_ping_pong.sh
@@ -1,4 +1,12 @@
-timeout_set 1 minutes
+# Under the FDB backend every lock and unlock is a durable transaction, so this
+# 100k-operation ping-pong runs far longer than on the in-memory master (which
+# applies locks in memory). Give the FDB backend a larger budget; the in-memory
+# master keeps the historical timeout.
+if [[ "${METADATA_BACKEND:-}" == "FDB" ]]; then
+	timeout_set '10 minutes'
+else
+	timeout_set '1 minute'
+fi
 
 USE_RAMDISK=YES \
 	MOUNTS=5

--- a/tests/test_suites/ShortSystemTests/test_unlink_trash_config_hot_reload.sh
+++ b/tests/test_suites/ShortSystemTests/test_unlink_trash_config_hot_reload.sh
@@ -1,6 +1,8 @@
 timeout_set 6 minutes
 
-CHUNKSERVERS=4 \
+chunkserver_count=4
+
+CHUNKSERVERS=${chunkserver_count} \
 	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER" \
 	MASTER_EXTRA_CONFIG="CHUNKS_LOOP_MIN_TIME = 1`
 			`|CHUNKS_LOOP_MAX_CPU = 90`
@@ -28,7 +30,6 @@ reload_chunkserver_config() {
 		xargs -r kill -HUP
 }
 
-CHUNKSERVERS=$(grep -Eo '^CHUNKSERVERS=[^ ]+' "${BASH_SOURCE[0]}" | head -n1 | cut -d= -f2)
 etcdir="${TEMP_DIR}/saunafs/etc"
 
 ######################################################################
@@ -36,7 +37,7 @@ etcdir="${TEMP_DIR}/saunafs/etc"
 ######################################################################
 # truncate the log file
 truncate -s 0 "${TEMP_DIR}/log"
-for chunkserver_id in $(seq 0 "$((CHUNKSERVERS-1))"); do
+for chunkserver_id in $(seq 0 "$((chunkserver_count-1))"); do
 	chunkserver_cfg="${etcdir}/sfschunkserver_${chunkserver_id}.cfg"
 	sed -E -i 's/^CHUNK_TRASH_ENABLED=.*/CHUNK_TRASH_ENABLED=1/' "${chunkserver_cfg}"
 	sed -E -i 's/^CHUNK_TRASH_EXPIRATION_SECONDS=.*/CHUNK_TRASH_EXPIRATION_SECONDS=50/' \
@@ -110,7 +111,7 @@ assert_success test "${trashed_chunks_before_reload}" -gt 0
 
 # Change the config to disable chunk trashing and reload it
 truncate -s 0 "${TEMP_DIR}/log"
-for chunkserver_id in $(seq 0 "$((CHUNKSERVERS-1))"); do
+for chunkserver_id in $(seq 0 "$((chunkserver_count-1))"); do
 	chunkserver_cfg="${etcdir}/sfschunkserver_${chunkserver_id}.cfg"
 	sed -E -i 's/^CHUNK_TRASH_ENABLED=.*/CHUNK_TRASH_ENABLED=0/' "${chunkserver_cfg}"
 	sed -E -i 's/^CHUNK_TRASH_EXPIRATION_SECONDS=.*/CHUNK_TRASH_EXPIRATION_SECONDS=50/' \
@@ -134,7 +135,7 @@ fi
 ##### Change the config to disable chunk trashing and reload it
 ######################################################################
 truncate -s 0 "${TEMP_DIR}/log"
-for chunkserver_id in $(seq 0 "$((CHUNKSERVERS-1))"); do
+for chunkserver_id in $(seq 0 "$((chunkserver_count-1))"); do
 	chunkserver_cfg="${etcdir}/sfschunkserver_${chunkserver_id}.cfg"
 	sed -E -i 's/^CHUNK_TRASH_ENABLED=.*/CHUNK_TRASH_ENABLED=0/' "${chunkserver_cfg}"
 	sed -E -i 's/^CHUNK_TRASH_EXPIRATION_SECONDS=.*/CHUNK_TRASH_EXPIRATION_SECONDS=90/' "${chunkserver_cfg}"


### PR DESCRIPTION
Master-side changes so the FDB metadata backend increases functional
parity with the in-memory master. Every new path gates on an active
read-write transaction, so the in-memory master is unaffected: it
never defers and never retries.

Changelog:
- Defer changelog sinks (file, signal, metalogger, notifier) until
  after commit and drain them at a single confirmed-commit choke
  point, so retried KV commits no longer publish aborted or duplicate
  entries.
- Route every publication, deferred and inline, through one version
  sequencer so the emitted stream stays monotonic on a single MDS.

Locks:
- Replay FLOCK and SETLK through the retry harness so normal
  same-inode contention no longer surfaces as EIO, sharing one lock-op
  helper and clearing the applied set on failure. WAITING preserved.
- Route admin unlock and pending-lock interrupt through the same
  harness.

Repair and chunk locks:
- Persist repair edits to the file node via updateNode, otherwise
  erased or repaired chunk-table edits are lost after a restart (the
  in-memory master keeps the node itself and masks this).
- Expose chunk lockid and lockedto accessors so the KV backend can
  round-trip write-lock state without reaching into chunk internals.

Test:
- Track the trash hot-reload chunkserver count in one shell variable
  instead of grepping the test's own source, which broke when sourced
  from the FDB wrapper.

Known limitation: some direct-commit paths (disconnect cleanup,
reserved inodes, repair) still publish inline before durability, and
the sequencer is single-MDS; multi-MDS ordering is future work.

Related to: LS-906 LS-907

Signed-off-by: guillex <guillex@leil.io>