### PR TITLE
refactor(master): allow large files in KV backends

### DIFF
--- a/src/fdb/fdb_transaction.h
+++ b/src/fdb/fdb_transaction.h
@@ -136,6 +136,12 @@ public:
 	/// @throws std::logic_error when the wrapped transaction has no backend handle.
 	bool commit() override;
 
+	/// True when the wrapped transaction's last commit outcome is unknown (maybe
+	/// committed). @see kv::IReadWriteTransaction::commitOutcomeUnknown.
+	bool commitOutcomeUnknown() const override {
+		return tr_.state() == TransactionState::kIndeterminate;
+	}
+
 	/// Submits the commit asynchronously and returns a pollable future.
 	/// @throws std::logic_error when the wrapped transaction has no backend handle.
 	std::unique_ptr<kv::ICommitFuture> commitAsync() override;

--- a/src/kv/itransaction.h
+++ b/src/kv/itransaction.h
@@ -198,6 +198,14 @@ public:
 	///   failure.
 	virtual bool commit() = 0;
 
+	/// True when the last commit() attempt ended without a knowable outcome: the
+	/// backend cannot tell whether the mutations became durable (e.g. the commit
+	/// response was lost in flight). A false return from commit() paired with true
+	/// here means "maybe committed", so a caller mirroring durable state in memory
+	/// must re-verify against the store instead of assuming the commit was
+	/// discarded. Backends whose commits fail atomically keep the default.
+	virtual bool commitOutcomeUnknown() const { return false; }
+
 	/// Submits the commit asynchronously and returns a pollable future.
 	/// The caller drives completion via ICommitFuture::isReady()/getResult().
 	/// @note The transaction must stay alive until the future's getResult() returns.

--- a/src/master/chunk_operations_base.cc
+++ b/src/master/chunk_operations_base.cc
@@ -18,7 +18,9 @@
 
 #include "master/chunk_operations_base.h"
 
+#include "errors/sfserr.h"
 #include "master/chunks.h"
+#include "master/filesystem_operation_context.h"
 
 // Default behavior forwards to the existing chunks.cc free functions, which hold
 // the real in-memory logic. leil-master uses these as-is; ChunkOperationsKV (or similars)

--- a/src/master/chunk_operations_base.h
+++ b/src/master/chunk_operations_base.h
@@ -41,6 +41,10 @@ public:
 	               uint8_t goal) override;
 	int changeFile(const FilesystemOperationContext &fsOpContext, uint64_t chunkid,
 	               uint8_t prevGoal, uint8_t newGoal) override;
+	bool defersFileReferenceMutations(
+	    const FilesystemOperationContext & /*fsOpContext*/) const override {
+		return false;
+	}
 
 	int increaseVersion(const FilesystemOperationContext &fsOpContext, uint64_t chunkid) override;
 	int setVersion(const FilesystemOperationContext &fsOpContext, uint64_t chunkid,

--- a/src/master/chunk_operations_interface.h
+++ b/src/master/chunk_operations_interface.h
@@ -72,6 +72,11 @@ public:
 	                       uint8_t goal) = 0;
 	virtual int changeFile(const FilesystemOperationContext &fsOpContext, uint64_t chunkid,
 	                       uint8_t prevGoal, uint8_t newGoal) = 0;
