### PR TITLE
refactor(cs): add compression hooks

### DIFF
--- a/src/chunkserver/chunkserver-common/chunk_interface.h
+++ b/src/chunkserver/chunkserver-common/chunk_interface.h
@@ -165,9 +165,11 @@ public:
 	/// truncating a file.
 	virtual void shrinkToBlocks(uint16_t newBlocks) = 0;
 
-	/// Returns true if the Chunk is in an state considered as dirty.
-	/// For example the Chunk is fragmented and needs defragmentation.
-	virtual bool isDirty() = 0;
+	/// Releases memory the chunk caches only to speed up I/O (e.g. per-chunk
+	/// compression dictionaries). Called when the chunk leaves the open-chunks
+	/// cache (its descriptors are being closed), with the chunk locked, so the
+	/// caches can be rebuilt lazily on the next I/O. Default: no-op.
+	virtual void releaseCachedResources() noexcept {}
 
 	/// Returns the Chunk format. Check \ref ChunkFormat for more information.
 	virtual ChunkFormat chunkFormat() const = 0;

--- a/src/chunkserver/chunkserver-common/cmr_chunk.cc
+++ b/src/chunkserver/chunkserver-common/cmr_chunk.cc
@@ -102,8 +102,6 @@ off_t CmrChunk::getCrcOffset() const { return kMaxSignatureBlockSize; }
 
 void CmrChunk::shrinkToBlocks(uint16_t newBlocks) { (void)newBlocks; }
 
-bool CmrChunk::isDirty() { return false; }
-
 std::string CmrChunk::toString() const {
 	std::stringstream result;
 

--- a/src/chunkserver/chunkserver-common/cmr_chunk.h
+++ b/src/chunkserver/chunkserver-common/cmr_chunk.h
@@ -66,11 +66,6 @@ public:
 	/// function does nothing, but we need the function in the interface.
 	void shrinkToBlocks(uint16_t newBlocks) override;
 
-	/// Returns true if the Chunk is in an state considered as dirty. For
-	/// CmrChunk, this function always returns false because CmrChunk doesn't
-	/// require fragmentation, so it never becomes dirty.
-	bool isDirty() override;
-
 	/// String representation of CmrChunk members, useful for debugging.
 	std::string toString() const override;
 };

--- a/src/chunkserver/chunkserver-common/disk_interface.h
+++ b/src/chunkserver/chunkserver-common/disk_interface.h
@@ -140,6 +140,11 @@ public:
 	virtual IChunk *instantiateNewConcreteChunk(uint64_t chunkId,
 	                                            ChunkPartType type) = 0;
 
