### PR TITLE
chore(rpm): rebrand binaries and manpages refs

### DIFF
--- a/rpm/README.md
+++ b/rpm/README.md
@@ -63,9 +63,9 @@ Don't install any debuginfo packages. Replace **VERSION** and **RELEASE** with a
 After installation, follow [this quick guide on setting up local manual test](https://docs.leil.io/quick-start).
 
 > [!IMPORTANT]
-> Also copy sfsexports to /etc/saunafs:
+> Also copy leil-exports to /etc/saunafs:
 ```
-sudo cp /usr/share/doc/saunafs-master/examples/sfsexports.cfg /etc/saunafs/
+sudo cp /usr/share/doc/saunafs-master/examples/leil-exports.cfg /etc/saunafs/
 ```
 
 Navigate to the */mnt/client* after starting services and try to create and delete files to confirm the binaries are working.

--- a/rpm/service-files/saunafs-cgiserv.service
+++ b/rpm/service-files/saunafs-cgiserv.service
@@ -1,14 +1,14 @@
 [Unit]
 Description=LeilFS CGI server daemon
-Documentation=man:saunafs-cgiserver(8)
+Documentation=man:leil-cgiserver(8)
 After=network-online.target
 
 [Service]
 Environment=BIND_HOST=0.0.0.0
 Environment=BIND_PORT=9425
-Environment=ROOT_PATH=/usr/share/sfscgi
+Environment=ROOT_PATH=/usr/share/leil-cgi
 EnvironmentFile=-/etc/sysconfig/%p
-ExecStart=/usr/sbin/saunafs-cgiserver -H ${BIND_HOST} -P ${BIND_PORT} -R ${ROOT_PATH}
+ExecStart=/usr/sbin/leil-cgiserver -H ${BIND_HOST} -P ${BIND_PORT} -R ${ROOT_PATH}
 Restart=on-abort
 User=saunafs
 

--- a/rpm/service-files/saunafs-chunkserver.service
+++ b/rpm/service-files/saunafs-chunkserver.service
@@ -1,13 +1,13 @@
 [Unit]
 Description=LeilFS chunkserver daemon
-Documentation=man:sfschunkserver(8) man:sfschunkserver.cfg(5) man:sfshdd.cfg(5)
+Documentation=man:leil-chunkserver(8) man:leil-chunkserver.cfg(5) man:leil-hdd.cfg(5)
 After=network-online.target
 
 [Service]
 Type=forking
-ExecStart=/usr/sbin/sfschunkserver start
-ExecStop=/usr/sbin/sfschunkserver stop
-ExecReload=/usr/sbin/sfschunkserver reload
+ExecStart=/usr/sbin/leil-chunkserver start
+ExecStop=/usr/sbin/leil-chunkserver stop
+ExecReload=/usr/sbin/leil-chunkserver reload
 Restart=on-abort
 
 [Install]

--- a/rpm/service-files/saunafs-ha-master.service
+++ b/rpm/service-files/saunafs-ha-master.service
@@ -1,15 +1,15 @@
 [Unit]
 Description=LeilFS high availability master server daemon
-Documentation=man:sfsmaster(8) man:sfsgoals.cfg(5) man:sfsmaster.cfg(5) man:sfsglobaliolimits.cfg(5) man:saunafs(7) man:sfsmaster(8) man:sfsmetadump(8) man:sfsrestoremaster(8)
+Documentation=man:leil-master(8) man:leil-goals.cfg(5) man:leil-master.cfg(5) man:leil-globaliolimits.cfg(5) man:leil(7) man:leil-master(8) man:leil-metadump(8) man:leil-restoremaster(8)
 After=network-online.target
 PartOf=saunafs-uraft.service
 
 [Service]
 Type=forking
 TimeoutSec=0
-ExecStart=/usr/sbin/sfsmaster -o ha-cluster-managed -o initial-personality=shadow start
-ExecStop=/usr/sbin/sfsmaster -o ha-cluster-managed -o initial-personality=shadow stop
-ExecReload=/usr/sbin/sfsmaster -o ha-cluster-managed -o initial-personality=shadow reload
+ExecStart=/usr/sbin/leil-master -o ha-cluster-managed -o initial-personality=shadow start
+ExecStop=/usr/sbin/leil-master -o ha-cluster-managed -o initial-personality=shadow stop
+ExecReload=/usr/sbin/leil-master -o ha-cluster-managed -o initial-personality=shadow reload
 Restart=no
 
 [Install]

--- a/rpm/service-files/saunafs-master.service
+++ b/rpm/service-files/saunafs-master.service
@@ -1,14 +1,14 @@
 [Unit]
 Description=LeilFS master server daemon
-Documentation=man:sfsmaster(8) man:sfsgoals.cfg(5) man:sfsmaster.cfg(5) man:sfsglobaliolimits.cfg(5) man:saunafs(7) man:sfsmaster(8) man:sfsmetadump(8) man:sfsrestoremaster(8)
+Documentation=man:leil-master(8) man:leil-goals.cfg(5) man:leil-master.cfg(5) man:leil-globaliolimits.cfg(5) man:leil(7) man:leil-master(8) man:leil-metadump(8) man:leil-restoremaster(8)
 After=network-online.target
 
 [Service]
 Type=forking
 TimeoutSec=0
-ExecStart=/usr/sbin/sfsmaster start
-ExecStop=/usr/sbin/sfsmaster stop
-ExecReload=/usr/sbin/sfsmaster reload
+ExecStart=/usr/sbin/leil-master start
+ExecStop=/usr/sbin/leil-master stop
+ExecReload=/usr/sbin/leil-master reload
 Restart=no
 
 [Install]

--- a/rpm/service-files/saunafs-metalogger.service
+++ b/rpm/service-files/saunafs-metalogger.service
@@ -1,13 +1,13 @@
 [Unit]
 Description=LeilFS metalogger server daemon
-Documentation=man:sfsmetalogger(8) man:sfsmetalogger.cfg(5)
+Documentation=man:leil-metalogger(8) man:leil-metalogger.cfg(5)
 After=network-online.target
 
 [Service]
 Type=forking
-ExecStart=/usr/sbin/sfsmetalogger start
-ExecStop=/usr/sbin/sfsmetalogger stop
-ExecReload=/usr/sbin/sfsmetalogger reload
+ExecStart=/usr/sbin/leil-metalogger start
+ExecStop=/usr/sbin/leil-metalogger stop
+ExecReload=/usr/sbin/leil-metalogger reload
 Restart=on-abort
 
 [Install]

--- a/rpm/service-files/saunafs-uraft.service
+++ b/rpm/service-files/saunafs-uraft.service
@@ -1,15 +1,15 @@
 [Unit]
 Description=LeilFS uraft high availability daemon
-Documentation=man:saunafs-uraft(8) man:saunafs-uraft-helper(8) man:saunafs-uraft.cfg(5)
+Documentation=man:leil-uraft(8) man:leil-uraft-helper(8) man:leil-uraft.cfg(5)
 Wants=saunafs-ha-master.service
 After=network-online.target
 After=saunafs-ha-master.service
 
 [Service]
-PIDFile=/var/run/saunafs-uraft.pid
+PIDFile=/var/run/leil-uraft.pid
 TimeoutSec=0
-ExecStart=/usr/sbin/saunafs-uraft
-ExecStopPost=/usr/sbin/saunafs-uraft-helper demote
+ExecStart=/usr/sbin/leil-uraft
+ExecStopPost=/usr/sbin/leil-uraft-helper demote
 Restart=on-failure
 RestartSec=60
 User=saunafs


### PR DESCRIPTION
This commit updates the binaries and manpages used as part of the RPM packages services to follow the new LeilFS-based naming.

Related to: LS-1006