### PR TITLE
feat(fdb): add getApproximateSize to transactions

### DIFF
--- a/src/fdb/fdb.cc
+++ b/src/fdb/fdb.cc
@@ -384,22 +384,25 @@ bool Transaction::commit() {
 	return true;
 }
 
-std::optional<uint64_t> Transaction::getApproximateSize() {
+std::optional<uint64_t> Transaction::getApproximateSize() const {
 	if (!tr_) { return std::nullopt; }
 
+	// This is an advisory query: on failure we return std::nullopt and let the caller fall back
+	// to a count-based bound. Errors are kept in a local variable rather than the member error_,
+	// so a transient/unsupported query does not poison the transaction's validity (operator bool).
 	UniqueFDBFuture future(fdb_transaction_get_approximate_size(tr_.get()));
-	error_ = fdb_future_block_until_ready(future.get());
-	if (error_ != 0) {
+	fdb_error_t error = fdb_future_block_until_ready(future.get());
+	if (error != 0) {
 		safs::log_err("Transaction::getApproximateSize: fdb_future_block_until_ready: error: {}",
-		              fdb_get_error(error_));
+		              fdb_get_error(error));
 		return std::nullopt;
 	}
 
 	int64_t size{};
-	error_ = fdb_future_get_int64(future.get(), &size);
-	if (error_ != 0) {
+	error = fdb_future_get_int64(future.get(), &size);
+	if (error != 0) {
 		safs::log_err("Transaction::getApproximateSize: fdb_future_get_int64: error: {}",
-		              fdb_get_error(error_));
+		              fdb_get_error(error));
 		return std::nullopt;
 	}
 

--- a/src/fdb/fdb.cc
+++ b/src/fdb/fdb.cc
@@ -384,6 +384,28 @@ bool Transaction::commit() {
 	return true;
 }
 
+std::optional<uint64_t> Transaction::getApproximateSize() {
+	if (!tr_) { return std::nullopt; }
+
+	UniqueFDBFuture future(fdb_transaction_get_approximate_size(tr_.get()));
+	error_ = fdb_future_block_until_ready(future.get());
+	if (error_ != 0) {
+		safs::log_err("Transaction::getApproximateSize: fdb_future_block_until_ready: error: {}",
+		              fdb_get_error(error_));
+		return std::nullopt;
+	}
+
+	int64_t size{};
+	error_ = fdb_future_get_int64(future.get(), &size);
+	if (error_ != 0) {
+		safs::log_err("Transaction::getApproximateSize: fdb_future_get_int64: error: {}",
+		              fdb_get_error(error_));
+		return std::nullopt;
+	}
+
+	return static_cast<uint64_t>(size);
+}
+
 namespace {
 
 /// Pollable wrapper around an in-flight fdb_transaction_commit() future.

--- a/src/fdb/fdb.h
+++ b/src/fdb/fdb.h
@@ -270,6 +270,11 @@ public:
 	/// @return The committed version, if available.
 	std::optional<int64_t> getCommittedVersion() const { return committedVersion_; }
 
+	/// Approximate byte size that the buffered mutations and conflict ranges would contribute
+	/// to a commit (fdb_transaction_get_approximate_size). Computed client-side.
+	/// @return The approximate size, or std::nullopt on error.
+	std::optional<uint64_t> getApproximateSize();
+
 private:
 	/// Custom deleter for FDBTransaction (C struct), to ensure proper cleanup.
 	struct FDBTransactionDeleter {

--- a/src/fdb/fdb.h
+++ b/src/fdb/fdb.h
@@ -273,7 +273,7 @@ public:
 	/// Approximate byte size that the buffered mutations and conflict ranges would contribute
 	/// to a commit (fdb_transaction_get_approximate_size). Computed client-side.
 	/// @return The approximate size, or std::nullopt on error.
-	std::optional<uint64_t> getApproximateSize();
+	std::optional<uint64_t> getApproximateSize() const;
 
 private:
 	/// Custom deleter for FDBTransaction (C struct), to ensure proper cleanup.

--- a/src/fdb/fdb_transaction.cc
+++ b/src/fdb/fdb_transaction.cc
@@ -107,7 +107,7 @@ std::optional<int64_t> FDBTransaction::getCommittedVersion() const {
 	return tr_.getCommittedVersion();
 }
 
-std::optional<uint64_t> FDBTransaction::getApproximateSize() {
+std::optional<uint64_t> FDBTransaction::getApproximateSize() const {
 	if (!tr_) { return std::nullopt; }
 
 	return tr_.getApproximateSize();

--- a/src/fdb/fdb_transaction.cc
+++ b/src/fdb/fdb_transaction.cc
@@ -107,4 +107,10 @@ std::optional<int64_t> FDBTransaction::getCommittedVersion() const {
 	return tr_.getCommittedVersion();
 }
 
+std::optional<uint64_t> FDBTransaction::getApproximateSize() {
+	if (!tr_) { return std::nullopt; }
+
+	return tr_.getApproximateSize();
+}
+
 }  // namespace fdb

--- a/src/fdb/fdb_transaction.h
+++ b/src/fdb/fdb_transaction.h
@@ -114,7 +114,7 @@ public:
 	uint64_t mutationCount() const override { return mutationCount_; }
 
 	/// Approximate byte size of the buffered writes so far (client-side estimate).
-	std::optional<uint64_t> getApproximateSize() override;
+	std::optional<uint64_t> getApproximateSize() const override;
 
 	/// Returns the error code of the last operation.
 	fdb_error_t error() const { return error_; }

--- a/src/fdb/fdb_transaction.h
+++ b/src/fdb/fdb_transaction.h
@@ -113,6 +113,9 @@ public:
 	/// Number of buffered mutations issued on this transaction so far.
 	uint64_t mutationCount() const override { return mutationCount_; }
 
+	/// Approximate byte size of the buffered writes so far (client-side estimate).
+	std::optional<uint64_t> getApproximateSize() override;
+
 	/// Returns the error code of the last operation.
 	fdb_error_t error() const { return error_; }
 

--- a/src/fdb/fdb_unittest.cc
+++ b/src/fdb/fdb_unittest.cc
@@ -931,6 +931,44 @@ TEST_F(FDBKVEngineTest, MutationCount) {
 	EXPECT_EQ(txn->mutationCount(), uint64_t{5}) << "removeRange() buffers one mutation.";
 }
 
+// getApproximateSize() reports the client-side estimate of the transaction's buffered writes.
+// It is supported by the FDB backend, grows as mutations are added, and reflects the payload
+// size (a large value increases it substantially more than a small one). The writer relies on
+// this to bound a flush transaction below FDB's per-transaction size limit. The transaction is
+// dropped without committing: the size is a property of the buffered mutations, not of the
+// commit.
+TEST_F(FDBKVEngineTest, GetApproximateSize) {
+	auto txn = kvEngine->createReadWriteTransaction();
+
+	// A fresh transaction reports a value (baseline overhead); the FDB backend supports it.
+	auto initial = txn->getApproximateSize();
+	ASSERT_TRUE(initial.has_value())
+	    << "getApproximateSize() must be supported by the FDB backend.";
+
+	// A buffered set() grows the estimate by at least the value payload.
+	const auto key = kv::toBytes("approx_size_key");
+	const kv::Value smallValue(64, 'x');
+	txn->set(key, smallValue);
+	auto afterSmall = txn->getApproximateSize();
+	ASSERT_TRUE(afterSmall.has_value());
+	EXPECT_GT(*afterSmall, *initial) << "A buffered set() must increase the approximate size.";
+	EXPECT_GE(*afterSmall - *initial, smallValue.size())
+	    << "The growth must cover at least the written value bytes.";
+
+	// A large value grows the estimate substantially more than a small one.
+	const auto bigKey = kv::toBytes("approx_size_big_key");
+	const kv::Value bigValue(64 * 1024, 'y');  // 64 KiB, under FDB's per-value limit
+	txn->set(bigKey, bigValue);
+	auto afterBig = txn->getApproximateSize();
+	ASSERT_TRUE(afterBig.has_value());
+	EXPECT_GE(*afterBig - *afterSmall, bigValue.size())
+	    << "A large buffered value must be reflected in the approximate size.";
+
+	safs::log_info("Approximate size: initial={}, after 64B set={}, after 64KiB set={}", *initial,
+	               *afterSmall, *afterBig);
+	// No cleanup: the transaction is intentionally dropped without committing.
+}
+
 // Exercises the async-commit path end to end: poll isReady(), finalize via getResult(),
 // confirm the committed version is captured, that getResult() is single-use, and that
 // the write is durable.

--- a/src/fdb/fdb_unittest.cc
+++ b/src/fdb/fdb_unittest.cc
@@ -951,8 +951,9 @@ TEST_F(FDBKVEngineTest, GetApproximateSize) {
 	txn->set(key, smallValue);
 	auto afterSmall = txn->getApproximateSize();
 	ASSERT_TRUE(afterSmall.has_value());
-	EXPECT_GT(*afterSmall, *initial) << "A buffered set() must increase the approximate size.";
-	EXPECT_GE(*afterSmall - *initial, smallValue.size())
+	EXPECT_GT(afterSmall.value(), initial.value())
+	    << "A buffered set() must increase the approximate size.";
+	EXPECT_GE(afterSmall.value(), initial.value() + smallValue.size())
 	    << "The growth must cover at least the written value bytes.";
 
 	// A large value grows the estimate substantially more than a small one.
@@ -961,11 +962,11 @@ TEST_F(FDBKVEngineTest, GetApproximateSize) {
 	txn->set(bigKey, bigValue);
 	auto afterBig = txn->getApproximateSize();
 	ASSERT_TRUE(afterBig.has_value());
-	EXPECT_GE(*afterBig - *afterSmall, bigValue.size())
+	EXPECT_GE(afterBig.value(), afterSmall.value() + bigValue.size())
 	    << "A large buffered value must be reflected in the approximate size.";
 
-	safs::log_info("Approximate size: initial={}, after 64B set={}, after 64KiB set={}", *initial,
-	               *afterSmall, *afterBig);
+	safs::log_info("Approximate size: initial={}, after 64B set={}, after 64KiB set={}",
+	               initial.value(), afterSmall.value(), afterBig.value());
 	// No cleanup: the transaction is intentionally dropped without committing.
 }
 

--- a/src/kv/itransaction.h
+++ b/src/kv/itransaction.h
@@ -173,6 +173,13 @@ public:
 	/// the shared transaction (it must be rebuilt), or failed clean (no rebuild needed).
 	virtual uint64_t mutationCount() const = 0;
 
+	/// Approximate byte size of the transaction's buffered writes so far, including the
+	/// mutations, read/write conflict ranges and backend overhead that count toward the
+	/// backend's per-transaction size limit. Returns std::nullopt when the backend cannot
+	/// report it (callers then fall back to a count-based bound). Computed client-side, so it
+	/// is cheap to poll while applying a batch.
+	virtual std::optional<uint64_t> getApproximateSize() { return std::nullopt; }
+
 protected:
 	IReadWriteTransaction() = default;
 };

--- a/src/kv/itransaction.h
+++ b/src/kv/itransaction.h
@@ -178,7 +178,7 @@ public:
 	/// backend's per-transaction size limit. Returns std::nullopt when the backend cannot
 	/// report it (callers then fall back to a count-based bound). Computed client-side, so it
 	/// is cheap to poll while applying a batch.
-	virtual std::optional<uint64_t> getApproximateSize() { return std::nullopt; }
+	virtual std::optional<uint64_t> getApproximateSize() const { return std::nullopt; }
 
 protected:
 	IReadWriteTransaction() = default;


### PR DESCRIPTION
Wrap fdb_transaction_get_approximate_size to expose the client-side estimate of a transaction's buffered writes, like mutations, conflict ranges and backend overhead that count toward FDB's per-transaction size limit. Cheap to poll while applying a batch, so callers can split before hitting the limit instead of relying on a count-based bound.

Adds the raw wrapper on fdb::Transaction, an FDBTransaction override, and a virtual on the IReadWriteTransaction interface defaulting to std::nullopt for backends that cannot report it. Covered by a new FDBKVEngineTest.GetApproximateSize unit test.

Signed-off-by: Crash <<crash@leil.io>>