### PR TITLE
chore: ignore renamed MDS config symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,7 @@ tests/test_suites/WindowsClientTests
 ###########
 src/mds
 src/data/sfsmds*
+src/data/leil-mds.cfg.in
 tests/test_suites/FDBTests
 
 # Windows #


### PR DESCRIPTION
The MDS repo renamed src/data/sfsmds.cfg.in to leil-mds.cfg.in. The local dev symlink from leilfs into the sibling MDS tree follows the new name, so ignore src/data/leil-mds.cfg.in next to the legacy sfsmds* entry.