### PR TITLE
feat(fdb): add typed errors, throwing reads

### DIFF
--- a/src/common/event_loop.cc
+++ b/src/common/event_loop.cc
@@ -42,22 +42,28 @@ ExitingStatus gExitingStatus = ExitingStatus::kRunning;
 bool gReloadRequested = false;
 static bool nextPollNonblocking = false;
 
-/// Runs one event-loop handler, containing retryable KV backend errors.
+/// Runs one event-loop handler, containing KV backend errors.
 ///
 /// Op bodies replay these on a fresh transaction at the op boundary, but periodic
 /// and connection handlers (session sweeps, disconnect bookkeeping, ...) have no
-/// such boundary; before this guard an escaped kv::RetryableTransactionError
-/// (e.g. a transaction_timed_out read while the backend is slow or shutting
-/// down) reached std::terminate and aborted the whole server. The interrupted
-/// handler simply runs again on a later loop iteration.
+/// such boundary. An escaped backend error must not reach std::terminate and abort
+/// the whole server: retryable failures are warnings, non-retryable failures are
+/// errors, and the interrupted handler runs again on a later loop iteration. Exceptions
+/// outside the backend error family still propagate and retain fail-stop behavior.
 template <typename Handler, typename... Args>
 static void eventloop_run_handler(const char *kind, Handler &&handler, Args &&...args) {
 	try {
 		handler(std::forward<Args>(args)...);
 	} catch (const kv::RetryableTransactionError &e) {
 		safs::log_warn(
-		    "event loop: retryable backend error escaped a {} handler, skipping this run: {}", kind,
-		    e.what());
+		    "event loop: retryable backend error escaped a {} handler (err {}), skipping this "
+		    "run: {}",
+		    kind, e.errorCode(), e.what());
+	} catch (const kv::TransactionError &e) {
+		safs::log_err(
+		    "event loop: backend transaction error escaped a {} handler (err {}), skipping this "
+		    "run: {}",
+		    kind, e.errorCode(), e.what());
 	}
 }
 

--- a/src/fdb/fdb.cc
+++ b/src/fdb/fdb.cc
@@ -75,6 +75,18 @@ inline void addNanos(std::atomic<uint64_t> &counter, uint64_t nanos) {
 	counter.fetch_add(nanos, std::memory_order_relaxed);
 }
 
