### PR TITLE
test: reduce flakiness of timing-sensitive system tests

### DIFF
--- a/tests/test_suites/SanityChecks/test_quota_size.sh
+++ b/tests/test_suites/SanityChecks/test_quota_size.sh
@@ -1,4 +1,5 @@
-timeout_set 45 seconds
+# Budget must absorb one master chunk-lock expiry (120s LOCKTIMEOUT, unscaled).
+timeout_set 150 seconds
 
 USE_RAMDISK=YES \
 	SFSEXPORTS_EXTRA_OPTIONS="allcanchangequota,ignoregid" \
@@ -46,7 +47,18 @@ sudo -nu saunafstest_1 truncate -s 1P file_2
 sudo -nu saunafstest_1 dd if=/dev/zero of=file_2 bs=1M seek=63 count=1 conv=notrunc
 # .. one can't create new chunks:
 expect_failure sudo -nu saunafstest_1 dd if=/dev/zero of=file_2 bs=1M seek=64 count=1 conv=notrunc
-sudo -nu saunafstest_1 truncate -s 1024 file_2
+# The rejected write's quota error stays latched on the mount's inode until the
+# writer's state is released asynchronously. A tight retry cadence re-adopts
+# that state and keeps the stale error alive, so space the attempts out.
+truncated=""
+for _ in {1..30}; do
+	if sudo -nu saunafstest_1 truncate -s 1024 file_2; then
+		truncated="yes"
+		break
+	fi
+	sleep $(timeout_rescale_seconds 2)
+done
+assert_equals "yes" "${truncated}"
 
 # changing group should affect usage:
 sudo -nu saunafstest_1 chgrp $gid file_2

--- a/tests/test_suites/ShortSystemTests/test_custom_goal_replication_delay_disconnect.sh
+++ b/tests/test_suites/ShortSystemTests/test_custom_goal_replication_delay_disconnect.sh
@@ -1,4 +1,8 @@
-timeout_set "1 minute"
+timeout_set "2 minutes"
+
+# The disconnect-delay window and the waits tied to it scale with the machine
+# multiplier, so slow machines keep the same proportions.
+delay_disconnect=$(timeout_rescale_seconds 15)
 
 # Start an installation with:
 #   two servers labeled 'ssd' and 2 unlabeled servers
@@ -11,7 +15,7 @@ USE_RAMDISK=YES \
 			`|ACCEPTABLE_DIFFERENCE = 1.0`
 			`|CHUNKS_WRITE_REP_LIMIT = 5`
 			`|OPERATIONS_DELAY_INIT = 0`
-			`|OPERATIONS_DELAY_DISCONNECT = 15" \
+			`|OPERATIONS_DELAY_DISCONNECT = ${delay_disconnect}" \
 	setup_local_empty_saunafs info
 
 # Leave only one unlabeled and one 'ssd' server
@@ -19,8 +23,9 @@ saunafs_chunkserver_daemon 1 stop
 saunafs_chunkserver_daemon 3 stop
 saunafs_wait_for_ready_chunkservers 2
 
-# Wait few seconds to avoid unwanted replication delay.
-sleep 17
+# Wait out the window armed by the stops above so it cannot leak into the
+# phases measured below.
+sleep $((delay_disconnect + 2))
 
 # Create 20 files. Expect that for each file there are 2 chunk copies.
 FILE_SIZE=1K file-generate "${info[mount0]}"/file{1..20}
@@ -32,21 +37,21 @@ saunafs_chunkserver_daemon 0 stop
 saunafs_chunkserver_daemon 3 start
 saunafs_wait_for_ready_chunkservers 2
 
