### PR TITLE
fix(cs): duplicate chunks in the target format

### DIFF
--- a/src/chunkserver/README.md
+++ b/src/chunkserver/README.md
@@ -38,7 +38,7 @@ Files in the top-level directory are grouped by subsystem:
 | `chunk_file_creator.*`            | RAII helper for safe chunk creation           |
 | `chunk_filename_parser.*`         | Parse chunk filenames to extract metadata     |
 | `io_buffers.*`                    | Aligned I/O buffers for moving data between network and disk        |
-| `buffers_pool.h`                  | Thread-safe buffer (`OutputBuffer`, `InputBuffer`, `ReplicatorBuffer`) recycling pool     |
+| `buffers_pool.h`                  | Thread-safe buffer (`OutputBuffer`, `InputBuffer`, `ChunkCopyBuffer`) recycling pool     |
 | `slice_recovery_planner.h`        | EC/XOR slice recovery planning                |
 | `g_limiters.*`                    | Singleton for replication bandwidth limiter   |
 | `replication_bandwidth_limiter.*` | I/O throttling for replication                |
@@ -465,10 +465,11 @@ IPlugin (root interface: name, version, initialize)
   tracks which writes were already acknowledged, and `hddspacemgr` may use the
   buffered data to patch later reads until the disk write completes.
   Pool-recycled via `BuffersPool`.
-- **`ReplicatorBuffer`** (`io_buffers.h`) -- specialized for replications. Contains only
+- **`ChunkCopyBuffer`** (`io_buffers.h`) -- specialized for the paths that stage whole
+  chunk blocks while copying them: replication and local chunk duplication. Contains only
   a block buffer aligned to 4 KiB (`disk::kIoBlockSize`). Pool-recycled via `BuffersPool`.
 - **`BuffersPool<T>`** (`buffers_pool.h`) -- thread-safe pool of
-  `OutputBuffer`, `InputBuffer` and `ReplicatorBuffer` objects, keyed by
+  `OutputBuffer`, `InputBuffer` and `ChunkCopyBuffer` objects, keyed by
   `(headerSize, numBlocks)`. Auto-creates new buffers when the pool is empty, recycles
   after use, and supports TTL-based expiration via `releaseOldBuffers()`.
 

--- a/src/chunkserver/chunk_replicator.cc
+++ b/src/chunkserver/chunk_replicator.cc
@@ -142,7 +142,7 @@ void ChunkReplicator::replicate(ChunkFileCreator& fileCreator,
 	SliceRecoveryPlanner planner;
 	ReadPlanExecutor::ChunkTypeLocations locations;
 	SliceRecoveryPlanner::PartsContainer available_parts;
-	auto buffer = getReplicateBuffersPool().get(kReplicatorBufferHeaderSize, batchSize);
+	auto buffer = getChunkCopyBuffersPool().get(kChunkCopyBufferHeaderSize, batchSize);
 
 	try {
 		for (const auto &source : sources) {
@@ -186,9 +186,9 @@ void ChunkReplicator::replicate(ChunkFileCreator& fileCreator,
 			                  static_cast<uint16_t>(firstBlock), static_cast<uint16_t>(nrOfBlocks),
 			                  crcData);
 		}
-		getReplicateBuffersPool().put(std::move(buffer));
+		getChunkCopyBuffersPool().put(std::move(buffer));
 	} catch (...) {
-		getReplicateBuffersPool().put(std::move(buffer));
+		getChunkCopyBuffersPool().put(std::move(buffer));
 		throw;
 	}
 

--- a/src/chunkserver/chunkserver-common/cmr_disk.cc
+++ b/src/chunkserver/chunkserver-common/cmr_disk.cc
@@ -174,7 +174,8 @@ std::unique_ptr<ChunkSignature> CmrDisk::createChunkSignature() {
 void CmrDisk::serializeEmptyChunkSignature(uint8_t **destination,
                                            uint64_t chunkId,
                                            uint32_t chunkVersion,
-                                           ChunkPartType chunkType) {
+                                           ChunkPartType chunkType,
+                                           const IChunk * /*formatSource*/) {
 	serialize(destination, ChunkSignature(chunkId, chunkVersion, chunkType));
 }
 

--- a/src/chunkserver/chunkserver-common/cmr_disk.h
+++ b/src/chunkserver/chunkserver-common/cmr_disk.h
@@ -76,7 +76,8 @@ public:
 
 	void serializeEmptyChunkSignature(uint8_t **destination, uint64_t chunkId,
 	                                  uint32_t chunkVersion,
-	                                  ChunkPartType chunkType) override;
+	                                  ChunkPartType chunkType,
+	                                  const IChunk *formatSource = nullptr) override;
 
 	/// Instantiates a new Chunk for this type of Disk.
 	/// The ChunkState is CH_LOCKED by default.

--- a/src/chunkserver/chunkserver-common/disk_interface.h
+++ b/src/chunkserver/chunkserver-common/disk_interface.h
@@ -130,10 +130,13 @@ public:
 
 	/// Initializes an empty metadata signature in the provided buffer.
 	/// Useful in the duplicate and duplicate-truncate operations.
+	/// @param formatSource Chunk whose on-disk format the signature must match;
+	///        null selects the legacy default.
 	virtual void serializeEmptyChunkSignature(uint8_t **destination,
 	                                          uint64_t chunkId,
 	                                          uint32_t chunkVersion,
-	                                          ChunkPartType chunkType) = 0;
+	                                          ChunkPartType chunkType,
+	                                          const IChunk *formatSource = nullptr) = 0;
 
 	/// Instantiates a new Chunk for this type of Disk.
 	/// The ChunkState is CH_LOCKED by default.
@@ -141,8 +144,9 @@ public:
 	                                            ChunkPartType type) = 0;
 
 	/// Applies any disk-specific on-disk format to a brand-new chunk before its
-	/// header is sized and serialized. Called only from the new-chunk creation
-	/// path (not for duplicates). Default: no-op.
+	/// header is sized and serialized. Called when creating a chunk and when
+	/// duplicating one: a duplicate adopts this disk's configured format
+	/// instead of the source chunk's. Default: no-op.
 	virtual int applyNewChunkFormat(IChunk * /*chunk*/) = 0;
 
 	/// Sets the number of blocks for \a chunk from \a originalBlocks to \a

--- a/src/chunkserver/hddspacemgr.cc
+++ b/src/chunkserver/hddspacemgr.cc
@@ -1533,18 +1533,275 @@ private:
 	bool committed_ = false;
 };
 