+/// Attributes a failed commit to the conflict or failure counter. Gated on accounting
+/// because evaluatePredicate() calls into the FDB C API. Matches
+/// FDBCommitFuture::getResult: a commit_unknown_result / maybe-committed error is a
+/// commitFailure, not a (definitely-not-committed) conflict.
+inline void countFailedCommit(fdb_error_t err) {
+	if (!opCountersEnabled()) { return; }
+	auto &counter = DB::evaluatePredicate(FDB_ERROR_PREDICATE_RETRYABLE_NOT_COMMITTED, err)
+	                    ? gOpCounters.commitConflicts
+	                    : gOpCounters.commitFailures;
+	counter.fetch_add(1, std::memory_order_relaxed);
+}
+
 /// Nanoseconds elapsed since `start` on the steady clock, for accumulating the
 /// wall time the single MDS thread spends blocked in FDB read/commit futures.
 inline uint64_t elapsedNanosSince(std::chrono::steady_clock::time_point start) {
@@ -201,6 +213,18 @@ std::optional<kv::Value> Transaction::get(const kv::Key &key, bool snapshot) {
 
 	bump(gOpCounters.pointReads);
 	bumpReadPrefix(key);
+
+	// TEST-ONLY scripted read failure; short-circuits before contacting the cluster and
+	// mirrors the real error path below (sync reads report via error_, they do not throw).
+	if (faultInjection_ != nullptr) {
+		fdb_error_t injected = FaultInjection::next(faultInjection_->readErrors);
+		if (injected != 0) {
+			error_ = injected;
+			safs::log_err("Transaction::get: injected error: {}", fdb_get_error(injected));
+			return std::nullopt;
+		}
+	}
+
 	UniqueFDBFuture future(
 	    fdb_transaction_get(tr_.get(), key.data(), static_cast<int>(key.size()), snapshot));
 
@@ -243,7 +267,7 @@ std::unique_ptr<kv::IFuture> Transaction::getAsync(const kv::Key &key, bool snap
 	FDBFuture *future = fdb_transaction_get(tr_.get(), key.data(), static_cast<int>(key.size()),
 	                                        static_cast<fdb_bool_t>(snapshot));
 
-	return std::make_unique<FDBFutureValue>(future);
+	return std::make_unique<FDBFutureValue>(future, faultInjection_);
 }
 
 kv::GetRangeResult Transaction::getRange(
@@ -284,7 +308,7 @@ std::unique_ptr<kv::IRangeFuture> Transaction::getRangeAsync(
 	    endOffset, limit, kBytesLimit, streamingMode, iteration, static_cast<fdb_bool_t>(snapshot),
 	    static_cast<fdb_bool_t>(reverse));
 
-	return std::make_unique<FDBFutureRange>(future);
+	return std::make_unique<FDBFutureRange>(future, faultInjection_);
 }
 
 void Transaction::set(const kv::Key &key, const kv::Value &value) {
@@ -332,6 +356,20 @@ bool Transaction::commit() {
 	if (!tr_) { return false; }
 
 	bump(gOpCounters.commits);
+
+	// TEST-ONLY scripted pre-commit failure: nothing is submitted to the cluster; the
+	// scripted code takes the same classification path as a real failed commit.
+	if (faultInjection_ != nullptr) {
+		fdb_error_t injected = FaultInjection::next(faultInjection_->preCommitErrors);
+		if (injected != 0) {
+			error_ = injected;
+			safs::log_err("Transaction::commit: injected pre-commit error: {}",
+			              fdb_get_error(injected));
+			countFailedCommit(injected);
+			return false;
+		}
+	}
+
 	UniqueFDBFuture future(fdb_transaction_commit(tr_.get()));
 
 	const bool profiling = opCountersEnabled();
@@ -352,25 +390,26 @@ bool Transaction::commit() {
 	// future itself and must be checked with fdb_future_get_error().
 	error_ = fdb_future_get_error(future.get());
 
+	// TEST-ONLY scripted post-commit override: at this point the commit IS durable; the
+	// caller is nevertheless told it failed with the scripted code (commit_unknown_result
+	// 1021 reproduces the maybe-committed case).
+	if (error_ == 0 && faultInjection_ != nullptr) {
+		error_ = FaultInjection::next(faultInjection_->postCommitErrors);
+	}
+
 	if (error_ != 0) {
 		safs::log_err("Transaction::commit: commit failed: {}", fdb_get_error(error_));
-		// evaluatePredicate() calls into the FDB C API, so only pay for it when
-		// accounting is on; keeps the disabled path a single relaxed bool load.
-		// The gate is already known here, so increment directly instead of bump().
-		if (opCountersEnabled()) {
-			// Match FDBCommitFuture::getResult: a commit_unknown_result / maybe-committed
-			// error is a commitFailure, not a (definitely-not-committed) conflict.
-			auto &counter =
-			    DB::evaluatePredicate(FDB_ERROR_PREDICATE_RETRYABLE_NOT_COMMITTED, error_)
-			        ? gOpCounters.commitConflicts
-			        : gOpCounters.commitFailures;
-			counter.fetch_add(1, std::memory_order_relaxed);
-		}
+		countFailedCommit(error_);
 		return false;
 	}
 
 	int64_t version{};
 	fdb_error_t versionError = fdb_transaction_get_committed_version(tr_.get(), &version);
+
+	// TEST-ONLY scripted committed-version-lookup failure after a successful commit.
+	if (versionError == 0 && faultInjection_ != nullptr) {
+		versionError = FaultInjection::next(faultInjection_->committedVersionErrors);
+	}
 
 	if (versionError != 0) {
 		safs::log_err("Transaction::commit: fdb_transaction_get_committed_version: error: {}",
@@ -419,11 +458,13 @@ namespace {
 class FDBCommitFuture final : public kv::ICommitFuture {
 public:
 	FDBCommitFuture(FDBFuture *commitFuture, FDBTransaction *trHandle,
-	                std::optional<int64_t> *committedVersionOut, fdb_error_t *errorOut)
+	                std::optional<int64_t> *committedVersionOut, fdb_error_t *errorOut,
+	                FaultInjection *fault)
 	    : future_(commitFuture),
 	      trHandle_(trHandle),
 	      committedVersionOut_(committedVersionOut),
-	      errorOut_(errorOut) {}
+	      errorOut_(errorOut),
+	      faultInjection_(fault) {}
 
 	~FDBCommitFuture() override {
 		if (future_ != nullptr) { fdb_future_destroy(future_); }
@@ -486,6 +527,13 @@ public:
 		if (profiling) { addNanos(gOpCounters.commitWaitNanos, elapsedNanosSince(waitStart)); }
 		if (err == 0) { err = fdb_future_get_error(future_); }
 
+		// TEST-ONLY scripted post-commit override: at this point the commit IS durable;
+		// the caller is nevertheless told it failed with the scripted code
+		// (commit_unknown_result 1021 reproduces the maybe-committed case).
+		if (err == 0 && faultInjection_ != nullptr) {
+			err = FaultInjection::next(faultInjection_->postCommitErrors);
+		}
+
 		if (err != 0) {
 			*errorOut_ = err;
 			consumedError_ = err;
@@ -512,6 +560,12 @@ public:
 
 		int64_t version{};
 		fdb_error_t versionError = fdb_transaction_get_committed_version(trHandle_, &version);
+
+		// TEST-ONLY scripted committed-version-lookup failure after a successful commit.
+		if (versionError == 0 && faultInjection_ != nullptr) {
+			versionError = FaultInjection::next(faultInjection_->committedVersionErrors);
+		}
+
 		if (versionError != 0) {
 			*errorOut_ = versionError;
 			consumedError_ = versionError;
@@ -544,9 +598,39 @@ private:
 	FDBTransaction *trHandle_;
 	std::optional<int64_t> *committedVersionOut_;
 	fdb_error_t *errorOut_;
+	FaultInjection *faultInjection_;
 	bool consumed_ = false;
 	fdb_error_t consumedError_ = 0;
 	bool consumedRetryable_ = false;
+};
+
+/// TEST-ONLY already-failed commit future for a scripted pre-commit error: reports the
+/// scripted code with the same RETRYABLE_NOT_COMMITTED classification and accounting as
+/// a real failed commit, but nothing was submitted to the cluster.
+class InjectedCommitFuture final : public kv::ICommitFuture {
+public:
+	explicit InjectedCommitFuture(fdb_error_t err) : error_(err) {}
+
+	bool isReady() override { return true; }
+
+	void setReadyCallback(void (*callback)(void *), void *arg) override {
+		if (callback != nullptr) { callback(arg); }
+	}
+
+	bool getResult(int *error, bool *retryable) override {
+		const bool isRetryable =
+		    DB::evaluatePredicate(FDB_ERROR_PREDICATE_RETRYABLE_NOT_COMMITTED, error_);
+		if (error != nullptr) { *error = error_; }
+		if (retryable != nullptr) { *retryable = isRetryable; }
+		if (consumed_) { return false; }
+		consumed_ = true;
+		countFailedCommit(error_);
+		return false;
+	}
+
+private:
+	fdb_error_t error_;
+	bool consumed_ = false;
 };
 
 }  // namespace
@@ -555,9 +639,22 @@ std::unique_ptr<kv::ICommitFuture> Transaction::commitAsync() {
 	if (!tr_) { return std::make_unique<kv::ImmediateCommitFuture>(false); }
 
 	bump(gOpCounters.commits);
+
+	// TEST-ONLY scripted pre-commit failure: nothing is submitted to the cluster.
+	if (faultInjection_ != nullptr) {
+		fdb_error_t injected = FaultInjection::next(faultInjection_->preCommitErrors);
+		if (injected != 0) {
+			error_ = injected;
+			safs::log_err("Transaction::commitAsync: injected pre-commit error: {}",
+			              fdb_get_error(injected));
+			return std::make_unique<InjectedCommitFuture>(injected);
+		}
+	}
+
 	FDBFuture *future = fdb_transaction_commit(tr_.get());
 
-	return std::make_unique<FDBCommitFuture>(future, tr_.get(), &committedVersion_, &error_);
+	return std::make_unique<FDBCommitFuture>(future, tr_.get(), &committedVersion_, &error_,
+	                                         faultInjection_);
 }
 
 }  // namespace fdb

--- a/src/fdb/fdb.cc
+++ b/src/fdb/fdb.cc
@@ -26,6 +26,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -33,6 +34,7 @@
 #include <foundationdb/fdb_c_types.h>
 
 #include "fdb/fdb.h"
+#include "fdb/fdb_errors.h"
 #include "fdb/fdb_future.h"
 #include "slogger/slogger.h"
 
@@ -204,24 +206,31 @@ fdb_error_t DB::setOption(FDBDatabaseOption option, std::string_view value) {
 // Transaction
 
 fdb_error_t Transaction::setOption(FDBTransactionOption option, std::string_view value) {
+	requireHandle("setOption");
 	return fdb_transaction_set_option(tr_.get(), option, toU8(value),
 	                                  static_cast<int>(value.length()));
 }
 
+void Transaction::requireHandle(const char *operation) const {
+	if (tr_) { return; }
+	throw std::logic_error(std::string("fdb::Transaction::") + operation +
+	                       ": no backend transaction handle");
+}
+
 std::optional<kv::Value> Transaction::get(const kv::Key &key, bool snapshot) {
-	if (!tr_) { return std::nullopt; }
+	requireHandle("get");
 
 	bump(gOpCounters.pointReads);
 	bumpReadPrefix(key);
 
 	// TEST-ONLY scripted read failure; short-circuits before contacting the cluster and
-	// mirrors the real error path below (sync reads report via error_, they do not throw).
+	// takes exactly the real error path below.
 	if (faultInjection_ != nullptr) {
 		fdb_error_t injected = FaultInjection::next(faultInjection_->readErrors);
 		if (injected != 0) {
 			error_ = injected;
 			safs::log_err("Transaction::get: injected error: {}", fdb_get_error(injected));
-			return std::nullopt;
+			detail::throwTransactionError(injected);
 		}
 	}
 
@@ -237,7 +246,7 @@ std::optional<kv::Value> Transaction::get(const kv::Key &key, bool snapshot) {
 	if (error_ != 0) {
 		safs::log_err("Transaction::get: fdb_future_block_until_ready: error: {}",
 		              fdb_get_error(error_));
-		return std::nullopt;
+		detail::throwTransactionError(error_);
 	}
 
 	fdb_bool_t valuePresent{};
@@ -248,7 +257,7 @@ std::optional<kv::Value> Transaction::get(const kv::Key &key, bool snapshot) {
 
 	if (error_ != 0) {
 		safs::log_err("Transaction::get: fdb_future_get_value: error: {}", fdb_get_error(error_));
-		return std::nullopt;
+		detail::throwTransactionError(error_);
 	}
 
 	if (valuePresent == 0) {
@@ -260,7 +269,7 @@ std::optional<kv::Value> Transaction::get(const kv::Key &key, bool snapshot) {
 }
 
 std::unique_ptr<kv::IFuture> Transaction::getAsync(const kv::Key &key, bool snapshot) {
-	if (!tr_) { return nullptr; }
+	requireHandle("getAsync");
 
 	bump(gOpCounters.pointReads);
 	bumpReadPrefix(key);
@@ -275,7 +284,6 @@ kv::GetRangeResult Transaction::getRange(
     bool snapshot /* = false */, bool reverse /* = false */,
     FDBStreamingMode streamingMode /* = FDB_STREAMING_MODE_SERIAL */) {
 	auto future = getRangeAsync(begin, end, limit, iteration, snapshot, reverse, streamingMode);
-	if (!future) { return {{}, false}; }
 
 	return future->get();
 }
@@ -284,7 +292,7 @@ std::unique_ptr<kv::IRangeFuture> Transaction::getRangeAsync(
     const kv::KeySelector &begin, const kv::KeySelector &end, int limit, int iteration /* = 0 */,
     bool snapshot /* = false */, bool reverse /* = false */,
     FDBStreamingMode streamingMode /* = FDB_STREAMING_MODE_SERIAL */) {
-	if (!tr_) { return nullptr; }
+	requireHandle("getRangeAsync");
 
 	bump(gOpCounters.rangeReads);
 	bumpReadPrefix(begin.getKey());
@@ -312,7 +320,7 @@ std::unique_ptr<kv::IRangeFuture> Transaction::getRangeAsync(
 }
 
 void Transaction::set(const kv::Key &key, const kv::Value &value) {
-	if (!tr_) { return; }
+	requireHandle("set");
 
 	bump(gOpCounters.sets);
 	fdb_transaction_set(tr_.get(), key.data(), static_cast<int>(key.size()), value.data(),
@@ -320,7 +328,7 @@ void Transaction::set(const kv::Key &key, const kv::Value &value) {
 }
 
 void Transaction::atomicAdd(const kv::Key &key, const kv::Value &delta) {
-	if (!tr_) { return; }
+	requireHandle("atomicAdd");
 
 	bump(gOpCounters.atomicAdds);
 	fdb_transaction_atomic_op(tr_.get(), key.data(), static_cast<int>(key.size()), delta.data(),
@@ -328,7 +336,7 @@ void Transaction::atomicAdd(const kv::Key &key, const kv::Value &delta) {
 }
 
 void Transaction::atomicMax(const kv::Key &key, const kv::Value &value) {
-	if (!tr_) { return; }
+	requireHandle("atomicMax");
 
 	// Counted under atomicAdds is wrong, and adding a positional counter field would
 	// desync the FdbOpCounters snapshot init; atomicMax is profiling-irrelevant, so it
@@ -338,14 +346,14 @@ void Transaction::atomicMax(const kv::Key &key, const kv::Value &value) {
 }
 
 void Transaction::remove(const kv::Key &key) {
-	if (!tr_) { return; }
+	requireHandle("remove");
 
 	bump(gOpCounters.clears);
 	fdb_transaction_clear(tr_.get(), key.data(), static_cast<int>(key.size()));
 }
 
 void Transaction::removeRange(const kv::Key &start, const kv::Key &end) {
-	if (!tr_) { return; }
+	requireHandle("removeRange");
 
 	bump(gOpCounters.clearRanges);
 	fdb_transaction_clear_range(tr_.get(), start.data(), static_cast<int>(start.size()), end.data(),
@@ -353,7 +361,11 @@ void Transaction::removeRange(const kv::Key &start, const kv::Key &end) {
 }
 
 bool Transaction::commit() {
-	if (!tr_) { return false; }
+	requireHandle("commit");
+
+	// A new attempt invalidates the previous attempt's version: a failed re-commit on a
+	// reused transaction must not leave a stale success visible via getCommittedVersion.
+	committedVersion_.reset();
 
 	bump(gOpCounters.commits);
 
@@ -381,7 +393,7 @@ bool Transaction::commit() {
 	if (error_ != 0) {
 		safs::log_err("Transaction::commit: fdb_future_block_until_ready: error: {}",
 		              fdb_get_error(error_));
-		bump(gOpCounters.commitFailures);
+		countFailedCommit(error_);
 		return false;
 	}
 
@@ -412,10 +424,15 @@ bool Transaction::commit() {
 	}
 
 	if (versionError != 0) {
-		safs::log_err("Transaction::commit: fdb_transaction_get_committed_version: error: {}",
-		              fdb_get_error(versionError));
-		error_ = versionError;
-		return false;
+		// The commit itself succeeded and is durable; only the version lookup failed.
+		// Report success without a version (committedVersion_ stays cleared from the
+		// attempt start): signaling failure here would invite the caller to replay an
+		// already-applied operation.
+		safs::log_err(
+		    "Transaction::commit: fdb_transaction_get_committed_version failed after a "
+		    "successful commit, continuing without a committed version: {}",
+		    fdb_get_error(versionError));
+		return true;
 	}
 
 	committedVersion_ = version;
@@ -508,9 +525,10 @@ public:
 	bool getResult(int *error, bool *retryable) override {
 		if (retryable != nullptr) { *retryable = false; }
 		if (consumed_ || future_ == nullptr) {
-			// A null future is a defensive failure (commitAsync never builds one: it
-			// returns an ImmediateCommitFuture when there is no transaction). Report a
-			// generic non-zero error rather than the success-looking consumedError_ (0).
+			// A consumed future re-reports the first call's outcome (consumedError_, 0
+			// after a successful commit). A null future is a defensive failure
+			// (commitAsync never builds one: it throws when there is no transaction
+			// handle) and reports a generic non-zero error instead.
 			if (error != nullptr) { *error = future_ == nullptr ? 1 : consumedError_; }
 			if (retryable != nullptr) { *retryable = consumedRetryable_; }
 			return false;
@@ -567,12 +585,17 @@ public:
 		}
 
 		if (versionError != 0) {
-			*errorOut_ = versionError;
-			consumedError_ = versionError;
-			safs::log_err("FDBCommitFuture::getResult: fdb_transaction_get_committed_version: {}",
-			              fdb_get_error(versionError));
-			if (error != nullptr) { *error = versionError; }
-			return false;
+			// The commit itself succeeded and is durable; only the version lookup
+			// failed. Report success without a version (the version out-param stays
+			// cleared from the attempt start): signaling failure here would invite the
+			// caller to replay an already-applied operation.
+			safs::log_err(
+			    "FDBCommitFuture::getResult: fdb_transaction_get_committed_version failed "
+			    "after a successful commit, continuing without a committed version: {}",
+			    fdb_get_error(versionError));
+			*errorOut_ = 0;
+			if (error != nullptr) { *error = 0; }
+			return true;
 		}
 
 		*committedVersionOut_ = version;
@@ -636,7 +659,11 @@ private:
 }  // namespace
 
 std::unique_ptr<kv::ICommitFuture> Transaction::commitAsync() {
-	if (!tr_) { return std::make_unique<kv::ImmediateCommitFuture>(false); }
+	requireHandle("commitAsync");
+
+	// A new attempt invalidates the previous attempt's version: a failed re-commit on a
+	// reused transaction must not leave a stale success visible via getCommittedVersion.
+	committedVersion_.reset();
 
 	bump(gOpCounters.commits);
 

--- a/src/fdb/fdb.h
+++ b/src/fdb/fdb.h
@@ -165,29 +165,23 @@ private:
 
 /// TEST-ONLY deterministic fault injection for fdb::Transaction and its futures.
 ///
-/// Each queue scripts the outcomes of one injection point, consumed front-to-back, one
-/// entry per call: a non-zero entry makes that call fail with exactly that FDB error
-/// code, a zero entry leaves that call untouched, and an exhausted (empty) queue stops
-/// injecting. This makes error sequences fully deterministic, e.g. "fail only the second
-/// read with not_committed" is {0, 1020}.
-///
-/// Production never constructs one of these; transactions carry a null pointer and each
-/// injection point costs a single null check. Not owned by the transaction: the test
-/// keeps the instance alive for the transaction's (and its futures') lifetime.
+/// Each queue scripts one injection point, consumed front-to-back, one entry per call:
+/// non-zero fails that call with exactly that FDB error code, zero skips it, empty stops
+/// injecting ("fail only the second read with not_committed" is {0, 1020}). Not owned by
+/// the transaction; production carries a null pointer, one null check per operation.
 struct FaultInjection {
-	/// Read results (point get and range get, sync and async): the read fails with the
-	/// scripted error before contacting the cluster.
+	/// Read results (point and range, sync and async); the injected failure takes the
+	/// real error path when the result is consumed. Sync point reads short-circuit
+	/// before contacting the cluster; async and range reads have already issued the
+	/// real request, only its result is overridden.
 	std::deque<fdb_error_t> readErrors;
-	/// Commit attempts, checked BEFORE submitting: the commit fails with the scripted
-	/// error and nothing is sent to the cluster.
+	/// Commit attempts, checked BEFORE submitting; nothing is sent to the cluster.
 	std::deque<fdb_error_t> preCommitErrors;
-	/// Commit results, checked AFTER a real successful commit: the already-durable
-	/// commit is reported as failed with the scripted error. With commit_unknown_result
-	/// (1021) this reproduces the maybe-committed case: the data IS in the database but
-	/// the caller is told the outcome is unknown.
+	/// Commit results, checked AFTER a real successful commit: the already-durable commit
+	/// is reported as failed. With commit_unknown_result (1021) this reproduces the
+	/// maybe-committed case, the data IS in the database but the caller cannot know it.
 	std::deque<fdb_error_t> postCommitErrors;
-	/// Committed-version lookups after a successful commit: the lookup fails with the
-	/// scripted error although the commit itself succeeded.
+	/// Committed-version lookups after a successful commit.
 	std::deque<fdb_error_t> committedVersionErrors;
 
 	/// Pops the next scripted outcome from `queue`: the error to inject, or 0 for none.
@@ -220,31 +214,51 @@ using UniqueFDBFuture = std::unique_ptr<FDBFuture, FDBFutureDeleter>;
 
 /// A class that wraps a FoundationDB transaction.
 /// Provides methods to perform read and write operations on the database.
+/// Every read, write, and commit operation throws std::logic_error when the transaction
+/// has no backend handle (moved-from, or constructed from a null or errored database):
+/// per the kv error-domain rules a wrong-state call must never pose as a missing key, an
+/// empty range, or a silently dropped write.
 class Transaction {
 public:
 	/// Constructs a Transaction object using the provided DB instance.
 	/// @param db A pointer to the FoundationDB database instance.
 	/// @note The transaction is created with default options.
 	Transaction(DB *db) {
+		// A null or errored DB has no handle to create a transaction from; keep the
+		// default nonzero error_ so operator bool is false, instead of passing nullptr
+		// into fdb_database_create_transaction (undefined behavior).
+		if (db == nullptr || db->getDB() == nullptr) { return; }
+
 		FDBTransaction *auxTr{nullptr};
 		error_ = fdb_database_create_transaction(db->getDB(), &auxTr);
 
 		if (error_ == 0) { tr_.reset(auxTr); }
 	}
 
+	/// Returns the last backend error recorded directly by this wrapper.
+	/// Synchronous point reads and commit outcomes update it. Future-based reads,
+	/// including getRange(), report failures through kv::TransactionError and do not
+	/// update it. A committed-version lookup failure after a durable commit leaves it at 0.
 	fdb_error_t error() const { return error_; }
 	explicit operator bool() const { return error_ == 0 && tr_; }
 
+	/// Sets an option on the transaction.
+	/// @throws std::logic_error when the transaction has no backend handle.
 	fdb_error_t setOption(FDBTransactionOption option, std::string_view value = {});
 
 	/// Gets a value for a given key.
 	/// @param key The key to retrieve the value for.
+	/// @return The value, or std::nullopt only when the key does not exist.
+	/// @throws kv::RetryableTransactionError / kv::TransactionError when the read fails,
+	///   so a backend failure can never be mistaken for a missing key.
 	std::optional<kv::Value> get(const kv::Key &key, bool snapshot = false);
 
 	/// Gets a value for a given key asynchronously.
 	/// @param key The key to retrieve the value for.
 	/// @param snapshot Whether to use a snapshot for the transaction.
 	/// @return A future that will contain the value when ready.
+	/// @note Backend read failures are reported by the future's get(), which throws
+	///   kv::RetryableTransactionError / kv::TransactionError (see kv::IFuture::get()).
 	/// @note The transaction must remain alive until the future's get() method is called.
 	std::unique_ptr<kv::IFuture> getAsync(const kv::Key &key, bool snapshot = false);
 
@@ -256,8 +270,10 @@ public:
 	/// @param snapshot Whether to use a snapshot for the transaction.
 	/// @param reverse Whether to retrieve the range in reverse order.
 	/// @param streamingMode The streaming mode to use for the range query.
-	/// @return GetRangeResult with key-value pairs and whether more results are available.
-	/// @note If the transaction is not valid, it returns an empty GetRangeResult
+	/// @return GetRangeResult with key-value pairs and whether more results are available;
+	///   empty only when no keys fall in the range.
+	/// @throws kv::RetryableTransactionError / kv::TransactionError when the read fails,
+	///   so a backend failure can never be mistaken for an empty range.
 	kv::GetRangeResult getRange(const kv::KeySelector &begin, const kv::KeySelector &end, int limit,
 	                            int iteration = 0, bool snapshot = false, bool reverse = false,
 	                            FDBStreamingMode streamingMode = FDB_STREAMING_MODE_SERIAL);
@@ -271,6 +287,8 @@ public:
 	/// @param reverse Whether to retrieve the range in reverse order.
 	/// @param streamingMode The streaming mode to use for the range query.
 	/// @return A future that will contain the range when ready.
+	/// @note Backend read failures are reported by the future's get(), which throws
+	///   kv::RetryableTransactionError / kv::TransactionError (see kv::IRangeFuture::get()).
 	/// @note The transaction must remain alive until the future's get() method is called.
 	std::unique_ptr<kv::IRangeFuture> getRangeAsync(
 	    const kv::KeySelector &begin, const kv::KeySelector &end, int limit, int iteration = 0,
@@ -303,12 +321,16 @@ public:
 	void removeRange(const kv::Key &start, const kv::Key &end);
 
 	/// Commits the transaction.
-	/// @return True if the commit was successful, false otherwise.
+	/// @return True if the commit succeeded and is durable, false on a backend commit
+	///   failure. A wrong-state call (no backend handle) throws std::logic_error instead
+	///   of returning false.
 	bool commit();
 
 	/// Submits the commit asynchronously, returning a pollable future.
 	/// The future references this transaction's state, so the Transaction must
 	/// outlive the returned future.
+	/// A wrong-state call (no backend handle) throws std::logic_error instead of
+	/// returning a failed future.
 	std::unique_ptr<kv::ICommitFuture> commitAsync();
 
 	/// Gets the committed version of the transaction.
@@ -317,15 +339,28 @@ public:
 
 	/// Approximate byte size that the buffered mutations and conflict ranges would contribute
 	/// to a commit (fdb_transaction_get_approximate_size). Computed client-side.
-	/// @return The approximate size, or std::nullopt on error.
+	/// @return The approximate size, or std::nullopt when the size cannot be reported (no
+	///   backend handle, or a backend error). Diagnostic-only, so unlike the data reads
+	///   this deliberately does not throw: nullopt is not confusable with real data.
 	std::optional<uint64_t> getApproximateSize() const;
 
 	/// TEST-ONLY: attaches a deterministic fault-injection script to this transaction and
 	/// the futures it creates afterwards. Not owned; pass nullptr to detach. The script
-	/// must outlive the transaction and its futures. See FaultInjection.
+	/// must outlive the transaction and its futures. Injected synchronous point-read and
+	/// pre/post-commit failures update error(). Future-based reads (getAsync(), getRange(),
+	/// and getRangeAsync()) carry the code in the thrown kv::TransactionError without
+	/// updating error(); async callers may also request it through the future get() error
+	/// out-param. A committed-version lookup failure leaves error() at 0 because the commit
+	/// itself succeeded. See FaultInjection.
 	void setFaultInjection(FaultInjection *fault) { faultInjection_ = fault; }
 
 private:
+	/// Throws std::logic_error when this transaction has no backend handle (moved-from,
+	/// or constructed from a null database). Per the kv error-domain rules a wrong-state
+	/// call must never pose as a missing key, an empty range, or a silently dropped
+	/// write.
+	void requireHandle(const char *operation) const;
+
 	/// Custom deleter for FDBTransaction (C struct), to ensure proper cleanup.
 	struct FDBTransactionDeleter {
 		constexpr FDBTransactionDeleter() noexcept = default;

--- a/src/fdb/fdb.h
+++ b/src/fdb/fdb.h
@@ -21,6 +21,7 @@
 #include "common/platform.h"
 
 #include <cstdint>
+#include <deque>
 #include <memory>
 #include <string>
 #include <utility>
@@ -162,6 +163,50 @@ private:
 	fdb_error_t error_ = 1;  ///< The error code of the last operation.
 };
 
+/// TEST-ONLY deterministic fault injection for fdb::Transaction and its futures.
+///
+/// Each queue scripts the outcomes of one injection point, consumed front-to-back, one
+/// entry per call: a non-zero entry makes that call fail with exactly that FDB error
+/// code, a zero entry leaves that call untouched, and an exhausted (empty) queue stops
+/// injecting. This makes error sequences fully deterministic, e.g. "fail only the second
+/// read with not_committed" is {0, 1020}.
+///
+/// Production never constructs one of these; transactions carry a null pointer and each
+/// injection point costs a single null check. Not owned by the transaction: the test
+/// keeps the instance alive for the transaction's (and its futures') lifetime.
+struct FaultInjection {
+	/// Read results (point get and range get, sync and async): the read fails with the
+	/// scripted error before contacting the cluster.
+	std::deque<fdb_error_t> readErrors;
+	/// Commit attempts, checked BEFORE submitting: the commit fails with the scripted
+	/// error and nothing is sent to the cluster.
+	std::deque<fdb_error_t> preCommitErrors;
+	/// Commit results, checked AFTER a real successful commit: the already-durable
+	/// commit is reported as failed with the scripted error. With commit_unknown_result
+	/// (1021) this reproduces the maybe-committed case: the data IS in the database but
+	/// the caller is told the outcome is unknown.
+	std::deque<fdb_error_t> postCommitErrors;
+	/// Committed-version lookups after a successful commit: the lookup fails with the
+	/// scripted error although the commit itself succeeded.
+	std::deque<fdb_error_t> committedVersionErrors;
+
+	/// Pops the next scripted outcome from `queue`: the error to inject, or 0 for none.
+	static fdb_error_t next(std::deque<fdb_error_t> &queue) {
+		if (queue.empty()) { return 0; }
+		fdb_error_t err = queue.front();
+		queue.pop_front();
+		return err;
+	}
+
+	/// Clears all scripted outcomes (for reuse between test cases).
+	void reset() {
+		readErrors.clear();
+		preCommitErrors.clear();
+		postCommitErrors.clear();
+		committedVersionErrors.clear();
+	}
+};
+
 /// Custom deleter for FDBFuture (C struct), to ensure proper cleanup.
 struct FDBFutureDeleter {
 	constexpr FDBFutureDeleter() noexcept = default;
@@ -275,6 +320,11 @@ public:
 	/// @return The approximate size, or std::nullopt on error.
 	std::optional<uint64_t> getApproximateSize() const;
 
+	/// TEST-ONLY: attaches a deterministic fault-injection script to this transaction and
+	/// the futures it creates afterwards. Not owned; pass nullptr to detach. The script
+	/// must outlive the transaction and its futures. See FaultInjection.
+	void setFaultInjection(FaultInjection *fault) { faultInjection_ = fault; }
+
 private:
 	/// Custom deleter for FDBTransaction (C struct), to ensure proper cleanup.
 	struct FDBTransactionDeleter {
@@ -291,6 +341,9 @@ private:
 
 	/// The commit version of the transaction, if applicable.
 	std::optional<int64_t> committedVersion_;
+
+	/// TEST-ONLY fault-injection script; null in production (see setFaultInjection).
+	FaultInjection *faultInjection_{nullptr};
 };
 
 }  // namespace fdb

--- a/src/fdb/fdb_errors.h
+++ b/src/fdb/fdb_errors.h
@@ -1,0 +1,52 @@
+/*
+   Copyright 2023      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "common/platform.h"
+
+// Needs to be included before foundationdb/fdb_c.h
+#include <fdb/fdb_api_version.h>
+
+#include <foundationdb/fdb_c.h>
+
+#include "kv/ifuture.h"
+
+namespace fdb::detail {
+
+/// Translates a RETRYABLE FoundationDB read error into a typed exception so the
+/// master's op boundary can replay the op on a fresh transaction instead of letting
+/// the read failure (e.g. transaction_timed_out under load) propagate uncaught and
+/// abort the whole MDS. Non-retryable errors are left for the caller to report via
+/// the *error out-parameter as before.
+inline void throwIfRetryable(fdb_error_t err) {
+	// transaction_timed_out (1031) is deliberately absent from FDB's RETRYABLE
+	// predicate because a timeout during COMMIT has an unknown result. This helper
+	// guards READ futures only, and the op-boundary replay runs on a fresh
+	// transaction with a fresh timeout budget, so a timed-out read is safe to
+	// replay. The commit path (FDBCommitFuture::getResult) uses RETRYABLE_NOT_COMMITTED,
+	// which excludes 1031 and the whole maybe-committed class, so a commit with an
+	// unknown result is never blindly replayed.
+	constexpr fdb_error_t kTransactionTimedOut = 1031;
+	if (err == kTransactionTimedOut ||
+	    fdb_error_predicate(FDB_ERROR_PREDICATE_RETRYABLE, err) != 0) {
+		throw kv::RetryableTransactionError(static_cast<int>(err), fdb_get_error(err));
+	}
+}
+
+}  // namespace fdb::detail

--- a/src/fdb/fdb_errors.h
+++ b/src/fdb/fdb_errors.h
@@ -29,15 +29,15 @@
 
 namespace fdb::detail {
 
-/// Translates a RETRYABLE FoundationDB read error into a typed exception so the
-/// master's op boundary can replay the op on a fresh transaction instead of letting
-/// the read failure (e.g. transaction_timed_out under load) propagate uncaught and
-/// abort the whole MDS. Non-retryable errors are left for the caller to report via
-/// the *error out-parameter as before.
-inline void throwIfRetryable(fdb_error_t err) {
+/// Translates a failed FoundationDB READ into the typed error contract: retryable
+/// errors throw kv::RetryableTransactionError so the master's op boundary replays the
+/// op on a fresh transaction, and every other backend error throws the
+/// kv::TransactionError base so a backend failure can never be mistaken for a missing
+/// key (absent keys are the only thing reported as an empty result).
+[[noreturn]] inline void throwTransactionError(fdb_error_t err) {
 	// transaction_timed_out (1031) is deliberately absent from FDB's RETRYABLE
 	// predicate because a timeout during COMMIT has an unknown result. This helper
-	// guards READ futures only, and the op-boundary replay runs on a fresh
+	// guards READ paths only, and the op-boundary replay runs on a fresh
 	// transaction with a fresh timeout budget, so a timed-out read is safe to
 	// replay. The commit path (FDBCommitFuture::getResult) uses RETRYABLE_NOT_COMMITTED,
 	// which excludes 1031 and the whole maybe-committed class, so a commit with an
@@ -47,6 +47,7 @@ inline void throwIfRetryable(fdb_error_t err) {
 	    fdb_error_predicate(FDB_ERROR_PREDICATE_RETRYABLE, err) != 0) {
 		throw kv::RetryableTransactionError(static_cast<int>(err), fdb_get_error(err));
 	}
+	throw kv::TransactionError(static_cast<int>(err), fdb_get_error(err));
 }
 
 }  // namespace fdb::detail

--- a/src/fdb/fdb_future.cc
+++ b/src/fdb/fdb_future.cc
@@ -21,6 +21,7 @@
 #include <cassert>
 #include <chrono>
 #include <iterator>
+#include <stdexcept>
 #include <utility>
 #include <vector>
 
@@ -33,7 +34,7 @@
 
 namespace fdb {
 
-using detail::throwIfRetryable;
+using detail::throwTransactionError;
 
 namespace {
 
@@ -59,10 +60,11 @@ bool FDBFutureValue::isReady() {
 }
 
 std::optional<kv::Value> FDBFutureValue::get(int *error) {
-	// Return nullopt if already consumed or invalid
+	// Wrong-state call per the kv error-domain rules: posing as a missing key would hide
+	// the caller's bug, and no real backend error code exists to report.
 	if (consumed_ || future_ == nullptr) {
-		if (error != nullptr) { *error = 1; }
-		return std::nullopt;
+		throw std::logic_error(consumed_ ? "FDBFutureValue::get: future already consumed"
+		                                 : "FDBFutureValue::get: invalid future");
 	}
 
 	// Mark as consumed
@@ -72,8 +74,7 @@ std::optional<kv::Value> FDBFutureValue::get(int *error) {
 	// takes exactly the real error path below.
 	if (fdb_error_t injected = injectedReadError(faultInjection_); injected != 0) {
 		if (error != nullptr) { *error = static_cast<int>(injected); }
-		throwIfRetryable(injected);
-		return std::nullopt;
+		throwTransactionError(injected);
 	}
 
 	// Block until the future is ready. Times the wait so a pipelined read (issued
@@ -94,8 +95,7 @@ std::optional<kv::Value> FDBFutureValue::get(int *error) {
 		safs::log_err("FDBFutureValue::get: fdb_future_block_until_ready: error: {}",
 		              fdb_get_error(fdbError));
 		if (error != nullptr) { *error = static_cast<int>(fdbError); }
-		throwIfRetryable(fdbError);
-		return std::nullopt;
+		throwTransactionError(fdbError);
 	}
 
 	// Extract the value from the future
@@ -109,8 +109,7 @@ std::optional<kv::Value> FDBFutureValue::get(int *error) {
 		safs::log_err("FDBFutureValue::get: fdb_future_get_value: error: {}",
 		              fdb_get_error(fdbError));
 		if (error != nullptr) { *error = static_cast<int>(fdbError); }
-		throwIfRetryable(fdbError);
-		return std::nullopt;
+		throwTransactionError(fdbError);
 	}
 
 	// Set error to success
@@ -140,10 +139,11 @@ bool FDBFutureRange::isReady() {
 }
 
 kv::GetRangeResult FDBFutureRange::get(int *error) {
-	// Return an empty result if already consumed or invalid.
+	// Wrong-state call per the kv error-domain rules: posing as an empty range would
+	// hide the caller's bug, and no real backend error code exists to report.
 	if (consumed_ || future_ == nullptr) {
-		if (error != nullptr) { *error = 1; }
-		return {{}, false};
+		throw std::logic_error(consumed_ ? "FDBFutureRange::get: future already consumed"
+		                                 : "FDBFutureRange::get: invalid future");
 	}
 
 	consumed_ = true;
@@ -152,8 +152,7 @@ kv::GetRangeResult FDBFutureRange::get(int *error) {
 	// takes exactly the real error path below.
 	if (fdb_error_t injected = injectedReadError(faultInjection_); injected != 0) {
 		if (error != nullptr) { *error = static_cast<int>(injected); }
-		throwIfRetryable(injected);
-		return {{}, false};
+		throwTransactionError(injected);
 	}
 
 	const bool profiling = opCountersEnabled();
@@ -171,8 +170,7 @@ kv::GetRangeResult FDBFutureRange::get(int *error) {
 		safs::log_err("FDBFutureRange::get: fdb_future_block_until_ready: error: {}",
 		              fdb_get_error(fdbError));
 		if (error != nullptr) { *error = static_cast<int>(fdbError); }
-		throwIfRetryable(fdbError);
-		return {{}, false};
+		throwTransactionError(fdbError);
 	}
 
 	const FDBKeyValue *keyValues = nullptr;
@@ -185,8 +183,7 @@ kv::GetRangeResult FDBFutureRange::get(int *error) {
 		safs::log_err("FDBFutureRange::get: fdb_future_get_keyvalue_array: error: {}",
 		              fdb_get_error(fdbError));
 		if (error != nullptr) { *error = static_cast<int>(fdbError); }
-		throwIfRetryable(fdbError);
-		return {{}, false};
+		throwTransactionError(fdbError);
 	}
 
 	std::vector<kv::KeyValuePair> pairs;

--- a/src/fdb/fdb_future.cc
+++ b/src/fdb/fdb_future.cc
@@ -27,36 +27,26 @@
 #include <foundationdb/fdb_c_types.h>
 
 #include "fdb/fdb.h"
+#include "fdb/fdb_errors.h"
 #include "fdb/fdb_future.h"
 #include "slogger/slogger.h"
 
 namespace fdb {
 
+using detail::throwIfRetryable;
+
 namespace {
 
-/// Translates a RETRYABLE FoundationDB read error into a typed exception so the
-/// master's op boundary can replay the op on a fresh transaction instead of letting
-/// the read failure (e.g. transaction_timed_out under load) propagate uncaught and
-/// abort the whole MDS. Non-retryable errors are left for the caller to report via
-/// the *error out-parameter as before.
-void throwIfRetryable(fdb_error_t err) {
-	// transaction_timed_out (1031) is deliberately absent from FDB's RETRYABLE
-	// predicate because a timeout during COMMIT has an unknown result. This helper
-	// guards READ futures only, and the op-boundary replay runs on a fresh
-	// transaction with a fresh timeout budget, so a timed-out read is safe to
-	// replay. The commit path (FDBCommitFuture::getResult) uses RETRYABLE_NOT_COMMITTED,
-	// which excludes 1031 and the whole maybe-committed class, so a commit with an
-	// unknown result is never blindly replayed.
-	constexpr fdb_error_t kTransactionTimedOut = 1031;
-	if (err == kTransactionTimedOut ||
-	    fdb_error_predicate(FDB_ERROR_PREDICATE_RETRYABLE, err) != 0) {
-		throw kv::RetryableTransactionError(static_cast<int>(err), fdb_get_error(err));
-	}
+/// Pops the next TEST-ONLY scripted read failure, or 0 when none is armed.
+fdb_error_t injectedReadError(FaultInjection *fault) {
+	if (fault == nullptr) { return 0; }
+	return FaultInjection::next(fault->readErrors);
 }
 
 }  // namespace
 
-FDBFutureValue::FDBFutureValue(FDBFuture *future) : future_(future) {}
+FDBFutureValue::FDBFutureValue(FDBFuture *future, FaultInjection *fault)
+    : future_(future), faultInjection_(fault) {}
 
 FDBFutureValue::~FDBFutureValue() {
 	if (future_ != nullptr) { fdb_future_destroy(future_); }
@@ -77,6 +67,14 @@ std::optional<kv::Value> FDBFutureValue::get(int *error) {
 
 	// Mark as consumed
 	consumed_ = true;
+
+	// TEST-ONLY scripted read failure; short-circuits before waiting on the cluster and
+	// takes exactly the real error path below.
+	if (fdb_error_t injected = injectedReadError(faultInjection_); injected != 0) {
+		if (error != nullptr) { *error = static_cast<int>(injected); }
+		throwIfRetryable(injected);
+		return std::nullopt;
+	}
 
 	// Block until the future is ready. Times the wait so a pipelined read (issued
 	// earlier, already resolved here) shows as near-zero, while a serial read shows
@@ -128,7 +126,8 @@ std::optional<kv::Value> FDBFutureValue::get(int *error) {
 	return std::nullopt;
 }
 
-FDBFutureRange::FDBFutureRange(FDBFuture *future) : future_(future) {}
+FDBFutureRange::FDBFutureRange(FDBFuture *future, FaultInjection *fault)
+    : future_(future), faultInjection_(fault) {}
 
 FDBFutureRange::~FDBFutureRange() {
 	if (future_ != nullptr) { fdb_future_destroy(future_); }
@@ -148,6 +147,14 @@ kv::GetRangeResult FDBFutureRange::get(int *error) {
 	}
 
 	consumed_ = true;
+
+	// TEST-ONLY scripted read failure; short-circuits before waiting on the cluster and
+	// takes exactly the real error path below.
+	if (fdb_error_t injected = injectedReadError(faultInjection_); injected != 0) {
+		if (error != nullptr) { *error = static_cast<int>(injected); }
+		throwIfRetryable(injected);
+		return {{}, false};
+	}
 
 	const bool profiling = opCountersEnabled();
 	const auto waitStart =

--- a/src/fdb/fdb_future.h
+++ b/src/fdb/fdb_future.h
@@ -57,9 +57,14 @@ public:
 	bool isReady() override;
 
 	/// Blocks until the result is ready and retrieves the value.
-	/// @param error Optional pointer to store error code (0 on success, non-zero on error).
-	/// @return The value if successful and present, std::nullopt on error or if key not found.
-	/// @note This method can only be called once. Subsequent calls return std::nullopt.
+	/// @param error Optional out-param for the backend error code: 0 on success; on a
+	///   backend failure the code is stored before the throw. Exceptions are the failure
+	///   signal, the code is diagnostic only.
+	/// @return The value, or std::nullopt only when the key does not exist.
+	/// @throws kv::RetryableTransactionError / kv::TransactionError when the backend read
+	///   fails, so a backend failure can never be mistaken for a missing key.
+	/// @note This method can only be called once. Subsequent calls are wrong-state calls
+	///   and throw std::logic_error.
 	std::optional<kv::Value> get(int *error = nullptr) override;
 
 private:
@@ -95,9 +100,14 @@ public:
 	bool isReady() override;
 
 	/// Blocks until the result is ready and retrieves the range.
-	/// @param error Optional pointer to store error code (0 on success, non-zero on error).
-	/// @return The range result, or an empty result on error.
-	/// @note This method can only be called once. Subsequent calls return an empty result.
+	/// @param error Optional out-param for the backend error code: 0 on success; on a
+	///   backend failure the code is stored before the throw. Exceptions are the failure
+	///   signal, the code is diagnostic only.
+	/// @return The range result; empty only when no keys fall in the range.
+	/// @throws kv::RetryableTransactionError / kv::TransactionError when the backend read
+	///   fails, so a backend failure can never be mistaken for an empty range.
+	/// @note This method can only be called once. Subsequent calls are wrong-state calls
+	///   and throw std::logic_error.
 	kv::GetRangeResult get(int *error = nullptr) override;
 
 private:

--- a/src/fdb/fdb_future.h
+++ b/src/fdb/fdb_future.h
@@ -29,6 +29,8 @@
 
 namespace fdb {
 
+struct FaultInjection;
+
 /// Wraps a FoundationDB future (FDBFuture*) with RAII semantics.
 /// Implements the kv::IFuture interface for asynchronous get operations.
 ///
@@ -38,7 +40,8 @@ class FDBFutureValue final : public kv::IFuture {
 public:
 	/// Constructs a FDBFutureValue wrapping the given FDBFuture*.
 	/// @param future The FDB future to wrap. Takes ownership.
-	explicit FDBFutureValue(FDBFuture *future);
+	/// @param fault Optional TEST-ONLY fault-injection script (not owned, may be null).
+	explicit FDBFutureValue(FDBFuture *future, FaultInjection *fault = nullptr);
 
 	/// Destructor. Destroys the wrapped FDB future.
 	~FDBFutureValue() override;
@@ -62,6 +65,8 @@ public:
 private:
 	FDBFuture *future_;
 	bool consumed_ = false;
+	/// TEST-ONLY fault-injection script; null in production.
+	FaultInjection *faultInjection_;
 };
 
 /// Wraps a FoundationDB range future (FDBFuture*) with RAII semantics.
@@ -73,7 +78,8 @@ class FDBFutureRange final : public kv::IRangeFuture {
 public:
 	/// Constructs a FDBFutureRange wrapping the given FDBFuture*.
 	/// @param future The FDB future to wrap. Takes ownership.
-	explicit FDBFutureRange(FDBFuture *future);
+	/// @param fault Optional TEST-ONLY fault-injection script (not owned, may be null).
+	explicit FDBFutureRange(FDBFuture *future, FaultInjection *fault = nullptr);
 
 	/// Destructor. Destroys the wrapped FDB future.
 	~FDBFutureRange() override;
@@ -97,6 +103,8 @@ public:
 private:
 	FDBFuture *future_;
 	bool consumed_ = false;
+	/// TEST-ONLY fault-injection script; null in production.
+	FaultInjection *faultInjection_;
 };
 
 }  // namespace fdb

--- a/src/fdb/fdb_transaction.cc
+++ b/src/fdb/fdb_transaction.cc
@@ -23,85 +23,63 @@
 
 namespace fdb {
 
-std::optional<kv::Value> FDBTransaction::get(const kv::Key &key) {
-	if (!tr_) { return std::nullopt; }
+// The adapter adds no handle guards to data operations: an absent backend handle
+// (moved-from wrapper) is a wrong-state call and the wrapped fdb::Transaction throws
+// std::logic_error for it, per the kv error-domain rules. Swallowing it here would pose
+// as a missing key, an empty range, or a silently dropped write. Mutations are counted
+// only after the wrapper accepts them, so a throwing call leaves the count untouched.
+// getApproximateSize() remains a diagnostic exception that returns std::nullopt when no
+// estimate can be reported.
 
-	return tr_.get(key);
-}
+std::optional<kv::Value> FDBTransaction::get(const kv::Key &key) { return tr_.get(key); }
 
 std::optional<kv::Value> FDBTransaction::getSnapshot(const kv::Key &key) {
-	if (!tr_) { return std::nullopt; }
-
 	return tr_.get(key, /*snapshot=*/true);
 }
 
 std::unique_ptr<kv::IFuture> FDBTransaction::getAsync(const kv::Key &key) {
-	if (!tr_) { return nullptr; }
-
 	return tr_.getAsync(key);
 }
 
 kv::GetRangeResult FDBTransaction::getRange(const kv::KeySelector &start,
                                             const kv::KeySelector &end, int limit) {
-	if (!tr_) { return {{}, false}; }
-
 	return tr_.getRange(start, end, limit);
 }
 
 std::unique_ptr<kv::IRangeFuture> FDBTransaction::getRangeAsync(const kv::KeySelector &start,
                                                                 const kv::KeySelector &end,
                                                                 int limit) {
-	if (!tr_) { return nullptr; }
-
 	return tr_.getRangeAsync(start, end, limit);
 }
 
 void FDBTransaction::set(const kv::Key &key, const kv::Value &value) {
-	if (!tr_) { return; }
-
-	mutationCount_++;
 	tr_.set(key, value);
+	mutationCount_++;
 }
 
 void FDBTransaction::atomicAdd(const kv::Key &key, const kv::Value &delta) {
-	if (!tr_) { return; }
-
-	mutationCount_++;
 	tr_.atomicAdd(key, delta);
+	mutationCount_++;
 }
 
 void FDBTransaction::atomicMax(const kv::Key &key, const kv::Value &value) {
-	if (!tr_) { return; }
-
-	mutationCount_++;
 	tr_.atomicMax(key, value);
+	mutationCount_++;
 }
 
 void FDBTransaction::remove(const kv::Key &key) {
-	if (!tr_) { return; }
-
-	mutationCount_++;
 	tr_.remove(key);
+	mutationCount_++;
 }
 
 void FDBTransaction::removeRange(const kv::Key &start, const kv::Key &end) {
-	if (!tr_) { return; }
-
-	mutationCount_++;
 	tr_.removeRange(start, end);
+	mutationCount_++;
 }
 
-bool FDBTransaction::commit() {
-	if (!tr_) { return false; }
+bool FDBTransaction::commit() { return tr_.commit(); }
 
-	return tr_.commit();
-}
-
-std::unique_ptr<kv::ICommitFuture> FDBTransaction::commitAsync() {
-	if (!tr_) { return std::make_unique<kv::ImmediateCommitFuture>(false); }
-
-	return tr_.commitAsync();
-}
+std::unique_ptr<kv::ICommitFuture> FDBTransaction::commitAsync() { return tr_.commitAsync(); }
 
 std::optional<int64_t> FDBTransaction::getCommittedVersion() const {
 	return tr_.getCommittedVersion();

--- a/src/fdb/fdb_transaction.h
+++ b/src/fdb/fdb_transaction.h
@@ -28,11 +28,16 @@ namespace fdb {
 /// Provides an implementation of a read-write transaction for FoundationDB, compatible with the
 /// kv::IReadWriteTransaction interface, to be used with the kv::IKVEngine interface.
 /// Wraps a fdb::Transaction to provide the necessary methods for key-value operations.
+/// The adapter adds no guards to data operations: wrong-state calls (an absent backend
+/// handle in the wrapped transaction) propagate std::logic_error from fdb::Transaction,
+/// and backend failures throw the kv::TransactionError family, per the error-domain rules
+/// in kv/ifuture.h. The diagnostic getApproximateSize() query is the deliberate exception:
+/// it returns std::nullopt when no estimate can be reported.
 class FDBTransaction final : public kv::IReadWriteTransaction {
 public:
 	/// Constructs a FDBTransaction using the provided fdb::Transaction.
-	/// @param tr The fdb::Transaction to wrap.
-	FDBTransaction(fdb::Transaction &&_tr) : tr_(std::move(_tr)), error_(0) {}
+	/// @param _tr The fdb::Transaction to wrap.
+	FDBTransaction(fdb::Transaction &&_tr) : tr_(std::move(_tr)) {}
 
 	// Non-copyable, non-movable (base class is non-movable)
 	FDBTransaction(const FDBTransaction &) = delete;
@@ -45,6 +50,8 @@ public:
 
 	/// Retrieves the value for a given key.
 	/// @param key The key to retrieve the value for.
+	/// @return The value, or std::nullopt only when the key does not exist.
+	/// @throws kv::RetryableTransactionError / kv::TransactionError on a backend failure.
 	std::optional<kv::Value> get(const kv::Key &key) override;
 
 	/// Retrieves the value for a given key without adding it to the
@@ -54,18 +61,24 @@ public:
 	///          logic. They are intended for advisory reads (e.g. observing
 	///          a hot counter) where occasional anomalies are acceptable.
 	/// @param key The key to retrieve the value for.
+	/// @return The value, or std::nullopt only when the key does not exist.
+	/// @throws kv::RetryableTransactionError / kv::TransactionError on a backend failure.
 	std::optional<kv::Value> getSnapshot(const kv::Key &key) override;
 
 	/// Retrieves the value for a given key asynchronously.
 	/// @param key The key to retrieve the value for.
 	/// @return A future that will contain the value when ready.
 	/// @note The transaction must remain alive until the future's get() method is called.
+	/// @note Backend failures are reported by the future's get() as
+	///   kv::RetryableTransactionError / kv::TransactionError.
 	std::unique_ptr<kv::IFuture> getAsync(const kv::Key &key) override;
 
 	/// Retrieves a range of keys and values
 	/// @param start The starting key for the range.
 	/// @param end The ending key for the range.
 	/// @param limit The maximum number of key-value pairs to retrieve.
+	/// @return The range result; empty only when no keys fall in the range.
+	/// @throws kv::RetryableTransactionError / kv::TransactionError on a backend failure.
 	kv::GetRangeResult getRange(const kv::KeySelector &start, const kv::KeySelector &end,
 	                            int limit = kv::kDefaultGetRangeLimit) override;
 
@@ -74,6 +87,8 @@ public:
 	/// @param end The ending key for the range.
 	/// @param limit The maximum number of key-value pairs to retrieve.
 	/// @return A future that will contain the range when ready.
+	/// @note Backend failures are reported by the future's get() as
+	///   kv::RetryableTransactionError / kv::TransactionError.
 	/// @note The transaction must remain alive until the future's get() method is called.
 	std::unique_ptr<kv::IRangeFuture> getRangeAsync(const kv::KeySelector &start,
 	                                                const kv::KeySelector &end,
@@ -102,9 +117,12 @@ public:
 	void removeRange(const kv::Key &start, const kv::Key &end) override;
 
 	/// Commits the transaction, making all changes permanent.
+	/// @return True if the commit succeeded and is durable, false on a backend failure.
+	/// @throws std::logic_error when the wrapped transaction has no backend handle.
 	bool commit() override;
 
 	/// Submits the commit asynchronously and returns a pollable future.
+	/// @throws std::logic_error when the wrapped transaction has no backend handle.
 	std::unique_ptr<kv::ICommitFuture> commitAsync() override;
 
 	/// Returns the committed version of the transaction, if available.
@@ -114,14 +132,16 @@ public:
 	uint64_t mutationCount() const override { return mutationCount_; }
 
 	/// Approximate byte size of the buffered writes so far (client-side estimate).
+	/// @return The estimate, or std::nullopt when it cannot be reported. This diagnostic
+	///   query deliberately does not throw for a missing backend handle.
 	std::optional<uint64_t> getApproximateSize() const override;
 
-	/// Returns the error code of the last operation.
-	fdb_error_t error() const { return error_; }
+	/// Returns the error state recorded by the wrapped transaction; see
+	/// fdb::Transaction::error() for the sync/async distinction.
+	fdb_error_t error() const { return tr_.error(); }
 
 private:
 	fdb::Transaction tr_;
-	fdb_error_t error_{1};
 	uint64_t mutationCount_{0};
 };
 

--- a/src/fdb/fdb_unittest.cc
+++ b/src/fdb/fdb_unittest.cc
@@ -1018,3 +1018,292 @@ TEST_F(FDBKVEngineTest, CommitAsync) {
 		ASSERT_TRUE(cleanup->commit());
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Deterministic fault injection (fdb::FaultInjection)
+// ---------------------------------------------------------------------------
+
+namespace {
+
+constexpr fdb_error_t kNotCommitted = 1020;         // retryable, definitely not committed
+constexpr fdb_error_t kCommitUnknownResult = 1021;  // maybe committed, NOT retryable
+constexpr fdb_error_t kTransactionCancelled = 1025;
+constexpr fdb_error_t kTransactionTooLarge = 2101;  // non-retryable
+
+}  // namespace
+
+TEST_F(FDBKVEngineTest, FaultInjectionRetryableAsyncReadThrows) {
+	fdb::Transaction transaction(fdbDB.get());
+	ASSERT_TRUE(transaction);
+
+	fdb::FaultInjection fault;
+	fault.readErrors = {kNotCommitted};
+	transaction.setFaultInjection(&fault);
+
+	auto future = transaction.getAsync(kv::toBytes("fi_read_retryable"));
+	ASSERT_NE(future, nullptr);
+	int error = 0;
+	EXPECT_THROW(future->get(&error), kv::RetryableTransactionError);
+}
+
+TEST_F(FDBKVEngineTest, FaultInjectionRetryableIsCatchableAsBase) {
+	fdb::Transaction transaction(fdbDB.get());
+	ASSERT_TRUE(transaction);
+
+	fdb::FaultInjection fault;
+	fault.readErrors = {kNotCommitted};
+	transaction.setFaultInjection(&fault);
+
+	auto future = transaction.getAsync(kv::toBytes("fi_read_base_catch"));
+	ASSERT_NE(future, nullptr);
+	bool caught = false;
+	try {
+		future->get();
+	} catch (const kv::TransactionError &error) {
+		caught = true;
+		EXPECT_EQ(error.errorCode(), kNotCommitted);
+		EXPECT_TRUE(error.retryable());
+	}
+	EXPECT_TRUE(caught);
+}
+
+TEST_F(FDBKVEngineTest, FaultInjectionNonRetryableAsyncReadReportsError) {
+	// Baseline of TODAY's contract: a non-retryable read error does not throw, it is
+	// reported via the error out-parameter and an empty optional. The uniform error
+	// contract (next change in this series) flips this to a thrown TransactionError.
+	fdb::Transaction transaction(fdbDB.get());
+	ASSERT_TRUE(transaction);
+
+	fdb::FaultInjection fault;
+	fault.readErrors = {kTransactionTooLarge};
+	transaction.setFaultInjection(&fault);
+
+	auto future = transaction.getAsync(kv::toBytes("fi_read_nonretryable"));
+	ASSERT_NE(future, nullptr);
+	int error = 0;
+	std::optional<kv::Value> value;
+	EXPECT_NO_THROW(value = future->get(&error));
+	EXPECT_EQ(error, kTransactionTooLarge);
+	EXPECT_FALSE(value.has_value());
+}
+
+TEST_F(FDBKVEngineTest, FaultInjectionRetryableRangeReadThrows) {
+	fdb::Transaction transaction(fdbDB.get());
+	ASSERT_TRUE(transaction);
+
+	fdb::FaultInjection fault;
+	fault.readErrors = {kNotCommitted};
+	transaction.setFaultInjection(&fault);
+
+	kv::KeySelector begin(kv::toBytes("fi_range_a"), true, 0);
+	kv::KeySelector end(kv::toBytes("fi_range_z"), true, 0);
+	auto future = transaction.getRangeAsync(begin, end, 10);
+	ASSERT_NE(future, nullptr);
+	EXPECT_THROW(future->get(), kv::RetryableTransactionError);
+}
+
+TEST_F(FDBKVEngineTest, FaultInjectionSyncReadReportsErrorWithoutThrowing) {
+	// Baseline of TODAY's sync/async asymmetry: the sync read swallows even retryable
+	// errors into error_ + nullopt. The uniform error contract flips this to a throw.
+	fdb::Transaction transaction(fdbDB.get());
+	ASSERT_TRUE(transaction);
+
+	fdb::FaultInjection fault;
+	fault.readErrors = {kNotCommitted};
+	transaction.setFaultInjection(&fault);
+
+	std::optional<kv::Value> value;
+	EXPECT_NO_THROW(value = transaction.get(kv::toBytes("fi_read_sync")));
+	EXPECT_FALSE(value.has_value());
+	EXPECT_EQ(transaction.error(), kNotCommitted);
+}
+
+TEST_F(FDBKVEngineTest, FaultInjectionZeroEntriesSkipInjection) {
+	fdb::Transaction transaction(fdbDB.get());
+	ASSERT_TRUE(transaction);
+
+	fdb::FaultInjection fault;
+	fault.readErrors = {0, kTransactionTooLarge};
+	transaction.setFaultInjection(&fault);
+
+	// First read: zero entry, no injection; absent key reads as nullopt with no error.
+	auto value = transaction.get(kv::toBytes("fi_read_zero_skip_absent"));
+	EXPECT_FALSE(value.has_value());
+	EXPECT_EQ(transaction.error(), 0);
+
+	// Second read: scripted failure.
+	value = transaction.get(kv::toBytes("fi_read_zero_skip_absent"));
+	EXPECT_FALSE(value.has_value());
+	EXPECT_EQ(transaction.error(), kTransactionTooLarge);
+}
+
+TEST_F(FDBKVEngineTest, FaultInjectionPreCommitFailsWithoutWriting) {
+	const kv::Key key = kv::toBytes("fi_pre_commit");
+	{  // Clean slate.
+		auto cleanup = kvEngine->createReadWriteTransaction();
+		cleanup->remove(key);
+		ASSERT_TRUE(cleanup->commit());
+	}
+
+	fdb::Transaction transaction(fdbDB.get());
+	ASSERT_TRUE(transaction);
+
+	fdb::FaultInjection fault;
+	fault.preCommitErrors = {kNotCommitted};
+	transaction.setFaultInjection(&fault);
+
+	transaction.set(key, kv::toBytes("value"));
+	EXPECT_FALSE(transaction.commit());
+	EXPECT_EQ(transaction.error(), kNotCommitted);
+
+	// Nothing was submitted: the key must not exist.
+	auto verify = kvEngine->createReadWriteTransaction();
+	EXPECT_FALSE(verify->get(key).has_value());
+}
+
+TEST_F(FDBKVEngineTest, FaultInjectionPreCommitAsyncReportsRetryable) {
+	const kv::Key key = kv::toBytes("fi_pre_commit_async");
+	{  // Clean slate.
+		auto cleanup = kvEngine->createReadWriteTransaction();
+		cleanup->remove(key);
+		ASSERT_TRUE(cleanup->commit());
+	}
+
+	fdb::Transaction transaction(fdbDB.get());
+	ASSERT_TRUE(transaction);
+
+	fdb::FaultInjection fault;
+	fault.preCommitErrors = {kNotCommitted};
+	transaction.setFaultInjection(&fault);
+
+	transaction.set(key, kv::toBytes("value"));
+	auto future = transaction.commitAsync();
+	ASSERT_NE(future, nullptr);
+	EXPECT_TRUE(future->isReady());
+
+	int error = 0;
+	bool retryable = false;
+	EXPECT_FALSE(future->getResult(&error, &retryable));
+	EXPECT_EQ(error, kNotCommitted);
+	EXPECT_TRUE(retryable) << "not_committed is definitely-not-committed, hence retryable.";
+
+	auto verify = kvEngine->createReadWriteTransaction();
+	EXPECT_FALSE(verify->get(key).has_value());
+}
+
+TEST_F(FDBKVEngineTest, FaultInjectionPostCommitOverrideCommitIsDurable) {
+	// The maybe-committed detector: the commit really happens, then the result is
+	// overridden with commit_unknown_result. The database value is the oracle proving
+	// the data IS durable although the caller was told the outcome is unknown.
+	const kv::Key key = kv::toBytes("fi_post_commit");
+	const kv::Value value = kv::toBytes("durable");
+	{  // Clean slate.
+		auto cleanup = kvEngine->createReadWriteTransaction();
+		cleanup->remove(key);
+		ASSERT_TRUE(cleanup->commit());
+	}
+
+	fdb::Transaction transaction(fdbDB.get());
+	ASSERT_TRUE(transaction);
+
+	fdb::FaultInjection fault;
+	fault.postCommitErrors = {kCommitUnknownResult};
+	transaction.setFaultInjection(&fault);
+
+	transaction.set(key, value);
+	EXPECT_FALSE(transaction.commit());
+	EXPECT_EQ(transaction.error(), kCommitUnknownResult);
+
+	{  // The write is durable despite the reported failure.
+		auto verify = kvEngine->createReadWriteTransaction();
+		auto got = verify->get(key);
+		ASSERT_TRUE(got.has_value());
+		EXPECT_EQ(*got, value);
+	}
+
+	{  // Cleanup.
+		auto cleanup = kvEngine->createReadWriteTransaction();
+		cleanup->remove(key);
+		ASSERT_TRUE(cleanup->commit());
+	}
+}
+
+TEST_F(FDBKVEngineTest, FaultInjectionPostCommitOverrideAsyncNotRetryable) {
+	const kv::Key key = kv::toBytes("fi_post_commit_async");
+	const kv::Value value = kv::toBytes("durable");
+	{  // Clean slate.
+		auto cleanup = kvEngine->createReadWriteTransaction();
+		cleanup->remove(key);
+		ASSERT_TRUE(cleanup->commit());
+	}
+
+	fdb::Transaction transaction(fdbDB.get());
+	ASSERT_TRUE(transaction);
+
+	fdb::FaultInjection fault;
+	fault.postCommitErrors = {kCommitUnknownResult};
+	transaction.setFaultInjection(&fault);
+
+	transaction.set(key, value);
+	auto future = transaction.commitAsync();
+	ASSERT_NE(future, nullptr);
+
+	int error = 0;
+	bool retryable = true;
+	EXPECT_FALSE(future->getResult(&error, &retryable));
+	EXPECT_EQ(error, kCommitUnknownResult);
+	EXPECT_FALSE(retryable) << "A maybe-committed outcome must never be reported retryable: "
+	                           "a blind replay could double-apply.";
+
+	{  // The write is durable despite the reported failure.
+		auto verify = kvEngine->createReadWriteTransaction();
+		auto got = verify->get(key);
+		ASSERT_TRUE(got.has_value());
+		EXPECT_EQ(*got, value);
+	}
+
+	{  // Cleanup.
+		auto cleanup = kvEngine->createReadWriteTransaction();
+		cleanup->remove(key);
+		ASSERT_TRUE(cleanup->commit());
+	}
+}
+
+TEST_F(FDBKVEngineTest, FaultInjectionCommittedVersionLookupFailure) {
+	// Baseline of TODAY's behavior: a committed-version lookup failure after a
+	// successful commit is reported as a FAILED commit although the data is durable.
+	// The read-path correctness change in this series flips this to success without a
+	// version; this test documents the current (wrong-direction) contract until then.
+	const kv::Key key = kv::toBytes("fi_version_lookup");
+	const kv::Value value = kv::toBytes("durable");
+	{  // Clean slate.
+		auto cleanup = kvEngine->createReadWriteTransaction();
+		cleanup->remove(key);
+		ASSERT_TRUE(cleanup->commit());
+	}
+
+	fdb::Transaction transaction(fdbDB.get());
+	ASSERT_TRUE(transaction);
+
+	fdb::FaultInjection fault;
+	fault.committedVersionErrors = {kTransactionCancelled};
+	transaction.setFaultInjection(&fault);
+
+	transaction.set(key, value);
+	EXPECT_FALSE(transaction.commit());
+	EXPECT_EQ(transaction.error(), kTransactionCancelled);
+	EXPECT_FALSE(transaction.getCommittedVersion().has_value());
+
+	{  // The write is durable despite the reported failure.
+		auto verify = kvEngine->createReadWriteTransaction();
+		auto got = verify->get(key);
+		ASSERT_TRUE(got.has_value());
+		EXPECT_EQ(*got, value);
+	}
+
+	{  // Cleanup.
+		auto cleanup = kvEngine->createReadWriteTransaction();
+		cleanup->remove(key);
+		ASSERT_TRUE(cleanup->commit());
+	}
+}

--- a/src/fdb/fdb_unittest.cc
+++ b/src/fdb/fdb_unittest.cc
@@ -23,6 +23,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <thread>
 #include <vector>
@@ -289,11 +290,8 @@ TEST_F(FDBKVEngineTest, GetRangeAsync) {
 		ASSERT_EQ(rangeResult.getPairs().size(), 2U);
 		ASSERT_TRUE(rangeResult.hasMore());
 
-		error = 0;
-		auto secondRead = future->get(&error);
-		ASSERT_NE(error, 0);
-		ASSERT_TRUE(secondRead.getPairs().empty());
-		ASSERT_FALSE(secondRead.hasMore());
+		// The future is single-use: a second get() is a wrong-state call.
+		EXPECT_THROW(future->get(), std::logic_error);
 	}
 
 	{
@@ -1044,6 +1042,8 @@ TEST_F(FDBKVEngineTest, FaultInjectionRetryableAsyncReadThrows) {
 	ASSERT_NE(future, nullptr);
 	int error = 0;
 	EXPECT_THROW(future->get(&error), kv::RetryableTransactionError);
+	EXPECT_EQ(error, kNotCommitted);
+	EXPECT_EQ(transaction.error(), 0);
 }
 
 TEST_F(FDBKVEngineTest, FaultInjectionRetryableIsCatchableAsBase) {
@@ -1067,10 +1067,10 @@ TEST_F(FDBKVEngineTest, FaultInjectionRetryableIsCatchableAsBase) {
 	EXPECT_TRUE(caught);
 }
 
-TEST_F(FDBKVEngineTest, FaultInjectionNonRetryableAsyncReadReportsError) {
-	// Baseline of TODAY's contract: a non-retryable read error does not throw, it is
-	// reported via the error out-parameter and an empty optional. The uniform error
-	// contract (next change in this series) flips this to a thrown TransactionError.
+TEST_F(FDBKVEngineTest, FaultInjectionNonRetryableAsyncReadThrowsBase) {
+	// A non-retryable read error throws the TransactionError base (and specifically
+	// NOT the retryable subclass): a failed read never looks like a missing key, and
+	// the op boundary never replays it.
 	fdb::Transaction transaction(fdbDB.get());
 	ASSERT_TRUE(transaction);
 
@@ -1080,11 +1080,17 @@ TEST_F(FDBKVEngineTest, FaultInjectionNonRetryableAsyncReadReportsError) {
 
 	auto future = transaction.getAsync(kv::toBytes("fi_read_nonretryable"));
 	ASSERT_NE(future, nullptr);
-	int error = 0;
-	std::optional<kv::Value> value;
-	EXPECT_NO_THROW(value = future->get(&error));
-	EXPECT_EQ(error, kTransactionTooLarge);
-	EXPECT_FALSE(value.has_value());
+	bool caughtBase = false;
+	try {
+		future->get();
+	} catch (const kv::RetryableTransactionError &) {
+		FAIL() << "A non-retryable error must not be catchable as retryable.";
+	} catch (const kv::TransactionError &error) {
+		caughtBase = true;
+		EXPECT_EQ(error.errorCode(), kTransactionTooLarge);
+		EXPECT_FALSE(error.retryable());
+	}
+	EXPECT_TRUE(caughtBase);
 }
 
 TEST_F(FDBKVEngineTest, FaultInjectionRetryableRangeReadThrows) {
@@ -1099,12 +1105,13 @@ TEST_F(FDBKVEngineTest, FaultInjectionRetryableRangeReadThrows) {
 	kv::KeySelector end(kv::toBytes("fi_range_z"), true, 0);
 	auto future = transaction.getRangeAsync(begin, end, 10);
 	ASSERT_NE(future, nullptr);
-	EXPECT_THROW(future->get(), kv::RetryableTransactionError);
+	int error = 0;
+	EXPECT_THROW(future->get(&error), kv::RetryableTransactionError);
+	EXPECT_EQ(error, kNotCommitted);
+	EXPECT_EQ(transaction.error(), 0);
 }
 
-TEST_F(FDBKVEngineTest, FaultInjectionSyncReadReportsErrorWithoutThrowing) {
-	// Baseline of TODAY's sync/async asymmetry: the sync read swallows even retryable
-	// errors into error_ + nullopt. The uniform error contract flips this to a throw.
+TEST_F(FDBKVEngineTest, FaultInjectionSyncRangeReadThrowsWithoutUpdatingError) {
 	fdb::Transaction transaction(fdbDB.get());
 	ASSERT_TRUE(transaction);
 
@@ -1112,9 +1119,26 @@ TEST_F(FDBKVEngineTest, FaultInjectionSyncReadReportsErrorWithoutThrowing) {
 	fault.readErrors = {kNotCommitted};
 	transaction.setFaultInjection(&fault);
 
-	std::optional<kv::Value> value;
-	EXPECT_NO_THROW(value = transaction.get(kv::toBytes("fi_read_sync")));
-	EXPECT_FALSE(value.has_value());
+	kv::KeySelector begin(kv::toBytes("fi_sync_range_a"), true, 0);
+	kv::KeySelector end(kv::toBytes("fi_sync_range_z"), true, 0);
+	try {
+		(void)transaction.getRange(begin, end, 10);
+		FAIL() << "The injected range-read failure must throw.";
+	} catch (const kv::TransactionError &error) { EXPECT_EQ(error.errorCode(), kNotCommitted); }
+	EXPECT_EQ(transaction.error(), 0);
+}
+
+TEST_F(FDBKVEngineTest, FaultInjectionSyncReadThrowsLikeAsync) {
+	// The sync read follows the same contract as the async path: a retryable error
+	// throws instead of being swallowed into an empty result.
+	fdb::Transaction transaction(fdbDB.get());
+	ASSERT_TRUE(transaction);
+
+	fdb::FaultInjection fault;
+	fault.readErrors = {kNotCommitted};
+	transaction.setFaultInjection(&fault);
+
+	EXPECT_THROW(transaction.get(kv::toBytes("fi_read_sync")), kv::RetryableTransactionError);
 	EXPECT_EQ(transaction.error(), kNotCommitted);
 }
 
@@ -1131,9 +1155,8 @@ TEST_F(FDBKVEngineTest, FaultInjectionZeroEntriesSkipInjection) {
 	EXPECT_FALSE(value.has_value());
 	EXPECT_EQ(transaction.error(), 0);
 
-	// Second read: scripted failure.
-	value = transaction.get(kv::toBytes("fi_read_zero_skip_absent"));
-	EXPECT_FALSE(value.has_value());
+	// Second read: scripted non-retryable failure throws the base type.
+	EXPECT_THROW(transaction.get(kv::toBytes("fi_read_zero_skip_absent")), kv::TransactionError);
 	EXPECT_EQ(transaction.error(), kTransactionTooLarge);
 }
 
@@ -1191,12 +1214,12 @@ TEST_F(FDBKVEngineTest, FaultInjectionPreCommitAsyncReportsRetryable) {
 	EXPECT_FALSE(verify->get(key).has_value());
 }
 
-TEST_F(FDBKVEngineTest, FaultInjectionPostCommitOverrideCommitIsDurable) {
+TEST_F(FDBKVEngineTest, FaultInjectionPostCommitOverrideCommitAppliesExactlyOnce) {
 	// The maybe-committed detector: the commit really happens, then the result is
-	// overridden with commit_unknown_result. The database value is the oracle proving
-	// the data IS durable although the caller was told the outcome is unknown.
+	// overridden with commit_unknown_result. A non-idempotent atomicAdd is the oracle:
+	// the value becomes exactly one, proving that the durable mutation applied once.
 	const kv::Key key = kv::toBytes("fi_post_commit");
-	const kv::Value value = kv::toBytes("durable");
+	const kv::Value increment = kv::toBytesLE(uint64_t{1});
 	{  // Clean slate.
 		auto cleanup = kvEngine->createReadWriteTransaction();
 		cleanup->remove(key);
@@ -1210,7 +1233,7 @@ TEST_F(FDBKVEngineTest, FaultInjectionPostCommitOverrideCommitIsDurable) {
 	fault.postCommitErrors = {kCommitUnknownResult};
 	transaction.setFaultInjection(&fault);
 
-	transaction.set(key, value);
+	transaction.atomicAdd(key, increment);
 	EXPECT_FALSE(transaction.commit());
 	EXPECT_EQ(transaction.error(), kCommitUnknownResult);
 
@@ -1218,7 +1241,7 @@ TEST_F(FDBKVEngineTest, FaultInjectionPostCommitOverrideCommitIsDurable) {
 		auto verify = kvEngine->createReadWriteTransaction();
 		auto got = verify->get(key);
 		ASSERT_TRUE(got.has_value());
-		EXPECT_EQ(*got, value);
+		EXPECT_EQ(kv::fromBytesLE<uint64_t>(*got), uint64_t{1});
 	}
 
 	{  // Cleanup.
@@ -1228,9 +1251,9 @@ TEST_F(FDBKVEngineTest, FaultInjectionPostCommitOverrideCommitIsDurable) {
 	}
 }
 
-TEST_F(FDBKVEngineTest, FaultInjectionPostCommitOverrideAsyncNotRetryable) {
+TEST_F(FDBKVEngineTest, FaultInjectionPostCommitOverrideAsyncAppliesOnceAndIsNotRetryable) {
 	const kv::Key key = kv::toBytes("fi_post_commit_async");
-	const kv::Value value = kv::toBytes("durable");
+	const kv::Value increment = kv::toBytesLE(uint64_t{1});
 	{  // Clean slate.
 		auto cleanup = kvEngine->createReadWriteTransaction();
 		cleanup->remove(key);
@@ -1244,7 +1267,7 @@ TEST_F(FDBKVEngineTest, FaultInjectionPostCommitOverrideAsyncNotRetryable) {
 	fault.postCommitErrors = {kCommitUnknownResult};
 	transaction.setFaultInjection(&fault);
 
-	transaction.set(key, value);
+	transaction.atomicAdd(key, increment);
 	auto future = transaction.commitAsync();
 	ASSERT_NE(future, nullptr);
 
@@ -1259,7 +1282,7 @@ TEST_F(FDBKVEngineTest, FaultInjectionPostCommitOverrideAsyncNotRetryable) {
 		auto verify = kvEngine->createReadWriteTransaction();
 		auto got = verify->get(key);
 		ASSERT_TRUE(got.has_value());
-		EXPECT_EQ(*got, value);
+		EXPECT_EQ(kv::fromBytesLE<uint64_t>(*got), uint64_t{1});
 	}
 
 	{  // Cleanup.
@@ -1270,10 +1293,9 @@ TEST_F(FDBKVEngineTest, FaultInjectionPostCommitOverrideAsyncNotRetryable) {
 }
 
 TEST_F(FDBKVEngineTest, FaultInjectionCommittedVersionLookupFailure) {
-	// Baseline of TODAY's behavior: a committed-version lookup failure after a
-	// successful commit is reported as a FAILED commit although the data is durable.
-	// The read-path correctness change in this series flips this to success without a
-	// version; this test documents the current (wrong-direction) contract until then.
+	// A committed-version lookup failure AFTER a successful commit is reported as a
+	// SUCCESSFUL commit without a version: the data is durable, and reporting a
+	// failure would invite the caller to replay an already-applied operation.
 	const kv::Key key = kv::toBytes("fi_version_lookup");
 	const kv::Value value = kv::toBytes("durable");
 	{  // Clean slate.
@@ -1290,11 +1312,12 @@ TEST_F(FDBKVEngineTest, FaultInjectionCommittedVersionLookupFailure) {
 	transaction.setFaultInjection(&fault);
 
 	transaction.set(key, value);
-	EXPECT_FALSE(transaction.commit());
-	EXPECT_EQ(transaction.error(), kTransactionCancelled);
+	EXPECT_TRUE(transaction.commit()) << "The commit is durable; a failed version lookup "
+	                                     "must not be reported as a failed commit.";
+	EXPECT_EQ(transaction.error(), 0);
 	EXPECT_FALSE(transaction.getCommittedVersion().has_value());
 
-	{  // The write is durable despite the reported failure.
+	{  // The write is durable and the commit reported success.
 		auto verify = kvEngine->createReadWriteTransaction();
 		auto got = verify->get(key);
 		ASSERT_TRUE(got.has_value());
@@ -1306,4 +1329,155 @@ TEST_F(FDBKVEngineTest, FaultInjectionCommittedVersionLookupFailure) {
 		cleanup->remove(key);
 		ASSERT_TRUE(cleanup->commit());
 	}
+}
+
+TEST_F(FDBKVEngineTest, FaultInjectionCommittedVersionLookupFailureAsync) {
+	// Async twin of the sync case: getResult() reports success without a version.
+	const kv::Key key = kv::toBytes("fi_version_lookup_async");
+	const kv::Value value = kv::toBytes("durable");
+	{  // Clean slate.
+		auto cleanup = kvEngine->createReadWriteTransaction();
+		cleanup->remove(key);
+		ASSERT_TRUE(cleanup->commit());
+	}
+
+	fdb::Transaction transaction(fdbDB.get());
+	ASSERT_TRUE(transaction);
+
+	fdb::FaultInjection fault;
+	fault.committedVersionErrors = {kTransactionCancelled};
+	transaction.setFaultInjection(&fault);
+
+	transaction.set(key, value);
+	auto future = transaction.commitAsync();
+	ASSERT_NE(future, nullptr);
+
+	int error = -1;
+	bool retryable = true;
+	EXPECT_TRUE(future->getResult(&error, &retryable))
+	    << "The commit is durable; a failed version lookup must not fail the commit.";
+	EXPECT_EQ(error, 0);
+	EXPECT_FALSE(retryable);
+	EXPECT_FALSE(transaction.getCommittedVersion().has_value());
+	EXPECT_EQ(transaction.error(), 0);
+
+	{  // Cleanup.
+		auto cleanup = kvEngine->createReadWriteTransaction();
+		cleanup->remove(key);
+		ASSERT_TRUE(cleanup->commit());
+	}
+}
+
+TEST_F(FDBKVEngineTest, FailedRecommitClearsCommittedVersion) {
+	// A failed commit attempt on a previously committed transaction must not leave the
+	// earlier attempt's version visible: every attempt clears the version on entry.
+	const kv::Key key = kv::toBytes("fi_recommit_version");
+	{  // Clean slate.
+		auto cleanup = kvEngine->createReadWriteTransaction();
+		cleanup->remove(key);
+		ASSERT_TRUE(cleanup->commit());
+	}
+
+	fdb::Transaction transaction(fdbDB.get());
+	ASSERT_TRUE(transaction);
+
+	transaction.set(key, kv::toBytes("value"));
+	ASSERT_TRUE(transaction.commit());
+	ASSERT_TRUE(transaction.getCommittedVersion().has_value());
+
+	// Second attempt on the same transaction, failed deterministically before
+	// submission: the version from the first attempt must be gone.
+	fdb::FaultInjection fault;
+	fault.preCommitErrors = {kNotCommitted};
+	transaction.setFaultInjection(&fault);
+	EXPECT_FALSE(transaction.commit());
+	EXPECT_FALSE(transaction.getCommittedVersion().has_value());
+
+	{  // Cleanup.
+		auto cleanup = kvEngine->createReadWriteTransaction();
+		cleanup->remove(key);
+		ASSERT_TRUE(cleanup->commit());
+	}
+}
+
+TEST_F(FDBKVEngineTest, FailedRecommitAsyncClearsCommittedVersion) {
+	// Async twin: commitAsync() clears the version on entry as well.
+	const kv::Key key = kv::toBytes("fi_recommit_version_async");
+	{  // Clean slate.
+		auto cleanup = kvEngine->createReadWriteTransaction();
+		cleanup->remove(key);
+		ASSERT_TRUE(cleanup->commit());
+	}
+
+	fdb::Transaction transaction(fdbDB.get());
+	ASSERT_TRUE(transaction);
+
+	transaction.set(key, kv::toBytes("value"));
+	ASSERT_TRUE(transaction.commit());
+	ASSERT_TRUE(transaction.getCommittedVersion().has_value());
+
+	fdb::FaultInjection fault;
+	fault.preCommitErrors = {kNotCommitted};
+	transaction.setFaultInjection(&fault);
+	auto future = transaction.commitAsync();
+	ASSERT_NE(future, nullptr);
+	int error = 0;
+	EXPECT_FALSE(future->getResult(&error));
+	EXPECT_EQ(error, kNotCommitted);
+	EXPECT_FALSE(transaction.getCommittedVersion().has_value());
+
+	{  // Cleanup.
+		auto cleanup = kvEngine->createReadWriteTransaction();
+		cleanup->remove(key);
+		ASSERT_TRUE(cleanup->commit());
+	}
+}
+
+TEST_F(FDBKVEngineTest, TransactionFromNullDBIsInvalidNotUB) {
+	// Constructing a transaction from a null DB pointer must produce an invalid
+	// transaction, never pass nullptr into the C API. Using it is a wrong-state call
+	// per the kv error-domain rules: reads, writes and commits throw std::logic_error
+	// instead of posing as a missing key or silently dropping a mutation. (An errored
+	// DB cannot be built through the public API to test the getDB()==nullptr branch
+	// the same way: fdb_create_database is lazy and succeeds even for a bogus
+	// cluster-file path, deferring the failure to the first operation.)
+	fdb::Transaction fromNull(nullptr);
+	EXPECT_FALSE(fromNull);
+	const kv::Key key = kv::toBytes("any");
+	const kv::Value value = kv::toBytesLE(uint64_t{1});
+	kv::KeySelector begin(kv::toBytes("a"), true, 0);
+	kv::KeySelector end(kv::toBytes("z"), true, 0);
+
+	EXPECT_THROW(fromNull.setOption(FDB_TR_OPTION_READ_YOUR_WRITES_DISABLE), std::logic_error);
+	EXPECT_THROW(fromNull.get(key), std::logic_error);
+	EXPECT_THROW(fromNull.getAsync(key), std::logic_error);
+	EXPECT_THROW(fromNull.getRange(begin, end, 1), std::logic_error);
+	EXPECT_THROW(fromNull.getRangeAsync(begin, end, 1), std::logic_error);
+	EXPECT_THROW(fromNull.set(key, value), std::logic_error);
+	EXPECT_THROW(fromNull.atomicAdd(key, value), std::logic_error);
+	EXPECT_THROW(fromNull.atomicMax(key, value), std::logic_error);
+	EXPECT_THROW(fromNull.remove(key), std::logic_error);
+	EXPECT_THROW(fromNull.removeRange(begin.getKey(), end.getKey()), std::logic_error);
+	EXPECT_THROW(fromNull.commit(), std::logic_error);
+	EXPECT_THROW(fromNull.commitAsync(), std::logic_error);
+	EXPECT_FALSE(fromNull.getCommittedVersion().has_value());
+	EXPECT_FALSE(fromNull.getApproximateSize().has_value());
+}
+
+TEST_F(FDBKVEngineTest, ConsumedReadFutureThrowsLogicError) {
+	// Double-get on a single-use read future is a wrong-state call: it must throw
+	// std::logic_error, never pose as a missing key or an empty range.
+	auto transaction = kvEngine->createReadWriteTransaction();
+
+	auto valueFuture = transaction->getAsync(kv::toBytes("consumed_future_key"));
+	ASSERT_TRUE(valueFuture != nullptr);
+	(void)valueFuture->get();
+	EXPECT_THROW(valueFuture->get(), std::logic_error);
+
+	auto rangeFuture =
+	    transaction->getRangeAsync(kv::KeySelector(kv::toBytes("consumed_range_a"), true, 0),
+	                               kv::KeySelector(kv::toBytes("consumed_range_b"), false, 0));
+	ASSERT_TRUE(rangeFuture != nullptr);
+	(void)rangeFuture->get();
+	EXPECT_THROW(rangeFuture->get(), std::logic_error);
 }

--- a/src/kv/ifuture.h
+++ b/src/kv/ifuture.h
@@ -28,6 +28,35 @@
 
 namespace kv {
 
+/// Base type for backend transaction failures, carrying the backend error code and
+/// whether the failed operation may be replayed.
+///
+/// Error-domain rules for the kv/fdb layers:
+///  - Backend failures (the operation reached the backend and failed there) are reported
+///    as a TransactionError; retryable() says whether the caller may replay the op.
+///  - Invalid argument values (e.g. a bad versionstamp offset) are std::invalid_argument.
+///  - Calls in the wrong transaction state are std::logic_error.
+/// The local domains carry no backend error code, so they can never be mistaken for (or
+/// fed into) backend retry handling.
+///
+/// Today only the retryable subclass is thrown; non-retryable backend read failures are
+/// still reported via error out-parameters and empty results. Reads start throwing this
+/// base type for non-retryable errors when the uniform error contract lands.
+class TransactionError : public std::runtime_error {
+public:
+	TransactionError(int errorCode, const std::string &message)
+	    : std::runtime_error(message), errorCode_(errorCode) {}
+
+	int errorCode() const noexcept { return errorCode_; }
+
+	/// Whether the caller may replay the failed operation (transient conflict/timeout
+	/// class, as opposed to a permanent backend failure).
+	virtual bool retryable() const noexcept { return false; }
+
+private:
+	int errorCode_;
+};
+
 /// Thrown by a read future's get() when the underlying transaction failed with a
 /// RETRYABLE backend error (e.g. FoundationDB transaction_timed_out / not_committed /
 /// transaction_too_old). The single-threaded master event loop catches this at the op
@@ -35,15 +64,12 @@ namespace kv {
 /// transient read failure abort the whole MDS. Non-retryable read failures (corruption,
 /// genuinely-absent keys) are still reported the old way (error code / nullopt), not via
 /// this type.
-class RetryableTransactionError : public std::runtime_error {
+class RetryableTransactionError : public TransactionError {
 public:
 	RetryableTransactionError(int errorCode, const std::string &message)
-	    : std::runtime_error(message), errorCode_(errorCode) {}
+	    : TransactionError(errorCode, message) {}
 
-	int errorCode() const noexcept { return errorCode_; }
-
-private:
-	int errorCode_;
+	bool retryable() const noexcept override { return true; }
 };
 
 /// Interface for asynchronous future results from key-value operations.

--- a/src/kv/ifuture.h
+++ b/src/kv/ifuture.h
@@ -39,9 +39,10 @@ namespace kv {
 /// The local domains carry no backend error code, so they can never be mistaken for (or
 /// fed into) backend retry handling.
 ///
-/// Today only the retryable subclass is thrown; non-retryable backend read failures are
-/// still reported via error out-parameters and empty results. Reads start throwing this
-/// base type for non-retryable errors when the uniform error contract lands.
+/// Read contract: an empty result (nullopt) means only that the key does not exist.
+/// Every backend read failure throws this family, the retryable subclass for transient
+/// errors the op boundary may replay, this base type for everything else, so a backend
+/// failure can never be mistaken for a missing key.
 class TransactionError : public std::runtime_error {
 public:
 	TransactionError(int errorCode, const std::string &message)
@@ -61,9 +62,8 @@ private:
 /// RETRYABLE backend error (e.g. FoundationDB transaction_timed_out / not_committed /
 /// transaction_too_old). The single-threaded master event loop catches this at the op
 /// boundary and replays the op on a fresh transaction (bounded) instead of letting a
-/// transient read failure abort the whole MDS. Non-retryable read failures (corruption,
-/// genuinely-absent keys) are still reported the old way (error code / nullopt), not via
-/// this type.
+/// transient read failure abort the whole MDS. Non-retryable backend failures throw the
+/// TransactionError base instead.
 class RetryableTransactionError : public TransactionError {
 public:
 	RetryableTransactionError(int errorCode, const std::string &message)
@@ -92,12 +92,15 @@ public:
 	virtual bool isReady() = 0;
 
 	/// Blocks until the result is ready and retrieves the value.
-	/// @param error Optional pointer to store error code (0 on success, non-zero on error).
-	/// @return The value if successful and present, std::nullopt on error or if key not found.
+	/// @param error Optional out-param for the backend error code: 0 on success; on a
+	///   backend failure the code is stored before the throw. Exceptions are the failure
+	///   signal, the code is diagnostic only.
+	/// @return The value, or std::nullopt only when the key does not exist.
 	/// @throws RetryableTransactionError if the backend read failed with a retryable
-	///   error; callers must catch it at the op boundary. Non-retryable failures and
-	///   genuinely-absent keys still report via @p error / std::nullopt.
-	/// @note This method can only be called once. Subsequent calls return std::nullopt.
+	///   error (callers catch it at the op boundary and replay), TransactionError for
+	///   any other backend failure. A failed read never looks like a missing key.
+	/// @note This method can only be called once. Subsequent calls are wrong-state calls
+	///   and throw std::logic_error.
 	/// @note The caller must keep the transaction alive until this method returns.
 	virtual std::optional<Value> get(int *error = nullptr) = 0;
 
@@ -124,12 +127,15 @@ public:
 	virtual bool isReady() = 0;
 
 	/// Blocks until the result is ready and retrieves the range.
-	/// @param error Optional pointer to store error code (0 on success, non-zero on error).
-	/// @return The range result, or an empty result on error.
+	/// @param error Optional out-param for the backend error code: 0 on success; on a
+	///   backend failure the code is stored before the throw. Exceptions are the failure
+	///   signal, the code is diagnostic only.
+	/// @return The range result; empty only when no keys fall in the range.
 	/// @throws RetryableTransactionError if the backend read failed with a retryable
-	///   error; callers must catch it at the op boundary. Non-retryable failures still
-	///   report via @p error / an empty result.
-	/// @note This method can only be called once. Subsequent calls return an empty result.
+	///   error (callers catch it at the op boundary and replay), TransactionError for
+	///   any other backend failure. A failed read never looks like an empty range.
+	/// @note This method can only be called once. Subsequent calls are wrong-state calls
+	///   and throw std::logic_error.
 	/// @note The caller must keep the transaction alive until this method returns.
 	virtual GetRangeResult get(int *error = nullptr) = 0;
 

--- a/src/kv/itransaction.h
+++ b/src/kv/itransaction.h
@@ -70,6 +70,9 @@ public:
 
 	/// Retrieves the value for a given key.
 	/// @param key The key to retrieve the value for.
+	/// @return The value, or std::nullopt only when the key does not exist.
+	/// @throws RetryableTransactionError / TransactionError when the backend read fails,
+	///   so a backend failure can never be mistaken for a missing key.
 	virtual std::optional<Value> get(const Key &key) = 0;
 
 	/// Retrieves the value for a given key without adding it to the
@@ -83,11 +86,16 @@ public:
 	///          conflict. Use get() for reads that must be transactionally
 	///          consistent.
 	/// @param key The key to retrieve the value for.
+	/// @return The value, or std::nullopt only when the key does not exist.
+	/// @throws RetryableTransactionError / TransactionError when the backend read fails,
+	///   so a backend failure can never be mistaken for a missing key.
 	virtual std::optional<Value> getSnapshot(const Key &key) = 0;
 
 	/// Retrieves the value for a given key asynchronously.
 	/// @param key The key to retrieve the value for.
 	/// @return A future that will contain the value when ready.
+	/// @note Backend read failures are reported by the future's get(), which throws
+	///   RetryableTransactionError / TransactionError (see IFuture::get()).
 	/// @note The transaction must remain alive until the future's get() method is called.
 	virtual std::unique_ptr<IFuture> getAsync(const Key &key) = 0;
 
@@ -95,6 +103,9 @@ public:
 	/// @param start The starting key for the range.
 	/// @param end The ending key for the range.
 	/// @param limit The maximum number of key-value pairs to retrieve.
+	/// @return The range result; empty only when no keys fall in the range.
+	/// @throws RetryableTransactionError / TransactionError when the backend read fails,
+	///   so a backend failure can never be mistaken for an empty range.
 	virtual GetRangeResult getRange(const KeySelector &start, const KeySelector &end,
 	                                int limit = kDefaultGetRangeLimit) = 0;
 
@@ -103,6 +114,8 @@ public:
 	/// @param end The ending key for the range.
 	/// @param limit The maximum number of key-value pairs to retrieve.
 	/// @return A future that will contain the range when ready.
+	/// @note Backend read failures are reported by the future's get(), which throws
+	///   RetryableTransactionError / TransactionError (see IRangeFuture::get()).
 	/// @note The transaction must remain alive until the future's get() method is called.
 	virtual std::unique_ptr<IRangeFuture> getRangeAsync(const KeySelector &start,
 	                                                    const KeySelector &end,
@@ -114,6 +127,9 @@ protected:
 
 /// Interface for read-write transactions in the key-value store.
 /// Inherits from IReadOnlyTransaction and adds methods for modifying the database.
+/// Per the error-domain rules in kv/ifuture.h, backend failures throw the
+/// TransactionError family and wrong-state calls (e.g. operations on a moved-from
+/// backend transaction) throw std::logic_error; a write is never silently dropped.
 class IReadWriteTransaction : public IReadOnlyTransaction {
 public:
 	virtual ~IReadWriteTransaction() override = default;
@@ -157,6 +173,8 @@ public:
 	virtual void removeRange(const Key &start, const Key &end) = 0;
 
 	/// Commits the transaction, making all changes permanent.
+	/// @return True if the commit succeeded and is durable, false on a backend commit
+	///   failure.
 	virtual bool commit() = 0;
 
 	/// Submits the commit asynchronously and returns a pollable future.

--- a/src/kv/transaction_error_unittest.cc
+++ b/src/kv/transaction_error_unittest.cc
@@ -1,0 +1,74 @@
+/*
+   Copyright 2023      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "common/platform.h"
+
+#include <gtest/gtest.h>
+
+#include "kv/ifuture.h"
+
+namespace {
+
+// FoundationDB error codes used as representative examples.
+constexpr int kNotCommitted = 1020;
+constexpr int kTransactionTimedOut = 1031;
+constexpr int kTransactionTooLarge = 2101;
+
+}  // namespace
+
+TEST(KVTransactionErrorTest, BaseIsNotRetryable) {
+	kv::TransactionError error(kTransactionTooLarge, "transaction too large");
+	EXPECT_EQ(error.errorCode(), kTransactionTooLarge);
+	EXPECT_FALSE(error.retryable());
+	EXPECT_STREQ(error.what(), "transaction too large");
+}
+
+TEST(KVTransactionErrorTest, RetryableSubclassIsRetryable) {
+	kv::RetryableTransactionError error(kNotCommitted, "not committed");
+	EXPECT_EQ(error.errorCode(), kNotCommitted);
+	EXPECT_TRUE(error.retryable());
+	EXPECT_STREQ(error.what(), "not committed");
+}
+
+TEST(KVTransactionErrorTest, CatchingBaseCatchesRetryable) {
+	bool caught = false;
+	try {
+		throw kv::RetryableTransactionError(kTransactionTimedOut, "transaction timed out");
+	} catch (const kv::TransactionError &error) {
+		caught = true;
+		EXPECT_EQ(error.errorCode(), kTransactionTimedOut);
+		EXPECT_TRUE(error.retryable());
+	}
+	EXPECT_TRUE(caught);
+}
+
+TEST(KVTransactionErrorTest, CatchingRetryableSkipsBase) {
+	// A non-retryable base error must NOT be caught by a retryable-only handler;
+	// the op boundary relies on this to keep replay decisions strict.
+	bool caughtRetryable = false;
+	bool caughtBase = false;
+	try {
+		throw kv::TransactionError(kTransactionTooLarge, "transaction too large");
+	} catch (const kv::RetryableTransactionError &) {
+		caughtRetryable = true;
+	} catch (const kv::TransactionError &) {
+		caughtBase = true;
+	}
+	EXPECT_FALSE(caughtRetryable);
+	EXPECT_TRUE(caughtBase);
+}

--- a/src/kv/transaction_error_unittest.cc
+++ b/src/kv/transaction_error_unittest.cc
@@ -66,9 +66,7 @@ TEST(KVTransactionErrorTest, CatchingRetryableSkipsBase) {
 		throw kv::TransactionError(kTransactionTooLarge, "transaction too large");
 	} catch (const kv::RetryableTransactionError &) {
 		caughtRetryable = true;
-	} catch (const kv::TransactionError &) {
-		caughtBase = true;
-	}
+	} catch (const kv::TransactionError &) { caughtBase = true; }
 	EXPECT_FALSE(caughtRetryable);
 	EXPECT_TRUE(caughtBase);
 }

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -386,6 +386,14 @@ static uint8_t matoclserv_commit_op_with_retry(const OpReplay &body) {
 			    "matoclserv: retryable read error in op body (err {}), retrying, attempt {}",
 			    e.errorCode(), attempt + 1);
 			continue;
+		} catch (const kv::TransactionError &e) {
+			// Non-retryable backend failure while running the op body: fail this op with
+			// EIO instead of letting the exception escape the event loop. Nothing throws
+			// this base type yet (non-retryable read errors still report via error
+			// codes); this is the safety net for when they start to.
+			safs::log_err("matoclserv: backend transaction error in op body (err {}): {}",
+			              e.errorCode(), e.what());
+			return SAUNAFS_ERROR_IO;
 		}
 
 		if (status != SAUNAFS_STATUS_OK) { return status; }  // op error/status, do not commit
@@ -538,6 +546,15 @@ static bool matoclserv_replay_members_iteration(std::vector<BatchMember> &member
 			    "attempt {}",
 			    e.errorCode(), member.attempts);
 		}
+		return true;
+	} catch (const kv::TransactionError &e) {
+		// Non-retryable backend failure: fail this member with EIO and restart the batch
+		// on a fresh transaction (the shared transaction is unusable after a thrown
+		// error). Nothing throws this base type yet; safety net for when reads start to.
+		safs::log_err("matoclserv: backend transaction error in batch member (err {}): {}",
+		              e.errorCode(), e.what());
+		matoclserv_finish_member(member, SAUNAFS_ERROR_IO);
+		members.erase(members.begin() + idx);
 		return true;
 	}
 }

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -387,10 +387,8 @@ static uint8_t matoclserv_commit_op_with_retry(const OpReplay &body) {
 			    e.errorCode(), attempt + 1);
 			continue;
 		} catch (const kv::TransactionError &e) {
-			// Non-retryable backend failure while running the op body: fail this op with
-			// EIO instead of letting the exception escape the event loop. Nothing throws
-			// this base type yet (non-retryable read errors still report via error
-			// codes); this is the safety net for when they start to.
+			// Non-retryable backend failure: fail this op with EIO instead of letting
+			// the exception escape the event loop.
 			safs::log_err("matoclserv: backend transaction error in op body (err {}): {}",
 			              e.errorCode(), e.what());
 			return SAUNAFS_ERROR_IO;
@@ -550,7 +548,7 @@ static bool matoclserv_replay_members_iteration(std::vector<BatchMember> &member
 	} catch (const kv::TransactionError &e) {
 		// Non-retryable backend failure: fail this member with EIO and restart the batch
 		// on a fresh transaction (the shared transaction is unusable after a thrown
-		// error). Nothing throws this base type yet; safety net for when reads start to.
+		// error).
 		safs::log_err("matoclserv: backend transaction error in batch member (err {}): {}",
 		              e.errorCode(), e.what());
 		matoclserv_finish_member(member, SAUNAFS_ERROR_IO);
@@ -6799,15 +6797,23 @@ void matoclserv_gotpacket(matoclserventry *eptr, uint32_t type, const uint8_t *d
 		// the dispatch boundary from a read-only or not-yet-wrapped op. Do NOT abort the
 		// single-threaded master: drop this client connection so it reconnects and retries
 		// the request. Write ops route their bodies through the group-commit batch, which
-		// retries retryable read errors in replay before ever reaching here. Non-retryable
-		// failures (corruption, genuinely-absent required keys) still propagate and
-		// fail-stop the master.
+		// retries retryable read errors in replay before ever reaching here.
 		safs::log_warn(
 				"main master server module: retryable backend read error handling message "
 				"(type:{}, length:{}, err:{}): {}; dropping client connection",
 				type, length, e.errorCode(), e.what());
 		eptr->mode = ClientConnectionMode::KILL;
-	} catch (IncorrectDeserializationException& e) {
+	} catch (const kv::TransactionError &e) {
+		// A non-retryable backend failure on a single request. Also not worth aborting
+		// the whole master: drop the connection and let the client decide whether to
+		// retry. Exceptions from outside the backend error family (corruption-class
+		// invariant violations) still propagate and fail-stop the master.
+		safs::log_err(
+		    "main master server module: backend transaction error handling message "
+		    "(type:{}, length:{}, err:{}): {}; dropping client connection",
+		    type, length, e.errorCode(), e.what());
+		eptr->mode = ClientConnectionMode::KILL;
+	} catch (IncorrectDeserializationException &e) {
 		safs::log_info(
 				"main master server module: got inconsistent message from mount "
 				"(type:{}, length:{}), {}", type, length, e.what());


### PR DESCRIPTION
The fdb library had only one way to report a failure: the
RetryableTransactionError exception used for errors that are safe to
retry. Every other backend failure was returned as an empty result,
which looks exactly like "this key does not exist". A filesystem must
never confuse "the database failed" with "the file is not there". The
error-handling paths were also effectively untestable, since there
was no way to make the backend fail on purpose.

The first commit lands the vocabulary and the test tooling.
kv::TransactionError becomes the base type for "a backend transaction
failed", carrying the error code and a retryable() flag;
RetryableTransactionError now derives from it, so existing catch
sites keep working and callers can catch the base type to handle any
backend failure in one place. The two master op-boundary replay sites
do exactly that and answer the affected request with EIO.
fdb::Transaction also gains an optional, test-only fault script (a
null pointer in production): tests can now make a specific read or
commit fail with a specific error code on demand, including the most
dangerous case where the commit really happens but the caller is
told the outcome is unknown.

The second commit makes the behavior change: every failed read now
throws, using the retryable exception for errors the op boundary may
replay and the TransactionError base for everything else, so an
empty result means only "the key does not exist". The master handles
the new errors at the op boundaries (reply EIO for that request) and
at the dispatch boundary (drop the client connection instead of
aborting the whole master). A committed-version lookup failure after
a successful commit is now reported as a success without a version,
never as a failed commit that could invite replaying an
already-applied operation. Also guards transaction creation against
a null database handle and drops an unused error field from the kv
adapter.

New unit tests cover the error hierarchy and every injection point,
including a regression proving the data is durable exactly once in
the unknown-outcome case. SanityChecks, ShortSystemTests and
FDBTests all green.

Related to: LS-949

Signed-off-by: guillex <guillex@leil.io>