+	/// Applies any disk-specific on-disk format to a brand-new chunk before its
+	/// header is sized and serialized. Called only from the new-chunk creation
+	/// path (not for duplicates). Default: no-op.
+	virtual int applyNewChunkFormat(IChunk * /*chunk*/) = 0;
+
 	/// Sets the number of blocks for \a chunk from \a originalBlocks to \a
 	/// newBlocks.
 	virtual void setChunkBlocks(IChunk *chunk, uint16_t originalBlocks,

--- a/src/chunkserver/chunkserver-common/disk_with_fd.cc
+++ b/src/chunkserver/chunkserver-common/disk_with_fd.cc
@@ -474,3 +474,7 @@ const std::string &FDDisk::metaPath() const { return metaPath_; }
 void FDDisk::setMetaPath(const std::string &newMetaPath) {
 	metaPath_ = newMetaPath;
 }
+
+int FDDisk::applyNewChunkFormat(IChunk * /*chunk*/) {
+	return 0;
+}

--- a/src/chunkserver/chunkserver-common/disk_with_fd.h
+++ b/src/chunkserver/chunkserver-common/disk_with_fd.h
@@ -206,6 +206,11 @@ public:
 	/// Setter for lastErrorIndex_
 	void setLastErrorIndex(uint32_t newLastErrorIndex) override;
 
+	/// Applies any disk-specific on-disk format to a brand-new chunk before its
+	/// header is sized and serialized. Called only from the new-chunk creation
+	/// path (not for duplicates). Default: no-op.
+	int applyNewChunkFormat(IChunk * /*chunk*/) override;
+
 private:
 	/// Internal helper to sync both FDs (metadata and data)
 	int fsyncFD(IChunk *chunk, bool isForMetadata);

--- a/src/chunkserver/chunkserver-common/open_chunk.h
+++ b/src/chunkserver/chunkserver-common/open_chunk.h
@@ -89,6 +89,10 @@ public:
 
 			chunk_->setMetaFD(-1);
 			chunk_->setDataFD(-1);
+			// The chunk is leaving the open-chunks cache: drop I/O-speedup
+			// caches (e.g. compression dictionaries) so idle chunks do not pin
+			// memory. They are rebuilt lazily on the next I/O.
+			chunk_->releaseCachedResources();
 			hddChunkRelease(chunk_);
 		} else if (metaFD_ >= 0) {
 			::close(metaFD_);

--- a/src/chunkserver/hddspacemgr.cc
+++ b/src/chunkserver/hddspacemgr.cc
@@ -1205,6 +1205,17 @@ std::pair<int, IChunk *> hddInternalCreateChunk(uint64_t chunkId,
 		return {SAUNAFS_ERROR_IO, ChunkNotFound};
 	}
 
+	// Let the disk stamp any format-specific state (e.g. compression) on the
+	// brand-new chunk before its header is sized and serialized.
+	status = disk->applyNewChunkFormat(chunk);
+	if (status != SAUNAFS_STATUS_OK) {
+		hddAddErrorAndPreserveErrno(chunk);
+		hddIOEnd(chunk);
+		disk->unlinkChunk(chunk);
+		hddDeleteChunkFromRegistry(chunk);
+		return {SAUNAFS_ERROR_IO, ChunkNotFound};
+	}
+
 	uint8_t *ptr = chunk->getChunkHeaderBuffer();
 	memset(ptr, 0, chunk->getHeaderSize());
 

--- a/tests/tools/valgrind-helgrind.supp
+++ b/tests/tools/valgrind-helgrind.supp
@@ -81,3 +81,22 @@
    ...
    fun:start_thread
 }
+
+{
+   # False positive at shutdown: glibc caches exited threads' stacks, and a
+   # later pthread_join() (JobPool::stop()) trims that cache, freeing the TLS
+   # blocks of OTHER, already-dead threads. glibc knows those threads are gone
+   # via the kernel CLEARTID futex, which helgrind cannot observe, so (with
+   # --free-is-write=yes) the free() looks like a write racing the dead
+   # thread's own thread_local destructors (e.g. the zonefs_disk compressed
+   # I/O scratch buffers). The frames between the TLS free and join vary with
+   # the glibc version, hence the "...".
+   jobpool_stop_tls_teardown_race
+   Helgrind:Race
+   fun:free
+   ...
+   fun:_dl_deallocate_tls
+   ...
+   fun:_ZNSt6thread4joinEv
+   fun:_ZN7JobPool4stopEv*
+}


### PR DESCRIPTION
Add the common-interface hooks the zonefs_disk plugin needs for transparent per-chunk Zstd compression on SMR drives (feat-data-compression, companion zonefs_disk PR):

- Replace IChunk::isDirty() with a releaseCachedResources() no-op hook. The only real isDirty() implementation lived in the zonefs plugin, which now tracks dirtiness at zone level instead; CmrChunk drops its trivial override. The new hook lets a chunk free memory kept only to speed up I/O (e.g. digested compression dictionaries) when it leaves the open-chunks cache, and OpenChunk calls it while closing descriptors so idle chunks do not pin dictionary memory.

- Add IDisk::applyNewChunkFormat(), called from the new-chunk creation path before the header is sized and serialized, so a plugin can stamp its on-disk format (e.g. compressed V2) on brand new chunks only - duplicates and replicas keep the source format.

- Add a helgrind suppression for a glibc TLS-teardown false positive at shutdown, triggered by the plugin's thread_local Zstd contexts: pthread_join() in JobPool::stop() trims glibc's cached dead-thread stacks, and with --free-is-write=yes that free() looks like a race against the dead threads' own thread_local destructors.