### PR TITLE
chore: ignore FDBTests* test suite symlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,7 +92,7 @@ tests/test_suites/WindowsClientTests
 src/mds
 src/data/sfsmds*
 src/data/leil-mds.cfg.in
-tests/test_suites/FDBTests
+tests/test_suites/FDBTests*
 
 # Windows #
 ###########


### PR DESCRIPTION
create-softlinks.sh generates the FDBTests suites as symlinks. Ignore them with a glob so future FDBTests* variants (e.g. FDBTestsLong) are covered without editing .gitignore again.

Related to: LS-972