### PR TITLE
fix(tests): stabilize fileinfo availability check

### DIFF
--- a/tests/test_suites/ShortSystemTests/test_fileinfo_missing_parts.sh
+++ b/tests/test_suites/ShortSystemTests/test_fileinfo_missing_parts.sh
@@ -14,9 +14,11 @@ FILE_SIZE=123456789 BLOCK_SIZE=12345 file-generate dir_ec/file
 saunafs_chunkserver_daemon 0 stop
 saunafs_chunkserver_daemon 1 stop
 saunafs_chunkserver_daemon 2 stop
+saunafs_wait_for_ready_chunkservers 4
 
 assert_failure "saunafs fileinfo dir_ec/file | grep 'not enough parts available'"
 
 saunafs_chunkserver_daemon 3 stop
+saunafs_wait_for_ready_chunkservers 3
 
 saunafs fileinfo dir_ec/file | grep "not enough parts available"


### PR DESCRIPTION
Add an explicit wait for the expected chunkserver availability state before checking fileinfo output. This prevents the test from racing against master state updates after chunkservers are stopped.

The fileinfo assertion depends on the cluster reaching the reduced availability condition first; without waiting for that state, the command can observe stale readiness information and produce inconsistent results.

Related to: LS-980