+/// The buffers a chunk copy sets up once and then threads through every step:
+/// the destination's header buffer, which accumulates the copy's CRCs until
+/// they are persisted, and both chunks' in-memory CRC blocks.
+///
+/// The header buffer belongs to the calling thread and is sized for one chunk,
+/// so it only stays valid while nothing else on this thread asks for another
+/// chunk's header buffer.
+struct ChunkCopyBuffers {
+	uint8_t *header = nullptr;
+	uint8_t *sourceCrc = nullptr;
+	uint8_t *copyCrc = nullptr;
+};
+
+/// Picks a destination disk and registers the copy on it, handing the new chunk
+/// to @p guard and to @p copy.
+static int createChunkCopy(ChunkCopyGuard &guard, ChunkPartType chunkType, uint64_t copyChunkId,
+                           uint32_t copyChunkVersion, IChunk **copy) {
+	IChunk *newChunk = ChunkNotFound;
+
+	{
+		std::unique_lock disksUniqueLock(gDisksMutex);
+
+		IDisk *copyDisk = gDiskManager->getDiskForNewChunk(chunkType);
+
+		if (copyDisk == DiskNotFound) {
+			// The guard lives in the caller, so the source chunk is released
+			// well after this scope drops gDisksMutex.
+			return SAUNAFS_ERROR_NOSPACE;
+		}
+
+		newChunk = hddChunkCreate(copyDisk, copyChunkId, chunkType, copyChunkVersion);
+	}
+
+	if (newChunk == ChunkNotFound) { return SAUNAFS_ERROR_CHUNKEXIST; }
+
+	guard.copyRegistered(newChunk);
+	*copy = newChunk;
+
+	return SAUNAFS_STATUS_OK;
+}
+
+/// Opens the source chunk for reading, first moving it from @p chunkVersion to
+/// @p chunkNewVersion when the two differ.
+///
+/// The bump is the same three steps hddInternalUpdateVersion() and
+/// hddInternalTruncate() use, in the same order: rename the files to the new
+/// version, open with the version the header still holds so its CRCs validate,
+/// then rewrite the header. All three act on the chunk whose version changes,
+/// which is the source - the copy is created at its own version and never
+/// renamed.
+static int openSourceForCopy(ChunkCopyGuard &guard, IChunk *sourceChunk, uint32_t chunkVersion,
+                             uint32_t chunkNewVersion, const char *errorMsg) {
+	if (chunkNewVersion == chunkVersion) {
+		const int status = hddIOBegin(sourceChunk, 0);
+
+		if (status != SAUNAFS_STATUS_OK) {
+			hddAddErrorAndPreserveErrno(sourceChunk);
+			guard.sourceIsDamaged();
+			return status;
+		}
+
+		guard.sourceIoBegan();
+
+		return SAUNAFS_STATUS_OK;
+	}
+
+	if (sourceChunk->renameChunkFile(chunkNewVersion) < 0) {
+		hddAddErrorAndPreserveErrno(sourceChunk);
+		safs_silent_errlog(LOG_WARNING, "%s: file:%s - rename error", errorMsg,
+		                   sourceChunk->fullMetaFilename().c_str());
+		return SAUNAFS_ERROR_IO;
+	}
+
+	int status = hddIOBegin(sourceChunk, 0, chunkVersion);
+	if (status != SAUNAFS_STATUS_OK) {
+		hddAddErrorAndPreserveErrno(sourceChunk);
+		return status;  //can't change file version
+	}
+	guard.sourceIoBegan();
+
+	status = sourceChunk->owner()->overwriteChunkVersion(sourceChunk, chunkNewVersion);
+	if (status != SAUNAFS_STATUS_OK) {
+		hddAddErrorAndPreserveErrno(sourceChunk);
+		safs_silent_errlog(LOG_WARNING, "%s: file:%s - write error", errorMsg,
+		                   sourceChunk->fullMetaFilename().c_str());
+		return SAUNAFS_ERROR_IO;
+	}
+
+	return SAUNAFS_STATUS_OK;
+}
+
+/// Opens the copy for writing and gives it a valid header: the destination
+/// disk's format, an empty signature carrying its own id and version, and the
+/// source's CRC block, which the copy then updates in place as blocks arrive.
+static int prepareChunkCopyForWriting(ChunkCopyGuard &guard, IChunk *sourceChunk, IChunk *copy,
+                                      const char *errorMsg, ChunkCopyBuffers *buffers) {
+	int status = hddIOBegin(copy, 1);
+	if (status != SAUNAFS_STATUS_OK) {
+		hddAddErrorAndPreserveErrno(copy);
+		return status;
+	}
+	guard.copyIoBegan();
+
+	IDisk *copyDisk = copy->owner();
+
+	// The copy takes the destination disk's configured format, not the source
+	// chunk's, and must be stamped before getChunkHeaderBuffer() below sizes
+	// the header buffer from it.
+	status = copyDisk->applyNewChunkFormat(copy);
+	if (status != SAUNAFS_STATUS_OK) {
+		hddAddErrorAndPreserveErrno(copy);
+		return SAUNAFS_ERROR_IO;
+	}
+
+	// hddChunkCreate() built the copy from the requested id and version, so the
+	// chunk itself carries what the signature needs.
+	buffers->header = copy->getChunkHeaderBuffer();
+	memset(buffers->header, 0, copy->getHeaderSize());
+
+	uint8_t *headerPtr = buffers->header;
+	copyDisk->serializeEmptyChunkSignature(&headerPtr, copy->id(), copy->version(), copy->type(),
+	                                       copy);
+
+	buffers->sourceCrc = gOpenChunks.getResource(sourceChunk->metaFD()).crcData();
+	buffers->copyCrc = gOpenChunks.getResource(copy->metaFD()).crcData();
+
+	// Into the header buffer to reach the device, and into the in-memory block
+	// the write paths keep up to date.
+	memcpy(buffers->header + copy->getCrcOffset(), buffers->sourceCrc, copy->getCrcBlockSize());
+	memcpy(buffers->copyCrc, buffers->sourceCrc, copy->getCrcBlockSize());
+
+	// Write the header before the copy, which may add format-specific metadata
+	// of its own to that same region (a compressed chunk stores its dictionary
+	// there), so nothing here can overwrite it afterwards.
+	copyDisk->lseekMetadata(copy, 0, SEEK_SET);
+
+	{
+		DiskWriteStatsUpdater updater(copyDisk, copy->getHeaderSize());
+
+		if (copyDisk->writeChunkHeader(copy) != SAUNAFS_STATUS_OK) {
+			hddAddErrorAndPreserveErrno(copy);
+			safs::log_warn_with_error_code(errno, "{}: file:{} - hdr write error", errorMsg,
+			                               copy->fullMetaFilename());
+			updater.markWriteAsFailed();
+			return SAUNAFS_ERROR_IO;
+		}
+	}
+
+	HddStats::overheadWrite(copy->getHeaderSize());
+
+	return SAUNAFS_STATUS_OK;
+}
+
+/// Finishes a copy whose block count differs from the source's: fills in the
+/// CRCs of the blocks an expansion adds and grows the file, or copies the block
+/// a misaligned shrink cuts in half, with its CRC recomputed over the bytes
+/// that survive. Does nothing when the truncation lands on a block boundary.
+static int finishTruncatedCopy(ChunkCopyGuard &guard, IChunk *sourceChunk, IChunk *copy,
+                               uint16_t blocks, uint32_t lastBlockSize,
+                               const ChunkCopyBuffers &buffers, const char *errorMsg) {
+	IDisk *copyDisk = copy->owner();
+
+	if (blocks > sourceChunk->blocks()) {
+		for (uint16_t block = sourceChunk->blocks(); block < blocks; block++) {
+			memcpy(buffers.header + copy->getCrcOffset() + kCrcSize * block, &gEmptyBlockCrc,
+			       kCrcSize);
+		}
+
+		if (copyDisk->ftruncateData(copy, copy->getFileSizeFromBlockCount(blocks)) < 0) {
+			hddAddErrorAndPreserveErrno(copy);
+			safs_silent_errlog(LOG_WARNING, "%s: file:%s - ftruncate error", errorMsg,
+			                   copy->fullMetaFilename().c_str());
+			return SAUNAFS_ERROR_IO;        //write error
+		}
+
+		return SAUNAFS_STATUS_OK;
+	}
+
+	if (lastBlockSize == 0) { return SAUNAFS_STATUS_OK; }
+
+	const uint16_t block = blocks - 1;
+	uint8_t *blockBuffer = getChunkBlockBuffer() + kCrcSize;
+	int32_t retSize = 0;
+
+	{
+		DiskReadStatsUpdater updater(sourceChunk->owner(), SFSBLOCKSIZE);
+
+		retSize = sourceChunk->owner()->preadData(sourceChunk, blockBuffer, SFSBLOCKSIZE,
+		                                          static_cast<uint64_t>(block) * SFSBLOCKSIZE);
+
+		if (retSize != static_cast<int32_t>(SFSBLOCKSIZE)) {
+			hddAddErrorAndPreserveErrno(sourceChunk);
+			safs::log_warn_with_error_code(errno, "{}: file:{} - data read error", errorMsg,
+			                               sourceChunk->fullMetaFilename());
+			guard.sourceIsDamaged();
+			updater.markReadAsFailed();
+			return SAUNAFS_ERROR_IO;
+		}
+	}
+	HddStats::overheadRead(SFSBLOCKSIZE);
+
+	uint8_t *crcPtr = buffers.header + copy->getCrcOffset() + kCrcSize * block;
+	const uint32_t crc =
+	    mycrc32_zeroexpanded(0, blockBuffer, lastBlockSize, SFSBLOCKSIZE - lastBlockSize);
+	put32bit(&crcPtr, crc);
+
+	// Fill with zeros the remaining part of the block
+	memset(blockBuffer + lastBlockSize, 0, SFSBLOCKSIZE - lastBlockSize);
+
+	{
+		DiskWriteStatsUpdater updater(copyDisk, SFSBLOCKSIZE);
+
+		if (copyDisk->isZonedDevice()) {
+			retSize = copyDisk->writeChunkBlock(copy, copy->version(), block, 0, SFSBLOCKSIZE, crc,
+			                                    buffers.copyCrc, blockBuffer) == SAUNAFS_STATUS_OK
+			              ? SFSBLOCKSIZE
+			              : 0;
+		} else {
+			retSize = copyDisk->writeChunkData(copy, blockBuffer, SFSBLOCKSIZE, 0);
+		}
+
+		if (retSize != static_cast<int32_t>(SFSBLOCKSIZE)) {
+			hddAddErrorAndPreserveErrno(copy);
+			safs::log_warn_with_error_code(errno, "{}: file:{} - data write error", errorMsg,
+			                               copy->fullMetaFilename());
+			updater.markWriteAsFailed();
+			return SAUNAFS_ERROR_IO;
+		}
+	}
+	HddStats::overheadWrite(SFSBLOCKSIZE);
+
+	return SAUNAFS_STATUS_OK;
+}
+
+/// Persists the CRCs the copy accumulated in its header buffer.
+static int persistChunkCopyCrc(IChunk *copy, const ChunkCopyBuffers &buffers,
+                               const char *errorMsg) {
+	IDisk *copyDisk = copy->owner();
+
+	// The header buffer accumulated the copy's CRCs; persist just those.
+	memcpy(buffers.copyCrc, buffers.header + copy->getCrcOffset(), copy->getCrcBlockSize());
+
+	{
+		DiskWriteStatsUpdater updater(copyDisk, copy->getCrcBlockSize());
+
+		if (copyDisk->writeCrc(copy, buffers.copyCrc) !=
+		    static_cast<ssize_t>(copy->getCrcBlockSize())) {
+			hddAddErrorAndPreserveErrno(copy);
+			safs::log_warn_with_error_code(errno, "{}: file:{} - crc write error", errorMsg,
+			                               copy->fullMetaFilename());
+			updater.markWriteAsFailed();
+			return SAUNAFS_ERROR_IO;
+		}
+	}
+
+	HddStats::overheadWrite(copy->getCrcBlockSize());
+
+	return SAUNAFS_STATUS_OK;
+}
+
 static int hddInternalDuplicate(uint64_t chunkId, uint32_t chunkVersion,
                                 uint32_t chunkNewVersion,
                                 ChunkPartType chunkType, uint64_t copyChunkId,
                                 uint32_t copyChunkVersion) {
 	TRACETHIS();
-	int status;
-	IChunk *dupChunk, *originalChunk;
-	IDisk *dupDisk, *originalDisk;
 
 	HddStats::gStatsOperationsDuplicate++;
 
-	originalChunk = hddChunkFindAndLock(chunkId, chunkType);
+	IChunk *originalChunk = hddChunkFindAndLock(chunkId, chunkType);
 
 	if (originalChunk == ChunkNotFound) {
 		safs::log_err("hddInternalDuplicate: Couldn't find original chunk, ID {}", chunkId);
@@ -1562,118 +1819,27 @@ static int hddInternalDuplicate(uint64_t chunkId, uint32_t chunkVersion,
 		copyChunkVersion = chunkNewVersion;
 	}
 
-	{
-		std::unique_lock disksUniqueLock(gDisksMutex);
-		dupDisk = gDiskManager->getDiskForNewChunk(chunkType);
-		if (dupDisk == DiskNotFound) {
-			// The guard runs after this scope, so the chunk is released with
-			// gDisksMutex already dropped.
-			return SAUNAFS_ERROR_NOSPACE;
-		}
-
-		dupChunk = hddChunkCreate(dupDisk, copyChunkId, chunkType,
-		                          copyChunkVersion);
-	}
-
-	if (dupChunk == ChunkNotFound) {
-		return SAUNAFS_ERROR_CHUNKEXIST;
-	}
-
-	guard.copyRegistered(dupChunk);
+	IChunk *dupChunk = nullptr;
+	int status = createChunkCopy(guard, chunkType, copyChunkId, copyChunkVersion, &dupChunk);
+	if (status != SAUNAFS_STATUS_OK) { return status; }
 
 	sassert(dupChunk->chunkFormat() == originalChunk->chunkFormat());
 
-	originalDisk = originalChunk->owner();
+	status = openSourceForCopy(guard, originalChunk, chunkVersion, chunkNewVersion, "duplicate");
+	if (status != SAUNAFS_STATUS_OK) { return status; }
 
-	if (chunkNewVersion != chunkVersion) {
-		if (dupChunk->renameChunkFile(chunkNewVersion) < 0) {
-			hddAddErrorAndPreserveErrno(originalChunk);
-			safs_silent_errlog(LOG_WARNING, "duplicate: file:%s - rename error",
-			                   originalChunk->fullMetaFilename().c_str());
-			return SAUNAFS_ERROR_IO;
-		}
+	ChunkCopyBuffers buffers;
+	status = prepareChunkCopyForWriting(guard, originalChunk, dupChunk, "duplicate", &buffers);
+	if (status != SAUNAFS_STATUS_OK) { return status; }
 
-		status = hddIOBegin(originalChunk, 0, chunkVersion);
-		if (status != SAUNAFS_STATUS_OK) {
-			hddAddErrorAndPreserveErrno(originalChunk);
-			return status;  //can't change file version
-		}
-		guard.sourceIoBegan();
+	IDisk *dupDisk = dupChunk->owner();
 
-		status = originalDisk->overwriteChunkVersion(originalChunk,
-		                                             chunkNewVersion);
-		if (status != SAUNAFS_STATUS_OK) {
-			hddAddErrorAndPreserveErrno(originalChunk);
-			safs_silent_errlog(LOG_WARNING, "duplicate: file:%s - write error",
-			                   dupChunk->fullMetaFilename().c_str());
-			return SAUNAFS_ERROR_IO;
-		}
-	} else {  // chunkNewVersion == chunkVersion
-		status = hddIOBegin(originalChunk, 0);
-		if (status != SAUNAFS_STATUS_OK) {
-			hddAddErrorAndPreserveErrno(originalChunk);
-			guard.sourceIsDamaged();
-			return status;
-		}
-		guard.sourceIoBegan();
-	}
-
-	status = hddIOBegin(dupChunk, 1);
-	if (status != SAUNAFS_STATUS_OK) {
-		hddAddErrorAndPreserveErrno(dupChunk);
-		return status;
-	}
-	guard.copyIoBegan();
-
-	// The copy takes the destination disk's configured format, not the source
-	// chunk's, and must be stamped before its header is sized below.
-	status = dupDisk->applyNewChunkFormat(dupChunk);
-	if (status != SAUNAFS_STATUS_OK) {
-		hddAddErrorAndPreserveErrno(dupChunk);
-		return SAUNAFS_ERROR_IO;
-	}
-
-	// Clean the header buffer and copy the signature
-	uint8_t *ptr = dupChunk->getChunkHeaderBuffer();
-	memset(ptr, 0, dupChunk->getHeaderSize());
-
-	dupDisk->serializeEmptyChunkSignature(&ptr,
-	                                      copyChunkId,
-	                                      copyChunkVersion,
-	                                      chunkType,
-	                                      dupChunk);
-
-	uint8_t *dupCrcData = gOpenChunks.getResource(dupChunk->metaFD()).crcData();
-	uint8_t *origCrcData =
-	    gOpenChunks.getResource(originalChunk->metaFD()).crcData();
-	// Copy the CRC to the in-memory OpenChunk
-	memcpy(dupCrcData, origCrcData, dupChunk->getCrcBlockSize());
-	// and to the header buffer to save it to device
-	memcpy(dupChunk->getChunkHeaderBuffer() + dupChunk->getCrcOffset(),
-	       origCrcData, dupChunk->getCrcBlockSize());
-
-	{
-		DiskWriteStatsUpdater updater(dupDisk, dupChunk->getHeaderSize());
-
-		if (dupDisk->writeChunkHeader(dupChunk) != SAUNAFS_STATUS_OK) {
-			hddAddErrorAndPreserveErrno(dupChunk);
-			safs_silent_errlog(LOG_WARNING,
-			                   "duplicate: file:%s - hdr write error",
-			                   dupChunk->fullMetaFilename().c_str());
-			updater.markWriteAsFailed();
-			return SAUNAFS_ERROR_IO;
-		}
-	}
-
-	HddStats::overheadWrite(dupChunk->getHeaderSize());
-
-	originalDisk->lseekData(originalChunk, dupChunk->getBlockOffset(0),
-	                        SEEK_SET);
+	originalChunk->owner()->lseekData(originalChunk, dupChunk->getBlockOffset(0), SEEK_SET);
 
 	// Read each original block and write it to the duplicated chunk
 	const auto copyResult =
 	    hddCopyChunkBlocks(originalChunk, dupChunk, originalChunk->blocks(),
-	                       origCrcData, dupCrcData, "duplicate");
+	                       buffers.sourceCrc, buffers.copyCrc, "duplicate");
 
 	if (copyResult != ChunkCopyResult::Ok) {
 		if (copyResult == ChunkCopyResult::ReadFailed) {
@@ -1984,12 +2150,6 @@ static int hddInternalDuplicateTruncate(uint64_t chunkId, uint32_t chunkVersion,
                                         uint32_t copyChunkVersion,
                                         uint32_t copyChunkLength) {
 	TRACETHIS();
-	uint16_t block;
-	uint16_t blocks;
-	int32_t retSize;
-	int status;
-	IChunk *dupChunk, *originalChunk;
-	IDisk *dupDisk, *origDisk;
 
 	HddStats::gStatsOperationsDupTrunc++;
 
@@ -1997,7 +2157,7 @@ static int hddInternalDuplicateTruncate(uint64_t chunkId, uint32_t chunkVersion,
 		return SAUNAFS_ERROR_WRONGSIZE;
 	}
 
-	originalChunk = hddChunkFindAndLock(chunkId, chunkType);
+	IChunk *originalChunk = hddChunkFindAndLock(chunkId, chunkType);
 
 	if (originalChunk == nullptr) {
 		safs::log_err("hddInternalDuplicateTruncate: Couldn't find original chunk, ID {}", chunkId);
@@ -2016,125 +2176,22 @@ static int hddInternalDuplicateTruncate(uint64_t chunkId, uint32_t chunkVersion,
 		copyChunkVersion = chunkNewVersion;
 	}
 
-	uint8_t *blockBuffer = getChunkBlockBuffer() + kCrcSize;
+	IChunk *dupChunk = nullptr;
+	int status = createChunkCopy(guard, chunkType, copyChunkId, copyChunkVersion, &dupChunk);
+	if (status != SAUNAFS_STATUS_OK) { return status; }
 
-	{
-		std::unique_lock disksUniqueLock(gDisksMutex);
+	status = openSourceForCopy(guard, originalChunk, chunkVersion, chunkNewVersion, "duptrunc");
+	if (status != SAUNAFS_STATUS_OK) { return status; }
 
-		dupDisk = gDiskManager->getDiskForNewChunk(chunkType);
+	ChunkCopyBuffers buffers;
+	status = prepareChunkCopyForWriting(guard, originalChunk, dupChunk, "duptrunc", &buffers);
+	if (status != SAUNAFS_STATUS_OK) { return status; }
 
-		if (dupDisk == DiskNotFound) {
-			// The guard runs after this scope, so the chunk is released with
-			// gDisksMutex already dropped.
-			return SAUNAFS_ERROR_NOSPACE;
-		}
+	IDisk *dupDisk = dupChunk->owner();
+	IDisk *origDisk = originalChunk->owner();
 
-		dupChunk = hddChunkCreate(dupDisk, copyChunkId, chunkType,
-		                          copyChunkVersion);
-	}
-
-	if (dupChunk == ChunkNotFound) {
-		return SAUNAFS_ERROR_CHUNKEXIST;
-	}
-
-	guard.copyRegistered(dupChunk);
-
-	origDisk = originalChunk->owner();
-
-	if (chunkNewVersion != chunkVersion) { // Different versions
-		if (originalChunk->renameChunkFile(chunkNewVersion) < 0) {
-			hddAddErrorAndPreserveErrno(originalChunk);
-			safs_silent_errlog(LOG_WARNING,
-			                   "duptrunc: file:%s - rename error",
-			                   originalChunk->fullMetaFilename().c_str());
-			return SAUNAFS_ERROR_IO;
-		}
-
-		status = hddIOBegin(originalChunk, 0, chunkVersion);
-		if (status != SAUNAFS_STATUS_OK) {
-			hddAddErrorAndPreserveErrno(originalChunk);
-			return status;  //can't change file version
-		}
-		guard.sourceIoBegan();
-
-		status = origDisk->overwriteChunkVersion(originalChunk,
-		                                         chunkNewVersion);
-		if (status != SAUNAFS_STATUS_OK) {
-			hddAddErrorAndPreserveErrno(originalChunk);
-			safs_silent_errlog(LOG_WARNING,
-			                   "duptrunc: file:%s - write error",
-			                   dupChunk->fullMetaFilename().c_str());
-			return SAUNAFS_ERROR_IO;
-		}
-	} else { // It is the same version
-		status = hddIOBegin(originalChunk, 0);
-		if (status != SAUNAFS_STATUS_OK) {
-			hddAddErrorAndPreserveErrno(originalChunk);
-			guard.sourceIsDamaged();
-			return status;
-		}
-		guard.sourceIoBegan();
-	}
-
-	status = hddIOBegin(dupChunk, 1);
-	if (status != SAUNAFS_STATUS_OK) {
-		hddAddErrorAndPreserveErrno(dupChunk);
-		return status;
-	}
-	guard.copyIoBegan();
-
-	// The copy takes the destination disk's configured format, not the source
-	// chunk's, and must be stamped before getChunkHeaderBuffer() below sizes
-	// the header buffer from it.
-	status = dupDisk->applyNewChunkFormat(dupChunk);
-	if (status != SAUNAFS_STATUS_OK) {
-		hddAddErrorAndPreserveErrno(dupChunk);
-		return SAUNAFS_ERROR_IO;
-	}
-
-	sassert((dupChunk == nullptr && originalChunk == nullptr) ||
-	        (dupChunk != nullptr && originalChunk != nullptr));
-
-	blocks = (copyChunkLength + SFSBLOCKSIZE - 1) / SFSBLOCKSIZE;
-	int32_t blockSize = SFSBLOCKSIZE;
-
-	uint8_t *crcDataOriginal = nullptr;
-	uint8_t *crcDataDup = nullptr;
-
-	uint8_t *headerBuffer = dupChunk->getChunkHeaderBuffer();
-
-	if (dupChunk) {
-		memset(headerBuffer, 0, dupChunk->getHeaderSize());
-		uint8_t *ptr = headerBuffer;
-
-		dupDisk->serializeEmptyChunkSignature(&ptr, copyChunkId,
-		                                      copyChunkVersion, chunkType,
-		                                      dupChunk);
-
-		crcDataOriginal = gOpenChunks.getResource(originalChunk->metaFD()).crcData();
-		memcpy(headerBuffer + dupChunk->getCrcOffset(), crcDataOriginal,
-		       dupChunk->getCrcBlockSize());
-		crcDataDup = gOpenChunks.getResource(dupChunk->metaFD()).crcData();
-
-		// Write the header before the copy, which may add format-specific
-		// metadata of its own to that same region (a compressed chunk stores
-		// its dictionary there), so nothing here can overwrite it afterwards.
-		dupDisk->lseekMetadata(dupChunk, 0, SEEK_SET);
-
-		{
-			DiskWriteStatsUpdater updater(dupDisk, dupChunk->getHeaderSize());
-
-			if (dupDisk->writeChunkHeader(dupChunk) != SAUNAFS_STATUS_OK) {
-				hddAddErrorAndPreserveErrno(dupChunk);
-				safs::log_warn_with_error_code(
-				    errno, "duptrunc: file:{} - hdr write error",
-				    dupChunk->fullMetaFilename());
-				updater.markWriteAsFailed();
-				return SAUNAFS_ERROR_IO;
-			}
-		}
-		HddStats::overheadWrite(dupChunk->getHeaderSize());
-	}
+	const uint16_t blocks =
+	    static_cast<uint16_t>((copyChunkLength + SFSBLOCKSIZE - 1) / SFSBLOCKSIZE);
 
 	// Seek to the beginning of data block on both chunks
 	if (!dupDisk->isZonedDevice()) {
@@ -2155,8 +2212,8 @@ static int hddInternalDuplicateTruncate(uint64_t chunkId, uint32_t chunkVersion,
 	                : static_cast<uint16_t>(lastBlockSize == 0 ? blocks : blocks - 1);
 
 	const auto copyResult =
-	    hddCopyChunkBlocks(originalChunk, dupChunk, blocksToCopy, crcDataOriginal,
-	                       crcDataDup, "duptrunc");
+	    hddCopyChunkBlocks(originalChunk, dupChunk, blocksToCopy, buffers.sourceCrc,
+	                       buffers.copyCrc, "duptrunc");
 
 	if (copyResult != ChunkCopyResult::Ok) {
 		if (copyResult == ChunkCopyResult::ReadFailed) {
@@ -2165,104 +2222,12 @@ static int hddInternalDuplicateTruncate(uint64_t chunkId, uint32_t chunkVersion,
 		return SAUNAFS_ERROR_IO;
 	}
 
-	if (isExpanding) {
-		if (dupChunk) {
-			for (block = originalChunk->blocks(); block < blocks; block++) {
-				memcpy(headerBuffer + dupChunk->getCrcOffset() +
-				       kCrcSize * block, &gEmptyBlockCrc, kCrcSize);
-			}
-		}
+	status = finishTruncatedCopy(guard, originalChunk, dupChunk, blocks, lastBlockSize, buffers,
+	                             "duptrunc");
+	if (status != SAUNAFS_STATUS_OK) { return status; }
 
-		if (dupDisk->ftruncateData(
-		        dupChunk, dupChunk->getFileSizeFromBlockCount(blocks)) < 0) {
-			hddAddErrorAndPreserveErrno(dupChunk);
-			safs_silent_errlog(LOG_WARNING,
-			                   "duptrunc: file:%s - ftruncate error",
-			                   dupChunk->fullMetaFilename().c_str());
-			return SAUNAFS_ERROR_IO;        //write error
-		}
-	} else if (lastBlockSize > 0) {
-		block = blocks - 1;
-		auto toBeRead = lastBlockSize;
-
-		{
-			DiskReadStatsUpdater updater(origDisk, SFSBLOCKSIZE);
-
-			retSize = origDisk->preadData(originalChunk, blockBuffer,
-			                              SFSBLOCKSIZE,
-			                              block * SFSBLOCKSIZE);
-
-			if (retSize != (signed)SFSBLOCKSIZE) {
-				hddAddErrorAndPreserveErrno(originalChunk);
-				safs::log_warn_with_error_code(
-				    errno, "duptrunc: file:{} - data read error",
-				    originalChunk->fullMetaFilename());
-				guard.sourceIsDamaged();
-				updater.markReadAsFailed();
-				return SAUNAFS_ERROR_IO;
-			}
-		}
-		HddStats::overheadRead(SFSBLOCKSIZE);
-
-		auto* ptr = headerBuffer + dupChunk->getCrcOffset()
-		            + kCrcSize * block;
-		auto crc = mycrc32_zeroexpanded(0, blockBuffer, lastBlockSize,
-		                                SFSBLOCKSIZE - lastBlockSize);
-		put32bit(&ptr, crc);
-
-		// Fill with zeros the remaining part of the block
-		memset(blockBuffer + toBeRead, 0, SFSBLOCKSIZE - lastBlockSize);
-
-		{
-			DiskWriteStatsUpdater updater(dupDisk, blockSize);
-
-			if (dupDisk->isZonedDevice()) {
-
-				if (dupDisk->writeChunkBlock(dupChunk, dupChunk->version(),
-				                             block, 0, SFSBLOCKSIZE, crc,
-				                             crcDataDup, blockBuffer) ==
-				    SAUNAFS_STATUS_OK) {
-					retSize = SFSBLOCKSIZE;
-				} else {
-					retSize = 0;
-				}
-			} else {
-				retSize = dupDisk->writeChunkData(dupChunk, blockBuffer,
-				                                  blockSize, 0);
-			}
-
-			if (retSize != blockSize) {
-				hddAddErrorAndPreserveErrno(dupChunk);
-				safs::log_warn_with_error_code(
-				    errno, "duptrunc: file:{} - data write error",
-				    dupChunk->fullMetaFilename());
-				updater.markWriteAsFailed();
-				return SAUNAFS_ERROR_IO;
-			}
-		}
-		HddStats::overheadWrite(blockSize);
-	}
-
-	if (dupChunk) {
-		// The header buffer accumulated the copy's CRCs; persist just those.
-		memcpy(crcDataDup, headerBuffer + dupChunk->getCrcOffset(),
-		       dupChunk->getCrcBlockSize());
-
-		{
-			DiskWriteStatsUpdater updater(dupDisk, dupChunk->getCrcBlockSize());
-
-			if (dupDisk->writeCrc(dupChunk, crcDataDup) !=
-			    static_cast<ssize_t>(dupChunk->getCrcBlockSize())) {
-				hddAddErrorAndPreserveErrno(dupChunk);
-				safs::log_warn_with_error_code(
-				    errno, "duptrunc: file:{} - crc write error",
-				    dupChunk->fullMetaFilename());
-				updater.markWriteAsFailed();
-				return SAUNAFS_ERROR_IO;
-			}
-		}
-		HddStats::overheadWrite(dupChunk->getCrcBlockSize());
-	}
+	status = persistChunkCopyCrc(dupChunk, buffers, "duptrunc");
+	if (status != SAUNAFS_STATUS_OK) { return status; }
 
 	status = guard.endSourceIo();
 	if (status != SAUNAFS_STATUS_OK) {

--- a/src/chunkserver/hddspacemgr.cc
+++ b/src/chunkserver/hddspacemgr.cc
@@ -58,6 +58,7 @@
 #ifdef SAUNAFS_HAVE_THREAD_LOCAL
 #include <array>
 #endif // SAUNAFS_HAVE_THREAD_LOCAL
+#include <algorithm>
 #include <atomic>
 #include <deque>
 #include <list>
@@ -79,6 +80,7 @@
 #include "chunkserver-common/subfolder.h"
 #include "chunkserver/chartsdata.h"
 #include "chunkserver/chunk_filename_parser.h"
+#include "chunkserver/io_buffers.h"
 #include "common/chunk_version_with_todel_flag.h"
 #include "common/crc.h"
 #include "common/datapack.h"
@@ -1352,20 +1354,116 @@ static int hddInternalTestChunk(uint64_t chunkId, uint32_t version,
 	return SAUNAFS_STATUS_OK;
 }
 
+/// Blocks per read+write batch when copying a chunk. It matters most on a
+/// zoned destination, which writes one fragment per call, so batching keeps a
+/// full chunk well below the fragment limit; 256 matches the batch a compressed
+/// write flushes at, and bounds the staging buffer at 16 MiB.
+static constexpr uint16_t kChunkCopyBatchBlocks = 256;
+
+/// Which side of a copy failed; only a failed read means a damaged source.
+enum class ChunkCopyResult { Ok, ReadFailed, WriteFailed };
+
+/// Copies the first \a blockCount blocks of \a sourceChunk into \a dupChunk,
+/// reusing the source CRCs in \a sourceCrcData (reads decompress, so they
+/// still describe the copied bytes) and updating \a dupCrcData.
+///
+/// Both formats copy in batches of kChunkCopyBatchBlocks: zoned destinations
+/// through writeChunkBlocks(), the rest appending to the caller's data seek
+/// through writeChunkData().
+static ChunkCopyResult hddCopyChunkBlocks(IChunk *sourceChunk, IChunk *dupChunk,
+                                          uint16_t blockCount,
+                                          const uint8_t *sourceCrcData,
+                                          uint8_t *dupCrcData,
+                                          const char *errorMsg) {
+	IDisk *sourceDisk = sourceChunk->owner();
+	IDisk *dupDisk = dupChunk->owner();
+	const bool isZonedDestination = dupDisk->isZonedDevice();
+
+	// Pooled, so repeated duplications reuse the allocation; zone reads are
+	// O_DIRECT straight into it, hence the buffer's IO alignment.
+	auto buffer =
+	    getChunkCopyBuffersPool().get(kChunkCopyBufferHeaderSize, kChunkCopyBatchBlocks);
+	auto &blockBuffer = buffer->getBlockBuffer();
+	blockBuffer.resize(static_cast<size_t>(kChunkCopyBatchBlocks) * SFSBLOCKSIZE);
+
+	// Reused across batches; only the last batch may hold fewer blocks.
+	std::vector<uint32_t> crcs;
+	std::vector<uint16_t> blocksPerBuffer{0};
+	const std::vector<const uint8_t *> buffers{blockBuffer.data()};
+
+	ChunkCopyResult result = ChunkCopyResult::Ok;
+
+	for (uint16_t block = 0; block < blockCount; block += kChunkCopyBatchBlocks) {
+		const uint16_t blocksInBatch =
+		    std::min<uint16_t>(kChunkCopyBatchBlocks, blockCount - block);
+		const int32_t batchSize =
+		    static_cast<int32_t>(blocksInBatch) * SFSBLOCKSIZE;
+
+		{
+			DiskReadStatsUpdater updater(sourceDisk, batchSize);
+
+			if (sourceDisk->preadData(
+			        sourceChunk, blockBuffer.data(), batchSize,
+			        static_cast<uint64_t>(block) * SFSBLOCKSIZE) != batchSize) {
+				hddAddErrorAndPreserveErrno(sourceChunk);
+				safs::log_warn_with_error_code(
+				    errno, "{}: file:{} - data read error", errorMsg,
+				    sourceChunk->fullMetaFilename());
+				updater.markReadAsFailed();
+				result = ChunkCopyResult::ReadFailed;
+				break;
+			}
+		}
+		HddStats::overheadRead(batchSize);
+
+		{
+			DiskWriteStatsUpdater updater(dupDisk, batchSize);
+			int written = 0;
+
+			if (isZonedDestination) {
+				crcs.resize(blocksInBatch);
+				for (uint16_t i = 0; i < blocksInBatch; i++) {
+					const uint8_t *crcPointer =
+					    sourceCrcData + static_cast<size_t>(block + i) * kCrcSize;
+					get32bit(&crcPointer, crcs[i]);
+				}
+				blocksPerBuffer[0] = blocksInBatch;
+
+				written = dupDisk->writeChunkBlocks(
+				    dupChunk, dupChunk->version(), block, blocksInBatch, crcs,
+				    dupCrcData, blocksPerBuffer, buffers);
+			} else {
+				written = dupDisk->writeChunkData(dupChunk, blockBuffer.data(),
+				                                 batchSize, 0);
+			}
+
+			if (written != batchSize) {
+				hddAddErrorAndPreserveErrno(dupChunk);
+				safs::log_warn_with_error_code(
+				    errno, "{}: file:{} - data write error", errorMsg,
+				    dupChunk->fullMetaFilename());
+				updater.markWriteAsFailed();
+				result = ChunkCopyResult::WriteFailed;
+				break;
+			}
+		}
+		HddStats::overheadWrite(batchSize);
+	}
+
+	getChunkCopyBuffersPool().put(std::move(buffer));
+	return result;
+}
+
 static int hddInternalDuplicate(uint64_t chunkId, uint32_t chunkVersion,
                                 uint32_t chunkNewVersion,
                                 ChunkPartType chunkType, uint64_t copyChunkId,
                                 uint32_t copyChunkVersion) {
 	TRACETHIS();
-	uint16_t block;
-	int32_t retSize;
 	int status;
 	IChunk *dupChunk, *originalChunk;
 	IDisk *dupDisk, *originalDisk;
 
 	HddStats::gStatsOperationsDuplicate++;
-
-	uint8_t *blockBuffer = getChunkBlockBuffer() + kCrcSize;
 
 	originalChunk = hddChunkFindAndLock(chunkId, chunkType);
 
@@ -1452,7 +1550,18 @@ static int hddInternalDuplicate(uint64_t chunkId, uint32_t chunkVersion,
 		return status;
 	}
 
-	int32_t blockSize = SFSBLOCKSIZE;
+	// The copy takes the destination disk's configured format, not the source
+	// chunk's, and must be stamped before its header is sized below.
+	status = dupDisk->applyNewChunkFormat(dupChunk);
+	if (status != SAUNAFS_STATUS_OK) {
+		hddAddErrorAndPreserveErrno(dupChunk);
+		hddIOEnd(dupChunk);
+		dupDisk->unlinkChunk(dupChunk);
+		hddDeleteChunkFromRegistry(dupChunk);
+		hddIOEnd(originalChunk);
+		hddChunkRelease(originalChunk);
+		return SAUNAFS_ERROR_IO;
+	}
 
 	// Clean the header buffer and copy the signature
 	uint8_t *ptr = dupChunk->getChunkHeaderBuffer();
@@ -1461,7 +1570,8 @@ static int hddInternalDuplicate(uint64_t chunkId, uint32_t chunkVersion,
 	dupDisk->serializeEmptyChunkSignature(&ptr,
 	                                      copyChunkId,
 	                                      copyChunkVersion,
-	                                      chunkType);
+	                                      chunkType,
+	                                      dupChunk);
 
 	uint8_t *dupCrcData = gOpenChunks.getResource(dupChunk->metaFD()).crcData();
 	uint8_t *origCrcData =
@@ -1496,64 +1606,20 @@ static int hddInternalDuplicate(uint64_t chunkId, uint32_t chunkVersion,
 	                        SEEK_SET);
 
 	// Read each original block and write it to the duplicated chunk
-	for (block = 0; block < originalChunk->blocks(); block++) {
-		{
-			DiskReadStatsUpdater updater(originalDisk, blockSize);
+	const auto copyResult =
+	    hddCopyChunkBlocks(originalChunk, dupChunk, originalChunk->blocks(),
+	                       origCrcData, dupCrcData, "duplicate");
 
-			retSize = originalDisk->preadData(originalChunk, blockBuffer,
-			                                  blockSize, block * SFSBLOCKSIZE);
-
-			if (retSize != blockSize) {
-				hddAddErrorAndPreserveErrno(originalChunk);
-				safs_silent_errlog(LOG_WARNING,
-				                   "duplicate: file:%s - data read error",
-				                   dupChunk->fullMetaFilename().c_str());
-				hddIOEnd(dupChunk);
-				dupDisk->unlinkChunk(dupChunk);
-				hddDeleteChunkFromRegistry(dupChunk);
-				hddIOEnd(originalChunk);
-				hddReportDamagedChunk(chunkId, chunkType);
-				hddChunkRelease(originalChunk);
-				updater.markReadAsFailed();
-				return SAUNAFS_ERROR_IO;
-			}
+	if (copyResult != ChunkCopyResult::Ok) {
+		hddIOEnd(dupChunk);
+		dupDisk->unlinkChunk(dupChunk);
+		hddDeleteChunkFromRegistry(dupChunk);
+		hddIOEnd(originalChunk);
+		if (copyResult == ChunkCopyResult::ReadFailed) {
+			hddReportDamagedChunk(chunkId, chunkType);
 		}
-		HddStats::overheadRead(blockSize);
-
-		{
-			DiskWriteStatsUpdater updater(dupDisk, blockSize);
-
-			if (dupDisk->isZonedDevice()) {
-				const uint8_t *dupCrcBlock = dupCrcData + kCrcSize * block;
-				uint32_t crc;
-				get32bit(&dupCrcBlock, crc);
-				if (dupDisk->writeChunkBlock(
-				        dupChunk, dupChunk->version(), block, 0, SFSBLOCKSIZE,
-				        crc, dupCrcData, blockBuffer) == SAUNAFS_STATUS_OK) {
-					retSize = SFSBLOCKSIZE;
-				} else {
-					retSize = SAUNAFS_ERROR_IO;
-				}
-			} else {
-				retSize = dupDisk->writeChunkData(dupChunk, blockBuffer,
-				                                  blockSize, 0);
-			}
-
-			if (retSize != blockSize) {
-				hddAddErrorAndPreserveErrno(dupChunk);
-				safs_silent_errlog(LOG_WARNING,
-				                   "duplicate: file:%s - data write error",
-				                   dupChunk->fullMetaFilename().c_str());
-				hddIOEnd(dupChunk);
-				dupDisk->unlinkChunk(dupChunk);
-				hddDeleteChunkFromRegistry(dupChunk);
-				hddIOEnd(originalChunk);
-				hddChunkRelease(originalChunk);
-				updater.markWriteAsFailed();
-				return SAUNAFS_ERROR_IO;        //write error
-			}
-		}
-		HddStats::overheadWrite(blockSize);
+		hddChunkRelease(originalChunk);
+		return SAUNAFS_ERROR_IO;
 	}
 
 	status = hddIOEnd(originalChunk);
@@ -1916,7 +1982,6 @@ static int hddInternalDuplicateTruncate(uint64_t chunkId, uint32_t chunkVersion,
 		return SAUNAFS_ERROR_CHUNKEXIST;
 	}
 
-	uint8_t *headerBuffer = dupChunk->getChunkHeaderBuffer();
 	origDisk = originalChunk->owner();
 
 	if (chunkNewVersion != chunkVersion) { // Different versions
@@ -1970,6 +2035,20 @@ static int hddInternalDuplicateTruncate(uint64_t chunkId, uint32_t chunkVersion,
 		return status;
 	}
 
+	// The copy takes the destination disk's configured format, not the source
+	// chunk's, and must be stamped before getChunkHeaderBuffer() below sizes
+	// the header buffer from it.
+	status = dupDisk->applyNewChunkFormat(dupChunk);
+	if (status != SAUNAFS_STATUS_OK) {
+		hddAddErrorAndPreserveErrno(dupChunk);
+		hddIOEnd(dupChunk);
+		dupDisk->unlinkChunk(dupChunk);
+		hddDeleteChunkFromRegistry(dupChunk);
+		hddIOEnd(originalChunk);
+		hddChunkRelease(originalChunk);
+		return SAUNAFS_ERROR_IO;
+	}
+
 	sassert((dupChunk == nullptr && originalChunk == nullptr) ||
 	        (dupChunk != nullptr && originalChunk != nullptr));
 
@@ -1979,17 +2058,44 @@ static int hddInternalDuplicateTruncate(uint64_t chunkId, uint32_t chunkVersion,
 	uint8_t *crcDataOriginal = nullptr;
 	uint8_t *crcDataDup = nullptr;
 
+	uint8_t *headerBuffer = dupChunk->getChunkHeaderBuffer();
+
 	if (dupChunk) {
 		memset(headerBuffer, 0, dupChunk->getHeaderSize());
 		uint8_t *ptr = headerBuffer;
 
 		dupDisk->serializeEmptyChunkSignature(&ptr, copyChunkId,
-		                                      copyChunkVersion, chunkType);
+		                                      copyChunkVersion, chunkType,
+		                                      dupChunk);
 
 		crcDataOriginal = gOpenChunks.getResource(originalChunk->metaFD()).crcData();
 		memcpy(headerBuffer + dupChunk->getCrcOffset(), crcDataOriginal,
 		       dupChunk->getCrcBlockSize());
 		crcDataDup = gOpenChunks.getResource(dupChunk->metaFD()).crcData();
+
+		// Write the header before the copy, which may add format-specific
+		// metadata of its own to that same region (a compressed chunk stores
+		// its dictionary there), so nothing here can overwrite it afterwards.
+		dupDisk->lseekMetadata(dupChunk, 0, SEEK_SET);
+
+		{
+			DiskWriteStatsUpdater updater(dupDisk, dupChunk->getHeaderSize());
+
+			if (dupDisk->writeChunkHeader(dupChunk) != SAUNAFS_STATUS_OK) {
+				hddAddErrorAndPreserveErrno(dupChunk);
+				safs::log_warn_with_error_code(
+				    errno, "duptrunc: file:{} - hdr write error",
+				    dupChunk->fullMetaFilename());
+				hddIOEnd(dupChunk);
+				dupDisk->unlinkChunk(dupChunk);
+				hddDeleteChunkFromRegistry(dupChunk);
+				hddIOEnd(originalChunk);
+				hddChunkRelease(originalChunk);
+				updater.markWriteAsFailed();
+				return SAUNAFS_ERROR_IO;
+			}
+		}
+		HddStats::overheadWrite(dupChunk->getHeaderSize());
 	}
 
 	// Seek to the beginning of data block on both chunks
@@ -2002,69 +2108,31 @@ static int hddInternalDuplicateTruncate(uint64_t chunkId, uint32_t chunkVersion,
 		                    SEEK_SET);
 	}
 
-	if (blocks > originalChunk->blocks()) { // expanding
-		for (block = 0 ; block < originalChunk->blocks() ; block++) {
-			{
-				DiskReadStatsUpdater updater(origDisk, blockSize);
+	// A misaligned shrink ends mid-block: that trailing block is copied on its
+	// own below, with a CRC recomputed over the bytes that survive.
+	const uint32_t lastBlockSize = copyChunkLength % SFSBLOCKSIZE;
+	const bool isExpanding = blocks > originalChunk->blocks();
+	const uint16_t blocksToCopy =
+	    isExpanding ? originalChunk->blocks()
+	                : static_cast<uint16_t>(lastBlockSize == 0 ? blocks : blocks - 1);
 
-				retSize = origDisk->preadData(originalChunk, blockBuffer,
-				                              blockSize, block * SFSBLOCKSIZE);
+	const auto copyResult =
+	    hddCopyChunkBlocks(originalChunk, dupChunk, blocksToCopy, crcDataOriginal,
+	                       crcDataDup, "duptrunc");
 
-				if (retSize != blockSize) {
-					hddAddErrorAndPreserveErrno(originalChunk);
-					safs_silent_errlog(LOG_WARNING,
-					    "duptrunc: file:%s - data read error",
-					    originalChunk->fullMetaFilename().c_str());
-					hddIOEnd(dupChunk);
-					dupDisk->unlinkChunk(dupChunk);
-					hddDeleteChunkFromRegistry(dupChunk);
-					hddIOEnd(originalChunk);
-					hddReportDamagedChunk(chunkId, chunkType);
-					hddChunkRelease(originalChunk);
-					updater.markReadAsFailed();
-					return SAUNAFS_ERROR_IO;
-				}
-			}
-			HddStats::overheadRead(blockSize);
-
-			{
-				DiskWriteStatsUpdater updater(dupDisk, blockSize);
-
-				if (dupDisk->isZonedDevice()) {
-					const uint8_t *dupCrcBlock = crcDataOriginal + kCrcSize * block;
-					uint32_t crc;
-					get32bit(&dupCrcBlock, crc);
-
-					if (dupDisk->writeChunkBlock(dupChunk, dupChunk->version(),
-					                             block, 0, SFSBLOCKSIZE, crc,
-					                             crcDataDup, blockBuffer) ==
-					    SAUNAFS_STATUS_OK) {
-						retSize = SFSBLOCKSIZE;
-					} else {
-						retSize = SAUNAFS_ERROR_IO;
-					}
-				} else {
-					retSize = dupDisk->writeChunkData(dupChunk, blockBuffer,
-					                                  blockSize, 0);
-				}
-
-				if (retSize != blockSize) {
-					hddAddErrorAndPreserveErrno(dupChunk);
-					safs_silent_errlog(LOG_WARNING,
-					    "duptrunc: file:%s - data write error",
-					    dupChunk->fullMetaFilename().c_str());
-					hddIOEnd(dupChunk);
-					dupDisk->unlinkChunk(dupChunk);
-					hddDeleteChunkFromRegistry(dupChunk);
-					hddIOEnd(originalChunk);
-					hddChunkRelease(originalChunk);
-					updater.markWriteAsFailed();
-					return SAUNAFS_ERROR_IO;
-				}
-			}
-			HddStats::overheadWrite(blockSize);
+	if (copyResult != ChunkCopyResult::Ok) {
+		hddIOEnd(dupChunk);
+		dupDisk->unlinkChunk(dupChunk);
+		hddDeleteChunkFromRegistry(dupChunk);
+		hddIOEnd(originalChunk);
+		if (copyResult == ChunkCopyResult::ReadFailed) {
+			hddReportDamagedChunk(chunkId, chunkType);
 		}
+		hddChunkRelease(originalChunk);
+		return SAUNAFS_ERROR_IO;
+	}
 
+	if (isExpanding) {
 		if (dupChunk) {
 			for (block = originalChunk->blocks(); block < blocks; block++) {
 				memcpy(headerBuffer + dupChunk->getCrcOffset() +
@@ -2085,224 +2153,66 @@ static int hddInternalDuplicateTruncate(uint64_t chunkId, uint32_t chunkVersion,
 			hddChunkRelease(originalChunk);
 			return SAUNAFS_ERROR_IO;        //write error
 		}
-	} else { // shrinking
-		uint32_t lastBlockSize =
-		    copyChunkLength - (copyChunkLength / SFSBLOCKSIZE) * SFSBLOCKSIZE;
-
-		if (lastBlockSize == 0) { // aligned shrink
-			for (block = 0; block < blocks; block++) {
-				{
-					DiskReadStatsUpdater updater(origDisk, blockSize);
-
-					retSize = origDisk->preadData(originalChunk, blockBuffer,
-					                              blockSize,
-					                              block * SFSBLOCKSIZE);
-
-					if (retSize != blockSize) {
-						hddAddErrorAndPreserveErrno(originalChunk);
-						safs_silent_errlog(LOG_WARNING,
-						    "duptrunc: file:%s - data read error",
-						    originalChunk->fullMetaFilename().c_str());
-						hddIOEnd(dupChunk);
-						dupDisk->unlinkChunk(dupChunk);
-						hddDeleteChunkFromRegistry(dupChunk);
-						hddIOEnd(originalChunk);
-						hddReportDamagedChunk(chunkId, chunkType);
-						hddChunkRelease(originalChunk);
-						updater.markReadAsFailed();
-						return SAUNAFS_ERROR_IO;
-					}
-				}
-				HddStats::overheadRead(blockSize);
-
-				{
-					DiskWriteStatsUpdater updater(dupDisk, blockSize);
-
-					if (dupDisk->isZonedDevice()) {
-						const uint8_t *dupCrcBlock = crcDataOriginal + kCrcSize * block;
-						uint32_t crc;
-						get32bit(&dupCrcBlock, crc);
-
-						if (dupDisk->writeChunkBlock(
-						        dupChunk, dupChunk->version(), block, 0,
-						        SFSBLOCKSIZE, crc, crcDataDup,
-						        blockBuffer) == SAUNAFS_STATUS_OK) {
-							retSize = SFSBLOCKSIZE;
-						} else {
-							retSize = SAUNAFS_ERROR_IO;
-						}
-					} else {
-						retSize = dupDisk->writeChunkData(dupChunk, blockBuffer,
-						                                  blockSize, 0);
-					}
-
-					if (retSize != blockSize) {
-						hddAddErrorAndPreserveErrno(dupChunk);
-						safs_silent_errlog(LOG_WARNING,
-						    "duptrunc: file:%s - data write error",
-						    dupChunk->fullMetaFilename().c_str());
-						hddIOEnd(dupChunk);
-						dupDisk->unlinkChunk(dupChunk);
-						hddDeleteChunkFromRegistry(dupChunk);
-						hddIOEnd(originalChunk);
-						hddChunkRelease(originalChunk);
-						updater.markWriteAsFailed();
-						return SAUNAFS_ERROR_IO;
-					}
-				}
-				HddStats::overheadWrite(blockSize);
-			}
-		} else { // misaligned shrink
-			for (block = 0; block < blocks - 1; block++) {
-				{
-					DiskReadStatsUpdater updater(origDisk, blockSize);
-
-					retSize = origDisk->preadData(originalChunk, blockBuffer,
-					                              blockSize,
-					                              block * SFSBLOCKSIZE);
-
-					if (retSize != blockSize) {
-						hddAddErrorAndPreserveErrno(originalChunk);
-						safs_silent_errlog(LOG_WARNING,
-						    "duptrunc: file:%s - data read error",
-						    originalChunk->fullMetaFilename().c_str());
-						hddIOEnd(dupChunk);
-						dupDisk->unlinkChunk(dupChunk);
-						hddDeleteChunkFromRegistry(dupChunk);
-						hddIOEnd(originalChunk);
-						hddReportDamagedChunk(chunkId, chunkType);
-						hddChunkRelease(originalChunk);
-						updater.markReadAsFailed();
-						return SAUNAFS_ERROR_IO;
-					}
-				}
-				HddStats::overheadRead(blockSize);
-
-				{
-					DiskWriteStatsUpdater updater(dupDisk, blockSize);
-
-					if (dupDisk->isZonedDevice()) {
-						const uint8_t *dupCrcBlock = crcDataOriginal + kCrcSize * block;
-						uint32_t crc;
-						get32bit(&dupCrcBlock, crc);
-
-						if (dupDisk->writeChunkBlock(
-						        dupChunk, dupChunk->version(), block, 0,
-						        SFSBLOCKSIZE, crc, crcDataDup,
-						        blockBuffer) == SAUNAFS_STATUS_OK) {
-							retSize = SFSBLOCKSIZE;
-						} else {
-							retSize = SAUNAFS_ERROR_IO;
-						}
-					} else {
-						retSize = dupDisk->writeChunkData(dupChunk, blockBuffer,
-						                                  blockSize, 0);
-					}
-
-					if (retSize != blockSize) {
-						hddAddErrorAndPreserveErrno(dupChunk);
-						safs_silent_errlog(LOG_WARNING,
-						    "duptrunc: file:%s - data write error",
-						    dupChunk->fullMetaFilename().c_str());
-						hddIOEnd(dupChunk);
-						dupDisk->unlinkChunk(dupChunk);
-						hddDeleteChunkFromRegistry(dupChunk);
-						hddIOEnd(originalChunk);
-						hddChunkRelease(originalChunk);
-						updater.markWriteAsFailed();
-						return SAUNAFS_ERROR_IO;        //write error
-					}
-				}
-				HddStats::overheadWrite(blockSize);
-			}
-
-			block = blocks - 1;
-			auto toBeRead = lastBlockSize;
-
-			{
-				DiskReadStatsUpdater updater(origDisk, SFSBLOCKSIZE);
-
-				retSize = origDisk->preadData(originalChunk, blockBuffer,
-				                              SFSBLOCKSIZE,
-				                              block * SFSBLOCKSIZE);
-
-				if (retSize != (signed)SFSBLOCKSIZE) {
-					hddAddErrorAndPreserveErrno(originalChunk);
-					safs_silent_errlog(LOG_WARNING,
-					    "duptrunc: file:%s - data read error",
-					    originalChunk->fullMetaFilename().c_str());
-					hddIOEnd(dupChunk);
-					dupDisk->unlinkChunk(dupChunk);
-					hddDeleteChunkFromRegistry(dupChunk);
-					hddIOEnd(originalChunk);
-					hddReportDamagedChunk(chunkId, chunkType);
-					hddChunkRelease(originalChunk);
-					updater.markReadAsFailed();
-					return SAUNAFS_ERROR_IO;
-				}
-			}
-			HddStats::overheadRead(SFSBLOCKSIZE);
-
-			auto* ptr = headerBuffer + dupChunk->getCrcOffset()
-			            + kCrcSize * block;
-			auto crc = mycrc32_zeroexpanded(0, blockBuffer, lastBlockSize,
-			                                SFSBLOCKSIZE - lastBlockSize);
-			put32bit(&ptr, crc);
-
-			// Fill with zeros the remaining part of the block
-			memset(blockBuffer + toBeRead, 0, SFSBLOCKSIZE - lastBlockSize);
-
-			{
-				DiskWriteStatsUpdater updater(dupDisk, blockSize);
-
-				if (dupDisk->isZonedDevice()) {
-
-					if (dupDisk->writeChunkBlock(dupChunk, dupChunk->version(),
-					                             block, 0, SFSBLOCKSIZE, crc,
-					                             crcDataDup, blockBuffer) ==
-					    SAUNAFS_STATUS_OK) {
-						retSize = SFSBLOCKSIZE;
-					} else {
-						retSize = 0;
-					}
-				} else {
-					retSize = dupDisk->writeChunkData(dupChunk, blockBuffer,
-					                                  blockSize, 0);
-				}
-
-				if (retSize != blockSize) {
-					hddAddErrorAndPreserveErrno(dupChunk);
-					safs_silent_errlog(LOG_WARNING,
-					    "duptrunc: file:%s - data write error",
-					    dupChunk->fullMetaFilename().c_str());
-					hddIOEnd(dupChunk);
-					dupDisk->unlinkChunk(dupChunk);
-					hddDeleteChunkFromRegistry(dupChunk);
-					hddIOEnd(originalChunk);
-					hddChunkRelease(originalChunk);
-					updater.markWriteAsFailed();
-					return SAUNAFS_ERROR_IO;
-				}
-			}
-			HddStats::overheadWrite(blockSize);
-		}
-	}
-
-	if (dupChunk) {
-		memcpy(crcDataDup, headerBuffer + dupChunk->getCrcOffset(),
-		       dupChunk->getCrcBlockSize());
-
-		dupDisk->lseekMetadata(dupChunk, 0, SEEK_SET);
+	} else if (lastBlockSize > 0) {
+		block = blocks - 1;
+		auto toBeRead = lastBlockSize;
 
 		{
-			DiskWriteStatsUpdater updater(dupDisk,
-			                              dupChunk->getHeaderSize());
+			DiskReadStatsUpdater updater(origDisk, SFSBLOCKSIZE);
 
-			if (dupDisk->writeChunkHeader(dupChunk) != SAUNAFS_STATUS_OK) {
+			retSize = origDisk->preadData(originalChunk, blockBuffer,
+			                              SFSBLOCKSIZE,
+			                              block * SFSBLOCKSIZE);
+
+			if (retSize != (signed)SFSBLOCKSIZE) {
+				hddAddErrorAndPreserveErrno(originalChunk);
+				safs::log_warn_with_error_code(
+				    errno, "duptrunc: file:{} - data read error",
+				    originalChunk->fullMetaFilename());
+				hddIOEnd(dupChunk);
+				dupDisk->unlinkChunk(dupChunk);
+				hddDeleteChunkFromRegistry(dupChunk);
+				hddIOEnd(originalChunk);
+				hddReportDamagedChunk(chunkId, chunkType);
+				hddChunkRelease(originalChunk);
+				updater.markReadAsFailed();
+				return SAUNAFS_ERROR_IO;
+			}
+		}
+		HddStats::overheadRead(SFSBLOCKSIZE);
+
+		auto* ptr = headerBuffer + dupChunk->getCrcOffset()
+		            + kCrcSize * block;
+		auto crc = mycrc32_zeroexpanded(0, blockBuffer, lastBlockSize,
+		                                SFSBLOCKSIZE - lastBlockSize);
+		put32bit(&ptr, crc);
+
+		// Fill with zeros the remaining part of the block
+		memset(blockBuffer + toBeRead, 0, SFSBLOCKSIZE - lastBlockSize);
+
+		{
+			DiskWriteStatsUpdater updater(dupDisk, blockSize);
+
+			if (dupDisk->isZonedDevice()) {
+
+				if (dupDisk->writeChunkBlock(dupChunk, dupChunk->version(),
+				                             block, 0, SFSBLOCKSIZE, crc,
+				                             crcDataDup, blockBuffer) ==
+				    SAUNAFS_STATUS_OK) {
+					retSize = SFSBLOCKSIZE;
+				} else {
+					retSize = 0;
+				}
+			} else {
+				retSize = dupDisk->writeChunkData(dupChunk, blockBuffer,
+				                                  blockSize, 0);
+			}
+
+			if (retSize != blockSize) {
 				hddAddErrorAndPreserveErrno(dupChunk);
-				safs_silent_errlog(LOG_WARNING,
-				                   "duptrunc: file:%s - hdr write error",
-				                   dupChunk->fullMetaFilename().c_str());
+				safs::log_warn_with_error_code(
+				    errno, "duptrunc: file:{} - data write error",
+				    dupChunk->fullMetaFilename());
 				hddIOEnd(dupChunk);
 				dupDisk->unlinkChunk(dupChunk);
 				hddDeleteChunkFromRegistry(dupChunk);
@@ -2312,7 +2222,33 @@ static int hddInternalDuplicateTruncate(uint64_t chunkId, uint32_t chunkVersion,
 				return SAUNAFS_ERROR_IO;
 			}
 		}
-		HddStats::overheadWrite(dupChunk->getHeaderSize());
+		HddStats::overheadWrite(blockSize);
+	}
+
+	if (dupChunk) {
+		// The header buffer accumulated the copy's CRCs; persist just those.
+		memcpy(crcDataDup, headerBuffer + dupChunk->getCrcOffset(),
+		       dupChunk->getCrcBlockSize());
+
+		{
+			DiskWriteStatsUpdater updater(dupDisk, dupChunk->getCrcBlockSize());
+
+			if (dupDisk->writeCrc(dupChunk, crcDataDup) !=
+			    static_cast<ssize_t>(dupChunk->getCrcBlockSize())) {
+				hddAddErrorAndPreserveErrno(dupChunk);
+				safs::log_warn_with_error_code(
+				    errno, "duptrunc: file:{} - crc write error",
+				    dupChunk->fullMetaFilename());
+				hddIOEnd(dupChunk);
+				dupDisk->unlinkChunk(dupChunk);
+				hddDeleteChunkFromRegistry(dupChunk);
+				hddIOEnd(originalChunk);
+				hddChunkRelease(originalChunk);
+				updater.markWriteAsFailed();
+				return SAUNAFS_ERROR_IO;
+			}
+		}
+		HddStats::overheadWrite(dupChunk->getCrcBlockSize());
 	}
 
 	status = hddIOEnd(originalChunk);

--- a/src/chunkserver/hddspacemgr.cc
+++ b/src/chunkserver/hddspacemgr.cc
@@ -1454,6 +1454,85 @@ static ChunkCopyResult hddCopyChunkBlocks(IChunk *sourceChunk, IChunk *dupChunk,
 	return result;
 }
 
+/// Unwinds a half-built chunk copy on the failure paths of duplicate and
+/// duptrunc.
+///
+/// Both operations lock a source chunk, register a copy, open both for I/O and
+/// then run a dozen fallible steps, and every one of them has to undo exactly
+/// the steps that already succeeded - in reverse order, without ending an I/O
+/// twice and without leaving a registered chunk whose file was never written.
+/// Spelled out at each site that is the same five calls repeated nine times.
+/// Here every step records what it completed and the destructor undoes whatever
+/// is still outstanding, so a new early return cannot forget one.
+class ChunkCopyGuard {
+public:
+	explicit ChunkCopyGuard(IChunk *sourceChunk) : source_(sourceChunk) {}
+
+	ChunkCopyGuard(const ChunkCopyGuard &) = delete;
+	ChunkCopyGuard(ChunkCopyGuard &&) = delete;
+	ChunkCopyGuard &operator=(const ChunkCopyGuard &) = delete;
+	ChunkCopyGuard &operator=(ChunkCopyGuard &&) = delete;
+
+	~ChunkCopyGuard() {
+		if (committed_) {
+			if (copy_ != nullptr) { hddChunkRelease(copy_); }
+			hddChunkRelease(source_);
+			return;
+		}
+
+		if (copyIoOpen_) { hddIOEnd(copy_); }
+		if (copyHasFiles_) { copy_->owner()->unlinkChunk(copy_); }
+		// Deleting the copy also unlocks it, so it never needs releasing.
+		if (copy_ != nullptr) { hddDeleteChunkFromRegistry(copy_); }
+		if (sourceIoOpen_) { hddIOEnd(source_); }
+		if (sourceDamaged_) {
+			hddReportDamagedChunk(source_->id(), source_->type());
+		}
+		hddChunkRelease(source_);
+	}
+
+	/// The copy is in the chunk registry, but has no files of its own yet.
+	void copyRegistered(IChunk *copyChunk) { copy_ = copyChunk; }
+
+	/// hddIOBegin() succeeded on the source chunk.
+	void sourceIoBegan() { sourceIoOpen_ = true; }
+
+	/// hddIOBegin() succeeded on the copy, creating its files.
+	void copyIoBegan() {
+		copyIoOpen_ = true;
+		copyHasFiles_ = true;
+	}
+
+	/// Ends the source chunk's I/O and returns hddIOEnd()'s status. Whether it
+	/// succeeds or not, the unwind will not end that I/O again.
+	int endSourceIo() {
+		sourceIoOpen_ = false;
+		return hddIOEnd(source_);
+	}
+
+	/// Ends the copy's I/O and returns hddIOEnd()'s status. As above, but the
+	/// files it created are still unlinked if the operation fails later.
+	int endCopyIo() {
+		copyIoOpen_ = false;
+		return hddIOEnd(copy_);
+	}
+
+	/// Report the source chunk to the master as damaged while unwinding.
+	void sourceIsDamaged() { sourceDamaged_ = true; }
+
+	/// The copy is complete: keep it, and only release both chunks.
+	void commit() { committed_ = true; }
+
+private:
+	IChunk *source_;
+	IChunk *copy_ = nullptr;
+	bool sourceIoOpen_ = false;
+	bool copyIoOpen_ = false;
+	bool copyHasFiles_ = false;
+	bool sourceDamaged_ = false;
+	bool committed_ = false;
+};
+
 static int hddInternalDuplicate(uint64_t chunkId, uint32_t chunkVersion,
                                 uint32_t chunkNewVersion,
                                 ChunkPartType chunkType, uint64_t copyChunkId,
@@ -1471,8 +1550,12 @@ static int hddInternalDuplicate(uint64_t chunkId, uint32_t chunkVersion,
 		safs::log_err("hddInternalDuplicate: Couldn't find original chunk, ID {}", chunkId);
 		return SAUNAFS_ERROR_NOCHUNK;
 	}
+
+	// Owns the source chunk, and the copy once it is registered: every return
+	// below unwinds whatever has been done so far unless commit() runs.
+	ChunkCopyGuard guard(originalChunk);
+
 	if (originalChunk->version() != chunkVersion && chunkVersion > 0) {
-		hddChunkRelease(originalChunk);
 		return SAUNAFS_ERROR_WRONGVERSION;
 	}
 	if (copyChunkVersion == 0) {
@@ -1483,8 +1566,8 @@ static int hddInternalDuplicate(uint64_t chunkId, uint32_t chunkVersion,
 		std::unique_lock disksUniqueLock(gDisksMutex);
 		dupDisk = gDiskManager->getDiskForNewChunk(chunkType);
 		if (dupDisk == DiskNotFound) {
-			disksUniqueLock.unlock();
-			hddChunkRelease(originalChunk);
+			// The guard runs after this scope, so the chunk is released with
+			// gDisksMutex already dropped.
 			return SAUNAFS_ERROR_NOSPACE;
 		}
 
@@ -1493,9 +1576,10 @@ static int hddInternalDuplicate(uint64_t chunkId, uint32_t chunkVersion,
 	}
 
 	if (dupChunk == ChunkNotFound) {
-		hddChunkRelease(originalChunk);
 		return SAUNAFS_ERROR_CHUNKEXIST;
 	}
+
+	guard.copyRegistered(dupChunk);
 
 	sassert(dupChunk->chunkFormat() == originalChunk->chunkFormat());
 
@@ -1506,18 +1590,15 @@ static int hddInternalDuplicate(uint64_t chunkId, uint32_t chunkVersion,
 			hddAddErrorAndPreserveErrno(originalChunk);
 			safs_silent_errlog(LOG_WARNING, "duplicate: file:%s - rename error",
 			                   originalChunk->fullMetaFilename().c_str());
-			hddDeleteChunkFromRegistry(dupChunk);
-			hddChunkRelease(originalChunk);
 			return SAUNAFS_ERROR_IO;
 		}
 
 		status = hddIOBegin(originalChunk, 0, chunkVersion);
 		if (status != SAUNAFS_STATUS_OK) {
 			hddAddErrorAndPreserveErrno(originalChunk);
-			hddDeleteChunkFromRegistry(dupChunk);
-			hddChunkRelease(originalChunk);
 			return status;  //can't change file version
 		}
+		guard.sourceIoBegan();
 
 		status = originalDisk->overwriteChunkVersion(originalChunk,
 		                                             chunkNewVersion);
@@ -1525,41 +1606,30 @@ static int hddInternalDuplicate(uint64_t chunkId, uint32_t chunkVersion,
 			hddAddErrorAndPreserveErrno(originalChunk);
 			safs_silent_errlog(LOG_WARNING, "duplicate: file:%s - write error",
 			                   dupChunk->fullMetaFilename().c_str());
-			hddDeleteChunkFromRegistry(dupChunk);
-			hddIOEnd(originalChunk);
-			hddChunkRelease(originalChunk);
 			return SAUNAFS_ERROR_IO;
 		}
 	} else {  // chunkNewVersion == chunkVersion
 		status = hddIOBegin(originalChunk, 0);
 		if (status != SAUNAFS_STATUS_OK) {
 			hddAddErrorAndPreserveErrno(originalChunk);
-			hddDeleteChunkFromRegistry(dupChunk);
-			hddReportDamagedChunk(chunkId, chunkType);
-			hddChunkRelease(originalChunk);
+			guard.sourceIsDamaged();
 			return status;
 		}
+		guard.sourceIoBegan();
 	}
 
 	status = hddIOBegin(dupChunk, 1);
 	if (status != SAUNAFS_STATUS_OK) {
 		hddAddErrorAndPreserveErrno(dupChunk);
-		hddDeleteChunkFromRegistry(dupChunk);
-		hddIOEnd(originalChunk);
-		hddChunkRelease(originalChunk);
 		return status;
 	}
+	guard.copyIoBegan();
 
 	// The copy takes the destination disk's configured format, not the source
 	// chunk's, and must be stamped before its header is sized below.
 	status = dupDisk->applyNewChunkFormat(dupChunk);
 	if (status != SAUNAFS_STATUS_OK) {
 		hddAddErrorAndPreserveErrno(dupChunk);
-		hddIOEnd(dupChunk);
-		dupDisk->unlinkChunk(dupChunk);
-		hddDeleteChunkFromRegistry(dupChunk);
-		hddIOEnd(originalChunk);
-		hddChunkRelease(originalChunk);
 		return SAUNAFS_ERROR_IO;
 	}
 
@@ -1590,11 +1660,6 @@ static int hddInternalDuplicate(uint64_t chunkId, uint32_t chunkVersion,
 			safs_silent_errlog(LOG_WARNING,
 			                   "duplicate: file:%s - hdr write error",
 			                   dupChunk->fullMetaFilename().c_str());
-			hddIOEnd(dupChunk);
-			dupDisk->unlinkChunk(dupChunk);
-			hddDeleteChunkFromRegistry(dupChunk);
-			hddIOEnd(originalChunk);
-			hddChunkRelease(originalChunk);
 			updater.markWriteAsFailed();
 			return SAUNAFS_ERROR_IO;
 		}
@@ -1611,41 +1676,28 @@ static int hddInternalDuplicate(uint64_t chunkId, uint32_t chunkVersion,
 	                       origCrcData, dupCrcData, "duplicate");
 
 	if (copyResult != ChunkCopyResult::Ok) {
-		hddIOEnd(dupChunk);
-		dupDisk->unlinkChunk(dupChunk);
-		hddDeleteChunkFromRegistry(dupChunk);
-		hddIOEnd(originalChunk);
 		if (copyResult == ChunkCopyResult::ReadFailed) {
-			hddReportDamagedChunk(chunkId, chunkType);
+			guard.sourceIsDamaged();
 		}
-		hddChunkRelease(originalChunk);
 		return SAUNAFS_ERROR_IO;
 	}
 
-	status = hddIOEnd(originalChunk);
+	status = guard.endSourceIo();
 	if (status != SAUNAFS_STATUS_OK) {
 		hddAddErrorAndPreserveErrno(originalChunk);
-		hddIOEnd(dupChunk);
-		dupDisk->unlinkChunk(dupChunk);
-		hddDeleteChunkFromRegistry(dupChunk);
-		hddReportDamagedChunk(chunkId, chunkType);
-		hddChunkRelease(originalChunk);
+		guard.sourceIsDamaged();
 		return status;
 	}
 
-	status = hddIOEnd(dupChunk);
+	status = guard.endCopyIo();
 	if (status != SAUNAFS_STATUS_OK) {
 		hddAddErrorAndPreserveErrno(dupChunk);
-		dupDisk->unlinkChunk(dupChunk);
-		hddDeleteChunkFromRegistry(dupChunk);
-		hddChunkRelease(originalChunk);
 		return status;
 	}
 
 	dupChunk->setBlocks(originalChunk->blocks());
 	dupDisk->setNeedRefresh(true);
-	hddChunkRelease(dupChunk);
-	hddChunkRelease(originalChunk);
+	guard.commit();
 
 	return SAUNAFS_STATUS_OK;
 }
@@ -1951,8 +2003,12 @@ static int hddInternalDuplicateTruncate(uint64_t chunkId, uint32_t chunkVersion,
 		safs::log_err("hddInternalDuplicateTruncate: Couldn't find original chunk, ID {}", chunkId);
 		return SAUNAFS_ERROR_NOCHUNK;
 	}
+
+	// Owns the source chunk, and the copy once it is registered: every return
+	// below unwinds whatever has been done so far unless commit() runs.
+	ChunkCopyGuard guard(originalChunk);
+
 	if (originalChunk->version() != chunkVersion && chunkVersion > 0) {
-		hddChunkRelease(originalChunk);
 		return SAUNAFS_ERROR_WRONGVERSION;
 	}
 
@@ -1968,8 +2024,8 @@ static int hddInternalDuplicateTruncate(uint64_t chunkId, uint32_t chunkVersion,
 		dupDisk = gDiskManager->getDiskForNewChunk(chunkType);
 
 		if (dupDisk == DiskNotFound) {
-			disksUniqueLock.unlock();
-			hddChunkRelease(originalChunk);
+			// The guard runs after this scope, so the chunk is released with
+			// gDisksMutex already dropped.
 			return SAUNAFS_ERROR_NOSPACE;
 		}
 
@@ -1978,9 +2034,10 @@ static int hddInternalDuplicateTruncate(uint64_t chunkId, uint32_t chunkVersion,
 	}
 
 	if (dupChunk == ChunkNotFound) {
-		hddChunkRelease(originalChunk);
 		return SAUNAFS_ERROR_CHUNKEXIST;
 	}
+
+	guard.copyRegistered(dupChunk);
 
 	origDisk = originalChunk->owner();
 
@@ -1990,18 +2047,15 @@ static int hddInternalDuplicateTruncate(uint64_t chunkId, uint32_t chunkVersion,
 			safs_silent_errlog(LOG_WARNING,
 			                   "duptrunc: file:%s - rename error",
 			                   originalChunk->fullMetaFilename().c_str());
-			hddDeleteChunkFromRegistry(dupChunk);
-			hddChunkRelease(originalChunk);
 			return SAUNAFS_ERROR_IO;
 		}
 
 		status = hddIOBegin(originalChunk, 0, chunkVersion);
 		if (status != SAUNAFS_STATUS_OK) {
 			hddAddErrorAndPreserveErrno(originalChunk);
-			hddDeleteChunkFromRegistry(dupChunk);
-			hddChunkRelease(originalChunk);
 			return status;  //can't change file version
 		}
+		guard.sourceIoBegan();
 
 		status = origDisk->overwriteChunkVersion(originalChunk,
 		                                         chunkNewVersion);
@@ -2010,30 +2064,24 @@ static int hddInternalDuplicateTruncate(uint64_t chunkId, uint32_t chunkVersion,
 			safs_silent_errlog(LOG_WARNING,
 			                   "duptrunc: file:%s - write error",
 			                   dupChunk->fullMetaFilename().c_str());
-			hddDeleteChunkFromRegistry(dupChunk);
-			hddIOEnd(originalChunk);
-			hddChunkRelease(originalChunk);
 			return SAUNAFS_ERROR_IO;
 		}
 	} else { // It is the same version
 		status = hddIOBegin(originalChunk, 0);
 		if (status != SAUNAFS_STATUS_OK) {
 			hddAddErrorAndPreserveErrno(originalChunk);
-			hddDeleteChunkFromRegistry(dupChunk);
-			hddReportDamagedChunk(chunkId, chunkType);
-			hddChunkRelease(originalChunk);
+			guard.sourceIsDamaged();
 			return status;
 		}
+		guard.sourceIoBegan();
 	}
 
 	status = hddIOBegin(dupChunk, 1);
 	if (status != SAUNAFS_STATUS_OK) {
 		hddAddErrorAndPreserveErrno(dupChunk);
-		hddDeleteChunkFromRegistry(dupChunk);
-		hddIOEnd(originalChunk);
-		hddChunkRelease(originalChunk);
 		return status;
 	}
+	guard.copyIoBegan();
 
 	// The copy takes the destination disk's configured format, not the source
 	// chunk's, and must be stamped before getChunkHeaderBuffer() below sizes
@@ -2041,11 +2089,6 @@ static int hddInternalDuplicateTruncate(uint64_t chunkId, uint32_t chunkVersion,
 	status = dupDisk->applyNewChunkFormat(dupChunk);
 	if (status != SAUNAFS_STATUS_OK) {
 		hddAddErrorAndPreserveErrno(dupChunk);
-		hddIOEnd(dupChunk);
-		dupDisk->unlinkChunk(dupChunk);
-		hddDeleteChunkFromRegistry(dupChunk);
-		hddIOEnd(originalChunk);
-		hddChunkRelease(originalChunk);
 		return SAUNAFS_ERROR_IO;
 	}
 
@@ -2086,11 +2129,6 @@ static int hddInternalDuplicateTruncate(uint64_t chunkId, uint32_t chunkVersion,
 				safs::log_warn_with_error_code(
 				    errno, "duptrunc: file:{} - hdr write error",
 				    dupChunk->fullMetaFilename());
-				hddIOEnd(dupChunk);
-				dupDisk->unlinkChunk(dupChunk);
-				hddDeleteChunkFromRegistry(dupChunk);
-				hddIOEnd(originalChunk);
-				hddChunkRelease(originalChunk);
 				updater.markWriteAsFailed();
 				return SAUNAFS_ERROR_IO;
 			}
@@ -2121,14 +2159,9 @@ static int hddInternalDuplicateTruncate(uint64_t chunkId, uint32_t chunkVersion,
 	                       crcDataDup, "duptrunc");
 
 	if (copyResult != ChunkCopyResult::Ok) {
-		hddIOEnd(dupChunk);
-		dupDisk->unlinkChunk(dupChunk);
-		hddDeleteChunkFromRegistry(dupChunk);
-		hddIOEnd(originalChunk);
 		if (copyResult == ChunkCopyResult::ReadFailed) {
-			hddReportDamagedChunk(chunkId, chunkType);
+			guard.sourceIsDamaged();
 		}
-		hddChunkRelease(originalChunk);
 		return SAUNAFS_ERROR_IO;
 	}
 
@@ -2146,11 +2179,6 @@ static int hddInternalDuplicateTruncate(uint64_t chunkId, uint32_t chunkVersion,
 			safs_silent_errlog(LOG_WARNING,
 			                   "duptrunc: file:%s - ftruncate error",
 			                   dupChunk->fullMetaFilename().c_str());
-			hddIOEnd(dupChunk);
-			dupDisk->unlinkChunk(dupChunk);
-			hddDeleteChunkFromRegistry(dupChunk);
-			hddIOEnd(originalChunk);
-			hddChunkRelease(originalChunk);
 			return SAUNAFS_ERROR_IO;        //write error
 		}
 	} else if (lastBlockSize > 0) {
@@ -2169,12 +2197,7 @@ static int hddInternalDuplicateTruncate(uint64_t chunkId, uint32_t chunkVersion,
 				safs::log_warn_with_error_code(
 				    errno, "duptrunc: file:{} - data read error",
 				    originalChunk->fullMetaFilename());
-				hddIOEnd(dupChunk);
-				dupDisk->unlinkChunk(dupChunk);
-				hddDeleteChunkFromRegistry(dupChunk);
-				hddIOEnd(originalChunk);
-				hddReportDamagedChunk(chunkId, chunkType);
-				hddChunkRelease(originalChunk);
+				guard.sourceIsDamaged();
 				updater.markReadAsFailed();
 				return SAUNAFS_ERROR_IO;
 			}
@@ -2213,11 +2236,6 @@ static int hddInternalDuplicateTruncate(uint64_t chunkId, uint32_t chunkVersion,
 				safs::log_warn_with_error_code(
 				    errno, "duptrunc: file:{} - data write error",
 				    dupChunk->fullMetaFilename());
-				hddIOEnd(dupChunk);
-				dupDisk->unlinkChunk(dupChunk);
-				hddDeleteChunkFromRegistry(dupChunk);
-				hddIOEnd(originalChunk);
-				hddChunkRelease(originalChunk);
 				updater.markWriteAsFailed();
 				return SAUNAFS_ERROR_IO;
 			}
@@ -2239,11 +2257,6 @@ static int hddInternalDuplicateTruncate(uint64_t chunkId, uint32_t chunkVersion,
 				safs::log_warn_with_error_code(
 				    errno, "duptrunc: file:{} - crc write error",
 				    dupChunk->fullMetaFilename());
-				hddIOEnd(dupChunk);
-				dupDisk->unlinkChunk(dupChunk);
-				hddDeleteChunkFromRegistry(dupChunk);
-				hddIOEnd(originalChunk);
-				hddChunkRelease(originalChunk);
 				updater.markWriteAsFailed();
 				return SAUNAFS_ERROR_IO;
 			}
@@ -2251,14 +2264,10 @@ static int hddInternalDuplicateTruncate(uint64_t chunkId, uint32_t chunkVersion,
 		HddStats::overheadWrite(dupChunk->getCrcBlockSize());
 	}
 
-	status = hddIOEnd(originalChunk);
+	status = guard.endSourceIo();
 	if (status != SAUNAFS_STATUS_OK) {
 		hddAddErrorAndPreserveErrno(originalChunk);
-		hddIOEnd(dupChunk);
-		dupDisk->unlinkChunk(dupChunk);
-		hddDeleteChunkFromRegistry(dupChunk);
-		hddReportDamagedChunk(chunkId, chunkType);
-		hddChunkRelease(originalChunk);
+		guard.sourceIsDamaged();
 		return status;
 	}
 
@@ -2269,24 +2278,16 @@ static int hddInternalDuplicateTruncate(uint64_t chunkId, uint32_t chunkVersion,
 
 	if (status != SAUNAFS_STATUS_OK) {
 		hddAddErrorAndPreserveErrno(dupChunk);
-		hddIOEnd(dupChunk);
-		dupDisk->unlinkChunk(dupChunk);
-		hddDeleteChunkFromRegistry(dupChunk);
-		hddChunkRelease(originalChunk);
 		return status;
 	}
 
-	status = hddIOEnd(dupChunk);
+	status = guard.endCopyIo();
 	if (status != SAUNAFS_STATUS_OK) {
 		hddAddErrorAndPreserveErrno(dupChunk);
-		dupDisk->unlinkChunk(dupChunk);
-		hddDeleteChunkFromRegistry(dupChunk);
-		hddChunkRelease(originalChunk);
 		return status;
 	}
 
-	hddChunkRelease(dupChunk);
-	hddChunkRelease(originalChunk);
+	guard.commit();
 
 	return SAUNAFS_STATUS_OK;
 }

--- a/src/chunkserver/hddspacemgr.cc
+++ b/src/chunkserver/hddspacemgr.cc
@@ -1361,7 +1361,7 @@ static int hddInternalTestChunk(uint64_t chunkId, uint32_t version,
 static constexpr uint16_t kChunkCopyBatchBlocks = 256;
 
 /// Which side of a copy failed; only a failed read means a damaged source.
-enum class ChunkCopyResult { Ok, ReadFailed, WriteFailed };
+enum class ChunkCopyResult : std::uint8_t { Ok, ReadFailed, WriteFailed };
 
 /// Copies the first \a blockCount blocks of \a sourceChunk into \a dupChunk,
 /// reusing the source CRCs in \a sourceCrcData (reads decompress, so they
@@ -1371,18 +1371,15 @@ enum class ChunkCopyResult { Ok, ReadFailed, WriteFailed };
 /// through writeChunkBlocks(), the rest appending to the caller's data seek
 /// through writeChunkData().
 static ChunkCopyResult hddCopyChunkBlocks(IChunk *sourceChunk, IChunk *dupChunk,
-                                          uint16_t blockCount,
-                                          const uint8_t *sourceCrcData,
-                                          uint8_t *dupCrcData,
-                                          const char *errorMsg) {
+                                          uint16_t blockCount, const uint8_t *sourceCrcData,
+                                          uint8_t *dupCrcData, const char *errorMsg) {
 	IDisk *sourceDisk = sourceChunk->owner();
 	IDisk *dupDisk = dupChunk->owner();
 	const bool isZonedDestination = dupDisk->isZonedDevice();
 
 	// Pooled, so repeated duplications reuse the allocation; zone reads are
 	// O_DIRECT straight into it, hence the buffer's IO alignment.
-	auto buffer =
-	    getChunkCopyBuffersPool().get(kChunkCopyBufferHeaderSize, kChunkCopyBatchBlocks);
+	auto buffer = getChunkCopyBuffersPool().get(kChunkCopyBufferHeaderSize, kChunkCopyBatchBlocks);
 	auto &blockBuffer = buffer->getBlockBuffer();
 	blockBuffer.resize(static_cast<size_t>(kChunkCopyBatchBlocks) * SFSBLOCKSIZE);
 
@@ -1396,19 +1393,16 @@ static ChunkCopyResult hddCopyChunkBlocks(IChunk *sourceChunk, IChunk *dupChunk,
 	for (uint16_t block = 0; block < blockCount; block += kChunkCopyBatchBlocks) {
 		const uint16_t blocksInBatch =
 		    std::min<uint16_t>(kChunkCopyBatchBlocks, blockCount - block);
-		const int32_t batchSize =
-		    static_cast<int32_t>(blocksInBatch) * SFSBLOCKSIZE;
+		const int32_t batchSize = static_cast<int32_t>(blocksInBatch) * SFSBLOCKSIZE;
 
 		{
 			DiskReadStatsUpdater updater(sourceDisk, batchSize);
 
-			if (sourceDisk->preadData(
-			        sourceChunk, blockBuffer.data(), batchSize,
-			        static_cast<uint64_t>(block) * SFSBLOCKSIZE) != batchSize) {
+			if (sourceDisk->preadData(sourceChunk, blockBuffer.data(), batchSize,
+			                          static_cast<uint64_t>(block) * SFSBLOCKSIZE) != batchSize) {
 				hddAddErrorAndPreserveErrno(sourceChunk);
-				safs::log_warn_with_error_code(
-				    errno, "{}: file:{} - data read error", errorMsg,
-				    sourceChunk->fullMetaFilename());
+				safs::log_warn_with_error_code(errno, "{}: file:{} - data read error", errorMsg,
+				                               sourceChunk->fullMetaFilename());
 				updater.markReadAsFailed();
 				result = ChunkCopyResult::ReadFailed;
 				break;
@@ -1429,19 +1423,17 @@ static ChunkCopyResult hddCopyChunkBlocks(IChunk *sourceChunk, IChunk *dupChunk,
 				}
 				blocksPerBuffer[0] = blocksInBatch;
 
-				written = dupDisk->writeChunkBlocks(
-				    dupChunk, dupChunk->version(), block, blocksInBatch, crcs,
-				    dupCrcData, blocksPerBuffer, buffers);
+				written =
+				    dupDisk->writeChunkBlocks(dupChunk, dupChunk->version(), block, blocksInBatch,
+				                              crcs, dupCrcData, blocksPerBuffer, buffers);
 			} else {
-				written = dupDisk->writeChunkData(dupChunk, blockBuffer.data(),
-				                                 batchSize, 0);
+				written = dupDisk->writeChunkData(dupChunk, blockBuffer.data(), batchSize, 0);
 			}
 
 			if (written != batchSize) {
 				hddAddErrorAndPreserveErrno(dupChunk);
-				safs::log_warn_with_error_code(
-				    errno, "{}: file:{} - data write error", errorMsg,
-				    dupChunk->fullMetaFilename());
+				safs::log_warn_with_error_code(errno, "{}: file:{} - data write error", errorMsg,
+				                               dupChunk->fullMetaFilename());
 				updater.markWriteAsFailed();
 				result = ChunkCopyResult::WriteFailed;
 				break;
@@ -1518,7 +1510,7 @@ public:
 	}
 
 	/// Report the source chunk to the master as damaged while unwinding.
-	void sourceIsDamaged() { sourceDamaged_ = true; }
+	void markSourceAsDamaged() { sourceDamaged_ = true; }
 
 	/// The copy is complete: keep it, and only release both chunks.
 	void commit() { committed_ = true; }
@@ -1590,7 +1582,7 @@ static int openSourceForCopy(ChunkCopyGuard &guard, IChunk *sourceChunk, uint32_
 
 		if (status != SAUNAFS_STATUS_OK) {
 			hddAddErrorAndPreserveErrno(sourceChunk);
-			guard.sourceIsDamaged();
+			guard.markSourceAsDamaged();
 			return status;
 		}
 
@@ -1601,8 +1593,8 @@ static int openSourceForCopy(ChunkCopyGuard &guard, IChunk *sourceChunk, uint32_
 
 	if (sourceChunk->renameChunkFile(chunkNewVersion) < 0) {
 		hddAddErrorAndPreserveErrno(sourceChunk);
-		safs_silent_errlog(LOG_WARNING, "%s: file:%s - rename error", errorMsg,
-		                   sourceChunk->fullMetaFilename().c_str());
+		safs::log_warn_with_error_code(errno, "{}: file:{} - rename error", errorMsg,
+		                               sourceChunk->fullMetaFilename());
 		return SAUNAFS_ERROR_IO;
 	}
 
@@ -1616,8 +1608,8 @@ static int openSourceForCopy(ChunkCopyGuard &guard, IChunk *sourceChunk, uint32_
 	status = sourceChunk->owner()->overwriteChunkVersion(sourceChunk, chunkNewVersion);
 	if (status != SAUNAFS_STATUS_OK) {
 		hddAddErrorAndPreserveErrno(sourceChunk);
-		safs_silent_errlog(LOG_WARNING, "%s: file:%s - write error", errorMsg,
-		                   sourceChunk->fullMetaFilename().c_str());
+		safs::log_warn_with_error_code(errno, "{}: file:{} - write error", errorMsg,
+		                               sourceChunk->fullMetaFilename());
 		return SAUNAFS_ERROR_IO;
 	}
 
@@ -1703,9 +1695,9 @@ static int finishTruncatedCopy(ChunkCopyGuard &guard, IChunk *sourceChunk, IChun
 
 		if (copyDisk->ftruncateData(copy, copy->getFileSizeFromBlockCount(blocks)) < 0) {
 			hddAddErrorAndPreserveErrno(copy);
-			safs_silent_errlog(LOG_WARNING, "%s: file:%s - ftruncate error", errorMsg,
-			                   copy->fullMetaFilename().c_str());
-			return SAUNAFS_ERROR_IO;        //write error
+			safs::log_warn_with_error_code(errno, "{}: file:{} - ftruncate error", errorMsg,
+			                               copy->fullMetaFilename());
+			return SAUNAFS_ERROR_IO;  // write error
 		}
 
 		return SAUNAFS_STATUS_OK;
@@ -1727,7 +1719,7 @@ static int finishTruncatedCopy(ChunkCopyGuard &guard, IChunk *sourceChunk, IChun
 			hddAddErrorAndPreserveErrno(sourceChunk);
 			safs::log_warn_with_error_code(errno, "{}: file:{} - data read error", errorMsg,
 			                               sourceChunk->fullMetaFilename());
-			guard.sourceIsDamaged();
+			guard.markSourceAsDamaged();
 			updater.markReadAsFailed();
 			return SAUNAFS_ERROR_IO;
 		}
@@ -1843,7 +1835,7 @@ static int hddInternalDuplicate(uint64_t chunkId, uint32_t chunkVersion,
 
 	if (copyResult != ChunkCopyResult::Ok) {
 		if (copyResult == ChunkCopyResult::ReadFailed) {
-			guard.sourceIsDamaged();
+			guard.markSourceAsDamaged();
 		}
 		return SAUNAFS_ERROR_IO;
 	}
@@ -1851,7 +1843,7 @@ static int hddInternalDuplicate(uint64_t chunkId, uint32_t chunkVersion,
 	status = guard.endSourceIo();
 	if (status != SAUNAFS_STATUS_OK) {
 		hddAddErrorAndPreserveErrno(originalChunk);
-		guard.sourceIsDamaged();
+		guard.markSourceAsDamaged();
 		return status;
 	}
 
@@ -2217,7 +2209,7 @@ static int hddInternalDuplicateTruncate(uint64_t chunkId, uint32_t chunkVersion,
 
 	if (copyResult != ChunkCopyResult::Ok) {
 		if (copyResult == ChunkCopyResult::ReadFailed) {
-			guard.sourceIsDamaged();
+			guard.markSourceAsDamaged();
 		}
 		return SAUNAFS_ERROR_IO;
 	}
@@ -2232,7 +2224,7 @@ static int hddInternalDuplicateTruncate(uint64_t chunkId, uint32_t chunkVersion,
 	status = guard.endSourceIo();
 	if (status != SAUNAFS_STATUS_OK) {
 		hddAddErrorAndPreserveErrno(originalChunk);
-		guard.sourceIsDamaged();
+		guard.markSourceAsDamaged();
 		return status;
 	}
 

--- a/src/chunkserver/io_buffers.cc
+++ b/src/chunkserver/io_buffers.cc
@@ -464,11 +464,11 @@ const uint8_t *InputBuffer::getBlockBufferData(size_t blockIndex, size_t offsetI
 void releaseOldIoBuffers(uint32_t expirationTime_ms) {
 	auto initialTotalOutputBufferBlocks = gCurrentTotalOutputBufferBlocks.load();
 	auto initialTotalInputBufferBlocks = gCurrentTotalInputBufferBlocks.load();
-	auto initialTotalReplicatorBufferBlocks = gCurrentTotalReplicatorBufferBlocks.load();
+	auto initialTotalChunkCopyBufferBlocks = gCurrentTotalChunkCopyBufferBlocks.load();
 
 	getReadOutputBufferPool().releaseOldBuffers(expirationTime_ms);
 	getWriteInputBufferPool().releaseOldBuffers(expirationTime_ms);
-	getReplicateBuffersPool().releaseOldBuffers(expirationTime_ms);
+	getChunkCopyBuffersPool().releaseOldBuffers(expirationTime_ms);
 
 	// Calculate the number of released blocks. Please note that the number of released
 	// could be negative because some buffers could be added to the pools in the meantime.
@@ -476,18 +476,18 @@ void releaseOldIoBuffers(uint32_t expirationTime_ms) {
 	    initialTotalOutputBufferBlocks - gCurrentTotalOutputBufferBlocks.load();
 	int releasedInputBuffers =
 	    initialTotalInputBufferBlocks - gCurrentTotalInputBufferBlocks.load();
-	int releasedReplicatorBuffers =
-	    initialTotalReplicatorBufferBlocks - gCurrentTotalReplicatorBufferBlocks.load();
+	int releasedChunkCopyBuffers =
+	    initialTotalChunkCopyBufferBlocks - gCurrentTotalChunkCopyBufferBlocks.load();
 	// Log the number of released buffers.
-	safs::log_debug("({}) Released buffer blocks per operation: read {}, write {}, replicate {}",
+	safs::log_debug("({}) Released buffer blocks per operation: read {}, write {}, chunk copy {}",
 	                __func__, releasedOutputBuffers, releasedInputBuffers,
-	                releasedReplicatorBuffers);
+	                releasedChunkCopyBuffers);
 
 	// Log the current amount of blocks buffers per operation.
 	safs::log_debug(
-	    "({}) Current total buffer blocks per operation: read {}, write {}, replicate {}",
+	    "({}) Current total buffer blocks per operation: read {}, write {}, chunk copy {}",
 	    __func__, gCurrentTotalOutputBufferBlocks.load(), gCurrentTotalInputBufferBlocks.load(),
-	    gCurrentTotalReplicatorBufferBlocks.load());
+	    gCurrentTotalChunkCopyBufferBlocks.load());
 }
 
 void setNewMaxIoBuffersPoolSize(size_t maxBuffersPoolSize_mb) {
@@ -501,5 +501,5 @@ void setNewMaxIoBuffersPoolSize(size_t maxBuffersPoolSize_mb) {
 	size_t maxBuffersPoolSize_blocks = (maxBuffersPoolSize_mb * 1024 * 1024) / SFSBLOCKSIZE;
 	getReadOutputBufferPool().setMaxNumberOfBlocks(maxBuffersPoolSize_blocks);
 	getWriteInputBufferPool().setMaxNumberOfBlocks(maxBuffersPoolSize_blocks);
-	getReplicateBuffersPool().setMaxNumberOfBlocks(maxBuffersPoolSize_blocks);
+	getChunkCopyBuffersPool().setMaxNumberOfBlocks(maxBuffersPoolSize_blocks);
 }

--- a/src/chunkserver/io_buffers.h
+++ b/src/chunkserver/io_buffers.h
@@ -34,7 +34,7 @@
 
 inline std::atomic<uint32_t> gCurrentTotalOutputBufferBlocks = 0;
 inline std::atomic<uint32_t> gCurrentTotalInputBufferBlocks = 0;
-inline std::atomic<uint32_t> gCurrentTotalReplicatorBufferBlocks = 0;
+inline std::atomic<uint32_t> gCurrentTotalChunkCopyBufferBlocks = 0;
 
 /// @class Buffer
 /// @brief Manages a data buffer.
@@ -519,27 +519,32 @@ protected:
 	std::vector<WriteInfo> writeInfo_;
 };
 
-/// @brief The size of the header for the replicator buffer.
+/// @brief The size of the header for the chunk-copy buffer.
 /// The 0 is picked for simplicity, main goal is to make it a single value.
-constexpr size_t kReplicatorBufferHeaderSize = 0;
+constexpr size_t kChunkCopyBufferHeaderSize = 0;
 
 /**
- * @class ReplicatorBuffer
- * @brief Wraps an IO aligned buffer for the replicator to fit the BuffersPool interface.
+ * @class ChunkCopyBuffer
+ * @brief Wraps an IO aligned buffer to fit the BuffersPool interface, for the
+ * paths that stage whole chunk blocks while copying them: replication and
+ * local chunk duplication.
+ *
+ * The block buffer starts out empty; consumers size it to the batch they need,
+ * and pooling keeps that capacity across uses.
  */
-class ReplicatorBuffer {
+class ChunkCopyBuffer {
 public:
-	/// @brief Constructs a ReplicatorBuffer with the given number of blocks.
+	/// @brief Constructs a ChunkCopyBuffer with the given number of blocks.
 	/// @param headerSize The size of the header (not used, but required for compatibility).
 	/// @param numBlocks The number of blocks the buffer can hold.
-	ReplicatorBuffer(size_t headerSize, size_t numBlocks) : numBlocks_(numBlocks) {
+	ChunkCopyBuffer(size_t headerSize, size_t numBlocks) : numBlocks_(numBlocks) {
 		(void)headerSize;
-		gCurrentTotalReplicatorBufferBlocks += numBlocks_;
+		gCurrentTotalChunkCopyBufferBlocks += numBlocks_;
 	}
 
-	/// @brief Destructor only decreases the global counter of replicator buffers blocks.
-	~ReplicatorBuffer() {
-		gCurrentTotalReplicatorBufferBlocks -= numBlocks_;
+	/// @brief Destructor only decreases the global counter of chunk-copy buffers blocks.
+	~ChunkCopyBuffer() {
+		gCurrentTotalChunkCopyBufferBlocks -= numBlocks_;
 	}
 
 	/// @brief Clears the buffer.
@@ -554,7 +559,7 @@ public:
 	const uint8_t *data() const { return blockBuffer_.data(); }
 
 	/// @brief Returns the type of the buffer.
-	std::pair<size_t, size_t> type() const { return {kReplicatorBufferHeaderSize, numBlocks_}; }
+	std::pair<size_t, size_t> type() const { return {kChunkCopyBufferHeaderSize, numBlocks_}; }
 
 private:
 	const size_t numBlocks_;  ///< The number of blocks.
@@ -565,7 +570,7 @@ private:
 
 using OutputBufferPool = BuffersPool<OutputBuffer>;
 using InputBufferPool = BuffersPool<InputBuffer>;
-using ReplicatorBufferPool = BuffersPool<ReplicatorBuffer>;
+using ChunkCopyBufferPool = BuffersPool<ChunkCopyBuffer>;
 
 /// @brief Returns the read output buffer pool.
 /// It is a singleton.
@@ -581,11 +586,12 @@ inline InputBufferPool &getWriteInputBufferPool() {
 	return writeInputBuffersPool;
 }
 
-/// @brief Returns the replicate buffer pool.
+/// @brief Returns the chunk-copy buffer pool, shared by replication and
+/// local chunk duplication.
 /// It is a singleton.
-inline ReplicatorBufferPool &getReplicateBuffersPool() {
-	static ReplicatorBufferPool replicateBuffersPool;
-	return replicateBuffersPool;
+inline ChunkCopyBufferPool &getChunkCopyBuffersPool() {
+	static ChunkCopyBufferPool chunkCopyBuffersPool;
+	return chunkCopyBuffersPool;
 }
 
 /// @brief Releases the old IO buffers that have been in the pool for longer than the given

--- a/tests/tools/saunafs.sh
+++ b/tests/tools/saunafs.sh
@@ -1180,14 +1180,14 @@ sfschunkserver_check_no_buffer_in_use() {
 	sleep 5
 
 	# Assert that the last 5 seconds of log contains chunkserver_count lines with:
-	# "Current total buffer blocks per operation: read 0, write 0, replicate 0"
+	# "Current total buffer blocks per operation: read 0, write 0, chunk copy 0"
 	# Plus, the last chunkserver_count lines should be unique disregarding the timestamp.
 	# The difference should be the CS pid. This means that the buffers were released correctly.
 	last_total_entries=$(
 		grep '(releaseOldIoBuffers) Current total' "${TEMP_DIR}/log" | tail -n \
 			${chunkserver_count} | awk '{for(i=4;i<=NF;++i) printf "%s%s", $i, (i<NF?" ":"\n")}'
 	)
-	full_zeroes=$(echo "${last_total_entries}" | grep -c 'read 0, write 0, replicate 0')
+	full_zeroes=$(echo "${last_total_entries}" | grep -c 'read 0, write 0, chunk copy 0')
 	unique_count=$(echo "${last_total_entries}" | sort | uniq | wc -l)
 
 	assert_equals "${chunkserver_count}" "${full_zeroes}"


### PR DESCRIPTION
## Summary

`hddInternalDuplicate()` and `hddInternalDuplicateTruncate()` always created the
copy as a legacy V1 chunk and wrote it one block at a time through
`writeChunkBlock()`. That is harmless for plain chunks, but for the SMR
implementation it silently drops compression on every local duplicate, and
simply making the copy format-aware without also fixing the copy loop would mint
**one fragment per block** — reintroducing the write-amplification failure class
already fixed for the garbage collector there.

This PR makes a duplicate adopt its destination disk's configured format, and
rewrites the four block-copy loops as a single batched helper so that
format-awareness does not come at the cost of fragment explosion.

Needs the companion commit on the SMR implementation's `feat-data-compression`
branch: every `IDisk` implementation has to match the new
`serializeEmptyChunkSignature()` signature, and the new SMR integration test
lives in that repo too.

## Changes

**A duplicate takes the destination disk's format.** Both dup paths now call the
existing `applyNewChunkFormat()` hook, exactly as `hddInternalCreateChunk()`
already does. The copy does *not* inherit the source chunk's format — same
behaviour as a replication receiver.

**`serializeEmptyChunkSignature()` gained an optional `formatSource` chunk** so
the placeholder header written for the duplicate matches the format that was
just stamped. The parameter is defaulted; `CmrDisk` ignores it.

**Fixed a latent data-loss bug in `hddInternalDuplicateTruncate()`.** Its
`writeChunkHeader()` ran *after* the data copy and spanned the whole header
region, so on a compressed copy it erased both the dictionary bytes and the
`dictLen` field that the copy's first batch had just persisted there.
`setChunkBlocks()` then restored the fragment table but not the dictionary,
leaving every compressed block in the duplicate undecodable once the chunk left
the open-chunks cache. The header is now written before the copy and only the
CRCs are persisted afterwards, via `writeCrc()`. All three
`writeChunkHeader()` call sites now precede their data writes. The
`getChunkHeaderBuffer()` capture also moved after the format is stamped, since
that call sizes the buffer from the format.

**Collapsed all four block-copy loops** (one in duplicate, three in duptrunc)
into a single `hddCopyChunkBlocks()`, copying `kChunkCopyBatchBlocks` (256)
blocks at a time regardless of format. The only per-format difference left is
the write call:

- a zoned destination goes through the existing multi-block
  `writeChunkBlocks()`, so a compressed copy packs many blocks into one
  fragment instead of one fragment per block. 256 is also the batch a
  compressed write flushes at, so a copy batch maps onto one fragment;
- everything else appends through `writeChunkData()`, which also drops that
  path from one write syscall per 64 KiB block to one per batch.

**Simplified duptrunc's expand/shrink branches.** They differed only in how many
blocks they copy, so the copy moved out of them entirely, leaving just the
expanding CRC fill and the misaligned trailing block as the genuine special
cases.

**Reused the IO buffers pool for staging.** The copy stages its blocks in a
buffer from the existing pool rather than allocating one per call, so
duplications reuse the allocation and the 16 MiB is accounted and reclaimed
alongside the read and write pools under `MAX_BUFFERS_POOL_SIZE_MB` (the
replicator already pools a whole chunk's worth, 64 MiB, through the same pool).
That pool's buffer type was already exactly what this needs — an IO-aligned
block buffer with no header — so it is reused as is and renamed
`ReplicatorBuffer` → `ChunkCopyBuffer` (with its pool accessor and block
counter) now that replication is not its only user. That also renames the pool's
column in the `releaseOldIoBuffers` debug line from `replicate` to `chunk copy`,
which `sfschunkserver_check_no_buffer_in_use()` greps for, so the test helper
and the chunkserver README follow.

## Impact

| | Before | After |
|---|---|---|
| Duplicate of a compressed chunk | copied as uncompressed V1 | keeps the destination's compressed format |
| Fragments per duplicated chunk (SMR) | one per block, up to 1024 | one per 256-block batch, ≤ 4 for a full chunk |
| Write syscalls per chunk (non-SMR) | one per 64 KiB block | one per 16 MiB batch |
| Duptrunc of a compressed chunk | dictionary erased after copy → undecodable blocks | dictionary preserved |

No on-disk format change, no configuration change, and no behavioural change for
plain (non-SMR) chunks beyond the larger write batches.

## Bonus

Two follow-up refactors of the same duplication code, done after the above landed.

**Guarded the failure-path cleanup.** Both duplicate operations unwound a
half-built copy by hand on every early return: end the copy's I/O, unlink it,
drop it from the registry, end the source's I/O, release the source — five
steps, repeated ten times across the two functions (113 cleanup calls in
total), each site having to know which of the five actually applied (a copy
with no files yet, an I/O already ended, whether the source should be
reported damaged). A small RAII guard now owns both chunks: each phase marks
what it completed, and the guard's teardown unwinds only what's still
outstanding, in the same order the hand-written blocks used. A final step
keeps the copy and releases both locks. No intended behaviour change.

**Extracted the phases both operations share.** The two functions ran very
long bodies, most of it the same sequence: pick a destination disk,
register the copy, bump the source's version, open both chunks, stamp the
copy's header from the source's CRCs, copy the blocks, commit — with one
operation's truncation-specific logic and old-style variable declarations
obscuring the overlap with the other. Five short helpers now hold those
phases, three of them shared by both callers. Both operations drop to a
short sequence of named steps instead of one long body.

Comparing the two turned up a real bug: one of the operations was renaming
the *copy* on a version bump instead of the source, but a freshly registered
chunk has no files yet — they're created later — so the rename found nothing
to act on, and every request of that kind carrying a new version failed
before any data moved. That path had never run to completion and nothing
covered it. Fixed to rename the source, matching how every other version-
changing operation in this file behaves.

A handful of other small divergences between the two callers were settled as
no-ops in the shared helpers (a redundant seek to an already-zero offset, an
early CRC copy one operation used to redo later, which chunk's identifying
fields a placeholder header is built from) and two cosmetic log-line
differences were unified. Also drops a dead assertion and three redundant
null checks that were never reachable once the shared setup guarantees the
chunk exists.