### PR TITLE
test: select the MDS command for the backend

### DIFF
--- a/tests/test_suites/SanityChecks/test_readdir_faulty_master.sh
+++ b/tests/test_suites/SanityChecks/test_readdir_faulty_master.sh
@@ -17,7 +17,8 @@ slice_size = int(${FILE_COUNT}) // 2
 dirents = 0
 with os.scandir("${info[mount0]}") as dir:
 	dirents += len(list(itertools.islice(dir, slice_size)))
-	os.system("sfsmaster -c ${MASTER_CFG_FILE} restart")
+	if os.system("${mds_command} -c ${MASTER_CFG_FILE} restart") != 0:
+		raise SystemExit("restart failed")
 	dirents += len(list(itertools.islice(dir, slice_size)))
 print(dirents)
 END_OF_SCRIPT


### PR DESCRIPTION
The readdir faulty master test restarted the master by invoking sfsmaster directly. That binary only serves the FILE backend; the harness selects leil-mds whenever METADATA_BACKEND is not FILE and already exposes the choice as mds_command. Restart through it so the test exercises the real master on both backends.

Assert the restart succeeded. os.system reports the exit status but the test discarded it, so a restart that never ran left the scandir uninterrupted and the entry count still matched.

Related to: LS-998