### PR TITLE
fix(cs): retry attribute reads and propagate setChunkBlocks status

### DIFF
--- a/src/chunkserver/chunkserver-common/cmr_disk.cc
+++ b/src/chunkserver/chunkserver-common/cmr_disk.cc
@@ -127,7 +127,10 @@ int CmrDisk::updateChunkAttributes(IChunk *chunk, bool isFromScan) {
 	if (::stat(chunk->fullMetaFilename().c_str(), &metaStat) < 0) {
 		safs::log_err("CmrDisk::updateChunkAttributes: could not access chunk metadata: chunk->metaFilename ({}), strerror ({})",
 				chunk->fullMetaFilename(), strerror(errno));
-		return SAUNAFS_ERROR_NOCHUNK;
+		// Only a confirmed-gone file is NOCHUNK; other errno values
+		// (EMFILE, EINTR, EIO...) must not delete a healthy chunk.
+		return (errno == ENOENT || errno == ENOTDIR) ? SAUNAFS_ERROR_NOCHUNK
+		                                             : SAUNAFS_ERROR_IO;
 	}
 	if (!S_ISREG(metaStat.st_mode)) {
 		safs::log_critical("CmrDisk::updateChunkAttributes: chunk metadata file not a regular file: metaFilename ({})",
@@ -139,7 +142,8 @@ int CmrDisk::updateChunkAttributes(IChunk *chunk, bool isFromScan) {
 	if (::stat(chunk->fullDataFilename().c_str(), &dataStat) < 0) {
 		safs::log_err("CmrDisk::updateChunkAttributes: could not access chunk data {}: {}",
 				chunk->fullDataFilename(), strerror(errno));
-		return SAUNAFS_ERROR_NOCHUNK;
+		return (errno == ENOENT || errno == ENOTDIR) ? SAUNAFS_ERROR_NOCHUNK
+		                                             : SAUNAFS_ERROR_IO;
 	}
 	if ((dataStat.st_mode & S_IFMT) != S_IFREG) {
 		safs::log_critical("CmrDisk::updateChunkAttributes: chunk data file not a regular file: dataFilename ({})",

--- a/src/chunkserver/chunkserver-common/cmr_disk.cc
+++ b/src/chunkserver/chunkserver-common/cmr_disk.cc
@@ -182,10 +182,11 @@ IChunk *CmrDisk::instantiateNewConcreteChunk(uint64_t chunkId,
 	return chunk;
 }
 
-void CmrDisk::setChunkBlocks(IChunk *chunk, uint16_t originalBlocks,
-                             uint16_t newBlocks) {
+int CmrDisk::setChunkBlocks(IChunk *chunk, uint16_t originalBlocks,
+                            uint16_t newBlocks) {
 	(void)originalBlocks;
 	chunk->setBlocks(newBlocks);
+	return SAUNAFS_STATUS_OK;
 }
 
 void CmrDisk::updateAfterScan() {

--- a/src/chunkserver/chunkserver-common/cmr_disk.h
+++ b/src/chunkserver/chunkserver-common/cmr_disk.h
@@ -83,8 +83,8 @@ public:
 	IChunk *instantiateNewConcreteChunk(uint64_t chunkId,
 	                                    ChunkPartType type) override;
 
-	void setChunkBlocks(IChunk *chunk, uint16_t originalBlocks,
-	                    uint16_t newBlocks) override;
+	int setChunkBlocks(IChunk *chunk, uint16_t originalBlocks,
+	                   uint16_t newBlocks) override;
 
 	void updateAfterScan() override;
 

--- a/src/chunkserver/chunkserver-common/disk_interface.h
+++ b/src/chunkserver/chunkserver-common/disk_interface.h
@@ -147,8 +147,10 @@ public:
 
 	/// Sets the number of blocks for \a chunk from \a originalBlocks to \a
 	/// newBlocks.
-	virtual void setChunkBlocks(IChunk *chunk, uint16_t originalBlocks,
-	                            uint16_t newBlocks) = 0;
+	/// @return SAUNAFS_STATUS_OK on success, or a SAUNAFS_ERROR_* code if the
+	///         new layout could not be persisted.
+	virtual int setChunkBlocks(IChunk *chunk, uint16_t originalBlocks,
+	                           uint16_t newBlocks) = 0;
 
 	/// Updates this disk attributes after a scan.
 	/// Useful for SMR drives, for instance, to update the zones state after

--- a/src/chunkserver/chunkserver-common/hdd_utils.cc
+++ b/src/chunkserver/chunkserver-common/hdd_utils.cc
@@ -20,7 +20,6 @@
 
 #include "chunkserver-common/hdd_utils.h"
 
-#include <cinttypes>
 #include <fcntl.h>
 #include <sys/time.h>
 
@@ -308,11 +307,12 @@ int hddIOBegin(IChunk *chunk, int newFlag, uint32_t chunkVersion) {
 bool hddScansInProgress() { return gScansInProgress != 0; }
 
 int hddUpdateChunkAttributesWithRetry(IDisk *disk, IChunk *chunk, bool isFromScan) {
-	int status = SAUNAFS_ERROR_IO;
-	for (int i = 0; i < kOpenRetryCount && status == SAUNAFS_ERROR_IO; ++i) {
-		if (i > 0) { usleep(kOpenRetry_ms * 1000); }
+	int status;
+	int attempt = 0;
+	do {
+		if (attempt > 0) { usleep((kOpenRetry_ms * 1000) << (attempt - 1)); }
 		status = disk->updateChunkAttributes(chunk, isFromScan);
-	}
+	} while (status == SAUNAFS_ERROR_IO && ++attempt < kOpenRetryCount);
 	return status;
 }
 

--- a/src/chunkserver/chunkserver-common/hdd_utils.cc
+++ b/src/chunkserver/chunkserver-common/hdd_utils.cc
@@ -20,6 +20,7 @@
 
 #include "chunkserver-common/hdd_utils.h"
 
+#include <cinttypes>
 #include <fcntl.h>
 #include <sys/time.h>
 
@@ -306,6 +307,15 @@ int hddIOBegin(IChunk *chunk, int newFlag, uint32_t chunkVersion) {
 
 bool hddScansInProgress() { return gScansInProgress != 0; }
 
+int hddUpdateChunkAttributesWithRetry(IDisk *disk, IChunk *chunk, bool isFromScan) {
+	int status = SAUNAFS_ERROR_IO;
+	for (int i = 0; i < kOpenRetryCount && status == SAUNAFS_ERROR_IO; ++i) {
+		if (i > 0) { usleep(kOpenRetry_ms * 1000); }
+		status = disk->updateChunkAttributes(chunk, isFromScan);
+	}
+	return status;
+}
+
 IChunk *hddChunkFindAndLock(uint64_t chunkId, ChunkPartType chunkType) {
 	LOG_AVG_TILL_END_OF_SCOPE0("chunk_find");
 
@@ -349,8 +359,9 @@ IChunk *hddChunkFindOrCreatePlusLock(IDisk *disk, uint64_t chunkid,
 			chunk->setState(ChunkState::Locked);
 			chunksMapLock.unlock();
 			if (chunk->validAttr() == 0) {
-				if (effectiveDisk->updateChunkAttributes(chunk, false) ==
-				    SAUNAFS_ERROR_NOCHUNK) {
+				int attrStatus =
+				    hddUpdateChunkAttributesWithRetry(effectiveDisk, chunk, false);
+				if (attrStatus != SAUNAFS_STATUS_OK) {
 					// The chunk was found as available, but we can not
 					// update its attributes, let's recreate it only if
 					// requested

--- a/src/chunkserver/chunkserver-common/hdd_utils.h
+++ b/src/chunkserver/chunkserver-common/hdd_utils.h
@@ -84,6 +84,11 @@ IChunk *hddChunkFindAndLock(uint64_t chunkId, ChunkPartType chunkType);
 
 int chunkWriteCrc(IChunk *chunk);
 
+/// Calls disk->updateChunkAttributes(), retrying a few times (with backoff)
+/// while it keeps returning SAUNAFS_ERROR_IO, since that's a transient read
+/// failure rather than a confirmed-absent chunk.
+int hddUpdateChunkAttributesWithRetry(IDisk *disk, IChunk *chunk, bool isFromScan);
+
 /// Finds an existing chunk or creates a new one, and locks it anyway.
 ///
 /// The function locks the returned chunk (may block if the chunk is already

--- a/src/chunkserver/disk_unittest.cc
+++ b/src/chunkserver/disk_unittest.cc
@@ -1,6 +1,28 @@
 #include <gtest/gtest.h>
 
 #include "chunkserver-common/cmr_disk.h"
+#include "chunkserver-common/global_shared_resources.h"
+#include "chunkserver-common/hdd_utils.h"
+#include "errors/saunafs_error_codes.h"
+
+namespace {
+
+// Fails with SAUNAFS_ERROR_IO on every call before succeedOnAttempt, then
+// succeeds; the chunk pointer is never dereferenced.
+class FlakyAttributesDisk : public CmrDisk {
+public:
+	using CmrDisk::CmrDisk;
+
+	int updateChunkAttributes(IChunk * /*chunk*/, bool /*isFromScan*/) override {
+		++callCount;
+		return callCount < succeedOnAttempt ? SAUNAFS_ERROR_IO : SAUNAFS_STATUS_OK;
+	}
+
+	int callCount = 0;
+	int succeedOnAttempt = 1;
+};
+
+}  // namespace
 
 TEST(DiskTests, ParseSingleHddLine) {
 	const std::string hddCfgLine {"/mnt/hdd_22/"};
@@ -71,3 +93,22 @@ TEST(DiskTests, ParseZonedHddLine) {
 	ASSERT_FALSE(diskConfig2.isValid);
 }
 
+TEST(DiskTests, UpdateChunkAttributesRetrySucceedsAfterTransientErrors) {
+	const disk::Configuration diskConfig("/mnt/hdd_22/");
+	FlakyAttributesDisk disk(diskConfig);
+	disk.succeedOnAttempt = kOpenRetryCount;
+
+	ASSERT_EQ(hddUpdateChunkAttributesWithRetry(&disk, nullptr, false),
+	          SAUNAFS_STATUS_OK);
+	ASSERT_EQ(disk.callCount, kOpenRetryCount);
+}
+
+TEST(DiskTests, UpdateChunkAttributesRetryGivesUpAfterMaxAttempts) {
+	const disk::Configuration diskConfig("/mnt/hdd_22/");
+	FlakyAttributesDisk disk(diskConfig);
+	disk.succeedOnAttempt = kOpenRetryCount + 1;  // never succeeds in time
+
+	ASSERT_EQ(hddUpdateChunkAttributesWithRetry(&disk, nullptr, false),
+	          SAUNAFS_ERROR_IO);
+	ASSERT_EQ(disk.callCount, kOpenRetryCount);
+}

--- a/src/chunkserver/hddspacemgr.cc
+++ b/src/chunkserver/hddspacemgr.cc
@@ -1839,7 +1839,15 @@ static int hddInternalTruncate(uint64_t chunkId, ChunkPartType chunkType,
 		disk->setNeedRefresh(true);
 	}
 
-	disk->setChunkBlocks(chunk, chunk->blocks(), blocks);
+	status = disk->setChunkBlocks(chunk, chunk->blocks(), blocks);
+	if (status != SAUNAFS_STATUS_OK) {
+		hddAddErrorAndPreserveErrno(chunk);
+		safs::log_warn("truncate: file:{} - set chunk blocks error",
+		               chunk->fullMetaFilename().c_str());
+		hddIOEnd(chunk);
+		hddChunkRelease(chunk);
+		return status;
+	}
 
 	status = hddIOEnd(chunk);
 	if (status != SAUNAFS_STATUS_OK) {
@@ -2327,8 +2335,16 @@ static int hddInternalDuplicateTruncate(uint64_t chunkId, uint32_t chunkVersion,
 		return status;
 	}
 
-	dupDisk->setChunkBlocks(dupChunk, originalChunk->blocks(), blocks);
+	status = dupDisk->setChunkBlocks(dupChunk, originalChunk->blocks(), blocks);
 	dupDisk->setNeedRefresh(true);
+
+	if (status != SAUNAFS_STATUS_OK) {
+		hddAddErrorAndPreserveErrno(dupChunk);
+		dupDisk->unlinkChunk(dupChunk);
+		hddDeleteChunkFromRegistry(dupChunk);
+		hddChunkRelease(originalChunk);
+		return status;
+	}
 
 	hddChunkRelease(dupChunk);
 	hddChunkRelease(originalChunk);
@@ -2551,10 +2567,17 @@ static inline void hddAddChunkFromDiskScan(IDisk *disk,
 	chunk->setVersion(version);
 	sassert(chunk->fullMetaFilename() == fullname);
 
-	{
-		disk->updateChunkAttributes(chunk, true);
-		chunk->setValidAttr(0);
+	int attrStatus = hddUpdateChunkAttributesWithRetry(disk, chunk, true);
+	if (attrStatus != SAUNAFS_STATUS_OK) {
+		safs::log_err(
+		    "hddAddChunkFromDiskScan: could not read attributes "
+		    "for {} (status {}); reporting damaged",
+		    fullname.c_str(), attrStatus);
+		hddReportDamagedChunk(chunk->id(), chunk->type());
+		hddChunkRelease(chunk);
+		return;
 	}
+	chunk->setValidAttr(0);
 
 	{
 		std::lock_guard testsLockGuard(gTestsMutex);

--- a/src/chunkserver/hddspacemgr.cc
+++ b/src/chunkserver/hddspacemgr.cc
@@ -1842,8 +1842,8 @@ static int hddInternalTruncate(uint64_t chunkId, ChunkPartType chunkType,
 	status = disk->setChunkBlocks(chunk, chunk->blocks(), blocks);
 	if (status != SAUNAFS_STATUS_OK) {
 		hddAddErrorAndPreserveErrno(chunk);
-		safs::log_warn("truncate: file:{} - set chunk blocks error",
-		               chunk->fullMetaFilename().c_str());
+		safs::log_warn("truncate: file:{} - set chunk blocks error (status {})",
+		               chunk->fullMetaFilename(), status);
 		hddIOEnd(chunk);
 		hddChunkRelease(chunk);
 		return status;
@@ -2326,18 +2326,21 @@ static int hddInternalDuplicateTruncate(uint64_t chunkId, uint32_t chunkVersion,
 		return status;
 	}
 
-	status = hddIOEnd(dupChunk);
+	// Persist the new layout before ending dupChunk's IO, so it lands inside
+	// the same fsync as the rest of the header (matches hddInternalTruncate).
+	status = dupDisk->setChunkBlocks(dupChunk, originalChunk->blocks(), blocks);
+	dupDisk->setNeedRefresh(true);
+
 	if (status != SAUNAFS_STATUS_OK) {
 		hddAddErrorAndPreserveErrno(dupChunk);
+		hddIOEnd(dupChunk);
 		dupDisk->unlinkChunk(dupChunk);
 		hddDeleteChunkFromRegistry(dupChunk);
 		hddChunkRelease(originalChunk);
 		return status;
 	}
 
-	status = dupDisk->setChunkBlocks(dupChunk, originalChunk->blocks(), blocks);
-	dupDisk->setNeedRefresh(true);
-
+	status = hddIOEnd(dupChunk);
 	if (status != SAUNAFS_STATUS_OK) {
 		hddAddErrorAndPreserveErrno(dupChunk);
 		dupDisk->unlinkChunk(dupChunk);
@@ -2359,7 +2362,7 @@ int hddInternalDelete(IChunk *chunk, uint32_t version) {
 		hddChunkRelease(chunk);
 		return SAUNAFS_ERROR_WRONGVERSION;
 	}
-	if (chunk->owner()->unlinkChunk(chunk) < 0) {
+	if (chunk->owner()->unlinkChunk(chunk) != SAUNAFS_STATUS_OK) {
 		uint8_t err = errno;
 		hddAddErrorAndPreserveErrno(chunk);
 		safs_silent_errlog(LOG_WARNING,
@@ -2569,14 +2572,11 @@ static inline void hddAddChunkFromDiskScan(IDisk *disk,
 
 	int attrStatus = hddUpdateChunkAttributesWithRetry(disk, chunk, true);
 	if (attrStatus != SAUNAFS_STATUS_OK) {
-		safs::log_err(
-		    "hddAddChunkFromDiskScan: could not read attributes "
-		    "for {} (status {}); reporting damaged",
-		    fullname.c_str(), attrStatus);
-		hddReportDamagedChunk(chunk->id(), chunk->type());
-		hddChunkRelease(chunk);
-		return;
+		safs::log_warn("hddAddChunkFromDiskScan: could not read attributes for {} (status {})",
+		               fullname, attrStatus);
 	}
+
+	// Attributes are re-read on first access, whether or not the scan read them.
 	chunk->setValidAttr(0);
 
 	{

--- a/tests/tools/valgrind-helgrind.supp
+++ b/tests/tools/valgrind-helgrind.supp
@@ -100,3 +100,23 @@
    fun:_ZNSt6thread4joinEv
    fun:_ZN7JobPool4stopEv*
 }
+
+{
+   # Same false positive as jobpool_stop_tls_teardown_race above (see its
+   # comment for the full explanation), reached via a different, equally
+   # legitimate join(): mainNetworkThreadTerm() joins each NetworkWorkerThread's
+   # own thread directly, and that join's internal __nptl_free_stacks() cache
+   # trim can free the TLS blocks of OTHER, separately-already-exited threads
+   # (e.g. a JobPool worker) that glibc had been retaining in its dead-stack
+   # cache. Only the join() call site differs from the stanza above.
+   network_thread_term_tls_teardown_race
+   Helgrind:Race
+   fun:free
+   ...
+   fun:_dl_deallocate_tls
+   ...
+   fun:_ZNSt6thread4joinEv
+   fun:_Z21mainNetworkThreadTermv
+   fun:_Z18eventloop_destructv
+   fun:main
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -11,7 +11,8 @@
     "gtest",
     "openssl",
     "prometheus-cpp",
-    "spdlog"
+    "spdlog",
+    "zstd"
   ],
   "overrides": [
     {


### PR DESCRIPTION
From suggestions in a recent PR review, the following changes are applied to strengthen chunkserver reliability:
- retry updateChunkAttributes() a bounded number of times when it returns SAUNAFS_ERROR_IO, since that error signals a transient read failure and not a confirmed-absent chunk. Applies to both the disk-scan path (hddAddChunkFromDiskScan) and the find-or-create path (hddChunkFindOrCreatePlusLock).
- change IDisk::setChunkBlocks() to return a status instead of void, and propagate/surface that status from its two call sites (hddInternalTruncate, hddInternalDuplicateTruncate), so a failed persist is now reported and cleaned up instead of silently leaving a chunk whose blocks count doesn't match its on-disk layout. CmrDisk::setChunkBlocks() always succeeds; ZoneFSDisk::setChunkBlocks() (zonefs_disk submodule, companion PR) now surfaces overwriteAllFragments() failures through this same path.

I also included this changes not strictly related:
- add zstd to the vcpkg manifest dependencies (it was only present under overrides, which pins a version without actually installing it) — needed by the zonefs_disk plugin's compressed-chunk support.
- suppress a second, previously-unseen helgrind TLS-teardown false positive (same root cause as the existing jobpool_stop_tls_teardown_race suppression, reached this time via mainNetworkThreadTerm()'s join instead of JobPool::stop()).