+	/// Whether successful add/delete/change calls are only staged for the transaction.
+	/// Generic callers use this to avoid compensating changes that never reached the
+	/// in-memory registry.
+	virtual bool defersFileReferenceMutations(
+	    const FilesystemOperationContext &fsOpContext) const = 0;
 
 	// --- Version (persisted version) ---
 	virtual int increaseVersion(const FilesystemOperationContext &fsOpContext,

--- a/src/master/chunks.cc
+++ b/src/master/chunks.cc
@@ -848,7 +848,7 @@ void chunk_emergency_increase_version(Chunk *c) {
 
 	// Commit the transaction under KV backends
 	if (fsOpContext.hasReadWriteTransaction()) {
-		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+		if (!fsOpContext.commitTransaction()) {
 			safs::log_critical(
 			    "{}: Failed to commit transaction for increasing version of chunk {}.", __func__,
 			    c->chunkid);
@@ -1693,26 +1693,18 @@ uint8_t chunk_apply_modification(uint32_t ts, uint64_t oldChunkId, uint32_t lock
 }
 
 #ifndef METARESTORE
-int chunk_repair(uint8_t goal, uint64_t ochunkid, uint32_t *nversion, uint8_t correct_only) {
+ChunkRepairPlan chunk_plan_repair(uint64_t ochunkid, uint8_t correct_only) {
 	uint32_t best_version;
 	Chunk *c;
 
-	*nversion=0;
-	if (ochunkid==0) {
-		return 0; // not changed
-	}
+	if (ochunkid == 0) { return {}; }
 
 	c = chunk_find(ochunkid);
-	if (c==NULL) { // no such chunk - erase (nchunkid already is 0 - so just return with "changed" status)
-		if (correct_only == 1) { // don't erase if correct only flag is set
-			return 0;
-		} else {
-			return 1;
-		}
+	if (c == NULL) {
+		if (correct_only == 1) { return {}; }
+		return {.action = ChunkRepairAction::kEraseReference};
 	}
-	if (c->isLocked()) { // can't repair locked chunks - but if it's locked, then likely it doesn't need to be repaired
-		return 0;
-	}
+	if (c->isLocked()) { return {}; }
 
 	// calculators will be sorted by decreasing keys, so highest version will be first.
 	std::map<uint32_t, ChunkCopiesCalculator, std::greater<uint32_t>> calculators;
@@ -1737,30 +1729,44 @@ int chunk_repair(uint8_t goal, uint64_t ochunkid, uint32_t *nversion, uint8_t co
 		}
 	}
 	// current version is readable
-	if (best_version == c->version) {
-		return 0;
-	}
+	if (best_version == c->version) { return {}; }
 	// didn't find sensible chunk
 	if (best_version == 0) {
-		if (correct_only == 1) { // don't erase if correct only flag is set
-			return 0;
-		} else {                  // otherwise erase it
-			chunk_delete_file_int(c, goal);
-			return 1;
-		}
+		if (correct_only == 1) { return {}; }
+		return {.action = ChunkRepairAction::kEraseReference};
 	}
-	// found previous version which is readable
-	c->version = best_version;
+
+	return {.action = ChunkRepairAction::kSetVersion, .version = best_version};
+}
+
+bool chunk_apply_repair_plan(uint8_t goal, uint64_t ochunkid, const ChunkRepairPlan &plan) {
+	if (plan.action == ChunkRepairAction::kUnchanged) { return true; }
+
+	Chunk *c = chunk_find(ochunkid);
+	if (plan.action == ChunkRepairAction::kEraseReference) {
+		return c == nullptr || chunk_delete_file_int(c, goal) == SAUNAFS_STATUS_OK;
+	}
+	if (c == nullptr || plan.version == 0) { return false; }
+
+	c->version = plan.version;
 	for (auto &part : c->parts) {
-		if (part.state == ChunkPart::INVALID && part.version==best_version) {
+		if (part.state == ChunkPart::INVALID && part.version == plan.version) {
 			part.state = ChunkPart::VALID;
 		}
 	}
-	*nversion = best_version;
 	c->needVersionIncrease = 1;
 	c->updateStats();
 	chunk_update_checksum(c);
 	emit_chunk_changed(c);
+	return true;
+}
+
+int chunk_repair(uint8_t goal, uint64_t ochunkid, uint32_t *nversion, uint8_t correct_only) {
+	*nversion = 0;
+	const ChunkRepairPlan plan = chunk_plan_repair(ochunkid, correct_only);
+	if (plan.action == ChunkRepairAction::kUnchanged) { return 0; }
+	if (!chunk_apply_repair_plan(goal, ochunkid, plan)) { return 0; }
+	*nversion = plan.version;
 	return 1;
 }
 #endif

--- a/src/master/chunks.h
+++ b/src/master/chunks.h
@@ -99,6 +99,24 @@ bool chunk_has_only_invalid_copies(uint64_t chunkid);
 
 int chunk_get_fullcopies(uint64_t chunkid,uint8_t *vcopies);
 int chunk_get_partstomodify(uint64_t chunkid, int &recover, int &remove);
+
+enum class ChunkRepairAction : uint8_t {
+	kUnchanged = 0,
+	kEraseReference = 1,
+	kSetVersion = 2,
+};
+
+struct ChunkRepairPlan {
+	ChunkRepairAction action = ChunkRepairAction::kUnchanged;
+	uint32_t version = 0;
+};
+
+/// Computes repair work without changing the in-memory chunk registry.
+ChunkRepairPlan chunk_plan_repair(uint64_t ochunkid, uint8_t correct_only);
+
+/// Applies an exact plan produced by chunk_plan_repair().
+bool chunk_apply_repair_plan(uint8_t goal, uint64_t ochunkid, const ChunkRepairPlan &plan);
+
 int chunk_repair(uint8_t goal,uint64_t ochunkid,uint32_t *nversion, uint8_t correct_only);
 
 int chunk_getversionandlocations(uint64_t chunkid, uint32_t currentIp, uint32_t& version,

--- a/src/master/filesystem_node.cc
+++ b/src/master/filesystem_node.cc
@@ -27,8 +27,10 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
+#include <limits>
 #include <string_view>
 #include <type_traits>
+#include <vector>
 
 #include "common/attributes.h"
 #include "common/massert.h"
@@ -57,7 +59,8 @@ uint32_t FilesystemNodeOperationsBase::lastChunkBlocks(FSNodeFile *node) {
 	return blockCount;
 }
 
-bool FilesystemNodeOperationsBase::isLastChunkNonEmpty(FSNodeFile *node) {
+bool FilesystemNodeOperationsBase::isLastFileChunkNonEmpty(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, FSNodeFile *node) {
 	std::size_t chunks = node->chunks.size();
 	if (chunks == 0) {
 		// no non-zero chunks, return now
@@ -75,15 +78,17 @@ bool FilesystemNodeOperationsBase::isLastChunkNonEmpty(FSNodeFile *node) {
 	return false;
 }
 
-uint32_t FilesystemNodeOperationsBase::fileChunksCount(FSNodeFile *node) {
+uint32_t FilesystemNodeOperationsBase::getLiveFileChunkCount(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, FSNodeFile *node) {
 	return std::accumulate(node->chunks.begin(), node->chunks.end(), (uint32_t)0,
 	                       [](uint32_t sum, uint64_t v) { return sum + (v != 0); });
 }
 
-uint64_t FilesystemNodeOperationsBase::fileSize(FSNodeFile *node, uint32_t nonZeroChunks) {
+uint64_t FilesystemNodeOperationsBase::fileSize(const FilesystemOperationContext &fsOpContext,
+                                                FSNodeFile *node, uint32_t nonZeroChunks) {
 	uint64_t size = static_cast<uint64_t>(nonZeroChunks) * (SFSCHUNKSIZE + SFSHDRSIZE);
 
-	if (isLastChunkNonEmpty(node)) {
+	if (isLastFileChunkNonEmpty(fsOpContext, node)) {
 		size -= SFSCHUNKSIZE;
 		size += lastChunkBlocks(node) * SFSBLOCKSIZE;
 	}
@@ -106,9 +111,11 @@ uint32_t FilesystemNodeOperationsBase::ecChunkRealSize(uint32_t blocks, uint32_t
 }
 #endif
 
-uint64_t FilesystemNodeOperationsBase::fileRealSize(FSNodeFile *node, uint32_t nonZeroChunks,
+uint64_t FilesystemNodeOperationsBase::fileRealSize(const FilesystemOperationContext &fsOpContext,
+                                                    FSNodeFile *node, uint32_t nonZeroChunks,
                                                     uint64_t logicalFileSize) {
 #ifdef METARESTORE
+	(void)fsOpContext;
 	(void)node;
 	(void)nonZeroChunks;
 	(void)logicalFileSize;
@@ -127,7 +134,7 @@ uint64_t FilesystemNodeOperationsBase::fileRealSize(FSNodeFile *node, uint32_t n
 			uint32_t fullChunkRealSize =
 			    ecChunkRealSize(SFSBLOCKSINCHUNK, dataPartCount, parityPartCount);
 			uint64_t size = (uint64_t)nonZeroChunks * fullChunkRealSize;
-			if (isLastChunkNonEmpty(node)) {
+			if (isLastFileChunkNonEmpty(fsOpContext, node)) {
 				size -= fullChunkRealSize;
 				size += ecChunkRealSize(lastChunkBlocks(node), dataPartCount, parityPartCount);
 			}
@@ -354,11 +361,11 @@ void FilesystemNodeOperationsBase::getStats(
 		statsOut->dirs = 0;
 		statsOut->files = 1;
 		statsOut->links = 0;
-		statsOut->chunks = fileChunksCount(static_cast<FSNodeFile *>(node));
+		statsOut->chunks = getLiveFileChunkCount(fsOpContext, static_cast<FSNodeFile *>(node));
 		statsOut->length = static_cast<FSNodeFile *>(node)->length;
-		statsOut->size = fileSize(static_cast<FSNodeFile *>(node), statsOut->chunks);
-		statsOut->realsize =
-		    fileRealSize(static_cast<FSNodeFile *>(node), statsOut->chunks, statsOut->size);
+		statsOut->size = fileSize(fsOpContext, static_cast<FSNodeFile *>(node), statsOut->chunks);
+		statsOut->realsize = fileRealSize(fsOpContext, static_cast<FSNodeFile *>(node),
+		                                  statsOut->chunks, statsOut->size);
 		break;
 	case FSNodeType::kSymlink:
 		statsOut->inodes = 1;
@@ -387,6 +394,105 @@ int64_t FilesystemNodeOperationsBase::getSize(const FilesystemOperationContext &
 	StatsRecord stats;
 	getStats(fsOpContext, node, &stats);
 	return stats.size;
+}
+
+// Chunk-table access seam (in-memory implementations over FSNodeFile::chunks)
+
+uint64_t FilesystemNodeOperationsBase::getFileChunkId(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, const FSNodeFile *nodeFile,
+    uint32_t index) {
+	return index < nodeFile->chunks.size() ? nodeFile->chunks[index] : 0;
+}
+
+void FilesystemNodeOperationsBase::setFileChunkId(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, FSNodeFile *nodeFile,
+    uint32_t index, uint64_t chunkId) {
+	assert(index < nodeFile->chunks.size());
+	nodeFile->chunks[index] = chunkId;
+}
+
+uint32_t FilesystemNodeOperationsBase::getFileChunkTableSize(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, const FSNodeFile *nodeFile) {
+	return nodeFile->chunks.size();
+}
+
+void FilesystemNodeOperationsBase::growFileChunkTable(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, FSNodeFile *nodeFile,
+    uint32_t newSize) {
+	if (newSize > nodeFile->chunks.size()) { nodeFile->chunks.resize(newSize, 0); }
+}
+
+void FilesystemNodeOperationsBase::resizeFileChunkTable(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, FSNodeFile *nodeFile,
+    uint32_t newSize) {
+	nodeFile->chunks.resize(newSize, 0);
+}
+
+uint8_t FilesystemNodeOperationsBase::validateFileChunkRows(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext,
+    [[maybe_unused]] const FSNodeFile *nodeFile, [[maybe_unused]] uint32_t fromIndex,
+    [[maybe_unused]] uint32_t endIndex) {
+	return SAUNAFS_STATUS_OK;
+}
+
+uint32_t FilesystemNodeOperationsBase::getFileChunkCount(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, const FSNodeFile *nodeFile) {
+	return nodeFile->chunkCount();
+}
+
+uint8_t FilesystemNodeOperationsBase::canGrowFileChunkTable(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext,
+    [[maybe_unused]] const FSNodeFile *nodeFile, [[maybe_unused]] uint32_t newSize) {
+	return SAUNAFS_STATUS_OK;
+}
+
+void FilesystemNodeOperationsBase::forEachFileChunk(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, const FSNodeFile *nodeFile,
+    uint32_t fromIndex, const std::function<bool(uint32_t, uint64_t)> &callback) {
+	for (uint32_t i = fromIndex; i < nodeFile->chunks.size(); ++i) {
+		if (nodeFile->chunks[i] == 0) { continue; }
+		if (!callback(i, nodeFile->chunks[i])) { return; }
+	}
+}
+
+FileChunkCutResult FilesystemNodeOperationsBase::truncateFileChunks(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, FSNodeFile *nodeFile,
+    uint32_t newSize, const std::function<void(uint32_t, uint64_t)> &callback) {
+	for (uint32_t i = newSize; i < nodeFile->chunks.size(); ++i) {
+		if (nodeFile->chunks[i] != 0) { callback(i, nodeFile->chunks[i]); }
+	}
+	if (newSize < nodeFile->chunks.size()) { nodeFile->chunks.resize(newSize); }
+	return {};
+}
+
+FileChunkCutResult FilesystemNodeOperationsBase::removeAllFileChunks(
+    const FilesystemOperationContext &fsOpContext, FSNodeFile *nodeFile,
+    const std::function<void(uint32_t, uint64_t)> &callback) {
+	return truncateFileChunks(fsOpContext, nodeFile, 0, callback);
+}
+
+void FilesystemNodeOperationsBase::getFileChunkIds(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, const FSNodeFile *nodeFile,
+    uint32_t fromIndex, uint32_t count, std::vector<uint64_t> &chunkIdsOut) {
+	chunkIdsOut.clear();
+	for (uint32_t i = fromIndex; i < nodeFile->chunks.size() && count > 0; ++i, --count) {
+		chunkIdsOut.push_back(nodeFile->chunks[i]);
+	}
+}
+
+bool FilesystemNodeOperationsBase::fileChunksEqual(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, const FSNodeFile *nodeFileA,
+    const FSNodeFile *nodeFileB) {
+	return nodeFileA->chunks == nodeFileB->chunks;
+}
+
+void FilesystemNodeOperationsBase::copyFileChunks(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext, FSNodeFile *destNodeFile,
+    const FSNodeFile *srcNodeFile, const std::function<bool(uint32_t, uint64_t)> &callback) {
+	destNodeFile->chunks = srcNodeFile->chunks;
+	for (uint32_t i = 0; i < srcNodeFile->chunks.size(); ++i) {
+		if (srcNodeFile->chunks[i] != 0 && !callback(i, srcNodeFile->chunks[i])) { return; }
+	}
 }
 
 uint64_t FilesystemNodeOperationsBase::getNumberOfParents(
@@ -718,7 +824,8 @@ void FilesystemNodeOperationsBase::removeEdge(const FilesystemOperationContext &
 void FilesystemNodeOperationsBase::persistDirChildChangeTime(
     const FilesystemOperationContext & /*fsOpContext*/, FSNodeDirectory * /*dir*/,
     uint32_t /*timeStamp*/) {
-	// Default no-op: the in-memory master keeps dir mtime/ctime in the node; the KV backend overrides.
+	// Default no-op: the in-memory master keeps dir mtime/ctime in the node; the KV backend
+	// overrides.
 }
 
 uint32_t FilesystemNodeOperationsBase::getDirChildChangeTime(
@@ -803,13 +910,30 @@ FSNode *FilesystemNodeOperationsBase::createNode(
     const FilesystemOperationContext &fsOpContext, uint32_t timeStamp, FSNodeDirectory *parent,
     const HString &name, FSNodeType type, uint16_t mode, uint16_t umask, uint32_t uid, uint32_t gid,
     uint8_t copysgid, AclInheritance inheritAcl, inode_t requestedINode) {
+	const inode_t inode = gInodeIdGenerator->getNextId(timeStamp, requestedINode);
+	return createNodeWithIdInternal(fsOpContext, timeStamp, parent, name, type, mode, umask, uid,
+	                                gid, copysgid, inheritAcl, inode);
+}
+
+FSNode *FilesystemNodeOperationsBase::createNodeWithPreallocatedId(
+    const FilesystemOperationContext &fsOpContext, uint32_t timeStamp, FSNodeDirectory *parent,
+    const HString &name, FSNodeType type, uint16_t mode, uint16_t umask, uint32_t uid, uint32_t gid,
+    uint8_t copysgid, AclInheritance inheritAcl, inode_t inode) {
+	assert(inode != 0);
+	return createNodeWithIdInternal(fsOpContext, timeStamp, parent, name, type, mode, umask, uid,
+	                                gid, copysgid, inheritAcl, inode);
+}
+
+FSNode *FilesystemNodeOperationsBase::createNodeWithIdInternal(
+    const FilesystemOperationContext &fsOpContext, uint32_t timeStamp, FSNodeDirectory *parent,
+    const HString &name, FSNodeType type, uint16_t mode, uint16_t umask, uint32_t uid, uint32_t gid,
+    uint8_t copysgid, AclInheritance inheritAcl, inode_t inode) {
 	assert(type != FSNodeType::kTrash);
 
 	FSNode *node = FSNode::create(type);
 	incrementNodeCounters(fsOpContext, type);  // Increment global metadata counters
 
-	// Ask for a node id
-	node->id = gInodeIdGenerator->getNextId(timeStamp, requestedINode);
+	node->id = inode;
 
 	// Init timestamps
 	node->ctime = node->mtime = node->atime = timeStamp;
@@ -1350,18 +1474,17 @@ void FilesystemNodeOperationsBase::getDir(const FilesystemOperationContext &fsOp
 	}
 }
 
-void FilesystemNodeOperationsBase::checkFile(FSNodeFile *nodeFile, ChunkCountArray &chunkCount) {
-	uint8_t count;
-
+void FilesystemNodeOperationsBase::checkFile(const FilesystemOperationContext &fsOpContext,
+                                             FSNodeFile *nodeFile, ChunkCountArray &chunkCount) {
 	chunkCount.fill(0);
 
-	for (const auto &chunkid : nodeFile->chunks) {
-		if (chunkid > 0) {
-			gChunkOperations->getFullCopies(chunkid, &count);
-			count = std::min<unsigned>(count, CHUNK_MATRIX_SIZE - 1);
-			chunkCount[count]++;
-		}
-	}
+	forEachFileChunk(fsOpContext, nodeFile, 0, [&chunkCount](uint32_t /*index*/, uint64_t chunkid) {
+		uint8_t count = 0;
+		gChunkOperations->getFullCopies(chunkid, &count);
+		count = std::min<unsigned>(count, CHUNK_MATRIX_SIZE - 1);
+		chunkCount[count]++;
+		return true;
+	});
 }
 #endif
 
@@ -1404,36 +1527,77 @@ std::string FilesystemNodeOperationsBase::getBaseStoredChildName(
 uint8_t FilesystemNodeOperationsBase::appendChunks(const FilesystemOperationContext &fsOpContext,
                                                    uint32_t timeStamp, FSNodeFile *destNodeFile,
                                                    FSNodeFile *srcNodeFile) {
-	if (srcNodeFile->chunks.empty()) { return SAUNAFS_STATUS_OK; }
+	if (getFileChunkTableSize(fsOpContext, srcNodeFile) == 0) { return SAUNAFS_STATUS_OK; }
 
-	uint32_t srcChunks = srcNodeFile->chunkCount();
-	uint32_t dstChunks = destNodeFile->chunkCount();
+	uint32_t srcChunks = getFileChunkCount(fsOpContext, srcNodeFile);
+	uint32_t dstChunks = getFileChunkCount(fsOpContext, destNodeFile);
 
 	if (((uint64_t)srcChunks + (uint64_t)dstChunks) > ((uint64_t)kMaxChunkIndex + 1)) {
 		return SAUNAFS_ERROR_INDEXTOOBIG;
 	}
 
+	uint32_t resultChunks = srcChunks + dstChunks;
+	uint8_t growStatus = canGrowFileChunkTable(fsOpContext, destNodeFile, resultChunks);
+	if (growStatus != SAUNAFS_STATUS_OK) { return growStatus; }
+
+	// Rows the append reads (source) or updates (destination tail) must decode
+	// before anything mutates: a skipped source row would append holes while its
+	// chunks miss their added references, and a refused destination write would
+	// strand references without a mapping.
+	uint8_t validateStatus = validateFileChunkRows(fsOpContext, srcNodeFile, 0, srcChunks);
+	if (validateStatus != SAUNAFS_STATUS_OK) { return validateStatus; }
+	validateStatus = validateFileChunkRows(fsOpContext, destNodeFile, dstChunks, resultChunks);
+	if (validateStatus != SAUNAFS_STATUS_OK) { return validateStatus; }
+
 	StatsRecord previousStats;
 	StatsRecord newStats;
 	getStats(fsOpContext, destNodeFile, &previousStats);
 
-	uint32_t resultChunks = srcChunks + dstChunks;
-	destNodeFile->chunks.resize(resultChunks, 0);
+	// Exact resize, not grow: the destination may carry rounded trailing-hole padding
+	// from chunk-table growth, and append sizes its result from the trimmed counts.
+	resizeFileChunkTable(fsOpContext, destNodeFile, resultChunks);
 
-	// Copy source chunks to the end of destination chunks
-	std::copy(srcNodeFile->chunks.begin(), srcNodeFile->chunks.begin() + srcChunks,
-	          destNodeFile->chunks.begin() + dstChunks);
-
-	// Add each source chunk to the destination file's goal and handle errors
-	for (uint32_t i = 0; i < srcChunks; ++i) {
-		auto chunkId = srcNodeFile->chunks[i];
-		if (chunkId > 0) {
-			if (gChunkOperations->addFile(fsOpContext, chunkId, destNodeFile->goal) !=
-			    SAUNAFS_STATUS_OK) {
-				safs::log_err("structure error - chunk {:016X} not found (inode: {} ; index: {})",
-				              chunkId, srcNodeFile->id, i);
+	// Copy source chunks to the end of destination chunks and add each one to the
+	// destination file's goal. A failed reference add must not commit: the copied
+	// slot would reference a chunk that never gained the reference, and deleting
+	// the destination would then drop a reference the source still owns. With a
+	// transaction the whole append aborts (the caller discards it); the in-memory
+	// backend keeps the legacy log-and-continue (its slot writes cannot unwind).
+	uint8_t appendStatus = SAUNAFS_STATUS_OK;
+	std::vector<uint64_t> immediatelyAddedChunkIds;
+	forEachFileChunk(fsOpContext, srcNodeFile, 0, [&](uint32_t index, uint64_t chunkId) {
+		if (index >= srcChunks) { return false; }
+		setFileChunkId(fsOpContext, destNodeFile, dstChunks + index, chunkId);
+		const int addStatus = gChunkOperations->addFile(fsOpContext, chunkId, destNodeFile->goal);
+		if (addStatus != SAUNAFS_STATUS_OK) {
+			safs::log_err("structure error - chunk {:016X} not found (inode: {} ; index: {})",
+			              chunkId, srcNodeFile->id, index);
+			if (fsOpContext.hasReadWriteTransaction()) {
+				appendStatus = static_cast<uint8_t>(addStatus);
+				return false;
+			}
+		} else if (fsOpContext.hasReadWriteTransaction() &&
+		           !gChunkOperations->defersFileReferenceMutations(fsOpContext)) {
+			// A transactional backend without deferred effects changed the registry
+			// immediately and still needs legacy compensation. KV attaches effects,
+			// so its staged additions are discarded with the transaction instead.
+			immediatelyAddedChunkIds.push_back(chunkId);
+		}
+		return true;
+	});
+	if (appendStatus != SAUNAFS_STATUS_OK) {
+		bool rollbackFailed = false;
+		for (auto chunkId = immediatelyAddedChunkIds.rbegin();
+		     chunkId != immediatelyAddedChunkIds.rend(); ++chunkId) {
+			const int rollbackStatus = chunk_delete_file(*chunkId, destNodeFile->goal);
+			if (rollbackStatus != SAUNAFS_STATUS_OK) {
+				safs::log_critical(
+				    "appendChunks: cannot reverse chunk {:#016x} after failure, status {}",
+				    *chunkId, rollbackStatus);
+				rollbackFailed = true;
 			}
 		}
+		return rollbackFailed ? static_cast<uint8_t>(SAUNAFS_ERROR_IO) : appendStatus;
 	}
 
 	uint64_t previousLength = destNodeFile->length;
@@ -1468,30 +1632,81 @@ uint8_t FilesystemNodeOperationsBase::appendChunks(const FilesystemOperationCont
 	return SAUNAFS_STATUS_OK;
 }
 
-void FilesystemNodeOperationsBase::changeFileGoal(const FilesystemOperationContext &fsOpContext,
-                                                  FSNodeFile *nodeFile, uint8_t goal) {
+uint8_t FilesystemNodeOperationsBase::changeFileGoal(
+    const FilesystemOperationContext &fsOpContext, FSNodeFile *nodeFile, uint8_t goal,
+    [[maybe_unused]] const FileGoalChangeRequest &request) {
+	// A backend may fence a range while a bulk operation owns its chunk references.
+	// Guard here so no recursive or direct caller can bypass that ownership.
+	const uint8_t canChangeStatus = canChangeFileGoal(fsOpContext, nodeFile);
+	if (canChangeStatus != SAUNAFS_STATUS_OK) { return canChangeStatus; }
+	// A row this change cannot iterate would leave its chunks registered under the
+	// old goal while the node advertises the new one; fail before touching anything.
+	uint8_t status = validateFileChunkRows(fsOpContext, nodeFile, 0,
+	                                       getFileChunkTableSize(fsOpContext, nodeFile));
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+
 	uint8_t oldGoal = nodeFile->goal;
 	StatsRecord previousStats;
 	StatsRecord newStats;
+
+	uint8_t changeStatus = SAUNAFS_STATUS_OK;
+	uint32_t failedIndex = 0;
+	forEachFileChunk(fsOpContext, nodeFile, 0, [&](uint32_t index, uint64_t chunkId) {
+		changeStatus = gChunkOperations->changeFile(fsOpContext, chunkId, oldGoal, goal);
+		failedIndex = index;
+		return changeStatus == SAUNAFS_STATUS_OK;
+	});
+	if (changeStatus != SAUNAFS_STATUS_OK) {
+		// KV callers discard their staged transaction effects. Master and Shadow
+		// mutate immediately, so undo every successful prefix mutation here.
+		if (!fsOpContext.hasReadWriteTransaction()) {
+			forEachFileChunk(fsOpContext, nodeFile, 0, [&](uint32_t index, uint64_t chunkId) {
+				if (index >= failedIndex) { return false; }
+				const int rollbackStatus = chunk_change_file(chunkId, goal, oldGoal);
+				if (rollbackStatus != SAUNAFS_STATUS_OK) {
+					safs::log_critical(
+					    "changeFileGoal: cannot reverse chunk {:#016x} after failure, status {}",
+					    chunkId, rollbackStatus);
+				}
+				return true;
+			});
+		}
+		return changeStatus;
+	}
 
 	getStats(fsOpContext, nodeFile, &previousStats);
 	nodeFile->goal = goal;
 
 	newStats = previousStats;
-	newStats.realsize = fileRealSize(nodeFile, newStats.chunks, newStats.size);
+	newStats.realsize = fileRealSize(fsOpContext, nodeFile, newStats.chunks, newStats.size);
 
 	for (const auto &[parentId, _] : nodeFile->parents) {
 		auto *parentNode = idToNodeVerify<FSNodeDirectory>(fsOpContext, parentId);
 		addSubStats(fsOpContext, parentNode, &newStats, &previousStats);
 	}
 
-	for (const auto &chunkId : nodeFile->chunks) {
-		if (chunkId > 0) { gChunkOperations->changeFile(fsOpContext, chunkId, oldGoal, goal); }
-	}
-
 	fsnodes_update_checksum(nodeFile);
 
 	if (!fsOpContext.hasReadWriteTransaction()) { gMetadata->nodeChangedSignal.emit(nodeFile); }
+	return SAUNAFS_STATUS_OK;
+}
+
+uint8_t FilesystemNodeOperationsBase::canChangeFileGoal(
+    const FilesystemOperationContext &fsOpContext, const FSNodeFile *nodeFile) {
+	return canMutateFileChunks(fsOpContext, nodeFile, 0, std::numeric_limits<uint32_t>::max());
+}
+
+uint8_t FilesystemNodeOperationsBase::canMutateFileChunks(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext,
+    [[maybe_unused]] const FSNodeFile *nodeFile, [[maybe_unused]] uint32_t beginIndex,
+    [[maybe_unused]] uint32_t endIndex) {
+	return SAUNAFS_STATUS_OK;
+}
+
+uint8_t FilesystemNodeOperationsBase::canTruncateFileChunks(
+    [[maybe_unused]] const FilesystemOperationContext &fsOpContext,
+    [[maybe_unused]] const FSNodeFile *nodeFile, [[maybe_unused]] uint64_t newLength) {
+	return SAUNAFS_STATUS_OK;
 }
 
 void FilesystemNodeOperationsBase::setLength(const FilesystemOperationContext &fsOpContext,
@@ -1514,19 +1729,13 @@ void FilesystemNodeOperationsBase::setLength(const FilesystemOperationContext &f
 			chunks = 0;
 		}
 
-		for (uint32_t i = chunks; i < nodeFile->chunks.size(); i++) {
-			uint64_t chunkId = nodeFile->chunks[i];
-			if (chunkId > 0) {
-				if (gChunkOperations->deleteFile(fsOpContext, chunkId, nodeFile->goal) !=
-				    SAUNAFS_STATUS_OK) {
-					safs::log_err(
-					    "structure error - chunk {:#016x} not found (inode: {} ; index: {})",
-					    chunkId, nodeFile->id, i);
-				}
+		truncateFileChunks(fsOpContext, nodeFile, chunks, [&](uint32_t index, uint64_t chunkId) {
+			if (gChunkOperations->deleteFile(fsOpContext, chunkId, nodeFile->goal) !=
+			    SAUNAFS_STATUS_OK) {
+				safs::log_err("structure error - chunk {:#016x} not found (inode: {} ; index: {})",
+				              chunkId, nodeFile->id, index);
 			}
-		}
-
-		if (chunks < nodeFile->chunks.size()) { nodeFile->chunks.resize(chunks); }
+		});
 	}
 
 	getStats(fsOpContext, nodeFile, &newStats);
@@ -1630,20 +1839,25 @@ void FilesystemNodeOperationsBase::removeNode(const FilesystemOperationContext &
 
 	if (node->type == FSNodeType::kDirectory) { gMetadata->dirNodes--; }
 
+	// The quota refund below needs the file's size, and discarding the chunk table
+	// destroys the bookkeeping getSize reads from, so capture the size first.
+	int64_t fileSizeToRefund = 0;
+
 	if (node->type == FSNodeType::kFile || node->type == FSNodeType::kTrash ||
 	    node->type == FSNodeType::kReserved) {
 		gMetadata->fileNodes--;
-		for (uint32_t i = 0; i < static_cast<FSNodeFile *>(node)->chunks.size(); ++i) {
-			uint64_t chunkid = static_cast<FSNodeFile *>(node)->chunks[i];
-			if (chunkid > 0) {
-				if (gChunkOperations->deleteFile(fsOpContext, chunkid, node->goal) !=
-				    SAUNAFS_STATUS_OK) {
-					safs::log_err(
-					    "structure error - chunk {:#016x} not found (inode: {} ; index: {})",
-					    chunkid, node->id, i);
-				}
-			}
-		}
+		fileSizeToRefund = getSize(fsOpContext, node);
+		// Releases every live chunk and discards the chunk table's own storage (a no-op
+		// for the in-memory backend, whose table dies with the node object below).
+		removeAllFileChunks(
+		    fsOpContext, static_cast<FSNodeFile *>(node), [&](uint32_t index, uint64_t chunkid) {
+			    if (gChunkOperations->deleteFile(fsOpContext, chunkid, node->goal) !=
+			        SAUNAFS_STATUS_OK) {
+				    safs::log_err(
+				        "structure error - chunk {:#016x} not found (inode: {} ; index: {})",
+				        chunkid, node->id, index);
+			    }
+		    });
 	}
 
 	if (node->type == FSNodeType::kSymlink) { gMetadata->linkNodes--; }
@@ -1652,9 +1866,8 @@ void FilesystemNodeOperationsBase::removeNode(const FilesystemOperationContext &
 	xattr_removeinode(node->id);
 	if (node->type == FSNodeType::kFile || node->type == FSNodeType::kTrash ||
 	    node->type == FSNodeType::kReserved) {
-		nodeQuotaUpdate(
-		    fsOpContext, node,
-		    {{QuotaResource::kInodes, -1}, {QuotaResource::kSize, -getSize(fsOpContext, node)}});
+		nodeQuotaUpdate(fsOpContext, node,
+		                {{QuotaResource::kInodes, -1}, {QuotaResource::kSize, -fileSizeToRefund}});
 	} else {
 		nodeQuotaUpdate(fsOpContext, node, {{QuotaResource::kInodes, -1}});
 	}
@@ -1881,7 +2094,14 @@ void FilesystemNodeOperationsBase::getGoalRecursive(const FilesystemOperationCon
 	    node->type == FSNodeType::kReserved) {
 		if (!GoalId::isValid(node->goal)) {
 			safs::log_warn("file inode {}: unknown goal !!! - fixing", node->id);
-			changeFileGoal(fsOpContext, static_cast<FSNodeFile *>(node), DEFAULT_GOAL);
+			if (changeFileGoal(fsOpContext, static_cast<FSNodeFile *>(node), DEFAULT_GOAL, {}) !=
+			    SAUNAFS_STATUS_OK) {
+				safs::log_err(
+				    "file inode {}: unknown goal not fixed (chunk table busy or unreadable)",
+				    node->id);
+				// Still invalid: it cannot index the statistics table; skip the file.
+				return;
+			}
 		}
 
 		fileGoalsTab[node->goal]++;
@@ -1958,20 +2178,27 @@ void FilesystemNodeOperationsBase::setgoalRecursive(const FilesystemOperationCon
 			(*permissionDeniedINodesOut)++;
 		} else {
 			if ((smode & SMODE_TMASK) == SMODE_SET && node->goal != goal) {
+				bool goalApplied = true;
 				if (node->type != FSNodeType::kDirectory) {
-					changeFileGoal(fsOpContext, static_cast<FSNodeFile *>(node), goal);
-					(*modifiedINodesOut)++;
+					// LOCKED (bulk operation active) or unreadable chunk-table
+					// rows leave the file untouched; count it as unchanged.
+					goalApplied = changeFileGoal(fsOpContext, static_cast<FSNodeFile *>(node), goal,
+					                             {}) == SAUNAFS_STATUS_OK;
 				} else {
 					node->goal = goal;
 					if (!fsOpContext.hasReadWriteTransaction()) {
 						gMetadata->nodeChangedSignal.emit(node);
 					}
-					(*modifiedINodesOut)++;
 				}
 
-				updateCTime(fsOpContext, node, timeStamp);
-				fsnodes_update_checksum(node);
-				nodeChanged = true;
+				if (goalApplied) {
+					(*modifiedINodesOut)++;
+					updateCTime(fsOpContext, node, timeStamp);
+					fsnodes_update_checksum(node);
+					nodeChanged = true;
+				} else {
+					(*unchangedINodesOut)++;
+				}
 			} else {
 				(*unchangedINodesOut)++;
 			}

--- a/src/master/filesystem_node.h
+++ b/src/master/filesystem_node.h
@@ -53,6 +53,13 @@ public:
 	                   uint16_t umask, uint32_t uid, uint32_t gid, uint8_t copysgid,
 	                   AclInheritance inheritAcl, inode_t requestedINode = 0) override;
 
+	FSNode *createNodeWithPreallocatedId(const FilesystemOperationContext &fsOpContext,
+	                                     uint32_t timeStamp, FSNodeDirectory *parent,
+	                                     const HString &name, FSNodeType type, uint16_t mode,
+	                                     uint16_t umask, uint32_t uid, uint32_t gid,
+	                                     uint8_t copysgid, AclInheritance inheritAcl,
+	                                     inode_t inode) override;
+
 	/// Syncs the current state of the node to persistent storage on backends that need it.
 	/// @see IFilesystemNodeOperations::updateNode
 	/// @note This implementation is a no-op for in-memory storage.
@@ -118,11 +125,114 @@ public:
 	               uint64_t length, bool eraseFurtherChunks) override;
 	uint8_t appendChunks(const FilesystemOperationContext &fsOpContext, uint32_t timeStamp,
 	                     FSNodeFile *destNodeFile, FSNodeFile *srcNodeFile) override;
-	void changeFileGoal(const FilesystemOperationContext &fsOpContext, FSNodeFile *nodeFile,
-	                    uint8_t goal) override;
+	/// Allows file-goal changes unconditionally for the in-memory backend.
+	/// @see IFilesystemNodeOperations::canChangeFileGoal
+	uint8_t canChangeFileGoal(const FilesystemOperationContext &fsOpContext,
+	                          const FSNodeFile *nodeFile) override;
+	/// Allows every chunk-index range for the in-memory backend.
+	/// @see IFilesystemNodeOperations::canMutateFileChunks
+	uint8_t canMutateFileChunks(const FilesystemOperationContext &fsOpContext,
+	                            const FSNodeFile *nodeFile, uint32_t beginIndex,
+	                            uint32_t endIndex) override;
+	uint8_t changeFileGoal(const FilesystemOperationContext &fsOpContext, FSNodeFile *nodeFile,
+	                       uint8_t goal, const FileGoalChangeRequest &request) override;
 #ifndef METARESTORE
-	void checkFile(FSNodeFile *nodeFile, ChunkCountArray &chunkCount) override;
+	void checkFile(const FilesystemOperationContext &fsOpContext, FSNodeFile *nodeFile,
+	               ChunkCountArray &chunkCount) override;
 #endif
+
+	// Chunk-table access seam: in-memory implementations over FSNodeFile::chunks.
+
+	/// Reads the vector slot; an index past the vector is a hole.
+	/// @see IFilesystemNodeOperations::getFileChunkId
+	uint64_t getFileChunkId(const FilesystemOperationContext &fsOpContext,
+	                        const FSNodeFile *nodeFile, uint32_t index) override;
+
+	/// Writes the vector slot; asserts the index is within the table.
+	/// @see IFilesystemNodeOperations::setFileChunkId
+	void setFileChunkId(const FilesystemOperationContext &fsOpContext, FSNodeFile *nodeFile,
+	                    uint32_t index, uint64_t chunkId) override;
+
+	/// Returns FSNodeFile::chunks.size().
+	/// @see IFilesystemNodeOperations::getFileChunkTableSize
+	uint32_t getFileChunkTableSize(const FilesystemOperationContext &fsOpContext,
+	                               const FSNodeFile *nodeFile) override;
+
+	/// Zero-fill resize of the vector when newSize exceeds it.
+	/// @see IFilesystemNodeOperations::growFileChunkTable
+	void growFileChunkTable(const FilesystemOperationContext &fsOpContext, FSNodeFile *nodeFile,
+	                        uint32_t newSize) override;
+
+	/// Unconditional vector resize (zero-fills growth).
+	/// @see IFilesystemNodeOperations::resizeFileChunkTable
+	void resizeFileChunkTable(const FilesystemOperationContext &fsOpContext, FSNodeFile *nodeFile,
+	                          uint32_t newSize) override;
+
+	/// Always SAUNAFS_STATUS_OK: the vector has no backing rows to fail.
+	/// @see IFilesystemNodeOperations::validateFileChunkRows
+	uint8_t validateFileChunkRows(const FilesystemOperationContext &fsOpContext,
+	                              const FSNodeFile *nodeFile, uint32_t fromIndex,
+	                              uint32_t endIndex) override;
+
+	/// Always SAUNAFS_STATUS_OK: this backend never defers chunk releases.
+	/// @see IFilesystemNodeOperations::canGrowFileChunkTable
+	uint8_t canGrowFileChunkTable(const FilesystemOperationContext &fsOpContext,
+	                              const FSNodeFile *nodeFile, uint32_t newSize) override;
+
+	/// Always SAUNAFS_STATUS_OK: the in-memory table releases every discarded chunk inline.
+	/// @see IFilesystemNodeOperations::canTruncateFileChunks
+	uint8_t canTruncateFileChunks(const FilesystemOperationContext &fsOpContext,
+	                              const FSNodeFile *nodeFile, uint64_t newLength) override;
+
+	/// Returns FSNodeFile::chunkCount().
+	/// @see IFilesystemNodeOperations::getFileChunkCount
+	uint32_t getFileChunkCount(const FilesystemOperationContext &fsOpContext,
+	                           const FSNodeFile *nodeFile) override;
+
+	/// Counts the non-zero slots of the vector.
+	/// @see IFilesystemNodeOperations::getLiveFileChunkCount
+	uint32_t getLiveFileChunkCount(const FilesystemOperationContext &fsOpContext,
+	                               FSNodeFile *nodeFile) override;
+
+	/// Checks the slot covering the file's last byte directly in the vector.
+	/// @see IFilesystemNodeOperations::isLastFileChunkNonEmpty
+	bool isLastFileChunkNonEmpty(const FilesystemOperationContext &fsOpContext,
+	                             FSNodeFile *nodeFile) override;
+
+	/// Plain forward loop over the vector, skipping holes.
+	/// @see IFilesystemNodeOperations::forEachFileChunk
+	void forEachFileChunk(const FilesystemOperationContext &fsOpContext, const FSNodeFile *nodeFile,
+	                      uint32_t fromIndex,
+	                      const std::function<bool(uint32_t, uint64_t)> &callback) override;
+
+	/// Hands each discarded live slot to the callback (no deferral), then shrinks the vector.
+	/// @see IFilesystemNodeOperations::truncateFileChunks
+	FileChunkCutResult truncateFileChunks(
+	    const FilesystemOperationContext &fsOpContext, FSNodeFile *nodeFile, uint32_t newSize,
+	    const std::function<void(uint32_t, uint64_t)> &callback) override;
+
+	/// Equivalent to truncateFileChunks to size zero (no deferral).
+	/// @see IFilesystemNodeOperations::removeAllFileChunks
+	FileChunkCutResult removeAllFileChunks(
+	    const FilesystemOperationContext &fsOpContext, FSNodeFile *nodeFile,
+	    const std::function<void(uint32_t, uint64_t)> &callback) override;
+
+	/// Direct copy from the vector.
+	/// @see IFilesystemNodeOperations::getFileChunkIds
+	void getFileChunkIds(const FilesystemOperationContext &fsOpContext, const FSNodeFile *nodeFile,
+	                     uint32_t fromIndex, uint32_t count,
+	                     std::vector<uint64_t> &chunkIdsOut) override;
+
+	/// Exact vector comparison.
+	/// @see IFilesystemNodeOperations::fileChunksEqual
+	bool fileChunksEqual(const FilesystemOperationContext &fsOpContext, const FSNodeFile *nodeFileA,
+	                     const FSNodeFile *nodeFileB) override;
+
+	/// Vector assignment; every copied live slot reaches the callback (no deferral).
+	/// @see IFilesystemNodeOperations::copyFileChunks
+	void copyFileChunks(const FilesystemOperationContext &fsOpContext, FSNodeFile *destNodeFile,
+	                    const FSNodeFile *srcNodeFile,
+	                    const std::function<bool(uint32_t, uint64_t)> &callback) override;
 	int64_t getSize(const FilesystemOperationContext &fsOpContext, FSNode *node) override;
 
 	/// Returns the number of parents of the given node.
@@ -319,6 +429,12 @@ public:
 	           FSNode *node, uint8_t modeMask) override;
 
 protected:
+	FSNode *createNodeWithIdInternal(const FilesystemOperationContext &fsOpContext,
+	                                 uint32_t timeStamp, FSNodeDirectory *parent,
+	                                 const HString &name, FSNodeType type, uint16_t mode,
+	                                 uint16_t umask, uint32_t uid, uint32_t gid, uint8_t copysgid,
+	                                 AclInheritance inheritAcl, inode_t inode);
+
 	/// Returns the stored RichACL for @p node, or nullptr if none is present.
 	/// @p scratch is an optional caller-supplied buffer; implementations that need
 	/// to materialise a temporary ACL (e.g. KV backends) emplace into @p scratch
@@ -437,21 +553,16 @@ private:
 	/// Number of blocks in the last chunk before EOF
 	static uint32_t lastChunkBlocks(FSNodeFile *node);
 
-	/// Does the last chunk exist and contain non-zero data?
-	static bool isLastChunkNonEmpty(FSNodeFile *node);
-
-	/// Count chunks in a file, disregard sparse file holes
-	static uint32_t fileChunksCount(FSNodeFile *node);
-
 	/// Compute the "size" statistic for a file node
-	static uint64_t fileSize(FSNodeFile *node, uint32_t nonZeroChunks);
+	uint64_t fileSize(const FilesystemOperationContext &fsOpContext, FSNodeFile *node,
+	                  uint32_t nonZeroChunks);
 
 	/// Compute the "realsize" statistic for a file node.
 	/// @param node file node (used e.g. to detect a partial last chunk and goal).
 	/// @param nonZeroChunks number of non-empty chunks (used for EC/XOR slice calculations).
 	/// @param logicalFileSize logical file "size" as returned by fileSize(...).
-	static uint64_t fileRealSize(FSNodeFile *node, uint32_t nonZeroChunks,
-	                             uint64_t logicalFileSize);
+	uint64_t fileRealSize(const FilesystemOperationContext &fsOpContext, FSNodeFile *node,
+	                      uint32_t nonZeroChunks, uint64_t logicalFileSize);
 
 #ifndef METARESTORE
 	/// Compute the disk space cost of all parts of a xor/ec chunk of given size

--- a/src/master/filesystem_node_arena.cc
+++ b/src/master/filesystem_node_arena.cc
@@ -28,15 +28,19 @@
 // Moves clear the source explicitly. A moved-from std::unordered_map is only "valid but
 // unspecified", so without the clear() the moved-from arena's destructor could still see
 // entries and destroy nodes that are now owned by the destination arena.
-FSNodeArena::FSNodeArena(FSNodeArena &&other) noexcept : nodes_(std::move(other.nodes_)) {
+FSNodeArena::FSNodeArena(FSNodeArena &&other) noexcept
+    : nodes_(std::move(other.nodes_)), chunkTableMetadata_(std::move(other.chunkTableMetadata_)) {
 	other.nodes_.clear();
+	other.chunkTableMetadata_.clear();
 }
 
 FSNodeArena &FSNodeArena::operator=(FSNodeArena &&other) noexcept {
 	if (this != &other) {
 		destroyAll();
 		nodes_ = std::move(other.nodes_);
+		chunkTableMetadata_ = std::move(other.chunkTableMetadata_);
 		other.nodes_.clear();
+		other.chunkTableMetadata_.clear();
 	}
 	return *this;
 }
@@ -48,6 +52,7 @@ void FSNodeArena::destroyAll() {
 		if (node != nullptr) { FSNode::destroy(node); }
 	}
 	nodes_.clear();
+	chunkTableMetadata_.clear();
 }
 
 std::optional<FSNode *> FSNodeArena::lookup(inode_t inode) const {
@@ -74,4 +79,27 @@ FSNode *FSNodeArena::adopt(inode_t inode, FSNode *node) {
 	return entryIt->second;
 }
 
-void FSNodeArena::releaseAndTombstone(inode_t inode) { nodes_[inode] = nullptr; }
+OutOfLineChunkTableMeta *FSNodeArena::chunkTableMeta(inode_t inode) {
+	auto entryIt = chunkTableMetadata_.find(inode);
+	return entryIt == chunkTableMetadata_.end() ? nullptr : &entryIt->second;
+}
+
+const OutOfLineChunkTableMeta *FSNodeArena::chunkTableMeta(inode_t inode) const {
+	auto entryIt = chunkTableMetadata_.find(inode);
+	return entryIt == chunkTableMetadata_.end() ? nullptr : &entryIt->second;
+}
+
+OutOfLineChunkTableMeta &FSNodeArena::ensureChunkTableMeta(inode_t inode) {
+	return chunkTableMetadata_[inode];
+}
+
+void FSNodeArena::setChunkTableMeta(inode_t inode, OutOfLineChunkTableMeta metadata) {
+	chunkTableMetadata_[inode] = metadata;
+}
+
+void FSNodeArena::releaseAndTombstone(inode_t inode) {
+	releaseNodeOwnershipAndTombstone(inode);
+	chunkTableMetadata_.erase(inode);
+}
+
+void FSNodeArena::releaseNodeOwnershipAndTombstone(inode_t inode) { nodes_[inode] = nullptr; }

--- a/src/master/filesystem_node_arena.h
+++ b/src/master/filesystem_node_arena.h
@@ -20,12 +20,31 @@
 
 #include "common/platform.h"
 
+#include <cstdint>
 #include <optional>
 #include <unordered_map>
 
 #include "common/type_defs.h"
 
 class FSNode;
+
+/// KV-only bookkeeping for file chunk tables stored outside FSNodeFile.
+///
+/// In-memory Master and Shadow never create these entries. KV backends attach one to
+/// each file-like node materialized in an operation arena and persist it inside NODE_.
+struct OutOfLineChunkTableMeta {
+	/// Sentinel for mutablePrefixEnd: no bulk operation fences the file.
+	static constexpr uint32_t kNoMutablePrefix = 0xFFFFFFFF;
+
+	uint32_t liveChunkCount{};
+	uint32_t chunkTableSize{};
+	/// Monotonic content revision used to detect a source table changing during a bulk copy.
+	uint64_t chunkTableRevision{};
+	/// Monotonic identity assigned to durable bulk operations targeting this inode.
+	uint64_t bulkOperationGeneration{};
+	/// While an operation is active, only indices below this exclusive bound may mutate.
+	uint32_t mutablePrefixEnd{kNoMutablePrefix};
+};
 
 /// Per-operation owner of FSNode objects materialized from a KV backend.
 ///
@@ -57,14 +76,32 @@ public:
 	/// node is destroyed and the pinned instance returned; adopting over a tombstone re-pins.
 	[[nodiscard]] FSNode *adopt(inode_t inode, FSNode *node);
 
-	/// Drops ownership without destroying the node and tombstones the inode, so a later
-	/// resolve in the same operation returns null instead of a dangling pointer.
-	/// For delete paths where the removal call destroys the node itself.
+	/// Returns the KV chunk-table metadata attached to @p inode, or nullptr when absent.
+	OutOfLineChunkTableMeta *chunkTableMeta(inode_t inode);
+	const OutOfLineChunkTableMeta *chunkTableMeta(inode_t inode) const;
+
+	/// Returns the existing metadata or creates a default, unfenced entry.
+	OutOfLineChunkTableMeta &ensureChunkTableMeta(inode_t inode);
+
+	/// Replaces the metadata attached to @p inode.
+	void setChunkTableMeta(inode_t inode, OutOfLineChunkTableMeta metadata);
+
+	/// Drops ownership and chunk-table metadata, then tombstones the inode.
+	/// A later resolve in the same operation returns null instead of a dangling pointer.
+	/// Used by delete paths where the removal call destroys the node itself.
 	void releaseAndTombstone(inode_t inode);
+
+	/// Drops node ownership and tombstones the inode while retaining its out-of-line metadata.
+	/// Delete paths use this before removeNode(), which still needs chunk-table metadata, then
+	/// call releaseAndTombstone() after the node has been destroyed.
+	void releaseNodeOwnershipAndTombstone(inode_t inode);
 
 private:
 	void destroyAll();
 
 	/// Owned nodes by inode; a null value is a tombstone for a node deleted this operation.
 	std::unordered_map<inode_t, FSNode *> nodes_;
+
+	/// KV-only file chunk-table metadata. Empty for in-memory Master and Shadow operations.
+	std::unordered_map<inode_t, OutOfLineChunkTableMeta> chunkTableMetadata_;
 };

--- a/src/master/filesystem_node_arena_unittest.cc
+++ b/src/master/filesystem_node_arena_unittest.cc
@@ -53,6 +53,23 @@ TEST_F(FSNodeArenaTest, AdoptPinsAndLookupReturnsSameInstance) {
 	EXPECT_EQ(*pinned, node);
 }
 
+TEST_F(FSNodeArenaTest, ChunkTableMetadataDefaultsAndRoundTrips) {
+	FSNodeArena arena;
+	EXPECT_EQ(arena.chunkTableMeta(7), nullptr);
+
+	auto &metadata = arena.ensureChunkTableMeta(7);
+	EXPECT_EQ(metadata.liveChunkCount, 0U);
+	EXPECT_EQ(metadata.chunkTableSize, 0U);
+	EXPECT_EQ(metadata.chunkTableRevision, 0U);
+
+	metadata.liveChunkCount = 4;
+	metadata.chunkTableSize = 8;
+	const auto *stored = std::as_const(arena).chunkTableMeta(7);
+	ASSERT_NE(stored, nullptr);
+	EXPECT_EQ(stored->liveChunkCount, 4U);
+	EXPECT_EQ(stored->chunkTableSize, 8U);
+}
+
 TEST_F(FSNodeArenaTest, AdoptDuplicateKeepsPinnedInstance) {
 	FSNodeArena arena;
 	FSNode *first = makeNode(7);
@@ -69,12 +86,33 @@ TEST_F(FSNodeArenaTest, ReleaseAndTombstoneMakesLookupReturnNull) {
 	FSNodeArena arena;
 	FSNode *node = makeNode(7);
 	ASSERT_EQ(arena.adopt(7, node), node);
+	arena.ensureChunkTableMeta(7).chunkTableSize = 8;
 	arena.releaseAndTombstone(7);
 	auto entry = arena.lookup(7);
 	ASSERT_TRUE(entry.has_value());
 	EXPECT_EQ(*entry, nullptr);
+	EXPECT_EQ(arena.chunkTableMeta(7), nullptr);
 	// The arena released ownership; the caller-side owner destroys the node
 	// (removeNode in production).
+	FSNode::destroy(node);
+}
+
+TEST_F(FSNodeArenaTest, ReleaseNodeOwnershipRetainsChunkTableMetadata) {
+	FSNodeArena arena;
+	FSNode *node = makeNode(7);
+	ASSERT_EQ(arena.adopt(7, node), node);
+	arena.ensureChunkTableMeta(7).chunkTableSize = 8;
+
+	arena.releaseNodeOwnershipAndTombstone(7);
+
+	auto entry = arena.lookup(7);
+	ASSERT_TRUE(entry.has_value());
+	EXPECT_EQ(*entry, nullptr);
+	ASSERT_NE(arena.chunkTableMeta(7), nullptr);
+	EXPECT_EQ(arena.chunkTableMeta(7)->chunkTableSize, 8U);
+
+	arena.releaseAndTombstone(7);
+	EXPECT_EQ(arena.chunkTableMeta(7), nullptr);
 	FSNode::destroy(node);
 }
 
@@ -104,28 +142,38 @@ TEST_F(FSNodeArenaTest, MoveConstructorTransfersOwnershipAndEmptiesSource) {
 	FSNodeArena source;
 	FSNode *node = makeNode(7);
 	ASSERT_EQ(source.adopt(7, node), node);
+	source.ensureChunkTableMeta(7).chunkTableSize = 8;
 
 	FSNodeArena destination(std::move(source));
 	auto pinned = destination.lookup(7);
 	ASSERT_TRUE(pinned.has_value());
 	EXPECT_EQ(*pinned, node);
+	ASSERT_NE(destination.chunkTableMeta(7), nullptr);
+	EXPECT_EQ(destination.chunkTableMeta(7)->chunkTableSize, 8U);
 	// The moved-from arena must be empty, or its destructor would double-free.
 	EXPECT_FALSE(source.lookup(7).has_value());
+	EXPECT_EQ(source.chunkTableMeta(7), nullptr);
 }
 
 TEST_F(FSNodeArenaTest, MoveAssignmentReplacesOwnedNodesAndEmptiesSource) {
 	FSNodeArena source;
 	FSNode *kept = makeNode(7);
 	ASSERT_EQ(source.adopt(7, kept), kept);
+	source.ensureChunkTableMeta(7).liveChunkCount = 4;
 
 	FSNodeArena destination;
 	// The destination's prior node is destroyed by the assignment.
 	ASSERT_NE(destination.adopt(9, makeNode(9)), nullptr);
+	destination.ensureChunkTableMeta(9).liveChunkCount = 2;
 
 	destination = std::move(source);
 	auto pinned = destination.lookup(7);
 	ASSERT_TRUE(pinned.has_value());
 	EXPECT_EQ(*pinned, kept);
+	ASSERT_NE(destination.chunkTableMeta(7), nullptr);
+	EXPECT_EQ(destination.chunkTableMeta(7)->liveChunkCount, 4U);
 	EXPECT_FALSE(destination.lookup(9).has_value());
+	EXPECT_EQ(destination.chunkTableMeta(9), nullptr);
 	EXPECT_FALSE(source.lookup(7).has_value());
+	EXPECT_EQ(source.chunkTableMeta(7), nullptr);
 }

--- a/src/master/filesystem_node_chunk_table_unittest.cc
+++ b/src/master/filesystem_node_chunk_table_unittest.cc
@@ -1,0 +1,368 @@
+/*
+   Copyright 2026      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "common/platform.h"
+
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "errors/saunafs_error_codes.h"
+#include "kv/ifuture.h"
+#include "master/chunk_operations_base.h"
+#include "master/chunks.h"
+#include "master/filesystem_metadata.h"
+#include "master/filesystem_node.h"
+#include "master/filesystem_node_types.h"
+#include "master/filesystem_operation_context.h"
+#include "master/filesystem_operations.h"
+
+namespace {
+
+class ChunkTableOps : public FilesystemNodeOperationsBase {};
+
+class AppendChunkTableOps : public ChunkTableOps {
+public:
+	void getStats(const FilesystemOperationContext &, FSNode *, StatsRecord *statsOut) override {
+		*statsOut = {};
+	}
+};
+
+class AppendTestFilesystemOperations : public FilesystemOperationsBase {
+public:
+	AppendTestFilesystemOperations()
+	    : FilesystemOperationsBase(std::make_unique<AppendChunkTableOps>()) {}
+
+	const Goal &getGoalDefinition(uint8_t) const override { return goal_; }
+
+private:
+	Goal goal_;
+};
+
+class NoopReadWriteTransaction : public kv::IReadWriteTransaction {
+public:
+	std::optional<kv::Value> get(const kv::Key &) override { return std::nullopt; }
+	std::optional<kv::Value> getSnapshot(const kv::Key &) override { return std::nullopt; }
+	std::unique_ptr<kv::IFuture> getAsync(const kv::Key &) override { return nullptr; }
+	std::unique_ptr<kv::IFuture> getSnapshotAsync(const kv::Key &) override { return nullptr; }
+	kv::GetRangeResult getRange(const kv::KeySelector &, const kv::KeySelector &, int) override {
+		return {{}, false};
+	}
+	std::unique_ptr<kv::IRangeFuture> getRangeAsync(const kv::KeySelector &,
+	                                                const kv::KeySelector &, int) override {
+		return nullptr;
+	}
+	void set(const kv::Key &, const kv::Value &) override {}
+	void atomicAdd(const kv::Key &, const kv::Value &) override {}
+	void atomicMax(const kv::Key &, const kv::Value &) override {}
+	void remove(const kv::Key &) override {}
+	void removeRange(const kv::Key &, const kv::Key &) override {}
+	void addReadConflictKey(const kv::Key &) override {}
+	bool commit() override { return true; }
+	std::unique_ptr<kv::ICommitFuture> commitAsync() override { return nullptr; }
+	std::optional<int64_t> getCommittedVersion() const override { return std::nullopt; }
+	uint64_t mutationCount() const override { return 0; }
+	std::unique_ptr<kv::IVoidFuture> recoverAsync(int) override { return nullptr; }
+};
+
+class FailThirdAddChunkOperations : public ChunkOperationsBase {
+public:
+	int addFile(const FilesystemOperationContext &fsOpContext, uint64_t chunkid, uint8_t goal,
+	            bool isMetadataLoading) override {
+		addAttempts_++;
+		if (addAttempts_ == 3) { return SAUNAFS_ERROR_IO; }
+		return ChunkOperationsBase::addFile(fsOpContext, chunkid, goal, isMetadataLoading);
+	}
+
+private:
+	uint32_t addAttempts_ = 0;
+};
+
+class NoopTransactionEffects : public FilesystemTransactionEffects {
+public:
+	void finish(FilesystemTransactionOutcome) noexcept override {}
+};
+
+class FailThirdDeferredAddChunkOperations : public ChunkOperationsBase {
+public:
+	int addFile(const FilesystemOperationContext &fsOpContext, uint64_t, uint8_t, bool) override {
+		if (fsOpContext.transactionEffects() == nullptr) {
+			fsOpContext.setTransactionEffects(std::make_unique<NoopTransactionEffects>());
+		}
+		return ++addAttempts_ == 3 ? SAUNAFS_ERROR_IO : SAUNAFS_STATUS_OK;
+	}
+	bool defersFileReferenceMutations(
+	    const FilesystemOperationContext & /*fsOpContext*/) const override {
+		return true;
+	}
+
+private:
+	uint32_t addAttempts_ = 0;
+};
+
+class AppendChunksRollbackTest : public ::testing::Test {
+protected:
+	void SetUp() override {
+		gFSOperations = std::make_unique<AppendTestFilesystemOperations>();
+		ASSERT_EQ(1, chunk_strinit());
+		gChunkOperations = std::make_unique<FailThirdAddChunkOperations>();
+	}
+
+	void TearDown() override {
+		gChunkOperations.reset();
+		chunk_unload();
+		gFSOperations.reset();
+	}
+};
+
+/// Admits the fence but refuses the truncate preflight, standing in for a backend that
+/// cannot release the discarded tail without dropping references. Session and node
+/// lookup are stubbed so the truncate entry points can run without a live metadata tree.
+class RefuseTruncateOps : public AppendChunkTableOps {
+public:
+	FSNodeFile *node = nullptr;
+	uint32_t preflights = 0;
+
+protected:
+	uint8_t verifySession(const FsContext &, OperationMode, SessionType) override {
+		return SAUNAFS_STATUS_OK;
+	}
+
+	uint8_t getNodeForOperation(const FsContext &, const FilesystemOperationContext &,
+	                            ExpectedNodeType, uint8_t, inode_t, FSNode **nodeOut,
+	                            FSNodeDirectory **rootDirOut) override {
+		if (rootDirOut != nullptr) { *rootDirOut = nullptr; }
+		*nodeOut = node;
+		return SAUNAFS_STATUS_OK;
+	}
+
+	uint8_t canTruncateFileChunks(const FilesystemOperationContext &, const FSNodeFile *,
+	                              uint64_t) override {
+		++preflights;
+		return SAUNAFS_ERROR_IO;
+	}
+};
+
+class CountingTruncateChunkOperations : public ChunkOperationsBase {
+public:
+	uint32_t truncates = 0;
+
+	uint8_t multiTruncate(const FilesystemOperationContext &, uint64_t, uint32_t, uint32_t, uint8_t,
+	                      bool, bool, uint64_t *newChunkId) override {
+		++truncates;
+		*newChunkId = 999;
+		return SAUNAFS_STATUS_OK;
+	}
+};
+
+class TruncateGuardFilesystemOperations : public FilesystemOperationsBase {
+public:
+	explicit TruncateGuardFilesystemOperations(std::unique_ptr<RefuseTruncateOps> ops)
+	    : FilesystemOperationsBase(std::move(ops)) {}
+
+	const Goal &getGoalDefinition(uint8_t) const override { return goal_; }
+
+private:
+	Goal goal_;
+};
+
+class TruncatePreflightTest : public ::testing::Test {
+protected:
+	void SetUp() override {
+		gMetadata = new FilesystemMetadata;
+		auto ops = std::make_unique<RefuseTruncateOps>();
+		ops_ = ops.get();
+		operations_ = std::make_unique<TruncateGuardFilesystemOperations>(std::move(ops));
+		gChunkOperations = std::make_unique<CountingTruncateChunkOperations>();
+
+		file_.id = 1;
+		file_.goal = 2;
+		file_.length = 2 * SFSCHUNKSIZE;
+		ops_->node = &file_;
+		ops_->resizeFileChunkTable(context_, &file_, 2);
+		ops_->setFileChunkId(context_, &file_, 1, kBoundaryChunkId);
+	}
+
+	void TearDown() override {
+		gChunkOperations.reset();
+		operations_.reset();
+		delete gMetadata;
+		gMetadata = nullptr;
+	}
+
+	uint32_t truncateCalls() const {
+		return static_cast<CountingTruncateChunkOperations *>(gChunkOperations.get())->truncates;
+	}
+
+	static constexpr uint64_t kBoundaryChunkId = 555;
+
+	FilesystemOperationContext context_;
+	FSNodeFile file_{FSNodeType::kFile};
+	RefuseTruncateOps *ops_ = nullptr;
+	std::unique_ptr<TruncateGuardFilesystemOperations> operations_;
+};
+
+}  // namespace
+
+TEST(FileChunkTableResizeTest, ResizeShrinksRoundedTrailingPadding) {
+	// writeChunk grows the table in rounded blocks, so a file whose last live chunk
+	// sits at index 8 carries a 16-slot vector. Append sizes its result from the
+	// trimmed counts and must drop that padding, or chunks-info reports phantom
+	// trailing holes until serialization trims them on the next restart.
+	ChunkTableOps ops;
+	FilesystemOperationContext ctx;
+	FSNodeFile node(FSNodeType::kFile);
+	ops.resizeFileChunkTable(ctx, &node, 16);
+	for (uint32_t index = 0; index <= 8; ++index) { node.chunks[index] = 100 + index; }
+
+	ASSERT_EQ(9U, ops.getFileChunkCount(ctx, &node));
+	ASSERT_EQ(16U, ops.getFileChunkTableSize(ctx, &node));
+
+	// The append sequence: exact resize to trimmed dst + trimmed src, then the copy.
+	ops.resizeFileChunkTable(ctx, &node, 10);
+	ASSERT_EQ(10U, ops.getFileChunkTableSize(ctx, &node));
+	ops.setFileChunkId(ctx, &node, 9, 200);
+
+	EXPECT_EQ(10U, ops.getFileChunkTableSize(ctx, &node));
+	EXPECT_EQ(10U, ops.getFileChunkCount(ctx, &node));
+	EXPECT_EQ(200U, ops.getFileChunkId(ctx, &node, 9));
+	for (uint32_t index = 0; index <= 8; ++index) {
+		EXPECT_EQ(100U + index, ops.getFileChunkId(ctx, &node, index));
+	}
+}
+
+TEST(FileChunkTableResizeTest, ResizeGrowsWithHoles) {
+	ChunkTableOps ops;
+	FilesystemOperationContext ctx;
+	FSNodeFile node(FSNodeType::kFile);
+	ops.resizeFileChunkTable(ctx, &node, 2);
+	node.chunks[1] = 7;
+
+	ops.resizeFileChunkTable(ctx, &node, 5);
+	EXPECT_EQ(5U, ops.getFileChunkTableSize(ctx, &node));
+	EXPECT_EQ(2U, ops.getFileChunkCount(ctx, &node));
+	EXPECT_EQ(0U, ops.getFileChunkId(ctx, &node, 4));
+}
+
+TEST(FileChunkTableResizeTest, GrowNeverShrinks) {
+	ChunkTableOps ops;
+	FilesystemOperationContext ctx;
+	FSNodeFile node(FSNodeType::kFile);
+	ops.resizeFileChunkTable(ctx, &node, 16);
+	node.chunks[8] = 1;
+
+	ops.growFileChunkTable(ctx, &node, 10);
+	EXPECT_EQ(16U, ops.getFileChunkTableSize(ctx, &node));
+	ops.growFileChunkTable(ctx, &node, 32);
+	EXPECT_EQ(32U, ops.getFileChunkTableSize(ctx, &node));
+}
+
+TEST_F(AppendChunksRollbackTest, FailedAddReversesSuccessfulPrefix) {
+	constexpr uint8_t goal = 2;
+	const std::vector<uint64_t> chunkIds = {101, 102, 103};
+	for (uint64_t chunkId : chunkIds) {
+		chunk_create_with_goal_counters(chunkId, 1, {{goal, 1}}, 0, 0);
+	}
+
+	AppendChunkTableOps operations;
+	std::unique_ptr<kv::IReadWriteTransaction> transaction =
+	    std::make_unique<NoopReadWriteTransaction>();
+	FilesystemOperationContext context(std::move(transaction));
+	FSNodeFile source(FSNodeType::kFile);
+	source.goal = goal;
+	source.length = chunkIds.size() * SFSCHUNKSIZE;
+	operations.resizeFileChunkTable(context, &source, chunkIds.size());
+	for (size_t index = 0; index < chunkIds.size(); ++index) {
+		operations.setFileChunkId(context, &source, index, chunkIds[index]);
+	}
+	FSNodeFile destination(FSNodeType::kFile);
+	destination.goal = goal;
+
+	EXPECT_EQ(SAUNAFS_ERROR_IO, operations.appendChunks(context, 1, &destination, &source));
+
+	for (uint64_t chunkId : chunkIds) {
+		uint32_t version = 0;
+		ChunkGoalCounters counters;
+		ASSERT_TRUE(chunk_get_version_and_goal_counters(chunkId, version, counters));
+		EXPECT_EQ(1U, counters.fileCount());
+	}
+}
+
+TEST_F(TruncatePreflightTest, TrySetLengthRefusesBeforeTouchingTheBoundaryChunk) {
+	// The boundary chunk is truncated in place and written to the changelog before the
+	// table is cut, so a refusal that arrives later cannot undo it.
+	Attributes attr;
+	uint64_t chunkId = 0;
+	const uint64_t newLength = SFSCHUNKSIZE + 100;
+
+	EXPECT_EQ(SAUNAFS_ERROR_IO,
+	          operations_->trySetLength(FsContext::getForMaster(0), context_, file_.id, 1,
+	                                    newLength, false, 0, attr, &chunkId));
+
+	EXPECT_EQ(1U, ops_->preflights);
+	EXPECT_EQ(0U, truncateCalls());
+	EXPECT_EQ(kBoundaryChunkId, ops_->getFileChunkId(context_, &file_, 1));
+}
+
+TEST_F(TruncatePreflightTest, DoSetLengthRefusesBeforeChangingTheLength) {
+	// setLength() returns void, so a backend that refuses the cut here would otherwise
+	// leave the shortened length published with its discarded tail still referenced.
+	Attributes attr;
+	const uint64_t previousLength = file_.length;
+
+	EXPECT_EQ(SAUNAFS_ERROR_IO,
+	          operations_->doSetLength(FsContext::getForMaster(0), context_, file_.id, 0, attr));
+
+	EXPECT_EQ(1U, ops_->preflights);
+	EXPECT_EQ(previousLength, file_.length);
+	EXPECT_EQ(2U, ops_->getFileChunkTableSize(context_, &file_));
+}
+
+TEST_F(AppendChunksRollbackTest, FailedDeferredAddDoesNotTouchLiveRegistry) {
+	constexpr uint8_t goal = 2;
+	const std::vector<uint64_t> chunkIds = {111, 112, 113};
+	for (uint64_t chunkId : chunkIds) {
+		chunk_create_with_goal_counters(chunkId, 1, {{goal, 1}}, 0, 0);
+	}
+	gChunkOperations = std::make_unique<FailThirdDeferredAddChunkOperations>();
+
+	AppendChunkTableOps operations;
+	std::unique_ptr<kv::IReadWriteTransaction> transaction =
+	    std::make_unique<NoopReadWriteTransaction>();
+	FilesystemOperationContext context(std::move(transaction));
+	FSNodeFile source(FSNodeType::kFile);
+	source.goal = goal;
+	source.length = chunkIds.size() * SFSCHUNKSIZE;
+	operations.resizeFileChunkTable(context, &source, chunkIds.size());
+	for (size_t index = 0; index < chunkIds.size(); ++index) {
+		operations.setFileChunkId(context, &source, index, chunkIds[index]);
+	}
+	FSNodeFile destination(FSNodeType::kFile);
+	destination.goal = goal;
+
+	EXPECT_EQ(SAUNAFS_ERROR_IO, operations.appendChunks(context, 1, &destination, &source));
+
+	for (uint64_t chunkId : chunkIds) {
+		uint32_t version = 0;
+		ChunkGoalCounters counters;
+		ASSERT_TRUE(chunk_get_version_and_goal_counters(chunkId, version, counters));
+		EXPECT_EQ(1U, counters.fileCount());
+	}
+}

--- a/src/master/filesystem_node_operations_interface.h
+++ b/src/master/filesystem_node_operations_interface.h
@@ -22,6 +22,7 @@
 
 #include <array>
 #include <cstdint>
+#include <functional>
 #include <string>
 #include <vector>
 
@@ -45,6 +46,35 @@ struct HandleInodeEntry;
 struct NamedInodeEntry;
 
 using ChunkCountArray = std::array<uint32_t, CHUNK_MATRIX_SIZE>;
+
+enum class FileChunkCutState : std::uint8_t {
+	kComplete,
+	kDeferred,
+};
+
+/// Result of logically cutting a file's chunk table.
+///
+/// A deferred result means the visible table was cut atomically, while durable reference
+/// cleanup continues in bounded backend work. Generation is backend-defined and zero when no
+/// durable operation was needed.
+struct FileChunkCutResult {
+	FileChunkCutState state = FileChunkCutState::kComplete;
+	uint64_t generation = 0;
+
+	bool deferred() const { return state == FileChunkCutState::kDeferred; }
+};
+
+/// Request metadata needed when a backend completes a file-goal change asynchronously.
+///
+/// Synchronous backends leave publication to SetGoalTask. A durable backend records these
+/// fields so any worker can publish ctime, metadata version, and changelog without owning the
+/// original task.
+struct FileGoalChangeRequest {
+	uint32_t timestamp = 0;
+	uint32_t uid = 0;
+	uint8_t mode = 0;
+	bool emitChangelog = false;
+};
 
 /// Maximum length for a file or directory name in bytes
 inline constexpr size_t kMaxFileNameLength = 255;
@@ -135,6 +165,14 @@ public:
 	                           uint16_t mode, uint16_t umask, uint32_t uid, uint32_t gid,
 	                           uint8_t copysgid, AclInheritance inheritAcl,
 	                           inode_t requestedINode = 0) = 0;
+
+	/// Creates and links a node using an inode already reserved by the active backend.
+	virtual FSNode *createNodeWithPreallocatedId(const FilesystemOperationContext &fsOpContext,
+	                                             uint32_t timeStamp, FSNodeDirectory *parent,
+	                                             const HString &name, FSNodeType type,
+	                                             uint16_t mode, uint16_t umask, uint32_t uid,
+	                                             uint32_t gid, uint8_t copysgid,
+	                                             AclInheritance inheritAcl, inode_t inode) = 0;
 
 	/// Syncs the current state of the node to persistent storage on backends that need it.
 	///
@@ -368,11 +406,149 @@ public:
 	                       uint64_t length, bool eraseFurtherChunks) = 0;
 	virtual uint8_t appendChunks(const FilesystemOperationContext &fsOpContext, uint32_t timeStamp,
 	                             FSNodeFile *destNodeFile, FSNodeFile *srcNodeFile) = 0;
-	virtual void changeFileGoal(const FilesystemOperationContext &fsOpContext, FSNodeFile *nodeFile,
-	                            uint8_t goal) = 0;
+	/// Returns whether a file goal change may start. KV backends use this to reject a
+	/// file fenced by another bulk operation; in-memory returns OK.
+	virtual uint8_t canChangeFileGoal(const FilesystemOperationContext &fsOpContext,
+	                                  const FSNodeFile *nodeFile) = 0;
+	/// Returns whether the half-open chunk-index range [beginIndex, endIndex) may be
+	/// mutated. A backend with a durable bulk operation may allow only a safe prefix.
+	virtual uint8_t canMutateFileChunks(const FilesystemOperationContext &fsOpContext,
+	                                    const FSNodeFile *nodeFile, uint32_t beginIndex,
+	                                    uint32_t endIndex) = 0;
+	/// Changes the goal of every chunk the file's table references and of the node.
+	/// Every file goal change funnels through here, so the guards cannot be bypassed
+	/// by recursive paths: returns SAUNAFS_ERROR_LOCKED while another bulk operation
+	/// fences the file, and the validateFileChunkRows status when part of the table is unreadable.
+	/// Neither read-side failure modifies the file. A chunk-reference move failure
+	/// propagates its status; the in-memory backend reverses the applied prefix, but
+	/// a failed reversal can leave residue and is logged at critical severity.
+	virtual uint8_t changeFileGoal(const FilesystemOperationContext &fsOpContext,
+	                               FSNodeFile *nodeFile, uint8_t goal,
+	                               const FileGoalChangeRequest &request) = 0;
 #ifndef METARESTORE
-	virtual void checkFile(FSNodeFile *nodeFile, ChunkCountArray &chunkCount) = 0;
+	virtual void checkFile(const FilesystemOperationContext &fsOpContext, FSNodeFile *nodeFile,
+	                       ChunkCountArray &chunkCount) = 0;
 #endif
+
+	// Chunk-table access seam
+	//
+	// All reads and writes of a file's chunk table go through these methods so a backend
+	// may store the table outside the node itself. The in-memory backend operates on
+	// FSNodeFile::chunks; a KV backend keeps the node value free of chunk ids and resolves
+	// slots from its own storage. A "live" chunk is a slot holding a non-zero chunk id.
+
+	/// Returns the chunk id at @p index, or 0 when the slot is a hole or beyond the table.
+	virtual uint64_t getFileChunkId(const FilesystemOperationContext &fsOpContext,
+	                                const FSNodeFile *nodeFile, uint32_t index) = 0;
+
+	/// Stores @p chunkId at @p index. The slot must already be covered by the table
+	/// (see growFileChunkTable). Implementations maintain any live-chunk bookkeeping.
+	virtual void setFileChunkId(const FilesystemOperationContext &fsOpContext, FSNodeFile *nodeFile,
+	                            uint32_t index, uint64_t chunkId) = 0;
+
+	/// Returns the chunk-table size (the analogue of FSNodeFile::chunks.size(): one past
+	/// the highest slot the table currently covers, holes included). Serialization trims
+	/// trailing holes, so backends that round-trip the node through storage on every
+	/// operation report the trimmed size (== getFileChunkCount); callers must not rely
+	/// on grow padding staying observable.
+	virtual uint32_t getFileChunkTableSize(const FilesystemOperationContext &fsOpContext,
+	                                       const FSNodeFile *nodeFile) = 0;
+
+	/// Grows the chunk table to cover at least @p newSize slots (new slots are holes).
+	/// Never shrinks; shrinking goes through truncateFileChunks. Backends whose holes
+	/// are implicit may treat this as a no-op (see getFileChunkTableSize).
+	virtual void growFileChunkTable(const FilesystemOperationContext &fsOpContext,
+	                                FSNodeFile *nodeFile, uint32_t newSize) = 0;
+
+	/// Sets the chunk table to exactly @p newSize slots. Unlike growFileChunkTable it
+	/// also shrinks, dropping trailing hole padding a rounded growth left behind; the
+	/// caller guarantees every slot at or past @p newSize is a hole (appendChunks
+	/// computes @p newSize from the trimmed chunk counts). Backends whose table
+	/// storage keeps no trailing holes may treat this as a no-op.
+	virtual void resizeFileChunkTable(const FilesystemOperationContext &fsOpContext,
+	                                  FSNodeFile *nodeFile, uint32_t newSize) = 0;
+
+	/// Returns SAUNAFS_STATUS_OK when the stored chunk-table rows covering indices
+	/// [@p fromIndex, @p endIndex) are readable, SAUNAFS_ERROR_IO otherwise.
+	/// Mutating operations call this before touching chunk counters, node state or
+	/// destination tables: reads may degrade an unreadable row to holes, but a
+	/// mutation doing so would acknowledge work it silently dropped. Backends that
+	/// store the table as keyed rows also verify key shape; a whole-visible-table
+	/// check fails when any stored key under the file's prefix cannot be attributed
+	/// to a bucket. The in-memory table is always readable (returns OK).
+	virtual uint8_t validateFileChunkRows(const FilesystemOperationContext &fsOpContext,
+	                                      const FSNodeFile *nodeFile, uint32_t fromIndex,
+	                                      uint32_t endIndex) = 0;
+
+	/// Returns SAUNAFS_STATUS_OK when the table may grow to cover @p newSize slots now.
+	/// A backend that is still releasing chunks discarded by an earlier truncate returns
+	/// SAUNAFS_ERROR_LOCKED for growth past the truncation point until that finishes
+	/// (the mount retries LOCKED writes); other callers surface the status as-is.
+	virtual uint8_t canGrowFileChunkTable(const FilesystemOperationContext &fsOpContext,
+	                                      const FSNodeFile *nodeFile, uint32_t newSize) = 0;
+
+	/// Returns SAUNAFS_STATUS_OK when the file may be truncated to @p newLength bytes
+	/// now. A backend that cannot release the discarded tail without silently dropping
+	/// chunk references returns SAUNAFS_ERROR_IO; callers fail the truncate before
+	/// mutating anything (length, boundary chunk, table rows).
+	virtual uint8_t canTruncateFileChunks(const FilesystemOperationContext &fsOpContext,
+	                                      const FSNodeFile *nodeFile, uint64_t newLength) = 0;
+
+	/// Returns one past the highest live slot (the analogue of FSNodeFile::chunkCount()).
+	virtual uint32_t getFileChunkCount(const FilesystemOperationContext &fsOpContext,
+	                                   const FSNodeFile *nodeFile) = 0;
+
+	/// Returns the number of live chunks in the table.
+	virtual uint32_t getLiveFileChunkCount(const FilesystemOperationContext &fsOpContext,
+	                                       FSNodeFile *nodeFile) = 0;
+
+	/// Returns true when the chunk covering the file's last byte is live.
+	virtual bool isLastFileChunkNonEmpty(const FilesystemOperationContext &fsOpContext,
+	                                     FSNodeFile *nodeFile) = 0;
+
+	/// Invokes @p callback(index, chunkId) for every live chunk with index >= @p fromIndex,
+	/// in increasing index order. The callback returns false to stop the iteration.
+	virtual void forEachFileChunk(const FilesystemOperationContext &fsOpContext,
+	                              const FSNodeFile *nodeFile, uint32_t fromIndex,
+	                              const std::function<bool(uint32_t, uint64_t)> &callback) = 0;
+
+	/// Shrinks the chunk table to @p newSize slots, invoking @p callback(index, chunkId)
+	/// for every live chunk being discarded (so the caller can release it).
+	/// A backend may defer a bulk discard: the table size retreats immediately, but part
+	/// of the discarded chunks is released asynchronously and the callback is NOT invoked
+	/// for those. Callers must not rely on the callback covering every discarded chunk.
+	virtual FileChunkCutResult truncateFileChunks(
+	    const FilesystemOperationContext &fsOpContext, FSNodeFile *nodeFile, uint32_t newSize,
+	    const std::function<void(uint32_t, uint64_t)> &callback) = 0;
+
+	/// Discards the whole chunk table of a node that is being removed, invoking
+	/// @p callback(index, chunkId) for live chunks it releases synchronously. Unlike
+	/// truncateFileChunks(0), the backend knows the node itself is going away and may
+	/// defer the entire release without leaving truncation state on the node.
+	virtual FileChunkCutResult removeAllFileChunks(
+	    const FilesystemOperationContext &fsOpContext, FSNodeFile *nodeFile,
+	    const std::function<void(uint32_t, uint64_t)> &callback) = 0;
+
+	/// Copies chunk ids for slots [@p fromIndex, @p fromIndex + @p count) into @p chunkIdsOut,
+	/// clamped to the chunk-table size (holes are returned as 0).
+	virtual void getFileChunkIds(const FilesystemOperationContext &fsOpContext,
+	                             const FSNodeFile *nodeFile, uint32_t fromIndex, uint32_t count,
+	                             std::vector<uint64_t> &chunkIdsOut) = 0;
+
+	/// Returns true when both files' chunk tables are known identical. A conservative
+	/// false (e.g. for a fenced table, or for tables differing only in trailing hole
+	/// padding) is allowed: callers use equality only to skip work.
+	virtual bool fileChunksEqual(const FilesystemOperationContext &fsOpContext,
+	                             const FSNodeFile *nodeFileA, const FSNodeFile *nodeFileB) = 0;
+
+	/// Replaces @p destNodeFile's chunk table with a copy of @p srcNodeFile's, invoking
+	/// @p callback(index, chunkId) for every live chunk copied (so the caller can add a
+	/// reference to it). Returning false from the callback stops iteration, allowing
+	/// callers to abort after a failed chunk-reference update.
+	virtual void copyFileChunks(const FilesystemOperationContext &fsOpContext,
+	                            FSNodeFile *destNodeFile, const FSNodeFile *srcNodeFile,
+	                            const std::function<bool(uint32_t, uint64_t)> &callback) = 0;
+
 	virtual int64_t getSize(const FilesystemOperationContext &fsOpContext, FSNode *node) = 0;
 
 	/// Returns the number of parents of the given node, possibly reusing the transaction

--- a/src/master/filesystem_node_types.h
+++ b/src/master/filesystem_node_types.h
@@ -212,7 +212,7 @@ constexpr FSNode *kUnknownNode = nullptr;
 /*! \brief Node used for storing file object.
  *
  * Node size = 64B + 40B + 8 * chunks_count + 4 * session_count
- * Avg size (assuming 1 chunk and session id) = 104 + 8 + 4 ~ 120B
+ * Avg size (assuming 1 chunk and session id) = 104 + 8 + 4 ~ 116B
  */
 class FSNodeFile : public FSNode {
 public:
@@ -569,7 +569,7 @@ public:
 	 * For case-insensitive directories, this populates lowerCaseEntries so that
 	 * lookups can be performed in a case-insensitive manner. If multiple entries
 	 * exist whose names differ only by case (e.g., "foo" and "Foo"), only one of
-	 * them will be present in lowerCaseEntries after this operation—the first one
+	 * them will be present in lowerCaseEntries after this operation; the first one
 	 * encountered during iteration. This means only one will be found by a
 	 * case-insensitive lookup, and others will be hidden.
 	 */

--- a/src/master/filesystem_node_types_unittest.cc
+++ b/src/master/filesystem_node_types_unittest.cc
@@ -91,6 +91,9 @@ protected:
 	std::array<uint8_t, kMaxSize> serializeBuffer;
 };
 
+static_assert(sizeof(FSNodeFile) == 104,
+              "KV-only chunk-table bookkeeping must not grow in-memory file nodes");
+
 TEST_F(FilesystemNodeTypesTest, SerializeFSNodeDirectory) {
 	constexpr int finalNode = 12;
 

--- a/src/master/filesystem_operation_context.cc
+++ b/src/master/filesystem_operation_context.cc
@@ -20,6 +20,8 @@
 
 #include "master/filesystem_operation_context.h"
 
+#include <stdexcept>
+
 #include "kv/itransaction.h"
 
 FilesystemOperationContext::FilesystemOperationContext(
@@ -29,6 +31,44 @@ FilesystemOperationContext::FilesystemOperationContext(
 FilesystemOperationContext::FilesystemOperationContext(
     std::unique_ptr<kv::IReadWriteTransaction> txn)
     : rwTransaction_(std::move(txn)), transactionType_(TransactionType::kReadWrite) {}
+
+FilesystemOperationContext::FilesystemOperationContext(
+    FilesystemOperationContext &&other) noexcept = default;
+
+FilesystemOperationContext &FilesystemOperationContext::operator=(
+    FilesystemOperationContext &&other) noexcept {
+	if (this == &other) { return *this; }
+	if (transactionEffects_ != nullptr && !transactionEffectsFinished_) {
+		transactionEffects_->finish(FilesystemTransactionOutcome::kAborted);
+	}
+	assert(deferredChangelogEntries_.empty() || !commitConfirmed_);
+
+	rwTransaction_ = std::move(other.rwTransaction_);
+	roTransaction_ = std::move(other.roTransaction_);
+	transactionType_ = other.transactionType_;
+	nodeArena_ = std::move(other.nodeArena_);
+	bucketRowCache_ = std::move(other.bucketRowCache_);
+	deferChangelog_ = other.deferChangelog_;
+	deferredChangelogEntries_ = std::move(other.deferredChangelogEntries_);
+	groupCommitBatch_ = other.groupCommitBatch_;
+	commitConfirmed_ = other.commitConfirmed_;
+	transactionEffects_ = std::move(other.transactionEffects_);
+	transactionEffectsFinished_ = other.transactionEffectsFinished_;
+
+	other.transactionType_ = TransactionType::kNone;
+	other.deferChangelog_ = false;
+	other.groupCommitBatch_ = false;
+	other.commitConfirmed_ = false;
+	other.transactionEffectsFinished_ = true;
+	return *this;
+}
+
+FilesystemOperationContext::~FilesystemOperationContext() {
+	if (transactionEffects_ != nullptr && !transactionEffectsFinished_) {
+		transactionEffects_->finish(FilesystemTransactionOutcome::kAborted);
+	}
+	assert(deferredChangelogEntries_.empty() || !commitConfirmed_);
+}
 
 bool FilesystemOperationContext::hasTransaction() const {
 	return rwTransaction_ != nullptr || roTransaction_ != nullptr;
@@ -55,4 +95,38 @@ std::unique_ptr<kv::IReadWriteTransaction>
 FilesystemOperationContext::releaseReadWriteTransaction() {
 	if (rwTransaction_ != nullptr) { transactionType_ = TransactionType::kNone; }
 	return std::move(rwTransaction_);
+}
+
+void FilesystemOperationContext::setTransactionEffects(
+    std::unique_ptr<FilesystemTransactionEffects> effects) const {
+	if (effects == nullptr) { throw std::invalid_argument("transaction effects must not be null"); }
+	if (transactionEffects_ != nullptr || transactionEffectsFinished_) {
+		throw std::logic_error("transaction effects already attached or finished");
+	}
+	transactionEffects_ = std::move(effects);
+}
+
+void FilesystemOperationContext::finishTransactionEffects(
+    FilesystemTransactionOutcome outcome) const noexcept {
+	if (transactionEffectsFinished_) { return; }
+	if (transactionEffects_ != nullptr) { transactionEffects_->finish(outcome); }
+	transactionEffectsFinished_ = true;
+}
+
+bool FilesystemOperationContext::commitTransaction() const {
+	if (rwTransaction_ == nullptr) { return true; }
+	const bool committed = rwTransaction_->commit();
+	finishTransactionEffectsAfterCommit(committed);
+	return committed;
+}
+
+void FilesystemOperationContext::finishTransactionEffectsAfterCommit(
+    bool committed) const noexcept {
+	if (committed) {
+		finishTransactionEffects(FilesystemTransactionOutcome::kCommitted);
+	} else if (rwTransaction_ != nullptr && rwTransaction_->commitOutcomeUnknown()) {
+		finishTransactionEffects(FilesystemTransactionOutcome::kIndeterminate);
+	} else {
+		finishTransactionEffects(FilesystemTransactionOutcome::kAborted);
+	}
 }

--- a/src/master/filesystem_operation_context.h
+++ b/src/master/filesystem_operation_context.h
@@ -21,6 +21,7 @@
 #include "common/platform.h"
 
 #include <cassert>
+#include <map>
 #include <memory>
 #include <string>
 #include <utility>
@@ -35,6 +36,29 @@ namespace kv {
 class IReadOnlyTransaction;
 class IReadWriteTransaction;
 }  // namespace kv
+
+/// Final durability outcome delivered to backend-owned transaction effects.
+enum class FilesystemTransactionOutcome : std::uint8_t {
+	kCommitted,
+	kAborted,
+	kIndeterminate,
+};
+
+/// Backend-owned effects that must follow the durability outcome of one transaction.
+///
+/// The public filesystem layer deliberately does not know what an effect contains. A KV
+/// backend can use this object to stage cache changes while its transaction is active, apply
+/// them after a known commit, discard them after a definite abort, and reconcile them from
+/// durable state after an indeterminate commit.
+class FilesystemTransactionEffects {
+public:
+	FilesystemTransactionEffects() = default;
+	FilesystemTransactionEffects(const FilesystemTransactionEffects &) = delete;
+	FilesystemTransactionEffects &operator=(const FilesystemTransactionEffects &) = delete;
+	virtual ~FilesystemTransactionEffects() = default;
+
+	virtual void finish(FilesystemTransactionOutcome outcome) noexcept = 0;
+};
 
 /// Context for filesystem operations that may require database transactions.
 ///
@@ -71,8 +95,8 @@ public:
 	/// Move-only semantics (transactions cannot be copied)
 	FilesystemOperationContext(const FilesystemOperationContext &) = delete;
 	FilesystemOperationContext &operator=(const FilesystemOperationContext &) = delete;
-	FilesystemOperationContext(FilesystemOperationContext &&) = default;
-	FilesystemOperationContext &operator=(FilesystemOperationContext &&) = default;
+	FilesystemOperationContext(FilesystemOperationContext &&other) noexcept;
+	FilesystemOperationContext &operator=(FilesystemOperationContext &&other) noexcept;
 
 	/// Destructor.
 	/// Destroying the context releases any owned transaction objects and destroys the nodes
@@ -81,9 +105,7 @@ public:
 	/// before the context is destroyed.
 	/// Debug builds catch a committed context whose deferred changelog was not drained,
 	/// because dropping those entries would lose changelog, metalogger and notifier sinks.
-	~FilesystemOperationContext() {
-		assert(deferredChangelogEntries_.empty() || !commitConfirmed_);
-	}
+	~FilesystemOperationContext();
 
 	/// Returns true if this context has an active transaction
 	bool hasTransaction() const;
@@ -105,6 +127,31 @@ public:
 	/// destroyed.
 	std::unique_ptr<kv::IReadWriteTransaction> releaseReadWriteTransaction();
 
+	/// Returns the backend-owned effects object, or nullptr when none is attached.
+	FilesystemTransactionEffects *transactionEffects() const { return transactionEffects_.get(); }
+
+	/// Attaches the effects object for this transaction.
+	///
+	/// A context has one backend owner, so replacing an existing object is a programming
+	/// error. The object may be attached through a const operation seam because it is
+	/// transaction-local physical state, like nodeArena().
+	void setTransactionEffects(std::unique_ptr<FilesystemTransactionEffects> effects) const;
+
+	/// Delivers the transaction's final durability outcome exactly once.
+	///
+	/// Destroying an unfinished context delivers kAborted automatically. Callers must
+	/// explicitly deliver kIndeterminate because reconciliation can require backend reads.
+	void finishTransactionEffects(FilesystemTransactionOutcome outcome) const noexcept;
+
+	/// Commits the owned read-write transaction and finalizes backend effects from the
+	/// reported outcome. Returns true without work when the context has no transaction.
+	bool commitTransaction() const;
+
+	/// Finalizes backend effects after an externally driven synchronous or asynchronous
+	/// commit. The transaction's commitOutcomeUnknown() distinguishes a definite abort
+	/// from an indeterminate result.
+	void finishTransactionEffectsAfterCommit(bool committed) const noexcept;
+
 	/// Get the transaction type hint
 	TransactionType getTransactionType() const { return transactionType_; }
 
@@ -113,6 +160,15 @@ public:
 	/// const resolution seam, not a logical filesystem mutation.
 	/// @see FSNodeArena
 	FSNodeArena &nodeArena() const { return nodeArena_; }
+
+	/// Per-operation cache of decoded chunk-table bucket rows, keyed by (inode,
+	/// bucket); an empty vector caches an absent row. Only KV backends populate
+	/// it, mirroring their transaction's view so one operation reads each row at
+	/// most once. Mutable like nodeArena_: physical cache state shared through
+	/// the const resolution seam.
+	std::map<std::pair<inode_t, uint32_t>, std::vector<uint64_t>> &bucketRowCache() const {
+		return bucketRowCache_;
+	}
 
 	/// A changelog entry whose publication is held until the owning transaction commits.
 	struct DeferredChangelogEntry {
@@ -142,6 +198,16 @@ public:
 	/// Records that the transaction committed so the destructor catches an undrained buffer.
 	void confirmCommitted() const { commitConfirmed_ = true; }
 
+	/// Marks this context as the shared transaction of a client group-commit batch.
+	/// Batch bodies stage in-memory-derived blind writes long before the batch's
+	/// asynchronous commit is submitted; those writes must be conflict-checked (see
+	/// kv::IReadWriteTransaction::addReadConflictKey) or a synchronous commit landing
+	/// inside that window is silently overwritten by the stale staged value.
+	void setGroupCommitBatch() { groupCommitBatch_ = true; }
+
+	/// Returns true for the shared transaction of a client group-commit batch.
+	bool isGroupCommitBatch() const { return groupCommitBatch_; }
+
 private:
 	/// The active read-write transaction (if any)
 	std::unique_ptr<kv::IReadWriteTransaction> rwTransaction_ = nullptr;
@@ -156,12 +222,24 @@ private:
 	/// Mutable so the const seam can pin; see nodeArena().
 	mutable FSNodeArena nodeArena_;
 
+	/// See bucketRowCache(); mutable like nodeArena_.
+	mutable std::map<std::pair<inode_t, uint32_t>, std::vector<uint64_t>> bucketRowCache_;
+
 	/// See setDeferChangelog().
 	bool deferChangelog_ = false;
 
 	/// Changelog entries buffered for post-commit publication; mutable like nodeArena_.
 	mutable std::vector<DeferredChangelogEntry> deferredChangelogEntries_;
 
+	/// See setGroupCommitBatch().
+	bool groupCommitBatch_ = false;
+
 	/// See confirmCommitted(); mutable like the entry buffer it guards.
 	mutable bool commitConfirmed_ = false;
+
+	/// Type-erased backend effects whose lifetime is tied to the transaction.
+	mutable std::unique_ptr<FilesystemTransactionEffects> transactionEffects_;
+
+	/// Guards the exactly-once outcome contract.
+	mutable bool transactionEffectsFinished_ = false;
 };

--- a/src/master/filesystem_operations.cc
+++ b/src/master/filesystem_operations.cc
@@ -26,6 +26,7 @@
 #include <algorithm>
 #include <cstdarg>
 #include <cstdint>
+#include <limits>
 #include <sstream>
 #include <string_view>
 
@@ -60,6 +61,7 @@
 #include "master/recursive_remove_task.h"
 #include "master/task_manager.h"
 #include "metrics/metrics.h"
+#include "protocol/matocl.h"
 #include "slogger/slogger.h"
 
 inline bool isDepletedSpace() {
@@ -70,6 +72,14 @@ inline bool isDepletedSpace() {
 }
 
 static const int kInitialTaskBatchSize = 1000;
+
+static bool (*gCommitPipelineIdleCheck)() = nullptr;
+
+void fs_register_commit_pipeline_idle_check(bool (*check)()) { gCommitPipelineIdleCheck = check; }
+
+bool fs_commit_pipeline_idle() {
+	return gCommitPipelineIdleCheck == nullptr || gCommitPipelineIdleCheck();
+}
 
 FilesystemOperationsBase::FilesystemOperationsBase(
     std::unique_ptr<IFilesystemNodeOperations> _nodeOps)
@@ -151,6 +161,12 @@ void FilesystemOperationsBase::doEmptyTrash(uint32_t timeStamp) {
 		assert(node->type == FSNodeType::kTrash);
 
 		auto nodeId = node->id;
+		const uint8_t fenceStatus = nodeOperations()->canMutateFileChunks(
+		    fsOpContext, node, 0, std::numeric_limits<uint32_t>::max());
+		if (fenceStatus != SAUNAFS_STATUS_OK) {
+			++trashIter;
+			continue;
+		}
 		nodeOperations()->purge(fsOpContext, timeStamp, node);
 
 		// Purge operation should be performed anyway - if it fails, inode will be reserved
@@ -863,6 +879,10 @@ uint8_t FilesystemOperationsBase::undel(const FsContext &context, inode_t inode)
 
 	if (node->type != FSNodeType::kTrash) { return SAUNAFS_ERROR_ENOENT; }
 
+	status = nodeOperations_->canMutateFileChunks(fsOpContext, static_cast<FSNodeFile *>(node), 0,
+	                                              std::numeric_limits<uint32_t>::max());
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+
 	status = nodeOperations_->undel(fsOpContext, context.ts(), static_cast<FSNodeFile *>(node));
 	if (context.isPersonalityMaster()) {
 		if (status == SAUNAFS_STATUS_OK) {
@@ -873,7 +893,7 @@ uint8_t FilesystemOperationsBase::undel(const FsContext &context, inode_t inode)
 	}
 
 	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
-		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+		if (!fsOpContext.commitTransaction()) {
 			safs::log_err("undel: failed to commit transaction for inode {}", inode);
 			status = SAUNAFS_ERROR_IO;
 		}
@@ -897,6 +917,10 @@ uint8_t FilesystemOperationsBase::purge(const FsContext &context,
 	if (status != SAUNAFS_STATUS_OK) { return status; }
 
 	if (node->type != FSNodeType::kTrash) { return SAUNAFS_ERROR_ENOENT; }
+
+	status = nodeOperations_->canMutateFileChunks(fsOpContext, static_cast<FSNodeFile *>(node), 0,
+	                                              std::numeric_limits<uint32_t>::max());
+	if (status != SAUNAFS_STATUS_OK) { return status; }
 
 	// This should be equal to inode, because `node` is not a directory
 	inode_t purgedInode = node->id;
@@ -1275,12 +1299,27 @@ uint8_t FilesystemOperationsBase::trySetLength(const FsContext &context,
 
 	auto *fileNode = static_cast<FSNodeFile *>(node);
 
+	status = nodeOperations_->canMutateFileChunks(fsOpContext, fileNode, 0,
+	                                              std::numeric_limits<uint32_t>::max());
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+
+	// setLength() cannot report a refused shrink: it returns void and its caller
+	// has already truncated the boundary chunk. Ask the backend first, so a shrink
+	// it cannot release cleanly fails before anything is mutated or logged.
+	status = nodeOperations_->canTruncateFileChunks(fsOpContext, fileNode, length);
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+
 	if (length & SFSCHUNKMASK) {
 		uint32_t chunkIndex = (length >> SFSCHUNKBITS);
-		if (chunkIndex < fileNode->chunks.size()) {
-			uint64_t oldChunkId = fileNode->chunks[chunkIndex];
+		if (chunkIndex < nodeOperations_->getFileChunkTableSize(fsOpContext, fileNode)) {
+			// An unreadable boundary row would read as a hole and silently skip
+			// truncating the boundary chunk; fail the operation instead.
+			status = nodeOperations_->validateFileChunkRows(fsOpContext, fileNode, chunkIndex,
+			                                                chunkIndex + 1);
+			if (status != SAUNAFS_STATUS_OK) { return status; }
+			uint64_t oldChunkId =
+			    nodeOperations_->getFileChunkId(fsOpContext, fileNode, chunkIndex);
 			if (oldChunkId > 0) {
-				uint8_t status;
 				uint64_t newChunkId;
 				// We deny truncating parity only if truncating down
 				denyTruncatingParity = denyTruncatingParity && (length < fileNode->length);
@@ -1291,7 +1330,7 @@ uint8_t FilesystemOperationsBase::trySetLength(const FsContext &context,
 				    fsOpContext, oldChunkId, lockId, (length & SFSCHUNKMASK), node->goal,
 				    denyTruncatingParity, quotaCheck.exceeded, &newChunkId);
 				if (status != SAUNAFS_STATUS_OK) { return status; }
-				fileNode->chunks[chunkIndex] = newChunkId;
+				nodeOperations_->setFileChunkId(fsOpContext, fileNode, chunkIndex, newChunkId);
 				*chunkid = newChunkId;
 				changeLog(fsOpContext, timeStamp,
 				          "TRUNC(%" PRIiNode ",%" PRIu32 ",%" PRIu32 "):%" PRIu64, node->id,
@@ -1382,10 +1421,14 @@ uint8_t FilesystemOperationsBase::applyTrunc(const FilesystemOperationContext &f
 	}
 
 	if (indx > kMaxChunkIndex) { return SAUNAFS_ERROR_INDEXTOOBIG; }
+	status = nodeOperations_->canMutateFileChunks(fsOpContext, nodeFile, indx, indx + 1);
+	if (status != SAUNAFS_STATUS_OK) { return status; }
 
-	if (indx >= nodeFile->chunks.size()) { return SAUNAFS_ERROR_EINVAL; }
+	if (indx >= nodeOperations_->getFileChunkTableSize(fsOpContext, nodeFile)) {
+		return SAUNAFS_ERROR_EINVAL;
+	}
 
-	oldChunkId = nodeFile->chunks[indx];
+	oldChunkId = nodeOperations_->getFileChunkId(fsOpContext, nodeFile, indx);
 
 	if (oldChunkId == 0) {
 		safs::log_err("fs_apply_trunc: node does not have a chunk at index {} chunks, inode {}",
@@ -1400,7 +1443,7 @@ uint8_t FilesystemOperationsBase::applyTrunc(const FilesystemOperationContext &f
 
 	if (chunkid != newChunkId) { return SAUNAFS_ERROR_MISMATCH; }
 
-	nodeFile->chunks[indx] = newChunkId;
+	nodeOperations_->setFileChunkId(fsOpContext, nodeFile, indx, newChunkId);
 	gMetadata->metadataVersion++;
 	fsnodes_update_checksum(nodeFile);
 
@@ -1464,13 +1507,21 @@ uint8_t FilesystemOperationsBase::doSetLength(const FsContext &context,
 	                                              MODE_MASK_EMPTY, inode, &node);
 	if (status != SAUNAFS_STATUS_OK) { return status; }
 
+	auto *fileNode = static_cast<FSNodeFile *>(node);
+
+	status = nodeOperations_->canMutateFileChunks(fsOpContext, fileNode, 0,
+	                                              std::numeric_limits<uint32_t>::max());
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+
+	status = nodeOperations_->canTruncateFileChunks(fsOpContext, fileNode, length);
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+
 	// This function is called only when the file is being truncated, in
 	// matoclserv_chunk_status and in matoclserv_fuse_truncate. Therefore,
 	// eraseFurtherChunks should be set to true because we are setting the
 	// length of the file and we should erase further chunks.
 	bool eraseFurtherChunks = true;
-	nodeOperations_->setLength(fsOpContext, static_cast<FSNodeFile *>(node), length,
-	                           eraseFurtherChunks);
+	nodeOperations_->setLength(fsOpContext, fileNode, length, eraseFurtherChunks);
 	changeLog(fsOpContext, timeStamp, "LENGTH(%" PRIiNode ",%" PRIu64 ",%" PRIu32 ")", inode,
 	          static_cast<FSNodeFile *>(node)->length, static_cast<uint32_t>(eraseFurtherChunks));
 	node->mtime = timeStamp;
@@ -1682,9 +1733,12 @@ uint8_t FilesystemOperationsBase::applyLength(const FilesystemOperationContext &
 	    node->type != FSNodeType::kReserved) {
 		return SAUNAFS_ERROR_EINVAL;
 	}
+	auto *fileNode = static_cast<FSNodeFile *>(node);
+	const uint8_t fenceStatus = nodeOperations_->canMutateFileChunks(
+	    fsOpContext, fileNode, 0, std::numeric_limits<uint32_t>::max());
+	if (fenceStatus != SAUNAFS_STATUS_OK) { return fenceStatus; }
 
-	nodeOperations_->setLength(fsOpContext, static_cast<FSNodeFile *>(node), length,
-	                           eraseFurtherChunks);
+	nodeOperations_->setLength(fsOpContext, fileNode, length, eraseFurtherChunks);
 	node->mtime = timestamp;
 	nodeOperations_->updateCTime(fsOpContext, node, timestamp);
 	fsnodes_update_checksum(node);
@@ -2051,6 +2105,12 @@ uint8_t FilesystemOperationsBase::unlink(const FsContext &context,
 	}
 
 	if (child->type == FSNodeType::kDirectory) { return SAUNAFS_ERROR_EPERM; }
+	if (child->type == FSNodeType::kFile || child->type == FSNodeType::kTrash ||
+	    child->type == FSNodeType::kReserved) {
+		status = nodeOperations_->canMutateFileChunks(fsOpContext, static_cast<FSNodeFile *>(child),
+		                                              0, std::numeric_limits<uint32_t>::max());
+		if (status != SAUNAFS_STATUS_OK) { return status; }
+	}
 
 	changeLog(fsOpContext, timeStamp, "UNLINK(%" PRIiNode ",%s):%" PRIiNode, workDir->id,
 	          nodeOperations_->escapeName(baseName).c_str(), child->id);
@@ -2162,12 +2222,18 @@ uint8_t FilesystemOperationsBase::applyUnlink(const FilesystemOperationContext &
 	    !static_cast<FSNodeDirectory *>(child)->entries.empty()) {
 		return SAUNAFS_ERROR_ENOTEMPTY;
 	}
+	if (child->type == FSNodeType::kFile || child->type == FSNodeType::kTrash ||
+	    child->type == FSNodeType::kReserved) {
+		const uint8_t status = nodeOperations_->canMutateFileChunks(
+		    fsOpContext, static_cast<FSNodeFile *>(child), 0, std::numeric_limits<uint32_t>::max());
+		if (status != SAUNAFS_STATUS_OK) { return status; }
+	}
 
 	nodeOperations_->unlink(fsOpContext, timestamp, static_cast<FSNodeDirectory *>(workDir), name,
 	                        child);
 
 	// Commit the transaction
-	if (fsOpContext.hasReadWriteTransaction() && !fsOpContext.getReadWriteTransaction()->commit()) {
+	if (fsOpContext.hasReadWriteTransaction() && !fsOpContext.commitTransaction()) {
 		safs::log_err("applyUnlink: failed to commit transaction");
 
 		return SAUNAFS_ERROR_IO;
@@ -2289,6 +2355,14 @@ uint8_t FilesystemOperationsBase::rename(const FsContext &context,
 	if (quotaStatus != SAUNAFS_STATUS_OK) { return quotaStatus; }
 
 	if (destinationChildNode != kNodeNotFound) {
+		if (destinationChildNode->type == FSNodeType::kFile ||
+		    destinationChildNode->type == FSNodeType::kTrash ||
+		    destinationChildNode->type == FSNodeType::kReserved) {
+			status = nodeOperations_->canMutateFileChunks(
+			    fsOpContext, static_cast<FSNodeFile *>(destinationChildNode), 0,
+			    std::numeric_limits<uint32_t>::max());
+			if (status != SAUNAFS_STATUS_OK) { return status; }
+		}
 		nodeOperations_->unlink(fsOpContext, context.ts(), destWorkDir, baseNameDst,
 		                        destinationChildNode);
 	}
@@ -2400,6 +2474,15 @@ uint8_t FilesystemOperationsBase::append(const FsContext &context,
 
 	if (status != SAUNAFS_STATUS_OK) { return status; }
 
+	status =
+	    nodeOperations_->canMutateFileChunks(fsOpContext, static_cast<FSNodeFile *>(targetNode), 0,
+	                                         std::numeric_limits<uint32_t>::max());
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+	status =
+	    nodeOperations_->canMutateFileChunks(fsOpContext, static_cast<FSNodeFile *>(sourceNode), 0,
+	                                         std::numeric_limits<uint32_t>::max());
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+
 	if (context.isPersonalityMaster()) {
 		uint8_t quotaStatus = statusFromQuotaCheck(
 		    quotaExceeded(fsOpContext, targetNode, {{QuotaResource::kSize, 1}}));
@@ -2421,6 +2504,19 @@ uint8_t FilesystemOperationsBase::append(const FsContext &context,
 		          sourceNode->id);
 	} else {
 		gMetadata->metadataVersion++;
+	}
+	return status;
+}
+
+uint8_t FilesystemOperationsBase::appendAsync(
+    const FsContext &context, inode_t inode, inode_t sourceInode,
+    [[maybe_unused]] const std::function<void(int)> &callback) {
+	auto fsOpContext =
+	    createFilesystemOperationContext(FilesystemOperationContext::TransactionType::kReadWrite);
+	uint8_t status = append(context, fsOpContext, inode, sourceInode);
+	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction() &&
+	    !fsOpContext.commitTransaction()) {
+		status = SAUNAFS_ERROR_IO;
 	}
 	return status;
 }
@@ -2806,8 +2902,14 @@ uint8_t FilesystemOperationsBase::checkFile(const FsContext &context, inode_t in
 
 	if (status != SAUNAFS_STATUS_OK) { return status; }
 
-	nodeOperations_->checkFile(static_cast<FSNodeFile *>(node), chunkCount);
+	nodeOperations_->checkFile(fsOpContext, static_cast<FSNodeFile *>(node), chunkCount);
 	return SAUNAFS_STATUS_OK;
+}
+
+uint8_t FilesystemOperationsBase::checkFileAsync(
+    const FsContext &context, inode_t inode, std::shared_ptr<ChunkCountArray> chunkCount,
+    [[maybe_unused]] const std::function<void(int)> &callback) {
+	return checkFile(context, inode, *chunkCount);
 }
 
 uint8_t FilesystemOperationsBase::openCheck(const FsContext &context,
@@ -2900,6 +3002,11 @@ uint8_t FilesystemOperationsBase::release(const FsContext &context,
 	auto iter = std::find(fileNode->sessionIds.begin(), fileNode->sessionIds.end(), sessionid);
 
 	if (iter != fileNode->sessionIds.end()) {
+		if (fileNode->type == FSNodeType::kReserved && fileNode->sessionIds.size() == 1) {
+			const uint8_t fenceStatus = nodeOperations_->canMutateFileChunks(
+			    fsOpContext, fileNode, 0, std::numeric_limits<uint32_t>::max());
+			if (fenceStatus != SAUNAFS_STATUS_OK) { return fenceStatus; }
+		}
 		fileNode->sessionIds.erase(iter);
 
 		if (fileNode->type == FSNodeType::kReserved && fileNode->sessionIds.empty()) {
@@ -2960,12 +3067,41 @@ uint8_t FilesystemOperationsBase::applySession(uint32_t sessionid) {
 }
 
 #ifndef METARESTORE
-uint8_t fs_auto_repair_if_needed(FSNodeFile *p, uint32_t chunkIndex) {
-	uint64_t chunkId = (chunkIndex < p->chunks.size() ? p->chunks[chunkIndex] : 0);
+uint8_t fs_auto_repair_if_needed(const FilesystemOperationContext &fsOpContext, FSNodeFile *p,
+                                 uint32_t chunkIndex) {
+	uint64_t chunkId = gFSOperations->nodeOperations()->getFileChunkId(fsOpContext, p, chunkIndex);
 	if (chunkId != 0 && gChunkOperations->hasOnlyInvalidCopies(chunkId)) {
-		uint32_t notchanged, erased, repaired;
 		FsContext context =
 		    FsContext::getForMasterWithSession(0, SPECIAL_INODE_ROOT, 0, 0, 0, 0, 0);
+
+		// A transactional backend must not run the synchronous whole-table repair
+		// inside the caller's transaction. Its async seam starts the same bounded
+		// durable executor used by filerepair. Small repairs may finish inline.
+		if (fsOpContext.hasReadWriteTransaction()) {
+			auto stats = std::make_shared<FileRepairStats>();
+			auto report = [inode = p->id, chunkId, stats](int status) {
+				if (status != SAUNAFS_STATUS_OK) {
+					if (status != SAUNAFS_ERROR_LOCKED) {
+						safs::log_warn(
+						    "bounded automatic repair failed for inode {} chunk {:#016x}: {}",
+						    inode, chunkId, status);
+					}
+					return;
+				}
+				safs_pretty_syslog(
+				    LOG_NOTICE,
+				    "auto repair inode %" PRIiNode ", chunk %016" PRIX64 ": not changed: %" PRIu32
+				    ", erased: %" PRIu32 ", repaired: %" PRIu32,
+				    inode, chunkId, stats->notChanged, stats->erased, stats->repaired);
+				safs_silent_syslog(LOG_DEBUG,
+				                   "master.fs.file_auto_repaired: %" PRIiNode " %" PRIu32, inode,
+				                   stats->repaired);
+			};
+			const uint8_t status = gFSOperations->repairAsync(context, p->id, 0, stats, report);
+			if (status != SAUNAFS_ERROR_WAITING) { report(status); }
+			return SAUNAFS_STATUS_OK;
+		}
+		uint32_t notchanged, erased, repaired;
 		gFSOperations->repair(context, p->id, 0, &notchanged, &erased, &repaired);
 		safs_pretty_syslog(LOG_NOTICE,
 		                   "auto repair inode %" PRIiNode ", chunk %016" PRIX64
@@ -2996,9 +3132,9 @@ uint8_t FilesystemOperationsBase::readChunk(const FilesystemOperationContext &fs
 
 	if (indx > kMaxChunkIndex) { return SAUNAFS_ERROR_INDEXTOOBIG; }
 #ifndef METARESTORE
-	if (gMagicAutoFileRepair) { fs_auto_repair_if_needed(nodeFile, indx); }
+	if (gMagicAutoFileRepair) { fs_auto_repair_if_needed(fsOpContext, nodeFile, indx); }
 #endif
-	if (indx < nodeFile->chunks.size()) { *chunkid = nodeFile->chunks[indx]; }
+	*chunkid = nodeOperations_->getFileChunkId(fsOpContext, nodeFile, indx);
 	*length = nodeFile->length;
 	fs_update_atime(fsOpContext, nodeFile, timeStamp);
 	incrementFSStat(FsStats::Read);
@@ -3030,10 +3166,12 @@ uint8_t FilesystemOperationsBase::writeChunk(const FsContext &context,
 	if (index > kMaxChunkIndex) { return SAUNAFS_ERROR_INDEXTOOBIG; }
 
 	auto *fileNode = static_cast<FSNodeFile *>(node);
+	status = nodeOperations_->canMutateFileChunks(fsOpContext, fileNode, index, index + 1);
+	if (status != SAUNAFS_STATUS_OK) { return status; }
 
 #ifndef METARESTORE
 	if (gMagicAutoFileRepair && context.isPersonalityMaster()) {
-		fs_auto_repair_if_needed(fileNode, index);
+		fs_auto_repair_if_needed(fsOpContext, fileNode, index);
 	}
 #endif
 
@@ -3041,12 +3179,18 @@ uint8_t FilesystemOperationsBase::writeChunk(const FsContext &context,
 	if (quotaCheck.status != SAUNAFS_STATUS_OK) { return quotaCheck.status; }
 	const bool isQuotaExceeded = quotaCheck.exceeded;
 
+	// An unreadable row covering this index must fail the write here, before any
+	// chunk is created: setFileChunkId refuses such a row, and acknowledging the
+	// write without the recorded mapping would lose the data silently.
+	status = nodeOperations_->validateFileChunkRows(fsOpContext, fileNode, index, index + 1);
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+
 	// Cache original stats for quota and parent update
 	StatsRecord originalStats;
 	nodeOperations_->getStats(fsOpContext, fileNode, &originalStats);
 
 	/* resize chunks structure */
-	if (index >= fileNode->chunks.size()) {
+	if (index >= nodeOperations_->getFileChunkTableSize(fsOpContext, fileNode)) {
 		if (context.isPersonalityMaster() && isQuotaExceeded) { return SAUNAFS_ERROR_QUOTA; }
 		uint32_t newSize;
 		if (index < 8) {
@@ -3057,10 +3201,12 @@ uint8_t FilesystemOperationsBase::writeChunk(const FsContext &context,
 			newSize = (index & 0xFFFFFFC0) + 64;
 		}
 		assert(newSize > index);
-		fileNode->chunks.resize(newSize, 0);
+		status = nodeOperations_->canGrowFileChunkTable(fsOpContext, fileNode, index + 1);
+		if (status != SAUNAFS_STATUS_OK) { return status; }
+		nodeOperations_->growFileChunkTable(fsOpContext, fileNode, newSize);
 	}
 
-	oldChunkId = fileNode->chunks[index];
+	oldChunkId = nodeOperations_->getFileChunkId(fsOpContext, fileNode, index);
 	if (context.isPersonalityMaster()) {
 #ifndef METARESTORE
 		status =
@@ -3085,7 +3231,7 @@ uint8_t FilesystemOperationsBase::writeChunk(const FsContext &context,
 		return SAUNAFS_ERROR_MISMATCH;
 	}
 
-	fileNode->chunks[index] = newChunkId;
+	nodeOperations_->setFileChunkId(fsOpContext, fileNode, index, newChunkId);
 	*chunkid = newChunkId;
 
 	// Propagate size changes to parent directories
@@ -3140,6 +3286,14 @@ uint8_t FilesystemOperationsBase::writeEnd(const FilesystemOperationContext &fsO
 		}
 
 		if (length > nodeFile->length) {
+			const uint64_t tableEnd = (length - 1) / SFSCHUNKSIZE + 1;
+			if (tableEnd > static_cast<uint64_t>(kMaxChunkIndex) + 1) {
+				return SAUNAFS_ERROR_INDEXTOOBIG;
+			}
+			status = nodeOperations_->canMutateFileChunks(fsOpContext, nodeFile, 0,
+			                                              static_cast<uint32_t>(tableEnd));
+			if (status != SAUNAFS_STATUS_OK) { return status; }
+
 			// eraseFurtherChunks should be set to false because we don't want
 			// to erase the further chunks while we are write operations. The
 			// reason is that those might be done by other clients and we don't
@@ -3182,7 +3336,8 @@ uint8_t FilesystemOperationsBase::applyIncreaseChunkVersion(
 #ifndef METARESTORE
 uint8_t FilesystemOperationsBase::removeChunkFromFile(const FsContext &context,
                                                       const FilesystemOperationContext &fsOpContext,
-                                                      inode_t inode, uint64_t chunkId) {
+                                                      inode_t inode, uint32_t chunkIndex,
+                                                      uint64_t chunkId) {
 	uint32_t timeStamp = eventloop_time();
 	ChecksumUpdater checksumUpdater(timeStamp);
 	StatsRecord previousStats;
@@ -3201,18 +3356,22 @@ uint8_t FilesystemOperationsBase::removeChunkFromFile(const FsContext &context,
 
 	auto *fileNode = dynamic_cast<FSNodeFile *>(nodeFile);
 	nodeOperations_->getStats(fsOpContext, nodeFile, &previousStats);
-	auto chunkIter = std::ranges::find(fileNode->chunks, chunkId);
-	uint32_t chunkIndex = (chunkIter == fileNode->chunks.end())
-	                          ? fileNode->chunks.size()
-	                          : std::distance(fileNode->chunks.begin(), chunkIter);
 
-	// not found
-	if (chunkIndex == fileNode->chunks.size()) { return SAUNAFS_ERROR_NOCHUNK; }
+	status =
+	    nodeOperations_->canMutateFileChunks(fsOpContext, fileNode, chunkIndex, chunkIndex + 1);
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+
+	status =
+	    nodeOperations_->validateFileChunkRows(fsOpContext, fileNode, chunkIndex, chunkIndex + 1);
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+	if (nodeOperations_->getFileChunkId(fsOpContext, fileNode, chunkIndex) != chunkId) {
+		return SAUNAFS_ERROR_NOCHUNK;
+	}
 
 	status = gChunkOperations->deleteFile(fsOpContext, chunkId, nodeFile->goal);
 	if (status != SAUNAFS_STATUS_OK) { return status; }
 
-	fileNode->chunks[chunkIndex] = 0;
+	nodeOperations_->setFileChunkId(fsOpContext, fileNode, chunkIndex, 0);
 	nodeFile->mtime = timeStamp;
 	nodeOperations_->updateCTime(fsOpContext, nodeFile, timeStamp);
 
@@ -3226,6 +3385,11 @@ uint8_t FilesystemOperationsBase::removeChunkFromFile(const FsContext &context,
 	quotaUpdate(fsOpContext, nodeFile,
 	            {{QuotaResource::kSize, newStats.size - previousStats.size}});
 	fsnodes_update_checksum(nodeFile);
+
+	// Make the chunk-table and mtime edits persistent for KV backends
+	if (fsOpContext.hasReadWriteTransaction()) {
+		nodeOperations_->updateNode(fsOpContext, nodeFile);
+	}
 	return SAUNAFS_STATUS_OK;
 }
 #endif /* #ifndef METARESTORE */
@@ -3237,7 +3401,6 @@ uint8_t FilesystemOperationsBase::repair(const FsContext &context, inode_t inode
 	uint32_t timeStamp = eventloop_time();
 	ChecksumUpdater checksumUpdater(timeStamp);
 	uint32_t newVersion;
-	uint32_t chunkIndex;
 	StatsRecord previousStats;
 	StatsRecord newStats;
 	FSNode *node;
@@ -3259,24 +3422,40 @@ uint8_t FilesystemOperationsBase::repair(const FsContext &context, inode_t inode
 	if (status != SAUNAFS_STATUS_OK) { return status; }
 
 	auto *fileNode = static_cast<FSNodeFile *>(node);
+	status = nodeOperations_->canMutateFileChunks(fsOpContext, fileNode, 0,
+	                                              std::numeric_limits<uint32_t>::max());
+	if (status != SAUNAFS_STATUS_OK) { return status; }
 	nodeOperations_->getStats(fsOpContext, node, &previousStats);
-	for (chunkIndex = 0; chunkIndex < fileNode->chunks.size(); chunkIndex++) {
-		if (gChunkOperations->repair(fsOpContext, node->goal, fileNode->chunks[chunkIndex],
-		                             &newVersion, correct_only)) {
-			changeLog(fsOpContext, timeStamp, "REPAIR(%" PRIiNode ",%" PRIu32 "):%" PRIu32, inode,
-			          chunkIndex, newVersion);
-			node->mtime = timeStamp;
-			nodeOperations_->updateCTime(fsOpContext, node, timeStamp);
-			if (newVersion > 0) {
-				(*repaired)++;
-			} else {
-				fileNode->chunks[chunkIndex] = 0;
-				(*erased)++;
-			}
-		} else {
-			(*notchanged)++;
-		}
-	}
+	const uint32_t chunkTableSize = nodeOperations_->getFileChunkTableSize(fsOpContext, fileNode);
+
+	// An unreadable row reads as holes, which repair would count as untouched
+	// slots while mutating the rest of the table; fail before changing anything.
+	status = nodeOperations_->validateFileChunkRows(fsOpContext, fileNode, 0, chunkTableSize);
+	if (status != SAUNAFS_STATUS_OK) { return status; }
+
+	uint32_t liveChunksVisited = 0;
+	nodeOperations_->forEachFileChunk(
+	    fsOpContext, fileNode, 0, [&](uint32_t index, uint64_t chunkId) {
+		    liveChunksVisited++;
+		    if (gChunkOperations->repair(fsOpContext, node->goal, chunkId, &newVersion,
+		                                 correct_only)) {
+			    changeLog(fsOpContext, timeStamp, "REPAIR(%" PRIiNode ",%" PRIu32 "):%" PRIu32,
+			              inode, index, newVersion);
+			    node->mtime = timeStamp;
+			    nodeOperations_->updateCTime(fsOpContext, node, timeStamp);
+			    if (newVersion > 0) {
+				    (*repaired)++;
+			    } else {
+				    nodeOperations_->setFileChunkId(fsOpContext, fileNode, index, 0);
+				    (*erased)++;
+			    }
+		    } else {
+			    (*notchanged)++;
+		    }
+		    return true;
+	    });
+	// Hole slots always count as "not changed" (repairing chunk id 0 is a no-op).
+	*notchanged += chunkTableSize - liveChunksVisited;
 	if (*erased > 0 || *repaired > 0) {
 		// Chunk-table and mtime edits only touch the materialized node on KV.
 		// Persist them; in-memory backend already stores the node itself.
@@ -3287,7 +3466,7 @@ uint8_t FilesystemOperationsBase::repair(const FsContext &context, inode_t inode
 	quotaUpdate(fsOpContext, node, {{QuotaResource::kSize, newStats.size - previousStats.size}});
 	fsnodes_update_checksum(node);
 
-	if (fsOpContext.hasReadWriteTransaction() && !fsOpContext.getReadWriteTransaction()->commit()) {
+	if (fsOpContext.hasReadWriteTransaction() && !fsOpContext.commitTransaction()) {
 		safs::log_err("{}: failed to commit transaction for inode {}", __func__, inode);
 		return SAUNAFS_ERROR_IO;
 	}
@@ -3312,14 +3491,18 @@ uint8_t FilesystemOperationsBase::applyRepair(const FilesystemOperationContext &
 	}
 
 	if (indx > kMaxChunkIndex) { return SAUNAFS_ERROR_INDEXTOOBIG; }
+	status = nodeOperations_->canMutateFileChunks(fsOpContext, nodeFile, indx, indx + 1);
+	if (status != SAUNAFS_STATUS_OK) { return status; }
 
-	if (indx >= nodeFile->chunks.size()) {
+	const uint32_t chunkTableSize = nodeOperations_->getFileChunkTableSize(fsOpContext, nodeFile);
+	if (indx >= chunkTableSize) {
 		safs::log_err("fs_apply_repair: indx {} is greater than number of chunks ({}), inode {}",
-		              indx, nodeFile->chunks.size(), inode);
+		              indx, chunkTableSize, inode);
 		return SAUNAFS_ERROR_NOCHUNK;
 	}
 
-	if (nodeFile->chunks[indx] == 0) {
+	const uint64_t chunkId = nodeOperations_->getFileChunkId(fsOpContext, nodeFile, indx);
+	if (chunkId == 0) {
 		safs::log_err("fs_apply_repair: node chunks at index {} has no chunks, inode {}", indx,
 		              inode);
 		return SAUNAFS_ERROR_NOCHUNK;
@@ -3328,10 +3511,10 @@ uint8_t FilesystemOperationsBase::applyRepair(const FilesystemOperationContext &
 	nodeOperations_->getStats(fsOpContext, nodeFile, &previousStats);
 
 	if (nversion == 0) {
-		status = gChunkOperations->deleteFile(fsOpContext, nodeFile->chunks[indx], nodeFile->goal);
-		nodeFile->chunks[indx] = 0;
+		status = gChunkOperations->deleteFile(fsOpContext, chunkId, nodeFile->goal);
+		nodeOperations_->setFileChunkId(fsOpContext, nodeFile, indx, 0);
 	} else {
-		status = gChunkOperations->setVersion(fsOpContext, nodeFile->chunks[indx], nversion);
+		status = gChunkOperations->setVersion(fsOpContext, chunkId, nversion);
 	}
 
 	nodeOperations_->getStats(fsOpContext, nodeFile, &newStats);
@@ -3371,6 +3554,14 @@ uint8_t FilesystemOperationsBase::getGoal(const FsContext &context,
 	nodeOperations_->getGoalRecursive(fsOpContext, node, gmode, fgtab, dgtab);
 
 	return SAUNAFS_STATUS_OK;
+}
+
+uint8_t FilesystemOperationsBase::repairAsync(
+    const FsContext &context, inode_t inode, uint8_t correctOnly,
+    std::shared_ptr<FileRepairStats> stats,
+    [[maybe_unused]] const std::function<void(int)> &callback) {
+	return repair(context, inode, correctOnly, &stats->notChanged, &stats->erased,
+	              &stats->repaired);
 }
 
 uint8_t FilesystemOperationsBase::getTrashTimePrepare(const FsContext &context, inode_t inode,
@@ -3595,7 +3786,7 @@ uint8_t FilesystemOperationsBase::applySetTrashTime(const FsContext &context, in
 	if (master_result != myResult) { return SAUNAFS_ERROR_MISMATCH; }
 	if (myResult == SetTrashtimeTask::kChanged && fsOpContext.hasReadWriteTransaction()) {
 		nodeOperations_->updateNode(fsOpContext, node);
-		if (!fsOpContext.getReadWriteTransaction()->commit()) { return SAUNAFS_ERROR_IO; }
+		if (!fsOpContext.commitTransaction()) { return SAUNAFS_ERROR_IO; }
 	}
 
 	return SAUNAFS_STATUS_OK;
@@ -4033,11 +4224,7 @@ uint8_t FilesystemOperationsBase::getChunkId(const FsContext &context,
 	auto *fileNode = static_cast<FSNodeFile *>(node);
 	if (status != SAUNAFS_STATUS_OK) { return status; }
 	if (index > kMaxChunkIndex) { return SAUNAFS_ERROR_INDEXTOOBIG; }
-	if (index < fileNode->chunks.size()) {
-		*chunkid = fileNode->chunks[index];
-	} else {
-		*chunkid = 0;
-	}
+	*chunkid = nodeOperations_->getFileChunkId(fsOpContext, fileNode, index);
 	return SAUNAFS_STATUS_OK;
 }
 #endif
@@ -4128,11 +4315,17 @@ uint8_t FilesystemOperationsBase::getChunksInfo(const FsContext &context, uint32
 
 	std::vector<ChunkPartWithAddressAndLabel> chunkParts;
 
-	if (chunk_count == 0) { chunk_count = fileNode->chunks.size(); }
+	const uint32_t chunkTableSize = nodeOperations_->getFileChunkTableSize(fsOpContext, fileNode);
+	if (chunk_count == 0) { chunk_count = chunkTableSize; }
+	// The wire handler clamps too; this guards direct callers against materializing a
+	// huge file's whole table (a sparse 1 PiB file would allocate a ~128 MiB vector).
+	chunk_count = std::min(chunk_count, matocl::chunksInfo::kMaxNumberOfResultEntries);
+
+	std::vector<uint64_t> chunkIds;
+	nodeOperations_->getFileChunkIds(fsOpContext, fileNode, chunk_index, chunk_count, chunkIds);
 
 	chunks.clear();
-	while (chunk_index < fileNode->chunks.size() && chunk_count > 0) {
-		uint64_t chunkId = fileNode->chunks[chunk_index];
+	for (uint64_t chunkId : chunkIds) {
 		uint32_t chunkVersion = 0;
 		chunkParts.clear();
 
@@ -4143,8 +4336,6 @@ uint8_t FilesystemOperationsBase::getChunksInfo(const FsContext &context, uint32
 		}
 
 		chunks.emplace_back(chunkId, chunkVersion, std::move(chunkParts));
-		chunk_index++;
-		chunk_count--;
 	}
 
 	return SAUNAFS_STATUS_OK;

--- a/src/master/filesystem_operations.h
+++ b/src/master/filesystem_operations.h
@@ -65,6 +65,16 @@ public:
 		return {};
 	}
 
+	TaskManager::Task *createSnapshotTask(SnapshotTask::SubtaskContainer &&subtasks,
+	                                      inode_t originalInode, inode_t destinationParentInode,
+	                                      inode_t destinationInode, uint8_t canOverwrite,
+	                                      uint8_t ignoreMissingSource, bool emitChangelog,
+	                                      bool enqueueWork) override {
+		return new SnapshotTask(std::move(subtasks), originalInode, destinationParentInode,
+		                        destinationInode, canOverwrite, ignoreMissingSource, emitChangelog,
+		                        enqueueWork);
+	}
+
 	/// Returns version of the loaded metadata.
 	uint64_t getMetadataVersion() override;
 
@@ -94,6 +104,8 @@ public:
 	/// @see IFilesystemOperations::append
 	uint8_t append(const FsContext &context, const FilesystemOperationContext &fsOpContext,
 	               inode_t inode, inode_t inode_src) override;
+	uint8_t appendAsync(const FsContext &context, inode_t inode, inode_t sourceInode,
+	                    const std::function<void(int)> &callback) override;
 
 	/// Removes or prunes the ACL stored on a node, given its inode.
 	/// @see IFilesystemOperations::deleteAcl
@@ -255,12 +267,15 @@ public:
 	/// @see IFilesystemOperations::removeChunkFromFile
 	uint8_t removeChunkFromFile(const FsContext &context,
 	                            const FilesystemOperationContext &fsOpContext, inode_t inode,
-	                            uint64_t chunkId) override;
+	                            uint32_t chunkIndex, uint64_t chunkId) override;
 
 	/// Scans and repairs chunk metadata for a file-like node.
 	/// @see IFilesystemOperations::repair
 	uint8_t repair(const FsContext &context, inode_t inode, uint8_t correct_only,
 	               uint32_t *notchanged, uint32_t *erased, uint32_t *repaired) override;
+	uint8_t repairAsync(const FsContext &context, inode_t inode, uint8_t correctOnly,
+	                    std::shared_ptr<FileRepairStats> stats,
+	                    const std::function<void(int)> &callback) override;
 
 	/// Removes an empty directory from the filesystem.
 	/// @see IFilesystemOperations::rmdir
@@ -290,6 +305,9 @@ public:
 
 	uint8_t checkFile(const FsContext &context, inode_t inode,
 	                  ChunkCountArray &chunkCount) override;
+	uint8_t checkFileAsync(const FsContext &context, inode_t inode,
+	                       std::shared_ptr<ChunkCountArray> chunkCount,
+	                       const std::function<void(int)> &callback) override;
 	uint8_t openCheck(const FsContext &context, const FilesystemOperationContext &fsOpContext,
 	                  inode_t inode, uint8_t flags, Attributes &attr) override;
 	uint8_t getGoal(const FsContext &context, const FilesystemOperationContext &fsOpContext,
@@ -435,6 +453,10 @@ public:
 	/// of whether those sessions are still active.
 	/// @see IFilesystemOperations::doEmptyReserved
 	void doEmptyReserved(uint32_t timeStamp) override;
+
+	/// No-op: the in-memory backend completes file operations synchronously.
+	/// @see IFilesystemOperations::drainPendingFileOperations
+	void drainPendingFileOperations([[maybe_unused]] uint32_t timeStamp) override {}
 #endif
 
 	// QUOTAS
@@ -714,3 +736,13 @@ private:
 	/// Node operations object
 	std::unique_ptr<IFilesystemNodeOperations> nodeOperations_;
 };
+
+/// Registers the check consulted by fs_commit_pipeline_idle. The client-server
+/// layer registers its group-commit pipeline state at init; nothing registered
+/// means no pipeline exists and the state reads idle.
+void fs_register_commit_pipeline_idle_check(bool (*check)());
+
+/// True when no client group-commit batch is open, held, or in flight.
+/// Background maintenance whose own transactions must not commit between a
+/// batch's staged writes and that batch's commit consults this before writing.
+bool fs_commit_pipeline_idle();

--- a/src/master/filesystem_operations_interface.h
+++ b/src/master/filesystem_operations_interface.h
@@ -40,6 +40,7 @@
 #include "master/locks.h"
 #include "master/setgoal_task.h"
 #include "master/settrashtime_task.h"
+#include "master/snapshot_task.h"
 #include "protocol/quota.h"
 
 class HString;
@@ -51,6 +52,13 @@ struct ChunkWithAddressAndLabel;
 
 struct QuotaEntry;
 struct QuotaOwner;
+
+/// Counts chunk slots left unchanged, erased, and repaired by a file repair.
+struct FileRepairStats {
+	uint32_t notChanged = 0;
+	uint32_t erased = 0;
+	uint32_t repaired = 0;
+};
 
 /// Result of a quota enforcement check. Fallible backends must report quota read failures
 /// through status, because a KV backend read error may not reliably fail the later commit.
@@ -121,6 +129,14 @@ public:
 	/// In-memory implementation should return a context without transactions.
 	virtual FilesystemOperationContext createFilesystemOperationContext(
 	    FilesystemOperationContext::TransactionType type) = 0;
+
+	/// Creates one snapshot task for the active metadata backend.
+	virtual TaskManager::Task *createSnapshotTask(SnapshotTask::SubtaskContainer &&subtasks,
+	                                              inode_t originalInode,
+	                                              inode_t destinationParentInode,
+	                                              inode_t destinationInode, uint8_t canOverwrite,
+	                                              uint8_t ignoreMissingSource, bool emitChangelog,
+	                                              bool enqueueWork) = 0;
 
 	/// Returns version of the loaded metadata.
 	virtual uint64_t getMetadataVersion() = 0;
@@ -244,6 +260,13 @@ public:
 	/// @return SAUNAFS_ERROR_INDEXTOOBIG if the resulting chunk index range would overflow.
 	virtual uint8_t append(const FsContext &context, const FilesystemOperationContext &fsOpContext,
 	                       inode_t inode, inode_t inode_src) = 0;
+
+	/// Asynchronous append seam for backends that require bounded transactions.
+	///
+	/// A synchronous implementation returns its final status and does not invoke callback.
+	/// A deferred implementation returns SAUNAFS_ERROR_WAITING and invokes callback once.
+	virtual uint8_t appendAsync(const FsContext &context, inode_t inode, inode_t sourceInode,
+	                            const std::function<void(int)> &callback) = 0;
 
 	/// Removes or prunes the ACL stored on a node, given its inode.
 	///
@@ -1135,12 +1158,14 @@ public:
 	///
 	/// Used to roll back a chunk allocation after chunkserver-side work fails. Verifies a
 	/// read-write session, resolves `inode` as a writable file-like node, locates the first slot
-	/// equal to `chunkId`, drops the file's reference in chunk metadata, clears that slot, and
+	/// verifies the exact slot equals `chunkId`, drops the file's reference in chunk metadata,
+	/// clears that slot, and
 	/// logs `REPAIR(inode,index):0`.
 	///
 	/// @param context The FS operation context (user credentials, session flags, timestamp).
 	/// @param fsOpContext The operation context (read-write transaction in KV backends).
 	/// @param inode The file-like node to update.
+	/// @param chunkIndex The exact slot allocated by the failed write.
 	/// @param chunkId The chunk id to remove. Must be non-zero.
 	/// @return SAUNAFS_STATUS_OK on success.
 	/// @return SAUNAFS_ERROR_NOCHUNK if `chunkId` is zero, absent from the file layout, or absent
@@ -1152,7 +1177,7 @@ public:
 	/// @return SAUNAFS_ERROR_CHUNKLOST if chunk metadata cannot remove the file reference cleanly.
 	virtual uint8_t removeChunkFromFile(const FsContext &context,
 	                                    const FilesystemOperationContext &fsOpContext,
-	                                    inode_t inode, uint64_t chunkId) = 0;
+	                                    inode_t inode, uint32_t chunkIndex, uint64_t chunkId) = 0;
 
 	/// Scans and repairs chunk metadata for a file-like node.
 	///
@@ -1175,6 +1200,11 @@ public:
 	/// @return SAUNAFS_ERROR_ENOENT if the inode cannot be resolved.
 	virtual uint8_t repair(const FsContext &context, inode_t inode, uint8_t correct_only,
 	                       uint32_t *notchanged, uint32_t *erased, uint32_t *repaired) = 0;
+
+	/// Asynchronous repair seam for backends that require bounded transactions.
+	virtual uint8_t repairAsync(const FsContext &context, inode_t inode, uint8_t correctOnly,
+	                            std::shared_ptr<FileRepairStats> stats,
+	                            const std::function<void(int)> &callback) = 0;
 
 	/// Removes an empty directory from the filesystem.
 	///
@@ -1307,6 +1337,10 @@ public:
 
 	virtual uint8_t checkFile(const FsContext &context, inode_t inode,
 	                          ChunkCountArray &chunkCount) = 0;
+	/// Asynchronous check seam for backends that page a large file across task turns.
+	virtual uint8_t checkFileAsync(const FsContext &context, inode_t inode,
+	                               std::shared_ptr<ChunkCountArray> chunkCount,
+	                               const std::function<void(int)> &callback) = 0;
 	virtual uint8_t openCheck(const FsContext &context,
 	                          const FilesystemOperationContext &fsOpContext, inode_t inode,
 	                          uint8_t flags, Attributes &attr) = 0;
@@ -1864,6 +1898,14 @@ public:
 	///
 	/// @param timeStamp Current wall-clock time (seconds since epoch).
 	virtual void doEmptyReserved(uint32_t timeStamp) = 0;
+
+	/// Runs one bounded round of pending durable file-operation work.
+	///
+	/// The in-memory backend completes operations synchronously and implements this as a no-op.
+	/// KV backends override it to advance worker-neutral durable records.
+	///
+	/// @param timeStamp Current wall-clock time (seconds since epoch).
+	virtual void drainPendingFileOperations(uint32_t timeStamp) = 0;
 
 	// CHECKSUM
 

--- a/src/master/filesystem_periodic.cc
+++ b/src/master/filesystem_periodic.cc
@@ -92,6 +92,10 @@ void fs_periodic_emptyreserved(void) {
 	gFSOperations->doEmptyReserved(eventloop_time());
 }
 
+void fs_periodic_file_operations(void) {
+	gFSOperations->drainPendingFileOperations(eventloop_time());
+}
+
 void fs_read_periodic_config_file() {
 	FilesystemOperationsBase::setFileTestLoopTime(cfg_get_minmaxvalue<uint32_t>(
 	    "FILE_TEST_LOOP_MIN_TIME", 3600, FILETESTSMINLOOPTIME, FILETESTSMAXLOOPTIME));
@@ -105,5 +109,6 @@ void fs_periodic_master_init() {
 	eventloop_eachloopregister(fs_background_file_test);
 	eventloop_timeregister_ms(100, fs_periodic_emptytrash);
 	eventloop_timeregister_ms(gEmptyReservedFilesPeriod, fs_periodic_emptyreserved);
+	eventloop_timeregister_ms(100, fs_periodic_file_operations);
 }
 #endif

--- a/src/master/filesystem_snapshot.cc
+++ b/src/master/filesystem_snapshot.cc
@@ -70,9 +70,10 @@ uint8_t fs_snapshot(const FsContext &context, inode_t inode_src, inode_t parent_
 
 	assert(context.isPersonalityMaster());
 
-	auto task = new SnapshotTask({{src_node->id, name_dst}}, src_node->id,
-	                                   static_cast<FSNodeDirectory *>(dst_parent_node)->id,
-	                                   0, can_overwrite, ignore_missing_src, true, true);
+	auto *task =
+	    gFSOperations->createSnapshotTask({{src_node->id, name_dst}}, src_node->id,
+	                                      static_cast<FSNodeDirectory *>(dst_parent_node)->id, 0,
+	                                      can_overwrite, ignore_missing_src, true, true);
 	std::string src_path;
 	FSNodeDirectory *parent =
 	    gFSOperations->nodeOperations()->getFirstParent(fsOpContext, src_node);

--- a/src/master/kv_common_keys.h
+++ b/src/master/kv_common_keys.h
@@ -112,6 +112,29 @@ inline constexpr std::string_view kFreeKeyPrefix = "FREE_";  // Section FREE 1.0
 /// Write locks live elsewhere (a future CHNK_LOCK_ prefix), so they are not part of this record.
 inline constexpr std::string_view kChunkKeyPrefix = "CHNK_";  // Section CHNK 1.0
 
+/// Number of chunk-id slots covered by one FCHK_ bucket.
+inline constexpr uint32_t kChunkIdsPerBucket = 1024;
+
+/// Prefix for a file's out-of-line chunk-id table, stored in fixed-span buckets.
+/// Format: FCHK_<InodeId><BucketIndex> -> [<ChunkId>]*
+/// - InodeId: inode_t serialized as Big Endian; BucketIndex: uint32_t Big Endian.
+///   Bucket b covers chunk indexes [b*kChunkIdsPerBucket, (b+1)*kChunkIdsPerBucket).
+/// - Value: 64-bit Big Endian chunk ids for the covered slots in index order, with
+///   trailing zero slots trimmed (value length / 8 = stored slot count). An absent
+///   bucket, or a slot beyond the stored count, reads as chunk id 0 (a hole). A bucket
+///   whose slots are all zero is removed rather than stored, so the last stored slot of
+///   a file's last bucket always holds a live chunk id.
+/// @note Big Endian numeric key parts keep the buckets of one inode contiguous and in
+/// index order, so a file's whole table is one range scan by the FCHK_<InodeId> prefix.
+/// @note Caps the value size at 8 KiB regardless of file length: the chunk table of a
+/// file is no longer serialized into its NODE_ value, whose size would grow with the
+/// highest written chunk index and overflow the KV store's value limit.
+inline constexpr std::string_view kFileChunksKeyPrefix = "FCHK_";
+
+/// Prefix for worker-neutral durable file operations.
+/// Format: BULKOP_<TargetInode><Generation> -> <VersionedBulkOperationRecord>
+inline constexpr std::string_view kBulkOperationKeyPrefix = "BULKOP_";
+
 /// Prefix for extended attributes (xattrs)
 /// Format: XATR_<InodeId><AttributeName>:<AttributeValue>
 /// e.g.: XATR_1999UserAttr:UserValue
@@ -172,6 +195,10 @@ inline constexpr std::string_view kFileTestLeaseKey = "FILETEST_LEASE";
 /// @note InodeId inside LastCommittedNodeKey is serialized as Big Endian.
 inline constexpr std::string_view kFileTestCursorKey = "FILETEST_CURSOR";
 
+/// Durable partial state while the scanner processes one file's FCHK pages.
+/// The NODE cursor does not advance until this row is removed after finalizing the file.
+inline constexpr std::string_view kFileTestFileProgressKey = "FILETEST_FILE_PROGRESS";
+
 /// Running counters for the in-progress scan cycle; written by the lease owner each committed page.
 /// Reset to a fresh Stats with the new generation when a cycle completes or a new one begins.
 /// Format: FILETEST_ACTIVE_STATS:<ScanGeneration><LoopStart><LoopEnd><Files>
@@ -205,10 +232,12 @@ inline constexpr std::string_view kFileTestPublishedStatsKey = "FILETEST_PUBLISH
 inline constexpr std::string_view kFileTestPublishedReportKey = "FILETEST_PUBLISHED_REPORT";
 
 /// Prefix for per-defective-inode file-test rows.
-/// Format: FILETEST_DEFECTIVE_<InodeId>:<ScanGeneration><Flags>
+/// Format:
+/// FILETEST_DEFECTIVE_<InodeId>:<ScanGeneration><Flags><PreviousScanGeneration><PreviousFlags>
 /// - InodeId: inode_t serialized as Big Endian
 /// - ScanGeneration: uint64_t serialized as Big Endian
 /// - Flags: uint8_t NodeErrorFlag bitmask
+/// - PreviousScanGeneration and PreviousFlags: fixed predecessor snapshot for published readers
 /// @note InodeId is encoded in the key to preserve numeric ordering for scans.
 inline constexpr std::string_view kFileTestDefectiveKeyPrefix = "FILETEST_DEFECTIVE_";
 

--- a/src/master/matoclserv.cc
+++ b/src/master/matoclserv.cc
@@ -137,6 +137,7 @@ struct matoclserventry;
 struct DelayedChunkOperation {
 	uint64_t chunkId = 0;     ///< Chunk ID
 	uint64_t fileLength = 0;  ///< File length
+	uint32_t chunkIndex = 0;  ///< Exact file slot for failed-write cleanup
 	uint32_t lockId = 0;      ///< Lock ID
 	uint32_t messageId = 0;   ///< Message ID for reply
 	inode_t inode = 0;        ///< Inode
@@ -346,8 +347,9 @@ void matoclserv_emit_changelog_sinks(uint64_t version, char *entry, std::size_t 
 /// Staged KV versions can collide, so this is the total-order point that reissues
 /// monotonically increasing versions for changelog, metaloggers and notifiers.
 /// Gaps are allowed; direct inline KV publications use the same sequencer.
-static void matoclserv_publish_deferred_changelog(const FilesystemOperationContext &ctx) {
-	auto entries = ctx.takeDeferredChangelogEntries();
+void matoclserv_publish_committed_changelog(const FilesystemOperationContext &context) {
+	context.confirmCommitted();
+	auto entries = context.takeDeferredChangelogEntries();
 	for (auto &deferred : entries) {
 		deferred.version = matoclserv_sequence_published_changelog_version(deferred.version);
 		matoclserv_emit_changelog_sinks(deferred.version, deferred.entry.data(),
@@ -358,8 +360,8 @@ static void matoclserv_publish_deferred_changelog(const FilesystemOperationConte
 /// Confirms a durable deferring commit and drains its changelog buffer.
 /// confirmCommitted() arms the destructor tripwire before publication drains entries.
 static void matoclserv_commit_confirmed(const FilesystemOperationContext &ctx) {
-	ctx.confirmCommitted();
-	matoclserv_publish_deferred_changelog(ctx);
+	ctx.finishTransactionEffects(FilesystemTransactionOutcome::kCommitted);
+	matoclserv_publish_committed_changelog(ctx);
 }
 
 /// Replay pacing for fresh-transaction replays (the sync retry loop and the timed
@@ -587,6 +589,7 @@ static uint8_t matoclserv_commit_op_with_retry_impl(
 			} else {
 				safs::log_err("matoclserv: sync commit failed (err {}, retryable {}), giving up",
 				              commitError, retryable);
+				ctx.finishTransactionEffectsAfterCommit(false);
 				return SAUNAFS_ERROR_IO;
 			}
 		} catch (const kv::TransactionStateError &e) {
@@ -672,6 +675,10 @@ struct OpBatch {
 static OpBatch gOpenBatch;
 static std::optional<OpBatch> gInFlightBatch;
 static std::deque<BatchMember> gHeldOps;
+// A bounded background-maintenance request. Existing staged/open work is flushed before
+// the idle check grants the window; arriving operation bodies remain unexecuted in
+// gHeldOps, so they carry no stale writes while the background transaction commits.
+static bool gBatchMaintenanceRequested = false;
 // True while matoclserv_poll_batch is resolving an in-flight batch (running
 // finishes / replaying members). A finish can submit a follow-up op (e.g. the
 // truncate finalize via matoclserv_resolve_pending_delayed_op); it must be HELD
@@ -717,6 +724,23 @@ static MatoclBatchStats gBatchStats;
 void matoclserv_set_batch_stats_enabled(bool enabled) { gBatchStatsEnabled = enabled; }
 
 MatoclBatchStats matoclserv_get_batch_stats() { return gBatchStats; }
+
+void matoclserv_request_commit_pipeline_maintenance() { gBatchMaintenanceRequested = true; }
+
+void matoclserv_complete_commit_pipeline_maintenance() { gBatchMaintenanceRequested = false; }
+
+/// @see fs_register_commit_pipeline_idle_check. Member bodies stage writes
+/// derived from in-memory state long before the batch commit is submitted; a
+/// background transaction committing inside that window either aborts the whole
+/// batch into replay (conflict-checked keys) or is silently overwritten by the
+/// batch's stale value (blind ones). "Idle" therefore covers the open batch,
+/// held ops, and a parked retry (whose members' in-memory effects are applied
+/// but not durable), not just the in-flight commit.
+static bool matoclserv_commit_pipeline_idle() {
+	const bool stagedWorkIsDurable = !gInFlightBatch.has_value() && !gBatchRetry.has_value() &&
+	                                 !gBatchResolving && gOpenBatch.members.empty();
+	return stagedWorkIsDurable && (gBatchMaintenanceRequested || gHeldOps.empty());
+}
 
 /// Records a committed batch of `size` members in the stats (size-histogram bucketed by
 /// power of two as 1, 2-3, 4-7, 8-15, 16+). No-op unless accounting is enabled.
@@ -810,7 +834,10 @@ static FilesystemOperationContext matoclserv_replay_members(std::vector<BatchMem
 	for (;;) {
 		FilesystemOperationContext ctx = gFSOperations->createFilesystemOperationContext(
 		    FilesystemOperationContext::TransactionType::kReadWrite);
-		if (ctx.hasReadWriteTransaction()) { ctx.setDeferChangelog(); }
+		if (ctx.hasReadWriteTransaction()) {
+			ctx.setDeferChangelog();
+			ctx.setGroupCommitBatch();
+		}
 		bool restart = false;
 		for (size_t idx = 0; idx < members.size() && !restart;) {
 			restart = matoclserv_replay_members_iteration(members, idx, ctx);
@@ -839,9 +866,13 @@ static void matoclserv_join_open_batch(BatchMember member) {
 		gOpenBatch.ctx = gFSOperations->createFilesystemOperationContext(
 		    FilesystemOperationContext::TransactionType::kReadWrite);
 		// Batched KV ops buffer changelog entries until commit, avoiding uncommitted
-		// publication and duplicate entries from replayed batches.
+		// publication and duplicate entries from replayed batches. The batch flag
+		// makes registry-derived blind writes conflict-checked: the async commit
+		// leaves a window where an interleaved synchronous commit would otherwise
+		// be overwritten by the batch's stale staged value.
 		if (gOpenBatch.ctx.hasReadWriteTransaction()) {
 			gOpenBatch.ctx.setDeferChangelog();
+			gOpenBatch.ctx.setGroupCommitBatch();
 		}
 		gOpenBatch.hasContext = true;
 	}
@@ -872,7 +903,8 @@ static void matoclserv_submit_op(matoclserventry *eptr, OpReplay body,
                                  std::function<void(uint8_t status)> finish,
                                  std::function<void(uint8_t status)> onCommit = {}) {
 	eptr->pendingCommits++;
-	if (gInFlightBatch.has_value() || gBatchRetry.has_value() || gBatchResolving) {
+	if (gBatchMaintenanceRequested || gInFlightBatch.has_value() || gBatchRetry.has_value() ||
+	    gBatchResolving) {
 		// Hold the body until the in-flight batch (or its parked retry) is durable
 		// so it runs against committed state (the soundness core of this design).
 		if (gBatchStatsEnabled) { gBatchStats.heldOps++; }
@@ -933,6 +965,7 @@ static void matoclserv_poll_batch() {
 			BatchRetry retry;
 			retry.members = std::move(gInFlightBatch->members);
 			retry.attempt = attempt;
+			gInFlightBatch->ctx.finishTransactionEffectsAfterCommit(false);
 			// The launch-time injected flag, NOT the reloadable setting: re-deriving it
 			// here could release a transaction the injected future never committed,
 			// still Active, and recoverAsync on it would fail stop the event loop.
@@ -958,6 +991,7 @@ static void matoclserv_poll_batch() {
 		} else {
 			safs::log_err("matoclserv: batch commit failed (err {}, retryable {}), giving up",
 			              commitError, retryable);
+			gInFlightBatch->ctx.finishTransactionEffectsAfterCommit(false);
 			for (BatchMember &member : gInFlightBatch->members) {
 				matoclserv_finish_member(member, SAUNAFS_ERROR_IO);
 			}
@@ -981,9 +1015,13 @@ static void matoclserv_poll_batch() {
 					retry.recovery->get();
 					retry.recovery.reset();
 					// Replay onto the recovered transaction; if a member invalidates
-					// it, fall back to the fresh-transaction rebuild.
+					// it, fall back to the fresh-transaction rebuild. Batch flags as in
+					// matoclserv_join_open_batch: the replayed bodies stage the same
+					// registry-derived blind writes, so they need the same
+					// conflict-checking.
 					FilesystemOperationContext ctx(std::move(retry.txn));
 					ctx.setDeferChangelog();
+					ctx.setGroupCommitBatch();
 					bool restart = false;
 					for (size_t idx = 0; idx < retry.members.size() && !restart;) {
 						restart = matoclserv_replay_members_iteration(retry.members, idx, ctx);
@@ -1049,7 +1087,8 @@ static void matoclserv_poll_batch() {
 	// Drain held ops into the open batch once neither a batch nor a parked retry is
 	// pending. Bodies run here, against the now-durable state. FIFO keeps
 	// per-connection op order.
-	while (!gInFlightBatch.has_value() && !gBatchRetry.has_value() && !gHeldOps.empty()) {
+	while (!gBatchMaintenanceRequested && !gInFlightBatch.has_value() && !gBatchRetry.has_value() &&
+	       !gHeldOps.empty()) {
 		BatchMember held = std::move(gHeldOps.front());
 		gHeldOps.pop_front();
 		if (held.eptr->mode == ClientConnectionMode::KILL) {
@@ -1443,6 +1482,7 @@ static void matoclserv_process_chunk_status(matoclserventry *eptr,
 	const uint8_t operationType = operation.type;
 	const inode_t inode = operation.inode;
 	const uint64_t chunkId = operation.chunkId;
+	const uint32_t chunkIndex = operation.chunkIndex;
 
 	if (status == SAUNAFS_STATUS_OK) { dcm_modify(inode, eptr->sessionData->sessionId); }
 
@@ -1489,12 +1529,16 @@ static void matoclserv_process_chunk_status(matoclserventry *eptr,
 		// killed client) and does not depend on this commit, so the on-commit hook only
 		// logs a commit failure (mirrors the FUSE_TRUNCATE_END path); the log lives in
 		// onCommit, not finish, so a killed client cannot suppress it.
-		OpReplay runCleanup = [context, inode, chunkId,
+		OpReplay runCleanup = [context, inode, chunkIndex, chunkId,
 		                       removeChunk](FilesystemOperationContext &ctx) -> uint8_t {
-			if (removeChunk) {
-				gFSOperations->removeChunkFromFile(context, ctx, inode, chunkId);
-			}
+			// Persist the lock release before staging a possible reference removal.
+			// KV reference effects then read the lock-cleared CHNK_ value through
+			// transaction read-your-writes and cannot be overwritten by a later
+			// registry-derived persist.
 			gFSOperations->writeEnd(ctx, 0, 0, chunkId, 0);  // ignore status, just release
+			if (removeChunk) {
+				gFSOperations->removeChunkFromFile(context, ctx, inode, chunkIndex, chunkId);
+			}
 			return SAUNAFS_STATUS_OK;
 		};
 		matoclserv_submit_op(
@@ -2619,7 +2663,7 @@ void matoclserv_update_mount_info(matoclserventry *eptr, const uint8_t *data, ui
                                           size_t &operationCount) {
 	assert(fsOpContext.hasReadWriteTransaction());
 
-	auto commitResult = fsOpContext.getReadWriteTransaction()->commit();
+	auto commitResult = fsOpContext.commitTransaction();
 
 	fsOpContext = gFSOperations->createFilesystemOperationContext(
 	    FilesystemOperationContext::TransactionType::kReadWrite);
@@ -2734,7 +2778,7 @@ void matoclserv_fuse_reserved_inodes(matoclserventry *eptr, const uint8_t *data,
 
 	// Commit the final batch for KV backends
 	if (transactional && operationCount > 0) {
-		const bool committed = fsOpContext.getReadWriteTransaction()->commit();
+		const bool committed = fsOpContext.commitTransaction();
 		if (!committed) {
 			safs::log_err("{}: failed to commit final transaction for reserving inodes", __func__);
 		}
@@ -3284,7 +3328,7 @@ void matoclserv_fuse_readlink(matoclserventry *eptr, const uint8_t *data, uint32
 	status = gFSOperations->readlink(context, fsOpContext, inode, path);
 
 	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
-		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+		if (!fsOpContext.commitTransaction()) {
 			// Best-effort: atime update only, do not fail the readlink.
 			safs::log_err("{}: transaction failed to commit: inode {}", __func__, inode);
 		}
@@ -3997,7 +4041,7 @@ void matoclserv_fuse_getdir(matoclserventry *eptr,const PacketHeader &header, co
 			                                number_of_entries, dir_entries);
 
 			if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
-				if (!fsOpContext.getReadWriteTransaction()->commit()) {
+				if (!fsOpContext.commitTransaction()) {
 					// Best-effort: atime update only, do not fail the directory listing.
 					safs::log_err("{}: Failed to commit atime update for inode {}", __func__,
 					              inode);
@@ -4083,7 +4127,7 @@ void matoclserv_fuse_getdir(matoclserventry *eptr, const uint8_t *data, uint32_t
 
 		// Best effort to update atime
 		if (fsOpContext.hasReadWriteTransaction()) {
-			if (!fsOpContext.getReadWriteTransaction()->commit()) {
+			if (!fsOpContext.commitTransaction()) {
 				safs::log_err("{}: Failed to commit atime update for inode {}", __func__, inode);
 			}
 		}
@@ -4214,7 +4258,7 @@ void matoclserv_fuse_read_chunk(matoclserventry *eptr, PacketHeader header, cons
 	}
 
 	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
-		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+		if (!fsOpContext.commitTransaction()) {
 			// Best-effort: atime update only, do not fail the chunk read.
 			safs::log_err("{}: transaction failed to commit: inode {}, chunk index {}", __func__,
 			              inode, index);
@@ -4293,6 +4337,9 @@ void matoclserv_fuse_write_chunk(matoclserventry *eptr, PacketHeader header, con
 	// flight.
 	struct WriteChunkState {
 		uint64_t chunkId = 0;
+		// Lock created by an earlier replay attempt. This remains valid input state,
+		// unlike chunkId, which is output from the current attempt only.
+		uint64_t retainedChunkId = 0;
 		uint64_t fileLength = 0;
 		uint32_t lockId = 0;
 		uint8_t opflag = 0;
@@ -4313,13 +4360,23 @@ void matoclserv_fuse_write_chunk(matoclserventry *eptr, PacketHeader header, con
 	                          wc](FilesystemOperationContext &ctx) -> uint8_t {
 		matoclserv_drop_queued_delayed_op(eptr, wc->queued);
 		wc->queued = nullptr;
+		// Reset the previous attempt's outputs so a failed replay cannot leak them
+		// into the error handling below; retainedChunkId alone survives (see above).
+		wc->chunkId = 0;
+		wc->fileLength = 0;
+		wc->opflag = 0;
+		wc->tookDelayedPath = false;
+
 		uint8_t st = gFSOperations->writeChunk(matoclserv_get_context(eptr), ctx, inode,
 		                                       chunkIndex, &wc->lockId, &wc->chunkId, &wc->opflag,
 		                                       &wc->fileLength, min_server_version);
+		if (st == SAUNAFS_STATUS_OK) { wc->retainedChunkId = wc->chunkId; }
+
 		if (st == SAUNAFS_STATUS_OK && wc->opflag) {
 			auto operation = std::make_unique<DelayedChunkOperation>();
 			operation->inode = inode;
 			operation->chunkId = wc->chunkId;
+			operation->chunkIndex = chunkIndex;
 			operation->messageId = messageId;
 			operation->fileLength = wc->fileLength;
 			operation->lockId = wc->lockId;
@@ -4332,11 +4389,34 @@ void matoclserv_fuse_write_chunk(matoclserventry *eptr, PacketHeader header, con
 		return st;
 	};
 
-	auto sendWriteChunkError = [eptr, serializer, messageId, inode, chunkIndex,
-	                            wc](uint8_t errorStatus) {
-		if (errorStatus == SAUNAFS_ERROR_LOCKED) {
+	auto releaseWriteLockById = [inode, chunkIndex](uint64_t chunkId, const char *reason) {
+		if (chunkId == 0) { return; }
+		OpReplay runWriteEndCleanup = [chunkId](FilesystemOperationContext &ctx) -> uint8_t {
+			gFSOperations->writeEnd(ctx, 0, 0, chunkId, 0);
+			return SAUNAFS_STATUS_OK;
+		};
+		if (matoclserv_commit_op_with_retry(runWriteEndCleanup) != SAUNAFS_STATUS_OK) {
+			safs::log_err("matoclserv_fuse_write_chunk: {}, inode {}, chunk index {}, chunk {}",
+			              reason, inode, chunkIndex, chunkId);
+		}
+	};
+
+	auto releaseRetainedWriteLock = [wc, releaseWriteLockById]() {
+		if (wc->retainedChunkId == 0) { return; }
+		const uint64_t chunkId = wc->retainedChunkId;
+		wc->retainedChunkId = 0;
+		releaseWriteLockById(chunkId, "failed retained-lock cleanup");
+	};
+
+	auto sendWriteChunkError = [eptr, serializer, messageId, inode, chunkIndex, wc,
+	                            releaseRetainedWriteLock](uint8_t errorStatus) {
+		releaseRetainedWriteLock();
+
+		if (errorStatus == SAUNAFS_ERROR_LOCKED && wc->chunkId != 0) {
 			// The chunk is locked, so we need to add this client to the wait-for-unlock
-			// list. The chunkId must have been set by writeChunk above.
+			// list. LOCKED without a chunk id means an active bulk operation fenced the
+			// write, not a chunk lock; no unlock notice will ever fire for it, so
+			// leave it to the mount's own LOCKED retry loop.
 			matoclserv_add_to_wait_for_unlock_list(eptr, wc->chunkId, inode, chunkIndex);
 		}
 		std::vector<uint8_t> outMessage;
@@ -4353,8 +4433,8 @@ void matoclserv_fuse_write_chunk(matoclserventry *eptr, PacketHeader header, con
 	// (LOCKED keeps the wait-for-unlock path).
 	matoclserv_submit_op(
 	    eptr, std::move(runWriteChunk),
-	    [eptr, serializer, messageId, inode, chunkIndex, wc,
-	     sendWriteChunkError](uint8_t commitStatus) {
+	    [eptr, serializer, messageId, inode, wc, sendWriteChunkError,
+	     releaseWriteLockById](uint8_t commitStatus) {
 		    // Reply only (kill-gated). The delayed-op queue transition runs in onCommit below.
 		    if (commitStatus != SAUNAFS_STATUS_OK) {
 			    sendWriteChunkError(commitStatus);
@@ -4371,18 +4451,7 @@ void matoclserv_fuse_write_chunk(matoclserventry *eptr, PacketHeader header, con
 		    if (respondStatus != SAUNAFS_STATUS_OK) {
 			    // The write transaction is already durable; release the chunk lock with
 			    // its own small op (conflict-retried, since other commits are in flight).
-			    const uint64_t chunkId = wc->chunkId;
-			    OpReplay runWriteEndCleanup =
-			        [chunkId](FilesystemOperationContext &ctx) -> uint8_t {
-				    gFSOperations->writeEnd(ctx, 0, 0, chunkId, 0);  // ignore status, just do it
-				    return SAUNAFS_STATUS_OK;
-			    };
-			    if (matoclserv_commit_op_with_retry(runWriteEndCleanup) != SAUNAFS_STATUS_OK) {
-				    safs::log_err(
-				        "matoclserv_fuse_write_chunk: transaction failed to commit during write "
-				        "end: inode {}, chunk index {}",
-				        inode, chunkIndex);
-			    }
+			    releaseWriteLockById(wc->chunkId, "transaction failed during write-end cleanup");
 		    }
 	    },
 	    [eptr, wc](uint8_t commitStatus) {
@@ -4451,12 +4520,31 @@ void matoclserv_fuse_write_chunk_end(matoclserventry *eptr, PacketHeader header,
 	});
 }
 
+static void matoclserv_fuse_repair_wake_up(uint32_t sessionId, uint32_t msgid,
+                                           const std::shared_ptr<FileRepairStats> &stats,
+                                           int status) {
+	matoclserventry *eptr = matoclserv_find_connection(sessionId);
+	if (eptr == nullptr) { return; }
+
+	constexpr uint32_t kFailedSize = sizeof(msgid) + sizeof(uint8_t);
+	constexpr uint32_t kSuccessSize =
+	    sizeof(msgid) + sizeof(stats->notChanged) + sizeof(stats->erased) + sizeof(stats->repaired);
+	uint8_t *ptr = matoclserv_createpacket(
+	    eptr, MATOCL_FUSE_REPAIR, status == SAUNAFS_STATUS_OK ? kSuccessSize : kFailedSize);
+	put32bit(&ptr, msgid);
+	if (status != SAUNAFS_STATUS_OK) {
+		put8bit(&ptr, static_cast<uint8_t>(status));
+		return;
+	}
+	put32bit(&ptr, stats->notChanged);
+	put32bit(&ptr, stats->erased);
+	put32bit(&ptr, stats->repaired);
+}
+
 void matoclserv_fuse_repair(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	inode_t inode;
-	uint32_t uid,gid;
+	uint32_t uid, gid;
 	uint32_t msgid;
-	uint32_t chunksnotchanged, chunkserased, chunksrepaired;
-	uint8_t *ptr;
 	uint8_t status;
 	uint8_t correct_only = 0;
 
@@ -4479,37 +4567,44 @@ void matoclserv_fuse_repair(matoclserventry *eptr, const uint8_t *data, uint32_t
 	}
 
 	status = matoclserv_check_group_cache(eptr, gid);
+	auto stats = std::make_shared<FileRepairStats>();
 
 	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		status = gFSOperations->repair(context, inode, correct_only, &chunksnotchanged,
-		                               &chunkserased, &chunksrepaired);
+		const uint32_t sessionId = eptr->sessionData->sessionId;
+		status = gFSOperations->repairAsync(
+		    context, inode, correct_only, stats, [sessionId, msgid, stats](int repairStatus) {
+			    matoclserv_fuse_repair_wake_up(sessionId, msgid, stats, repairStatus);
+		    });
 	}
+	if (status != SAUNAFS_ERROR_WAITING) {
+		matoclserv_fuse_repair_wake_up(eptr->sessionData->sessionId, msgid, stats, status);
+	}
+}
 
-	constexpr uint32_t kFailedSize = sizeof(msgid) + sizeof(status);
-	constexpr uint32_t kSuccessSize =
-	    sizeof(msgid) + sizeof(chunksnotchanged) + sizeof(chunkserased) + sizeof(chunksrepaired);
+static void matoclserv_fuse_check_wake_up(uint32_t sessionId, uint32_t msgid,
+                                          const std::shared_ptr<ChunkCountArray> &chunkCount,
+                                          int status) {
+	matoclserventry *eptr = matoclserv_find_connection(sessionId);
+	if (eptr == nullptr) { return; }
 
-	ptr = matoclserv_createpacket(eptr, MATOCL_FUSE_REPAIR,
-	                              (status != SAUNAFS_STATUS_OK) ? kFailedSize : kSuccessSize);
-
-	put32bit(&ptr,msgid);
-
+	uint8_t *ptr;
 	if (status != SAUNAFS_STATUS_OK) {
-		put8bit(&ptr, status);
-	} else {
-		put32bit(&ptr, chunksnotchanged);
-		put32bit(&ptr, chunkserased);
-		put32bit(&ptr, chunksrepaired);
+		ptr = matoclserv_createpacket(eptr, MATOCL_FUSE_CHECK, sizeof(msgid) + sizeof(uint8_t));
+		put32bit(&ptr, msgid);
+		put8bit(&ptr, static_cast<uint8_t>(status));
+		return;
 	}
+
+	ptr = matoclserv_createpacket(eptr, MATOCL_FUSE_CHECK,
+	                              sizeof(msgid) + CHUNK_MATRIX_SIZE * sizeof(uint32_t));
+	put32bit(&ptr, msgid);
+	for (uint32_t count : *chunkCount) { put32bit(&ptr, count); }
 }
 
 void matoclserv_fuse_check(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	inode_t inode;
-	ChunkCountArray chunkCount;
 	uint32_t msgid;
-	uint8_t *ptr;
-	uint8_t status;
 
 	constexpr uint32_t kExpectedSize = sizeof(msgid) + sizeof(inode);
 
@@ -4523,17 +4618,16 @@ void matoclserv_fuse_check(matoclserventry *eptr, const uint8_t *data, uint32_t 
 	get32bit(&data, msgid);
 	getINode(&data, inode);
 
-	status = gFSOperations->checkFile(matoclserv_get_context(eptr), inode, chunkCount);
+	auto chunkCount = std::make_shared<ChunkCountArray>();
+	const uint32_t sessionId = eptr->sessionData->sessionId;
+	const uint8_t status = gFSOperations->checkFileAsync(
+	    matoclserv_get_context(eptr), inode, chunkCount,
+	    [sessionId, msgid, chunkCount](int checkStatus) {
+		    matoclserv_fuse_check_wake_up(sessionId, msgid, chunkCount, checkStatus);
+	    });
 
-	if (status != SAUNAFS_STATUS_OK) {
-		ptr = matoclserv_createpacket(eptr,MATOCL_FUSE_CHECK, sizeof(msgid) + sizeof(status));
-		put32bit(&ptr,msgid);
-		put8bit(&ptr,status);
-	} else {
-		ptr = matoclserv_createpacket(eptr, MATOCL_FUSE_CHECK,
-		                              sizeof(msgid) + CHUNK_MATRIX_SIZE * sizeof(uint32_t));
-		put32bit(&ptr, msgid);
-		for (uint32_t i = 0; i < CHUNK_MATRIX_SIZE; i++) { put32bit(&ptr, chunkCount[i]); }
+	if (status != SAUNAFS_ERROR_WAITING) {
+		matoclserv_fuse_check_wake_up(sessionId, msgid, chunkCount, status);
 	}
 }
 
@@ -4683,7 +4777,7 @@ void matoclserv_fuse_getgoal(matoclserventry *eptr, PacketHeader header, const u
 	    gFSOperations->getGoal(matoclserv_get_context(eptr), fsOpContext, inode, gmode, fgtab, dgtab);
 
 	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
-		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+		if (!fsOpContext.commitTransaction()) {
 			safs::log_err("{}: transaction failed to commit: inode {}, gmode {}", __func__, inode,
 			              static_cast<uint32_t>(gmode));
 			status = SAUNAFS_ERROR_IO;
@@ -5095,6 +5189,16 @@ void matoclserv_fuse_setxattr(matoclserventry *eptr, const uint8_t *data, uint32
 	matoclserv_submit_op(eptr, std::move(runSetXattr), sendSetXattrReply);
 }
 
+static void matoclserv_fuse_append_wake_up(uint32_t sessionId, uint32_t msgid, int status) {
+	matoclserventry *eptr = matoclserv_find_connection(sessionId);
+	if (eptr == nullptr) { return; }
+
+	uint8_t *ptr =
+	    matoclserv_createpacket(eptr, MATOCL_FUSE_APPEND, sizeof(msgid) + sizeof(uint8_t));
+	put32bit(&ptr, msgid);
+	put8bit(&ptr, static_cast<uint8_t>(status));
+}
+
 void matoclserv_fuse_append(matoclserventry *eptr, const uint8_t *data, uint32_t length) {
 	inode_t inode;
 	inode_t inode_src;
@@ -5121,31 +5225,17 @@ void matoclserv_fuse_append(matoclserventry *eptr, const uint8_t *data, uint32_t
 
 	status = matoclserv_check_group_cache(eptr, gid);
 
-	// Replayable body: append copies the source file's chunk references onto the target
-	// (addFile bumps each chunk's in-memory refcount + persists the chunk record), so it
-	// shares write_chunk's accepted property -- a whole-batch replay re-runs addFile and
-	// the failed attempt's in-memory refcount bump lingers (backend rolls back). That is a
-	// conservative leak (refcount too high => extra COW, never too low), not corruption.
-	OpReplay runAppend = [eptr, uid, gid, inode,
-	                      inode_src](FilesystemOperationContext &ctx) -> uint8_t {
+	if (status == SAUNAFS_STATUS_OK) {
 		FsContext context = matoclserv_get_context(eptr, uid, gid);
-		return gFSOperations->append(context, ctx, inode, inode_src);
-	};
-
-	auto sendAppendReply = [eptr, msgid](uint8_t replyStatus) {
-		uint8_t *ptr =
-		    matoclserv_createpacket(eptr, MATOCL_FUSE_APPEND, sizeof(msgid) + sizeof(replyStatus));
-		put32bit(&ptr, msgid);
-		put8bit(&ptr, replyStatus);
-	};
-
-	if (status != SAUNAFS_STATUS_OK) {  // group-cache error: reply without running the op
-		sendAppendReply(status);
-		return;
+		const uint32_t sessionId = eptr->sessionData->sessionId;
+		status = gFSOperations->appendAsync(
+		    context, inode, inode_src, [sessionId, msgid](int appendStatus) {
+			    matoclserv_fuse_append_wake_up(sessionId, msgid, appendStatus);
+		    });
 	}
-
-	matoclserv_submit_op(eptr, std::move(runAppend),
-	                     [sendAppendReply](uint8_t commitStatus) { sendAppendReply(commitStatus); });
+	if (status != SAUNAFS_ERROR_WAITING) {
+		matoclserv_fuse_append_wake_up(eptr->sessionData->sessionId, msgid, status);
+	}
 }
 
 void matoclserv_fuse_snapshot_wake_up(uint32_t type, uint32_t session_id, uint32_t msgid, int status) {
@@ -6527,7 +6617,7 @@ bool matocl_close_files(Session *currentSession) {
 
 	// Commits one pending batch for transactional backends.
 	auto flushBatch = [&](bool isFinal) -> bool {
-		if (!fsOpContext.getReadWriteTransaction()->commit()) { return false; }
+		if (!fsOpContext.commitTransaction()) { return false; }
 
 		if (!isFinal) {
 			committed.insert(committed.end(), pendingBatch.begin(), pendingBatch.end());
@@ -6660,20 +6750,20 @@ void matocl_before_disconnect(matoclserventry *eptr) {
 		if (operation->type == FUSE_TRUNCATE) {
 			gFSOperations->endSetLength(fsOpContext, operation->chunkId);
 		} else if (operation->type == FUSE_WRITE) {
+			gFSOperations->writeEnd(fsOpContext, 0, 0, operation->chunkId, 0);
 			if (operation->statusArrived && operation->pendingIsFailedCreate && eptr->sessionData) {
 				FsContext context = FsContext::getForMasterWithSession(
 				    eventloop_time(), eptr->sessionData->rootInode, eptr->sessionData->flags,
 				    operation->uid, operation->gid, operation->auid, operation->agid);
 				gFSOperations->removeChunkFromFile(context, fsOpContext, operation->inode,
-				                                   operation->chunkId);
+				                                   operation->chunkIndex, operation->chunkId);
 			}
-			gFSOperations->writeEnd(fsOpContext, 0, 0, operation->chunkId, 0);
 		}
 	}
 
 	// Commit the transaction for KV backends
 	if (fsOpContext.hasReadWriteTransaction()) {
-		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+		if (!fsOpContext.commitTransaction()) {
 			safs::log_critical(
 			    "{}: transaction failed to commit while unlocking chunks for session {}", __func__,
 			    eptr->sessionData ? eptr->sessionData->sessionId : 0);
@@ -7171,6 +7261,7 @@ void matoclserv_term() {
 	gInFlightBatch.reset();
 	gBatchRetry.reset();
 	gHeldOps.clear();
+	gBatchMaintenanceRequested = false;
 	gOpenBatch.members.clear();
 	gOpenBatch.hasContext = false;
 	gOpenBatch.ctx = FilesystemOperationContext();
@@ -7650,6 +7741,8 @@ int matoclserv_network_init() {
 	gDebugInjectConflicts = cfg_getuint32("MATOCL_DEBUG_INJECT_COMMIT_CONFLICTS", 0U);
 	gDebugInjectReadConflicts = cfg_getuint32("MATOCL_DEBUG_INJECT_READ_CONFLICTS", 0U);
 	gDebugInjectRecoveryErrors = cfg_getuint32("MATOCL_DEBUG_INJECT_RECOVERY_ERRORS", 0U);
+
+	fs_register_commit_pipeline_idle_check(matoclserv_commit_pipeline_idle);
 
 	if (matoclserv_iolimits_reload() != 0) {
 		return -1;

--- a/src/master/matoclserv.h
+++ b/src/master/matoclserv.h
@@ -27,6 +27,8 @@
 
 #include "common/type_defs.h"
 
+class FilesystemOperationContext;
+
 /// Get stats from client and reset them in the server.
 /// @param stats Array of 5 elements to store stats in the following order:
 /// 0 - packets received
@@ -56,6 +58,11 @@ uint64_t matoclserv_sequence_published_changelog_version(uint64_t stagedVersion)
 /// C-string sinks; `size` counts the trailing NUL so broadcasts match the inline framing.
 void matoclserv_emit_changelog_sinks(uint64_t version, char *entry, std::size_t size);
 
+/// Publishes and drains changelog entries buffered by a transaction whose commit is known
+/// durable. The context is marked committed before publication so an undrained buffer trips its
+/// destructor invariant.
+void matoclserv_publish_committed_changelog(const FilesystemOperationContext &context);
+
 /// Initializes the network configuration and register the eventloop callbacks.
 /// @return 0 on success, negative value on error
 int matoclserv_network_init();
@@ -68,7 +75,8 @@ void matoclserv_broadcast_metadata_saved(uint8_t status);
 /// @param status Status of the metadata checksum recalculation process
 void matoclserv_broadcast_metadata_checksum_recalculated(uint8_t status);
 
-/// Check whether there are any async filesystem operations that still need to finished (e.g delayed chunk operations)
+/// Check whether there are any async filesystem operations that still need to finished (e.g delayed
+/// chunk operations)
 bool matoclserv_client_async_operations_finished();
 
 /// Group-commit runtime counters, for diagnosing how well batching amortizes
@@ -91,3 +99,11 @@ void matoclserv_set_batch_stats_enabled(bool enabled);
 
 /// Returns the current group-commit batch-stats counters (process-wide, since process start).
 MatoclBatchStats matoclserv_get_batch_stats();
+
+/// Requests one quiescent group-commit window for background metadata maintenance.
+/// Already staged client work is committed first; newly submitted bodies remain held
+/// and unexecuted until matoclserv_complete_commit_pipeline_maintenance is called.
+void matoclserv_request_commit_pipeline_maintenance();
+
+/// Ends a previously requested maintenance window and lets held client operations resume.
+void matoclserv_complete_commit_pipeline_maintenance();

--- a/src/master/matocsserv.cc
+++ b/src/master/matocsserv.cc
@@ -1666,6 +1666,10 @@ bool matocsserv_is_killed(matocsserventry* eptr) {
 	return eptr != nullptr && eptr->mode == ChunkserverConnectionMode::KILL;
 }
 
+void matocsserv_request_disconnect(matocsserventry *eptr) {
+	if (eptr != nullptr) { eptr->mode = ChunkserverConnectionMode::KILL; }
+}
+
 uint32_t matocsserv_get_version(matocsserventry *eptr) {
 	return eptr->version;
 }

--- a/src/master/matocsserv.h
+++ b/src/master/matocsserv.h
@@ -94,6 +94,9 @@ std::vector<ServerWithUsage> matocsserv_getservers_sorted();
 /*! \brief Check if chunkserver is killed. */
 bool matocsserv_is_killed(matocsserventry* eptr);
 
+/*! \brief Mark a chunkserver connection for disconnection by the event loop. */
+void matocsserv_request_disconnect(matocsserventry *eptr);
+
 uint32_t matocsserv_get_version(matocsserventry* eptr);
 void matocsserv_usagedifference(double *minusage, double *maxusage, uint16_t *usablescount,
                                 uint16_t *totalscount);

--- a/src/master/recursive_remove_task.cc
+++ b/src/master/recursive_remove_task.cc
@@ -21,6 +21,8 @@
 
 #include "master/recursive_remove_task.h"
 
+#include <limits>
+
 #include "master/filesystem_operations_interface.h"
 #include "master/filesystem_stats.h"
 
@@ -44,6 +46,12 @@ int RemoveTask::retrieveNodes(const FilesystemOperationContext &fsOpContext, FSN
 	}
 	if (!gFSOperations->nodeOperations()->stickyAccess(wd, child, context_->uid())) {
 		return SAUNAFS_ERROR_EPERM;
+	}
+	if (child->type == FSNodeType::kFile || child->type == FSNodeType::kTrash ||
+	    child->type == FSNodeType::kReserved) {
+		const uint8_t status = gFSOperations->nodeOperations()->canMutateFileChunks(
+		    fsOpContext, static_cast<FSNodeFile *>(child), 0, std::numeric_limits<uint32_t>::max());
+		if (status != SAUNAFS_STATUS_OK) { return status; }
 	}
 	return SAUNAFS_STATUS_OK;
 }
@@ -89,8 +97,7 @@ int RemoveTask::execute(uint32_t ts, intrusive_list<Task> &work_queue) {
 		doUnlink(fsOpContext, ts, wd, child);
 
 		// commit the transaction
-		if (fsOpContext.hasReadWriteTransaction() &&
-		    !fsOpContext.getReadWriteTransaction()->commit()) {
+		if (fsOpContext.hasReadWriteTransaction() && !fsOpContext.commitTransaction()) {
 			return SAUNAFS_ERROR_IO;
 		}
 

--- a/src/master/restore.cc
+++ b/src/master/restore.cc
@@ -214,7 +214,7 @@ int do_access(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
 	int status = gFSOperations->applyAccess(fsOpContext, ts, inode);
 
 	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
-		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+		if (!fsOpContext.commitTransaction()) {
 			safs::log_err("{}: transaction failed to commit: inode {}", __func__, inode);
 			status = SAUNAFS_ERROR_IO;
 		}
@@ -238,7 +238,7 @@ int do_append(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
 	int status = gFSOperations->append(FsContext::getForRestore(ts), fsOpContext, inode, inode_src);
 
 	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
-		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+		if (!fsOpContext.commitTransaction()) {
 			safs::log_err("{}: transaction failed to commit: inode {}, source inode {}", __func__,
 			              inode, inode_src);
 			status = SAUNAFS_ERROR_IO;
@@ -263,7 +263,7 @@ int do_acquire(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) 
 	int status = gFSOperations->acquire(FsContext::getForRestore(ts), fsOpContext, inode, cuid);
 
 	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
-		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+		if (!fsOpContext.commitTransaction()) {
 			safs::log_err("{}: transaction failed to commit: inode {}, session id {}", __func__,
 			              inode, cuid);
 			status = SAUNAFS_ERROR_IO;
@@ -296,7 +296,7 @@ int do_attr(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
 	int status = gFSOperations->applyAttr(fsOpContext, ts, inode, mode, uid, gid, atime, mtime);
 
 	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
-		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+		if (!fsOpContext.commitTransaction()) {
 			safs::log_err(
 			    "{}: transaction failed to commit: inode {}, mode {}, uid {}, gid {}, atime {}, mtime {}",
 			    __func__, inode, mode, uid, gid, atime, mtime);
@@ -348,7 +348,7 @@ int do_create(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
 	                                        static_cast<FSNodeType>(type), mode, uid, gid, rdev, inode);
 
 	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
-		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+		if (!fsOpContext.commitTransaction()) {
 			safs::log_err(
 			    "{}: transaction failed to commit: parent {}, type {}, inode {}",
 			    __func__, parent, type, inode);
@@ -382,7 +382,7 @@ int do_incversion(const char *filename, uint64_t lv, uint32_t ts, const char *pt
 	int status = gFSOperations->applyIncreaseChunkVersion(fsOpContext, chunkid);
 
 	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
-		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+		if (!fsOpContext.commitTransaction()) {
 			safs::log_err("{}: transaction failed to commit: chunk {}", __func__, chunkid);
 			status = SAUNAFS_ERROR_IO;
 		}
@@ -410,7 +410,7 @@ int do_link(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
 	                                 HString((const char *)name), nullptr, nullptr);
 
 	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
-		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+		if (!fsOpContext.commitTransaction()) {
 			safs::log_err("{}: transaction failed to commit: inode {}, parent inode {}, name {}",
 			              __func__, inode, parent,
 			              std::string(reinterpret_cast<const char *>(name)));
@@ -446,7 +446,7 @@ int do_length(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
 	    gFSOperations->applyLength(fsOpContext, ts, inode, length, eraseFurtherChunks != 0);
 
 	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
-		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+		if (!fsOpContext.commitTransaction()) {
 			safs::log_err(
 			    "{}: transaction failed to commit: inode {}, length {}, eraseFurtherChunks {}",
 			    __func__, inode, length, eraseFurtherChunks);
@@ -482,7 +482,7 @@ int do_move(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
 	                                   HString((const char *)name_dst), &inode, nullptr);
 
 	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
-		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+		if (!fsOpContext.commitTransaction()) {
 			safs::log_err(
 			    "{}: transaction failed to commit: src inode {}, src name {}, dst inode {}, dst name {}",
 			    __func__, parent_src, (char *)name_src, parent_dst, (char *)name_dst);
@@ -540,7 +540,7 @@ int do_lock_op(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) 
 
 	if ((status == SAUNAFS_STATUS_OK || status == SAUNAFS_ERROR_WAITING) &&
 	    fsOpContext.hasReadWriteTransaction()) {
-		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+		if (!fsOpContext.commitTransaction()) {
 			safs::log_err("{}: transaction failed to commit: inode {}", __func__, inode);
 			status = SAUNAFS_ERROR_IO;
 		}
@@ -578,7 +578,7 @@ int do_remove_pending_op(const char *filename, uint64_t lv, uint32_t ts, const c
 	                                               lock_type, ownerid, sessionid, inode, reqid);
 
 	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
-		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+		if (!fsOpContext.commitTransaction()) {
 			safs::log_err("{}: transaction failed to commit: inode {}", __func__, inode);
 			status = SAUNAFS_ERROR_IO;
 		}
@@ -607,7 +607,7 @@ int do_lock_clear_session(const char *filename, uint64_t lv, uint32_t ts, const 
 	                                              lock_type, inode, sessionid, applied);
 
 	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
-		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+		if (!fsOpContext.commitTransaction()) {
 			safs::log_err("{}: transaction failed to commit: inode {}", __func__, inode);
 			status = SAUNAFS_ERROR_IO;
 		}
@@ -634,7 +634,7 @@ int do_lock_unlock_inode(const char *filename, uint64_t lv, uint32_t ts, const c
 	                                             lock_type, inode, applied);
 
 	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
-		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+		if (!fsOpContext.commitTransaction()) {
 			safs::log_err("{}: transaction failed to commit: inode {}", __func__, inode);
 			status = SAUNAFS_ERROR_IO;
 		}
@@ -655,7 +655,7 @@ int do_purge(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
 	int status = gFSOperations->purge(FsContext::getForRestore(ts), fsOpContext, inode);
 
 	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
-		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+		if (!fsOpContext.commitTransaction()) {
 			safs::log_err("{}: transaction failed to commit: inode {}", __func__, inode);
 			status = SAUNAFS_ERROR_IO;
 		}
@@ -679,7 +679,7 @@ int do_release(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) 
 	int status = gFSOperations->release(FsContext::getForRestore(ts), fsOpContext, inode, cuid);
 
 	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
-		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+		if (!fsOpContext.commitTransaction()) {
 			safs::log_err("{}: transaction failed to commit: inode {}, cuid {}", __func__, inode,
 			              cuid);
 			status = SAUNAFS_ERROR_IO;
@@ -707,7 +707,7 @@ int do_repair(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
 	int status = gFSOperations->applyRepair(fsOpContext, ts, inode, indx, version);
 
 	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
-		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+		if (!fsOpContext.commitTransaction()) {
 			safs::log_err("{}: transaction failed to commit: inode {}, chunk index {}, version {}",
 			              __func__, inode, indx, version);
 			status = SAUNAFS_ERROR_IO;
@@ -747,7 +747,7 @@ int do_seteattr(const char* filename, uint64_t lv, uint32_t ts, const char* ptr)
 	                                         fsOpContext, inode, eattr, smode, &ci, &nci, &npi);
 
 	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
-		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+		if (!fsOpContext.commitTransaction()) {
 			safs::log_err("{}: transaction failed to commit: inode {}, uid {}, eattr {}, smode {}",
 			              __func__, inode, uid, static_cast<uint32_t>(eattr),
 			              static_cast<uint32_t>(smode));
@@ -846,7 +846,7 @@ int do_setxattr(const char* filename, uint64_t lv, uint32_t ts, const char* ptr)
 	                                          valueleng, value, mode);
 
 	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
-		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+		if (!fsOpContext.commitTransaction()) {
 			safs::log_err("{}: transaction failed to commit: inode {}", __func__, inode);
 			status = SAUNAFS_ERROR_IO;
 		}
@@ -883,7 +883,7 @@ int do_deleteacl(const char *filename, uint64_t lv, uint32_t ts, const char *ptr
 	    gFSOperations->deleteAcl(FsContext::getForRestore(ts), fsOpContext, inode, aclType);
 
 	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
-		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+		if (!fsOpContext.commitTransaction()) {
 			safs::log_err("{}: transaction failed to commit: inode {}, ACL type {}", __func__,
 			              inode, aclTypeRaw);
 			return SAUNAFS_ERROR_IO;
@@ -914,7 +914,7 @@ int do_setacl(const char *filename, uint64_t lv, uint32_t ts, const char *ptr) {
 	                                        reinterpret_cast<const char *>(aclString));
 
 	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
-		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+		if (!fsOpContext.commitTransaction()) {
 			safs::log_err("{}: transaction failed to commit: inode {}, ACL type {}", __func__,
 			              inode, aclType);
 			return SAUNAFS_ERROR_IO;
@@ -942,7 +942,7 @@ int do_setrichacl(const char *filename, uint64_t lv, uint32_t ts, const char *pt
 	                                            reinterpret_cast<const char *>(acl_string));
 
 	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
-		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+		if (!fsOpContext.commitTransaction()) {
 			safs::log_err("{}: transaction failed to commit: inode {}", __func__, inode);
 			return SAUNAFS_ERROR_IO;
 		}
@@ -975,7 +975,7 @@ int do_setquota(const char *filename, uint64_t lv, uint32_t /*ts*/, const char *
 	                                          limit);
 
 	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
-		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+		if (!fsOpContext.commitTransaction()) {
 			safs::log_err("{}: transaction failed to commit: ownerType {}, ownerId {}", __func__,
 			              ownerType, ownerId);
 			return SAUNAFS_ERROR_IO;
@@ -1038,7 +1038,7 @@ int do_symlink(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) 
 	                                   std::string((char *)path), &inode, nullptr);
 
 	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
-		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+		if (!fsOpContext.commitTransaction()) {
 			safs::log_err("{}: transaction failed to commit: parent inode {}, name {}, path {}",
 			              __func__, parent, reinterpret_cast<const char *>(name),
 			              reinterpret_cast<const char *>(path));
@@ -1074,7 +1074,7 @@ int do_unlink(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
 	int status = gFSOperations->applyUnlink(fsOpContext, ts, parent, HString((char *)name), inode);
 
 	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
-		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+		if (!fsOpContext.commitTransaction()) {
 			safs::log_err("{}: transaction failed to commit: parent {}, inode {}",
 			              __func__, parent, inode);
 			status = SAUNAFS_ERROR_IO;
@@ -1126,7 +1126,7 @@ int do_trunc(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
 	int status = gFSOperations->applyTrunc(fsOpContext, ts, inode, indx, chunkid, lockid);
 
 	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
-		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+		if (!fsOpContext.commitTransaction()) {
 			safs::log_err("{}: transaction failed to commit: inode {}, chunk index {}, chunkid {}",
 			              __func__, inode, indx, chunkid);
 			status = SAUNAFS_ERROR_IO;
@@ -1169,7 +1169,7 @@ int do_write(const char* filename, uint64_t lv, uint32_t ts, const char* ptr) {
 	                                       &lockid, &chunkid, &opflag, nullptr);
 
 	if (status == SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
-		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+		if (!fsOpContext.commitTransaction()) {
 			safs::log_err("{}: transaction failed to commit: inode {}, chunk index {}, chunk id {}",
 			              __func__, inode, indx, chunkid);
 			status = SAUNAFS_ERROR_IO;
@@ -1353,7 +1353,7 @@ uint64_t currentFsVersion = 0; /* Metadata version from before restore_line() ca
 const char *lastfn = NULL;
 uint8_t verbosity = 0;
 
-}
+}  // namespace
 
 void restore_reset() {
 	nextFsVersion = 0;

--- a/src/master/setgoal_task.cc
+++ b/src/master/setgoal_task.cc
@@ -22,6 +22,7 @@
 
 #include "master/setgoal_task.h"
 
+#include "kv/ifuture.h"
 #include "master/filesystem_checksum.h"
 #include "master/filesystem_metadata.h"
 #include "master/filesystem_operations_interface.h"
@@ -31,7 +32,6 @@ int SetGoalTask::execute(uint32_t ts, intrusive_list<Task> &work_queue) {
 	assert(current_inode_ != inode_list_.end());
 
 	inode_t inode = *current_inode_;
-	++current_inode_;
 
 	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
 	    FilesystemOperationContext::TransactionType::kReadWrite);
@@ -40,7 +40,43 @@ int SetGoalTask::execute(uint32_t ts, intrusive_list<Task> &work_queue) {
 
 	if (!node) { return SAUNAFS_ERROR_EINVAL; }
 
-	uint8_t result = setGoal(fsOpContext, node, ts);
+	uint8_t result;
+	try {
+		result = setGoal(fsOpContext, node, ts);
+	} catch (const kv::TransactionError &e) {
+		safs::log_warn("setgoal: backend error: {}", e.what());
+		return SAUNAFS_ERROR_IO;
+	}
+
+	if (result == kBackendWaiting) {
+		if (fsOpContext.hasReadWriteTransaction() &&
+		    fsOpContext.getReadWriteTransaction()->mutationCount() > 0 &&
+		    !fsOpContext.commitTransaction()) {
+			safs::log_err("{}: transaction failed to start setgoal: inode {}, goal {}, smode {}",
+			              __func__, inode, static_cast<uint32_t>(goal_),
+			              static_cast<uint32_t>(smode_));
+			return SAUNAFS_ERROR_IO;
+		}
+		waitingForChange_ = true;
+		return SAUNAFS_STATUS_OK;
+	}
+
+	const bool backendPublished = waitingForChange_ && result == kNotChanged && node->goal == goal_;
+	if (backendPublished) { result = kChanged; }
+	waitingForChange_ = false;
+	++current_inode_;
+
+	// A file with an active bulk operation keeps one goal for its owned range.
+	// The client retries once the operation finishes and clears its fence.
+	// A recursive job walks on (parity with setgoalRecursive: the file counts as
+	// unchanged) so one fenced file cannot abort the whole tree.
+	if (result == kTemporarilyLocked || result == kChunkTableError) {
+		if (smode_ & SMODE_RMASK) {
+			(*stats_)[kNotChanged] += 1;
+			return SAUNAFS_STATUS_OK;
+		}
+		return result == kTemporarilyLocked ? SAUNAFS_ERROR_LOCKED : SAUNAFS_ERROR_IO;
+	}
 
 	if (result != kNoAction) {
 		if (node->type == FSNodeType::kDirectory && (smode_ & SMODE_RMASK)) {
@@ -56,15 +92,16 @@ int SetGoalTask::execute(uint32_t ts, intrusive_list<Task> &work_queue) {
 			return SAUNAFS_ERROR_EPERM;
 		}
 		(*stats_)[result] += 1;
-		if (result == kChanged) {
+		if (result == kChanged && !backendPublished) {
 			gFSOperations->changeLog(fsOpContext, ts,
 			                         "SETGOAL(%" PRIiNode ",%" PRIu32 ",%" PRIu8 ",%" PRIu8 ")",
 			                         inode, uid_, goal_, smode_);
 		}
 	}
 
-	if (result == kChanged && fsOpContext.hasReadWriteTransaction()) {
-		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+	if (result == kChanged && fsOpContext.hasReadWriteTransaction() &&
+	    fsOpContext.getReadWriteTransaction()->mutationCount() > 0) {
+		if (!fsOpContext.commitTransaction()) {
 			safs::log_err("{}: transaction failed to commit: inode {}, goal {}, smode {}", __func__,
 			              inode, static_cast<uint32_t>(goal_), static_cast<uint32_t>(smode_));
 			return SAUNAFS_ERROR_IO;
@@ -88,8 +125,18 @@ uint8_t SetGoalTask::setGoal(const FilesystemOperationContext &fsOpContext, FSNo
 		} else {
 			if ((smode_ & SMODE_TMASK) == SMODE_SET && node->goal != goal_) {
 				if (node->type != FSNodeType::kDirectory) {
-					gFSOperations->nodeOperations()->changeFileGoal(
-					    fsOpContext, static_cast<FSNodeFile *>(node), goal_);
+					// changeFileGoal reports LOCKED while a bulk operation owns the
+					// chunk table, and IO when a row is unreadable.
+					const uint8_t changeStatus = gFSOperations->nodeOperations()->changeFileGoal(
+					    fsOpContext, static_cast<FSNodeFile *>(node), goal_,
+					    {.timestamp = ts, .uid = uid_, .mode = smode_, .emitChangelog = true});
+					if (changeStatus == SAUNAFS_ERROR_LOCKED) {
+						return SetGoalTask::kTemporarilyLocked;
+					}
+					if (changeStatus == SAUNAFS_ERROR_WAITING) {
+						return SetGoalTask::kBackendWaiting;
+					}
+					if (changeStatus != SAUNAFS_STATUS_OK) { return SetGoalTask::kChunkTableError; }
 				} else {
 					node->goal = goal_;
 					if (!fsOpContext.hasReadWriteTransaction()) {

--- a/src/master/setgoal_task.h
+++ b/src/master/setgoal_task.h
@@ -33,7 +33,10 @@ public:
 	  kNotChanged,
 	  kNotPermitted,
 	  kStatsSize,
-	  kNoAction
+	  kNoAction,
+	  kTemporarilyLocked,
+	  kChunkTableError,
+	  kBackendWaiting
 	};
 
 	using StatsArray = std::array<inode_t, kStatsSize>;
@@ -79,7 +82,8 @@ private:
 	uint8_t goal_;
 	uint8_t smode_;
 	std::shared_ptr<StatsArray> stats_; /*< array for setgoal operation statistics
-			                       [kChanged] - number of inodes with changed goal
-			                    [kNotChanged] - number of inodes with not changed goal
-			                  [kNotPermitted] - number of inodes with permission denied */
+	                               [kChanged] - number of inodes with changed goal
+	                            [kNotChanged] - number of inodes with not changed goal
+	                          [kNotPermitted] - number of inodes with permission denied */
+	bool waitingForChange_ = false;
 };

--- a/src/master/settrashtime_task.cc
+++ b/src/master/settrashtime_task.cc
@@ -65,7 +65,7 @@ int SetTrashtimeTask::execute(uint32_t ts, intrusive_list<Task> &work_queue) {
 	}
 
 	if (result == kChanged && fsOpContext.hasReadWriteTransaction()) {
-		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+		if (!fsOpContext.commitTransaction()) {
 			safs::log_err("{}: transaction failed to commit: inode {}, trashtime {}, smode {}",
 			              __func__, inode, trashtime_, static_cast<uint32_t>(smode_));
 			return SAUNAFS_ERROR_IO;

--- a/src/master/snapshot_task.cc
+++ b/src/master/snapshot_task.cc
@@ -21,6 +21,9 @@
 
 #include "master/snapshot_task.h"
 
+#include <limits>
+
+#include "kv/ifuture.h"
 #include "master/chunk_operations_interface.h"
 #include "master/chunks.h"
 #include "master/filesystem_checksum.h"
@@ -38,6 +41,15 @@ int SnapshotTask::cloneNodeTest(const FilesystemOperationContext &fsOpContext, F
 		quotaStatus = gFSOperations->checkQuotaUgDir(
 		    fsOpContext, src_node->uid, src_node->gid, dst_parent, {{QuotaResource::kSize, 1}});
 		if (quotaStatus != SAUNAFS_STATUS_OK) { return quotaStatus; }
+
+		// A source row the copy cannot decode must fail the clone before any
+		// destination mutation; skipping it would commit a snapshot that silently
+		// misses part of the file.
+		const auto *srcFile = static_cast<const FSNodeFile *>(src_node);
+		const uint8_t chunkRowStatus = gFSOperations->nodeOperations()->validateFileChunkRows(
+		    fsOpContext, srcFile, 0,
+		    gFSOperations->nodeOperations()->getFileChunkTableSize(fsOpContext, srcFile));
+		if (chunkRowStatus != SAUNAFS_STATUS_OK) { return chunkRowStatus; }
 	}
 
 	if (dst_node) {
@@ -56,7 +68,8 @@ int SnapshotTask::cloneNodeTest(const FilesystemOperationContext &fsOpContext, F
 
 FSNode *SnapshotTask::cloneToExistingNode(const FilesystemOperationContext &fsOpContext,
                                           uint32_t ts, FSNode *src_node,
-                                          FSNodeDirectory *dst_parent, FSNode *dst_node) {
+                                          FSNodeDirectory *dst_parent, FSNode *dst_node,
+                                          int &status) {
 	assert(src_node->type == dst_node->type);
 
 	switch (src_node->type) {
@@ -66,7 +79,7 @@ FSNode *SnapshotTask::cloneToExistingNode(const FilesystemOperationContext &fsOp
 		break;
 	case FSNodeType::kFile:
 		dst_node = cloneToExistingFileNode(fsOpContext, ts, static_cast<FSNodeFile *>(src_node),
-		                                   dst_parent, static_cast<FSNodeFile *>(dst_node));
+		                                   dst_parent, static_cast<FSNodeFile *>(dst_node), status);
 		break;
 	case FSNodeType::kSymlink:
 		cloneSymlinkData(fsOpContext, static_cast<FSNodeSymlink *>(src_node),
@@ -92,7 +105,7 @@ FSNode *SnapshotTask::cloneToExistingNode(const FilesystemOperationContext &fsOp
 }
 
 FSNode *SnapshotTask::cloneToNewNode(const FilesystemOperationContext &fsOpContext, uint32_t ts,
-                                     FSNode *src_node, FSNodeDirectory *dst_parent) {
+                                     FSNode *src_node, FSNodeDirectory *dst_parent, int &status) {
 	FSNode *dst_node = gFSOperations->nodeOperations()->createNode(fsOpContext,
 	    ts, dst_parent, current_subtask_->second, src_node->type, src_node->mode, 0, src_node->uid,
 	    src_node->gid, 0, AclInheritance::kDontInheritAcl, dst_inode_);
@@ -109,8 +122,8 @@ FSNode *SnapshotTask::cloneToNewNode(const FilesystemOperationContext &fsOpConte
 		                   static_cast<FSNodeDirectory *>(dst_node));
 		break;
 	case FSNodeType::kFile:
-		cloneChunkData(fsOpContext, static_cast<FSNodeFile *>(src_node),
-		               static_cast<FSNodeFile *>(dst_node), dst_parent);
+		status = cloneChunkData(fsOpContext, static_cast<FSNodeFile *>(src_node),
+		                        static_cast<FSNodeFile *>(dst_node), dst_parent);
 		break;
 	case FSNodeType::kSymlink:
 		cloneSymlinkData(fsOpContext, static_cast<FSNodeSymlink *>(src_node),
@@ -130,9 +143,10 @@ FSNode *SnapshotTask::cloneToNewNode(const FilesystemOperationContext &fsOpConte
 
 FSNodeFile *SnapshotTask::cloneToExistingFileNode(const FilesystemOperationContext &fsOpContext,
                                                   uint32_t ts, FSNodeFile *src_node,
-                                                  FSNodeDirectory *dst_parent,
-                                                  FSNodeFile *dst_node) {
-	bool same = dst_node->length == src_node->length && dst_node->chunks == src_node->chunks;
+                                                  FSNodeDirectory *dst_parent, FSNodeFile *dst_node,
+                                                  int &status) {
+	bool same = dst_node->length == src_node->length &&
+	            gFSOperations->nodeOperations()->fileChunksEqual(fsOpContext, dst_node, src_node);
 
 	if (same) {
 		return dst_node;
@@ -145,39 +159,45 @@ FSNodeFile *SnapshotTask::cloneToExistingFileNode(const FilesystemOperationConte
 	    fsOpContext, ts, dst_parent, current_subtask_->second, FSNodeType::kFile, src_node->mode, 0,
 	    src_node->uid, src_node->gid, 0, AclInheritance::kDontInheritAcl, dst_inode_));
 
-	cloneChunkData(fsOpContext, src_node, dst_node, dst_parent);
+	status = cloneChunkData(fsOpContext, src_node, dst_node, dst_parent);
 
 	return dst_node;
 }
 
-void SnapshotTask::cloneChunkData(const FilesystemOperationContext &fsOpContext,
-                                  const FSNodeFile *src_node, FSNodeFile *dst_node,
-                                  FSNodeDirectory *dst_parent) {
+int SnapshotTask::cloneChunkData(const FilesystemOperationContext &fsOpContext,
+                                 const FSNodeFile *src_node, FSNodeFile *dst_node,
+                                 FSNodeDirectory *dst_parent) {
 	StatsRecord psr, nsr;
+	int copyStatus = SAUNAFS_STATUS_OK;
 
 	gFSOperations->nodeOperations()->getStats(fsOpContext, dst_node, &psr);
 
 	dst_node->goal = src_node->goal;
 	dst_node->trashtime = src_node->trashtime;
-	dst_node->chunks = src_node->chunks;
 	dst_node->length = src_node->length;
-	for (uint32_t i = 0; i < src_node->chunks.size(); ++i) {
-		auto chunkid = src_node->chunks[i];
-		if (chunkid > 0) {
-			if (gChunkOperations->addFile(fsOpContext, chunkid, dst_node->goal) !=
-			    SAUNAFS_STATUS_OK) {
-				safs_pretty_syslog(LOG_ERR,
-				       "structure error - chunk %016" PRIX64
-				       " not found (inode: %" PRIiNode " ; index: %" PRIu32 ")",
-				       chunkid, src_node->id, i);
-			}
-		}
+	gFSOperations->nodeOperations()->copyFileChunks(
+	    fsOpContext, dst_node, src_node, [&](uint32_t index, uint64_t chunkid) {
+		    copyStatus = gChunkOperations->addFile(fsOpContext, chunkid, dst_node->goal);
+		    if (copyStatus != SAUNAFS_STATUS_OK) {
+			    safs_pretty_syslog(LOG_ERR,
+			                       "structure error - chunk %016" PRIX64
+			                       " not found (inode: %" PRIiNode " ; index: %" PRIu32 ")",
+			                       chunkid, src_node->id, index);
+			    // Master has no transaction to discard partially built nodes, so preserve
+			    // its historical best-effort behavior. KV callers abort and roll back.
+			    return !fsOpContext.hasReadWriteTransaction();
+		    }
+		    return true;
+	    });
+	if (copyStatus != SAUNAFS_STATUS_OK && fsOpContext.hasReadWriteTransaction()) {
+		return copyStatus;
 	}
 
 	gFSOperations->nodeOperations()->getStats(fsOpContext, dst_node, &nsr);
 	gFSOperations->nodeOperations()->addSubStats(fsOpContext, dst_parent, &nsr, &psr);
 	gFSOperations->quotaUpdate(fsOpContext, dst_node,
 	                           {{QuotaResource::kSize, nsr.size - psr.size}});
+	return SAUNAFS_STATUS_OK;
 }
 
 void SnapshotTask::cloneDirectoryData(const FilesystemOperationContext &fsOpContext,
@@ -194,8 +214,9 @@ void SnapshotTask::cloneDirectoryData(const FilesystemOperationContext &fsOpCont
 		data.emplace_back(childId, std::move(name));
 	}
 	if (!data.empty()) {
-		auto task = new SnapshotTask(std::move(data), orig_inode_, dst_node->id, 0, can_overwrite_,
-		                             ignore_missing_src_, emit_changelog_, enqueue_work_);
+		auto *task = gFSOperations->createSnapshotTask(std::move(data), orig_inode_, dst_node->id,
+		                                               0, can_overwrite_, ignore_missing_src_,
+		                                               emit_changelog_, enqueue_work_);
 		local_tasks_.push_back(*task);
 	}
 }
@@ -231,6 +252,16 @@ void SnapshotTask::emitChangelog(const FilesystemOperationContext &fsOpContext, 
 int SnapshotTask::cloneNode(uint32_t ts) {
 	auto fsOpContext = gFSOperations->createFilesystemOperationContext(
 	    FilesystemOperationContext::TransactionType::kReadWrite);
+
+	try {
+		return cloneNodeStep(fsOpContext, ts);
+	} catch (const kv::TransactionError &e) {
+		safs::log_warn("snapshot: backend error: {}", e.what());
+		return SAUNAFS_ERROR_IO;
+	}
+}
+
+int SnapshotTask::cloneNodeStep(const FilesystemOperationContext &fsOpContext, uint32_t ts) {
 	FSNode *src_node =
 	    gFSOperations->nodeOperations()->idToNode(fsOpContext, current_subtask_->first);
 	auto *dst_parent =
@@ -240,12 +271,22 @@ int SnapshotTask::cloneNode(uint32_t ts) {
 	    src_node->type == FSNodeType::kReserved) {
 		return SAUNAFS_ERROR_ENOENT;
 	}
-	if (!dst_parent || dst_parent->type != FSNodeType::kDirectory) {
-		return SAUNAFS_ERROR_EINVAL;
+	if (!dst_parent || dst_parent->type != FSNodeType::kDirectory) { return SAUNAFS_ERROR_EINVAL; }
+	if (src_node->type == FSNodeType::kFile) {
+		const int fenceStatus = gFSOperations->nodeOperations()->canMutateFileChunks(
+		    fsOpContext, static_cast<FSNodeFile *>(src_node), 0,
+		    std::numeric_limits<uint32_t>::max());
+		if (fenceStatus != SAUNAFS_STATUS_OK) { return fenceStatus; }
 	}
 
 	FSNode *dst_node =
 	    gFSOperations->nodeOperations()->lookup(fsOpContext, dst_parent, current_subtask_->second);
+	if (dst_node != nullptr && dst_node->type == FSNodeType::kFile) {
+		const int fenceStatus = gFSOperations->nodeOperations()->canMutateFileChunks(
+		    fsOpContext, static_cast<FSNodeFile *>(dst_node), 0,
+		    std::numeric_limits<uint32_t>::max());
+		if (fenceStatus != SAUNAFS_STATUS_OK) { return fenceStatus; }
+	}
 
 	int status = cloneNodeTest(fsOpContext, src_node, dst_node, dst_parent);
 	if (status != SAUNAFS_STATUS_OK) {
@@ -253,10 +294,11 @@ int SnapshotTask::cloneNode(uint32_t ts) {
 	}
 
 	if (dst_node) {
-		dst_node = cloneToExistingNode(fsOpContext, ts, src_node, dst_parent, dst_node);
+		dst_node = cloneToExistingNode(fsOpContext, ts, src_node, dst_parent, dst_node, status);
 	} else {
-		dst_node = cloneToNewNode(fsOpContext, ts, src_node, dst_parent);
+		dst_node = cloneToNewNode(fsOpContext, ts, src_node, dst_parent, status);
 	}
+	if (status != SAUNAFS_STATUS_OK) { return status; }
 
 	assert(dst_node);
 	fsnodes_update_checksum(dst_node);
@@ -275,7 +317,7 @@ int SnapshotTask::cloneNode(uint32_t ts) {
 	}
 
 	if (fsOpContext.hasReadWriteTransaction()) {
-		if (!fsOpContext.getReadWriteTransaction()->commit()) {
+		if (!fsOpContext.commitTransaction()) {
 			safs::log_err(
 			    "{}: transaction failed to commit: source inode {}, destination parent inode {}, name {}",
 			    __func__, current_subtask_->first, dst_parent_inode_, current_subtask_->second);

--- a/src/master/snapshot_task.h
+++ b/src/master/snapshot_task.h
@@ -66,6 +66,10 @@ public:
 	 */
 	int cloneNode(uint32_t ts);
 
+	/// One clone attempt on an established context; cloneNode wraps it with backend
+	/// transaction handling so aborted attempts discard staged reference effects.
+	int cloneNodeStep(const FilesystemOperationContext &fsOpContext, uint32_t ts);
+
 	/*! \brief Execute task specified by this SnapshotTask object.
 	 *
 	 * This function overrides pure virtual execute function of TaskManager::Task.
@@ -89,15 +93,20 @@ protected:
 	/*! \brief Test if node can be cloned. */
 	int cloneNodeTest(const FilesystemOperationContext &fsOpContext, FSNode *src_node,
 	                  FSNode *dst_node, FSNodeDirectory *dst_parent);
+	/// Clones a node and writes @p status only when cloning a file branch.
+	/// The caller must initialize @p status to SAUNAFS_STATUS_OK.
 	FSNode *cloneToExistingNode(const FilesystemOperationContext &fsOpContext, uint32_t ts,
-	                            FSNode *src_node, FSNodeDirectory *dst_parent, FSNode *dst_node);
+	                            FSNode *src_node, FSNodeDirectory *dst_parent, FSNode *dst_node,
+	                            int &status);
+	/// Clones a new node and writes @p status only when cloning a file branch.
+	/// The caller must initialize @p status to SAUNAFS_STATUS_OK.
 	FSNode *cloneToNewNode(const FilesystemOperationContext &fsOpContext, uint32_t ts,
-	                       FSNode *src_node, FSNodeDirectory *dst_parent);
+	                       FSNode *src_node, FSNodeDirectory *dst_parent, int &status);
 	FSNodeFile *cloneToExistingFileNode(const FilesystemOperationContext &fsOpContext, uint32_t ts,
 	                                    FSNodeFile *src_node, FSNodeDirectory *dst_parent,
-	                                    FSNodeFile *dst_node);
-	void cloneChunkData(const FilesystemOperationContext &fsOpContext, const FSNodeFile *src_node,
-	                    FSNodeFile *dst_node, FSNodeDirectory *dst_parent);
+	                                    FSNodeFile *dst_node, int &status);
+	int cloneChunkData(const FilesystemOperationContext &fsOpContext, const FSNodeFile *src_node,
+	                   FSNodeFile *dst_node, FSNodeDirectory *dst_parent);
 	void cloneDirectoryData(const FilesystemOperationContext &fsOpContext,
 	                        const FSNodeDirectory *src_node, FSNodeDirectory *dst_node);
 	void cloneSymlinkData(const FilesystemOperationContext &fsOpContext, FSNodeSymlink *src_node,

--- a/src/master/task_manager.cc
+++ b/src/master/task_manager.cc
@@ -22,6 +22,9 @@
 #include "master/task_manager.h"
 
 #include "common/loop_watchdog.h"
+#include "errors/sfserr.h"
+#include "kv/ifuture.h"
+#include "slogger/slogger.h"
 
 void TaskManager::Job::finalize(int status) {
 	if (finish_callback_) {
@@ -41,7 +44,17 @@ void TaskManager::Job::finalizeTask(TaskIterator itask, int status) {
 void TaskManager::Job::processTask(uint32_t ts) {
 	if (!tasks_.empty()) {
 		auto i_front = tasks_.begin();
-		int status = i_front->execute(ts, tasks_);
+		int status;
+		try {
+			status = i_front->execute(ts, tasks_);
+		} catch (const kv::TransactionError &e) {
+			// Without this boundary the job stays at the front of the queue and
+			// re-executes (and fails again) every loop iteration, never answering
+			// the client. Fail the whole job cleanly instead.
+			safs::log_warn("task manager: backend error, failing job '{}': {}", description_,
+			               e.what());
+			status = SAUNAFS_ERROR_IO;
+		}
 		finalizeTask(i_front, status);
 	}
 }

--- a/src/master/task_manager_unittest.cc
+++ b/src/master/task_manager_unittest.cc
@@ -1,0 +1,47 @@
+/*
+   Copyright 2026      Leil Storage OÜ
+
+   This file is part of SaunaFS.
+
+   SaunaFS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 3.
+
+   SaunaFS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SaunaFS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "common/platform.h"
+
+#include <gtest/gtest.h>
+
+#include "errors/sfserr.h"
+#include "kv/ifuture.h"
+#include "master/task_manager.h"
+
+namespace {
+
+class ThrowingTask : public TaskManager::Task {
+public:
+	int execute(uint32_t /*ts*/, intrusive_list<Task> & /*work_queue*/) override {
+		throw kv::RetryableTransactionError(1007, "transaction too old");
+	}
+	bool isFinished() const override { return false; }
+};
+
+}  // namespace
+
+TEST(TaskManagerTests, RetryableBackendErrorFailsJobClean) {
+	// A retryable backend error escaping a task used to unwind past finalizeTask,
+	// leaving the job queued to re-execute (and fail again) forever without ever
+	// answering the client. It must surface as a clean job failure instead.
+	TaskManager manager;
+	const int status = manager.submitTask(/*ts=*/0, /*initial_batch_size=*/1, new ThrowingTask(),
+	                                      "throwing task", [](int /*code*/) {});
+	EXPECT_EQ(SAUNAFS_ERROR_IO, status);
+}


### PR DESCRIPTION
A file's chunk table lived as one blob inside its node value, so maximum file size was capped by
the backend's value-size limit and every read of a node carried its whole table. This routes all
chunk-table access through the node-operations interface, so a backend can keep the table outside
the node value and page it in bounded rows.

Storage does not change for Master and Shadow. The in-memory backend keeps operating on
`FSNodeFile::chunks`, every new substitution point has a synchronous default, and the KV-only
bookkeeping lives in a per-operation arena sidecar rather than in new `FSNodeFile` fields, so
`sizeof(FSNodeFile)` is unchanged and an in-memory master pays no node-memory growth. Three shared
behaviors do change; they are listed below.

## What this adds

- **Chunk-table seam.** Every read and write of a file's chunk table goes through
  `IFilesystemNodeOperations`.
- **Transaction effects.** `FilesystemOperationContext` owns at most one opaque backend effects
  object and delivers exactly one of committed, aborted or indeterminate. Destroying an unfinished
  context defaults to aborted, and commit coordinators finalize effects before publishing deferred
  changelog entries or replying to a client. A backend that mirrors durable state in memory needs a
  definite outcome before it may apply or discard what it staged.
- **Mutation fence.** Chunk mutation admission is a half-open chunk-index range, so a backend can
  keep part of a file writable while a long operation walks the rest. The in-memory backend always
  admits.
- **Deferred results.** Truncate and remove-all return an explicit complete or deferred result, so
  logical POSIX completion does not wait for reference cleanup that a backend defers.
- **Substitution points.** `appendAsync`, `checkFileAsync`, `repairAsync` and `createSnapshotTask`,
  plus a `drainPendingFileOperations` hook that is a no-op in memory. The synchronous defaults keep
  Master, Shadow and restore fully synchronous.

## Three behavior changes for Master and Shadow

The shared code paths these sit on had to stop doing work proportional to a whole file.

1. `removeChunkFromFile` takes the exact chunk index instead of scanning the table for the first
   slot holding the id. That scan reads the whole table, which a backend storing the table outside
   the node cannot afford. The caller already knows the index it allocated, so the only difference
   is that a wrong index now fails with `NOCHUNK` instead of silently clearing a different slot
   that happens to hold the same id.
2. `getChunksInfo` clamps a zero chunk count to `kMaxNumberOfResultEntries`. Reading the table
   through the seam materializes a vector, and an unclamped count on a sparse maximal file would
   allocate about 128 MiB. The wire handler already applied the same limit, so no client sees a
   difference; only in-process callers do.
3. `changeFileGoal` moves every chunk reference before publishing the new goal, and reports a
   failed move after reversing the references it already moved. Publishing the goal first would let
   a backend that defers reference work expose a goal with no references behind it. The old code
   set the goal first and discarded each `changeFile` status without logging it, so a partial move
   left the node advertising a goal its chunks did not have while `setgoal` reported success.

The first two are forced consequences of moving the table behind the seam. The third is a behavior
fix rather than a consequence, and it can be split into its own change if you would rather this
pair stayed strictly behavior-preserving.

## Reviewing

The branch is a single squashed commit on purpose. The earlier history contained two designs that
were replaced wholesale, so replaying it would mean reading the wrong architecture twice before
reaching the one shipped here. The commit message carries the reasoning those dropped commits held.

Suggested order: `filesystem_node_operations_interface.h` for the seam,
`filesystem_operation_context.{h,cc}` for the effects boundary, then the three changed paths in
`filesystem_operations.cc`, `chunk_operations_base.cc` and `setgoal_task.cc`.

## Validation

Warning-as-error configure and install build pass. Unit suites pass, including 124 Master tests,
with new coverage for the chunk-table seam (`filesystem_node_chunk_table_unittest.cc`) and for task
manager behavior (`task_manager_unittest.cc`). The non-KV system suites are the evidence that
Master and Shadow are unaffected: `SanityChecks` 43 pass and `ShortSystemTests` 219 pass, with five
upgrade tests skipped by the runner's own policy.

The only change made after that evidence was collected was removing formatting-only churn, which
preserved the exact C++ token stream and was followed by a rebuild with both unit suites passing.

## Dependencies

Related to: LS-949

The seam, the fence and the effects boundary are only meaningful to a backend that implements them,
so this must land together with, or before, the matching metadata-server change that does. On its
own it is a no-op for Master and Shadow.
