### PR TITLE
fix(clang-tidy): enable analyzer checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -23,7 +23,7 @@ Checks: "-*,
   bugprone-*,
     -bugprone-easily-swappable-parameters,
   cert-*,
-  -cert-err58-cpp
+  -cert-err58-cpp,
   clang-analyzer-*,
   cppcoreguidelines-*,
   -google-*,


### PR DESCRIPTION
A missing comma joins the CERT exclusion to the Clang analyzer wildcard, preventing the analyzer checks from being enabled.

Restore the intended check configuration.

Related to: LS-405