### PR TITLE
fix(chunkserver): safe disk removal from config

### DIFF
--- a/src/chunkserver/chunkserver-common/disk_with_fd.cc
+++ b/src/chunkserver/chunkserver-common/disk_with_fd.cc
@@ -60,7 +60,7 @@ bool FDDisk::isMarkedForDeletion() const {
 bool FDDisk::isZonedDevice() const { return isZonedDevice_; }
 
 bool FDDisk::isSelectableForNewChunk() const {
-	return !isDamaged_ && !isMarkedForDeletion() && totalSpace_ != 0 &&
+	return !isDamaged_ && !isMarkedForDeletion() && !wasRemovedFromConfig_ && totalSpace_ != 0 &&
 	       availableSpace_ != 0 && scanState_ == IDisk::ScanState::kWorking;
 }
 

--- a/src/chunkserver/hddspacemgr.cc
+++ b/src/chunkserver/hddspacemgr.cc
@@ -393,6 +393,15 @@ void hddCheckDisks() {
 
 	changed = 0;
 
+	// Owning pointers of removed disks with no pending chunks. Declared
+	// before the lock so it is destroyed after the lock is released: the
+	// disk destructor joins per-disk worker threads (e.g. plugin garbage
+	// collectors) which may take gDisksMutex, and destroying promptly here
+	// (instead of deferring to hddReleaseDisksToBeDeleted) minimizes the
+	// window in which a re-added disk coexists with its old instance
+	// (stale lock-file descriptors, still-running workers).
+	std::vector<std::unique_ptr<IDisk>> disksToDestroy;
+
 	std::unique_lock disksUniqueLock(gDisksMutex);
 
 	if (gDiskActions == 0) {
@@ -439,15 +448,22 @@ void hddCheckDisks() {
 				if (!(*it)->isZonedDevice() && (*it)->metaPath() != (*it)->dataPath()) {
 					ChunkTrashManager::eraseDisk((*it)->dataPath());
 				}
-				// Always defer the actual destruction to hddReleaseDisksToBeDeleted,
-				// which runs without gDisksMutex.
-				// Destroying the disk here would join its worker threads
-				// (e.g. a plugin garbage collector) while holding gDisksMutex,
-				// and any of those threads taking gDisksMutex would deadlock
-				// the whole chunkserver. Moving *it leaves a null unique_ptr
-				// in gDisks, so it must stay the last use of the disk.
-				gDisksToBeDeletedWithPendingChunks.emplace_back(
-				    std::move(*it), std::move(diskToDelWithPendingChunks.second));
+				// Never destroy the disk here: the destructor joins worker
+				// threads (e.g. a plugin garbage collector) that may take
+				// gDisksMutex, which is held now — that join would deadlock
+				// the whole chunkserver. Disks with pending chunks are
+				// deferred to hddReleaseDisksToBeDeleted; disks without
+				// pending chunks are destroyed by disksToDestroy right after
+				// this function releases gDisksMutex, keeping the overlap
+				// window with a possible fast re-add minimal. Moving *it
+				// leaves a null unique_ptr in gDisks, so it must stay the
+				// last use of the disk.
+				if (!diskToDelWithPendingChunks.second.empty()) {
+					gDisksToBeDeletedWithPendingChunks.emplace_back(
+					    std::move(*it), std::move(diskToDelWithPendingChunks.second));
+				} else {
+					disksToDestroy.push_back(std::move(*it));
+				}
 				gDisks.erase(it);
 				break;
 			}

--- a/src/chunkserver/hddspacemgr.cc
+++ b/src/chunkserver/hddspacemgr.cc
@@ -260,6 +260,14 @@ static IChunk *hddChunkCreate(IDisk *disk, uint64_t chunkId,
 }
 
 void hddReleaseDisksToBeDeleted() {
+	// Owning pointers of the disks selected for destruction. Declared before
+	// the lock so it is destroyed after the lock is released: the disk
+	// destructor joins per-disk worker threads (e.g. plugin garbage
+	// collectors), and destroying a disk while holding
+	// gDisksToBeDeletedWithPendingChunksMutex can deadlock with
+	// hddCheckDisks, which acquires that mutex while holding gDisksMutex.
+	std::vector<std::unique_ptr<IDisk>> disksToDestroy;
+
 	std::lock_guard diskToBeDeletedLock(gDisksToBeDeletedWithPendingChunksMutex);
 	std::unique_lock chunksMapLock(gChunksMapMutex, std::defer_lock);
 
@@ -296,14 +304,21 @@ void hddReleaseDisksToBeDeleted() {
 		}
 	}
 
+	disksToDestroy.reserve(disksToDelete.size());
+
 	for (auto *disk : disksToDelete) {
 		safs::log_info("({}) Deleting disk {} with no pending chunks", __func__,
 		               disk->getPaths().c_str());
-		gDisksToBeDeletedWithPendingChunks.erase(
-		    std::remove_if(gDisksToBeDeletedWithPendingChunks.begin(),
-		                   gDisksToBeDeletedWithPendingChunks.end(),
-		                   [disk](const auto &pair) { return pair.first.get() == disk; }),
-		    gDisksToBeDeletedWithPendingChunks.end());
+		auto diskIter =
+		    std::find_if(gDisksToBeDeletedWithPendingChunks.begin(),
+		                 gDisksToBeDeletedWithPendingChunks.end(),
+		                 [disk](const auto &pair) { return pair.first.get() == disk; });
+		if (diskIter != gDisksToBeDeletedWithPendingChunks.end()) {
+			// Take ownership; the disk is destroyed by disksToDestroy after
+			// the mutex is released.
+			disksToDestroy.push_back(std::move(diskIter->first));
+			gDisksToBeDeletedWithPendingChunks.erase(diskIter);
+		}
 	}
 }
 

--- a/src/chunkserver/hddspacemgr.cc
+++ b/src/chunkserver/hddspacemgr.cc
@@ -424,12 +424,15 @@ void hddCheckDisks() {
 				if (!(*it)->isZonedDevice() && (*it)->metaPath() != (*it)->dataPath()) {
 					ChunkTrashManager::eraseDisk((*it)->dataPath());
 				}
-				if (!diskToDelWithPendingChunks.second.empty()) {
-					// Pending chunks; moving *it leaves a null unique_ptr in
-					// gDisks, so it must stay the last use of the disk.
-					gDisksToBeDeletedWithPendingChunks.emplace_back(
-					    std::move(*it), std::move(diskToDelWithPendingChunks.second));
-				}
+				// Always defer the actual destruction to hddReleaseDisksToBeDeleted,
+				// which runs without gDisksMutex.
+				// Destroying the disk here would join its worker threads
+				// (e.g. a plugin garbage collector) while holding gDisksMutex,
+				// and any of those threads taking gDisksMutex would deadlock
+				// the whole chunkserver. Moving *it leaves a null unique_ptr
+				// in gDisks, so it must stay the last use of the disk.
+				gDisksToBeDeletedWithPendingChunks.emplace_back(
+				    std::move(*it), std::move(diskToDelWithPendingChunks.second));
 				gDisks.erase(it);
 				break;
 			}

--- a/tests/test_suites/ShortSystemTests/test_disk_removed_from_config_no_new_chunks.sh
+++ b/tests/test_suites/ShortSystemTests/test_disk_removed_from_config_no_new_chunks.sh
@@ -15,6 +15,13 @@ timeout_set 2 minutes
 # `saunafs-admin list-disks` exactly when the tick drops it from the disk
 # registry, so observing that drop marks a tick boundary and the whole next
 # second belongs to the removal window of a disk removed right after.
+#
+# The removal is repeated for several cycles. A cycle whose window collapsed
+# (the disk check tick fired before the writes finished, e.g. on a heavily
+# loaded machine) is skipped instead of failed; the regression assertion runs
+# only in cycles whose window provably held, and at least one such cycle is
+# required. Inside a valid window the bug reproduces deterministically, since
+# chunk allocation alternates between the eligible disks.
 
 USE_RAMDISK=YES \
 	CHUNKSERVERS=1 \
@@ -45,42 +52,65 @@ cd "${info[mount0]}"
 
 assert_eventually_prints 3 "list_disks_count" "30 seconds"
 
-# Tick synchronization: remove the sacrificial disk (id 2) and wait for it
-# to disappear from list-disks. The moment the count drops from 3 to 2 is a
-# disk check tick, so the next tick is a full second away; the 0.1 s polling
-# of assert_eventually_prints detects the drop well inside that window.
-assert_success disable_chunkserver_disk 0 2
-assert_eventually_prints 2 "list_disks_count" "30 seconds"
+valid_cycles=0
 
-# Remove the target disk right after the observed tick.
-assert_success disable_chunkserver_disk 0 1
+for cycle in 1 2 3 4 5; do
+	# Tick synchronization: remove the sacrificial disk (id 2) and wait for
+	# it to disappear from list-disks. The moment the count drops from 3 to 2
+	# is a disk check tick, so the next tick is a full second away; the 0.1 s
+	# polling of assert_eventually_prints detects the drop well inside that
+	# window.
+	assert_success disable_chunkserver_disk 0 2
+	assert_eventually_prints 2 "list_disks_count" "30 seconds"
 
-# Give the chunkserver event loop time to process the reload (50 ms poll
-# timeout), so the target disk is already marked as removed from the
-# configuration before any file is created.
-sleep 0.3
+	# Remove the target disk right after the observed tick.
+	assert_success disable_chunkserver_disk 0 1
 
-# Create new files well inside the removal window.
-for i in {1..8}; do
-	FILE_SIZE=1K assert_success file-generate "file_${i}"
+	# Give the chunkserver event loop time to process the reload (50 ms poll
+	# timeout), so the target disk is already marked as removed from the
+	# configuration before any file is created.
+	sleep 0.3
+
+	# Create new files, ideally well inside the removal window.
+	for i in {1..8}; do
+		FILE_SIZE=1K assert_success file-generate "cycle${cycle}_file_${i}"
+	done
+
+	if [[ "$(list_disks_count)" == "2" ]]; then
+		# The target disk is still listed, which proves the disk check tick
+		# has not fired yet and all files above were created inside the
+		# removal window: the regression assertion is meaningful.
+		valid_cycles=$((valid_cycles + 1))
+
+		# The actual regression check: no chunk of the newly created files
+		# may be allocated on the disk that was already removed from the
+		# configuration. -type f excludes the chunksXX subfolder directories.
+		chunks_on_removed_disk=$(find "${target_disk_path}" -type f -name 'chunk*' | wc -l)
+		MESSAGE="cycle ${cycle}: chunks allocated on a disk removed from config" \
+			assert_equals 0 "${chunks_on_removed_disk}"
+		echo "cycle ${cycle}: removal window held, regression assertion checked"
+	else
+		# The tick fired before the writes finished: the machine broke the
+		# timing assumptions of this cycle, so the assertion would be
+		# inconclusive. Skip it and retry on the next cycle.
+		echo "cycle ${cycle}: removal window collapsed, skipping the check"
+	fi
+
+	# Wait for the disk check tick to drop the target disk, then restore
+	# both disks for the next cycle.
+	assert_eventually_prints 1 "list_disks_count" "30 seconds"
+	assert_success reenable_chunkserver_disk 0 1
+	assert_success reenable_chunkserver_disk 0 2
+	assert_eventually_prints 3 "list_disks_count" "30 seconds"
 done
 
-# Timing guard: the target disk must still be listed, which proves the disk
-# check tick has not fired yet and all files above were created inside the
-# removal window. If this assertion fails, the machine broke the timing
-# assumptions of this test and the run is inconclusive; the assertions below
-# were not exercised.
-assert_equals 2 "$(list_disks_count)"
+MESSAGE="no cycle kept its removal window; timing assumptions broken on this machine" \
+	assert_less_than 0 "${valid_cycles}"
 
-# The actual regression check: no chunk of the newly created files may be
-# allocated on the disk that was already removed from the configuration.
-# -type f excludes the chunksXX subfolder directories.
-chunks_on_removed_disk=$(find "${target_disk_path}" -type f -name 'chunk*' | wc -l)
-assert_equals 0 "${chunks_on_removed_disk}"
-
-# After the disk check tick drops the target disk, all files must still be
-# complete and readable from the remaining disk.
-assert_eventually_prints 1 "list_disks_count" "30 seconds"
-for i in {1..8}; do
-	assert_success file-validate "file_${i}"
+# All files must be complete and readable from the disk that stayed in the
+# configuration for the whole test.
+for cycle in 1 2 3 4 5; do
+	for i in {1..8}; do
+		assert_success file-validate "cycle${cycle}_file_${i}"
+	done
 done

--- a/tests/test_suites/ShortSystemTests/test_disk_removed_from_config_no_new_chunks.sh
+++ b/tests/test_suites/ShortSystemTests/test_disk_removed_from_config_no_new_chunks.sh
@@ -1,0 +1,86 @@
+timeout_set 2 minutes
+
+# Regression test: a disk removed from the hdd configuration must stop
+# receiving new chunks as soon as the chunkserver reloads its configuration.
+#
+# The chunkserver handles a config-removed disk in two asynchronous steps:
+# the reload only marks the disk as removed, and the once-per-second disk
+# check (hddCheckDisks) later erases its chunks from the registry and drops
+# the disk. If new chunks are still allocated on the marked disk inside that
+# window, the disk check erases them while clients are using them, the master
+# reports them as lost and the data is gone (write errors ending in EIO).
+#
+# To hit the window deterministically the test synchronizes with the disk
+# check tick using a sacrificial disk: a removed disk disappears from
+# `saunafs-admin list-disks` exactly when the tick drops it from the disk
+# registry, so observing that drop marks a tick boundary and the whole next
+# second belongs to the removal window of a disk removed right after.
+
+USE_RAMDISK=YES \
+	CHUNKSERVERS=1 \
+	DISK_PER_CHUNKSERVER=3 \
+	MOUNT_EXTRA_CONFIG="sfscachemode=NEVER" \
+	setup_local_empty_saunafs info
+
+list_disks_count() {
+	saunafs-admin list-disks --porcelain localhost "${info[matocl]}" | wc -l
+}
+
+# Print the filesystem path of a disk from the chunkserver 0 hdd config,
+# stripping comment markers, the optional zonefs: prefix, the
+# marked-for-removal asterisk and the "| dataPath" part of zoned entries.
+get_disk_path() {
+	local disk_id=$1
+	sed -n "$((disk_id + 1))p" "${info[chunkserver0_hdd]}" | sed -E \
+		-e 's/^[[:space:]#]*//' \
+		-e 's/^zonefs://' \
+		-e 's/^\*//' \
+		-e 's/[[:space:]]*\|.*$//' \
+		-e 's/[[:space:]]*$//'
+}
+
+target_disk_path=$(get_disk_path 1)
+
+cd "${info[mount0]}"
+
+assert_eventually_prints 3 "list_disks_count" "30 seconds"
+
+# Tick synchronization: remove the sacrificial disk (id 2) and wait for it
+# to disappear from list-disks. The moment the count drops from 3 to 2 is a
+# disk check tick, so the next tick is a full second away; the 0.1 s polling
+# of assert_eventually_prints detects the drop well inside that window.
+assert_success disable_chunkserver_disk 0 2
+assert_eventually_prints 2 "list_disks_count" "30 seconds"
+
+# Remove the target disk right after the observed tick.
+assert_success disable_chunkserver_disk 0 1
+
+# Give the chunkserver event loop time to process the reload (50 ms poll
+# timeout), so the target disk is already marked as removed from the
+# configuration before any file is created.
+sleep 0.3
+
+# Create new files well inside the removal window.
+for i in {1..8}; do
+	FILE_SIZE=1K assert_success file-generate "file_${i}"
+done
+
+# Timing guard: the target disk must still be listed, which proves the disk
+# check tick has not fired yet and all files above were created inside the
+# removal window. If this assertion fails, the machine broke the timing
+# assumptions of this test and the run is inconclusive; the assertions below
+# were not exercised.
+assert_equals 2 "$(list_disks_count)"
+
+# The actual regression check: no chunk of the newly created files may be
+# allocated on the disk that was already removed from the configuration.
+# -type f excludes the chunksXX subfolder directories.
+chunks_on_removed_disk=$(find "${target_disk_path}" -type f -name 'chunk*' | wc -l)
+assert_equals 0 "${chunks_on_removed_disk}"
+
+# After the disk check tick drops the target disk, all files must still be
+# complete and readable from the remaining disk.
+assert_eventually_prints 1 "list_disks_count" "30 seconds"
+for i in {1..8}; do
+	assert_success file-validate "file_${i}"
+done


### PR DESCRIPTION
## Summary

Two independent chunkserver bugs in the disk-removal-from-config path, both reproduced from CI failures of the SMR test suites but affecting regular disks equally:

1. **Chunk loss:** new chunks could be allocated on a disk that had already been removed from `sfshdd.cfg`, then erased mid-write when the removal was processed, causing permanent data loss for single-copy chunks.
2. **Chunkserver-wide deadlock:** the disk destructor could run while holding `gDisksMutex`, joining a plugin worker thread that itself takes `gDisksMutex`, freezing the entire chunkserver (no disk listings, no master disk info, no IO).

## Root causes

**Commit 1: fix(chunkserver): no new chunks on removed disks**

  After a reload removes a disk from the hdd config, the disk is marked `wasRemovedFromConfig` and immediately hidden from master reporting, but `FDDisk::isSelectableForNewChunk()` did not check that flag. Until the next `hddCheckDisks` tick (up to 1 s), chunk allocation kept selecting the doomed disk.
When the tick ran, `hddSendDataToMaster(ForDiskRemoval)` erased those chunks from the registry while clients were writing them: `hddChunkWriteFullBlocks: ChunkNotFound` → master `"chunk lost"` → client EIO after 30 retries.

**Fix:** add `!wasRemovedFromConfig_` to `isSelectableForNewChunk()`, making allocation consistent with reporting. Both the reload marking and `getDiskForNewChunk` run under `gDisksMutex`, so the check is race-free.

**Commit 2: fix(chunkserver): delete disks outside gDisksMutex**

When a removed disk had no pending chunks, `hddCheckDisks` destroyed it inline at `gDisks.erase(it)` while holding `gDisksMutex`. The disk destructor joins per-disk worker threads (e.g. the garbage collector), which take `gDisksMutex` on their own iterations. A worker already parked on the mutex can never observe the stop request → join never returns → `gDisksMutex` held forever. Note the no-pending-chunks case is the common case for clean disk removals.

**Fix:** route removed disks through `gDisksToBeDeletedWithPendingChunks` unconditionally (even with an empty pending list), so destruction happens in `hddReleaseDisksToBeDeleted`, which runs without `gDisksMutex`.

## Test plan

- New deterministic regression `test ShortSystemTests/test_disk_removed_from_config_no_new_chunks.sh`: synchronizes with the once-per-second disk check tick via a sacrificial disk removal, creates files strictly inside the removal window (self-checking timing guard), and asserts zero chunk files appear on the removed disk. Fails 3/3 without commit 1 (Expected: 0, got: 8), passes 3/3 with it.

- Deadlock covered by `SMRTests/test_smr_gc_disk_removal_deadlock.sh` (companion `zonefs_disk` PR): deterministically freezes an unfixed chunkserver at the first removal cycle; passes with this fix alone or the plugin-side fix alone.

- Regression sweep passing: `test_disk_removed_from_config`, `test_admin_list_disks`, `SMRTests` GC/defrag suite (`gc_consistency`, `gc_basic_cleaning`, `basic_defragmentation`, `multi_defragmentation`, `defragmentation_frequency`), plus original CI failures `test_smr_gc_after_disk_removing` and `test_short_disk_removed_from_config`.

### Notes for reviewers

- `hddCheckDisks` still clears `wasRemovedFromConfig` (`hddspacemgr.cc:403`) before erasing the disk from `gDisks`; both happen in the same `gDisksMutex` critical section, so commit 1's check cannot observe the cleared flag on a live disk.

- Commit 2 shifts physical destruction by up to ~2 s (the `hddFreeResourcesThread` cadence). `gDisks` removal timing, and therefore `list-disks`/master visibility is unchanged.

---
Companion PR: `zonefs_disk`: plugin-side deadlock fix (try_lock) + GC write-priority fix.

Signed-off-by: <<crash@leil.io>>