-# All chunks has 1 missing replica on 'ssd' server
-# but they never should be replicated to some random server.
+# All chunks have 1 missing replica on an 'ssd' server, but within the
+# disconnect-delay window (measured from the stop above) they must not be
+# replicated to some random server.
 assert_equals 20 $(saunafs checkfile "${info[mount0]}"/* | grep 'with 1 copy:' | wc -l)
-sleep 7
+sleep $(timeout_rescale_seconds 7)
 assert_equals 20 $(saunafs checkfile "${info[mount0]}"/* | grep 'with 1 copy:' | wc -l)
 
 # Restart 'ssd' server.
 saunafs_chunkserver_daemon 1 start
 saunafs_wait_for_ready_chunkservers 3
 
-# Replication should start immediately
-assert_eventually_prints 20 'find_chunkserver_metadata_chunks 1 | wc -l' "4 seconds"
+# Replication should start immediately: reconnecting an 'ssd' server unblocks
+# the delayed recovery.
+assert_eventually_prints 20 'find_chunkserver_metadata_chunks 1 | wc -l'
 
-# Replication loop is no longer atomic, so we need some time to ensure
-# that chunk loop tested all chunks.
-sleep 2
-
-assert_equals 20 $(saunafs checkfile "${info[mount0]}"/* | grep 'with 2 copies:' | wc -l)
+# The master registers the new copies only after the chunk files appear, so
+# wait for its view instead of sleeping.
+assert_eventually_prints 20 "saunafs checkfile \"${info[mount0]}\"/* | grep 'with 2 copies:' | wc -l"

--- a/tests/test_suites/ShortSystemTests/test_slow_rereads.sh
+++ b/tests/test_suites/ShortSystemTests/test_slow_rereads.sh
@@ -1,4 +1,6 @@
-timeout_set 3 minutes
+# Most of the runtime is a fixed wall-clock floor (75s buffer-expiry wait,
+# slowed preads); the budget needs headroom for the ~6 GB of real I/O on top.
+timeout_set 5 minutes
 
 cacheexpirationtime_ms=15000
 readbuffersexpirationtime_ms=60000
@@ -27,14 +29,31 @@ dd if=file of=/dev/null bs=1M count=$((30 * 64)) status=none
 saunafs settrashtime 0 file
 rm file
 
+# The next file needs the ramdisk space; a restart mid-deletion would make the
+# chunkserver rejoin with the leftover chunks still on disk and fail the
+# writes below with ENOSPC.
+assert_eventually '[[ $(find_chunkserver_chunks 0 | wc -l) == 0 ]]' "2 minutes"
+
 # Restart the first chunkserver preloading pread with slow version of reads
 LD_PRELOAD="${SAUNAFS_INSTALL_FULL_LIBDIR}/libchunk_operations_eio.so" \
 		assert_success saunafs_chunkserver_daemon 0 restart
 saunafs_wait_for_all_ready_chunkservers
 
 create-and-reread-file "file" $(( (cacheexpirationtime_ms + readbuffersexpirationtime_ms) / 1000)) &
+helper_pid=$!
 
-while ! [[ -f notify_file_reread ]]; do sleep 0.1; done
+# The helper keeps the notify file around for only one second before removing
+# it and exiting, so a clean helper exit is an equivalent success signal; a
+# failed exit fails the test fast instead of spinning until the timeout.
+while ! [[ -f notify_file_reread ]]; do
+	if ! kill -0 "${helper_pid}" 2>/dev/null; then
+		helper_status=0
+		wait "${helper_pid}" || helper_status=$?
+		assert_equals 0 "${helper_status}"
+		break
+	fi
+	sleep 0.1
+done
 
 # At least 75s must have passed since the last read of the file (see create_and_reread_file.cc),
 # so all read buffers should have been expired by now. Check that sfsmount is not using too much 


### PR DESCRIPTION
Three system tests failed one-off on loaded CI machines. Waits now
scale with the machine multiplier or wait for the observable state
instead of sleeping.

- test_quota_size: the mount latches an async write error on the
  inode until the writer's FUSE release lands, so a fresh truncate
  right after the expected EDQUOT write inherits the stale error.
  Retry until it drains. The budget must absorb one master
  chunk-lock expiry (hardcoded 120s LOCKTIMEOUT), which no
  multiplier rescales.
- test_custom_goal_replication_delay_disconnect: under load the 15s
  disconnect-delay window expired before the no-replication checks
  ran, so the master legitimately replicated to an unlabeled server.
  Scale the window and the waits tied to it with the machine
  multiplier and use the rescaled default assert timeouts (the fixed
  4s window had zero slack for 20 chunks at CHUNKS_WRITE_REP_LIMIT=5
  with 1s chunk loops).
- test_slow_rereads: restarting the chunkserver mid-deletion of the
  previous file's chunks left them filling the 2GB ramdisk; the
  helper then died on ENOSPC and the notify wait loop spun until the
  timeout. Drain the chunks before the restart and fail fast if the
  helper dies. The budget grows because the runtime floor (75s
  buffer-expiry wait, throttled preads) is fixed wall-clock.