### PR TITLE
feat(kv): add getSnapshotAsync and addReadConflictKey

### DIFF
--- a/src/fdb/fdb.cc
+++ b/src/fdb/fdb.cc
@@ -360,6 +360,24 @@ void Transaction::removeRange(const kv::Key &start, const kv::Key &end) {
 	                            static_cast<int>(end.size()));
 }
 
+void Transaction::addReadConflictKey(const kv::Key &key) {
+	requireHandle("addReadConflictKey");
+
+	// FDB conflict ranges are half-open; a single key is [key, key + '\0').
+	kv::Key end = key;
+	end.push_back('\0');
+	const fdb_error_t err = fdb_transaction_add_conflict_range(
+	    tr_.get(), key.data(), static_cast<int>(key.size()), end.data(),
+	    static_cast<int>(end.size()), FDB_CONFLICT_RANGE_TYPE_READ);
+	if (err != 0) {
+		// add_conflict_range is a synchronous client call; a failure is local misuse,
+		// not a backend read failure, and must not silently drop the caller's protection.
+		safs::log_err("Transaction::addReadConflictKey: error: {}", fdb_get_error(err));
+		throw std::invalid_argument("fdb::Transaction::addReadConflictKey: " +
+		                            std::string(fdb_get_error(err)));
+	}
+}
+
 bool Transaction::commit() {
 	requireHandle("commit");
 

--- a/src/fdb/fdb.h
+++ b/src/fdb/fdb.h
@@ -320,6 +320,10 @@ public:
 	/// Removes a half-open key range [start, end) from the database.
 	void removeRange(const kv::Key &start, const kv::Key &end);
 
+	/// Adds the single key to the read-conflict set without reading it.
+	/// @see kv::IReadWriteTransaction::addReadConflictKey
+	void addReadConflictKey(const kv::Key &key);
+
 	/// Commits the transaction.
 	/// @return True if the commit succeeded and is durable, false on a backend commit
 	///   failure. A wrong-state call (no backend handle) throws std::logic_error instead

--- a/src/fdb/fdb_transaction.cc
+++ b/src/fdb/fdb_transaction.cc
@@ -41,6 +41,10 @@ std::unique_ptr<kv::IFuture> FDBTransaction::getAsync(const kv::Key &key) {
 	return tr_.getAsync(key);
 }
 
+std::unique_ptr<kv::IFuture> FDBTransaction::getSnapshotAsync(const kv::Key &key) {
+	return tr_.getAsync(key, /*snapshot=*/true);
+}
+
 kv::GetRangeResult FDBTransaction::getRange(const kv::KeySelector &start,
                                             const kv::KeySelector &end, int limit) {
 	return tr_.getRange(start, end, limit);
@@ -76,6 +80,8 @@ void FDBTransaction::removeRange(const kv::Key &start, const kv::Key &end) {
 	tr_.removeRange(start, end);
 	mutationCount_++;
 }
+
+void FDBTransaction::addReadConflictKey(const kv::Key &key) { tr_.addReadConflictKey(key); }
 
 bool FDBTransaction::commit() { return tr_.commit(); }
 

--- a/src/fdb/fdb_transaction.h
+++ b/src/fdb/fdb_transaction.h
@@ -73,6 +73,10 @@ public:
 	///   kv::RetryableTransactionError / kv::TransactionError.
 	std::unique_ptr<kv::IFuture> getAsync(const kv::Key &key) override;
 
+	/// Retrieves the value for a given key asynchronously as a snapshot read.
+	/// @see kv::IReadOnlyTransaction::getSnapshotAsync.
+	std::unique_ptr<kv::IFuture> getSnapshotAsync(const kv::Key &key) override;
+
 	/// Retrieves a range of keys and values
 	/// @param start The starting key for the range.
 	/// @param end The ending key for the range.
@@ -115,6 +119,11 @@ public:
 
 	/// Removes a half-open key range [start, end) from the database.
 	void removeRange(const kv::Key &start, const kv::Key &end) override;
+
+	/// Adds a key to the transaction's read-conflict set without reading it,
+	/// turning a blind write into a conflict-checked one.
+	/// @see kv::IReadWriteTransaction::addReadConflictKey.
+	void addReadConflictKey(const kv::Key &key) override;
 
 	/// Commits the transaction, making all changes permanent.
 	/// @return True if the commit succeeded and is durable, false on a backend failure.

--- a/src/fdb/fdb_unittest.cc
+++ b/src/fdb/fdb_unittest.cc
@@ -583,6 +583,166 @@ TEST_F(FDBKVEngineTest, GetAsync) {
 	               nonExistentKeyStr);
 }
 
+TEST_F(FDBKVEngineTest, GetSnapshotAsync) {
+	auto key = kv::toBytes("snapshot_async_key");
+	constexpr uint64_t initialValue = 42;
+
+	// Write the initial value.
+	{
+		auto transaction = kvEngine->createReadWriteTransaction();
+		transaction->set(key, kv::toBytesLE(initialValue));
+		ASSERT_TRUE(transaction->commit())
+		    << "Failed to commit initial value for snapshot async test.";
+	}
+
+	// getSnapshotAsync returns the correct value when the key exists.
+	{
+		auto transaction = kvEngine->createReadWriteTransaction();
+		auto future = transaction->getSnapshotAsync(key);
+		ASSERT_TRUE(future != nullptr) << "Failed to create snapshot async future.";
+
+		int error = 0;
+		auto result = future->get(&error);
+		ASSERT_EQ(error, 0) << "Error occurred while getting snapshot async value.";
+		ASSERT_TRUE(result.has_value())
+		    << "getSnapshotAsync should return a value for an existing key.";
+		ASSERT_EQ(kv::fromBytesLE<uint64_t>(*result), initialValue)
+		    << "getSnapshotAsync returned an unexpected value.";
+	}
+
+	// getSnapshotAsync returns nullopt for a non-existent key.
+	{
+		auto transaction = kvEngine->createReadWriteTransaction();
+		auto future = transaction->getSnapshotAsync(kv::toBytes("snapshot_async_key_missing"));
+		ASSERT_TRUE(future != nullptr) << "Failed to create snapshot async future.";
+
+		int error = 0;
+		auto result = future->get(&error);
+		ASSERT_EQ(error, 0) << "Error occurred while getting non-existent snapshot async value.";
+		ASSERT_FALSE(result.has_value())
+		    << "getSnapshotAsync should return nullopt for a non-existent key.";
+	}
+
+	// getSnapshotAsync does not add the key to the read conflict range:
+	// a transaction that snapshot-reads a key can still commit even if
+	// another transaction modifies that key concurrently.
+	{
+		constexpr uint64_t kSideValue = 123U;
+		const auto sideKey = kv::toBytes("snapshot_async_side_key");
+
+		// Txn A: snapshot-read key asynchronously and write to a different key.
+		auto txnA = kvEngine->createReadWriteTransaction();
+		auto future = txnA->getSnapshotAsync(key);
+		ASSERT_TRUE(future != nullptr) << "Failed to create snapshot async future.";
+
+		int error = 0;
+		auto snapResult = future->get(&error);
+		ASSERT_EQ(error, 0) << "Error occurred while getting snapshot async value.";
+		ASSERT_TRUE(snapResult.has_value())
+		    << "Snapshot async read should return a value for existing key.";
+		txnA->set(sideKey, kv::toBytesLE(kSideValue));
+
+		// Txn B: concurrently modify key and commit.
+		auto txnB = kvEngine->createReadWriteTransaction();
+		txnB->atomicAdd(key, kv::toBytesLE(uint64_t{1}));
+		ASSERT_TRUE(txnB->commit()) << "Concurrent writer (Txn B) should commit successfully.";
+
+		// Txn A should still commit: the snapshot read on key does not register
+		// a read conflict, so Txn B's write does not cause a conflict.
+		ASSERT_TRUE(txnA->commit())
+		    << "Transaction with only a snapshot async read on key should commit "
+		       "despite a concurrent write to that key.";
+
+		// Verify sideKey was written by Txn A.
+		auto verifyTxn = kvEngine->createReadWriteTransaction();
+		auto sideVal = verifyTxn->get(sideKey);
+		ASSERT_TRUE(sideVal.has_value()) << "Side key written by Txn A should exist.";
+		ASSERT_EQ(kv::fromBytesLE<uint64_t>(*sideVal), kSideValue)
+		    << "Side key should contain the value written by Txn A.";
+	}
+
+	// Cleanup.
+	{
+		auto transaction = kvEngine->createReadWriteTransaction();
+		transaction->remove(key);
+		transaction->remove(kv::toBytes("snapshot_async_side_key"));
+		ASSERT_TRUE(transaction->commit()) << "Failed to clean up snapshot async test keys.";
+	}
+}
+
+TEST_F(FDBKVEngineTest, AddReadConflictKey) {
+	auto key = kv::toBytes("read_conflict_key");
+	constexpr uint64_t initialValue = 42;
+
+	// Write the initial value.
+	{
+		auto transaction = kvEngine->createReadWriteTransaction();
+		transaction->set(key, kv::toBytesLE(initialValue));
+		ASSERT_TRUE(transaction->commit())
+		    << "Failed to commit initial value for read conflict test.";
+	}
+
+	// Control: a snapshot read of key followed by a blind write elsewhere commits
+	// despite a concurrent write to key -- nothing conflicts on its own.
+	{
+		constexpr uint64_t kSideValue = 123U;
+		const auto sideKey = kv::toBytes("read_conflict_control_side_key");
+
+		auto txnA = kvEngine->createReadWriteTransaction();
+		auto snapResult = txnA->getSnapshot(key);
+		ASSERT_TRUE(snapResult.has_value())
+		    << "Snapshot read should return a value for existing key.";
+		txnA->set(sideKey, kv::toBytesLE(kSideValue));
+
+		auto txnB = kvEngine->createReadWriteTransaction();
+		txnB->atomicAdd(key, kv::toBytesLE(uint64_t{1}));
+		ASSERT_TRUE(txnB->commit()) << "Concurrent writer (Txn B) should commit successfully.";
+
+		ASSERT_TRUE(txnA->commit())
+		    << "Control transaction without addReadConflictKey should commit.";
+	}
+
+	// addReadConflictKey turns the same shape into a conflict-checked one:
+	// Txn A never reads key with conflict tracking, but declaring it as a read
+	// conflict makes Txn B's concurrent write abort Txn A's commit.
+	{
+		constexpr uint64_t kSideValue = 456U;
+		const auto sideKey = kv::toBytes("read_conflict_side_key");
+
+		// Txn A: pin the read version with a snapshot read, declare the read
+		// conflict on key without reading it, and write to a different key.
+		auto txnA = kvEngine->createReadWriteTransaction();
+		auto snapResult = txnA->getSnapshot(key);
+		ASSERT_TRUE(snapResult.has_value())
+		    << "Snapshot read should return a value for existing key.";
+		txnA->addReadConflictKey(key);
+		txnA->set(sideKey, kv::toBytesLE(kSideValue));
+
+		// Txn B: concurrently modify key and commit.
+		auto txnB = kvEngine->createReadWriteTransaction();
+		txnB->atomicAdd(key, kv::toBytesLE(uint64_t{1}));
+		ASSERT_TRUE(txnB->commit()) << "Concurrent writer (Txn B) should commit successfully.";
+
+		// Txn A should fail: key is in its read conflict set and Txn B wrote it.
+		ASSERT_FALSE(txnA->commit())
+		    << "Transaction with addReadConflictKey on key should fail to commit "
+		       "when another transaction modifies that key first.";
+
+		// Verify sideKey was not written by the aborted Txn A.
+		auto verifyTxn = kvEngine->createReadWriteTransaction();
+		ASSERT_FALSE(verifyTxn->get(sideKey).has_value())
+		    << "Side key from the aborted transaction should not exist.";
+	}
+
+	// Cleanup.
+	{
+		auto transaction = kvEngine->createReadWriteTransaction();
+		transaction->remove(key);
+		transaction->remove(kv::toBytes("read_conflict_control_side_key"));
+		ASSERT_TRUE(transaction->commit()) << "Failed to clean up read conflict test keys.";
+	}
+}
+
 /// Tests extractIntegralLEFromFuture with various integral types and scenarios.
 TEST_F(FDBKVEngineTest, ExtractIntegralLEFromFuture) {
 	// Test with int64_t

--- a/src/kv/itransaction.h
+++ b/src/kv/itransaction.h
@@ -99,6 +99,16 @@ public:
 	/// @note The transaction must remain alive until the future's get() method is called.
 	virtual std::unique_ptr<IFuture> getAsync(const Key &key) = 0;
 
+	/// Retrieves the value for a given key asynchronously without adding it to
+	/// the transaction's read conflict range (snapshot/advisory read).
+	/// @see getSnapshot for the conflict-semantics warning; it applies here too.
+	/// @param key The key to retrieve the value for.
+	/// @return A future that will contain the value when ready.
+	/// @note Backend read failures are reported by the future's get(), which throws
+	///   RetryableTransactionError / TransactionError (see IFuture::get()).
+	/// @note The transaction must remain alive until the future's get() method is called.
+	virtual std::unique_ptr<IFuture> getSnapshotAsync(const Key &key) = 0;
+
 	/// Retrieves a range of keys and values
 	/// @param start The starting key for the range.
 	/// @param end The ending key for the range.
@@ -171,6 +181,16 @@ public:
 	/// @param start Inclusive start key.
 	/// @param end Exclusive end key.
 	virtual void removeRange(const Key &start, const Key &end) = 0;
+
+	/// Adds @p key to the transaction's read-conflict set without reading it, as if
+	/// the transaction had read the key. This turns a blind write into a
+	/// conflict-checked one: another transaction committing a write to @p key between
+	/// this transaction's read version and its commit aborts this transaction with a
+	/// retryable conflict instead of being silently overwritten by it.
+	/// @param key The key to add to the read-conflict set.
+	/// @throws std::invalid_argument if the backend rejects the conflict-range
+	///   registration; the annotation is never silently dropped.
+	virtual void addReadConflictKey(const Key &key) = 0;
 
 	/// Commits the transaction, making all changes permanent.
 	/// @return True if the commit succeeded and is durable, false on a backend commit


### PR DESCRIPTION
Transactions could either read with conflict tracking or write blindly, with nothing in between. getSnapshotAsync gives pipelined advisory reads that stay out of the conflict footprint; addReadConflictKey declares a key as read, so a blind write aborts on a concurrent commit instead of silently overwriting it.

Related to: LS-949